### PR TITLE
ci(goldenflow-duckdb): prove multi-DuckDB-version portability via LOAD sweep

### DIFF
--- a/.github/workflows/goldenflow-duckdb-dist.yml
+++ b/.github/workflows/goldenflow-duckdb-dist.yml
@@ -148,9 +148,12 @@ jobs:
           if-no-files-found: error
 
   # Prove the portability claim: ONE stable-C-API build loads across a sweep of
-  # DuckDB versions. Reuses the linux_amd64 artifact (build once, load many). If
-  # an older DuckDB rejects it, this reveals the true floor instead of asserting
-  # ">= 1.2.0" -- measure, don't claim.
+  # DuckDB versions. Reuses the linux_amd64 artifact (build once, load many).
+  # The sweep MEASURED the true floor: DuckDB 1.2.x wants the old
+  # `linux_amd64_gcc4` platform string, while 1.3.0 unified it to `linux_amd64`
+  # (what we stamp). So the C API (v1.2.0) is fine but the platform naming caps
+  # the floor at DuckDB 1.3.0 -- supporting 1.2.x would need a separate
+  # gcc4-stamped artifact, not shipped.
   portability:
     name: portability (DuckDB ${{ matrix.duckdb }})
     needs: build
@@ -158,7 +161,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        duckdb: [v1.2.0, v1.3.2, v1.4.0, v1.5.4]
+        duckdb: [v1.3.0, v1.3.2, v1.4.0, v1.5.4]
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -205,5 +208,5 @@ jobs:
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --title "goldenflow-duckdb $GITHUB_REF_NAME" \
-            --notes "Loadable DuckDB extension (stable C API ${DUCKDB_C_API_VERSION}, loads on DuckDB >= 1.2.0). Download your platform's zip, extract \`goldenflow_duckdb.duckdb_extension\`, and LOAD it with \`duckdb -unsigned\` (or \`SET allow_unsigned_extensions=true\`). The filename must stay \`goldenflow_duckdb.duckdb_extension\`." \
+            --notes "Loadable DuckDB extension (stable C API ${DUCKDB_C_API_VERSION}; loads on DuckDB >= 1.3.0 -- 1.2.x used a different platform string). Download your platform's zip, extract \`goldenflow_duckdb.duckdb_extension\`, and LOAD it with \`duckdb -unsigned\` (or \`SET allow_unsigned_extensions=true\`). The filename must stay \`goldenflow_duckdb.duckdb_extension\`." \
             out/*.zip

--- a/.github/workflows/goldenflow-duckdb-dist.yml
+++ b/.github/workflows/goldenflow-duckdb-dist.yml
@@ -136,13 +136,15 @@ jobs:
           grep -q "^42$" smoke.out
           echo "LOAD smoke passed on ${{ matrix.platform }}"
 
-      - name: Stage named artifact
-        run: cp goldenflow_duckdb.duckdb_extension "goldenflow_duckdb-${{ matrix.platform }}.duckdb_extension"
-
+      # Upload the file under its REQUIRED basename (goldenflow_duckdb.duckdb_extension).
+      # DuckDB derives the init symbol from the filename, so it must stay
+      # `goldenflow_duckdb` -- a `-<platform>` suffix breaks LOAD ("undefined
+      # symbol goldenflow_duckdb-<platform>_init_c_api"). Platform lives in the
+      # ARTIFACT NAME instead; the release job zips per platform below.
       - uses: actions/upload-artifact@v4
         with:
           name: goldenflow_duckdb-${{ matrix.platform }}
-          path: packages/rust/extensions/goldenflow-duckdb/goldenflow_duckdb-${{ matrix.platform }}.duckdb_extension
+          path: packages/rust/extensions/goldenflow-duckdb/goldenflow_duckdb.duckdb_extension
           if-no-files-found: error
 
   # Prove the portability claim: ONE stable-C-API build loads across a sweep of
@@ -180,21 +182,28 @@ jobs:
 
   publish:
     name: publish release assets
-    needs: build
+    needs: [build, portability]
     if: startsWith(github.ref, 'refs/tags/goldenflow-duckdb-v')
     runs-on: ubuntu-latest
     steps:
+      # No merge: every artifact holds the SAME filename
+      # (goldenflow_duckdb.duckdb_extension), so keep them in per-artifact dirs
+      # and zip each. Each zip extracts to the correctly-named, LOAD-able file.
       - uses: actions/download-artifact@v4
         with:
           path: dist
-          merge-multiple: true
-      - name: Upload to release
+      - name: Package + upload to release
         working-directory: ${{ github.workspace }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          mkdir -p out
+          for d in dist/goldenflow_duckdb-*; do
+            plat="$(basename "$d")" # goldenflow_duckdb-<platform>
+            (cd "$d" && zip -q "$GITHUB_WORKSPACE/out/${plat}.zip" goldenflow_duckdb.duckdb_extension)
+          done
           gh release create "$GITHUB_REF_NAME" \
             --repo "$GITHUB_REPOSITORY" \
             --title "goldenflow-duckdb $GITHUB_REF_NAME" \
-            --notes "Loadable DuckDB extension (stable C API ${DUCKDB_C_API_VERSION}, loads on DuckDB >= 1.2.0). LOAD with \`duckdb -unsigned\` (or \`SET allow_unsigned_extensions=true\`)." \
-            dist/*.duckdb_extension
+            --notes "Loadable DuckDB extension (stable C API ${DUCKDB_C_API_VERSION}, loads on DuckDB >= 1.2.0). Download your platform's zip, extract \`goldenflow_duckdb.duckdb_extension\`, and LOAD it with \`duckdb -unsigned\` (or \`SET allow_unsigned_extensions=true\`). The filename must stay \`goldenflow_duckdb.duckdb_extension\`." \
+            out/*.zip

--- a/.github/workflows/goldenflow-duckdb-dist.yml
+++ b/.github/workflows/goldenflow-duckdb-dist.yml
@@ -145,6 +145,39 @@ jobs:
           path: packages/rust/extensions/goldenflow-duckdb/goldenflow_duckdb-${{ matrix.platform }}.duckdb_extension
           if-no-files-found: error
 
+  # Prove the portability claim: ONE stable-C-API build loads across a sweep of
+  # DuckDB versions. Reuses the linux_amd64 artifact (build once, load many). If
+  # an older DuckDB rejects it, this reveals the true floor instead of asserting
+  # ">= 1.2.0" -- measure, don't claim.
+  portability:
+    name: portability (DuckDB ${{ matrix.duckdb }})
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        duckdb: [v1.2.0, v1.3.2, v1.4.0, v1.5.4]
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: goldenflow_duckdb-linux_amd64
+          path: ext
+      - name: LOAD on DuckDB ${{ matrix.duckdb }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          curl -sL -o duckdb.zip \
+            "https://github.com/duckdb/duckdb/releases/download/${{ matrix.duckdb }}/duckdb_cli-linux-amd64.zip"
+          unzip -o -q duckdb.zip
+          EXT=$(ls ext/*.duckdb_extension | head -1)
+          ./duckdb -unsigned -noheader -list -c "
+            LOAD '$EXT';
+            SELECT goldenflow_email_normalize('  A.B@Example.COM ');
+            SELECT goldenflow_cc_validate('4242424242424242');
+          " | tee out.txt
+          grep -q "a.b@example.com" out.txt
+          grep -qi "true" out.txt
+          echo "the v1.2.0-C-API build LOADs on DuckDB ${{ matrix.duckdb }}"
+
   publish:
     name: publish release assets
     needs: build

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -129,6 +129,8 @@ Get dataset statistics: record count, cluster count, match rate, cluster sizes.
 
 Search for duplicate records matching a query.
 
+_Also answers to `dedupe` (the TypeScript server's name for this operation)._
+
 ```text
 "Find duplicates of John Smith"
 ```
@@ -145,6 +147,8 @@ Get details of a specific cluster including all member records and pair scores.
 
 Match a new record against the loaded dataset.
 
+_Also answers to `match` (the TypeScript server's name for this operation)._
+
 ```text
 "Does this record match anything: name=Jane Doe, email=jane@example.com?"
 ```
@@ -152,6 +156,8 @@ Match a new record against the loaded dataset.
 ### explain_match
 
 Explain why two specific records were matched or not matched.
+
+_Also answers to `explain_pair` (the TypeScript server's name for this operation)._
 
 ```text
 "Why were records 42 and 108 matched?"
@@ -374,7 +380,9 @@ Three tools plan and validate distributed execution routing for a run.
 
 ### Tool count breakdown
 
-The 69 tools reconcile as: 18 agent-level + 7 Learning Memory + 15 Identity Graph + 3 routing + 26 base data/inspection tools.
+The 69 distinct tools reconcile as: 18 agent-level + 7 Learning Memory + 15 Identity Graph + 3 routing + 26 base data/inspection tools.
+
+The server additionally advertises 5 cross-language naming aliases — `dedupe`, `match`, `explain_pair`, `profile`, and `explain_cluster` — alternate names that match the TypeScript server's tool names, so an agent trained against either server can call the other. They forward to the canonical handlers above (`find_duplicates`, `match_record`, `explain_match`, `profile_data`, `agent_explain_cluster`), bringing the advertised total to 74. The TypeScript server mirrors this: it also answers to the Python names (`find_duplicates`, `match_record`, `explain_match`, `profile_data`).
 
 ## How it works
 

--- a/packages/rust/extensions/goldenflow-duckdb/README.md
+++ b/packages/rust/extensions/goldenflow-duckdb/README.md
@@ -23,22 +23,27 @@ UDF names are `goldenflow_<kernel>` -- a predictable 1:1 with the underlying
 
 ## Install
 
-Download the `.duckdb_extension` for your platform from the
-[`goldenflow-duckdb-v*` release assets](https://github.com/benseverndev-oss/goldenmatch/releases)
-and `LOAD` it. Extensions built outside the DuckDB signing chain need the
-unsigned flag:
+Download `goldenflow_duckdb-<platform>.zip` from the
+[`goldenflow-duckdb-v*` release assets](https://github.com/benseverndev-oss/goldenmatch/releases),
+extract it, and `LOAD` the file. Extensions built outside the DuckDB signing
+chain need the unsigned flag:
 
 ```sh
-# CLI
+unzip goldenflow_duckdb-linux_amd64.zip   # -> goldenflow_duckdb.duckdb_extension
 duckdb -unsigned
 ```
 ```sql
 -- or, from any client
 SET allow_unsigned_extensions = true;
-LOAD '/path/to/goldenflow_duckdb-linux_amd64.duckdb_extension';
+LOAD '/path/to/goldenflow_duckdb.duckdb_extension';
 
 SELECT goldenflow_email_normalize('  A.B@Example.COM ');  -- a.b@example.com
 ```
+
+> The file **must** keep the name `goldenflow_duckdb.duckdb_extension` -- DuckDB
+> derives the extension's init symbol from the filename, so a renamed file fails
+> to load. (That's why the assets are per-platform zips of the correctly-named
+> file rather than platform-suffixed bare extensions.)
 
 **Portable across DuckDB versions:** the extension targets the *stable* C API
 (`v1.2.0`), which is versioned separately from -- and well below -- the DuckDB

--- a/packages/rust/extensions/goldenflow-duckdb/README.md
+++ b/packages/rust/extensions/goldenflow-duckdb/README.md
@@ -47,10 +47,13 @@ SELECT goldenflow_email_normalize('  A.B@Example.COM ');  -- a.b@example.com
 
 **Portable across DuckDB versions:** the extension targets the *stable* C API
 (`v1.2.0`), which is versioned separately from -- and well below -- the DuckDB
-release number, so one build loads on **any DuckDB >= 1.2.0** (smoke-tested
-against the current v1.5.4 CLI). Five platforms are built and each proven by a
-real `LOAD` smoke in CI: `linux_amd64`, `linux_arm64`, `osx_arm64`, `osx_amd64`
-(cross-built, smoked under Rosetta), `windows_amd64`.
+release number, so one build loads on **any DuckDB >= 1.3.0** (a CI sweep LOADs
+the single build on v1.3.0 / v1.3.2 / v1.4.0 / v1.5.4). The floor is 1.3.0, not
+1.2.x, because DuckDB 1.2.x expects the older `linux_amd64_gcc4` platform string
+while 1.3.0 unified it to `linux_amd64` -- a packaging detail, not the C API.
+Five platforms are built, each proven by a real `LOAD` smoke in CI:
+`linux_amd64`, `linux_arm64`, `osx_arm64`, `osx_amd64` (cross-built, smoked
+under Rosetta), `windows_amd64`.
 
 ## Status: Slice 2b (full single-arg catalogue)
 


### PR DESCRIPTION
## Finding
Per-DuckDB-version **builds are unnecessary.** The extension targets DuckDB's **stable C API**, which has been pinned at **v1.2.0 from DuckDB 1.2.0 through 1.5.4** — so one artifact already covers the whole range. What was missing was *proof*, not more builds.

## What
Adds a `portability` job to `goldenflow-duckdb-dist.yml`: it reuses the single `linux_amd64` build and `LOAD`s it across a DuckDB CLI sweep (`v1.2.0 / v1.3.2 / v1.4.0 / v1.5.4`), running the UDFs on each. **Build once, load many.**

Measure-don't-claim: if an older DuckDB rejects the build (e.g. duckdb-rs reaches for a post-1.2.0 C symbol), the sweep reveals the true floor instead of the README asserting `>= 1.2.0`. I'll reconcile the README floor to whatever the sweep proves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)