### PR TITLE
release(golden-suite): 0.1.4 — lockstep bump for fused-apply

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.4] - 2026-07-06
+
+### Changed
+- Bumped the goldenflow-family floors after the fused-columnar-apply release
+  (lockstep policy): **`goldenflow>=1.14.0`** (was `>=1.13.0`) and
+  **`goldenflow-native>=0.12.0`** (was `>=0.11.0`). goldenflow 1.14.0 flips
+  fused columnar apply on by default (a run of owned string transforms fuses
+  into one native Arrow pass — byte-identical output, ~22% lower peak RSS at
+  scale); goldenflow-native 0.12.0 ships the `apply_chain_arrow` kernel it needs.
+
 ## [0.1.3] - 2026-07-05
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.3"
+version = "0.1.4"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.13.0",                # transform / standardize / normalize (>=1.13.0 = owned-kernel Wave D complete)
+    "goldenflow>=1.14.0",                # transform / standardize / normalize (>=1.14.0 = fused columnar apply default-on)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.11.0",
+    "goldenflow-native>=0.12.0",
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
The fused columnar apply release (goldenflow-native 0.12.0 + goldenflow 1.14.0, both live on PyPI) triggers the golden-suite lockstep rule. Bumps floors: `goldenflow>=1.14.0` + `goldenflow-native>=0.12.0`; version 0.1.3 -> 0.1.4 + CHANGELOG. Both floors satisfiable on PyPI. Deps-only. Tag `golden-suite-v0.1.4` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)