### PR TITLE
chore(golden-suite): 0.1.3 — bump goldenflow floors after Wave D release

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.3] - 2026-07-05
+
+### Changed
+- Bumped the goldenflow-family floors after the Wave D owned-kernel release:
+  **`goldenflow>=1.13.0`** (was `>=1.4.0`) and **`goldenflow-native>=0.11.0`**
+  (was `>=0.2.0`), per the lockstep policy. goldenflow 1.13.0 completes the
+  owned-kernel + cross-surface migration of every byte-parity-achievable
+  transform family (identifiers, names, email, url, numeric, categorical,
+  address, the full text family, and fuzzy category_auto_correct); the
+  goldenflow-native 0.11.0 wheel ships the matching compiled kernels.
+
 ## [0.1.2] - 2026-07-04
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.2"
+version = "0.1.3"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.4.0",                # transform / standardize / normalize (>=1.4.0 = latest PyPI)
+    "goldenflow>=1.13.0",                # transform / standardize / normalize (>=1.13.0 = owned-kernel Wave D complete)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.2.0",
+    "goldenflow-native>=0.11.0",
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
Lockstep bump after the goldenflow Wave D owned-kernel releases.

- `goldenflow>=1.13.0` (was `>=1.4.0`) — the owned-kernel + cross-surface migration of every byte-parity-achievable transform family is complete (identifiers, names, email, url, numeric, categorical, address, the full text family, and fuzzy `category_auto_correct`).
- `goldenflow-native>=0.11.0` (was `>=0.2.0`) — the matching compiled-kernel wheel.
- golden-suite `0.1.2 -> 0.1.3`.

Deps-only meta-package. Release (tag `golden-suite-v0.1.3`) is gated on goldenflow 1.13.0 + goldenflow-native 0.11.0 being on PyPI (the floors must be satisfiable) — will tag after those publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)