### PR TITLE
feat(goldenflow): fuse parameterized string ops (truncate/pad)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/transformer.py
+++ b/packages/python/goldenflow/goldenflow/engine/transformer.py
@@ -256,11 +256,14 @@ class TransformEngine:
         sample = df.head(3).select(pl.col(column))
         for (info, params), n_changed in zip(run, changed):
             before = sample[column].head(3).cast(pl.Utf8).to_list()
-            typed = self._cast_params(params) if params else []
+            # Match the per-transform param handling EXACTLY: series-mode casts
+            # params, expr-mode passes them raw (pad_left's pad char "0" must stay
+            # a str, not be int-cast). Mixing these breaks the parameterized replay.
             if info.mode == "series":
+                typed = self._cast_params(params) if params else []
                 sample = sample.with_columns(info.func(sample[column], *typed).alias(column))
-            else:  # expr
-                sample = sample.with_columns(info.func(column, *typed).alias(column))
+            else:  # expr — raw string params, exactly like _apply_single_transform_body
+                sample = sample.with_columns(info.func(column, *params).alias(column))
             after = sample[column].head(3).cast(pl.Utf8).to_list()
             manifest.add_record(TransformRecord(
                 column=column,

--- a/packages/python/goldenflow/goldenflow/engine/transformer.py
+++ b/packages/python/goldenflow/goldenflow/engine/transformer.py
@@ -198,23 +198,27 @@ class TransformEngine:
         ops: list[tuple[TransformInfo, list[str]]],
         manifest: Manifest,
     ) -> pl.DataFrame:
-        """Apply an ordered list of ``(info, params)`` to ``column``. When
-        ``GOLDENFLOW_FUSED_APPLY`` is on (and native is available and the column is
-        string), maximal runs of owned string->string no-arg kernels are fused into
-        ONE native Arrow round-trip (Pillar-1 of the Rust cutover); everything else
-        takes the per-transform path unchanged. Default-off, so behavior is
-        byte-identical to the per-transform path until opted in."""
-        from goldenflow.transforms._chain import FUSABLE_KERNELS, fused_enabled
+        """Apply an ordered list of ``(info, params)`` to ``column``. When fusion is
+        on (default; native available; string column), maximal runs of owned
+        string->string kernels are fused into ONE native Arrow round-trip (Pillar-1
+        of the Rust cutover); everything else takes the per-transform path unchanged.
+        The fusable set is symbol-aware — parameterized ops (truncate/pad) only join
+        a run when the native ``apply_chain_ops_arrow`` symbol is present."""
+        from goldenflow.transforms._chain import fusable_names, fused_enabled, is_fusable
 
-        fuse = fused_enabled() and df.schema.get(column) in (pl.String, pl.Utf8)
+        available = (
+            fusable_names()
+            if fused_enabled() and df.schema.get(column) in (pl.String, pl.Utf8)
+            else frozenset()
+        )
         n = len(ops)
         i = 0
         while i < n:
             info, params = ops[i]
-            if fuse and not params and info.name in FUSABLE_KERNELS:
+            if is_fusable(info.name, params, available):
                 # Extend the maximal fusable run starting at i.
                 j = i
-                while j < n and not ops[j][1] and ops[j][0].name in FUSABLE_KERNELS:
+                while j < n and is_fusable(ops[j][0].name, ops[j][1], available):
                     j += 1
                 if j - i >= 2:
                     applied = self._apply_fused_run(df, column, ops[i:j], manifest)
@@ -243,19 +247,20 @@ class TransformEngine:
         declined (caller falls back to the per-op path)."""
         from goldenflow.transforms._chain import apply_chain_native
 
-        names = [info.name for info, _ in run]
-        res = apply_chain_native(df[column], names)
+        ops_spec = [(info.name, [str(p) for p in params]) for info, params in run]
+        res = apply_chain_native(df[column], ops_spec)
         if res is None:
             return None
         new_series, changed = res
         total_rows = df.shape[0]
         sample = df.head(3).select(pl.col(column))
-        for (info, _params), n_changed in zip(run, changed):
+        for (info, params), n_changed in zip(run, changed):
             before = sample[column].head(3).cast(pl.Utf8).to_list()
+            typed = self._cast_params(params) if params else []
             if info.mode == "series":
-                sample = sample.with_columns(info.func(sample[column]).alias(column))
+                sample = sample.with_columns(info.func(sample[column], *typed).alias(column))
             else:  # expr
-                sample = sample.with_columns(info.func(column).alias(column))
+                sample = sample.with_columns(info.func(column, *typed).alias(column))
             after = sample[column].head(3).cast(pl.Utf8).to_list()
             manifest.add_record(TransformRecord(
                 column=column,

--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -1,12 +1,16 @@
-"""Fused columnar apply bridge — run a whole run of owned, string->string, no-arg
-transforms over one column in a single native Arrow round-trip, instead of the
-engine crossing the boundary once per transform.
+"""Fused columnar apply bridge — run a whole run of owned string->string transforms
+over one column in a single native Arrow round-trip, instead of the engine crossing
+the boundary once per transform.
 
-``FUSABLE_KERNELS`` is the single Python-side source of truth for which transforms
-the fused chain supports; it MUST mirror ``goldenflow_core::chain::Kernel`` (the
-coverage guard in ``tests/transforms/test_fused_chain.py`` asserts they agree).
-Opt-in via ``GOLDENFLOW_FUSED_APPLY``; native must also be enabled
-(``GOLDENFLOW_NATIVE`` != ``0`` and the ``apply_chain_arrow`` symbol present).
+``FUSABLE_KERNELS`` (no-arg) + ``FUSABLE_PARAM_KERNELS`` (parameterized) are the
+Python-side source of truth for which transforms the fused chain supports; together
+they MUST mirror ``goldenflow_core::chain`` (``ALL_NAMES`` + ``PARAM_NAMES``) — the
+coverage guard in ``tests/transforms/test_fused_chain.py`` asserts they agree.
+
+Two native symbols back this: ``apply_chain_arrow`` (no-arg, since goldenflow-native
+0.12.0) and ``apply_chain_ops_arrow`` (superset, adds the parameterized ops, since
+0.13.0). The parameterized ops only fuse when the ops symbol is present, so a 0.12.0
+wheel still fuses the no-arg families and only the param ops break a run.
 """
 from __future__ import annotations
 
@@ -18,8 +22,8 @@ from goldenflow.core._native_loader import native_module
 
 # Owned, no-arg, TOTAL (never-null) string->string kernels eligible for fusion.
 # Mirror of goldenflow_core::chain::Kernel::ALL_NAMES. Option-returning
-# (email_extract_domain, *_validate, *_mask), parameterized (truncate/pad), and
-# multi-arity (split_*/merge_name) transforms are intentionally excluded.
+# (email_extract_domain, *_validate, *_mask) and multi-arity (split_*/merge_name)
+# transforms are intentionally excluded.
 FUSABLE_KERNELS: frozenset[str] = frozenset(
     {
         "strip",
@@ -52,36 +56,78 @@ FUSABLE_KERNELS: frozenset[str] = frozenset(
     }
 )
 
+# Parameterized (total string->string) kernels — need the ``apply_chain_ops_arrow``
+# symbol (goldenflow-native >= 0.13.0). Mirror of Kernel::PARAM_NAMES.
+FUSABLE_PARAM_KERNELS: frozenset[str] = frozenset({"truncate", "pad_left", "pad_right"})
+
+
+def _native_if_on():
+    """The native module if fusion is not opted out and native is not forced off,
+    else ``None``."""
+    if os.environ.get("GOLDENFLOW_FUSED_APPLY", "").lower() in ("0", "false", "off"):
+        return None
+    if os.environ.get("GOLDENFLOW_NATIVE", "auto").lower() == "0":
+        return None
+    return native_module()
+
 
 def fused_enabled() -> bool:
     """The fused chain path is active by DEFAULT whenever the native fused kernel is
     available (measured byte-identical to the per-transform path, faster wall + ~20%
     lower peak RSS at scale). Opt-OUT via ``GOLDENFLOW_FUSED_APPLY=0`` (mirrors
-    ``GOLDENFLOW_NATIVE``'s auto/0 semantics); it also stays off when native is
-    forced off or the fused symbol isn't in the installed wheel (graceful fallback
-    to per-transform, so a pre-0.12.0 goldenflow-native is unaffected)."""
-    if os.environ.get("GOLDENFLOW_FUSED_APPLY", "").lower() in ("0", "false", "off"):
-        return False
-    if os.environ.get("GOLDENFLOW_NATIVE", "auto").lower() == "0":
-        return False
-    nm = native_module()
+    ``GOLDENFLOW_NATIVE``); off when native is forced off or the fused symbol isn't
+    in the installed wheel (graceful fallback, so a pre-0.12.0 wheel is unaffected)."""
+    nm = _native_if_on()
     return nm is not None and hasattr(nm, "apply_chain_arrow")
 
 
+def fusable_names() -> frozenset[str]:
+    """The transform names the engine may fuse, given the AVAILABLE native symbol:
+    the parameterized ops only join a run when ``apply_chain_ops_arrow`` is present
+    (0.13.0+); a 0.12.0 wheel fuses the no-arg families only."""
+    nm = _native_if_on()
+    if nm is None:
+        return frozenset()
+    if hasattr(nm, "apply_chain_ops_arrow"):
+        return FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
+    if hasattr(nm, "apply_chain_arrow"):
+        return FUSABLE_KERNELS
+    return frozenset()
+
+
+def is_fusable(name: str, params: list[str], available: frozenset[str]) -> bool:
+    """An op fuses iff its name is in the symbol-available set AND either it's a
+    parameterized kernel (params are its args) or a no-arg kernel with no params."""
+    if name not in available:
+        return False
+    if name in FUSABLE_PARAM_KERNELS:
+        return True
+    return not params
+
+
 def apply_chain_native(
-    series: pl.Series, kernel_names: list[str]
+    series: pl.Series, ops: list[tuple[str, list[str]]]
 ) -> tuple[pl.Series, list[int]] | None:
-    """Apply ``kernel_names`` (all in ``FUSABLE_KERNELS``) in order over ``series``
-    in one native pass. Returns ``(transformed_series, per_kernel_changed_counts)``,
-    or ``None`` when the native path is unavailable (caller falls back to the
-    per-transform path). The Arrow round-trip is zero-copy; Polars exports strings
-    as LargeUtf8, which the kernel handles natively (i64 offsets)."""
+    """Apply ``ops`` (each ``(name, params)``, all fusable for the available symbol)
+    in order over ``series`` in one native pass. Prefers ``apply_chain_ops_arrow``
+    (parameterized); falls back to ``apply_chain_arrow`` when every op is no-arg.
+    Returns ``(transformed_series, per_kernel_changed_counts)`` or ``None`` if the
+    native path is unavailable. Zero-copy; Polars exports LargeUtf8, handled natively."""
     nm = native_module()
-    if nm is None or not hasattr(nm, "apply_chain_arrow"):
+    if nm is None:
         return None
     try:
         import pyarrow  # noqa: F401  (zero-copy bridge)
     except ImportError:
         return None
-    out_arrow, changed = nm.apply_chain_arrow(series.to_arrow(), list(kernel_names))
+    if hasattr(nm, "apply_chain_ops_arrow"):
+        out_arrow, changed = nm.apply_chain_ops_arrow(
+            series.to_arrow(), [(name, list(params)) for name, params in ops]
+        )
+    elif hasattr(nm, "apply_chain_arrow") and all(not params for _, params in ops):
+        out_arrow, changed = nm.apply_chain_arrow(
+            series.to_arrow(), [name for name, _ in ops]
+        )
+    else:
+        return None
     return pl.from_arrow(out_arrow), [int(c) for c in changed]

--- a/packages/python/goldenflow/tests/transforms/test_fused_chain.py
+++ b/packages/python/goldenflow/tests/transforms/test_fused_chain.py
@@ -12,7 +12,7 @@ import polars as pl
 import pytest
 from goldenflow.core._native_loader import native_module
 from goldenflow.transforms import get_transform, registry
-from goldenflow.transforms._chain import FUSABLE_KERNELS
+from goldenflow.transforms._chain import FUSABLE_KERNELS, FUSABLE_PARAM_KERNELS
 
 
 def test_fusable_kernels_registered_and_single_col_mode() -> None:
@@ -21,8 +21,8 @@ def test_fusable_kernels_registered_and_single_col_mode() -> None:
     mode; a dataframe-mode (multi-column) kernel would break it — this guard blocks
     that and any unregistered name."""
     reg = set(registry())
-    for name in sorted(FUSABLE_KERNELS):
-        assert name in reg, f"{name} in FUSABLE_KERNELS but not registered"
+    for name in sorted(FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS):
+        assert name in reg, f"{name} in the fusable set but not registered"
         info = get_transform(name)
         assert info is not None and info.mode in ("expr", "series"), (
             f"{name} must be mode 'expr'/'series' for the fused sample replay, got "
@@ -31,13 +31,13 @@ def test_fusable_kernels_registered_and_single_col_mode() -> None:
 
 
 def test_fusable_matches_native_kernel_table() -> None:
-    """Python FUSABLE_KERNELS must mirror goldenflow_core::chain::Kernel (native
-    ``fusable_kernel_names``): the host must never send a name the kernel can't
-    fuse, nor silently under-fuse a kernel the kernel supports."""
+    """The Python fusable set (no-arg + parameterized) must mirror
+    goldenflow_core::chain (native ``fusable_kernel_names`` = ALL_NAMES + PARAM_NAMES):
+    the host must never send a name the kernel can't fuse, nor under-fuse one it can."""
     nm = native_module()
     if nm is None or not hasattr(nm, "fusable_kernel_names"):
         pytest.skip("native chain kernel not built")
-    assert set(nm.fusable_kernel_names()) == set(FUSABLE_KERNELS)
+    assert set(nm.fusable_kernel_names()) == set(FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS)
 
 
 def _cfg(column: str, ops: list[str]):
@@ -70,6 +70,10 @@ def _manifest_rows(result) -> list[tuple]:
         ["strip", "lowercase", "email_normalize", "email_canonical"],
         ["name_transliterate", "name_proper", "strip_titles", "strip_suffixes"],
         ["strip", "name_proper", "strip_middle", "name_initials"],
+        # parameterized ops mixed into a fusable run (need apply_chain_ops_arrow)
+        ["strip", "lowercase", "truncate:5"],
+        ["strip", "pad_left:8:0"],
+        ["strip", "collapse_whitespace", "truncate:20", "pad_right:25"],
         ["strip", "extract_numbers"],
     ],
 )

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -59,6 +59,10 @@ pub enum Kernel {
     NicknameStandardize,
     NameInitials,
     StripMiddle,
+    // parameterized string->string (carry their args; total, never null)
+    Truncate(usize),
+    PadLeft(usize, char),
+    PadRight(usize, char),
 }
 
 impl Kernel {
@@ -96,6 +100,35 @@ impl Kernel {
             _ => return None,
         })
     }
+
+    /// Resolve a transform name + its (string) params to a chain kernel — the
+    /// superset of [`from_name`](Self::from_name) that also handles the
+    /// parameterized string ops. Defaults + negative-clamping mirror the
+    /// native-flow arrow shims exactly (`truncate` n=255; `pad_left` width=10
+    /// pad='0'; `pad_right` width=10 pad=' '; a negative width/n clamps to 0).
+    pub fn from_op(name: &str, params: &[&str]) -> Option<Kernel> {
+        let usize_arg = |i: usize, default: usize| {
+            params
+                .get(i)
+                .and_then(|p| p.parse::<i64>().ok())
+                .map(|n| if n < 0 { 0 } else { n as usize })
+                .unwrap_or(default)
+        };
+        let char_arg = |i: usize, default: char| {
+            params.get(i).and_then(|p| p.chars().next()).unwrap_or(default)
+        };
+        match name {
+            "truncate" => Some(Kernel::Truncate(usize_arg(0, 255))),
+            "pad_left" => Some(Kernel::PadLeft(usize_arg(0, 10), char_arg(1, '0'))),
+            "pad_right" => Some(Kernel::PadRight(usize_arg(0, 10), char_arg(1, ' '))),
+            _ => Kernel::from_name(name),
+        }
+    }
+
+    /// Parameterized fusable names — need `apply_chain_ops_arrow` (not the older
+    /// no-arg `apply_chain_arrow`). Kept separate so a pre-0.13.0 wheel still fuses
+    /// the no-arg families and only these break a run.
+    pub const PARAM_NAMES: &'static [&'static str] = &["truncate", "pad_left", "pad_right"];
 
     /// Every fusable kernel name, for the coverage guard.
     pub const ALL_NAMES: &'static [&'static str] = &[
@@ -158,6 +191,9 @@ impl Kernel {
             Kernel::NicknameStandardize => out.push_str(&names::nickname_standardize(s)),
             Kernel::NameInitials => out.push_str(&names::name_initials(s)),
             Kernel::StripMiddle => out.push_str(&names::strip_middle(s)),
+            Kernel::Truncate(n) => out.push_str(&text::truncate(s, n)),
+            Kernel::PadLeft(w, p) => text::pad_left_into(s, w, p, out),
+            Kernel::PadRight(w, p) => text::pad_right_into(s, w, p, out),
         }
     }
 }
@@ -295,6 +331,10 @@ mod tests {
             ],
             &[Kernel::NicknameStandardize, Kernel::NameInitials],
             &[Kernel::ExtractNumbers],
+            // parameterized string ops mixed into a run.
+            &[Kernel::Strip, Kernel::Lowercase, Kernel::Truncate(5)],
+            &[Kernel::Strip, Kernel::PadLeft(8, '0')],
+            &[Kernel::Truncate(3), Kernel::PadRight(6, '_')],
         ];
         let arr = sample();
         for chain in chains {
@@ -302,6 +342,29 @@ mod tests {
             let seq = sequential(&arr, chain);
             assert_eq!(fused.array, seq, "chain {chain:?} != sequential");
         }
+    }
+
+    #[test]
+    fn from_op_parses_params_and_defaults() {
+        // explicit params
+        assert_eq!(Kernel::from_op("truncate", &["50"]), Some(Kernel::Truncate(50)));
+        assert_eq!(
+            Kernel::from_op("pad_left", &["10", "0"]),
+            Some(Kernel::PadLeft(10, '0'))
+        );
+        assert_eq!(
+            Kernel::from_op("pad_right", &["6", " "]),
+            Some(Kernel::PadRight(6, ' '))
+        );
+        // defaults mirror the arrow shims when a param is missing
+        assert_eq!(Kernel::from_op("truncate", &[]), Some(Kernel::Truncate(255)));
+        assert_eq!(Kernel::from_op("pad_left", &[]), Some(Kernel::PadLeft(10, '0')));
+        assert_eq!(Kernel::from_op("pad_right", &[]), Some(Kernel::PadRight(10, ' ')));
+        // negative width clamps to 0 (matches the shim)
+        assert_eq!(Kernel::from_op("truncate", &["-5"]), Some(Kernel::Truncate(0)));
+        // no-arg names delegate to from_name; unknown -> None
+        assert_eq!(Kernel::from_op("strip", &[]), Some(Kernel::Strip));
+        assert_eq!(Kernel::from_op("split_name", &[]), None);
     }
 
     #[test]

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/packages/rust/extensions/native-flow/src/chain.rs
+++ b/packages/rust/extensions/native-flow/src/chain.rs
@@ -4,6 +4,11 @@
 //! handled (Polars exports strings as LargeUtf8, so the i64 arm is the one that
 //! fires on real data). Returns the transformed array plus the per-kernel
 //! affected-row counts so the host can emit a byte-identical per-transform audit.
+//!
+//! Two entry points: [`apply_chain_arrow`] (no-arg names only, the original 0.12.0
+//! symbol) and [`apply_chain_ops_arrow`] (superset — also the parameterized string
+//! ops via `(name, params)` tuples). The host prefers the ops form when present and
+//! falls back to the no-arg form on an older wheel.
 
 use arrow::array::{make_array, Array, ArrayData, LargeStringArray, StringArray};
 use arrow::pyarrow::PyArrowType;
@@ -11,18 +16,49 @@ use goldenflow_core::chain::{apply_chain, Kernel};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 
-/// The fusable kernel names the compiled chain supports, for the host's
-/// coverage guard (asserts Python `FUSABLE_KERNELS` == this set).
+/// The fusable kernel names the compiled chain supports (no-arg + parameterized),
+/// for the host's coverage guard (asserts Python `FUSABLE_KERNELS ∪
+/// FUSABLE_PARAM_KERNELS` == this set).
 #[pyfunction]
 pub fn fusable_kernel_names() -> Vec<String> {
-    Kernel::ALL_NAMES.iter().map(|s| s.to_string()).collect()
+    Kernel::ALL_NAMES
+        .iter()
+        .chain(Kernel::PARAM_NAMES.iter())
+        .map(|s| s.to_string())
+        .collect()
 }
 
-/// Apply `kernel_names` (registry transform names, e.g. `["strip","lowercase"]`)
-/// in order over `array`. Every name must be a fusable chain kernel
-/// (`Kernel::from_name`); an unknown name is an error (the host only sends names
-/// it resolved against the same table). Returns `(transformed_array, changed)`
-/// where `changed[i]` is the number of non-null rows the i-th kernel altered.
+/// Downcast `data` to Utf8 / LargeUtf8 and run `kernels` in one pass (GIL released),
+/// returning the transformed array + per-kernel affected counts.
+fn run_kernels(
+    py: Python,
+    data: ArrayData,
+    kernels: &[Kernel],
+) -> PyResult<(PyArrowType<ArrayData>, Vec<u64>)> {
+    let arr = make_array(data);
+    if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+        let (out, changed) = py.detach(|| {
+            let r = apply_chain(s, kernels);
+            (r.array.into_data(), r.changed)
+        });
+        Ok((PyArrowType(out), changed))
+    } else if let Some(s) = arr.as_any().downcast_ref::<LargeStringArray>() {
+        let (out, changed) = py.detach(|| {
+            let r = apply_chain(s, kernels);
+            (r.array.into_data(), r.changed)
+        });
+        Ok((PyArrowType(out), changed))
+    } else {
+        Err(PyTypeError::new_err(
+            "fused apply requires a Utf8 or LargeUtf8 array",
+        ))
+    }
+}
+
+/// Apply `kernel_names` (no-arg registry names, e.g. `["strip","lowercase"]`) in
+/// order over `array`. Every name must be a no-arg fusable kernel
+/// (`Kernel::from_name`). Returns `(transformed_array, changed)` where `changed[i]`
+/// is the number of non-null rows the i-th kernel altered.
 #[pyfunction]
 pub fn apply_chain_arrow(
     py: Python,
@@ -36,23 +72,26 @@ pub fn apply_chain_arrow(
                 PyValueError::new_err(format!("not a fusable chain kernel: {n}"))
             })?);
     }
-    let data = array.0;
-    let arr = make_array(data.clone());
-    if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
-        let (out, changed) = py.detach(|| {
-            let r = apply_chain(s, &kernels);
-            (r.array.into_data(), r.changed)
-        });
-        Ok((PyArrowType(out), changed))
-    } else if let Some(s) = arr.as_any().downcast_ref::<LargeStringArray>() {
-        let (out, changed) = py.detach(|| {
-            let r = apply_chain(s, &kernels);
-            (r.array.into_data(), r.changed)
-        });
-        Ok((PyArrowType(out), changed))
-    } else {
-        Err(PyTypeError::new_err(
-            "apply_chain_arrow requires a Utf8 or LargeUtf8 array",
-        ))
+    run_kernels(py, array.0, &kernels)
+}
+
+/// Superset of [`apply_chain_arrow`]: each op is a `(name, params)` tuple, so the
+/// parameterized string ops (`truncate` / `pad_left` / `pad_right`) fuse too
+/// (`Kernel::from_op`; defaults/clamping match the per-transform arrow shims).
+#[pyfunction]
+pub fn apply_chain_ops_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    ops: Vec<(String, Vec<String>)>,
+) -> PyResult<(PyArrowType<ArrayData>, Vec<u64>)> {
+    let mut kernels = Vec::with_capacity(ops.len());
+    for (name, params) in &ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        kernels.push(
+            Kernel::from_op(name, &refs).ok_or_else(|| {
+                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
+            })?,
+        );
     }
+    run_kernels(py, array.0, &kernels)
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -30,6 +30,7 @@ mod util;
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::fusable_kernel_names, m)?)?;
     m.add_function(wrap_pyfunction!(company::company_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(company::company_strip_legal_arrow, m)?)?;


### PR DESCRIPTION
Closes the last hole in the *string* fusion story: `truncate`/`pad_left`/`pad_right` currently break an otherwise-fusable run. Now they fuse (`strip -> lowercase -> truncate:255` fuses end-to-end).

- core: `Kernel::{Truncate,PadLeft,PadRight}` + `from_op` (defaults/clamping mirror the arrow shims) + `PARAM_NAMES`.
- native: **new** `apply_chain_ops_arrow` (superset; keeps 0.12.0 `apply_chain_arrow` for back-compat).
- host: **symbol-aware** fusion — param ops only join a run when the ops symbol is present, so a 0.12.0 wheel keeps no-arg fusion (no regression); the rest falls back gracefully until the 0.13.0 republish (batched with numeric later).
- goldenflow-core 0.5.0 -> 0.6.0 (bust the rust-cache — the documented footgun).

Parity by construction; coverage guard now asserts Python union == native table; parity test adds truncate/pad chains. Local: core 7 + clippy; native check/clippy/fmt; Python 8 pass / 12 native-skip; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)