### PR TITLE
docs+bench(goldenpipe): Stage 0 baseline — the handoff is not the bottleneck

### DIFF
--- a/docs/design/2026-07-06-goldenpipe-stage0-findings.md
+++ b/docs/design/2026-07-06-goldenpipe-stage0-findings.md
@@ -1,0 +1,89 @@
+# GoldenPipe Stage 0 findings — the handoff is not the bottleneck
+
+**Status:** done (measurement). **Created:** 2026-07-06.
+**Feeds:** `2026-07-06-goldenpipe-orchestrator-pivot.md` (Stage 0 gate).
+
+## The question
+
+The orchestrator-pivot roadmap gates pillar 2 (a Rust streaming executor) on a
+Stage-0 measurement: **in the single-process pipeline, are the DataFrame handoffs
+between stages a real bottleneck?** If they aren't, a streaming Arrow executor
+would optimize a non-bottleneck, and pillar 2's value lies elsewhere.
+
+## Method
+
+`benchmarks/stage0_handoff_profile.py` generates a dirty entity table (name /
+email / city with typos, casing noise, ~20% near-duplicate rows) and runs the
+real auto-config pipeline `goldencheck.scan → goldenflow.transform →
+goldenmatch.dedupe`. It reads the Runner's per-stage `ctx.timing`, the total wall,
+and isolates the two concrete handoff / re-materialization costs a shared Arrow
+buffer would remove:
+1. the CSV **re-read** `goldencheck.scan` does (it takes the source *path*, not
+   `ctx.df`, so the data is parsed twice), and
+2. the full-df **`cast({col: Utf8})`** `goldenmatch.dedupe` does at its boundary.
+
+## Results (median wall)
+
+| | 20,000 rows | 50,000 rows |
+|---|--:|--:|
+| **TOTAL wall** | 2176 ms | 4806 ms |
+| `goldencheck.scan` (compute) | 307 ms · 14.1% | 613 ms · 12.7% |
+| `goldenflow.transform` (compute) | 232 ms · 10.6% | 551 ms · 11.5% |
+| **`goldenmatch.dedupe` (compute)** | **1626 ms · 74.7%** | **3622 ms · 75.3%** |
+| orchestration gap (plan/route/ctx) | 12 ms · 0.5% | 21 ms · 0.4% |
+| handoff: CSV re-read | 3.5 ms · 0.2% | 5.7 ms · 0.1% |
+| handoff: full-df Utf8 cast | 1.6 ms · 0.1% | 2.2 ms · 0.0% |
+| **handoff total** | **5.1 ms · 0.2%** | **7.9 ms · 0.2%** |
+
+## Verdict — do NOT build the single-process streaming executor
+
+The wall is **~99% per-stage kernel compute**, and `goldenmatch.dedupe` alone is
+**~75%** of it. The handoff / re-materialization costs a streaming Arrow data
+plane would eliminate are **0.2% of the wall** (and *shrinking* as data grows —
+the compute is superlinear, the handoff linear). The orchestration gap is 0.4%.
+
+So a Rust streaming executor that made the between-stage handoff free would win
+**<1% end-to-end** in the single-process case. That directly disconfirms the
+thesis framing for this workload: the cost is not "translating objects across the
+boundary" — it's the ER math inside the kernels. This is the same lesson
+GoldenCheck's zero-copy FFI work produced: once Arrow's C Data Interface is in
+play, the boundary is nearly free; the wall lives in compute.
+
+**Corollary — where the leverage actually is:** the highest-value perf lever for a
+pipeline is `goldenmatch.dedupe` (blocking + scoring), which is exactly what the
+*other* pillars already target (the `-core` kernels + native acceleration + the
+HNSW/LSH blockers). The pipe is already a thin, cheap orchestrator; making it
+"smarter" in Rust optimizes the wrong 1%.
+
+## Where pillar 2 *should* aim
+
+The streaming Arrow plane becomes load-bearing only where the handoff stops being
+a free in-process reference pass:
+- **Out-of-core** — data larger than memory, where stages must stream
+  record-batches rather than hold a whole DataFrame (today's design materializes
+  the full frame in `ctx.df`).
+- **Cross-process / cross-language** — a stage on another engine (DuckDB /
+  Postgres / a TS worker), where the handoff becomes real serialization and Arrow
+  IPC / the C Data Interface earns its keep.
+- **Parallel DAG branches** — independent stages that could run concurrently; the
+  current `Runner` is a sequential `for`-loop, but that's a *scheduling* win
+  (thread pool over the existing `ExecutionPlan`), not an *Arrow-streaming* win,
+  and it's only worth it when branches are both independent and heavy.
+
+Recommended next step is therefore **not** Stage 1/2 of the executor as written,
+but to re-scope pillar 2 around one of the above — most likely an **out-of-core /
+batched-streaming** target with a measured workload, or the parallel-DAG
+scheduler if real pipelines have independent heavy branches. Either should get its
+own Stage-0-style baseline before any build.
+
+## Two cheap tidy-ups noted (not worth an executor)
+
+Independent of pillar 2, the profile surfaced two real (if negligible) micro-costs
+that a shared buffer would remove and that could be tidied trivially if ever
+touched: `goldencheck.scan` re-reading the file instead of consuming `ctx.df`
+(~0.2%), and the whole-frame Utf8 cast in `goldenmatch.dedupe` (~0.1%). Left as-is;
+they are noise against the dedupe wall.
+
+## Repro
+
+`python packages/python/goldenpipe/benchmarks/stage0_handoff_profile.py --rows 50000`

--- a/packages/python/goldenpipe/benchmarks/stage0_handoff_profile.py
+++ b/packages/python/goldenpipe/benchmarks/stage0_handoff_profile.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Stage 0 of the GoldenPipe orchestrator pivot: where does the wall actually go?
+
+Measures a real ``scan -> transform -> dedupe`` pipeline and splits the wall into
+**per-stage compute** vs the **handoff / re-materialization** costs that a
+streaming Arrow data plane (pillar 2) would remove — so the decision to build a
+Rust streaming executor is driven by data, not the thesis diagram.
+
+The two concrete handoff costs in today's design (see the adapters):
+  1. ``goldencheck.scan`` takes the source *path* and RE-READS/RE-PARSES the CSV,
+     even though the pipeline already holds the data in ``ctx.df`` — the data is
+     loaded twice.
+  2. ``goldenmatch.dedupe`` does ``ctx.df.cast({col: Utf8})`` — a full-column
+     materialization at the match boundary.
+
+A shared Arrow buffer across stages would eliminate both. If they (plus the
+between-stage orchestration gap) are a small fraction of the wall, a streaming
+executor optimizes a non-bottleneck and pillar 2 should target out-of-core /
+cross-process instead.
+
+Run:
+    python benchmarks/stage0_handoff_profile.py --rows 20000
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import statistics
+import tempfile
+import time
+
+import polars as pl
+
+_FIRST = ["Jon", "John", "Jonathan", "Mary", "Maria", "Bob", "Robert", "Sue", "Susan", "Bill"]
+_LAST = ["Smith", "Smyth", "Jones", "Brown", "Browne", "Lee", "Garcia", "Nguyen", "Patel", "Kim"]
+_DOMAINS = ["example.com", "test.org", "mail.net", "corp.co"]
+_CITIES = ["New York", "new york", "NYC", "Los Angeles", "LA", "Chicago", "Boston"]
+
+
+def _make_dataset(path: str, rows: int, seed: int = 7) -> None:
+    """A dirty entity table: name/email/city with typos, casing noise, and
+    ~20% near-duplicate rows — the shape an ER pipeline is built for."""
+    rng = random.Random(seed)
+    recs = []
+    for i in range(rows):
+        f = rng.choice(_FIRST)
+        last = rng.choice(_LAST)
+        city = rng.choice(_CITIES)
+        email = f"{f.lower()}.{last.lower()}{rng.randint(0, 99)}@{rng.choice(_DOMAINS)}"
+        recs.append({"id": i, "first": f, "last": last, "email": email, "city": city,
+                     "amount": round(rng.random() * 1000, 2)})
+        # ~20% near-dup: same person, noisy re-entry
+        if rng.random() < 0.2:
+            recs.append({"id": rows + i, "first": f, "last": last,
+                         "email": f"  {email.upper()} ", "city": city.upper(),
+                         "amount": round(rng.random() * 1000, 2)})
+    df = pl.DataFrame(recs)
+    df.write_csv(path)
+
+
+def _median_wall(fn, runs: int = 3) -> float:
+    return statistics.median(_time(fn) for _ in range(runs))
+
+
+def _time(fn) -> float:
+    t0 = time.perf_counter()
+    fn()
+    return time.perf_counter() - t0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=20_000)
+    ap.add_argument("--runs", type=int, default=3)
+    args = ap.parse_args()
+
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, "entities.csv")
+    _make_dataset(path, args.rows)
+    on_disk = os.path.getsize(path)
+    print(f"GoldenPipe Stage-0 handoff profile  (rows≈{args.rows:,}, csv={on_disk/1e6:.1f} MB)\n")
+
+    from goldenpipe import Pipeline
+
+    # --- the pipeline wall + per-stage compute (ctx.timing) ---
+    timings: dict[str, float] = {}
+    walls: list[float] = []
+    for _ in range(args.runs):
+        pipe = Pipeline()  # auto-config: scan -> transform -> dedupe
+        t0 = time.perf_counter()
+        res = pipe.run(source=path)
+        walls.append(time.perf_counter() - t0)
+        for k, v in (res.timing or {}).items():
+            timings.setdefault(k, []).append(v)
+    wall = statistics.median(walls)
+    stage_med = {k: statistics.median(v) for k, v in timings.items()}
+    stage_sum = sum(stage_med.values())
+
+    print(f"  status: {res.status}  |  stages: {list(stage_med)}\n")
+    print(f"  {'TOTAL wall':<34}: {wall*1000:9.1f} ms")
+    for name, ms in stage_med.items():
+        print(f"    stage  {name:<27}: {ms*1000:9.1f} ms  ({ms/wall*100:4.1f}%)")
+    gap = wall - stage_sum
+    print(f"  {'orchestration gap (plan/route/ctx)':<34}: {gap*1000:9.1f} ms  ({gap/wall*100:4.1f}%)\n")
+
+    # --- isolate the two handoff / re-materialization costs ---
+    print("  Handoff / re-materialization costs a shared Arrow buffer would remove:")
+    # (1) the CSV re-read goldencheck.scan does (pipeline already loaded ctx.df)
+    reread = _median_wall(lambda: pl.read_csv(path, ignore_errors=True, encoding="utf8-lossy"),
+                          args.runs)
+    print(f"    (1) CSV re-read in scan (path, not ctx.df)  : {reread*1000:9.1f} ms  "
+          f"({reread/wall*100:4.1f}% of wall)")
+    # (2) the full-df Utf8 cast dedupe does at the match boundary
+    df = pl.read_csv(path, ignore_errors=True, encoding="utf8-lossy")
+    cast = _median_wall(lambda: df.cast({c: pl.Utf8 for c in df.columns}), args.runs)
+    print(f"    (2) full-df Utf8 cast at dedupe boundary    : {cast*1000:9.1f} ms  "
+          f"({cast/wall*100:4.1f}% of wall)")
+    handoff = reread + cast
+    print(f"    {'sum of these handoff costs':<41}: {handoff*1000:9.1f} ms  "
+          f"({handoff/wall*100:4.1f}% of wall)\n")
+
+    print("  Read: if per-stage COMPUTE dominates and the handoff costs are a small")
+    print("  slice, a streaming Arrow executor optimizes a non-bottleneck — pillar 2")
+    print("  should target out-of-core / cross-process pipelines instead.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What and why

Stage 0 of the GoldenPipe orchestrator pivot (from `2026-07-06-goldenpipe-orchestrator-pivot.md`): before committing to a Rust streaming executor (pillar 2), **measure** whether the DataFrame handoffs between stages are actually a bottleneck in the single-process pipeline. Adds a repro benchmark + a findings doc.

## The experiment

`benchmarks/stage0_handoff_profile.py` runs the real auto-config pipeline (`goldencheck.scan → goldenflow.transform → goldenmatch.dedupe`) on a dirty entity table and splits the wall into per-stage compute vs. the two concrete handoff / re-materialization costs a shared Arrow buffer would remove: the CSV **re-read** in `scan` (it takes the source path, not `ctx.df`) and the full-df **`cast({col: Utf8})`** in `dedupe`.

## Result — decisive

| | 20k rows | 50k rows |
|---|--:|--:|
| TOTAL wall | 2176 ms | 4806 ms |
| `goldenmatch.dedupe` (compute) | **74.7%** | **75.3%** |
| `goldencheck.scan` + `goldenflow.transform` | 24.7% | 24.2% |
| orchestration gap | 0.5% | 0.4% |
| **handoff / re-materialization total** | **0.2%** | **0.2%** |

The wall is **~99% per-stage kernel compute** (dedupe alone ~75%); the handoff costs a streaming Arrow plane would eliminate are **0.2% and shrinking** (compute is superlinear, handoff linear).

## Verdict

**Do NOT build the single-process streaming executor** — it would win <1% end-to-end, optimizing the wrong 1%. This is the same lesson GoldenCheck's zero-copy FFI produced: once Arrow's C Data Interface is in play, the boundary is nearly free; the wall is compute. The highest-leverage pipeline perf lever is `goldenmatch.dedupe` (blocking/scoring) — already the target of the `-core` kernels + native acceleration.

**Re-scope pillar 2** around where the handoff is genuinely load-bearing: **out-of-core** (data > memory), **cross-process/cross-language** (real serialization), or a **parallel-DAG scheduler** — each with its own Stage-0 baseline before any build.

## Testing

Benchmark runs clean at 20k and 50k (numbers above are its output). `ruff check` clean. Docs-only otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_