### PR TITLE
ci(goldenflow-js): build workspace deps before publish (fix TS2307)

### DIFF
--- a/.github/workflows/publish-goldenflow-js.yml
+++ b/.github/workflows/publish-goldenflow-js.yml
@@ -25,7 +25,11 @@ jobs:
     uses: ./.github/workflows/_publish-js.yml
     with:
       package: goldenflow
-      build_deps: false
+      # goldenflow bundles the goldenmatch-wasm-runtime workspace dep (tsup
+      # noExternal) since the Wave 0c wasm work. tsc/tsup can't resolve its dist
+      # entrypoint unless it's built first, so this MUST stay true or the publish
+      # fails with TS2307 on backend.ts (every publish since 0.4.0 silently did).
+      build_deps: true
       ref: ${{ inputs.ref || '' }}
       dry_run: ${{ inputs.dry_run || 'false' }}
     secrets: inherit


### PR DESCRIPTION
## Problem
Every goldenflow npm publish since **0.4.0** has silently failed. npm latest is stuck at `0.3.0` while the git-tag / PyPI side advanced to `0.13.0`.

Root cause: goldenflow bundles the `goldenmatch-wasm-runtime` workspace dep (tsup `noExternal`) since the Wave 0c wasm work, but `publish-goldenflow-js.yml` still passed `build_deps: false`. The shared `_publish-js.yml` template's `pnpm exec tsc --noEmit` step then can't resolve the dep's dist entrypoint:

```
src/core/wasm/backend.ts(119,39): error TS2307: Cannot find module 'goldenmatch-wasm-runtime' or its corresponding type declarations.
```

## Fix
Flip `build_deps: true` so the "Build workspace deps" step (`turbo --filter=goldenflow^...`) runs before typecheck/build. The dep is inlined by tsup + rolled into the `.d.ts` (`dts.resolve`), so the published `dependencies` stay clean (`commander` only) — no new runtime dep reaches npm.

After merge: re-fire the publish for the existing `goldenflow-js-v0.13.0` tag via `workflow_dispatch` (reads the fixed workflow from main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)