### PR TITLE
feat(goldenflow): Wave D — category_auto_correct owned fuzzy kernel (cross-surface)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-goldenflow-wave-d-autocorrect-plan.md
+++ b/docs/superpowers/plans/2026-07-05-goldenflow-wave-d-autocorrect-plan.md
@@ -1,0 +1,95 @@
+# Wave D category_auto_correct — owned fuzzy kernel (cross-surface)
+
+**Program:** GoldenFlow owned-kernel + cross-surface (Rust-is-the-reference).
+**Predecessors:** the whole text family (text-1 #1439 + text-2 #1443, MERGED).
+This is the last non-date family — the FUZZY, data-dependent one Ben flagged.
+**Decision (Ben, 2026-07-05):** OWN THE WHOLE ALGORITHM in Rust (not just the
+`fuzz_ratio` primitive), so the corrections are byte-identical across all three
+surfaces — fixing the CURRENT Py/TS divergence (Python uses rapidfuzz Indel/LCS
+ratio; TS used a Levenshtein ratio; they also differ on whitespace stripping).
+
+## Owned kernel: `goldenflow-core::autocorrect`
+Two functions:
+- **`fuzz_ratio(a, b) -> f64`** — the rapidfuzz `fuzz.ratio` primitive:
+  `100 * (1 - indel/(len_a+len_b))`, `indel = len_a+len_b-2*LCS` (LCS over
+  chars). Special case `("","") -> 100`. Pinned vs rapidfuzz: active/actve=90.909,
+  aaa/aa=80, kitten/sitting=61.538, abc/""=0, ""/""=100. (Threshold decisions
+  only depend on which side of 85.0 a value falls, so last-ULP float differences
+  are immaterial; the kernel returns STRINGS, not the float.)
+- **`build_canonical_map(values, counts, freq_threshold, match_threshold) ->
+  Vec<(from, to)>`** — the whole `_build_canonical_map` algorithm, ORDER-
+  DETERMINISTIC (mirrors Python's Counter/dict insertion order = the
+  `value_counts(sort=True)` order): frequency count (case-insensitive) ->
+  canonical determination (>= freq_threshold; best casing = most_common, ties
+  broken by INSERTION ORDER, i.e. first-max/`c > best` strictly) -> exact
+  case-insensitive corrections -> fuzzy corrections for low-freq (`score >
+  best_score` strictly = first-wins tie, `>= match_threshold`). Returns the
+  corrections as (from_casing, to_canonical) pairs keyed by the STRIPPED casing.
+
+## Data-dependent shape (host owns value_counts + apply, kernel owns the algo)
+`category_auto_correct` is `mode="series"`, whole-column. The host computes
+`value_counts` (polars / JS) -> passes (values[], counts[]) to the kernel ->
+gets the corrections map -> applies per-element `corrections.get(v.strip(),
+v.strip())` (this STRIPS every value, a documented side effect). value_counts +
+apply are orchestration (stay host); the correction-map algorithm is the kernel.
+
+## New marshaling: (str[], i64[]) -> (str[], str[])
+`build_canonical_map_arrow(values, counts, freq_threshold, match_threshold) ->
+(from_arr, to_arr)`. Read a Utf8 array + an Int64 array, call the kernel, return
+two Utf8 arrays. New `util.rs` helper `zip_str_i64_to_str_pair` (or inline in the
+shim). `_native.py` `build_canonical_map_native()` returns a
+`Callable[[Series, Series], tuple[Series, Series]]`.
+
+## Parity: pinned-vector (data-dependent, doesn't fit the string->scalar corpus)
+- `fuzz_ratio` (two-input -> float): pinned-vector `test_autocorrect_kernels.py`
+  (native + fallback; value-parity like numeric).
+- `category_auto_correct` (column -> column): pinned-vector cases with a clear
+  canonical + typo variants + case variants + a below-threshold non-match; assert
+  the corrected column on BOTH the fallback (GOLDENFLOW_NATIVE=0, which uses the
+  existing rapidfuzz-based `_build_canonical_map`) and native paths.
+- The Python fallback (`_build_canonical_map` using `rapidfuzz.fuzz.ratio`) IS the
+  byte-match reference: my `fuzz_ratio` replicates rapidfuzz, and my Rust ordering
+  replicates Python's insertion order, so native == fallback on non-tie inputs.
+
+## Cross-surface fan-out
+goldenflow-core::autocorrect (fuzz_ratio + build_canonical_map + tests) ->
+native-flow shim (build_canonical_map_arrow) -> `_native.py` runner + Python
+migration (category_auto_correct calls native build_canonical_map, falls back to
+the rapidfuzz `_build_canonical_map`) -> `_native_loader` `autocorrect` component
+(floor `build_canonical_map_arrow`) -> goldenflow-wasm export (buildCanonicalMap
++ fuzzRatio) -> TS auto-correct.ts (REWRITE to call wasm build_canonical_map with
+a pure-TS fallback that faithfully ports the Rust algorithm: LCS ratio + ordered
+map + STRIP on apply -- unifies TS with Python) -> pinned-vector tests.
+
+## Tasks
+1. goldenflow-core `autocorrect.rs` (fuzz_ratio + build_canonical_map) + unit
+   tests (pin the rapidfuzz values + a full build_canonical_map scenario).
+   `pub mod autocorrect` in lib.rs.
+2. native-flow shim + util helper (str[]+i64[] -> str[]+str[]).
+3. `_native.py` runner + Python migration; `autocorrect` loader component.
+4. goldenflow-wasm exports + TS rewrite (subagent) + backend/loader.
+5. Pinned-vector parity: `test_autocorrect_kernels.py` (Python) +
+   `autocorrect-kernels.test.ts` (TS). NOT the shared corpus.
+6. Versions: goldenflow 1.13.0 / native 0.11.0 / npm 0.13.0. goldenflow-core:
+   NEW module + lib.rs edit forces a rebuild (unlike text's existing-module
+   edit), so the gotcha-5 core version bump is NOT strictly needed — but bump
+   0.3.0 -> 0.4.0 anyway as cheap insurance if the maturin lane is uncertain.
+
+## Landmines
+- **Ordering determinism**: Python Counter.most_common + dict insertion order.
+  Rust MUST use insertion-ordered structures + first-max-on-ties (`c > best`
+  strictly, `score > best_score` strictly). Feed the kernel the value_counts in
+  the SAME order Python iterates (value_counts sort=True). Ties are inherently
+  ambiguous -> keep pinned-vector inputs tie-free.
+- **STRIP on apply**: category_auto_correct strips every value (`corrections.get(
+  v.strip(), v.strip())`). The unified TS apply MUST strip too (it currently
+  does NOT -- a real fix).
+- **auto_apply=True** -> user-visible; but it's suppressed for high-cardinality
+  columns by selector.py (>10% unique). Pin the corpus/vectors to low-card.
+- **rapidfuzz stays a Python dep** (the fallback uses it); the native path
+  replaces it. Do NOT drop rapidfuzz from pyproject.
+- **pre-push routine** (all 5): whole-pkg ruff + native-flow fmt + core clippy +
+  TS */-grep + (no corpus, but keep the pinned-vector tests green).
+
+## Base / merge
+Off origin/main (text family merged). PR + arm auto-merge (squash).

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.0 (2026-07-05)
+
+Wave D (category_auto_correct): the fuzzy, data-dependent categorical-autocorrect transform is now backed by an owned Rust kernel in `goldenflow-core::autocorrect` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. Migration, not addition (count unchanged).
+
+- `goldenflow-core::autocorrect` owns the WHOLE correction-map algorithm: `fuzz_ratio` (the rapidfuzz `fuzz.ratio` Indel/LCS similarity) + `build_canonical_map` (frequency analysis → canonical determination → fuzzy matching → correction map, order-deterministic). The host computes `value_counts` and applies the returned map.
+- **Cross-surface fix:** the TypeScript surface previously used a *different* fuzzy ratio (Levenshtein-based) than Python (rapidfuzz Indel), and did not strip whitespace on apply — so TS and Python produced different corrections. Both now conform to the single Rust kernel, so the corrected column is byte-identical across native, WASM/TS, and pure-Python. The Python fallback (rapidfuzz `_build_canonical_map`) remains the byte-exact reference the kernel replicates. `rapidfuzz` stays a Python dependency for that fallback.
+
 ## 1.12.0 (2026-07-04)
 
 Wave D (text, part 2): the 5 Unicode-heavy text transforms are now backed by owned Rust kernels in `goldenflow-core::text` (native + WASM/TS + pure-Python fallback), Rust is the reference implementation. This completes the text family migration (count unchanged).

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -321,6 +321,23 @@ package. Loader discover order in `goldenflow/core/_native_loader.py`:
   row so any divergence fails the build). **gotcha 5:** text-2 edits the
   existing text.rs, so goldenflow-core was bumped 0.2.0->0.3.0 to bust the stale
   maturin rust-cache.
+- **category_auto_correct migrated to an owned FUZZY kernel (Wave D) -- the
+  data-dependent one.** goldenflow-core `autocorrect.rs` owns `fuzz_ratio` (the
+  rapidfuzz `fuzz.ratio` Indel/LCS similarity, `100*(1-indel/(la+lb))`,
+  `("","")->100`) + `build_canonical_map` (the WHOLE frequency->canonical->fuzzy
+  correction-map algorithm, ORDER-DETERMINISTIC via insertion-ordered structures
+  + first-max-on-ties to match Python Counter/dict). Data-dependent (whole-
+  column): the host computes `value_counts(sort=True)` + applies the returned map
+  (`corrections.get(v.strip(), v.strip())` -- STRIPS every value); the kernel owns
+  the algorithm. Wired via the `autocorrect` `_native_loader` component (floor
+  `build_canonical_map_arrow`); marshaling shape (Utf8[]+Int64[] -> Utf8[]+Utf8[]).
+  wasm `build_canonical_map(values, counts, freq, match)` returns a FLAT
+  `[from0,to0,...]` array. **This UNIFIED a pre-existing Py/TS divergence** (Python
+  used rapidfuzz Indel ratio; TS used a Levenshtein ratio + no strip-on-apply --
+  both fixed to the Rust reference). rapidfuzz stays the Python fallback (byte-
+  exact reference). Data-dependent -> pinned-vector `test_autocorrect_kernels.py`
+  (NOT the shared corpus). `auto_apply=True` but suppressed for high-cardinality
+  columns (>10% unique) by selector.py.
 - **Byte-parity harness (cross-surface oracle = goldenflow-core).**
   `packages/python/goldenflow/tests/parity/identifiers_corpus.jsonl` (mirrored
   byte-identical into `packages/typescript/goldenflow/tests/parity/`) is the

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.12.0"
+__version__ = "1.13.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/core/_native_loader.py
+++ b/packages/python/goldenflow/goldenflow/core/_native_loader.py
@@ -121,6 +121,9 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     # unit_normalize (scalar) + split_address (1->4 quad) -- floor symbol only
     # (address_standardize_arrow), US-scoped/locale-free.
     "address": ("address_standardize_arrow",),
+    # autocorrect: the data-dependent fuzzy category-autocorrect algorithm
+    # (fuzz_ratio + build_canonical_map) -- floor symbol build_canonical_map_arrow.
+    "autocorrect": ("build_canonical_map_arrow",),
     # text: the mechanical text family (strip/collapse_whitespace/
     # normalize_quotes/normalize_line_endings/truncate/pad_left/pad_right/
     # remove_html_tags/remove_urls/remove_digits/remove_punctuation/

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -682,6 +682,37 @@ def fix_mojibake_native() -> Callable[[pl.Series], pl.Series] | None:
     return _text_kernel_runner("fix_mojibake_arrow")
 
 
+def build_canonical_map_native(
+    freq_threshold: float = 0.05, match_threshold: float = 85.0
+) -> Callable[[pl.Series, pl.Series], tuple[pl.Series, pl.Series]] | None:
+    """Build a runner for the data-dependent category-autocorrect kernel: a
+    ``values`` (Utf8) + ``counts`` (Int64) pair in, a ``(from, to)`` pair of
+    Utf8 Series out (the corrections map). ``None`` when native ``autocorrect``
+    is off/unbuilt. The thresholds are bound at construction (per-call params)."""
+    if not native_enabled("autocorrect"):
+        return None
+    nm = native_module()
+    attr = "build_canonical_map_arrow"
+    if nm is None or not hasattr(nm, attr):
+        return None
+    try:
+        import pyarrow  # noqa: F401  (zero-copy bridge)
+    except ImportError:
+        return None
+    func = getattr(nm, attr)
+
+    def run(values: pl.Series, counts: pl.Series) -> tuple[pl.Series, pl.Series]:
+        from_arr, to_arr = func(
+            _as_str_series(values).to_arrow(),
+            counts.cast(pl.Int64).to_arrow(),
+            freq_threshold=freq_threshold,
+            match_threshold=match_threshold,
+        )
+        return pl.from_arrow(from_arr), pl.from_arrow(to_arr)
+
+    return run
+
+
 def _email_kernel_runner(attr: str) -> Callable[[pl.Series], pl.Series] | None:
     """Build a whole-series runner for email kernel function ``attr`` if
     native ``email`` is enabled and the dependencies are importable; else

--- a/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
+++ b/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
@@ -7,6 +7,7 @@ import polars as pl
 from rapidfuzz import fuzz
 
 from goldenflow.transforms import register_transform
+from goldenflow.transforms._native import build_canonical_map_native
 
 
 def _build_canonical_map(
@@ -110,10 +111,21 @@ def category_auto_correct(
     """
     vc = series.value_counts(sort=True)
     # value_counts returns a 2-column DataFrame: [<series.name>, "count"].
-    # iter_rows() yields plain Python tuples; only n_unique tuples are
-    # ever produced (no per-row materialization of the source Series).
-    pairs: list[tuple[str | None, int]] = list(vc.iter_rows())
-    corrections = _build_canonical_map(pairs, frequency_threshold, match_threshold)
+    # Native-first (goldenflow-core's ``autocorrect::build_canonical_map`` owns
+    # the whole frequency->canonical->fuzzy algorithm); the pure-Python
+    # ``_build_canonical_map`` (rapidfuzz) is the byte-exact reference the kernel
+    # replicates. Feed the kernel the value_counts in order so its insertion-
+    # ordered tie-breaking matches Python's Counter/dict.
+    native = build_canonical_map_native(frequency_threshold, match_threshold)
+    if native is not None:
+        value_col, count_col = vc.columns[0], vc.columns[1]
+        from_s, to_s = native(vc[value_col], vc[count_col])
+        corrections = dict(zip(from_s.to_list(), to_s.to_list(), strict=True))
+    else:
+        # iter_rows() yields plain Python tuples; only n_unique tuples are
+        # ever produced (no per-row materialization of the source Series).
+        pairs: list[tuple[str | None, int]] = list(vc.iter_rows())
+        corrections = _build_canonical_map(pairs, frequency_threshold, match_threshold)
 
     if not corrections:
         return series

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.12.0"
+version = "1.13.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.12.0",
+      "version": "1.13.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/transforms/test_autocorrect_kernels.py
+++ b/packages/python/goldenflow/tests/transforms/test_autocorrect_kernels.py
@@ -1,0 +1,55 @@
+"""Pinned-vector parity for the data-dependent category_auto_correct kernel
+(Wave D). It builds a correction map from a column's value frequencies, so it
+doesn't fit the string->scalar corpus. Asserts both the pure-Python fallback
+(``GOLDENFLOW_NATIVE=0``, which uses the rapidfuzz-based ``_build_canonical_map``)
+and the native path (goldenflow-core's ``autocorrect::build_canonical_map``)
+produce the same corrected column -- the pinned-vector pattern.
+
+The Python fallback IS the byte-exact reference: the Rust ``fuzz_ratio``
+replicates rapidfuzz, and the Rust ordering replicates Python's Counter/dict
+insertion order, so native == fallback on tie-free inputs (used here).
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenflow.core._native_loader import native_available, native_module
+from goldenflow.transforms.auto_correct import category_auto_correct
+
+# Tie-free scenario: "active" dominant; case variants; a typo (fuzzy match);
+# an unrelated low-freq value (no match); nulls preserved.
+_COLUMN = (
+    ["active"] * 50
+    + ["Active"] * 10
+    + ["ACTIVE"] * 5
+    + ["actve"] * 2
+    + ["banana"] * 1
+    + [None] * 3
+)
+_EXPECTED = (
+    ["active"] * 67  # active + Active + ACTIVE + actve all -> "active"
+    + ["banana"] * 1  # below match_threshold vs "active" -> unchanged
+    + [None] * 3
+)
+
+
+def _check() -> None:
+    out = category_auto_correct(pl.Series("s", _COLUMN))
+    assert out.to_list() == _EXPECTED
+
+
+def test_fallback_matches_expected(monkeypatch):
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "0")
+    _check()
+
+
+def test_native_matches_expected(monkeypatch):
+    if not native_available():
+        import pytest
+
+        pytest.skip("goldenflow-native not built/importable")
+    if not hasattr(native_module(), "build_canonical_map_arrow"):
+        import pytest
+
+        pytest.skip("installed goldenflow-native predates the autocorrect kernel")
+    monkeypatch.setenv("GOLDENFLOW_NATIVE", "auto")
+    _check()

--- a/packages/rust/extensions/goldenflow-core/src/autocorrect.rs
+++ b/packages/rust/extensions/goldenflow-core/src/autocorrect.rs
@@ -1,0 +1,261 @@
+//! Owned fuzzy category-autocorrect kernel (pyo3-free). The reference
+//! implementation; the Python (`goldenflow/transforms/auto_correct.py`) and TS
+//! (`transforms/auto-correct.ts`) surfaces conform to its output byte-for-byte.
+//!
+//! `category_auto_correct` is data-dependent: it builds a correction map from a
+//! column's value frequencies, then applies it. This kernel owns the WHOLE
+//! map-building algorithm (frequency -> canonical -> fuzzy) so the corrections
+//! are identical across surfaces. The host computes `value_counts` and applies
+//! the returned map; only the algorithm lives here.
+//!
+//! `fuzz_ratio` is the rapidfuzz `fuzz.ratio` primitive (normalized Indel /
+//! LCS similarity), replacing the pure-Python `rapidfuzz` call and the (wrongly
+//! divergent) Levenshtein-based TS ratio.
+
+use std::collections::HashMap;
+
+/// Length of the longest common subsequence of `a` and `b` (over chars).
+fn lcs_len(a: &[char], b: &[char]) -> usize {
+    let n = b.len();
+    if a.is_empty() || n == 0 {
+        return 0;
+    }
+    // Single-row DP.
+    let mut prev = vec![0usize; n + 1];
+    for &ca in a {
+        let mut prev_diag = 0usize;
+        let mut row = vec![0usize; n + 1];
+        for j in 1..=n {
+            row[j] = if ca == b[j - 1] {
+                prev_diag + 1
+            } else {
+                prev[j].max(row[j - 1])
+            };
+            prev_diag = prev[j];
+        }
+        prev = row;
+    }
+    prev[n]
+}
+
+/// rapidfuzz `fuzz.ratio`: `100 * (1 - indel/(len_a+len_b))` where
+/// `indel = len_a + len_b - 2*LCS`. Two empty strings -> 100. Operates on
+/// chars (codepoints), matching rapidfuzz on Python `str`.
+pub fn fuzz_ratio(a: &str, b: &str) -> f64 {
+    let ca: Vec<char> = a.chars().collect();
+    let cb: Vec<char> = b.chars().collect();
+    let la = ca.len();
+    let lb = cb.len();
+    if la == 0 && lb == 0 {
+        return 100.0;
+    }
+    let lcs = lcs_len(&ca, &cb);
+    let total = (la + lb) as f64;
+    let indel = (la + lb - 2 * lcs) as f64;
+    100.0 * (1.0 - indel / total)
+}
+
+/// An insertion-ordered accumulator: keeps keys in first-seen order (mirrors a
+/// Python dict / `Counter`) while allowing O(1)-ish count updates.
+struct OrderedCounts {
+    order: Vec<String>,
+    idx: HashMap<String, usize>,
+    counts: Vec<i64>,
+}
+
+impl OrderedCounts {
+    fn new() -> Self {
+        Self {
+            order: Vec::new(),
+            idx: HashMap::new(),
+            counts: Vec::new(),
+        }
+    }
+
+    fn add(&mut self, key: &str, count: i64) {
+        if let Some(&i) = self.idx.get(key) {
+            self.counts[i] += count;
+        } else {
+            let i = self.order.len();
+            self.idx.insert(key.to_string(), i);
+            self.order.push(key.to_string());
+            self.counts.push(count);
+        }
+    }
+}
+
+/// Build the variant->canonical correction map from `(value, count)` pairs
+/// (typically a `value_counts(sort=True)` result). Byte-identical to
+/// `auto_correct.py::_build_canonical_map`. Returns `(from_casing,
+/// to_canonical)` pairs (keyed by the STRIPPED original casing).
+///
+/// Order-deterministic: keys are processed in the input order (= value_counts
+/// order), `most_common`/`best-score` ties resolve to the FIRST (insertion
+/// order), exactly like Python's `Counter.most_common` + `score > best`.
+pub fn build_canonical_map(
+    values: &[Option<&str>],
+    counts: &[i64],
+    freq_threshold: f64,
+    match_threshold: f64,
+) -> Vec<(String, String)> {
+    // lowercase -> total count (insertion-ordered), and lowercase -> ordered
+    // list of (original casing, count).
+    let mut lower = OrderedCounts::new();
+    let mut case_map: HashMap<String, Vec<(String, i64)>> = HashMap::new();
+
+    for (v_opt, &count) in values.iter().zip(counts.iter()) {
+        let Some(v) = v_opt else { continue };
+        let v_stripped = v.trim();
+        if v_stripped.is_empty() {
+            continue;
+        }
+        let low = v_stripped.to_lowercase();
+        lower.add(&low, count);
+        let casings = case_map.entry(low).or_default();
+        if let Some(entry) = casings.iter_mut().find(|(c, _)| c == v_stripped) {
+            entry.1 += count;
+        } else {
+            casings.push((v_stripped.to_string(), count));
+        }
+    }
+
+    let total: i64 = lower.counts.iter().sum();
+    if total == 0 {
+        return Vec::new();
+    }
+
+    // Canonical determination (in insertion order).
+    let mut canonical: HashMap<String, String> = HashMap::new(); // low -> best casing
+    let mut canonical_order: Vec<String> = Vec::new();
+    let mut low_freq: Vec<String> = Vec::new();
+
+    for (i, low) in lower.order.iter().enumerate() {
+        let count = lower.counts[i];
+        if (count as f64 / total as f64) >= freq_threshold {
+            // most_common(1): highest count; tie -> first (insertion order).
+            let casings = &case_map[low];
+            let mut best_casing = &casings[0].0;
+            let mut best_count = casings[0].1;
+            for (casing, c) in &casings[1..] {
+                if *c > best_count {
+                    best_count = *c;
+                    best_casing = casing;
+                }
+            }
+            canonical.insert(low.clone(), best_casing.clone());
+            canonical_order.push(low.clone());
+        } else {
+            low_freq.push(low.clone());
+        }
+    }
+
+    let mut corrections: Vec<(String, String)> = Vec::new();
+
+    // Exact case-insensitive corrections (non-best casings -> best casing).
+    for low in &canonical_order {
+        let best = &canonical[low];
+        for (casing, _) in &case_map[low] {
+            if casing != best {
+                corrections.push((casing.clone(), best.clone()));
+            }
+        }
+    }
+
+    // Fuzzy corrections for low-frequency values.
+    for low in &low_freq {
+        let mut best_score = 0.0f64;
+        let mut best_match: Option<&String> = None;
+        for canon_low in &canonical_order {
+            let score = fuzz_ratio(low, canon_low);
+            if score > best_score {
+                best_score = score;
+                best_match = Some(canon_low);
+            }
+        }
+        if best_score >= match_threshold {
+            if let Some(bm) = best_match {
+                let canon_casing = &canonical[bm];
+                for (casing, _) in &case_map[low] {
+                    corrections.push((casing.clone(), canon_casing.clone()));
+                }
+            }
+        }
+    }
+
+    corrections
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fuzz_ratio_matches_rapidfuzz() {
+        // Pinned against Python rapidfuzz.fuzz.ratio.
+        assert!((fuzz_ratio("active", "actve") - 90.9090909090909).abs() < 1e-9);
+        assert!((fuzz_ratio("aaa", "aa") - 80.0).abs() < 1e-9);
+        assert!((fuzz_ratio("kitten", "sitting") - 61.53846153846154).abs() < 1e-9);
+        assert_eq!(fuzz_ratio("abc", ""), 0.0);
+        assert_eq!(fuzz_ratio("", ""), 100.0);
+        assert_eq!(fuzz_ratio("abc", "abc"), 100.0);
+    }
+
+    fn corrections_map(pairs: &[(Option<&str>, i64)], ft: f64, mt: f64) -> HashMap<String, String> {
+        let values: Vec<Option<&str>> = pairs.iter().map(|(v, _)| *v).collect();
+        let counts: Vec<i64> = pairs.iter().map(|(_, c)| *c).collect();
+        build_canonical_map(&values, &counts, ft, mt)
+            .into_iter()
+            .collect()
+    }
+
+    #[test]
+    fn build_map_case_and_fuzzy() {
+        // "active" dominant; "Active"/"ACTIVE" are case variants; "actve" is a
+        // low-freq typo (fuzzy match); "banana" is unrelated (no match).
+        let m = corrections_map(
+            &[
+                (Some("active"), 50),
+                (Some("Active"), 10),
+                (Some("ACTIVE"), 5),
+                (Some("actve"), 2),
+                (Some("banana"), 1),
+            ],
+            0.05,
+            85.0,
+        );
+        // canonical low "active" -> best casing "active" (highest count).
+        assert_eq!(m.get("Active").map(String::as_str), Some("active"));
+        assert_eq!(m.get("ACTIVE").map(String::as_str), Some("active"));
+        // "actve" fuzzy-matches "active" (90.9 >= 85) -> "active".
+        assert_eq!(m.get("actve").map(String::as_str), Some("active"));
+        // "banana" is below threshold vs "active" -> no correction.
+        assert!(!m.contains_key("banana"));
+        // the canonical best casing itself is not a correction key.
+        assert!(!m.contains_key("active"));
+    }
+
+    #[test]
+    fn build_map_empty_and_whitespace() {
+        // None / empty / whitespace-only inputs are skipped; no canonicals -> {}.
+        let m = corrections_map(&[(None, 3), (Some(""), 2), (Some("   "), 1)], 0.05, 85.0);
+        assert!(m.is_empty());
+    }
+
+    #[test]
+    fn build_map_no_canonical_when_all_below_threshold() {
+        // All values equally rare (each 20%): with freq_threshold 0.25 none is
+        // canonical -> no corrections.
+        let m = corrections_map(
+            &[
+                (Some("aa"), 1),
+                (Some("bb"), 1),
+                (Some("cc"), 1),
+                (Some("dd"), 1),
+                (Some("ee"), 1),
+            ],
+            0.25,
+            85.0,
+        );
+        assert!(m.is_empty());
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -6,6 +6,7 @@
 //! The pure-Python / pure-TS transform paths are non-authoritative fallbacks
 //! that must reproduce these bytes (asserted by the byte-parity harness).
 pub mod address;
+pub mod autocorrect;
 pub mod categorical;
 pub mod email;
 pub mod identifiers;

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -13,6 +13,7 @@
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use goldenflow_core::address;
+    use goldenflow_core::autocorrect;
     use goldenflow_core::categorical;
     use goldenflow_core::email;
     use goldenflow_core::identifiers::{aba, ean, iban, imei, isbn, luhn, swift, vat};
@@ -310,6 +311,35 @@ mod wasm {
     #[wasm_bindgen]
     pub fn url_extract_domain(s: &str) -> Option<String> {
         url::url_extract_domain(s)
+    }
+
+    /// rapidfuzz `fuzz.ratio` (Indel/LCS similarity, 0-100).
+    #[wasm_bindgen]
+    pub fn fuzz_ratio(a: &str, b: &str) -> f64 {
+        autocorrect::fuzz_ratio(a, b)
+    }
+
+    /// Category-autocorrect correction map from parallel `values` (non-null) +
+    /// `counts` arrays. Returns a FLAT `[from0, to0, from1, to1, ...]` array of
+    /// correction pairs (the caller unflattens). The caller must pass the pairs
+    /// in value_counts order (count DESC) so the kernel's tie-breaking matches.
+    #[wasm_bindgen]
+    pub fn build_canonical_map(
+        values: Vec<String>,
+        counts: Vec<i32>,
+        freq_threshold: f64,
+        match_threshold: f64,
+    ) -> Vec<String> {
+        let refs: Vec<Option<&str>> = values.iter().map(|s| Some(s.as_str())).collect();
+        let counts64: Vec<i64> = counts.iter().map(|&c| c as i64).collect();
+        let pairs =
+            autocorrect::build_canonical_map(&refs, &counts64, freq_threshold, match_threshold);
+        let mut out = Vec::with_capacity(pairs.len() * 2);
+        for (from, to) in pairs {
+            out.push(from);
+            out.push(to);
+        }
+        out
     }
 
     #[wasm_bindgen]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -423,7 +423,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.10.0"
+version = "0.11.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.10.0"
+    __version__ = "0.11.0"

--- a/packages/rust/extensions/native-flow/src/autocorrect.rs
+++ b/packages/rust/extensions/native-flow/src/autocorrect.rs
@@ -1,0 +1,48 @@
+//! Arrow shim over goldenflow_core::autocorrect. The category-autocorrect
+//! algorithm is data-dependent: it takes the column's (value, count) pairs and
+//! returns the corrections map as a pair of arrays. All logic lives in the core.
+use crate::util::read_opt_strings;
+use arrow::array::{make_array, Array, ArrayData, Int64Array, StringBuilder};
+use arrow::pyarrow::PyArrowType;
+use goldenflow_core::autocorrect;
+use pyo3::exceptions::PyTypeError;
+use pyo3::prelude::*;
+
+/// Build the variant->canonical correction map from `values` (Utf8) + `counts`
+/// (Int64) arrays. Returns `(from_arr, to_arr)` -- two Utf8 arrays of equal
+/// length, the correction pairs.
+#[pyfunction]
+#[pyo3(signature = (values, counts, freq_threshold=0.05, match_threshold=85.0))]
+pub fn build_canonical_map_arrow(
+    py: Python,
+    values: PyArrowType<ArrayData>,
+    counts: PyArrowType<ArrayData>,
+    freq_threshold: f64,
+    match_threshold: f64,
+) -> PyResult<(PyArrowType<ArrayData>, PyArrowType<ArrayData>)> {
+    let vv = read_opt_strings(&values.0)?;
+    let carr = make_array(counts.0);
+    let ci = carr
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .ok_or_else(|| PyTypeError::new_err("expected an Arrow Int64 array for counts"))?;
+    let cv: Vec<i64> = (0..ci.len())
+        .map(|i| if ci.is_null(i) { 0 } else { ci.value(i) })
+        .collect();
+
+    let pairs = py.detach(|| {
+        let refs: Vec<Option<&str>> = vv.iter().map(|o| o.as_deref()).collect();
+        autocorrect::build_canonical_map(&refs, &cv, freq_threshold, match_threshold)
+    });
+
+    let mut from_b = StringBuilder::with_capacity(pairs.len(), pairs.len() * 8);
+    let mut to_b = StringBuilder::with_capacity(pairs.len(), pairs.len() * 8);
+    for (from, to) in &pairs {
+        from_b.append_value(from);
+        to_b.append_value(to);
+    }
+    Ok((
+        PyArrowType(from_b.finish().into_data()),
+        PyArrowType(to_b.finish().into_data()),
+    ))
+}

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -12,6 +12,7 @@
 use pyo3::prelude::*;
 
 mod address;
+mod autocorrect;
 mod categorical;
 mod email;
 mod identifiers;
@@ -65,6 +66,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(address::country_standardize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(address::unit_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(address::split_address_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(autocorrect::build_canonical_map_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::strip_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::collapse_whitespace_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(text::normalize_quotes_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/util.rs
+++ b/packages/rust/extensions/native-flow/src/util.rs
@@ -32,6 +32,14 @@ fn for_each_str<F: FnMut(usize, Option<&str>)>(data: &ArrayData, mut f: F) -> Py
     }
 }
 
+/// Read a Utf8/LargeUtf8 array into an owned `Vec<Option<String>>` (used by
+/// multi-array kernels like `build_canonical_map` that need the full column).
+pub fn read_opt_strings(data: &ArrayData) -> PyResult<Vec<Option<String>>> {
+    let mut out = Vec::new();
+    for_each_str(data, |_, v| out.push(v.map(|s| s.to_string())))?;
+    Ok(out)
+}
+
 pub fn map_str_to_str<F>(py: Python, data: ArrayData, f: F) -> PyResult<ArrayData>
 where
     F: Fn(&str) -> Option<String> + Sync,

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/transforms/auto-correct.ts
+++ b/packages/typescript/goldenflow/src/core/transforms/auto-correct.ts
@@ -1,55 +1,171 @@
 /**
- * Auto-correct transform — ported from goldenflow/transforms/auto_correct.py
- * Side-effect module: registers the category_auto_correct transform on import.
+ * Auto-correct transform — owned FUZZY kernel (Wave D autocorrect), the
+ * data-dependent one. Ported byte-for-byte from goldenflow-core::autocorrect
+ * (the Rust reference) + the host-side value_counts + apply spec in
+ * goldenflow/transforms/auto_correct.py.
  *
- * Uses Levenshtein-based fuzzy matching to correct low-frequency categorical
- * values to their most likely canonical form.
+ * `category_auto_correct` is `mode="series"` (whole column): the host computes
+ * `value_counts` over the RAW non-null string values, passes (values[],
+ * counts[]) to the kernel's `build_canonical_map`, gets a variant->canonical
+ * corrections map, then applies `corrections.get(v.strip(), v.strip())` per
+ * element (STRIPS every value — a documented side effect). value_counts + apply
+ * are orchestration (stay host); the correction-map algorithm is the kernel.
+ *
+ * The algorithm is a faithful port of the Rust kernel:
+ *   - `fuzzRatioTs` = the rapidfuzz `fuzz.ratio` Indel/LCS similarity
+ *     (`100*(1 - indel/(la+lb))`, `indel = la+lb-2*LCS`, `("","")->100`), over
+ *     code points. This REPLACES the previous WRONG Levenshtein-based ratio.
+ *   - `buildCanonicalMapTs` = the insertion-ordered frequency->canonical->fuzzy
+ *     map builder, order-deterministic (insertion-ordered `Map`s + first-max on
+ *     ties, `c > best` / `score > bestScore` strictly) to match Python's
+ *     `Counter`/dict + `value_counts(sort=True)` order. The apply now STRIPS
+ *     (the prior TS did not) — both fixes unify TS with the Python reference.
+ *
+ * Dispatches native-first through the opt-in WASM backend (`FlowWasmBackend`)
+ * when `enableWasm()` has succeeded; otherwise runs the pure-TS port below.
+ * Pure-TS is the default + fallback.
  */
 
 import type { ColumnValue } from "../types.js";
 import { registerTransform } from "./registry.js";
+import { getFlowWasmBackend } from "../wasm/backend.js";
 
 // ---------------------------------------------------------------------------
-// Levenshtein distance + fuzzy ratio
+// Pure-TS kernel references (byte-identical to goldenflow-core::autocorrect).
 // ---------------------------------------------------------------------------
 
-function levenshtein(a: string, b: string): number {
-  const m = a.length;
+/** Length of the longest common subsequence of two code-point arrays
+ * (single-row DP), matching the Rust `lcs_len`. */
+function lcsLen(a: readonly string[], b: readonly string[]): number {
   const n = b.length;
-
-  if (m === 0) return n;
-  if (n === 0) return m;
-
-  // Use single-row DP for space efficiency
-  const prev = new Array<number>(n + 1);
-  for (let j = 0; j <= n; j++) prev[j] = j;
-
-  for (let i = 1; i <= m; i++) {
-    let prevDiag = prev[0]!;
-    prev[0] = i;
+  if (a.length === 0 || n === 0) return 0;
+  let prev = new Array<number>(n + 1).fill(0);
+  for (const ca of a) {
+    const row = new Array<number>(n + 1).fill(0);
+    let prevDiag = 0;
     for (let j = 1; j <= n; j++) {
-      const temp = prev[j]!;
-      if (a[i - 1] === b[j - 1]) {
-        prev[j] = prevDiag;
-      } else {
-        prev[j] = 1 + Math.min(prevDiag, prev[j]!, prev[j - 1]!);
-      }
-      prevDiag = temp;
+      row[j] = ca === b[j - 1] ? prevDiag + 1 : Math.max(prev[j]!, row[j - 1]!);
+      prevDiag = prev[j]!;
     }
+    prev = row;
   }
-
   return prev[n]!;
 }
 
 /**
- * Fuzzy similarity ratio between two strings (0-100).
- * 100 means identical, 0 means completely different.
+ * rapidfuzz `fuzz.ratio`: `100 * (1 - indel/(len_a+len_b))` where
+ * `indel = len_a + len_b - 2*LCS`. Two empty strings -> 100. Operates on code
+ * points (matching rapidfuzz on Python `str` / the Rust `chars()` kernel).
  */
-function fuzzyRatio(a: string, b: string): number {
-  if (a.length === 0 && b.length === 0) return 100;
-  const maxLen = Math.max(a.length, b.length);
-  const dist = levenshtein(a, b);
-  return 100 * (1 - dist / maxLen);
+export function fuzzRatioTs(a: string, b: string): number {
+  const ca = [...a];
+  const cb = [...b];
+  const la = ca.length;
+  const lb = cb.length;
+  if (la === 0 && lb === 0) return 100;
+  const lcs = lcsLen(ca, cb);
+  const total = la + lb;
+  const indel = la + lb - 2 * lcs;
+  return 100 * (1 - indel / total);
+}
+
+/**
+ * Build the variant->canonical correction map from `(value, count)` pairs
+ * (typically a `value_counts(sort=True)` result). Byte-identical to the Rust
+ * `autocorrect::build_canonical_map` / Python `_build_canonical_map`. Returns
+ * the corrections keyed by the STRIPPED original casing.
+ *
+ * Order-deterministic: values are processed in the input order (= value_counts
+ * order); `most_common`/best-score ties resolve to the FIRST (insertion order),
+ * exactly like Python's `Counter.most_common` + `score > best`.
+ */
+export function buildCanonicalMapTs(
+  values: readonly (string | null)[],
+  counts: readonly number[],
+  freqThreshold: number,
+  matchThreshold: number,
+): Map<string, string> {
+  // lowercase -> total count (insertion-ordered), and lowercase -> ordered list
+  // of [original casing, count]. `Map` preserves insertion order.
+  const lowerCounts = new Map<string, number>();
+  const caseMap = new Map<string, Array<[string, number]>>();
+
+  for (let i = 0; i < values.length; i++) {
+    const v = values[i];
+    if (v === null || v === undefined) continue;
+    const count = counts[i]!;
+    const vStripped = v.trim();
+    if (vStripped === "") continue;
+    const low = vStripped.toLowerCase();
+    lowerCounts.set(low, (lowerCounts.get(low) ?? 0) + count);
+    let casings = caseMap.get(low);
+    if (!casings) {
+      casings = [];
+      caseMap.set(low, casings);
+    }
+    const entry = casings.find(([c]) => c === vStripped);
+    if (entry) entry[1] += count;
+    else casings.push([vStripped, count]);
+  }
+
+  const corrections = new Map<string, string>();
+  let total = 0;
+  for (const c of lowerCounts.values()) total += c;
+  if (total === 0) return corrections;
+
+  // Canonical determination (in insertion order).
+  const canonical = new Map<string, string>(); // low -> best casing
+  const canonicalOrder: string[] = [];
+  const lowFreq: string[] = [];
+
+  for (const [low, count] of lowerCounts) {
+    if (count / total >= freqThreshold) {
+      // most_common(1): highest count; tie -> first (insertion order).
+      const casings = caseMap.get(low)!;
+      let bestCasing = casings[0]![0];
+      let bestCount = casings[0]![1];
+      for (let k = 1; k < casings.length; k++) {
+        const [casing, c] = casings[k]!;
+        if (c > bestCount) {
+          bestCount = c;
+          bestCasing = casing;
+        }
+      }
+      canonical.set(low, bestCasing);
+      canonicalOrder.push(low);
+    } else {
+      lowFreq.push(low);
+    }
+  }
+
+  // Exact case-insensitive corrections (non-best casings -> best casing).
+  for (const low of canonicalOrder) {
+    const best = canonical.get(low)!;
+    for (const [casing] of caseMap.get(low)!) {
+      if (casing !== best) corrections.set(casing, best);
+    }
+  }
+
+  // Fuzzy corrections for low-frequency values.
+  for (const low of lowFreq) {
+    let bestScore = 0;
+    let bestMatch: string | null = null;
+    for (const canonLow of canonicalOrder) {
+      const score = fuzzRatioTs(low, canonLow);
+      if (score > bestScore) {
+        bestScore = score;
+        bestMatch = canonLow;
+      }
+    }
+    if (bestScore >= matchThreshold && bestMatch !== null) {
+      const canonCasing = canonical.get(bestMatch)!;
+      for (const [casing] of caseMap.get(low)!) {
+        corrections.set(casing, canonCasing);
+      }
+    }
+  }
+
+  return corrections;
 }
 
 // ---------------------------------------------------------------------------
@@ -66,85 +182,46 @@ function categoryAutoCorrect(
       ? frequencyThreshold
       : Number(frequencyThreshold) || 0.05;
   const matchThresh =
-    typeof matchThreshold === "number"
-      ? matchThreshold
-      : Number(matchThreshold) || 85;
+    typeof matchThreshold === "number" ? matchThreshold : Number(matchThreshold) || 85;
 
-  // 1. Count case-insensitive frequencies
-  const freqMap = new Map<string, number>(); // lowercase -> count
-  const casingMap = new Map<string, Map<string, number>>(); // lowercase -> (original -> count)
-  let totalNonNull = 0;
-
+  // value_counts over the RAW non-null string values: polars `value_counts`
+  // counts the raw values BEFORE stripping (" active " / "active" are distinct
+  // rows); the kernel strips/lowercases internally. `Map` keeps first-seen
+  // order, and `Array.prototype.sort` is stable (ES2019+), so sorting by count
+  // DESC mirrors polars `value_counts(sort=True)` (ties keep first-seen order).
+  const vc = new Map<string, number>();
   for (const v of values) {
     if (v === null || typeof v !== "string") continue;
-    const lower = v.toLowerCase();
-    totalNonNull++;
-    freqMap.set(lower, (freqMap.get(lower) ?? 0) + 1);
+    vc.set(v, (vc.get(v) ?? 0) + 1);
+  }
+  const pairs = [...vc.entries()];
+  pairs.sort((a, b) => b[1] - a[1]);
+  const valuesArr = pairs.map(([v]) => v);
+  const countsArr = pairs.map(([, c]) => c);
 
-    let casings = casingMap.get(lower);
-    if (!casings) {
-      casings = new Map<string, number>();
-      casingMap.set(lower, casings);
+  const backend = getFlowWasmBackend();
+  let corrections: Map<string, string>;
+  if (backend) {
+    // wasm returns a FLAT [from0, to0, from1, to1, ...] array; unflatten it.
+    const flat = backend.buildCanonicalMap(valuesArr, countsArr, freqThresh, matchThresh);
+    corrections = new Map<string, string>();
+    for (let i = 0; i + 1 < flat.length; i += 2) {
+      corrections.set(flat[i]!, flat[i + 1]!);
     }
-    casings.set(v, (casings.get(v) ?? 0) + 1);
+  } else {
+    corrections = buildCanonicalMapTs(valuesArr, countsArr, freqThresh, matchThresh);
   }
 
-  if (totalNonNull === 0) return values.slice();
+  // No corrections -> return the column unchanged (matches Python `if not
+  // corrections: return series` — no strip when there's nothing to correct).
+  if (corrections.size === 0) return values.slice();
 
-  // 2. Determine canonical candidates: values above frequency threshold
-  //    Use the most common casing for each canonical
-  const canonicals = new Map<string, string>(); // lowercase -> best casing
-
-  for (const [lower, count] of freqMap) {
-    if (count / totalNonNull >= freqThresh) {
-      // Pick the most common casing
-      const casings = casingMap.get(lower)!;
-      let bestCasing = lower;
-      let bestCount = 0;
-      for (const [original, c] of casings) {
-        if (c > bestCount) {
-          bestCount = c;
-          bestCasing = original;
-        }
-      }
-      canonicals.set(lower, bestCasing);
-    }
-  }
-
-  if (canonicals.size === 0) return values.slice();
-
-  // 3. Build correction map for low-frequency values
-  const corrections = new Map<string, string>(); // lowercase -> canonical
-
-  for (const [lower] of freqMap) {
-    if (canonicals.has(lower)) continue; // Already canonical
-
-    let bestCanonical: string | null = null;
-    let bestScore = 0;
-
-    for (const [canonLower, canonOriginal] of canonicals) {
-      const score = fuzzyRatio(lower, canonLower);
-      if (score >= matchThresh && score > bestScore) {
-        bestScore = score;
-        bestCanonical = canonOriginal;
-      }
-    }
-
-    if (bestCanonical !== null) {
-      corrections.set(lower, bestCanonical);
-    }
-  }
-
-  // 4. Apply corrections
+  // Apply — STRIP every value (matches Python `corrections.get(v.strip(),
+  // v.strip())`; returns the stripped value even when uncorrected).
   return values.map((v) => {
     if (v === null || typeof v !== "string") return v;
-    const lower = v.toLowerCase();
-    const correction = corrections.get(lower);
-    if (correction !== undefined) return correction;
-    // If it's a canonical, normalize to best casing
-    const canonical = canonicals.get(lower);
-    if (canonical !== undefined) return canonical;
-    return v;
+    const stripped = v.trim();
+    return corrections.get(stripped) ?? stripped;
   });
 }
 

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -14,8 +14,9 @@
  * (strip/collapse_whitespace/normalize_quotes/normalize_line_endings/
  * remove_html_tags/remove_urls/remove_digits/remove_punctuation/remove_emojis/
  * extract_numbers/truncate/pad_left/pad_right + the text-2 Unicode-heavy five
- * lowercase/uppercase/title_case/normalize_unicode/fix_mojibake); everything
- * else stays pure-TS.
+ * lowercase/uppercase/title_case/normalize_unicode/fix_mojibake), and the
+ * category_auto_correct fuzzy kernel (fuzz_ratio + build_canonical_map);
+ * everything else stays pure-TS.
  * Mirrors goldenmatch's `setScorerBackend(null)` module-singleton pattern for
  * test isolation.
  */
@@ -102,6 +103,17 @@ export interface FlowWasmBackend {
   titleCase(s: string): string;
   normalizeUnicode(s: string): string;
   fixMojibake(s: string): string;
+  /** rapidfuzz `fuzz.ratio` (Indel/LCS similarity, 0-100). */
+  fuzzRatio(a: string, b: string): number;
+  /** category-autocorrect correction map from parallel `values`/`counts`
+   * arrays (in value_counts DESC order). Returns a FLAT `[from0, to0, from1,
+   * to1, ...]` array of correction pairs; the caller unflattens. */
+  buildCanonicalMap(
+    values: string[],
+    counts: number[],
+    freqThreshold: number,
+    matchThreshold: number,
+  ): string[];
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -110,6 +110,15 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     title_case: (s: string) => string;
     normalize_unicode: (s: string) => string;
     fix_mojibake: (s: string) => string;
+    fuzz_ratio: (a: string, b: string) => number;
+    // wasm-bindgen `Vec<i32>` maps to `Int32Array`; `Vec<String>` in/out map to
+    // `string[]`.
+    build_canonical_map: (
+      values: string[],
+      counts: Int32Array,
+      freqThreshold: number,
+      matchThreshold: number,
+    ) => string[];
   };
   await glue.default({ module_or_path: bytes });
 
@@ -183,5 +192,8 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     titleCase: (s) => glue.title_case(s),
     normalizeUnicode: (s) => glue.normalize_unicode(s),
     fixMojibake: (s) => glue.fix_mojibake(s),
+    fuzzRatio: (a, b) => glue.fuzz_ratio(a, b),
+    buildCanonicalMap: (values, counts, freqThreshold, matchThreshold) =>
+      glue.build_canonical_map(values, Int32Array.from(counts), freqThreshold, matchThreshold),
   };
 }

--- a/packages/typescript/goldenflow/tests/unit/autocorrect-kernels.test.ts
+++ b/packages/typescript/goldenflow/tests/unit/autocorrect-kernels.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Pinned-vector parity for the data-dependent FUZZY autocorrect kernel (Wave D
+ * autocorrect): `fuzzRatioTs` (rapidfuzz `fuzz.ratio`) + `categoryAutoCorrect`
+ * (the whole value_counts -> build_canonical_map -> strip+apply pipeline).
+ *
+ * These don't fit the shared string->scalar corpus: `fuzz_ratio` is two-input
+ * -> float, and `category_auto_correct` is column -> column (data-dependent).
+ * They're asserted here with the SAME pinned vectors as the Python
+ * `tests/transforms/test_autocorrect_kernels.py`, against the goldenflow-core
+ * Rust kernel's values.
+ *
+ * The pure-TS leg always runs; the WASM leg runs only when the `.wasm` artifact
+ * has been built (a CI-only build product, never committed) -- the skip-guarded
+ * pattern from the text-kernel harness.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { fuzzRatioTs } from "../../src/core/transforms/auto-correct.js";
+import { getTransform } from "../../src/core/transforms/registry.js";
+import type { ColumnValue } from "../../src/core/types.js";
+import "../../src/core/transforms/auto-correct.js";
+import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
+import { getFlowWasmBackend, type FlowWasmBackend } from "../../src/core/wasm/backend.js";
+
+// (a, b, expected) rows — pinned vs Python rapidfuzz.fuzz.ratio.
+const FUZZ: Array<[string, string, number]> = [
+  ["active", "actve", 90.9090909090909],
+  ["aaa", "aa", 80],
+  ["kitten", "sitting", 61.53846153846154],
+  ["abc", "", 0],
+  ["", "", 100],
+  ["abc", "abc", 100],
+];
+
+// The scenario column: 50×"active" + 10×"Active" + 5×"ACTIVE" + 2×"actve" +
+// 1×"banana" + 3×null. Case variants + a fuzzy typo all collapse to "active";
+// "banana" is below threshold; nulls stay null. Tie-free counts.
+function scenarioColumn(): ColumnValue[] {
+  const out: ColumnValue[] = [];
+  for (let i = 0; i < 50; i++) out.push("active");
+  for (let i = 0; i < 10; i++) out.push("Active");
+  for (let i = 0; i < 5; i++) out.push("ACTIVE");
+  for (let i = 0; i < 2; i++) out.push("actve");
+  out.push("banana");
+  for (let i = 0; i < 3; i++) out.push(null);
+  return out;
+}
+
+function expectScenario(result: ColumnValue[]): void {
+  // All 67 active-variants -> "active".
+  for (let i = 0; i < 67; i++) expect(result[i]).toBe("active");
+  // "banana" unchanged.
+  expect(result[67]).toBe("banana");
+  // nulls stay null.
+  expect(result[68]).toBeNull();
+  expect(result[69]).toBeNull();
+  expect(result[70]).toBeNull();
+}
+
+describe("goldenflow autocorrect kernels: pure-TS matches pinned vectors", () => {
+  it("fuzzRatioTs", () => {
+    for (const [a, b, expected] of FUZZ) {
+      expect(fuzzRatioTs(a, b)).toBeCloseTo(expected, 9);
+    }
+  });
+
+  it("category_auto_correct scenario", () => {
+    const transform = getTransform("category_auto_correct");
+    if (!transform) throw new Error("category_auto_correct not registered");
+    const result = transform.func(scenarioColumn()) as ColumnValue[];
+    expectScenario(result);
+  });
+});
+
+describe("goldenflow autocorrect kernels: wasm matches pinned vectors", () => {
+  let wasmAvailable = false;
+
+  beforeAll(async () => {
+    // Resolves false (no throw) when the `.wasm` artifact isn't built -- the
+    // true default/local state (CI-only build product; never committed).
+    wasmAvailable = await enableWasm();
+  });
+
+  afterAll(() => {
+    disableWasm();
+  });
+
+  it("reports wasm availability", () => {
+    if (!wasmAvailable) {
+      console.warn(
+        "goldenflow wasm artifact not built (src/core/wasm/artifacts/*.wasm absent) " +
+          "-- skipping the wasm autocorrect-kernel leg. Expected outside the wasm_flow CI lane.",
+      );
+    }
+    expect(true).toBe(true);
+  });
+
+  it.skipIf(!wasmAvailable)("fuzzRatio + build_canonical_map via category_auto_correct", () => {
+    const backend = getFlowWasmBackend() as FlowWasmBackend;
+    if (!backend) throw new Error("wasmAvailable=true but getFlowWasmBackend() returned null");
+
+    for (const [a, b, expected] of FUZZ) {
+      expect(backend.fuzzRatio(a, b)).toBeCloseTo(expected, 9);
+    }
+
+    // With the wasm backend active, the transform dispatches through
+    // build_canonical_map -> same corrected column.
+    const transform = getTransform("category_auto_correct");
+    if (!transform) throw new Error("category_auto_correct not registered");
+    const result = transform.func(scenarioColumn()) as ColumnValue[];
+    expectScenario(result);
+  });
+});


### PR DESCRIPTION
## Wave D — category_auto_correct (owned fuzzy kernel, cross-surface)

Migrates the fuzzy, data-dependent categorical-autocorrect transform to an owned Rust kernel in `goldenflow-core::autocorrect`. This is the last non-date family. Migration, count stays 92.

Ben's call: **own the whole algorithm** (not just the `fuzz_ratio` primitive), so the corrections are byte-identical across all three surfaces.

### Fixes a pre-existing Py/TS divergence
`category_auto_correct` was *never* cross-surface-parity-tested, and Python and TS actually produced **different** results: Python used `rapidfuzz.fuzz.ratio` (Indel/LCS), TS used a Levenshtein-based ratio, and TS didn't strip whitespace on apply. All three now conform to the single Rust kernel.

### The kernel (`autocorrect.rs`)
- **`fuzz_ratio(a, b)`** — the rapidfuzz `fuzz.ratio` primitive: `100·(1 − indel/(lenₐ+len_b))`, `indel = lenₐ+len_b−2·LCS`, `("","")→100`. Pinned to rapidfuzz (active/actve=90.909, aaa/aa=80, kitten/sitting=61.538, …).
- **`build_canonical_map(values, counts, freq_threshold, match_threshold)`** — the whole `_build_canonical_map` algorithm (frequency → canonical → exact-case + fuzzy corrections), **order-deterministic**: insertion-ordered structures + first-max-on-ties (`c > best` / `score > best_score` strictly), matching Python's `Counter`/dict.

### Data-dependent decomposition
`mode="series"`, whole-column. The host computes `value_counts(sort=True)` and applies the returned map (`corrections.get(v.strip(), v.strip())` — strips every value); the kernel owns the algorithm. New marshaling: `(Utf8[], Int64[]) → (Utf8[], Utf8[])`; the wasm export returns a flat `[from0, to0, …]` array.

### Fan-out
- **native shim** + **Python** (`build_canonical_map` native-first; rapidfuzz `_build_canonical_map` fallback = the byte-exact reference; `rapidfuzz` stays a dep). **wasm** (`fuzz_ratio` + `build_canonical_map`). **TS** (`auto-correct.ts` rewritten: `fuzzRatioTs` codepoint-LCS, `buildCanonicalMapTs` insertion-order port, JS `value_counts` + stable count-DESC sort, strip-on-apply).
- **Parity**: pinned-vector `test_autocorrect_kernels.py` + `autocorrect-kernels.test.ts` (data-dependent → not the shared string→scalar corpus).

### Versions
`goldenflow` 1.13.0 · `native-flow` 0.11.0 · TS `goldenflow` 0.13.0. (No goldenflow-core bump: a new module + `lib.rs` edit forces a fresh rebuild, so the maturin cache-bust that text needed doesn't apply.)

### Verification
- Rust: 4 unit tests + clippy clean; native-flow `cargo fmt --check` clean; **VERIFIED the kernel produces identical corrections to the rapidfuzz-based Python** on a case+fuzzy scenario.
- Python: whole-package `ruff` clean; pinned-vector test passes; count 92.
- TS: CI-only; statically cross-checked exports/registration, wasm↔loader names, and hand-traced `fuzz_ratio` + the full scenario against the Rust/Python values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
