### PR TITLE
perf(goldenflow-core): 3-8x faster hot kernels (measured, byte-identical)

### DIFF
--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
@@ -49,3 +49,7 @@ required-features = ["arrow"]
 name = "chain_apply"
 harness = false
 required-features = ["arrow"]
+
+[[bench]]
+name = "kernel_rank"
+harness = false

--- a/packages/rust/extensions/goldenflow-core/benches/kernel_rank.rs
+++ b/packages/rust/extensions/goldenflow-core/benches/kernel_rank.rs
@@ -5,6 +5,9 @@
 //! before designing — the repo's standing perf lesson). Plain `fn main()` +
 //! 5-run-median wall, arrow-free (times the raw `text/email/names` fns per value
 //! over a realistic messy corpus). Run: `cargo bench --bench kernel_rank`.
+// The kernel table trades a couple of clippy nits for a uniform, readable shape.
+#![allow(clippy::type_complexity)] // `&[(&str, Box<dyn Fn>)]` is fine for a bench
+#![allow(clippy::redundant_closure)] // uniform `|s| f(s)` reads better than mixed fn paths
 
 use std::hint::black_box;
 use std::time::Instant;

--- a/packages/rust/extensions/goldenflow-core/benches/kernel_rank.rs
+++ b/packages/rust/extensions/goldenflow-core/benches/kernel_rank.rs
@@ -1,0 +1,117 @@
+//! Per-kernel cost ranking — WHICH owned kernels dominate the fused-apply wall.
+//!
+//! The frame-container spike showed the native kernel is ~97% of a fused run; this
+//! ranks the individual kernels so optimization targets the hot ones (measure
+//! before designing — the repo's standing perf lesson). Plain `fn main()` +
+//! 5-run-median wall, arrow-free (times the raw `text/email/names` fns per value
+//! over a realistic messy corpus). Run: `cargo bench --bench kernel_rank`.
+
+use std::hint::black_box;
+use std::time::Instant;
+
+use goldenflow_core::{email, names, text};
+
+const RUNS: usize = 5;
+const REPEAT: usize = 40_000; // corpus rows = REPEAT * base.len()
+
+/// A realistic messy corpus: a mix of clean ASCII, multi-space, HTML, URLs,
+/// punctuation, digits, accented Latin, and names/emails — the shapes these
+/// kernels actually see in a cleanup pipeline.
+fn corpus() -> Vec<String> {
+    let base = [
+        "  John   SMITH  ",
+        "<b>o'Brien</b>  http://x.com/y?utm_source=a",
+        "café  éé  #7  résumé",
+        "Dr. Jane A. Doe Jr.",
+        "MARY-JANE   o'neil",
+        "hello world this is a normal sentence",
+        "Contact: JANE@Example.COM  ",
+        "price is $1,234.56 and 99.9%",
+        "  multiple    spaces   everywhere  ",
+        "Ünïcödé ströng wïth àccênts",
+        "no-punctuation-here just words and 123 numbers",
+        "The Quick Brown Fox Jumps Over The Lazy Dog",
+    ];
+    let mut v = Vec::with_capacity(base.len() * REPEAT);
+    for _ in 0..REPEAT {
+        for s in base {
+            v.push(s.to_string());
+        }
+    }
+    v
+}
+
+fn bench(name: &str, corpus: &[String], f: &dyn Fn(&str) -> String, total_bytes: usize) {
+    let mut best = f64::INFINITY;
+    for _ in 0..RUNS {
+        let t = Instant::now();
+        let mut acc = 0usize;
+        for s in corpus {
+            acc += black_box(f(s)).len();
+        }
+        black_box(acc);
+        best = best.min(t.elapsed().as_secs_f64());
+    }
+    let rows = corpus.len();
+    let ns_row = best * 1e9 / rows as f64;
+    let mb_s = (total_bytes as f64 / 1e6) / best;
+    println!("{name:<22} {ns_row:>8.1} ns/row   {mb_s:>8.1} MB/s");
+}
+
+fn main() {
+    let c = corpus();
+    let total_bytes: usize = c.iter().map(|s| s.len()).sum();
+    println!(
+        "corpus: {} rows, {:.1} MB, {} runs (min wall)\n",
+        c.len(),
+        total_bytes as f64 / 1e6,
+        RUNS
+    );
+    let kernels: &[(&str, Box<dyn Fn(&str) -> String>)] = &[
+        ("strip", Box::new(|s| text::strip(s).to_string())),
+        ("lowercase", Box::new(|s| text::lowercase(s))),
+        ("uppercase", Box::new(|s| text::uppercase(s))),
+        ("title_case", Box::new(|s| text::title_case(s))),
+        (
+            "collapse_whitespace",
+            Box::new(|s| text::collapse_whitespace(s)),
+        ),
+        ("normalize_quotes", Box::new(|s| text::normalize_quotes(s))),
+        (
+            "normalize_line_endings",
+            Box::new(|s| text::normalize_line_endings(s)),
+        ),
+        (
+            "normalize_unicode",
+            Box::new(|s| text::normalize_unicode(s)),
+        ),
+        ("remove_html_tags", Box::new(|s| text::remove_html_tags(s))),
+        ("remove_urls", Box::new(|s| text::remove_urls(s))),
+        ("remove_digits", Box::new(|s| text::remove_digits(s))),
+        (
+            "remove_punctuation",
+            Box::new(|s| text::remove_punctuation(s)),
+        ),
+        ("remove_emojis", Box::new(|s| text::remove_emojis(s))),
+        ("extract_numbers", Box::new(|s| text::extract_numbers(s))),
+        ("fix_mojibake", Box::new(|s| text::fix_mojibake(s))),
+        ("email_normalize", Box::new(|s| email::email_normalize(s))),
+        ("email_canonical", Box::new(|s| email::email_canonical(s))),
+        (
+            "name_transliterate",
+            Box::new(|s| names::name_transliterate(s)),
+        ),
+        ("strip_titles", Box::new(|s| names::strip_titles(s))),
+        ("strip_suffixes", Box::new(|s| names::strip_suffixes(s))),
+        ("name_proper", Box::new(|s| names::name_proper(s))),
+        (
+            "nickname_standardize",
+            Box::new(|s| names::nickname_standardize(s)),
+        ),
+        ("name_initials", Box::new(|s| names::name_initials(s))),
+        ("strip_middle", Box::new(|s| names::strip_middle(s))),
+    ];
+    for (name, f) in kernels {
+        bench(name, &c, f.as_ref(), total_bytes);
+    }
+}

--- a/packages/rust/extensions/goldenflow-core/src/names.rs
+++ b/packages/rust/extensions/goldenflow-core/src/names.rs
@@ -226,19 +226,21 @@ const TITLES: [&str; 9] = ["Mr", "Mrs", "Ms", "Miss", "Dr", "Prof", "Rev", "Sr",
 /// leading-title regex match; whitespace uses Unicode `char::is_whitespace`
 /// (Python `\s` under `re.UNICODE` + polars `strip_chars`).
 fn strip_leading_title(s: &str) -> Option<&str> {
-    let lower = s.to_ascii_lowercase();
+    // Zero-alloc: case-insensitive prefix compare on the leading bytes instead of
+    // lowercasing the whole string + each title. Byte-identical (titles are ASCII).
+    let bytes = s.as_bytes();
     for title in TITLES {
-        let t = title.to_ascii_lowercase();
-        if lower.starts_with(&t) {
-            // ASCII-lowercasing preserves byte offsets, so `title.len()` indexes
-            // the original safely (the prefix is ASCII).
-            let after_title = &s[title.len()..];
-            let after_dot = after_title.strip_prefix('.').unwrap_or(after_title);
-            let after_ws = after_dot.trim_start();
-            if after_ws.len() < after_dot.len() {
-                // at least one whitespace consumed -> the `\s+` matched.
-                return Some(after_ws);
-            }
+        let tl = title.len();
+        if bytes.len() < tl || !bytes[..tl].eq_ignore_ascii_case(title.as_bytes()) {
+            continue;
+        }
+        // `tl` ends an ASCII prefix run, so it's a char boundary.
+        let after_title = &s[tl..];
+        let after_dot = after_title.strip_prefix('.').unwrap_or(after_title);
+        let after_ws = after_dot.trim_start();
+        if after_ws.len() < after_dot.len() {
+            // at least one whitespace consumed -> the `\s+` matched.
+            return Some(after_ws);
         }
     }
     None
@@ -273,24 +275,32 @@ const SUFFIXES: [(&str, bool); 14] = [
 
 /// If `s` ends (case-insensitively) with `\s+ suffix (\.)? $`, return everything
 /// before the trailing whitespace run; else `None`.
+///
+/// Zero-alloc: the match only concerns the string's tail and the suffix table is
+/// constant, so we compare the trailing bytes with `eq_ignore_ascii_case` instead
+/// of lowercasing the whole string + each suffix every call. Byte-identical to the
+/// old `to_ascii_lowercase()` form (suffixes are ASCII; ASCII-folding matches).
 fn strip_trailing_suffix(s: &str) -> Option<&str> {
-    let lower = s.to_ascii_lowercase();
+    let bytes = s.as_bytes();
     for (suf, allow_dot) in SUFFIXES {
-        let suf_l = suf.to_ascii_lowercase();
-        // `\.?$` greedily takes the trailing dot when present.
-        let core = if allow_dot {
-            lower.strip_suffix('.').unwrap_or(&lower)
+        // `\.?$` greedily takes a single trailing dot when the suffix allows it.
+        let end = if allow_dot && bytes.last() == Some(&b'.') {
+            bytes.len() - 1
         } else {
-            &lower
+            bytes.len()
         };
-        if let Some(before) = core.strip_suffix(&suf_l) {
-            // the `\s+` requires whitespace immediately before the suffix.
-            if before.ends_with(char::is_whitespace) {
-                // ASCII-lowercasing preserves byte offsets; `before.len()`
-                // indexes the original (`before` is all-ASCII up to here only
-                // where it matters -- it's a prefix, so the offset is valid).
-                return Some(&s[..before.len()]);
-            }
+        let sl = suf.len();
+        if end < sl {
+            continue;
+        }
+        if !bytes[end - sl..end].eq_ignore_ascii_case(suf.as_bytes()) {
+            continue;
+        }
+        // `end - sl` starts an ASCII suffix run, so it's a char boundary.
+        let before = &s[..end - sl];
+        // the `\s+` requires whitespace immediately before the suffix.
+        if before.ends_with(char::is_whitespace) {
+            return Some(before);
         }
     }
     None
@@ -308,6 +318,29 @@ pub fn strip_suffixes(s: &str) -> String {
 /// non-ASCII behavior is bounded by the Unicode `to_uppercase`/`to_lowercase`
 /// case maps (documented boundary -- reference-mode resolves in Rust's favor).
 pub(crate) fn ascii_title(s: &str) -> String {
+    // ASCII fast path (the common case for names): work byte-by-byte, no UTF-8
+    // decode and no `char::to_uppercase()` iterator per char. Byte-identical to
+    // the Unicode path below for ASCII input (ASCII a-z case ops == Unicode's).
+    if s.is_ascii() {
+        let mut out = String::with_capacity(s.len());
+        let mut prev_alpha = false;
+        for &b in s.as_bytes() {
+            let ch = if b.is_ascii_alphabetic() {
+                let m = if prev_alpha {
+                    b.to_ascii_lowercase()
+                } else {
+                    b.to_ascii_uppercase()
+                };
+                prev_alpha = true;
+                m
+            } else {
+                prev_alpha = false;
+                b
+            };
+            out.push(ch as char);
+        }
+        return out;
+    }
     let mut out = String::with_capacity(s.len());
     let mut prev_alpha = false;
     for c in s.chars() {
@@ -357,9 +390,22 @@ fn fixup_prefix(s: &str, p0: char, p1: char) -> String {
 /// fixups. Byte-identical to `names.py::name_proper` (title -> Mc sub -> O' sub)
 /// on ASCII input.
 pub fn name_proper(s: &str) -> String {
-    let titled = ascii_title(s);
-    let mc = fixup_prefix(&titled, 'M', 'c');
-    fixup_prefix(&mc, 'O', '\'')
+    let mut out = ascii_title(s);
+    fixup_prefix_inplace(&mut out, 'M', 'c');
+    fixup_prefix_inplace(&mut out, 'O', '\'');
+    out
+}
+
+/// Apply the `fixup_prefix` rule to `s` in place. The rule can only change the
+/// string where the `(p0,p1)` byte pair occurs, so when that pair is absent it is
+/// a guaranteed no-op and we skip the char-based rebuild entirely (no `Vec<char>`
+/// materialization, no realloc). Byte-identical — most names carry no `Mc`/`O'`.
+fn fixup_prefix_inplace(s: &mut String, p0: char, p1: char) {
+    let (b0, b1) = (p0 as u8, p1 as u8); // p0/p1 are ASCII
+    if !s.as_bytes().windows(2).any(|w| w[0] == b0 && w[1] == b1) {
+        return;
+    }
+    *s = fixup_prefix(s, p0, p1);
 }
 
 /// Map a common nickname (looked up by trimmed-lowercased key) to its formal
@@ -489,11 +535,14 @@ pub fn name_initials(s: &str) -> String {
 /// (`John Quincy Adams` -> `John Adams`). 0 tokens -> `""`; 1 token -> itself;
 /// >=2 -> `"first last"`. Collapses internal whitespace.
 pub fn strip_middle(s: &str) -> String {
-    let tokens: Vec<&str> = s.split_whitespace().collect();
-    match tokens.as_slice() {
-        [] => String::new(),
-        [only] => (*only).to_string(),
-        [first, .., last] => format!("{first} {last}"),
+    // First + last whitespace token, without collecting every token into a Vec.
+    let mut it = s.split_whitespace();
+    let Some(first) = it.next() else {
+        return String::new();
+    };
+    match it.last() {
+        None => first.to_string(),
+        Some(last) => format!("{first} {last}"),
     }
 }
 

--- a/packages/rust/extensions/goldenflow-core/src/text.rs
+++ b/packages/rust/extensions/goldenflow-core/src/text.rs
@@ -156,35 +156,41 @@ pub fn remove_html_tags(s: &str) -> String {
 
 /// Streaming [`remove_html_tags`] (appends to `out`) for the columnar path.
 pub fn remove_html_tags_into(s: &str, out: &mut String) {
-    let chars: Vec<char> = s.chars().collect();
-    let n = chars.len();
+    // Byte scan: `<` (0x3C) and `>` (0x3E) are ASCII, so they never appear as
+    // UTF-8 continuation bytes -- scanning bytes is safe for any string, and we
+    // copy the KEPT runs verbatim via `push_str` (bulk memcpy, valid UTF-8), no
+    // `Vec<char>` and no per-char push. Byte-identical to the char version.
+    let b = s.as_bytes();
+    let n = b.len();
     let mut i = 0;
+    let mut keep_start = 0;
     while i < n {
-        if chars[i] == '<' {
+        if b[i] == b'<' {
             let mut j = i + 1;
-            while j < n && chars[j] != '>' {
+            while j < n && b[j] != b'>' {
                 j += 1;
             }
-            // matched `<[^>]+>`: at least one non-`>` char (j > i+1) then a `>`.
+            // matched `<[^>]+>`: >=1 non-`>` byte (j > i+1) then a `>`.
             if j < n && j > i + 1 {
+                out.push_str(&s[keep_start..i]);
                 i = j + 1;
+                keep_start = i;
                 continue;
             }
         }
-        out.push(chars[i]);
         i += 1;
     }
+    out.push_str(&s[keep_start..]);
 }
 
-/// `"http://"` (7 chars) or `"https://"` (8 chars) at `chars[i..]`; returns the
-/// index just past the `://`. `https` is tried first (regex `s?` is greedy).
-fn match_url_scheme(chars: &[char], i: usize) -> Option<usize> {
-    const HTTP: [char; 7] = ['h', 't', 't', 'p', ':', '/', '/'];
-    const HTTPS: [char; 8] = ['h', 't', 't', 'p', 's', ':', '/', '/'];
-    if chars[i..].starts_with(&HTTPS) {
-        Some(i + HTTPS.len())
-    } else if chars[i..].starts_with(&HTTP) {
-        Some(i + HTTP.len())
+/// `"http://"` (7 bytes) or `"https://"` (8 bytes) at `b[i..]`; returns the byte
+/// index just past the `://`. `https` is tried first (regex `s?` is greedy). The
+/// scheme is ASCII, so a byte compare is byte-identical to matching chars.
+fn match_url_scheme(b: &[u8], i: usize) -> Option<usize> {
+    if b[i..].starts_with(b"https://") {
+        Some(i + 8)
+    } else if b[i..].starts_with(b"http://") {
+        Some(i + 7)
     } else {
         None
     }
@@ -201,24 +207,36 @@ pub fn remove_urls(s: &str) -> String {
 
 /// Streaming [`remove_urls`] (appends to `out`) for the columnar path.
 pub fn remove_urls_into(s: &str, out: &mut String) {
-    let chars: Vec<char> = s.chars().collect();
-    let n = chars.len();
+    // Byte scan for the ASCII scheme; the `\S+` tail is Unicode-whitespace-aware
+    // so we advance it char-by-char (whitespace can be multi-byte). Kept runs are
+    // copied verbatim via `push_str` -- no `Vec<char>`. Byte-identical.
+    let b = s.as_bytes();
+    let n = b.len();
     let mut i = 0;
+    let mut keep_start = 0;
     while i < n {
-        if let Some(after) = match_url_scheme(&chars, i) {
+        if let Some(after) = match_url_scheme(b, i) {
+            // `\S+`: advance over non-whitespace chars from `after`.
             let mut j = after;
-            while j < n && !chars[j].is_whitespace() {
-                j += 1;
+            while j < n {
+                let c = s[j..].chars().next().unwrap();
+                if c.is_whitespace() {
+                    break;
+                }
+                j += c.len_utf8();
             }
             if j > after {
                 // scheme + `\S+` (>=1 non-ws char) -> drop the whole URL.
+                out.push_str(&s[keep_start..i]);
                 i = j;
+                keep_start = i;
                 continue;
             }
         }
-        out.push(chars[i]);
-        i += 1;
+        // not a URL start: advance one char (i is at a char boundary).
+        i += s[i..].chars().next().unwrap().len_utf8();
     }
+    out.push_str(&s[keep_start..]);
 }
 
 /// Remove ASCII digit characters. The old polars `\d` was Unicode-aware; this
@@ -258,28 +276,35 @@ pub fn remove_punctuation_into(s: &str, out: &mut String) {
 /// dot, zero-or-more digits) joined by single spaces. ASCII digits only
 /// (documented boundary). Byte-identical to `text.py::extract_numbers`.
 pub fn extract_numbers(s: &str) -> String {
-    let chars: Vec<char> = s.chars().collect();
-    let n = chars.len();
-    let mut nums: Vec<String> = Vec::new();
+    // Byte scan: digits and `.` are ASCII single bytes (never UTF-8 continuation
+    // bytes), so non-ASCII chars are skipped byte-wise and each number run is an
+    // ASCII `&str` slice appended directly (no `Vec<char>`, no `Vec<String>`).
+    // Byte-identical to the char version.
+    let b = s.as_bytes();
+    let n = b.len();
+    let mut out = String::new();
     let mut i = 0;
     while i < n {
-        if chars[i].is_ascii_digit() {
+        if b[i].is_ascii_digit() {
             let start = i;
-            while i < n && chars[i].is_ascii_digit() {
+            while i < n && b[i].is_ascii_digit() {
                 i += 1; // \d+
             }
-            if i < n && chars[i] == '.' {
+            if i < n && b[i] == b'.' {
                 i += 1; // greedy \.?
-                while i < n && chars[i].is_ascii_digit() {
+                while i < n && b[i].is_ascii_digit() {
                     i += 1; // \d*
                 }
             }
-            nums.push(chars[start..i].iter().collect());
+            if !out.is_empty() {
+                out.push(' ');
+            }
+            out.push_str(&s[start..i]);
         } else {
             i += 1;
         }
     }
-    nums.join(" ")
+    out
 }
 
 /// True if `c` is in the emoji codepoint set (the exact ranges of the Python

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,14 +79,14 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "phonenumber",
 ]
 
 [[package]]
 name = "goldenflow-wasm"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "goldenflow-core",
  "wasm-bindgen",

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-wasm"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.14.0"
+version = "0.15.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.14.0"
+    __version__ = "0.15.0"

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",


### PR DESCRIPTION
The "irreducible 97%" from the frame-container spike — the owned kernels themselves. Measure-first, then optimize the hot ones. **Byte-identical** (120 core tests + 1416 Python cross-surface parity tests: native == pure-Python == pinned corpus).

## Measured wins (new `benches/kernel_rank.rs`, 5-run-median)
| kernel | before | after | speedup |
|---|---:|---:|---:|
| strip_suffixes | 530 | 69 | **7.7×** |
| extract_numbers | 178 | 25 | **7.1×** |
| strip_titles | 383 | 57 | **6.7×** |
| name_proper | 703 | 175 | **4.0×** |
| remove_html_tags | 193 | 50 | **3.9×** |
| remove_urls | 199 | 72 | **2.9×** |
| title_case | 206 | 113 | **1.8×** |

(ns/row on a realistic messy corpus.)

## How (all byte-identical, no `unsafe`)
- **names.rs** — `strip_suffixes`/`strip_titles` lowercased the *whole string + every table entry* each call (~15/~10 allocs even on no match); now a zero-alloc `eq_ignore_ascii_case` on the tail/head bytes. `name_proper` got an ASCII byte fast-path for `ascii_title` (which also sped `title_case`) + skips each `Mc`/`O'` fixup (and its `Vec<char>` rebuild) when the trigger byte-pair is absent. `strip_middle` iterates for first+last instead of collecting all tokens.
- **text.rs** — `extract_numbers`/`remove_html_tags`/`remove_urls` dropped the `Vec<char>` materialization: byte-scan the ASCII delimiters (`<`/`>`/`http://`/digits — none collide with UTF-8 continuation bytes) and copy the KEPT runs via `push_str` (bulk memcpy).

## Delivery
Versions: goldenflow-core 0.9→0.10, native-flow 0.14→**0.15** (republish → PyPI `[native]`), goldenflow-wasm 0.2→0.3 + goldenflow(npm) 0.14→**0.15** (faster wasm to npm). No output/behavior change anywhere — pure speed. golden-suite lockstep handled at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg