### PR TITLE
docs+bench(goldenpipe): Phase C baseline — the engine boundary is real; in-engine wins

### DIFF
--- a/docs/design/2026-07-06-goldenpipe-phasec-baseline-findings.md
+++ b/docs/design/2026-07-06-goldenpipe-phasec-baseline-findings.md
@@ -1,0 +1,81 @@
+# GoldenPipe Phase C baseline — the engine boundary is real; in-engine wins
+
+**Status:** done (measurement). **Created:** 2026-07-06.
+**Gates:** Phase C of `2026-07-06-goldenpipe-relocatable-stage-contract.md`.
+
+## The question
+
+Phase C is a stage relocated to another engine (DuckDB / Postgres / a TS worker)
+instead of in-process Python. Unlike the in-process handoff (**Stage 0**: 0.2% of
+the wall) and out-of-core streaming (**Phase B**: the input frame is 200–300×
+smaller than peak RSS), the **engine boundary** is where the handoff should become
+a *real* cost: pulling a table out of DuckDB into Python and pushing the result
+back is a full serialize + materialize. Does keeping a stage **in-engine** beat
+that round-trip for engine-resident data?
+
+## Method
+
+`benchmarks/phasec_engine_boundary.py`, one **fresh process per mode/size**. A
+DuckDB-resident table; one representative transform (normalize email =
+`lower(trim(email))`) run three ways: `inengine` (`CREATE TABLE … SELECT`, data
+never leaves), `pull` (`.pl()` → Polars transform → reinsert), and `crossing`
+(just the `.pl()` extract + reinsert, to size the boundary).
+
+## Results
+
+| rows | in-engine | pull → Python | crossing (extract + reinsert) | transform only |
+|--:|--:|--:|--:|--:|
+| 1,000,000 | 170 ms | 236 ms | 214 ms (97 + 117) | 35 ms |
+| 5,000,000 | **569 ms** | **1022 ms** | **906 ms (89% of pull)** | 116 ms |
+
+- **The engine boundary is the cost.** At 5M rows the crossing is **89% of the
+  pull path**; the actual transform is **11%**. The crossing scales linearly with
+  data (~190 ms/M).
+- **In-engine is ~1.4–1.8× faster**, and the gap **grows with data** (1.4× at 1M →
+  1.8× at 5M), because in-engine skips the crossing entirely.
+- Peak RSS was similar here (both hold the table in in-memory DuckDB); for a
+  larger-than-memory / on-disk warehouse table, in-engine would also win on memory
+  (DuckDB spills; a Python materialization does not).
+
+## Verdict — Phase C is justified; build it
+
+Unlike Stage 0 and Phase B, **this handoff is load-bearing** (89% of the pull path
+for a cheap stage, scaling with data). For **engine-resident data**, running a
+stage in-engine and keeping the data there is a real, growing win. This is the
+first pillar-2 phase the measurement supports building — and it validates the
+`location="remote"` seam from Phase A against a real engine.
+
+**Where the win applies (be precise):**
+- **Stages that have an in-engine surface** — the transform (`goldenflow-duckdb`),
+  profiling (`goldencheck_*` P5 UDFs), and blocking (`goldenmatch_hnsw_pairs` /
+  `_lsh_pairs`) already run in DuckDB/Postgres from the cross-surface work. Those
+  can be `location="remote"` and skip the crossing.
+- **Warehouse-resident pipelines** — when the data *originates* in and *lands* back
+  in the engine, `pull` pays both extract **and** reinsert (the full 906 ms at 5M);
+  in-engine pays neither. This is the strongest case.
+- **Caveat — the dominant stage still crosses.** `goldenmatch.dedupe`'s scoring
+  (blocking + Fellegi-Sunter) has no full in-engine surface (only the blockers do),
+  so a full dedupe pipeline still pulls to Python (or the native kernel) for that
+  stage. Phase C's win is real for every *other* stage and for keeping data
+  in-engine *between* them — it does not (yet) make the whole ER pipeline in-engine.
+
+## Recommended build — the `RemoteStage` (DuckDB first)
+
+Implement Phase C behind the Phase-A seam:
+1. A `RemoteStage` adapter that, for a `location="remote"` stage over
+   engine-resident data, runs the stage's work as SQL/UDF in the engine (via the
+   already-shipped `goldenflow_*` / `goldencheck_*` surfaces) and leaves the result
+   in-engine — using `ctx.frame.arrow_batches()` / `from_arrow()` only at the true
+   ingress/egress of the pipeline, not between in-engine stages.
+2. The Runner's existing `location` dispatch (Phase A) routes to it; the
+   `ExecutionPlan` is unchanged.
+3. Byte-identical output vs the local stage (pillar-4 discipline) before the local
+   path is considered replaceable for that stage.
+
+Start with **one** relocated stage (the transform, into DuckDB) end-to-end, its own
+before/after on a warehouse-resident table, then widen.
+
+## Repro
+
+`python packages/python/goldenpipe/benchmarks/phasec_engine_boundary.py --rows 5000000 --mode {inengine,pull,crossing}`
+(each mode in a fresh process).

--- a/packages/python/goldenpipe/benchmarks/phasec_engine_boundary.py
+++ b/packages/python/goldenpipe/benchmarks/phasec_engine_boundary.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Phase C baseline: for engine-resident data, does an in-engine stage beat
+pulling the whole table into Python?
+
+Phase C of the relocatable-stage contract is a stage that runs on another engine
+(DuckDB / Postgres / a TS worker) instead of in-process Python. Unlike the
+in-process handoff (Stage 0: free, 0.2%) and the input-frame streaming (Phase B:
+the frame is a rounding error), the ENGINE boundary is where the handoff becomes
+real: pulling a table out of DuckDB into Python and pushing the result back is a
+full serialization + materialization.
+
+This probe compares, on a DuckDB-resident table, one representative transform
+stage (normalize email = ``lower(trim(email))``) run two ways:
+
+  - **pull**  : DuckDB table -> Polars (``.pl()``) -> transform in Polars ->
+                write result back into DuckDB. (Today's goldenpipe model: every
+                stage materializes the whole table in Python.)
+  - **inengine**: ``CREATE TABLE out AS SELECT lower(trim(email)) ... FROM t`` --
+                the data never leaves the engine.
+  - **crossing**: just the boundary cost -- ``.pl()`` extract + reinsert -- to
+                size the handoff a relocated stage's Arrow path would carry.
+
+Run one mode in a FRESH process (peak RSS is a process-lifetime max):
+    python benchmarks/phasec_engine_boundary.py --rows 1000000 --mode inengine
+"""
+from __future__ import annotations
+
+import argparse
+import random
+import resource
+import time
+
+import duckdb
+import polars as pl
+
+
+def _peak_rss_mb() -> float:
+    return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024  # KB->MB on Linux
+
+
+def _seed_table(con: duckdb.DuckDBPyConnection, rows: int, seed: int = 7) -> float:
+    """Create table ``t`` of entity rows inside DuckDB. Returns its in-DB size (MB)."""
+    rng = random.Random(seed)
+    first = ["Jon", "John", "Mary", "Bob", "Robert", "Sue"]
+    last = ["Smith", "Smyth", "Jones", "Lee", "Kim", "Patel"]
+    recs = []
+    for i in range(rows):
+        f, ln = rng.choice(first), rng.choice(last)
+        recs.append({"id": i, "first": f, "last": ln,
+                     "email": f"  {f.upper()}.{ln.upper()}{rng.randint(0, 99)}@X.COM  ",
+                     "city": rng.choice(["NYC", "LA", "Chicago"]), "amt": round(rng.random() * 1000, 2)})
+    df = pl.DataFrame(recs)
+    con.register("seed_df", df)
+    con.execute("CREATE TABLE t AS SELECT * FROM seed_df")
+    con.unregister("seed_df")
+    mb = df.estimated_size() / 1e6
+    del df
+    return mb
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--rows", type=int, default=1_000_000)
+    ap.add_argument("--mode", choices=["pull", "inengine", "crossing"], default="inengine")
+    args = ap.parse_args()
+
+    con = duckdb.connect()
+    frame_mb = _seed_table(con, args.rows)
+
+    t0 = time.perf_counter()
+    if args.mode == "pull":
+        # Stage runs in Python: extract whole table -> transform -> reinsert.
+        t_e0 = time.perf_counter()
+        df = con.sql("SELECT * FROM t").pl()
+        extract = time.perf_counter() - t_e0
+        t_t0 = time.perf_counter()
+        out = df.with_columns(pl.col("email").str.to_lowercase().str.strip_chars())
+        transform = time.perf_counter() - t_t0
+        t_r0 = time.perf_counter()
+        con.register("out_df", out)
+        con.execute("CREATE TABLE out AS SELECT * FROM out_df")
+        reinsert = time.perf_counter() - t_r0
+        total = time.perf_counter() - t0
+        print(f"mode=pull      rows={args.rows:>8}  frame={frame_mb:6.1f}MB  "
+              f"total={total * 1000:7.0f}ms  (extract={extract * 1000:.0f} + "
+              f"transform={transform * 1000:.0f} + reinsert={reinsert * 1000:.0f})  "
+              f"peak_RSS={_peak_rss_mb():6.0f}MB")
+    elif args.mode == "inengine":
+        # Stage runs in the engine: data never leaves DuckDB.
+        con.execute("CREATE TABLE out AS SELECT id, first, last, "
+                    "lower(trim(email)) AS email, city, amt FROM t")
+        total = time.perf_counter() - t0
+        print(f"mode=inengine  rows={args.rows:>8}  frame={frame_mb:6.1f}MB  "
+              f"total={total * 1000:7.0f}ms  peak_RSS={_peak_rss_mb():6.0f}MB")
+    else:  # crossing
+        t_e0 = time.perf_counter()
+        df = con.sql("SELECT * FROM t").pl()
+        extract = time.perf_counter() - t_e0
+        t_r0 = time.perf_counter()
+        con.register("out_df", df)
+        con.execute("CREATE TABLE out AS SELECT * FROM out_df")
+        reinsert = time.perf_counter() - t_r0
+        print(f"mode=crossing  rows={args.rows:>8}  frame={frame_mb:6.1f}MB  "
+              f"extract={extract * 1000:6.0f}ms  reinsert={reinsert * 1000:6.0f}ms  "
+              f"peak_RSS={_peak_rss_mb():6.0f}MB")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What and why

Phase C is a stage relocated to another engine (DuckDB / Postgres / TS worker). Unlike Stage 0 (in-process handoff = 0.2%) and Phase B (input frame is 200–300× smaller than peak RSS), the **engine boundary** is where the handoff becomes load-bearing. This baseline tests whether keeping a stage **in-engine** beats pulling the table into Python. Adds a repro probe + findings doc.

## Measured (DuckDB-resident table, fresh process per mode)

| rows | in-engine | pull → Python | crossing (extract+reinsert) | transform only |
|--:|--:|--:|--:|--:|
| 1M | 170 ms | 236 ms | 214 ms | 35 ms |
| 5M | **569 ms** | **1022 ms** | **906 ms (89% of pull)** | 116 ms |

At 5M the boundary crossing is **89% of the pull path**; the transform is 11%. In-engine is **~1.4–1.8× faster** and the gap **grows with data** (crossing scales ~190 ms/M).

## Verdict — Phase C is justified; build it

Unlike the prior baselines, **this handoff is real**. For engine-resident data, running a stage in-engine and keeping the data there is a measured, growing win. This is the first pillar-2 phase measurement supports building, and it validates the `location="remote"` seam from Phase A against a real engine.

**Precise scope (honest):**
- **Wins for stages with an in-engine surface** — transform (`goldenflow-duckdb`), profiling (`goldencheck_*` P5 UDFs), blocking (`goldenmatch_hnsw_pairs`/`_lsh_pairs`) — all shipped from the cross-surface work.
- **Strongest for warehouse-resident pipelines** — data originates + lands in-engine, so `pull` pays both extract *and* reinsert (the full 906 ms at 5M).
- **Caveat:** `goldenmatch.dedupe` scoring has no full in-engine surface, so a full ER pipeline still crosses for that stage. Phase C's win is real for every *other* stage and for keeping data in-engine *between* them.

## Recommended build

A `RemoteStage` adapter behind the Phase-A `location` dispatch: for a `location="remote"` stage over engine-resident data, run the work as SQL/UDF in the engine (via the shipped `goldenflow_*`/`goldencheck_*` surfaces), materializing Arrow only at the pipeline's true ingress/egress. Start with **one** relocated transform stage (into DuckDB) end-to-end, byte-identical vs local, then widen.

## Testing

Probe runs clean at 1M/5M (numbers above). `ruff check` clean. Docs+bench only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_