### PR TITLE
feat(documents): MCP tool + CLI + AI-assisted schema (image/PDF ingest Phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-document-ingest-phase2.md
+++ b/docs/superpowers/plans/2026-07-06-document-ingest-phase2.md
@@ -191,8 +191,10 @@ Refactor only — no behavior change. Move the transport factory and image-encod
                       "image_url": {"url": f"data:image/png;base64,{b64}"}})
       return out
   ```
-  Then edit `vlm_backend.py`: delete its inline `_urllib_transport` and the base64 loop in
-  `_payload`; import `from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport`;
+  Then edit `vlm_backend.py`: delete its inline `_urllib_transport`, the base64 loop in
+  `_payload`, AND the now-orphaned `import base64` + the module-level `_ENDPOINT` constant (both
+  become unused once moved to `_openai.py` — ruff will fail the commit otherwise); import
+  `from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport`;
   use `urllib_transport(api_key)` where `_urllib_transport(api_key)` was, and build `content` as
   `[{"type": "text", "text": _instruction(schema)}] + image_blocks(pages)`.
   Then edit `config.py`: add
@@ -326,7 +328,11 @@ Handler returns a plain `dict` (mirrors `handle_routing_tool`), so it serves bot
   from goldenmatch.documents.extractor import FakeExtractor
   from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
 
-  SCHEMA_JSON = {"fields": [{"name": "full_name"}, {"name": "email", "kind": "email"}]}
+  # canonical full form: schema_to_dict always emits name/kind/hint, and schema_from_dict
+  # accepts this form as input too, so it works as both expected-output and ingest-input.
+  SCHEMA_JSON = {"fields": [
+      {"name": "full_name", "kind": "text", "hint": None},
+      {"name": "email", "kind": "email", "hint": None}]}
 
 
   def test_tool_names_and_list():

--- a/docs/superpowers/plans/2026-07-06-document-ingest-phase2.md
+++ b/docs/superpowers/plans/2026-07-06-document-ingest-phase2.md
@@ -1,0 +1,643 @@
+# Document Ingest Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose `goldenmatch.documents` on the MCP + CLI surfaces and add AI-assisted schema generation (a VLM proposes a reviewable JSON schema file from a sample doc).
+
+**Architecture:** A JSON schema-file round-trip (`schema_io`), a `suggest_schema` VLM call that reuses the extracted OpenAI transport/image helpers, two MCP tools (`documents_suggest_schema`, `documents_ingest`) wired like `ROUTING_TOOLS`, and a `goldenmatch ingest-docs` typer sub-app (`suggest-schema`, `run`). Everything offline-testable via the injectable transport / `FakeExtractor`.
+
+**Tech Stack:** Python 3.11+, Polars, typer, the `mcp` package (`mcp.types.Tool`/`TextContent`), stdlib `urllib`. TDD with pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-06-document-ingest-phase2-design.md`
+
+---
+
+## Conventions for every task
+
+- **Worktree:** `D:/show_case/gm-docingest-p2` (branch `feat/document-ingest-phase2`, stacked on `feat/document-image-ingest`). Package root: `packages/python/goldenmatch`. Do NOT push, do NOT touch `main`.
+- **Test env** (run from `packages/python/goldenmatch`; note BOTH PYTHONPATH entries point at THIS worktree so `import goldenflow` uses the clean copy — see the phase-1 plan for why):
+  ```bash
+  cd D:/show_case/gm-docingest-p2/packages/python/goldenmatch
+  PY="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="D:/show_case/gm-docingest-p2/packages/python/goldenmatch;D:/show_case/gm-docingest-p2/packages/python/goldenflow"
+  export GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+  ```
+- **Prereq:** ensure the `mcp` package is importable (Task 4+): `"$PY" -c "import mcp" || "$PY" -m pip install "mcp>=1.0"`.
+- **Lint before each commit:** `"$PY" -m ruff check goldenmatch/documents goldenmatch/mcp/document_tools.py goldenmatch/cli/ingest_docs.py tests/documents`.
+- **Commit trailers:** copy the two trailer lines from an existing commit (`git log -1 --format=%B`). Use `git -c commit.gpgsign=false commit`.
+- **Regression guard:** after Tasks 2, always re-run `tests/documents/test_vlm_backend.py` — Task 2 refactors shared helpers OUT of `vlm_backend.py` and must not change its behavior.
+
+---
+
+## File structure (locked)
+
+| path | responsibility |
+|---|---|
+| `goldenmatch/documents/schema_io.py` | `TargetSchema` ⇄ dict/JSON file: `schema_to_dict`, `schema_from_dict`, `save_schema`, `load_schema` |
+| `goldenmatch/documents/_openai.py` | shared VLM plumbing extracted from `vlm_backend.py`: `Transport`, `urllib_transport(api_key)`, `image_blocks(pages)` |
+| `goldenmatch/documents/vlm_backend.py` (modify) | import the extracted helpers instead of defining them inline |
+| `goldenmatch/documents/config.py` (modify) | expose `resolve_api_key() -> str` (factored out of `resolve_extractor`) |
+| `goldenmatch/documents/suggest.py` | `suggest_schema(pages, *, transport, model)` + `suggest_schema_from_file(path, *, backend, model)` |
+| `goldenmatch/mcp/document_tools.py` | `DOCUMENT_TOOLS`, `DOCUMENT_TOOL_NAMES`, `handle_document_tool(name, args) -> dict` |
+| `goldenmatch/mcp/server.py` (modify) | register in 4 spots (import+frozenset, `TOOLS`, `dispatch()`, `list_tools()`, `call_tool()`) |
+| `goldenmatch/cli/ingest_docs.py` | `ingest_docs_app` typer sub-app: `suggest-schema`, `run` |
+| `goldenmatch/cli/main.py` (modify) | `app.add_typer(ingest_docs_app, name="ingest-docs")` |
+| `tests/documents/test_schema_io.py`, `test_suggest.py`, `test_document_tools.py`, `test_cli_ingest_docs.py` | offline tests |
+
+---
+
+## Task 1: Schema JSON round-trip
+
+**Files:** Create `goldenmatch/documents/schema_io.py`; Test `tests/documents/test_schema_io.py`
+
+- [ ] **Step 1: Failing test.**
+  ```python
+  import json
+  import pytest
+  from goldenmatch.documents.schema_io import (
+      load_schema, save_schema, schema_from_dict, schema_to_dict,
+  )
+  from goldenmatch.documents.types import Field, TargetSchema
+
+  SCHEMA = TargetSchema([Field("full_name"), Field("email", kind="email", hint="work email")])
+
+
+  def test_round_trip_dict():
+      d = schema_to_dict(SCHEMA)
+      assert d == {"fields": [
+          {"name": "full_name", "kind": "text", "hint": None},
+          {"name": "email", "kind": "email", "hint": "work email"}]}
+      assert schema_from_dict(d) == SCHEMA
+
+
+  def test_round_trip_file(tmp_path):
+      p = tmp_path / "schema.json"
+      save_schema(SCHEMA, p)
+      assert json.loads(p.read_text())["fields"][0]["name"] == "full_name"
+      assert load_schema(p) == SCHEMA
+
+
+  def test_load_rejects_malformed(tmp_path):
+      p = tmp_path / "bad.json"
+      p.write_text('{"nope": 1}')
+      with pytest.raises(ValueError, match="fields"):
+          load_schema(p)
+  ```
+- [ ] **Step 2: Run → fail.** `"$PY" -m pytest tests/documents/test_schema_io.py -q`
+- [ ] **Step 3: Implement.**
+  ```python
+  """TargetSchema <-> JSON. Pure stdlib, offline. The serializable schema form used by the
+  MCP tools and the CLI."""
+  from __future__ import annotations
+
+  import json
+  from pathlib import Path
+
+  from goldenmatch.documents.types import Field, TargetSchema
+
+
+  def schema_to_dict(schema: TargetSchema) -> dict:
+      return {"fields": [{"name": f.name, "kind": f.kind, "hint": f.hint}
+                         for f in schema.fields]}
+
+
+  def schema_from_dict(d: dict) -> TargetSchema:
+      if not isinstance(d, dict) or "fields" not in d or not isinstance(d["fields"], list):
+          raise ValueError("schema must be an object with a 'fields' list")
+      fields = []
+      for item in d["fields"]:
+          if "name" not in item:
+              raise ValueError(f"schema field missing 'name': {item!r}")
+          fields.append(Field(name=item["name"], kind=item.get("kind", "text"),
+                              hint=item.get("hint")))
+      if not fields:
+          raise ValueError("schema has no fields")
+      return TargetSchema(fields)
+
+
+  def save_schema(schema: TargetSchema, path) -> None:
+      Path(path).write_text(json.dumps(schema_to_dict(schema), indent=2), encoding="utf-8")
+
+
+  def load_schema(path) -> TargetSchema:
+      return schema_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+  ```
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(documents): schema JSON round-trip (schema_io)`.
+
+---
+
+## Task 2: Extract shared OpenAI helpers + `resolve_api_key`
+
+Refactor only — no behavior change. Move the transport factory and image-encoding out of
+`vlm_backend.py` into `_openai.py`, and factor the key lookup out of `config.resolve_extractor`.
+
+**Files:** Create `goldenmatch/documents/_openai.py`; Modify `vlm_backend.py`, `config.py`; Test `tests/documents/test_openai_helpers.py`
+
+- [ ] **Step 1: Failing test.**
+  ```python
+  from goldenmatch.documents._openai import image_blocks, urllib_transport
+  from goldenmatch.documents.types import PageImage
+
+
+  def test_image_blocks_emit_data_uris():
+      pages = [PageImage(b"\x89PNG\r\n\x1a\n0", 1, 1, 0), PageImage(b"abc", 1, 1, 1)]
+      blocks = image_blocks(pages)
+      assert len(blocks) == 2
+      assert blocks[0]["type"] == "image_url"
+      assert blocks[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+  def test_urllib_transport_is_callable():
+      assert callable(urllib_transport("k"))
+  ```
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement `_openai.py`** (move the exact logic out of `vlm_backend.py`):
+  ```python
+  """Shared OpenAI-vision plumbing for the documents backends (extractor + schema suggest).
+  Kept dependency-free (stdlib urllib) and transport-injectable so callers test offline."""
+  from __future__ import annotations
+
+  import base64
+  import json
+  from collections.abc import Callable
+
+  from goldenmatch.documents.types import PageImage
+
+  ENDPOINT = "https://api.openai.com/v1/chat/completions"
+  Transport = Callable[[dict], dict]
+
+
+  def urllib_transport(api_key: str) -> Transport:
+      import urllib.request
+
+      def send(payload: dict) -> dict:
+          body = json.dumps(payload).encode()
+          req = urllib.request.Request(
+              ENDPOINT, data=body,
+              headers={"Authorization": f"Bearer {api_key}",
+                       "Content-Type": "application/json"})
+          with urllib.request.urlopen(req, timeout=120) as r:
+              return json.loads(r.read())
+
+      return send
+
+
+  def image_blocks(pages: list[PageImage]) -> list[dict]:
+      out = []
+      for pg in pages:
+          b64 = base64.b64encode(pg.png_bytes).decode()
+          out.append({"type": "image_url",
+                      "image_url": {"url": f"data:image/png;base64,{b64}"}})
+      return out
+  ```
+  Then edit `vlm_backend.py`: delete its inline `_urllib_transport` and the base64 loop in
+  `_payload`; import `from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport`;
+  use `urllib_transport(api_key)` where `_urllib_transport(api_key)` was, and build `content` as
+  `[{"type": "text", "text": _instruction(schema)}] + image_blocks(pages)`.
+  Then edit `config.py`: add
+  ```python
+  def resolve_api_key() -> str:
+      key = next((os.environ[e] for e in _KEY_ENV_ORDER if os.environ.get(e)), None)
+      if not key:
+          raise ValueError("no OpenAI API key found; set OPENAI_API_KEY_PERSONAL "
+                           "(or OPENAI_API_KEY)")
+      return key
+  ```
+  and have `resolve_extractor` call it (`VLMExtractor(api_key=resolve_api_key(), model=model)`).
+- [ ] **Step 4: Run → pass**, then the regression guard: `"$PY" -m pytest tests/documents/test_vlm_backend.py tests/documents/test_ingest.py -q` (all still green).
+- [ ] **Step 5: Commit** `refactor(documents): extract shared OpenAI transport/image helpers + resolve_api_key`.
+
+---
+
+## Task 3: `suggest_schema`
+
+**Files:** Create `goldenmatch/documents/suggest.py`; Test `tests/documents/test_suggest.py`
+
+- [ ] **Step 1: Failing test.**
+  ```python
+  import json
+  import pytest
+  from goldenmatch.documents.suggest import suggest_schema
+  from goldenmatch.documents.types import PageImage
+
+  PAGES = [PageImage(b"\x89PNG\r\n\x1a\n0", 10, 10, 0)]
+
+
+  def _resp(fields):
+      return {"choices": [{"message": {"content": json.dumps({"fields": fields})}}]}
+
+
+  def test_suggests_fields_from_a_sample():
+      fields = [{"name": "full_name", "kind": "text", "hint": "the person's name"},
+                {"name": "email", "kind": "email"}]
+      out = suggest_schema(PAGES, transport=lambda p: _resp(fields), model="gpt-4o")
+      assert out.column_names() == ["full_name", "email"]
+      assert out.fields[1].kind == "email"
+
+
+  def test_empty_fields_is_an_error():
+      with pytest.raises(ValueError):
+          suggest_schema(PAGES, transport=lambda p: _resp([]), model="gpt-4o")
+
+
+  def test_malformed_json_is_an_error():
+      bad = {"choices": [{"message": {"content": "not json"}}]}
+      with pytest.raises(ValueError):
+          suggest_schema(PAGES, transport=lambda p: bad, model="gpt-4o")
+
+
+  def test_truncation_is_an_error():
+      trunc = {"choices": [{"message": {"content": "{"}, "finish_reason": "length"}]}
+      with pytest.raises(ValueError, match="truncat"):
+          suggest_schema(PAGES, transport=lambda p: trunc, model="gpt-4o")
+  ```
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.**
+  ```python
+  """VLM-assisted target-schema suggestion: look at a sample document and PROPOSE fields.
+  Distinct prompt from vlm_backend (which extracts against a KNOWN schema); shares only the
+  transport + image encoding."""
+  from __future__ import annotations
+
+  import json
+
+  from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport
+  from goldenmatch.documents.config import resolve_api_key
+  from goldenmatch.documents.loader import load_pages
+  from goldenmatch.documents.schema_io import schema_from_dict
+  from goldenmatch.documents.types import PageImage, TargetSchema
+
+  _PROMPT = (
+      "You are shown a sample document. Propose a compact extraction schema: the fields a "
+      "person would want pulled from documents like this for record matching (names, "
+      "emails, addresses, phones, ids, dates...). Return ONLY JSON:\n"
+      '{"fields": [{"name": "<snake_case>", "kind": "text|email|phone|address|date|number", '
+      '"hint": "<short guidance>"}, ...]}\n'
+      "Prefer 3-12 stable, matchable fields. No prose."
+  )
+
+
+  def suggest_schema(pages: list[PageImage], *, transport: Transport,
+                     model: str = "gpt-4o", max_attempts: int = 3) -> TargetSchema:
+      payload = {"model": model, "temperature": 0, "max_tokens": 1500,
+                 "messages": [{"role": "user",
+                               "content": [{"type": "text", "text": _PROMPT}] + image_blocks(pages)}]}
+      last = "no response"
+      for _ in range(max(1, max_attempts)):
+          try:
+              resp = transport(payload)
+              break
+          except Exception as e:  # transport/network: retry
+              last = f"{type(e).__name__}: {e}"
+      else:
+          raise ValueError(f"schema suggestion failed: {last}")
+      choice = resp["choices"][0]
+      if choice.get("finish_reason") == "length":
+          raise ValueError("schema suggestion truncated (finish_reason=length); raise max_tokens")
+      text = choice["message"]["content"].strip()
+      if text.startswith("```"):
+          text = text.split("\n", 1)[1].rsplit("```", 1)[0] if "\n" in text else text
+      return schema_from_dict(json.loads(text))  # raises ValueError on empty/malformed
+
+
+  def suggest_schema_from_file(path, *, backend: str = "vlm", model: str = "gpt-4o") -> TargetSchema:
+      if backend != "vlm":
+          raise ValueError(f"unknown backend: {backend!r} (Phase 2 supports 'vlm')")
+      return suggest_schema(load_pages(path), transport=urllib_transport(resolve_api_key()),
+                            model=model)
+  ```
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(documents): VLM-assisted suggest_schema`.
+
+---
+
+## Task 4: MCP tools (`document_tools.py`)
+
+**Files:** Create `goldenmatch/mcp/document_tools.py`; Test `tests/documents/test_document_tools.py`
+
+Handler returns a plain `dict` (mirrors `handle_routing_tool`), so it serves both the stdio
+`call_tool` and the aggregator `dispatch` paths.
+
+- [ ] **Step 1: Failing test** (inject fakes by monkeypatching the names the module imported):
+  ```python
+  import json
+  import goldenmatch.mcp.document_tools as dt
+  from goldenmatch.documents.extractor import FakeExtractor
+  from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+
+  SCHEMA_JSON = {"fields": [{"name": "full_name"}, {"name": "email", "kind": "email"}]}
+
+
+  def test_tool_names_and_list():
+      names = {t.name for t in dt.DOCUMENT_TOOLS}
+      assert names == {"documents_suggest_schema", "documents_ingest"}
+      assert dt.DOCUMENT_TOOL_NAMES == names
+
+
+  def test_suggest_schema_tool(monkeypatch, tmp_path):
+      from PIL import Image
+      p = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(p)
+      schema = TargetSchema([Field("full_name"), Field("email", kind="email")])
+      monkeypatch.setattr(dt, "suggest_schema_from_file", lambda path, **k: schema)
+      out = dt.handle_document_tool("documents_suggest_schema", {"sample_path": str(p)})
+      assert out["schema"] == SCHEMA_JSON
+
+
+  def test_ingest_tool_returns_records_and_report(monkeypatch, tmp_path):
+      from PIL import Image
+      a = tmp_path / "a.png"; Image.new("RGB", (10, 10), "white").save(a)
+      schema = TargetSchema([Field("full_name"), Field("email")])
+      row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {}, schema,
+                                      source_file="", source_page=0)
+      monkeypatch.setattr(dt, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+      out = dt.handle_document_tool("documents_ingest",
+                                    {"paths": [str(a)], "schema": SCHEMA_JSON})
+      assert out["report"]["n_rows"] == 1
+      assert out["records"][0]["full_name"] == "Ada"
+      assert out["records"][0]["email"] == "a@x.io"
+  ```
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement.**
+  ```python
+  """MCP tools for document/image ingest. Handlers return JSON-serializable dicts, matching
+  handle_routing_tool so both the stdio call_tool and aggregator dispatch paths work."""
+  from __future__ import annotations
+
+  from mcp.types import Tool
+
+  from goldenmatch.documents import ingest_documents
+  from goldenmatch.documents.config import resolve_extractor  # noqa: F401 (monkeypatch seam)
+  from goldenmatch.documents.schema_io import schema_from_dict, schema_to_dict
+  from goldenmatch.documents.suggest import suggest_schema_from_file  # noqa: F401 (seam)
+
+  DOCUMENT_TOOLS = [
+      Tool(
+          name="documents_suggest_schema",
+          description="Propose a target extraction schema (JSON) from a sample document image/PDF.",
+          inputSchema={
+              "type": "object",
+              "properties": {
+                  "sample_path": {"type": "string"},
+                  "backend": {"type": "string", "default": "vlm"},
+                  "model": {"type": "string", "default": "gpt-4o"},
+              },
+              "required": ["sample_path"],
+          },
+      ),
+      Tool(
+          name="documents_ingest",
+          description=("Extract records from documents (PDF/image) against a target schema into "
+                       "rows ready for dedupe_df. Returns records + an ingest report."),
+          inputSchema={
+              "type": "object",
+              "properties": {
+                  "paths": {"type": "array", "items": {"type": "string"}},
+                  "schema": {"type": "object", "description": "schema JSON: {'fields':[...]}"},
+                  "backend": {"type": "string", "default": "vlm"},
+                  "model": {"type": "string", "default": "gpt-4o"},
+                  "drop_empty": {"type": "boolean", "default": True},
+                  "out_path": {"type": "string", "description": "optional CSV/parquet to also write"},
+              },
+              "required": ["paths", "schema"],
+          },
+      ),
+  ]
+  DOCUMENT_TOOL_NAMES = frozenset(t.name for t in DOCUMENT_TOOLS)
+
+
+  def handle_document_tool(name: str, arguments: dict) -> dict:
+      if name == "documents_suggest_schema":
+          schema = suggest_schema_from_file(
+              arguments["sample_path"],
+              backend=arguments.get("backend", "vlm"),
+              model=arguments.get("model", "gpt-4o"))
+          return {"schema": schema_to_dict(schema)}
+
+      if name == "documents_ingest":
+          schema = schema_from_dict(arguments["schema"])
+          extractor = resolve_extractor(arguments.get("backend", "vlm"),
+                                        arguments.get("model", "gpt-4o"))
+          df, report = ingest_documents(
+              arguments["paths"], schema, extractor=extractor,
+              drop_empty=arguments.get("drop_empty", True), return_report=True)
+          out_path = arguments.get("out_path")
+          if out_path:
+              (df.write_parquet if str(out_path).endswith(".parquet") else df.write_csv)(out_path)
+          return {
+              "records": df.to_dicts(),
+              "report": {"n_files": report.n_files, "n_rows": report.n_rows,
+                         "errors": [{"file": f, "error": e} for (f, e) in report.errors]},
+              **({"out_path": str(out_path)} if out_path else {}),
+          }
+      raise ValueError(f"unknown document tool: {name}")
+  ```
+  Note the two `# noqa` imports of `resolve_extractor` / `suggest_schema_from_file` at module scope
+  are deliberate: they are the monkeypatch seams the tests patch on `dt.<name>`. Reference them
+  inside the handler via the module globals (call `resolve_extractor(...)` / `suggest_schema_from_file(...)`
+  as bare names) so the patched versions take effect.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(mcp): documents_suggest_schema + documents_ingest tools`.
+
+---
+
+## Task 5: Wire MCP tools into `server.py`
+
+**Files:** Modify `goldenmatch/mcp/server.py`; Test `tests/documents/test_document_tools_wiring.py`
+
+Register in the four places, mirroring `ROUTING_TOOLS`.
+
+- [ ] **Step 1: Failing test.**
+  ```python
+  import goldenmatch.mcp.server as srv
+
+
+  def test_document_tools_registered_in_all_surfaces():
+      names = {t.name for t in srv.TOOLS}
+      assert {"documents_suggest_schema", "documents_ingest"} <= names
+      # dispatch routes doc tools without falling through to the base handler
+      import goldenmatch.mcp.document_tools as dt
+      assert dt.DOCUMENT_TOOL_NAMES <= {t.name for t in srv.TOOLS}
+  ```
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement — edit `server.py` in these exact spots:**
+  1. Import (near the other `*_tools` imports, ~line 35):
+     `from goldenmatch.mcp.document_tools import DOCUMENT_TOOLS, DOCUMENT_TOOL_NAMES, handle_document_tool`
+  2. `TOOLS` union (~line 621): append ` + DOCUMENT_TOOLS`.
+  3. `dispatch()` (~line 642, before the final `return _handle_tool(...)`):
+     ```python
+     if name in DOCUMENT_TOOL_NAMES:
+         return handle_document_tool(name, args)
+     ```
+  4. `list_tools()` (~line 657): append ` + DOCUMENT_TOOLS` to the returned list.
+  5. `call_tool()` try-block (~line 916, alongside the ROUTING branch):
+     ```python
+     if name in DOCUMENT_TOOL_NAMES:
+         result = handle_document_tool(name, arguments)
+     elif name in ROUTING_TOOL_NAMES:
+         result = handle_routing_tool(name, arguments)
+     else:
+         result = _handle_tool(name, arguments)
+     ```
+- [ ] **Step 4: Run → pass.** Also `"$PY" -c "import goldenmatch.mcp.server"` (no import error).
+- [ ] **Step 5: Commit** `feat(mcp): wire document tools into server (list/dispatch/call)`.
+
+---
+
+## Task 6: CLI `ingest-docs` sub-app
+
+**Files:** Create `goldenmatch/cli/ingest_docs.py`; Modify `goldenmatch/cli/main.py`; Test `tests/documents/test_cli_ingest_docs.py`
+
+- [ ] **Step 1: Failing test** (patch `resolve_extractor` at the CLI module's reference):
+  ```python
+  import json
+  from pathlib import Path
+  from PIL import Image
+  from typer.testing import CliRunner
+  import goldenmatch.cli.ingest_docs as ci
+  from goldenmatch.documents.extractor import FakeExtractor
+  from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+
+  runner = CliRunner()
+  SCHEMA = TargetSchema([Field("full_name"), Field("email")])
+
+
+  def _schema_file(tmp_path):
+      p = tmp_path / "schema.json"
+      p.write_text(json.dumps({"fields": [{"name": "full_name"}, {"name": "email"}]}))
+      return p
+
+
+  def test_run_writes_records_csv(tmp_path, monkeypatch):
+      img = tmp_path / "a.png"; Image.new("RGB", (10, 10), "white").save(img)
+      row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {}, SCHEMA,
+                                      source_file="", source_page=0)
+      monkeypatch.setattr(ci, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+      out = tmp_path / "recs.csv"
+      r = runner.invoke(ci.ingest_docs_app, ["run", str(img), "--schema", str(_schema_file(tmp_path)),
+                                             "--out", str(out)])
+      assert r.exit_code == 0, r.output
+      assert out.exists() and "Ada" in out.read_text()
+
+
+  def test_suggest_schema_writes_file(tmp_path, monkeypatch):
+      img = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(img)
+      monkeypatch.setattr(ci, "suggest_schema_from_file", lambda path, **k: SCHEMA)
+      out = tmp_path / "schema.json"
+      r = runner.invoke(ci.ingest_docs_app, ["suggest-schema", str(img), "--out", str(out)])
+      assert r.exit_code == 0, r.output
+      assert json.loads(out.read_text())["fields"][0]["name"] == "full_name"
+  ```
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement `ingest_docs.py`.**
+  ```python
+  """`goldenmatch ingest-docs` — suggest a schema from a sample, then ingest documents to rows."""
+  from __future__ import annotations
+
+  import typer
+
+  from goldenmatch.documents import ingest_documents
+  from goldenmatch.documents.config import resolve_extractor
+  from goldenmatch.documents.schema_io import load_schema, save_schema
+  from goldenmatch.documents.suggest import suggest_schema_from_file
+
+  ingest_docs_app = typer.Typer(help="Ingest documents (PDF/image) into matchable records.")
+
+
+  @ingest_docs_app.command("suggest-schema")
+  def suggest_schema_cmd(
+      sample: str = typer.Argument(..., help="A representative document (PDF/image)."),
+      out: str = typer.Option(..., "--out", "-o", help="Write the proposed schema JSON here."),
+      backend: str = typer.Option("vlm", help="Extraction backend."),
+      model: str = typer.Option("gpt-4o", help="Vision model."),
+  ):
+      try:
+          schema = suggest_schema_from_file(sample, backend=backend, model=model)
+      except Exception as e:
+          typer.echo(f"schema suggestion failed: {e}", err=True)
+          raise typer.Exit(code=1) from e
+      save_schema(schema, out)
+      typer.echo(f"Wrote {len(schema.fields)}-field schema to {out} -- review before running.", err=True)
+
+
+  @ingest_docs_app.command("run")
+  def run_cmd(
+      docs: list[str] = typer.Argument(..., help="Document paths (PDF/image)."),
+      schema: str = typer.Option(..., "--schema", "-s", help="Target schema JSON file."),
+      out: str = typer.Option(..., "--out", "-o", help="Write records here (.csv or .parquet)."),
+      backend: str = typer.Option("vlm", help="Extraction backend."),
+      model: str = typer.Option("gpt-4o", help="Vision model."),
+  ):
+      target = load_schema(schema)
+      extractor = resolve_extractor(backend, model)
+      df, report = ingest_documents(docs, target, extractor=extractor, return_report=True)
+      if str(out).endswith(".parquet"):
+          df.write_parquet(out)
+      else:
+          df.write_csv(out)
+      typer.echo(f"{report.n_rows} rows from {report.n_files} docs -> {out}", err=True)
+      for f, err in report.errors:
+          typer.echo(f"  skipped {f}: {err}", err=True)
+  ```
+  Then edit `main.py`: `from goldenmatch.cli.ingest_docs import ingest_docs_app` (with the other cli
+  imports) and `app.add_typer(ingest_docs_app, name="ingest-docs")` (with the other `add_typer` calls).
+- [ ] **Step 4: Run → pass.** Also `"$PY" -m goldenmatch --help` shows `ingest-docs` (or
+  `"$PY" -c "from goldenmatch.cli.main import app"` imports clean).
+- [ ] **Step 5: Commit** `feat(cli): ingest-docs suggest-schema + run`.
+
+---
+
+## Task 7: README + gated live smoke
+
+**Files:** Modify `goldenmatch/documents/README.md`; Create `tests/documents/test_phase2_live_smoke.py`
+
+- [ ] **Step 1: Live smoke (skipped without a key).**
+  ```python
+  import os
+  import pytest
+  from PIL import Image, ImageDraw
+  from goldenmatch.documents.suggest import suggest_schema_from_file
+
+  pytestmark = pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY_PERSONAL"),
+                                  reason="live VLM smoke; set OPENAI_API_KEY_PERSONAL")
+
+
+  def test_live_suggest_schema(tmp_path):
+      p = tmp_path / "card.png"
+      img = Image.new("RGB", (400, 200), "white"); d = ImageDraw.Draw(img)
+      d.text((20, 40), "Ada Lovelace", fill="black"); d.text((20, 80), "ada@x.io", fill="black")
+      img.save(p)
+      schema = suggest_schema_from_file(p)
+      assert len(schema.fields) >= 1
+  ```
+- [ ] **Step 2: Run → SKIPPED** (no key).
+- [ ] **Step 3: Append a "CLI + MCP" section to `goldenmatch/documents/README.md`:**
+  ````markdown
+  ## CLI
+
+  ```bash
+  # 1. propose a schema from a sample doc (review/edit the file after)
+  goldenmatch ingest-docs suggest-schema samples/form.pdf --out schema.json
+  # 2. ingest the pile against it
+  goldenmatch ingest-docs run inbox/*.pdf --schema schema.json --out records.csv
+  ```
+
+  ## MCP
+
+  - `documents_suggest_schema(sample_path)` → proposed schema JSON
+  - `documents_ingest(paths, schema, out_path?)` → `{records, report}` (records ready for dedupe)
+  ````
+- [ ] **Step 4: Full suite + lint.** `"$PY" -m pytest tests/documents -q` (all pass, live smokes
+  skipped) and ruff clean on the new/edited files.
+- [ ] **Step 5: Commit** `docs(documents): CLI + MCP usage + gated live smoke`.
+
+---
+
+## Done-when
+
+- `tests/documents/` green (2 live smokes skipped without a key), ruff clean.
+- `goldenmatch ingest-docs suggest-schema` / `run` work; `documents_suggest_schema` /
+  `documents_ingest` registered in all four `server.py` surfaces (`TOOLS`, `dispatch`,
+  `list_tools`, `call_tool`).
+- `vlm_backend.py` behavior unchanged (its Phase-1 tests still green after the Task 2 refactor).
+- Deferred (not here): inline auto-infer, local OCR backend, review-queue integration.

--- a/docs/superpowers/specs/2026-07-06-document-ingest-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-06-document-ingest-phase2-design.md
@@ -31,12 +31,21 @@ This spec's branch is stacked on `feat/document-image-ingest`.
 | `goldenmatch/documents/suggest.py` | `suggest_schema(pages, *, extractor_or_transport, model) -> TargetSchema`: VLM proposes fields from a sample doc | reuses the injectable-transport pattern from `vlm_backend.py`; offline-testable |
 | `goldenmatch/mcp/document_tools.py` | `DOCUMENT_TOOLS = [Tool(documents_suggest_schema…), Tool(documents_ingest…)]` + `handle_document_tool(name, args)` | mirrors `agent_tools.py` (`AGENT_TOOLS` + `handle_agent_tool`) |
 | `goldenmatch/cli/ingest_docs.py` | `ingest_docs_app` (typer sub-app) with `suggest-schema` + `run` commands | mirrors `identity_app`/`memory_app` sub-app style |
-| wire-in: `goldenmatch/mcp/server.py` | import `DOCUMENT_TOOLS` + dispatch to `handle_document_tool` alongside the other `*_TOOLS` | follow the existing `_BASE_TOOLS`/`AGENT_TOOLS` wiring |
+| wire-in: `goldenmatch/mcp/server.py` | register `DOCUMENT_TOOLS` + `handle_document_tool` in **all four** touch points (see below) | mirrors each existing `*_TOOL_NAMES` frozenset |
 | wire-in: `goldenmatch/cli/main.py` | `app.add_typer(ingest_docs_app, name="ingest-docs")` | mirrors `identity_app` registration |
 
-`suggest.py` reuses `loader.load_pages` for the sample and the same base64-data-URI + injectable
-`transport` mechanism as `vlm_backend.py` (do not duplicate the transport; factor the shared
-`_urllib_transport` / payload-image helper if that keeps each file focused).
+**MCP wiring is four places, not one** (each existing `*_TOOLS` pair is registered in all of them;
+missing one — e.g. the aggregator `dispatch()` — silently breaks that access path): (1) the
+module-level `TOOLS` union list, (2) `create_server()`'s inline `list_tools()` return, (3)
+`call_tool()`'s dispatch chain, (4) the standalone `dispatch()` used by the goldensuite-mcp
+aggregator. The plan must enumerate all four.
+
+`suggest.py` reuses only the **mechanical** halves of `vlm_backend.py`: `loader.load_pages` for the
+sample, and the base64-data-URI image encoding + injectable `transport` (factor the shared
+`_urllib_transport` / image-payload helper out of `vlm_backend.py` so both files import it rather
+than duplicating). The **prompt is written fresh** — `vlm_backend._instruction()` walks a known
+`TargetSchema` to extract; suggestion has no schema yet and needs a different prompt asking the VLM
+to *propose* fields (name/kind/hint). Do NOT try to reuse `_instruction()`.
 
 ## Data flow
 
@@ -67,8 +76,12 @@ This spec's branch is stacked on `feat/document-image-ingest`.
 - MCP `document_tools`: call `handle_document_tool` with a `FakeExtractor`/fake transport injected;
   assert the returned JSON shape for both tools. No network.
 - CLI `ingest-docs`: use typer's `CliRunner`; inject the fake backend by monkeypatching
-  `resolve_extractor` (or a small documented test seam). Assert `suggest-schema` writes a valid file
-  and `run` writes the records file + non-zero rows.
+  `resolve_extractor` **at the reference the CLI module imported** (`goldenmatch.cli.ingest_docs
+  .resolve_extractor`, not `documents.config.resolve_extractor`) — patching the wrong reference is a
+  known foot-gun here. Assert `suggest-schema` writes a valid file and `run` writes the records file
+  + non-zero rows.
+- The two MCP tools' `inputSchema` arg names (`paths`, `schema_path`/`schema`, `out_path`,
+  `backend`, `model`) are spelled out in the plan, not here.
 - One optional gated live smoke (`OPENAI_API_KEY_PERSONAL`), excluded from CI.
 
 ## Scope (YAGNI)

--- a/docs/superpowers/specs/2026-07-06-document-ingest-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-06-document-ingest-phase2-design.md
@@ -1,0 +1,86 @@
+# Document Ingest Phase 2 — MCP tool + CLI + AI-assisted schema
+
+**Goal.** Expose the Phase 1 `goldenmatch.documents` capability on the MCP and CLI surfaces,
+and add **AI-assisted schema generation** so users don't hand-author the target schema — a VLM
+proposes it from a sample document into a reviewable JSON file.
+
+**Builds on:** Phase 1 (`ingest_documents`, `TargetSchema`, `vlm_backend`), currently in PR #1508.
+This spec's branch is stacked on `feat/document-image-ingest`.
+
+## Decisions (settled in brainstorming)
+
+- **Two-step explicit flow:** `suggest-schema` (VLM proposes a schema file) → user reviews/edits →
+  `run` (ingest the pile against that file). Inline auto-infer (`run` with no schema) is deferred —
+  the point of a *file* is reviewing the AI's guess before a batch, and a fixed schema keeps the
+  batch deterministic.
+- **Schema as a JSON file** (the serializable form of `TargetSchema`, needed by both MCP and CLI):
+  ```json
+  {"fields": [
+    {"name": "full_name", "kind": "text", "hint": "person's full name"},
+    {"name": "email", "kind": "email"}
+  ]}
+  ```
+- **Names:** CLI `goldenmatch ingest-docs {suggest-schema, run}`; MCP `documents_suggest_schema`,
+  `documents_ingest`.
+
+## Components / files
+
+| path | responsibility | notes |
+|---|---|---|
+| `goldenmatch/documents/schema_io.py` | `TargetSchema` ⇄ JSON: `schema_to_dict`, `schema_from_dict`, `load_schema(path)`, `save_schema(schema, path)` | pure, offline |
+| `goldenmatch/documents/suggest.py` | `suggest_schema(pages, *, extractor_or_transport, model) -> TargetSchema`: VLM proposes fields from a sample doc | reuses the injectable-transport pattern from `vlm_backend.py`; offline-testable |
+| `goldenmatch/mcp/document_tools.py` | `DOCUMENT_TOOLS = [Tool(documents_suggest_schema…), Tool(documents_ingest…)]` + `handle_document_tool(name, args)` | mirrors `agent_tools.py` (`AGENT_TOOLS` + `handle_agent_tool`) |
+| `goldenmatch/cli/ingest_docs.py` | `ingest_docs_app` (typer sub-app) with `suggest-schema` + `run` commands | mirrors `identity_app`/`memory_app` sub-app style |
+| wire-in: `goldenmatch/mcp/server.py` | import `DOCUMENT_TOOLS` + dispatch to `handle_document_tool` alongside the other `*_TOOLS` | follow the existing `_BASE_TOOLS`/`AGENT_TOOLS` wiring |
+| wire-in: `goldenmatch/cli/main.py` | `app.add_typer(ingest_docs_app, name="ingest-docs")` | mirrors `identity_app` registration |
+
+`suggest.py` reuses `loader.load_pages` for the sample and the same base64-data-URI + injectable
+`transport` mechanism as `vlm_backend.py` (do not duplicate the transport; factor the shared
+`_urllib_transport` / payload-image helper if that keeps each file focused).
+
+## Data flow
+
+- **suggest-schema:** `load_pages(sample)` → `suggest_schema(pages, …)` (VLM returns a fields list)
+  → `TargetSchema` → `save_schema(schema, out_path)`. The user edits the file.
+- **run:** `load_schema(schema_path)` → `ingest_documents(paths, schema)` → DataFrame → write
+  `--out` (CSV or parquet by extension) + print the `IngestReport` to stderr.
+- **MCP `documents_ingest`:** a DataFrame can't cross MCP, so return
+  `{"records": [...], "report": {n_files, n_rows, errors}}` as JSON; an optional `out_path` also
+  writes a file and returns its path.
+- **MCP `documents_suggest_schema`:** returns the proposed schema as JSON (the client saves it).
+
+## Error handling
+
+- `suggest_schema`: malformed VLM JSON, `finish_reason == "length"`, or an empty/invalid fields
+  list → raise a clear error; **do not write a garbage schema file**.
+- `run`: missing schema file or invalid schema JSON → fail fast with a clear message before
+  processing. Per-document batch errors are already captured by `ingest_documents`'s `IngestReport`.
+- MCP handlers wrap exceptions as tool-error responses (match the existing `handle_*_tool`
+  convention). CLI commands raise `typer.Exit(code=…)` on bad input (match `anomalies.py`).
+
+## Testing (offline-first, matches repo culture)
+
+- `schema_io`: round-trip (`save_schema` → `load_schema` yields an equal `TargetSchema`); malformed
+  file → clear error. Pure.
+- `suggest`: fake transport returns a proposed-fields JSON → `suggest_schema` yields the expected
+  `TargetSchema`; malformed/empty → error. Offline.
+- MCP `document_tools`: call `handle_document_tool` with a `FakeExtractor`/fake transport injected;
+  assert the returned JSON shape for both tools. No network.
+- CLI `ingest-docs`: use typer's `CliRunner`; inject the fake backend by monkeypatching
+  `resolve_extractor` (or a small documented test seam). Assert `suggest-schema` writes a valid file
+  and `run` writes the records file + non-zero rows.
+- One optional gated live smoke (`OPENAI_API_KEY_PERSONAL`), excluded from CI.
+
+## Scope (YAGNI)
+
+**In:** schema JSON I/O, `suggest_schema`, the two MCP tools, the `ingest-docs` CLI sub-app, wiring.
+**Out (deferred):** inline auto-infer (`run` with no schema); local OCR backend (Phase 3);
+review-queue integration (Phase 3); a one-shot ingest→dedupe command (compose via existing
+`dedupe`/`find_duplicates` instead).
+
+## Open risks
+
+- **Suggest quality:** the VLM's proposed field names/kinds are a *starting point the user edits*,
+  so imperfect suggestions are acceptable — but measure on a real document before claiming it's good.
+- **CLI test injection:** the fake backend needs a clean seam. Prefer monkeypatching
+  `resolve_extractor` over adding a production-only injection param; the plan will specify.

--- a/packages/python/goldenmatch/goldenmatch/cli/ingest_docs.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/ingest_docs.py
@@ -1,0 +1,47 @@
+"""`goldenmatch ingest-docs` — suggest a schema from a sample, then ingest documents to rows."""
+from __future__ import annotations
+
+import typer
+
+from goldenmatch.documents import ingest_documents
+from goldenmatch.documents.config import resolve_extractor
+from goldenmatch.documents.schema_io import load_schema, save_schema
+from goldenmatch.documents.suggest import suggest_schema_from_file
+
+ingest_docs_app = typer.Typer(help="Ingest documents (PDF/image) into matchable records.")
+
+
+@ingest_docs_app.command("suggest-schema")
+def suggest_schema_cmd(
+    sample: str = typer.Argument(..., help="A representative document (PDF/image)."),
+    out: str = typer.Option(..., "--out", "-o", help="Write the proposed schema JSON here."),
+    backend: str = typer.Option("vlm", help="Extraction backend."),
+    model: str = typer.Option("gpt-4o", help="Vision model."),
+):
+    try:
+        schema = suggest_schema_from_file(sample, backend=backend, model=model)
+    except Exception as e:
+        typer.echo(f"schema suggestion failed: {e}", err=True)
+        raise typer.Exit(code=1) from e
+    save_schema(schema, out)
+    typer.echo(f"Wrote {len(schema.fields)}-field schema to {out} -- review before running.", err=True)
+
+
+@ingest_docs_app.command("run")
+def run_cmd(
+    docs: list[str] = typer.Argument(..., help="Document paths (PDF/image)."),
+    schema: str = typer.Option(..., "--schema", "-s", help="Target schema JSON file."),
+    out: str = typer.Option(..., "--out", "-o", help="Write records here (.csv or .parquet)."),
+    backend: str = typer.Option("vlm", help="Extraction backend."),
+    model: str = typer.Option("gpt-4o", help="Vision model."),
+):
+    target = load_schema(schema)
+    extractor = resolve_extractor(backend, model)
+    df, report = ingest_documents(docs, target, extractor=extractor, return_report=True)
+    if str(out).endswith(".parquet"):
+        df.write_parquet(out)
+    else:
+        df.write_csv(out)
+    typer.echo(f"{report.n_rows} rows from {report.n_files} docs -> {out}", err=True)
+    for f, err in report.errors:
+        typer.echo(f"  skipped {f}: {err}", err=True)

--- a/packages/python/goldenmatch/goldenmatch/cli/ingest_docs.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/ingest_docs.py
@@ -35,8 +35,12 @@ def run_cmd(
     backend: str = typer.Option("vlm", help="Extraction backend."),
     model: str = typer.Option("gpt-4o", help="Vision model."),
 ):
-    target = load_schema(schema)
-    extractor = resolve_extractor(backend, model)
+    try:
+        target = load_schema(schema)
+        extractor = resolve_extractor(backend, model)
+    except Exception as e:
+        typer.echo(f"ingest failed: {e}", err=True)
+        raise typer.Exit(code=1) from e
     df, report = ingest_documents(docs, target, extractor=extractor, return_report=True)
     if str(out).endswith(".parquet"):
         df.write_parquet(out)

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -21,6 +21,7 @@ from goldenmatch.cli.evaluate import evaluate_cmd
 from goldenmatch.cli.explain import explain_cmd
 from goldenmatch.cli.identity import identity_app
 from goldenmatch.cli.incremental import incremental_cmd
+from goldenmatch.cli.ingest_docs import ingest_docs_app
 from goldenmatch.cli.label import label_cmd
 from goldenmatch.cli.lineage import lineage_cmd
 from goldenmatch.cli.match import match_cmd
@@ -125,6 +126,7 @@ app.command("evaluate", help="Evaluate matching quality against ground truth pai
 app.add_typer(pprl_app, name="pprl")
 app.add_typer(memory_app, name="memory")
 app.add_typer(identity_app, name="identity")
+app.add_typer(ingest_docs_app, name="ingest-docs")
 app.command("label", help="Build ground truth by labeling record pairs interactively.")(label_cmd)
 app.command("review", help="Review borderline pairs interactively; decisions feed Learning Memory.")(review_cmd)
 app.command("explain", help="Explain why a pair matched or summarize a cluster (plain language).")(explain_cmd)

--- a/packages/python/goldenmatch/goldenmatch/documents/README.md
+++ b/packages/python/goldenmatch/goldenmatch/documents/README.md
@@ -20,5 +20,18 @@ clusters = dedupe_df(
 ```
 
 Install the extra: `pip install "goldenmatch[documents]"`. The VLM backend reads
-`OPENAI_API_KEY_PERSONAL` (or `OPENAI_API_KEY`). A local OCR backend and MCP/CLI wrappers
-are planned (Phases 2-3).
+`OPENAI_API_KEY_PERSONAL` (or `OPENAI_API_KEY`). A local OCR backend is planned (Phase 3).
+
+## CLI
+
+```bash
+# 1. propose a schema from a sample doc (review/edit the file after)
+goldenmatch ingest-docs suggest-schema samples/form.pdf --out schema.json
+# 2. ingest the pile against it
+goldenmatch ingest-docs run inbox/*.pdf --schema schema.json --out records.csv
+```
+
+## MCP
+
+- `documents_suggest_schema(sample_path)` → proposed schema JSON
+- `documents_ingest(paths, schema, out_path?)` → `{records, report}` (records ready for dedupe)

--- a/packages/python/goldenmatch/goldenmatch/documents/_openai.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/_openai.py
@@ -1,0 +1,36 @@
+"""Shared OpenAI-vision plumbing for the documents backends (extractor + schema suggest).
+Kept dependency-free (stdlib urllib) and transport-injectable so callers test offline."""
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+
+from goldenmatch.documents.types import PageImage
+
+ENDPOINT = "https://api.openai.com/v1/chat/completions"
+Transport = Callable[[dict], dict]
+
+
+def urllib_transport(api_key: str) -> Transport:
+    import urllib.request
+
+    def send(payload: dict) -> dict:
+        body = json.dumps(payload).encode()
+        req = urllib.request.Request(
+            ENDPOINT, data=body,
+            headers={"Authorization": f"Bearer {api_key}",
+                     "Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=120) as r:
+            return json.loads(r.read())
+
+    return send
+
+
+def image_blocks(pages: list[PageImage]) -> list[dict]:
+    out = []
+    for pg in pages:
+        b64 = base64.b64encode(pg.png_bytes).decode()
+        out.append({"type": "image_url",
+                    "image_url": {"url": f"data:image/png;base64,{b64}"}})
+    return out

--- a/packages/python/goldenmatch/goldenmatch/documents/_openai.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/_openai.py
@@ -27,6 +27,24 @@ def urllib_transport(api_key: str) -> Transport:
     return send
 
 
+def parse_message_text(resp: dict) -> str:
+    """Assistant message text from a chat-completions response. Raises ValueError on a
+    truncated (finish_reason=length) or malformed envelope; strips a ```json ... ``` fence."""
+    try:
+        choice = resp["choices"][0]
+    except (KeyError, IndexError, TypeError) as e:
+        raise ValueError(f"unexpected response envelope: {e}") from e
+    if choice.get("finish_reason") == "length":
+        raise ValueError("response truncated (finish_reason=length); increase max_tokens")
+    text = (choice.get("message") or {}).get("content")
+    if not isinstance(text, str):
+        raise ValueError("response has no message content")
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0] if "\n" in text else text
+    return text.strip()
+
+
 def image_blocks(pages: list[PageImage]) -> list[dict]:
     out = []
     for pg in pages:

--- a/packages/python/goldenmatch/goldenmatch/documents/config.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/config.py
@@ -10,12 +10,15 @@ from goldenmatch.documents.vlm_backend import VLMExtractor
 _KEY_ENV_ORDER = ("OPENAI_API_KEY_PERSONAL", "OPENAI_API_KEY")
 
 
+def resolve_api_key() -> str:
+    key = next((os.environ[e] for e in _KEY_ENV_ORDER if os.environ.get(e)), None)
+    if not key:
+        raise ValueError("no OpenAI API key found; set OPENAI_API_KEY_PERSONAL "
+                         "(or OPENAI_API_KEY)")
+    return key
+
+
 def resolve_extractor(backend: str, model: str) -> Extractor:
     if backend != "vlm":
         raise ValueError(f"unknown backend: {backend!r} (Phase 1 supports 'vlm')")
-    key = next((os.environ[e] for e in _KEY_ENV_ORDER if os.environ.get(e)), None)
-    if not key:
-        raise ValueError(
-            "no OpenAI API key found; set OPENAI_API_KEY_PERSONAL "
-            "(or OPENAI_API_KEY) for the 'vlm' backend")
-    return VLMExtractor(api_key=key, model=model)
+    return VLMExtractor(api_key=resolve_api_key(), model=model)

--- a/packages/python/goldenmatch/goldenmatch/documents/config.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/config.py
@@ -20,5 +20,5 @@ def resolve_api_key() -> str:
 
 def resolve_extractor(backend: str, model: str) -> Extractor:
     if backend != "vlm":
-        raise ValueError(f"unknown backend: {backend!r} (Phase 1 supports 'vlm')")
+        raise ValueError(f"unsupported backend: {backend!r} (only 'vlm' is supported)")
     return VLMExtractor(api_key=resolve_api_key(), model=model)

--- a/packages/python/goldenmatch/goldenmatch/documents/loader.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/loader.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import io
 from pathlib import Path
 
-from PIL import Image
-
 from goldenmatch.documents.types import PageImage
 
 _PDF = {".pdf"}
@@ -13,7 +11,28 @@ _IMG = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}
 _PDF_DPI = 200  # rasterization DPI; enough for text, bounded for cost
 
 
-def _png(img: Image.Image) -> PageImage:
+def _import_pil():
+    try:
+        from PIL import Image
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "document ingest needs the extra: pip install 'goldenmatch[documents]'"
+        ) from e
+    return Image
+
+
+def _import_fitz():
+    try:
+        import fitz
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "document ingest needs the extra: pip install 'goldenmatch[documents]'"
+        ) from e
+    return fitz
+
+
+def _png(img) -> PageImage:
+    Image = _import_pil()
     if img.mode not in ("RGB", "L"):
         if img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info):
             # img.convert("RGB") on its own composites alpha onto black, burying dark
@@ -33,11 +52,13 @@ def load_pages(path: str | Path) -> list[PageImage]:
     path = Path(path)
     ext = path.suffix.lower()
     if ext in _IMG:
+        Image = _import_pil()
         with Image.open(path) as img:
             img.load()
             return [_png(img)]
     if ext in _PDF:
-        import fitz  # imported lazily so the extra is only needed for PDFs
+        fitz = _import_fitz()  # imported lazily so the extra is only needed for PDFs
+        Image = _import_pil()
         out: list[PageImage] = []
         with fitz.open(str(path)) as doc:
             zoom = _PDF_DPI / 72.0

--- a/packages/python/goldenmatch/goldenmatch/documents/schema_io.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/schema_io.py
@@ -1,0 +1,35 @@
+"""TargetSchema <-> JSON. Pure stdlib, offline. The serializable schema form used by the
+MCP tools and the CLI."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from goldenmatch.documents.types import Field, TargetSchema
+
+
+def schema_to_dict(schema: TargetSchema) -> dict:
+    return {"fields": [{"name": f.name, "kind": f.kind, "hint": f.hint}
+                       for f in schema.fields]}
+
+
+def schema_from_dict(d: dict) -> TargetSchema:
+    if not isinstance(d, dict) or "fields" not in d or not isinstance(d["fields"], list):
+        raise ValueError("schema must be an object with a 'fields' list")
+    fields = []
+    for item in d["fields"]:
+        if "name" not in item:
+            raise ValueError(f"schema field missing 'name': {item!r}")
+        fields.append(Field(name=item["name"], kind=item.get("kind", "text"),
+                            hint=item.get("hint")))
+    if not fields:
+        raise ValueError("schema has no fields")
+    return TargetSchema(fields)
+
+
+def save_schema(schema: TargetSchema, path) -> None:
+    Path(path).write_text(json.dumps(schema_to_dict(schema), indent=2), encoding="utf-8")
+
+
+def load_schema(path) -> TargetSchema:
+    return schema_from_dict(json.loads(Path(path).read_text(encoding="utf-8")))

--- a/packages/python/goldenmatch/goldenmatch/documents/schema_io.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/schema_io.py
@@ -18,6 +18,8 @@ def schema_from_dict(d: dict) -> TargetSchema:
         raise ValueError("schema must be an object with a 'fields' list")
     fields = []
     for item in d["fields"]:
+        if not isinstance(item, dict):
+            raise ValueError(f"schema field must be an object, got {item!r}")
         if "name" not in item:
             raise ValueError(f"schema field missing 'name': {item!r}")
         fields.append(Field(name=item["name"], kind=item.get("kind", "text"),

--- a/packages/python/goldenmatch/goldenmatch/documents/suggest.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/suggest.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 
 import json
 
-from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport
+from goldenmatch.documents._openai import (
+    Transport,
+    image_blocks,
+    parse_message_text,
+    urllib_transport,
+)
 from goldenmatch.documents.config import resolve_api_key
 from goldenmatch.documents.loader import load_pages
 from goldenmatch.documents.schema_io import schema_from_dict
@@ -36,17 +41,12 @@ def suggest_schema(pages: list[PageImage], *, transport: Transport,
             last = f"{type(e).__name__}: {e}"
     else:
         raise ValueError(f"schema suggestion failed: {last}")
-    choice = resp["choices"][0]
-    if choice.get("finish_reason") == "length":
-        raise ValueError("schema suggestion truncated (finish_reason=length); raise max_tokens")
-    text = choice["message"]["content"].strip()
-    if text.startswith("```"):
-        text = text.split("\n", 1)[1].rsplit("```", 1)[0] if "\n" in text else text
+    text = parse_message_text(resp)
     return schema_from_dict(json.loads(text))  # raises ValueError on empty/malformed
 
 
 def suggest_schema_from_file(path, *, backend: str = "vlm", model: str = "gpt-4o") -> TargetSchema:
     if backend != "vlm":
-        raise ValueError(f"unknown backend: {backend!r} (Phase 2 supports 'vlm')")
+        raise ValueError(f"unsupported backend: {backend!r} (only 'vlm' is supported)")
     return suggest_schema(load_pages(path), transport=urllib_transport(resolve_api_key()),
                           model=model)

--- a/packages/python/goldenmatch/goldenmatch/documents/suggest.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/suggest.py
@@ -1,0 +1,52 @@
+"""VLM-assisted target-schema suggestion: look at a sample document and PROPOSE fields.
+Distinct prompt from vlm_backend (which extracts against a KNOWN schema); shares only the
+transport + image encoding."""
+from __future__ import annotations
+
+import json
+
+from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport
+from goldenmatch.documents.config import resolve_api_key
+from goldenmatch.documents.loader import load_pages
+from goldenmatch.documents.schema_io import schema_from_dict
+from goldenmatch.documents.types import PageImage, TargetSchema
+
+_PROMPT = (
+    "You are shown a sample document. Propose a compact extraction schema: the fields a "
+    "person would want pulled from documents like this for record matching (names, "
+    "emails, addresses, phones, ids, dates...). Return ONLY JSON:\n"
+    '{"fields": [{"name": "<snake_case>", "kind": "text|email|phone|address|date|number", '
+    '"hint": "<short guidance>"}, ...]}\n'
+    "Prefer 3-12 stable, matchable fields. No prose."
+)
+
+
+def suggest_schema(pages: list[PageImage], *, transport: Transport,
+                   model: str = "gpt-4o", max_attempts: int = 3) -> TargetSchema:
+    payload = {"model": model, "temperature": 0, "max_tokens": 1500,
+               "messages": [{"role": "user",
+                             "content": [{"type": "text", "text": _PROMPT}] + image_blocks(pages)}]}
+    last = "no response"
+    resp = None
+    for _ in range(max(1, max_attempts)):
+        try:
+            resp = transport(payload)
+            break
+        except Exception as e:  # transport/network: retry
+            last = f"{type(e).__name__}: {e}"
+    else:
+        raise ValueError(f"schema suggestion failed: {last}")
+    choice = resp["choices"][0]
+    if choice.get("finish_reason") == "length":
+        raise ValueError("schema suggestion truncated (finish_reason=length); raise max_tokens")
+    text = choice["message"]["content"].strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1].rsplit("```", 1)[0] if "\n" in text else text
+    return schema_from_dict(json.loads(text))  # raises ValueError on empty/malformed
+
+
+def suggest_schema_from_file(path, *, backend: str = "vlm", model: str = "gpt-4o") -> TargetSchema:
+    if backend != "vlm":
+        raise ValueError(f"unknown backend: {backend!r} (Phase 2 supports 'vlm')")
+    return suggest_schema(load_pages(path), transport=urllib_transport(resolve_api_key()),
+                          model=model)

--- a/packages/python/goldenmatch/goldenmatch/documents/vlm_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/vlm_backend.py
@@ -6,7 +6,12 @@ from __future__ import annotations
 
 import json
 
-from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport
+from goldenmatch.documents._openai import (
+    Transport,
+    image_blocks,
+    parse_message_text,
+    urllib_transport,
+)
 from goldenmatch.documents.types import (
     ExtractedRow,
     ExtractResult,
@@ -62,13 +67,8 @@ class VLMExtractor:
         # Response received: parsing is deterministic (temperature=0), so a parse
         # failure is not retried -- it would just reproduce the same bad response.
         try:
-            choice = resp["choices"][0]
-            if choice.get("finish_reason") == "length":
-                return ExtractResult(
-                    rows=[],
-                    error="response truncated (finish_reason=length); increase max_tokens")
-            text = choice["message"]["content"]
-            data = json.loads(_strip_fence(text))
+            text = parse_message_text(resp)
+            data = json.loads(text)
             rows = [
                 ExtractedRow.from_partial(
                     rec.get("values", {}), rec.get("confidence", {}), schema,
@@ -78,12 +78,3 @@ class VLMExtractor:
             return ExtractResult(rows=rows)
         except (KeyError, ValueError, TypeError, IndexError) as e:
             return ExtractResult(rows=[], error=f"parse: {type(e).__name__}: {e}")
-
-
-def _strip_fence(text: str) -> str:
-    t = text.strip()
-    if t.startswith("```"):
-        t = t.split("\n", 1)[1] if "\n" in t else t
-        if t.endswith("```"):
-            t = t[: -3]
-    return t.strip()

--- a/packages/python/goldenmatch/goldenmatch/documents/vlm_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/vlm_backend.py
@@ -4,34 +4,15 @@ Network I/O is a `transport(payload: dict) -> dict` callable so the class tests 
 """
 from __future__ import annotations
 
-import base64
 import json
-from collections.abc import Callable
 
+from goldenmatch.documents._openai import Transport, image_blocks, urllib_transport
 from goldenmatch.documents.types import (
     ExtractedRow,
     ExtractResult,
     PageImage,
     TargetSchema,
 )
-
-_ENDPOINT = "https://api.openai.com/v1/chat/completions"
-Transport = Callable[[dict], dict]
-
-
-def _urllib_transport(api_key: str) -> Transport:
-    import urllib.request
-
-    def send(payload: dict) -> dict:
-        body = json.dumps(payload).encode()
-        req = urllib.request.Request(
-            _ENDPOINT, data=body,
-            headers={"Authorization": f"Bearer {api_key}",
-                     "Content-Type": "application/json"})
-        with urllib.request.urlopen(req, timeout=120) as r:
-            return json.loads(r.read())
-
-    return send
 
 
 def _instruction(schema: TargetSchema) -> str:
@@ -56,14 +37,10 @@ class VLMExtractor:
             raise ValueError(f"max_attempts must be >= 1, got {max_attempts}")
         self._model = model
         self._max_attempts = max_attempts
-        self._send = transport or _urllib_transport(api_key)
+        self._send = transport or urllib_transport(api_key)
 
     def _payload(self, pages: list[PageImage], schema: TargetSchema) -> dict:
-        content: list[dict] = [{"type": "text", "text": _instruction(schema)}]
-        for pg in pages:
-            b64 = base64.b64encode(pg.png_bytes).decode()
-            content.append({"type": "image_url",
-                            "image_url": {"url": f"data:image/png;base64,{b64}"}})
+        content = [{"type": "text", "text": _instruction(schema)}] + image_blocks(pages)
         return {"model": self._model, "temperature": 0, "max_tokens": 8000,
                 "messages": [{"role": "user", "content": content}]}
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/document_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/document_tools.py
@@ -1,0 +1,71 @@
+"""MCP tools for document/image ingest. Handlers return JSON-serializable dicts, matching
+handle_routing_tool so both the stdio call_tool and aggregator dispatch paths work."""
+from __future__ import annotations
+
+from mcp.types import Tool
+
+from goldenmatch.documents import ingest_documents
+from goldenmatch.documents.config import resolve_extractor  # noqa: F401 (monkeypatch seam)
+from goldenmatch.documents.schema_io import schema_from_dict, schema_to_dict
+from goldenmatch.documents.suggest import suggest_schema_from_file  # noqa: F401 (seam)
+
+DOCUMENT_TOOLS = [
+    Tool(
+        name="documents_suggest_schema",
+        description="Propose a target extraction schema (JSON) from a sample document image/PDF.",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "sample_path": {"type": "string"},
+                "backend": {"type": "string", "default": "vlm"},
+                "model": {"type": "string", "default": "gpt-4o"},
+            },
+            "required": ["sample_path"],
+        },
+    ),
+    Tool(
+        name="documents_ingest",
+        description=("Extract records from documents (PDF/image) against a target schema into "
+                     "rows ready for dedupe_df. Returns records + an ingest report."),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "paths": {"type": "array", "items": {"type": "string"}},
+                "schema": {"type": "object", "description": "schema JSON: {'fields':[...]}"},
+                "backend": {"type": "string", "default": "vlm"},
+                "model": {"type": "string", "default": "gpt-4o"},
+                "drop_empty": {"type": "boolean", "default": True},
+                "out_path": {"type": "string", "description": "optional CSV/parquet to also write"},
+            },
+            "required": ["paths", "schema"],
+        },
+    ),
+]
+DOCUMENT_TOOL_NAMES = frozenset(t.name for t in DOCUMENT_TOOLS)
+
+
+def handle_document_tool(name: str, arguments: dict) -> dict:
+    if name == "documents_suggest_schema":
+        schema = suggest_schema_from_file(
+            arguments["sample_path"],
+            backend=arguments.get("backend", "vlm"),
+            model=arguments.get("model", "gpt-4o"))
+        return {"schema": schema_to_dict(schema)}
+
+    if name == "documents_ingest":
+        schema = schema_from_dict(arguments["schema"])
+        extractor = resolve_extractor(arguments.get("backend", "vlm"),
+                                      arguments.get("model", "gpt-4o"))
+        df, report = ingest_documents(
+            arguments["paths"], schema, extractor=extractor,
+            drop_empty=arguments.get("drop_empty", True), return_report=True)
+        out_path = arguments.get("out_path")
+        if out_path:
+            (df.write_parquet if str(out_path).endswith(".parquet") else df.write_csv)(out_path)
+        return {
+            "records": df.to_dicts(),
+            "report": {"n_files": report.n_files, "n_rows": report.n_rows,
+                       "errors": [{"file": f, "error": e} for (f, e) in report.errors]},
+            **({"out_path": str(out_path)} if out_path else {}),
+        }
+    raise ValueError(f"unknown document tool: {name}")

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -33,6 +33,11 @@ from mcp.types import (
 
 from goldenmatch.core._paths import PathOutsideAllowedRootError, safe_path
 from goldenmatch.mcp.agent_tools import AGENT_TOOLS, handle_agent_tool
+from goldenmatch.mcp.document_tools import (
+    DOCUMENT_TOOL_NAMES,
+    DOCUMENT_TOOLS,
+    handle_document_tool,
+)
 from goldenmatch.mcp.identity_tools import (
     IDENTITY_TOOL_NAMES,
     IDENTITY_TOOLS,
@@ -618,7 +623,7 @@ def _build_alias_tools() -> list[Tool]:
 _BASE_TOOLS += _build_alias_tools()
 
 # TOOLS is the union of agent tools + memory tools + base tools, in the same order list_tools returns.
-TOOLS = AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS
+TOOLS = AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS + DOCUMENT_TOOLS
 
 
 def dispatch(name: str, args: dict) -> dict:
@@ -641,6 +646,8 @@ def dispatch(name: str, args: dict) -> dict:
         return _identity_dispatch(name, args)
     if name in ROUTING_TOOL_NAMES:
         return handle_routing_tool(name, args)
+    if name in DOCUMENT_TOOL_NAMES:
+        return handle_document_tool(name, args)
     return _handle_tool(name, args)
 
 
@@ -654,7 +661,7 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:
-        return AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS
+        return AGENT_TOOLS + MEMORY_TOOLS + IDENTITY_TOOLS + ROUTING_TOOLS + _BASE_TOOLS + DOCUMENT_TOOLS
 
     @server.list_resources()
     async def list_resources() -> list[Resource]:
@@ -913,7 +920,9 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
         if name in IDENTITY_TOOL_NAMES:
             return await handle_identity_tool(name, arguments)
         try:
-            if name in ROUTING_TOOL_NAMES:
+            if name in DOCUMENT_TOOL_NAMES:
+                result = handle_document_tool(name, arguments)
+            elif name in ROUTING_TOOL_NAMES:
                 result = handle_routing_tool(name, arguments)
             else:
                 result = _handle_tool(name, arguments)

--- a/packages/python/goldenmatch/tests/documents/test_cli_ingest_docs.py
+++ b/packages/python/goldenmatch/tests/documents/test_cli_ingest_docs.py
@@ -28,6 +28,18 @@ def test_run_writes_records_csv(tmp_path, monkeypatch):
     assert out.exists() and "Ada" in out.read_text()
 
 
+def test_run_missing_schema_file_exits_cleanly(tmp_path):
+    from PIL import Image
+    img = tmp_path / "a.png"; Image.new("RGB", (10, 10), "white").save(img)
+    missing_schema = tmp_path / "does-not-exist.json"
+    out = tmp_path / "recs.csv"
+    r = runner.invoke(ci.ingest_docs_app, ["run", str(img), "--schema", str(missing_schema),
+                                           "--out", str(out)])
+    assert r.exit_code == 1
+    assert "Traceback" not in r.output
+    assert "ingest failed" in r.output
+
+
 def test_suggest_schema_writes_file(tmp_path, monkeypatch):
     from PIL import Image
     img = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(img)

--- a/packages/python/goldenmatch/tests/documents/test_cli_ingest_docs.py
+++ b/packages/python/goldenmatch/tests/documents/test_cli_ingest_docs.py
@@ -1,0 +1,38 @@
+import json
+
+import goldenmatch.cli.ingest_docs as ci
+from goldenmatch.documents.extractor import FakeExtractor
+from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+from typer.testing import CliRunner
+
+runner = CliRunner()
+SCHEMA = TargetSchema([Field("full_name"), Field("email")])
+
+
+def _schema_file(tmp_path):
+    p = tmp_path / "schema.json"
+    p.write_text(json.dumps({"fields": [{"name": "full_name"}, {"name": "email"}]}))
+    return p
+
+
+def test_run_writes_records_csv(tmp_path, monkeypatch):
+    from PIL import Image
+    img = tmp_path / "a.png"; Image.new("RGB", (10, 10), "white").save(img)
+    row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {}, SCHEMA,
+                                    source_file="", source_page=0)
+    monkeypatch.setattr(ci, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+    out = tmp_path / "recs.csv"
+    r = runner.invoke(ci.ingest_docs_app, ["run", str(img), "--schema", str(_schema_file(tmp_path)),
+                                           "--out", str(out)])
+    assert r.exit_code == 0, r.output
+    assert out.exists() and "Ada" in out.read_text()
+
+
+def test_suggest_schema_writes_file(tmp_path, monkeypatch):
+    from PIL import Image
+    img = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(img)
+    monkeypatch.setattr(ci, "suggest_schema_from_file", lambda path, **k: SCHEMA)
+    out = tmp_path / "schema.json"
+    r = runner.invoke(ci.ingest_docs_app, ["suggest-schema", str(img), "--out", str(out)])
+    assert r.exit_code == 0, r.output
+    assert json.loads(out.read_text())["fields"][0]["name"] == "full_name"

--- a/packages/python/goldenmatch/tests/documents/test_document_tools.py
+++ b/packages/python/goldenmatch/tests/documents/test_document_tools.py
@@ -1,0 +1,38 @@
+import goldenmatch.mcp.document_tools as dt
+from goldenmatch.documents.extractor import FakeExtractor
+from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+
+# canonical full form: schema_to_dict always emits name/kind/hint, and schema_from_dict
+# accepts this form as input too, so it works as both expected-output and ingest-input.
+SCHEMA_JSON = {"fields": [
+    {"name": "full_name", "kind": "text", "hint": None},
+    {"name": "email", "kind": "email", "hint": None}]}
+
+
+def test_tool_names_and_list():
+    names = {t.name for t in dt.DOCUMENT_TOOLS}
+    assert names == {"documents_suggest_schema", "documents_ingest"}
+    assert dt.DOCUMENT_TOOL_NAMES == names
+
+
+def test_suggest_schema_tool(monkeypatch, tmp_path):
+    from PIL import Image
+    p = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(p)
+    schema = TargetSchema([Field("full_name"), Field("email", kind="email")])
+    monkeypatch.setattr(dt, "suggest_schema_from_file", lambda path, **k: schema)
+    out = dt.handle_document_tool("documents_suggest_schema", {"sample_path": str(p)})
+    assert out["schema"] == SCHEMA_JSON
+
+
+def test_ingest_tool_returns_records_and_report(monkeypatch, tmp_path):
+    from PIL import Image
+    a = tmp_path / "a.png"; Image.new("RGB", (10, 10), "white").save(a)
+    schema = TargetSchema([Field("full_name"), Field("email")])
+    row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {}, schema,
+                                    source_file="", source_page=0)
+    monkeypatch.setattr(dt, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+    out = dt.handle_document_tool("documents_ingest",
+                                  {"paths": [str(a)], "schema": SCHEMA_JSON})
+    assert out["report"]["n_rows"] == 1
+    assert out["records"][0]["full_name"] == "Ada"
+    assert out["records"][0]["email"] == "a@x.io"

--- a/packages/python/goldenmatch/tests/documents/test_document_tools_wiring.py
+++ b/packages/python/goldenmatch/tests/documents/test_document_tools_wiring.py
@@ -1,0 +1,9 @@
+import goldenmatch.mcp.server as srv
+
+
+def test_document_tools_registered_in_all_surfaces():
+    names = {t.name for t in srv.TOOLS}
+    assert {"documents_suggest_schema", "documents_ingest"} <= names
+    # dispatch routes doc tools without falling through to the base handler
+    import goldenmatch.mcp.document_tools as dt
+    assert dt.DOCUMENT_TOOL_NAMES <= {t.name for t in srv.TOOLS}

--- a/packages/python/goldenmatch/tests/documents/test_document_tools_wiring.py
+++ b/packages/python/goldenmatch/tests/documents/test_document_tools_wiring.py
@@ -7,3 +7,9 @@ def test_document_tools_registered_in_all_surfaces():
     # dispatch routes doc tools without falling through to the base handler
     import goldenmatch.mcp.document_tools as dt
     assert dt.DOCUMENT_TOOL_NAMES <= {t.name for t in srv.TOOLS}
+
+
+def test_dispatch_routes_document_tools(monkeypatch):
+    monkeypatch.setattr(srv, "handle_document_tool", lambda name, args: {"routed": name})
+    out = srv.dispatch("documents_ingest", {"paths": [], "schema": {"fields": [{"name": "x"}]}})
+    assert out == {"routed": "documents_ingest"}

--- a/packages/python/goldenmatch/tests/documents/test_ingest.py
+++ b/packages/python/goldenmatch/tests/documents/test_ingest.py
@@ -54,7 +54,7 @@ def test_missing_key_for_vlm_backend_fails_fast(tmp_path, monkeypatch):
 
 def test_unknown_backend_fails_fast(tmp_path):
     a = tmp_path / "a.png"; _img(a)
-    with pytest.raises(ValueError, match="unknown backend"):
+    with pytest.raises(ValueError, match="unsupported backend"):
         ingest_documents([a], SCHEMA, backend="nope")
 
 

--- a/packages/python/goldenmatch/tests/documents/test_openai_helpers.py
+++ b/packages/python/goldenmatch/tests/documents/test_openai_helpers.py
@@ -1,0 +1,14 @@
+from goldenmatch.documents._openai import image_blocks, urllib_transport
+from goldenmatch.documents.types import PageImage
+
+
+def test_image_blocks_emit_data_uris():
+    pages = [PageImage(b"\x89PNG\r\n\x1a\n0", 1, 1, 0), PageImage(b"abc", 1, 1, 1)]
+    blocks = image_blocks(pages)
+    assert len(blocks) == 2
+    assert blocks[0]["type"] == "image_url"
+    assert blocks[0]["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_urllib_transport_is_callable():
+    assert callable(urllib_transport("k"))

--- a/packages/python/goldenmatch/tests/documents/test_openai_helpers.py
+++ b/packages/python/goldenmatch/tests/documents/test_openai_helpers.py
@@ -1,4 +1,5 @@
-from goldenmatch.documents._openai import image_blocks, urllib_transport
+import pytest
+from goldenmatch.documents._openai import image_blocks, parse_message_text, urllib_transport
 from goldenmatch.documents.types import PageImage
 
 
@@ -12,3 +13,19 @@ def test_image_blocks_emit_data_uris():
 
 def test_urllib_transport_is_callable():
     assert callable(urllib_transport("k"))
+
+
+def test_parse_message_text_strips_fence():
+    resp = {"choices": [{"message": {"content": '```json\n{"a": 1}\n```'}}]}
+    assert parse_message_text(resp) == '{"a": 1}'
+
+
+def test_parse_message_text_truncated_is_error():
+    resp = {"choices": [{"message": {"content": "{"}, "finish_reason": "length"}]}
+    with pytest.raises(ValueError, match="truncat"):
+        parse_message_text(resp)
+
+
+def test_parse_message_text_missing_choices_is_error():
+    with pytest.raises(ValueError):
+        parse_message_text({"nope": True})

--- a/packages/python/goldenmatch/tests/documents/test_phase2_live_smoke.py
+++ b/packages/python/goldenmatch/tests/documents/test_phase2_live_smoke.py
@@ -1,0 +1,17 @@
+import os
+
+import pytest
+from goldenmatch.documents.suggest import suggest_schema_from_file
+from PIL import Image, ImageDraw
+
+pytestmark = pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY_PERSONAL"),
+                                reason="live VLM smoke; set OPENAI_API_KEY_PERSONAL")
+
+
+def test_live_suggest_schema(tmp_path):
+    p = tmp_path / "card.png"
+    img = Image.new("RGB", (400, 200), "white"); d = ImageDraw.Draw(img)
+    d.text((20, 40), "Ada Lovelace", fill="black"); d.text((20, 80), "ada@x.io", fill="black")
+    img.save(p)
+    schema = suggest_schema_from_file(p)
+    assert len(schema.fields) >= 1

--- a/packages/python/goldenmatch/tests/documents/test_schema_io.py
+++ b/packages/python/goldenmatch/tests/documents/test_schema_io.py
@@ -32,3 +32,8 @@ def test_load_rejects_malformed(tmp_path):
     p.write_text('{"nope": 1}')
     with pytest.raises(ValueError, match="fields"):
         load_schema(p)
+
+
+def test_load_rejects_non_dict_field():
+    with pytest.raises(ValueError):
+        schema_from_dict({"fields": ["full_name"]})

--- a/packages/python/goldenmatch/tests/documents/test_schema_io.py
+++ b/packages/python/goldenmatch/tests/documents/test_schema_io.py
@@ -1,0 +1,34 @@
+import json
+
+import pytest
+from goldenmatch.documents.schema_io import (
+    load_schema,
+    save_schema,
+    schema_from_dict,
+    schema_to_dict,
+)
+from goldenmatch.documents.types import Field, TargetSchema
+
+SCHEMA = TargetSchema([Field("full_name"), Field("email", kind="email", hint="work email")])
+
+
+def test_round_trip_dict():
+    d = schema_to_dict(SCHEMA)
+    assert d == {"fields": [
+        {"name": "full_name", "kind": "text", "hint": None},
+        {"name": "email", "kind": "email", "hint": "work email"}]}
+    assert schema_from_dict(d) == SCHEMA
+
+
+def test_round_trip_file(tmp_path):
+    p = tmp_path / "schema.json"
+    save_schema(SCHEMA, p)
+    assert json.loads(p.read_text())["fields"][0]["name"] == "full_name"
+    assert load_schema(p) == SCHEMA
+
+
+def test_load_rejects_malformed(tmp_path):
+    p = tmp_path / "bad.json"
+    p.write_text('{"nope": 1}')
+    with pytest.raises(ValueError, match="fields"):
+        load_schema(p)

--- a/packages/python/goldenmatch/tests/documents/test_suggest.py
+++ b/packages/python/goldenmatch/tests/documents/test_suggest.py
@@ -1,0 +1,36 @@
+import json
+
+import pytest
+from goldenmatch.documents.suggest import suggest_schema
+from goldenmatch.documents.types import PageImage
+
+PAGES = [PageImage(b"\x89PNG\r\n\x1a\n0", 10, 10, 0)]
+
+
+def _resp(fields):
+    return {"choices": [{"message": {"content": json.dumps({"fields": fields})}}]}
+
+
+def test_suggests_fields_from_a_sample():
+    fields = [{"name": "full_name", "kind": "text", "hint": "the person's name"},
+              {"name": "email", "kind": "email"}]
+    out = suggest_schema(PAGES, transport=lambda p: _resp(fields), model="gpt-4o")
+    assert out.column_names() == ["full_name", "email"]
+    assert out.fields[1].kind == "email"
+
+
+def test_empty_fields_is_an_error():
+    with pytest.raises(ValueError):
+        suggest_schema(PAGES, transport=lambda p: _resp([]), model="gpt-4o")
+
+
+def test_malformed_json_is_an_error():
+    bad = {"choices": [{"message": {"content": "not json"}}]}
+    with pytest.raises(ValueError):
+        suggest_schema(PAGES, transport=lambda p: bad, model="gpt-4o")
+
+
+def test_truncation_is_an_error():
+    trunc = {"choices": [{"message": {"content": "{"}, "finish_reason": "length"}]}
+    with pytest.raises(ValueError, match="truncat"):
+        suggest_schema(PAGES, transport=lambda p: trunc, model="gpt-4o")

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -28,7 +28,7 @@ def test_total_tool_count_is_69():
     assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
     assert len(_BASE_TOOLS) == 31   # 26 + 5 cross-language naming aliases (#1451)
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 74   # 69 + 5 cross-language naming aliases (#1451)
+    assert len(TOOLS) == 76   # 71 (69 + documents_ingest/documents_suggest_schema) + 5 aliases
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -87,6 +87,8 @@ mcp_tools:
   - compare_clusters
   - config_weaknesses
   - create_domain
+  - documents_ingest
+  - documents_suggest_schema
   - explain_routing
   - export_results
   - get_cluster
@@ -152,6 +154,7 @@ cli_commands:
   - config
   - explain
   - incremental
+  - ingest-docs
   - init
   - interactive
   - label


### PR DESCRIPTION
## Summary
Builds on #1508 (Phase 1). Exposes `goldenmatch.documents` on the MCP + CLI surfaces and adds **AI-assisted schema generation**.

- **AI-assisted, two-step:** `documents_suggest_schema` / `ingest-docs suggest-schema` — a VLM proposes a target schema (fields with name/kind/hint) from a sample document into a reviewable JSON file. You edit it, then `documents_ingest` / `ingest-docs run` extracts the pile against it. Records feed `dedupe_df` unchanged.
- **MCP:** `documents_suggest_schema` + `documents_ingest` (dict-returning handler, so it serves both the stdio `call_tool` and the aggregator `dispatch`), wired into all four `server.py` surfaces.
- **CLI:** `goldenmatch ingest-docs {suggest-schema, run}` (typer sub-app).
- **Refactor:** shared OpenAI transport / image-encoding / response-parsing helpers hoisted into `documents/_openai.py`, used by both the extractor and the suggester (no duplication). Lazy `PIL`/`fitz` imports so `import goldenmatch.documents` (and the MCP server) degrade gracefully without the `[documents]` extra, with a clear "install goldenmatch[documents]" message.

## Test Plan
- [x] `pytest tests/documents` -> **46 passed, 2 skipped** (the skips are the gated live VLM smokes)
- [x] `ruff` clean; `import goldenmatch.mcp.server` imports clean
- [x] MCP tools registered in `TOOLS` / `dispatch` / `list_tools` / `call_tool`; CLI `run`/`suggest-schema` fail-fast on bad input
- [ ] Optional: run a live smoke with `OPENAI_API_KEY_PERSONAL` set

## Notes
- Design + plan: `docs/superpowers/{specs,plans}/2026-07-06-document-ingest-phase2-*.md`. Both went through spec + plan review; the implementation passed spec-compliance and code-quality review.
- Deferred to Phase 3: local OCR backend, review-queue integration, inline auto-infer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JThTtceZ9kStY5jWjwGk6v