### PR TITLE
docs(goldenpipe): close out the relocatable-stage contract — in-engine dedupe verdict + docs sweep

### DIFF
--- a/docs/design/2026-07-06-goldenpipe-in-engine-dedupe-scope.md
+++ b/docs/design/2026-07-06-goldenpipe-in-engine-dedupe-scope.md
@@ -1,0 +1,135 @@
+# In-engine dedupe scoring — scope + Stage 0 verdict
+
+**Date:** 2026-07-06
+**Status:** SCOPED — **DO NOT BUILD** (Stage 0 measured the ceiling at <1% and shrinking)
+**Context:** closes the open caveat from the relocatable-stage contract Phase C
+(`2026-07-06-goldenpipe-phasec-baseline-findings.md`): "the dominant
+`goldenmatch.dedupe` scoring stage has no in-engine surface, so a full ER pipeline
+still crosses for it." This doc asks whether that caveat is a gap worth closing.
+**Reproducer:** `packages/python/goldenpipe/benchmarks/stage0_inengine_dedupe_probe.py`
+
+---
+
+## The question
+
+Phase C proved that keeping a cheap stage *in-engine* (DuckDB) pays, because the
+DuckDB<->Python crossing was **~89% of the pull path** for a plain projection. The
+natural next target is the one stage Phase C could not place in-engine: the dedupe
+*scoring* stage. Should we build an in-engine dedupe so a full ER pipeline never has
+to leave the warehouse?
+
+The measure-first discipline says: **do not assume it wins.** Phase C's 89% was for a
+*compute-trivial* projection. Dedupe is *compute-heavy* (scoring is O(candidate
+pairs) of rapidfuzz work). Before designing anything, measure whether the crossing is
+even a material fraction of a dedupe.
+
+## What "in-engine dedupe" would actually be
+
+`dedupe_df` (`goldenmatch/_api.py:400` -> `core/pipeline.py:1127`) is a four-stage
+machine, not one kernel:
+
+| Stage | Today | In-engine equivalent |
+|---|---|---|
+| **Blocking** (candidate-pair gen) | Polars `group_by("__block_key__")` (`core/blocker.py:315`) | `GROUP BY` / self-join — already SQL-shaped |
+| **Scoring** (fuzzy / Fellegi-Sunter) | rapidfuzz `cdist`; native block-scorer `score_block_pairs_arrow` (`backends/score_buckets.py:778`) over **`score-core`** | scalar UDF per candidate pair |
+| **Threshold** | Polars filter | `WHERE score >= t` — pure SQL |
+| **Clustering** (connected components) | native `connected_components` (`core/cluster.py:832`) over **`graph-core`** | UDF over the pair list |
+
+The two hard kernels — scoring and clustering — **already have pyo3-free Rust core
+crates with Arrow entry points** (`goldenmatch-score-core`, `goldenmatch-graph-core`),
+and the `datafusion-udf` + Postgres extensions already link them. So this is not
+"rewrite dedupe in Rust." It is "compose kernels that mostly exist into an in-engine
+plan." The work splits sharply by surface.
+
+### Surface map (what already runs in-engine vs. new work)
+
+**Postgres (pgrx) is ~80% there** — native-direct, no embedded CPython:
+- `goldenmatch_score(a,b,scorer)` for jaro_winkler/levenshtein/token_sort/exact
+  (`postgres/src/quick.rs:156`, over `score-core`).
+- `goldenmatch_connected_components` + `goldenmatch_pair_dedup`
+  (`postgres/src/kernels.rs:202`, over `graph-core`).
+- LSH / HNSW blocking already native-direct (`kernels.rs:99` / `:37`).
+- Composing these into a block -> score -> threshold -> CC SQL is **mostly wiring,
+  near-zero new Rust.**
+
+**DuckDB is greenfield** — there is **no compiled goldenmatch cdylib at all** (unlike
+`goldenflow-duckdb`). Every `goldenmatch_*` DuckDB UDF marshals to Python; e.g.
+`goldenmatch_dedupe_table` does `cursor.sql(...).pl()` then `dedupe_df` in the Python
+process (`extensions/duckdb/goldenmatch_duckdb/functions.py:275`). A zero-Python
+in-engine path would be a **new compiled `goldenmatch-duckdb` cdylib** (score-core +
+graph-core), 5-platform release, CI parity lane — a real, disproportionate lift.
+
+### The honest boundary (smart pipe / dumb kernels)
+
+Only the *mechanical* dedupe could ever go in-engine. The *smart* parts stay host:
+auto-config profiling, Fellegi-Sunter EM training, MST splitting of oversized
+clusters (`core/cluster.py:183`), correction memory, `explain`. Those run **once on
+samples/summaries, not per-pair**, so they were never the crossing bottleneck. An
+in-engine path is therefore a **reference-simplified** dedupe (explicit config only),
+NOT byte-identical to `dedupe_df` across every blocking nuance — it would have to be
+parity-gated and documented, never silently divergent (the #688 lesson).
+
+### The phased plan (what we WOULD build, if Stage 0 said go)
+
+- **Stage 0** — measure the crossing fraction of a warehouse-resident dedupe. *Gates
+  everything.*
+- **Phase 1 (Postgres)** — a goldenpipe `EngineDedupeStage` emitting block -> score ->
+  threshold -> `connected_components` SQL, reusing the native-direct UDFs. Minimal new
+  Rust. Parity-gated vs `dedupe_df` on explicit configs.
+- **Phase 2 (DuckDB)** — new compiled `goldenmatch-duckdb` cdylib (the greenfield
+  lift), only if Phase 1 wins *and* per-value Python is shown to be the residual cost.
+- **Phase 3** — wire it as the in-engine dedupe `RemoteStage`, keeping auto-config /
+  FS / MST host-side.
+
+---
+
+## Stage 0 measurement — the ceiling on any in-engine-dedupe win
+
+The compute (block + score + cluster) runs at the **same speed** whether the kernel is
+called from Python-over-Arrow or from an in-engine UDF — both are `score-core` /
+`graph-core` underneath. So the ONLY thing an in-engine dedupe can save is the
+**crossing**: pulling the warehouse table into Python (ingress) and pushing the result
+back (egress). Therefore:
+
+> `crossing_fraction = (ingress + egress) / total`  **is the CEILING on any
+> in-engine-dedupe speedup** for a warehouse-resident dedupe.
+
+Explicit config (auto-config excluded — it is host-side "smart pipe" either way), data
+originating in a DuckDB table and written back to one, median of fresh runs
+(`goldenmatch 2.8.0`, `duckdb 1.5.4`, 760 surnames so blocking on `last_name` yields
+bounded block sizes):
+
+| rows | ingress | compute | egress | total | **crossing %** |
+|---:|---:|---:|---:|---:|---:|
+| 10,000 | 3.2 ms | 1356 ms | 5.5 ms | 1365 ms | **0.64 %** |
+| 40,000 | 9.0 ms | 3549 ms | 9.2 ms | 3568 ms | **0.51 %** |
+| 100,000 | 20.1 ms | 7643 ms | 10.9 ms | 7674 ms | **0.40 %** |
+
+## Verdict — DO NOT BUILD
+
+The crossing is **0.4–0.64 % of the dedupe wall, and shrinking** as data grows
+(compute is superlinear O(pairs); the crossing is linear O(rows), so the ratio decays).
+Against Phase C's **89 %** for a plain projection, this is the opposite regime: the
+rapidfuzz scoring compute utterly dominates, and the DuckDB<->Python crossing is
+rounding error.
+
+An in-engine dedupe could save **at most ~0.5 % of wall, less at scale** — and because
+the in-engine kernels *are* the same `score-core` / `graph-core` the host path already
+calls, there is no compute speedup on top. Building it (a compiled `goldenmatch-duckdb`
+cdylib + Postgres SQL composition + reference-simplified parity gates) would be a large,
+high-maintenance surface for a sub-1 % win. **The Phase C v2 caveat is not a gap to
+close; it is correct by construction.** The right architecture is exactly "smart pipe,
+dumb kernels": dedupe stays a host stage that calls native kernels, and the ~0.5 %
+crossing it pays when it sits among in-engine stages is negligible and paid once.
+
+This is the fourth measure-first "don't" (Stage 0 handoff 0.2 %, Phase B frame a
+rounding error, in-engine dedupe crossing 0.4 %) against Phase C's one "do" — the
+discipline earning its keep: three baselines said don't, and we did not build them.
+
+### When to revisit
+
+Only if a future workload inverts the ratio — a *cheap* dedupe (tiny blocks, exact/
+hash scoring, no fuzzy) sitting inside a long chain of OTHER in-engine stages, where
+forcing it through Python would break engine-residency and the crossing compounds
+across stages. That is not entity resolution's cost shape. Re-run the probe against the
+real workload before reconsidering; do not build on the assumption.

--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -28,8 +28,10 @@ laying now). **Phase A is inert groundwork — no behavior/perf change:**
 - `PipeContext.frame` — a derived property over `df` (the canonical store stays
   `df`, so existing `ctx.df` stages + `PipeContext(df=...)` are untouched). The
   pipeline path never calls it today; it's the accessor a remote adapter will use.
-- `StageInfo.location` (default `"local"`) + a Runner guard that raises
-  `NotImplementedError` for any non-local stage (remote = Phase C, not built). The
+- `StageInfo.location` (default `"local"`) + a Runner guard. In Phase A this raised
+  `NotImplementedError` for ANY non-local stage; **Phase C (below) made `location="remote"`
+  run in-engine**, so the guard now raises only for a plain remote stage *without* a
+  `RemoteStage` marker (the "declared-but-not-implemented placement" case). The
   `ExecutionPlan`/planner is unchanged — placement is orthogonal to ordering.
 - Guardrails: no forced Arrow round-trip in-process; Stage 0 numbers verified
   unchanged (`benchmarks/stage0_handoff_profile.py`). Tests: `tests/test_relocatable_stage.py`.
@@ -73,9 +75,29 @@ Phase C **v2** closes the two documented gaps (`tests/test_engine_stage_v2.py`):
   runs on the relation's own con, which must be where the UDFs were registered).
   Caveat: with the default auto-config (local `load` first), the source materializes
   at `load` — the WIN needs the first stage to be remote.
-- The dominant `goldenmatch.dedupe` scoring stage still has no in-engine surface, so
-  a full ER pipeline crosses for it — Phase C wins every *other* stage + keeps data
-  in-engine between them.
+- The dominant `goldenmatch.dedupe` scoring stage has no in-engine surface, so a full
+  ER pipeline crosses for it — Phase C wins every *other* stage + keeps data in-engine
+  between them. **Building an in-engine dedupe was scoped + measured — verdict: DON'T**
+  (`docs/design/2026-07-06-goldenpipe-in-engine-dedupe-scope.md`, probe
+  `benchmarks/stage0_inengine_dedupe_probe.py`): a warehouse-resident dedupe's crossing
+  is **0.4–0.6% of wall and shrinking** with rows (rapidfuzz scoring is superlinear and
+  dominates; the crossing is linear). And the in-engine kernels would be the SAME
+  `score-core` / `graph-core` the host path already calls, so there's **no compute win
+  on top** — only the sub-1% crossing to save. So the caveat is correct by construction,
+  not a gap: "smart pipe, dumb kernels" — dedupe stays a host stage calling native
+  kernels. (Surface map: Postgres is ~80% native-direct already; DuckDB has no compiled
+  goldenmatch cdylib at all — a disproportionate lift for <1%.)
+
+**Contract status (2026-07-06): COMPLETE through Phase C.** Four measure-first "don'ts"
+(Stage 0 handoff 0.2%, Phase B frame 250–310× smaller than peak RSS, in-engine dedupe
+crossing 0.4%) vs Phase C's one "do" — the discipline earning its keep. **Not built, by
+decision (each with a baseline that said don't):** the streaming executor (Stage 0),
+the out-of-core `Frame` (Phase B), the in-engine dedupe (above). **Stretch ambition,
+deliberately deferred:** a true **cross-process / cross-language** `RemoteStage` over a
+transport. Phase C placed stages *in-engine* (DuckDB, same-process); the relocatable
+contract (`Frame` / `StageInfo.location` / Runner routing) was laid precisely so a
+transport-backed placement is a **build-forward, not a rewrite**. Gate it on a measured
+distributed/polyglot workload before building — none exists today.
 
 ## Pipeline Flow
 ```

--- a/packages/python/goldenpipe/benchmarks/stage0_inengine_dedupe_probe.py
+++ b/packages/python/goldenpipe/benchmarks/stage0_inengine_dedupe_probe.py
@@ -1,0 +1,171 @@
+"""Stage 0 baseline for the **in-engine dedupe** scope.
+
+Design: ``docs/design/2026-07-06-goldenpipe-in-engine-dedupe-scope.md``.
+
+The question this gates: **is the DuckDB<->Python crossing a material fraction of a
+real DEDUPE, or does the (rapidfuzz) scoring compute swallow it?**
+
+Phase C measured the crossing at ~89% of a *plain projection* pull path. But dedupe
+is compute-heavy: scoring is O(candidate pairs) of rapidfuzz work, and that compute
+runs at the SAME speed whether the kernel is called from Python-over-Arrow or from an
+in-engine UDF (both are ``score-core`` / ``graph-core`` under the hood). So the ONLY
+thing an in-engine dedupe can save is the **crossing** — pulling the warehouse table
+into Python (ingress) and pushing the result back (egress). Therefore:
+
+    crossing_fraction = (ingress + egress) / total   ==   the CEILING on any
+                                                          in-engine-dedupe speedup.
+
+This probe measures that ceiling for a **warehouse-resident** dedupe (data starts in
+a DuckDB table; result written back to a DuckDB table — the only scenario where
+in-engine dedupe could win). If the ceiling is small, in-engine dedupe is a Phase-B
+"don't build"; if large, it justifies Phase 1 (Postgres) / Phase 2 (DuckDB cdylib).
+
+Run:  python benchmarks/stage0_inengine_dedupe_probe.py
+No external deps beyond goldenmatch + duckdb + polars (already required for Phase C).
+"""
+from __future__ import annotations
+
+import random
+import statistics
+import time
+
+import duckdb
+import goldenmatch
+import polars as pl
+
+# --- deterministic synthetic people data with injected duplicates -----------
+
+# Procedurally expand the name pools so blocking on ``last_name`` yields realistic,
+# BOUNDED block sizes (avg ~ n / |surnames|). A tiny pool would make one low-card
+# block key blow up to O(block^2) billions of pairs — an artifact, not a dedupe.
+_SYL_A = ["smi", "john", "will", "brow", "jon", "gar", "mil", "dav", "rod", "mar",
+          "her", "lop", "wil", "lee", "walk", "hall", "young", "king", "wright",
+          "scott", "green", "adam", "baker", "nel", "car", "mit", "per", "rob",
+          "tur", "phil", "camp", "par", "evan", "edw", "coll", "stew", "san", "mor"]
+_SYL_B = ["th", "son", "iams", "wn", "es", "cia", "ler", "is", "riguez", "tinez",
+          "nandez", "ez", "ford", "man", "ton", "sen", "by", "ner", "ley", "combe"]
+_LAST = sorted({a.capitalize() + b for a in _SYL_A for b in _SYL_B})  # ~760 surnames
+_FIRST = ["James", "Mary", "John", "Patricia", "Robert", "Jennifer", "Michael",
+          "Linda", "William", "Elizabeth", "David", "Barbara", "Richard", "Susan",
+          "Joseph", "Jessica", "Thomas", "Sarah", "Charles", "Karen", "Daniel",
+          "Nancy", "Matthew", "Lisa", "Anthony", "Betty", "Mark", "Sandra"]
+_CITY = ["Springfield", "Franklin", "Greenville", "Bristol", "Clinton",
+         "Fairview", "Salem", "Madison", "Georgetown", "Arlington"]
+
+
+def _noise(s: str, rng: random.Random) -> str:
+    """Light typo/case/whitespace noise to make fuzzy scoring do real work."""
+    r = rng.random()
+    if r < 0.30:
+        return s.upper()
+    if r < 0.50:
+        return f"  {s} "
+    if r < 0.70 and len(s) > 3:  # single-char typo
+        i = rng.randrange(1, len(s) - 1)
+        return s[:i] + s[i + 1] + s[i] + s[i + 2:]
+    return s
+
+
+def make_people(n_rows: int, seed: int = 7) -> pl.DataFrame:
+    """~35% of rows are noisy duplicates of an earlier row (realistic dup rate)."""
+    rng = random.Random(seed)
+    rows: list[dict] = []
+    while len(rows) < n_rows:
+        if rows and rng.random() < 0.35:  # duplicate an existing entity
+            base = rng.choice(rows)
+            rows.append({
+                "first_name": _noise(base["first_name"], rng),
+                "last_name": _noise(base["last_name"], rng),
+                "email": base["email"],
+                "city": _noise(base["city"], rng),
+            })
+        else:  # fresh entity
+            fn, ln = rng.choice(_FIRST), rng.choice(_LAST)
+            rows.append({
+                "first_name": fn,
+                "last_name": ln,
+                "email": f"{fn.lower()}.{ln.lower()}{rng.randrange(1000)}@mail.com",
+                "city": rng.choice(_CITY),
+            })
+    return pl.DataFrame(rows[:n_rows])
+
+
+def _dedupe(df: pl.DataFrame):
+    # Explicit config (not zero-config): auto-config profiling is the "smart pipe"
+    # that stays host regardless, so excluding it keeps the crossing ceiling honest
+    # — we compare the crossing against ONLY the block+score+cluster compute that an
+    # in-engine path would actually replace.
+    return goldenmatch.dedupe_df(
+        df,
+        fuzzy={"first_name": 0.85, "last_name": 0.85},
+        blocking=["last_name"],
+        threshold=0.85,
+    )
+
+
+def probe_once(n_rows: int) -> dict:
+    con = duckdb.connect()
+    df = make_people(n_rows)
+    con.register("src_view", df.to_arrow())
+    con.execute("CREATE TABLE people AS SELECT * FROM src_view")
+    con.unregister("src_view")
+
+    # ingress: warehouse table -> Python (the pull an in-engine path avoids)
+    t0 = time.perf_counter()
+    pulled = con.sql("SELECT * FROM people").pl()
+    t1 = time.perf_counter()
+
+    # compute: block + score + cluster (runs the same in-engine or in-process)
+    result = _dedupe(pulled)
+    t2 = time.perf_counter()
+
+    # egress: result -> warehouse table (the push-back an in-engine path avoids)
+    out = result.golden if getattr(result, "golden", None) is not None else pulled
+    con.register("out_view", out.to_arrow())
+    con.execute("CREATE TABLE deduped AS SELECT * FROM out_view")
+    con.unregister("out_view")
+    t3 = time.perf_counter()
+    con.close()
+
+    ingress, compute, egress = t1 - t0, t2 - t1, t3 - t2
+    total = ingress + compute + egress
+    return {
+        "rows": n_rows,
+        "ingress": ingress,
+        "compute": compute,
+        "egress": egress,
+        "total": total,
+        "crossing": ingress + egress,
+        "crossing_pct": 100.0 * (ingress + egress) / total,
+    }
+
+
+def probe(n_rows: int, trials: int = 2) -> dict:
+    probe_once(n_rows)  # warm up (native kernel load, rapidfuzz JIT of tables)
+    runs = [probe_once(n_rows) for _ in range(trials)]
+    med = {k: statistics.median(r[k] for r in runs) for k in
+           ("ingress", "compute", "egress", "total", "crossing", "crossing_pct")}
+    med["rows"] = n_rows
+    return med
+
+
+def main() -> None:
+    print(f"goldenmatch {goldenmatch.__version__}  duckdb {duckdb.__version__}  "
+          f"|surnames|={len(_LAST)}\n", flush=True)
+    print(f"{'rows':>10} {'ingress':>9} {'compute':>9} {'egress':>9} "
+          f"{'total':>9} {'crossing':>9} {'crossing%':>10}", flush=True)
+    print("-" * 72, flush=True)
+    results = []
+    for n in (10_000, 40_000, 100_000):
+        m = probe(n)
+        results.append(m)
+        print(f"{m['rows']:>10} {m['ingress']*1e3:>8.1f}m {m['compute']*1e3:>8.1f}m "
+              f"{m['egress']*1e3:>8.1f}m {m['total']*1e3:>8.1f}m "
+              f"{m['crossing']*1e3:>8.1f}m {m['crossing_pct']:>9.2f}%", flush=True)
+    print("-" * 72, flush=True)
+    print("\ncrossing% is the CEILING on any in-engine-dedupe speedup for a")
+    print("warehouse-resident dedupe. Compare to Phase C's 89% (plain projection).")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What and why

Closes out the goldenpipe relocatable-stage contract now that Phase A + C v1 + C v2 have landed. Two things:

1. **In-engine dedupe: scoped and measured → verdict DON'T BUILD.** Answers the one open Phase C caveat (*"`goldenmatch.dedupe` has no in-engine surface"*) with a measurement instead of a build.
2. **Docs sweep** — reconciles `goldenpipe/CLAUDE.md` with the completed contract so the reasoning lives on `main` and doesn't get re-litigated.

## The measurement that decides it

The block/score/cluster compute runs at the **same speed** in-engine or in-process (both are `score-core` / `graph-core`). So the only thing an in-engine dedupe can save is the **crossing** — pull the warehouse table into Python + push the result back. That makes `crossing_fraction = (ingress + egress) / total` the **ceiling** on any win.

Stage 0 probe (`benchmarks/stage0_inengine_dedupe_probe.py`, warehouse-resident dedupe, explicit config, median of fresh runs):

| rows | ingress | compute | egress | total | **crossing %** |
|---:|---:|---:|---:|---:|---:|
| 10,000 | 3.2 ms | 1356 ms | 5.5 ms | 1365 ms | **0.64 %** |
| 40,000 | 9.0 ms | 3549 ms | 9.2 ms | 3568 ms | **0.51 %** |
| 100,000 | 20.1 ms | 7643 ms | 10.9 ms | 7674 ms | **0.40 %** |

**0.4–0.64 % of wall, and shrinking** (compute is superlinear O(pairs); crossing is linear O(rows)). Against Phase C's 89 % for a plain projection, this is the opposite regime — rapidfuzz scoring dominates, the DuckDB↔Python crossing is rounding error. And no compute win on top, since the in-engine kernels *are* the host kernels. Building it (a compiled `goldenmatch-duckdb` cdylib + Postgres SQL composition + reference-simplified parity gates) is a large surface for sub-1 %. The caveat is **correct by construction** — "smart pipe, dumb kernels".

## Changes

- **`docs/design/2026-07-06-goldenpipe-in-engine-dedupe-scope.md`** — the scope + verdict: stage decomposition, surface map (Postgres ~80 % native-direct, DuckDB greenfield), the smart-pipe/dumb-kernel boundary, the phased plan that *would* build it, the Stage 0 numbers, and the narrow condition to revisit.
- **`benchmarks/stage0_inengine_dedupe_probe.py`** — the reproducer.
- **`packages/python/goldenpipe/CLAUDE.md`** — docs sweep: dedupe caveat now records the DON'T verdict; the Phase A Runner-guard note corrected ("remote = Phase C, not built" → Phase C landed); a **"Contract status: COMPLETE through Phase C"** closing note (the four measure-first "don'ts" vs the one "do", and the deliberately-deferred cross-process/cross-language stretch ambition).

Doc-only + a benchmark script; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_