### PR TITLE
feat(goldenpipe): TS infer_schema stage (InferMap port)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md
@@ -1,0 +1,489 @@
+# goldenpipe TS `infer_schema` Stage — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the Python goldenpipe `infer_schema` stage to TypeScript, consuming the TS `infermap` package, producing the identical `InferredSchema` + `infer_schema_evidence` artifacts.
+
+**Architecture:** A new TS goldenpipe adapter stage (`infer_schema`) that runs InferMap's `detectDomainDetailed` + `map` and converts the `MapResult` to a shared `goldencheck-types.InferredSchema` — a faithful translation of `stages/infer_schema.py`. Registered but opt-in (not in `DEFAULT_STAGE_ORDER`), matching Python.
+
+**Tech Stack:** TypeScript (goldenpipe adapter + infermap barrel), vitest, `goldencheck-types` shared types.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md`
+
+**Reference skill:** @superpowers:test-driven-development
+
+---
+
+## Environment & Constraints (READ FIRST)
+
+**Repo:** `D:\show_case\gg-local-llm`, branch `feat/goldenpipe-ts-infer-schema` (off fresh `origin/main`, spec committed).
+
+**Box CANNOT run `tsc`/`vitest`/`tsup`/`pnpm build`** (TS OOMs, CI-only). Box CAN: `node --check` (`.mjs`/`.cjs` only, NOT `.ts`), `python` (to cross-check the Python reference), `git`, `grep`/read, `python -c` JSON validation. **Every TS task is write-against-spec + eye-verify + commit; CI is the first real test.** The Python `infer_schema` reference + its tests ARE box-runnable for cross-checking expected values.
+
+**Reference files (read first):**
+- Python stage (the reference): `packages/python/goldenpipe/goldenpipe/stages/infer_schema.py`.
+- Python tests (mirror these 7): `packages/python/goldenpipe/tests/test_infer_schema_stage.py`.
+- TS goldenpipe stage exemplar: `packages/typescript/goldenpipe/src/core/adapters/check.ts` (`ScanStage` shape).
+- TS models: `packages/typescript/goldenpipe/src/core/models.ts` (`Stage`, `PipeContext`, `Row`, `StageResult`, `StageStatus`, `makePipeContext`).
+- Registry wiring: `packages/typescript/goldenpipe/src/core/adapters/index.ts` (`buildDefaultRegistry`).
+- infermap barrel: `packages/typescript/infermap/src/core/index.ts:5` (`export { detectDomain, DEFAULT_MIN_SCORE } from "./detect.js";`).
+- Shared types: `packages/typescript/goldencheck-types/src/index.ts` (`InferredSchema`, `FieldMapping`, `UNMAPPED_TYPE`, `loadDomain`, `DomainPack`).
+
+**Git:** benzsevern (`unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)`). Merge-queue — `--auto --squash`, no `--delete-branch`. Trailer:
+```
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+```
+
+---
+
+## File Structure
+
+| File | Change | Action |
+| --- | --- | --- |
+| `packages/typescript/infermap/src/core/index.ts` | re-export `detectDomainDetailed` from the barrel | Modify |
+| `packages/typescript/goldenpipe/package.json` | add `infermap` + `goldencheck-types` deps | Modify |
+| `packages/typescript/goldenpipe/src/core/adapters/infer.ts` | new `InferSchemaStage` + `resultToInferredSchema` | Create |
+| `packages/typescript/goldenpipe/src/core/adapters/index.ts` | register + export `InferSchemaStage` (NOT in DEFAULT_STAGE_ORDER) | Modify |
+| `packages/typescript/goldenpipe/tests/unit/infer-schema-stage.test.ts` | 7-case parity test | Create |
+| `pnpm-lock.yaml` | regenerated for the 2 new goldenpipe deps | Modify (generated) |
+
+---
+
+## Task 1: Surface `detectDomainDetailed` from the infermap barrel
+
+**Files:** Modify `packages/typescript/infermap/src/core/index.ts`. Box: eye-review.
+
+The stage imports `detectDomainDetailed` from `"infermap"`, but the barrel only re-exports `detectDomain`. Add it (it's already a public export of `detect.ts`; also aligns with Python's top-level `detect_domain_detailed`).
+
+- [ ] **Step 1: Edit the re-export line.** In `core/index.ts`, change line 5:
+```ts
+export { detectDomain, DEFAULT_MIN_SCORE } from "./detect.js";
+```
+to:
+```ts
+export { detectDomain, detectDomainDetailed, DEFAULT_MIN_SCORE } from "./detect.js";
+```
+
+- [ ] **Step 2: Verify.** `grep -n "detectDomainDetailed" packages/typescript/infermap/src/core/index.ts packages/typescript/infermap/src/core/detect.ts` — confirm it's now in the barrel export AND is an `export function` in `detect.ts` (so the re-export resolves). The top-level `index.ts` does `export * from "./core/index.js"`, so it's now reachable as `import { detectDomainDetailed } from "infermap"`.
+
+- [ ] **Step 3: Commit.**
+```bash
+cd "D:/show_case/gg-local-llm"
+git add packages/typescript/infermap/src/core/index.ts
+git commit -m "feat(infermap-ts): surface detectDomainDetailed from the barrel (Wave C follow-on)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, grep, SHA.
+
+---
+
+## Task 2: Add the two goldenpipe dependencies
+
+**Files:** Modify `packages/typescript/goldenpipe/package.json`; regenerate `pnpm-lock.yaml`. Box: JSON + `pnpm install --lockfile-only` (box-runnable — resolution only, ~seconds, does NOT OOM).
+
+- [ ] **Step 1: Read `package.json`.** `cat packages/typescript/goldenpipe/package.json` — find the `dependencies` block (currently `commander, goldencheck, goldenflow, goldenmatch`).
+
+- [ ] **Step 2: Add both deps** to `dependencies`, matching the existing formatting + alphabetical order:
+```json
+    "goldencheck-types": "workspace:^",
+    "infermap": "workspace:^",
+```
+(Both are absent today; both are required — `infermap` for the API, `goldencheck-types` for `InferredSchema`/`FieldMapping`/`UNMAPPED_TYPE`/`loadDomain`. Do not rely on transitive resolution.)
+
+- [ ] **Step 3: Validate JSON + regenerate the lockfile.**
+```bash
+"D:/show_case/goldenmatch/.venv/Scripts/python.exe" -c "import json; json.load(open('packages/typescript/goldenpipe/package.json')); print('package.json OK')"
+export COREPACK_INTEGRITY_KEYS=0
+pnpm install --lockfile-only 2>&1 | tail -4
+git status --short pnpm-lock.yaml
+```
+Expect: `package.json OK`; `pnpm install` completes (resolves the new workspace links); `pnpm-lock.yaml` shows as modified. If `pnpm install --lockfile-only` fails/OOMs, note it for the controller (CI can regenerate) — but per prior experience `--lockfile-only` is light and works on the box.
+
+- [ ] **Step 4: Commit** (package.json + lockfile together):
+```bash
+git add packages/typescript/goldenpipe/package.json pnpm-lock.yaml
+git commit -m "build(goldenpipe-ts): add infermap + goldencheck-types deps for infer_schema stage
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, package.json-OK, lockfile-regen result, SHA.
+
+---
+
+## Task 3: The `InferSchemaStage` adapter (byte-faithful port)
+
+**Files:** Create `packages/typescript/goldenpipe/src/core/adapters/infer.ts`. Box: eye-review (no tsc). Cross-check logic against `infer_schema.py`.
+
+- [ ] **Step 1: Read the Python stage** (`infer_schema.py`) fully — the `_validate_flags`, the 4 branches, `_result_to_inferred_schema`, the `detect_evidence` shapes, the `confidence = detect_score` replace, and the `setdefault("infer_schema_evidence", ...)`.
+
+- [ ] **Step 2: Create `infer.ts`:**
+```ts
+/**
+ * infer_schema — GoldenPipe stage that runs InferMap to label columns.
+ * TS port of goldenpipe/stages/infer_schema.py. Produces
+ * `inferred_schema` (goldencheck-types.InferredSchema | null) + (on the
+ * auto-detect path) `infer_schema_evidence`. Consumes nothing — meant to run
+ * before stages that want typed columns. Opt-in (not in DEFAULT_STAGE_ORDER),
+ * matching Python.
+ *
+ * Config (ctx.stageConfig): schema?: InferredSchema | no_infer?: boolean |
+ * domain?: string. Precedence: schema > no_infer > domain > auto-detect;
+ * the three are mutually exclusive (conflict throws in run()).
+ */
+import {
+  UNMAPPED_TYPE,
+  loadDomain,
+  type FieldMapping,
+  type InferredSchema,
+} from "goldencheck-types";
+import {
+  detectDomainDetailed,
+  map,
+  DomainPackTarget,
+  type MapResult,
+} from "infermap";
+
+import type { PipeContext, Stage, StageResult } from "../models.js";
+import { StageStatus } from "../models.js";
+
+/** Mirror of Python `_result_to_inferred_schema`. `confidence` is overwritten
+ *  by the caller with the detection score. */
+function resultToInferredSchema(result: MapResult, domain: string): InferredSchema {
+  const fields: Record<string, FieldMapping> = {};
+  for (const fm of result.mappings) {
+    fields[fm.source] = {
+      source_col: fm.source,
+      canonical: fm.target, // soft mode sets target = null -> canonical null
+      type: fm.target ? fm.target : UNMAPPED_TYPE,
+      confidence: fm.confidence,
+      evidence: { reasoning: fm.reasoning },
+    };
+  }
+  for (const col of result.unmappedSource) {
+    if (!(col in fields)) {
+      fields[col] = {
+        source_col: col,
+        canonical: null,
+        type: UNMAPPED_TYPE,
+        confidence: 0.0,
+        evidence: {},
+      };
+    }
+  }
+  const confidence = result.mappings.length
+    ? Math.min(...result.mappings.map((m) => m.confidence))
+    : 0.0;
+  return { domain, fields, confidence };
+}
+
+/** Mirror of Python `_validate_flags`: at most one of schema/no_infer/domain. */
+function validateFlags(cfg: Record<string, unknown>): void {
+  const set =
+    (cfg.schema != null ? 1 : 0) +
+    (cfg.no_infer ? 1 : 0) +
+    (cfg.domain != null ? 1 : 0);
+  if (set > 1) {
+    throw new Error(
+      "conflict: 'schema', 'no_infer', and 'domain' are mutually exclusive. " +
+        "Precedence: schema > no_infer > domain > auto-detect.",
+    );
+  }
+}
+
+export const InferSchemaStage: Stage = {
+  info: {
+    name: "infer_schema",
+    produces: ["inferred_schema", "infer_schema_evidence"],
+    consumes: [],
+  },
+
+  // No precondition: consumes [] and a null df is a valid SUCCESS branch, so
+  // validate() must NOT throw. The flag-conflict check lives in run() (mirrors
+  // Python's _validate_flags at the top of run()).
+  validate(_ctx: PipeContext): void {},
+
+  async run(ctx: PipeContext): Promise<StageResult> {
+    const cfg = ctx.stageConfig ?? {};
+    validateFlags(cfg);
+
+    if (cfg.schema != null) {
+      ctx.artifacts["inferred_schema"] = cfg.schema;
+      return { status: StageStatus.SUCCESS };
+    }
+    if (cfg.no_infer) {
+      ctx.artifacts["inferred_schema"] = null;
+      return { status: StageStatus.SUCCESS };
+    }
+    if (ctx.df === null) {
+      ctx.artifacts["inferred_schema"] = null;
+      return { status: StageStatus.SUCCESS };
+    }
+
+    const explicit = cfg.domain as string | undefined;
+    let domain: string;
+    let detectScore: number;
+    let detectEvidence: Record<string, unknown>;
+
+    if (explicit != null) {
+      domain = explicit;
+      detectScore = 1.0;
+      detectEvidence = { detect_reason: "explicit" };
+    } else {
+      const detection = detectDomainDetailed({ records: ctx.df });
+      if (detection.domain !== null) {
+        domain = detection.domain;
+        detectScore = detection.score;
+        detectEvidence = {
+          detect_reason: detection.reason,
+          detect_score: detection.score,
+          runner_up: detection.runner_up,
+          runner_up_score: detection.runner_up_score,
+        };
+      } else {
+        domain = "generic";
+        detectScore = 0.0;
+        detectEvidence = {
+          detect_reason: detection.reason,
+          detect_score: detection.score,
+          runner_up: detection.runner_up,
+          runner_up_score: detection.runner_up_score,
+          fallback: true,
+        };
+      }
+    }
+
+    const result = map(
+      { records: ctx.df },
+      new DomainPackTarget(loadDomain(domain)),
+      { soft: true },
+    );
+    const inferred: InferredSchema = {
+      ...resultToInferredSchema(result, domain),
+      confidence: detectScore,
+    };
+
+    ctx.artifacts["inferred_schema"] = inferred;
+    // setdefault: only set when a prior stage hasn't already.
+    if (!("infer_schema_evidence" in ctx.artifacts)) {
+      ctx.artifacts["infer_schema_evidence"] = detectEvidence;
+    }
+    return { status: StageStatus.SUCCESS };
+  },
+};
+```
+
+- [ ] **Step 3: Eye-verify against the spec + Python.**
+  - Imports resolve: `UNMAPPED_TYPE`/`loadDomain`/`FieldMapping`/`InferredSchema` from `goldencheck-types`; `detectDomainDetailed`/`map`/`DomainPackTarget`/`MapResult` from `infermap` (Task 1 surfaced `detectDomainDetailed`). Confirm `MapResult` is exported from the infermap barrel (`grep -n "MapResult" packages/typescript/infermap/src/core/index.ts`); if it's `export type`, keep the `type MapResult` import.
+  - Confirm `StageStatus` + `Stage`/`PipeContext`/`StageResult` are the real exports of `../models.js` (`grep -n "export.*StageStatus\|export interface Stage\b\|export interface PipeContext" packages/typescript/goldenpipe/src/core/models.ts`). If `StageResult` needs more than `{status}` (e.g. a required field), match the real interface — read it.
+  - `resultToInferredSchema` matches `_result_to_inferred_schema` line-for-line (snake_case fields; `unmappedSource` camelCase; `type: fm.target ? fm.target : UNMAPPED_TYPE`; unmapped-source loop; `min` confidence with 0.0 default).
+  - The 4 branches + precedence + the 3 `detectEvidence` shapes + `setdefault` match Python.
+  - `.js` on all relative imports.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/typescript/goldenpipe/src/core/adapters/infer.ts
+git commit -m "feat(goldenpipe-ts): infer_schema stage (InferMap port)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, the import/StageResult-shape confirmations, SHA.
+
+---
+
+## Task 4: Register the stage (opt-in, NOT default)
+
+**Files:** Modify `packages/typescript/goldenpipe/src/core/adapters/index.ts`. Box: eye-review.
+
+- [ ] **Step 1: Read `adapters/index.ts`** — note the import block, the `export { ... }` re-exports, and `buildDefaultRegistry()` (which does `registry.register(LoadStage)` etc.).
+
+- [ ] **Step 2: Add the import + re-export + registration.**
+  - Add to the import block: `import { InferSchemaStage } from "./infer.js";`
+  - Add to the re-exports: `export { InferSchemaStage } from "./infer.js";`
+  - Add inside `buildDefaultRegistry()`, after the other `registry.register(...)` calls: `registry.register(InferSchemaStage);`
+
+- [ ] **Step 3: Do NOT touch `DEFAULT_STAGE_ORDER`** (`core/pipeline.ts`). The stage is registered (available by name) but opt-in — matching Python, whose default pipeline is the same 3 stages without `infer_schema`. Confirm you did not edit `pipeline.ts`.
+
+- [ ] **Step 4: Verify.**
+```bash
+grep -n "InferSchemaStage\|infer.js" packages/typescript/goldenpipe/src/core/adapters/index.ts
+grep -n "infer_schema\|InferSchema" packages/typescript/goldenpipe/src/core/pipeline.ts || echo "pipeline.ts untouched (correct — opt-in)"
+```
+Confirm: import + re-export + `registry.register(InferSchemaStage)` present; `pipeline.ts` has no infer_schema reference.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/typescript/goldenpipe/src/core/adapters/index.ts
+git commit -m "feat(goldenpipe-ts): register infer_schema stage (opt-in, not default)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, grep, SHA.
+
+---
+
+## Task 5: 7-case parity unit test
+
+**Files:** Create `packages/typescript/goldenpipe/tests/unit/infer-schema-stage.test.ts`. Box: eye-review (no vitest). Mirrors `test_infer_schema_stage.py`.
+
+- [ ] **Step 1: Create the test** (uses `makePipeContext` + `StageStatus` from models; the same finance rows as the Python test → detects `finance` by cross-surface parity):
+```ts
+import { describe, it, expect } from "vitest";
+import { makePipeContext, StageStatus, type Row } from "../../src/core/models.js";
+import { InferSchemaStage } from "../../src/core/adapters/infer.js";
+import type { InferredSchema } from "goldencheck-types";
+
+// Same columns/values as the Python test's _ctx() -> detects "finance".
+const FINANCE_ROWS: Row[] = [
+  { account_number: "A1234", currency: "USD" },
+  { account_number: "A5678", currency: "EUR" },
+];
+
+describe("infer_schema stage (InferMap port)", () => {
+  it("auto-detects the finance domain", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS });
+    const result = await InferSchemaStage.run(ctx);
+    expect(result.status).toBe(StageStatus.SUCCESS);
+    const inferred = ctx.artifacts["inferred_schema"] as InferredSchema | null;
+    expect(inferred).not.toBeNull();
+    expect(inferred!.domain).toBe("finance");
+  });
+
+  it("honors an explicit domain", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { domain: "finance" } });
+    await InferSchemaStage.run(ctx);
+    expect((ctx.artifacts["inferred_schema"] as InferredSchema).domain).toBe("finance");
+  });
+
+  it("no_infer returns null", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { no_infer: true } });
+    await InferSchemaStage.run(ctx);
+    expect(ctx.artifacts["inferred_schema"]).toBeNull();
+  });
+
+  it("passes a user-provided schema through unchanged", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { schema: user } });
+    await InferSchemaStage.run(ctx);
+    expect(ctx.artifacts["inferred_schema"]).toBe(user);
+  });
+
+  it("throws on conflicting schema + domain", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ stageConfig: { schema: user, domain: "finance" } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+
+  it("throws on conflicting no_infer + domain", async () => {
+    const ctx = makePipeContext({ stageConfig: { no_infer: true, domain: "finance" } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+
+  it("throws on conflicting no_infer + schema", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ stageConfig: { no_infer: true, schema: user } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+});
+```
+
+- [ ] **Step 2: Cross-check the finance detection on the box (Python reference).** The TS test asserts `domain === "finance"` for these rows; confirm the Python detect agrees (same domain dictionaries, cross-surface parity):
+```bash
+PYTHONPATH="packages/python/infermap" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 INFERMAP_NATIVE=0 "D:/show_case/goldenmatch/.venv/Scripts/python.exe" -c "import infermap; r=infermap.detect_domain_detailed({'records':[{'account_number':'A1234','currency':'USD'},{'account_number':'A5678','currency':'EUR'}]}); print('domain=', r.domain)"
+```
+Expect: `domain= finance`. (If Python's `detect_domain_detailed` takes a different input form, adapt the check — the point is to confirm these columns detect finance so the TS expectation is right. The Python unit test already asserts finance for the same columns, so this is a sanity cross-check.)
+
+- [ ] **Step 3: Eye-verify.** `makePipeContext`/`StageStatus`/`Row` are real exports of `../../src/core/models.js`; imports use `.js`; the 7 cases match the Python tests (3 conflict cases use `rejects.toThrow(/conflict/)`); the finance rows match the Python `_ctx`.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/typescript/goldenpipe/tests/unit/infer-schema-stage.test.ts
+git commit -m "test(goldenpipe-ts): infer_schema stage 7-case parity with Python
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, the Python finance-detect cross-check output, SHA.
+
+---
+
+## Task 6: Rebase + push + PR + arm (controller runs this)
+
+**Files:** none.
+
+- [ ] **Step 1: Rebase onto fresh origin/main** (main moves fast):
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q
+git rebase origin/main
+```
+Conflicts unlikely (new file + isolated edits). If `pnpm-lock.yaml` conflicts, prefer re-running `pnpm install --lockfile-only` after taking main's lockfile, then re-add. Re-validate.
+
+- [ ] **Step 2: Confirm the three-dot diff is clean:**
+```bash
+git diff --stat origin/main...HEAD
+```
+Expect only: the spec, the plan, `infermap/src/core/index.ts`, `goldenpipe/package.json`, `pnpm-lock.yaml`, `goldenpipe/src/core/adapters/infer.ts`, `goldenpipe/src/core/adapters/index.ts`, `goldenpipe/tests/unit/infer-schema-stage.test.ts`. If unrelated files appear, STOP.
+
+- [ ] **Step 3: Push.**
+```bash
+git push -u origin feat/goldenpipe-ts-infer-schema
+```
+
+- [ ] **Step 4: Open the PR.**
+```bash
+gh pr create --repo benseverndev-oss/goldenmatch --base main \
+  --title "feat(goldenpipe): TS infer_schema stage (InferMap port)" \
+  --body "$(cat <<'EOF'
+## What
+
+Ports goldenpipe's Python `infer_schema` stage to TypeScript, so TS goldenpipe can do domain-aware schema inference via the (now WASM-capable) TS `infermap` — mirroring how the Python pipeline consumes InferMap.
+
+- New adapter `infer_schema` (opt-in; registered but NOT in `DEFAULT_STAGE_ORDER`, matching Python's default pipeline).
+- Runs `detectDomainDetailed` → domain (generic fallback), then `map(..., { soft: true })` → converts the `MapResult` to a shared `goldencheck-types.InferredSchema` (byte-faithful mirror of `_result_to_inferred_schema`).
+- Produces both `inferred_schema` and `infer_schema_evidence`, same as Python.
+- Surfaces `detectDomainDetailed` from the infermap barrel; adds `infermap` + `goldencheck-types` as goldenpipe deps.
+
+## Parity
+
+7-case unit test mirroring `test_infer_schema_stage.py` (auto-detect finance, explicit domain, no_infer→null, schema passthrough, 3 conflict-throws). The `InferredSchema` type is shared via `goldencheck-types`, so the artifact is structurally identical cross-surface. Since the stage calls the InferMap scorers, it inherits their WASM/kernel path when the consumer enables it.
+
+Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md`
+Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+EOF
+)"
+```
+
+- [ ] **Step 5: Arm auto-merge + STOP.**
+```bash
+gh pr merge <PR#> --repo benseverndev-oss/goldenmatch --squash --auto
+```
+No `--delete-branch`. Do NOT poll CI. Report the PR number and STOP.
+
+---
+
+## Verification Summary
+
+| What | How | Where |
+| --- | --- | --- |
+| Barrel exports detectDomainDetailed | grep + CI tsc | Box + CI (Task 1) |
+| Deps resolve | `pnpm install --lockfile-only` + CI | Box + CI (Task 2) |
+| Stage logic byte-faithful to Python | eye-review vs infer_schema.py | Box (Task 3) |
+| Opt-in registration (not default) | grep pipeline.ts untouched | Box (Task 4) |
+| 7-case parity | vitest | CI (Task 5) |
+| Finance detection correct | Python detect cross-check | Box (Task 5) |
+| No unrelated diff | three-dot diff | Box (Task 6) |

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md
@@ -198,8 +198,12 @@ function validateFlags(cfg: Record<string, unknown>): void {
 
 export const InferSchemaStage: Stage = {
   info: {
+    // Matches Python's declared produces=["inferred_schema"]. The stage ALSO sets
+    // `infer_schema_evidence` at runtime (via setdefault) but, like Python, does
+    // not declare it — replicated faithfully so the stage contract is identical
+    // cross-surface.
     name: "infer_schema",
-    produces: ["inferred_schema", "infer_schema_evidence"],
+    produces: ["inferred_schema"],
     consumes: [],
   },
 
@@ -230,7 +234,10 @@ export const InferSchemaStage: Stage = {
     let detectScore: number;
     let detectEvidence: Record<string, unknown>;
 
-    if (explicit != null) {
+    // Truthy check mirrors Python `if explicit_domain:` — a degenerate empty-string
+    // domain falls through to auto-detect (validateFlags counted it via `!= null`,
+    // mirroring Python's `is not None`, so it still can't co-exist with schema/no_infer).
+    if (explicit) {
       domain = explicit;
       detectScore = 1.0;
       detectEvidence = { detect_reason: "explicit" };
@@ -279,7 +286,7 @@ export const InferSchemaStage: Stage = {
 ```
 
 - [ ] **Step 3: Eye-verify against the spec + Python.**
-  - Imports resolve: `UNMAPPED_TYPE`/`loadDomain`/`FieldMapping`/`InferredSchema` from `goldencheck-types`; `detectDomainDetailed`/`map`/`DomainPackTarget`/`MapResult` from `infermap` (Task 1 surfaced `detectDomainDetailed`). Confirm `MapResult` is exported from the infermap barrel (`grep -n "MapResult" packages/typescript/infermap/src/core/index.ts`); if it's `export type`, keep the `type MapResult` import.
+  - Imports resolve: `UNMAPPED_TYPE`/`loadDomain`/`FieldMapping`/`InferredSchema` from `goldencheck-types`; `detectDomainDetailed`/`map`/`DomainPackTarget`/`MapResult` from `infermap` (Task 1 surfaced `detectDomainDetailed`). NOTE: `MapResult` is exported via `export * from "./types.js"` in `core/index.ts` (a direct `grep MapResult core/index.ts` shows only `MapResultConfig` — do NOT conclude it's missing; it IS reachable, confirm with `grep -n "export interface MapResult\b" packages/typescript/infermap/src/core/types.ts`). The `type MapResult` import from `"infermap"` resolves.
   - Confirm `StageStatus` + `Stage`/`PipeContext`/`StageResult` are the real exports of `../models.js` (`grep -n "export.*StageStatus\|export interface Stage\b\|export interface PipeContext" packages/typescript/goldenpipe/src/core/models.ts`). If `StageResult` needs more than `{status}` (e.g. a required field), match the real interface — read it.
   - `resultToInferredSchema` matches `_result_to_inferred_schema` line-for-line (snake_case fields; `unmappedSource` camelCase; `type: fm.target ? fm.target : UNMAPPED_TYPE`; unmapped-source loop; `min` confidence with 0.0 default).
   - The 4 branches + precedence + the 3 `detectEvidence` shapes + `setdefault` match Python.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
@@ -25,9 +25,15 @@ additive port.
   (detect_score = 1.0 when the domain is explicitly pinned; else the detection
   score; 0.0 on the generic fallback).
 - `result = infermap.map(df, DomainPackTarget(load_domain(domain)), soft=True)`.
-- `_result_to_inferred_schema(result, domain)` → `InferredSchema`, then
+- `_result_to_inferred_schema(result, domain)` -> `InferredSchema`, then
   `confidence` is replaced with `detect_score` (reflects detection quality, not
   the min-of-mapping-confidences the converter computes).
+- Sets **two** artifacts on the auto-detect path: `ctx.artifacts["inferred_schema"]
+  = inferred` and `ctx.artifacts.setdefault("infer_schema_evidence",
+  detect_evidence)` -- where `detect_evidence` is `{detect_reason: "explicit"}`
+  (pinned domain), or `{detect_reason, detect_score, runner_up, runner_up_score}`
+  (detected), or that plus `fallback: True` (generic fallback). The
+  schema/no_infer/no-df early returns set only `inferred_schema` (no evidence).
 
 `_result_to_inferred_schema`:
 ```python
@@ -73,34 +79,58 @@ return InferredSchema(domain=domain, fields=fields, confidence=confidence)
 New file `packages/typescript/goldenpipe/src/core/adapters/infer.ts`:
 ```ts
 export const InferSchemaStage: Stage = {
-  info: { name: "infer_schema", produces: ["inferred_schema"], consumes: [] },
-  validate(ctx) { /* mutual-exclusivity of schema/no_infer/domain -> throw */ },
-  async run(ctx) { /* the 4 branches + convert */ },
+  info: { name: "infer_schema", produces: ["inferred_schema", "infer_schema_evidence"], consumes: [] },
+  validate(_ctx) { /* no precondition — consumes []; df===null is a valid SUCCESS branch */ },
+  async run(ctx) { /* flag-conflict check FIRST (throws), then the 4 branches + convert */ },
 };
 ```
 - **Name `infer_schema`** (no dotted prefix) matches the Python stage name, so a
   shared pipeline config referencing `infer_schema` resolves on both surfaces.
 - `stageConfig` keys mirror Python: `schema?: InferredSchema`, `no_infer?: boolean`,
   `domain?: string`.
-- `validate`: throw if more than one of `{schema, no_infer, domain}` is set (same
-  message intent as Python's `_validate_flags`).
-- `run`:
-  - `schema` present → `ctx.artifacts.inferred_schema = schema`; SUCCESS.
-  - `no_infer` → `inferred_schema = null`; SUCCESS.
-  - `ctx.df === null` → `inferred_schema = null`; SUCCESS.
-  - else: `const explicit = cfg.domain`; `domain = explicit ?? (detectDomainDetailed({
-    records: ctx.df }).domain ?? "generic")`; `detectScore = explicit ? 1.0 :
-    (detection.domain ? detection.score : 0.0)`.
-  - `const result = map({ records: ctx.df }, new DomainPackTarget(loadDomain(domain)),
-    { soft: true })`.
-  - `const inferred = resultToInferredSchema(result, domain)` then set
-    `inferred.confidence = detectScore` (build a fresh object since `InferredSchema`
-    is readonly).
-  - `ctx.artifacts.inferred_schema = inferred`; SUCCESS.
+- **Flag-conflict check lives in `run()`, not `validate()`** — mirroring Python,
+  where `_validate_flags(cfg)` is the first line of `run()` and *raises* on
+  conflict. The TS `run()` calls a `validateFlags(cfg)` helper first; it throws
+  when more than one of `{schema, no_infer, domain}` is set. (The Python tests call
+  `.run()` and expect the raise; the TS tests mirror that — §7. `validate()` stays
+  a no-op: `consumes: []` and `df === null` is a legitimate SUCCESS branch, so
+  `validate` must NOT throw on a null df.)
+- `run` (after `validateFlags`):
+  - `schema` present → `ctx.artifacts.inferred_schema = schema`; SUCCESS. (No
+    evidence artifact — matches Python's early return.)
+  - `no_infer` → `inferred_schema = null`; SUCCESS. (No evidence.)
+  - `ctx.df === null` → `inferred_schema = null`; SUCCESS. (No evidence.)
+  - else (auto-detect / explicit-domain path):
+    - `const explicit = cfg.domain;`
+    - explicit set → `domain = explicit; detectScore = 1.0; detectEvidence =
+      { detect_reason: "explicit" };`
+    - else → `const detection = detectDomainDetailed({ records: ctx.df });` (bind
+      ONCE). If `detection.domain !== null`: `domain = detection.domain; detectScore
+      = detection.score; detectEvidence = { detect_reason: detection.reason,
+      detect_score: detection.score, runner_up: detection.runner_up,
+      runner_up_score: detection.runner_up_score };` else (generic fallback):
+      `domain = "generic"; detectScore = 0.0; detectEvidence = { detect_reason:
+      detection.reason, detect_score: detection.score, runner_up:
+      detection.runner_up, runner_up_score: detection.runner_up_score, fallback:
+      true };`
+    - `const result = map({ records: ctx.df }, new DomainPackTarget(loadDomain(domain)),
+      { soft: true });`
+    - `const inferred = { ...resultToInferredSchema(result, domain), confidence:
+      detectScore };` (fresh object — `InferredSchema` is readonly; overwrite
+      `confidence` with `detectScore`, matching Python's `replace(inferred,
+      confidence=detect_score)`).
+    - `ctx.artifacts.inferred_schema = inferred;`
+    - **setdefault semantics:** `if (!("infer_schema_evidence" in ctx.artifacts))
+      ctx.artifacts.infer_schema_evidence = detectEvidence;` (Python uses
+      `setdefault` — only set when a prior stage hasn't already).
+    - SUCCESS.
 
 `resultToInferredSchema` is the direct mirror of `_result_to_inferred_schema`
 (§2), using the snake_case `FieldMapping` fields, `UNMAPPED_TYPE`, and
-`result.unmappedSource` (camelCase).
+`result.unmappedSource` (camelCase). Confirmed: TS `soft` sets `target: null` and
+keeps the mapping in `mappings` (not moved to `unmappedSource`), so
+`canonical: fm.target` (→ null) and `type: fm.target ? fm.target : UNMAPPED_TYPE`
+reproduce Python's `None` handling exactly.
 
 > **Fidelity detail to verify in the plan:** the Python `soft=True` sets a
 > below-threshold `fm.target` to `None` (→ `canonical=None`, `type=UNMAPPED_TYPE`).
@@ -122,24 +152,32 @@ opt-in there too. Matching that (available, not default) is the true parity and
 keeps the default TS pipeline unchanged. Consumers opt in by naming `infer_schema`
 in their pipeline config (as they do in Python).
 
-## 6. Dependency
+## 6. Dependencies
 
-Add `"infermap": "workspace:^"` to `packages/typescript/goldenpipe/package.json`
-`dependencies` (it has none today). `goldencheck-types` is already a goldenpipe
-dependency (used elsewhere), so `InferredSchema`/`FieldMapping`/`UNMAPPED_TYPE`/
-`loadDomain` are already resolvable — confirm in the plan; add if absent.
+Add **both** to `packages/typescript/goldenpipe/package.json` `dependencies`
+(goldenpipe currently depends only on `commander, goldencheck, goldenflow,
+goldenmatch` — it references neither package today):
+- `"infermap": "workspace:^"` — the `map`/`detectDomainDetailed`/`DomainPackTarget` API.
+- `"goldencheck-types": "workspace:^"` — the `InferredSchema`/`FieldMapping`/
+  `UNMAPPED_TYPE`/`loadDomain` types + loader. It is NOT currently a goldenpipe dep
+  and has zero imports in goldenpipe `src`; do not rely on transitive/hoisted
+  resolution — add the direct dep.
 
 ## 7. Testing — mirror the Python suite
 
-Port `packages/python/goldenpipe/tests/test_infer_schema_stage.py`'s six cases to
-a TS unit test (`tests/unit/infer-schema-stage.test.ts` or the goldenpipe test
-convention):
+Port all **seven** `packages/python/goldenpipe/tests/test_infer_schema_stage.py`
+cases to a TS unit test (`tests/unit/infer-schema-stage.test.ts` or the goldenpipe
+test convention). The Python tests call `stage.run(ctx)` and, for conflicts,
+expect it to throw (`pytest.raises(ValueError, match="conflict")`) — the TS tests
+mirror that (`await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/)`,
+since the conflict check is in `run()`):
 1. auto-detect finance columns → `inferred.domain === "finance"`.
 2. explicit `domain: "finance"` config → `inferred.domain === "finance"`.
 3. `no_infer: true` → `inferred_schema === null`.
 4. user `schema` passthrough → `ctx.artifacts.inferred_schema` **is** the input.
-5. conflict `schema` + `domain` → `validate` throws.
-6. conflict `no_infer` + `domain` → `validate` throws.
+5. conflict `schema` + `domain` → `run` throws (`/conflict/`).
+6. conflict `no_infer` + `domain` → `run` throws.
+7. conflict `no_infer` + `schema` → `run` throws.
 
 The `InferredSchema` shape is shared via `goldencheck-types`, so structural
 cross-surface parity is by construction; these behavior tests lock the branch

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
@@ -201,7 +201,7 @@ force-enable WASM — consumer's choice, consistent with every other WASM surfac
 
 Low — every building block exists (shared `InferredSchema` type, the `infermap`
 API, the goldenpipe stage/registry pattern). It's a faithful translation of a
-~90-line Python stage with a mirrored 6-case test. The single care point is §4's
+~90-line Python stage with a mirrored 7-case test. The single care point is §4's
 soft-mode `target` fidelity in `resultToInferredSchema`; the plan resolves it by
 reading the TS `map` soft path and matching the None-handling.
 

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md
@@ -1,0 +1,176 @@
+# goldenpipe TS `infer_schema` stage (InferMap port) design
+
+**Date:** 2026-07-07
+**Status:** Approved (design)
+**Branch:** `feat/goldenpipe-ts-infer-schema` off `origin/main`.
+
+## 1. Goal
+
+Give TypeScript goldenpipe the domain-aware schema-inference stage the Python
+pipeline already has (`packages/python/goldenpipe/goldenpipe/stages/infer_schema.py`),
+consuming the TS `infermap` package (now WASM-capable), and producing the
+**identical `InferredSchema` artifact** — cross-surface parity with the Python
+stage. TS goldenpipe references `infermap` nowhere today; this is a purely
+additive port.
+
+## 2. What the Python stage does (the reference)
+
+`@stage(name="infer_schema", produces=["inferred_schema"], consumes=[])`:
+- Validates that at most one of `schema` / `no_infer` / `domain` is set (else
+  raises). Precedence: **schema > no_infer > domain > auto-detect**.
+- `schema` set → `ctx.artifacts["inferred_schema"] = schema` (passthrough).
+- `no_infer` → `inferred_schema = None`.
+- `ctx.df is None` → `inferred_schema = None`.
+- else: `domain = cfg["domain"] or detect_domain_detailed(df).domain or "generic"`
+  (detect_score = 1.0 when the domain is explicitly pinned; else the detection
+  score; 0.0 on the generic fallback).
+- `result = infermap.map(df, DomainPackTarget(load_domain(domain)), soft=True)`.
+- `_result_to_inferred_schema(result, domain)` → `InferredSchema`, then
+  `confidence` is replaced with `detect_score` (reflects detection quality, not
+  the min-of-mapping-confidences the converter computes).
+
+`_result_to_inferred_schema`:
+```python
+fields = {}
+for fm in result.mappings:
+    fields[fm.source] = FieldMapping(
+        source_col=fm.source, canonical=fm.target,
+        type=fm.target if fm.target else UNMAPPED_TYPE,
+        confidence=fm.confidence, evidence={"reasoning": fm.reasoning})
+for col in result.unmapped_source:
+    if col not in fields:
+        fields[col] = FieldMapping(source_col=col, canonical=None,
+            type=UNMAPPED_TYPE, confidence=0.0, evidence={})
+confidence = min((fm.confidence for fm in result.mappings), default=0.0)
+return InferredSchema(domain=domain, fields=fields, confidence=confidence)
+```
+
+## 3. TS building blocks (all exist)
+
+- **`goldencheck-types`** exports `InferredSchema`, `FieldMapping`, `UNMAPPED_TYPE`,
+  `loadDomain`, `DomainPack`. The TS `FieldMapping` uses the SAME snake_case field
+  names as Python (`source_col`, `canonical: string | null`, `type`, `confidence`,
+  `evidence: Record<string, unknown>`), and `InferredSchema = { domain, fields:
+  Record<string, FieldMapping>, confidence, schema_version? }`. So the conversion
+  is a 1:1 mirror and the artifact is structurally identical cross-surface.
+- **`infermap`** exports `map(source, target, options)` (with `options.soft`),
+  `DomainPackTarget`, `MapResult` (`{ mappings: {source, target, confidence,
+  reasoning}[], unmappedSource: string[] }` — camelCase `unmappedSource`).
+- **`detectDomainDetailed`** exists (`infermap/src/core/detect.ts`) and accepts
+  `{ records }` or `{ columns }`. **BUT it is not re-exported from the barrel** —
+  `core/index.ts` only surfaces `detectDomain`. This spec adds `detectDomainDetailed`
+  (and `DEFAULT_MIN_SCORE` is already there) to that re-export so the stage can
+  `import { detectDomainDetailed } from "infermap"` (also aligns with Python, which
+  exports `detect_domain_detailed` at the top level).
+- **goldenpipe** `Stage = { info: { name, produces, consumes }, validate(ctx),
+  run(ctx): Promise<StageResult> }`; `PipeContext = { df: Row[] | null, artifacts:
+  Record<string, unknown>, stageConfig: Record<string, unknown> }`; `Row =
+  Record<string, unknown>`. Stages are registered in `buildDefaultRegistry()`
+  (`core/adapters/index.ts`).
+
+## 4. The stage
+
+New file `packages/typescript/goldenpipe/src/core/adapters/infer.ts`:
+```ts
+export const InferSchemaStage: Stage = {
+  info: { name: "infer_schema", produces: ["inferred_schema"], consumes: [] },
+  validate(ctx) { /* mutual-exclusivity of schema/no_infer/domain -> throw */ },
+  async run(ctx) { /* the 4 branches + convert */ },
+};
+```
+- **Name `infer_schema`** (no dotted prefix) matches the Python stage name, so a
+  shared pipeline config referencing `infer_schema` resolves on both surfaces.
+- `stageConfig` keys mirror Python: `schema?: InferredSchema`, `no_infer?: boolean`,
+  `domain?: string`.
+- `validate`: throw if more than one of `{schema, no_infer, domain}` is set (same
+  message intent as Python's `_validate_flags`).
+- `run`:
+  - `schema` present → `ctx.artifacts.inferred_schema = schema`; SUCCESS.
+  - `no_infer` → `inferred_schema = null`; SUCCESS.
+  - `ctx.df === null` → `inferred_schema = null`; SUCCESS.
+  - else: `const explicit = cfg.domain`; `domain = explicit ?? (detectDomainDetailed({
+    records: ctx.df }).domain ?? "generic")`; `detectScore = explicit ? 1.0 :
+    (detection.domain ? detection.score : 0.0)`.
+  - `const result = map({ records: ctx.df }, new DomainPackTarget(loadDomain(domain)),
+    { soft: true })`.
+  - `const inferred = resultToInferredSchema(result, domain)` then set
+    `inferred.confidence = detectScore` (build a fresh object since `InferredSchema`
+    is readonly).
+  - `ctx.artifacts.inferred_schema = inferred`; SUCCESS.
+
+`resultToInferredSchema` is the direct mirror of `_result_to_inferred_schema`
+(§2), using the snake_case `FieldMapping` fields, `UNMAPPED_TYPE`, and
+`result.unmappedSource` (camelCase).
+
+> **Fidelity detail to verify in the plan:** the Python `soft=True` sets a
+> below-threshold `fm.target` to `None` (→ `canonical=None`, `type=UNMAPPED_TYPE`).
+> The plan must confirm how the TS `map(..., { soft: true })` represents an
+> unmapped target on `MapResult.mappings[].target` (typed `string`) — whether it
+> becomes `""`, `null`, or the mapping moves to `unmappedSource`. The conversion's
+> `canonical`/`type` branch (`fm.target ? fm.target : UNMAPPED_TYPE`) must reproduce
+> the Python None-handling exactly for whatever representation TS uses. This is the
+> one place a structural drift could hide.
+
+## 5. Registration — opt-in, NOT default (parity-true)
+
+Register `InferSchemaStage` in `buildDefaultRegistry()` (add
+`registry.register(InferSchemaStage)` + export it from `adapters/index.ts`), but
+**do NOT add it to `DEFAULT_STAGE_ORDER`**. Verified: the Python default/auto
+pipeline (`pipeline.py:121`) is also just `["goldencheck.scan",
+"goldenflow.transform", "goldenmatch.dedupe"]` — `infer_schema` is registered but
+opt-in there too. Matching that (available, not default) is the true parity and
+keeps the default TS pipeline unchanged. Consumers opt in by naming `infer_schema`
+in their pipeline config (as they do in Python).
+
+## 6. Dependency
+
+Add `"infermap": "workspace:^"` to `packages/typescript/goldenpipe/package.json`
+`dependencies` (it has none today). `goldencheck-types` is already a goldenpipe
+dependency (used elsewhere), so `InferredSchema`/`FieldMapping`/`UNMAPPED_TYPE`/
+`loadDomain` are already resolvable — confirm in the plan; add if absent.
+
+## 7. Testing — mirror the Python suite
+
+Port `packages/python/goldenpipe/tests/test_infer_schema_stage.py`'s six cases to
+a TS unit test (`tests/unit/infer-schema-stage.test.ts` or the goldenpipe test
+convention):
+1. auto-detect finance columns → `inferred.domain === "finance"`.
+2. explicit `domain: "finance"` config → `inferred.domain === "finance"`.
+3. `no_infer: true` → `inferred_schema === null`.
+4. user `schema` passthrough → `ctx.artifacts.inferred_schema` **is** the input.
+5. conflict `schema` + `domain` → `validate` throws.
+6. conflict `no_infer` + `domain` → `validate` throws.
+
+The `InferredSchema` shape is shared via `goldencheck-types`, so structural
+cross-surface parity is by construction; these behavior tests lock the branch
+logic + the conversion. (A deeper Python↔TS golden-vector parity test is possible
+but out of scope — the shared type + mirrored tests are sufficient for this port.)
+
+## 8. WASM note
+
+The stage calls `infermap.map`, whose scorers are WASM-capable. If the consumer
+has called `enableInfermapWasm()`, the stage's scorers dispatch to the Rust
+kernels automatically; otherwise pure-TS (byte-identical). The stage does NOT
+force-enable WASM — consumer's choice, consistent with every other WASM surface.
+
+## 9. Out of scope
+
+- Changing `DEFAULT_STAGE_ORDER` on either surface, or auto-inserting `infer_schema`.
+- The goldenpipe CLI, or a Python↔TS golden-vector parity harness for this stage.
+- Any change to the Python stage.
+
+## 10. Risk assessment
+
+Low — every building block exists (shared `InferredSchema` type, the `infermap`
+API, the goldenpipe stage/registry pattern). It's a faithful translation of a
+~90-line Python stage with a mirrored 6-case test. The single care point is §4's
+soft-mode `target` fidelity in `resultToInferredSchema`; the plan resolves it by
+reading the TS `map` soft path and matching the None-handling.
+
+## 11. Build environment constraints
+
+- **Box-runnable:** the Python reference stage + its tests run locally (for
+  cross-checking expected outputs); TS is CI-only (tsc/vitest OOM) — write against
+  spec + eye/`node --check` verify, CI is the first real test.
+- **Merge-queue repo:** `gh pr merge --auto --squash` without `--delete-branch`;
+  benzsevern gh account.

--- a/packages/typescript/goldencheck-types/package.json
+++ b/packages/typescript/goldencheck-types/package.json
@@ -3,10 +3,15 @@
   "version": "0.1.0",
   "description": "Shared TypeScript types and domain schemas for the goldencheck data-quality toolkit",
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    ".": { "types": "./dist/index.d.ts", "import": "./dist/index.js" }
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
   },
   "files": ["dist", "domains"],
   "engines": { "node": ">=20" },

--- a/packages/typescript/goldencheck-types/tsup.config.ts
+++ b/packages/typescript/goldencheck-types/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 
 export default defineConfig({
   entry: ["src/index.ts"],
-  format: ["esm"],
+  format: ["esm", "cjs"],
   dts: true,
   sourcemap: true,
   clean: true,

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -69,8 +69,10 @@
   "dependencies": {
     "commander": "^15.0.0",
     "goldencheck": "workspace:^",
+    "goldencheck-types": "workspace:^",
     "goldenflow": "workspace:^",
-    "goldenmatch": "workspace:^"
+    "goldenmatch": "workspace:^",
+    "infermap": "workspace:^"
   },
   "peerDependencies": {
     "yaml": "*"

--- a/packages/typescript/goldenpipe/src/core/adapters/index.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/index.ts
@@ -10,11 +10,13 @@ import { LoadStage } from "./load.js";
 import { ScanStage } from "./check.js";
 import { TransformStage } from "./flow.js";
 import { DedupeStage } from "./match.js";
+import { InferSchemaStage } from "./infer.js";
 
 export { LoadStage } from "./load.js";
 export { ScanStage } from "./check.js";
 export { TransformStage } from "./flow.js";
 export { DedupeStage, buildConfigFromContexts } from "./match.js";
+export { InferSchemaStage } from "./infer.js";
 
 /**
  * Build a registry with all built-in suite stages registered:
@@ -31,5 +33,6 @@ export function buildDefaultRegistry(): StageRegistry {
   registry.register(ScanStage);
   registry.register(TransformStage);
   registry.register(DedupeStage);
+  registry.register(InferSchemaStage);
   return registry;
 }

--- a/packages/typescript/goldenpipe/src/core/adapters/infer.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/infer.ts
@@ -51,8 +51,10 @@ function resultToInferredSchema(result: MapResult, domain: string): InferredSche
       };
     }
   }
+  // Loop-based min — never spread an array into Math.min/max (it throws
+  // RangeError past ~65K elements; banned by ast-grep ts-no-spread-math-min-max).
   const confidence = result.mappings.length
-    ? Math.min(...result.mappings.map((m) => m.confidence))
+    ? result.mappings.reduce((m, fm) => (fm.confidence < m ? fm.confidence : m), Infinity)
     : 0.0;
   // Stamp schema_version like the Python InferredSchema dataclass (default
   // SCHEMA_VERSION) so the artifact is field-identical cross-surface.

--- a/packages/typescript/goldenpipe/src/core/adapters/infer.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/infer.ts
@@ -1,0 +1,157 @@
+/**
+ * infer_schema — GoldenPipe stage that runs InferMap to label columns.
+ * TS port of goldenpipe/stages/infer_schema.py. Produces
+ * `inferred_schema` (goldencheck-types.InferredSchema | null) + (on the
+ * auto-detect path) `infer_schema_evidence`. Consumes nothing — meant to run
+ * before stages that want typed columns. Opt-in (not in DEFAULT_STAGE_ORDER),
+ * matching Python.
+ *
+ * Config (ctx.stageConfig): schema?: InferredSchema | no_infer?: boolean |
+ * domain?: string. Precedence: schema > no_infer > domain > auto-detect;
+ * the three are mutually exclusive (conflict throws in run()).
+ */
+import {
+  UNMAPPED_TYPE,
+  loadDomain,
+  type FieldMapping,
+  type InferredSchema,
+} from "goldencheck-types";
+import {
+  detectDomainDetailed,
+  map,
+  DomainPackTarget,
+  type MapResult,
+} from "infermap";
+
+import type { PipeContext, Stage, StageResult } from "../models.js";
+import { StageStatus } from "../models.js";
+
+/** Mirror of Python `_result_to_inferred_schema`. `confidence` is overwritten
+ *  by the caller with the detection score. */
+function resultToInferredSchema(result: MapResult, domain: string): InferredSchema {
+  const fields: Record<string, FieldMapping> = {};
+  for (const fm of result.mappings) {
+    fields[fm.source] = {
+      source_col: fm.source,
+      canonical: fm.target, // soft mode sets target = null -> canonical null
+      type: fm.target ? fm.target : UNMAPPED_TYPE,
+      confidence: fm.confidence,
+      evidence: { reasoning: fm.reasoning },
+    };
+  }
+  for (const col of result.unmappedSource) {
+    if (!(col in fields)) {
+      fields[col] = {
+        source_col: col,
+        canonical: null,
+        type: UNMAPPED_TYPE,
+        confidence: 0.0,
+        evidence: {},
+      };
+    }
+  }
+  const confidence = result.mappings.length
+    ? Math.min(...result.mappings.map((m) => m.confidence))
+    : 0.0;
+  return { domain, fields, confidence };
+}
+
+/** Mirror of Python `_validate_flags`: at most one of schema/no_infer/domain. */
+function validateFlags(cfg: Record<string, unknown>): void {
+  const set =
+    (cfg.schema != null ? 1 : 0) +
+    (cfg.no_infer ? 1 : 0) +
+    (cfg.domain != null ? 1 : 0);
+  if (set > 1) {
+    throw new Error(
+      "conflict: 'schema', 'no_infer', and 'domain' are mutually exclusive. " +
+        "Precedence: schema > no_infer > domain > auto-detect.",
+    );
+  }
+}
+
+export const InferSchemaStage: Stage = {
+  info: {
+    // Matches Python's declared produces=["inferred_schema"]. The stage ALSO sets
+    // `infer_schema_evidence` at runtime (via setdefault) but, like Python, does
+    // not declare it — replicated faithfully so the stage contract is identical.
+    name: "infer_schema",
+    produces: ["inferred_schema"],
+    consumes: [],
+  },
+
+  // No precondition: consumes [] and a null df is a valid SUCCESS branch, so
+  // validate() must NOT throw. The flag-conflict check lives in run() (mirrors
+  // Python's _validate_flags at the top of run()).
+  validate(_ctx: PipeContext): void {},
+
+  async run(ctx: PipeContext): Promise<StageResult> {
+    const cfg = ctx.stageConfig ?? {};
+    validateFlags(cfg);
+
+    if (cfg.schema != null) {
+      ctx.artifacts["inferred_schema"] = cfg.schema;
+      return { status: StageStatus.SUCCESS };
+    }
+    if (cfg.no_infer) {
+      ctx.artifacts["inferred_schema"] = null;
+      return { status: StageStatus.SUCCESS };
+    }
+    if (ctx.df === null) {
+      ctx.artifacts["inferred_schema"] = null;
+      return { status: StageStatus.SUCCESS };
+    }
+
+    const explicit = cfg.domain as string | undefined;
+    let domain: string;
+    let detectScore: number;
+    let detectEvidence: Record<string, unknown>;
+
+    // Truthy check mirrors Python `if explicit_domain:` — an empty-string domain
+    // falls through to auto-detect (validateFlags counted it via `!= null`).
+    if (explicit) {
+      domain = explicit;
+      detectScore = 1.0;
+      detectEvidence = { detect_reason: "explicit" };
+    } else {
+      const detection = detectDomainDetailed({ records: ctx.df });
+      if (detection.domain !== null) {
+        domain = detection.domain;
+        detectScore = detection.score;
+        detectEvidence = {
+          detect_reason: detection.reason,
+          detect_score: detection.score,
+          runner_up: detection.runner_up,
+          runner_up_score: detection.runner_up_score,
+        };
+      } else {
+        domain = "generic";
+        detectScore = 0.0;
+        detectEvidence = {
+          detect_reason: detection.reason,
+          detect_score: detection.score,
+          runner_up: detection.runner_up,
+          runner_up_score: detection.runner_up_score,
+          fallback: true,
+        };
+      }
+    }
+
+    const result = map(
+      { records: ctx.df },
+      new DomainPackTarget(loadDomain(domain)),
+      { soft: true },
+    );
+    const inferred: InferredSchema = {
+      ...resultToInferredSchema(result, domain),
+      confidence: detectScore,
+    };
+
+    ctx.artifacts["inferred_schema"] = inferred;
+    // setdefault: only set when a prior stage hasn't already.
+    if (!("infer_schema_evidence" in ctx.artifacts)) {
+      ctx.artifacts["infer_schema_evidence"] = detectEvidence;
+    }
+    return { status: StageStatus.SUCCESS };
+  },
+};

--- a/packages/typescript/goldenpipe/src/core/adapters/infer.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/infer.ts
@@ -11,6 +11,7 @@
  * the three are mutually exclusive (conflict throws in run()).
  */
 import {
+  SCHEMA_VERSION,
   UNMAPPED_TYPE,
   loadDomain,
   type FieldMapping,
@@ -53,7 +54,9 @@ function resultToInferredSchema(result: MapResult, domain: string): InferredSche
   const confidence = result.mappings.length
     ? Math.min(...result.mappings.map((m) => m.confidence))
     : 0.0;
-  return { domain, fields, confidence };
+  // Stamp schema_version like the Python InferredSchema dataclass (default
+  // SCHEMA_VERSION) so the artifact is field-identical cross-surface.
+  return { domain, fields, confidence, schema_version: SCHEMA_VERSION };
 }
 
 /** Mirror of Python `_validate_flags`: at most one of schema/no_infer/domain. */

--- a/packages/typescript/goldenpipe/tests/unit/infer-schema-stage.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/infer-schema-stage.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { makePipeContext, StageStatus, type Row } from "../../src/core/models.js";
+import { InferSchemaStage } from "../../src/core/adapters/infer.js";
+import type { InferredSchema } from "goldencheck-types";
+
+// Same columns/values as the Python test's _ctx() -> detects "finance".
+const FINANCE_ROWS: Row[] = [
+  { account_number: "A1234", currency: "USD" },
+  { account_number: "A5678", currency: "EUR" },
+];
+
+describe("infer_schema stage (InferMap port)", () => {
+  it("auto-detects the finance domain", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS });
+    const result = await InferSchemaStage.run(ctx);
+    expect(result.status).toBe(StageStatus.SUCCESS);
+    const inferred = ctx.artifacts["inferred_schema"] as InferredSchema | null;
+    expect(inferred).not.toBeNull();
+    expect(inferred!.domain).toBe("finance");
+  });
+
+  it("honors an explicit domain", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { domain: "finance" } });
+    await InferSchemaStage.run(ctx);
+    expect((ctx.artifacts["inferred_schema"] as InferredSchema).domain).toBe("finance");
+  });
+
+  it("no_infer returns null", async () => {
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { no_infer: true } });
+    await InferSchemaStage.run(ctx);
+    expect(ctx.artifacts["inferred_schema"]).toBeNull();
+  });
+
+  it("passes a user-provided schema through unchanged", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ df: FINANCE_ROWS, stageConfig: { schema: user } });
+    await InferSchemaStage.run(ctx);
+    expect(ctx.artifacts["inferred_schema"]).toBe(user);
+  });
+
+  it("throws on conflicting schema + domain", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ stageConfig: { schema: user, domain: "finance" } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+
+  it("throws on conflicting no_infer + domain", async () => {
+    const ctx = makePipeContext({ stageConfig: { no_infer: true, domain: "finance" } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+
+  it("throws on conflicting no_infer + schema", async () => {
+    const user: InferredSchema = { domain: "user", fields: {}, confidence: 1.0 };
+    const ctx = makePipeContext({ stageConfig: { no_infer: true, schema: user } });
+    await expect(InferSchemaStage.run(ctx)).rejects.toThrow(/conflict/);
+  });
+});

--- a/packages/typescript/goldenpipe/tests/unit/mcp.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/mcp.test.ts
@@ -56,6 +56,7 @@ describe("MCP server — handleTool dispatcher", () => {
       "goldencheck.scan",
       "goldenflow.transform",
       "goldenmatch.dedupe",
+      "infer_schema",
       "load",
     ]);
     expect(result["load"]!.produces).toContain("df");

--- a/packages/typescript/infermap/src/core/index.ts
+++ b/packages/typescript/infermap/src/core/index.ts
@@ -2,7 +2,7 @@
 export * from "./types.js";
 export * from "./assignment/hungarian.js";
 export { DomainPackTarget, isDomainPackTarget } from "./domainPack.js";
-export { detectDomain, DEFAULT_MIN_SCORE } from "./detect.js";
+export { detectDomain, detectDomainDetailed, DEFAULT_MIN_SCORE } from "./detect.js";
 export type { Scorer } from "./scorers/base.js";
 export { ExactScorer } from "./scorers/exact.js";
 export { AliasScorer, DEFAULT_ALIASES } from "./scorers/alias.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/goldenanalysis:
     dependencies:
@@ -127,7 +127,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/goldencheck:
     dependencies:
@@ -155,7 +155,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -183,7 +183,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/goldenflow:
     dependencies:
@@ -208,7 +208,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -229,7 +229,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/goldenmatch:
     dependencies:
@@ -260,7 +260,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -281,7 +281,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/goldenpipe:
     dependencies:
@@ -291,12 +291,18 @@ importers:
       goldencheck:
         specifier: workspace:^
         version: link:../goldencheck
+      goldencheck-types:
+        specifier: workspace:^
+        version: link:../goldencheck-types
       goldenflow:
         specifier: workspace:^
         version: link:../goldenflow
       goldenmatch:
         specifier: workspace:^
         version: link:../goldenmatch
+      infermap:
+        specifier: workspace:^
+        version: link:../infermap
     devDependencies:
       '@types/node':
         specifier: ^25.9.4
@@ -315,7 +321,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
       yaml:
         specifier: ^2.9.0
         version: 2.9.0
@@ -336,7 +342,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
   packages/typescript/infermap:
     dependencies:
@@ -364,7 +370,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0)
 
 packages:
 
@@ -2437,7 +2443,6 @@ packages:
       '@vitest/ui': 4.1.10
       happy-dom: '*'
       jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -4356,7 +4361,7 @@ snapshots:
       jiti: 2.7.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.9.4)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(yaml@2.9.0):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -4382,7 +4387,18 @@ snapshots:
       '@types/node': 25.9.4
       jsdom: 29.1.1
     transitivePeerDependencies:
+      - '@vitejs/devtools'
+      - esbuild
+      - jiti
+      - less
       - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## What

Ports goldenpipe's Python `infer_schema` stage to TypeScript, so TS goldenpipe can do domain-aware schema inference via the (now WASM-capable) TS `infermap` — mirroring how the Python pipeline consumes InferMap. TS goldenpipe referenced `infermap` nowhere before this.

- New adapter `infer_schema` (opt-in; registered but NOT in `DEFAULT_STAGE_ORDER`, matching Python's default 3-stage pipeline).
- `detectDomainDetailed` → domain (generic fallback), then `map(..., { soft: true })` → `resultToInferredSchema` (byte-faithful mirror of `_result_to_inferred_schema`, including `schema_version` stamping + the soft→null target handling).
- Produces `inferred_schema` and (on the auto-detect path, via setdefault) `infer_schema_evidence`, same as Python.
- Surfaces `detectDomainDetailed` from the infermap barrel; adds `infermap` + `goldencheck-types` as goldenpipe deps.

## Parity

7-case unit test mirroring `test_infer_schema_stage.py` (auto-detect finance, explicit domain, no_infer→null, schema passthrough, 3 conflict-throws). The `InferredSchema` type is shared via `goldencheck-types`, so the artifact is field-identical cross-surface (verified the finance-detection expectation against the Python reference). Because the stage calls the InferMap scorers, it inherits their Rust-kernel path when the consumer enables the WASM backend.

Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-ts-infer-schema-design.md`
Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-ts-infer-schema.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44