### PR TITLE
perf(goldencheck): zero-copy Arrow FFI + dict-array interning + Polars-free kernel fallbacks

### DIFF
--- a/packages/python/goldencheck/CLAUDE.md
+++ b/packages/python/goldencheck/CLAUDE.md
@@ -56,7 +56,28 @@ is already Polars/Arrow-vectorized and is NOT a native target.
 
 - **Crates:** `packages/rust/extensions/goldencheck-core/` (pyo3-free kernels, the
   `score-core` analogue) + `goldencheck-native/` (abi3 PyO3 shim, standalone
-  workspace, reads Arrow zero-copy via `PyArrowType<ArrayData>`, pinned `arrow=55`).
+  workspace, reads Arrow zero-copy via `PyArrowType<ArrayData>`, pinned `arrow=59`).
+- **Zero-copy FFI (the shim never copies a whole column).** Data crosses via the
+  Arrow C Data Interface (`PyArrowType<ArrayData>`) — the buffer is shared, not
+  copied. Two boundaries were tightened so the *Rust side* also avoids a full
+  materialization:
+  - **benford** (`profile.rs`): on the no-null path the Arrow values buffer *is*
+    `&[f64]` (deref of the shared `ScalarBuffer`), handed straight to the kernel —
+    no owned `Vec`. Avoids an 8 MB memcpy per call on a 1M-row column: **25.3 → 22.0 ms**
+    (~13%). The null path still compacts only the non-null subset (a raw buffer with
+    null slots has undefined backing f64s).
+  - **key/FD interning** (`keys.rs`): reads the primitive values buffer as a slice
+    (`arr.values()`) with a **no-null fast path** (drops the per-row validity branch),
+    instead of per-element `value(i)`. The interned `Vec<u64>` is unavoidable (the
+    kernels run on dense ids), but the reads are now buffer-slice: FD discovery
+    **11.5 → 10.3 ms** (~11%, it's interning-bound); composite ~flat (search-bound).
+  - **Measured and NOT taken** (the `measure, the naive kernel LOST` law): a single
+    **RecordBatch** import in place of N per-column arrays *regressed* Python-side prep
+    30–40% (`df.select().to_arrow().to_batches()` 1078 µs vs `[df[c].to_arrow() …]`
+    818 µs for 6 cols — the per-column exports are already single-chunk zero-copy);
+    and Arrow-izing **fuzzy near-dup** (`fuzzy.rs`) saves <0.3% (the `list[str]` copy of
+    ≤2000 *distinct* values is µs; the trigram-block + Levenshtein is the ~38 ms wall).
+    Both left as-is by design.
 - **Loader:** `goldencheck/core/_native_loader.py` — discover order
   `goldencheck._native` (in-tree build) → `goldencheck_native._native` (wheel) →
   pure Python. `GOLDENCHECK_NATIVE=auto|0|1`. A component runs native only if it's

--- a/packages/python/goldencheck/CLAUDE.md
+++ b/packages/python/goldencheck/CLAUDE.md
@@ -71,6 +71,16 @@ is already Polars/Arrow-vectorized and is NOT a native target.
     instead of per-element `value(i)`. The interned `Vec<u64>` is unavoidable (the
     kernels run on dense ids), but the reads are now buffer-slice: FD discovery
     **11.5 → 10.3 ms** (~11%, it's interning-bound); composite ~flat (search-bound).
+  - **Dictionary-array fast path** (`keys.rs`): when a key/FD column arrives as an
+    Arrow `DictionaryArray` (a Polars `Categorical`/`Enum` column), the dictionary
+    *is* the interning — intern the small values array ONCE, then map each row's key
+    through it (O(dict) hash + O(rows) index lookup) instead of O(rows) string hashing.
+    **~2× faster** kernel interning on a 200k string column (15.7 → 6.5 ms). It's a
+    zero-extra-cost fast path: exploited when the layout is already dictionary-encoded,
+    NOT manufactured — **measured**: forcing `cast(pl.Categorical)` in the profiler
+    *regressed* end-to-end (cast costs more than the interning it saves), so no cast is
+    added. Pays off automatically when a caller (or goldenpipe streaming Arrow) hands a
+    categorical column across. Parity locked in `test_native_parity.py`.
   - **Measured and NOT taken** (the `measure, the naive kernel LOST` law): a single
     **RecordBatch** import in place of N per-column arrays *regressed* Python-side prep
     30–40% (`df.select().to_arrow().to_batches()` 1078 µs vs `[df[c].to_arrow() …]`
@@ -78,6 +88,20 @@ is already Polars/Arrow-vectorized and is NOT a native target.
     and Arrow-izing **fuzzy near-dup** (`fuzzy.rs`) saves <0.3% (the `list[str]` copy of
     ≤2000 *distinct* values is µs; the trigram-block + Levenshtein is the ~38 ms wall).
     Both left as-is by design.
+- **Polars-free kernel fallbacks (pillar-1 partial eviction).** The native kernel is
+  the fast reference; the *fallbacks* for FD (`_discover_python`) and composite-key
+  (`_python_search`) now do their distinct-counting in **pure Python** (`set` over
+  column values / value-tuples) instead of Polars `n_unique` — so the Polars *engine*
+  is out of the kernel-compute path. Values are still pulled from the Polars frame via
+  `to_list` and candidate selection still inspects the frame (the scanner hands these
+  profilers a Polars `DataFrame` — the substrate stays Polars; this is not a
+  whole-package eviction). The pure-Python fallback is ~4× slower than the old Polars
+  one, acceptable as a no-native safety net. **Deferred (a decision, not an oversight):**
+  the full *native-required* cutover (delete the fallback, make `goldencheck-native` a
+  hard dependency) is NOT done here — it would (a) crash a plain `pip install goldencheck`
+  `--deep` scan that hits FD/composite, and (b) break `uv sync --all-packages` on the
+  shared `python` CI lane (no Rust on most legs → the base-dep maturin build fails). It
+  needs its own packaging PR (Rust in the base lane / wheel-resolution rework).
 - **Loader:** `goldencheck/core/_native_loader.py` — discover order
   `goldencheck._native` (in-tree build) → `goldencheck_native._native` (wheel) →
   pure Python. `GOLDENCHECK_NATIVE=auto|0|1`. A component runs native only if it's

--- a/packages/python/goldencheck/goldencheck/functional_dependencies.py
+++ b/packages/python/goldencheck/goldencheck/functional_dependencies.py
@@ -44,9 +44,9 @@ def _strict_pairs(df: pl.DataFrame, n: int) -> list[tuple[str, str]]:
         try:
             pairs = native_module().discover_functional_dependencies([df[c].to_arrow() for c in cols])
         except Exception:  # noqa: BLE001 - native failure -> Python fallback
-            pairs = _fd._discover_polars(df, cols, n)
+            pairs = _fd._discover_python(df, cols, n)
     else:
-        pairs = _fd._discover_polars(df, cols, n)
+        pairs = _fd._discover_python(df, cols, n)
     return [(cols[i], cols[j]) for i, j in pairs]
 
 

--- a/packages/python/goldencheck/goldencheck/relations/composite_key.py
+++ b/packages/python/goldencheck/goldencheck/relations/composite_key.py
@@ -69,11 +69,16 @@ def _has_single_column_key(df: pl.DataFrame, n_rows: int) -> bool:
 def _python_search(
     df: pl.DataFrame, candidates: list[str], n_rows: int, max_size: int
 ) -> list[list[int]]:
-    """Pure-Python mirror of goldencheck_core::composite_key_search.
+    """Polars-free mirror of goldencheck_core::composite_key_search.
 
     Identical BFS: candidates are all non-unique here (we only run when no
     single-column key exists), subsets stay sorted via the ``c <= last`` guard,
-    and supersets of a found key are pruned."""
+    and supersets of a found key are pruned. The distinct-tuple test runs in
+    pure Python (``len(set(zip(...)))``) rather than Polars ``n_unique`` — the
+    Rust kernel is the fast reference; this is the correctness fallback when the
+    native wheel isn't installed. Columns are pulled out of the Polars frame once
+    with ``to_list``; the Polars *engine* no longer runs the distinct counts."""
+    col_values = [df[c].to_list() for c in candidates]
     idxs = list(range(len(candidates)))
     found: list[list[int]] = []
     cap = min(max_size, len(idxs))
@@ -88,8 +93,7 @@ def _python_search(
                 subset = base + [c]
                 if any(all(x in subset for x in k) for k in found):
                     continue
-                cols = [candidates[j] for j in subset]
-                if df.select(cols).n_unique() == n_rows:
+                if len(set(zip(*(col_values[j] for j in subset)))) == n_rows:
                     found.append(subset)
                 else:
                     nxt.append(subset)

--- a/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
+++ b/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
@@ -12,8 +12,9 @@ Strict FD `det -> dep` holds iff ``n_distinct(det, dep) == n_distinct(det)``.
 When ``goldencheck[native]`` is installed, discovery runs in the Rust kernel
 (``discover_functional_dependencies`` -- interns each column once, reuses it
 across every pair, and early-exits on the first violation, which beats Polars
-recomputing a full two-column distinct per pair). Pure-Polars fallback uses the
-``n_unique`` identity above. Both are integer-exact -> identical results.
+recomputing a full two-column distinct per pair). The fallback (no native wheel)
+is pure Python — ``set``-based distinct counts, no Polars engine. Both are
+integer-exact -> identical results.
 
 Guards against noise: needs >= _MIN_ROWS rows of support, skips constant
 dependents and unique determinants (trivial), caps candidate columns, and
@@ -54,10 +55,18 @@ def _select_candidates(df: pl.DataFrame, n_rows: int) -> list[str]:
     return [c for _nu, c in scored[:_MAX_CANDIDATES]]
 
 
-def _discover_polars(df: pl.DataFrame, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
-    """Pure-Polars mirror of the kernel: det->dep holds iff
-    n_distinct(det, dep) == n_distinct(det). Skips trivial pairs identically."""
-    distinct = {c: df[c].n_unique() for c in cols}
+def _discover_python(df: pl.DataFrame, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
+    """Polars-free mirror of the kernel: det->dep holds iff
+    n_distinct(det, dep) == n_distinct(det). Skips trivial pairs identically.
+
+    The distinct-counting compute runs in pure Python (``set`` over the column
+    values / value-tuples) rather than Polars ``n_unique`` — the Rust kernel is
+    the fast reference; this is the correctness fallback when the native wheel
+    isn't installed (roughly ~4x slower than the old Polars path, acceptable for
+    a safety net). Values are pulled out of the Polars frame once with
+    ``to_list``; the Polars *engine* no longer runs the distinct counts."""
+    lists = {c: df[c].to_list() for c in cols}
+    distinct = {c: len(set(lists[c])) for c in cols}
     out: list[tuple[int, int]] = []
     for i, det in enumerate(cols):
         if distinct[det] == n_rows:  # unique determinant -> trivial
@@ -65,7 +74,7 @@ def _discover_polars(df: pl.DataFrame, cols: list[str], n_rows: int) -> list[tup
         for j, dep in enumerate(cols):
             if i == j or distinct[dep] <= 1:
                 continue
-            if df.select([det, dep]).n_unique() == distinct[det]:
+            if len(set(zip(lists[det], lists[dep]))) == distinct[det]:
                 out.append((i, j))
     return out
 
@@ -87,10 +96,10 @@ class FunctionalDependencyProfiler:
             try:
                 arrays = [df[c].to_arrow() for c in cols]
                 pairs = native_module().discover_functional_dependencies(arrays)
-            except Exception:  # noqa: BLE001 - any native failure -> Polars path
-                pairs = _discover_polars(df, cols, n_rows)
+            except Exception:  # noqa: BLE001 - any native failure -> pure-Python path
+                pairs = _discover_python(df, cols, n_rows)
         else:
-            pairs = _discover_polars(df, cols, n_rows)
+            pairs = _discover_python(df, cols, n_rows)
 
         if not pairs:
             return []

--- a/packages/python/goldencheck/tests/core/test_native_parity.py
+++ b/packages/python/goldencheck/tests/core/test_native_parity.py
@@ -181,10 +181,48 @@ def test_discover_fd_parity(seed: int) -> None:
     cols = fd._select_candidates(df, df.height)
     if len(cols) < 2:
         pytest.skip("not enough candidates")
-    py = set(fd._discover_polars(df, cols, df.height))
+    py = set(fd._discover_python(df, cols, df.height))
     arrays = [df[c].to_arrow() for c in cols]
     nat = set(native_module().discover_functional_dependencies(arrays))
     assert nat == py
+
+
+@native_only
+@pytest.mark.parametrize("seed", range(4))
+def test_dictionary_encoded_input_matches_string(seed: int) -> None:
+    """A dictionary-encoded (Polars Categorical) column must intern to the same
+    ids as its plain string form — so the key/FD kernels return identical
+    results whether a column arrives as Utf8 or as an Arrow dictionary. Covers
+    the zero-copy dict fast path in intern_column."""
+    rng = random.Random(seed)
+    n = 500
+    a = [f"z{rng.randint(0, 12)}" for _ in range(n)]
+    a2c: dict[str, str] = {}
+    b = [a2c.setdefault(z, f"c{rng.randint(0, 20)}") for z in a]  # a -> b strict
+    noise = [f"n{rng.randint(0, 40)}" for _ in range(n)]
+    df = pl.DataFrame({"a": a, "b": b, "noise": noise})
+
+    str_arrays = [df[c].to_arrow() for c in df.columns]
+    cat_arrays = [df[c].cast(pl.Categorical).to_arrow() for c in df.columns]
+
+    # Strict FD discovery: same (det, dep) set either encoding.
+    assert set(native_module().discover_functional_dependencies(cat_arrays)) == set(
+        native_module().discover_functional_dependencies(str_arrays)
+    )
+    # Composite-key search: same key sets either encoding.
+    su = [False] * len(df.columns)
+    assert native_module().composite_key_search(cat_arrays, 3, su) == (
+        native_module().composite_key_search(str_arrays, 3, su)
+    )
+    # A dictionary column with a null category interns null -> shared id 0.
+    with_null = pl.Series("x", ["p", None, "p", "q", None]).cast(pl.Categorical)
+    plain = pl.Series("x", ["p", None, "p", "q", None])
+    other = pl.Series("y", ["1", "1", "2", "2", "3"])
+    assert native_module().discover_functional_dependencies(
+        [with_null.to_arrow(), other.to_arrow()]
+    ) == native_module().discover_functional_dependencies(
+        [plain.to_arrow(), other.to_arrow()]
+    )
 
 
 from goldencheck.profilers import fuzzy_values as fv  # noqa: E402

--- a/packages/rust/extensions/goldencheck-native/src/keys.rs
+++ b/packages/rust/extensions/goldencheck-native/src/keys.rs
@@ -6,10 +6,14 @@
 //! value, never a lossy hash). Supports the dtypes the deep-profiler hands us:
 //! Utf8/LargeUtf8, the signed/unsigned ints, Float64/Float32, and Boolean.
 use arrow::array::{
-    Array, ArrayData, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array,
-    Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    Array, ArrayData, BooleanArray, DictionaryArray, Float32Array, Float64Array, Int16Array,
+    Int32Array, Int64Array, Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array,
+    UInt64Array, UInt8Array,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{
+    ArrowNativeType, DataType, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
+};
 use arrow::pyarrow::PyArrowType;
 use pyo3::prelude::*;
 use rustc_hash::FxHashMap;
@@ -126,6 +130,45 @@ fn intern_column(data: ArrayData) -> PyResult<Vec<u64>> {
                 }
             }
             Ok(ids)
+        }
+        // Dictionary-encoded (e.g. a Polars Categorical/Enum column). The
+        // dictionary *is* the interning: intern the (small) values array ONCE,
+        // then map each row's key through it — O(dict) hashing + O(rows) index
+        // lookups, instead of O(rows) hashing on the raw path. A null row keeps
+        // id 0. This is the zero-extra-work path when a categorical column flows
+        // straight through as an Arrow dictionary.
+        DataType::Dictionary(key_type, _) => {
+            macro_rules! intern_dict {
+                ($kt:ty) => {{
+                    let dict = DictionaryArray::<$kt>::from(data);
+                    // Dense id per dictionary entry (recurses on the small values
+                    // array; null entries -> 0, values -> 1,2,… first-seen).
+                    let value_ids = intern_column(dict.values().to_data())?;
+                    let keys = dict.keys();
+                    let mut ids = Vec::with_capacity(keys.len());
+                    for i in 0..keys.len() {
+                        if keys.is_null(i) {
+                            ids.push(0);
+                        } else {
+                            ids.push(value_ids[keys.value(i).as_usize()]);
+                        }
+                    }
+                    Ok(ids)
+                }};
+            }
+            match key_type.as_ref() {
+                DataType::Int8 => intern_dict!(Int8Type),
+                DataType::Int16 => intern_dict!(Int16Type),
+                DataType::Int32 => intern_dict!(Int32Type),
+                DataType::Int64 => intern_dict!(Int64Type),
+                DataType::UInt8 => intern_dict!(UInt8Type),
+                DataType::UInt16 => intern_dict!(UInt16Type),
+                DataType::UInt32 => intern_dict!(UInt32Type),
+                DataType::UInt64 => intern_dict!(UInt64Type),
+                other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                    "key/FD kernels: unsupported dictionary key type {other:?}"
+                ))),
+            }
         }
         other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
             "key/FD kernels do not support Arrow dtype {other:?}; \

--- a/packages/rust/extensions/goldencheck-native/src/keys.rs
+++ b/packages/rust/extensions/goldencheck-native/src/keys.rs
@@ -17,24 +17,44 @@ use rustc_hash::FxHashMap;
 /// Intern one Arrow column to dense `u64` value-ids. Null slots all share a
 /// single reserved id distinct from every real value's id.
 fn intern_column(data: ArrayData) -> PyResult<Vec<u64>> {
+    // Intern a primitive column by reading its Arrow **values buffer as a
+    // slice** (`arr.values()`, zero-copy) rather than per-element `value(i)`,
+    // and split a no-null fast path (skips the per-row validity branch) from the
+    // masked path. `keymap` turns a raw native value into the map key (identity
+    // for ints, bit-pattern for floats).
     macro_rules! intern_primitive {
-        ($arr:expr, $keyty:ty, $keyexpr:expr) => {{
+        ($arr:expr, $keyty:ty, $keymap:expr) => {{
             let arr = $arr;
+            let values = arr.values(); // &[native], the shared Arrow buffer
+            let keymap = $keymap;
             let mut map: FxHashMap<$keyty, u64> = FxHashMap::default();
             let mut ids = Vec::with_capacity(arr.len());
             let mut next: u64 = 1; // 0 is reserved for null
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
+            match arr.nulls() {
+                None => {
+                    for &raw in values.iter() {
+                        let id = *map.entry(keymap(raw)).or_insert_with(|| {
+                            let v = next;
+                            next += 1;
+                            v
+                        });
+                        ids.push(id);
+                    }
                 }
-                let key: $keyty = $keyexpr(&arr, i);
-                let id = *map.entry(key).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
+                Some(nulls) => {
+                    for (i, &raw) in values.iter().enumerate() {
+                        if nulls.is_null(i) {
+                            ids.push(0);
+                            continue;
+                        }
+                        let id = *map.entry(keymap(raw)).or_insert_with(|| {
+                            let v = next;
+                            next += 1;
+                            v
+                        });
+                        ids.push(id);
+                    }
+                }
             }
             Ok(ids)
         }};
@@ -79,44 +99,21 @@ fn intern_column(data: ArrayData) -> PyResult<Vec<u64>> {
             }
             Ok(ids)
         }
-        DataType::Int8 => {
-            intern_primitive!(Int8Array::from(data), i8, |a: &Int8Array, i| a.value(i))
-        }
-        DataType::Int16 => {
-            intern_primitive!(Int16Array::from(data), i16, |a: &Int16Array, i| a.value(i))
-        }
-        DataType::Int32 => {
-            intern_primitive!(Int32Array::from(data), i32, |a: &Int32Array, i| a.value(i))
-        }
-        DataType::Int64 => {
-            intern_primitive!(Int64Array::from(data), i64, |a: &Int64Array, i| a.value(i))
-        }
-        DataType::UInt8 => {
-            intern_primitive!(UInt8Array::from(data), u8, |a: &UInt8Array, i| a.value(i))
-        }
-        DataType::UInt16 => {
-            intern_primitive!(UInt16Array::from(data), u16, |a: &UInt16Array, i| a
-                .value(i))
-        }
-        DataType::UInt32 => {
-            intern_primitive!(UInt32Array::from(data), u32, |a: &UInt32Array, i| a
-                .value(i))
-        }
-        DataType::UInt64 => {
-            intern_primitive!(UInt64Array::from(data), u64, |a: &UInt64Array, i| a
-                .value(i))
-        }
+        DataType::Int8 => intern_primitive!(Int8Array::from(data), i8, |v: i8| v),
+        DataType::Int16 => intern_primitive!(Int16Array::from(data), i16, |v: i16| v),
+        DataType::Int32 => intern_primitive!(Int32Array::from(data), i32, |v: i32| v),
+        DataType::Int64 => intern_primitive!(Int64Array::from(data), i64, |v: i64| v),
+        DataType::UInt8 => intern_primitive!(UInt8Array::from(data), u8, |v: u8| v),
+        DataType::UInt16 => intern_primitive!(UInt16Array::from(data), u16, |v: u16| v),
+        DataType::UInt32 => intern_primitive!(UInt32Array::from(data), u32, |v: u32| v),
+        DataType::UInt64 => intern_primitive!(UInt64Array::from(data), u64, |v: u64| v),
         // Floats keyed by bit pattern (exact value identity; matches Polars
         // equality semantics for finite values, which is all a key column has).
         DataType::Float32 => {
-            intern_primitive!(Float32Array::from(data), u32, |a: &Float32Array, i| a
-                .value(i)
-                .to_bits())
+            intern_primitive!(Float32Array::from(data), u32, |v: f32| v.to_bits())
         }
         DataType::Float64 => {
-            intern_primitive!(Float64Array::from(data), u64, |a: &Float64Array, i| a
-                .value(i)
-                .to_bits())
+            intern_primitive!(Float64Array::from(data), u64, |v: f64| v.to_bits())
         }
         DataType::Boolean => {
             let arr = BooleanArray::from(data);

--- a/packages/rust/extensions/goldencheck-native/src/profile.rs
+++ b/packages/rust/extensions/goldencheck-native/src/profile.rs
@@ -25,13 +25,18 @@ pub fn benford_leading_digits(values: PyArrowType<ArrayData>) -> PyResult<[u64; 
     }
     let arr = Float64Array::from(data);
     // Honour the null mask: a null slot's backing f64 is undefined.
-    let vals: Vec<f64> = if arr.null_count() == 0 {
-        arr.values().to_vec()
+    if arr.null_count() == 0 {
+        // True zero-copy: the Arrow values buffer *is* `&[f64]` (deref of the
+        // shared `ScalarBuffer`) — hand it straight to the kernel, no owned Vec.
+        // On a 1M-row column this avoids an 8 MB memcpy per call.
+        Ok(goldencheck_core::benford_leading_digits(arr.values()))
     } else {
-        (0..arr.len())
+        // Null slots have an undefined backing f64, so we can't pass the raw
+        // buffer; compact the valid values (only the non-null subset) instead.
+        let vals: Vec<f64> = (0..arr.len())
             .filter(|&i| !arr.is_null(i))
             .map(|i| arr.value(i))
-            .collect()
-    };
-    Ok(goldencheck_core::benford_leading_digits(&vals))
+            .collect();
+        Ok(goldencheck_core::benford_leading_digits(&vals))
+    }
 }


### PR DESCRIPTION
## What and why

A GoldenCheck Rust-cutover pass on the deep-profiling kernel path, advancing the ecosystem thesis (pure-Rust muscle, Arrow zero-copy memory, Polars evicted from the hot path). Every leg is measured against `benchmarks/deep_profile_benchmark.py`; per the repo's *"measure, the naive kernel LOST"* law, only changes that move the wall (or are clearly correct/cleaner) are kept.

## Changes

**1. True zero-copy FFI on the hot boundaries** (`goldencheck-native`)
- **benford**: no-null path hands the Arrow values buffer straight to the kernel (`arr.values()` *is* `&[f64]`) instead of `arr.values().to_vec()` — kills an 8 MB memcpy/call. **25.3 → 22.0 ms (~13%)**.
- **key/FD interning**: reads the primitive values buffer as a slice with a no-null fast path (drops the per-row validity branch). **FD discovery 11.5 → 10.3 ms (~11%)**.

**2. Dictionary-array fast path** (`keys.rs`)
- When a key/FD column arrives as an Arrow `DictionaryArray` (Polars `Categorical`/`Enum`), the dictionary *is* the interning: intern the small values array once, map each row's key through it (O(dict) hash + O(rows) index lookup) vs O(rows) string hashing. **~2× faster** kernel interning on a 200k string column (15.7 → 6.5 ms). Zero-extra-cost — exploited when the layout is already dict-encoded, **not manufactured** (measured: forcing `cast(Categorical)` regresses end-to-end, so no cast is added). Pays off when goldenpipe streams categorical Arrow across.

**3. Polars-free kernel fallbacks** (pillar-1 partial eviction)
- The FD (`_discover_python`, renamed from `_discover_polars`) and composite-key (`_python_search`) fallbacks do their distinct-counting in pure Python (`set` over values / value-tuples) instead of Polars `n_unique`. The Polars *engine* is out of the kernel-compute path. The scanner still hands these profilers a Polars `DataFrame` (values read via `to_list`, candidate selection inspects the frame) — the substrate stays Polars; this is **not** a whole-package eviction.

**Measured and NOT taken:** RecordBatch single-import (regressed Python prep 30–40%), Arrow-izing fuzzy near-dup (<0.3% of the call). Documented in `CLAUDE.md`.

## ⚠️ A decision deferred, not an oversight

The requested endgame was *native-required + delete the fallback + make `goldencheck-native` a hard dependency*. I stopped short of that here because investigation showed it (a) **crashes** a plain `pip install goldencheck` `--deep` scan that hits FD/composite (no native, no fallback), and (b) **breaks `uv sync --all-packages`** on the shared `python` CI lane — that lane has no Rust on most legs, so a base-dep maturin build fails for all 7 packages. That flip is a real packaging PR (add Rust to the base lane / rework wheel resolution) and is trivially reachable from this state (delete the fallback + flip the dep). This PR delivers the safe, non-breaking Polars-eviction of the kernel compute; the hard-dep flip is a clean follow-up to green-light explicitly. *(I tried to confirm this sequencing interactively but the prompt tool was unavailable.)*

## Measurements (median-of-5, native built locally)

| Kernel | before | after | Δ |
|---|--:|--:|--:|
| Benford (1M) | 25.34 ms | 22.0 ms | ~13% |
| FD discovery (200k) | 11.53 ms | 10.3 ms | ~11% |
| Dict-interning (200k string col) | 15.7 ms | 6.5 ms | ~2× |
| Pure-Python FD fallback (200k) | 105 ms (Polars) | 452 ms | ~4× slower (safety net) |

## Testing

- `GOLDENCHECK_NATIVE=1 pytest tests/core/test_native_parity.py` — 41 passed (incl. 4 new dict-array parity cases; native == the new pure-Python fallback).
- `GOLDENCHECK_NATIVE=0 pytest tests/relations/…` — fallback path works without native.
- Broad native-path sweep (core + relations + fuzzy + functional_dependencies) — 113 passed.
- `cargo fmt --check` + `cargo clippy --release` + `ruff check` — clean.

## Checklist

- [x] Tests passing (41 parity + 113 sweep), native on and off
- [x] `cargo fmt`/`clippy`/`ruff` clean
- [x] `goldencheck-core` untouched — kernels byte-identical
- [x] `CLAUDE.md` updated (dict path, Polars-free fallbacks, deferred hard-dep rationale)
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)