### PR TITLE
docs+bench(goldenpipe): Phase B baseline — out-of-core streaming is the wrong target for ER

### DIFF
--- a/docs/design/2026-07-06-goldenpipe-phaseb-baseline-findings.md
+++ b/docs/design/2026-07-06-goldenpipe-phaseb-baseline-findings.md
@@ -1,0 +1,73 @@
+# GoldenPipe Phase B baseline — out-of-core streaming is the wrong target for ER
+
+**Status:** done (measurement). **Created:** 2026-07-06.
+**Gates:** Phase B of `2026-07-06-goldenpipe-relocatable-stage-contract.md`.
+
+## The question
+
+The relocatable-stage contract's **Phase B** is an out-of-core streaming `Frame`
+(yield/consume Arrow record batches instead of holding the whole DataFrame). Per
+the design's own gate, it must first be shown that **holding the whole frame is
+the bottleneck** at scale. This is that baseline.
+
+## Method
+
+`benchmarks/phaseb_outofcore_probe.py`, one **fresh process per size** (peak RSS
+is a process-lifetime max, so isolation is required for a clean number). Two
+measurements: peak RSS vs the input-frame size, and which stage dominates.
+
+## Results
+
+| rows | input frame | peak RSS | peak / frame | dedupe share |
+|--:|--:|--:|--:|--:|
+| 20,000 | 1.09 MB | 273 MB | **249×** | 77% |
+| 50,000 | 2.73 MB | 610 MB | **223×** | 79% |
+| 100,000 | 5.47 MB | 1697 MB | **310×** | 89% |
+
+Two facts jump out:
+1. **The input frame is a rounding error.** Peak process memory is **223–310× the
+   frame**. Streaming the frame out-of-core would relieve well under 0.5% of peak
+   RSS.
+2. **Memory grows superlinearly with rows** (273 → 610 → 1697 MB; doubling
+   50k→100k nearly *tripled* memory), and `goldenmatch.dedupe` climbs to **89%** of
+   stage time. That growth is dedupe's candidate/scored-pair structures, not the
+   frame.
+
+## Verdict — skip Phase B (streaming Frame); it can't help ER
+
+The memory (and compute) bottleneck is **dedupe's internal, whole-dataset
+structures**, not the input frame. And dedupe is **inherently non-streamable** —
+deduplication must see *all* records to find cross-record matches; blocking
+reduces comparisons but still indexes the whole dataset. A streaming `Frame` at
+the orchestrator would stream a 5 MB input while dedupe balloons to 1.7 GB
+internally. It optimizes the wrong thing, again — the same shape as Stage 0.
+
+**Stage streamability (why the dominant stage can't stream):**
+- `goldenflow.transform` — row-wise → **streamable** (but it's ~11% of the wall).
+- `goldencheck.scan` — needs whole columns (n_unique / FD / composite); already
+  sample-capped at 100k → bounded, not the target.
+- `goldenmatch.dedupe` — **whole-dataset, non-streamable, superlinear** → the
+  dominant stage, and the one a streaming Frame cannot touch.
+
+**Where out-of-core ER actually lives (if ever needed):** it is a *dedupe
+algorithm* project inside `goldenmatch` — external / disk-backed blocking +
+streaming candidate generation — **not** a goldenpipe orchestration / `Frame`
+concern. Tracked there, separately, gated on a real >memory workload.
+
+## Recommendation — go to Phase C (cross-process / cross-language)
+
+- **Phase A stands** (the relocatable-stage seam is merged/ready) — it is the
+  groundwork for Phase C, not Phase B.
+- **Phase B (streaming Frame) is deprioritized** on this evidence — not blocked,
+  just not the ER bottleneck's tool.
+- **Phase C** — a stage relocated to another process / language / engine (DuckDB /
+  Postgres / a TS worker), where the handoff is *real* Arrow serialization — is the
+  right pillar-2 target and the stated goal. It gets its own Stage-0-style baseline
+  first: a workload where a remote stage's compute + Arrow IPC beats running it
+  locally (e.g. pushing a transform or a blocking pass into DuckDB/Postgres, which
+  already have Arrow-native surfaces from the goldencheck/goldenflow SQL work).
+
+## Repro
+
+`python packages/python/goldenpipe/benchmarks/phaseb_outofcore_probe.py --rows 100000`
+(run per size in a fresh process).

--- a/packages/python/goldenpipe/benchmarks/phaseb_outofcore_probe.py
+++ b/packages/python/goldenpipe/benchmarks/phaseb_outofcore_probe.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Phase B baseline: is out-of-core streaming the right target for the ER pipeline?
+
+The relocatable-stage-contract's Phase B is an out-of-core streaming ``Frame``.
+Per the design gate, it must first be shown that holding the whole frame is the
+bottleneck. This probe answers that with two measurements, on a FRESH PROCESS per
+size (``ru_maxrss`` is a process-lifetime peak, so per-size isolation is required
+for a clean number):
+
+  1. **Peak RSS vs input-frame size.** If peak process memory is a small multiple
+     of the input frame, streaming the frame could help. If peak RSS dwarfs the
+     frame, the memory bottleneck is a *stage's internal structures* (dedupe's
+     candidate / scored pairs), and streaming the input frame cannot relieve it.
+  2. **Which stage dominates, and can it stream?** ``goldenmatch.dedupe`` needs
+     ALL records to find cross-record duplicates -- it is inherently whole-dataset
+     and cannot process a stream batch-by-batch.
+
+Run one size (fresh process):
+    python benchmarks/phaseb_outofcore_probe.py --rows 100000
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import resource
+import tempfile
+
+import polars as pl
+
+
+def _peak_rss_mb() -> float:
+    # ru_maxrss is KB on Linux, bytes on macOS. Assume Linux (CI) -> KB.
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+
+
+def _make(path: str, rows: int, seed: int = 7) -> None:
+    rng = random.Random(seed)
+    first = ["Jon", "John", "Mary", "Bob", "Robert", "Sue"]
+    last = ["Smith", "Smyth", "Jones", "Lee", "Kim", "Patel"]
+    recs = []
+    for i in range(rows):
+        f, ln = rng.choice(first), rng.choice(last)
+        e = f"{f.lower()}.{ln.lower()}{rng.randint(0, 99)}@x.com"
+        recs.append({"id": i, "first": f, "last": ln, "email": e,
+                     "city": rng.choice(["NYC", "LA", "Chicago"]), "amt": round(rng.random() * 1000, 2)})
+        if rng.random() < 0.2:  # ~20% near-duplicate rows
+            recs.append({"id": rows + i, "first": f, "last": ln, "email": f"  {e.upper()} ",
+                         "city": "NYC", "amt": round(rng.random() * 1000, 2)})
+    pl.DataFrame(recs).write_csv(path)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=100_000)
+    args = ap.parse_args()
+
+    tmp = tempfile.mkdtemp()
+    path = os.path.join(tmp, "e.csv")
+    _make(path, args.rows)
+    frame_mb = pl.read_csv(path, ignore_errors=True, encoding="utf8-lossy").estimated_size() / 1e6
+
+    from goldenpipe import Pipeline
+
+    res = Pipeline().run(source=path)
+    peak = _peak_rss_mb()
+    dedupe_ms = (res.timing or {}).get("goldenmatch.dedupe", 0.0) * 1000
+    total_ms = sum((res.timing or {}).values()) * 1000
+    print(
+        f"rows={args.rows:>7}  frame={frame_mb:6.2f} MB  peak_RSS={peak:7.0f} MB  "
+        f"peak/frame={peak / max(frame_mb, 0.01):6.1f}x  "
+        f"dedupe={dedupe_ms:6.0f} ms ({dedupe_ms / max(total_ms, 1) * 100:4.1f}% of stages)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What and why

Phase B of the relocatable-stage contract (#1479) is an out-of-core streaming `Frame`. Its design **gate** requires first showing that holding the whole frame is the bottleneck at scale. **It isn't — decisively.** Adds a repro probe + findings doc.

## Measured (fresh process per size, clean peak RSS)

| rows | input frame | peak RSS | peak / frame | dedupe share |
|--:|--:|--:|--:|--:|
| 20,000 | 1.09 MB | 273 MB | **249×** | 77% |
| 50,000 | 2.73 MB | 610 MB | **223×** | 79% |
| 100,000 | 5.47 MB | 1697 MB | **310×** | 89% |

The input frame is **223–310× smaller than peak RSS** — streaming it out-of-core relieves **<0.5%** of peak. Memory grows **superlinearly** (doubling 50k→100k nearly tripled it), and `goldenmatch.dedupe` climbs to **89%** of stage time.

## Verdict — skip Phase B

The bottleneck is **dedupe's whole-dataset candidate/scored-pair structures**, not the frame. And dedupe is **inherently non-streamable** — it must see *all* records to find cross-record matches. A streaming `Frame` would stream a 5 MB input while dedupe balloons to 1.7 GB internally — optimizing the wrong thing (same shape as Stage 0).

Out-of-core ER, if ever needed, is a **`goldenmatch` dedupe-algorithm** project (external / disk-backed blocking + streaming candidate generation) — **not** a goldenpipe orchestration / `Frame` concern.

## Recommendation

- **Phase A stands** (the seam is the groundwork for Phase C, not B).
- **Phase B (streaming Frame) deprioritized** on this evidence — not blocked, just not ER's bottleneck.
- **Go to Phase C (cross-process / cross-language)** — the stated goal, where the handoff is *real* Arrow serialization — with its own Stage-0-style baseline first (e.g. pushing a transform or blocking pass into DuckDB/Postgres, which already have Arrow-native surfaces).

## Testing

Probe runs clean at 20k/50k/100k (numbers above are its output). `ruff check` clean. Docs+bench only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_