### PR TITLE
docs(infermap): sweep the Rust-kernel + WASM/native acceleration arc

### DIFF
--- a/docs-site/infermap/overview.mdx
+++ b/docs-site/infermap/overview.mdx
@@ -22,6 +22,15 @@ npm install infermap
 
 Python database extras: `infermap[postgres]`, `infermap[mysql]`, `infermap[duckdb]`, `infermap[all]`. The TypeScript package requires Node 20+ and is edge-runtime compatible.
 
+<Note>
+**Native acceleration.** The scorers + domain detection share a pyo3-free Rust
+core (`infermap-core`). Install `infermap[native]` to auto-dispatch to the
+compiled kernels — byte-identical output (CI parity-gated), governed by
+`INFERMAP_NATIVE` (`auto` / `1` / `0`). The TypeScript package runs the same
+kernels via an opt-in WASM backend (`enableInfermapWasm()`); the MCP
+`infermap://scorer-info` resource reports the active backend.
+</Note>
+
 ## Quickstart
 
 ```python

--- a/packages/python/infermap/CHANGELOG.md
+++ b/packages/python/infermap/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **Compiled Rust scorer kernels** (`pip install infermap[native]`). The five scorers (exact, fuzzy-name, initialism, profile, pattern-type) and `detect_domain` now share a pyo3-free Rust core (`infermap-core`), wrapped by the abi3 `infermap-native` wheel. Under the default `INFERMAP_NATIVE=auto` the scorers auto-dispatch to the compiled kernels when the wheel is importable, else the pure-Python reference — byte-identical, CI parity-gated. `INFERMAP_NATIVE=1` requires native (raises if absent); `=0` forces pure Python.
+- **TypeScript WASM backend** — the same `infermap-core` kernels compiled to WASM (`infermap-wasm`), exposed as an opt-in backend via `enableInfermapWasm()`. Pure-TS stays the default + byte-identical fallback. The MCP servers enable it best-effort at startup and report the active backend through the `infermap://scorer-info` resource (Python: `native`/`pure-python`; TS: `wasm`/`pure-ts`).
+- Top-level re-export of `detect_domain_detailed` on the TypeScript surface (parity with Python).
+
 ## [0.5.1] - 2026-06-24
 
 ### Security

--- a/packages/python/infermap/CLAUDE.md
+++ b/packages/python/infermap/CLAUDE.md
@@ -32,6 +32,13 @@
 - `infermap/types.py` — FieldInfo, SchemaInfo, ScorerResult, FieldMapping, MapResult
 - `tests/conftest.py` — FIXTURES_DIR (not FIXTURES), make_field(), make_schema()
 
+## Native / WASM kernels (cross-surface Rust core)
+- Scorers + `detect_domain` share a pyo3-free Rust core `infermap-core` (`packages/rust/extensions/infermap-core`). Two thin wrappers: `infermap-native` (pyo3/abi3 wheel → `infermap[native]`) and `infermap-wasm` (wasm-bindgen → TS opt-in backend). The core is the single source of truth; pure Python/TS are byte-identical lossy fallbacks.
+- Python dispatch: `infermap/_native_loader.py`. `INFERMAP_NATIVE=auto` (default) uses native per-component when the wheel symbol exists; `=1` requires it (raises); `=0` forces pure. A new kernel joins `_GATED_ON`/`_COMPONENT_SYMBOLS` only after `tests/test_native_parity.py` proves byte-identity. `check_native_symbols.py` reconciles host references vs kernel exports (silent-fallback guard).
+- TS/WASM is **opt-in** — `enableInfermapWasm()` must be called or the WASM path stays dormant (the MCP servers now call it at startup; a plain consumer must too). The `infermap://scorer-info` MCP resource reports the live backend on both surfaces.
+- pattern_type is the sharpest parity surface: three regex engines (Python `re`, Rust `regex`, JS `RegExp`) — the contract is ASCII-domain byte-identity; the `\d`/`\s` Unicode divergence is the documented edge. currency `\£\€` are dropped to `[$£€]` in the Rust pattern (the crate rejects those escapes).
+- When adding a TS re-export the barrel doesn't surface (e.g. `detectDomainDetailed` lived in `detect.ts` but not `core/index.ts`), surface it — cross-package consumers import from the barrel. Cross-surface `InferredSchema` must stamp `schema_version` (the Python dataclass defaults it; TS must set it explicitly).
+
 ## Gotchas
 - `print(polars_df)` crashes on Windows cp1252 terminal — use `.to_pandas().to_string()` instead
 - PyPI `publish.yml` needs `skip-existing: true` to handle manual+workflow publish conflicts

--- a/packages/python/infermap/README.md
+++ b/packages/python/infermap/README.md
@@ -62,7 +62,17 @@ pip install infermap[postgres]   # psycopg2-binary
 pip install infermap[mysql]      # mysql-connector-python
 pip install infermap[duckdb]     # duckdb
 pip install infermap[all]        # all extras
+pip install infermap[native]     # compiled Rust scorer kernels (faster, identical results)
 ```
+
+**Native acceleration.** InferMap's scorers (exact, fuzzy-name, initialism,
+profile, pattern-type) and domain detection share a pyo3-free Rust core
+(`infermap-core`). With `infermap[native]` installed, they auto-dispatch to the
+compiled kernels — no code change, byte-identical output (CI parity-gated). This
+is governed by `INFERMAP_NATIVE`: `auto` (default; use the native wheel when
+importable, else pure Python), `1` (require native, raise if absent), `0` (force
+pure Python). The TypeScript package runs the same kernels via an opt-in WASM
+backend (`enableInfermapWasm()`).
 
 ### TypeScript / Next.js
 

--- a/packages/typescript/goldenpipe/README.md
+++ b/packages/typescript/goldenpipe/README.md
@@ -150,8 +150,9 @@ A **column-context pipeline** carries semantic metadata across stages: GoldenChe
 ## Deferred (not in this v1 port)
 
 - **`identity_resolve` stage** — GoldenMatch-JS Identity Graph wiring through the pipeline. The edge-safe `InMemoryIdentityStore` exists in `goldenmatch`, but the pipeline-driven `resolveClusters` population is not yet exposed.
-- **`infer_schema` stage** — InferMap-based schema inference is not ported.
 - **Textual TUI** — the Python Textual TUI is not ported. (The MCP, A2A, and REST servers **are** ported — see above.)
+
+> **`infer_schema` is now ported** — InferMap-based domain detection + schema mapping runs as an opt-in TS stage (`infer_schema`, registered but not in the default stage order, matching Python). It produces the shared `inferred_schema` artifact and, because it calls the InferMap scorers, inherits their Rust-kernel WASM path when `enableInfermapWasm()` is active.
 
 ### Sibling version-skew artifacts
 


### PR DESCRIPTION
## What

Doc sweep after the InferMap arc (Rust-kernel cutover Waves 1-4, WASM/TS Waves A-C, MCP backend reporting #1514, goldenpipe TS `infer_schema` #1520). All additions — no removed/renamed public symbols.

## Surfaces updated

- **infermap Python README** — added the `infermap[native]` extra (was missing from the extras list) + a "Native acceleration" note documenting `INFERMAP_NATIVE` (auto/1/0) and the shared `infermap-core` Rust kernels. `INFERMAP_NATIVE` was documented **nowhere** before.
- **docs-site `infermap/overview.mdx`** — a native-acceleration `<Note>` (native extra, INFERMAP_NATIVE, WASM `enableInfermapWasm()`, the `scorer-info` backend resource).
- **infermap `CHANGELOG.md`** — `[Unreleased]`: compiled kernels + `[native]`, the WASM backend, and MCP backend-reporting. (Sits above the released `[0.5.1]`, so the changelog↔version gate stays green.)
- **infermap `CLAUDE.md`** — durable dev gotchas: the `-core`/`-native`/`-wasm` crate layout, the `INFERMAP_NATIVE=auto` dispatch + parity-gate flow, WASM being opt-in, the pattern_type three-engine regex edge, and the barrel-export / `schema_version` cross-surface lessons.
- **goldenpipe TS `README.md`** — `infer_schema` moved out of "Deferred (not ported)" (it's ported opt-in via #1520).

## Gates

`check_docs_consistency.py` — all load-bearing checks PASS (version_consistency, readme_callouts --check, roster→README+nav, docs.json parse + nav resolution, CHANGELOG↔version). The one FAIL is the documented Windows-only orphan false-positive (backslash FS paths vs forward-slash nav — flags all 50+ pages; passes on Linux CI). No new `.mdx` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44