### PR TITLE
feat(goldenflow-duckdb): zero-Python DuckDB extension spike (Slice 1)

### DIFF
--- a/.github/workflows/goldenflow-duckdb.yml
+++ b/.github/workflows/goldenflow-duckdb.yml
@@ -1,0 +1,52 @@
+name: goldenflow-duckdb
+
+# Spike CI for the zero-Python DuckDB extension (Slice 1). Two proofs:
+#   1. test-bundled  -- hermetic in-process parity: SQL output == goldenflow-core
+#      reference (compiles DuckDB in via the `bundled` feature).
+#   2. loadable build -- the shippable cdylib artifact compiles against the
+#      DuckDB C Extension API (the version-portability path).
+# Dedicated workflow rather than a lane in ci.yml: self-contained while the
+# surface is still a spike; folds into ci.yml when it graduates.
+
+on:
+  push:
+    paths:
+      - "packages/rust/extensions/goldenflow-duckdb/**"
+      - "packages/rust/extensions/goldenflow-core/**"
+      - ".github/workflows/goldenflow-duckdb.yml"
+  pull_request:
+    paths:
+      - "packages/rust/extensions/goldenflow-duckdb/**"
+      - "packages/rust/extensions/goldenflow-core/**"
+      - ".github/workflows/goldenflow-duckdb.yml"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: packages/rust/extensions/goldenflow-duckdb
+
+jobs:
+  parity-and-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: packages/rust/extensions/goldenflow-duckdb
+
+      # Hermetic parity gate. `bundled` compiles the DuckDB amalgamation in, so
+      # the scalars run against a real in-process DuckDB with no libduckdb on the
+      # box. Slow, but it proves SQL == reference end-to-end.
+      - name: Parity test (in-process, bundled)
+        run: cargo test --no-default-features --features test-bundled -- --nocapture
+
+      # Prove the shippable extension compiles against the C Extension API.
+      # (Appending the metadata footer + LOAD smoke is the distribution slice.)
+      - name: Build loadable cdylib
+        run: cargo build --release
+
+      - name: Show artifact
+        run: ls -la target/release/ | grep -i goldenflow || true

--- a/packages/rust/extensions/Cargo.toml
+++ b/packages/rust/extensions/Cargo.toml
@@ -15,6 +15,10 @@ exclude = [
     # goldenflow-core is native-flow's pyo3-free path dependency (standalone
     # workspace, like score-core/goldencheck-core). Not a bridge member.
     "goldenflow-core",
+    # goldenflow-duckdb is a cdylib DuckDB loadable extension over goldenflow-core
+    # (zero-Python SQL surface). Its own [workspace] + special DuckDB linking keep
+    # it out of the bridge build, like native-flow.
+    "goldenflow-duckdb",
     # analysis-native is a standalone abi3 ext-module workspace (like the above);
     # analysis-core is its pyo3-free path dependency. GoldenAnalysis's optional
     # accelerator (goldenanalysis[native]); neither belongs in `bridge`.

--- a/packages/rust/extensions/goldenflow-duckdb/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-duckdb/Cargo.toml
@@ -1,0 +1,37 @@
+# goldenflow-duckdb: a zero-Python DuckDB loadable extension over goldenflow-core.
+#
+# Self-isolated (`[workspace]`) + excluded from the bridge workspace, exactly
+# like native-flow/postgres: it's a cdylib with special DuckDB linking that
+# should never enter a `cargo build --workspace` at the extensions root.
+[workspace]
+
+[package]
+name = "goldenflow-duckdb"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Zero-Python DuckDB loadable extension exposing GoldenFlow transforms (goldenflow-core reference kernels) as SQL scalar functions."
+repository = "https://github.com/benseverndev-oss/goldenmatch"
+
+[lib]
+# -> goldenflow_duckdb.duckdb_extension once the metadata footer is appended.
+name = "goldenflow_duckdb"
+crate-type = ["cdylib"]
+
+[dependencies]
+# The pyo3-free reference kernels. Same crate the native + wasm surfaces wrap,
+# so SQL output is byte-identical to Python/TS/wasm by construction.
+goldenflow-core = { path = "../goldenflow-core" }
+# `loadable-extension` is gated behind our own `loadable` feature so the
+# hermetic `test-bundled` build (which needs `bundled`) can turn it off --
+# the two DuckDB link modes are mutually exclusive.
+duckdb = { version = "1.10504.0", default-features = false, features = ["vscalar"] }
+
+[features]
+default = ["loadable"]
+# The shippable artifact: links against libduckdb provided at LOAD time.
+loadable = ["duckdb/loadable-extension"]
+# Hermetic parity gate: compiles DuckDB in-process so a `cargo test` can
+# register the scalars and assert SQL output == goldenflow-core reference.
+# Build with `--no-default-features --features test-bundled`.
+test-bundled = ["duckdb/bundled"]

--- a/packages/rust/extensions/goldenflow-duckdb/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-duckdb/Cargo.toml
@@ -5,8 +5,11 @@
 # should never enter a `cargo build --workspace` at the extensions root.
 [workspace]
 
+# Underscore name: `#[duckdb_entrypoint_c_api]` derives the C init symbol
+# (`<pkg>_init_c_api`) from the package name, so a hyphen makes an invalid
+# identifier and the macro panics. This also becomes the LOAD name.
 [package]
-name = "goldenflow-duckdb"
+name = "goldenflow_duckdb"
 version = "0.1.0"
 edition = "2021"
 license = "MIT"

--- a/packages/rust/extensions/goldenflow-duckdb/README.md
+++ b/packages/rust/extensions/goldenflow-duckdb/README.md
@@ -1,0 +1,43 @@
+# goldenflow-duckdb
+
+A **zero-Python** DuckDB loadable extension that exposes GoldenFlow transforms
+as SQL scalar functions, backed directly by the `goldenflow-core` reference
+kernels. No CPython interpreter in the DuckDB process -- the same Rust kernels
+that drive the Python, TypeScript, and WebAssembly surfaces run natively inside
+the query engine, so results are byte-identical across all four surfaces by
+construction.
+
+```sql
+LOAD 'goldenflow_duckdb.duckdb_extension';
+
+SELECT
+  goldenflow_normalize_email(email)         AS email,
+  goldenflow_normalize_name_proper(name)    AS name
+FROM read_parquet('s3://bucket/raw/*.parquet');
+```
+
+## Status: Slice 1 (spike)
+
+Two transforms are wired end-to-end to validate the mechanism:
+
+| SQL function                       | Kernel                          |
+| ---------------------------------- | ------------------------------- |
+| `goldenflow_normalize_email`       | `goldenflow_core::email::email_normalize` |
+| `goldenflow_normalize_name_proper` | `goldenflow_core::names::name_proper`     |
+
+Next slices: table-drive the full byte-parity catalogue (`Slice 2`) and the
+per-platform `.duckdb_extension` build + distribution (`Slice 3`).
+
+## Build & test
+
+```sh
+# Hermetic parity gate -- compiles DuckDB in-process and asserts SQL output
+# equals the goldenflow-core reference kernel.
+cargo test --no-default-features --features test-bundled
+
+# The shippable artifact (links libduckdb at LOAD time via the C Extension API).
+cargo build --release
+```
+
+Both run in CI (`.github/workflows/goldenflow-duckdb.yml`); the `bundled` build
+is heavy, so CI is the authoritative build environment.

--- a/packages/rust/extensions/goldenflow-duckdb/README.md
+++ b/packages/rust/extensions/goldenflow-duckdb/README.md
@@ -11,22 +11,31 @@ construction.
 LOAD 'goldenflow_duckdb.duckdb_extension';
 
 SELECT
-  goldenflow_normalize_email(email)         AS email,
-  goldenflow_normalize_name_proper(name)    AS name
+  goldenflow_email_normalize(email)      AS email,
+  goldenflow_name_proper(name)           AS name,
+  goldenflow_address_standardize(addr)   AS addr,
+  goldenflow_url_normalize(website)      AS website  -- NULL when unparseable
 FROM read_parquet('s3://bucket/raw/*.parquet');
 ```
 
-## Status: Slice 1 (spike)
+UDF names are `goldenflow_<kernel>` -- a predictable 1:1 with the underlying
+`goldenflow-core` function.
 
-Two transforms are wired end-to-end to validate the mechanism:
+## Status: Slice 2 (VARCHAR catalogue)
 
-| SQL function                       | Kernel                          |
-| ---------------------------------- | ------------------------------- |
-| `goldenflow_normalize_email`       | `goldenflow_core::email::email_normalize` |
-| `goldenflow_normalize_name_proper` | `goldenflow_core::names::name_proper`     |
+The full single-argument `VARCHAR -> VARCHAR` catalogue is wired -- 36 UDFs
+across address, email, names, text, and categorical families, in both the total
+(`fn(&str) -> String`) and nullable (`fn(&str) -> Option<String>`, `None` ->
+SQL `NULL`) shapes. Registration is table-driven, so adding a transform is one
+`"name" => kernel` line.
 
-Next slices: table-drive the full byte-parity catalogue (`Slice 2`) and the
-per-platform `.duckdb_extension` build + distribution (`Slice 3`).
+Deferred to later slices:
+
+| Slice | Scope |
+| ----- | ----- |
+| **2b** | Typed outputs: validators (`-> BOOLEAN`) + numeric parsers (`-> DOUBLE`/`BIGINT`), and the identifier family. Needs the primitive output-vector write API. |
+| **3**  | Per-platform `.duckdb_extension` build (metadata footer + 5-target matrix) and distribution. |
+| **later** | Multi-argument / multi-output kernels: phone (region arg), `split_*`, `truncate`, `pad_*`, `merge_name`, `auto_correct`. |
 
 ## Build & test
 

--- a/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
@@ -1,0 +1,140 @@
+//! GoldenFlow DuckDB extension -- a zero-Python SQL surface over the owned
+//! reference kernels.
+//!
+//! Each SQL scalar function is a thin [`VScalar`] that runs the corresponding
+//! `goldenflow-core` kernel (the byte-parity oracle) element-wise over a DuckDB
+//! data chunk. Because the kernel *is* the cross-surface reference, SQL output
+//! is byte-identical to the Python / TS / wasm surfaces by construction -- and
+//! there is no CPython interpreter anywhere in the process.
+//!
+//! Spike scope (Slice 1): two VARCHAR->VARCHAR transforms + a hermetic
+//! in-process parity test. Breadth (the full byte-parity catalogue) and the
+//! per-platform `.duckdb_extension` distribution build are later slices.
+
+use duckdb::{
+    core::{DataChunkHandle, Inserter, LogicalTypeId},
+    ffi::duckdb_string_t,
+    types::DuckString,
+    vscalar::{ScalarFunctionSignature, VScalar},
+    vtab::arrow::WritableVector,
+    Connection, Result,
+};
+use std::error::Error;
+
+/// Define a `VARCHAR -> VARCHAR` [`VScalar`] that applies a
+/// `fn(&str) -> String` goldenflow-core kernel to every non-null row of the
+/// chunk, preserving SQL NULLs.
+macro_rules! str_scalar {
+    ($ty:ident, $kernel:path) => {
+        struct $ty;
+        impl VScalar for $ty {
+            type State = ();
+
+            fn invoke(
+                _state: &Self::State,
+                input: &mut DataChunkHandle,
+                output: &mut dyn WritableVector,
+            ) -> std::result::Result<(), Box<dyn Error>> {
+                let in_vec = input.flat_vector(0);
+                let rows =
+                    unsafe { in_vec.as_slice_with_len::<duckdb_string_t>(input.len()) };
+                let mut out = output.flat_vector();
+                for (i, row) in rows.iter().enumerate() {
+                    if in_vec.row_is_null(i as u64) {
+                        out.set_null(i);
+                        continue;
+                    }
+                    let mut row = *row;
+                    let s = DuckString::new(&mut row).as_str();
+                    out.insert(i, $kernel(s.as_ref()).as_str());
+                }
+                Ok(())
+            }
+
+            fn signatures() -> Vec<ScalarFunctionSignature> {
+                vec![ScalarFunctionSignature::exact(
+                    vec![LogicalTypeId::Varchar.into()],
+                    LogicalTypeId::Varchar.into(),
+                )]
+            }
+        }
+    };
+}
+
+str_scalar!(EmailNormalize, goldenflow_core::email::email_normalize);
+str_scalar!(NameProper, goldenflow_core::names::name_proper);
+
+/// Register every GoldenFlow scalar UDF on a connection. Single source of truth
+/// for both the loadable entrypoint and the in-process test harness, so the two
+/// can never drift on names.
+fn register_all(con: &Connection) -> Result<(), Box<dyn Error>> {
+    con.register_scalar_function::<EmailNormalize>("goldenflow_normalize_email")?;
+    con.register_scalar_function::<NameProper>("goldenflow_normalize_name_proper")?;
+    Ok(())
+}
+
+/// The DuckDB C Extension API entrypoint. Compiled only for the shippable
+/// artifact (`loadable` feature); the `test-bundled` build omits it because it
+/// links DuckDB in-process instead.
+#[cfg(feature = "loadable")]
+mod entry {
+    use super::register_all;
+    use duckdb::{duckdb_entrypoint_c_api, Connection, Result};
+    use std::error::Error;
+
+    #[duckdb_entrypoint_c_api]
+    pub unsafe fn goldenflow_duckdb_init(con: Connection) -> Result<(), Box<dyn Error>> {
+        register_all(&con)?;
+        Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "test-bundled"))]
+mod tests {
+    use super::register_all;
+    use duckdb::Connection;
+
+    /// The SQL surface must return exactly what the goldenflow-core reference
+    /// kernel returns -- that is the cross-surface parity contract, asserted
+    /// here through a real in-process DuckDB.
+    #[test]
+    fn sql_output_matches_reference_kernel() {
+        let con = Connection::open_in_memory().expect("open duckdb");
+        register_all(&con).expect("register udfs");
+
+        let email_cases = ["  Foo.Bar@Example.COM ", "no-at-sign", "A@B@C.com", ""];
+        for input in email_cases {
+            let got: String = con
+                .query_row("SELECT goldenflow_normalize_email(?)", [input], |r| r.get(0))
+                .expect("query email");
+            assert_eq!(
+                got,
+                goldenflow_core::email::email_normalize(input),
+                "email_normalize parity on {input:?}",
+            );
+        }
+
+        let name_cases = ["mcdonald o'brien", "JANE  SMITH", "de la cruz", ""];
+        for input in name_cases {
+            let got: String = con
+                .query_row("SELECT goldenflow_normalize_name_proper(?)", [input], |r| r.get(0))
+                .expect("query name");
+            assert_eq!(
+                got,
+                goldenflow_core::names::name_proper(input),
+                "name_proper parity on {input:?}",
+            );
+        }
+    }
+
+    /// SQL NULL in -> SQL NULL out (not the empty string, not a panic).
+    #[test]
+    fn preserves_sql_null() {
+        let con = Connection::open_in_memory().expect("open duckdb");
+        register_all(&con).expect("register udfs");
+        let got: Option<String> = con
+            .query_row("SELECT goldenflow_normalize_email(NULL)", [], |r| r.get(0))
+            .expect("query null");
+        assert_eq!(got, None);
+    }
+}

--- a/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
@@ -30,17 +30,6 @@ fn strip_owned(s: &str) -> String {
     goldenflow_core::text::strip(s).to_string()
 }
 
-/// Read the sole VARCHAR argument of a chunk as `(FlatVector, &[duckdb_string_t])`.
-/// The macros below share this; nulls are checked per-row via `in_vec.row_is_null`.
-macro_rules! read_str_input {
-    ($input:expr) => {{
-        let in_vec = $input.flat_vector(0);
-        let rows =
-            unsafe { in_vec.as_slice_with_len::<duckdb_string_t>($input.len()) };
-        (in_vec, rows)
-    }};
-}
-
 /// Register a batch of `VARCHAR -> VARCHAR` UDFs whose kernel is `fn(&str) -> String`.
 /// Each entry generates a block-local zero-sized [`VScalar`] and registers it, so
 /// adding a transform is a single `"name" => kernel` line.
@@ -55,7 +44,9 @@ macro_rules! register_str {
                     input: &mut DataChunkHandle,
                     output: &mut dyn WritableVector,
                 ) -> std::result::Result<(), Box<dyn Error>> {
-                    let (in_vec, rows) = read_str_input!(input);
+                    let in_vec = input.flat_vector(0);
+                    let rows =
+                        unsafe { in_vec.as_slice_with_len::<duckdb_string_t>(input.len()) };
                     let mut out = output.flat_vector();
                     for (i, row) in rows.iter().enumerate() {
                         if in_vec.row_is_null(i as u64) {
@@ -93,7 +84,9 @@ macro_rules! register_opt_str {
                     input: &mut DataChunkHandle,
                     output: &mut dyn WritableVector,
                 ) -> std::result::Result<(), Box<dyn Error>> {
-                    let (in_vec, rows) = read_str_input!(input);
+                    let in_vec = input.flat_vector(0);
+                    let rows =
+                        unsafe { in_vec.as_slice_with_len::<duckdb_string_t>(input.len()) };
                     let mut out = output.flat_vector();
                     for (i, row) in rows.iter().enumerate() {
                         if in_vec.row_is_null(i as u64) {

--- a/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-duckdb/src/lib.rs
@@ -7,9 +7,12 @@
 //! is byte-identical to the Python / TS / wasm surfaces by construction -- and
 //! there is no CPython interpreter anywhere in the process.
 //!
-//! Spike scope (Slice 1): two VARCHAR->VARCHAR transforms + a hermetic
-//! in-process parity test. Breadth (the full byte-parity catalogue) and the
-//! per-platform `.duckdb_extension` distribution build are later slices.
+//! Slice 2 exposes the full single-argument `VARCHAR -> VARCHAR` catalogue
+//! (address, email, names, text, categorical), both the total (`-> String`) and
+//! nullable (`-> Option<String>`) shapes. Typed outputs (BOOLEAN / DOUBLE /
+//! BIGINT: validators + numeric parsers) and the identifier family are Slice 2b;
+//! multi-argument / multi-output kernels (phone, `split_*`, `truncate`, `pad_*`,
+//! `merge_name`, `auto_correct`) are later slices.
 
 use duckdb::{
     core::{DataChunkHandle, Inserter, LogicalTypeId},
@@ -21,55 +24,157 @@ use duckdb::{
 };
 use std::error::Error;
 
-/// Define a `VARCHAR -> VARCHAR` [`VScalar`] that applies a
-/// `fn(&str) -> String` goldenflow-core kernel to every non-null row of the
-/// chunk, preserving SQL NULLs.
-macro_rules! str_scalar {
-    ($ty:ident, $kernel:path) => {
-        struct $ty;
-        impl VScalar for $ty {
-            type State = ();
-
-            fn invoke(
-                _state: &Self::State,
-                input: &mut DataChunkHandle,
-                output: &mut dyn WritableVector,
-            ) -> std::result::Result<(), Box<dyn Error>> {
-                let in_vec = input.flat_vector(0);
-                let rows =
-                    unsafe { in_vec.as_slice_with_len::<duckdb_string_t>(input.len()) };
-                let mut out = output.flat_vector();
-                for (i, row) in rows.iter().enumerate() {
-                    if in_vec.row_is_null(i as u64) {
-                        out.set_null(i);
-                        continue;
-                    }
-                    let mut row = *row;
-                    let s = DuckString::new(&mut row).as_str();
-                    out.insert(i, $kernel(s.as_ref()).as_str());
-                }
-                Ok(())
-            }
-
-            fn signatures() -> Vec<ScalarFunctionSignature> {
-                vec![ScalarFunctionSignature::exact(
-                    vec![LogicalTypeId::Varchar.into()],
-                    LogicalTypeId::Varchar.into(),
-                )]
-            }
-        }
-    };
+/// `goldenflow-core`'s `strip` returns a borrowed `&str`; give it an owned-String
+/// shape so it slots into the `VARCHAR -> VARCHAR` registration table.
+fn strip_owned(s: &str) -> String {
+    goldenflow_core::text::strip(s).to_string()
 }
 
-str_scalar!(EmailNormalize, goldenflow_core::email::email_normalize);
-str_scalar!(NameProper, goldenflow_core::names::name_proper);
+/// Read the sole VARCHAR argument of a chunk as `(FlatVector, &[duckdb_string_t])`.
+/// The macros below share this; nulls are checked per-row via `in_vec.row_is_null`.
+macro_rules! read_str_input {
+    ($input:expr) => {{
+        let in_vec = $input.flat_vector(0);
+        let rows =
+            unsafe { in_vec.as_slice_with_len::<duckdb_string_t>($input.len()) };
+        (in_vec, rows)
+    }};
+}
+
+/// Register a batch of `VARCHAR -> VARCHAR` UDFs whose kernel is `fn(&str) -> String`.
+/// Each entry generates a block-local zero-sized [`VScalar`] and registers it, so
+/// adding a transform is a single `"name" => kernel` line.
+macro_rules! register_str {
+    ($con:expr, $($name:literal => $kernel:path),+ $(,)?) => {{
+        $({
+            struct S;
+            impl VScalar for S {
+                type State = ();
+                fn invoke(
+                    _state: &Self::State,
+                    input: &mut DataChunkHandle,
+                    output: &mut dyn WritableVector,
+                ) -> std::result::Result<(), Box<dyn Error>> {
+                    let (in_vec, rows) = read_str_input!(input);
+                    let mut out = output.flat_vector();
+                    for (i, row) in rows.iter().enumerate() {
+                        if in_vec.row_is_null(i as u64) {
+                            out.set_null(i);
+                            continue;
+                        }
+                        let mut row = *row;
+                        let s = DuckString::new(&mut row).as_str();
+                        out.insert(i, $kernel(s.as_ref()).as_str());
+                    }
+                    Ok(())
+                }
+                fn signatures() -> Vec<ScalarFunctionSignature> {
+                    vec![ScalarFunctionSignature::exact(
+                        vec![LogicalTypeId::Varchar.into()],
+                        LogicalTypeId::Varchar.into(),
+                    )]
+                }
+            }
+            $con.register_scalar_function::<S>($name)?;
+        })+
+    }};
+}
+
+/// Register a batch of nullable `VARCHAR -> VARCHAR` UDFs whose kernel is
+/// `fn(&str) -> Option<String>`: `None` becomes SQL `NULL`.
+macro_rules! register_opt_str {
+    ($con:expr, $($name:literal => $kernel:path),+ $(,)?) => {{
+        $({
+            struct S;
+            impl VScalar for S {
+                type State = ();
+                fn invoke(
+                    _state: &Self::State,
+                    input: &mut DataChunkHandle,
+                    output: &mut dyn WritableVector,
+                ) -> std::result::Result<(), Box<dyn Error>> {
+                    let (in_vec, rows) = read_str_input!(input);
+                    let mut out = output.flat_vector();
+                    for (i, row) in rows.iter().enumerate() {
+                        if in_vec.row_is_null(i as u64) {
+                            out.set_null(i);
+                            continue;
+                        }
+                        let mut row = *row;
+                        let s = DuckString::new(&mut row).as_str();
+                        match $kernel(s.as_ref()) {
+                            Some(v) => out.insert(i, v.as_str()),
+                            None => out.set_null(i),
+                        }
+                    }
+                    Ok(())
+                }
+                fn signatures() -> Vec<ScalarFunctionSignature> {
+                    vec![ScalarFunctionSignature::exact(
+                        vec![LogicalTypeId::Varchar.into()],
+                        LogicalTypeId::Varchar.into(),
+                    )]
+                }
+            }
+            $con.register_scalar_function::<S>($name)?;
+        })+
+    }};
+}
 
 /// Register every GoldenFlow scalar UDF on a connection. Single source of truth
 /// for both the loadable entrypoint and the in-process test harness, so the two
-/// can never drift on names.
+/// can never drift on names. UDF names are `goldenflow_<kernel>` -- predictable
+/// 1:1 with the reference function.
 fn register_all(con: &Connection) -> Result<(), Box<dyn Error>> {
-    con.register_scalar_function::<EmailNormalize>("goldenflow_normalize_email")?;
-    con.register_scalar_function::<NameProper>("goldenflow_normalize_name_proper")?;
+    // VARCHAR -> VARCHAR (total).
+    register_str!(con,
+        // address
+        "goldenflow_address_standardize"  => goldenflow_core::address::address_standardize,
+        "goldenflow_address_expand"       => goldenflow_core::address::address_expand,
+        "goldenflow_state_abbreviate"     => goldenflow_core::address::state_abbreviate,
+        "goldenflow_state_expand"         => goldenflow_core::address::state_expand,
+        "goldenflow_zip_normalize"        => goldenflow_core::address::zip_normalize,
+        "goldenflow_country_standardize"  => goldenflow_core::address::country_standardize,
+        "goldenflow_unit_normalize"       => goldenflow_core::address::unit_normalize,
+        // categorical
+        "goldenflow_category_normalize_key" => goldenflow_core::categorical::category_normalize_key,
+        "goldenflow_gender_standardize"     => goldenflow_core::categorical::gender_standardize,
+        // email
+        "goldenflow_email_lowercase"      => goldenflow_core::email::email_lowercase,
+        "goldenflow_email_normalize"      => goldenflow_core::email::email_normalize,
+        // names
+        "goldenflow_name_transliterate"   => goldenflow_core::names::name_transliterate,
+        "goldenflow_name_script"          => goldenflow_core::names::name_script,
+        "goldenflow_strip_titles"         => goldenflow_core::names::strip_titles,
+        "goldenflow_strip_suffixes"       => goldenflow_core::names::strip_suffixes,
+        "goldenflow_name_proper"          => goldenflow_core::names::name_proper,
+        "goldenflow_nickname_standardize" => goldenflow_core::names::nickname_standardize,
+        // text
+        "goldenflow_strip"                => strip_owned,
+        "goldenflow_collapse_whitespace"  => goldenflow_core::text::collapse_whitespace,
+        "goldenflow_normalize_quotes"     => goldenflow_core::text::normalize_quotes,
+        "goldenflow_normalize_line_endings" => goldenflow_core::text::normalize_line_endings,
+        "goldenflow_remove_html_tags"     => goldenflow_core::text::remove_html_tags,
+        "goldenflow_remove_urls"          => goldenflow_core::text::remove_urls,
+        "goldenflow_remove_digits"        => goldenflow_core::text::remove_digits,
+        "goldenflow_remove_punctuation"   => goldenflow_core::text::remove_punctuation,
+        "goldenflow_extract_numbers"      => goldenflow_core::text::extract_numbers,
+        "goldenflow_remove_emojis"        => goldenflow_core::text::remove_emojis,
+        "goldenflow_lowercase"            => goldenflow_core::text::lowercase,
+        "goldenflow_uppercase"            => goldenflow_core::text::uppercase,
+        "goldenflow_title_case"           => goldenflow_core::text::title_case,
+        "goldenflow_fix_mojibake"         => goldenflow_core::text::fix_mojibake,
+        "goldenflow_normalize_unicode"    => goldenflow_core::text::normalize_unicode,
+    );
+
+    // VARCHAR -> VARCHAR (nullable; None -> SQL NULL).
+    register_opt_str!(con,
+        "goldenflow_null_standardize"     => goldenflow_core::categorical::null_standardize,
+        "goldenflow_email_extract_domain" => goldenflow_core::email::email_extract_domain,
+        "goldenflow_url_normalize"        => goldenflow_core::url::url_normalize,
+        "goldenflow_url_extract_domain"   => goldenflow_core::url::url_extract_domain,
+    );
+
     Ok(())
 }
 
@@ -94,47 +199,90 @@ mod tests {
     use super::register_all;
     use duckdb::Connection;
 
-    /// The SQL surface must return exactly what the goldenflow-core reference
-    /// kernel returns -- that is the cross-surface parity contract, asserted
-    /// here through a real in-process DuckDB.
-    #[test]
-    fn sql_output_matches_reference_kernel() {
+    fn conn() -> Connection {
         let con = Connection::open_in_memory().expect("open duckdb");
         register_all(&con).expect("register udfs");
+        con
+    }
 
-        let email_cases = ["  Foo.Bar@Example.COM ", "no-at-sign", "A@B@C.com", ""];
-        for input in email_cases {
-            let got: String = con
-                .query_row("SELECT goldenflow_normalize_email(?)", [input], |r| r.get(0))
-                .expect("query email");
-            assert_eq!(
-                got,
-                goldenflow_core::email::email_normalize(input),
-                "email_normalize parity on {input:?}",
-            );
-        }
+    fn sql_str(con: &Connection, udf: &str, input: &str) -> Option<String> {
+        con.query_row(&format!("SELECT {udf}(?)"), [input], |r| r.get(0))
+            .expect("query")
+    }
 
-        let name_cases = ["mcdonald o'brien", "JANE  SMITH", "de la cruz", ""];
-        for input in name_cases {
-            let got: String = con
-                .query_row("SELECT goldenflow_normalize_name_proper(?)", [input], |r| r.get(0))
-                .expect("query name");
+    /// The SQL surface must return exactly what the `goldenflow-core` reference
+    /// kernel returns -- the cross-surface parity contract -- across a sample of
+    /// every family, asserted through a real in-process DuckDB. (The kernels'
+    /// own exhaustive byte-parity lives in goldenflow-core; here we prove the
+    /// DuckDB marshaling reproduces them.)
+    #[test]
+    fn total_str_udfs_match_reference() {
+        use goldenflow_core as gf;
+        let con = conn();
+        // (udf, input, expected-from-kernel)
+        let cases: &[(&str, &str, String)] = &[
+            ("goldenflow_email_normalize", "  Foo.Bar@Example.COM ", gf::email::email_normalize("  Foo.Bar@Example.COM ")),
+            ("goldenflow_email_lowercase", "USER@Domain.COM", gf::email::email_lowercase("USER@Domain.COM")),
+            ("goldenflow_name_proper", "mcdonald o'brien", gf::names::name_proper("mcdonald o'brien")),
+            ("goldenflow_strip_titles", "Dr. Jane Smith", gf::names::strip_titles("Dr. Jane Smith")),
+            ("goldenflow_nickname_standardize", "Bob", gf::names::nickname_standardize("Bob")),
+            ("goldenflow_gender_standardize", "F", gf::categorical::gender_standardize("F")),
+            ("goldenflow_state_abbreviate", "California", gf::address::state_abbreviate("California")),
+            ("goldenflow_zip_normalize", "12345-6789", gf::address::zip_normalize("12345-6789")),
+            ("goldenflow_address_standardize", "123 Main Street", gf::address::address_standardize("123 Main Street")),
+            ("goldenflow_collapse_whitespace", "a   b\t c", gf::text::collapse_whitespace("a   b\t c")),
+            ("goldenflow_remove_html_tags", "<b>hi</b>", gf::text::remove_html_tags("<b>hi</b>")),
+            ("goldenflow_lowercase", "HeLLo", gf::text::lowercase("HeLLo")),
+            ("goldenflow_uppercase", "HeLLo", gf::text::uppercase("HeLLo")),
+            ("goldenflow_title_case", "the quick fox", gf::text::title_case("the quick fox")),
+            ("goldenflow_normalize_quotes", "\u{201c}hi\u{201d}", gf::text::normalize_quotes("\u{201c}hi\u{201d}")),
+            ("goldenflow_strip", "  padded  ", gf::text::strip("  padded  ").to_string()),
+        ];
+        for (udf, input, expected) in cases {
             assert_eq!(
-                got,
-                goldenflow_core::names::name_proper(input),
-                "name_proper parity on {input:?}",
+                sql_str(&con, udf, input).as_deref(),
+                Some(expected.as_str()),
+                "UDF {udf} on {input:?}",
             );
         }
     }
 
-    /// SQL NULL in -> SQL NULL out (not the empty string, not a panic).
+    /// Nullable kernels: a value round-trips, an unparseable input yields SQL NULL.
+    #[test]
+    fn nullable_str_udfs_null_on_none() {
+        use goldenflow_core as gf;
+        let con = conn();
+
+        // url_normalize returns Some on a real url, None on junk.
+        let good = "HTTP://Example.com/Path";
+        assert_eq!(
+            sql_str(&con, "goldenflow_url_normalize", good).as_deref(),
+            gf::url::url_normalize(good).as_deref(),
+        );
+        assert_eq!(sql_str(&con, "goldenflow_url_normalize", "").as_deref(), None);
+
+        // email_extract_domain: domain on a real address, NULL otherwise.
+        assert_eq!(
+            sql_str(&con, "goldenflow_email_extract_domain", "a@b.com").as_deref(),
+            gf::email::email_extract_domain("a@b.com").as_deref(),
+        );
+        assert_eq!(
+            sql_str(&con, "goldenflow_email_extract_domain", "no-domain").as_deref(),
+            None,
+        );
+    }
+
+    /// SQL NULL in -> SQL NULL out for both macro families (not "", not a panic).
     #[test]
     fn preserves_sql_null() {
-        let con = Connection::open_in_memory().expect("open duckdb");
-        register_all(&con).expect("register udfs");
-        let got: Option<String> = con
-            .query_row("SELECT goldenflow_normalize_email(NULL)", [], |r| r.get(0))
-            .expect("query null");
-        assert_eq!(got, None);
+        let con = conn();
+        let total: Option<String> = con
+            .query_row("SELECT goldenflow_email_normalize(NULL)", [], |r| r.get(0))
+            .expect("query null total");
+        assert_eq!(total, None);
+        let nullable: Option<String> = con
+            .query_row("SELECT goldenflow_url_normalize(NULL)", [], |r| r.get(0))
+            .expect("query null nullable");
+        assert_eq!(nullable, None);
     }
 }


### PR DESCRIPTION
## What
Slice 1 of the DuckDB SQL surface for GoldenFlow — a **compiled cdylib DuckDB extension** linking `goldenflow-core`, with **no CPython in the process**. Each SQL function is a `VScalar` running the owned reference kernel element-wise over the data chunk.

This is the "Rust is the source of truth pays off" expansion: the surface that already exists (`goldenmatch_duckdb/goldenflow.py`) predates the owned-kernel work and dispatches the *Python* transform registry per value (builds a 1-element `pl.Series` per row). This replaces that shape entirely with the Rust core.

## Slice 1 scope
Two `VARCHAR -> VARCHAR` transforms wired end-to-end to validate the mechanism:

| SQL function | Kernel |
|---|---|
| `goldenflow_normalize_email` | `email::email_normalize` |
| `goldenflow_normalize_name_proper` | `names::name_proper` |

## Parity
Proven through a **real in-process DuckDB** (`test-bundled` feature): the test asserts SQL output `==` the `goldenflow-core` reference kernel across cases + NULL preservation. Because the kernel *is* the cross-surface oracle, this proves SQL == Python == TS == wasm by construction.

## Why a spike (not auto-merged)
The point is to settle two unknowns in CI before investing in breadth + distribution:
1. **duckdb-rs loadable-extension API** — the `VScalar` / `#[duckdb_entrypoint_c_api]` shape is copied from the official `extension-template-rs`, but the API churns; CI is the first real build.
2. **Version pinning** — the entrypoint targets DuckDB's **stable C Extension API** (`duckdb_entrypoint_c_api`), which should make one artifact portable across DuckDB versions. The `loadable` build step confirms it compiles that way.

## CI
Dedicated `goldenflow-duckdb.yml`: (1) `cargo test --features test-bundled` (hermetic parity, compiles DuckDB in), (2) `cargo build --release` (shippable cdylib compiles against the C API). Folds into `ci.yml` when it graduates.

## Not in this slice
Full catalogue breadth (Slice 2) and the per-platform `.duckdb_extension` footer/signing/distribution (Slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)