### PR TITLE
feat(goldenpipe): relocatable-stage contract Phase C v2 — real UDF + engine-resident source

### DIFF
--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -53,12 +53,29 @@ in-engine pays (unlike Stage 0 / Phase B). Phase C v1 turns `location="remote"` 
   `lower(trim(col))` transform run in DuckDB), byte-identical to the local Polars
   path, reusing one engine connection via `ctx.metadata["duckdb_con"]`. Tests:
   `tests/test_engine_stage.py`.
-- **v2 follow-ons (not in v1):** wire the real `goldenflow_*` / `goldencheck_*`
-  DuckDB UDFs (already shipped) behind `RemoteStage`, and a DuckDB-table **source**
-  for `Pipeline.run` so the data originates in-engine (killing the ingress crossing
-  too). The dominant `goldenmatch.dedupe` scoring stage has no in-engine surface, so
-  a full ER pipeline still crosses for it — Phase C wins the other stages + keeps
-  data in-engine between them.
+Phase C **v2** closes the two documented gaps (`tests/test_engine_stage_v2.py`):
+- `adapters/engine.py` — **`EngineFlowTransformStage`**: runs a **real shipped**
+  `goldenflow_*` DuckDB UDF (from `goldenmatch_duckdb` — the same kernel on the
+  DuckDB/Postgres/dbt surfaces) as an in-engine projection, byte-identical to the
+  goldenflow Python transform. `transform` is a friendly alias (`email`/`strip`/…);
+  the UDFs register ONCE per engine con (`_goldenflow_udfs_registered` guard).
+  **Honest caveat:** the DuckDB `goldenflow_*` UDFs are per-value **Python**
+  callbacks (in-process polars), NOT the compiled zero-Python `goldenflow-duckdb`
+  cdylib — so v2 removes the DataFrame **materialization** boundary *between* stages
+  (the 89% pull), not Python from the per-value path. `validate()` raises if
+  `goldenmatch-duckdb`/`goldenflow` are absent.
+- `pipeline.py` — **DuckDB-table source**: `Pipeline.run(duckdb_con=, duckdb_table=)`
+  seeds `ctx.frame` as an engine-resident `DuckDBFrame` (table name regex-validated;
+  row count via a scalar `COUNT`, not a full pull). A remote stage right after pays
+  **no** ingress crossing (proven by a `.polars()` spy staying at 0). Invariant: **a
+  `DuckDBFrame` on `ctx` is always paired with its con in `ctx.metadata["duckdb_con"]`**
+  (both the source and the engine stages maintain this — the in-engine `.project`
+  runs on the relation's own con, which must be where the UDFs were registered).
+  Caveat: with the default auto-config (local `load` first), the source materializes
+  at `load` — the WIN needs the first stage to be remote.
+- The dominant `goldenmatch.dedupe` scoring stage still has no in-engine surface, so
+  a full ER pipeline crosses for it — Phase C wins every *other* stage + keeps data
+  in-engine between them.
 
 ## Pipeline Flow
 ```

--- a/packages/python/goldenpipe/goldenpipe/adapters/engine.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/engine.py
@@ -12,10 +12,21 @@ engine -- the Python round-trip is paid once, at egress, only when a local stage
 next needs the data (the Runner materializes it there).
 
 Scope (v1): ``EngineNormalizeStage`` demonstrates the mechanism with a plain SQL
-projection. Wiring the real ``goldenflow_*`` / ``goldencheck_*`` DuckDB UDFs
-(already shipped from the cross-surface work) behind this same contract, and a
-DuckDB-table *source* for ``Pipeline.run`` so the data originates in-engine, are
-the v2 follow-ons.
+projection.
+
+Scope (v2): ``EngineFlowTransformStage`` wires a **real shipped** ``goldenflow_*``
+DuckDB UDF (from ``goldenmatch_duckdb``, the same kernel exposed on the DuckDB /
+Postgres / dbt surfaces) behind this same contract; and ``Pipeline.run`` gains a
+DuckDB-table *source* (``duckdb_con`` + ``duckdb_table``) so the data originates
+in-engine -- a remote stage right after it pays **no** ingress crossing.
+
+Honest caveat (v2): the DuckDB ``goldenflow_*`` UDFs are per-value **Python**
+callbacks (in-process polars), NOT the compiled zero-Python ``goldenflow-duckdb``
+cdylib. So this does not remove Python from the per-value path; what it removes
+is the DataFrame **materialization** boundary *between* stages -- the ~89% pull
+Phase C measured -- because the relation stays lazy and engine-resident across
+the chain. The dominant ``goldenmatch.dedupe`` scoring stage still has no
+in-engine surface, so a full ER pipeline crosses for it.
 """
 from __future__ import annotations
 
@@ -80,5 +91,100 @@ class EngineNormalizeStage(RemoteStage):
             f"lower(trim({c})) AS {c}" if c == self.column else c for c in cols
         )
         # Stays a lazy DuckDBFrame -> stored on ctx without materializing.
+        ctx.frame = ddf.project(projection)
+        return StageResult(status=StageStatus.SUCCESS)
+
+
+# Friendly alias -> the shipped ``goldenmatch_duckdb`` UDF name. These are the
+# exact UDFs ``register_goldenflow_functions`` puts on a DuckDB connection.
+_FLOW_UDF_BY_ALIAS = {
+    "email": "goldenflow_normalize_email",
+    "phone": "goldenflow_normalize_phone",
+    "date": "goldenflow_normalize_date",
+    "name": "goldenflow_normalize_name_proper",
+    "url": "goldenflow_canonicalize_url",
+    "address": "goldenflow_canonicalize_address",
+    "strip": "goldenflow_strip",
+    "whitespace": "goldenflow_whitespace_normalize",
+}
+
+
+class EngineFlowTransformStage(RemoteStage):
+    """Apply a **real shipped** ``goldenflow_*`` DuckDB UDF to a column **in the
+    engine** (Phase C v2).
+
+    Where ``EngineNormalizeStage`` proved the mechanism with a hand-written
+    ``lower(trim(...))``, this wires an actual cross-surface kernel: the same
+    ``goldenflow_normalize_email`` / ``goldenflow_strip`` / ... that
+    ``goldenmatch_duckdb`` registers for the DuckDB SQL surface (and whose
+    Postgres / dbt siblings share the goldenflow transform registry). The UDF is
+    applied as an in-engine projection, so the frame stays a lazy
+    ``DuckDBFrame`` -- a chain of these avoids the pull-to-Python between stages.
+
+    ``transform`` is a friendly alias (``"email"``, ``"strip"``, ...); see
+    ``_FLOW_UDF_BY_ALIAS``. The UDFs are registered ONCE per engine connection
+    (idempotent-guarded on ``ctx.metadata``), reusing the shared
+    ``ctx.metadata["duckdb_con"]`` so remote stages chain in one engine.
+
+    Requires ``goldenmatch-duckdb`` (for the registration entrypoint) and
+    ``goldenflow`` (for the transforms) to be installed; ``validate`` raises a
+    clear, actionable error otherwise rather than silently passing values
+    through.
+    """
+
+    def __init__(self, column: str, transform: str = "email", con=None) -> None:
+        if transform not in _FLOW_UDF_BY_ALIAS:
+            raise ValueError(
+                f"unknown flow transform {transform!r}; "
+                f"expected one of {sorted(_FLOW_UDF_BY_ALIAS)}"
+            )
+        self.column = column
+        self.transform = transform
+        self._udf = _FLOW_UDF_BY_ALIAS[transform]
+        self._con = con
+        self.info = StageInfo(
+            name=f"engine.flow.{transform}",
+            produces=["df"], consumes=["df"], location="remote",
+        )
+
+    def validate(self, ctx: PipeContext) -> None:
+        try:
+            import goldenflow  # noqa: F401
+            from goldenmatch_duckdb.goldenflow import (  # noqa: F401
+                register_goldenflow_functions,
+            )
+        except ImportError as exc:  # pragma: no cover - env-dependent
+            raise RuntimeError(
+                "EngineFlowTransformStage needs the shipped goldenflow DuckDB "
+                "UDFs. Install both: `pip install goldenmatch-duckdb goldenflow`."
+            ) from exc
+
+    def run(self, ctx: PipeContext) -> StageResult:
+        import duckdb
+
+        frame = ctx.frame
+        con = self._con or ctx.metadata.get("duckdb_con")
+        if con is None:
+            con = duckdb.connect()
+            ctx.metadata["duckdb_con"] = con
+
+        # Register the shipped goldenflow_* UDFs once per engine connection.
+        if not ctx.metadata.get("_goldenflow_udfs_registered"):
+            from goldenmatch_duckdb.goldenflow import register_goldenflow_functions
+            register_goldenflow_functions(con)
+            ctx.metadata["_goldenflow_udfs_registered"] = True
+
+        if isinstance(frame, DuckDBFrame):
+            ddf = frame  # already engine-resident: chain in-engine, no crossing
+        else:
+            # Ingress from Python (a LocalFrame over ctx.df) -- paid once. With
+            # the v2 DuckDB-table source this branch never runs.
+            ddf = DuckDBFrame(con.from_arrow(frame.polars().to_arrow()))
+
+        cols = ddf.relation().columns
+        projection = ", ".join(
+            f'{self._udf}("{c}") AS "{c}"' if c == self.column else f'"{c}"'
+            for c in cols
+        )
         ctx.frame = ddf.project(projection)
         return StageResult(status=StageStatus.SUCCESS)

--- a/packages/python/goldenpipe/goldenpipe/pipeline.py
+++ b/packages/python/goldenpipe/goldenpipe/pipeline.py
@@ -1,6 +1,8 @@
 """Pipeline -- thin wrapper over the engine layer."""
 from __future__ import annotations
 
+import re
+
 import polars as pl
 
 from goldenpipe.engine.registry import StageRegistry
@@ -9,6 +11,8 @@ from goldenpipe.engine.resolver import Resolver
 from goldenpipe.engine.runner import Runner
 from goldenpipe.models.config import PipelineConfig, StageSpec
 from goldenpipe.models.context import PipeContext, PipeResult, PipeStatus
+
+_TABLE_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_.]*$")
 
 
 class Pipeline:
@@ -29,10 +33,49 @@ class Pipeline:
         # YAML is authoritative and identity_opts is ignored.
         self._identity_opts = identity_opts
 
-    def run(self, source: str | None = None, df: pl.DataFrame | None = None) -> PipeResult:
+    def run(
+        self,
+        source: str | None = None,
+        df: pl.DataFrame | None = None,
+        *,
+        duckdb_con=None,
+        duckdb_table: str | None = None,
+    ) -> PipeResult:
         ctx = PipeContext()
 
-        if df is not None:
+        if duckdb_con is not None and duckdb_table is not None:
+            # Engine-resident source (relocatable-stage contract, Phase C v2):
+            # the data ORIGINATES in DuckDB, so ``ctx.frame`` starts as a lazy
+            # ``DuckDBFrame`` and a remote stage right after pays NO ingress
+            # crossing. It materializes to ``df`` only at the first LOCAL stage
+            # (the Runner does that once), or never for an all-remote pipeline.
+            from goldenpipe.models.frame import DuckDBFrame
+
+            if not _TABLE_NAME_RE.match(duckdb_table):
+                return PipeResult(
+                    status=PipeStatus.FAILED,
+                    source=f"duckdb:{duckdb_table}",
+                    input_rows=0,
+                    errors=[f"Invalid DuckDB table name: {duckdb_table!r}"],
+                )
+            try:
+                rel = duckdb_con.sql(f"SELECT * FROM {duckdb_table}")  # noqa: S608 - name validated above
+                ctx.frame = DuckDBFrame(rel)  # engine-resident, NOT materialized
+                ctx.metadata["duckdb_con"] = duckdb_con
+                ctx.metadata["source"] = f"duckdb:{duckdb_table}"
+                # Row count via a scalar COUNT -- a cheap engine aggregate, NOT
+                # the full DataFrame pull Phase C confines to egress.
+                ctx.metadata["input_rows"] = duckdb_con.sql(
+                    f"SELECT count(*) FROM {duckdb_table}"  # noqa: S608 - name validated above
+                ).fetchone()[0]
+            except Exception as e:
+                return PipeResult(
+                    status=PipeStatus.FAILED,
+                    source=f"duckdb:{duckdb_table}",
+                    input_rows=0,
+                    errors=[f"Failed to load DuckDB table: {e}"],
+                )
+        elif df is not None:
             ctx.df = df
             ctx.metadata["source"] = "<DataFrame>"
             ctx.metadata["input_rows"] = len(df)

--- a/packages/python/goldenpipe/tests/test_engine_stage_v2.py
+++ b/packages/python/goldenpipe/tests/test_engine_stage_v2.py
@@ -1,0 +1,181 @@
+"""Relocatable-stage contract, Phase C v2: real shipped UDF + engine-resident source.
+
+Design: ``docs/design/2026-07-06-goldenpipe-phasec-baseline-findings.md`` (v2 follow-ons).
+
+v1 proved the RemoteStage mechanism with a hand-written ``lower(trim(...))`` and
+a ``LocalFrame`` ingress. v2 closes the two documented gaps:
+
+- **Real UDF** -- ``EngineFlowTransformStage`` runs an actual shipped
+  ``goldenflow_*`` DuckDB UDF (from ``goldenmatch_duckdb``) in-engine, byte-
+  identical to the goldenflow Python transform.
+- **Engine-resident source** -- ``Pipeline.run(duckdb_con=, duckdb_table=)``
+  originates the data in DuckDB, so a remote stage right after pays NO ingress
+  crossing (proven here by a ``.polars()`` spy that stays at zero).
+"""
+from __future__ import annotations
+
+import duckdb
+import polars as pl
+import pytest
+from goldenpipe.adapters import LoadStage
+from goldenpipe.adapters.engine import (
+    EngineFlowTransformStage,
+    EngineNormalizeStage,
+    RemoteStage,
+)
+from goldenpipe.engine.registry import StageRegistry
+from goldenpipe.engine.resolver import ExecutionPlan, PlannedStage
+from goldenpipe.engine.runner import Runner
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import PipeContext, PipeStatus
+from goldenpipe.models.frame import DuckDBFrame
+from goldenpipe.pipeline import Pipeline
+
+# Skip the whole module unless the shipped goldenflow DuckDB UDFs are available.
+_HAS_FLOW_UDFS = True
+try:  # pragma: no cover - import guard
+    import goldenflow  # noqa: F401
+    from goldenmatch_duckdb.goldenflow import (  # noqa: F401
+        register_goldenflow_functions,
+    )
+except ImportError:  # pragma: no cover
+    _HAS_FLOW_UDFS = False
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_FLOW_UDFS,
+    reason="needs goldenmatch-duckdb + goldenflow for the shipped goldenflow_* UDFs",
+)
+
+_DF = pl.DataFrame({
+    "id": [1, 2, 3],
+    "email": ["  A@X.COM  ", "B@Y.COM", " c@z.com "],
+    "city": ["NYC", "LA", "Chicago"],
+})
+
+
+def _plan(*stages) -> ExecutionPlan:
+    return ExecutionPlan(stages=[
+        PlannedStage(name=s.info.name, stage=s, spec=StageSpec(use=s.info.name))
+        for s in stages
+    ])
+
+
+def _flow_reference(col: str, transform_name: str) -> list:
+    """The goldenflow Python transform applied to a column -- the parity oracle."""
+    from goldenflow.transforms import get_transform
+    info = get_transform(transform_name)
+    out = info.func(pl.Series(_DF[col]))
+    return out.to_list()
+
+
+class TestEngineFlowTransformStage:
+    def test_is_remote_capable(self):
+        st = EngineFlowTransformStage(column="email", transform="email")
+        assert isinstance(st, RemoteStage)
+        assert st.remote_capable is True
+        assert st.info.location == "remote"
+        assert st.info.name == "engine.flow.email"
+
+    def test_unknown_transform_raises(self):
+        with pytest.raises(ValueError, match="unknown flow transform"):
+            EngineFlowTransformStage(column="email", transform="nope")
+
+    def test_byte_identical_to_goldenflow_python(self):
+        ctx = PipeContext(df=_DF)
+        st = EngineFlowTransformStage(column="email", transform="email")
+        st.validate(ctx)
+        st.run(ctx)
+        got = ctx.frame.polars().sort("id")["email"].to_list()
+        assert got == _flow_reference("email", "email_normalize")
+
+    def test_stays_engine_resident(self):
+        ctx = PipeContext(df=_DF)
+        st = EngineFlowTransformStage(column="email", transform="email")
+        st.run(ctx)
+        # Result is a lazy DuckDBFrame held on ctx -- not pulled into Python.
+        assert isinstance(getattr(ctx, "_frame", None), DuckDBFrame)
+
+    def test_chains_with_normalize_in_one_engine(self):
+        # A goldenflow-UDF stage then a plain-SQL stage reuse the same engine
+        # connection; the flow UDFs are registered exactly once.
+        ctx = PipeContext(df=_DF)
+        EngineFlowTransformStage(column="email", transform="strip").run(ctx)
+        first_con = ctx.metadata["duckdb_con"]
+        assert ctx.metadata.get("_goldenflow_udfs_registered") is True
+        EngineNormalizeStage(column="email").run(ctx)
+        assert ctx.metadata["duckdb_con"] is first_con
+        assert isinstance(getattr(ctx, "_frame", None), DuckDBFrame)
+
+
+class TestRunnerRoutesFlowStage:
+    def test_runner_routes_and_materializes(self):
+        ctx = PipeContext(df=_DF)
+        Runner(registry=StageRegistry()).run(
+            _plan(EngineFlowTransformStage("email", "email")), ctx
+        )
+        assert isinstance(getattr(ctx, "_frame", None), DuckDBFrame)
+        assert ctx.frame.polars().sort("id")["email"].to_list() == _flow_reference(
+            "email", "email_normalize"
+        )
+
+
+def _load_only_pipeline() -> Pipeline:
+    reg = StageRegistry()
+    reg.register(LoadStage())
+    return Pipeline(config=PipelineConfig(pipeline="t", stages=[]), registry=reg)
+
+
+class TestDuckDBTableSource:
+    def test_pipeline_run_loads_from_duckdb_table(self):
+        # End-to-end through Pipeline.run: a minimal load-only pipeline sources
+        # from a DuckDB table (materializes at the local `load` stage) and
+        # reports the right rows + source label.
+        con = duckdb.connect()
+        con.register("df_view", _DF.to_arrow())
+        con.execute("CREATE TABLE people AS SELECT * FROM df_view")
+
+        result = _load_only_pipeline().run(duckdb_con=con, duckdb_table="people")
+
+        assert result.status == PipeStatus.SUCCESS
+        assert result.input_rows == 3
+        assert result.source == "duckdb:people"
+
+    def test_invalid_table_name_fails_cleanly(self):
+        con = duckdb.connect()
+        result = _load_only_pipeline().run(
+            duckdb_con=con, duckdb_table="bad; DROP TABLE x"
+        )
+        assert result.status == PipeStatus.FAILED
+        assert any("Invalid DuckDB table name" in e for e in result.errors)
+
+    def test_remote_stage_after_source_pays_no_ingress(self):
+        # THE v2 WIN: data originates in DuckDB, the first stage is remote, so
+        # the frame is never materialized to Python (no ingress crossing). A
+        # `.polars()` spy on the seeded frame stays at zero across the stage.
+        con = duckdb.connect()
+        con.register("df_view", _DF.to_arrow())
+        con.execute("CREATE TABLE people AS SELECT * FROM df_view")
+        rel = con.sql("SELECT * FROM people")
+
+        materialized = {"n": 0}
+
+        class SpyFrame(DuckDBFrame):
+            def polars(self):  # noqa: D401
+                materialized["n"] += 1
+                return super().polars()
+
+        ctx = PipeContext()
+        ctx.frame = SpyFrame(rel)  # engine-resident seed (as Pipeline.run does)
+        ctx.metadata["duckdb_con"] = con
+
+        Runner(registry=StageRegistry()).run(
+            _plan(EngineFlowTransformStage("email", "email")), ctx
+        )
+
+        # The seeded frame was NEVER materialized -> no ingress crossing.
+        assert materialized["n"] == 0
+        assert ctx.df is None  # nothing pulled to Python during the remote stage
+        # ...and the result is still byte-correct at egress.
+        assert ctx.frame.polars().sort("id")["email"].to_list() == _flow_reference(
+            "email", "email_normalize"
+        )


### PR DESCRIPTION
## What and why

Phase C **v1** (#1489) proved the in-engine RemoteStage mechanism with a hand-written `lower(trim(...))` and a `LocalFrame` ingress. **v2 closes the two follow-ons the v1 scope note flagged** — wiring a *real shipped* UDF, and originating data in-engine so there's no ingress crossing.

> **Stacked on Phase C v1 (#1489)** → which is stacked on Phase A (#1484). This PR's base is the v1 branch, so the diff is v2-only. Merge order: #1484 → #1489 → this.

## Changes

- **`adapters/engine.py` — `EngineFlowTransformStage`**: runs a **real shipped** `goldenflow_*` DuckDB UDF (from `goldenmatch_duckdb` — the same kernel exposed on the DuckDB / Postgres / dbt surfaces) as an in-engine projection behind the same `RemoteStage` contract, **byte-identical** to the goldenflow Python transform. `transform` is a friendly alias (`email`/`strip`/`phone`/…); the UDFs register **once** per engine connection (guarded on `ctx.metadata`). `validate()` raises a clear, actionable error if `goldenmatch-duckdb`/`goldenflow` aren't installed.
- **`pipeline.py` — DuckDB-table source**: `Pipeline.run(duckdb_con=, duckdb_table=)` seeds `ctx.frame` as an **engine-resident** `DuckDBFrame` (table name regex-validated; row count via a scalar `COUNT`, **not** a full pull). A remote stage right after pays **no** ingress crossing.

## Honest scope (the caveat that matters)

The DuckDB `goldenflow_*` UDFs are per-value **Python** callbacks (in-process polars), **NOT** the compiled zero-Python `goldenflow-duckdb` cdylib. So v2 removes the DataFrame **materialization** boundary *between* stages — the ~89% pull Phase C's baseline (#1487) measured — **not** Python from the per-value path. The frame stays a lazy relation across the chain; the pull is paid once, at egress.

Invariant documented + enforced by construction: **a `DuckDBFrame` on `ctx` is always paired with its connection in `ctx.metadata["duckdb_con"]`** (the in-engine `.project` runs on the relation's own con, which must be where the UDFs were registered). With the default auto-config (local `load` first) the source materializes at `load` — the win needs the first stage to be remote.

The dominant `goldenmatch.dedupe` *scoring* stage still has no in-engine surface, so a full ER pipeline crosses for it — Phase C wins every *other* stage and keeps data in-engine between them.

## Verification

- **`tests/test_engine_stage_v2.py` (9):** `EngineFlowTransformStage` is a `RemoteStage` / byte-identical to `goldenflow` email-normalize / stays engine-resident / chains with `EngineNormalizeStage` in one engine / unknown transform raises; Runner routes it; DuckDB-table source loads end-to-end through `Pipeline.run`, invalid table name fails cleanly, and a remote stage after the source **pays no ingress** (a `.polars()` spy on the seeded frame stays at **0**).
- Full goldenpipe suite unchanged — 177 passed; the only reds are pre-existing env failures (TUI needs `pytest-asyncio`, `test_rest` needs `httpx`), identical on the parent commit. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_