### PR TITLE
feat(goldenflow-duckdb): Slice 3b -- linux_arm64 + osx_amd64 platforms

### DIFF
--- a/.github/workflows/goldenflow-duckdb-dist.yml
+++ b/.github/workflows/goldenflow-duckdb-dist.yml
@@ -49,11 +49,22 @@ jobs:
             target: x86_64-unknown-linux-gnu
             lib: libgoldenflow_duckdb.so
             cli_asset: duckdb_cli-linux-amd64.zip
+          - os: ubuntu-24.04-arm # native arm64 runner -> native build + smoke
+            platform: linux_arm64
+            target: aarch64-unknown-linux-gnu
+            lib: libgoldenflow_duckdb.so
+            cli_asset: duckdb_cli-linux-arm64.zip
           - os: macos-14
             platform: osx_arm64
             target: aarch64-apple-darwin
             lib: libgoldenflow_duckdb.dylib
             cli_asset: duckdb_cli-osx-arm64.zip
+          - os: macos-14 # Apple-Silicon runner cross-builds x86_64; smoke via Rosetta
+            platform: osx_amd64
+            target: x86_64-apple-darwin
+            lib: libgoldenflow_duckdb.dylib
+            cli_asset: duckdb_cli-osx-amd64.zip
+            needs_rosetta: true
           - os: windows-latest
             platform: windows_amd64
             target: x86_64-pc-windows-msvc
@@ -80,9 +91,9 @@ jobs:
             echo "EXT_VERSION=0.1.0" >> "$GITHUB_ENV"
           fi
 
-      # The macro reads these: the init symbol name and the min (== target,
-      # unstable C API) DuckDB version baked into the binary. They MUST match the
-      # footer's -dv or DuckDB refuses the load.
+      # The macro reads these: the init symbol name and the min DuckDB (stable
+      # C API) version baked into the binary. It MUST match the footer's -dv or
+      # DuckDB refuses the load.
       - name: Build loadable cdylib
         env:
           DUCKDB_EXTENSION_NAME: goldenflow_duckdb
@@ -99,6 +110,12 @@ jobs:
             -ev "$EXT_VERSION" \
             --abi-type C_STRUCT \
             -o "goldenflow_duckdb.duckdb_extension"
+
+      # osx_amd64 is cross-built on an Apple-Silicon runner; run the x86 CLI +
+      # extension under Rosetta so this leg is LOAD-smoked too, not just built.
+      - name: Install Rosetta
+        if: matrix.needs_rosetta
+        run: sudo softwareupdate --install-rosetta --agree-to-license
 
       # The real proof: a stock DuckDB CLI LOADs the extension and runs the UDFs.
       - name: LOAD smoke test

--- a/packages/rust/extensions/goldenflow-duckdb/README.md
+++ b/packages/rust/extensions/goldenflow-duckdb/README.md
@@ -43,9 +43,9 @@ SELECT goldenflow_email_normalize('  A.B@Example.COM ');  -- a.b@example.com
 **Portable across DuckDB versions:** the extension targets the *stable* C API
 (`v1.2.0`), which is versioned separately from -- and well below -- the DuckDB
 release number, so one build loads on **any DuckDB >= 1.2.0** (smoke-tested
-against the current v1.5.4 CLI). Platforms built today: `linux_amd64`,
-`osx_arm64`, `windows_amd64` (each proven by a real `LOAD` smoke in CI).
-`linux_arm64` + `osx_amd64` are a follow-up.
+against the current v1.5.4 CLI). Five platforms are built and each proven by a
+real `LOAD` smoke in CI: `linux_amd64`, `linux_arm64`, `osx_arm64`, `osx_amd64`
+(cross-built, smoked under Rosetta), `windows_amd64`.
 
 ## Status: Slice 2b (full single-arg catalogue)
 
@@ -76,8 +76,7 @@ Deferred to later slices:
 
 | Slice | Scope |
 | ----- | ----- |
-| **3b** | Remaining platforms (`linux_arm64`, `osx_amd64`) + multi-DuckDB-version builds. |
-| **later** | Multi-argument / multi-output kernels: phone (region arg), `split_*`, `truncate`, `pad_*`, `merge_name`, `auto_correct`. |
+| **later** | Multi-DuckDB-version builds; multi-argument / multi-output kernels: phone (region arg), `split_*`, `truncate`, `pad_*`, `merge_name`, `auto_correct`. |
 
 ## Build & test
 


### PR DESCRIPTION
## What
Rounds out the distribution matrix from 3 to **5 platforms**, each still proven by a real `LOAD` smoke:
- **`linux_arm64`** — native GitHub `ubuntu-24.04-arm` runner (native build + smoke, no cross tooling).
- **`osx_amd64`** — cross-built (`x86_64-apple-darwin`) on the macos-14 Apple-Silicon runner; the x86 CLI + extension are smoke-`LOAD`ed under **Rosetta 2** (installed on that leg), so it's proven rather than just built.

Follows #1453 (Slice 3, the 3 native platforms).

## Coverage now
`linux_amd64`, `linux_arm64`, `osx_arm64`, `osx_amd64`, `windows_amd64` — the full desktop/server set.

Also drops a stale "unstable C API" comment left over from before the stable-C-API (v1.2.0, portable) fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)