### PR TITLE
feat(goldenflow): fused columnar apply default-ON (opt-out) + native floor >=0.12.0

### DIFF
--- a/docs-site/goldenflow/performance.mdx
+++ b/docs-site/goldenflow/performance.mdx
@@ -83,6 +83,34 @@ mirroring `GOLDENMATCH_NATIVE`):
   product-chosen `is_possible` spec). `phone_digits` is pure Polars.
 </Note>
 
+### Fused columnar apply
+
+When a column has a run of two or more consecutive owned string transforms
+(e.g. `strip → lowercase → collapse_whitespace → remove_punctuation`, or
+`name_transliterate → name_proper → strip_titles`), the native path **fuses**
+them into a single pass over the Arrow buffer instead of crossing the
+Python/Polars/Arrow boundary once per transform. The output and the audit trail
+are **byte-identical** to applying the transforms one at a time; the win is
+lower memory (fusion avoids materializing one intermediate column per transform)
+plus a smaller wall-time drop.
+
+Measured at 5M rows: **~20% lower peak RSS** and a modest wall speedup, growing
+with row count. It is **on by default** when the native kernel is available
+(needs `goldenflow-native >= 0.12.0`); older wheels fall back gracefully.
+
+| `GOLDENFLOW_FUSED_APPLY` | Behavior |
+|---|---|
+| unset | Fuse when the native fused kernel is present. **Default.** |
+| `0` | Force the per-transform path (each transform applied individually). |
+
+<Note>
+  The fused set is the owned, single-value, total (never-null) string transforms
+  (text + email + name-normalizer families). Parameterized (`truncate`/`pad`),
+  numeric, `Option`-returning (URL / company), and residual-tier (`phone`/date)
+  transforms are not fused and take the per-transform path — automatically, no
+  configuration needed.
+</Note>
+
 ## Cross-surface (WASM / TypeScript)
 
 The identifier kernels also compile to WebAssembly (`goldenflow-wasm`). The

--- a/packages/python/goldenflow/benchmarks/fused_apply_benchmark.py
+++ b/packages/python/goldenflow/benchmarks/fused_apply_benchmark.py
@@ -123,10 +123,9 @@ def run_variant(variant: str, rows: int, runs: int, seed: int) -> dict:
     """Run one leg (per_transform | fused): warmup + `runs` timed passes, returning
     the median wall, throughput, peak RSS, output digest, and whether the fused
     native path actually engaged."""
-    if variant == "fused":
-        os.environ["GOLDENFLOW_FUSED_APPLY"] = "1"
-    else:
-        os.environ.pop("GOLDENFLOW_FUSED_APPLY", None)
+    # Explicit both ways: fused is default-on now, so the per-transform baseline
+    # must FORCE off (=0) rather than rely on an unset var.
+    os.environ["GOLDENFLOW_FUSED_APPLY"] = "1" if variant == "fused" else "0"
 
     from goldenflow.transforms._chain import fused_enabled
 

--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -54,8 +54,13 @@ FUSABLE_KERNELS: frozenset[str] = frozenset(
 
 
 def fused_enabled() -> bool:
-    """The fused chain path is active iff explicitly opted in AND native is on."""
-    if os.environ.get("GOLDENFLOW_FUSED_APPLY", "").lower() not in ("1", "true", "on"):
+    """The fused chain path is active by DEFAULT whenever the native fused kernel is
+    available (measured byte-identical to the per-transform path, faster wall + ~20%
+    lower peak RSS at scale). Opt-OUT via ``GOLDENFLOW_FUSED_APPLY=0`` (mirrors
+    ``GOLDENFLOW_NATIVE``'s auto/0 semantics); it also stays off when native is
+    forced off or the fused symbol isn't in the installed wheel (graceful fallback
+    to per-transform, so a pre-0.12.0 goldenflow-native is unaffected)."""
+    if os.environ.get("GOLDENFLOW_FUSED_APPLY", "").lower() in ("0", "false", "off"):
         return False
     if os.environ.get("GOLDENFLOW_NATIVE", "auto").lower() == "0":
         return False

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -48,7 +48,7 @@ agent = ["aiohttp>=3.14.0"]
 # Optional Rust/PyO3 acceleration runtime (mirrors goldenmatch[native]). Pulls
 # pyarrow for the zero-copy Series<->kernel bridge. Off by default at runtime --
 # see goldenflow.core._native_loader (GOLDENFLOW_NATIVE / _GATED_ON).
-native = ["goldenflow-native>=0.1.0", "pyarrow>=10"]
+native = ["goldenflow-native>=0.12.0", "pyarrow>=10"]
 all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
 
 [project.scripts]

--- a/packages/python/goldenflow/tests/transforms/test_fused_chain.py
+++ b/packages/python/goldenflow/tests/transforms/test_fused_chain.py
@@ -96,7 +96,7 @@ def test_fused_equals_per_transform(monkeypatch, ops) -> None:
     )
     cfg = _cfg("name", ops)
 
-    monkeypatch.delenv("GOLDENFLOW_FUSED_APPLY", raising=False)
+    monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "0")  # opt-OUT -> per-transform
     per_op = transform_df(df, config=cfg)
 
     monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "1")
@@ -106,14 +106,30 @@ def test_fused_equals_per_transform(monkeypatch, ops) -> None:
     assert _manifest_rows(fused) == _manifest_rows(per_op), "fused manifest diverged"
 
 
-def test_flag_off_is_the_per_transform_path(monkeypatch) -> None:
-    """Default-off: the engine refactor must not change behavior when the flag is
-    unset (runs locally with no native — the fused path can't engage anyway)."""
+def test_opt_out_is_the_per_transform_path(monkeypatch) -> None:
+    """Opt-out: GOLDENFLOW_FUSED_APPLY=0 forces the per-transform path (and it's the
+    only path anyway with no native). Output + audit records unchanged."""
     from goldenflow import transform_df
 
-    monkeypatch.delenv("GOLDENFLOW_FUSED_APPLY", raising=False)
+    monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "0")
     df = pl.DataFrame({"name": ["  John  ", "MARY  ", None]})
     out = transform_df(df, config=_cfg("name", ["strip", "lowercase"]))
     assert out.df["name"].to_list() == ["john", "mary", None]
     # two ops -> two audit records, in order.
     assert [r.transform for r in out.manifest.records] == ["strip", "lowercase"]
+
+
+def test_default_is_fused_when_native_available(monkeypatch) -> None:
+    """The default (flag unset) now fuses whenever the native kernel is present —
+    opt-OUT semantics. With native absent, fused_enabled() is False (graceful)."""
+    from goldenflow.core._native_loader import native_module
+    from goldenflow.transforms._chain import fused_enabled
+
+    monkeypatch.delenv("GOLDENFLOW_FUSED_APPLY", raising=False)
+    monkeypatch.delenv("GOLDENFLOW_NATIVE", raising=False)
+    nm = native_module()
+    expected = nm is not None and hasattr(nm, "apply_chain_arrow")
+    assert fused_enabled() is expected
+    # explicit off always wins
+    monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "0")
+    assert fused_enabled() is False


### PR DESCRIPTION
Now that **goldenflow-native 0.12.0 is on PyPI with the fused kernel** (symbol verified in the published wheel), the measured win can reach `pip install goldenflow[native]` users — so flip the default.

- **`fused_enabled()` -> opt-out** (mirrors `GOLDENFLOW_NATIVE`): fuse by default when the native fused kernel is present; `GOLDENFLOW_FUSED_APPLY=0` forces per-transform; off when native is off or the symbol is absent (pre-0.12.0 wheels fall back gracefully).
- **`goldenflow[native]` floor 0.1.0 -> 0.12.0** to mandate the fused-capable wheel (0.12.0 is live, so satisfiable).
- Inverted-flag fallout fixed (parity test + bench per-transform legs force `=0`; new default-semantics test).
- Docs: new *Fused columnar apply* section in performance.mdx.

**Why default-on:** byte-identical output in every measured config, never slower on wall, **-22% peak RSS at scale** (a tracked workstream). Native-only + graceful fallback, so pure-Python installs are unaffected.

Next: golden-suite lockstep (bump its `goldenflow-native` floor to 0.12.0 + release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)