### PR TITLE
docs(goldenflow): note WASM ships in npm since 0.14.0 (was inert before)

### DIFF
--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -57,8 +57,18 @@ npx goldenflow-js transform data.csv  # CLI
 - Tests: `tests/smoke.test.ts`, `tests/parity/`, `tests/unit/`
 - npm package name: `goldenflow`
 - CLI binary: `goldenflow-js`
-- Publish: tag `goldenflow-js-vX.Y.Z` triggers `.github/workflows/npm-publish.yml`
+- Publish: tag `goldenflow-js-vX.Y.Z` triggers `publish-goldenflow-js.yml` -> `_publish-js.yml`
 - `NPM_TOKEN` secret is set on the GitHub repo
+- **WASM ships in the npm package (since 0.14.0) — it did NOT before.** The
+  `goldenflow-wasm` artifact is gitignored (CI-built), and the publish flow never
+  built it, so **every tarball <=0.13.0 carried ZERO `.wasm`** — `enableWasm()`
+  silently fell back to pure-TS for all published users (the whole opt-in WASM
+  backend was inert on npm). Fixed by `scripts/build_wasm.sh` + the `build_wasm: true`
+  input on `_publish-js.yml` (runs `cargo build wasm32` + version-pinned
+  `wasm-bindgen` before tsup, so `copy_wasm_artifact.mjs` lands it in `dist/`). The
+  dry-run Pack step asserts `tar tzf *.tgz | grep .wasm` (fails loud if dropped).
+  **Always `dry_run: true` first + verify the published tarball has `.wasm`** on any
+  wasm-affecting release. Verified: 0.14.0 tarball has 3 `.wasm` (dist/{,core/,core/wasm/}artifacts).
 
 ## Architecture
 


### PR DESCRIPTION
Records the publish gotcha found + fixed this session: the wasm backend never shipped to npm before 0.14.0 (gitignored artifact, never built at publish -> zero .wasm in the tarball -> enableWasm() inert). Now built via scripts/build_wasm.sh + the build_wasm publish input, with a dry-run tarball assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg