### PR TITLE
goldenmatch MCP naming-alias parity (P0 aliases + P1 gap docs)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
+++ b/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
@@ -178,12 +178,17 @@ def _tiny_csv(tmp_path: Path) -> str:
 
 def test_dispatch_routes_alias_to_canonical_handler(tmp_path, monkeypatch):
     # The aggregator entrypoint (module-level dispatch) must resolve aliases —
-    # this is the path goldensuite-mcp uses. profile/profile_data is the cheapest pair.
+    # this is the path goldensuite-mcp uses.
+    # NOTE: profile_data takes NO path arg (empty inputSchema) — it reads the
+    # loaded engine (global _engine, None until _initialize). So preload the
+    # engine, then call both with {}. dispatch() has no try/except, so an
+    # unresolved alias raises out of the first call (which is the pre-fix failure).
     monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
     path = _tiny_csv(tmp_path)
     from goldenmatch.mcp import server as gm
-    via_alias = gm.dispatch("profile", {"path": path})
-    via_canonical = gm.dispatch("profile_data", {"path": path})
+    gm._initialize([path])
+    via_alias = gm.dispatch("profile", {})
+    via_canonical = gm.dispatch("profile_data", {})
     assert via_alias == via_canonical
 
 
@@ -198,7 +203,7 @@ def test_dispatch_explain_cluster_resolves_into_agent_path():
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py::test_dispatch_routes_alias_to_canonical_handler -v`
-Expected: FAIL — `dispatch("profile", ...)` falls through to `_handle_tool("profile", ...)` with no matching branch (KeyError / unknown-tool error), so it won't equal the `profile_data` result.
+Expected: FAIL — `dispatch("profile", {})` falls through to `_handle_tool("profile", {})` with no matching branch (unknown-tool error raised out of the un-try/excepted `dispatch`), so it errors before the `==`.
 
 - [ ] **Step 3: Implement — add `_resolve_alias` at the top of both dispatchers**
 
@@ -251,12 +256,16 @@ def test_suite_profile_stays_goldencheck_not_goldenmatch_alias():
     """goldenmatch's new `profile` alias must NOT shadow goldencheck's `profile`
     file-profiler in the aggregated surface."""
     from goldensuite_mcp.server import _aggregate
+    from goldenmatch.mcp import server as gm
     tools, name_to_dispatch = _aggregate()
     names = {t.name for t in tools}
     assert "profile" in names
-    # profile must dispatch to goldencheck, not goldenmatch
-    from goldencheck.mcp import server as gc
-    assert name_to_dispatch["profile"] is gc.dispatch
+    # profile must NOT dispatch to goldenmatch. gm.dispatch is the one stable
+    # module-level identity to compare against — goldencheck's adapter returns a
+    # fresh local closure (no `goldencheck.mcp.server.dispatch` symbol exists),
+    # so an `is gc.dispatch` check is impossible. `is not gm.dispatch` + the
+    # alias-absence test below together prove profile stays goldencheck's.
+    assert name_to_dispatch["profile"] is not gm.dispatch
 
 
 def test_goldenmatch_aliases_absent_from_aggregated_surface():
@@ -268,12 +277,10 @@ def test_goldenmatch_aliases_absent_from_aggregated_surface():
         "goldenmatch aliases must be filtered from the suite surface"
 ```
 
-(If goldencheck's dispatcher isn't `gc.dispatch`, adjust the identity check to the callable `_adapt_goldencheck()` returns — verify against `goldensuite_mcp/server.py`'s goldencheck adapter.)
-
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `cd packages/python/goldensuite-mcp && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_aggregator_smoke.py -k "profile or aliases" -v`
-Expected: FAIL — goldenmatch is first-wins, so `profile` maps to `gm.dispatch` and the alias names appear in the surface.
+Expected: FAIL — goldenmatch is first-wins, so `profile` maps to `gm.dispatch` (`is not gm.dispatch` fails) and the alias names appear in the surface.
 
 - [ ] **Step 3: Implement — filter aliases in `_adapt_goldenmatch`**
 

--- a/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
+++ b/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
@@ -268,19 +268,27 @@ def test_suite_profile_stays_goldencheck_not_goldenmatch_alias():
     assert name_to_dispatch["profile"] is not gm.dispatch
 
 
-def test_goldenmatch_aliases_absent_from_aggregated_surface():
+def test_no_goldenmatch_alias_is_served_by_goldenmatch_in_the_suite():
+    # The real invariant is OWNERSHIP, not name-absence: `profile` is BOTH a
+    # goldenmatch alias key AND a legitimate goldencheck tool, so it may still
+    # appear in the surface (served by goldencheck). What must never happen is a
+    # goldenmatch alias being SERVED BY goldenmatch through the suite.
     from goldensuite_mcp.server import _aggregate
     from goldenmatch.mcp import server as gm
-    tools, _ = _aggregate()
+    tools, name_to_dispatch = _aggregate()
     names = {t.name for t in tools}
-    assert not (set(gm._MCP_TOOL_ALIASES) & names), \
-        "goldenmatch aliases must be filtered from the suite surface"
+    served_by_gm = [n for n in gm._MCP_TOOL_ALIASES
+                    if name_to_dispatch.get(n) is gm.dispatch]
+    assert served_by_gm == []
+    # The 4 non-colliding aliases don't leak into the surface at all (only
+    # `profile` collides with another package's real tool).
+    assert not ((set(gm._MCP_TOOL_ALIASES) - {"profile"}) & names)
 ```
 
 - [ ] **Step 2: Run to verify it fails**
 
 Run: `cd packages/python/goldensuite-mcp && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_aggregator_smoke.py -k "profile or aliases" -v`
-Expected: FAIL — goldenmatch is first-wins, so `profile` maps to `gm.dispatch` (`is not gm.dispatch` fails) and the alias names appear in the surface.
+Expected: FAIL — goldenmatch is first-wins, so `profile` maps to `gm.dispatch` (`is not gm.dispatch` fails) and the non-colliding alias names leak into the surface.
 
 - [ ] **Step 3: Implement — filter aliases in `_adapt_goldenmatch`**
 

--- a/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
+++ b/docs/superpowers/plans/2026-07-05-mcp-naming-aliases-parity.md
@@ -1,0 +1,524 @@
+# goldenmatch MCP Naming-Alias Parity — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make goldenmatch's five divergently-named MCP operations answerable by both names on both servers (Python + TypeScript), non-breakingly, and move the nine alias names to `shared` in the parity manifest.
+
+**Architecture:** Aliases are pure name indirection to existing handlers — no operation logic is duplicated. Python funnels aliases through the shared `_BASE_TOOLS` component (both advertise paths sum it) and a shared `_resolve_alias()` called by both dispatchers (`call_tool` + the aggregator's `dispatch`). The suite aggregator filters goldenmatch's aliases out so the suite's `profile` stays goldencheck's. TS adds derived alias tool-defs + fall-through `switch` cases.
+
+**Tech Stack:** Python (mcp SDK `Tool`, pytest), TypeScript (mcp SDK `Tool`, vitest), YAML manifest, `check_api_parity.py` gate.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md`
+
+**Environment / SOP:**
+- Branch `feat/parity-p0-mcp-aliases` (worktree `D:\show_case\gg-local-llm`), based on `origin/main`.
+- Python tests are box-safe: run with `POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0` and the main `.venv` (has `goldenmatch[mcp]`). Prefer `.venv/Scripts/python -m pytest` over `uv run`.
+- **TS is CI-only — the box OOMs TS builds/vitest.** Write the TS test + code; do NOT run vitest locally. The `api_parity` + TS CI lanes verify it.
+- benzsevern gh account (`unset GH_TOKEN; gh auth switch --user benzsevern`). Merge-queue repo → `gh pr merge --auto --squash` WITHOUT `--delete-branch`.
+- Verify all symbols against this worktree, NEVER the stale `D:\show_case\goldenmatch`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+| --- | --- | --- |
+| `packages/python/goldenmatch/goldenmatch/mcp/server.py` | Python MCP server: tool defs, advertise paths, both dispatchers | Add alias map + resolver + `ALIAS_TOOLS` into `_BASE_TOOLS`; normalize in `dispatch` + `call_tool` |
+| `packages/python/goldenmatch/tests/test_mcp_aliases.py` | Python alias unit + integration tests | **Create** |
+| `packages/python/goldensuite-mcp/goldensuite_mcp/server.py` | Suite aggregator | Filter gm aliases in `_adapt_goldenmatch` |
+| `packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py` | Aggregator smoke tests | Add `profile`-owner + alias-absence test |
+| `packages/typescript/goldenmatch/src/node/mcp/server.ts` | TS MCP server: tool defs + `handleTool` switch | Add `ALIAS_TOOLS` + fall-through cases |
+| `packages/typescript/goldenmatch/tests/unit/mcp-aliases.test.ts` | TS alias tests | **Create** (CI-only) |
+| `parity/goldenmatch.yaml` | Parity manifest | Move 9 names to `mcp_tools.shared`; update header |
+
+**Anchor lines (this worktree, verified):** `_BASE_TOOLS` = server.py:94-582; `TOOLS` sum = :585; `dispatch` = :588; inline `list_tools` rebuild = :620; `call_tool` = :862; `_AGENT_TOOL_NAMES` = :54; `AGENT_TOOLS` import = :35. Aggregator `_adapt_goldenmatch` = goldensuite-mcp server.py:47-50. TS `EXISTING_TOOLS` = server.ts:88; `TOOLS` spread = :369-374; `switch (name)` = :509 (`dedupe`:510, `match`:543, `explain_pair`:593, `explain_cluster`:615, `profile`:667).
+
+---
+
+## Task 1: Python — alias map, resolver, and advertised alias tools
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/server.py` (insert after `_BASE_TOOLS` closes at :582, before the `TOOLS =` sum at :585)
+- Test: `packages/python/goldenmatch/tests/test_mcp_aliases.py` (Create)
+
+- [ ] **Step 1: Write the failing test** (`tests/test_mcp_aliases.py`)
+
+```python
+"""Alias parity for the goldenmatch MCP server. Box-safe: needs goldenmatch[mcp].
+Run: POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 python -m pytest tests/test_mcp_aliases.py -v"""
+import pytest
+from goldenmatch.mcp import server as gm
+
+EXPECTED_ALIASES = {
+    "dedupe": "find_duplicates",
+    "match": "match_record",
+    "explain_pair": "explain_match",
+    "profile": "profile_data",
+    "explain_cluster": "agent_explain_cluster",
+}
+
+
+def test_alias_map_is_exactly_the_five_pairs():
+    assert gm._MCP_TOOL_ALIASES == EXPECTED_ALIASES
+
+
+def test_resolve_alias_maps_each_alias_to_canonical():
+    for alias, canonical in EXPECTED_ALIASES.items():
+        assert gm._resolve_alias(alias) == canonical
+    # non-alias names pass through untouched
+    assert gm._resolve_alias("find_duplicates") == "find_duplicates"
+    assert gm._resolve_alias("nonexistent") == "nonexistent"
+
+
+def test_aliases_are_advertised_in_the_base_component():
+    # Load-bearing: aliases MUST live in _BASE_TOOLS so BOTH advertise paths
+    # (the TOOLS var at :585 AND the inline list_tools rebuild at :620) see them.
+    base_names = {t.name for t in gm._BASE_TOOLS}
+    assert set(EXPECTED_ALIASES) <= base_names
+
+
+def test_aliases_appear_in_TOOLS_union():
+    names = {t.name for t in gm.TOOLS}
+    assert set(EXPECTED_ALIASES) <= names
+
+
+def test_alias_schema_matches_canonical():
+    by_name = {t.name: t for t in gm.TOOLS}
+    for alias, canonical in EXPECTED_ALIASES.items():
+        assert by_name[alias].inputSchema == by_name[canonical].inputSchema
+        assert canonical in (by_name[alias].description or "")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py -v`
+Expected: FAIL — `AttributeError: module ... has no attribute '_MCP_TOOL_ALIASES'`.
+
+- [ ] **Step 3: Implement the alias map, resolver, and alias-tool builder**
+
+Insert immediately after the `_BASE_TOOLS = [ ... ]` literal closes (server.py:582), before the `# TOOLS is the union ...` comment at :584:
+
+```python
+# --- Cross-language naming aliases (Python<->TS MCP parity) -----------------
+# Each alias forwards to an EXISTING handler; no operation logic is duplicated.
+# See docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md.
+_MCP_TOOL_ALIASES = {
+    "dedupe": "find_duplicates",
+    "match": "match_record",
+    "explain_pair": "explain_match",
+    "profile": "profile_data",
+    "explain_cluster": "agent_explain_cluster",
+}
+
+
+def _resolve_alias(name: str) -> str:
+    """Map an alias tool name to its canonical name (identity for non-aliases)."""
+    return _MCP_TOOL_ALIASES.get(name, name)
+
+
+def _build_alias_tools() -> list[Tool]:
+    """Derive alias Tool objects from their canonical tools so schemas can't drift.
+    Canonicals live in AGENT_TOOLS (agent_explain_cluster) + _BASE_TOOLS (the rest)."""
+    canon = {t.name: t for t in AGENT_TOOLS + _BASE_TOOLS}
+    tools = []
+    for alias, target in _MCP_TOOL_ALIASES.items():
+        c = canon[target]
+        tools.append(Tool(
+            name=alias,
+            description=f"Alias for `{target}`. {c.description}",
+            inputSchema=c.inputSchema,
+        ))
+    return tools
+
+
+# Append aliases to the shared _BASE_TOOLS component so BOTH advertise paths
+# (the TOOLS var below AND the inline list_tools rebuild) pick them up.
+_BASE_TOOLS += _build_alias_tools()
+```
+
+(The existing `TOOLS = AGENT_TOOLS + ... + _BASE_TOOLS` at :585 now includes the aliases automatically.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py -v`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/mcp/server.py packages/python/goldenmatch/tests/test_mcp_aliases.py
+git commit -m "feat(mcp): advertise goldenmatch Python MCP naming aliases"
+```
+
+---
+
+## Task 2: Python — normalize aliases in both dispatchers
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/server.py` (`dispatch` head :589; `call_tool` head :862)
+- Test: `packages/python/goldenmatch/tests/test_mcp_aliases.py` (extend)
+
+- [ ] **Step 1: Write the failing test** (append to `test_mcp_aliases.py`)
+
+```python
+import csv
+from pathlib import Path
+
+
+def _tiny_csv(tmp_path: Path) -> str:
+    p = tmp_path / "people.csv"
+    with p.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["id", "name", "email"])
+        w.writerow(["1", "Alice Smith", "alice@example.com"])
+        w.writerow(["2", "Alice Smith", "alice@example.com"])
+        w.writerow(["3", "Bob Jones", "bob@example.com"])
+    return str(p)
+
+
+def test_dispatch_routes_alias_to_canonical_handler(tmp_path, monkeypatch):
+    # The aggregator entrypoint (module-level dispatch) must resolve aliases —
+    # this is the path goldensuite-mcp uses. profile/profile_data is the cheapest pair.
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    path = _tiny_csv(tmp_path)
+    from goldenmatch.mcp import server as gm
+    via_alias = gm.dispatch("profile", {"path": path})
+    via_canonical = gm.dispatch("profile_data", {"path": path})
+    assert via_alias == via_canonical
+
+
+def test_dispatch_explain_cluster_resolves_into_agent_path():
+    # explain_cluster -> agent_explain_cluster must resolve BEFORE the
+    # _AGENT_TOOL_NAMES check so it reaches the agent handler.
+    from goldenmatch.mcp import server as gm
+    assert gm._resolve_alias("explain_cluster") == "agent_explain_cluster"
+    assert "agent_explain_cluster" in gm._AGENT_TOOL_NAMES
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py::test_dispatch_routes_alias_to_canonical_handler -v`
+Expected: FAIL — `dispatch("profile", ...)` falls through to `_handle_tool("profile", ...)` with no matching branch (KeyError / unknown-tool error), so it won't equal the `profile_data` result.
+
+- [ ] **Step 3: Implement — add `_resolve_alias` at the top of both dispatchers**
+
+In `dispatch` (server.py:588), make the first line of the body:
+
+```python
+def dispatch(name: str, args: dict) -> dict:
+    """Unified dispatcher used by goldensuite-mcp aggregator. ..."""
+    name = _resolve_alias(name)   # <-- add as first statement
+    if name in _AGENT_TOOL_NAMES:
+        ...
+```
+
+In the `call_tool` handler (server.py:862), add resolution as the first statement of the body (before the analytics `capture`, so analytics record the canonical name):
+
+```python
+    @server.call_tool()
+    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+        name = _resolve_alias(name)   # <-- add first
+        # Anonymous, opt-in usage event ...
+        try:
+            from goldenmatch.core.analytics import capture
+            ...
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py -v`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/mcp/server.py packages/python/goldenmatch/tests/test_mcp_aliases.py
+git commit -m "feat(mcp): route goldenmatch MCP aliases through both dispatchers"
+```
+
+---
+
+## Task 3: Suite aggregator — exclude goldenmatch aliases
+
+**Files:**
+- Modify: `packages/python/goldensuite-mcp/goldensuite_mcp/server.py` (`_adapt_goldenmatch` :47-50)
+- Test: `packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py` (extend)
+
+- [ ] **Step 1: Write the failing test** (append to `test_aggregator_smoke.py`)
+
+```python
+def test_suite_profile_stays_goldencheck_not_goldenmatch_alias():
+    """goldenmatch's new `profile` alias must NOT shadow goldencheck's `profile`
+    file-profiler in the aggregated surface."""
+    from goldensuite_mcp.server import _aggregate
+    tools, name_to_dispatch = _aggregate()
+    names = {t.name for t in tools}
+    assert "profile" in names
+    # profile must dispatch to goldencheck, not goldenmatch
+    from goldencheck.mcp import server as gc
+    assert name_to_dispatch["profile"] is gc.dispatch
+
+
+def test_goldenmatch_aliases_absent_from_aggregated_surface():
+    from goldensuite_mcp.server import _aggregate
+    from goldenmatch.mcp import server as gm
+    tools, _ = _aggregate()
+    names = {t.name for t in tools}
+    assert not (set(gm._MCP_TOOL_ALIASES) & names), \
+        "goldenmatch aliases must be filtered from the suite surface"
+```
+
+(If goldencheck's dispatcher isn't `gc.dispatch`, adjust the identity check to the callable `_adapt_goldencheck()` returns — verify against `goldensuite_mcp/server.py`'s goldencheck adapter.)
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd packages/python/goldensuite-mcp && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_aggregator_smoke.py -k "profile or aliases" -v`
+Expected: FAIL — goldenmatch is first-wins, so `profile` maps to `gm.dispatch` and the alias names appear in the surface.
+
+- [ ] **Step 3: Implement — filter aliases in `_adapt_goldenmatch`**
+
+Replace `_adapt_goldenmatch` (server.py:47-50):
+
+```python
+def _adapt_goldenmatch() -> tuple[list[Tool], Callable[[str, dict], dict]]:
+    from goldenmatch.mcp import server as gm
+
+    # Exclude goldenmatch's internal Python<->TS naming aliases from the
+    # aggregated surface: the suite has one surface per operation, and the
+    # `profile` alias would otherwise shadow goldencheck's `profile` tool.
+    # gm.dispatch still resolves aliases (harmless — they're just never listed here).
+    aliases = set(gm._MCP_TOOL_ALIASES)
+    tools = [t for t in gm.TOOLS if t.name not in aliases]
+    return _normalize_tools(tools), gm.dispatch
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd packages/python/goldensuite-mcp && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_aggregator_smoke.py -v`
+Expected: PASS (existing smoke tests + the 2 new ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldensuite-mcp/goldensuite_mcp/server.py packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
+git commit -m "fix(suite-mcp): exclude goldenmatch aliases so suite profile stays goldencheck"
+```
+
+---
+
+## Task 4: TypeScript — alias tool-defs + fall-through dispatch (CI-only)
+
+**Files:**
+- Modify: `packages/typescript/goldenmatch/src/node/mcp/server.ts` (add `ALIAS_TOOLS` after `EXISTING_TOOLS` :356-ish; add to `TOOLS` spread :369-374; add fall-through cases in `switch` :509)
+- Test: `packages/typescript/goldenmatch/tests/unit/mcp-aliases.test.ts` (Create)
+
+> **Do NOT run vitest locally — the box OOMs.** Write test + code; CI verifies. The four TS aliases map: `find_duplicates`→`dedupe`, `match_record`→`match`, `explain_match`→`explain_pair`, `profile_data`→`profile`. (No `agent_explain_cluster` alias — already shared.)
+
+- [ ] **Step 1: Write the test** (`tests/unit/mcp-aliases.test.ts`)
+
+```ts
+import { describe, it, expect } from "vitest";
+import { TOOLS, handleTool } from "../../src/node/mcp/server.js";
+
+const ALIAS_TO_CANONICAL: Record<string, string> = {
+  find_duplicates: "dedupe",
+  match_record: "match",
+  explain_match: "explain_pair",
+  profile_data: "profile",
+};
+
+describe("MCP naming aliases", () => {
+  it("advertises all four alias names", () => {
+    const names = new Set(TOOLS.map((t) => t.name));
+    for (const alias of Object.keys(ALIAS_TO_CANONICAL)) {
+      expect(names.has(alias)).toBe(true);
+    }
+  });
+
+  it("each alias schema equals its canonical schema", () => {
+    const byName = new Map(TOOLS.map((t) => [t.name, t]));
+    for (const [alias, canonical] of Object.entries(ALIAS_TO_CANONICAL)) {
+      expect(byName.get(alias)!.inputSchema).toEqual(byName.get(canonical)!.inputSchema);
+      expect(byName.get(alias)!.description).toContain(canonical);
+    }
+  });
+
+  it("profile_data dispatches identically to profile", async () => {
+    const viaAlias = await handleTool("profile_data", { path: "nonexistent_xyz.csv" });
+    const viaCanonical = await handleTool("profile", { path: "nonexistent_xyz.csv" });
+    expect(viaAlias).toEqual(viaCanonical);
+  });
+});
+```
+
+- [ ] **Step 2: Implement — derive `ALIAS_TOOLS` and add to `TOOLS`**
+
+After the `EXISTING_TOOLS` array closes (server.ts ~:356), add:
+
+```ts
+// Cross-language naming aliases (Python<->TS MCP parity). Each forwards to an
+// existing handler via a fall-through switch case below; schemas are derived
+// from the canonical tool so they can't drift.
+const _TS_TOOL_ALIASES: Record<string, string> = {
+  find_duplicates: "dedupe",
+  match_record: "match",
+  explain_match: "explain_pair",
+  profile_data: "profile",
+};
+
+const ALIAS_TOOLS: Tool[] = Object.entries(_TS_TOOL_ALIASES).map(([alias, canonical]) => {
+  const c = EXISTING_TOOLS.find((t) => t.name === canonical);
+  if (!c) throw new Error(`alias canonical not found: ${canonical}`);
+  return { ...c, name: alias, description: `Alias for \`${canonical}\`. ${c.description}` };
+});
+```
+
+Add `...ALIAS_TOOLS` to the `TOOLS` spread (server.ts:369-374):
+
+```ts
+export const TOOLS: readonly Tool[] = [
+  ...EXISTING_TOOLS,
+  ...ALIAS_TOOLS,
+  ...MEMORY_TOOLS,
+  ...IDENTITY_TOOLS,
+  ...AGENT_MCP_TOOLS,
+];
+```
+
+- [ ] **Step 3: Implement — fall-through switch cases**
+
+In `handleTool`'s `switch (name)` (server.ts:509), stack each alias label directly above its canonical `case` so it falls through (no body duplicated):
+
+```ts
+      case "find_duplicates":   // alias
+      case "dedupe": {
+        ...existing dedupe body...
+      }
+```
+
+Do the same for: `case "match_record":` above `case "match":` (:543); `case "explain_match":` above `case "explain_pair":` (:593); `case "profile_data":` above `case "profile":` (:667).
+
+- [ ] **Step 4: Update the manifest expectation in the existing TS test if needed**
+
+Check `tests/unit/mcp-server.test.ts:21` ("every tool name is unique") — aliases have distinct names, so it still passes. No change expected; confirm by reading, don't run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/typescript/goldenmatch/src/node/mcp/server.ts packages/typescript/goldenmatch/tests/unit/mcp-aliases.test.ts
+git commit -m "feat(mcp-ts): add goldenmatch TS MCP naming aliases (find_duplicates/match_record/explain_match/profile_data)"
+```
+
+---
+
+## Task 5: Manifest — move nine names to `shared`
+
+**Files:**
+- Modify: `parity/goldenmatch.yaml`
+
+- [ ] **Step 1: Edit the manifest**
+
+In `mcp_tools`:
+- **Add to `shared`** (keep alphabetical): `dedupe`, `explain_cluster`, `explain_match`, `explain_pair`, `find_duplicates`, `match`, `match_record`, `profile`, `profile_data`.
+- **Remove from `python_only`**: `explain_match`, `find_duplicates`, `match_record`, `profile_data`.
+- **Remove from `ts_only`**: `dedupe`, `explain_cluster`, `explain_pair`, `match`, `profile`.
+
+Every partition must stay **sorted** and **disjoint** (the gate's `check_structure` enforces both).
+
+- [ ] **Step 2: Update the header** (lines 8-13)
+
+Replace category-1 text so it reads as resolved:
+
+```yaml
+#   1. NAMING ALIASES (resolved 2026-07-05 via non-breaking aliases — both
+#      servers now answer to both names, so these are shared: dedupe/find_duplicates,
+#      match/match_record, explain_pair/explain_match, profile/profile_data, and
+#      explain_cluster (alias of the shared agent_explain_cluster)). CLI info/score/
+#      tui(TS) vs interactive(PY) are NOT aliases (distinct ops) — left as coverage gaps.
+```
+
+- [ ] **Step 3: Verify structure locally with the gate's structural check**
+
+Run: `POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 .venv/Scripts/python -c "import yaml,pathlib; from importlib.util import spec_from_file_location,module_from_spec; s=spec_from_file_location('g','scripts/check_api_parity.py'); m=module_from_spec(s); s.loader.exec_module(m); man=yaml.safe_load(open('parity/goldenmatch.yaml')); fails=m.check_structure(man); print('STRUCTURE FAILS:', [f.kind for f in fails])"`
+Expected: `STRUCTURE FAILS: []` (sorted + disjoint + known surfaces).
+
+> The full partition check needs the TS descriptor (CI-only). CI's `api_parity` goldenmatch shard is the authoritative green/red. Structure check above is the box-safe pre-flight.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add parity/goldenmatch.yaml
+git commit -m "chore(parity): move 9 goldenmatch MCP aliases to shared"
+```
+
+---
+
+## Task 6: P1 docs — annotate the remaining gaps as intentional
+
+**Files:**
+- Modify: `parity/goldenmatch.yaml` (header, category 2)
+
+- [ ] **Step 1: Extend the category-2 header note**
+
+Add explicit intent for the stateful-query tools and the Python-only subsystems:
+
+```yaml
+#   2. PYTHON-RICHER COVERAGE (intentional — Python is the fuller, STATEFUL server):
+#      get_stats / get_cluster / list_clusters are Python-only BECAUSE the TS MCP is
+#      stateless — its dedupe() returns stats + clusters inline (DedupeResult), so there
+#      is no server-held dataset to query. Domains (create_domain/list_domains/test_domain)
+#      and PPRL (pprl_link/pprl_auto_config) are Python-only subsystems. Plus the
+#      Python-only CLI commands (autoconfig, anomalies, lineage, sensitivity, serve-ui, ...).
+```
+
+- [ ] **Step 2: Note the goldencheck deferral** (comment near the header end)
+
+```yaml
+# NOTE: goldencheck's sole py-only MCP tool `install_domain` is likewise intentional
+# (TS core exposes a read-only domain registry, no install path). That annotation
+# lands in parity/goldencheck.yaml once PR #1449 (the 6-package rollout) merges.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add parity/goldenmatch.yaml
+git commit -m "docs(parity): document intentional Python-only MCP gaps (stateful query, domains, pprl)"
+```
+
+---
+
+## Task 7: Docs sweep + PR
+
+**Files:** doc surfaces listing MCP tool names (per `.claude/doc-surfaces.md` if present).
+
+- [ ] **Step 1: Grep doc surfaces for the canonical tool names**
+
+Run: `grep -rniE "find_duplicates|match_record|explain_match|profile_data|agent_explain_cluster" docs-site docs README*.md 2>/dev/null | grep -viE "spec|plan|parity" | head`
+For each doc that lists the canonical tool, add a one-line note that the alias name also works (e.g. "`find_duplicates` (alias: `dedupe`)"). Keep tool-count claims honest: Python MCP +5, TS MCP +4. Use the rollout-docs-sweep skill's inventory if `.claude/doc-surfaces.md` exists.
+
+- [ ] **Step 2: Run the box-safe Python suite one more time**
+
+Run: `cd packages/python/goldenmatch && POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 ../../../.venv/Scripts/python -m pytest tests/test_mcp_aliases.py -v` and the aggregator test.
+Expected: all PASS.
+
+- [ ] **Step 3: Push + open PR + arm auto-merge (then STOP)**
+
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern
+git push -u origin feat/parity-p0-mcp-aliases
+gh pr create --repo benseverndev-oss/goldenmatch --title "goldenmatch MCP naming-alias parity (P0 + P1 docs)" --body "..."
+gh pr merge --auto --squash    # NO --delete-branch (merge-queue repo)
+```
+
+PR body: summarize P0 (Python 5 + TS 4 aliases, 9 names → shared), the aggregator `profile` fix, P1 header docs, and that goldencheck's note follows #1449. Do NOT poll CI — arm auto-merge and stop.
+
+---
+
+## Notes for the implementer
+
+- **DRY:** alias schemas are *derived* from canonicals on both sides — never hand-copy a schema.
+- **The two-path trap (Python):** aliases go in `_BASE_TOOLS` (a component both advertise paths sum), and `_resolve_alias` is called in BOTH `dispatch` and `call_tool`. Touching only one path advertises-but-can't-serve or serves-but-isn't-listed.
+- **`explain_cluster`** must resolve before the `_AGENT_TOOL_NAMES` check (it's an agent tool); Task 2's test guards this.
+- **TS is CI-only.** Write it, commit it, let CI verify. Do not run vitest/build on the box.
+- **Manifest + code in the same PR** — the `api_parity` gate fails otherwise (that coupling is the point).

--- a/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
@@ -1,0 +1,201 @@
+# goldenmatch MCP naming-alias parity — design
+
+**Status:** approved (brainstorm 2026-07-05), pending spec review
+**Depends on:** the API parity gate (PR #1446, on main) and its 6-package rollout
+(PR #1449, armed) — this closes the P0 gap that gate *surfaced*.
+**Related memory:** `project_api_parity_gate`.
+
+## 1. Problem
+
+The cross-language API parity gate (`scripts/check_api_parity.py` +
+`parity/goldenmatch.yaml`) surfaced that goldenmatch's Python and TypeScript MCP
+servers expose the **same operation under different names**. An agent that learned
+the tool surface against one server cannot call the other by the names it knows:
+
+| Operation            | Python MCP tool     | TypeScript MCP tool |
+| -------------------- | ------------------- | ------------------- |
+| deduplicate a file   | `find_duplicates`   | `dedupe`            |
+| match against ref    | `match_record`      | `match`             |
+| explain a pair score | `explain_match`     | `explain_pair`      |
+| profile a dataset    | `profile_data`      | `profile`           |
+| explain a cluster    | `agent_explain_cluster` (shared) | `explain_cluster` |
+
+The first four are clean 1:1 renames (each name lives in exactly one server's
+`python_only`/`ts_only` partition). The fifth is asymmetric: `agent_explain_cluster`
+is already **shared** (both servers expose it), while TS additionally exposes a
+bare `explain_cluster` doing the same job — so only the bare name diverges.
+
+The gate records these today as declared `python_only` / `ts_only` entries with a
+header note calling them a "real parity bug, FOLLOW-UP to reconcile the aliases."
+This spec is that follow-up.
+
+### Out of scope (deliberately)
+
+- **CLI naming.** The header also flags `info`/`score`/`tui` (TS) vs `interactive`
+  (PY). These are **not** a clean 1:1 rename — `info`/`score`/`tui` are genuinely
+  TS-specific convenience commands and `interactive` is a genuinely Python-only
+  TUI. There is no shared operation hiding under different names, so there is
+  nothing to alias. Left as declared, intentional coverage gaps.
+- **A2A skill naming.** A2A has the *same* divergence (`deduplicate` id in Python
+  vs `dedupe` name with no `id` in the TS agent card), but reconciling it needs
+  the TS agent-card `id` field added first — a larger, separate change. Deferred
+  (parity gate §9 already lists A2A as deferred; it is not yet gated).
+- **The P1 "port the missing tools" idea is dropped.** Recon established the TS
+  MCP surface is *stateless by design* (`dedupe(rows)` returns a `DedupeResult`
+  with `clusters` + `stats` inline — see `src/core/types.ts`), so Python's
+  stateful `get_stats` / `get_cluster` / `list_clusters` query tools have no
+  TS analogue to build, and TS lacks the domains/PPRL subsystems entirely. Those
+  gaps are real and intentional, not bugs. We **document** them (§4), not build them.
+
+## 2. Goal
+
+Make every one of the five operations answerable by **both** names on **both**
+servers, non-breakingly (no existing name changes or is removed). After this
+change the nine alias names move from `python_only`/`ts_only` to `shared` in
+`parity/goldenmatch.yaml`, and the gate enforces that they stay there.
+
+Concretely:
+
+- **Python MCP gains 5 alias tools:** `dedupe`, `match`, `explain_pair`,
+  `profile`, `explain_cluster`.
+- **TypeScript MCP gains 4 alias tools:** `find_duplicates`, `match_record`,
+  `explain_match`, `profile_data`.
+  (No TS `agent_explain_cluster` alias is needed — it is already shared.)
+
+Nine names move to `shared`:
+`dedupe`, `explain_cluster`, `explain_pair`, `find_duplicates`, `explain_match`,
+`match`, `match_record`, `profile`, `profile_data`.
+
+## 3. Design
+
+### 3.1 Aliases are pure name indirection — never a second implementation
+
+Each alias resolves to the **existing** handler. No operation logic is copied.
+An alias tool advertises the **same input schema** as its canonical tool and a
+description of the form `Alias for \`<canonical>\`. <canonical one-liner>`, so a
+client sees an identical calling contract under either name.
+
+### 3.2 Python (`packages/python/goldenmatch/goldenmatch/mcp/server.py`)
+
+The server's `call_tool(name, arguments)` (server.py:862) dispatches by `name`:
+agent tools via `if name in _AGENT_TOOL_NAMES`, then base tools inline. Two edits:
+
+1. **Normalize at the top of `call_tool`.** Add a module-level map and resolve
+   the alias to its canonical name *before* any dispatch branch, so
+   `explain_cluster` correctly routes into the agent-tool path:
+
+   ```python
+   _MCP_TOOL_ALIASES = {
+       "dedupe": "find_duplicates",
+       "match": "match_record",
+       "explain_pair": "explain_match",
+       "profile": "profile_data",
+       "explain_cluster": "agent_explain_cluster",
+   }
+   ```
+   First line of `call_tool`: `name = _MCP_TOOL_ALIASES.get(name, name)`.
+
+2. **Advertise the aliases.** Build 5 alias `Tool` objects (each a copy of its
+   canonical tool's `inputSchema` with the alias `name` and the "Alias for …"
+   description) and append them to the exported `TOOLS` list so `list_tools`
+   and the parity emitter both see them. A small helper derives the alias tools
+   from `_MCP_TOOL_ALIASES` + the canonical `Tool` objects rather than
+   hand-writing five schemas (DRY; a schema change to a canonical tool
+   automatically flows to its alias).
+
+`len(TOOLS)` grows by exactly 5; the parity smoke test (which asserts the emitter
+count equals the measured `len(TOOLS)`) keeps that honest.
+
+### 3.3 TypeScript (`packages/typescript/goldenmatch/src/node/mcp/server.ts`)
+
+`TOOLS` (server.ts:369) = `[...EXISTING_TOOLS, ...MEMORY_TOOLS, ...IDENTITY_TOOLS,
+...AGENT_MCP_TOOLS]`. The four target ops live in `EXISTING_TOOLS` and are
+dispatched by the `switch (name)` in `handleTool` (~server.ts:509). Two edits:
+
+1. **Advertise the aliases.** Append 4 alias `Tool` defs to `EXISTING_TOOLS`
+   (or a dedicated `ALIAS_TOOLS` array folded into the `TOOLS` spread), each
+   carrying the canonical tool's `inputSchema` with the alias `name` +
+   "Alias for …" description. Derive them from a
+   `{ find_duplicates: "dedupe", match_record: "match", explain_match:
+   "explain_pair", profile_data: "profile" }` map applied over the canonical
+   defs (mirror of the Python helper).
+
+2. **Dispatch the aliases.** Stack each alias as a fall-through `case` above its
+   canonical case, e.g.:
+   ```ts
+   case "find_duplicates":
+   case "dedupe": { /* existing dedupe body */ }
+   ```
+   No body is duplicated — the alias label falls through to the canonical block.
+
+### 3.4 Manifest (`parity/goldenmatch.yaml`)
+
+Move the nine names into `mcp_tools.shared` (keeping every partition sorted and
+disjoint — the gate's structural check enforces both). Remove them from
+`python_only` (`find_duplicates`, `match_record`, `explain_match`, `profile_data`)
+and `ts_only` (`dedupe`, `match`, `explain_pair`, `profile`, `explain_cluster`).
+Update the header: category 1 ("naming divergence … FOLLOW-UP") becomes "resolved
+via non-breaking aliases (both servers answer to both names)."
+
+This manifest edit lands in the **same PR** as the code (the gate fails otherwise —
+that coupling is the whole point of the gate).
+
+## 4. P1 documentation — intentional gaps, no code
+
+Refine the manifest header(s) so the remaining Python-only / TS-only entries read
+as deliberate decisions rather than unexamined drift:
+
+- **`parity/goldenmatch.yaml`:** extend category 2 to name the stateful query tools
+  explicitly — `get_stats` / `get_cluster` / `list_clusters` are Python-only
+  **because** the TS MCP is stateless (`dedupe` returns `stats` + `clusters`
+  inline via `DedupeResult`), so there is no server-held dataset to query. Note
+  domains (`create_domain`/`list_domains`/`test_domain`) and PPRL
+  (`pprl_link`/`pprl_auto_config`) are Python-only because those subsystems are
+  Python-only.
+- **`parity/goldencheck.yaml`:** annotate `install_domain` (its sole py-only MCP
+  tool) as intentional — the TS core exposes a read-only domain registry
+  (`listAvailableDomains`/`getDomainTypes`, no install path).
+  **Sequencing:** `parity/goldencheck.yaml` is created by PR #1449 (not yet on
+  main). If #1449 has merged when this work lands, fold the goldencheck header
+  note into this PR; otherwise it is a one-line follow-up after #1449 merges.
+  This PR does not block on #1449.
+
+## 5. Testing
+
+- **Python (box-safe, runs locally with `goldenmatch[mcp]`):**
+  - `list_tools` now contains all five alias names, and each alias's
+    `inputSchema` equals its canonical tool's schema.
+  - `await call_tool("dedupe", args)` returns byte-identical output to
+    `call_tool("find_duplicates", args)` on a small fixture; same for the other
+    four pairs (`explain_cluster` vs `agent_explain_cluster`).
+  - The existing parity smoke test (`scripts/test_api_parity.py`) still passes
+    with the emitter count matching the grown `len(TOOLS)`.
+- **TypeScript (CI-only — the box OOMs TS builds):**
+  - `TOOLS` contains the four alias names; a unit test asserts calling
+    `find_duplicates` and `dedupe` through `handleTool` yields identical results
+    on a fixture (same for the other three pairs).
+- **Gate (CI):** `check_api_parity.py goldenmatch` is green with the nine names in
+  `shared`. As a red/green teeth check, moving one alias out of `shared` in the
+  manifest must fail the gate (already covered by the gate's own unit tests; no
+  new gate test needed).
+
+## 6. Rollout / docs
+
+- Single PR: Python aliases + TS aliases + `parity/goldenmatch.yaml` update +
+  P1 header notes. Branch `feat/parity-p0-mcp-aliases` off `origin/main`.
+  benzsevern gh; merge-queue repo → `gh pr merge --auto --squash` (no
+  `--delete-branch`); arm auto-merge and stop.
+- Docs sweep (rollout-docs-sweep): the MCP tool reference / tuning docs list tool
+  names — add the alias names where the canonical tools are documented, noting
+  they are aliases. Keep tool-count claims honest (Python MCP +5, TS MCP +4).
+
+## 7. Risks
+
+- **Low.** Purely additive — no existing tool name changes or is removed, so no
+  client breaks. The only behavioral surface is five/four *new* names that
+  forward to audited handlers.
+- **Schema drift between alias and canonical** is prevented by deriving alias
+  schemas from the canonical `Tool` objects (not hand-copying), on both sides.
+- **`explain_cluster` routing:** the Python alias must be normalized *before* the
+  `_AGENT_TOOL_NAMES` check so it reaches the agent handler; the test in §5
+  covers this exact path.

--- a/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
@@ -77,12 +77,28 @@ client sees an identical calling contract under either name.
 
 ### 3.2 Python (`packages/python/goldenmatch/goldenmatch/mcp/server.py`)
 
-The server's `call_tool(name, arguments)` (server.py:862) dispatches by `name`:
-agent tools via `if name in _AGENT_TOOL_NAMES`, then base tools inline. Two edits:
+**Critical:** goldenmatch's Python MCP has *two* advertise paths and *two*
+dispatch paths, not one. The fix must funnel aliases through the shared
+**component** structures both paths reference, not the top-level composed objects.
 
-1. **Normalize at the top of `call_tool`.** Add a module-level map and resolve
-   the alias to its canonical name *before* any dispatch branch, so
-   `explain_cluster` correctly routes into the agent-tool path:
+- **Advertise path A** — the `@server.list_tools` handler (server.py:618-620)
+  does **not** return the composed `TOOLS` var; it *rebuilds the sum inline*:
+  `return AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS`.
+- **Advertise path B** — the exported `TOOLS` var (server.py:585, same sum) is
+  what the parity emitter (`emit_python_surface.py`) and smoke test import.
+- **Dispatch path A** — the `@server.call_tool` handler (server.py:862), used by
+  the standalone server; agent tools via `if name in _AGENT_TOOL_NAMES` (:871),
+  then base tools.
+- **Dispatch path B** — the module-level `dispatch(name, args)` (server.py:588),
+  used by the `goldensuite-mcp` aggregator (`goldensuite_mcp/server.py:50` does
+  `return _normalize_tools(list(gm.TOOLS)), gm.dispatch`). Same name-routing,
+  separate function.
+
+Appending aliases only to the `TOOLS` var (path B) or normalizing only in
+`call_tool` (dispatch A) would advertise aliases the live/aggregated servers
+can't serve. Three edits:
+
+1. **One alias map + one resolver helper (shared by both dispatch paths).**
 
    ```python
    _MCP_TOOL_ALIASES = {
@@ -92,16 +108,27 @@ agent tools via `if name in _AGENT_TOOL_NAMES`, then base tools inline. Two edit
        "profile": "profile_data",
        "explain_cluster": "agent_explain_cluster",
    }
-   ```
-   First line of `call_tool`: `name = _MCP_TOOL_ALIASES.get(name, name)`.
 
-2. **Advertise the aliases.** Build 5 alias `Tool` objects (each a copy of its
-   canonical tool's `inputSchema` with the alias `name` and the "Alias for …"
-   description) and append them to the exported `TOOLS` list so `list_tools`
-   and the parity emitter both see them. A small helper derives the alias tools
-   from `_MCP_TOOL_ALIASES` + the canonical `Tool` objects rather than
-   hand-writing five schemas (DRY; a schema change to a canonical tool
-   automatically flows to its alias).
+   def _resolve_alias(name: str) -> str:
+       return _MCP_TOOL_ALIASES.get(name, name)
+   ```
+
+2. **Normalize at the top of BOTH dispatch functions.** First line of
+   `dispatch` (server.py:588) *and* of the `call_tool` handler (server.py:862):
+   `name = _resolve_alias(name)`. Placing it before the `_AGENT_TOOL_NAMES`
+   check in each means `explain_cluster` routes into the agent path correctly.
+
+3. **Advertise via a component list, not the composed var.** Build an
+   `ALIAS_TOOLS` list of 5 `Tool` objects (each derived from its canonical
+   tool's `inputSchema` with the alias `name` + "Alias for `<canonical>`. …"
+   description — a helper reads `_MCP_TOOL_ALIASES` + the canonical `Tool`
+   objects so schemas never diverge) and **append it to `_BASE_TOOLS`**.
+   Because both advertise paths sum `_BASE_TOOLS`, this single append flows into
+   the live `list_tools` (path A), the exported `TOOLS` var (path B), and the
+   aggregator (which reads `gm.TOOLS`). `_BASE_TOOLS` is chosen because it is
+   summed by every path; the alias for `explain_cluster` still *dispatches* to
+   the agent handler via the resolver — the advertising list is orthogonal to
+   the routing.
 
 `len(TOOLS)` grows by exactly 5; the parity smoke test (which asserts the emitter
 count equals the measured `len(TOOLS)`) keeps that honest.
@@ -163,11 +190,17 @@ as deliberate decisions rather than unexamined drift:
 ## 5. Testing
 
 - **Python (box-safe, runs locally with `goldenmatch[mcp]`):**
-  - `list_tools` now contains all five alias names, and each alias's
-    `inputSchema` equals its canonical tool's schema.
-  - `await call_tool("dedupe", args)` returns byte-identical output to
-    `call_tool("find_duplicates", args)` on a small fixture; same for the other
-    four pairs (`explain_cluster` vs `agent_explain_cluster`).
+  - The live `list_tools` handler (not just the `TOOLS` var) returns all five
+    alias names, and each alias's `inputSchema` equals its canonical tool's
+    schema. Assert against the handler from `create_server`, so a regression to
+    advertise-path-A is caught.
+  - **Dispatch path A:** `dispatch("dedupe", args)` returns byte-identical output
+    to `dispatch("find_duplicates", args)` on a small fixture; same for the other
+    four pairs, including `dispatch("explain_cluster", …)` ==
+    `dispatch("agent_explain_cluster", …)` (the agent-route case). This is the
+    aggregator path — the one Issue 2 flagged as previously unrouted.
+  - The `call_tool` handler resolves the same aliases (a lighter test, since both
+    now share `_resolve_alias`).
   - The existing parity smoke test (`scripts/test_api_parity.py`) still passes
     with the emitter count matching the grown `len(TOOLS)`.
 - **TypeScript (CI-only — the box OOMs TS builds):**
@@ -199,3 +232,10 @@ as deliberate decisions rather than unexamined drift:
 - **`explain_cluster` routing:** the Python alias must be normalized *before* the
   `_AGENT_TOOL_NAMES` check so it reaches the agent handler; the test in §5
   covers this exact path.
+- **Two-path drift (the main implementation trap):** Python advertises via two
+  paths (composed `TOOLS` var + inline `list_tools` rebuild) and dispatches via
+  two (`call_tool` + module-level `dispatch` for the suite aggregator). Aliases
+  that touch only one path advertise-but-can't-serve or serve-but-aren't-listed.
+  §3.2 funnels through the shared `_BASE_TOOLS` component + a shared
+  `_resolve_alias` called by both dispatchers so they cannot drift; §5 tests the
+  aggregator `dispatch` path explicitly.

--- a/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
+++ b/docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md
@@ -155,7 +155,42 @@ dispatched by the `switch (name)` in `handleTool` (~server.ts:509). Two edits:
    ```
    No body is duplicated — the alias label falls through to the canonical block.
 
-### 3.4 Manifest (`parity/goldenmatch.yaml`)
+### 3.4 Suite aggregator (`packages/python/goldensuite-mcp/goldensuite_mcp/server.py`)
+
+The aggregator composes every package's `gm.TOOLS` under first-wins precedence,
+goldenmatch first (`_SUITE_ORDER`, server.py:126-133; collision logic :159-167).
+goldencheck already ships a distinct MCP tool named **`profile`** (an A–F *file*
+health score — goldencheck server.py:83). Today goldenmatch has no `profile`, so
+the suite's `profile` resolves to goldencheck. Once goldenmatch's `profile` alias
+lands in `gm.TOOLS`, it would register first and **silently shadow** goldencheck's
+`profile` (a `tool collision` warning + the suite's `profile` flips meaning).
+
+The aliases are a goldenmatch-*internal* Python↔TS naming concern; the aggregated
+suite has one surface per operation, so exposing both `dedupe` and
+`find_duplicates` (both → goldenmatch) is noise, and the `profile` flip is a
+regression. **Fix: exclude goldenmatch's alias names from the aggregated
+surface.** In `_adapt_goldenmatch` (server.py:48), filter the tool list:
+
+```python
+def _adapt_goldenmatch():
+    from goldenmatch.mcp import server as gm
+    aliases = set(gm._MCP_TOOL_ALIASES)
+    tools = [t for t in gm.TOOLS if t.name not in aliases]
+    return _normalize_tools(tools), gm.dispatch
+```
+
+`gm.dispatch` still resolves aliases (harmless — the suite just never advertises
+them). This keeps §3.2 intact (the single `_BASE_TOOLS` append still feeds the
+gate + standalone server); only the aggregated surface is trimmed. The suite's
+`profile` stays goldencheck's file-profiler; goldenmatch's canonical names
+(`find_duplicates`/`match_record`/`explain_match`/`profile_data`/
+`agent_explain_cluster`) remain the suite's goldenmatch surface, unchanged.
+
+(Only `profile` actually collides across packages — a grep of `**/mcp/**` shows
+the other eight alias names are unique — but filtering the whole alias set is
+simpler and correct than special-casing `profile`.)
+
+### 3.5 Manifest (`parity/goldenmatch.yaml`)
 
 Move the nine names into `mcp_tools.shared` (keeping every partition sorted and
 disjoint — the gate's structural check enforces both). Remove them from
@@ -203,6 +238,10 @@ as deliberate decisions rather than unexamined drift:
     now share `_resolve_alias`).
   - The existing parity smoke test (`scripts/test_api_parity.py`) still passes
     with the emitter count matching the grown `len(TOOLS)`.
+  - **Aggregator (§3.4):** after aggregation, the suite's `profile` tool still
+    dispatches to goldencheck (not goldenmatch), and none of goldenmatch's nine
+    alias names appear in the aggregated tool list. This locks in the exclusion
+    so the collision can't regress silently.
 - **TypeScript (CI-only — the box OOMs TS builds):**
   - `TOOLS` contains the four alias names; a unit test asserts calling
     `find_duplicates` and `dedupe` through `handleTool` yields identical results

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- **MCP naming aliases for cross-language parity.** The Python and TypeScript MCP servers previously exposed the same operations under different names (`find_duplicates`/`dedupe`, `match_record`/`match`, `explain_match`/`explain_pair`, `profile_data`/`profile`, plus TS's `explain_cluster`). Both servers now answer to both names via non-breaking aliases, so an agent trained against either server can call the other. The Python server gains `dedupe`/`match`/`explain_pair`/`profile`/`explain_cluster`; the TypeScript server gains `find_duplicates`/`match_record`/`explain_match`/`profile_data`. The API-parity gate enforces the nine names stay `shared` in `parity/goldenmatch.yaml`. Aliases are excluded from the `goldensuite-mcp` aggregated surface so the suite's `profile` still resolves to goldencheck's file-profiler.
+
 ## [2.8.0] - 2026-07-02
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -581,6 +581,42 @@ _BASE_TOOLS = [
     ),
 ]
 
+# --- Cross-language naming aliases (Python<->TS MCP parity) -----------------
+# Each alias forwards to an EXISTING handler; no operation logic is duplicated.
+# See docs/superpowers/specs/2026-07-05-mcp-naming-aliases-parity-design.md.
+_MCP_TOOL_ALIASES = {
+    "dedupe": "find_duplicates",
+    "match": "match_record",
+    "explain_pair": "explain_match",
+    "profile": "profile_data",
+    "explain_cluster": "agent_explain_cluster",
+}
+
+
+def _resolve_alias(name: str) -> str:
+    """Map an alias tool name to its canonical name (identity for non-aliases)."""
+    return _MCP_TOOL_ALIASES.get(name, name)
+
+
+def _build_alias_tools() -> list[Tool]:
+    """Derive alias Tool objects from their canonical tools so schemas can't drift.
+    Canonicals live in AGENT_TOOLS (agent_explain_cluster) + _BASE_TOOLS (the rest)."""
+    canon = {t.name: t for t in AGENT_TOOLS + _BASE_TOOLS}
+    tools = []
+    for alias, target in _MCP_TOOL_ALIASES.items():
+        c = canon[target]
+        tools.append(Tool(
+            name=alias,
+            description=f"Alias for `{target}`. {c.description}",
+            inputSchema=c.inputSchema,
+        ))
+    return tools
+
+
+# Append aliases to the shared _BASE_TOOLS component so BOTH advertise paths
+# (the TOOLS var below AND the inline list_tools rebuild) pick them up.
+_BASE_TOOLS += _build_alias_tools()
+
 # TOOLS is the union of agent tools + memory tools + base tools, in the same order list_tools returns.
 TOOLS = AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -628,6 +628,7 @@ def dispatch(name: str, args: dict) -> dict:
     memory tools via memory_tools._dispatch, and base tool calls to
     _handle_tool. Returns a JSON-serializable dict for all.
     """
+    name = _resolve_alias(name)
     if name in _AGENT_TOOL_NAMES:
         from goldenmatch.core.agent import AgentSession
         from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
@@ -896,6 +897,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+        name = _resolve_alias(name)
         # Anonymous, opt-in usage event: the TOOL NAME only -- never `arguments`
         # (which can carry user data). No-op unless GOLDENMATCH_ANALYTICS=1.
         try:

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1743,7 +1743,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 69 MCP tools for matching, semantic retrieval, explaining, reviewing, evaluating, blocking analysis, config critique, config healing, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 74 MCP tools for matching, semantic retrieval, explaining, reviewing, evaluating, blocking analysis, config critique, config healing, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/tests/test_mcp_aliases.py
+++ b/packages/python/goldenmatch/tests/test_mcp_aliases.py
@@ -1,0 +1,40 @@
+"""Alias parity for the goldenmatch MCP server. Box-safe: needs goldenmatch[mcp].
+Run: POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 python -m pytest tests/test_mcp_aliases.py -v"""
+import pytest
+from goldenmatch.mcp import server as gm
+
+EXPECTED_ALIASES = {
+    "dedupe": "find_duplicates",
+    "match": "match_record",
+    "explain_pair": "explain_match",
+    "profile": "profile_data",
+    "explain_cluster": "agent_explain_cluster",
+}
+
+
+def test_alias_map_is_exactly_the_five_pairs():
+    assert gm._MCP_TOOL_ALIASES == EXPECTED_ALIASES
+
+
+def test_resolve_alias_maps_each_alias_to_canonical():
+    for alias, canonical in EXPECTED_ALIASES.items():
+        assert gm._resolve_alias(alias) == canonical
+    assert gm._resolve_alias("find_duplicates") == "find_duplicates"
+    assert gm._resolve_alias("nonexistent") == "nonexistent"
+
+
+def test_aliases_are_advertised_in_the_base_component():
+    base_names = {t.name for t in gm._BASE_TOOLS}
+    assert set(EXPECTED_ALIASES) <= base_names
+
+
+def test_aliases_appear_in_TOOLS_union():
+    names = {t.name for t in gm.TOOLS}
+    assert set(EXPECTED_ALIASES) <= names
+
+
+def test_alias_schema_matches_canonical():
+    by_name = {t.name: t for t in gm.TOOLS}
+    for alias, canonical in EXPECTED_ALIASES.items():
+        assert by_name[alias].inputSchema == by_name[canonical].inputSchema
+        assert canonical in (by_name[alias].description or "")

--- a/packages/python/goldenmatch/tests/test_mcp_aliases.py
+++ b/packages/python/goldenmatch/tests/test_mcp_aliases.py
@@ -1,6 +1,5 @@
 """Alias parity for the goldenmatch MCP server. Box-safe: needs goldenmatch[mcp].
 Run: POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 python -m pytest tests/test_mcp_aliases.py -v"""
-import pytest
 from goldenmatch.mcp import server as gm
 
 EXPECTED_ALIASES = {

--- a/packages/python/goldenmatch/tests/test_mcp_aliases.py
+++ b/packages/python/goldenmatch/tests/test_mcp_aliases.py
@@ -38,3 +38,38 @@ def test_alias_schema_matches_canonical():
     for alias, canonical in EXPECTED_ALIASES.items():
         assert by_name[alias].inputSchema == by_name[canonical].inputSchema
         assert canonical in (by_name[alias].description or "")
+
+
+import csv
+from pathlib import Path
+
+
+def _tiny_csv(tmp_path: Path) -> str:
+    p = tmp_path / "people.csv"
+    with p.open("w", newline="") as f:
+        w = csv.writer(f)
+        w.writerow(["id", "name", "email"])
+        w.writerow(["1", "Alice Smith", "alice@example.com"])
+        w.writerow(["2", "Alice Smith", "alice@example.com"])
+        w.writerow(["3", "Bob Jones", "bob@example.com"])
+    return str(p)
+
+
+def test_dispatch_routes_alias_to_canonical_handler(tmp_path, monkeypatch):
+    # The aggregator entrypoint (module-level dispatch) must resolve aliases.
+    # profile_data takes NO path arg — it reads the loaded engine (None until
+    # _initialize). Preload, then call both with {}. dispatch() has no try/except,
+    # so an unresolved alias raises out of the first call (the pre-fix failure).
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    path = _tiny_csv(tmp_path)
+    from goldenmatch.mcp import server as gm
+    gm._initialize([path])
+    via_alias = gm.dispatch("profile", {})
+    via_canonical = gm.dispatch("profile_data", {})
+    assert via_alias == via_canonical
+
+
+def test_dispatch_explain_cluster_resolves_into_agent_path():
+    from goldenmatch.mcp import server as gm
+    assert gm._resolve_alias("explain_cluster") == "agent_explain_cluster"
+    assert "agent_explain_cluster" in gm._AGENT_TOOL_NAMES

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -26,9 +26,9 @@ def test_total_tool_count_is_69():
     assert len(AGENT_TOOLS) == 18   # +1 retrieve_similar (#1089)
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
-    assert len(_BASE_TOOLS) == 26   # +1 config_weaknesses +1 review_config (healer)
+    assert len(_BASE_TOOLS) == 31   # 26 + 5 cross-language naming aliases (#1451)
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 69
+    assert len(TOOLS) == 74   # 69 + 5 cross-language naming aliases (#1451)
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -164,4 +164,4 @@ def test_server_card_description_count():
     text = server_path.read_text(encoding="utf-8")
     match = re.search(r"(\d+) MCP tools", text)
     assert match is not None
-    assert int(match.group(1)) == 69
+    assert int(match.group(1)) == 74   # 69 + 5 cross-language naming aliases (#1451)

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -47,7 +47,13 @@ def _normalize_tools(raw_tools: list) -> list[Tool]:
 def _adapt_goldenmatch() -> tuple[list[Tool], Callable[[str, dict], dict]]:
     from goldenmatch.mcp import server as gm
 
-    return _normalize_tools(list(gm.TOOLS)), gm.dispatch
+    # Exclude goldenmatch's internal Python<->TS naming aliases from the
+    # aggregated surface: the suite has one surface per operation, and the
+    # `profile` alias would otherwise shadow goldencheck's `profile` tool.
+    # gm.dispatch still resolves aliases (harmless — they're just never listed here).
+    aliases = set(gm._MCP_TOOL_ALIASES)
+    tools = [t for t in gm.TOOLS if t.name not in aliases]
+    return _normalize_tools(tools), gm.dispatch
 
 
 def _adapt_goldencheck() -> tuple[list[Tool], Callable[[str, dict], dict]]:

--- a/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
+++ b/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
@@ -139,8 +139,8 @@ def test_dispatch_routes_goldenmatch_tools(name):
 
 def test_suite_profile_stays_goldencheck_not_goldenmatch_alias():
     """goldenmatch's new `profile` alias must NOT shadow goldencheck's `profile`."""
-    from goldensuite_mcp.server import _aggregate
     from goldenmatch.mcp import server as gm
+    from goldensuite_mcp.server import _aggregate
     tools, name_to_dispatch = _aggregate()
     names = {t.name for t in tools}
     assert "profile" in names
@@ -154,8 +154,8 @@ def test_no_goldenmatch_alias_is_served_by_goldenmatch_in_the_suite():
     # goldenmatch alias key AND a legitimate goldencheck tool, so it may still
     # appear in the surface (served by goldencheck). What must never happen is a
     # goldenmatch alias being SERVED BY goldenmatch through the suite.
-    from goldensuite_mcp.server import _aggregate
     from goldenmatch.mcp import server as gm
+    from goldensuite_mcp.server import _aggregate
     tools, name_to_dispatch = _aggregate()
     names = {t.name for t in tools}
     served_by_gm = [n for n in gm._MCP_TOOL_ALIASES

--- a/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
+++ b/packages/python/goldensuite-mcp/tests/test_aggregator_smoke.py
@@ -135,3 +135,32 @@ def test_dispatch_routes_goldenmatch_tools(name):
         # Structured errors from the handler are fine; bare crashes are not.
         msg = str(e).lower()
         assert "unknown tool" not in msg, f"{name} not routed: {e}"
+
+
+def test_suite_profile_stays_goldencheck_not_goldenmatch_alias():
+    """goldenmatch's new `profile` alias must NOT shadow goldencheck's `profile`."""
+    from goldensuite_mcp.server import _aggregate
+    from goldenmatch.mcp import server as gm
+    tools, name_to_dispatch = _aggregate()
+    names = {t.name for t in tools}
+    assert "profile" in names
+    # gm.dispatch is the one stable identity; goldencheck's adapter returns a
+    # fresh closure with no module-level symbol to compare against.
+    assert name_to_dispatch["profile"] is not gm.dispatch
+
+
+def test_no_goldenmatch_alias_is_served_by_goldenmatch_in_the_suite():
+    # The real invariant is OWNERSHIP, not name-absence: `profile` is BOTH a
+    # goldenmatch alias key AND a legitimate goldencheck tool, so it may still
+    # appear in the surface (served by goldencheck). What must never happen is a
+    # goldenmatch alias being SERVED BY goldenmatch through the suite.
+    from goldensuite_mcp.server import _aggregate
+    from goldenmatch.mcp import server as gm
+    tools, name_to_dispatch = _aggregate()
+    names = {t.name for t in tools}
+    served_by_gm = [n for n in gm._MCP_TOOL_ALIASES
+                    if name_to_dispatch.get(n) is gm.dispatch]
+    assert served_by_gm == []
+    # The 4 non-colliding aliases don't leak into the surface at all (only
+    # `profile` collides with another package's real tool).
+    assert not ((set(gm._MCP_TOOL_ALIASES) - {"profile"}) & names)

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -366,8 +366,25 @@ const EXISTING_TOOLS: readonly Tool[] = [
   },
 ];
 
+// Cross-language naming aliases (Python<->TS MCP parity). Each forwards to an
+// existing handler via a fall-through switch case below; schemas are derived
+// from the canonical tool so they can't drift.
+const _TS_TOOL_ALIASES: Record<string, string> = {
+  find_duplicates: "dedupe",
+  match_record: "match",
+  explain_match: "explain_pair",
+  profile_data: "profile",
+};
+
+const ALIAS_TOOLS: Tool[] = Object.entries(_TS_TOOL_ALIASES).map(([alias, canonical]) => {
+  const c = EXISTING_TOOLS.find((t) => t.name === canonical);
+  if (!c) throw new Error(`alias canonical not found: ${canonical}`);
+  return { ...c, name: alias, description: `Alias for \`${canonical}\`. ${c.description}` };
+});
+
 export const TOOLS: readonly Tool[] = [
   ...EXISTING_TOOLS,
+  ...ALIAS_TOOLS,
   ...MEMORY_TOOLS,
   ...IDENTITY_TOOLS,
   ...AGENT_MCP_TOOLS,
@@ -507,6 +524,7 @@ export async function handleTool(
       return await handleAgentTool(name, args);
     }
     switch (name) {
+      case "find_duplicates":   // alias
       case "dedupe": {
         const path = sanitizePath(String(args["path"]));
         const rows = readFile(path);
@@ -540,6 +558,7 @@ export async function handleTool(
         };
       }
 
+      case "match_record":      // alias
       case "match": {
         const targetPath = sanitizePath(String(args["target"]));
         const referencePath = sanitizePath(String(args["reference"]));
@@ -590,6 +609,7 @@ export async function handleTool(
         return { score, field_count: fields.length };
       }
 
+      case "explain_match":     // alias
       case "explain_pair": {
         const rowA = args["row_a"] as Row;
         const rowB = args["row_b"] as Row;
@@ -664,6 +684,7 @@ export async function handleTool(
         };
       }
 
+      case "profile_data":      // alias
       case "profile": {
         const path = sanitizePath(String(args["path"]));
         const rows = readFile(path);

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,7 +4,7 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 45 tools covering dedupe, match, scoring, explanation,
+ * Exposes 49 tools covering dedupe, match, scoring, explanation,
  * profiling, auto-config (shorthand), evaluation, listings, Learning
  * Memory (5 memory tools via MEMORY_TOOLS), the Identity Graph
  * (6 identity tools via IDENTITY_TOOLS), and the AgentSession skills

--- a/packages/typescript/goldenmatch/tests/unit/mcp-aliases.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-aliases.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { TOOLS, handleTool } from "../../src/node/mcp/server.js";
+
+const ALIAS_TO_CANONICAL: Record<string, string> = {
+  find_duplicates: "dedupe",
+  match_record: "match",
+  explain_match: "explain_pair",
+  profile_data: "profile",
+};
+
+describe("MCP naming aliases", () => {
+  it("advertises all four alias names", () => {
+    const names = new Set(TOOLS.map((t) => t.name));
+    for (const alias of Object.keys(ALIAS_TO_CANONICAL)) {
+      expect(names.has(alias)).toBe(true);
+    }
+  });
+
+  it("each alias schema equals its canonical schema", () => {
+    const byName = new Map(TOOLS.map((t) => [t.name, t]));
+    for (const [alias, canonical] of Object.entries(ALIAS_TO_CANONICAL)) {
+      expect(byName.get(alias)!.inputSchema).toEqual(byName.get(canonical)!.inputSchema);
+      expect(byName.get(alias)!.description).toContain(canonical);
+    }
+  });
+
+  it("profile_data dispatches identically to profile", async () => {
+    const viaAlias = await handleTool("profile_data", { path: "nonexistent_xyz.csv" });
+    const viaCanonical = await handleTool("profile", { path: "nonexistent_xyz.csv" });
+    expect(viaAlias).toEqual(viaCanonical);
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
@@ -183,8 +183,8 @@ describe("MCP server — handleTool dispatcher", () => {
 });
 
 describe("MCP server — agent tools wiring", () => {
-  it("TOOLS exposes 45 tools (agent wave-2 + healer review_config)", () => {
-    expect(TOOLS.length).toBe(45);
+  it("TOOLS exposes 49 tools (45 + 4 cross-language naming aliases, #1451)", () => {
+    expect(TOOLS.length).toBe(49);
   });
 
   it("TOOLS includes the agent skill names", () => {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -6,11 +6,11 @@
 # remove/rename of a tool or command must be reflected here in the same PR.
 #
 # Review of the current gaps (three categories):
-#   1. NAMING DIVERGENCE (same operation, different name per server — a real parity bug,
-#      FOLLOW-UP to reconcile the aliases): dedupe(TS)/find_duplicates(PY),
-#      match(TS)/match_record(PY), explain_pair(TS)/explain_match(PY),
-#      profile(TS)/profile_data(PY); CLI info/score/tui(TS) vs interactive(PY).
-#      (Core agent_deduplicate / agent_match_sources ARE shared — only the aliases drift.)
+#   1. NAMING ALIASES (resolved 2026-07-05 via non-breaking aliases — both
+#      servers now answer to both names, so these are shared: dedupe/find_duplicates,
+#      match/match_record, explain_pair/explain_match, profile/profile_data, and
+#      explain_cluster (alias of the shared agent_explain_cluster)). CLI info/score/
+#      tui(TS) vs interactive(PY) are NOT aliases (distinct ops) — left as coverage gaps.
 #   2. PYTHON-RICHER COVERAGE (intentional — Python is the fuller server): identity-audit
 #      trio, routing tools, pprl_link, domain management, learning-memory plugins, and the
 #      Python-only CLI commands (autoconfig, anomalies, lineage, sensitivity, serve-ui, ...).
@@ -42,7 +42,12 @@ mcp_tools:
   - analyze_data
   - auto_configure
   - controller_telemetry
+  - dedupe
   - evaluate
+  - explain_cluster
+  - explain_match
+  - explain_pair
+  - find_duplicates
   - fix_quality
   - identity_conflicts
   - identity_history
@@ -52,8 +57,12 @@ mcp_tools:
   - identity_split
   - learn_thresholds
   - list_corrections
+  - match
+  - match_record
   - memory_export
   - memory_stats
+  - profile
+  - profile_data
   - review_config
   - run_transforms
   - scan_quality
@@ -65,10 +74,8 @@ mcp_tools:
   - compare_clusters
   - config_weaknesses
   - create_domain
-  - explain_match
   - explain_routing
   - export_results
-  - find_duplicates
   - get_cluster
   - get_golden_record
   - get_stats
@@ -88,12 +95,10 @@ mcp_tools:
   - list_domains
   - list_plugins
   - list_runs
-  - match_record
   - memory_import
   - plan_routing
   - pprl_auto_config
   - pprl_link
-  - profile_data
   - retrieve_similar
   - rollback
   - schema_match
@@ -103,17 +108,12 @@ mcp_tools:
   - unmerge_record
   ts_only:
   - build_clusters
-  - dedupe
-  - explain_cluster
-  - explain_pair
   - find_exact_matches
   - find_fuzzy_matches
   - list_blocking_strategies
   - list_scorers
   - list_strategies
   - list_transforms
-  - match
-  - profile
   - read_file
   - score_pair
   - score_strings

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -11,11 +11,19 @@
 #      match/match_record, explain_pair/explain_match, profile/profile_data, and
 #      explain_cluster (alias of the shared agent_explain_cluster)). CLI info/score/
 #      tui(TS) vs interactive(PY) are NOT aliases (distinct ops) — left as coverage gaps.
-#   2. PYTHON-RICHER COVERAGE (intentional — Python is the fuller server): identity-audit
-#      trio, routing tools, pprl_link, domain management, learning-memory plugins, and the
-#      Python-only CLI commands (autoconfig, anomalies, lineage, sensitivity, serve-ui, ...).
+#   2. PYTHON-RICHER COVERAGE (intentional — Python is the fuller, STATEFUL server):
+#      get_stats / get_cluster / list_clusters are Python-only BECAUSE the TS MCP is
+#      stateless — its dedupe() returns stats + clusters inline (DedupeResult), so there
+#      is no server-held dataset to query. Domains (create_domain/list_domains/test_domain)
+#      and PPRL (pprl_link/pprl_auto_config) are Python-only subsystems. Plus identity-audit
+#      trio, routing tools, learning-memory plugins, and the Python-only CLI commands
+#      (autoconfig, anomalies, lineage, sensitivity, serve-ui, ...).
 #   3. TS-SPECIFIC PRIMITIVES (intentional — edge helpers): score_strings, score_pair,
 #      find_exact_matches, find_fuzzy_matches, read_file, write_csv, server_info.
+#
+# NOTE: goldencheck's sole py-only MCP tool `install_domain` is likewise intentional
+# (TS core exposes a read-only domain registry, no install path). That annotation
+# lands in parity/goldencheck.yaml once PR #1449 (the 6-package rollout) merges.
 #
 # a2a_skills surface (A2A AgentCard skills). The core ops share canonical ids and ARE shared
 # (deduplicate, match, explain, evaluate, identity_* , learn_thresholds, memory_stats, ...).


### PR DESCRIPTION
## What

Closes the goldenmatch cross-language MCP naming divergence the API parity gate surfaced: the Python and TypeScript MCP servers exposed the same operations under different names. Both servers now answer to **both** names via non-breaking aliases, and the nine names move to `shared` in `parity/goldenmatch.yaml` (the gate enforces it).

**P0 — aliases (non-breaking, both servers answer to both names):**
- **Python MCP** gains 5 aliases: `dedupe`, `match`, `explain_pair`, `profile`, `explain_cluster` — via one alias map + a shared `_resolve_alias()` called by **both** dispatch entrypoints (`call_tool` + the module-level `dispatch` used by `goldensuite-mcp`), plus derived alias `Tool` objects appended to the `_BASE_TOOLS` component so **both** advertise paths (the `TOOLS` var and the inline `list_tools` rebuild) list them.
- **TypeScript MCP** gains 4 aliases: `find_duplicates`, `match_record`, `explain_match`, `profile_data` — derived alias defs + fall-through `switch` cases (no handler logic duplicated).
- Alias schemas are **derived** from their canonical tools on both sides, so they can't drift.

**Suite aggregator:** `goldensuite-mcp` excludes goldenmatch's aliases from the aggregated surface, so the suite's `profile` still resolves to goldencheck's file-profiler (goldenmatch is first-wins and would otherwise shadow it).

**P1 — documentation (no code):** annotated the remaining Python-only MCP gaps in the manifest header as intentional (stateful query tools have no TS analogue because the TS MCP is stateless; domains + PPRL are Python-only subsystems). goldencheck's `install_domain` note follows once PR #1449 lands.

**Deferred:** A2A naming (needs the TS agent-card `id` field first) and CLI naming (`info`/`score`/`tui` vs `interactive` are distinct ops, not aliases).

## Tests

- Python (box-safe): alias advertise (both paths), resolver, schema equality, and dispatch parity through the **aggregator** `dispatch` path (the one that was previously unrouted). 7 pass locally.
- Aggregator: suite `profile` stays goldencheck's; no goldenmatch alias is served by goldenmatch in the suite. 2 pass locally.
- TypeScript (CI-only — box OOMs): alias advertisement + schema equality + `handleTool` dispatch parity.
- The `api_parity` goldenmatch shard is the authoritative green/red for the manifest partition.

## Provenance

Spec + plan under `docs/superpowers/`, each reviewed to approval (spec 3 rounds — caught two advertise paths, two dispatch paths, and the `profile` collision; plan 1 round + a test-logic fix caught during TDD execution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
