### PR TITLE
feat(infermap): WASM/TS Wave A — infermap-wasm foundation + detect_domain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
       wasm_score: ${{ steps.filter.outputs.wasm_score }}
       analysis_wasm: ${{ steps.filter.outputs.analysis_wasm }}
+      infermap_wasm: ${{ steps.filter.outputs.infermap_wasm }}
       ts_parity: ${{ steps.filter.outputs.ts_parity }}
       throughput: ${{ steps.filter.outputs.throughput }}
       autoconfig_wasm: ${{ steps.filter.outputs.autoconfig_wasm }}
@@ -238,6 +239,15 @@ jobs:
               - 'packages/typescript/goldenanalysis/src/core/aggregate.ts'
               - 'packages/typescript/goldenanalysis/tests/parity/wasm-aggregate.test.ts'
               - 'packages/typescript/goldenmatch-wasm-runtime/**'
+            infermap_wasm:
+              - 'packages/rust/extensions/infermap-wasm/**'
+              - 'packages/rust/extensions/infermap-core/**'
+              - 'packages/typescript/goldenmatch-wasm-runtime/**'
+              - 'packages/typescript/infermap/src/core/wasm/**'
+              - 'packages/typescript/infermap/src/core/detect.ts'
+              - 'packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts'
+              - 'packages/typescript/infermap/scripts/copy_wasm_artifact.mjs'
+              - 'packages/typescript/infermap/tsup.config.ts'
             wasm_flow:
               # Opt-in GoldenFlow WASM lane (Wave 0c): the wasm-bindgen wrapper,
               # the shared -core kernel it wraps, the TS wasm/loader + identifier
@@ -1940,6 +1950,39 @@ jobs:
         run: |
           pnpm --filter goldenanalysis build
           node packages/typescript/goldenanalysis/scripts/bench_wasm_aggregate.mjs 1000000
+
+  infermap_wasm:
+    needs: changes
+    if: needs.changes.outputs.infermap_wasm == 'true' || needs.changes.outputs.force_all == 'true'
+    # Opt-in WASM detect lane: builds the infermap-wasm artifact, then runs the
+    # detect parity test UN-skipped (skips elsewhere with no artifact). Advisory.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/infermap-wasm
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build WASM artifact (installs the matching wasm-bindgen-cli)
+        run: bash packages/rust/extensions/infermap-wasm/build_wasm.sh
+      - name: Build shared wasm-runtime (the parity test imports goldenmatch-wasm-runtime)
+        run: pnpm --filter goldenmatch-wasm-runtime build
+      - name: Build infermap's sibling deps (detect.ts imports goldencheck-types)
+        run: pnpm --filter "infermap^..." build
+      - name: WASM detect parity (un-skipped — artifact now present) [THE GATE]
+        run: pnpm --filter infermap exec vitest run tests/parity/infermap-wasm.parity.test.ts
+      - name: dist-path validation (enableInfermapWasm() must resolve the bundled artifact)
+        run: |
+          pnpm --filter infermap build
 
   wasm_flow:
     needs: changes

--- a/docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md
+++ b/docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md
@@ -1,0 +1,823 @@
+# InferMap WASM/TS Wave A — Implementation Plan (foundation + `detect_domain`)
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up the opt-in-WASM pipeline for the TS `infermap` package (a new `infermap-wasm` wasm-bindgen crate over `infermap-core`, TS `wasm/{backend,loader,index}.ts`, build script, CI lane, byte-parity gate) and wire `detect_domain` through it — making TS run the same Rust kernel Python's native wheel runs.
+
+**Architecture:** JSON-over-boundary (crossed once per call): the TS `detect.ts` resolves domain hints host-side into a flat `[name, hints[]][]`, hands it to a WASM backend that JSON-round-trips to `infermap_core::detect_domain`, with a pure-TS `scoreDomains` fallback. CI-built artifact (not committed; parity test skips locally, runs in the `infermap_wasm` lane). WASM is the reference; pure TS is the lossy fallback.
+
+**Tech Stack:** Rust (`infermap-wasm` cdylib+rlib, `serde`/`serde_json`, `wasm-bindgen`), `wasm-bindgen-cli`, TS/tsup, `goldenmatch-wasm-runtime`, vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md`
+
+**Reference skill:** @superpowers:test-driven-development
+
+---
+
+## Environment & Constraints (READ FIRST)
+
+**Repo:** `D:\show_case\gg-local-llm`, branch `feat/infermap-wasm-wave-a` (checked out, spec committed).
+
+**THE BOX CAN RUN ALMOST NOTHING HERE.** Per `feedback_box_memory_oom_ts` + the Rust-CI-only rule:
+- **NO `cargo build` / `cargo test` / `wasm-pack` / `wasm-bindgen`** — Rust + wasm are CI-only.
+- **NO `vitest` / `tsc` / `tsup` / `pnpm build`** — TS OOM-kills the box; CI-only.
+- **What the box CAN do:** `node --check <file.mjs>` (syntax-check `.mjs`), `git`, `python -c` for JSON/text checks, read/grep, and careful eye-review against the exemplars named per task.
+
+So every task is **write-against-spec + syntax/eye-verify + commit**; **CI is the first real test.** Be precise. When a step says "verify by eye," compare against the named real exemplar file line-by-line.
+
+**Exemplars to mirror (read them):**
+- Crate: `packages/rust/extensions/score-wasm/{Cargo.toml,src/lib.rs,build_wasm.sh}`, `packages/rust/extensions/analysis-wasm/src/lib.rs`.
+- TS wasm module: `packages/typescript/goldenanalysis/src/core/wasm/{backend,loader,index}.ts`.
+- tsup: `packages/typescript/goldenanalysis/tsup.config.ts`.
+- copy script: `packages/typescript/goldenanalysis/scripts/copy_wasm_artifact.mjs`.
+- parity test: `packages/typescript/goldenanalysis/tests/parity/wasm-aggregate.test.ts`.
+- CI lane: `.github/workflows/ci.yml` `analysis_wasm` job (~line 1904) + paths-filter (~line 234).
+- artifact gitignore: `packages/typescript/goldenanalysis/src/core/wasm/artifacts/.gitignore`.
+
+**Git:** benzsevern (`unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)`). Merge-queue — `gh pr merge --auto --squash` WITHOUT `--delete-branch`. Commit trailer:
+```
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+```
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `packages/rust/extensions/infermap-wasm/Cargo.toml` | standalone crate, serde+wasm-bindgen | Create |
+| `packages/rust/extensions/infermap-wasm/src/lib.rs` | `detect_domain_json_impl` + wasm re-export + host test | Create |
+| `packages/rust/extensions/infermap-wasm/build_wasm.sh` | cargo+wasm-bindgen build → TS artifacts | Create |
+| `packages/rust/extensions/infermap-wasm/Cargo.lock` | pins wasm-bindgen (committed) | Create (CI/generated note) |
+| `packages/typescript/infermap/src/core/wasm/backend.ts` | `InfermapBackend` iface + registry | Create |
+| `packages/typescript/infermap/src/core/wasm/loader.ts` | glue → backend adapter | Create |
+| `packages/typescript/infermap/src/core/wasm/index.ts` | `enable/disableInfermapWasm` | Create |
+| `packages/typescript/infermap/src/core/wasm/artifacts/.gitignore` | ignore built artifacts | Create |
+| `packages/typescript/infermap/src/core/detect.ts` | hoist refactor + `scoreDomains` + backend dispatch | Modify |
+| `packages/typescript/infermap/package.json` | add `goldenmatch-wasm-runtime` devDep | Modify |
+| `packages/typescript/infermap/tsup.config.ts` | artifact-shipping keys | Modify |
+| `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs` | fan artifact to dist | Create |
+| `packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts` | WASM-vs-pure gate | Create |
+| `.github/workflows/ci.yml` | `infermap_wasm` lane + filter | Modify |
+
+---
+
+## Task 1: The `infermap-wasm` crate
+
+**Files:** Create `packages/rust/extensions/infermap-wasm/Cargo.toml`, `.../src/lib.rs`.
+**Box:** eye-review only (no cargo). CI compiles + runs the host unit test.
+
+- [ ] **Step 1: `Cargo.toml`** (mirror `score-wasm/Cargo.toml`, add serde):
+```toml
+# Standalone workspace so this wasm-bindgen wrapper can path-depend on the
+# pyo3-free `infermap-core` WITHOUT either crate's workspace claiming it. This
+# crate is the TS analogue of `infermap-native` (pyo3): it wraps the SAME
+# `infermap-core`, so detect is byte-identical by construction. serde lives HERE
+# (the JSON boundary), never in infermap-core.
+[workspace]
+
+[package]
+name = "infermap-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "wasm-bindgen wrapper over infermap-core for the infermap TS opt-in WASM backend"
+
+[lib]
+name = "infermap_wasm"
+crate-type = ["cdylib", "rlib"]  # cdylib for wasm; rlib so host unit tests link
+
+[dependencies]
+infermap-core = { path = "../infermap-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+```
+
+- [ ] **Step 2: `src/lib.rs`**:
+```rust
+//! wasm-bindgen wrapper over `infermap-core`. The TS analogue of the
+//! `infermap-native` pyo3 crate: a thin JSON-boundary shim delegating to
+//! `detect_domain` so the TS surface is byte-identical to Python + the Rust FFI.
+//!
+//! Boundary: `detect_domain_json(input_json) -> output_json`, crossed ONCE per
+//! call (the perf-audit lesson: boundary cost dwarfs the kernel). serde DTOs live
+//! here; `infermap-core` stays serde-free.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct DetectInput {
+    columns: Vec<String>,
+    domains: Vec<(String, Vec<String>)>,
+    min_score: f64,
+}
+
+#[derive(Serialize)]
+struct DetectOutput {
+    domain: Option<String>,
+    score: f64,
+    runner_up: Option<String>,
+    runner_up_score: f64,
+    reason: String,
+}
+
+/// Host-testable core of the boundary. Parses the resolved detect input, calls
+/// the pyo3-free kernel, serializes the Detection. Panics on malformed JSON
+/// (the TS caller always sends well-formed input built from typed values).
+pub fn detect_domain_json_impl(input_json: &str) -> String {
+    let inp: DetectInput =
+        serde_json::from_str(input_json).expect("valid detect input json");
+    let d = infermap_core::detect_domain(&inp.columns, &inp.domains, inp.min_score);
+    let out = DetectOutput {
+        domain: d.domain,
+        score: d.score,
+        runner_up: d.runner_up,
+        runner_up_score: d.runner_up_score,
+        reason: d.reason,
+    };
+    serde_json::to_string(&out).expect("serialize detect output")
+}
+
+// wasm-only surface: the free `detect_domain_json` export the TS glue calls.
+// Mirrors analysis-wasm's `#[cfg(target_arch="wasm32")] mod` re-export.
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub fn detect_domain_json(input_json: &str) -> String {
+        super::detect_domain_json_impl(input_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confident_detect_round_trips() {
+        let input = r#"{"columns":["provider_npi","first_name"],
+            "domains":[["health",["provider npi"]],["fin",["iban"]]],"min_score":0.3}"#;
+        let out = detect_domain_json_impl(input);
+        // health scores 1/2=0.5 (provider_npi matches), fin 0 -> confident health.
+        assert!(out.contains(r#""domain":"health""#));
+        assert!(out.contains(r#""reason":"confident""#));
+    }
+
+    #[test]
+    fn empty_columns_is_no_data() {
+        let input = r#"{"columns":[],"domains":[["h",["x"]]],"min_score":0.3}"#;
+        let out = detect_domain_json_impl(input);
+        assert!(out.contains(r#""reason":"no_data""#));
+        assert!(out.contains(r#""domain":null"#));
+    }
+}
+```
+
+- [ ] **Step 3: Eye-verify (NO cargo).** Confirm against `score-wasm/src/lib.rs` + `analysis-wasm/src/lib.rs`: the `#[cfg(target_arch="wasm32")] mod wasm` re-export shape; the DTO fields match the real `Detection` struct (read `infermap-core/src/lib.rs`: `domain: Option<String>, score: f64, runner_up: Option<String>, runner_up_score: f64, reason: String`); the call is `infermap_core::detect_domain(&inp.columns, &inp.domains, inp.min_score)`. Confirm `serde`/`serde_json` are NOT added to `infermap-core`.
+
+- [ ] **Step 4: Commit** (Cargo.lock is generated by CI's first build; do NOT hand-write it — see Task 2 note):
+```bash
+cd "D:/show_case/gg-local-llm"
+git add packages/rust/extensions/infermap-wasm/Cargo.toml packages/rust/extensions/infermap-wasm/src/lib.rs
+git commit -m "feat(infermap-wasm): crate scaffold + detect_domain_json boundary (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, and confirm infermap-core untouched.
+
+> **Cargo.lock note:** the crate needs a committed `Cargo.lock` so `build_wasm.sh`
+> can read the pinned `wasm-bindgen` version. The box can't run `cargo generate-lockfile`.
+> Task 2 handles this: the lockfile is generated in CI on first run and committed,
+> OR (fallback) hand-authored minimally. Flag it for the controller; do NOT block Task 1.
+
+---
+
+## Task 2: `build_wasm.sh` + artifact gitignore
+
+**Files:** Create `packages/rust/extensions/infermap-wasm/build_wasm.sh`, `packages/typescript/infermap/src/core/wasm/artifacts/.gitignore`.
+**Box:** eye-review + `bash -n` syntax check only.
+
+- [ ] **Step 1: `build_wasm.sh`** — mirror `score-wasm/build_wasm.sh` MINUS its base64 universal-loader tail (spec §2 rejects it). Out-dir = the infermap TS package artifacts; out-name `infermap_wasm`:
+```bash
+#!/usr/bin/env bash
+# Build infermap-wasm for wasm32 and copy the artifact + glue into the infermap
+# TS package. Requires: rustup wasm32 target + wasm-bindgen-cli (installed here at
+# the version pinned in Cargo.lock — a CLI/crate skew produces broken glue that
+# fails at RUNTIME, not build time). Run from anywhere.
+set -euo pipefail
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+export PATH="$CARGO_HOME/bin:$PATH"
+
+CRATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$CRATE_DIR/../../../typescript/infermap/src/core/wasm/artifacts"
+
+rustup target add wasm32-unknown-unknown
+cargo build --manifest-path "$CRATE_DIR/Cargo.toml" --target wasm32-unknown-unknown --release
+
+WB_VER="$(grep -A1 '^name = "wasm-bindgen"$' "$CRATE_DIR/Cargo.lock" | grep '^version = ' | head -1 | sed -E 's/version = "([^"]+)"/\1/')"
+if [ -z "$WB_VER" ]; then echo "could not resolve wasm-bindgen version from Cargo.lock" >&2; exit 1; fi
+echo "Using wasm-bindgen $WB_VER"
+if ! wasm-bindgen --version 2>/dev/null | grep -q "$WB_VER"; then
+  cargo install wasm-bindgen-cli --version "=$WB_VER" --locked
+fi
+command -v wasm-bindgen >/dev/null 2>&1 || { echo "wasm-bindgen not on PATH after install; aborting" >&2; exit 1; }
+
+wasm-bindgen \
+  "$CRATE_DIR/target/wasm32-unknown-unknown/release/infermap_wasm.wasm" \
+  --target web --out-dir "$OUT_DIR" --out-name infermap_wasm
+
+echo "Artifact written to $OUT_DIR (infermap_wasm_bg.wasm + infermap_wasm.js)"
+```
+
+- [ ] **Step 2: artifacts `.gitignore`** — mirror the analysis one exactly (create the dir via the file):
+`packages/typescript/infermap/src/core/wasm/artifacts/.gitignore`:
+```
+# Built by infermap-wasm/build_wasm.sh (CI) — never committed.
+infermap_wasm_bg.wasm
+infermap_wasm.js
+infermap_wasm.d.ts
+infermap_wasm_bg.wasm.d.ts
+```
+
+- [ ] **Step 3: Verify.** `bash -n packages/rust/extensions/infermap-wasm/build_wasm.sh` (syntax OK). Confirm `OUT_DIR` resolves to `packages/typescript/infermap/src/core/wasm/artifacts` from the crate dir (3 `../` up from `extensions/infermap-wasm` → `packages/`, then `typescript/infermap/...`). Confirm the `.gitignore` matches `goldenanalysis/.../artifacts/.gitignore` with `infermap` substituted.
+
+- [ ] **Step 4: Commit:**
+```bash
+git add packages/rust/extensions/infermap-wasm/build_wasm.sh packages/typescript/infermap/src/core/wasm/artifacts/.gitignore
+git commit -m "build(infermap-wasm): build_wasm.sh + artifact gitignore (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, and the resolved `OUT_DIR` path.
+
+---
+
+## Task 3: TS wasm module — `backend.ts` / `loader.ts` / `index.ts`
+
+**Files:** Create the three under `packages/typescript/infermap/src/core/wasm/`.
+**Box:** eye-review only (no tsc). Mirror `goldenanalysis/src/core/wasm/*` exactly.
+
+- [ ] **Step 1: `backend.ts`:**
+```ts
+/**
+ * backend.ts — opt-in WASM detect backend registry. Edge-safe: no node:* here.
+ * Mirrors goldenanalysis's wasm/backend.ts (module-singleton registry).
+ */
+import { createBackendRegistry } from "goldenmatch-wasm-runtime";
+import type { DetectionResult } from "goldencheck-types";
+
+/** A WASM-backed detect kernel. Dictionary resolution stays host; this scores a
+ *  resolved [name, hints[]] domain list. */
+export interface InfermapBackend {
+  detectDomain(
+    columns: string[],
+    domains: Array<[string, string[]]>,
+    minScore: number,
+  ): DetectionResult;
+}
+
+const _registry = createBackendRegistry<InfermapBackend>();
+
+export function setInfermapBackend(b: InfermapBackend | null): void {
+  _registry.set(b);
+}
+
+export function getInfermapBackend(): InfermapBackend | null {
+  return _registry.get();
+}
+```
+
+- [ ] **Step 2: `loader.ts`** (mirror analysis loader; adapt the JSON boundary):
+```ts
+/**
+ * loader.ts — instantiate infermap-wasm and adapt it to an InfermapBackend.
+ * The wasm-bindgen glue import is dynamic (absent in a default checkout).
+ */
+import type { DetectionResult } from "goldencheck-types";
+import type { InfermapBackend } from "./backend.js";
+
+export async function instantiateBackend(bytes: Uint8Array): Promise<InfermapBackend> {
+  const glue = (await import("./artifacts/infermap_wasm.js" as string)) as {
+    default: (input: { module_or_path: Uint8Array }) => Promise<unknown>;
+    detect_domain_json: (input_json: string) => string;
+  };
+  await glue.default({ module_or_path: bytes });
+  return {
+    detectDomain(columns, domains, minScore) {
+      // One JSON crossing per call (perf-audit lesson).
+      const input = JSON.stringify({ columns, domains, min_score: minScore });
+      return JSON.parse(glue.detect_domain_json(input)) as DetectionResult;
+    },
+  };
+}
+```
+
+- [ ] **Step 3: `index.ts`** (mirror `goldenanalysis/src/core/wasm/index.ts`):
+```ts
+/**
+ * Public opt-in WASM API for infermap detect. enableInfermapWasm() is async;
+ * after it resolves, the sync detectDomain* runs against the instantiated module.
+ * Pure-TS stays the default + fallback. Plumbing lives in goldenmatch-wasm-runtime.
+ */
+import { enableWasmBackend, type EnableOptions } from "goldenmatch-wasm-runtime";
+import { setInfermapBackend } from "./backend.js";
+
+export type { InfermapBackend } from "./backend.js";
+export type EnableInfermapWasmOptions = EnableOptions;
+
+let _enabled = false;
+
+export async function enableInfermapWasm(
+  opts: EnableInfermapWasmOptions = {},
+): Promise<boolean> {
+  if (_enabled) return true;
+  try {
+    const { instantiateBackend } = await import("./loader.js");
+    const ok = await enableWasmBackend(
+      opts,
+      instantiateBackend,
+      setInfermapBackend,
+      new URL("./artifacts/infermap_wasm_bg.wasm", import.meta.url),
+    );
+    if (ok) _enabled = true;
+    return ok;
+  } catch (err) {
+    if (opts.require) throw err;
+    return false;
+  }
+}
+
+export function disableInfermapWasm(): void {
+  setInfermapBackend(null);
+  _enabled = false;
+}
+```
+
+- [ ] **Step 4: Eye-verify** against `goldenanalysis/src/core/wasm/{backend,loader,index}.ts`: the `createBackendRegistry`/`enableWasmBackend` arg order + `glue.default({module_or_path})` shape + the `new URL("./artifacts/infermap_wasm_bg.wasm", import.meta.url)` line must match (with `infermap`/`detect` substituted). Confirm `.js` extensions on all relative imports (ESM/nodenext).
+
+- [ ] **Step 5: Commit:**
+```bash
+git add packages/typescript/infermap/src/core/wasm/backend.ts packages/typescript/infermap/src/core/wasm/loader.ts packages/typescript/infermap/src/core/wasm/index.ts
+git commit -m "feat(infermap-ts): wasm backend/loader/index scaffold (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA.
+
+---
+
+## Task 4: `detect.ts` hoist refactor + `scoreDomains` + backend dispatch
+
+**Files:** Modify `packages/typescript/infermap/src/core/detect.ts`.
+**Box:** eye-review only. The existing `tests/domainPack.test.ts` (which tests `detectDomain`) must stay green — verified in CI.
+
+**Context:** Today `detectDomainDetailed` FUSES hint-resolution into the scoring loop (`domains` is a `string[]` of names; `loadDomain`+`allHints` Set built inline per-name). This task (a) hoists resolution into a pre-pass producing `resolved: Array<[string,string[]]>`, (b) extracts the pure scoring into an exported `scoreDomains(columns, resolved, minScore)` (byte-identical to the old inline scoring, for the parity gate), and (c) dispatches to the backend when set. Public API unchanged.
+
+- [ ] **Step 1: Add the import** near the top of `detect.ts` (after the existing `goldencheck-types` imports):
+```ts
+import { getInfermapBackend } from "./wasm/backend.js";
+```
+
+- [ ] **Step 2: Add the exported `scoreDomains`** (place it above `detectDomainDetailed`). This is the current inline scoring, verbatim, re-expressed over a resolved list:
+```ts
+/** Pure scoring over resolved [name, hints[]] domains — the WASM parity oracle.
+ *  Byte-identical to infermap-core::detect_domain for NON-EMPTY columns. The
+ *  empty-columns `no_data` guard lives in detectDomainDetailed (the kernel guards
+ *  it too), so scoreDomains is never called with empty columns in production. */
+export function scoreDomains(
+  columns: string[],
+  resolved: Array<[string, string[]]>,
+  minScore: number,
+): DetectionResult {
+  const scored: Array<[string, number]> = [];
+  for (const [name, hints] of resolved) {
+    if (hints.length === 0) continue; // == Rust `hints.is_empty()` skip
+    let hits = 0;
+    for (const c of columns) {
+      for (const h of hints) {
+        if (hintMatches(h, c)) {
+          hits++;
+          break;
+        }
+      }
+    }
+    scored.push([name, hits / Math.max(columns.length, 1)]);
+  }
+  if (scored.length === 0) {
+    return { domain: null, score: 0, runner_up: null, runner_up_score: 0, reason: "no_data" };
+  }
+  scored.sort((a, b) => b[1] - a[1]);
+  const [bestName, bestScore] = scored[0]!;
+  const runner = scored[1];
+  const runnerName = runner ? runner[0] : null;
+  const runnerScore = runner ? runner[1] : 0;
+  if (bestScore < minScore) {
+    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "below_min_score" };
+  }
+  const topCount = scored.filter(([, s]) => s === bestScore).length;
+  if (topCount > 1) {
+    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "tie" };
+  }
+  return { domain: bestName, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "confident" };
+}
+```
+
+- [ ] **Step 3: Rewrite the scoring region of `detectDomainDetailed`.** Keep the column-resolution + BOTH `no_data` early guards (no columns / empty columns) exactly as they are. Replace everything from `const domains = candidates ?? ...` through the final `return {... "confident"}` with the resolve pre-pass + dispatch:
+```ts
+  const domainNames = candidates ?? listDomains().filter((d) => d !== "generic");
+  // Hoist hint resolution into a pre-pass so the SAME resolved input feeds the
+  // kernel or the pure path. Empty-hint domains are INCLUDED (both paths skip
+  // them: kernel via hints.is_empty(), pure via hints.length===0), so scoring is
+  // identical to the pre-refactor inline loop.
+  const resolved: Array<[string, string[]]> = domainNames.map((d) => {
+    const pack = loadDomain(d);
+    const allHints = new Set<string>();
+    for (const spec of Object.values(pack.types)) {
+      for (const h of spec.name_hints) allHints.add(h);
+    }
+    return [d, Array.from(allHints)];
+  });
+
+  const backend = getInfermapBackend();
+  if (backend) {
+    return backend.detectDomain(columns, resolved, minScore);
+  }
+  return scoreDomains(columns, resolved, minScore);
+```
+
+- [ ] **Step 4: Eye-verify byte-identity.** Read the pre-refactor `detectDomainDetailed` (git: `git show HEAD:packages/typescript/infermap/src/core/detect.ts`). Confirm the pure path (resolve → `scoreDomains`) produces the SAME `scored` set and the SAME sort/tie/threshold tail: same domain iteration order (`domainNames` order == old `domains` order), empty-hint domains skipped identically, `hits / Math.max(columns.length, 1)` unchanged, `sort((a,b)=>b[1]-a[1])` + `filter(s===bestScore)` tail verbatim. Confirm `columns`/candidate resolution + the two `no_data` guards are untouched and still precede the resolve pre-pass.
+
+- [ ] **Step 5: Commit:**
+```bash
+git add packages/typescript/infermap/src/core/detect.ts
+git commit -m "refactor(infermap-ts): hoist detect hint-resolution + scoreDomains + wasm dispatch (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, and a one-line confirmation the pure path is byte-identical to pre-refactor.
+
+---
+
+## Task 5: `package.json` devDep + `tsup.config.ts` artifact keys
+
+**Files:** Modify `packages/typescript/infermap/package.json`, `.../tsup.config.ts`.
+**Box:** JSON/eye-review. Confirm against `goldenanalysis/{package.json,tsup.config.ts}`.
+
+- [ ] **Step 1: Add the devDependency.** In `packages/typescript/infermap/package.json`, add to **`devDependencies`** (NOT `dependencies` — it's inlined by tsup, never published):
+```json
+    "goldenmatch-wasm-runtime": "workspace:^",
+```
+(Match the existing `devDependencies` block's formatting/ordering. If there's no `devDependencies` block, add one.)
+
+- [ ] **Step 2: Update `tsup.config.ts`.** Replace `dts: true` with the resolve form and add the artifact-shipping keys (mirror `goldenanalysis/tsup.config.ts`):
+```ts
+  // resolve: roll the bundled goldenmatch-wasm-runtime types INTO our .d.ts
+  // (noExternal inlines the JS, but tsup keeps a bare import in the dts otherwise).
+  dts: { resolve: ["goldenmatch-wasm-runtime"] },
+  // Copy the opt-in WASM artifact into dist so the loader's
+  // new URL('./artifacts/infermap_wasm_bg.wasm', import.meta.url) resolves at
+  // runtime. Absent in a default checkout -> enableInfermapWasm() returns false.
+  loader: { ".wasm": "copy" },
+  publicDir: false,
+  onSuccess: "node scripts/copy_wasm_artifact.mjs",
+  // Inline the tiny WASM plumbing so it's not a published runtime dep.
+  noExternal: ["goldenmatch-wasm-runtime"],
+  external: [
+    // Runtime-only wasm-bindgen glue (dynamic-imported in enableInfermapWasm);
+    // absent in a default checkout. Mark external so esbuild never resolves it.
+    /infermap_wasm\.js$/,
+  ],
+```
+Keep the existing `entry`, `format`, `sourcemap`, `clean`, `target`, `splitting`, `treeshake` keys. (The `node/a2a/server` entry, if present from an earlier PR, stays.)
+
+- [ ] **Step 3: Verify.** `python -c "import json; json.load(open('packages/typescript/infermap/package.json')); print('package.json OK')"`. Eye-compare the tsup keys against `goldenanalysis/tsup.config.ts` (only the `analysis_wasm`→`infermap_wasm` substring differs). Confirm `dts: true` is gone.
+
+- [ ] **Step 4: Commit:**
+```bash
+git add packages/typescript/infermap/package.json packages/typescript/infermap/tsup.config.ts
+git commit -m "build(infermap-ts): wasm-runtime devDep + tsup artifact-shipping keys (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, package.json-OK.
+
+> **Lockfile note for the controller:** adding a workspace devDep changes
+> `pnpm-lock.yaml`. The box may not be able to run `pnpm install` (OOM). If the CI
+> `typescript`/`infermap_wasm` lane fails on a frozen-lockfile mismatch, the
+> controller regenerates `pnpm-lock.yaml` in a later step (or CI does). Flag, don't block.
+
+---
+
+## Task 6: `copy_wasm_artifact.mjs`
+
+**Files:** Create `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs`.
+**Box:** `node --check` (this IS box-runnable — it's an `.mjs`).
+
+- [ ] **Step 1: Create the script** (mirror `goldenanalysis/scripts/copy_wasm_artifact.mjs`, `analysis`→`infermap`):
+```js
+// Copy the built WASM artifact from src into the dist locations the bundled
+// loader might resolve `new URL('./artifacts/infermap_wasm_bg.wasm', import.meta.url)`
+// to. tsup bundling can land the loader at several depths; copy to every plausible
+// `./artifacts/` parent (a few KB, harmless). No-op (warns) when the artifact is absent.
+import { cp, mkdir, access } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, "..", "src", "core", "wasm", "artifacts");
+const files = ["infermap_wasm_bg.wasm", "infermap_wasm.js"];
+const dsts = [
+  join(here, "..", "dist", "core", "wasm", "artifacts"),
+  join(here, "..", "dist", "core", "artifacts"),
+  join(here, "..", "dist", "artifacts"),
+];
+
+try {
+  await access(join(src, files[0]));
+} catch {
+  console.warn("[copy_wasm_artifact] no WASM artifact in src — skipping (pure-TS default).");
+  process.exit(0);
+}
+for (const dst of dsts) {
+  await mkdir(dst, { recursive: true });
+  for (const f of files) await cp(join(src, f), join(dst, f));
+}
+console.log("[copy_wasm_artifact] copied", files.join(", "), "to", dsts.length, "dist locations");
+```
+
+- [ ] **Step 2: Verify:** `node --check packages/typescript/infermap/scripts/copy_wasm_artifact.mjs` → no output = OK. Eye-compare against the analysis script (`analysis_wasm`→`infermap_wasm` in `files`).
+
+- [ ] **Step 3: Commit:**
+```bash
+git add packages/typescript/infermap/scripts/copy_wasm_artifact.mjs
+git commit -m "build(infermap-ts): copy_wasm_artifact.mjs dist fan-out (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, `node --check` result.
+
+---
+
+## Task 7: Parity gate — `infermap-wasm.parity.test.ts`
+
+**Files:** Create `packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts`.
+**Box:** eye-review (no vitest). Runs un-skipped only in CI (artifact present).
+
+**Design:** compares the WASM backend (`getInfermapBackend().detectDomain`, the Rust kernel) against the pure `scoreDomains` over a SYNTHETIC domain corpus with NON-EMPTY columns — the 8 Wave-1 Python parity cases minus the empty-columns case (excluded because the kernel guards empty→no_data while `scoreDomains` assumes the caller guarded it; they are equivalent only for non-empty columns, which is all production ever feeds them). This is the truest drift audit: identical synthetic inputs to both engines.
+
+- [ ] **Step 1: Create the test:**
+```ts
+/**
+ * WASM-vs-pure-TS parity for infermap `detect`. The WASM backend wraps
+ * infermap-core::detect_domain (== Python == the Rust FFI); scoreDomains is the
+ * pure-TS reimplementation. This gate asserts they agree byte-for-byte over a
+ * synthetic domain corpus (the Wave-1 kernel-parity cases, non-empty columns).
+ *
+ * Skipped when the built artifact is absent (default checkout / no toolchain);
+ * the CI `infermap_wasm` lane builds it first and runs this un-skipped. Any
+ * DISAGREEMENT is a real TS-vs-Rust `detect` drift finding (hintMatches token
+ * logic, tie order) — WASM is the reference; surface it, don't skip it.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { scoreDomains } from "../../src/core/detect.js";
+import {
+  enableInfermapWasm,
+  disableInfermapWasm,
+} from "../../src/core/wasm/index.js";
+import { getInfermapBackend } from "../../src/core/wasm/backend.js";
+
+const artifact = fileURLToPath(
+  new URL("../../src/core/wasm/artifacts/infermap_wasm_bg.wasm", import.meta.url),
+);
+const d = existsSync(artifact) ? describe : describe.skip;
+
+// (columns, domains [name,hints[]][], minScore) — non-empty columns only.
+// Mirrors infermap Python test_native_parity._CASES (minus the empty-columns case).
+type Case = [string[], Array<[string, string[]]>, number];
+const CASES: Case[] = [
+  [["provider_npi", "first_name"], [["health", ["provider npi"]], ["fin", ["iban"]]], 0.3], // confident
+  [["a", "b"], [["x", ["a"]], ["y", ["b"]]], 0.3], // 2-way tie
+  [["a", "b"], [["x", ["a"]], ["y", ["b"]], ["z", ["a"]]], 0.3], // 3-way tie (host order)
+  [["a", "b", "c", "d"], [["h", ["a"]]], 0.3], // below_min_score (0.25)
+  [["a"], [["h", []]], 0.3], // no_data (all hint-less)
+  [["patient_id", "provider_npi", "dob"], [["health", ["patient id", "npi"]], ["fin", ["iban"]]], 0.3],
+  [["a"], [["h", ["a b c"]]], 0.3], // hint longer than column
+  [["ORDER_ID", "Sku"], [["ecom", ["order id", "sku"]]], 0.3], // ASCII case-insensitivity
+];
+
+d("infermap detect WASM-vs-pure parity", () => {
+  afterAll(() => disableInfermapWasm());
+
+  it("enableInfermapWasm() succeeds in this lane (artifact present)", async () => {
+    disableInfermapWasm();
+    const ok = await enableInfermapWasm({ require: true });
+    expect(ok).toBe(true);
+    disableInfermapWasm();
+  });
+
+  for (let i = 0; i < CASES.length; i++) {
+    const [columns, domains, minScore] = CASES[i]!;
+    it(`case ${i}: kernel == scoreDomains`, async () => {
+      const pure = scoreDomains(columns, domains, minScore);
+      const ok = await enableInfermapWasm({ require: true });
+      expect(ok).toBe(true);
+      const backend = getInfermapBackend()!;
+      const wasm = backend.detectDomain(columns, domains, minScore);
+      disableInfermapWasm();
+      expect(wasm).toEqual(pure); // deep-equal DetectionResult; drift => fail
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Eye-verify.** Confirm the `existsSync(artifact) ? describe : describe.skip` skip pattern matches `goldenanalysis/tests/parity/wasm-aggregate.test.ts`. Confirm imports resolve to real exports: `scoreDomains` from `detect.ts` (Task 4), `enable/disableInfermapWasm` from `wasm/index.ts`, `getInfermapBackend` from `wasm/backend.ts`. Confirm NO empty-columns case (would spuriously fail: kernel no_data vs scoreDomains below_min).
+
+- [ ] **Step 3: Commit:**
+```bash
+git add packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts
+git commit -m "test(infermap-ts): WASM-vs-pure detect parity gate (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA.
+
+---
+
+## Task 8: CI `infermap_wasm` lane + paths-filter
+
+**Files:** Modify `.github/workflows/ci.yml`.
+**Box:** YAML-validate.
+
+- [ ] **Step 1: Add the paths-filter output** in the `changes` job's `outputs:` block (near the `analysis_wasm:` output line, ~line 87):
+```yaml
+      infermap_wasm: ${{ steps.filter.outputs.infermap_wasm }}
+```
+
+- [ ] **Step 2: Add the filter entry** in the `dorny/paths-filter` `filters:` block (after the `analysis_wasm:` filter, ~line 234), mirroring it:
+```yaml
+            infermap_wasm:
+              - 'packages/rust/extensions/infermap-wasm/**'
+              - 'packages/rust/extensions/infermap-core/**'
+              - 'packages/typescript/goldenmatch-wasm-runtime/**'
+              - 'packages/typescript/infermap/src/core/wasm/**'
+              - 'packages/typescript/infermap/src/core/detect.ts'
+              - 'packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts'
+              - 'packages/typescript/infermap/scripts/copy_wasm_artifact.mjs'
+              - 'packages/typescript/infermap/tsup.config.ts'
+```
+
+- [ ] **Step 3: Add the job** after the `analysis_wasm:` job (~line 1934), mirroring it step-for-step:
+```yaml
+  infermap_wasm:
+    needs: changes
+    if: needs.changes.outputs.infermap_wasm == 'true' || needs.changes.outputs.force_all == 'true'
+    # Opt-in WASM detect lane: builds the infermap-wasm artifact, then runs the
+    # detect parity test UN-skipped (skips elsewhere with no artifact). Advisory.
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/infermap-wasm
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - name: Build WASM artifact (installs the matching wasm-bindgen-cli)
+        run: bash packages/rust/extensions/infermap-wasm/build_wasm.sh
+      - name: Build shared wasm-runtime (the parity test imports goldenmatch-wasm-runtime)
+        run: pnpm --filter goldenmatch-wasm-runtime build
+      - name: WASM detect parity (un-skipped — artifact now present) [THE GATE]
+        run: pnpm --filter infermap exec vitest run tests/parity/infermap-wasm.parity.test.ts
+      - name: dist-path validation (enableInfermapWasm() must resolve the bundled artifact)
+        run: |
+          pnpm --filter infermap build
+```
+
+- [ ] **Step 4: Validate YAML + eye-check** (a broken ci.yml = zero jobs = required gate never reports):
+```bash
+"D:/show_case/goldenmatch/.venv/Scripts/python.exe" -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml YAML OK')"
+grep -n "infermap_wasm" .github/workflows/ci.yml
+```
+Expect: `ci.yml YAML OK`; the output line, the filter block, and the job all present. **Confirm the `pnpm --filter infermap` name matches `packages/typescript/infermap/package.json`'s `"name"` (it's `infermap`).**
+
+- [ ] **Step 5: Commit:**
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(infermap): infermap_wasm advisory lane + paths-filter (Wave A)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, SHA, YAML-OK + grep output.
+
+---
+
+## Task 9: Rebase + push + PR + arm auto-merge (controller runs this)
+
+**Files:** none.
+
+- [ ] **Step 1: Rebase onto fresh origin/main** (main moves fast):
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q
+git rebase origin/main
+```
+Conflicts unlikely (all-new files + isolated `detect.ts`/`tsup.config.ts`/`package.json`/`ci.yml` regions). If `ci.yml` conflicts against another lane addition, keep both. Re-validate YAML after any resolution.
+
+- [ ] **Step 2: Confirm the three-dot diff is clean:**
+```bash
+git diff --stat origin/main...HEAD
+```
+Expect only the Wave A files (spec, plan, the crate, the TS wasm module + detect.ts + package.json + tsup + copy script + parity test + ci.yml). If unrelated files appear, STOP.
+
+- [ ] **Step 3: Push:**
+```bash
+git push -u origin feat/infermap-wasm-wave-a
+```
+
+- [ ] **Step 4: Open the PR:**
+```bash
+gh pr create --repo benseverndev-oss/goldenmatch --base main \
+  --title "feat(infermap): WASM/TS Wave A — infermap-wasm foundation + detect_domain" \
+  --body "$(cat <<'EOF'
+## What
+
+Wave A of the InferMap WASM/TS surface: a new `infermap-wasm` wasm-bindgen crate over `infermap-core`, the TS `wasm/{backend,loader,index}.ts` plumbing, a build script, a CI lane, and a byte-parity gate — with `detect_domain` wired through end to end.
+
+Makes the TS `infermap` surface run the SAME `infermap-core` kernel Python's native wheel runs, instead of its separate hand-written reimplementation (anti-drift).
+
+## How
+
+- **Crate**: `detect_domain_json(input_json) -> output_json` — JSON boundary crossed once per call; serde DTOs in the wrapper, `infermap-core` stays serde-free.
+- **TS**: `detect.ts` hoists hint-resolution into a pre-pass, then dispatches to the WASM backend (or the pure `scoreDomains` fallback). Public API unchanged; the pure path is byte-identical to before.
+- **Artifact**: CI-built, not committed (`describe.skip` locally; the `infermap_wasm` lane builds it then runs parity un-skipped). Build = `cargo build` + pinned `wasm-bindgen-cli`, mirroring `score-wasm/build_wasm.sh`.
+
+## Parity = drift audit
+
+`infermap-wasm.parity.test.ts` asserts `kernel.detectDomain` deep-equals pure `scoreDomains` over the 8 Wave-1 synthetic detect cases (non-empty columns). Any disagreement is a real TS-vs-Rust `detect` divergence (hintMatches token logic / tie order) — WASM is the reference; surfaced here, not papered over. **If CI reddens on a parity case, that is the audit working** — the PR notes the divergence + resolution.
+
+## Scope
+
+Foundation + one kernel. The other 5 kernels are Waves B/C.
+
+Spec: `docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md`
+Plan: `docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+EOF
+)"
+```
+
+- [ ] **Step 5: Arm auto-merge + STOP:**
+```bash
+gh pr merge <PR#> --repo benseverndev-oss/goldenmatch --squash --auto
+```
+Do NOT `--delete-branch`. Do NOT poll CI. **BUT:** this lane's parity test is a drift audit that may legitimately red. After arming, do ONE check of the `infermap_wasm` lane result: if it fails on a parity assertion, that is a real finding to investigate + report (not a flaky infra fail) — the WASM/Rust detect and the pure-TS detect genuinely diverge on that input, and the resolution is to make WASM the reference and document/fix the pure path in a follow-up. Report the PR number + the drift status.
+
+---
+
+## Verification Summary
+
+| What | How | Where |
+| --- | --- | --- |
+| Crate compiles + boundary round-trips | Rust `#[cfg(test)]` host unit tests | CI (Task 1) |
+| wasm builds + glue emitted | `build_wasm.sh` in the lane | CI (Task 8) |
+| TS wasm module typechecks | tsc/tsup in `typescript` + `infermap_wasm` lanes | CI (Tasks 3,5) |
+| detect pure path byte-identical | existing `domainPack.test.ts` stays green | CI (Task 4) |
+| **WASM kernel == pure scoreDomains** | `infermap-wasm.parity.test.ts` (8 cases, deep-equal) | CI `infermap_wasm` lane (Task 7) — **drift audit** |
+| copy script valid | `node --check` | Box (Task 6) |
+| ci.yml valid | `yaml.safe_load` | Box (Task 8) |
+| No unrelated diff | three-dot diff | Box (Task 9) |

--- a/docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md
+++ b/docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md
@@ -193,10 +193,13 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
 
 **Report:** `DONE`/`BLOCKED`, SHA, and confirm infermap-core untouched.
 
-> **Cargo.lock note:** the crate needs a committed `Cargo.lock` so `build_wasm.sh`
-> can read the pinned `wasm-bindgen` version. The box can't run `cargo generate-lockfile`.
-> Task 2 handles this: the lockfile is generated in CI on first run and committed,
-> OR (fallback) hand-authored minimally. Flag it for the controller; do NOT block Task 1.
+> **Cargo.lock note:** `build_wasm.sh` reads the pinned `wasm-bindgen` version from
+> `Cargo.lock`. The box can't run `cargo generate-lockfile`, and it is NOT needed to
+> commit one: the lane's `cargo build --release` regenerates `Cargo.lock` in-place in
+> the SAME run *before* the `grep '^name = "wasm-bindgen"'` reads it (no CLI/crate skew
+> within one run). Do NOT hand-author a lockfile. OPTIONAL polish (controller, after the
+> first green CI run): commit the generated `Cargo.lock` for reproducible pinning across
+> runs, matching score/analysis/goldenflow-wasm. Not a blocker.
 
 ---
 
@@ -716,6 +719,13 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
         run: bash packages/rust/extensions/infermap-wasm/build_wasm.sh
       - name: Build shared wasm-runtime (the parity test imports goldenmatch-wasm-runtime)
         run: pnpm --filter goldenmatch-wasm-runtime build
+      - name: Build infermap's sibling deps (detect.ts imports goldencheck-types)
+        # vitest resolves goldencheck-types from its dist/ (not checked in), and
+        # the parity test imports src/core/detect.ts which imports it. Build the
+        # upstream sibling graph first (the goldenpipe_wasm lane uses the same
+        # `^...` pattern). Also unblocks the final `pnpm --filter infermap build`
+        # whose dts:{resolve} needs goldencheck-types' dist .d.ts.
+        run: pnpm --filter "infermap^..." build
       - name: WASM detect parity (un-skipped — artifact now present) [THE GATE]
         run: pnpm --filter infermap exec vitest run tests/parity/infermap-wasm.parity.test.ts
       - name: dist-path validation (enableInfermapWasm() must resolve the bundled artifact)

--- a/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
+++ b/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
@@ -139,6 +139,12 @@ signature (`&[String]`, `&[(String, Vec<String>)]`, `f64`) already matches the D
 
 ## 4. TS wiring — `packages/typescript/infermap/src/core/wasm/`
 
+> **Dependency:** `packages/typescript/infermap/package.json` currently depends
+> only on `goldencheck-types`. Wave A must add
+> `"goldenmatch-wasm-runtime": "workspace:^"` (the source of
+> `createBackendRegistry` / `enableWasmBackend` / `EnableOptions`). Every existing
+> `*_wasm` TS package carries this dep.
+
 ### `backend.ts`
 ```ts
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";
@@ -171,41 +177,99 @@ whose `detectDomain` JSON-stringifies `{columns, domains, min_score}`, calls
 instantiateBackend, setInfermapBackend, new URL("./artifacts/infermap_wasm_bg.wasm",
 import.meta.url))`; `disable` calls `setInfermapBackend(null)`.
 
-## 5. Wire `detect.ts`
+## 5. Wire `detect.ts` (requires a hint-resolution hoist, not a drop-in)
 
-The **dictionary resolution stays host** (JS `listDomains()`/`loadDomain()`) —
-identical to Python's `detect.py` split, where only the resolved-input scoring
-core is the kernel. In `detectDomainDetailed`, after `columns` and the resolved
-`domains: Array<[string, string[]]>` are built and the early `no_data` guards
-pass, consult the backend:
+**Reality of the current code:** `detectDomainDetailed` does NOT materialize a
+`[name, hints[]][]` structure. At the scoring point `domains` is a `string[]` of
+*names only* (`candidates ?? listDomains().filter(d => d !== "generic")`), and
+hint expansion is **fused into the scoring loop** — for each name it calls
+`loadDomain(d)`, builds an `allHints` Set inline, `continue`s if empty, and
+scores in the same pass. So Wave A must **hoist** hint-resolution into a pre-pass
+before the backend call, then let the backend (or the pure loop) score over that
+hoisted structure. This is a real refactor of `detectDomainDetailed`, not an
+insert.
+
+The two input-shape `no_data` early returns (no columns / no records) stay host,
+unchanged, before resolution. Then:
 ```ts
+const domainNames = candidates ?? listDomains().filter((d) => d !== "generic");
+
+// Hoist: resolve each candidate's hint-set into a flat [name, hints[]] list so
+// the SAME resolved input feeds the kernel or the pure loop. Empty-hint domains
+// are INCLUDED here (the kernel skips them via `hints.is_empty()`, and the pure
+// loop skips them via `hints.length === 0`), so both paths score identically.
+const resolved: Array<[string, string[]]> = domainNames.map((d) => {
+  const pack = loadDomain(d);
+  const allHints = new Set<string>();
+  for (const spec of Object.values(pack.types)) {
+    for (const h of spec.name_hints) allHints.add(h);
+  }
+  return [d, Array.from(allHints)];
+});
+
 const backend = getInfermapBackend();
 if (backend) {
-  return backend.detectDomain(columns, resolvedDomains, minScore);
+  // Kernel owns ALL scoring below, INCLUDING the scored-empty `no_data`
+  // (Rust detect_domain returns reason "no_data" when nothing scores).
+  return backend.detectDomain(columns, resolved, minScore);
 }
-// ...existing pure-TS scoring below unchanged (the lossy fallback)...
+
+// Pure-TS fallback — byte-identical to today, re-expressed over `resolved`:
+const scored: Array<[string, number]> = [];
+for (const [d, hints] of resolved) {
+  if (hints.length === 0) continue;               // == Rust hints.is_empty() skip
+  let hits = 0;
+  for (const c of columns) {
+    for (const h of hints) { if (hintMatches(h, c)) { hits++; break; } }
+  }
+  scored.push([d, hits / Math.max(columns.length, 1)]);
+}
+if (scored.length === 0) {
+  return { domain: null, score: 0, runner_up: null, runner_up_score: 0, reason: "no_data" };
+}
+// ...existing sort / below-min / tie / confident tail unchanged...
 ```
 Public API (`detectDomain`, `detectDomainDetailed`, `DEFAULT_MIN_SCORE`) is
-**unchanged**; only an internal fast-path is inserted. The exact insertion point
-is after the `columns`/candidate resolution and the two `no_data` early returns,
-so the backend sees the same resolved inputs the pure path would score.
+**unchanged**. The pure path's output is byte-identical to the pre-refactor code
+(same iteration order, same empty-hint skip, same `hits/max(cols,1)`, same
+sort/tie/threshold tail). The backend path delegates the entire scored region —
+including the scored-empty `no_data` — to the kernel.
 
-> The `domains` value passed to the backend must be the SAME resolved
-> `[name, hints[]]` list the pure path scores over (post `listDomains()` filter +
-> `loadDomain()` hint expansion) — the kernel does no dictionary work.
+> Byte-equivalence of "include empty-hint domains in `resolved`": a domain with
+> an empty hint-set contributes nothing in the pure loop (`continue`) and is
+> skipped by the kernel (`hints.is_empty()`), so passing all candidates to the
+> kernel is equivalent to the pre-filter the pure loop did inline.
 
 ## 6. Build + artifact
 
-- `scripts/build_infermap_wasm.mjs` — mirrors `build_goldencheck_wasm.mjs` /
-  analysis: `wasm-pack build packages/rust/extensions/infermap-wasm --target web`,
-  then place `infermap_wasm_bg.wasm` + `infermap_wasm.js` glue into
-  `src/core/wasm/artifacts/`. Requires `wasm-pack` + `wasm32-unknown-unknown`
-  (CI-only; box lacks the toolchain).
-- `scripts/copy_wasm_artifact.mjs` — mirrors analysis: fan the two artifact files
-  out to every plausible `dist/**/artifacts/` parent (tsup bundling ambiguity);
-  no-op with a warning when the artifact is absent.
-- Artifacts are **git-ignored / not committed** (CI-built model). A default
-  checkout has no artifact → pure-TS default, parity test skips.
+**Build model = `cargo build` + pinned `wasm-bindgen-cli`, NOT `wasm-pack`.** The
+§3 crate declares `wasm-bindgen` under a `[target.'cfg(target_arch="wasm32")']`
+table (the score-wasm layout); `wasm-pack`'s dependency detection does not see
+that table, so `wasm-pack build` fails. The established build for this crate
+layout (score-wasm / analysis-wasm / goldenflow-wasm) is a cargo build + the
+`wasm-bindgen` CLI:
+
+- `packages/rust/extensions/infermap-wasm/build_wasm.sh` — a line-for-line mirror
+  of `score-wasm/build_wasm.sh`:
+  1. `rustup target add wasm32-unknown-unknown`
+  2. `cargo build --manifest-path <crate>/Cargo.toml --target wasm32-unknown-unknown --release`
+  3. resolve the pinned `wasm-bindgen` version from the crate's **committed
+     `Cargo.lock`** (`grep -A1 '^name = "wasm-bindgen"$' ... version`), and
+     `cargo install wasm-bindgen-cli --version "=$WB_VER" --locked` if the on-PATH
+     CLI doesn't already match. **A CLI/crate version skew produces broken glue
+     that fails at runtime, not build time** — this pin is load-bearing, which is
+     why `Cargo.lock` is committed for this crate.
+  4. `wasm-bindgen <crate>/target/wasm32-unknown-unknown/release/infermap_wasm.wasm
+     --target web --out-dir packages/typescript/infermap/src/core/wasm/artifacts
+     --out-name infermap_wasm` → emits `infermap_wasm_bg.wasm` + `infermap_wasm.js`.
+- `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs` — mirrors
+  goldenanalysis: fan the two artifact files out to every plausible
+  `dist/**/artifacts/` parent (tsup bundling ambiguity); no-op with a warning when
+  the artifact is absent.
+- **Commit the crate's `Cargo.lock`** (so the pinned `wasm-bindgen` version
+  resolves in CI). The `src/core/wasm/artifacts/*` outputs are **git-ignored /
+  not committed** (CI-built model). A default checkout has no artifact → pure-TS
+  default, parity test skips.
 
 ## 7. Parity gate — `tests/parity/infermap-wasm.parity.test.ts`
 
@@ -236,18 +300,27 @@ tie/edge cases (so the corpus controls the exact `domains` structure).
 
 ## 8. CI — `infermap_wasm` lane
 
-New job in `.github/workflows/ci.yml`, mirroring the `analysis_wasm` lane:
+New job in `.github/workflows/ci.yml`, mirroring the real `analysis_wasm` lane:
 1. `dorny/paths-filter` entry `infermap_wasm` covering
    `packages/rust/extensions/infermap-wasm/**`,
    `packages/rust/extensions/infermap-core/**`,
+   `packages/typescript/goldenmatch-wasm-runtime/**` (every `*_wasm` filter
+   includes it — the parity test imports it),
    `packages/typescript/infermap/src/core/wasm/**`,
    `packages/typescript/infermap/src/core/detect.ts`,
    `packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts`,
-   `scripts/build_infermap_wasm.mjs`.
-2. Job (gated on that filter): install `wasm-pack` + `wasm32-unknown-unknown`,
-   run `node scripts/build_infermap_wasm.mjs`, then run the vitest parity test
-   (un-skipped, artifact now present). Advisory lane (not in the required set),
-   matching the other `*_wasm` lanes.
+   `packages/typescript/infermap/build_wasm.sh` (via the crate path) and
+   `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs`.
+2. Job (gated on that filter), mirroring `analysis_wasm` step-for-step:
+   - `rustup target add wasm32-unknown-unknown`;
+   - run `packages/rust/extensions/infermap-wasm/build_wasm.sh` (cargo build +
+     pinned `wasm-bindgen-cli`, emits the artifact into the TS package);
+   - `pnpm --filter goldenmatch-wasm-runtime build` (the parity test imports this
+     package — the real `analysis_wasm` lane builds it first);
+   - run the vitest parity test un-skipped (artifact now present);
+   - (mirroring analysis) optionally `tsup` build + run `copy_wasm_artifact.mjs`
+     to catch bundled-`dist` path breakage.
+   Advisory lane (not in the required set), matching the other `*_wasm` lanes.
 
 ## 9. Out of scope
 
@@ -275,6 +348,14 @@ New job in `.github/workflows/ci.yml`, mirroring the `analysis_wasm` lane:
 - **Boundary encoding.** JSON is lossless for this shape (§3); the only
   theoretical risk (float formatting) is eliminated by round-trippable f64
   serialization on both sides. Verified by the parity gate.
+- **`detect.ts` hoist refactor must stay byte-identical.** §5 restructures the
+  fused resolve+score loop into a resolve pre-pass + score loop. The pure-path
+  output must be unchanged (same iteration order, empty-hint skip, `hits/max`,
+  sort/tie/threshold tail). This is covered by the existing TS `detect` unit
+  tests (which must stay green after the refactor, box-permitting via CI) AND the
+  new parity corpus. The refactor is mechanical but is the one place a
+  non-WASM regression could slip in, so the pure path is validated independently
+  of the backend.
 
 ## 11. Build environment constraints
 

--- a/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
+++ b/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
@@ -1,0 +1,286 @@
+# InferMap WASM/TS surface — Wave A (foundation + `detect_domain`) design
+
+**Date:** 2026-07-06
+**Status:** Approved (design)
+**Depends on:** InferMap Rust cutover Waves 1–4 (`infermap-core` now exports 6 kernels). Wave A consumes only `detect_domain` (Wave 1).
+**Branch:** `feat/infermap-wasm-wave-a` off fresh `origin/main`.
+
+## 1. Goal
+
+Stand up the *entire* opt-in-WASM pipeline for the TS `infermap` package — a new
+`infermap-wasm` wasm-bindgen crate over `infermap-core`, the TS
+`wasm/{backend,loader,index}.ts` plumbing, a build script, a CI lane, and a
+byte-parity gate — and wire **one** kernel (`detect_domain`) through it end to
+end as the proof.
+
+The payoff is anti-drift: TS `infermap` currently carries a *separate*
+hand-written reimplementation of every scorer + `detect`. WASM makes the TS
+surface run the **same** `infermap-core` kernel that Python's native wheel runs,
+collapsing three surfaces (Python, Rust FFI, TS) onto one reference. This is the
+`project_wasm_acceleration_arc` pattern (score-core #878/#879, analysis-core
+#880) applied to InferMap.
+
+Wave A is the vertical slice. Waves B (name scorers) and C (profile +
+pattern_type) reuse this foundation and are out of scope here.
+
+## 2. Established patterns this mirrors
+
+- **Crate:** `score-wasm` / `goldencheck-wasm` — standalone `[workspace]`,
+  `crate-type = ["cdylib","rlib"]`, path-dep on the `-core`, `wasm-bindgen` under
+  `[target.'cfg(target_arch="wasm32")'.dependencies]`, thin shims delegating to
+  the core so behavior is byte-identical by construction.
+- **Boundary = JSON string, crossed once per call:** `goldencheck-wasm` exposes
+  every entry as `fn foo_json(input_json: &str) -> String` with `serde`/`serde_json`
+  *in the wasm crate* (the `-core` stays serde-free). Correct for `detect_domain`,
+  whose input is nested (`domains: [[name, hints[]]]`) — not a flat typed array.
+- **Artifact model = CI-built, NOT committed:** `analysis-wasm` — the build script
+  emits `src/core/wasm/artifacts/<crate>{_bg.wasm,.js}`; the parity test is
+  `hasArtifact ? describe : describe.skip`; the CI `<pkg>_wasm` lane builds the
+  artifact first, then runs the parity test un-skipped. This is what lets a box
+  that cannot run `wasm-pack` ship the wave — local runs skip, CI proves it (same
+  contract as the Python native-parity lanes).
+- **Enable/loader plumbing:** `goldenmatch-wasm-runtime` provides
+  `createBackendRegistry` + `enableWasmBackend` (byte resolution + env detection);
+  `index.ts` owns the artifact URL + backend, `loader.ts` adapts the glue,
+  `backend.ts` defines the interface + registry.
+
+> Rejected: the `goldencheck-wasm` base64-embed-into-`.ts` artifact model (ships
+> the wasm inside the npm package, edge-safe). It requires a local `wasm-pack`
+> build to generate the committed bytes, which the box cannot do. Noted as a
+> possible later enhancement if edge/browser shipping is wanted; Wave A uses the
+> CI-built model so it is box-shippable.
+
+## 3. The `infermap-wasm` crate (new)
+
+`packages/rust/extensions/infermap-wasm/`
+
+### `Cargo.toml`
+```toml
+[workspace]                      # standalone: neither infermap-core's nor a parent
+                                 # workspace claims this wrapper
+
+[package]
+name = "infermap-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "wasm-bindgen wrapper over infermap-core for the infermap TS opt-in WASM backend"
+
+[lib]
+name = "infermap_wasm"
+crate-type = ["cdylib", "rlib"]  # cdylib for wasm; rlib so host unit tests link
+
+[dependencies]
+infermap-core = { path = "../infermap-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+```
+
+### `src/lib.rs`
+- Local serde DTOs (kept here, NOT in `infermap-core`):
+  ```rust
+  #[derive(Deserialize)]
+  struct DetectInput {
+      columns: Vec<String>,
+      domains: Vec<(String, Vec<String>)>,   // [ [name, hints[]], ... ]
+      min_score: f64,
+  }
+  #[derive(Serialize)]
+  struct DetectOutput {
+      domain: Option<String>,
+      score: f64,
+      runner_up: Option<String>,
+      runner_up_score: f64,
+      reason: String,
+  }
+  ```
+- Host-testable impl:
+  ```rust
+  pub fn detect_domain_json_impl(input_json: &str) -> String {
+      let inp: DetectInput = serde_json::from_str(input_json).expect("valid detect input json");
+      let d = infermap_core::detect_domain(&inp.columns, &inp.domains, inp.min_score);
+      let out = DetectOutput {
+          domain: d.domain, score: d.score,
+          runner_up: d.runner_up, runner_up_score: d.runner_up_score,
+          reason: d.reason,
+      };
+      serde_json::to_string(&out).expect("serialize detect output")
+  }
+  ```
+- wasm-only re-export (mirrors analysis-wasm's `#[cfg(target_arch="wasm32")] mod`):
+  ```rust
+  #[cfg(target_arch = "wasm32")]
+  mod wasm {
+      use wasm_bindgen::prelude::*;
+      #[wasm_bindgen]
+      pub fn detect_domain_json(input_json: &str) -> String {
+          super::detect_domain_json_impl(input_json)
+      }
+  }
+  ```
+- Host `#[cfg(test)]` unit test on `detect_domain_json_impl` (a confident case + a
+  no-data case), asserting the round-tripped JSON matches the expected `Detection`.
+
+**`infermap-core` is untouched** — no serde, no new deps. `detect_domain`'s
+signature (`&[String]`, `&[(String, Vec<String>)]`, `f64`) already matches the DTO.
+
+### Boundary correctness
+- One JSON crossing per `detect` call (perf-audit lesson: boundary cost dwarfs the
+  kernel).
+- `f64` scores round-trip bit-exactly through `serde_json` ↔ `JSON.parse`
+  (both use round-trippable shortest-float formatting).
+- `Option<String>` ↔ `null`; `reason` string verbatim. JSON transport is lossless
+  for this shape; the parity test compares the parsed `DetectionResult` objects,
+  never JSON text.
+
+## 4. TS wiring — `packages/typescript/infermap/src/core/wasm/`
+
+### `backend.ts`
+```ts
+import { createBackendRegistry } from "goldenmatch-wasm-runtime";
+import type { DetectionResult } from "goldencheck-types";
+
+export interface InfermapBackend {
+  /** Resolved-input detect scoring. Dictionary resolution stays host. */
+  detectDomain(
+    columns: string[],
+    domains: Array<[string, string[]]>,
+    minScore: number,
+  ): DetectionResult;
+}
+
+const _registry = createBackendRegistry<InfermapBackend>();
+export function setInfermapBackend(b: InfermapBackend | null): void { _registry.set(b); }
+export function getInfermapBackend(): InfermapBackend | null { return _registry.get(); }
+```
+
+### `loader.ts`
+`instantiateBackend(bytes)` dynamic-imports `./artifacts/infermap_wasm.js`,
+`await glue.default({ module_or_path: bytes })`, returns an `InfermapBackend`
+whose `detectDomain` JSON-stringifies `{columns, domains, min_score}`, calls
+`glue.detect_domain_json(json)`, and `JSON.parse`s the result into a
+`DetectionResult`.
+
+### `index.ts`
+`enableInfermapWasm(opts)` / `disableInfermapWasm()` mirroring
+`enableAnalysisWasm` — lazy-import `loader.js`, call `enableWasmBackend(opts,
+instantiateBackend, setInfermapBackend, new URL("./artifacts/infermap_wasm_bg.wasm",
+import.meta.url))`; `disable` calls `setInfermapBackend(null)`.
+
+## 5. Wire `detect.ts`
+
+The **dictionary resolution stays host** (JS `listDomains()`/`loadDomain()`) —
+identical to Python's `detect.py` split, where only the resolved-input scoring
+core is the kernel. In `detectDomainDetailed`, after `columns` and the resolved
+`domains: Array<[string, string[]]>` are built and the early `no_data` guards
+pass, consult the backend:
+```ts
+const backend = getInfermapBackend();
+if (backend) {
+  return backend.detectDomain(columns, resolvedDomains, minScore);
+}
+// ...existing pure-TS scoring below unchanged (the lossy fallback)...
+```
+Public API (`detectDomain`, `detectDomainDetailed`, `DEFAULT_MIN_SCORE`) is
+**unchanged**; only an internal fast-path is inserted. The exact insertion point
+is after the `columns`/candidate resolution and the two `no_data` early returns,
+so the backend sees the same resolved inputs the pure path would score.
+
+> The `domains` value passed to the backend must be the SAME resolved
+> `[name, hints[]]` list the pure path scores over (post `listDomains()` filter +
+> `loadDomain()` hint expansion) — the kernel does no dictionary work.
+
+## 6. Build + artifact
+
+- `scripts/build_infermap_wasm.mjs` — mirrors `build_goldencheck_wasm.mjs` /
+  analysis: `wasm-pack build packages/rust/extensions/infermap-wasm --target web`,
+  then place `infermap_wasm_bg.wasm` + `infermap_wasm.js` glue into
+  `src/core/wasm/artifacts/`. Requires `wasm-pack` + `wasm32-unknown-unknown`
+  (CI-only; box lacks the toolchain).
+- `scripts/copy_wasm_artifact.mjs` — mirrors analysis: fan the two artifact files
+  out to every plausible `dist/**/artifacts/` parent (tsup bundling ambiguity);
+  no-op with a warning when the artifact is absent.
+- Artifacts are **git-ignored / not committed** (CI-built model). A default
+  checkout has no artifact → pure-TS default, parity test skips.
+
+## 7. Parity gate — `tests/parity/infermap-wasm.parity.test.ts`
+
+`hasArtifact ? describe : describe.skip` (artifact existence via
+`existsSync(new URL(".../artifacts/infermap_wasm_bg.wasm"))`). The test:
+1. `await enableInfermapWasm({ require: true })`.
+2. For each corpus case, assert `detectDomainDetailed(input, candidates, minScore)`
+   **with the backend enabled** deep-equals the same call **with the backend
+   disabled** (pure TS). `afterAll(disableInfermapWasm)`.
+
+Corpus mirrors the Wave 1 Python parity corpus (ASCII):
+confident pick; exact 2-way tie (host stable-sort order); 3-way score tie;
+below-min-score; empty columns → no_data; all-hint-less → no_data; multi-token
+hint; hint longer than the column; case-insensitivity. Uses real dictionary
+domains via `listDomains()` where practical plus synthetic `candidates` for the
+tie/edge cases (so the corpus controls the exact `domains` structure).
+
+> **The parity gate is also a drift audit.** TS `detect.ts` is a *separate*
+> reimplementation of the Rust kernel; the corpus may surface pre-existing
+> divergences (tie-break order, the `hintMatches` token-run logic, `str.lower`
+> vs the Rust ASCII-lower edge). Where WASM (== the Rust kernel, == Python) and
+> pure-TS disagree on an ASCII case, that is a **real drift finding**, and the
+> resolution follows the thesis: WASM is the reference; the pure-TS path is the
+> documented lossy fallback — OR the pure TS is corrected to match. Any such
+> divergence is surfaced explicitly in the PR, never silently skipped. (Unicode
+> `str.lower`/token edges stay out of the must-pass corpus, per the Wave 1/2
+> documented edge.)
+
+## 8. CI — `infermap_wasm` lane
+
+New job in `.github/workflows/ci.yml`, mirroring the `analysis_wasm` lane:
+1. `dorny/paths-filter` entry `infermap_wasm` covering
+   `packages/rust/extensions/infermap-wasm/**`,
+   `packages/rust/extensions/infermap-core/**`,
+   `packages/typescript/infermap/src/core/wasm/**`,
+   `packages/typescript/infermap/src/core/detect.ts`,
+   `packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts`,
+   `scripts/build_infermap_wasm.mjs`.
+2. Job (gated on that filter): install `wasm-pack` + `wasm32-unknown-unknown`,
+   run `node scripts/build_infermap_wasm.mjs`, then run the vitest parity test
+   (un-skipped, artifact now present). Advisory lane (not in the required set),
+   matching the other `*_wasm` lanes.
+
+## 9. Out of scope
+
+- The other 5 kernels (`exact_score`, `fuzzy_name_score`, `initialism_score`,
+  `profile_score`, `pattern_match_types`) — Waves B/C.
+- The base64-embed edge-shipping artifact model (§2, noted for later).
+- Any change to `detect`'s public API, the dictionaries, or scoring semantics.
+- Wiring the WASM backend into `engine.ts`/`map.ts` auto-enable — Wave A leaves it
+  strictly opt-in (`enableInfermapWasm()`), like every other `*_wasm` surface.
+
+## 10. Risk assessment
+
+- **Almost entirely CI-verified.** The box can neither `cargo build`/`wasm-pack`
+  the crate nor run vitest (OOM, per `feedback_box_memory_oom_ts`). Local
+  verification is limited to hand/eye review + `tsc`-shape reasoning; the Rust
+  host unit test, the wasm build, and the parity test all first run in CI. This
+  raises write-against-spec care; there is no box smoke test. Mitigation: the
+  crate shim is trivial (delegates to the already-parity-proven `detect_domain`),
+  and the TS wiring is a line-for-line mirror of the goldenanalysis wasm module.
+- **Drift audit may find work.** As in §7, the parity corpus can expose
+  TS-vs-Rust `detect` divergences. That is a feature (it is exactly what this
+  surface exists to eliminate), but it means Wave A's parity step may branch into
+  "reconcile a divergence" rather than "green on first run." Handled by making
+  WASM the reference and documenting/fixing the pure path — surfaced in the PR.
+- **Boundary encoding.** JSON is lossless for this shape (§3); the only
+  theoretical risk (float formatting) is eliminated by round-trippable f64
+  serialization on both sides. Verified by the parity gate.
+
+## 11. Build environment constraints
+
+- **Box-runnable:** effectively only static review + `node -c` syntax checks of
+  the `.mjs` scripts. No `cargo`, no `wasm-pack`, no `vitest` (all CI-only).
+- **CI-only:** the Rust host unit test, the wasm build, `tsc`/`tsup`, and the
+  vitest parity test (the `infermap_wasm` advisory lane).
+- **Merge-queue repo:** `gh pr merge --auto --squash` without `--delete-branch`;
+  benzsevern gh account.

--- a/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
+++ b/docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md
@@ -139,11 +139,29 @@ signature (`&[String]`, `&[(String, Vec<String>)]`, `f64`) already matches the D
 
 ## 4. TS wiring — `packages/typescript/infermap/src/core/wasm/`
 
-> **Dependency:** `packages/typescript/infermap/package.json` currently depends
-> only on `goldencheck-types`. Wave A must add
-> `"goldenmatch-wasm-runtime": "workspace:^"` (the source of
-> `createBackendRegistry` / `enableWasmBackend` / `EnableOptions`). Every existing
-> `*_wasm` TS package carries this dep.
+> **Dependency (devDependency, NOT a runtime dep):**
+> `packages/typescript/infermap/package.json` must add
+> `"goldenmatch-wasm-runtime": "workspace:^"` under **`devDependencies`** — the
+> source of `createBackendRegistry` / `enableWasmBackend` / `EnableOptions`. Every
+> real `*_wasm` package (goldenanalysis/goldenflow/goldenmatch/goldenpipe) carries
+> it as a devDependency because tsup **inlines** the plumbing (`noExternal`) so it
+> is never a published runtime dep (it is not on npm).
+>
+> **`tsup.config.ts` must gain the artifact-shipping keys** (mirror
+> `goldenanalysis/tsup.config.ts`), or the loader's
+> `new URL('./artifacts/infermap_wasm_bg.wasm', import.meta.url)` won't resolve in
+> `dist` (parity in §7 runs vitest over `src/` so it would pass regardless — this
+> is the consumer-facing shipping model):
+> ```ts
+> dts: { resolve: ["goldenmatch-wasm-runtime"] },   // roll bundled types into .d.ts
+> loader: { ".wasm": "copy" },
+> publicDir: false,
+> onSuccess: "node scripts/copy_wasm_artifact.mjs",
+> noExternal: ["goldenmatch-wasm-runtime"],          // inline plumbing, not a pub dep
+> external: [/infermap_wasm\.js$/],                  // runtime-only glue; don't resolve at build
+> ```
+> (The existing infermap `tsup.config.ts` has `dts: true` and none of these; Wave A
+> replaces `dts: true` with the `dts: { resolve: [...] }` form and adds the rest.)
 
 ### `backend.ts`
 ```ts
@@ -249,8 +267,9 @@ that table, so `wasm-pack build` fails. The established build for this crate
 layout (score-wasm / analysis-wasm / goldenflow-wasm) is a cargo build + the
 `wasm-bindgen` CLI:
 
-- `packages/rust/extensions/infermap-wasm/build_wasm.sh` — a line-for-line mirror
-  of `score-wasm/build_wasm.sh`:
+- `packages/rust/extensions/infermap-wasm/build_wasm.sh` — mirrors
+  `score-wasm/build_wasm.sh` (minus its base64 universal-loader step, which §2
+  rejects for Wave A):
   1. `rustup target add wasm32-unknown-unknown`
   2. `cargo build --manifest-path <crate>/Cargo.toml --target wasm32-unknown-unknown --release`
   3. resolve the pinned `wasm-bindgen` version from the crate's **committed
@@ -309,8 +328,9 @@ New job in `.github/workflows/ci.yml`, mirroring the real `analysis_wasm` lane:
    `packages/typescript/infermap/src/core/wasm/**`,
    `packages/typescript/infermap/src/core/detect.ts`,
    `packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts`,
-   `packages/typescript/infermap/build_wasm.sh` (via the crate path) and
-   `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs`.
+   `packages/typescript/infermap/scripts/copy_wasm_artifact.mjs`,
+   `packages/typescript/infermap/tsup.config.ts`.
+   (`build_wasm.sh` is already covered by the `infermap-wasm/**` entry above.)
 2. Job (gated on that filter), mirroring `analysis_wasm` step-for-step:
    - `rustup target add wasm32-unknown-unknown`;
    - run `packages/rust/extensions/infermap-wasm/build_wasm.sh` (cargo build +

--- a/packages/rust/extensions/infermap-wasm/Cargo.toml
+++ b/packages/rust/extensions/infermap-wasm/Cargo.toml
@@ -1,0 +1,26 @@
+# Standalone workspace so this wasm-bindgen wrapper can path-depend on the
+# pyo3-free `infermap-core` WITHOUT either crate's workspace claiming it. This
+# crate is the TS analogue of `infermap-native` (pyo3): it wraps the SAME
+# `infermap-core`, so detect is byte-identical by construction. serde lives HERE
+# (the JSON boundary), never in infermap-core.
+[workspace]
+
+[package]
+name = "infermap-wasm"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Ben Severn <benzsevern@gmail.com>"]
+description = "wasm-bindgen wrapper over infermap-core for the infermap TS opt-in WASM backend"
+
+[lib]
+name = "infermap_wasm"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+infermap-core = { path = "../infermap-core" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"

--- a/packages/rust/extensions/infermap-wasm/build_wasm.sh
+++ b/packages/rust/extensions/infermap-wasm/build_wasm.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Build infermap-wasm for wasm32 and copy the artifact + glue into the infermap
+# TS package. Requires: rustup wasm32 target + wasm-bindgen-cli (installed here at
+# the version pinned in Cargo.lock — a CLI/crate skew produces broken glue that
+# fails at RUNTIME, not build time). Run from anywhere.
+set -euo pipefail
+export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"
+export RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}"
+export PATH="$CARGO_HOME/bin:$PATH"
+
+CRATE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUT_DIR="$CRATE_DIR/../../../typescript/infermap/src/core/wasm/artifacts"
+
+rustup target add wasm32-unknown-unknown
+cargo build --manifest-path "$CRATE_DIR/Cargo.toml" --target wasm32-unknown-unknown --release
+
+WB_VER="$(grep -A1 '^name = "wasm-bindgen"$' "$CRATE_DIR/Cargo.lock" | grep '^version = ' | head -1 | sed -E 's/version = "([^"]+)"/\1/')"
+if [ -z "$WB_VER" ]; then echo "could not resolve wasm-bindgen version from Cargo.lock" >&2; exit 1; fi
+echo "Using wasm-bindgen $WB_VER"
+if ! wasm-bindgen --version 2>/dev/null | grep -q "$WB_VER"; then
+  cargo install wasm-bindgen-cli --version "=$WB_VER" --locked
+fi
+command -v wasm-bindgen >/dev/null 2>&1 || { echo "wasm-bindgen not on PATH after install; aborting" >&2; exit 1; }
+
+wasm-bindgen \
+  "$CRATE_DIR/target/wasm32-unknown-unknown/release/infermap_wasm.wasm" \
+  --target web --out-dir "$OUT_DIR" --out-name infermap_wasm
+
+echo "Artifact written to $OUT_DIR (infermap_wasm_bg.wasm + infermap_wasm.js)"

--- a/packages/rust/extensions/infermap-wasm/src/lib.rs
+++ b/packages/rust/extensions/infermap-wasm/src/lib.rs
@@ -1,0 +1,77 @@
+//! wasm-bindgen wrapper over `infermap-core`. The TS analogue of the
+//! `infermap-native` pyo3 crate: a thin JSON-boundary shim delegating to
+//! `detect_domain` so the TS surface is byte-identical to Python + the Rust FFI.
+//!
+//! Boundary: `detect_domain_json(input_json) -> output_json`, crossed ONCE per
+//! call (the perf-audit lesson: boundary cost dwarfs the kernel). serde DTOs live
+//! here; `infermap-core` stays serde-free.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+struct DetectInput {
+    columns: Vec<String>,
+    domains: Vec<(String, Vec<String>)>,
+    min_score: f64,
+}
+
+#[derive(Serialize)]
+struct DetectOutput {
+    domain: Option<String>,
+    score: f64,
+    runner_up: Option<String>,
+    runner_up_score: f64,
+    reason: String,
+}
+
+/// Host-testable core of the boundary. Parses the resolved detect input, calls
+/// the pyo3-free kernel, serializes the Detection. Panics on malformed JSON
+/// (the TS caller always sends well-formed input built from typed values).
+pub fn detect_domain_json_impl(input_json: &str) -> String {
+    let inp: DetectInput =
+        serde_json::from_str(input_json).expect("valid detect input json");
+    let d = infermap_core::detect_domain(&inp.columns, &inp.domains, inp.min_score);
+    let out = DetectOutput {
+        domain: d.domain,
+        score: d.score,
+        runner_up: d.runner_up,
+        runner_up_score: d.runner_up_score,
+        reason: d.reason,
+    };
+    serde_json::to_string(&out).expect("serialize detect output")
+}
+
+// wasm-only surface: the free `detect_domain_json` export the TS glue calls.
+// Mirrors analysis-wasm's `#[cfg(target_arch="wasm32")] mod` re-export.
+#[cfg(target_arch = "wasm32")]
+mod wasm {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub fn detect_domain_json(input_json: &str) -> String {
+        super::detect_domain_json_impl(input_json)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confident_detect_round_trips() {
+        let input = r#"{"columns":["provider_npi","first_name"],
+            "domains":[["health",["provider npi"]],["fin",["iban"]]],"min_score":0.3}"#;
+        let out = detect_domain_json_impl(input);
+        // health scores 1/2=0.5 (provider_npi matches), fin 0 -> confident health.
+        assert!(out.contains(r#""domain":"health""#));
+        assert!(out.contains(r#""reason":"confident""#));
+    }
+
+    #[test]
+    fn empty_columns_is_no_data() {
+        let input = r#"{"columns":[],"domains":[["h",["x"]]],"min_score":0.3}"#;
+        let out = detect_domain_json_impl(input);
+        assert!(out.contains(r#""reason":"no_data""#));
+        assert!(out.contains(r#""domain":null"#));
+    }
+}

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -85,6 +85,7 @@
   "devDependencies": {
     "@types/node": "^25.9.4",
     "goldenmatch": "workspace:*",
+    "goldenmatch-wasm-runtime": "workspace:^",
     "rimraf": "^6.1.3",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/packages/typescript/infermap/scripts/copy_wasm_artifact.mjs
+++ b/packages/typescript/infermap/scripts/copy_wasm_artifact.mjs
@@ -1,0 +1,32 @@
+// Copy the built WASM artifact from src into the dist locations the bundled
+// loader might resolve `new URL('./artifacts/infermap_wasm_bg.wasm', import.meta.url)`
+// to. tsup bundling can land the loader code at dist/core/index.js, a
+// dist/core/wasm/ module, or a hoisted chunk — and `import.meta.url` then points
+// at whichever, so `./artifacts/` resolves to a DIFFERENT parent in each case.
+// Copying to every plausible `./artifacts/` parent (a few KB, harmless) makes
+// enableInfermapWasm() resolve the artifact in the published package regardless
+// of how tsup bundles. No-op (warns) when the artifact is absent.
+import { cp, mkdir, access } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, "..", "src", "core", "wasm", "artifacts");
+const files = ["infermap_wasm_bg.wasm", "infermap_wasm.js"];
+const dsts = [
+  join(here, "..", "dist", "core", "wasm", "artifacts"),
+  join(here, "..", "dist", "core", "artifacts"),
+  join(here, "..", "dist", "artifacts"),
+];
+
+try {
+  await access(join(src, files[0]));
+} catch {
+  console.warn("[copy_wasm_artifact] no WASM artifact in src — skipping (pure-TS default).");
+  process.exit(0);
+}
+for (const dst of dsts) {
+  await mkdir(dst, { recursive: true });
+  for (const f of files) await cp(join(src, f), join(dst, f));
+}
+console.log("[copy_wasm_artifact] copied", files.join(", "), "to", dsts.length, "dist locations");

--- a/packages/typescript/infermap/src/core/detect.ts
+++ b/packages/typescript/infermap/src/core/detect.ts
@@ -1,6 +1,7 @@
 // Lightweight domain-pack auto-detection from column names.
 import { listDomains, loadDomain } from "goldencheck-types";
 import type { DetectionResult } from "goldencheck-types";
+import { getInfermapBackend } from "./wasm/backend.js";
 
 export const DEFAULT_MIN_SCORE = 0.3;
 
@@ -37,6 +38,47 @@ function hintMatches(hint: string, col: string): boolean {
   return false;
 }
 
+/** Pure scoring over resolved [name, hints[]] domains — the WASM parity oracle.
+ *  Byte-identical to infermap-core::detect_domain for NON-EMPTY columns. The
+ *  empty-columns `no_data` guard lives in detectDomainDetailed (the kernel guards
+ *  it too), so scoreDomains is never called with empty columns in production. */
+export function scoreDomains(
+  columns: string[],
+  resolved: Array<[string, string[]]>,
+  minScore: number,
+): DetectionResult {
+  const scored: Array<[string, number]> = [];
+  for (const [name, hints] of resolved) {
+    if (hints.length === 0) continue; // == Rust `hints.is_empty()` skip
+    let hits = 0;
+    for (const c of columns) {
+      for (const h of hints) {
+        if (hintMatches(h, c)) {
+          hits++;
+          break;
+        }
+      }
+    }
+    scored.push([name, hits / Math.max(columns.length, 1)]);
+  }
+  if (scored.length === 0) {
+    return { domain: null, score: 0, runner_up: null, runner_up_score: 0, reason: "no_data" };
+  }
+  scored.sort((a, b) => b[1] - a[1]);
+  const [bestName, bestScore] = scored[0]!;
+  const runner = scored[1];
+  const runnerName = runner ? runner[0] : null;
+  const runnerScore = runner ? runner[1] : 0;
+  if (bestScore < minScore) {
+    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "below_min_score" };
+  }
+  const topCount = scored.filter(([, s]) => s === bestScore).length;
+  if (topCount > 1) {
+    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "tie" };
+  }
+  return { domain: bestName, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "confident" };
+}
+
 export function detectDomain(
   input: DetectInput | { records?: ReadonlyArray<Record<string, unknown>> },
   candidates?: string[],
@@ -66,44 +108,23 @@ export function detectDomainDetailed(
     return { domain: null, score: 0, runner_up: null, runner_up_score: 0, reason: "no_data" };
   }
 
-  const domains = candidates ?? listDomains().filter((d) => d !== "generic");
-  const scored: Array<[string, number]> = [];
-  for (const d of domains) {
+  const domainNames = candidates ?? listDomains().filter((d) => d !== "generic");
+  // Hoist hint resolution into a pre-pass so the SAME resolved input feeds the
+  // kernel or the pure path. Empty-hint domains are INCLUDED (both paths skip
+  // them: kernel via hints.is_empty(), pure via hints.length===0), so scoring is
+  // identical to the pre-refactor inline loop.
+  const resolved: Array<[string, string[]]> = domainNames.map((d) => {
     const pack = loadDomain(d);
     const allHints = new Set<string>();
     for (const spec of Object.values(pack.types)) {
       for (const h of spec.name_hints) allHints.add(h);
     }
-    if (allHints.size === 0) continue;
+    return [d, Array.from(allHints)];
+  });
 
-    let hits = 0;
-    for (const c of columns) {
-      for (const h of allHints) {
-        if (hintMatches(h, c)) {
-          hits++;
-          break;
-        }
-      }
-    }
-    scored.push([d, hits / Math.max(columns.length, 1)]);
+  const backend = getInfermapBackend();
+  if (backend) {
+    return backend.detectDomain(columns, resolved, minScore);
   }
-
-  if (scored.length === 0) {
-    return { domain: null, score: 0, runner_up: null, runner_up_score: 0, reason: "no_data" };
-  }
-
-  scored.sort((a, b) => b[1] - a[1]);
-  const [bestName, bestScore] = scored[0]!;
-  const runner = scored[1];
-  const runnerName = runner ? runner[0] : null;
-  const runnerScore = runner ? runner[1] : 0;
-
-  if (bestScore < minScore) {
-    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "below_min_score" };
-  }
-  const topCount = scored.filter(([, s]) => s === bestScore).length;
-  if (topCount > 1) {
-    return { domain: null, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "tie" };
-  }
-  return { domain: bestName, score: bestScore, runner_up: runnerName, runner_up_score: runnerScore, reason: "confident" };
+  return scoreDomains(columns, resolved, minScore);
 }

--- a/packages/typescript/infermap/src/core/wasm/artifacts/.gitignore
+++ b/packages/typescript/infermap/src/core/wasm/artifacts/.gitignore
@@ -1,0 +1,5 @@
+# Built by infermap-wasm/build_wasm.sh (CI) — never committed.
+infermap_wasm_bg.wasm
+infermap_wasm.js
+infermap_wasm.d.ts
+infermap_wasm_bg.wasm.d.ts

--- a/packages/typescript/infermap/src/core/wasm/backend.ts
+++ b/packages/typescript/infermap/src/core/wasm/backend.ts
@@ -1,0 +1,26 @@
+/**
+ * backend.ts — opt-in WASM detect backend registry. Edge-safe: no node:* here.
+ * Mirrors goldenanalysis's wasm/backend.ts (module-singleton registry).
+ */
+import { createBackendRegistry } from "goldenmatch-wasm-runtime";
+import type { DetectionResult } from "goldencheck-types";
+
+/** A WASM-backed detect kernel. Dictionary resolution stays host; this scores a
+ *  resolved [name, hints[]] domain list. */
+export interface InfermapBackend {
+  detectDomain(
+    columns: string[],
+    domains: Array<[string, string[]]>,
+    minScore: number,
+  ): DetectionResult;
+}
+
+const _registry = createBackendRegistry<InfermapBackend>();
+
+export function setInfermapBackend(b: InfermapBackend | null): void {
+  _registry.set(b);
+}
+
+export function getInfermapBackend(): InfermapBackend | null {
+  return _registry.get();
+}

--- a/packages/typescript/infermap/src/core/wasm/index.ts
+++ b/packages/typescript/infermap/src/core/wasm/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Public opt-in WASM API for infermap detect. enableInfermapWasm() is async;
+ * after it resolves, the sync detectDomain* runs against the instantiated module.
+ * Pure-TS stays the default + fallback. Plumbing lives in goldenmatch-wasm-runtime.
+ */
+import { enableWasmBackend, type EnableOptions } from "goldenmatch-wasm-runtime";
+import { setInfermapBackend } from "./backend.js";
+
+export type { InfermapBackend } from "./backend.js";
+export type EnableInfermapWasmOptions = EnableOptions;
+
+let _enabled = false;
+
+export async function enableInfermapWasm(
+  opts: EnableInfermapWasmOptions = {},
+): Promise<boolean> {
+  if (_enabled) return true;
+  try {
+    const { instantiateBackend } = await import("./loader.js");
+    const ok = await enableWasmBackend(
+      opts,
+      instantiateBackend,
+      setInfermapBackend,
+      new URL("./artifacts/infermap_wasm_bg.wasm", import.meta.url),
+    );
+    if (ok) _enabled = true;
+    return ok;
+  } catch (err) {
+    if (opts.require) throw err;
+    return false;
+  }
+}
+
+export function disableInfermapWasm(): void {
+  setInfermapBackend(null);
+  _enabled = false;
+}

--- a/packages/typescript/infermap/src/core/wasm/loader.ts
+++ b/packages/typescript/infermap/src/core/wasm/loader.ts
@@ -1,0 +1,21 @@
+/**
+ * loader.ts — instantiate infermap-wasm and adapt it to an InfermapBackend.
+ * The wasm-bindgen glue import is dynamic (absent in a default checkout).
+ */
+import type { DetectionResult } from "goldencheck-types";
+import type { InfermapBackend } from "./backend.js";
+
+export async function instantiateBackend(bytes: Uint8Array): Promise<InfermapBackend> {
+  const glue = (await import("./artifacts/infermap_wasm.js" as string)) as {
+    default: (input: { module_or_path: Uint8Array }) => Promise<unknown>;
+    detect_domain_json: (input_json: string) => string;
+  };
+  await glue.default({ module_or_path: bytes });
+  return {
+    detectDomain(columns, domains, minScore) {
+      // One JSON crossing per call (perf-audit lesson).
+      const input = JSON.stringify({ columns, domains, min_score: minScore });
+      return JSON.parse(glue.detect_domain_json(input)) as DetectionResult;
+    },
+  };
+}

--- a/packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts
+++ b/packages/typescript/infermap/tests/parity/infermap-wasm.parity.test.ts
@@ -1,0 +1,63 @@
+/**
+ * WASM-vs-pure-TS parity for infermap `detect`. The WASM backend wraps
+ * infermap-core::detect_domain (== Python == the Rust FFI); scoreDomains is the
+ * pure-TS reimplementation. This gate asserts they agree byte-for-byte over a
+ * synthetic domain corpus (the Wave-1 kernel-parity cases, non-empty columns).
+ *
+ * Skipped when the built artifact is absent (default checkout / no toolchain);
+ * the CI `infermap_wasm` lane builds it first and runs this un-skipped. Any
+ * DISAGREEMENT is a real TS-vs-Rust `detect` drift finding (hintMatches token
+ * logic, tie order) — WASM is the reference; surface it, don't skip it.
+ */
+import { describe, it, expect, afterAll } from "vitest";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { scoreDomains } from "../../src/core/detect.js";
+import {
+  enableInfermapWasm,
+  disableInfermapWasm,
+} from "../../src/core/wasm/index.js";
+import { getInfermapBackend } from "../../src/core/wasm/backend.js";
+
+const artifact = fileURLToPath(
+  new URL("../../src/core/wasm/artifacts/infermap_wasm_bg.wasm", import.meta.url),
+);
+const d = existsSync(artifact) ? describe : describe.skip;
+
+// (columns, domains [name,hints[]][], minScore) — non-empty columns only.
+// Mirrors infermap Python test_native_parity._CASES (minus the empty-columns case).
+type Case = [string[], Array<[string, string[]]>, number];
+const CASES: Case[] = [
+  [["provider_npi", "first_name"], [["health", ["provider npi"]], ["fin", ["iban"]]], 0.3], // confident
+  [["a", "b"], [["x", ["a"]], ["y", ["b"]]], 0.3], // 2-way tie
+  [["a", "b"], [["x", ["a"]], ["y", ["b"]], ["z", ["a"]]], 0.3], // 3-way tie (host order)
+  [["a", "b", "c", "d"], [["h", ["a"]]], 0.3], // below_min_score (0.25)
+  [["a"], [["h", []]], 0.3], // no_data (all hint-less)
+  [["patient_id", "provider_npi", "dob"], [["health", ["patient id", "npi"]], ["fin", ["iban"]]], 0.3],
+  [["a"], [["h", ["a b c"]]], 0.3], // hint longer than column
+  [["ORDER_ID", "Sku"], [["ecom", ["order id", "sku"]]], 0.3], // ASCII case-insensitivity
+];
+
+d("infermap detect WASM-vs-pure parity", () => {
+  afterAll(() => disableInfermapWasm());
+
+  it("enableInfermapWasm() succeeds in this lane (artifact present)", async () => {
+    disableInfermapWasm();
+    const ok = await enableInfermapWasm({ require: true });
+    expect(ok).toBe(true);
+    disableInfermapWasm();
+  });
+
+  for (let i = 0; i < CASES.length; i++) {
+    const [columns, domains, minScore] = CASES[i]!;
+    it(`case ${i}: kernel == scoreDomains`, async () => {
+      const pure = scoreDomains(columns, domains, minScore);
+      const ok = await enableInfermapWasm({ require: true });
+      expect(ok).toBe(true);
+      const backend = getInfermapBackend()!;
+      const wasm = backend.detectDomain(columns, domains, minScore);
+      disableInfermapWasm();
+      expect(wasm).toEqual(pure); // deep-equal DetectionResult; drift => fail
+    });
+  }
+});

--- a/packages/typescript/infermap/tsup.config.ts
+++ b/packages/typescript/infermap/tsup.config.ts
@@ -9,10 +9,23 @@ export default defineConfig({
     cli: "src/cli.ts",
   },
   format: ["esm", "cjs"],
-  dts: true,
+  dts: { resolve: ["goldenmatch-wasm-runtime"] },
   sourcemap: true,
   clean: true,
   target: "node20",
   splitting: false,
   treeshake: true,
+  // Copy the opt-in WASM artifact into dist so the loader's
+  // new URL('./artifacts/infermap_wasm_bg.wasm', import.meta.url) resolves at
+  // runtime. Absent in a default checkout -> enableInfermapWasm() returns false.
+  loader: { ".wasm": "copy" },
+  publicDir: false,
+  onSuccess: "node scripts/copy_wasm_artifact.mjs",
+  // Inline the tiny WASM plumbing so it's not a published runtime dep.
+  noExternal: ["goldenmatch-wasm-runtime"],
+  external: [
+    // Runtime-only wasm-bindgen glue (dynamic-imported in enableInfermapWasm);
+    // absent in a default checkout. Mark external so esbuild never resolves it.
+    /infermap_wasm\.js$/,
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,6 +350,9 @@ importers:
       goldenmatch:
         specifier: workspace:*
         version: link:../goldenmatch
+      goldenmatch-wasm-runtime:
+        specifier: workspace:^
+        version: link:../goldenmatch-wasm-runtime
       rimraf:
         specifier: ^6.1.3
         version: 6.1.3


### PR DESCRIPTION
## What

Wave A of the InferMap WASM/TS surface: a new `infermap-wasm` wasm-bindgen crate over `infermap-core`, the TS `wasm/{backend,loader,index}.ts` plumbing, a build script, a CI lane, and a byte-parity gate — with `detect_domain` wired through end to end. Makes the TS `infermap` surface run the SAME `infermap-core` kernel Python's native wheel runs, instead of its separate hand-written reimplementation (anti-drift).

## How

- **Crate**: `detect_domain_json(input_json) -> output_json` — JSON boundary crossed once per call; serde DTOs in the wrapper, `infermap-core` stays serde-free.
- **TS**: `detect.ts` hoists hint-resolution into a pre-pass, then dispatches to the WASM backend (or the pure `scoreDomains` fallback). Public API unchanged; the pure path is byte-identical to before (verified line-by-line).
- **Artifact**: CI-built, not committed (`describe.skip` locally; the `infermap_wasm` lane builds it then runs parity un-skipped). Build = `cargo build` + pinned `wasm-bindgen-cli`, mirroring `score-wasm/build_wasm.sh`.

## Parity = drift audit

`infermap-wasm.parity.test.ts` asserts `kernel.detectDomain` deep-equals pure `scoreDomains` over the 8 Wave-1 synthetic detect cases (non-empty columns). Any disagreement is a real TS-vs-Rust `detect` divergence (hintMatches token logic / tie order) — WASM is the reference. **If the `infermap_wasm` lane reddens on a parity case, that is the audit working** — a genuine divergence to investigate + resolve (WASM reference, pure TS documented/fixed), not flaky infra.

## Scope

Foundation + one kernel. The other 5 kernels are Waves B/C.

Spec: `docs/superpowers/specs/2026-07-06-infermap-wasm-wave-a-design.md`
Plan: `docs/superpowers/plans/2026-07-06-infermap-wasm-wave-a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44