### PR TITLE
feat(goldenpipe): relocatable-stage contract Phase A — the inert Arrow seam

### DIFF
--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -14,6 +14,26 @@ Sibling packages live in this monorepo at `packages/python/{goldencheck,goldenfl
 - Tools imported with try/except ImportError guards (HAS_CHECK, HAS_FLOW, HAS_MATCH)
 - Data flows as Polars DataFrames in memory between stages
 
+### Relocatable-stage seam (contract Phase A)
+Design: `docs/design/2026-07-06-goldenpipe-relocatable-stage-contract.md` (motivated
+by the Stage 0 finding: the single-process handoff is 0.2% of the wall, so the
+streaming executor is premature — but the *contract* that makes future
+out-of-core / cross-process / cross-language expansion a build-forward is worth
+laying now). **Phase A is inert groundwork — no behavior/perf change:**
+- `goldenpipe/models/frame.py` — `Frame` protocol + `LocalFrame`. **Arrow-capable,
+  not Arrow-mandatory:** `LocalFrame.polars()` returns the backing DataFrame BY
+  REFERENCE (zero copy); `arrow_batches()`/`from_arrow()` materialize Arrow ONLY
+  for a boundary-crossing (remote) stage. Streaming/remote frames (Phases B/C)
+  plug in behind this contract without touching the in-process path.
+- `PipeContext.frame` — a derived property over `df` (the canonical store stays
+  `df`, so existing `ctx.df` stages + `PipeContext(df=...)` are untouched). The
+  pipeline path never calls it today; it's the accessor a remote adapter will use.
+- `StageInfo.location` (default `"local"`) + a Runner guard that raises
+  `NotImplementedError` for any non-local stage (remote = Phase C, not built). The
+  `ExecutionPlan`/planner is unchanged — placement is orthogonal to ordering.
+- Guardrails: no forced Arrow round-trip in-process; Stage 0 numbers verified
+  unchanged (`benchmarks/stage0_handoff_profile.py`). Tests: `tests/test_relocatable_stage.py`.
+
 ## Pipeline Flow
 ```
 load_file -> GoldenCheck.scan_file(path) -> decide_flow(findings)

--- a/packages/python/goldenpipe/goldenpipe/engine/runner.py
+++ b/packages/python/goldenpipe/goldenpipe/engine/runner.py
@@ -35,6 +35,19 @@ class Runner:
                     )
                     continue
 
+            # Relocatable-stage seam (contract Phase A): only local stages run
+            # today. A stage declaring a non-local location is a not-yet-built
+            # remote/cross-engine placement (Phases B/C) -- fail loudly rather
+            # than silently running it in-process. Raised before the try/except
+            # so it surfaces as a configuration error, not a soft stage failure.
+            location = getattr(getattr(planned.stage, "info", None), "location", "local")
+            if location != "local":
+                raise NotImplementedError(
+                    f"Stage '{planned.name}' declares location={location!r}; remote "
+                    "stage execution is not implemented (relocatable-stage contract "
+                    "Phase C). Only 'local' stages run today."
+                )
+
             start = time.perf_counter()
             try:
                 # Make stage-level config available to the adapter via context

--- a/packages/python/goldenpipe/goldenpipe/models/context.py
+++ b/packages/python/goldenpipe/goldenpipe/models/context.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import polars as pl
 
+from goldenpipe.models.frame import Frame, LocalFrame
+
 
 class StageStatus(str, Enum):  # noqa: UP042  # explicit str+Enum preserves __str__ semantics; StrEnum behaves differently
     SUCCESS = "success"
@@ -46,6 +48,20 @@ class PipeContext:
     timing: dict[str, float] = field(default_factory=dict)
     reasoning: dict[str, str] = field(default_factory=dict)
     stage_config: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def frame(self) -> Frame | None:
+        """Arrow-capable handle over ``df`` -- the relocatable-stage seam. In
+        process this is a **zero-copy** ``LocalFrame`` view (``.polars()`` returns
+        ``df`` by reference); a remote-stage adapter (Phase C) would call
+        ``.arrow_batches()`` and assign a returned frame back via this setter. The
+        canonical store stays ``df`` so in-process stages are untouched and Stage 0
+        is not regressed. See the relocatable-stage-contract design doc."""
+        return LocalFrame(self.df) if self.df is not None else None
+
+    @frame.setter
+    def frame(self, value: Frame | None) -> None:
+        self.df = value.polars() if value is not None else None
 
 
 @dataclass

--- a/packages/python/goldenpipe/goldenpipe/models/frame.py
+++ b/packages/python/goldenpipe/goldenpipe/models/frame.py
@@ -1,0 +1,67 @@
+"""Relocatable-stage seam: an Arrow-capable frame handle (Phase A).
+
+Design: ``docs/design/2026-07-06-goldenpipe-relocatable-stage-contract.md``.
+
+Core principle -- **Arrow-CAPABLE, not Arrow-MANDATORY.** A ``Frame`` is the data
+handle at a stage boundary. In-process it is backed by a Polars DataFrame and
+``.polars()`` returns that frame **by reference** (zero copy, no Arrow
+round-trip) -- which is why introducing this seam does not regress the
+single-process pipeline (Stage 0: the handoff is 0.2% of the wall). The
+``arrow_batches()`` / ``from_arrow()`` seam materializes Arrow **only** when a
+stage actually crosses a process / language / engine boundary; a remote or
+streaming ``Frame`` (Phases B/C) plugs in behind this same contract without
+touching the in-process path.
+
+Phase A ships only ``LocalFrame``. Remote execution is not implemented -- the
+Runner raises for any stage that declares a non-local location.
+"""
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any, Protocol, runtime_checkable
+
+import polars as pl
+
+
+@runtime_checkable
+class Frame(Protocol):
+    """Data handle at a stage boundary: DataFrame-native in-process, Arrow-
+    representable when crossing a boundary."""
+
+    def polars(self) -> pl.DataFrame:
+        """The data as a Polars DataFrame. In-process impls return the backing
+        frame BY REFERENCE (no copy)."""
+        ...
+
+    def arrow_batches(self) -> Iterator[Any]:
+        """The data as an iterator of ``pyarrow.RecordBatch`` -- the wire form for
+        a boundary-crossing (remote) stage. Not called on the in-process path."""
+        ...
+
+
+class LocalFrame:
+    """In-process ``Frame`` backed by a Polars DataFrame (the only impl in Phase A)."""
+
+    __slots__ = ("_df",)
+
+    def __init__(self, df: pl.DataFrame) -> None:
+        self._df = df
+
+    def polars(self) -> pl.DataFrame:
+        # In-process fast path: return the backing frame BY REFERENCE. No copy,
+        # no Arrow round-trip -- this is why the seam doesn't regress Stage 0.
+        return self._df
+
+    def arrow_batches(self) -> Iterator[Any]:
+        # Lazy: only a boundary-crossing adapter calls this. Polars -> Arrow
+        # shares the underlying column buffers. ``to_arrow`` pulls pyarrow in on
+        # demand, so the pure in-process ``polars()`` path never needs it.
+        yield from self._df.to_arrow().to_batches()
+
+    @classmethod
+    def from_arrow(cls, batches: Iterable[Any]) -> LocalFrame:
+        """Build a ``LocalFrame`` from ``pyarrow.RecordBatch`` es -- the inverse of
+        ``arrow_batches`` (used when a remote stage returns Arrow)."""
+        import pyarrow as pa
+
+        return cls(pl.from_arrow(pa.Table.from_batches(list(batches))))

--- a/packages/python/goldenpipe/goldenpipe/models/stage.py
+++ b/packages/python/goldenpipe/goldenpipe/models/stage.py
@@ -15,6 +15,12 @@ class StageInfo:
     produces: list[str]
     consumes: list[str]
     config_schema: type | None = None
+    # Relocatable-stage seam (contract Phase A): where the stage runs. Only
+    # "local" (in-process Python) executes today; a non-local location is a
+    # not-yet-implemented remote / cross-engine placement (Phases B/C). Orthogonal
+    # to planning -- the ExecutionPlan is unchanged. See the design doc:
+    # docs/design/2026-07-06-goldenpipe-relocatable-stage-contract.md.
+    location: str = "local"
 
 
 @runtime_checkable
@@ -52,6 +58,7 @@ def stage(
     produces: list[str],
     consumes: list[str],
     config_schema: type | None = None,
+    location: str = "local",
 ) -> Callable[[Callable[[PipeContext], StageResult]], _FunctionStage]:
     """Decorator to create a stage from a plain function."""
     def decorator(fn: Callable[[PipeContext], StageResult]) -> _FunctionStage:
@@ -60,6 +67,7 @@ def stage(
             produces=produces,
             consumes=consumes,
             config_schema=config_schema,
+            location=location,
         )
         return _FunctionStage(fn, info)
     return decorator

--- a/packages/python/goldenpipe/tests/test_relocatable_stage.py
+++ b/packages/python/goldenpipe/tests/test_relocatable_stage.py
@@ -1,0 +1,113 @@
+"""Relocatable-stage contract, Phase A: the Frame seam + the location guard.
+
+Design: docs/design/2026-07-06-goldenpipe-relocatable-stage-contract.md.
+
+Phase A is deliberately inert -- it adds the Arrow-capable boundary (Frame /
+LocalFrame + ctx.frame) and the stage `location` dispatch, but only the in-process
+`local` path runs. These tests prove the contract mechanism works (Frame round-trips
+correctly, the in-process path is zero-copy) and that a non-local stage fails loudly
+rather than silently running in-process.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenpipe.engine.registry import StageRegistry
+from goldenpipe.engine.resolver import ExecutionPlan, PlannedStage
+from goldenpipe.engine.runner import Runner
+from goldenpipe.models.config import StageSpec
+from goldenpipe.models.context import PipeContext, StageResult, StageStatus
+from goldenpipe.models.frame import Frame, LocalFrame
+from goldenpipe.models.stage import StageInfo, stage
+
+
+class TestLocalFrame:
+    def test_polars_is_zero_copy_identity(self):
+        # The whole point of Phase A: the in-process path returns the backing
+        # DataFrame BY REFERENCE, so introducing the seam adds no copy.
+        df = pl.DataFrame({"a": [1, 2, 3]})
+        assert LocalFrame(df).polars() is df
+
+    def test_satisfies_frame_protocol(self):
+        assert isinstance(LocalFrame(pl.DataFrame({"a": [1]})), Frame)
+
+    def test_arrow_round_trip_preserves_data(self):
+        df = pl.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"], "c": [1.5, 2.5, None]})
+        batches = list(LocalFrame(df).arrow_batches())
+        assert LocalFrame.from_arrow(batches).polars().equals(df)
+
+    def test_arrow_batches_are_pyarrow_recordbatches(self):
+        import pyarrow as pa
+
+        batches = list(LocalFrame(pl.DataFrame({"a": [1, 2]})).arrow_batches())
+        assert batches and all(isinstance(b, pa.RecordBatch) for b in batches)
+
+
+class TestContextFrameSeam:
+    def test_frame_getter_is_zero_copy_view(self):
+        df = pl.DataFrame({"a": [1, 2]})
+        ctx = PipeContext(df=df)
+        assert isinstance(ctx.frame, LocalFrame)
+        assert ctx.frame.polars() is df  # no copy, no Arrow round-trip
+
+    def test_frame_none_when_df_none(self):
+        assert PipeContext().frame is None
+
+    def test_frame_setter_writes_back_to_df(self):
+        ctx = PipeContext(df=pl.DataFrame({"a": [1]}))
+        ctx.frame = LocalFrame(pl.DataFrame({"a": [9, 9]}))
+        assert ctx.df.to_series().to_list() == [9, 9]
+
+    def test_frame_setter_none_clears_df(self):
+        ctx = PipeContext(df=pl.DataFrame({"a": [1]}))
+        ctx.frame = None
+        assert ctx.df is None
+
+    def test_df_field_still_constructs(self):
+        # The property must NOT shadow the dataclass field -- existing callers do
+        # PipeContext(df=...).
+        df = pl.DataFrame({"a": [1]})
+        assert PipeContext(df=df).df is df
+
+
+class TestStageLocation:
+    def test_default_is_local(self):
+        assert StageInfo(name="x", produces=[], consumes=[]).location == "local"
+
+    def test_decorator_passes_location_through(self):
+        @stage(name="remote_x", produces=[], consumes=[], location="remote")
+        def remote_x(ctx: PipeContext) -> StageResult:
+            return StageResult(status=StageStatus.SUCCESS)
+
+        assert remote_x.info.location == "remote"
+
+
+@stage(name="local_ok", produces=["df"], consumes=[])
+def _local_ok(ctx: PipeContext) -> StageResult:
+    return StageResult(status=StageStatus.SUCCESS)
+
+
+@stage(name="remote_stage", produces=["df"], consumes=[], location="remote")
+def _remote_stage(ctx: PipeContext) -> StageResult:  # pragma: no cover - never runs
+    return StageResult(status=StageStatus.SUCCESS)
+
+
+def _plan(*stages) -> ExecutionPlan:
+    return ExecutionPlan(stages=[
+        PlannedStage(name=s.info.name, stage=s, spec=StageSpec(use=s.info.name))
+        for s in stages
+    ])
+
+
+class TestRunnerLocationGuard:
+    def test_local_stage_runs(self):
+        ctx = PipeContext()
+        result = Runner(registry=StageRegistry()).run(_plan(_local_ok), ctx)
+        assert result["local_ok"].status == StageStatus.SUCCESS
+
+    def test_remote_stage_raises_not_implemented(self):
+        # A non-local location must fail loudly (Phase C not built), not silently
+        # run in-process.
+        ctx = PipeContext()
+        with pytest.raises(NotImplementedError, match="Phase C"):
+            Runner(registry=StageRegistry()).run(_plan(_remote_stage), ctx)


### PR DESCRIPTION
## What and why

Phase A of the relocatable-stage contract (`docs/design/2026-07-06-goldenpipe-relocatable-stage-contract.md`, PR #1479). Stage 0 (#1477) showed the single-process handoff is **0.2% of the wall**, so a streaming executor is premature — but the *contract* that makes future **out-of-core / cross-process / cross-language** expansion a build-forward (not a rewrite) is worth laying now. **Phase A is inert groundwork: the seam exists, nothing is built behind it, and there is no behavior or performance change.**

## Changes

- **`models/frame.py`** — `Frame` protocol + `LocalFrame`. **Arrow-*capable*, not Arrow-*mandatory*:** `LocalFrame.polars()` returns the backing DataFrame **by reference** (zero copy); `arrow_batches()` / `from_arrow()` materialize Arrow **only** for a boundary-crossing stage (pyarrow pulled in lazily, off the in-process path). Streaming/remote frames (Phases B/C) plug in behind this contract.
- **`PipeContext.frame`** — a derived property over `df`. The canonical store stays `df`, so all existing `ctx.df` stages **and** `PipeContext(df=...)` construction are untouched (several tests construct that way — making `df` itself a property would have broken them).
- **`StageInfo.location`** (default `"local"`) + `stage()` param; the **Runner raises `NotImplementedError` for any non-local stage** (remote = Phase C, not built), *before* the try/except so it's a loud config error rather than a soft stage failure. The `ExecutionPlan` / planner is **unchanged** — placement is orthogonal to ordering.

## Verification

- **`tests/test_relocatable_stage.py` (13 passed):** `LocalFrame` zero-copy identity (`.polars() is df`) + Arrow round-trip + `Frame` protocol; `ctx.frame` getter/setter + `None`; `PipeContext(df=...)` still constructs; `location` default + decorator pass-through; Runner runs `local`, raises for `remote`.
- **Full goldenpipe engine/model/pipeline/adapter suite:** 139 passed, 6 skipped. (Ignored `test_rest/api/mcp/a2a/tui/cli` fail only on a missing `httpx` extra in this env — pre-existing, unrelated.)
- **Stage 0 benchmark re-run with the seam:** dedupe ~75%, handoff 0.2%, orchestration ~0 — **shape unchanged, seam is inert** (the pipeline path never calls `ctx.frame`; the `location` check is one getattr+compare per stage).
- `ruff check` clean.

## What this unlocks (later, gated)

Phase B (out-of-core streaming `Frame`) and Phase C (`RemoteStage` over a transport) plug in behind this contract — each gated on its own Stage-0 baseline per the design doc. Nothing here commits to building them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_