### PR TITLE
fix(ts): build node/a2a/server so the api_parity a2a emitter resolves it

### DIFF
--- a/packages/typescript/goldencheck/tsup.config.ts
+++ b/packages/typescript/goldencheck/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "core/goldencheckWasm": "src/core/goldencheckWasm.ts",
     "node/index": "src/node/index.ts",
     "node/mcp/server": "src/node/mcp/server.ts",
+    "node/a2a/server": "src/node/a2a/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/typescript/goldenflow/tsup.config.ts
+++ b/packages/typescript/goldenflow/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
     "node/mcp/server": "src/node/mcp/server.ts",
+    "node/a2a/server": "src/node/a2a/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],

--- a/packages/typescript/goldenmatch/tsup.config.ts
+++ b/packages/typescript/goldenmatch/tsup.config.ts
@@ -40,6 +40,7 @@ export default defineConfig({
     "core/goldenembedWasm": "src/core/goldenembedWasm.ts",
     "node/index": "src/node/index.ts",
     "node/mcp/server": "src/node/mcp/server.ts",
+    "node/a2a/server": "src/node/a2a/server.ts",
     cli: "src/cli.ts",
     // Separate entry so piscina can load it at runtime from disk.
     "node/backends/score-worker": "src/node/backends/score-worker.ts",

--- a/packages/typescript/goldenpipe/tsup.config.ts
+++ b/packages/typescript/goldenpipe/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     "core/index": "src/core/index.ts",
     "node/index": "src/node/index.ts",
     "node/mcp/server": "src/node/mcp/server.ts",
+    "node/a2a/server": "src/node/a2a/server.ts",
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],


### PR DESCRIPTION
## What

Fixes a latent, repo-wide break in the `api_parity` gate: its TS emitter (`scripts/emit_ts_surface.mjs`) imports each A2A package's `dist/node/a2a/server.js`, but **none of the 4 A2A packages' `tsup.config.ts` listed `node/a2a/server` as a build entry** — so that file was never built, and the emitter crashed with `ERR_MODULE_NOT_FOUND` whenever `api_parity` ran for the `a2a_skills` surface.

## Why it went unnoticed

`api_parity` is path-filtered and rarely runs on `main` (it only triggers when MCP/CLI/a2a surfaces or `ci.yml` change), so the break stayed dormant. It surfaced on #1468 because editing `ci.yml` forces *every* job to run — and it would bite the next `ci.yml`-touching PR regardless.

## Fix

Add `"node/a2a/server": "src/node/a2a/server.ts"` to the tsup entry map of the 4 A2A packages (goldenmatch, goldencheck, goldenflow, goldenpipe), mirroring the existing `node/mcp/server` entry. Each already has `src/node/a2a/server.ts`; it just wasn't being emitted to `dist`.

TS builds are CI-only here (box OOMs), so the actual `dist` emission + the `api_parity` pass are verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
