### PR TITLE
docs: per-package accuracy deep-dive (fix broken examples, signatures, counts)

### DIFF
--- a/docs-site/concepts/architecture.mdx
+++ b/docs-site/concepts/architecture.mdx
@@ -25,13 +25,13 @@ flowchart LR
     Discovers quality rules from the data itself: encoding, format, nullability, anomalies.
   </Step>
   <Step title="GoldenFlow standardizes">
-    Normalizes phone numbers, dates, addresses, and categorical spelling with 86 built-in transforms.
+    Normalizes phone numbers, dates, addresses, and categorical spelling with 92 built-in transforms.
   </Step>
   <Step title="GoldenMatch deduplicates">
     Blocks, scores, clusters, and synthesizes golden records using fuzzy, exact, probabilistic, and LLM scoring.
   </Step>
   <Step title="GoldenPipe orchestrates">
-    Runs the whole chain with adaptive logic on a dependency-DAG planner. It skips transformation if no issues are found and explains every decision.
+    Runs the whole chain with adaptive logic. It skips transformation if no issues are found and explains every decision.
   </Step>
   <Step title="GoldenAnalysis reports">
     Runs read-only analyzers over any stage's outputs — match rates, cluster distribution, quality rollups — with cross-run trend and regression detection.

--- a/docs-site/concepts/entity-resolution.mdx
+++ b/docs-site/concepts/entity-resolution.mdx
@@ -38,13 +38,16 @@ Pairwise matches are transitively closed into clusters: if A matches B and B mat
 
 ## Survivorship
 
-A **golden record** is the canonical record synthesized from a cluster. GoldenMatch offers five merge strategies:
+A **golden record** is the canonical record synthesized from a cluster. GoldenMatch offers eight merge strategies:
 
 - `most_complete`
 - `majority_vote`
 - `source_priority`
 - `most_recent`
 - `first_non_null`
+- `longest_value`
+- `unanimous_or_null`
+- `confidence_majority`
 
 Fields can be weighted by source quality (from GoldenCheck), and field-level provenance tracks which source row contributed each value.
 

--- a/docs-site/goldenanalysis/cross-run.mdx
+++ b/docs-site/goldenanalysis/cross-run.mdx
@@ -13,7 +13,7 @@ A single report tells you about one run. The cross-run layer answers "how did th
 ```python
 from goldenanalysis import ReportHistory
 
-hist = ReportHistory(path=".golden/analysis.jsonl")   # backend inferred from suffix
+hist = ReportHistory(path=".golden/analysis.jsonl")   # default backend="jsonl"; pass backend="sqlite" for .db
 hist.append(report)                                    # after each run
 
 series = hist.trend("cluster.singleton_ratio", "customers", last_n=30)

--- a/docs-site/goldenanalysis/native.mdx
+++ b/docs-site/goldenanalysis/native.mdx
@@ -14,7 +14,7 @@ The pure-Python path stays the **default and the byte-identical reference**. The
 
 ## Gate on the measured wall, not "it's Rust"
 
-A primitive is used only once it is in `_native_loader._GATED_ON`, which it joins after **two** gates clear: a parity test proves byte-identical output, **and** the wall-clock is measured to actually move on the target environment. The pure loops are tight, and the native path pays a list→Arrow conversion cost, so "it's compiled" is never enough — the goldencheck composite-key kernel was once 2.5x *slower* than its baseline, and the gate caught it.
+In reference mode a primitive runs native wherever its kernel symbol is present; `_native_loader._GATED_ON` records which primitives cleared the **two**-gate sign-off: a parity test proves byte-identical output, **and** the wall-clock is measured to actually move on the target environment. The pure loops are tight, and the native path pays a list→Arrow conversion cost, so "it's compiled" is never enough — the goldencheck composite-key kernel was once 2.5x *slower* than its baseline, and the gate caught it.
 
 `histogram` and `quantile` cleared both gates. The A/B harness (`bench-analysis-native.yml`, on Linux x86_64) measured the **realistic dispatch** — a Python list converted to Arrow, then the kernel, exactly what the call sites pay:
 

--- a/docs-site/goldencheck/cli.mdx
+++ b/docs-site/goldencheck/cli.mdx
@@ -33,7 +33,7 @@ The TypeScript CLI mirrors the core commands under `goldencheck-js` (`scan`, `va
 | `--no-tui` | — | Print results to the console. |
 | `--json` | — | JSON output. |
 | `--fail-on` | `error`, `warning` | Exit non-zero at this severity. |
-| `--domain` | `healthcare`, `finance`, `ecommerce`, `real_estate`, `people_hr` | Apply a domain pack. |
+| `--domain` | `healthcare`, `finance`, `ecommerce` | Apply a domain pack. |
 | `--llm-boost` | — | Enable LLM enhancement. |
 | `--llm-provider` | `anthropic` (default), `openai` | Choose the LLM provider. |
 | `--mode` | `safe`, `moderate`, `aggressive` | Fix mode (for `fix`). |

--- a/docs-site/goldencheck/integrations.mdx
+++ b/docs-site/goldencheck/integrations.mdx
@@ -13,7 +13,7 @@ Add the package to `packages.yml`:
 ```yaml
 packages:
   - git: "https://github.com/benseverndev-oss/goldenmatch.git"
-    subdirectory: "packages/dbt/goldencheck"
+    subdirectory: "packages/dbt/goldensuite"
     revision: main
 ```
 

--- a/docs-site/goldencheck/overview.mdx
+++ b/docs-site/goldencheck/overview.mdx
@@ -55,12 +55,12 @@ In Python:
 ```python
 import goldencheck
 
-findings = goldencheck.scan_file("data.csv")
+findings, profile = goldencheck.scan_file("data.csv")
 for f in findings:
     print(f"[{f.severity}] {f.column}: {f.check} — {f.message}")
 
-score = goldencheck.health_score("data.csv")
-print(score)  # e.g. "B (78/100)"
+grade, score = profile.health_score()
+print(f"{grade} ({score}/100)")  # e.g. "B (78/100)"
 ```
 
 The edge-safe TypeScript core:
@@ -84,8 +84,8 @@ for (const f of findings) {
 
 - **Profiling**: type inference, nullability, uniqueness, format detection, range and distribution, cardinality, pattern consistency, encoding and sequence detection, near-duplicate value detection (inconsistent categorical encodings such as `California`/`Californa`/`CALIFORNIA`), and freshness (future-dated values and name-gated staleness).
 - **Cross-column checks**: temporal ordering, null correlation, numeric constraints, age-versus-DOB, composite-key discovery, exact and near-duplicate rows, strict functional dependencies, and approximate-FD violations (rows that break a near-strict `zip → city`).
-- **Baseline and drift detection**: 13 check types including distribution drift, entropy drift, Benford drift, functional-dependency violation, and type drift.
-- **Domain packs**: healthcare, finance, ecommerce, real estate, and people/HR.
+- **Baseline and drift detection**: 12 check types including distribution drift, entropy drift, Benford drift, functional-dependency violation, and type drift.
+- **Domain packs**: healthcare, finance, and ecommerce.
 - **Auto-fix**: safe repairs such as trim, normalize case, fix encoding, and coerce types.
 - **LLM boost**: optional semantic understanding at roughly $0.01 per scan.
 - **Confidence scoring**: every finding carries a 0.0–1.0 confidence.

--- a/docs-site/goldenflow/cli.mdx
+++ b/docs-site/goldenflow/cli.mdx
@@ -30,7 +30,7 @@ keywords: ["goldenflow", "cli", "commands", "config", "transforms"]
 
 | Flag | Effect |
 |------|--------|
-| `--domain healthcare\|people_hr\|finance\|ecommerce\|real_estate` | Apply a domain pack. |
+| `--domain healthcare\|people_hr\|finance\|ecommerce\|real_estate\|carceral` | Apply a domain pack. |
 | `--strict` | Fail on the first transform error (exit 1). |
 | `--llm` | Enable LLM-enhanced corrections. |
 | `-c <config.yaml>` | Load an explicit config. |

--- a/docs-site/goldenflow/overview.mdx
+++ b/docs-site/goldenflow/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "GoldenFlow overview"
-description: "Standardize, reshape, and normalize messy data with 86 built-in transforms across 11 categories."
+description: "Standardize, reshape, and normalize messy data with 92 built-in transforms across 11 categories."
 keywords: ["goldenflow", "transforms", "standardization", "normalization", "data cleaning"]
 ---
 
-GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 86 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, and URLs), plus domain packs for healthcare, finance, ecommerce, people/HR, and real estate. The identifiers group includes checksummed/structural validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing numbers, and IMEI, running on owned Rust kernels. The name group includes two owned i18n kernels: `name_transliterate` (deterministic Unicode-to-ASCII fold via a curated map) and `name_script` (dominant-script detection). It scores 100/100 on the DQBench transform benchmarks.
+GoldenFlow standardizes, reshapes, and normalizes messy data before it enters a pipeline. In zero-config mode it auto-detects quality issues and applies safe transforms. It ships 92 built-in transforms across 11 categories (text, phone, name, address, date, categorical, numeric, email, identifiers, URLs, and auto-correct), plus domain packs for healthcare, finance, ecommerce, people/HR, real estate, and carceral. The identifiers group includes checksummed/structural validators/formatters for payment cards (Luhn), IBAN (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing numbers, and IMEI, running on owned Rust kernels. The name group includes two owned i18n kernels: `name_transliterate` (deterministic Unicode-to-ASCII fold via a curated map) and `name_script` (dominant-script detection). It scores 100/100 on the DQBench transform benchmarks.
 
 <CardGroup cols={2}>
   <Card title="CLI reference" icon="terminal" href="/goldenflow/cli">
@@ -65,8 +65,8 @@ console.log(result.rows[0]);
 ## Key features
 
 - **Zero-config mode**: auto-detects column types and applies safe transforms.
-- **86 transforms** across 11 categories, including checksummed/structural identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT, SWIFT/BIC, ABA routing, IMEI) and owned i18n name kernels (`name_transliterate`, `name_script`).
-- **5 domain packs**: healthcare, finance, ecommerce, people/HR, real estate.
+- **92 transforms** across 11 categories, including checksummed/structural identifiers (payment card, IBAN, ISBN, EAN/UPC, EU VAT, SWIFT/BIC, ABA routing, IMEI) and owned i18n name kernels (`name_transliterate`, `name_script`).
+- **6 domain packs**: healthcare, finance, ecommerce, people/HR, real estate, and carceral.
 - **Audit trail**: a JSON manifest of every transform, which rows changed, and before/after samples.
 - **Schema mapping**: auto-map columns between systems by name similarity and data profiling.
 - **Streaming**: process large files in chunks via `StreamProcessor`.

--- a/docs-site/goldenflow/performance.mdx
+++ b/docs-site/goldenflow/performance.mdx
@@ -42,9 +42,12 @@ works on its own; the native kernel is opt-in and accelerates:
 
 - the **phone** residual the Polars fast path can't reach (alpha numbers like
   `1-800-FLOWERS`, extensions, `+1`-prefixed forms), and
-- the **checksummed identifiers** — payment card (Luhn), IBAN (mod-97), ISBN,
-  EAN/UPC, and EU VAT — via owned Rust kernels with pure-Python fallbacks proven
-  byte-identical over a committed corpus.
+- the **checksummed / structural identifiers** — payment card (Luhn), IBAN
+  (mod-97), ISBN, EAN/UPC, EU VAT, SWIFT/BIC, US ABA routing, and IMEI — via owned
+  Rust kernels with pure-Python fallbacks proven byte-identical over a committed
+  corpus. In `auto` mode the native kernel also backs the email, URL, numeric,
+  categorical, name (incl. `name_transliterate` / `name_script`), and US-address
+  families — anywhere a component kernel exists.
 
 <CodeGroup>
 
@@ -68,7 +71,7 @@ mirroring `GOLDENMATCH_NATIVE`):
 
 | Value | Behavior |
 |---|---|
-| unset / `auto` | Use the native kernel wherever a component's kernel symbol exists (phone + the checksummed identifiers), except known-divergent components. **Default.** |
+| unset / `auto` | Use the native kernel wherever a component's kernel symbol exists (identifiers, email, URL, numeric, categorical, name, and US-address families), except known-divergent components (e.g. `phone_validate` stays pure-Python). **Default.** |
 | `0` | Force the pure-Python path everywhere. |
 | `1` | Require native; raise if the kernel isn't importable. Runs every component with no NANP restriction — a benchmarking/parity lane that **can** differ from Python on international phone numbers. |
 

--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ER Agent"
-description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 31 skills, confidence-gated review queue, and Python API."
+description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 38 skills, confidence-gated review queue, and Python API."
 keywords: ["agent", "A2A", "entity resolution", "autonomous", "review queue", "MCP"]
 ---
 
@@ -59,7 +59,7 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-## Agent Capabilities (31 Skills)
+## Agent Capabilities (38 Skills)
 
 ### Core & pipeline
 
@@ -90,6 +90,8 @@ Add to `claude_desktop_config.json`:
 | `incremental` | Match a batch of new records against an existing base dataset |
 | `list_runs` | List previous runs from the run log (for rollback) |
 | `rollback` | Undo a previous run by deleting its outputs (destructive) |
+| `review_config` | Run the config-suggestion (healer) loop and return advisory suggestions |
+| `retrieve_similar` | Retrieve records similar to a query value on a given column |
 
 ### Identity Graph (v2.0)
 
@@ -102,6 +104,11 @@ Add to `claude_desktop_config.json`:
 | `identity_conflicts` | Evidence edges marked `conflicts_with` |
 | `identity_merge` | Manually merge two identities |
 | `identity_split` | Split records off an identity into a new one |
+| `identity_claim` | Claim/assign a record to a specific durable identity |
+| `identity_resolve_conflict` | Resolve a flagged `conflicts_with` edge |
+| `identity_audit` | Audit-log entries for identity mutations |
+| `identity_audit_seal` | Seal the audit log (tamper-evident checkpoint) |
+| `identity_audit_verify` | Verify the audit log seal chain |
 
 ### Learning Memory
 
@@ -235,7 +242,7 @@ session.deduplicate("customers.csv")
 print(session.last_telemetry)                    # same shape as autoconfigure's telemetry
 ```
 
-## MCP Tools (16 Agent-Level)
+## MCP Tools (18 Agent-Level)
 
 | Tool | Description |
 |------|-------------|
@@ -255,6 +262,8 @@ print(session.last_telemetry)                    # same shape as autoconfigure's
 | `run_transforms` | Run GoldenFlow transforms (phone E.164, dates ISO, Unicode) |
 | `sensitivity` | Parameter-sweep stability analysis |
 | `incremental` | Match new records against an existing base dataset |
+| `certify_recall` | Certify recall on the loaded dataset |
+| `retrieve_similar` | Retrieve records similar to a query value on a column |
 
 These are additive -- existing MCP tools (`suggest_config`, `list_domains`, etc.) continue to work. The full MCP surface is **69 tools** spanning agent-level ER, data inspection, config suggestions, PPRL, Learning Memory, and Identity Graph -- see [MCP Server](/goldenmatch/mcp).
 
@@ -265,7 +274,7 @@ These are additive -- existing MCP tools (`suggest_config`, `list_domains`, etc.
   "name": "GoldenMatch ER Agent",
   "description": "Autonomous entity resolution agent for deduplication, matching, and data quality.",
   "url": "http://localhost:8200",
-  "version": "1.26.0",
+  "version": "2.8.0",
   "provider": {
     "organization": "GoldenMatch",
     "url": "https://github.com/benseverndev-oss/goldenmatch"
@@ -317,5 +326,5 @@ Poll `GET /tasks/{task_id}` for long-running skills.
 |-------|------|
 | MCP Server (Claude Desktop) | [MCP Server](/goldenmatch/mcp) |
 | Quick start with Python/CLI | [Quick Start](/goldenmatch/quickstart) |
-| Full Python API (101 exports) | [Python API](/goldenmatch/python-api) |
+| Full Python API (194 exports) | [Python API](/goldenmatch/python-api) |
 | Configuration reference | [Configuration](/goldenmatch/configuration) |

--- a/docs-site/goldenmatch/api-quick-reference.mdx
+++ b/docs-site/goldenmatch/api-quick-reference.mdx
@@ -70,13 +70,12 @@ StandardizationConfig(rules={
 
 `StandardizationConfig` has a single `rules: dict[str, list[str]]` field with a model validator. Keyword args will raise a Pydantic validation error.
 
-## `BlockingConfig` requires `keys` field
+## `BlockingConfig` multi_pass requires `keys` or `passes`
 
 ```python
-# keys is required even with multi_pass
+# multi_pass requires `keys` OR `passes` (at least one must be set)
 BlockingConfig(
     strategy="multi_pass",
-    keys=[BlockingKeyConfig(fields=["email"], transforms=["lowercase"])],  # required!
     passes=[
         BlockingKeyConfig(fields=["email"], transforms=["lowercase"]),
         BlockingKeyConfig(fields=["last_name"], transforms=["soundex"]),
@@ -158,5 +157,5 @@ config.llm_scorer = LLMScorerConfig(
 - Using `exact=["email"]` as sole matchkey - creates oversized clusters with common emails
 - Using `auto_configure()` on synthetic data - it may produce poor configs
 - Not setting `name=` on MatchkeyConfig - it's required
-- Not providing `keys=` on BlockingConfig - it's required even with multi_pass
+- Not providing `keys=` or `passes=` on a `multi_pass` BlockingConfig - it needs at least one of them (`keys` OR `passes`)
 - Extracting pairs from dupes DataFrame directly instead of using result.clusters

--- a/docs-site/goldenmatch/auto-config.mdx
+++ b/docs-site/goldenmatch/auto-config.mdx
@@ -36,9 +36,7 @@ The `HeuristicRefitPolicy` applies rules such as:
 | `rule_blocking_key_swap` | Switches to an orthogonal blocking key on low recall. |
 | `rule_corruption_normalize` | Adds normalization for corrupted identity columns. |
 | `rule_sparse_match_expand` | Lowers the threshold and adds side-channel blocking for sparse matches. |
-| `rule_demote_clustered_identity` | Demotes exact matchkeys with a collision rate above 0.75 (v1.11). |
 | `promote_negative_evidence` | Adds negative-evidence penalties for identity-discriminating columns (v1.11). |
-| `rule_negative_evidence_exact_filter` | Applies negative-evidence penalties to exact matchkeys via a post-filter (Path Y, v1.12). |
 
 Configs are ranked by a health metric: GREEN > YELLOW > RED, with the initial config as a virtual fallback.
 
@@ -77,17 +75,14 @@ When you point auto-config at the **local in-house embedding model** (a matchkey
 | Variable | Effect |
 |----------|--------|
 | `GOLDENMATCH_AUTOCONFIG_MEMORY=0` | Disable cross-run memory (default on; stored at `~/.goldenmatch/autoconfig_memory.db`). |
-| `GOLDENMATCH_AUTOCONFIG_MEMORY_PATH=<path>` | Custom path for the cross-run memory store. |
 | `GOLDENMATCH_AUTOCONFIG_LLM=1` | Enable the LLM fallback policy (requires `OPENAI_API_KEY`). |
-| `GOLDENMATCH_AUTOCONFIG_BACKEND=duckdb\|ray\|0` | Force a backend, or `0` to auto-select. |
-| `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD=<int>` | Row-count cutoff for DuckDB auto-selection (default 1,000,000). |
 | `GOLDENMATCH_AUTOCONFIG_INDICATOR_BUDGET=fast\|full` | Run the cheap or the full indicator set (default `fast`). |
 | `GOLDENMATCH_PLANNING_EFFORT=fast\|normal\|thinking\|einstein` | Planning-effort tier (default `normal`). Higher tiers search wider and measure full-frame blocking. |
 | `GOLDENMATCH_EMBEDDING_PROVIDER=inhouse` + `GOLDENMATCH_INHOUSE_MODEL=<path>` | Treat the local in-house embedding model as an offline-safe scorer (not demoted as a remote asset). |
 
 ## Cross-run memory
 
-By default the controller remembers what worked on prior runs and seeds future runs from it. Disable it with `GOLDENMATCH_AUTOCONFIG_MEMORY=0`, or point it elsewhere with `GOLDENMATCH_AUTOCONFIG_MEMORY_PATH`.
+By default the controller remembers what worked on prior runs and seeds future runs from it. Disable it with `GOLDENMATCH_AUTOCONFIG_MEMORY=0`.
 
 <Card title="Scale envelope" icon="gauge-high" href="/concepts/scale-envelope">
   The block-size guards the controller respects, and how it picks a backend.

--- a/docs-site/goldenmatch/backends-and-scale.mdx
+++ b/docs-site/goldenmatch/backends-and-scale.mdx
@@ -41,7 +41,7 @@ goldenmatch dedupe big.csv --backend ray
 goldenmatch dedupe big.csv --chunked
 ```
 
-Or let auto-config pick. By default it chooses `duckdb` at 1M+ rows and `chunked` for 5M+. Tune the cutoff with `GOLDENMATCH_AUTOCONFIG_BACKEND_THRESHOLD`.
+Or let auto-config pick. By default it chooses `duckdb` at 1M+ rows and `chunked` for 5M+. To override the choice, set `backend=` in config or pass `--backend` on the CLI.
 
 ## DuckDB spill path
 

--- a/docs-site/goldenmatch/cli.mdx
+++ b/docs-site/goldenmatch/cli.mdx
@@ -11,8 +11,8 @@ keywords: ["cli", "commands", "dedupe", "flags"]
 | `goldenmatch dedupe FILE [...]` | Deduplicate one or more CSV / Parquet / Excel files. |
 | `goldenmatch match TARGET --against REF` | Match a target against a reference file. |
 | `goldenmatch sync --table TABLE --connection-string "$DB"` | Incremental Postgres database sync. |
-| `goldenmatch watch --table TABLE` | Live stream mode (`--daemon` for service mode). |
-| `goldenmatch serve FILE [...]` | Start the REST API server (default `localhost:8000`). |
+| `goldenmatch watch --table TABLE --config CONFIG` | Live stream mode: poll a table and match new records continuously. |
+| `goldenmatch serve FILE [...]` | Start the REST API server (default `127.0.0.1:8080`). |
 | `goldenmatch mcp-serve FILE [...]` | Start the MCP server (stdio or HTTP transport). |
 | `goldenmatch interactive FILE [...]` | Launch the interactive TUI. |
 | `goldenmatch serve-ui [--project DIR]` | Start the web UI workbench. |
@@ -49,7 +49,6 @@ keywords: ["cli", "commands", "dedupe", "flags"]
 | `--chunked` | Large-dataset mode (process in chunks). |
 | `--backend ray` | Force a backend. |
 | `--llm-boost` | Improve accuracy with LLM-labeled training. |
-| `--daemon` | Run watch mode as a background service with a health endpoint. |
 
 ## Cloud storage
 

--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -159,14 +159,14 @@ validation:
     - column: zip
       rule_type: min_length
       params: {length: 5}
-      action: null
+      action: "null"
     - column: name
       rule_type: not_null
       action: quarantine
 
 domain:
   enabled: true
-  pack: electronics
+  mode: product          # product | person | bibliographic | company | auto
 
 llm_scorer:
   enabled: true
@@ -185,7 +185,7 @@ llm_scorer:
     warn_at_pct: 80
 
 memory:
-  enabled: true                 # default: false. Off => no memory work, zero overhead.
+  enabled: true                 # MemoryConfig.enabled defaults to True; memory is off only when the `memory:` section is absent. Omit the section for zero overhead.
   backend: sqlite               # sqlite | postgres
   path: .goldenmatch/memory.db  # sqlite path or postgres DSN
   reanchor: true                # default: true. Look up corrections by record_hash when row IDs miss.
@@ -287,7 +287,7 @@ Set `auto_select: true` to auto-pick the best blocking key by histogram analysis
 
 ## Golden rules
 
-Five merge strategies for building canonical records:
+Eight merge strategies for building canonical records:
 
 | Strategy | Description |
 |----------|-------------|
@@ -296,6 +296,9 @@ Five merge strategies for building canonical records:
 | `source_priority` | Prefer values from specified sources (requires `source_priority` list) |
 | `most_recent` | Latest value by date (requires `date_column`) |
 | `first_non_null` | First non-null value encountered |
+| `longest_value` | Pick the longest value |
+| `unanimous_or_null` | Keep the value only when all members agree, else null |
+| `confidence_majority` | Confidence-weighted majority vote |
 
 Set a default strategy and override per field:
 
@@ -393,14 +396,14 @@ golden_rules:
 
 **`when:` predicate syntax.** The predicate is a safe boolean mini-language, not Python `eval`. Supported operators: `== != < <= > >= in not in and or not`. Names resolve to already-resolved golden fields. Literals: list/tuple, numeric, string, boolean. Unsupported: function calls, attribute access, indexing, arithmetic. If a predicate references a field that is absent or `None` for a given cluster, the predicate is treated as unsatisfied (that clause is skipped) and evaluation continues to the next clause.
 
-**`validate:`.** An optional candidate filter applied before the merge strategy. Candidates that fail the validator are dropped from consideration before the strategy runs (fail-open: an unknown validator name drops nothing). Friendly aliases:
+**`validate:`.** An optional candidate filter applied before the merge strategy. Candidates that fail the validator are dropped from consideration before the strategy runs (fail-open: an unknown validator name drops nothing). Only `nanp` / `phone` are friendly aliases; every other validator is referenced by its full GoldenFlow transform name:
 
-| Alias | GoldenFlow validator |
+| Name | Resolves to |
 |-------|---------------------|
-| `nanp` or `phone` | `phone_validate` |
-| `email` | `email_validate` |
-| `npi` | `npi_validate` |
-| `date` | `date_validate` |
+| `nanp` or `phone` | `phone_validate` (aliases) |
+| `email_validate` | email format validator |
+| `npi_validate` | NPI checksum validator |
+| `date_validate` | date-parse validator |
 
 **Lineage.** The audit trail records how each field's value was chosen. For a field group the entry reads like `street, city, state, zip promoted together from record 7 via most_complete (group 'mailing_address')`. For a conditional rule it reads like `phone used most_recent because state in ['CA', 'NY']`.
 
@@ -448,11 +451,11 @@ validation:
     - column: zip
       rule_type: min_length
       params: { length: 5 }
-      action: null
+      action: "null"
 ```
 
 Rule types: `regex`, `min_length`, `max_length`, `not_null`, `in_set`, `format`.
-Actions: `flag` (mark but keep), `null` (set to null), `quarantine` (remove from matching).
+Actions: `flag` (mark but keep), `"null"` (set to null — quote it so YAML keeps the string; bare `null` parses as None and fails validation), `quarantine` (remove from matching).
 
 ## Environment variables
 
@@ -565,7 +568,7 @@ The optional `memory:` section enables persistent corrections. Once a steward, a
 
 | Field | Default | Notes |
 |---|---|---|
-| `enabled` | `false` | Zero-config preserved. Enabling does not change pipeline output until corrections exist. |
+| `enabled` | `true` (when the `memory:` section is present) | Memory is off by default because the section is absent; once you add a `memory:` block it defaults on. Enabling does not change pipeline output until corrections exist. |
 | `backend` | `"sqlite"` | `"postgres"` requires `pip install goldenmatch[postgres]`. |
 | `path` | `".goldenmatch/memory.db"` | SQLite file or full DSN for postgres. |
 | `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss; ambiguous re-anchors report `stale_ambiguous`. |

--- a/docs-site/goldenmatch/domain-packs.mdx
+++ b/docs-site/goldenmatch/domain-packs.mdx
@@ -45,8 +45,9 @@ enhanced_df, low_confidence = gm.extract_with_rulebook(df, "title", rulebooks["e
 ### Auto-detect domain
 
 ```python
-domain = gm.match_domain(df, "description")
-# Returns "electronics", "software", etc., or None
+rulebook = gm.match_domain(df.columns)
+# Scores rulebooks by signal words in the column names.
+# Returns the best-matching DomainRulebook, or None
 ```
 
 ## YAML config
@@ -56,7 +57,7 @@ Enable domain extraction in your config file:
 ```yaml
 domain:
   enabled: true
-  pack: electronics
+  mode: product
 ```
 
 Or let GoldenMatch auto-detect:
@@ -152,8 +153,8 @@ normalizers:
 ```python
 import goldenmatch as gm
 
-gm.save_rulebook("my_domain", rulebook)
-loaded = gm.load_rulebook("my_domain")
+gm.save_rulebook(rulebook, ".goldenmatch/domains/my_domain.yaml")
+loaded = gm.load_rulebook(".goldenmatch/domains/my_domain.yaml")
 ```
 
 ### Create via MCP

--- a/docs-site/goldenmatch/evaluation.mdx
+++ b/docs-site/goldenmatch/evaluation.mdx
@@ -76,12 +76,14 @@ jobs:
 ```python
 @dataclass
 class EvalResult:
-    precision: float    # TP / (TP + FP)
-    recall: float       # TP / (TP + FN)
-    f1: float           # 2 * P * R / (P + R)
-    tp: int             # True positives (correct matches)
-    fp: int             # False positives (incorrect matches)
-    fn: int             # False negatives (missed matches)
+    tp: int = 0    # True positives (correct matches)
+    fp: int = 0    # False positives (incorrect matches)
+    fn: int = 0    # False negatives (missed matches)
+
+    # Derived, read-only @property (computed from tp/fp/fn):
+    #   precision -> TP / (TP + FP)
+    #   recall    -> TP / (TP + FN)
+    #   f1        -> 2 * P * R / (P + R)
 
     def summary(self) -> dict
 ```
@@ -91,7 +93,8 @@ class EvalResult:
 ```python
 import goldenmatch as gm
 
-predicted = {(1, 42), (1, 108), (5, 200), (7, 300)}
+# predicted is a list of (id_a, id_b, score) triples
+predicted = [(1, 42, 0.98), (1, 108, 0.91), (5, 200, 0.87), (7, 300, 0.80)]
 ground_truth = {(1, 42), (1, 108), (5, 200), (5, 201)}
 
 result = gm.evaluate_pairs(predicted, ground_truth)

--- a/docs-site/goldenmatch/identity-graph.mdx
+++ b/docs-site/goldenmatch/identity-graph.mdx
@@ -101,11 +101,11 @@ Every surface returns the same JSON (the `IdentityView.to_dict()` shape). The cr
 ### Python
 
 ```python
-from goldenmatch import IdentityStore, find_by_record, get_entity, history, manual_merge
+from goldenmatch import IdentityStore, find_by_record, get_entity, identity_history, manual_merge
 
 with IdentityStore(path=".goldenmatch/identity.db") as s:
     view = find_by_record(s, "crm:42")
-    events = history(s, view.node.entity_id)
+    events = identity_history(s, view.node.entity_id)
     manual_merge(s, keep_entity_id="...", absorb_entity_id="...", reason="dup")
 ```
 
@@ -141,7 +141,7 @@ The "Identities" tab in `goldenmatch serve-ui` lists identities with dataset/sta
 
 ### MCP
 
-Seven tools on the standard MCP server (`goldenmatch mcp-serve`):
+Fifteen tools on the standard MCP server (`goldenmatch mcp-serve`):
 
 - `identity_resolve` — look up by `record_id`
 - `identity_show` — full payload by `entity_id`
@@ -149,10 +149,14 @@ Seven tools on the standard MCP server (`goldenmatch mcp-serve`):
 - `identity_history` — event log
 - `identity_conflicts` — list `conflicts_with` edges
 - `identity_merge` / `identity_split` — steward operations
+- `identity_claim` — assign a record to a durable identity
+- `identity_resolve_conflict` — resolve a flagged `conflicts_with` edge
+- `identity_profile` / `identity_stats` / `identity_worklist` — inspection + steward triage
+- `identity_audit` / `identity_audit_seal` / `identity_audit_verify` — tamper-evident audit log
 
 ### A2A
 
-Same seven skills on the A2A agent server (`goldenmatch agent-serve`). The agent card declares 31 total skills.
+Twelve of these are also A2A skills on the agent server (`goldenmatch agent-serve`); `identity_profile` / `identity_stats` / `identity_worklist` are MCP-only. The agent card declares 38 total skills.
 
 ### SQL (Postgres + DuckDB)
 

--- a/docs-site/goldenmatch/installation.mdx
+++ b/docs-site/goldenmatch/installation.mdx
@@ -57,7 +57,7 @@ docker run --rm -v $(pwd):/data ghcr.io/benseverndev-oss/goldenmatch:latest \
 
 # Start the REST API
 docker run --rm -p 8080:8080 -v $(pwd):/data ghcr.io/benseverndev-oss/goldenmatch:latest \
-    serve --file /data/customers.csv --port 8080
+    serve /data/customers.csv --port 8080
 ```
 
 ## PostgreSQL Extension
@@ -139,8 +139,8 @@ SELECT * FROM {{ ref('stg_customers') }}
 ## Verify installation
 
 ```bash
-goldenmatch --version
-# goldenmatch 1.1.1
+goldenmatch info
+# Shows version, Python, and installed extras
 
 goldenmatch demo
 # Runs a built-in demo with sample data
@@ -148,7 +148,7 @@ goldenmatch demo
 
 ```python
 import goldenmatch as gm
-print(gm.__version__)   # "1.1.1"
+print(gm.__version__)   # "2.8.0"
 ```
 
 ## Environment variables

--- a/docs-site/goldenmatch/learning-memory.mdx
+++ b/docs-site/goldenmatch/learning-memory.mdx
@@ -86,7 +86,7 @@ After 10+ corrections accumulate against a matchkey, `goldenmatch memory learn` 
 
 ```yaml
 memory:
-  enabled: true                 # default: false. Off => no memory work, zero overhead.
+  enabled: true                 # MemoryConfig.enabled defaults to true; memory is off only because the memory: block is absent by default. Adding this block turns it on.
   backend: sqlite               # sqlite | postgres
   path: .goldenmatch/memory.db  # sqlite path or postgres DSN
   reanchor: true                # default: true. Set false to require exact (id_a, id_b) match.
@@ -98,7 +98,7 @@ memory:
 
 | Field | Default | Notes |
 |---|---|---|
-| `enabled` | `false` | Zero-config preserved. Enabling does not change pipeline output until corrections exist. |
+| `enabled` | `true` (field default) | The feature is off by default only because the `memory:` block is absent; add the block to enable it. Enabling does not change pipeline output until corrections exist. |
 | `backend` | `"sqlite"` | `"postgres"` requires `pip install goldenmatch[postgres]`. |
 | `path` | `".goldenmatch/memory.db"` | SQLite file or full DSN for postgres. |
 | `reanchor` | `true` | Re-anchor by `record_hash` when row IDs miss. Disable for strictly positional behavior. |
@@ -122,15 +122,15 @@ The `goldenmatch memory` subgroup exposes the store directly.
 
 ```bash
 # Inspect
-goldenmatch memory stats --config goldenmatch.yml
-goldenmatch memory show --config goldenmatch.yml --limit 50
+goldenmatch memory stats --path .goldenmatch/memory.db
+goldenmatch memory show --path .goldenmatch/memory.db --limit 50
 
 # Train (run the learner over the current store)
-goldenmatch memory learn --config goldenmatch.yml
+goldenmatch memory learn --path .goldenmatch/memory.db
 
 # Move memory between environments
-goldenmatch memory export --config goldenmatch.yml --output corrections.jsonl
-goldenmatch memory import --config goldenmatch.yml --input corrections.jsonl
+goldenmatch memory export --path .goldenmatch/memory.db --output corrections.jsonl
+goldenmatch memory import --path .goldenmatch/memory.db --input corrections.jsonl
 ```
 
 | Command | Purpose |
@@ -173,7 +173,7 @@ for c in store.get_corrections(dataset="customers"):
 |---|---|
 | `goldenmatch.get_memory()` | The active `MemoryStore` (constructed from `config.memory`). |
 | `goldenmatch.add_correction(id_a, id_b, decision, ...)` | Upserts a correction, trust-weighted. |
-| `goldenmatch.learn()` | Runs `MemoryLearner`, returns the dict of threshold adjustments. |
+| `goldenmatch.learn()` | Runs `MemoryLearner`, returns a `list` of `LearnedAdjustment` objects. |
 | `goldenmatch.memory_stats()` | Same dict the CLI prints. |
 
 After a pipeline run, every result also carries a `memory_stats` field:

--- a/docs-site/goldenmatch/llm.mdx
+++ b/docs-site/goldenmatch/llm.mdx
@@ -16,8 +16,8 @@ result = gm.dedupe("products.csv", fuzzy={"title": 0.80}, llm_scorer=True)
 ```
 
 ```bash
-# CLI
-goldenmatch dedupe products.csv --config config.yaml --llm-scorer
+# CLI (LLM scoring is enabled via the llm_scorer block in config.yaml)
+goldenmatch dedupe products.csv --config config.yaml
 ```
 
 Requires `OPENAI_API_KEY` or `ANTHROPIC_API_KEY` environment variable.
@@ -49,7 +49,7 @@ How it works:
 ```python
 import goldenmatch as gm
 
-scored = gm.llm_score_pairs(borderline_pairs, df, llm_config)
+scored = gm.llm_score_pairs(borderline_pairs, df, config=llm_config)
 ```
 
 ## Iterative calibration
@@ -119,14 +119,14 @@ llm_scorer:
 ```python
 import goldenmatch as gm
 
-tracker = gm.BudgetTracker(max_cost_usd=0.05, max_calls=100)
-# tracker.record_call(input_tokens, output_tokens, model)
-# tracker.remaining_budget
-# tracker.total_cost
-# tracker.is_exhausted
+tracker = gm.BudgetTracker(gm.BudgetConfig(max_cost_usd=0.05, max_calls=100))
+# tracker.record_usage(input_tokens, output_tokens, model)
+# tracker.budget_remaining_pct
+# tracker.total_cost_usd
+# tracker.budget_exhausted
 ```
 
-The `BudgetTracker` class tracks token usage, cost, and enforces limits. When the budget runs out, scoring stops gracefully -- pairs are kept at their fuzzy scores.
+The `BudgetTracker` class is constructed from a `BudgetConfig`, tracks token usage and cost, and enforces limits. When the budget runs out, scoring stops gracefully -- pairs are kept at their fuzzy scores.
 
 Budget summary is available in `EngineStats.llm_cost` after a pipeline run.
 
@@ -163,7 +163,9 @@ Extract structured fields from unstructured text using the LLM. O(N) preprocessi
 ```python
 import goldenmatch as gm
 
-enhanced_df = gm.llm_extract_features(df, column="description", budget=tracker)
+# row_ids selects which (low-confidence) records to process; returns
+# {row_id: {field: value, ...}}
+features = gm.llm_extract_features(df, row_ids, text_column="description", budget_tracker=tracker)
 ```
 
 ## Provider configuration
@@ -193,8 +195,8 @@ With iterative calibration (v1.2.6+), the LLM scores only ~200 pairs to learn th
 
 | Function | Description |
 |----------|-------------|
-| `gm.llm_score_pairs(pairs, df, config)` | Pairwise LLM scoring |
+| `gm.llm_score_pairs(pairs, df, config=config)` | Pairwise LLM scoring |
 | `gm.llm_cluster_pairs(pairs, df, config)` | In-context block clustering |
-| `gm.BudgetTracker(max_cost_usd, max_calls)` | Track and limit LLM spending |
-| `gm.llm_label_pairs(pairs, df)` | Generate LLM-labeled training pairs |
-| `gm.llm_extract_features(df, column)` | LLM-based feature extraction |
+| `gm.BudgetTracker(BudgetConfig(...))` | Track and limit LLM spending |
+| `gm.llm_label_pairs(pairs, columns, context, provider, api_key, model)` | Generate LLM-labeled training pairs |
+| `gm.llm_extract_features(df, row_ids, text_column)` | LLM-based feature extraction |

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -293,7 +293,7 @@ Undo a previous run by deleting its output files (looked up by run_id). Destruct
 "Roll back run 2026-06-05-abc123"
 ```
 
-In addition, 16 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, controller_telemetry, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms, sensitivity, incremental). See [ER Agent](/goldenmatch/agent) for details.
+In addition, 18 **agent-level tools** are available for autonomous operation (analyze_data, auto_configure, controller_telemetry, agent_deduplicate, agent_match_sources, agent_explain_pair, agent_explain_cluster, agent_review_queue, agent_approve_reject, agent_compare_strategies, suggest_pprl, scan_quality, fix_quality, run_transforms, sensitivity, incremental, certify_recall, retrieve_similar). See [ER Agent](/goldenmatch/agent) for details.
 
 ### AutoConfigController telemetry (v1.7-v1.12)
 
@@ -320,7 +320,7 @@ The standalone `controller_telemetry` tool surfaces a per-session limitation not
 
 ### Learning Memory tools (v1.6.0)
 
-Six tools surface the persistent corrections store. See [Learning Memory](/goldenmatch/learning-memory) for the full feature.
+Seven tools surface the persistent corrections store. See [Learning Memory](/goldenmatch/learning-memory) for the full feature.
 
 | Tool | Behavior |
 |---|---|
@@ -330,6 +330,7 @@ Six tools surface the persistent corrections store. See [Learning Memory](/golde
 | `memory_stats` | Counts plus last-learned timestamps. |
 | `memory_export` | Returns all corrections as a JSON array (use server-side for review portability). |
 | `memory_import` | Upserts corrections from a list of dicts (the shape `memory_export` returns); higher trust wins. |
+| `list_plugins` | List registered Learning Memory plugins/adapters available to the store. |
 
 Natural-language workflow:
 
@@ -341,7 +342,7 @@ The host LLM calls `list_corrections` -> `add_correction` -> `learn_thresholds`.
 
 ### Identity Graph tools (v2.0)
 
-Seven tools expose the durable identity layer above run-local clusters. See [Identity Graph](/goldenmatch/identity-graph) for the full feature.
+Fifteen tools expose the durable identity layer above run-local clusters. See [Identity Graph](/goldenmatch/identity-graph) for the full feature.
 
 | Tool | Behavior |
 |---|---|
@@ -352,6 +353,28 @@ Seven tools expose the durable identity layer above run-local clusters. See [Ide
 | `identity_conflicts` | Evidence edges marked `conflicts_with` for steward review. |
 | `identity_merge` | Manually merge two identities. |
 | `identity_split` | Split records off an identity into a new identity. |
+| `identity_claim` | Claim/assign a record to a specific durable identity. |
+| `identity_resolve_conflict` | Resolve a flagged `conflicts_with` edge. |
+| `identity_profile` | Aggregate profile view across an identity's members. |
+| `identity_stats` | Counts and health metrics for the identity store. |
+| `identity_worklist` | Steward worklist of identities needing review. |
+| `identity_audit` | Audit-log entries for identity mutations. |
+| `identity_audit_seal` | Seal the audit log (tamper-evident checkpoint). |
+| `identity_audit_verify` | Verify the audit log seal chain. |
+
+### Routing tools
+
+Three tools plan and validate distributed execution routing for a run.
+
+| Tool | Behavior |
+|---|---|
+| `plan_routing` | Produce the per-stage distributed execution plan for a dataset/config. |
+| `lint_routing` | Lint a routing plan for misconfiguration or scale hazards. |
+| `explain_routing` | Explain why each stage was routed the way it was. |
+
+### Tool count breakdown
+
+The 69 tools reconcile as: 18 agent-level + 7 Learning Memory + 15 Identity Graph + 3 routing + 26 base data/inspection tools.
 
 ## How it works
 

--- a/docs-site/goldenmatch/overview.mdx
+++ b/docs-site/goldenmatch/overview.mdx
@@ -62,7 +62,7 @@ pip install goldenmatch[mcp]          # MCP server for Claude Desktop
 - **Probabilistic matching**: Fellegi-Sunter EM-trained m/u probabilities with automatic threshold estimation.
 - **LLM scorer**: scores borderline pairs with budget caps and graceful degradation.
 - **8+ blocking strategies**: static, adaptive, sorted-neighborhood, multi-pass, ANN, canopy, and learned.
-- **Golden records**: five merge strategies with field-level provenance and quality-weighted survivorship.
+- **Golden records**: eight merge strategies with field-level provenance and quality-weighted survivorship.
 - **PPRL**: privacy-preserving record linkage across organizations (F1 0.924 on FEBRL4).
 - **Learning Memory**: persists steward corrections, unmerges, and LLM votes across runs.
 - **Interactive TUI**, REST API, MCP server (69 tools), A2A agent, and a localhost web workbench.

--- a/docs-site/goldenmatch/pipeline.mdx
+++ b/docs-site/goldenmatch/pipeline.mdx
@@ -25,7 +25,7 @@ df = load_file("data.parquet").collect()  # Collect to DataFrame
 df = load_files([("a.csv", "source_a"), ("b.csv", "source_b")])
 ```
 
-Supported formats: `.csv`, `.tsv`, `.xlsx`, `.xls`, `.parquet`, `.json`. Cloud paths (`s3://`, `gs://`, `az://`) are handled by `cloud_ingest`.
+Supported formats: `.parquet`, `.xlsx`, and delimited-text suffixes (`.csv`, `.tsv`, `.txt`, `.dat`, `.tab`, `.psv`). Cloud paths (`s3://`, `gs://`, `az://`) are handled by `cloud_ingest`.
 
 Each record gets an `__row_id__` (int64) and `__source__` column.
 
@@ -35,7 +35,7 @@ Map columns between different schemas when matching across sources.
 
 ```python
 gm.auto_map_columns(df_a, df_b)
-# {'full_name': 'first_name', 'postal_code': 'zip'}
+# [{'col_a': 'full_name', 'col_b': 'first_name', 'score': 0.85, 'method': 'synonym'}, ...]
 ```
 
 Column maps can be specified in the config or auto-detected. File specs support a third element: `(path, source_name, column_map)`.
@@ -113,7 +113,7 @@ Compare record pairs within each block.
 **Exact matching** uses Polars self-join (not Python loops):
 
 ```python
-pairs = gm.find_exact_matches(df, fields)
+pairs = gm.find_exact_matches(lf, matchkey)  # lf: LazyFrame, matchkey: MatchkeyConfig
 ```
 
 **Fuzzy matching** uses `rapidfuzz.process.cdist` for vectorized NxN scoring:
@@ -152,17 +152,17 @@ gm.unmerge_cluster(cluster_id, clusters)           # Shatter to singletons
 Merge each cluster into one canonical record.
 
 ```python
-golden = gm.build_golden_record(cluster, df, golden_rules)
+golden = gm.build_golden_record(cluster_df, golden_rules)  # cluster_df is one cluster's rows
 ```
 
-Five merge strategies: `most_complete`, `majority_vote`, `source_priority`, `most_recent`, `first_non_null`. Strategies can be set per-field.
+Eight merge strategies: `most_complete`, `majority_vote`, `source_priority`, `most_recent`, `first_non_null`, `longest_value`, `unanimous_or_null`, `confidence_majority`. Strategies can be set per-field.
 
 ### Output
 
 Write results to files or database.
 
 ```python
-gm.write_output(result, config)
+gm.write_output(golden_df, "results/", "run1", "golden", "csv")  # df, directory, run_name, output_type, fmt
 ```
 
 Outputs: golden records, duplicates, unique records, lineage JSON, HTML report, dashboard.

--- a/docs-site/goldenmatch/pprl.mdx
+++ b/docs-site/goldenmatch/pprl.mdx
@@ -34,13 +34,15 @@ The trusted-third-party protocol scores every Party A record against every Party
 
 ```python
 import goldenmatch as gm
+import polars as pl
 
 cfg = gm.PPRLConfig(
     fields=["first_name", "last_name", "dob", "zip"],
     threshold=0.85,
     chunk_size=5000,        # process Party B in 5k-record blocks
 )
-result = gm.run_pprl("party_a.csv", "party_b.csv", config=cfg)
+# run_pprl takes Polars DataFrames, not file paths
+result = gm.run_pprl(pl.read_csv("party_a.csv"), pl.read_csv("party_b.csv"), config=cfg)
 ```
 
 `chunk_size=None` (the default) runs the original single-block dense path and is byte-for-byte identical to leaving it unset — the threshold test, the cluster output, and the match count are all invariant to `chunk_size`. On a 4000 × 4000 link, dense peak memory of ~305 MB drops to ~34 MB at `chunk_size=200` (~9×) and ~21 MB at `chunk_size=50` (~14×) for identical output. Smaller chunks trade a little extra Python overhead for lower peak memory.

--- a/docs-site/goldenmatch/python-api.mdx
+++ b/docs-site/goldenmatch/python-api.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Python API"
-description: "Complete reference for all 106 symbols exported by GoldenMatch from a single import."
+description: "Complete reference for all 194 symbols exported by GoldenMatch from a single import."
 keywords: ["python api", "goldenmatch", "dedupe", "match", "scoring", "pprl", "auto-config", "configuration", "result classes"]
 ---
 
-GoldenMatch exports 106 symbols from a single import. Every feature is accessible via `import goldenmatch as gm`.
+GoldenMatch exports 194 symbols from a single import. Every feature is accessible via `import goldenmatch as gm`.
 
 ```python
 import goldenmatch as gm
@@ -221,6 +221,7 @@ gm.PPRLConfig(
     hash_functions: int = 30,
     bloom_filter_size: int = 1024,
     protocol: str = "trusted_third_party",
+    scorer: str = "dice",             # "dice" or "jaccard"
     chunk_size: int | None = None,    # stream Party B in blocks of this size (memory-safe); None = dense single-block path
 )
 ```
@@ -260,8 +261,10 @@ metrics = gm.evaluate("data.csv", config="config.yaml", ground_truth="gt.csv")
 ### evaluate_pairs
 
 ```python
-gm.evaluate_pairs(predicted: set[tuple], ground_truth: set[tuple]) -> EvalResult
+gm.evaluate_pairs(predicted: list[tuple[int, int, float]], ground_truth: set[tuple]) -> EvalResult
 ```
+
+`predicted` is a list of `(id_a, id_b, score)` triples (the shape `score_pairs` returns); duplicate pairs are de-duped symmetrically.
 
 Evaluate predicted pairs against ground truth pairs directly.
 
@@ -278,14 +281,22 @@ Evaluate cluster dict (from `build_clusters`) against ground truth.
 ```python
 @dataclass
 class EvalResult:
-    precision: float
-    recall: float
-    f1: float
-    tp: int
-    fp: int
-    fn: int
+    tp: int = 0
+    fp: int = 0
+    fn: int = 0
 
-    def summary(self) -> dict  # Returns dict representation
+    # precision / recall / f1 are read-only @property values computed from
+    # tp / fp / fn -- they are NOT constructor fields. Construct with the
+    # counts (EvalResult(tp=.., fp=.., fn=..)); passing precision/recall/f1
+    # as kwargs raises TypeError.
+    @property
+    def precision(self) -> float: ...
+    @property
+    def recall(self) -> float: ...
+    @property
+    def f1(self) -> float: ...
+
+    def summary(self) -> dict  # {tp, fp, fn, precision, recall, f1, predicted_pairs, ground_truth_pairs}
 ```
 
 ### load_ground_truth_csv
@@ -575,7 +586,7 @@ In-context block clustering as alternative to pairwise scoring. Set `config.mode
 ### BudgetTracker
 
 ```python
-gm.BudgetTracker(max_cost_usd=0.05, max_calls=100)
+gm.BudgetTracker(gm.BudgetConfig(max_cost_usd=0.05, max_calls=100))
 ```
 
 Tracks token usage, cost, and enforces limits. Degrades gracefully: cluster mode falls back to pairwise, then stops.

--- a/docs-site/goldenmatch/rest-api.mdx
+++ b/docs-site/goldenmatch/rest-api.mdx
@@ -52,6 +52,11 @@ The default bind is `127.0.0.1`, which runs token-free for local use.
 | `GET` | `/reviews` | Review queue (borderline pairs) |
 | `GET` | `/reviews/decisions` | List completed review decisions |
 | `POST` | `/reviews/decide` | Approve or reject a pair |
+| `GET` | `/suggest` | Config-suggestion report for the loaded data |
+| `POST` | `/shatter` | Shatter a cluster into singletons |
+| `POST` | `/unmerge` | Unmerge a record from its cluster |
+| `POST` | `/certify-recall` | Certify recall on the loaded data |
+| `POST` | `/retrieve` | Retrieve similar records for a query |
 | `POST` | `/autoconfig` | Run AutoConfigController; return committed config + telemetry |
 | `GET` | `/controller/telemetry` | Last autoconfig's telemetry (stop_reason, health, decisions, NE fields) |
 
@@ -107,10 +112,10 @@ curl -X POST http://localhost:8080/match \
 ```bash
 curl -X POST http://localhost:8080/match/batch \
     -H "Content-Type: application/json" \
-    -d '[
+    -d '{"records": [
         {"name": "John Smith", "zip": "10001"},
         {"name": "Jane Doe", "zip": "90210"}
-    ]'
+    ]}'
 ```
 
 ## Explain a match
@@ -118,7 +123,10 @@ curl -X POST http://localhost:8080/match/batch \
 ```bash
 curl -X POST http://localhost:8080/explain \
     -H "Content-Type: application/json" \
-    -d '{"id_a": 42, "id_b": 108}'
+    -d '{
+        "record_a": {"name": "John Smith", "zip": "10001"},
+        "record_b": {"name": "John Smithe", "zip": "10001"}
+    }'
 ```
 
 ```json
@@ -186,7 +194,7 @@ curl http://localhost:8080/reviews
 
 ```json
 {
-    "reviews": [
+    "queue": [
         {
             "id": "rev_001",
             "id_a": 42,
@@ -195,7 +203,8 @@ curl http://localhost:8080/reviews
             "record_a": {"name": "John Smith", "zip": "10001"},
             "record_b": {"name": "J. Smithson", "zip": "10001"}
         }
-    ]
+    ],
+    "count": 1
 }
 ```
 
@@ -204,7 +213,7 @@ curl http://localhost:8080/reviews
 ```bash
 curl -X POST http://localhost:8080/reviews/decide \
     -H "Content-Type: application/json" \
-    -d '{"id": "rev_001", "decision": "approve"}'
+    -d '{"pair_id": "rev_001", "decision": "approve"}'
 ```
 
 Decision values: `"approve"` or `"reject"`.

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -76,7 +76,8 @@ matchkeys:
 ```
 
 ```python
-pairs = gm.find_exact_matches(df, fields)
+# The exact matchkey above is applied by the pipeline:
+result = gm.dedupe_df(df, exact=["email"])
 ```
 
 ## Probabilistic scoring (Fellegi-Sunter)

--- a/docs-site/goldenmatch/streaming.mdx
+++ b/docs-site/goldenmatch/streaming.mdx
@@ -35,12 +35,8 @@ processor = gm.StreamProcessor(existing_df, config)
 # Process a single record immediately
 matches = processor.process_record({"name": "John Smith", "zip": "10001"})
 
-# Micro-batch mode: buffer records and process in batches
-for record in incoming_records:
-    processor.add_record(record)
-
-# Flush the buffer
-results = processor.flush()
+# Micro-batch mode: process a list of records at once
+results = processor.process_batch(incoming_records)
 ```
 
 ### Immediate mode
@@ -59,9 +55,7 @@ Buffer records and process them together for better throughput:
 
 ```python
 processor = gm.StreamProcessor(df, config)
-for record in batch:
-    processor.add_record(record)
-batch_results = processor.flush()
+batch_results = processor.process_batch(batch)
 ```
 
 ## Incremental cluster updates
@@ -91,7 +85,7 @@ gm.unmerge_cluster(cluster_id, clusters)
 Match new CSV records against an existing base dataset:
 
 ```bash
-goldenmatch incremental base.csv --new new_records.csv --config config.yaml
+goldenmatch incremental base.csv --new-records new_records.csv --config config.yaml
 ```
 
 The incremental CLI handles exact and fuzzy matchkeys separately:
@@ -103,9 +97,9 @@ The incremental CLI handles exact and fuzzy matchkeys separately:
 For embedding-based matching, the ANN index supports incremental updates:
 
 ```python
-from goldenmatch.core.blocker import ANNBlocker
+from goldenmatch.core.ann_blocker import ANNBlocker
 
-blocker = ANNBlocker(model="all-MiniLM-L6-v2")
+blocker = ANNBlocker(top_k=20)
 blocker.add_to_index(embedding)        # Add a single embedding
 neighbors = blocker.query_one(embedding)  # Find nearest neighbors
 ```
@@ -117,21 +111,10 @@ The ANN index is persistent when using database sync mode. Embeddings are comput
 Continuously monitor a database table for new records and match them incrementally:
 
 ```bash
-goldenmatch watch --table customers --connection-string "$DATABASE_URL" --interval 30
+goldenmatch watch --table customers --connection-string "$DATABASE_URL" --config config.yaml --interval 30
 ```
 
-### Daemon mode
-
-Run watch as a background service with health endpoint and PID file:
-
-```bash
-goldenmatch watch --table customers --connection-string "$DATABASE_URL" --daemon
-```
-
-Daemon mode adds:
-- HTTP health endpoint at `/health`
-- PID file for process management
-- SIGTERM handling for graceful shutdown
+`watch` requires `--config`; it exits with an error if the flag is omitted. It stops gracefully on SIGTERM.
 
 ## Database sync
 
@@ -155,10 +138,17 @@ Features:
 
 Run a streaming pipeline programmatically:
 
+`run_stream` takes a `source_fn` polling callable (not a record list) and returns a `StreamProcessor` that runs a polling loop. `source_fn` is called every `poll_interval` seconds and returns new records as `list[dict]`.
+
 ```python
 import goldenmatch as gm
 
-result = gm.run_stream(existing_df, config, new_records)
+def poll_new_records():
+    # Return the latest batch of records as a list of dicts.
+    return fetch_new_rows()
+
+# Returns a StreamProcessor; call .stop() to halt the loop.
+processor = gm.run_stream(existing_df, config, poll_new_records, poll_interval=30)
 ```
 
 ## Architecture

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -219,13 +219,13 @@ The single most expensive distributed-tuning mistake is distributing a *stage* t
 | Clustering (WCC) | **Yes** — the scored pair set is small (~1.76 GB / 110M edges at 100M) | **In-memory** driver-side `scipy.csgraph` connected-components (~60s) | the distributed randomized-contraction WCC — its O(log N) `gs://`-checkpoint rounds are a multi-hour tail when forced on a pair set that fits |
 | Golden | depends | distributed groupby, or **skip it** if you only need cluster membership | building golden you then discard |
 
-**Concrete: don't force the distributed WCC on a pair set that fits.** `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` (default `50000000`) routes pair counts **below** it to the fast in-memory `scipy.csgraph` path. So at 100M (~110M pairs) the default sends clustering to the *distributed* WCC. If your pairs fit the driver (they do up to a few hundred million edges on a 64–256 GB head), **set the threshold above your pair count** so clustering stays in-memory:
+**Concrete: don't force the distributed WCC on a pair set that fits.** By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is **unset and the routing is memory-aware** — clustering stays on the fast in-memory `scipy.csgraph` path whenever the scored pair set fits available driver RAM, and only distributes when it genuinely won't. So at 100M (~110M pairs / ~1.76 GB) the default keeps clustering in-memory on a 64–256 GB head. Set an explicit integer only if you want to force a hard pair-count boundary either way:
 
 ```bash
-export GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=2000000000  # > your pair count -> in-memory WCC
+export GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=2000000000  # force in-memory WCC below 2B pairs
 ```
 
-Setting it to `0` does the **opposite** — it forces the slow distributed WCC on everything. (Making this routing memory-aware by default is tracked in [#956](https://github.com/benseverndev-oss/goldenmatch/issues/956).)
+Setting it to `0` does the **opposite** — it forces the slow distributed WCC on everything.
 
 **Recover a result without re-running.** The Phase-5 connected-components clustering is independent of the WCC algorithm, so a completed run's cluster *assignments* (written to gs:// via the `assignments_output_path` hook) **are** the result. If a run finishes but the output is lost, or you want to re-score, download the assignments and score them against your ground truth on a 64 GB box — no cluster, no re-run. The 100M `group_by` for that scoring OOMs a 16 GB box, so run it on a large runner, not your laptop.
 
@@ -283,6 +283,9 @@ These tune the [healer](/goldenmatch/config-suggestions) — the `review_config`
 | `GOLDENMATCH_SUGGEST_COVERAGE_CAP` | `0.50` | Coverage-saturation cap for the cohesion proxy (matched-rate at which coverage saturates to 1.0). | Leave alone; `0.50` is the safe operating point — tighter caps let a real-pair net-negative through. |
 | `GOLDENMATCH_SUGGEST_VERIFY` | on | The self-verify gate. Set `0` to return raw kernel suggestions **unfiltered** (no no-net-negative guarantee). | Diagnostics only — to see what the kernel would propose before the gate. |
 | `GOLDENMATCH_SUGGEST_FULL_DIST` | `0` (off) | Source the kernel's score distribution from a threshold-0 diagnostic run so the dip (`lower_threshold`) rule sees the full pre-threshold tail. | Set `1` when you want the dip rule to fire on configs whose threshold is well above the score valley. |
+| `GOLDENMATCH_SUGGEST_RECALL_MIN_SHED` | `0.02` | Min recall the tighten-key rule must shed before it will even consider vetoing a matchkey. | Leave alone; raising it makes the recall-shed guard more conservative. |
+| `GOLDENMATCH_SUGGEST_RECALL_COH_ABS` | `0.15` | Max cohesion gain that still counts as "small" when weighing a recall shed. | Leave alone; the gym-selected operating point. |
+| `GOLDENMATCH_SUGGEST_RECALL_RATIO` | `2.0` | Min cohesion-gain-per-recall-shed ratio required to justify shedding recall. | Leave alone; higher = demands more cohesion payoff per unit recall lost. |
 
 ---
 
@@ -335,7 +338,7 @@ Read these before a big run. Each is a real trap that produces a slow or wrong r
     The per-row Python address-normalize plugin is a real bottleneck at scale. Set `GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE=1` to use the Polars-native expression instead. It's off by default, so you have to opt in.
   </Accordion>
   <Accordion title="A distributed 100M run took hours instead of minutes">
-    The scored pair set is small (~1.76 GB at 100M) and fits one node, but the default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD=50000000` routes 50M+ pairs to the *distributed* WCC, whose `gs://`-checkpoint rounds are a multi-hour tail. Set the threshold **above** your pair count so clustering runs in-memory (`scipy.csgraph`, ~60s) — see [Fast path at scale](#fast-path-at-scale-distribute-only-what-doesnt-fit). Distribute the *scoring* (the rows don't fit), not the *clustering* (the pairs do). And never set the threshold to `0` — that forces the slow path on everything.
+    The scored pair set is small (~1.76 GB at 100M) and fits one node. By default `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` is unset and routing is **memory-aware** — clustering stays in-memory (`scipy.csgraph`, ~60s) whenever the pair set fits driver RAM, so a 100M run should already keep clustering on the fast path. The multi-hour tail happens if something forces the *distributed* WCC (whose `gs://`-checkpoint rounds are slow): check you haven't set the threshold to `0` (forces the slow path on everything) or to a value **below** your pair count. See [Fast path at scale](#fast-path-at-scale-distribute-only-what-doesnt-fit). Distribute the *scoring* (the rows don't fit), not the *clustering* (the pairs do).
   </Accordion>
   <Accordion title="Results changed between runs for no reason">
     Cross-run auto-config memory (`GOLDENMATCH_AUTOCONFIG_MEMORY=1`, the default) lets a prior run influence the next. For reproducible benchmarks set `GOLDENMATCH_AUTOCONFIG_MEMORY=0`.
@@ -495,6 +498,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_PLANNER_BUCKET` | `1` | `0`/`1` | Allow the planner to pick `bucket`. |
 | `GOLDENMATCH_ATTRIBUTE_DEMOTION` | `1` (on) | `0`/`1` | Demote an EXACT matchkey on a shared group/list/facility value (shared clinic phone, campaign id, facility NPI) when its large shared-value groups do not co-agree on the person name. `0` restores the pre-2.7.0 behavior. |
 | `GOLDENMATCH_DISCRIMINATIVE_VETO` | `1` (on) | `0`/`1` | The #1351 exact-key discriminative-power veto (demote a shared-locality exact key). `0` disables it. |
+| `GOLDENMATCH_DISCRIMINATIVE_TAU` | `0.5` | float [0,1] | Co-agreement floor for the discriminative veto: an exact key whose large shared-value groups co-agree on the person name below this fraction is vetoed. Out-of-range values fall back to the default. |
 | `GOLDENMATCH_TF_NAME_WEIGHTING` | `1` (on) | `0`/`1` | Data-driven per-dataset name-frequency downweight on `name_freq_weighted_jw` fields. `0` restores the static-census behavior. |
 | `GOLDENMATCH_BASE_STORE` | `auto` | `auto`/`memory`/`lance` | Candidate base store for the ANN `match_one` path. `auto` picks Lance only above ~2M rows when installed. |
 | `GOLDENMATCH_DUCKDB_SCORE_DB` | unset | path | DuckDB pair-store spill path. |
@@ -514,7 +518,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH` | unset | Randomized-contraction WCC scratch. **Must be shared (`gs://...`) on multi-node.** |
 | `GOLDENMATCH_DISTRIBUTED_WCC` | `two_phase` | WCC for `build_clusters_distributed`'s own callers (Phase-5-at-scale forces `randomized_contraction`). Avoid `pointer_jump`. |
 | `GOLDENMATCH_DISTRIBUTED_WCC_SEED` | unset | Randomized-contraction hash seed (reproducible cluster IDs). |
-| `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` | `50000000` | Pair count → distributed clustering. |
+| `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` | unset (memory-aware) | Pair count → distributed clustering. Unset default routes by driver-RAM fit; set an integer to force a hard boundary. |
 | `GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD` | `5000000` | Row count → distributed golden. |
 | `GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS` | `2` | CPUs per Ray scoring worker. |
 
@@ -588,6 +592,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_LLAMA_GGUF` | unset | Path to a local GGUF embedding model for the `model="llama"` / `"llama:/path.gguf"` backend — offline embeddings, no cloud/torch (`pip install goldenmatch[llama]`). Benchmarks: `scripts/bench_llama_embedder.py`, `scripts/bench_llama_product_matching.py`. |
 | `GOLDENMATCH_LLM_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible base URL for the LLM scorer — point at a local llama.cpp / llamafile server for offline, free LLM judging (also honors `OPENAI_BASE_URL`). |
 | `GOLDENMATCH_WEAKNESS_LLM` | `0` (off) | Opt-in: let the `config_weaknesses` tool phrase its one-paragraph `summary_plain` with an LLM (needs `OPENAI_API_KEY`/`ANTHROPIC_API_KEY`). Only a compact structured digest of the findings (ids/severities/short labels) is sent — never raw rows or data. The structured findings themselves are always deterministic and never depend on the LLM; off = deterministic template summary. |
+| `GOLDENMATCH_WEAKNESS_LLM_MODEL` | `gpt-4o-mini` (OpenAI) / `claude-3-5-haiku-latest` (Anthropic) | Model id for the `GOLDENMATCH_WEAKNESS_LLM` summary, per detected provider. |
 | `GOLDENMATCH_UDF_IMPORTS` | unset | Snowflake UDF import asset directory. |
 | `GOLDENMATCH_SYNC_STREAMING_THRESHOLD` / `_STREAMING_BLOCK_WORKERS` | `500000` / auto | Postgres streaming-store thresholds. |
 | `GOLDENMATCH_ANALYTICS` | `0` (off) | Opt-in anonymous, PII-free usage analytics to PostHog (needs `POSTHOG_API_KEY`). Off = nothing collected. |

--- a/docs-site/goldenmatch/typescript.mdx
+++ b/docs-site/goldenmatch/typescript.mdx
@@ -193,7 +193,7 @@ npx goldenmatch-js tui data.csv
 npx goldenmatch-js mcp-serve
 ```
 
-Exposes 19 MCP tools over JSON-RPC on stdio.
+Exposes 45 MCP tools over JSON-RPC on stdio.
 
 ### REST API server
 
@@ -209,7 +209,7 @@ Endpoints: `/health`, `/dedupe`, `/match`, `/score`, `/explain`, `/profile`, `/c
 npx goldenmatch-js agent-serve --port 8200
 ```
 
-Agent card at `/.well-known/agent.json` advertises 10 skills.
+Agent card at `/.well-known/agent.json` advertises 36 skills (the union of the base A2A skills plus the agent, memory, and identity registries, de-duped by id).
 
 ### Interactive TUI
 
@@ -229,12 +229,14 @@ All peer deps are optional. Install only what you need:
 | `hnswlib-node` | Sub-linear ANN blocking (vs brute-force) |
 | `@huggingface/transformers` | ONNX cross-encoder reranking (MiniLM) |
 | `piscina` | Worker-thread parallel block scoring |
+| `better-sqlite3` | SQLite-backed Learning Memory / review-queue persistence |
 | `ink`, `react`, `ink-table`, `ink-select-input`, `ink-text-input`, `ink-spinner`, `ink-gradient` | Interactive TUI |
-| `pg` | Postgres connector + sync |
-| `@duckdb/node-api` | DuckDB connector |
-| `snowflake-sdk` | Snowflake connector |
-| `@google-cloud/bigquery` | BigQuery connector |
-| `@databricks/sql` | Databricks connector |
+
+The database connectors below are **not declared peers** — they are loaded via
+runtime dynamic `import()` only when you use the matching Node connector, so
+install whichever you need directly: `pg` (Postgres), `@duckdb/node-api`
+(DuckDB), `snowflake-sdk` (Snowflake), `@google-cloud/bigquery` (BigQuery),
+`@databricks/sql` (Databricks).
 
 ## Advanced Features
 
@@ -269,7 +271,7 @@ See [`packages/goldenmatch-js/examples/`](https://github.com/benseverndev-oss/go
 | ANN blocking | FAISS | hnswlib-node |
 | Parallel scoring | Threads + Ray | piscina worker threads |
 | Interactive UI | Textual TUI | Ink TUI |
-| MCP server | 69 tools | 34 tools |
+| MCP server | 69 tools | 45 tools |
 | REST API | Yes | Yes |
 | A2A server | Yes | Yes |
 | YAML configs | Yes | Yes (round-trippable) |

--- a/docs-site/goldenmatch/v1-to-v2.mdx
+++ b/docs-site/goldenmatch/v1-to-v2.mdx
@@ -39,7 +39,7 @@ The headline posture of the suite, "find duplicates in 30 seconds with no config
 
 ### Identity Graph (v1.15)
 
-`dedupe()` returns run-local clusters whose IDs mean nothing across runs. **v1.15 (2026-05-12)** added a durable, queryable **Identity Graph**: stable `entity_id`s (UUIDv7) that survive re-runs, evidence edges that record *why* two records linked, an append-only event log, and the **same JSON view from six surfaces** (Python, CLI, REST, MCP, A2A, SQL, web UI). Off by default; opt in with an `identity:` config block. See [Identity Graph](/goldenmatch/identity-graph).
+`dedupe()` returns run-local clusters whose IDs mean nothing across runs. **v1.15 (2026-05-12)** added a durable, queryable **Identity Graph**: stable `entity_id`s (UUIDv7) that survive re-runs, evidence edges that record *why* two records linked, an append-only event log, and the **same JSON view from seven surfaces** (Python, CLI, REST, MCP, A2A, SQL, web UI). Off by default; opt in with an `identity:` config block. See [Identity Graph](/goldenmatch/identity-graph).
 
 ### Scale: single-box at scale, then distributed 100M
 

--- a/docs-site/goldenpipe/overview.mdx
+++ b/docs-site/goldenpipe/overview.mdx
@@ -4,7 +4,7 @@ description: "The orchestrator that chains data-quality checking, transformation
 keywords: ["goldenpipe", "orchestration", "pipeline", "check", "flow", "match"]
 ---
 
-GoldenPipe chains GoldenCheck, GoldenFlow, and GoldenMatch into one pipeline. It profiles your data, conditionally routes it through transformation, deduplicates it (or routes sensitive fields to privacy-preserving matching), and emits golden records. Its logic is adaptive: a dependency-DAG planner orders the stages from their declared dependencies, it skips transformation when no issues are found, and it explains the reasoning behind every decision.
+GoldenPipe chains GoldenCheck, GoldenFlow, and GoldenMatch into one pipeline. It profiles your data, conditionally routes it through transformation, deduplicates it (or routes sensitive fields to privacy-preserving matching), and emits golden records. Its logic is adaptive: it validates stage wiring (each stage's inputs must be produced upstream), skips transformation when no issues are found, and explains the reasoning behind every decision.
 
 It runs in Python and TypeScript, on the CLI, and behind MCP, REST, and A2A servers.
 
@@ -32,11 +32,11 @@ import goldenpipe as gp
 
 result = gp.run("customers.csv")
 
-print(result.status)     # "success"
-print(result.check)      # quality findings
-print(result.transform)  # what was fixed
-print(result.match)      # deduplicated clusters
+print(result.status)     # PipeStatus.SUCCESS
+print(result.stages)     # dict[str, StageResult] — per-stage status + output
+print(result.artifacts)  # dict, e.g. {"golden": ..., "manifest": ...}
 print(result.reasoning)  # why each decision was made
+print(result.skipped)    # stages that were skipped, and why
 ```
 
 ```ts TypeScript
@@ -54,8 +54,7 @@ On the CLI:
 ```bash
 goldenpipe run customers.csv                 # full pipeline
 goldenpipe run customers.csv --verbose       # show reasoning
-goldenpipe run customers.csv --skip-flow     # check + match only
-goldenpipe run customers.csv --strategy pprl # force privacy mode
+goldenpipe run customers.csv -c pipeline.yml # custom stage config (e.g. skip a stage)
 goldenpipe run customers.csv -o golden.csv   # save golden records
 goldenpipe stages                            # list registered stages
 goldenpipe validate -c pipeline.yml          # dry-run wiring validation
@@ -65,7 +64,7 @@ goldenpipe serve | mcp-serve | agent-serve   # REST / MCP / A2A servers
 ## Key features
 
 - **Orchestrates the full pipeline** (Check → Flow → Match) in one call.
-- **Dependency-DAG planner** that activates each stage's `needs`, reorders a consumer ahead of its sole producer instead of erroring, and rejects genuinely ambiguous co-production, cycles, and unknown `needs` as typed errors (`MissingProducer`, `AmbiguousProducer`, `Cycle`, `UnknownNeed`).
+- **Wiring validation** that auto-prepends the `load` stage, checks each stage's declared `consumes` against the artifacts produced by earlier stages (in declared order), and raises a typed `WiringError` when an input isn't available — or errors on an unknown stage `use`.
 - **Adaptive logic** that skips transformation when there are no quality issues.
 - **Privacy-preserving routing** that detects sensitive fields and routes to PPRL.
 - **Reasoning transparency** that reports why each stage ran or was skipped.
@@ -116,8 +115,9 @@ result.skipped     # list[str]
 
 ## Servers
 
-GoldenPipe ships three server surfaces, each exposing the same four operations —
-`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`:
+GoldenPipe ships three server surfaces. MCP and A2A expose all four operations —
+`list_stages`, `validate_pipeline`, `run_pipeline`, `explain_pipeline`; REST
+exposes list / validate / run (no explain):
 
 - **MCP** — remote `https://goldenpipe-mcp-production.up.railway.app/mcp/` or local `goldenpipe mcp-serve --transport http --port 8250` (4 tools).
 - **REST** — `goldenpipe serve` (`GET /stages`, `POST /validate`, `POST /run`).

--- a/docs-site/index.mdx
+++ b/docs-site/index.mdx
@@ -71,7 +71,7 @@ flowchart LR
     Data-quality scanning that discovers rules automatically.
   </Card>
   <Card title="GoldenFlow" icon="wand-magic-sparkles" href="/goldenflow/overview">
-    86 transforms across 11 categories for cleaning messy data.
+    92 transforms across 11 categories for cleaning messy data.
   </Card>
   <Card title="GoldenPipe" icon="diagram-project" href="/goldenpipe/overview">
     One call to chain Check, Flow, and Match.

--- a/docs-site/infermap/overview.mdx
+++ b/docs-site/infermap/overview.mdx
@@ -65,7 +65,7 @@ for (const m of result.mappings) {
 - **Domain dictionaries** for healthcare, finance, and ecommerce.
 - **Custom scorers** via the `@infermap.scorer` decorator (Python) or `defineScorer()` (TypeScript).
 - **Many input formats**: CSV, JSON, in-memory records, database tables, and schema definition files.
-- **Edge-runtime compatible** and zero-dependency in the TypeScript core.
+- **Edge-runtime compatible** with a minimal-dependency TypeScript core (only `goldencheck-types` for domain packs).
 - Accuracy benchmark: 162 test cases, F1 0.84 (Python); TypeScript parity within 0.0005.
 
 ## CLI
@@ -96,17 +96,20 @@ def prefix_scorer(source: FieldInfo, target: FieldInfo) -> ScorerResult | None:
     return ScorerResult(score=0.85, reasoning=f"Shared prefix '{source.name[:3]}'")
 ```
 
-## Default scorer weights
+## Scorer weights
 
-| Scorer | Weight |
-|--------|--------|
-| ExactScorer | 1.0 |
-| AliasScorer | 0.95 |
-| LLMScorer | 0.8 (pluggable, stubbed by default) |
-| InitialismScorer | 0.75 |
-| PatternTypeScorer | 0.7 |
-| ProfileScorer | 0.5 |
-| FuzzyNameScorer | 0.4 |
+The default pipeline (`default_scorers()`) is the six scorers below. `LLMScorer` is
+**not** in the default set — it is opt-in (and stubbed until you wire a provider).
+
+| Scorer | Weight | Default? |
+|--------|--------|----------|
+| ExactScorer | 1.0 | yes |
+| AliasScorer | 0.95 | yes |
+| InitialismScorer | 0.75 | yes |
+| PatternTypeScorer | 0.7 | yes |
+| ProfileScorer | 0.5 | yes |
+| FuzzyNameScorer | 0.4 | yes |
+| LLMScorer | 0.8 | opt-in |
 
 ## Config
 
@@ -115,7 +118,7 @@ domains:
   - healthcare
   - finance
 scorers:
-  LLMScorer:
+  ProfileScorer:
     enabled: false
   FuzzyNameScorer:
     weight: 0.3

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -122,9 +122,9 @@ findings with severities, auto-triage and fix, diff two versions.
 
 ## GoldenFlow
 
-Data transformation: 86 built-in transforms across 11 categories (phone, date,
+Data transformation: 92 built-in transforms across 11 categories (phone, date,
 address, name, categorical, identifiers, …), a transform registry, schema mapping,
-and owned identifier kernels (card / IBAN / ISBN / EAN / VAT).
+and owned identifier kernels (card / IBAN / ISBN / EAN / VAT / SWIFT / ABA / IMEI).
 
 **Python** — `import goldenflow`
 
@@ -155,8 +155,8 @@ to a `goldenflow-core` Rust kernel (opt-in WASM in TS).
 ## GoldenPipe
 
 Pipeline orchestration: chains Check → Flow → Match into one adaptive call, with a
-**dependency-DAG planner** that orders stages from their declared `needs` and
-`consumes`/`produces`, routes on decision gates, and explains every choice.
+planner that validates stage wiring (`consumes`/`produces`), routes on decision
+gates, and explains every choice.
 
 **Python** — `import goldenpipe as gp`
 
@@ -169,11 +169,10 @@ Pipeline orchestration: chains Check → Flow → Match into one adaptive call, 
 | `severity_gate` / `pii_router` / `row_count_gate` | Built-in decision stages |
 
 The planner is a pyo3-free `goldenpipe-core` Rust kernel — the single reference
-that Python and edge-TS compute identically. It activates the `needs` field,
-reorders a consumer ahead of its sole producer instead of erroring, and rejects
-genuinely ambiguous co-production, cycles, and unknown `needs` as typed errors
-(`MissingProducer`, `AmbiguousProducer`, `Cycle`, `UnknownNeed`). Opt into the WASM
-kernel in TypeScript with `enableWasm()`.
+that Python and edge-TS compute identically. It auto-prepends the `load` stage,
+validates each stage's `consumes` against the artifacts produced upstream (in
+declared order), and raises a typed `WiringError` when an input isn't produced.
+Opt into the WASM kernel in TypeScript with `enableWasm()`.
 
 **TypeScript** — `import { runDf, Pipeline, StageRegistry, enableWasm } from "goldenpipe"`
 
@@ -265,7 +264,7 @@ result = AgentSession().autoconfigure("customers.csv")
 
 - **TypeScript lags Python.** Every package has a TS twin, but the npm versions
   trail the PyPI ones and the TS MCP servers expose a subset of the Python tools
-  (e.g. GoldenMatch: 34 TS tools vs 69 Python). The public function names match.
+  (e.g. GoldenMatch: 45 TS tools vs 69 Python). The public function names match.
 - **REST + A2A are for the service-shaped packages only** — GoldenMatch,
   GoldenCheck, GoldenFlow, and GoldenPipe. GoldenAnalysis and InferMap ship a CLI
   and an MCP server but no long-running HTTP service.


### PR DESCRIPTION
Deep-dive accuracy pass across all six packages, cross-checking every doc claim against the actual code (one auditor per package, two for GoldenMatch's 33 pages). Follow-up to #1440.

## Corrections to the prior sweep (#1440)
- **GoldenFlow transform count is 92**, verified by importing the registry — the earlier 92→86 change was backwards. Also: 11 categories now lists all 11, 6 domain packs (not 5), native acceleration covers 8 identifiers + more families.
- **GoldenPipe: reverted the dependency-DAG-planner description** (overview, api-surface, architecture). That feature is on the still-unmerged #1438, so `main` has the linear wiring validator. Also fixed carried-over bugs: `result.check`/`.transform`/`.match` aren't `PipeResult` attributes, `--skip-flow`/`--strategy` aren't real flags, REST has no `explain`.
- api-surface: TS MCP is 45 (not 34).

## GoldenMatch — broken code examples that would raise
- **streaming**: `process_batch` (not `add_record`/`flush`), `ann_blocker` import, removed non-existent daemon mode
- **llm**: `BudgetTracker(BudgetConfig(...))`, `llm_extract_features` signature, real CLI flags
- **pipeline**: `write_output`/`build_golden_record`/`find_exact_matches` signatures, dropped `.xls`/`.json`
- **domain-packs**: `match_domain(df.columns)`, `save`/`load_rulebook(path)`, `mode` not `pack`
- **rest-api**: `pair_id`/`record_a`/`records`-wrapper request shapes, real `/reviews` response, +5 missing routes
- **mcp/agent**: real tool/skill counts (18 agent + 15 identity + 7 memory + 3 routing + 26 base = 69; A2A card 38)
- **configuration/python-api/typescript/tuning/evaluation/installation/cli/identity-graph/scoring**: signatures, counts, `__version__` 2.8.0, 8 merge strategies, memory-aware clustering default

## GoldenCheck / GoldenAnalysis / InferMap
- `scan_file` returns a tuple + `profile.health_score()`; domain packs 5→3; backend-inference wording; "zero-dependency TS core" corrected; LLMScorer isn't a default scorer.

All examples now verified against code. MDX components + code fences balanced; doc-consistency gate passes (the local Windows orphan-check false-fail is a `\`-vs-`/` path artifact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)