### PR TITLE
feat(goldenflow): widen the fused-apply set (email + name-normalizer + extract_numbers)

### DIFF
--- a/packages/python/goldenflow/benchmarks/fused_apply_benchmark.py
+++ b/packages/python/goldenflow/benchmarks/fused_apply_benchmark.py
@@ -66,29 +66,32 @@ BIO_POOL = [
     "see https://a.co?q=1&utm_source=z end",
     "<p>hello</p>  world",
 ]
-CITY_POOL = [
-    "SÃO PAULO",
-    "münchen",
-    "new york",
-    "MONTRÉAL",
-    "  zürich  ",
-    "São Paulo ",
+EMAIL_POOL = [
+    "  John.SMITH@Googlemail.com ",
+    "o'brien+tag@Example.CO ",
+    " MARY_JANE@work.org",
+    "DE.LA.CRUZ@Company.com  ",
+    " d'angelo@Foo.Bar ",
 ]
 
-# A per-column chain of ONLY fusable (owned, string->string, no-arg) ops — the
-# case the fused path targets. 11 ops across 3 columns: per-transform crosses the
-# boundary 11 times; fused, 3 (one run per column).
+# Per-column chains of ONLY fusable (owned, string->string, no-arg) ops — the case
+# the fused path targets, and now spanning the WIDENED set: text + NAME normalizers
+# + EMAIL family (these last two previously fell to the per-transform path). 13 ops
+# across 3 columns: per-transform crosses the boundary 13 times; fused, 3.
 CONFIG = GoldenFlowConfig(
     transforms=[
         TransformSpec(
             column="full_name",
-            ops=["strip", "lowercase", "collapse_whitespace", "remove_punctuation"],
+            ops=["strip", "name_transliterate", "name_proper", "strip_titles", "strip_suffixes"],
+        ),
+        TransformSpec(
+            column="email",
+            ops=["strip", "lowercase", "email_normalize", "email_canonical"],
         ),
         TransformSpec(
             column="bio",
             ops=["remove_html_tags", "remove_urls", "strip", "collapse_whitespace"],
         ),
-        TransformSpec(column="city", ops=["normalize_unicode", "strip", "title_case"]),
     ]
 )
 
@@ -98,8 +101,8 @@ def build_df(rows: int, seed: int = SEED) -> pl.DataFrame:
     return pl.DataFrame(
         {
             "full_name": [f"{rng.choice(NAME_POOL)}{i % 97}" for i in range(rows)],
+            "email": [rng.choice(EMAIL_POOL) for _ in range(rows)],
             "bio": [f"{rng.choice(BIO_POOL)} #{i % 89}" for i in range(rows)],
-            "city": [f"{rng.choice(CITY_POOL)}{i % 61}" for i in range(rows)],
         }
     )
 
@@ -196,8 +199,10 @@ def main() -> None:
     speedup = base["wall_ms"] / fused["wall_ms"] if fused["wall_ms"] else float("nan")
     rss_delta = fused["rss_mb"] - base["rss_mb"]
 
+    n_ops = sum(len(t.ops) for t in CONFIG.transforms)
+    n_cols = len(CONFIG.transforms)
     print(f"GoldenFlow fused-apply A/B -- {args.rows:,} rows, {args.runs}-run median wall")
-    print(f"config: 11 fusable ops across 3 columns ({base['records']} audit records)\n")
+    print(f"config: {n_ops} fusable ops across {n_cols} columns ({base['records']} audit records)\n")
     print(f"  {'variant':<16}{'wall (ms)':>12}{'M rows/s':>12}{'peak RSS MB':>14}")
     for r in (base, fused):
         print(

--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -36,6 +36,19 @@ FUSABLE_KERNELS: frozenset[str] = frozenset(
         "remove_digits",
         "remove_punctuation",
         "remove_emojis",
+        "extract_numbers",
+        # email family (total string->string)
+        "email_lowercase",
+        "email_normalize",
+        "email_canonical",
+        # name-normalizer family (total string->string)
+        "name_transliterate",
+        "strip_titles",
+        "strip_suffixes",
+        "name_proper",
+        "nickname_standardize",
+        "name_initials",
+        "strip_middle",
     }
 )
 

--- a/packages/python/goldenflow/tests/transforms/test_fused_chain.py
+++ b/packages/python/goldenflow/tests/transforms/test_fused_chain.py
@@ -66,6 +66,11 @@ def _manifest_rows(result) -> list[tuple]:
         ["strip", "lowercase", "collapse_whitespace", "remove_punctuation"],
         ["remove_html_tags", "remove_urls", "strip", "collapse_whitespace"],
         ["normalize_unicode", "lowercase", "remove_digits"],
+        # widened families (email / name normalizers / extract_numbers)
+        ["strip", "lowercase", "email_normalize", "email_canonical"],
+        ["name_transliterate", "name_proper", "strip_titles", "strip_suffixes"],
+        ["strip", "name_proper", "strip_middle", "name_initials"],
+        ["strip", "extract_numbers"],
     ],
 )
 def test_fused_equals_per_transform(monkeypatch, ops) -> None:

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -25,7 +25,7 @@
 use arrow_array::{Array, GenericStringArray, OffsetSizeTrait};
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 
-use crate::text;
+use crate::{email, names, text};
 
 /// One owned, no-arg, total string→string kernel eligible for the fused chain.
 /// The name mapping (`from_name`) is the single source of truth the host's
@@ -46,6 +46,19 @@ pub enum Kernel {
     RemoveDigits,
     RemovePunctuation,
     RemoveEmojis,
+    ExtractNumbers,
+    // email family (total string->string)
+    EmailLowercase,
+    EmailNormalize,
+    EmailCanonical,
+    // name family (total string->string normalizers)
+    NameTransliterate,
+    StripTitles,
+    StripSuffixes,
+    NameProper,
+    NicknameStandardize,
+    NameInitials,
+    StripMiddle,
 }
 
 impl Kernel {
@@ -69,6 +82,17 @@ impl Kernel {
             "remove_digits" => Kernel::RemoveDigits,
             "remove_punctuation" => Kernel::RemovePunctuation,
             "remove_emojis" => Kernel::RemoveEmojis,
+            "extract_numbers" => Kernel::ExtractNumbers,
+            "email_lowercase" => Kernel::EmailLowercase,
+            "email_normalize" => Kernel::EmailNormalize,
+            "email_canonical" => Kernel::EmailCanonical,
+            "name_transliterate" => Kernel::NameTransliterate,
+            "strip_titles" => Kernel::StripTitles,
+            "strip_suffixes" => Kernel::StripSuffixes,
+            "name_proper" => Kernel::NameProper,
+            "nickname_standardize" => Kernel::NicknameStandardize,
+            "name_initials" => Kernel::NameInitials,
+            "strip_middle" => Kernel::StripMiddle,
             _ => return None,
         })
     }
@@ -89,6 +113,17 @@ impl Kernel {
         "remove_digits",
         "remove_punctuation",
         "remove_emojis",
+        "extract_numbers",
+        "email_lowercase",
+        "email_normalize",
+        "email_canonical",
+        "name_transliterate",
+        "strip_titles",
+        "strip_suffixes",
+        "name_proper",
+        "nickname_standardize",
+        "name_initials",
+        "strip_middle",
     ];
 
     /// Append `s` transformed by this kernel into `out` (which the caller has
@@ -112,6 +147,17 @@ impl Kernel {
             Kernel::RemoveDigits => text::remove_digits_into(s, out),
             Kernel::RemovePunctuation => text::remove_punctuation_into(s, out),
             Kernel::RemoveEmojis => text::remove_emojis_into(s, out),
+            Kernel::ExtractNumbers => out.push_str(&text::extract_numbers(s)),
+            Kernel::EmailLowercase => out.push_str(&email::email_lowercase(s)),
+            Kernel::EmailNormalize => out.push_str(&email::email_normalize(s)),
+            Kernel::EmailCanonical => out.push_str(&email::email_canonical(s)),
+            Kernel::NameTransliterate => out.push_str(&names::name_transliterate(s)),
+            Kernel::StripTitles => out.push_str(&names::strip_titles(s)),
+            Kernel::StripSuffixes => out.push_str(&names::strip_suffixes(s)),
+            Kernel::NameProper => out.push_str(&names::name_proper(s)),
+            Kernel::NicknameStandardize => out.push_str(&names::nickname_standardize(s)),
+            Kernel::NameInitials => out.push_str(&names::name_initials(s)),
+            Kernel::StripMiddle => out.push_str(&names::strip_middle(s)),
         }
     }
 }
@@ -233,6 +279,22 @@ mod tests {
                 Kernel::NormalizeQuotes,
                 Kernel::Uppercase,
             ],
+            // widened families: email + name normalizers + extract_numbers.
+            &[
+                Kernel::Strip,
+                Kernel::Lowercase,
+                Kernel::EmailNormalize,
+                Kernel::EmailCanonical,
+            ],
+            &[
+                Kernel::NameTransliterate,
+                Kernel::NameProper,
+                Kernel::StripTitles,
+                Kernel::StripSuffixes,
+                Kernel::StripMiddle,
+            ],
+            &[Kernel::NicknameStandardize, Kernel::NameInitials],
+            &[Kernel::ExtractNumbers],
         ];
         let arr = sample();
         for chain in chains {

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",


### PR DESCRIPTION
Grows the fused columnar-apply set from **14 → 25** kernels so a typical config fuses more of its ops — the lever the at-scale bench flagged before flipping `GOLDENFLOW_FUSED_APPLY` default-on.

## Added (all owned, no-arg, TOTAL `fn(&str)->String`, parity by construction)
- **email:** `email_lowercase`, `email_normalize`, `email_canonical`
- **name normalizers:** `name_transliterate`, `strip_titles`, `strip_suffixes`, `name_proper`, `nickname_standardize`, `name_initials`, `strip_middle`
- **text:** `extract_numbers`

## Deliberately NOT added
- **URL + company kernels return `Option<String>`** (null on invalid input) — they don't fit the total-string chain (would diverge on nulls). A null-aware executor is a follow-up.
- `name_script` (a classifier, not a chain participant).
- Parameterized (`truncate`/`pad`) + numeric f64 chains — different shapes, separate follow-ups.

## Why it's low-risk
Same executor, **same FFI** — native `apply_chain_arrow` / `fusable_kernel_names` are data-driven off the core `Kernel` table, so they pick these up with **zero native-flow source change**. Each new `Kernel` dispatches to the exact owned kernel the per-transform path uses. Guarded by the coverage test (Python `FUSABLE_KERNELS` == native table, all registered + single-column mode) and the CI native parity test (now covering email/name/extract_numbers chains, byte-identical fused vs per-transform).

## Bench
Config widened to a realistic **name + email + freetext** cleanup (13 fusable ops / 3 cols) so a re-run of `bench-goldenflow-fused` measures the widened set's benefit — the name/email chains that previously fell to the per-transform path now fuse. **Still default-off**; re-bench post-merge gates the flip.

## Verification
core 6 chain tests + clippy(`--features arrow`); native-flow check+clippy; Python coverage guard + flag-off + 47 integration (transparent); bench smoke parity OK. Native e2e rides the CI native lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg