### PR TITLE
feat(goldenflow): fused chain on the edge — WASM applyChain + TS engine fusion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2049,8 +2049,8 @@ jobs:
             --target web --out-dir "$OUT_DIR" --out-name goldenflow_wasm
       - name: Build shared wasm-runtime (the loader imports goldenmatch-wasm-runtime)
         run: pnpm --filter goldenmatch-wasm-runtime build
-      - name: WASM identifier parity (un-skipped — artifact now present) [THE GATE]
-        run: pnpm --filter goldenflow exec vitest run tests/parity/identifiers.parity.test.ts
+      - name: WASM identifier + fused-chain parity (un-skipped — artifact now present) [THE GATE]
+        run: pnpm --filter goldenflow exec vitest run tests/parity/identifiers.parity.test.ts tests/parity/fused_chain.parity.test.ts
 
   goldenpipe_wasm:
     needs: changes

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -1,6 +1,8 @@
-//! Fused columnar apply (feature `arrow`, off by default) — Pillar-1 of the Rust
-//! cutover: run a WHOLE chain of owned string kernels over a `StringArray` in one
-//! pass, instead of crossing the Python/Polars/Arrow boundary once per transform.
+//! Fused apply — Pillar-1 of the Rust cutover: run a WHOLE chain of owned kernels
+//! over a column in one pass, instead of crossing the boundary once per transform.
+//! The `Kernel` enums + the arrow-free [`apply_chain_str`] are always compiled (the
+//! WASM / pure-TS surfaces fuse without arrow); the Arrow-columnar executors below
+//! are `#[cfg(feature = "arrow")]` (native-flow enables it).
 //!
 //! The host (`engine/transformer.py`) currently applies N transforms to a column
 //! as N × (Series→Arrow export + kernel + Arrow→Series import + `with_columns` +
@@ -29,11 +31,22 @@
 //! and the residual-tier phone/date families — see the boundary note in the design
 //! doc / ADR 0034.
 
+// Arrow imports back the columnar executors (native-flow, `--features arrow`).
+// The `Kernel`/`NumericKernel`/`NullableKernel` enums + `apply_chain_str` below are
+// arrow-FREE, so the WASM / pure surfaces get the fusable chain without pulling arrow.
+#[cfg(feature = "arrow")]
 use arrow_array::builder::Float64Builder;
+#[cfg(feature = "arrow")]
 use arrow_array::{Array, Float64Array, GenericStringArray, OffsetSizeTrait};
+#[cfg(feature = "arrow")]
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 
-use crate::{company, email, names, numeric, text, url};
+// `email`/`names`/`text` back the arrow-free `Kernel` (via `apply_into`); the
+// `numeric`/`company`/`url` families are only reached by the arrow-gated
+// NumericKernel/NullableKernel executors.
+#[cfg(feature = "arrow")]
+use crate::{company, numeric, url};
+use crate::{email, names, text};
 
 /// One owned, no-arg, total string→string kernel eligible for the fused chain.
 /// The name mapping (`from_name`) is the single source of truth the host's
@@ -214,6 +227,36 @@ impl Kernel {
 /// i-th kernel altered, comparing the value before vs after that kernel — exactly
 /// what the host's `(before != after).sum()` computes per transform). Generic over
 /// the offset width so the output matches the input (Utf8 `i32` / LargeUtf8 `i64`).
+/// Arrow-FREE total string chain, for non-arrow surfaces (WASM / TS): thread each
+/// value through `kernels` and return `(transformed values, per-kernel changed
+/// counts)`. Same composition + change-counting as the columnar [`apply_chain`]
+/// (identical `apply_into` dispatch, two reused scratch buffers, `changed[i]` =
+/// rows the i-th kernel altered), minus the offset-buffer machinery. Total kernels
+/// never null, so callers pass only the NON-NULL values and scatter the results
+/// back into their positions, leaving null cells untouched — hence `changed[i]`
+/// already matches the host's per-op `(before != after)` count over non-null rows.
+pub fn apply_chain_str(values: &[&str], kernels: &[Kernel]) -> (Vec<String>, Vec<u64>) {
+    let mut out = Vec::with_capacity(values.len());
+    let mut changed = vec![0u64; kernels.len()];
+    let mut cur = String::new();
+    let mut next = String::new();
+    for &s0 in values {
+        cur.clear();
+        cur.push_str(s0);
+        for (i, k) in kernels.iter().enumerate() {
+            next.clear();
+            k.apply_into(&cur, &mut next);
+            if next != cur {
+                changed[i] += 1;
+            }
+            std::mem::swap(&mut cur, &mut next);
+        }
+        out.push(cur.clone());
+    }
+    (out, changed)
+}
+
+#[cfg(feature = "arrow")]
 pub struct ChainResult<O: OffsetSizeTrait> {
     pub array: GenericStringArray<O>,
     pub changed: Vec<u64>,
@@ -226,6 +269,7 @@ pub struct ChainResult<O: OffsetSizeTrait> {
 /// Generic over `O` (i32 for `StringArray`/Utf8, i64 for `LargeStringArray`/
 /// LargeUtf8) because **Polars exports strings as LargeUtf8** — a non-generic i32
 /// path would silently never fire on real Polars data.
+#[cfg(feature = "arrow")]
 pub fn apply_chain<O: OffsetSizeTrait>(
     arr: &GenericStringArray<O>,
     kernels: &[Kernel],
@@ -319,6 +363,7 @@ impl NumericKernel {
     /// Apply this kernel to one optional value. Operates on `Option<f64>` because
     /// `fill_zero` is fundamentally a null-handling op (null -> 0.0); the value
     /// kernels pass a null straight through (`None -> None`).
+    #[cfg(feature = "arrow")]
     #[inline]
     fn apply(self, v: Option<f64>) -> Option<f64> {
         match self {
@@ -331,6 +376,7 @@ impl NumericKernel {
 }
 
 /// Fused f64 output: the transformed column + per-kernel affected-row counts.
+#[cfg(feature = "arrow")]
 pub struct F64ChainResult {
     pub array: Float64Array,
     pub changed: Vec<u64>,
@@ -347,6 +393,7 @@ pub struct F64ChainResult {
 /// (Edge: `-0.0`/`NaN` values compare by IEEE-754 here, not by their Utf8 text,
 /// so a `-0.0`->`0.0` or `NaN` row's count could differ from the Utf8 path; the
 /// output array is byte-identical regardless. Documented, not chased.)
+#[cfg(feature = "arrow")]
 pub fn apply_chain_f64(arr: &Float64Array, kernels: &[NumericKernel]) -> F64ChainResult {
     let len = arr.len();
     let mut changed = vec![0u64; kernels.len()];
@@ -439,6 +486,7 @@ impl NullableKernel {
 
     /// Apply to one present value, returning `None` when the kernel can't parse
     /// it (→ a null output cell). Total kernels always return `Some`.
+    #[cfg(feature = "arrow")]
     #[inline]
     fn apply(self, s: &str) -> Option<String> {
         match self {
@@ -469,6 +517,7 @@ impl NullableKernel {
 /// differ (a null on either side yields a null comparison, skipped by `.sum()`).
 /// So a row a kernel turns non-null→null is NOT counted (nor is a null-before
 /// row). Generic over offset width for the LargeUtf8 Polars shape.
+#[cfg(feature = "arrow")]
 pub fn apply_chain_nullable<O: OffsetSizeTrait>(
     arr: &GenericStringArray<O>,
     kernels: &[NullableKernel],
@@ -510,7 +559,72 @@ pub fn apply_chain_nullable<O: OffsetSizeTrait>(
     ChainResult { array, changed }
 }
 
+// Arrow-free tests — run on a plain `cargo test` (no `--features arrow`), so the
+// WASM/pure chain path stays covered even when arrow isn't compiled in.
 #[cfg(test)]
+mod vec_tests {
+    use super::*;
+
+    #[test]
+    fn apply_chain_str_threads_kernels_and_counts() {
+        let vals = ["  John  SMITH  ", "<b>a</b>  B", "café  #7"];
+        let kernels = [
+            Kernel::Strip,
+            Kernel::Lowercase,
+            Kernel::CollapseWhitespace,
+            Kernel::RemoveHtmlTags,
+        ];
+        let (out, changed) = apply_chain_str(&vals, &kernels);
+        // Values: compare against a manual sequential fold through the same apply_into.
+        let expect: Vec<String> = vals
+            .iter()
+            .map(|s| {
+                let mut cur = s.to_string();
+                for k in &kernels {
+                    let mut b = String::new();
+                    k.apply_into(&cur, &mut b);
+                    cur = b;
+                }
+                cur
+            })
+            .collect();
+        assert_eq!(out, expect);
+        // Counts: independently recompute per-step (before != after) over the values.
+        let mut cur: Vec<String> = vals.iter().map(|s| s.to_string()).collect();
+        let mut exp_changed = vec![0u64; kernels.len()];
+        for (i, k) in kernels.iter().enumerate() {
+            let nxt: Vec<String> = cur
+                .iter()
+                .map(|s| {
+                    let mut b = String::new();
+                    k.apply_into(s, &mut b);
+                    b
+                })
+                .collect();
+            for r in 0..cur.len() {
+                if cur[r] != nxt[r] {
+                    exp_changed[i] += 1;
+                }
+            }
+            cur = nxt;
+        }
+        assert_eq!(changed, exp_changed);
+    }
+
+    #[test]
+    fn apply_chain_str_empty_and_single() {
+        assert_eq!(
+            apply_chain_str(&[], &[Kernel::Strip]),
+            (Vec::<String>::new(), vec![0u64])
+        );
+        assert_eq!(
+            apply_chain_str(&["  x  "], &[Kernel::Strip]),
+            (vec!["x".to_string()], vec![1u64])
+        );
+    }
+}
+
+#[cfg(all(test, feature = "arrow"))]
 mod tests {
     use super::*;
     use arrow_array::StringArray;

--- a/packages/rust/extensions/goldenflow-core/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-core/src/lib.rs
@@ -9,9 +9,9 @@ pub mod address;
 pub mod autocorrect;
 pub mod categorical;
 pub mod company;
-/// Fused columnar apply (a whole owned-kernel chain in one pass) — only when
-/// built with `--features arrow`. Pillar-1 of the Rust cutover.
-#[cfg(feature = "arrow")]
+/// Fused apply — a whole owned-kernel chain in one pass (Pillar-1). The `Kernel`
+/// enums + the arrow-free `apply_chain_str` (WASM/pure surfaces) are always
+/// compiled; the Arrow-columnar executors inside are `#[cfg(feature = "arrow")]`.
 pub mod chain;
 /// Arrow-columnar apply paths — only when built with `--features arrow`
 /// (native-flow enables it; wasm/pure surfaces stay arrow-free).

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,14 +79,14 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.6.0"
+version = "0.9.0"
 dependencies = [
  "phonenumber",
 ]
 
 [[package]]
 name = "goldenflow-wasm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "goldenflow-core",
  "wasm-bindgen",

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-wasm"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenflow-wasm/src/lib.rs
@@ -539,4 +539,62 @@ mod wasm {
     pub fn category_normalize_key(s: &str) -> String {
         categorical::category_normalize_key(s)
     }
+
+    // -- Fused columnar apply (Pillar-1 on the edge) -----------------------------
+
+    /// Output of [`apply_chain`]: the transformed values plus the per-kernel affected
+    /// count (rows the i-th kernel altered), so the TS engine can emit a per-op audit
+    /// record without N boundary crossings — mirrors the native chain's `changed`.
+    #[wasm_bindgen]
+    pub struct ChainOut {
+        values: Vec<String>,
+        changed: Vec<u32>,
+    }
+
+    #[wasm_bindgen]
+    impl ChainOut {
+        #[wasm_bindgen(getter)]
+        pub fn values(&self) -> Vec<String> {
+            self.values.clone()
+        }
+        #[wasm_bindgen(getter)]
+        pub fn changed(&self) -> Vec<u32> {
+            self.changed.clone()
+        }
+    }
+
+    /// Run a whole chain of owned no-arg string kernels over a column of NON-NULL
+    /// values in ONE JS<->WASM crossing, instead of one crossing per value per
+    /// transform (the TS WASM backend otherwise dispatches per value). Byte-identical
+    /// to applying the kernels one at a time — same `goldenflow_core::chain` dispatch.
+    /// Total kernels never null, so the TS caller passes only the non-null values and
+    /// scatters the results back into their positions, leaving null cells untouched.
+    #[wasm_bindgen]
+    pub fn apply_chain(values: Vec<String>, names: Vec<String>) -> Result<ChainOut, JsError> {
+        use goldenflow_core::chain::Kernel;
+        let mut kernels = Vec::with_capacity(names.len());
+        for n in &names {
+            kernels.push(
+                Kernel::from_name(n)
+                    .ok_or_else(|| JsError::new(&format!("not a fusable chain kernel: {n}")))?,
+            );
+        }
+        let refs: Vec<&str> = values.iter().map(String::as_str).collect();
+        let (out, changed) = goldenflow_core::chain::apply_chain_str(&refs, &kernels);
+        Ok(ChainOut {
+            values: out,
+            changed: changed.into_iter().map(|c| c as u32).collect(),
+        })
+    }
+
+    /// The fusable no-arg kernel names the WASM chain supports — mirror of the TS
+    /// `FUSABLE_KERNELS` set (coverage-guarded in the TS parity test) and of the
+    /// native `fusable_kernel_names` no-arg subset.
+    #[wasm_bindgen]
+    pub fn fusable_kernel_names() -> Vec<String> {
+        goldenflow_core::chain::Kernel::ALL_NAMES
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
 }

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/core/engine/_chain.ts
+++ b/packages/typescript/goldenflow/src/core/engine/_chain.ts
@@ -1,0 +1,57 @@
+/**
+ * Fused columnar apply (Pillar-1 on the edge) — run a maximal run of owned no-arg
+ * string transforms over a column in ONE JS<->WASM crossing, instead of the WASM
+ * backend crossing the boundary once per value per transform.
+ *
+ * This is a WASM-path optimization ONLY: pure-TS applies transforms in-process
+ * (no boundary to collapse), so `fusedEnabled()` is false without an active WASM
+ * backend and the engine takes the per-transform path unchanged. `FUSABLE_KERNELS`
+ * mirrors `goldenflow_core::chain::Kernel::ALL_NAMES` (the no-arg total string
+ * kernels); a parity test asserts it equals the backend's `fusableKernelNames()`.
+ */
+
+import { getFlowWasmBackend } from "../wasm/backend.js";
+
+/** No-arg, total (never-null) string kernels eligible for the fused chain.
+ * Mirror of `goldenflow_core::chain::Kernel::ALL_NAMES`. Parameterized
+ * (`truncate`/`pad`), numeric, and `Option`-returning (URL/company) transforms
+ * are excluded — they take the per-transform path. */
+export const FUSABLE_KERNELS: ReadonlySet<string> = new Set([
+  "strip",
+  "lowercase",
+  "uppercase",
+  "title_case",
+  "fix_mojibake",
+  "collapse_whitespace",
+  "normalize_quotes",
+  "normalize_line_endings",
+  "normalize_unicode",
+  "remove_html_tags",
+  "remove_urls",
+  "remove_digits",
+  "remove_punctuation",
+  "remove_emojis",
+  "extract_numbers",
+  "email_lowercase",
+  "email_normalize",
+  "email_canonical",
+  "name_transliterate",
+  "strip_titles",
+  "strip_suffixes",
+  "name_proper",
+  "nickname_standardize",
+  "name_initials",
+  "strip_middle",
+]);
+
+/** The fused chain is active only when a WASM backend that exposes `applyChain`
+ * is registered (a 0.1.0 wheel without the fused export stays per-transform). */
+export function fusedEnabled(): boolean {
+  const b = getFlowWasmBackend();
+  return b != null && typeof b.applyChain === "function";
+}
+
+/** An op fuses iff it's a no-arg kernel in the fusable set. */
+export function isFusable(name: string, params: readonly string[]): boolean {
+  return params.length === 0 && FUSABLE_KERNELS.has(name);
+}

--- a/packages/typescript/goldenflow/src/core/engine/transformer.ts
+++ b/packages/typescript/goldenflow/src/core/engine/transformer.ts
@@ -13,8 +13,10 @@ import type {
 import { makeConfig, makeTransformRecord, MutableManifest } from "../types.js";
 import { toColumnValue } from "../data.js";
 import { getTransform, parseTransformName } from "../transforms/index.js";
+import { fusedEnabled, isFusable } from "./_chain.js";
 import { profileDataframe } from "./profiler-bridge.js";
 import { selectTransforms } from "./selector.js";
+import { getFlowWasmBackend } from "../wasm/backend.js";
 
 export class TransformEngine {
   readonly config: GoldenFlowConfig;
@@ -125,6 +127,7 @@ export class TransformEngine {
   ): Row[] {
     for (const spec of this.config.transforms) {
       if (rows.length === 0 || !(spec.column in rows[0]!)) continue;
+      const ops: Array<[TransformInfo, string[]]> = [];
       for (const opRaw of spec.ops) {
         const [name, params] = parseTransformName(opRaw);
         const info = getTransform(name);
@@ -137,8 +140,9 @@ export class TransformEngine {
           );
           continue;
         }
-        rows = this._applySingleTransform(rows, spec.column, info, params, manifest);
+        ops.push([info, params]);
       }
+      rows = this._applyColumnOps(rows, spec.column, ops, manifest);
     }
     return rows;
   }
@@ -153,17 +157,136 @@ export class TransformEngine {
 
     for (const colProfile of profile.columns) {
       const selected = selectTransforms(colProfile);
-      for (const info of selected) {
-        rows = this._applySingleTransform(
-          rows,
-          colProfile.name,
-          info,
-          [],
-          manifest,
-        );
-      }
+      const ops: Array<[TransformInfo, string[]]> = selected.map((info) => [
+        info,
+        [],
+      ]);
+      rows = this._applyColumnOps(rows, colProfile.name, ops, manifest);
     }
     return rows;
+  }
+
+  /**
+   * Apply an ordered list of `[info, params]` to `column`. When the WASM backend
+   * is active, a maximal run of owned no-arg string kernels is fused into ONE
+   * `applyChain` crossing (Pillar-1 on the edge); everything else takes the
+   * per-transform path unchanged. Pure-TS (no backend) always takes per-transform.
+   */
+  private _applyColumnOps(
+    rows: Row[],
+    column: string,
+    ops: Array<[TransformInfo, string[]]>,
+    manifest: MutableManifest,
+  ): Row[] {
+    const fuseOn = fusedEnabled();
+    let i = 0;
+    while (i < ops.length) {
+      const [info, params] = ops[i]!;
+      if (fuseOn && isFusable(info.name, params)) {
+        let j = i;
+        while (j < ops.length && isFusable(ops[j]![0].name, ops[j]![1])) j++;
+        if (j - i >= 2) {
+          const applied = this._applyFusedRun(
+            rows,
+            column,
+            ops.slice(i, j),
+            manifest,
+          );
+          if (applied !== null) {
+            rows = applied;
+            i = j;
+            continue;
+          }
+          // backend declined -> fall through to the per-op path.
+        }
+      }
+      rows = this._applySingleTransform(rows, column, info, params, manifest);
+      i++;
+    }
+    return rows;
+  }
+
+  /**
+   * Apply a run of fusable ops via one `backend.applyChain` crossing. Emits one
+   * audit record per op with the exact affected count from the kernel and per-step
+   * before/after samples from a cheap head(3) replay through the SAME transforms
+   * (byte-identical to the fused output). Returns the new rows, or `null` if the
+   * backend declined (caller falls back to per-op).
+   */
+  private _applyFusedRun(
+    rows: Row[],
+    column: string,
+    run: Array<[TransformInfo, string[]]>,
+    manifest: MutableManifest,
+  ): Row[] | null {
+    const backend = getFlowWasmBackend();
+    if (backend == null || typeof backend.applyChain !== "function") return null;
+
+    // Non-null values (coerced to string) + their row indices. Total kernels never
+    // null, so nulls stay put and only the non-null cells go across the boundary.
+    const idx: number[] = [];
+    const vals: string[] = [];
+    for (let r = 0; r < rows.length; r++) {
+      const v = rows[r]![column];
+      if (v === null || v === undefined) continue;
+      idx.push(r);
+      vals.push(typeof v === "string" ? v : String(v));
+    }
+    const names = run.map(([info]) => info.name);
+    let outVals: string[];
+    let changed: number[];
+    try {
+      const out = backend.applyChain(vals, names);
+      outVals = out.values;
+      changed = out.changed;
+    } catch {
+      return null; // fall back to per-op
+    }
+    if (outVals.length !== vals.length || changed.length !== run.length) {
+      return null;
+    }
+
+    // Manifest: one record per op. Affected count is exact from the kernel; the
+    // before/after samples come from replaying each op on the first-3 rows through
+    // the SAME transform funcs (which dispatch to the same backend kernels).
+    const totalRows = rows.length;
+    let sample: ColumnValue[] = rows.slice(0, 3).map((r) => {
+      const v = r[column];
+      if (v === null || v === undefined) return null;
+      return typeof v === "string" || typeof v === "number" || typeof v === "boolean"
+        ? v
+        : String(v);
+    });
+    for (let k = 0; k < run.length; k++) {
+      const [info, params] = run[k]!;
+      const before = sample.map((v) => String(v ?? ""));
+      const typedParams = castParams(params);
+      const res =
+        typedParams.length > 0 ? info.func(sample, ...typedParams) : info.func(sample);
+      sample = res as ColumnValue[];
+      const after = sample.map((v) => String(v ?? ""));
+      manifest.addRecord(
+        makeTransformRecord({
+          column,
+          transform: info.name,
+          affectedRows: changed[k] ?? 0,
+          totalRows,
+          sampleBefore: before,
+          sampleAfter: after,
+        }),
+      );
+    }
+
+    // Scatter the transformed values back into their (non-null) positions.
+    const newRows = rows.slice();
+    for (let m = 0; m < idx.length; m++) {
+      const r = idx[m]!;
+      const nv = outVals[m]!;
+      if (String(newRows[r]![column] ?? "") !== nv) {
+        newRows[r] = { ...newRows[r]!, [column]: nv };
+      }
+    }
+    return newRows;
   }
 
   private _applySingleTransform(

--- a/packages/typescript/goldenflow/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/backend.ts
@@ -139,6 +139,14 @@ export interface FlowWasmBackend {
     freqThreshold: number,
     matchThreshold: number,
   ): string[];
+  /** Fused columnar apply — run a chain of no-arg string kernels over the NON-null
+   * values in ONE JS<->WASM crossing (vs one per value per transform). Returns the
+   * transformed values + per-kernel affected counts (for the audit manifest).
+   * Byte-identical to applying the kernels one at a time. */
+  applyChain(values: string[], names: string[]): { values: string[]; changed: number[] };
+  /** The fusable no-arg kernel names the WASM chain supports (mirror of the TS
+   * `FUSABLE_KERNELS` set + the native `fusableKernelNames`). */
+  fusableKernelNames(): string[];
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenflow/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenflow/src/core/wasm/loader.ts
@@ -144,6 +144,13 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
       freqThreshold: number,
       matchThreshold: number,
     ) => string[];
+    // Fused chain: `Vec<String>` in, a `ChainOut` class out (wasm-bindgen getters
+    // `values` -> `string[]`, `changed` -> `Uint32Array`).
+    apply_chain: (
+      values: string[],
+      names: string[],
+    ) => { values: string[]; changed: Uint32Array };
+    fusable_kernel_names: () => string[];
   };
   await glue.default({ module_or_path: bytes });
 
@@ -245,5 +252,10 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<FlowWasmBac
     fuzzRatio: (a, b) => glue.fuzz_ratio(a, b),
     buildCanonicalMap: (values, counts, freqThreshold, matchThreshold) =>
       glue.build_canonical_map(values, Int32Array.from(counts), freqThreshold, matchThreshold),
+    applyChain: (values, names) => {
+      const out = glue.apply_chain(values, names);
+      return { values: out.values, changed: Array.from(out.changed) };
+    },
+    fusableKernelNames: () => glue.fusable_kernel_names(),
   };
 }

--- a/packages/typescript/goldenflow/tests/parity/fused_chain.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/fused_chain.parity.test.ts
@@ -48,7 +48,7 @@ const CHAINS: string[][] = [
   ["name_transliterate", "name_proper", "strip_titles", "strip_suffixes"],
 ];
 
-function run(ops: string[]): { rows: Row[]; records: unknown[] } {
+function run(ops: string[]): { rows: readonly Row[]; records: unknown[] } {
   const engine = new TransformEngine({ transforms: [{ column: "v", ops }] });
   const result = engine.transformDf(SAMPLE.map((r) => ({ ...r })));
   const records = result.manifest.records.map((r) => ({

--- a/packages/typescript/goldenflow/tests/parity/fused_chain.parity.test.ts
+++ b/packages/typescript/goldenflow/tests/parity/fused_chain.parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Fused columnar apply (Pillar-1 on the edge) — parity guard.
+ *
+ * When the WASM backend is active, a run of owned no-arg string transforms fuses
+ * into ONE `applyChain` crossing. It must be byte-identical to the per-transform
+ * path — same output rows AND same audit manifest — so the fusion is transparent
+ * except for the number of JS<->WASM boundary crossings.
+ *
+ * The fused path only engages when the `.wasm` artifact is built (a CI-only build
+ * product, never committed — see src/core/wasm/artifacts/.gitignore). Outside the
+ * `wasm_flow` lane `enableWasm()` resolves false and these legs skip.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+
+import { TransformEngine } from "../../src/core/engine/transformer.js";
+import { FUSABLE_KERNELS } from "../../src/core/engine/_chain.js";
+import { getFlowWasmBackend } from "../../src/core/wasm/backend.js";
+import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
+import type { Row } from "../../src/core/types.js";
+
+let wasmAvailable = false;
+
+beforeAll(async () => {
+  wasmAvailable = await enableWasm();
+  // Start each parity comparison from a known-off state; the tests toggle.
+  disableWasm();
+});
+
+afterAll(() => {
+  disableWasm();
+});
+
+const SAMPLE: Row[] = [
+  { v: "  <b>John</b>  SMITH!  http://x.com/y " },
+  { v: "o'BRIEN, jr.  123" },
+  { v: null },
+  { v: "  a   b  “Q” " },
+  { v: "" },
+  { v: "café  éé  #7" },
+];
+
+const CHAINS: string[][] = [
+  ["strip", "lowercase"],
+  ["strip", "lowercase", "collapse_whitespace", "remove_punctuation"],
+  ["remove_html_tags", "remove_urls", "strip", "collapse_whitespace"],
+  ["normalize_unicode", "lowercase", "remove_digits"],
+  ["strip", "lowercase", "email_normalize", "email_canonical"],
+  ["name_transliterate", "name_proper", "strip_titles", "strip_suffixes"],
+];
+
+function run(ops: string[]): { rows: Row[]; records: unknown[] } {
+  const engine = new TransformEngine({ transforms: [{ column: "v", ops }] });
+  const result = engine.transformDf(SAMPLE.map((r) => ({ ...r })));
+  const records = result.manifest.records.map((r) => ({
+    column: r.column,
+    transform: r.transform,
+    affectedRows: r.affectedRows,
+    sampleBefore: r.sampleBefore,
+    sampleAfter: r.sampleAfter,
+  }));
+  return { rows: result.rows, records };
+}
+
+describe("goldenflow fused chain: reports wasm availability", () => {
+  it("wasm artifact present?", () => {
+    if (!wasmAvailable) {
+      console.warn(
+        "goldenflow wasm artifact not built -- skipping the fused-chain parity legs " +
+          "(expected outside the wasm_flow CI lane).",
+      );
+    }
+    expect(true).toBe(true);
+  });
+});
+
+describe("goldenflow fused chain: coverage guard", () => {
+  it.skipIf(!wasmAvailable)(
+    "FUSABLE_KERNELS mirrors the backend fusableKernelNames()",
+    async () => {
+      await enableWasm();
+      const backend = getFlowWasmBackend();
+      expect(backend).not.toBeNull();
+      const native = new Set(backend!.fusableKernelNames());
+      expect(native).toEqual(new Set(FUSABLE_KERNELS));
+      disableWasm();
+    },
+  );
+});
+
+describe("goldenflow fused chain: fused === per-transform", () => {
+  for (const ops of CHAINS) {
+    it.skipIf(!wasmAvailable)(
+      `[${ops.join(" -> ")}] fused matches pure-TS`,
+      async () => {
+        // Reference: pure-TS, per-transform.
+        disableWasm();
+        const ref = run(ops);
+        // Fused: WASM backend active -> the run fuses into one applyChain.
+        await enableWasm();
+        const fused = run(ops);
+        disableWasm();
+
+        expect(fused.rows).toEqual(ref.rows);
+        expect(fused.records).toEqual(ref.records);
+      },
+    );
+  }
+});


### PR DESCRIPTION
Pillar-1 follow-up #2 (final of the three): extends the fused columnar apply to the **WASM/TS surface**. The frame-container (#3) was a measured NO-GO (#1512); the nullable executor (#1) shipped (#1511). This closes out the "remaining ones."

## The win
The TS WASM backend dispatches **per value** (`backend.strip(s)` for each string), so a chain of N transforms over M rows is **N×M** JS↔WASM crossings — a worse boundary problem than Python's per-column Arrow. This fuses a run of owned no-arg string kernels into **one** crossing. (Pure-TS default is unchanged — it has no boundary to collapse.)

## Core (arrow-free refactor)
`goldenflow-core::chain` is now **always compiled** (was `#[cfg(feature="arrow")]`). The `Kernel` enums + a new arrow-free `apply_chain_str(&[&str], &[Kernel]) -> (Vec<String>, Vec<u64>)` (values + per-kernel changed counts, mirroring the arrow `apply_chain`) are arrow-free; only the Arrow-columnar executors + result structs stay gated. **Single source of truth for the Kernel table preserved.** `cargo test` green both ways — **120** without arrow (incl. new vec_tests), **146** with; clippy clean both.

## WASM + TS
- `goldenflow-wasm`: `apply_chain(values, names) -> ChainOut { values, changed }` + `fusable_kernel_names()`. Builds clean for wasm32.
- TS engine: `_chain.ts` (FUSABLE mirror + fusedEnabled/isFusable) + `_applyColumnOps`/`_applyFusedRun` detect a maximal fusable run, apply via one `backend.applyChain`, scatter back into non-null positions, and emit a **byte-identical per-op manifest** (exact affected counts from the kernel + head(3) sample replay). `FlowWasmBackend.applyChain`/`fusableKernelNames` + loader glue wired.

## Parity
`tests/parity/fused_chain.parity.test.ts` — fused == pure-TS (output + manifest) over 6 chains + a coverage guard vs `fusableKernelNames()`. Added to the `wasm_flow` CI lane (artifact is CI-built; skips locally when absent). **This lane is the gate for the TS side** — validated in CI (TS builds OOM locally on this box).

## Versions
goldenflow-core 0.8→0.9 (busts rust-cache for the wasm build), goldenflow-wasm 0.1→0.2, goldenflow (npm) 0.13→0.14. **No native/PyPI change** — the arrow executors native-flow uses are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg