### PR TITLE
feat(infermap): MCP servers run the Rust kernels + report the active backend

### DIFF
--- a/packages/python/infermap/infermap/mcp/server.py
+++ b/packages/python/infermap/infermap/mcp/server.py
@@ -300,13 +300,35 @@ def create_server() -> Server:
             domains = list_domains()
             return json.dumps({"domains": domains}, indent=2)
         elif uri == "infermap://scorer-info":
+            from infermap._native_loader import native_available
             from infermap.scorers import default_scorers
             scorers = default_scorers()
             info = [
                 {"name": s.name, "weight": s.weight}
                 for s in scorers
             ]
-            return json.dumps({"scorers": info}, indent=2)
+            # Report which backend the scorers actually run on, so humans and
+            # agents can see whether the compiled Rust kernels are active. In the
+            # default INFERMAP_NATIVE=auto mode the scorers dispatch to the Rust
+            # infermap-core kernels when the native wheel is importable, else the
+            # pure-Python reference. Both are byte-identical (parity-gated).
+            native = native_available()
+            return json.dumps(
+                {
+                    "scorers": info,
+                    "backend": "native" if native else "pure-python",
+                    "note": (
+                        "Scorers run the compiled Rust infermap-core kernels "
+                        "(installed via `pip install infermap[native]`); "
+                        "byte-identical to the pure-Python reference."
+                        if native
+                        else "Scorers run the pure-Python reference. "
+                        "`pip install infermap[native]` adds the compiled Rust "
+                        "kernels (identical results, faster) with no code change."
+                    ),
+                },
+                indent=2,
+            )
         elif uri == "infermap://last-mapping/report":
             if _last_mapping_result is None:
                 return json.dumps({"error": "No mapping has been run yet"})

--- a/packages/python/infermap/llms.txt
+++ b/packages/python/infermap/llms.txt
@@ -11,6 +11,7 @@
 ## Install
 - `pip install infermap`
 - DB extras: `pip install infermap[postgres]` / `[mysql]` / `[duckdb]` / `[all]`
+- Compiled Rust kernels (optional; faster, identical results): `pip install infermap[native]`
 - TypeScript: `npm install infermap`
 
 ## Quick Examples
@@ -58,6 +59,7 @@ Plus common-prefix canonicalization (strips schema-wide prefixes like `prospect_
 - Providers: CSV / Parquet / XLSX files, in-memory (Polars / Pandas / `list[dict]`), DB (SQLite / Postgres / DuckDB)
 - Saved mapping config: YAML (Python) / JSON (TypeScript), interoperable shape
 - Python <-> TypeScript parity verified by a shared golden-test suite (within 0.0005)
+- Shared pyo3-free Rust core (`infermap-core`): scorers auto-dispatch to the compiled kernels when `infermap[native]` is installed (Python) or the WASM artifact is bundled (TS MCP), else the pure reference — byte-identical (CI parity-gated). The MCP `infermap://scorer-info` resource reports the active `backend`.
 
 ## Accuracy
 - 162-case benchmark F1 0.84; ChEMBL F1 0.819 with the InitialismScorer

--- a/packages/typescript/infermap/README.md
+++ b/packages/typescript/infermap/README.md
@@ -244,6 +244,23 @@ npx infermap validate ./crm.csv --config mapping.json --required email,id --stri
 
 The CLI uses only `node:util/parseArgs` — no extra runtime deps.
 
+## WASM acceleration (Rust kernels)
+
+The scorers have a pyo3-free Rust core (`infermap-core`) shared with the Python
+package. The TS surface runs it via an opt-in WASM backend:
+
+- **MCP server** (`infermap-mcp`): enables the WASM backend automatically at
+  startup, best-effort. When the built WASM artifact is bundled, the scorers run
+  the Rust kernels; otherwise they fall back to the pure-TS reference. Results are
+  **byte-identical** either way (enforced by the `infermap_wasm` CI parity gate) —
+  the WASM path is an anti-drift guarantee + speedup, never a behavior change. Read
+  the `infermap://scorer-info` MCP resource to see the active `backend`
+  (`"wasm"` or `"pure-ts"`).
+- **Library use**: call `await enableInfermapWasm()` once at startup to activate
+  the Rust kernels for your own `MapEngine` usage (import from
+  `infermap/core/wasm`). It returns `false` and leaves pure-TS active when the
+  artifact isn't present.
+
 ## Parity with Python
 
 This package is a faithful port of [`infermap` on PyPI](https://pypi.org/project/infermap/). Mapping decisions, confidence scores, and unmapped lists are verified to agree with the Python engine to 4 decimal places via shared golden tests that run on every CI build.

--- a/packages/typescript/infermap/src/node/mcp/server.ts
+++ b/packages/typescript/infermap/src/node/mcp/server.ts
@@ -30,6 +30,8 @@ import type { MapResultReport } from "../../core/types.js";
 import type { SchemaInfo } from "../../core/types.js";
 import { availableDomains } from "../../core/dictionaries/index.js";
 import { defaultScorers } from "../../core/scorers/registry.js";
+import { enableInfermapWasm } from "../../core/wasm/index.js";
+import { getInfermapBackend } from "../../core/wasm/backend.js";
 import { parseCsv } from "../../core/util/csv.js";
 import { extractSchemaFromFile } from "../fs.js";
 import { extractDbSchema } from "../db/provider.js";
@@ -382,7 +384,16 @@ export function readResource(uri: string): string {
   }
   if (uri === "infermap://scorer-info") {
     const scorers = defaultScorers().map((s) => ({ name: s.name, weight: s.weight }));
-    return JSON.stringify({ scorers }, null, 2);
+    // Report the active backend so humans + agents can see whether the Rust
+    // infermap-core kernels are running. The server enables the WASM backend
+    // best-effort at startup; with the artifact bundled the scorers dispatch to
+    // the Rust kernels (byte-identical to pure-TS), else pure-TS.
+    const backend = getInfermapBackend() ? "wasm" : "pure-ts";
+    const note =
+      backend === "wasm"
+        ? "Scorers run the Rust infermap-core kernels via WASM; byte-identical to the pure-TS reference."
+        : "Scorers run the pure-TS reference (WASM artifact not bundled). Identical results; the built WASM artifact activates the Rust kernels automatically.";
+    return JSON.stringify({ scorers, backend, note }, null, 2);
   }
   if (uri === "infermap://last-mapping/report") {
     if (_lastMappingReport === null) {
@@ -532,6 +543,15 @@ function writeMessage(msg: Record<string, unknown>): void {
 export function startMcpServer(): void {
   const rl = createInterface({ input: process.stdin, terminal: false });
 
+  // Best-effort: activate the Rust infermap-core kernels via the opt-in WASM
+  // backend when the artifact is bundled. enableInfermapWasm() resolves false
+  // (pure-TS stays active + identical results) when the artifact is absent — it
+  // never throws here (no `require`), and the extra .catch is belt-and-suspenders.
+  // Mirrors the Python MCP server auto-dispatching to the native wheel under
+  // INFERMAP_NATIVE=auto. Awaited before each request (below) so the backend state
+  // is settled + consistent for every tool call and resource read.
+  const wasmReady: Promise<boolean> = enableInfermapWasm().catch(() => false);
+
   rl.on("line", (line: string) => {
     if (line.trim() === "") return;
     let req: JsonRpcRequest;
@@ -546,6 +566,7 @@ export function startMcpServer(): void {
 
     void (async () => {
       try {
+        await wasmReady;
         if (req.method === "initialize") {
           writeMessage({
             jsonrpc: "2.0",

--- a/packages/typescript/infermap/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/infermap/tests/unit/mcp-server.test.ts
@@ -232,6 +232,15 @@ describe("MCP server — resources", () => {
     }
   });
 
+  it("Scorer Pipeline resource reports the active backend (wasm | pure-ts)", () => {
+    // Makes the WASM-vs-pure state legible to humans + agents. No artifact is
+    // bundled in the test env, so the backend is "pure-ts" here; the field +
+    // note are always present regardless.
+    const data = JSON.parse(readResource("infermap://scorer-info"));
+    expect(["wasm", "pure-ts"]).toContain(data.backend);
+    expect(typeof data.note).toBe("string");
+  });
+
   it("Last Mapping Report errors gracefully before any map", () => {
     const data = JSON.parse(readResource("infermap://last-mapping/report"));
     expect(data.error).toMatch(/no mapping/i);


### PR DESCRIPTION
## What

Makes the Wave A–C WASM cutover **load-bearing on the TS MCP surface** (it was proven-correct but dormant — nothing called `enableInfermapWasm()`), and makes the kernel-vs-pure state legible to humans and agents on both language surfaces.

## Changes

- **TS MCP server** (`node/mcp/server.ts`): enables the WASM backend best-effort at startup (`await enableInfermapWasm().catch(() => false)`), gated before each request so the state is settled. Falls back to pure-TS when the artifact isn't bundled — byte-identical either way (CI parity-gated), never a behavior change. This mirrors the Python MCP, which already auto-dispatches to the native wheel under `INFERMAP_NATIVE=auto`.
- **Scorer Pipeline resource** (`infermap://scorer-info`, both Python + TS): now reports the active `backend` (`native`/`pure-python` | `wasm`/`pure-ts`) + an actionable `note`. An agent reading the resource can *see* whether the Rust kernels are running and how to activate them.
- **Docs**: TS README gains a "WASM acceleration" section (humans); `llms.txt` notes the `[native]` extra + the backend-discovery resource (agents).
- **Test**: asserts the `scorer-info` resource reports the `backend` field.

## Why

The WASM/native cutover's value is anti-drift + speedup — but only if something actually runs the kernel. Python MCP already did (auto-dispatch). This wires the TS MCP to do the same, and documents the state so it's discoverable rather than invisible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44