### PR TITLE
feat(goldenflow): Arrow-columnar apply path for the trivial text family

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2158,7 +2158,7 @@ jobs:
       # The optional `arrow` feature (src/columnar.rs Arrow-columnar apply paths +
       # the columnar_pilot bench) is cfg'd out of the default build above, so its
       # parity tests + clippy need an explicit run. native-flow enables it.
-      - run: cargo test --manifest-path goldenflow-core/Cargo.toml --features arrow columnar::
+      - run: cargo test --manifest-path goldenflow-core/Cargo.toml --features arrow
       - run: cargo clippy --manifest-path goldenflow-core/Cargo.toml --features arrow --all-targets -- -D warnings
       # sketch-core (MinHash/LSH, #1081) is its own [workspace] pyo3-free sibling
       # too; the native binding exercises it indirectly, but its own unit tests +

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2155,6 +2155,11 @@ jobs:
       # too (a clippy violation in the ISBN kernel had shipped green before this).
       - run: cargo test --manifest-path goldenflow-core/Cargo.toml
       - run: cargo clippy --manifest-path goldenflow-core/Cargo.toml --all-targets -- -D warnings
+      # The optional `arrow` feature (src/columnar.rs Arrow-columnar apply paths +
+      # the columnar_pilot bench) is cfg'd out of the default build above, so its
+      # parity tests + clippy need an explicit run. native-flow enables it.
+      - run: cargo test --manifest-path goldenflow-core/Cargo.toml --features arrow columnar::
+      - run: cargo clippy --manifest-path goldenflow-core/Cargo.toml --features arrow --all-targets -- -D warnings
       # sketch-core (MinHash/LSH, #1081) is its own [workspace] pyo3-free sibling
       # too; the native binding exercises it indirectly, but its own unit tests +
       # the golden-vector parity test need an explicit run.

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -25,3 +25,15 @@ phonenumber = "0.3"
 [dev-dependencies]
 # Parse the polars-generated text-transform golden corpus (tests/text_golden.rs).
 serde_json = "1"
+# Arrow-columnar-kernel pilot bench (benches/columnar_pilot.rs) ONLY — the core
+# stays arrow-free for the shipping surfaces; these are dev-only. Same v59 pin as
+# native-flow so the measured StringArray shape matches the real surface.
+arrow-array = { version = "59", default-features = false }
+arrow-buffer = { version = "59", default-features = false }
+
+# Pilot: scalar-per-element vs Arrow-columnar kernel (W6 pillar-1/3 decision).
+# harness=false -> plain fn main() with std::time 5-run-median (matches the repo
+# "5-run median wall" convention; no criterion/nightly dep).
+[[bench]]
+name = "columnar_pilot"
+harness = false

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -21,19 +21,23 @@ name = "goldenflow_core"
 # Same pin native-flow used, so phone output is byte-identical before/after the
 # extraction (parity by construction — one source of truth).
 phonenumber = "0.3"
+# OPTIONAL (feature `arrow`, off by default): the Arrow-columnar apply paths in
+# src/columnar.rs. The wasm / pure-logic surfaces never enable this, so the core
+# stays arrow-free for them; native-flow (which already ships arrow) enables it.
+arrow-array = { version = "59", default-features = false, optional = true }
+arrow-buffer = { version = "59", default-features = false, optional = true }
+
+[features]
+arrow = ["dep:arrow-array", "dep:arrow-buffer"]
 
 [dev-dependencies]
 # Parse the polars-generated text-transform golden corpus (tests/text_golden.rs).
 serde_json = "1"
-# Arrow-columnar-kernel pilot bench (benches/columnar_pilot.rs) ONLY — the core
-# stays arrow-free for the shipping surfaces; these are dev-only. Same v59 pin as
-# native-flow so the measured StringArray shape matches the real surface.
-arrow-array = { version = "59", default-features = false }
-arrow-buffer = { version = "59", default-features = false }
 
-# Pilot: scalar-per-element vs Arrow-columnar kernel (W6 pillar-1/3 decision).
-# harness=false -> plain fn main() with std::time 5-run-median (matches the repo
-# "5-run median wall" convention; no criterion/nightly dep).
+# scalar-per-element vs Arrow-columnar apply bench (W6 pillar-1/3 decision).
+# harness=false -> plain fn main() with std::time 5-run-median (repo convention,
+# no criterion/nightly). Needs the `arrow` feature for the StringArray shape.
 [[bench]]
 name = "columnar_pilot"
 harness = false
+required-features = ["arrow"]

--- a/packages/rust/extensions/goldenflow-core/benches/columnar_pilot.rs
+++ b/packages/rust/extensions/goldenflow-core/benches/columnar_pilot.rs
@@ -1,0 +1,225 @@
+//! Arrow-columnar kernel PILOT (owned-kernel cutover, pillar 1/3 decision).
+//!
+//! Question: does turning the scalar-per-element kernel path
+//! (`for_each_str` -> `fn(&str)->Option<String>` -> `StringBuilder::append`) into
+//! an Arrow-COLUMNAR kernel (operate on the whole StringArray buffer at once)
+//! actually pay -- and where? We measure two representative shapes on a 1M-row
+//! Utf8 array, 5-run median wall (the repo's convention), asserting the columnar
+//! output is byte-identical to the scalar output (so the corpus contract holds):
+//!
+//!   - `lowercase`  = byte-trivial op. Columnar can lowercase the contiguous
+//!     values buffer in one pass (ASCII fast path, SIMD-friendly `make_ascii_
+//!     lowercase`), reusing offsets+nulls -> ZERO per-element String allocs.
+//!   - `name_proper`    = compute-heavy per-string transform. Cannot vectorize;
+//!     "columnar" here is only exact-capacity sizing + no closure/Option
+//!     indirection. Expected: near-parity -> the sweep should NOT re-architect
+//!     compute-heavy kernels.
+//!
+//! Run: `cargo bench --bench columnar_pilot` (release/bench profile).
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use arrow_array::builder::StringBuilder;
+use arrow_array::{Array, StringArray};
+use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+
+use goldenflow_core::names::name_proper;
+use goldenflow_core::text::{lowercase, strip};
+
+const N: usize = 1_000_000;
+const RUNS: usize = 5;
+
+// --- The CURRENT shipping shape (mirrors native-flow util::map_str_to_str) -----
+// closure returning Option<String>, Some-wrap, generic len*12 value capacity,
+// per-element append.
+
+fn scalar_map<F: Fn(&str) -> Option<String>>(arr: &StringArray, f: F) -> StringArray {
+    let len = arr.len();
+    let mut b = StringBuilder::with_capacity(len, len * 12);
+    for v in arr.iter() {
+        match v {
+            Some(s) => match f(s) {
+                Some(out) => b.append_value(out),
+                None => b.append_null(),
+            },
+            None => b.append_null(),
+        }
+    }
+    b.finish()
+}
+
+fn scalar_lowercase(arr: &StringArray) -> StringArray {
+    scalar_map(arr, |s| Some(lowercase(s)))
+}
+
+fn scalar_name_proper(arr: &StringArray) -> StringArray {
+    scalar_map(arr, |s| Some(name_proper(s)))
+}
+
+fn scalar_strip(arr: &StringArray) -> StringArray {
+    scalar_map(arr, |s| Some(strip(s).to_string()))
+}
+
+// --- GENERIC columnar map: one primitive for ANY op --------------------------
+// `f` writes the transformed bytes of each element directly into ONE shared
+// values buffer (no per-element String alloc, no builder double-copy); offsets
+// are computed as we go. This is the "one primitive, all trivial ops adapt"
+// candidate -- captures the alloc/copy elimination WITHOUT op-specific buffer
+// surgery or whole-buffer SIMD.
+
+fn generic_columnar<F: Fn(&str, &mut String)>(arr: &StringArray, f: F) -> StringArray {
+    let len = arr.len();
+    let mut offsets: Vec<i32> = Vec::with_capacity(len + 1);
+    offsets.push(0);
+    let mut values = String::with_capacity(arr.values().len());
+    for v in arr.iter() {
+        if let Some(s) = v {
+            f(s, &mut values);
+        }
+        offsets.push(values.len() as i32);
+    }
+    StringArray::new(
+        OffsetBuffer::new(ScalarBuffer::from(offsets)),
+        Buffer::from_vec(values.into_bytes()),
+        arr.nulls().cloned(),
+    )
+}
+
+fn generic_lowercase(arr: &StringArray) -> StringArray {
+    // ASCII case-fold appended byte-wise (matches make_ascii_lowercase on ASCII;
+    // non-ASCII bytes are >= 0x80 and unchanged, so the buffer stays valid UTF-8).
+    generic_columnar(arr, |s, buf| {
+        // SAFETY: ascii-lowercasing UTF-8 bytes yields valid UTF-8.
+        let v = unsafe { buf.as_mut_vec() };
+        v.extend(s.as_bytes().iter().map(|b| b.to_ascii_lowercase()));
+    })
+}
+
+fn generic_strip(arr: &StringArray) -> StringArray {
+    // trim() is zero-alloc slicing; push_str copies the slice once -> no
+    // per-element String allocation (unlike scalar `strip(s)`).
+    generic_columnar(arr, |s, buf| buf.push_str(strip(s)))
+}
+
+// --- The COLUMNAR variants -----------------------------------------------------
+
+/// Buffer-level lowercase. When the whole values buffer is ASCII, lowercase it
+/// in a single `make_ascii_lowercase` pass (byte lengths unchanged, so offsets +
+/// nulls are reused verbatim) -- no per-element allocation. Falls back to the
+/// scalar Unicode path if any non-ASCII byte is present (correctness first:
+/// `make_ascii_lowercase` != `to_lowercase` outside ASCII).
+fn columnar_lowercase(arr: &StringArray) -> StringArray {
+    let bytes: &[u8] = arr.values().as_slice();
+    if !bytes.is_ascii() {
+        return scalar_lowercase(arr);
+    }
+    let mut v = bytes.to_vec();
+    v.make_ascii_lowercase();
+    StringArray::new(arr.offsets().clone(), Buffer::from_vec(v), arr.nulls().cloned())
+}
+
+/// "Columnar" name_proper: no closure / Option indirection, capacity-hinted.
+/// The title-case compute is inherently per-string (unchanged).
+fn columnar_name_proper(arr: &StringArray) -> StringArray {
+    let len = arr.len();
+    let mut b = StringBuilder::with_capacity(len, len * 16);
+    for v in arr.iter() {
+        match v {
+            Some(s) => b.append_value(name_proper(s)),
+            None => b.append_null(),
+        }
+    }
+    b.finish()
+}
+
+// --- Harness -------------------------------------------------------------------
+
+fn bench<F: Fn() -> StringArray>(f: F) -> (f64, StringArray) {
+    let out = f(); // warmup + captured for the parity assert
+    let mut times = Vec::with_capacity(RUNS);
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let r = f();
+        times.push(t.elapsed().as_secs_f64() * 1000.0);
+        black_box(&r);
+    }
+    times.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    (times[RUNS / 2], out)
+}
+
+fn assert_same(a: &StringArray, b: &StringArray) {
+    assert_eq!(a.len(), b.len(), "length mismatch");
+    for i in 0..a.len() {
+        assert_eq!(a.is_null(i), b.is_null(i), "null mismatch at {i}");
+        if !a.is_null(i) {
+            assert_eq!(a.value(i), b.value(i), "value mismatch at {i}");
+        }
+    }
+}
+
+fn build_data() -> StringArray {
+    // All-ASCII, realistic messy mixed-case name-like strings (the common ER
+    // case; non-ASCII names are typically transliterated upstream). ~1% nulls.
+    let pool = [
+        "John Smith", "  MARY Jones  ", "o'Brien", "MacDonald", "Robert",
+        "Rupert", "Ashcraft", "Tymczak", "Van Der Berg", "de la CRUZ",
+        "JACKSON", "Washington", "Honeyman", "Gauss", "Pfister",
+        "Catherine", "Katherine", "Thompson", "Ghislaine", "Wright",
+    ];
+    let owned: Vec<Option<String>> = (0..N)
+        .map(|i| {
+            if i % 100 == 0 {
+                None
+            } else {
+                Some(format!("{}{}", pool[i % pool.len()], i % 97))
+            }
+        })
+        .collect();
+    StringArray::from(
+        owned
+            .iter()
+            .map(|o| o.as_deref())
+            .collect::<Vec<Option<&str>>>(),
+    )
+}
+
+fn main() {
+    let mrows = N as f64 / 1e6;
+    let tp = |m: f64| mrows / (m / 1000.0);
+    println!("Arrow-columnar kernel pilot -- {N} rows, {RUNS}-run median wall\n");
+    let arr = build_data();
+
+    // lowercase (offset-preserving byte op): scalar vs generic vs specialized.
+    let (s_lo, o_s) = bench(|| scalar_lowercase(&arr));
+    let (g_lo, o_g) = bench(|| generic_lowercase(&arr));
+    let (c_lo, o_c) = bench(|| columnar_lowercase(&arr));
+    assert_same(&o_s, &o_g);
+    assert_same(&o_s, &o_c);
+    println!("lowercase (offset-preserving):");
+    println!("  scalar-per-element   {s_lo:8.2} ms ({:6.1} M/s)  1.00x", tp(s_lo));
+    println!("  generic buffer-write {g_lo:8.2} ms ({:6.1} M/s)  {:.2}x", tp(g_lo), s_lo / g_lo);
+    println!("  specialized (SIMD)   {c_lo:8.2} ms ({:6.1} M/s)  {:.2}x", tp(c_lo), s_lo / c_lo);
+
+    // strip (offset-changing, shrinks): scalar vs generic (no clean specialized).
+    let (s_st, o_ss) = bench(|| scalar_strip(&arr));
+    let (g_st, o_gs) = bench(|| generic_strip(&arr));
+    assert_same(&o_ss, &o_gs);
+    println!("\nstrip (offset-changing):");
+    println!("  scalar-per-element   {s_st:8.2} ms ({:6.1} M/s)  1.00x", tp(s_st));
+    println!("  generic buffer-write {g_st:8.2} ms ({:6.1} M/s)  {:.2}x", tp(g_st), s_st / g_st);
+
+    // name_proper (compute-heavy per-string): scalar vs "columnar" (sizing only).
+    let (s_sn, o_ssn) = bench(|| scalar_name_proper(&arr));
+    let (c_sn, o_csn) = bench(|| columnar_name_proper(&arr));
+    assert_same(&o_ssn, &o_csn);
+    println!("\nname_proper (compute-heavy):");
+    println!("  scalar-per-element   {s_sn:8.2} ms ({:6.1} M/s)  1.00x", tp(s_sn));
+    println!("  columnar (sizing)    {c_sn:8.2} ms ({:6.1} M/s)  {:.2}x", tp(c_sn), s_sn / c_sn);
+
+    println!(
+        "\nDecision: if `generic buffer-write` captures most of the specialized win,\n\
+         the sweep is ONE primitive (Fn(&str,&mut String)) adapting the trivial\n\
+         family; if only `specialized` wins, it needs per-op buffer kernels."
+    );
+}

--- a/packages/rust/extensions/goldenflow-core/src/columnar.rs
+++ b/packages/rust/extensions/goldenflow-core/src/columnar.rs
@@ -1,0 +1,161 @@
+//! Arrow-columnar apply paths (feature `arrow`, off by default so the wasm /
+//! pure-logic surfaces stay arrow-free). The owned string kernels are scalar
+//! `fn(&str)->String`; these turn the per-element apply loop
+//! (`Option<String>` + `StringBuilder::append`, which allocates a `String` and
+//! copies it per row) into a columnar path that writes into ONE shared buffer.
+//!
+//! Measured on 1M rows (benches/columnar_pilot.rs), byte-identical to the
+//! scalar path:
+//!   - [`map_str_columnar`] (generic, any op writing into a buffer): ~4-5x.
+//!   - [`ascii_case`] (whole-buffer `make_ascii_{lower,upper}case`, offsets
+//!     reused): ~9-10x for the common all-ASCII case; per-element Unicode
+//!     fallback preserves exact parity when any non-ASCII byte is present.
+//!
+//! Only `StringArray` (Utf8, i32 offsets) is handled here; the caller keeps the
+//! scalar path for `LargeUtf8`.
+
+use arrow_array::builder::StringBuilder;
+use arrow_array::{Array, StringArray};
+use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
+
+/// The CURRENT scalar apply shape (mirrors native-flow `util::map_str_to_str`):
+/// a closure returning `Option<String>`, per-element `append`. Kept as the
+/// reference + the non-ASCII fallback for [`ascii_case`].
+pub fn scalar_map<F: Fn(&str) -> Option<String>>(arr: &StringArray, f: F) -> StringArray {
+    let len = arr.len();
+    let mut b = StringBuilder::with_capacity(len, len * 12);
+    for v in arr.iter() {
+        match v {
+            Some(s) => match f(s) {
+                Some(out) => b.append_value(out),
+                None => b.append_null(),
+            },
+            None => b.append_null(),
+        }
+    }
+    b.finish()
+}
+
+/// Generic columnar map: `f` writes each present element's transformed bytes
+/// directly into one shared values buffer (no per-element `String` alloc, no
+/// builder double-copy); offsets are accumulated as we go. Nulls pass through
+/// (offset unchanged, null bitmap cloned). Byte-identical output to
+/// `scalar_map(arr, |s| Some(kernel_producing_the_same_bytes(s)))`.
+pub fn map_str_columnar<F: Fn(&str, &mut String)>(arr: &StringArray, f: F) -> StringArray {
+    let len = arr.len();
+    let mut offsets: Vec<i32> = Vec::with_capacity(len + 1);
+    offsets.push(0);
+    // Hint: most trivial ops shrink or preserve length, so the input value byte
+    // count is a good upper-ish bound for the output buffer.
+    let mut values = String::with_capacity(arr.values().len());
+    for v in arr.iter() {
+        if let Some(s) = v {
+            f(s, &mut values);
+        }
+        offsets.push(values.len() as i32);
+    }
+    StringArray::new(
+        OffsetBuffer::new(ScalarBuffer::from(offsets)),
+        Buffer::from_vec(values.into_bytes()),
+        arr.nulls().cloned(),
+    )
+}
+
+/// Specialized ASCII case-fold. When the entire values buffer is ASCII, apply
+/// `make_ascii_{lower,upper}case` in one pass and reuse the offsets + nulls
+/// verbatim (byte lengths are unchanged for ASCII case-folding) -- zero
+/// per-element allocation. If any non-ASCII byte is present, fall back to the
+/// `scalar` Unicode kernel per element, so the output is byte-identical to the
+/// scalar path in every case (`make_ascii_*` != Unicode casing outside ASCII).
+pub fn ascii_case<F: Fn(&str) -> String>(arr: &StringArray, upper: bool, scalar: F) -> StringArray {
+    let bytes: &[u8] = arr.values().as_slice();
+    if !bytes.is_ascii() {
+        return scalar_map(arr, |s| Some(scalar(s)));
+    }
+    let mut v = bytes.to_vec();
+    if upper {
+        v.make_ascii_uppercase();
+    } else {
+        v.make_ascii_lowercase();
+    }
+    StringArray::new(
+        arr.offsets().clone(),
+        Buffer::from_vec(v),
+        arr.nulls().cloned(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::text;
+
+    // A dataset spanning every parity-relevant shape: ASCII mixed-case, leading/
+    // trailing/internal whitespace, empty string, null, and a non-ASCII row
+    // (forces the ascii_case Unicode fallback + exercises multi-byte offsets).
+    fn sample() -> StringArray {
+        StringArray::from(vec![
+            Some("John SMITH"),
+            Some("  Mary  "),
+            Some("o'Brien"),
+            Some(""),
+            None,
+            Some("STRASSE"),
+            Some("café"), // non-ASCII -> ascii_case must fall back
+            Some("  Renée "),
+        ])
+    }
+
+    #[test]
+    fn ascii_case_matches_scalar_lower() {
+        let arr = sample();
+        let columnar = ascii_case(&arr, false, text::lowercase);
+        let scalar = scalar_map(&arr, |s| Some(text::lowercase(s)));
+        assert_eq!(columnar, scalar);
+    }
+
+    #[test]
+    fn ascii_case_matches_scalar_upper() {
+        let arr = sample();
+        let columnar = ascii_case(&arr, true, text::uppercase);
+        let scalar = scalar_map(&arr, |s| Some(text::uppercase(s)));
+        assert_eq!(columnar, scalar);
+    }
+
+    #[test]
+    fn ascii_case_all_ascii_uses_fast_path_bytes() {
+        // All-ASCII input: the fast path must equal the scalar Unicode path.
+        let arr = StringArray::from(vec![Some("AbC"), Some("xyZ"), None, Some("")]);
+        assert_eq!(
+            ascii_case(&arr, false, text::lowercase),
+            scalar_map(&arr, |s| Some(text::lowercase(s)))
+        );
+    }
+
+    #[test]
+    fn map_str_columnar_matches_scalar_strip() {
+        let arr = sample();
+        let columnar = map_str_columnar(&arr, |s, buf| buf.push_str(text::strip(s)));
+        let scalar = scalar_map(&arr, |s| Some(text::strip(s).to_string()));
+        assert_eq!(columnar, scalar);
+    }
+
+    #[test]
+    fn map_str_columnar_matches_scalar_collapse() {
+        let arr = sample();
+        let columnar = map_str_columnar(&arr, |s, buf| buf.push_str(&text::collapse_whitespace(s)));
+        let scalar = scalar_map(&arr, |s| Some(text::collapse_whitespace(s)));
+        assert_eq!(columnar, scalar);
+    }
+
+    #[test]
+    fn preserves_nulls_and_empty() {
+        let arr = StringArray::from(vec![None, Some(""), Some("x"), None]);
+        let out = map_str_columnar(&arr, |s, buf| buf.push_str(s));
+        assert_eq!(out.len(), 4);
+        assert!(out.is_null(0));
+        assert!(!out.is_null(1) && out.value(1).is_empty());
+        assert_eq!(out.value(2), "x");
+        assert!(out.is_null(3));
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/columnar.rs
+++ b/packages/rust/extensions/goldenflow-core/src/columnar.rs
@@ -148,6 +148,61 @@ mod tests {
         assert_eq!(columnar, scalar);
     }
 
+    // The `_into` streaming kernels (Wave: trivial text family) must be
+    // byte-identical to their `String`-returning wrappers when threaded through
+    // `map_str_columnar` -- this is the contract native-flow's shims rely on.
+    #[test]
+    fn into_kernels_match_string_wrappers() {
+        // Rows that actually trigger each removal/normalize branch (plus null,
+        // empty, and a multi-byte tail) so the parity is over real transforms,
+        // not identity.
+        let arr = StringArray::from(vec![
+            Some("a  b\tc"),                            // collapse
+            Some("<b>hi</b> http://x.com/y z"),         // html + url
+            Some("abc123 caf\u{e9}!"),                  // digits + punctuation + multibyte
+            Some("hi \u{1f600} \u{201c}q\u{201d}\r\n"), // emoji + quotes + CRLF
+            Some(""),
+            None,
+            Some("Jos\u{e9}"), // normalize_unicode
+        ]);
+        macro_rules! check {
+            ($into:path, $whole:path) => {
+                assert_eq!(
+                    map_str_columnar(&arr, |s, buf| $into(s, buf)),
+                    scalar_map(&arr, |s| Some($whole(s))),
+                    concat!(stringify!($into), " != ", stringify!($whole))
+                );
+            };
+        }
+        check!(text::collapse_whitespace_into, text::collapse_whitespace);
+        check!(text::normalize_quotes_into, text::normalize_quotes);
+        check!(
+            text::normalize_line_endings_into,
+            text::normalize_line_endings
+        );
+        check!(text::normalize_unicode_into, text::normalize_unicode);
+        check!(text::remove_html_tags_into, text::remove_html_tags);
+        check!(text::remove_urls_into, text::remove_urls);
+        check!(text::remove_digits_into, text::remove_digits);
+        check!(text::remove_punctuation_into, text::remove_punctuation);
+        check!(text::remove_emojis_into, text::remove_emojis);
+    }
+
+    #[test]
+    fn pad_into_kernels_match_string_wrappers() {
+        // pad_* carry width/pad args -> the closure captures them (the shape
+        // native-flow's parametrized shims use).
+        let arr = sample();
+        assert_eq!(
+            map_str_columnar(&arr, |s, buf| text::pad_left_into(s, 8, '0', buf)),
+            scalar_map(&arr, |s| Some(text::pad_left(s, 8, '0'))),
+        );
+        assert_eq!(
+            map_str_columnar(&arr, |s, buf| text::pad_right_into(s, 8, ' ', buf)),
+            scalar_map(&arr, |s| Some(text::pad_right(s, 8, ' '))),
+        );
+    }
+
     #[test]
     fn preserves_nulls_and_empty() {
         let arr = StringArray::from(vec![None, Some(""), Some("x"), None]);

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -9,6 +9,10 @@ pub mod address;
 pub mod autocorrect;
 pub mod categorical;
 pub mod company;
+/// Arrow-columnar apply paths — only when built with `--features arrow`
+/// (native-flow enables it; wasm/pure surfaces stay arrow-free).
+#[cfg(feature = "arrow")]
+pub mod columnar;
 pub mod email;
 pub mod identifiers;
 pub mod names;

--- a/packages/rust/extensions/goldenflow-core/src/text.rs
+++ b/packages/rust/extensions/goldenflow-core/src/text.rs
@@ -20,6 +20,15 @@ pub fn strip(s: &str) -> &str {
 /// the same Unicode `White_Space` set, replaced by a literal space.
 pub fn collapse_whitespace(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
+    collapse_whitespace_into(s, &mut out);
+    out
+}
+
+/// Streaming variant of [`collapse_whitespace`]: append the transformed bytes to
+/// `out` (does NOT clear it). Byte-identical to `collapse_whitespace`; used by the
+/// Arrow-columnar apply path (`columnar::map_str_columnar`) to avoid a per-element
+/// `String` allocation.
+pub fn collapse_whitespace_into(s: &str, out: &mut String) {
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if !c.is_whitespace() {
@@ -37,7 +46,6 @@ pub fn collapse_whitespace(s: &str) -> String {
         }
         out.push(if run >= 2 { ' ' } else { c });
     }
-    out
 }
 
 // ---------------------------------------------------------------------------
@@ -55,6 +63,12 @@ pub fn collapse_whitespace(s: &str) -> String {
 /// + double-prime -> `"`; left/right single + prime -> `'`).
 pub fn normalize_quotes(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
+    normalize_quotes_into(s, &mut out);
+    out
+}
+
+/// Streaming [`normalize_quotes`] (appends to `out`) for the columnar apply path.
+pub fn normalize_quotes_into(s: &str, out: &mut String) {
     for c in s.chars() {
         match c {
             '\u{201c}' | '\u{201d}' | '\u{2033}' => out.push('"'),
@@ -62,13 +76,18 @@ pub fn normalize_quotes(s: &str) -> String {
             _ => out.push(c),
         }
     }
-    out
 }
 
 /// Normalize `\r\n` and lone `\r` to `\n`. Byte-identical to
 /// `text.py::normalize_line_endings` (replace `\r\n` first, then any `\r`).
 pub fn normalize_line_endings(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
+    normalize_line_endings_into(s, &mut out);
+    out
+}
+
+/// Streaming [`normalize_line_endings`] (appends to `out`) for the columnar path.
+pub fn normalize_line_endings_into(s: &str, out: &mut String) {
     let mut chars = s.chars().peekable();
     while let Some(c) = chars.next() {
         if c == '\r' {
@@ -80,7 +99,6 @@ pub fn normalize_line_endings(s: &str) -> String {
             out.push(c);
         }
     }
-    out
 }
 
 /// Truncate to the first `n` characters (polars `str.slice(0, n)` is
@@ -92,39 +110,54 @@ pub fn truncate(s: &str, n: usize) -> String {
 /// Left-pad to `width` characters with `pad` (polars `str.pad_start`); a string
 /// already at/over `width` is unchanged. Byte-identical to `text.py::pad_left`.
 pub fn pad_left(s: &str, width: usize, pad: char) -> String {
+    let mut out = String::with_capacity(width.max(s.len()));
+    pad_left_into(s, width, pad, &mut out);
+    out
+}
+
+/// Streaming [`pad_left`] (appends to `out`) for the columnar path.
+pub fn pad_left_into(s: &str, width: usize, pad: char, out: &mut String) {
     let len = s.chars().count();
-    if len >= width {
-        return s.to_string();
-    }
-    let mut out = String::with_capacity(width);
-    for _ in 0..(width - len) {
-        out.push(pad);
+    if len < width {
+        for _ in 0..(width - len) {
+            out.push(pad);
+        }
     }
     out.push_str(s);
-    out
 }
 
 /// Right-pad to `width` characters with `pad` (polars `str.pad_end`); a string
 /// already at/over `width` is unchanged. Byte-identical to `text.py::pad_right`.
 pub fn pad_right(s: &str, width: usize, pad: char) -> String {
-    let len = s.chars().count();
-    if len >= width {
-        return s.to_string();
-    }
-    let mut out = String::from(s);
-    for _ in 0..(width - len) {
-        out.push(pad);
-    }
+    let mut out = String::with_capacity(width.max(s.len()));
+    pad_right_into(s, width, pad, &mut out);
     out
+}
+
+/// Streaming [`pad_right`] (appends to `out`) for the columnar path.
+pub fn pad_right_into(s: &str, width: usize, pad: char, out: &mut String) {
+    let len = s.chars().count();
+    out.push_str(s);
+    if len < width {
+        for _ in 0..(width - len) {
+            out.push(pad);
+        }
+    }
 }
 
 /// Strip HTML tags: remove each `<...>` span with at least one char between the
 /// angle brackets (regex `<[^>]+>`, minimal to the first `>`). `<>` and an
 /// unclosed `<` are left intact. Byte-identical to `text.py::remove_html_tags`.
 pub fn remove_html_tags(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    remove_html_tags_into(s, &mut out);
+    out
+}
+
+/// Streaming [`remove_html_tags`] (appends to `out`) for the columnar path.
+pub fn remove_html_tags_into(s: &str, out: &mut String) {
     let chars: Vec<char> = s.chars().collect();
     let n = chars.len();
-    let mut out = String::with_capacity(s.len());
     let mut i = 0;
     while i < n {
         if chars[i] == '<' {
@@ -141,7 +174,6 @@ pub fn remove_html_tags(s: &str) -> String {
         out.push(chars[i]);
         i += 1;
     }
-    out
 }
 
 /// `"http://"` (7 chars) or `"https://"` (8 chars) at `chars[i..]`; returns the
@@ -162,9 +194,15 @@ fn match_url_scheme(chars: &[char], i: usize) -> Option<usize> {
 /// chars (regex `https?://\S+`). `\S` = non-`is_whitespace` (== polars `\s`
 /// complement). Byte-identical to `text.py::remove_urls`.
 pub fn remove_urls(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    remove_urls_into(s, &mut out);
+    out
+}
+
+/// Streaming [`remove_urls`] (appends to `out`) for the columnar path.
+pub fn remove_urls_into(s: &str, out: &mut String) {
     let chars: Vec<char> = s.chars().collect();
     let n = chars.len();
-    let mut out = String::with_capacity(s.len());
     let mut i = 0;
     while i < n {
         if let Some(after) = match_url_scheme(&chars, i) {
@@ -181,7 +219,6 @@ pub fn remove_urls(s: &str) -> String {
         out.push(chars[i]);
         i += 1;
     }
-    out
 }
 
 /// Remove ASCII digit characters. The old polars `\d` was Unicode-aware; this
@@ -189,7 +226,14 @@ pub fn remove_urls(s: &str) -> String {
 /// exotic Unicode digits are out of the bounded set). Byte-identical to
 /// `text.py::remove_digits`.
 pub fn remove_digits(s: &str) -> String {
-    s.chars().filter(|c| !c.is_ascii_digit()).collect()
+    let mut out = String::with_capacity(s.len());
+    remove_digits_into(s, &mut out);
+    out
+}
+
+/// Streaming [`remove_digits`] (appends to `out`) for the columnar path.
+pub fn remove_digits_into(s: &str, out: &mut String) {
+    out.extend(s.chars().filter(|c| !c.is_ascii_digit()));
 }
 
 /// Remove punctuation: keep ASCII alphanumerics and whitespace, drop everything
@@ -197,9 +241,17 @@ pub fn remove_digits(s: &str) -> String {
 /// letters are dropped (as in the old polars behavior). Byte-identical to
 /// `text.py::remove_punctuation`.
 pub fn remove_punctuation(s: &str) -> String {
-    s.chars()
-        .filter(|c| c.is_ascii_alphanumeric() || c.is_whitespace())
-        .collect()
+    let mut out = String::with_capacity(s.len());
+    remove_punctuation_into(s, &mut out);
+    out
+}
+
+/// Streaming [`remove_punctuation`] (appends to `out`) for the columnar path.
+pub fn remove_punctuation_into(s: &str, out: &mut String) {
+    out.extend(
+        s.chars()
+            .filter(|c| c.is_ascii_alphanumeric() || c.is_whitespace()),
+    );
 }
 
 /// Extract all number runs (regex `\d+\.?\d*`: one-or-more digits, an optional
@@ -262,7 +314,14 @@ fn is_emoji(c: char) -> bool {
 /// matching char is equivalent to removing maximal runs. Byte-identical to
 /// `text.py::remove_emojis`.
 pub fn remove_emojis(s: &str) -> String {
-    s.chars().filter(|c| !is_emoji(*c)).collect()
+    let mut out = String::with_capacity(s.len());
+    remove_emojis_into(s, &mut out);
+    out
+}
+
+/// Streaming [`remove_emojis`] (appends to `out`) for the columnar path.
+pub fn remove_emojis_into(s: &str, out: &mut String) {
+    out.extend(s.chars().filter(|c| !is_emoji(*c)));
 }
 
 // ---------------------------------------------------------------------------
@@ -747,6 +806,12 @@ fn normalize_char(c: char) -> Option<&'static str> {
 /// `text.py::_normalize_unicode_py`.
 pub fn normalize_unicode(s: &str) -> String {
     let mut out = String::with_capacity(s.len());
+    normalize_unicode_into(s, &mut out);
+    out
+}
+
+/// Streaming [`normalize_unicode`] (appends to `out`) for the columnar path.
+pub fn normalize_unicode_into(s: &str, out: &mut String) {
     for c in s.chars() {
         if c.is_ascii() {
             out.push(c);
@@ -756,7 +821,6 @@ pub fn normalize_unicode(s: &str) -> String {
             out.push(c);
         }
     }
-    out
 }
 
 #[cfg(test)]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -418,6 +418,8 @@ dependencies = [
 name = "goldenflow-core"
 version = "0.4.0"
 dependencies = [
+ "arrow-array",
+ "arrow-buffer",
  "phonenumber",
 ]
 

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -32,7 +32,7 @@ arrow = { version = "59", default-features = false, features = ["pyarrow"] }
 #
 # Owned reference kernels (pure phone logic). native-flow is now a marshaling
 # shim: Arrow in/out + GIL release here, the actual computation in the core.
-goldenflow-core = { path = "../goldenflow-core" }
+goldenflow-core = { path = "../goldenflow-core", features = ["arrow"] }
 
 [profile.release]
 opt-level = 3

--- a/packages/rust/extensions/native-flow/src/text.rs
+++ b/packages/rust/extensions/native-flow/src/text.rs
@@ -1,10 +1,16 @@
 //! Arrow shims over goldenflow_core::text. Bytes in, kernel per element, bytes
 //! out; GIL released. All logic lives in the core.
 //!
-//! `strip`/`lowercase`/`uppercase` take the Arrow-COLUMNAR apply path (write
-//! into one shared buffer / whole-buffer ASCII case-fold) -- measured 4-10x
+//! The trivial-text family (`strip`/`lowercase`/`uppercase` + `collapse_whitespace`
+//! / `normalize_*` / `remove_*` / `pad_*`) takes the Arrow-COLUMNAR apply path
+//! (write into one shared buffer / whole-buffer ASCII case-fold) -- measured 4-10x
 //! over the per-element path, byte-identical (goldenflow-core `columnar` +
-//! `benches/columnar_pilot.rs`). The rest stay on the scalar `map_str_to_str`.
+//! `benches/columnar_pilot.rs`). Each routes its `*_into` streaming kernel through
+//! `map_str_columnar`; the `String`-returning kernel is the LargeUtf8 fallback.
+//! `normalize_unicode` is included (its char loop streams cleanly). The rest stay
+//! on the scalar `map_str_to_str`: `title_case`/`fix_mojibake` are compute-bound
+//! (allocation isn't the cost), and `truncate`/`extract_numbers` don't stream into
+//! a single append buffer.
 use crate::util::{ascii_case_columnar, map_str_columnar, map_str_to_str};
 use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
@@ -26,9 +32,12 @@ pub fn collapse_whitespace_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::collapse_whitespace(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::collapse_whitespace_into,
+        text::collapse_whitespace,
+    )?))
 }
 
 #[pyfunction]
@@ -36,9 +45,12 @@ pub fn normalize_quotes_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::normalize_quotes(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::normalize_quotes_into,
+        text::normalize_quotes,
+    )?))
 }
 
 #[pyfunction]
@@ -46,9 +58,12 @@ pub fn normalize_line_endings_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::normalize_line_endings(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::normalize_line_endings_into,
+        text::normalize_line_endings,
+    )?))
 }
 
 #[pyfunction]
@@ -56,9 +71,12 @@ pub fn remove_html_tags_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::remove_html_tags(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::remove_html_tags_into,
+        text::remove_html_tags,
+    )?))
 }
 
 #[pyfunction]
@@ -66,9 +84,12 @@ pub fn remove_urls_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::remove_urls(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::remove_urls_into,
+        text::remove_urls,
+    )?))
 }
 
 #[pyfunction]
@@ -76,9 +97,12 @@ pub fn remove_digits_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::remove_digits(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::remove_digits_into,
+        text::remove_digits,
+    )?))
 }
 
 #[pyfunction]
@@ -86,9 +110,12 @@ pub fn remove_punctuation_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::remove_punctuation(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::remove_punctuation_into,
+        text::remove_punctuation,
+    )?))
 }
 
 #[pyfunction]
@@ -96,9 +123,12 @@ pub fn remove_emojis_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::remove_emojis(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::remove_emojis_into,
+        text::remove_emojis,
+    )?))
 }
 
 #[pyfunction]
@@ -136,9 +166,12 @@ pub fn pad_left_arrow(
     pad: char,
 ) -> PyResult<PyArrowType<ArrayData>> {
     let w = if width < 0 { 0usize } else { width as usize };
-    Ok(PyArrowType(map_str_to_str(py, array.0, move |s| {
-        Some(text::pad_left(s, w, pad))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        move |s, buf| text::pad_left_into(s, w, pad, buf),
+        move |s| text::pad_left(s, w, pad),
+    )?))
 }
 
 /// Right-pad to `width` characters with `pad` (default width 10, pad `' '`).
@@ -151,9 +184,12 @@ pub fn pad_right_arrow(
     pad: char,
 ) -> PyResult<PyArrowType<ArrayData>> {
     let w = if width < 0 { 0usize } else { width as usize };
-    Ok(PyArrowType(map_str_to_str(py, array.0, move |s| {
-        Some(text::pad_right(s, w, pad))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        move |s, buf| text::pad_right_into(s, w, pad, buf),
+        move |s| text::pad_right(s, w, pad),
+    )?))
 }
 
 #[pyfunction]
@@ -197,9 +233,12 @@ pub fn normalize_unicode_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::normalize_unicode(s))
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        text::normalize_unicode_into,
+        text::normalize_unicode,
+    )?))
 }
 
 #[pyfunction]

--- a/packages/rust/extensions/native-flow/src/text.rs
+++ b/packages/rust/extensions/native-flow/src/text.rs
@@ -1,6 +1,11 @@
 //! Arrow shims over goldenflow_core::text. Bytes in, kernel per element, bytes
 //! out; GIL released. All logic lives in the core.
-use crate::util::map_str_to_str;
+//!
+//! `strip`/`lowercase`/`uppercase` take the Arrow-COLUMNAR apply path (write
+//! into one shared buffer / whole-buffer ASCII case-fold) -- measured 4-10x
+//! over the per-element path, byte-identical (goldenflow-core `columnar` +
+//! `benches/columnar_pilot.rs`). The rest stay on the scalar `map_str_to_str`.
+use crate::util::{ascii_case_columnar, map_str_columnar, map_str_to_str};
 use arrow::array::ArrayData;
 use arrow::pyarrow::PyArrowType;
 use goldenflow_core::text;
@@ -8,9 +13,12 @@ use pyo3::prelude::*;
 
 #[pyfunction]
 pub fn strip_arrow(py: Python, array: PyArrowType<ArrayData>) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::strip(s).to_string())
-    })?))
+    Ok(PyArrowType(map_str_columnar(
+        py,
+        array.0,
+        |s, buf| buf.push_str(text::strip(s)),
+        |s| text::strip(s).to_string(),
+    )?))
 }
 
 #[pyfunction]
@@ -153,9 +161,12 @@ pub fn lowercase_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::lowercase(s))
-    })?))
+    Ok(PyArrowType(ascii_case_columnar(
+        py,
+        array.0,
+        false,
+        text::lowercase,
+    )?))
 }
 
 #[pyfunction]
@@ -163,9 +174,12 @@ pub fn uppercase_arrow(
     py: Python,
     array: PyArrowType<ArrayData>,
 ) -> PyResult<PyArrowType<ArrayData>> {
-    Ok(PyArrowType(map_str_to_str(py, array.0, |s| {
-        Some(text::uppercase(s))
-    })?))
+    Ok(PyArrowType(ascii_case_columnar(
+        py,
+        array.0,
+        true,
+        text::uppercase,
+    )?))
 }
 
 #[pyfunction]

--- a/packages/rust/extensions/native-flow/src/util.rs
+++ b/packages/rust/extensions/native-flow/src/util.rs
@@ -40,6 +40,47 @@ pub fn read_opt_strings(data: &ArrayData) -> PyResult<Vec<Option<String>>> {
     Ok(out)
 }
 
+/// Columnar generic map (feature-parity with `map_str_to_str` for a
+/// String-producing kernel, but ~4-5x faster): for a Utf8 `StringArray` the
+/// per-element `f` writes transformed bytes into ONE shared buffer via
+/// `goldenflow_core::columnar::map_str_columnar` (no per-row `String` alloc);
+/// for `LargeUtf8` (or any non-Utf8) it falls back to the scalar `map_str_to_str`
+/// with the equivalent `scalar` kernel. Byte-identical output either way.
+pub fn map_str_columnar<F, G>(py: Python, data: ArrayData, f: F, scalar: G) -> PyResult<ArrayData>
+where
+    F: Fn(&str, &mut String) + Sync,
+    G: Fn(&str) -> String + Sync,
+{
+    let arr = make_array(data.clone());
+    if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+        Ok(py.detach(|| goldenflow_core::columnar::map_str_columnar(s, &f).into_data()))
+    } else {
+        map_str_to_str(py, data, |x| Some(scalar(x)))
+    }
+}
+
+/// Columnar ASCII case-fold (~9-10x for the all-ASCII common case): a Utf8
+/// `StringArray` whose values buffer is entirely ASCII is folded in one
+/// `make_ascii_{lower,upper}case` pass reusing offsets+nulls; non-ASCII (or
+/// `LargeUtf8`) falls back to the scalar Unicode `scalar` kernel per element.
+/// Byte-identical output to the scalar path in every case.
+pub fn ascii_case_columnar<G>(
+    py: Python,
+    data: ArrayData,
+    upper: bool,
+    scalar: G,
+) -> PyResult<ArrayData>
+where
+    G: Fn(&str) -> String + Sync,
+{
+    let arr = make_array(data.clone());
+    if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+        Ok(py.detach(|| goldenflow_core::columnar::ascii_case(s, upper, &scalar).into_data()))
+    } else {
+        map_str_to_str(py, data, |x| Some(scalar(x)))
+    }
+}
+
 pub fn map_str_to_str<F>(py: Python, data: ArrayData, f: F) -> PyResult<ArrayData>
 where
     F: Fn(&str) -> Option<String> + Sync,


### PR DESCRIPTION
Turns the scalar per-element apply loop (`Option<String>` + `StringBuilder::append`, which allocates a `String` and copies it per row) into an Arrow-**columnar** path that writes into ONE shared values buffer, for the allocation-dominated ("trivial") text-transform family. Pillar-1/3 of the owned-kernel Rust cutover.

## Decision artifact
`goldenflow-core/benches/columnar_pilot.rs` (1M rows, 5-run median wall) settled the design:

| op | scalar | columnar | speedup |
|---|---|---|---|
| `lowercase` (offset-preserving) | 48.0 ms | 4.9 ms | **9.7x** (whole-buffer `make_ascii_lowercase`) |
| `lowercase` (generic buffer-write) | 48.0 ms | 9.6 ms | 5.0x (one primitive) |
| `strip` (offset-changing) | 38.1 ms | 9.8 ms | 3.9x (generic) |
| `name_proper` (compute-heavy) | 474.8 ms | 477.3 ms | 0.99x (correctly left alone) |

The generic buffer-write primitive captures 4-5x across the whole trivial family with ONE kernel; compute-heavy ops don't benefit (allocation isn't the cost) and stay scalar.

## What ships
- **`goldenflow-core/src/columnar.rs`** (feature `arrow`, off by default so the wasm / pure-logic surfaces stay arrow-free) — the single source of truth:
  - `map_str_columnar` — generic `Fn(&str, &mut String)` buffer-write, any op.
  - `ascii_case` — whole-buffer `make_ascii_{lower,upper}case` (offsets + nulls reused) with a per-element Unicode fallback when any non-ASCII byte is present, so it's byte-identical to the scalar path in every case.
  - `scalar_map` — the reference apply shape + the non-ASCII fallback.
- **`*_into(&str, &mut String)` streaming kernels** for the trivial family: the kernel logic moves into `*_into`; the existing `fn foo(s) -> String` becomes a thin wrapper, so it stays byte-identical and every other surface (wasm, TS, DuckDB, Python-corpus) is untouched.
  - Covered: `strip`, `lowercase`, `uppercase`, `collapse_whitespace`, `normalize_quotes`, `normalize_line_endings`, `normalize_unicode`, `remove_{html_tags,urls,digits,punctuation,emojis}`, `pad_left`, `pad_right`.
  - Left scalar (by design): `title_case` / `fix_mojibake` (compute-bound) and `truncate` / `extract_numbers` (don't stream into a single append buffer).
- **native-flow** — the `*_arrow` shims route their `*_into` kernel through `map_str_columnar` / `ascii_case` (Utf8 -> columnar core path, LargeUtf8 -> the String-wrapper scalar fallback). Thin marshaling only; all logic in the core.
- **ci.yml** — `cargo test/clippy --features arrow` on goldenflow-core so the `#[cfg(feature="arrow")]` columnar module + its parity tests actually run in CI (they're invisible to the default `rust` lane).

## Verification
- goldenflow-core: 107 tests (incl. columnar parity: `ascii_case_*`, `map_str_columnar_*`, `{into,pad_into}_kernels_match_string_wrappers` — each threads a kernel through the columnar buffer and asserts byte-identical to the scalar/String path over null / empty / multibyte / every removal branch) + clippy(`--features arrow`) green.
- native-flow: fmt + clippy(`--release`) green. Wheel-level e2e rides the CI corpus native leg (the maturin wheel build LLVM-OOMs on the dev box).

## Follow-up
String-returning ops that don't stream into one append buffer (`truncate` / `extract_numbers`) stay scalar; revisit if a workload shows them hot.