### PR TITLE
release(golden-suite): 0.1.7 — lockstep native floor >=0.15.0 (kernel perf)

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.7] - 2026-07-07
+
+### Changed
+- Bumped the goldenflow-native floor to **`goldenflow-native>=0.15.0`** (was
+  `>=0.14.0`), per the lockstep policy. goldenflow-native 0.15.0 ships 3-8×
+  faster hot transform kernels (name/URL/number families) — measured, byte-identical
+  (native == pure-Python == the pinned parity corpus), so it's a pure speed
+  improvement with no output change.
+
 ## [0.1.6] - 2026-07-06
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.6"
+version = "0.1.7"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -46,7 +46,7 @@ dependencies = [
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.14.0",
+    "goldenflow-native>=0.15.0",
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
Lockstep bump: goldenflow-native 0.15.0 (3-8x faster hot kernels, byte-identical) is on PyPI, so mandate it via the golden-suite floor. Pure speed, no output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg