### PR TITLE
fix(ci): provision aiohttp so the api_parity a2a_skills gate works

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1489,7 +1489,11 @@ jobs:
         # the Python MCP surface for all six packages.
         run: |
           uv sync --all-packages
-          uv pip install "mcp>=1.0"
+          # mcp: the MCP-tool surface; aiohttp: the a2a servers (the a2a_skills
+          # emitter imports <pkg>.a2a.server, which needs the [a2a] extra). Without
+          # aiohttp the a2a emitter exits 3 (env-gap) and the a2a surface is silently
+          # skipped — the gate must PROVISION it so a2a parity is actually checked.
+          uv pip install "mcp>=1.0" aiohttp
       - name: Gate unit tests (pure data + all-six emitter smoke)
         # Package-agnostic; run once (on the goldenmatch shard) to avoid 6x redundancy.
         if: matrix.package == 'goldenmatch'


### PR DESCRIPTION
**Latent bug from #1461** (the a2a_skills parity surface), now on main: the api_parity job installs only `mcp>=1.0`, but the a2a_skills emitter imports `<pkg>.a2a.server` which needs the `[a2a]` extra (`aiohttp`). Without it the emitter exits 3 (env-gap) → the a2a surface is silently skipped AND the emitter smoke test fails (`assert returncode==0`).

It didn't surface at #1461 merge time because the emitter runs locally against a venv that has aiohttp; it fails whenever `api_parity` re-runs in CI (caught it blocking #1451).

Fix: `uv pip install "mcp>=1.0" aiohttp` in the api_parity job, so the a2a surface is **actually validated** rather than skipped. Confirmed locally: goldencheck's a2a server does `from aiohttp import web`, and the box venv has aiohttp (which is why the emitter passed locally but not in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44