### PR TITLE
chore(goldenflow-native): bump 0.11.0 -> 0.12.0 (republish fused-capable wheel)

### DIFF
--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.11.0"
+version = "0.12.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.11.0"
+    __version__ = "0.12.0"


### PR DESCRIPTION
Prereq for delivering the fused columnar-apply win to PyPI users. The published 0.11.0 predates `apply_chain_arrow` + the 25 chain kernels (all landed today), so `pip install goldenflow[native]` users get no fused path. PyPI is immutable -> bump to 0.12.0 and republish. Bumps the 3 lockstep spots + lock. Publish (tag `goldenflow-native-v0.12.0`) follows this merge; then the `goldenflow[native]` floor bump + `GOLDENFLOW_FUSED_APPLY` default-on flip + golden-suite lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)