### PR TITLE
feat(goldenpipe): make run_pipeline an orchestration tool — full result + inline input

### DIFF
--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -116,6 +116,33 @@ load_file -> GoldenCheck.scan_file(path) -> decide_flow(findings)
 ## A2A Port Convention
 - GoldenCheck: 8100, GoldenFlow: 8150, GoldenMatch: 8200, GoldenPipe: 8250
 
+## MCP / A2A orchestration surface (`mcp/server.py`, `a2a/server.py`)
+
+4 MCP tools (`list_stages`, `validate_pipeline`, `explain_pipeline`, `run_pipeline`);
+the A2A `handle_task` dispatches the 4 hyphenated skill ids to the SAME tool
+functions, so both surfaces stay in lockstep (and `parity/goldenpipe.yaml` gates the
+name set — a tool/skill add/rename/remove must update it in the same PR).
+- **`run_pipeline` is the real orchestration tool** — an LLM can drive a pipeline
+  end-to-end through it, not just fire-and-forget:
+  - **Input** (precedence): `records` (list of row dicts) > `csv_text` (raw CSV) >
+    `source` (server file path). So data can come **inline over the wire**, not only
+    from a file on the server.
+  - **Config:** `stages` (inline chain, e.g. `["goldencheck.scan","goldenmatch.dedupe"]`;
+    an explicit `[]` = load-only) OR `config_path` (YAML) OR omit both for zero-config
+    auto. `identity_opts` forwards the Identity Graph knobs.
+  - **Returns the FULL result** (`_result_to_dict`): per-stage `status`/`reasoning`/
+    `timing`, `skipped`, `errors`, AND an **`output`** block with the deduped result —
+    `golden_records` count + a `golden_preview` (first `preview_rows`, max 100),
+    `unique_records`/`duplicate_records`, `cluster_count`, `match_stats`. This is why
+    the tool exists: the caller can SEE what the pipeline produced and branch on it.
+  - **How the output is sourced:** the golden/unique frames come from
+    `result.artifacts["golden"|"unique"|"clusters"|"match_stats"]` (populated by
+    `adapters/match.py::DedupeStage`) — the DedupeStage casts every column to string,
+    so `to_dicts()` is JSON-safe. No core-API change was needed (contrast the gotcha
+    below: `PipeResult` still doesn't expose `ctx.df`, but the dedupe ARTIFACTS carry
+    the golden output, which is what the tool returns). Tests: `tests/test_mcp.py`
+    (serialization + inline input + real dedupe), `tests/test_a2a.py` (dispatch parity).
+
 ## Remote MCP Server
 
 Hosted on Railway, registered on Smithery:

--- a/packages/python/goldenpipe/goldenpipe/a2a/server.py
+++ b/packages/python/goldenpipe/goldenpipe/a2a/server.py
@@ -18,7 +18,7 @@ AGENT_CARD = {
         {
             "id": "run-pipeline",
             "name": "Run Pipeline",
-            "description": "Execute a data quality pipeline",
+            "description": "Execute a pipeline (file or inline data) and return per-stage results + the deduped output",
             "inputModes": ["text"],
             "outputModes": ["text"],
         },

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -40,17 +40,120 @@ def validate_pipeline_tool(pipeline: str, stages: list[str]) -> dict[str, Any]:
         return {"valid": False, "error": str(e)}
 
 
-def run_pipeline_tool(source: str, config_path: str | None = None) -> dict[str, Any]:
-    """Run a pipeline and return results."""
-    from goldenpipe._api import run
-    result = run(source, config=config_path)
-    return {
+def run_pipeline_tool(
+    source: str | None = None,
+    config_path: str | None = None,
+    *,
+    records: list[dict] | None = None,
+    csv_text: str | None = None,
+    stages: list[str] | None = None,
+    identity_opts: dict | None = None,
+    preview_rows: int = 10,
+) -> dict[str, Any]:
+    """Run a pipeline and return the FULL result an LLM needs to orchestrate.
+
+    Input (one of, in precedence order): ``records`` (list of row dicts),
+    ``csv_text`` (raw CSV), or ``source`` (a file path on the server). Config:
+    ``stages`` (an inline stage-name list, e.g. ``["goldencheck.scan",
+    "goldenmatch.dedupe"]``) or ``config_path`` (a YAML on disk); omit both for
+    zero-config auto. ``identity_opts`` forwards the Identity Graph knobs.
+
+    Returns per-stage ``status``/``reasoning``/``timing``, ``skipped``,
+    ``errors``, AND — the reason this exists — an ``output`` block with the
+    deduped result: golden-record count + a ``preview`` (first ``preview_rows``
+    rows), unique/duplicate counts, cluster count, and match stats. This closes
+    the fire-and-forget gap: the caller can see what the pipeline produced and
+    branch on it, not just that it ran.
+    """
+    import polars as pl
+
+    from goldenpipe.pipeline import Pipeline
+
+    # Config: inline stages > YAML path > zero-config auto. An explicit (even
+    # empty) ``stages`` list wins over auto; ``None`` means zero-config.
+    cfg = None
+    if stages is not None:
+        cfg = PipelineConfig(pipeline="inline", stages=[StageSpec(use=s) for s in stages])
+    elif config_path:
+        from goldenpipe.config.loader import load_config
+        cfg = load_config(config_path)
+
+    try:
+        pipe = Pipeline(config=cfg, identity_opts=identity_opts)
+        if records is not None:
+            result = pipe.run(df=pl.DataFrame(records))
+        elif csv_text is not None:
+            import io
+            result = pipe.run(df=pl.read_csv(io.StringIO(csv_text), ignore_errors=True))
+        elif source:
+            result = pipe.run(source=source)
+        else:
+            return {"error": (
+                "provide one input: 'source' (file path), 'records' (list of "
+                "row dicts), or 'csv_text' (raw CSV)."
+            )}
+    except Exception as exc:  # surface config/build errors as data, not a crash
+        return {"error": str(exc)}
+
+    return _result_to_dict(result, preview_rows)
+
+
+def _is_frame(obj: Any) -> bool:
+    """A Polars-DataFrame-shaped artifact (duck-typed to avoid a hard import)."""
+    return obj is not None and hasattr(obj, "height") and hasattr(obj, "to_dicts")
+
+
+def _summarize_output(artifacts: dict, preview_rows: int) -> dict[str, Any]:
+    """Pull the deduped output out of the pipeline artifacts, JSON-safe.
+
+    The dedupe stage casts every column to string before matching, so
+    ``to_dicts()`` on golden/unique frames is JSON-serializable.
+    """
+    out: dict[str, Any] = {}
+    golden = artifacts.get("golden")
+    if _is_frame(golden):
+        out["golden_records"] = golden.height
+        if preview_rows:
+            out["golden_preview"] = golden.head(preview_rows).to_dicts()
+    unique = artifacts.get("unique")
+    if _is_frame(unique):
+        out["unique_records"] = unique.height
+    dupes = artifacts.get("dupes")
+    if _is_frame(dupes):
+        out["duplicate_records"] = dupes.height
+    stats = artifacts.get("match_stats")
+    if isinstance(stats, dict):
+        out["match_stats"] = stats
+    clusters = artifacts.get("clusters")
+    if clusters is not None:
+        try:
+            out["cluster_count"] = len(clusters)
+        except TypeError:
+            pass
+    return out
+
+
+def _result_to_dict(result: Any, preview_rows: int = 10) -> dict[str, Any]:
+    """Serialize a ``PipeResult`` into the full JSON payload for MCP/A2A."""
+    preview_rows = max(0, min(int(preview_rows), 100))  # bound the payload
+    out: dict[str, Any] = {
         "status": result.status.value,
         "source": result.source,
         "input_rows": result.input_rows,
-        "errors": result.errors,
-        "skipped": result.skipped,
+        "stages": {
+            name: ({"status": r.status.value, "error": r.error}
+                   if r.error else {"status": r.status.value})
+            for name, r in result.stages.items()
+        },
+        "reasoning": dict(result.reasoning),
+        "timing": {k: round(float(v), 4) for k, v in result.timing.items()},
+        "skipped": list(result.skipped),
+        "errors": list(result.errors),
     }
+    output = _summarize_output(result.artifacts, preview_rows)
+    if output:
+        out["output"] = output
+    return out
 
 
 def explain_pipeline_tool(config_path: str) -> dict[str, Any]:
@@ -82,11 +185,25 @@ def _build_tools() -> list:
                  "pipeline": {"type": "string"},
                  "stages": {"type": "array", "items": {"type": "string"}},
              }, "required": ["pipeline", "stages"]}),
-        Tool(name="run_pipeline", description="Run a pipeline on a file",
+        Tool(name="run_pipeline",
+             description=(
+                 "Run a pipeline on a file OR inline data (records / csv_text) and "
+                 "return per-stage status, reasoning and timing PLUS the deduped "
+                 "output (golden-record count + preview, unique/duplicate counts, "
+                 "cluster count, match stats). Give a `stages` list or `config_path` "
+                 "to control the chain, or omit both for zero-config auto."
+             ),
              inputSchema={"type": "object", "properties": {
-                 "source": {"type": "string"},
-                 "config_path": {"type": "string"},
-             }, "required": ["source"]}),
+                 "source": {"type": "string", "description": "Input file path on the server."},
+                 "records": {"type": "array", "items": {"type": "object"},
+                             "description": "Inline data as a list of row dicts."},
+                 "csv_text": {"type": "string", "description": "Inline data as raw CSV text."},
+                 "stages": {"type": "array", "items": {"type": "string"},
+                            "description": "Inline stage chain, e.g. ['goldencheck.scan','goldenmatch.dedupe']."},
+                 "config_path": {"type": "string", "description": "YAML pipeline config path on the server."},
+                 "identity_opts": {"type": "object", "description": "Identity Graph options (zero-config mode only)."},
+                 "preview_rows": {"type": "integer", "description": "Rows of golden output to preview (default 10, max 100)."},
+             }}),
         Tool(name="explain_pipeline", description="Explain what a pipeline config does",
              inputSchema={"type": "object", "properties": {
                  "config_path": {"type": "string"},
@@ -179,7 +296,7 @@ def run_server_http(host: str = "0.0.0.0", port: int = 8250) -> None:
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenPipe",
-            "description": "Orchestrator for the Golden Suite — chains data validation, transformation, and entity resolution into one adaptive pipeline. 4 MCP tools for listing stages, validating wiring, running pipelines, and explaining configs. Skips unnecessary stages automatically.",
+            "description": "Orchestrator for the Golden Suite — chains data validation, transformation, and entity resolution into one adaptive pipeline. 4 MCP tools for listing stages, validating wiring, explaining configs, and running pipelines (file or inline data, returning per-stage results + the deduped output). Skips unnecessary stages automatically.",
             "homepage": "https://github.com/benseverndev-oss/goldenpipe",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenpipe/tests/test_a2a.py
+++ b/packages/python/goldenpipe/tests/test_a2a.py
@@ -31,3 +31,22 @@ class TestHealthEndpoint:
         client = await a2a_client
         resp = await client.get("/health")
         assert resp.status == 200
+
+
+class TestRunPipelineSkill:
+    async def test_inline_records_dispatch(self, a2a_client):
+        # A2A dispatches run-pipeline to the SAME run_pipeline_tool the MCP server
+        # uses, so it inherits the enriched surface: inline `records` input and the
+        # full per-stage result. `stages: []` keeps it hermetic (load only).
+        client = await a2a_client
+        resp = await client.post("/tasks", json={
+            "skill": "run-pipeline",
+            "params": {"records": [{"a": 1}, {"a": 2}], "stages": []},
+        })
+        assert resp.status == 200
+        body = await resp.json()
+        assert body["status"] == "completed"
+        result = body["result"]
+        assert result["status"] == "success"
+        assert result["input_rows"] == 2
+        assert "load" in result["stages"]

--- a/packages/python/goldenpipe/tests/test_mcp.py
+++ b/packages/python/goldenpipe/tests/test_mcp.py
@@ -1,13 +1,34 @@
 """Tests for MCP server tools."""
+import polars as pl
 import pytest
 
 try:
-    from goldenpipe.mcp.server import list_stages_tool, validate_pipeline_tool
+    from goldenpipe.mcp.server import (
+        _result_to_dict,
+        _summarize_output,
+        list_stages_tool,
+        run_pipeline_tool,
+        validate_pipeline_tool,
+    )
     HAS_MCP = True
 except ImportError:
     HAS_MCP = False
 
 pytestmark = pytest.mark.skipif(not HAS_MCP, reason="mcp not installed")
+
+try:
+    import goldenmatch  # noqa: F401
+    HAS_MATCH = True
+except ImportError:
+    HAS_MATCH = False
+
+# Four records; the two Smiths are the same person (name variant, same email).
+_DUP_RECORDS = [
+    {"first_name": "Jon", "last_name": "Smith", "email": "jsmith@x.com", "city": "NYC"},
+    {"first_name": "John", "last_name": "Smith", "email": "jsmith@x.com", "city": "NYC"},
+    {"first_name": "Mary", "last_name": "Jones", "email": "mjones@y.com", "city": "LA"},
+    {"first_name": "Bob", "last_name": "Lee", "email": "blee@z.com", "city": "SF"},
+]
 
 
 class TestListStagesTool:
@@ -20,3 +41,96 @@ class TestValidatePipelineTool:
     def test_empty_pipeline(self):
         result = validate_pipeline_tool(pipeline="test", stages=[])
         assert "valid" in result
+
+
+class TestResultSerialization:
+    """Pure serialization — hermetic, no sibling tools needed."""
+
+    def test_result_to_dict_shape(self):
+        from goldenpipe.models.context import (
+            PipeResult,
+            PipeStatus,
+            StageResult,
+            StageStatus,
+        )
+        res = PipeResult(
+            status=PipeStatus.SUCCESS, source="x", input_rows=3,
+            stages={
+                "load": StageResult(status=StageStatus.SUCCESS),
+                "d": StageResult(status=StageStatus.FAILED, error="boom"),
+            },
+            reasoning={"d": "why"}, timing={"d": 0.12345678},
+            skipped=["s"], errors=["e"],
+        )
+        out = _result_to_dict(res)
+        assert out["status"] == "success"
+        assert out["input_rows"] == 3
+        assert out["stages"]["load"] == {"status": "success"}
+        assert out["stages"]["d"] == {"status": "failed", "error": "boom"}
+        assert out["timing"]["d"] == 0.1235  # rounded to 4 dp
+        assert out["reasoning"] == {"d": "why"}
+        assert out["skipped"] == ["s"]
+        assert out["errors"] == ["e"]
+        assert "output" not in out  # no artifacts -> no output block
+
+    def test_summarize_output_from_frames(self):
+        arts = {
+            "golden": pl.DataFrame({"a": ["x", "y"]}),
+            "unique": pl.DataFrame({"a": ["z"]}),
+            "dupes": pl.DataFrame({"a": ["x2", "y2"]}),
+            "match_stats": {"match_rate": 0.5},
+            "clusters": [1, 2, 3],
+        }
+        out = _summarize_output(arts, preview_rows=1)
+        assert out["golden_records"] == 2
+        assert out["golden_preview"] == [{"a": "x"}]
+        assert out["unique_records"] == 1
+        assert out["duplicate_records"] == 2
+        assert out["match_stats"] == {"match_rate": 0.5}
+        assert out["cluster_count"] == 3
+
+    def test_preview_rows_bounded_and_zero(self):
+        arts = {"golden": pl.DataFrame({"a": list("abcde")})}
+        # over-large preview is clamped to the frame height (<=100)
+        assert len(_summarize_output(arts, preview_rows=1000)["golden_preview"]) == 5
+        # zero preview -> count only, no preview key
+        zero = _summarize_output(arts, preview_rows=0)
+        assert zero["golden_records"] == 5
+        assert "golden_preview" not in zero
+
+
+class TestRunPipelineInputs:
+    def test_no_input_returns_error(self):
+        out = run_pipeline_tool()
+        assert "error" in out
+
+    def test_explicit_empty_stages_is_load_only(self):
+        # stages=[] is an explicit empty pipeline (just the load stage) — hermetic,
+        # exercises the inline-records path without any sibling tool.
+        out = run_pipeline_tool(records=[{"a": 1}, {"a": 2}], stages=[])
+        assert out["status"] == "success"
+        assert out["input_rows"] == 2
+        assert "load" in out["stages"]
+        assert "output" not in out  # load produces no golden/unique
+
+    def test_csv_text_input(self):
+        out = run_pipeline_tool(csv_text="a,b\n1,2\n3,4\n", stages=[])
+        assert out["status"] == "success"
+        assert out["input_rows"] == 2
+
+
+class TestRunPipelineDedupe:
+    @pytest.mark.skipif(not HAS_MATCH, reason="goldenmatch not installed")
+    def test_inline_dedupe_returns_output(self):
+        out = run_pipeline_tool(
+            records=_DUP_RECORDS, stages=["goldenmatch.dedupe"], preview_rows=5,
+        )
+        assert out["status"] == "success"
+        assert out["input_rows"] == 4
+        assert out["stages"]["goldenmatch.dedupe"]["status"] == "success"
+        # The reason this enrichment exists: the deduped output is returned.
+        output = out["output"]
+        assert output["golden_records"] >= 1
+        assert isinstance(output["golden_preview"], list)
+        assert output["golden_preview"]  # non-empty
+        assert output["match_stats"]["total_records"] == 4


### PR DESCRIPTION
## What and why

The MCP/A2A `run_pipeline` was **fire-and-forget**: file-path input only, and it returned just `{status, source, input_rows, errors, skipped}`. An LLM could *trigger* a GoldenPipe run but never *see what it produced* — which breaks the observe→decide→act loop orchestration needs. This closes that gap.

**No new tool.** The four tool/skill names are unchanged, so `api_parity` stays green and no TS mirror / manifest edit is needed. A2A inherits everything because its `handle_task` dispatches to the same `run_pipeline_tool`.

## `run_pipeline` now

- **Inline input** (precedence `records` > `csv_text` > `source`): data can travel **over the wire** as a list of row dicts or raw CSV, not only from a file on the server.
- **Inline config**: `stages` (a stage-name chain, e.g. `["goldencheck.scan","goldenmatch.dedupe"]`; an explicit `[]` = load-only) or `config_path` (YAML), or omit both for zero-config auto. `identity_opts` forwards the Identity Graph knobs.
- **Returns the full result**: per-stage `status`/`reasoning`/`timing`, `skipped`, `errors`, **and an `output` block** with the deduped result — `golden_records` + a bounded `golden_preview`, `unique_records`/`duplicate_records`, `cluster_count`, `match_stats`.

### Example (inline dedupe)

`run_pipeline(records=[…4 rows, two are the same person…], stages=["goldenmatch.dedupe"])` returns:

```json
{
  "status": "success", "input_rows": 4,
  "stages": {"load": {"status":"success"}, "goldenmatch.dedupe": {"status":"success"}},
  "output": {
    "golden_records": 1,
    "golden_preview": [{"__cluster_id__":1,"__golden_confidence__":0.925,"first_name":"John","last_name":"Smith","email":"jsmith@x.com","city":"NYC"}],
    "unique_records": 2, "duplicate_records": 2,
    "match_stats": {"total_records":4,"total_clusters":1,"matched_records":2,"match_rate":0.5}
  }
}
```

## How the output is sourced (no core-API change)

The golden/unique frames come from `result.artifacts["golden"|"unique"|"clusters"|"match_stats"]`, populated by `adapters/match.py::DedupeStage`. That stage casts every column to string before matching, so `to_dicts()` is JSON-safe. (The known gotcha — `PipeResult` doesn't expose `ctx.df` — still holds; but the dedupe **artifacts** carry the golden output, which is exactly what an orchestrator wants.)

## Honest scope

Closes the top gaps: **results retrieval**, **inline data**, **inline config**. Not included (deliberately): the Phase C DuckDB engine-resident source (`Pipeline.run(duckdb_con=, duckdb_table=)`) — a live DB connection isn't wire-friendly over MCP; and decision-gate tuning. Those weren't the blocker; results-retrieval was.

## Verification

- **`tests/test_mcp.py`**: result serialization (shape, rounding, no-output when empty), bounded/zero preview, no-input error, inline `records` + `csv_text`, and a real inline dedupe that asserts the returned golden output.
- **`tests/test_a2a.py`**: the `run-pipeline` skill dispatches inline `records` through the enriched tool (hermetic, `stages=[]`).
- Full goldenpipe suite **184 passed / 9 skipped**; `ruff` clean. Tool/skill/handler names verified unchanged (api_parity name set intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYeKXAKpstTBJSq66NiJ6T)_