### PR TITLE
ci(goldenflow-js): build + ship the WASM artifact in the npm package

### DIFF
--- a/.github/workflows/_publish-js.yml
+++ b/.github/workflows/_publish-js.yml
@@ -21,6 +21,11 @@ on:
         required: false
         type: boolean
         default: false
+      build_wasm:
+        description: "Build the package's opt-in WASM artifact (packages/typescript/<pkg>/scripts/build_wasm.sh) before typecheck/build so it ships in dist/"
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Tag or commit to build (default: the triggering ref)"
         required: false
@@ -68,6 +73,18 @@ jobs:
         if: inputs.build_deps
         working-directory: ${{ github.workspace }}
         run: pnpm turbo run build --filter=${{ inputs.package }}^...
+
+      # Build the opt-in WASM artifact into src/core/wasm/artifacts/ so tsup's
+      # copy step ships it in dist/. Without this the artifact is gitignored /
+      # CI-only and enableWasm() falls back to pure-TS for published users.
+      # ubuntu-latest ships rustup/cargo; the script pins wasm-bindgen from the
+      # crate's Cargo.lock. Runs before Typecheck/Test so those also see it.
+      - name: Build WASM artifact
+        if: inputs.build_wasm
+        working-directory: ${{ github.workspace }}
+        run: |
+          rustup target add wasm32-unknown-unknown
+          bash "packages/typescript/${{ inputs.package }}/scripts/build_wasm.sh"
 
       - name: Typecheck
         run: pnpm exec tsc --noEmit

--- a/.github/workflows/publish-goldenflow-js.yml
+++ b/.github/workflows/publish-goldenflow-js.yml
@@ -30,6 +30,9 @@ jobs:
       # entrypoint unless it's built first, so this MUST stay true or the publish
       # fails with TS2307 on backend.ts (every publish since 0.4.0 silently did).
       build_deps: true
+      # Build the opt-in WASM artifact so it ships in dist/ (enableWasm() +
+      # the fused chain reach published npm users; otherwise pure-TS only).
+      build_wasm: true
       ref: ${{ inputs.ref || '' }}
       dry_run: ${{ inputs.dry_run || 'false' }}
     secrets: inherit

--- a/packages/typescript/goldenflow/scripts/build_wasm.sh
+++ b/packages/typescript/goldenflow/scripts/build_wasm.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build the goldenflow-wasm artifact INTO the TS package's
+# src/core/wasm/artifacts/ so tsup's copy step (see tsup.config +
+# scripts/copy_wasm_artifact.mjs) ships it in dist/ and the published npm package
+# actually carries the opt-in WASM backend. The artifact is otherwise gitignored
+# (CI-built), so without this step `enableWasm()` always falls back to pure-TS for
+# published users. Mirrors the `goldenflow_wasm` CI lane's build exactly (same
+# wasm-bindgen version pinned from the crate's Cargo.lock).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+CRATE_DIR="$REPO_ROOT/packages/rust/extensions/goldenflow-wasm"
+OUT_DIR="$REPO_ROOT/packages/typescript/goldenflow/src/core/wasm/artifacts"
+
+cargo build --manifest-path "$CRATE_DIR/Cargo.toml" \
+  --target wasm32-unknown-unknown --release
+
+WB_VER="$(grep -A1 '^name = "wasm-bindgen"$' "$CRATE_DIR/Cargo.lock" \
+  | grep '^version = ' | head -1 | sed -E 's/version = "([^"]+)"/\1/')"
+if [ -z "$WB_VER" ]; then
+  echo "could not resolve wasm-bindgen version from Cargo.lock" >&2
+  exit 1
+fi
+echo "Using wasm-bindgen $WB_VER"
+if ! wasm-bindgen --version 2>/dev/null | grep -q "$WB_VER"; then
+  cargo install wasm-bindgen-cli --version "=$WB_VER" --locked
+fi
+
+wasm-bindgen \
+  "$CRATE_DIR/target/wasm32-unknown-unknown/release/goldenflow_wasm.wasm" \
+  --target web --out-dir "$OUT_DIR" --out-name goldenflow_wasm
+
+echo "built goldenflow-wasm artifact into $OUT_DIR"
+ls -la "$OUT_DIR"


### PR DESCRIPTION
Makes the opt-in WASM backend (incl. the fused chain from #1513) actually reach npm users.

## The gap
The goldenflow-wasm artifact is gitignored (CI-built) and the npm publish flow never built it, so **the published tarball carries zero `.wasm` files** — `enableWasm()` always falls back to pure-TS for published users. Verified: the `goldenflow` 0.13.0 npm tarball contains no `.wasm`. So the whole WASM backend (identifiers, text, and the new fused chain) has never actually shipped.

## Fix
- `packages/typescript/goldenflow/scripts/build_wasm.sh` — mirrors the `goldenflow_wasm` CI lane (cargo build wasm32 + version-pinned wasm-bindgen), outputs into `src/core/wasm/artifacts/`.
- A guarded `build_wasm` input on the shared `_publish-js.yml` runs it **before** typecheck/test/build, so tsup's copy step lands the artifact in `dist/` (which `files: ['dist']` ships). Running before Test means the publish also exercises the real wasm parity tests. Only goldenflow passes `build_wasm: true`; every other TS package is unchanged.

## Rollout
- No version change — goldenflow stays **0.14.0** (the fused chain); this makes that release carry the wasm.
- **Plan after merge:** `workflow_dispatch` with `dry_run: true` first → inspect the packed tarball for `.wasm` → then tag `goldenflow-js-v0.14.0` for the real publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg