### PR TITLE
A2A naming reconciliation (alias 3 verified pairs, document 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-05-a2a-naming-reconcile.md
+++ b/docs/superpowers/plans/2026-07-05-a2a-naming-reconcile.md
@@ -1,0 +1,171 @@
+# A2A Naming Reconciliation — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Alias goldenmatch's 3 verified same-op A2A skill pairs to Python's canonical id (non-breaking, TS-side) and move them to `a2a_skills.shared`; document the 2 non-aliasable pairs.
+
+**Architecture:** TS-only. A single `A2A_AGENT_ID_ALIASES` map (tool-id → canonical A2A id) drives (1) a card-id override in `buildCardSkills` so the card advertises the canonical id, and (2) a canonical→tool resolution at the top of `dispatchAnySkill` so the canonical id routes to the existing agent-tool handler. Legacy ids keep dispatching for free. Python is already the reference (unchanged).
+
+**Tech Stack:** TypeScript (a2a server, vitest), Python (pytest guard), YAML manifest.
+
+**Spec:** `docs/superpowers/specs/2026-07-05-a2a-naming-reconcile-design.md`
+
+**The 3 alias pairs (canonical ← legacy tool-id):** `autoconfig`←`auto_configure`, `compare_strategies`←`agent_compare_strategies`, `transform`←`run_transforms`. **Documented-different (untouched):** `quality` (1:2 vs scan_quality+fix_quality), `pprl` (runs) vs `suggest_pprl` (suggests).
+
+**Anchors (verified):** `src/node/a2a/server.ts` — `buildCardSkills` :192, AGENT_SKILLS loop :201, doc comment :186-190, `dispatchAnySkill` :505, `AGENT_TOOL_NAMES.has(skill)` :509. `src/core/agent/skills.ts` — `auto_configure` :279, `agent_compare_strategies` :318, `run_transforms` :491. `AGENT_TOOL_NAMES` from AGENT_SKILLS (`node/mcp/agent-tools.ts:40-42`). `emit_ts_surface.mjs:58` emits a2a from `AGENT_CARD.skills.map(s=>s.id)`. Existing test `tests/unit/a2a-skill-parity.test.ts` (#1457, canonical-not-legacy pattern :21-26). Manifest `parity/goldenmatch.yaml` a2a_skills: python_only has autoconfig/compare_strategies/transform; ts_only has auto_configure/agent_compare_strategies/run_transforms.
+
+**Environment / SOP:**
+- Branch `feat/a2a-naming-reconcile` off `origin/main`.
+- **TS is CI-only** (box OOMs) — write + read-verify. Python guard + manifest structure are box-safe (`POLARS_SKIP_CPU_CHECK=1 D:/show_case/goldenmatch/.venv/Scripts/python.exe`, PYTHONPATH shadow for the guard). Run **ruff** on any Python file touched (the #1451 lesson).
+- benzsevern gh; merge-queue → `gh pr merge --auto --squash` (no `--delete-branch`); arm auto-merge + STOP.
+
+---
+
+## Task 1: TypeScript — alias map + card override + dispatch resolution (CI-only)
+
+**Files:**
+- Modify: `packages/typescript/goldenmatch/src/node/a2a/server.ts`
+- Modify: `packages/typescript/goldenmatch/tests/unit/a2a-skill-parity.test.ts`
+
+> Do NOT run vitest/tsc. Write + read-verify; CI verifies.
+
+- [ ] **Step 1: Add the alias map** (near the top of the card section, before `buildCardSkills`):
+```ts
+// A2A naming reconciliation: 3 agent skills advertise Python's canonical id on
+// the A2A card (a2a_skills parity). The underlying agent-tool id (also the MCP
+// tool id) is UNCHANGED — the A2A card is a separate surface. tool-id -> canonical.
+const A2A_AGENT_ID_ALIASES: Record<string, string> = {
+  auto_configure: "autoconfig",
+  agent_compare_strategies: "compare_strategies",
+  run_transforms: "transform",
+};
+// canonical -> tool-id, for dispatch resolution.
+const A2A_CANONICAL_TO_TOOL: Record<string, string> = Object.fromEntries(
+  Object.entries(A2A_AGENT_ID_ALIASES).map(([tool, canon]) => [canon, tool]),
+);
+```
+
+- [ ] **Step 2: Override the advertised id in `buildCardSkills`** (:201). Change:
+```ts
+  for (const def of AGENT_SKILLS) push(toAgentSkill({ id: def.id, description: def.description }));
+```
+to:
+```ts
+  for (const def of AGENT_SKILLS)
+    push(toAgentSkill({ id: A2A_AGENT_ID_ALIASES[def.id] ?? def.id, description: def.description }));
+```
+
+- [ ] **Step 3: Resolve canonical→tool at the top of `dispatchAnySkill`** (:505-ish). Add `resolved` and use it for the routing (do NOT reassign the `skill` param — the reviewer flagged `no-param-reassign`):
+```ts
+export async function dispatchAnySkill(skill: string, input: Record<string, unknown>): Promise<unknown> {
+  const resolved = A2A_CANONICAL_TO_TOOL[skill] ?? skill;
+  if (AGENT_TOOL_NAMES.has(resolved)) return handleAgentTool(resolved, input);
+  if (MEMORY_TOOL_NAMES.has(resolved)) return unwrapTextContent(await handleMemoryTool(resolved, input));
+  if (IDENTITY_TOOL_NAMES.has(resolved)) return unwrapTextContent(await handleIdentityTool(resolved, input));
+  return dispatchSkill(resolved, input);
+}
+```
+(Read the actual current body first — replace each `skill` use in the routing with `resolved`. For every non-canonical id `resolved === skill`, so behavior is unchanged except the 3 canonical ids now route to their agent tool.)
+
+- [ ] **Step 4: Update the `buildCardSkills` doc comment** (:186-190) — add a parallel line to the existing dedupe/explain_pair note:
+> Three agent skills advertise Python's canonical id (`autoconfig`/`compare_strategies`/`transform` for the `auto_configure`/`agent_compare_strategies`/`run_transforms` handlers) via `A2A_AGENT_ID_ALIASES`; the legacy ids still dispatch.
+
+- [ ] **Step 5: Extend `tests/unit/a2a-skill-parity.test.ts`** — mirror the existing canonical-not-legacy block (:21-26). Add:
+```ts
+  it("advertises the reconciled canonical agent ids, not the legacy ones", () => {
+    const ids = new Set(AGENT_CARD.skills.map((s) => s.id));
+    for (const canon of ["autoconfig", "compare_strategies", "transform"]) expect(ids.has(canon)).toBe(true);
+    for (const legacy of ["auto_configure", "agent_compare_strategies", "run_transforms"]) expect(ids.has(legacy)).toBe(false);
+  });
+
+  it("dispatches the canonical id identically to the legacy tool id", async () => {
+    // both resolve to the same agent tool -> identical result on a fixture
+    for (const [canon, legacy] of [["autoconfig","auto_configure"],["compare_strategies","agent_compare_strategies"],["transform","run_transforms"]]) {
+      const input = { rows: [{ id: "1", name: "A" }, { id: "2", name: "A" }] };
+      expect(await dispatchAnySkill(canon, input)).toEqual(await dispatchAnySkill(legacy, input));
+    }
+  });
+```
+Read the existing test file's imports (`AGENT_CARD`, `dispatchAnySkill`) — they're already imported for the #1457 tests. If a skill's real input keys differ from `{ rows }`, read its handler and match them (the point is identical input to both ids).
+
+- [ ] **Step 6: Verify by reading** — the map + inverse; the card override; `dispatchAnySkill` uses `resolved` for all four routing branches; the doc comment; the test imports resolve. Brace balance intact.
+
+- [ ] **Step 7: Commit**
+```bash
+git add packages/typescript/goldenmatch/src/node/a2a/server.ts packages/typescript/goldenmatch/tests/unit/a2a-skill-parity.test.ts
+git commit -m "feat(a2a-ts): reconcile 3 agent skill ids to Python canonical (card + dispatch alias)"
+```
+
+---
+
+## Task 2: Manifest — move 3 canonical ids to a2a_skills.shared (box-safe)
+
+**Files:** `parity/goldenmatch.yaml`
+
+- [ ] **Step 1: Edit the `a2a_skills` partition.**
+  - **shared** — add (keep sorted): `autoconfig`, `compare_strategies`, `transform`.
+  - **python_only** — remove: `autoconfig`, `compare_strategies`, `transform`.
+  - **ts_only** — remove: `auto_configure`, `agent_compare_strategies`, `run_transforms`.
+  Result counts: shared 20, python_only 18, ts_only 16.
+
+- [ ] **Step 2: Update the a2a_skills header note** — the 3 reconciled pairs are now shared; refine the divergence note to:
+> Remaining a2a_skills divergences are VERIFIED-DIFFERENT ops, not drift: PY `quality` is one scan+fix skill vs TS's `scan_quality`+`fix_quality` (1:2 granularity); PY `pprl` RUNS linkage (`pprl_link`, two files) while TS `suggest_pprl` SUGGESTS params (`profileForAgent`, "recommend") — TS `suggest_pprl` is the A2A analogue of Python's own `suggest_pprl`, not `pprl`.
+
+- [ ] **Step 3: Box-safe structure check.**
+Run: `POLARS_SKIP_CPU_CHECK=1 D:/show_case/goldenmatch/.venv/Scripts/python.exe -c "import yaml; from importlib.util import spec_from_file_location,module_from_spec; import sys; s=spec_from_file_location('g','scripts/check_api_parity.py'); m=module_from_spec(s); sys.modules[s.name]=m; s.loader.exec_module(m); man=yaml.safe_load(open('parity/goldenmatch.yaml')); print('a2a:', {k:len(v) for k,v in man['a2a_skills'].items()}, 'structure:', [f.kind for f in m.check_structure(man)])"`
+Expected: `a2a: {'shared': 20, 'python_only': 18, 'ts_only': 16} structure: []`. (Full partition vs the real TS emitter is CI-verified.)
+
+- [ ] **Step 4: Commit**
+```bash
+git add parity/goldenmatch.yaml
+git commit -m "chore(parity): move 3 reconciled a2a_skills to shared; document the 2 different-op pairs"
+```
+
+---
+
+## Task 3: Python — canonical-id regression guard (box-safe)
+
+**Files:** `packages/python/goldenmatch/tests/test_a2a.py`
+
+- [ ] **Step 1: Append a guard** (Python is unchanged; this locks the canonical ids the TS side aligns to):
+```python
+def test_a2a_exposes_reconciled_canonical_ids():
+    """The 3 A2A skills the TS card aligns to must stay under their canonical ids."""
+    from goldenmatch.a2a.server import _SKILLS
+    ids = {s["id"] for s in _SKILLS}
+    assert {"autoconfig", "compare_strategies", "transform"} <= ids
+```
+
+- [ ] **Step 2: Run it + ruff.**
+Run: `cd packages/python/goldenmatch && PYTHONPATH=$(pwd) POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest tests/test_a2a.py::test_a2a_exposes_reconciled_canonical_ids -v` → PASS.
+Run: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check packages/python/goldenmatch/tests/test_a2a.py` → All checks passed.
+
+- [ ] **Step 3: Commit**
+```bash
+git add packages/python/goldenmatch/tests/test_a2a.py
+git commit -m "test(a2a): guard the 3 reconciled canonical skill ids on the Python reference"
+```
+
+---
+
+## Task 4: PR
+
+- [ ] **Step 1: Docs sweep** — grep docs for `auto_configure`/`agent_compare_strategies`/`run_transforms` presented as an **A2A skill id** (not MCP tool, where they're unchanged). `agent.mdx` is the Python card, already using the canonical ids; expect no changes. Skill counts unchanged (rename, not add/remove).
+
+- [ ] **Step 2: Push + PR + arm auto-merge (STOP).** PR body: 3 verified same-op pairs aliased to Python canonical (card-id override + dispatch map, legacy dispatch preserved); 2 pairs documented as verified-different; manifest a2a_skills 17/21/19→20/18/16; MCP tool ids untouched (A2A card is a separate surface). TS CI-verified; Python guard + manifest box-checked.
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern
+git push -u origin feat/a2a-naming-reconcile
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr create --repo benseverndev-oss/goldenmatch --base main --title "A2A naming reconciliation (alias 3 verified pairs)" --body-file <body>
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr merge --auto --squash --repo benseverndev-oss/goldenmatch  # NO --delete-branch
+```
+
+---
+
+## Notes for the implementer
+
+- **TS-only + Python unchanged.** The card override + dispatch map are the whole change; the map is the single source of truth (invert for dispatch).
+- **Don't rename the MCP tool.** The override is in `buildCardSkills` only; `AGENT_TOOL_NAMES`/`AGENT_MCP_TOOLS` still use `def.id` — `auto_configure` etc. stay MCP tools.
+- **Manifest in the same PR** — the emitter reads the card, so the override changes the emitted a2a set; the gate fails if the manifest doesn't match.
+- **Run ruff** on the Python guard (the #1451 lint lesson).
+- **Do NOT touch** `quality`/`scan_quality`/`fix_quality`/`pprl`/`suggest_pprl` — verified-different, documented.

--- a/docs/superpowers/specs/2026-07-05-a2a-naming-reconcile-design.md
+++ b/docs/superpowers/specs/2026-07-05-a2a-naming-reconcile-design.md
@@ -1,0 +1,131 @@
+# goldenmatch A2A naming reconciliation — design
+
+**Status:** approved (brainstorm 2026-07-05), pending spec review
+**Context:** the A2A parity gate (#1461) surfaced goldenmatch's A2A skill-id naming
+divergences and froze them in `parity/goldenmatch.yaml`'s `a2a_skills` header as a
+follow-up. This closes that follow-up for the *verified same-operation* pairs (like
+#1457 did for `dedupe`↔`deduplicate`), and documents the rest as intentional.
+Related: `project_api_parity_gate`.
+
+## 1. Problem
+
+Five candidate divergent pairs (Python `_SKILLS` id / TS `AGENT_CARD` skill id).
+Investigated each against both sides' handlers + descriptions:
+
+| Pair | Python | TypeScript | Verdict |
+| --- | --- | --- | --- |
+| `autoconfig` / `auto_configure` | Run AutoConfigController → config + telemetry | Run the iterative auto-config controller → committed config + telemetry | **same op → alias** |
+| `compare_strategies` / `agent_compare_strategies` | `session.compare_strategies` | Run multiple candidate strategies + compare metrics | **same op → alias** |
+| `transform` / `run_transforms` | Normalize formats via GoldenFlow (`run_transform`) | Run GoldenFlow transforms, normalize phone/date/… | **same op → alias** |
+| `quality` / `scan_quality` + `fix_quality` | one skill: scan **and** fix (mode) | two skills (scan; scan+apply) | **1:2 granularity — document** |
+| `pprl` / `suggest_pprl` | **runs** `pprl_link` on two files | **suggests** params (`profileForAgent`, "recommend") | **different ops — document** |
+
+The last two are genuine coverage/semantic differences, not renames: aliasing a 1:2
+split or a run-vs-suggest pair would be wrong. (`suggest_pprl` is actually the A2A
+analogue of Python's own `suggest_pprl` MCP tool, not `pprl`.)
+
+## 2. Goal
+
+Make the 3 verified same-op pairs answerable by the canonical (Python) id on both
+A2A cards, non-breakingly, and move those 3 ids to `a2a_skills.shared`. Document the
+2 non-aliasable pairs as verified-different. Python is unchanged (already the
+spec-shaped reference advertising the canonical ids).
+
+## 3. Design (all TypeScript, in `src/node/a2a/server.ts`)
+
+The 3 TS skills (`auto_configure`, `agent_compare_strategies`, `run_transforms`)
+are `AGENT_SKILLS` (from `src/core/agent/skills.ts`), whose ids double as the
+MCP agent-tool names and are dispatched via `AGENT_TOOL_NAMES` → `handleAgentTool`.
+Reconciliation decouples the **A2A card id** (advertised) from the underlying
+**agent-tool id** (dispatched) for these 3 — the A2A card is a separate surface
+from MCP tools, so the MCP tool ids are untouched.
+
+### 3.1 One source-of-truth alias map
+
+```ts
+// A2A card advertises Python's canonical id; the underlying agent-tool id
+// (also the MCP tool id) is unchanged. tool-id -> canonical A2A id.
+const A2A_AGENT_ID_ALIASES: Record<string, string> = {
+  auto_configure: "autoconfig",
+  agent_compare_strategies: "compare_strategies",
+  run_transforms: "transform",
+};
+```
+
+### 3.2 Advertise the canonical id (`buildCardSkills`, :201)
+
+In the `AGENT_SKILLS` mapping loop, override the advertised id:
+```ts
+for (const def of AGENT_SKILLS)
+  push(toAgentSkill({ id: A2A_AGENT_ID_ALIASES[def.id] ?? def.id, description: def.description }));
+```
+So the card advertises `autoconfig`/`compare_strategies`/`transform` for those 3;
+all other agent skills keep `def.id`. De-dup-by-id still holds (no collision — the
+3 canonical ids exist nowhere else in the card union; verified).
+
+### 3.3 Dispatch the canonical id (`dispatchAnySkill`, :505)
+
+The card now advertises `autoconfig`, but `AGENT_TOOL_NAMES` contains
+`auto_configure`. Resolve canonical → tool-id at the top of `dispatchAnySkill`,
+before the `AGENT_TOOL_NAMES.has(skill)` check (:509):
+```ts
+const A2A_CANONICAL_TO_TOOL = Object.fromEntries(
+  Object.entries(A2A_AGENT_ID_ALIASES).map(([tool, canon]) => [canon, tool]),
+);
+// inside dispatchAnySkill, first line:
+skill = A2A_CANONICAL_TO_TOOL[skill] ?? skill;
+```
+`autoconfig` → `auto_configure` → `handleAgentTool`. The legacy ids
+(`auto_configure`, …) still dispatch for free — they *are* the agent-tool names, so
+they pass the `AGENT_TOOL_NAMES` check unchanged. Non-breaking.
+
+### 3.4 Manifest (`parity/goldenmatch.yaml` a2a_skills, same PR)
+
+The emitted TS `a2a_skills` set gains `autoconfig`/`compare_strategies`/`transform`
+and loses `auto_configure`/`agent_compare_strategies`/`run_transforms` (no longer
+advertised — dispatch-only). Python's set is unchanged. So:
+- **shared**: add `autoconfig`, `compare_strategies`, `transform` (17 → 20)
+- **python_only**: remove those 3 (21 → 18)
+- **ts_only**: remove `auto_configure`, `agent_compare_strategies`, `run_transforms` (19 → 16)
+
+Update the a2a_skills header: the 3 reconciled pairs are now shared; refine the
+remaining note to "VERIFIED-DIFFERENT (not drift): PY `quality` is one scan+fix
+skill vs TS's `scan_quality`+`fix_quality` split (1:2); PY `pprl` RUNS linkage
+(`pprl_link`, two files) while TS `suggest_pprl` SUGGESTS params — different ops."
+
+## 4. Testing
+
+- **TypeScript (CI-only — box OOMs):** extend/add an a2a test:
+  - `AGENT_CARD.skills` advertises `autoconfig`, `compare_strategies`, `transform`
+    and does **not** advertise `auto_configure`/`agent_compare_strategies`/
+    `run_transforms` as separate skills.
+  - `dispatchAnySkill("autoconfig", …)` routes to the same handler as
+    `dispatchAnySkill("auto_configure", …)` (both resolve to the agent tool) — assert
+    identical results on a fixture; same for the other 2 pairs.
+- **Python (box-safe):** a light regression guard that `_SKILLS` still exposes
+  `autoconfig`, `compare_strategies`, `transform` (the canonical ids the TS side
+  now aligns to). Python code is otherwise untouched.
+- **Gate:** the `api_parity` goldenmatch shard verifies the manifest matches the
+  real emitted surfaces (the authoritative check for the partition move).
+
+## 5. Rollout / docs
+
+- Single PR, branch `feat/a2a-naming-reconcile` off `origin/main`. TS code + TS test
+  + Python guard + manifest update. benzsevern gh; merge-queue → `gh pr merge
+  --auto --squash` (no `--delete-branch`); arm auto-merge, stop.
+- rollout-docs-sweep: `agent.mdx` already advertises the Python ids (it's the
+  Python card); confirm no doc lists `auto_configure`/`run_transforms` as the A2A
+  skill id. Skill counts unchanged (rename, not add/remove).
+
+## 6. Risks
+
+- **Low, TS-only, additive** — 3 card-id renames + a 3-entry dispatch map, legacy
+  dispatch preserved. The one caveat (§3): the A2A card id is now decoupled from the
+  agent-tool id for these 3; that is intentional and correct (A2A card ≠ MCP tools),
+  and the MCP tool ids are untouched.
+- **De-dup / collision**: the 3 canonical ids don't collide with any existing card
+  id (verified). A collision would surface as a dropped skill — the §4 card test
+  (asserting all 3 are advertised) guards it.
+- **Semantic mis-call**: the 2 documented pairs were verified different from the
+  handlers, not assumed; the header records the evidence so a future reader doesn't
+  "reconcile" them by mistake.

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -688,3 +688,12 @@ def test_a2a_skills_are_spec_shaped_and_expose_canonical_ids():
         assert skill["name"] and isinstance(skill["name"], str)
     ids = {s["id"] for s in _SKILLS}
     assert {"deduplicate", "explain", "match"} <= ids
+
+
+def test_a2a_exposes_reconciled_canonical_ids():
+    """The 3 A2A skills the TS card aligns to must stay under their canonical ids
+    (autoconfig/compare_strategies/transform) — the Python reference the TS
+    reconciliation (2026-07-05) targets. Python is otherwise unchanged."""
+    from goldenmatch.a2a.server import _SKILLS
+    ids = {s["id"] for s in _SKILLS}
+    assert {"autoconfig", "compare_strategies", "transform"} <= ids

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -175,6 +175,19 @@ function toAgentSkill(entry: { readonly id: string; readonly description: string
   };
 }
 
+// A2A naming reconciliation: 3 agent skills advertise Python's canonical id on
+// the A2A card (a2a_skills parity). The underlying agent-tool id (also the MCP
+// tool id) is UNCHANGED -- the A2A card is a separate surface. tool-id -> canonical.
+const A2A_AGENT_ID_ALIASES: Record<string, string> = {
+  auto_configure: "autoconfig",
+  agent_compare_strategies: "compare_strategies",
+  run_transforms: "transform",
+};
+// canonical -> tool-id, for dispatch resolution.
+const A2A_CANONICAL_TO_TOOL: Record<string, string> = Object.fromEntries(
+  Object.entries(A2A_AGENT_ID_ALIASES).map(([tool, canon]) => [canon, tool]),
+);
+
 /**
  * Build the card's skill list from the union of every registry: the 10 base
  * A2A skills + the 15 `AGENT_SKILLS` + the memory tools + the identity tools.
@@ -184,7 +197,11 @@ function toAgentSkill(entry: { readonly id: string; readonly description: string
  * A2A parity note: the card is A2A-spec-shaped ({id, name}). The core skills
  * share canonical ids with the Python server (deduplicate, match, explain,
  * evaluate, ...); the legacy ids `dedupe`/`explain_pair` still dispatch (see
- * dispatchSkill). The remaining catalog differences (agent_* skills, Python's
+ * dispatchSkill). Three agent skills advertise Python's canonical id
+ * (autoconfig/compare_strategies/transform for the
+ * auto_configure/agent_compare_strategies/run_transforms handlers) via
+ * A2A_AGENT_ID_ALIASES; the legacy ids still dispatch. The remaining catalog
+ * differences (agent_* skills, Python's
  * finer granularity, TS-only score/profile, Python-only identity_audit/etc.,
  * and genuinely different ops like pprl vs suggest_pprl) are INTENTIONAL, not
  * drift — A2A is not gated for parity (MCP tools + CLI are).
@@ -198,7 +215,8 @@ function buildCardSkills(): readonly AgentSkill[] {
     out.push(skill);
   };
   for (const skill of BASE_SKILLS) push(skill);
-  for (const def of AGENT_SKILLS) push(toAgentSkill({ id: def.id, description: def.description }));
+  for (const def of AGENT_SKILLS)
+    push(toAgentSkill({ id: A2A_AGENT_ID_ALIASES[def.id] ?? def.id, description: def.description }));
   for (const tool of MEMORY_TOOLS) push(toAgentSkill({ id: tool.name, description: tool.description }));
   for (const tool of IDENTITY_TOOLS) push(toAgentSkill({ id: tool.name, description: tool.description }));
   return out;
@@ -506,16 +524,17 @@ export async function dispatchAnySkill(
   skill: string,
   input: Record<string, unknown>,
 ): Promise<unknown> {
-  if (AGENT_TOOL_NAMES.has(skill)) {
-    return handleAgentTool(skill, input);
+  const resolved = A2A_CANONICAL_TO_TOOL[skill] ?? skill;
+  if (AGENT_TOOL_NAMES.has(resolved)) {
+    return handleAgentTool(resolved, input);
   }
-  if (MEMORY_TOOL_NAMES.has(skill)) {
-    return unwrapTextContent(await handleMemoryTool(skill, input));
+  if (MEMORY_TOOL_NAMES.has(resolved)) {
+    return unwrapTextContent(await handleMemoryTool(resolved, input));
   }
-  if (IDENTITY_TOOL_NAMES.has(skill)) {
-    return unwrapTextContent(await handleIdentityTool(skill, input));
+  if (IDENTITY_TOOL_NAMES.has(resolved)) {
+    return unwrapTextContent(await handleIdentityTool(resolved, input));
   }
-  return dispatchSkill(skill, input);
+  return dispatchSkill(resolved, input);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/tests/unit/a2a-skill-parity.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/a2a-skill-parity.test.ts
@@ -44,6 +44,19 @@ describe("A2A skill parity", () => {
     );
   });
 
+  it("advertises the reconciled canonical agent ids, not the legacy ones", () => {
+    const ids = new Set(AGENT_CARD.skills.map((s) => s.id));
+    for (const canon of ["autoconfig", "compare_strategies", "transform"]) expect(ids.has(canon)).toBe(true);
+    for (const legacy of ["auto_configure", "agent_compare_strategies", "run_transforms"]) expect(ids.has(legacy)).toBe(false);
+  });
+
+  it("dispatches the canonical agent id identically to the legacy tool id", async () => {
+    for (const [canon, legacy] of [["autoconfig", "auto_configure"], ["compare_strategies", "agent_compare_strategies"], ["transform", "run_transforms"]] as const) {
+      const input = { rows: [{ id: "1", name: "A" }, { id: "2", name: "A" }] };
+      expect(await dispatchAnySkill(canon, input)).toEqual(await dispatchAnySkill(legacy, input));
+    }
+  });
+
   it("humanizes derived ids into labels", () => {
     expect(byId.get("agent_deduplicate")?.name).toBe("Agent Deduplicate");
     expect(byId.get("identity_resolve")?.name).toBe("Identity Resolve");

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -18,11 +18,16 @@
 #      find_exact_matches, find_fuzzy_matches, read_file, write_csv, server_info.
 #
 # a2a_skills surface (A2A AgentCard skills). The core ops share canonical ids and ARE shared
-# (deduplicate, match, explain, evaluate, identity_* , learn_thresholds, memory_stats, ...).
-# Known NAMING DIVERGENCES (same operation, different id per server — FOLLOW-UP to reconcile,
-# NOT reconciled here): PY autoconfig / TS auto_configure; PY compare_strategies / TS
-# agent_compare_strategies; PY quality / TS scan_quality + fix_quality; PY transform / TS
-# run_transforms; PY pprl / TS suggest_pprl. TS also exposes the agent_* skill variants
+# (deduplicate, match, explain, evaluate, autoconfig, compare_strategies, transform, identity_*,
+# learn_thresholds, memory_stats, ...). RECONCILED 2026-07-05: autoconfig/auto_configure,
+# compare_strategies/agent_compare_strategies, transform/run_transforms were verified same-op
+# and aliased to Python's canonical id (TS card advertises the canonical, legacy tool id still
+# dispatches) — now shared.
+# Remaining a2a_skills divergences are VERIFIED-DIFFERENT ops, NOT drift: PY `quality` is one
+# scan+fix skill vs TS's `scan_quality` + `fix_quality` (1:2 granularity); PY `pprl` RUNS
+# linkage (`pprl_link`, two files) while TS `suggest_pprl` SUGGESTS params (`profileForAgent`,
+# "recommend") — TS suggest_pprl is the A2A analogue of Python's own suggest_pprl, not pprl.
+# TS also exposes the agent_* skill variants
 # (agent_deduplicate/agent_match_sources/agent_explain_pair/agent_explain_cluster/
 # agent_review_queue/agent_approve_reject) and edge primitives (score, profile, suggest_config,
 # list_scorers/list_strategies/list_transforms, memory_export); Python ships the richer
@@ -162,6 +167,8 @@ a2a_skills:
   shared:
   - add_correction
   - analyze_data
+  - autoconfig
+  - compare_strategies
   - controller_telemetry
   - deduplicate
   - evaluate
@@ -177,11 +184,10 @@ a2a_skills:
   - match
   - memory_stats
   - review_config
+  - transform
   python_only:
   - analyze_blocking
-  - autoconfig
   - compare_clusters
-  - compare_strategies
   - configure
   - identity_audit
   - identity_audit_seal
@@ -198,23 +204,19 @@ a2a_skills:
   - rollback
   - schema_match
   - sensitivity
-  - transform
   ts_only:
   - agent_approve_reject
-  - agent_compare_strategies
   - agent_deduplicate
   - agent_explain_cluster
   - agent_explain_pair
   - agent_match_sources
   - agent_review_queue
-  - auto_configure
   - fix_quality
   - list_scorers
   - list_strategies
   - list_transforms
   - memory_export
   - profile
-  - run_transforms
   - scan_quality
   - score
   - suggest_config


### PR DESCRIPTION
## What

Closes the A2A skill-id naming divergence the parity gate (#1461) froze in `parity/goldenmatch.yaml`'s a2a_skills header — for the **verified same-operation** pairs, mirroring #1457's MCP-alias approach.

Investigated all 5 candidate divergent pairs against both sides' handlers:

| Pair | Verdict |
|---|---|
| `autoconfig` / `auto_configure` | same op (run AutoConfigController) → **alias** |
| `compare_strategies` / `agent_compare_strategies` | same op → **alias** |
| `transform` / `run_transforms` | same op (GoldenFlow transforms) → **alias** |
| `quality` / `scan_quality`+`fix_quality` | 1:2 granularity → **document** |
| `pprl` / `suggest_pprl` | PY **runs** `pprl_link`; TS **suggests** params → **document** |

## How

TS-side only (Python already advertises the canonical ids). A single `A2A_AGENT_ID_ALIASES` map drives:
- **`buildCardSkills`** override — the A2A card advertises Python's canonical id (`autoconfig`/`compare_strategies`/`transform`) for the 3 agent skills.
- **`dispatchAnySkill`** resolution — a `resolved = A2A_CANONICAL_TO_TOOL[skill] ?? skill` routes the canonical id to the underlying agent-tool handler; the legacy ids keep dispatching for free (they *are* the tool names). Non-breaking.

**The MCP tool ids are untouched** — the override is `buildCardSkills`-only; `AGENT_TOOL_NAMES`/`AGENT_MCP_TOOLS` still derive from `def.id`, so `auto_configure` etc. stay MCP tools (the A2A card is a separate surface).

Manifest a2a_skills: **17/21/19 → 20/18/16** (the 3 canonical ids move to shared; the 3 legacy TS ids leave ts_only — dispatch-only now). The 2 documented pairs get a "verified-different, not drift" header note.

## Tests

- **TS (CI-only):** the card advertises the 3 canonical ids and not the legacy 3; `dispatchAnySkill(canonical)` returns identically to `dispatchAnySkill(legacy)` for each (both resolve to the same handler; verified deterministic — no timestamps, fresh AgentSession per call).
- **Python (box-safe):** a guard that `_SKILLS` still exposes the 3 canonical ids (passes; Python unchanged). ruff-clean.
- **Gate:** the `api_parity` goldenmatch shard verifies the manifest matches the real emitted a2a surface (structure box-checked: 20/18/16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
