### PR TITLE
feat(goldenflow): fuse the Option-returning URL/company/email chains (nullable executor)

### DIFF
--- a/docs-site/goldenflow/performance.mdx
+++ b/docs-site/goldenflow/performance.mdx
@@ -97,9 +97,9 @@ drop.
 
 Measured at 5M rows: **~20% lower peak RSS** and a modest wall speedup, growing
 with row count. It is **on by default** when the native kernel is available
-(needs `goldenflow-native >= 0.13.0` for the numeric + parameterized ops;
-`>= 0.12.0` fuses the no-arg string families only); older wheels fall back
-gracefully.
+(needs `goldenflow-native >= 0.14.0` for the nullable URL/company/email ops,
+`>= 0.13.0` for numeric + parameterized, `>= 0.12.0` for the no-arg string
+families); older wheels fall back gracefully.
 
 | `GOLDENFLOW_FUSED_APPLY` | Behavior |
 |---|---|
@@ -107,15 +107,19 @@ gracefully.
 | `0` | Force the per-transform path (each transform applied individually). |
 
 <Note>
-  The fused set covers two dtypes: the owned, single-value, total (never-null)
+  The fused set covers three kernel shapes: the owned, total (never-null)
   **string** transforms (text + email + name-normalizer families, plus the
-  parameterized `truncate`/`pad`), and the owned **numeric** f64 transforms
-  (`round`/`clamp`/`abs_value`/`fill_zero`) on a `Float64` column. The engine
+  parameterized `truncate`/`pad`); the owned **numeric** f64 transforms
+  (`round`/`clamp`/`abs_value`/`fill_zero`) on a `Float64` column; and the
+  `Option`-returning **URL / company / email** transforms (`url_normalize`,
+  `company_normalize`, `email_mask`, …), where a value a kernel can't parse
+  becomes a null cell that passes through the rest of the run. The engine
   recomputes the fusable set as a run advances, so a parser that changes a
   column's dtype mid-chain (e.g. `currency_strip`: str→f64) lets the string head
-  and the numeric tail each fuse. `Option`-returning (URL / company) and
-  residual-tier (`phone`/date) transforms are not fused and take the
-  per-transform path — automatically, no configuration needed.
+  and the numeric tail each fuse; a nullable run may also mix in the total string
+  ops. Only `*_validate` (boolean), multi-column split/merge, and residual-tier
+  (`phone`/date) transforms stay on the per-transform path — automatically, no
+  configuration needed.
 </Note>
 
 ## Cross-surface (WASM / TypeScript)

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.6] - 2026-07-06
+
+### Changed
+- Bumped the goldenflow-family floors after the nullable fused-apply release
+  (lockstep policy): **`goldenflow>=1.16.0`** (was `>=1.15.0`) and
+  **`goldenflow-native>=0.14.0`** (was `>=0.13.0`). goldenflow 1.16.0 extends the
+  fused columnar apply to the `Option`-returning URL / company / email families
+  (`url_normalize`, `company_normalize`, `email_mask`, …) — a run of those fuses
+  into one native Arrow pass, byte-identical output (nulls included); goldenflow-native
+  0.14.0 ships the `apply_chain_nullable_arrow` kernel symbol they need.
+
 ## [0.1.5] - 2026-07-06
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.5"
+version = "0.1.6"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.15.0",                # transform / standardize / normalize (>=1.15.0 = numeric+param fused apply)
+    "goldenflow>=1.16.0",                # transform / standardize / normalize (>=1.16.0 = nullable URL/company/email fused apply)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.13.0",
+    "goldenflow-native>=0.14.0",
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.16.0 (2026-07-06)
+
+Pillar-1 (evict Polars from the transform execution path): the fused columnar apply now covers a **third kernel shape** — the `Option`-returning URL / company / email families — so those chains fuse too. Needs `goldenflow-native>=0.14.0`.
+
+- **Nullable (`Option<String>`) fused chains.** A run of owned URL (`url_normalize`/`url_strip_tracking`/`url_strip_www`/`url_canonical`/`url_extract_domain`), company (`company_normalize`/`company_strip_legal`/`company_extract_legal`), and email (`email_mask`/`email_extract_domain`) transforms now fuses into ONE native pass (`goldenflow_core::chain::apply_chain_nullable` → native `apply_chain_nullable_arrow`). A value a kernel can't parse becomes a null cell that passes through the rest of the run — exactly as the per-transform path does (each transform's `map_str_to_str` skips null input, nulls on `None`). Byte-identical output frame (nulls included) AND audit manifest; the per-kernel affected count matches Polars' `(before != after).sum()`, which counts a row only when both sides are non-null and differ (a non-null→null row isn't counted).
+- **Mixed runs.** A nullable run may include the total/parameterized string kernels (`strip`/`lowercase`/`truncate`/…) alongside the `Option`-returning ones — e.g. `strip → lowercase → url_normalize → url_strip_www` fuses as a single pass. Symbol-aware: a pre-0.14.0 wheel keeps fusing the total + numeric families and only the nullable ops break a run (no regression).
+
 ## 1.15.0 (2026-07-06)
 
 Pillar-1 (evict Polars from the transform execution path): the fused columnar apply now covers a **second dtype and the parameterized string ops**, so more real chains collapse into one native Arrow pass (byte-identical output, lower peak RSS). Needs `goldenflow-native>=0.13.0` (republished with the new kernel symbols).

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.15.0"
+__version__ = "1.16.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -70,6 +70,27 @@ FUSABLE_F64_KERNELS: frozenset[str] = frozenset(
 )
 FUSABLE_F64_PARAM_KERNELS: frozenset[str] = frozenset({"round", "clamp"})
 
+# Owned string->Option<string> kernels (URL / company / email families) eligible
+# for the NULLABLE fused chain — a value the kernel can't parse becomes a null cell
+# that passes through the rest of the run. Mirror of
+# goldenflow_core::chain::NullableKernel::NULLABLE_NAMES. All no-arg. Need the
+# ``apply_chain_nullable_arrow`` symbol (goldenflow-native >= 0.14.0). A nullable
+# run may MIX these with the total/param string kernels (wrapped as Total in Rust).
+FUSABLE_NULLABLE_KERNELS: frozenset[str] = frozenset(
+    {
+        "url_normalize",
+        "url_strip_tracking",
+        "url_strip_www",
+        "url_canonical",
+        "url_extract_domain",
+        "company_normalize",
+        "company_strip_legal",
+        "company_extract_legal",
+        "email_mask",
+        "email_extract_domain",
+    }
+)
+
 # Every parameterized fusable name (string + numeric), so ``is_fusable`` treats an
 # op-with-params as fusable when the op is one that legitimately carries args.
 _PARAM_KERNELS: frozenset[str] = FUSABLE_PARAM_KERNELS | FUSABLE_F64_PARAM_KERNELS
@@ -96,17 +117,22 @@ def fused_enabled() -> bool:
 
 
 def fusable_names() -> frozenset[str]:
-    """The transform names the engine may fuse, given the AVAILABLE native symbol:
-    the parameterized ops only join a run when ``apply_chain_ops_arrow`` is present
-    (0.13.0+); a 0.12.0 wheel fuses the no-arg families only."""
+    """The string transform names the engine may fuse, given the AVAILABLE native
+    symbols (symbol-aware, so older wheels don't regress): a 0.12.0 wheel fuses the
+    no-arg families only; ``apply_chain_ops_arrow`` (0.13.0+) adds the parameterized
+    string ops; ``apply_chain_nullable_arrow`` (0.14.0+) adds the URL/company/email
+    ``Option``-returning families (which may share a run with the others)."""
     nm = _native_if_on()
     if nm is None:
         return frozenset()
-    if hasattr(nm, "apply_chain_ops_arrow"):
-        return FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
+    names: set[str] = set()
     if hasattr(nm, "apply_chain_arrow"):
-        return FUSABLE_KERNELS
-    return frozenset()
+        names |= FUSABLE_KERNELS
+    if hasattr(nm, "apply_chain_ops_arrow"):
+        names |= FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
+    if hasattr(nm, "apply_chain_nullable_arrow"):
+        names |= FUSABLE_NULLABLE_KERNELS
+    return frozenset(names)
 
 
 def fusable_f64_names() -> frozenset[str]:
@@ -151,6 +177,14 @@ def apply_chain_native(
         if not hasattr(nm, "apply_chain_f64_arrow"):
             return None
         out_arrow, changed = nm.apply_chain_f64_arrow(
+            series.to_arrow(), [(name, list(params)) for name, params in ops]
+        )
+    elif any(name in FUSABLE_NULLABLE_KERNELS for name, _ in ops):
+        # The run contains an Option-returning kernel -> the nullable executor
+        # (which also handles the total/param kernels in the run, wrapped as Total).
+        if not hasattr(nm, "apply_chain_nullable_arrow"):
+            return None
+        out_arrow, changed = nm.apply_chain_nullable_arrow(
             series.to_arrow(), [(name, list(params)) for name, params in ops]
         )
     elif hasattr(nm, "apply_chain_ops_arrow"):

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.15.0"
+version = "1.16.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"
@@ -48,7 +48,7 @@ agent = ["aiohttp>=3.14.0"]
 # Optional Rust/PyO3 acceleration runtime (mirrors goldenmatch[native]). Pulls
 # pyarrow for the zero-copy Series<->kernel bridge. Off by default at runtime --
 # see goldenflow.core._native_loader (GOLDENFLOW_NATIVE / _GATED_ON).
-native = ["goldenflow-native>=0.13.0", "pyarrow>=10"]
+native = ["goldenflow-native>=0.14.0", "pyarrow>=10"]
 all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
 
 [project.scripts]

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.15.0",
+      "version": "1.16.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenflow/tests/transforms/test_fused_chain.py
+++ b/packages/python/goldenflow/tests/transforms/test_fused_chain.py
@@ -15,6 +15,7 @@ from goldenflow.transforms import get_transform, registry
 from goldenflow.transforms._chain import (
     FUSABLE_F64_KERNELS,
     FUSABLE_KERNELS,
+    FUSABLE_NULLABLE_KERNELS,
     FUSABLE_PARAM_KERNELS,
 )
 
@@ -100,6 +101,77 @@ def test_fused_f64_equals_per_transform(monkeypatch, ops) -> None:
 
     assert fused.df.equals(per_op.df), "fused f64 output frame diverged"
     assert _manifest_rows(fused) == _manifest_rows(per_op), "fused f64 manifest diverged"
+
+
+def test_fusable_nullable_registered_and_single_col_mode() -> None:
+    """Every nullable (URL/company/email) fusable kernel is a registered single-column
+    transform (mode 'expr'/'series') so the fused sample replay dispatches on mode."""
+    reg = set(registry())
+    for name in sorted(FUSABLE_NULLABLE_KERNELS):
+        assert name in reg, f"{name} in FUSABLE_NULLABLE_KERNELS but not registered"
+        info = get_transform(name)
+        assert info is not None and info.mode in ("expr", "series"), (
+            f"{name} must be mode 'expr'/'series', got "
+            f"{None if info is None else info.mode}"
+        )
+
+
+def test_fusable_nullable_matches_native_kernel_table() -> None:
+    """Python FUSABLE_NULLABLE_KERNELS must mirror the native nullable kernel table
+    (``fusable_nullable_kernel_names`` = NullableKernel::NULLABLE_NAMES)."""
+    nm = native_module()
+    if nm is None or not hasattr(nm, "fusable_nullable_kernel_names"):
+        pytest.skip("native nullable chain kernel not built (pre-0.14.0 wheel)")
+    assert set(nm.fusable_nullable_kernel_names()) == set(FUSABLE_NULLABLE_KERNELS)
+
+
+@pytest.mark.parametrize(
+    "ops",
+    [
+        ["url_normalize", "url_strip_tracking"],
+        ["url_normalize", "url_strip_www"],
+        ["url_canonical"],
+        ["url_normalize", "url_extract_domain"],
+        ["company_normalize", "company_strip_legal"],
+        ["email_mask"],
+        # MIXED: total string ops + nullable ones fuse as one run.
+        ["strip", "lowercase", "url_normalize", "url_strip_www"],
+        ["strip", "company_normalize"],
+        ["strip", "email_extract_domain", "uppercase"],
+    ],
+)
+def test_fused_nullable_equals_per_transform(monkeypatch, ops) -> None:
+    """The nullable (Option-returning) fused chain is byte-identical to the
+    per-transform path — same output frame (incl. nulls the kernels produce) AND
+    same manifest — including runs that MIX total and nullable kernels."""
+    nm = native_module()
+    if nm is None or not hasattr(nm, "apply_chain_nullable_arrow"):
+        pytest.skip("native nullable chain kernel not built (pre-0.14.0 wheel)")
+
+    from goldenflow import transform_df
+
+    df = pl.DataFrame(
+        {
+            "v": [
+                "  HTTP://WWW.Example.com/P/?utm_source=x&a=1  ",
+                "Acme, Inc.",
+                "not parseable at all",
+                None,
+                "john.doe@Gmail.com",
+                "",
+            ]
+        }
+    )
+    cfg = _cfg("v", ops)
+
+    monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "0")  # opt-OUT -> per-transform
+    per_op = transform_df(df, config=cfg)
+
+    monkeypatch.setenv("GOLDENFLOW_FUSED_APPLY", "1")
+    fused = transform_df(df, config=cfg)
+
+    assert fused.df.equals(per_op.df), "fused nullable output frame diverged"
+    assert _manifest_rows(fused) == _manifest_rows(per_op), "fused nullable manifest diverged"
 
 
 def test_fused_run_spans_dtype_change(monkeypatch) -> None:

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -16,17 +16,24 @@
 //! to `k2(k1(x))` applied sequentially. Proven in the tests below + the host-side
 //! parity test.
 //!
-//! Scope (Phase 1): the no-arg, TOTAL (never-null) string→string text family. Ops
-//! that return `Option` (email_extract_domain, url_extract_domain, *_validate,
-//! *_mask), carry params (truncate/pad), or change arity (split/merge) are NOT
-//! fusable here and stay on the per-transform path — see the boundary note in the
-//! design doc.
+//! Three fusable shapes now live here, each with its own executor + arrow symbol:
+//!   1. [`apply_chain`] — TOTAL string→string kernels (`Kernel`), incl. the
+//!      parameterized `truncate`/`pad`. The fast path (two reused scratch buffers).
+//!   2. [`apply_chain_f64`] — f64→f64 numeric kernels (`NumericKernel`:
+//!      round/clamp/abs_value/fill_zero) on a `Float64Array`.
+//!   3. [`apply_chain_nullable`] — `Option`-returning string kernels
+//!      (`NullableKernel`: the URL/company/email families), which may MIX with the
+//!      total kernels in one run; a value a kernel can't parse becomes a null cell
+//!      that passes through the rest of the run.
+//! Still on the per-transform path: `*_validate` (bool), multi-arity split/merge,
+//! and the residual-tier phone/date families — see the boundary note in the design
+//! doc / ADR 0034.
 
 use arrow_array::builder::Float64Builder;
 use arrow_array::{Array, Float64Array, GenericStringArray, OffsetSizeTrait};
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 
-use crate::{email, names, numeric, text};
+use crate::{company, email, names, numeric, text, url};
 
 /// One owned, no-arg, total string→string kernel eligible for the fused chain.
 /// The name mapping (`from_name`) is the single source of truth the host's
@@ -368,6 +375,141 @@ pub fn apply_chain_f64(arr: &Float64Array, kernels: &[NumericKernel]) -> F64Chai
     }
 }
 
+// ---------------------------------------------------------------------------
+// Nullable string chain — the third fusable shape. The URL / company / email
+// families return `Option<String>` (None when the input can't be parsed → a
+// NULL output cell). They can't ride the total `apply_chain` (which never
+// nulls), so this executor threads `Option<String>`: once a cell goes null it
+// passes through the rest of the run untouched, exactly as the per-transform
+// path does (each transform's `map_str_to_str` skips null input, nulls on None).
+// A run may MIX total kernels (wrapped as `Total`) with nullable ones.
+// ---------------------------------------------------------------------------
+
+/// One kernel eligible for the nullable fused chain: either an existing total
+/// kernel (always `Some`) or an `Option`-returning URL/company/email kernel.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum NullableKernel {
+    Total(Kernel),
+    UrlNormalize,
+    UrlStripTracking,
+    UrlStripWww,
+    UrlCanonical,
+    UrlExtractDomain,
+    CompanyNormalize,
+    CompanyStripLegal,
+    CompanyExtractLegal,
+    EmailMask,
+    EmailExtractDomain,
+}
+
+impl NullableKernel {
+    /// Resolve a name + params to a nullable chain kernel. Nullable names map to
+    /// their own variant; everything else falls back to a `Total(Kernel)` (so a
+    /// run mixing `strip`/`lowercase` with `url_normalize` fuses as one). `None`
+    /// only if the name isn't fusable at all.
+    pub fn from_op(name: &str, params: &[&str]) -> Option<NullableKernel> {
+        Some(match name {
+            "url_normalize" => NullableKernel::UrlNormalize,
+            "url_strip_tracking" => NullableKernel::UrlStripTracking,
+            "url_strip_www" => NullableKernel::UrlStripWww,
+            "url_canonical" => NullableKernel::UrlCanonical,
+            "url_extract_domain" => NullableKernel::UrlExtractDomain,
+            "company_normalize" => NullableKernel::CompanyNormalize,
+            "company_strip_legal" => NullableKernel::CompanyStripLegal,
+            "company_extract_legal" => NullableKernel::CompanyExtractLegal,
+            "email_mask" => NullableKernel::EmailMask,
+            "email_extract_domain" => NullableKernel::EmailExtractDomain,
+            _ => return Kernel::from_op(name, params).map(NullableKernel::Total),
+        })
+    }
+
+    /// The `Option`-returning kernel names (need `apply_chain_nullable_arrow`).
+    pub const NULLABLE_NAMES: &'static [&'static str] = &[
+        "url_normalize",
+        "url_strip_tracking",
+        "url_strip_www",
+        "url_canonical",
+        "url_extract_domain",
+        "company_normalize",
+        "company_strip_legal",
+        "company_extract_legal",
+        "email_mask",
+        "email_extract_domain",
+    ];
+
+    /// Apply to one present value, returning `None` when the kernel can't parse
+    /// it (→ a null output cell). Total kernels always return `Some`.
+    #[inline]
+    fn apply(self, s: &str) -> Option<String> {
+        match self {
+            NullableKernel::Total(k) => {
+                let mut buf = String::new();
+                k.apply_into(s, &mut buf);
+                Some(buf)
+            }
+            NullableKernel::UrlNormalize => url::url_normalize(s),
+            NullableKernel::UrlStripTracking => url::url_strip_tracking(s),
+            NullableKernel::UrlStripWww => url::url_strip_www(s),
+            NullableKernel::UrlCanonical => url::url_canonical(s),
+            NullableKernel::UrlExtractDomain => url::url_extract_domain(s),
+            NullableKernel::CompanyNormalize => company::company_normalize(s),
+            NullableKernel::CompanyStripLegal => company::company_strip_legal(s),
+            NullableKernel::CompanyExtractLegal => company::company_extract_legal(s),
+            NullableKernel::EmailMask => email::email_mask(s),
+            NullableKernel::EmailExtractDomain => email::email_extract_domain(s),
+        }
+    }
+}
+
+/// Apply `kernels` over `arr`, threading `Option<String>`: a null (input or
+/// produced by a kernel returning `None`) passes through the rest of the run.
+///
+/// `changed[i]` matches the host's per-transform `(before != after).sum()`,
+/// which in Polars counts a row only when BOTH before and after are non-null and
+/// differ (a null on either side yields a null comparison, skipped by `.sum()`).
+/// So a row a kernel turns non-null→null is NOT counted (nor is a null-before
+/// row). Generic over offset width for the LargeUtf8 Polars shape.
+pub fn apply_chain_nullable<O: OffsetSizeTrait>(
+    arr: &GenericStringArray<O>,
+    kernels: &[NullableKernel],
+) -> ChainResult<O> {
+    let len = arr.len();
+    let mut changed = vec![0u64; kernels.len()];
+    let mut offsets: Vec<O> = Vec::with_capacity(len + 1);
+    offsets.push(O::from_usize(0).expect("0 fits any offset"));
+    let mut values = String::with_capacity(arr.values().len());
+    let mut nulls = arrow_buffer::NullBufferBuilder::new(len);
+    for v in arr.iter() {
+        let mut cur: Option<String> = v.map(str::to_string);
+        for (i, k) in kernels.iter().enumerate() {
+            let next = match &cur {
+                Some(s) => k.apply(s),
+                None => None,
+            };
+            if let (Some(b), Some(a)) = (&cur, &next) {
+                if b != a {
+                    changed[i] += 1;
+                }
+            }
+            cur = next;
+        }
+        match cur {
+            Some(s) => {
+                values.push_str(&s);
+                nulls.append_non_null();
+            }
+            None => nulls.append_null(),
+        }
+        offsets.push(O::from_usize(values.len()).expect("string column exceeds offset width"));
+    }
+    let array = GenericStringArray::<O>::new(
+        OffsetBuffer::new(ScalarBuffer::from(offsets)),
+        Buffer::from_vec(values.into_bytes()),
+        nulls.finish(),
+    );
+    ChainResult { array, changed }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -678,6 +820,156 @@ mod tests {
                 NumericKernel::from_op(name, &[]).is_some(),
                 "{name} unmapped"
             );
+        }
+    }
+
+    // --- nullable (Option<String>) chain ---
+
+    /// Apply nullable kernels sequentially (fresh array per step, null-skipping
+    /// like `map_str_to_str`) as the parity oracle.
+    fn seq_nullable(arr: &StringArray, kernels: &[NullableKernel]) -> StringArray {
+        let mut cur = arr.clone();
+        for k in kernels {
+            let out: StringArray = cur.iter().map(|v| v.and_then(|s| k.apply(s))).collect();
+            cur = out;
+        }
+        cur
+    }
+
+    fn url_sample() -> StringArray {
+        StringArray::from(vec![
+            Some("HTTP://WWW.Example.com/Path/?utm_source=x&a=1"),
+            Some("not a url at all"),
+            None,
+            Some("https://foo.com/"),
+            Some(""),
+        ])
+    }
+
+    #[test]
+    fn nullable_chain_matches_sequential() {
+        let chains: &[&[NullableKernel]] = &[
+            &[
+                NullableKernel::UrlNormalize,
+                NullableKernel::UrlStripTracking,
+            ],
+            &[NullableKernel::UrlNormalize, NullableKernel::UrlStripWww],
+            &[NullableKernel::UrlCanonical],
+            &[
+                NullableKernel::UrlNormalize,
+                NullableKernel::UrlExtractDomain,
+            ],
+            // MIXED: total (strip/lowercase) + nullable (url_normalize).
+            &[
+                NullableKernel::Total(Kernel::Strip),
+                NullableKernel::Total(Kernel::Lowercase),
+                NullableKernel::UrlNormalize,
+                NullableKernel::UrlStripWww,
+            ],
+        ];
+        let arr = url_sample();
+        for chain in chains {
+            let fused = apply_chain_nullable(&arr, chain);
+            let seq = seq_nullable(&arr, chain);
+            assert_eq!(fused.array, seq, "nullable chain {chain:?} != sequential");
+        }
+    }
+
+    #[test]
+    fn nullable_company_and_email() {
+        let arr = StringArray::from(vec![
+            Some("  Acme, Inc.  "),
+            Some("John Doe <j@x.com>"),
+            None,
+            Some("Widgets LLC"),
+        ]);
+        // total strip -> nullable company_normalize; and email_mask alone.
+        let c1 = [
+            NullableKernel::Total(Kernel::Strip),
+            NullableKernel::CompanyNormalize,
+        ];
+        assert_eq!(
+            apply_chain_nullable(&arr, &c1).array,
+            seq_nullable(&arr, &c1)
+        );
+        let c2 = [NullableKernel::EmailMask];
+        assert_eq!(
+            apply_chain_nullable(&arr, &c2).array,
+            seq_nullable(&arr, &c2)
+        );
+    }
+
+    #[test]
+    fn nullable_null_propagates_and_not_counted() {
+        // email_extract_domain nulls a non-email (no `@`); the produced null then
+        // passes through the next kernel. The changed count must match the Polars
+        // rule: count a row only when BOTH before and after are non-null + differ.
+        let arr = StringArray::from(vec![Some("  a@B.com  "), Some("not-an-email"), None]);
+        let chain = [
+            NullableKernel::Total(Kernel::Strip),
+            NullableKernel::EmailExtractDomain,
+            NullableKernel::Total(Kernel::Uppercase),
+        ];
+        let out = apply_chain_nullable(&arr, &chain);
+        assert!(!out.array.is_null(0), "a@B.com has a domain");
+        assert!(
+            out.array.is_null(1),
+            "non-email -> null, then passes through"
+        );
+        assert!(out.array.is_null(2), "null input stays null");
+        // Independently recompute per-step changed via the sequential path with
+        // the same both-non-null-and-differ rule (the null-not-counted claim).
+        let mut cur = arr.clone();
+        let mut expected = vec![0u64; chain.len()];
+        for (i, k) in chain.iter().enumerate() {
+            let nxt = seq_nullable(&cur, &[*k]);
+            for r in 0..cur.len() {
+                if !cur.is_null(r) && !nxt.is_null(r) && cur.value(r) != nxt.value(r) {
+                    expected[i] += 1;
+                }
+            }
+            cur = nxt;
+        }
+        assert_eq!(out.changed, expected, "null-aware changed counts diverged");
+    }
+
+    #[test]
+    fn nullable_from_op_falls_back_to_total() {
+        assert_eq!(
+            NullableKernel::from_op("url_normalize", &[]),
+            Some(NullableKernel::UrlNormalize)
+        );
+        assert_eq!(
+            NullableKernel::from_op("strip", &[]),
+            Some(NullableKernel::Total(Kernel::Strip))
+        );
+        assert_eq!(
+            NullableKernel::from_op("truncate", &["5"]),
+            Some(NullableKernel::Total(Kernel::Truncate(5)))
+        );
+        assert_eq!(NullableKernel::from_op("split_name", &[]), None);
+        for name in NullableKernel::NULLABLE_NAMES {
+            assert!(
+                NullableKernel::from_op(name, &[]).is_some(),
+                "{name} unmapped"
+            );
+        }
+    }
+
+    #[test]
+    fn nullable_works_on_large_utf8() {
+        use arrow_array::LargeStringArray;
+        let large = LargeStringArray::from(vec![Some("HTTP://WWW.A.com/"), None, Some("bad url")]);
+        let small = StringArray::from(vec![Some("HTTP://WWW.A.com/"), None, Some("bad url")]);
+        let chain = [NullableKernel::UrlNormalize, NullableKernel::UrlStripWww];
+        let lo = apply_chain_nullable(&large, &chain);
+        let so = apply_chain_nullable(&small, &chain);
+        assert_eq!(lo.changed, so.changed);
+        for i in 0..lo.array.len() {
+            assert_eq!(lo.array.is_null(i), so.array.is_null(i));
+            if !lo.array.is_null(i) {
+                assert_eq!(lo.array.value(i), so.array.value(i));
+            }
         }
     }
 }

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.13.0"
+version = "0.14.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.13.0"
+    __version__ = "0.14.0"

--- a/packages/rust/extensions/native-flow/src/chain.rs
+++ b/packages/rust/extensions/native-flow/src/chain.rs
@@ -12,7 +12,9 @@
 
 use arrow::array::{make_array, Array, ArrayData, Float64Array, LargeStringArray, StringArray};
 use arrow::pyarrow::PyArrowType;
-use goldenflow_core::chain::{apply_chain, apply_chain_f64, Kernel, NumericKernel};
+use goldenflow_core::chain::{
+    apply_chain, apply_chain_f64, apply_chain_nullable, Kernel, NullableKernel, NumericKernel,
+};
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 
@@ -134,4 +136,55 @@ pub fn apply_chain_f64_arrow(
         (r.array.into_data(), r.changed)
     });
     Ok((PyArrowType(out), changed))
+}
+
+/// The fusable NULLABLE (`Option<String>`) kernel names — the URL / company /
+/// email `Option`-returning families — for the host's nullable coverage guard.
+#[pyfunction]
+pub fn fusable_nullable_kernel_names() -> Vec<String> {
+    NullableKernel::NULLABLE_NAMES
+        .iter()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Apply a run of nullable string kernels (`(name, params)` tuples) over a
+/// Utf8 / LargeUtf8 array in one pass. A run may MIX total kernels (strip,
+/// lowercase, …) with the `Option`-returning URL/company/email ones; a value a
+/// kernel can't parse becomes a NULL cell that passes through the rest of the
+/// run. Returns `(transformed_array, changed)` with the per-kernel affected
+/// counts (a non-null→null row is not counted, matching the per-transform path).
+#[pyfunction]
+pub fn apply_chain_nullable_arrow(
+    py: Python,
+    array: PyArrowType<ArrayData>,
+    ops: Vec<(String, Vec<String>)>,
+) -> PyResult<(PyArrowType<ArrayData>, Vec<u64>)> {
+    let mut kernels = Vec::with_capacity(ops.len());
+    for (name, params) in &ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        kernels.push(
+            NullableKernel::from_op(name, &refs).ok_or_else(|| {
+                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
+            })?,
+        );
+    }
+    let arr = make_array(array.0);
+    if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+        let (out, changed) = py.detach(|| {
+            let r = apply_chain_nullable(s, &kernels);
+            (r.array.into_data(), r.changed)
+        });
+        Ok((PyArrowType(out), changed))
+    } else if let Some(s) = arr.as_any().downcast_ref::<LargeStringArray>() {
+        let (out, changed) = py.detach(|| {
+            let r = apply_chain_nullable(s, &kernels);
+            (r.array.into_data(), r.changed)
+        });
+        Ok((PyArrowType(out), changed))
+    } else {
+        Err(PyTypeError::new_err(
+            "fused nullable apply requires a Utf8 or LargeUtf8 array",
+        ))
+    }
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -32,8 +32,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(chain::apply_chain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_f64_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(chain::apply_chain_nullable_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::fusable_kernel_names, m)?)?;
     m.add_function(wrap_pyfunction!(chain::fusable_f64_kernel_names, m)?)?;
+    m.add_function(wrap_pyfunction!(chain::fusable_nullable_kernel_names, m)?)?;
     m.add_function(wrap_pyfunction!(company::company_normalize_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(company::company_strip_legal_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(company::company_extract_legal_arrow, m)?)?;


### PR DESCRIPTION
Pillar-1, follow-up #1 of 3: extends the fused columnar apply to a **third kernel shape** — the `Option`-returning URL / company / email families. (Next: wasm/duckdb fused surfaces; then the frame-container investigation.)

## What
- **Nullable executor.** `goldenflow_core::chain::apply_chain_nullable` (new `NullableKernel` = `Total(Kernel)` | the 10 `Option`-returning URL/company/email kernels) threads `Option<String>` over a column in one native pass → native `apply_chain_nullable_arrow`. A value a kernel can't parse becomes a **null cell that passes through the rest of the run** — exactly the per-transform semantics (`map_str_to_str` skips null input, nulls on `None`).
- **Mixed runs.** A run may mix total/param string kernels with the nullable ones — `strip → lowercase → url_normalize → url_strip_www` fuses as one pass.
- **Byte-identical.** Output frame (nulls included) AND audit manifest. The per-kernel affected count matches Polars' `(before != after).sum()` (a non-null→null row isn't counted); tests recompute the expected counts independently rather than hard-coding.
- **Symbol-aware, no regression.** A pre-0.14.0 wheel keeps fusing the total + numeric families; only the nullable ops break a run. Host `transformer.py` unchanged (already dtype/symbol-aware via `fusable_names()`).

## Republish (0.14.0)
- `goldenflow-core` 0.7→**0.8** (busts rust-cache); `goldenflow-native` 0.13→**0.14** (`apply_chain_nullable_arrow` + `fusable_nullable_kernel_names`).
- `goldenflow` → **1.16.0** (native floor ≥0.14.0); `golden-suite` → **0.1.6** lockstep.

## Test plan
- `goldenflow-core` `cargo test --features arrow` — **144 pass** (5 new nullable: chain==sequential incl. mixed, company/email, null-propagates-not-counted, from_op→Total fallback, large-utf8).
- `native-flow` `cargo check` + clippy clean.
- `test_fused_chain.py` — nullable parity (9 chains incl. mixed) + coverage guard; full `transforms/`+`engine/` **1683 pass under `-n auto`**.

## Follow-up (post-merge)
- Republish `goldenflow-native` 0.14.0 → verify `apply_chain_nullable_arrow` in the wheel; publish `goldenflow` 1.16.0 → `golden-suite` 0.1.6.
- Update ADR 0034 (third shape) — folds in once PR #1509 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg