### PR TITLE
feat(goldenpipe): plan-first auto-config brain (slice 1, Python prototype)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain.md
@@ -1,0 +1,789 @@
+# goldenpipe auto-config brain (slice 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace goldenpipe's static `_auto_config()` with a plan-first "brain": profile the input up front → run a rule table → produce a `PipePlan` (stages + config + `rule_name` + confidence + evidence), then materialize it to the pipeline config.
+
+**Architecture:** A portable, Polars/Pydantic-free decision core (`PipeProfile` → `PipePlan` via a pure rule table) bracketed by host glue (Polars/InferMap profiling in; Pydantic `PipelineConfig` out). Python prototype = slice 1 of the Python→Rust→cross-surface arc; the core is written to port mechanically to `goldenpipe-core` later.
+
+**Tech Stack:** Python 3 (frozen dataclasses, Polars, Pydantic, InferMap `detect_domain_detailed`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md`
+
+**Reference skill:** @superpowers:test-driven-development
+
+---
+
+## Environment & Conventions
+
+**Repo:** `D:\show_case\gg-local-llm`, branch `feat/goldenpipe-autoconfig-brain` (off fresh `origin/main`, spec committed).
+
+**THIS SLICE IS FULLY BOX-RUNNABLE** — real Python TDD (red→green), unlike the CI-only TS work. Env:
+```bash
+INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+export PYTHONPATH="packages/python/goldenpipe:packages/python/infermap:packages/python/goldencheck-types"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+```
+Run pytest via `"$INTERP" -m pytest <path> -q`; ruff via `"$INTERP" -m ruff check <file>`. `cd "D:/show_case/gg-local-llm"` first.
+
+**Installed-metadata caveat (Task 4):** `StageRegistry.discover()` reads entry-points from *installed* package metadata, so a new `pyproject.toml` entry-point is NOT visible on the box without a reinstall. **Tests therefore register `infer_schema` explicitly** on the registry they build (install-independent + deterministic); the entry-point is the *production* wiring, verified by CI's fresh install. Also note: on the box, `discover()` currently yields `{goldencheck.scan, goldenmatch.dedupe, goldenmatch.identity_resolve, goldenanalysis.report, load}` — `goldenflow.transform` isn't installed in this venv — so tests must NOT assume the real registry has every sibling; they pass a controlled `available`/registry.
+
+**Git:** benzsevern (`unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)`). Merge-queue — `--auto --squash`, no `--delete-branch`. Trailer:
+```
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+```
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `packages/python/goldenpipe/goldenpipe/autoconfig_planner.py` | portable core: `PipeProfile`, `PlannedStage`, `PipePlan`, `PipePlannerRule`, `plan_pipeline` (NO Polars/Pydantic) | Create |
+| `packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py` | the 3 rules + `DEFAULT_RULES` (portable) | Create |
+| `packages/python/goldenpipe/goldenpipe/autoconfig_glue.py` | host glue: `profile_context(ctx)`, `plan_to_config(plan, available, identity_opts)` | Create |
+| `packages/python/goldenpipe/pyproject.toml` | register `infer_schema` entry-point | Modify |
+| `packages/python/goldenpipe/goldenpipe/pipeline.py` | `_auto_config(self, ctx)` + call site + `_last_plan` | Modify |
+| `packages/python/goldenpipe/tests/test_autoconfig_planner.py` | core + rules unit tests | Create |
+| `packages/python/goldenpipe/tests/test_autoconfig_glue.py` | glue + wiring/integration tests | Create |
+
+---
+
+## Task 1: Portable decision core (structs + `plan_pipeline`)
+
+**Files:** Create `goldenpipe/autoconfig_planner.py`; Test `tests/test_autoconfig_planner.py`.
+
+- [ ] **Step 1: Write the failing test** (create `tests/test_autoconfig_planner.py`):
+```python
+from goldenpipe.autoconfig_planner import (
+    PipeProfile, PlannedStage, PipePlan, PipePlannerRule, plan_pipeline,
+)
+
+
+def _profile(**kw):
+    base = dict(n_rows=100, n_cols=3, column_names=("a", "b", "c"),
+                dtypes=("String", "Int64", "String"),
+                inferred_domain=None, domain_confidence=0.0)
+    base.update(kw)
+    return PipeProfile(**base)
+
+
+def test_plan_pipeline_first_match_wins_else_default():
+    fired = PipePlannerRule(
+        rule_name="fired",
+        predicate=lambda p: p.n_rows == 100,
+        action=lambda p: PipePlan(stages=(PlannedStage("x", {}),), rule_name="fired",
+                                  confidence=0.9, evidence={"n_rows": p.n_rows}),
+    )
+    plan = plan_pipeline(_profile(), rules=[fired])
+    assert plan.rule_name == "fired"
+    assert plan.stages == (PlannedStage("x", {}),)
+    assert plan.evidence == {"n_rows": 100}
+
+
+def test_plan_pipeline_falls_through_to_default():
+    never = PipePlannerRule("never", lambda p: False,
+                            lambda p: PipePlan((), "never", 0.0, {}))
+    plan = plan_pipeline(_profile(), rules=[never])
+    assert plan.rule_name == "default"
+    # default plan is the standard 3-stage shape
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+
+
+def test_structs_are_frozen():
+    import dataclasses, pytest
+    p = _profile()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.n_rows = 5  # type: ignore[misc]
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+```
+Expect: ImportError (module doesn't exist).
+
+- [ ] **Step 3: Create `goldenpipe/autoconfig_planner.py`:**
+```python
+"""Plan-first auto-config decision core (portable — NO Polars/Pydantic).
+
+The pyo3-free-portable kernel: PipeProfile (in) -> PipePlan (out) via a pure
+rule table. Host glue (Polars profiling, Pydantic config) lives in
+`autoconfig_glue.py`. Mirrors goldenmatch's autoconfig_planner (PlannerRule +
+first-match plan) so the later `goldenpipe-core` Rust port is mechanical.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class PipeProfile:
+    """Cheap, up-front signals — no stage execution required."""
+    n_rows: int
+    n_cols: int
+    column_names: tuple[str, ...]
+    dtypes: tuple[str, ...]
+    inferred_domain: str | None
+    domain_confidence: float
+
+
+@dataclass(frozen=True)
+class PlannedStage:
+    name: str            # EXACT registry name (e.g. "goldencheck.scan", "infer_schema")
+    config: dict         # per-stage config
+
+
+@dataclass(frozen=True)
+class PipePlan:
+    stages: tuple[PlannedStage, ...]
+    rule_name: str
+    confidence: float
+    evidence: dict
+
+
+Predicate = Callable[[PipeProfile], bool]
+Action = Callable[[PipeProfile], "PipePlan"]
+
+
+@dataclass(frozen=True)
+class PipePlannerRule:
+    rule_name: str
+    predicate: Predicate
+    action: Action
+
+
+def default_evidence(p: PipeProfile) -> dict:
+    """Signal snapshot attached to every plan (evidence for humans/telemetry)."""
+    return {
+        "n_rows": p.n_rows,
+        "n_cols": p.n_cols,
+        "inferred_domain": p.inferred_domain,
+        "domain_confidence": p.domain_confidence,
+    }
+
+
+def _default_plan(p: PipeProfile) -> PipePlan:
+    """The current static shape: scan -> flow -> dedupe (no infer_schema)."""
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="default",
+        confidence=0.7,
+        evidence=default_evidence(p),
+    )
+
+
+def plan_pipeline(
+    profile: PipeProfile,
+    rules: Sequence[PipePlannerRule] | None = None,
+) -> PipePlan:
+    """First matching rule's action builds the plan; else the default shape."""
+    if rules is None:
+        from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES
+        rules = DEFAULT_RULES
+    for rule in rules:
+        if rule.predicate(profile):
+            return rule.action(profile)
+    return _default_plan(profile)
+```
+(The `field` import is unused — drop it; ruff will flag. Keep imports minimal.)
+
+- [ ] **Step 4: Run to verify PASS** + ruff
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+```
+Expect: 3 passed; ruff clean.
+
+- [ ] **Step 5: Commit**
+```bash
+cd "D:/show_case/gg-local-llm"
+git add packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git commit -m "feat(goldenpipe): portable auto-config decision core (PipeProfile/PipePlan/plan_pipeline)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, pytest summary, SHA.
+
+---
+
+## Task 2: The rule table
+
+**Files:** Create `goldenpipe/autoconfig_planner_rules.py`; extend `tests/test_autoconfig_planner.py`.
+
+- [ ] **Step 1: Append failing tests** to `tests/test_autoconfig_planner.py`:
+```python
+from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES  # noqa: E402
+
+
+def test_rule_pathological_skips_dedupe():
+    plan = plan_pipeline(_profile(n_rows=1))
+    assert plan.rule_name == "pathological"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform",
+    )
+    assert plan.confidence == 1.0
+
+
+def test_rule_confident_schema_prepends_infer_schema():
+    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.8))
+    assert plan.rule_name == "confident_schema"
+    assert tuple(s.name for s in plan.stages) == (
+        "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+    assert plan.stages[0].config == {"domain": "finance"}
+    assert plan.confidence == 0.8
+
+
+def test_rule_weak_domain_is_default():
+    # domain present but below threshold -> default (no infer_schema)
+    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.4))
+    assert plan.rule_name == "default"
+    assert all(s.name != "infer_schema" for s in plan.stages)
+
+
+def test_default_rules_is_the_module_table():
+    # sanity: plan_pipeline with no rules uses DEFAULT_RULES
+    assert plan_pipeline(_profile(n_rows=1)).rule_name == "pathological"
+    assert len(DEFAULT_RULES) >= 2  # pathological + confident_schema (+ default is fallthrough)
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q -k "rule or default_rules"
+```
+Expect: ImportError (`autoconfig_planner_rules`).
+
+- [ ] **Step 3: Create `goldenpipe/autoconfig_planner_rules.py`:**
+```python
+"""Concrete planner rules for the goldenpipe auto-config brain (slice 1).
+
+Ordered; first match wins (see plan_pipeline). All predicates read only cheap
+PipeProfile signals. Portable — no Polars/Pydantic.
+"""
+from __future__ import annotations
+
+from goldenpipe.autoconfig_planner import (
+    PipePlan, PipePlannerRule, PipeProfile, PlannedStage, default_evidence,
+)
+
+_CONFIDENT_DOMAIN_THRESHOLD = 0.5
+
+
+# ── Rule 1: pathological (n_rows <= 1) ──────────────────────────────────────
+def _is_pathological(p: PipeProfile) -> bool:
+    return p.n_rows <= 1
+
+
+def _pathological_plan(p: PipeProfile) -> PipePlan:
+    # Nothing to dedupe with <=1 row: skip dedupe (plan-visible row_count_gate).
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+        ),
+        rule_name="pathological",
+        confidence=1.0,
+        evidence=default_evidence(p),
+    )
+
+
+rule_pathological = PipePlannerRule("pathological", _is_pathological, _pathological_plan)
+
+
+# ── Rule 2: confident_schema (domain confidently inferred) ──────────────────
+def _is_confident_schema(p: PipeProfile) -> bool:
+    return p.inferred_domain is not None and p.domain_confidence >= _CONFIDENT_DOMAIN_THRESHOLD
+
+
+def _confident_schema_plan(p: PipeProfile) -> PipePlan:
+    # Run schema inference first (pinned to the detected domain) so downstream
+    # stages get typed columns.
+    return PipePlan(
+        stages=(
+            PlannedStage("infer_schema", {"domain": p.inferred_domain}),
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="confident_schema",
+        confidence=p.domain_confidence,
+        evidence=default_evidence(p),
+    )
+
+
+rule_confident_schema = PipePlannerRule(
+    "confident_schema", _is_confident_schema, _confident_schema_plan,
+)
+
+
+# The default (fallthrough) shape lives in plan_pipeline._default_plan.
+DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
+    rule_pathological,
+    rule_confident_schema,
+)
+```
+
+- [ ] **Step 4: Run to verify PASS** + ruff
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+```
+Expect: all pass (7 tests); ruff clean.
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git commit -m "feat(goldenpipe): auto-config rule table (pathological / confident_schema / default)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, pytest summary, SHA.
+
+---
+
+## Task 3: Host glue — `profile_context` + `plan_to_config`
+
+**Files:** Create `goldenpipe/autoconfig_glue.py`; Test `tests/test_autoconfig_glue.py`.
+
+- [ ] **Step 1: Write failing tests** (create `tests/test_autoconfig_glue.py`):
+```python
+import polars as pl
+
+from goldenpipe.models.context import PipeContext
+from goldenpipe.models.config import PipelineConfig
+from goldenpipe.autoconfig_planner import PipePlan, PlannedStage
+from goldenpipe.autoconfig_glue import profile_context, plan_to_config
+
+
+def test_profile_context_materialized_df_detects_finance():
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    ctx = PipeContext(df=df)
+    prof = profile_context(ctx)
+    assert prof.n_rows == 2
+    assert prof.n_cols == 2
+    assert prof.column_names == ("account_number", "currency")
+    assert prof.inferred_domain == "finance"
+    assert prof.domain_confidence > 0.0
+
+
+def test_profile_context_no_domain_gives_zero_confidence():
+    df = pl.DataFrame({"x": [1, 2], "y": [3, 4]})
+    prof = profile_context(PipeContext(df=df))
+    # unremarkable columns -> no confident domain
+    assert prof.domain_confidence == 0.0 or prof.inferred_domain is None
+    if prof.inferred_domain is None:
+        assert prof.domain_confidence == 0.0
+
+
+def test_profile_context_engine_resident_is_degraded():
+    ctx = PipeContext(df=None)
+    ctx.metadata["input_rows"] = 5000
+    prof = profile_context(ctx)
+    assert prof.n_rows == 5000
+    assert prof.column_names == ()
+    assert prof.inferred_domain is None
+    assert prof.domain_confidence == 0.0
+
+
+def test_plan_to_config_filters_by_availability_and_builds_stagespecs():
+    plan = PipePlan(
+        stages=(
+            PlannedStage("infer_schema", {"domain": "finance"}),
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("missing.stage", {}),
+        ),
+        rule_name="confident_schema", confidence=0.8, evidence={},
+    )
+    available = {"infer_schema": object(), "goldencheck.scan": object()}
+    cfg = plan_to_config(plan, available, identity_opts=None)
+    assert isinstance(cfg, PipelineConfig)
+    assert cfg.pipeline == "auto"
+    uses = [s.use for s in cfg.stages]
+    assert uses == ["infer_schema", "goldencheck.scan"]  # missing.stage dropped, order kept
+    assert cfg.stages[0].config == {"domain": "finance"}
+
+
+def test_plan_to_config_appends_identity_when_opts_and_available():
+    plan = PipePlan((PlannedStage("goldencheck.scan", {}),), "default", 0.7, {})
+    available = {"goldencheck.scan": object(), "goldenmatch.identity_resolve": object()}
+    cfg = plan_to_config(plan, available, identity_opts={"kinds": ["email"]})
+    assert [s.use for s in cfg.stages] == ["goldencheck.scan", "goldenmatch.identity_resolve"]
+    assert cfg.stages[-1].config == {"kinds": ["email"]}
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expect: ImportError (`autoconfig_glue`).
+
+- [ ] **Step 3: Create `goldenpipe/autoconfig_glue.py`:**
+```python
+"""Host glue for the auto-config brain (Polars/InferMap in; Pydantic out).
+
+NOT ported to Rust — the future `goldenpipe-core` kernel is the portable core
+(autoconfig_planner). This bracket does the impure extraction + materialization.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from goldenpipe.autoconfig_planner import PipePlan, PipeProfile
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import PipeContext
+
+
+def profile_context(ctx: PipeContext) -> PipeProfile:
+    """Build the portable PipeProfile from a loaded context (cheap, no row scan)."""
+    df = ctx.df
+    if df is None:
+        # Engine-resident (DuckDB) — degrade rather than force materialization.
+        return PipeProfile(
+            n_rows=int(ctx.metadata.get("input_rows", 0)),
+            n_cols=0,
+            column_names=(),
+            dtypes=(),
+            inferred_domain=None,
+            domain_confidence=0.0,
+        )
+
+    column_names = tuple(df.columns)
+    dtypes = tuple(str(dt) for dt in df.dtypes)
+
+    # InferMap detect reads only `.columns` (attribute) — no row scan. Pass a
+    # `.columns`-bearing object, NOT a dict (a dict raises AttributeError).
+    from infermap import detect_domain_detailed
+
+    det = detect_domain_detailed(SimpleNamespace(columns=list(column_names)))
+    inferred_domain = det.domain
+    domain_confidence = det.score if det.domain is not None else 0.0
+
+    return PipeProfile(
+        n_rows=len(df),
+        n_cols=len(column_names),
+        column_names=column_names,
+        dtypes=dtypes,
+        inferred_domain=inferred_domain,
+        domain_confidence=domain_confidence,
+    )
+
+
+def plan_to_config(
+    plan: PipePlan,
+    available: Any,           # anything supporting `name in available` (registry dict / set)
+    identity_opts: dict | None,
+) -> PipelineConfig:
+    """Materialize a PipePlan into a Pydantic PipelineConfig, filtering by availability."""
+    specs: list[StageSpec] = [
+        StageSpec(use=s.name, config=dict(s.config))
+        for s in plan.stages
+        if s.name in available
+    ]
+    if identity_opts and "goldenmatch.identity_resolve" in available:
+        specs.append(StageSpec(use="goldenmatch.identity_resolve", config={**identity_opts}))
+    return PipelineConfig(pipeline="auto", stages=specs)
+```
+> Verify `PipeContext` accepts `df=None` + a `metadata` dict (it does — dataclass
+> with `df: pl.DataFrame | None = None`, `metadata: dict = field(default_factory=dict)`).
+> Verify `detect_domain_detailed(SimpleNamespace(columns=[...]))` returns a
+> `DetectionResult` with `.domain`/`.score` — if the Python API rejects a
+> non-DataFrame, fall back to passing `df` directly (it also has `.columns`) and
+> note it; either works since detect reads only `.columns`.
+
+- [ ] **Step 4: Run to verify PASS** + ruff
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_glue.py packages/python/goldenpipe/tests/test_autoconfig_glue.py
+```
+Expect: 5 passed; ruff clean. (If `SimpleNamespace` detect raises, switch to `detect_domain_detailed(df)` and re-run — the finance test still asserts domain=="finance".)
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/python/goldenpipe/goldenpipe/autoconfig_glue.py packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git commit -m "feat(goldenpipe): auto-config host glue (profile_context + plan_to_config)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, pytest summary, whether `SimpleNamespace` or `df` was used for detect, SHA.
+
+---
+
+## Task 4: Register `infer_schema` (entry-point)
+
+**Files:** Modify `packages/python/goldenpipe/pyproject.toml`. Box: TOML-eye-check (production wiring; CI's fresh install activates it).
+
+- [ ] **Step 1: Add the entry-point.** In `pyproject.toml`, under
+`[project.entry-points."goldenpipe.stages"]` (after the existing `goldenanalysis.report` line), add:
+```toml
+infer_schema = "goldenpipe.stages.infer_schema:infer_schema_stage"
+```
+(Bare key `infer_schema` — no dot, no quotes needed, but quoting is harmless. Target verified: `goldenpipe/stages/infer_schema.py` exports `infer_schema_stage`.)
+
+- [ ] **Step 2: Verify the target resolves** (box-runnable import, independent of entry-point metadata):
+```bash
+PYTHONPATH="packages/python/goldenpipe:packages/python/infermap:packages/python/goldencheck-types" POLARS_SKIP_CPU_CHECK=1 "$INTERP" -c "from goldenpipe.stages.infer_schema import infer_schema_stage; print('target OK:', infer_schema_stage.info.name)"
+```
+Expect: `target OK: infer_schema`. (This proves the entry-point target is importable; the entry-point itself goes live on CI's fresh install/`uv sync`.)
+
+- [ ] **Step 3: Commit**
+```bash
+git add packages/python/goldenpipe/pyproject.toml
+git commit -m "build(goldenpipe): register infer_schema stage entry-point (Python parity with TS)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, the target-OK output, SHA.
+
+---
+
+## Task 5: Wire the planner into `_auto_config`
+
+**Files:** Modify `packages/python/goldenpipe/goldenpipe/pipeline.py`. Box: eye + the integration test (Task 6) verifies.
+
+- [ ] **Step 1: Add `_last_plan` init.** In `Pipeline.__init__`, after `self._identity_opts = identity_opts`, add:
+```python
+        self._last_plan = None  # the PipePlan from the most recent auto-config
+```
+
+- [ ] **Step 2: Change the `_auto_config` signature + body.** Replace the whole `_auto_config` method with:
+```python
+    def _auto_config(self, ctx: PipeContext) -> PipelineConfig:
+        from goldenpipe.autoconfig_planner import plan_pipeline
+        from goldenpipe.autoconfig_glue import profile_context, plan_to_config
+
+        profile = profile_context(ctx)
+        plan = plan_pipeline(profile)
+        self._last_plan = plan
+        return plan_to_config(plan, self._registry.list_all(), self._identity_opts)
+```
+(Lazy imports keep the planner modules out of the import path for callers who
+always supply an explicit config.)
+
+- [ ] **Step 3: Update the call site.** Change the line in `run()`:
+```python
+        config = self._config or self._auto_config()
+```
+to:
+```python
+        config = self._config or self._auto_config(ctx)
+```
+
+- [ ] **Step 4: Verify no other caller uses `_auto_config()` (arity change).**
+```bash
+grep -rn "_auto_config" packages/python/goldenpipe/goldenpipe packages/python/goldenpipe/tests | grep -v "def _auto_config"
+```
+Expect: only the one call site in `run()` (now passing `ctx`). If a test calls `_auto_config()` with no args, it'll be updated in Task 6 / must be fixed.
+
+- [ ] **Step 5: Run the existing goldenpipe pipeline tests** (regression — the wiring must not break the default path):
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/ -q -k "pipeline or auto_config or engine" 2>&1 | tail -15
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/pipeline.py
+```
+Expect: pass (or only pre-existing unrelated failures). If a test asserted the exact old static `_auto_config()` output and now gets a planned config, that's expected — reconcile it (the default-path plan for a normal df should still yield scan→flow→dedupe filtered by availability). Report any test that changed behavior.
+
+- [ ] **Step 6: Commit**
+```bash
+git add packages/python/goldenpipe/goldenpipe/pipeline.py
+git commit -m "feat(goldenpipe): wire plan-first brain into _auto_config (stash _last_plan)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, regression result (esp. any behavior-changed test), SHA.
+
+---
+
+## Task 6: Integration test (the wiring, box-runnable + deterministic)
+
+**Files:** Extend `tests/test_autoconfig_glue.py` (or a new `tests/test_autoconfig_integration.py`). Box-runnable via a controlled registry (register stub stages — install-independent).
+
+- [ ] **Step 1: Add the integration test.** Append to `tests/test_autoconfig_glue.py`:
+```python
+from goldenpipe.pipeline import Pipeline
+from goldenpipe.engine.registry import StageRegistry
+from goldenpipe.models.context import StageResult, StageStatus
+
+
+def _stub_stage(name: str, produces=(), consumes=()):
+    """Minimal registrable stage — the planner cares about names, not behavior."""
+    class _S:
+        info = type("Info", (), {"name": name, "produces": list(produces),
+                                 "consumes": list(consumes)})()
+        def validate(self, ctx): ...
+        def run(self, ctx) -> StageResult:  # noqa: ANN001
+            return StageResult(status=StageStatus.SUCCESS)
+    return _S()
+
+
+def _registry_with(*names) -> StageRegistry:
+    r = StageRegistry()
+    for n in names:
+        r.register(_stub_stage(n))
+    return r
+
+
+def _finance_df():
+    import polars as pl
+    return pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+
+
+def test_autoconfig_confident_df_includes_infer_schema():
+    reg = _registry_with("infer_schema", "goldencheck.scan",
+                         "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=_finance_df())
+    cfg = eng._auto_config(ctx)
+    assert eng._last_plan.rule_name == "confident_schema"
+    assert [s.use for s in cfg.stages][0] == "infer_schema"
+    assert cfg.stages[0].config == {"domain": "finance"}
+
+
+def test_autoconfig_one_row_df_skips_dedupe():
+    import polars as pl
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=pl.DataFrame({"a": [1]}))
+    cfg = eng._auto_config(ctx)
+    assert eng._last_plan.rule_name == "pathological"
+    assert "goldenmatch.dedupe" not in [s.use for s in cfg.stages]
+
+
+def test_autoconfig_missing_infer_schema_degrades():
+    # confident df but infer_schema NOT in registry -> it's dropped, no crash.
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    cfg = eng._auto_config(PipeContext(df=_finance_df()))
+    assert eng._last_plan.rule_name == "confident_schema"  # plan still says confident
+    assert "infer_schema" not in [s.use for s in cfg.stages]  # but it's filtered out
+```
+> `Pipeline(registry=reg)` skips `discover()` (a registry was supplied), so the
+> stub registry is authoritative — install-independent + deterministic on the box.
+> Verify `StageResult`/`StageStatus`/`StageRegistry.register` import paths against
+> the real modules; adjust the stub's `info` shape to match `StageInfo` if the
+> registry validates it on `register` (read `engine/registry.py::register`).
+
+- [ ] **Step 2: Run** + ruff
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+"$INTERP" -m ruff check packages/python/goldenpipe/tests/test_autoconfig_glue.py
+```
+Expect: all pass (8 tests). If `register()` rejects the stub (validates StageInfo), adjust the stub to satisfy it (read the register signature) — do NOT weaken the assertions.
+
+- [ ] **Step 3: Full goldenpipe planner-surface run** (all new tests together):
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expect: all pass (~15 tests).
+
+- [ ] **Step 4: Commit**
+```bash
+git add packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git commit -m "test(goldenpipe): auto-config brain integration (confident/pathological/degrade)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+**Report:** `DONE`/`BLOCKED`, pytest summary, whether the stub needed adjusting for `register()`, SHA.
+
+---
+
+## Task 7: Full regression + push + PR + arm (controller runs this)
+
+**Files:** none.
+
+- [ ] **Step 1: Full goldenpipe test suite** (catch any regression from the `_auto_config` wiring):
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/ -q 2>&1 | tail -20
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/goldenpipe/autoconfig_glue.py packages/python/goldenpipe/goldenpipe/pipeline.py
+```
+Expect: green (or only pre-existing unrelated failures — note any). Ruff clean.
+
+- [ ] **Step 2: Rebase onto fresh origin/main**
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q
+git rebase origin/main
+```
+If `pyproject.toml` conflicts, keep both the existing entry-points and the new `infer_schema` one.
+
+- [ ] **Step 3: Confirm three-dot diff is clean**
+```bash
+git diff --stat origin/main...HEAD
+```
+Expect only: the spec, the plan, the 3 new `autoconfig_*.py`, `pyproject.toml`, `pipeline.py`, and the 2 test files.
+
+- [ ] **Step 4: Push + PR**
+```bash
+git push -u origin feat/goldenpipe-autoconfig-brain
+gh pr create --repo benseverndev-oss/goldenmatch --base main \
+  --title "feat(goldenpipe): plan-first auto-config brain (slice 1, Python prototype)" \
+  --body "$(cat <<'EOF'
+## What
+
+Gives goldenpipe a plan-first "brain" analogous to GoldenMatch's auto-config controller: instead of statically assembling check→flow→dedupe, it profiles the input up front, runs a rule table, and produces a `PipePlan` (stages + config + `rule_name` + confidence + evidence) that materializes to the pipeline config.
+
+**Slice 1 = the Python prototype** of the Python→Rust→cross-surface arc: the decision core (`PipeProfile` → `PipePlan` via a pure rule table, `autoconfig_planner.py` + `_rules.py`) is written **portable** (no Polars/Pydantic) so it ports mechanically to a `goldenpipe-core` Rust kernel in a later slice — exactly how GoldenMatch's `autoconfig_planner` became `autoconfig-core`.
+
+## Behavior (new)
+
+- **`confident_schema`** (domain confidently inferred via a cheap column-only InferMap detect) → prepends `infer_schema` pinned to the domain, so downstream stages get typed columns.
+- **`pathological`** (`n_rows <= 1`) → skips dedupe (plan-visible form of the reactive `row_count_gate`).
+- **`default`** → the current static shape.
+
+Backward-compatible: an explicit user config bypasses the planner; missing stages degrade to the default shape. Also registers `infer_schema` in the Python entry-points (parity with the TS registration in #1520).
+
+## Scope (deferred to later slices)
+
+Refuse-on-low-confidence (`PipeNotConfidentError`), the `goldenpipe-core` Rust port + TS-WASM parity (the "harden and go cross-surface" phase), and any signal needing a stage to run first (PII stays reactive in `decisions.py`).
+
+Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md`
+Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain.md`
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
+EOF
+)"
+```
+
+- [ ] **Step 5: Arm auto-merge + STOP**
+```bash
+gh pr merge <PR#> --repo benseverndev-oss/goldenmatch --squash --auto
+```
+No `--delete-branch`. Report the PR number + the full-suite result and STOP.
+
+---
+
+## Verification Summary
+
+| What | How | Where |
+| --- | --- | --- |
+| Portable core (plan_pipeline, structs frozen) | unit tests | Box (Task 1) |
+| Rule table fires correctly | rule unit tests | Box (Task 2) |
+| profile_context (df + degraded) | glue tests | Box (Task 3) |
+| plan_to_config (filter + identity) | glue tests | Box (Task 3) |
+| infer_schema entry-point target resolves | import check | Box (Task 4) |
+| Wiring (_auto_config(ctx) + _last_plan) | regression + integration | Box (Tasks 5,6) |
+| Confident df → infer_schema; 1-row → skip dedupe; degrade | integration | Box (Task 6) |
+| No regression | full goldenpipe suite | Box (Task 7) |
+| Portable core stays Polars/Pydantic-free | eye (import boundary) | Box (all) |

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain.md
@@ -44,7 +44,7 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44
 | `packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py` | the 3 rules + `DEFAULT_RULES` (portable) | Create |
 | `packages/python/goldenpipe/goldenpipe/autoconfig_glue.py` | host glue: `profile_context(ctx)`, `plan_to_config(plan, available, identity_opts)` | Create |
 | `packages/python/goldenpipe/pyproject.toml` | register `infer_schema` entry-point | Modify |
-| `packages/python/goldenpipe/goldenpipe/pipeline.py` | `_auto_config(self, ctx)` + call site + `_last_plan` | Modify |
+| `packages/python/goldenpipe/goldenpipe/pipeline.py` | new `_plan_config(self, ctx)` brain + `run()` call site + `_last_plan` init (`_auto_config` untouched) | Modify |
 | `packages/python/goldenpipe/tests/test_autoconfig_planner.py` | core + rules unit tests | Create |
 | `packages/python/goldenpipe/tests/test_autoconfig_glue.py` | glue + wiring/integration tests | Create |
 
@@ -118,7 +118,7 @@ first-match plan) so the later `goldenpipe-core` Rust port is mechanical.
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
@@ -194,7 +194,7 @@ def plan_pipeline(
             return rule.action(profile)
     return _default_plan(profile)
 ```
-(The `field` import is unused — drop it; ruff will flag. Keep imports minimal.)
+(Import only `dataclass` from dataclasses — no `field`; ruff F401 would flag an unused import.)
 
 - [ ] **Step 4: Run to verify PASS** + ruff
 ```bash
@@ -554,18 +554,34 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
 
 ---
 
-## Task 5: Wire the planner into `_auto_config`
+## Task 5: Wire the planner into `run()` (as a NEW method — do NOT touch `_auto_config`)
 
 **Files:** Modify `packages/python/goldenpipe/goldenpipe/pipeline.py`. Box: eye + the integration test (Task 6) verifies.
 
+> **Why a new method, not a signature change to `_auto_config`:** `_auto_config()`
+> has other no-arg callers that must keep the OLD static behavior — production
+> `core/_planner_json.py` (the cross-surface parity bridge `auto_config_json`,
+> which has no data context and mirrors `goldenpipe-core/src/json.rs`) and
+> `tests/test_pipeline.py::test_auto_config`. Changing its arity breaks both, and
+> feeding the JSON bridge an empty ctx would silently regress its output
+> (n_rows=0 → `pathological` → dedupe dropped). So `_auto_config` stays untouched
+> (the data-less static default), and the brain is a **new** `_plan_config(ctx)`
+> that only `run()` calls (it has the loaded ctx). The JSON bridge keeps mirroring
+> the static planner until the brain itself is ported to `goldenpipe-core` (a later
+> slice), at which point the bridge moves too.
+
 - [ ] **Step 1: Add `_last_plan` init.** In `Pipeline.__init__`, after `self._identity_opts = identity_opts`, add:
 ```python
-        self._last_plan = None  # the PipePlan from the most recent auto-config
+        self._last_plan = None  # the PipePlan from the most recent brain run
 ```
 
-- [ ] **Step 2: Change the `_auto_config` signature + body.** Replace the whole `_auto_config` method with:
+- [ ] **Step 2: Add the brain method** `_plan_config` (leave `_auto_config` exactly as-is). Add it right after the existing `_auto_config` method:
 ```python
-    def _auto_config(self, ctx: PipeContext) -> PipelineConfig:
+    def _plan_config(self, ctx: PipeContext) -> PipelineConfig:
+        """Plan-first auto-config brain: profile the loaded ctx -> rule table ->
+        materialized PipelineConfig. Only called from run() (needs the loaded ctx).
+        `_auto_config` remains the data-less static default for the JSON parity bridge.
+        """
         from goldenpipe.autoconfig_planner import plan_pipeline
         from goldenpipe.autoconfig_glue import profile_context, plan_to_config
 
@@ -574,23 +590,29 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
         self._last_plan = plan
         return plan_to_config(plan, self._registry.list_all(), self._identity_opts)
 ```
-(Lazy imports keep the planner modules out of the import path for callers who
-always supply an explicit config.)
+(Lazy imports keep the planner modules off the import path for callers who supply
+an explicit config or use the static `_auto_config`.)
 
-- [ ] **Step 3: Update the call site.** Change the line in `run()`:
+- [ ] **Step 3: Update the `run()` call site.** Change the line in `run()`:
 ```python
         config = self._config or self._auto_config()
 ```
 to:
 ```python
-        config = self._config or self._auto_config(ctx)
+        config = self._config or self._plan_config(ctx)
 ```
+(This is the ONLY line that switches to the brain. `_auto_config()`'s other
+callers — `_planner_json.py`, `test_pipeline.py` — keep calling the untouched
+static method.)
 
-- [ ] **Step 4: Verify no other caller uses `_auto_config()` (arity change).**
+- [ ] **Step 4: Confirm the blast radius is exactly as expected.**
 ```bash
-grep -rn "_auto_config" packages/python/goldenpipe/goldenpipe packages/python/goldenpipe/tests | grep -v "def _auto_config"
+grep -rn "_auto_config\|_plan_config" packages/python/goldenpipe/goldenpipe packages/python/goldenpipe/tests | grep -v "def _auto_config\|def _plan_config"
 ```
-Expect: only the one call site in `run()` (now passing `ctx`). If a test calls `_auto_config()` with no args, it'll be updated in Task 6 / must be fixed.
+Expect: `_plan_config` appears ONLY at the new `run()` call site; `_auto_config()`
+still appears at `core/_planner_json.py:~148` and `tests/test_pipeline.py:~45`
+(both INTENTIONALLY unchanged — they use the static default). Do NOT edit those.
+If `_auto_config` appears at any NEW site you introduced, revert it.
 
 - [ ] **Step 5: Run the existing goldenpipe pipeline tests** (regression — the wiring must not break the default path):
 ```bash
@@ -651,7 +673,7 @@ def test_autoconfig_confident_df_includes_infer_schema():
                          "goldenflow.transform", "goldenmatch.dedupe")
     eng = Pipeline(registry=reg)
     ctx = PipeContext(df=_finance_df())
-    cfg = eng._auto_config(ctx)
+    cfg = eng._plan_config(ctx)
     assert eng._last_plan.rule_name == "confident_schema"
     assert [s.use for s in cfg.stages][0] == "infer_schema"
     assert cfg.stages[0].config == {"domain": "finance"}
@@ -662,7 +684,7 @@ def test_autoconfig_one_row_df_skips_dedupe():
     reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
     eng = Pipeline(registry=reg)
     ctx = PipeContext(df=pl.DataFrame({"a": [1]}))
-    cfg = eng._auto_config(ctx)
+    cfg = eng._plan_config(ctx)
     assert eng._last_plan.rule_name == "pathological"
     assert "goldenmatch.dedupe" not in [s.use for s in cfg.stages]
 
@@ -671,7 +693,7 @@ def test_autoconfig_missing_infer_schema_degrades():
     # confident df but infer_schema NOT in registry -> it's dropped, no crash.
     reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
     eng = Pipeline(registry=reg)
-    cfg = eng._auto_config(PipeContext(df=_finance_df()))
+    cfg = eng._plan_config(PipeContext(df=_finance_df()))
     assert eng._last_plan.rule_name == "confident_schema"  # plan still says confident
     assert "infer_schema" not in [s.use for s in cfg.stages]  # but it's filtered out
 ```

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md
@@ -1,0 +1,202 @@
+# goldenpipe auto-config brain — slice 1 (Python prototype) design
+
+**Date:** 2026-07-07
+**Status:** Approved (design)
+**Branch:** `feat/goldenpipe-autoconfig-brain` off `origin/main`.
+
+## 1. Goal & the arc this fits
+
+Give goldenpipe a **plan-first "brain"** analogous to GoldenMatch's auto-config
+controller: instead of statically assembling `check → flow → dedupe`, profile the
+input data up front, run a rule table, and produce a `PipePlan` (which stages, in
+what order, with what config) stamped with the rule that fired, a confidence
+score, and the evidence that drove it.
+
+This is **slice 1 of the standard Rust-thesis workflow**: prototype the feature in
+Python (fast iteration, box-runnable TDD), then — once the rules stabilize —
+harden the decision core into a pyo3-free `goldenpipe-core` Rust kernel (source of
+truth) with Python-native + TS-WASM as conforming surfaces. GoldenMatch's own
+auto-config took exactly this path (Python `autoconfig_planner` → `autoconfig-core`
+Rust → `autoconfig-wasm`); goldenpipe follows it. **Slice 1 ships only the Python
+prototype**; the Rust port + TS parity are later slices.
+
+Design consequence baked in from day one: the **decision core is written
+portable** — the profile→plan rule engine (`PipeProfile` → `PipePlan` via pure
+predicates) is free of Polars/pandas/Pydantic and Python-only idioms, so the later
+Rust port is a mechanical translation. The Polars-dependent *profiling* and the
+Pydantic `PipelineConfig` *materialization* are host glue that bracket the portable
+core (the "plain-struct-in, plain-struct-out" kernel boundary).
+
+## 2. Current state (the gap)
+
+- `pipeline.py::_auto_config()` statically lists the registry stages
+  `["goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe"]` (+ optional
+  `goldenmatch.identity_resolve` when identity opts are supplied) and returns
+  `PipelineConfig(pipeline="auto", stages=[...])`. It inspects **nothing** about
+  the data.
+- `decisions.py` (`severity_gate`, `pii_router`, `row_count_gate`) is **reactive**
+  — it routes *between* stages based on artifacts already produced (findings,
+  input_rows). It is not a plan-time decision.
+- `run(source=, df=, duckdb_con=/table=)` loads the data into `ctx` (`ctx.df`, or
+  the engine-resident `ctx.frame` + `ctx.metadata["input_rows"]`) **before**
+  `_auto_config()` is called — so plan-time profiling signals are available.
+
+The brain fills the plan-first gap. The reactive `decisions.py` layer stays as-is:
+the brain decides the **up-front shape** from cheap signals; `decisions.py` handles
+**post-stage routing** (e.g. PII → PPRL, which can only be known after `scan`
+runs). They are complementary, not competing.
+
+## 3. The portable decision core (the future Rust kernel)
+
+### `PipeProfile` — frozen dataclass, portable (no Polars/Pydantic)
+Cheap, up-front signals only — nothing that requires running a stage:
+```python
+@dataclass(frozen=True)
+class PipeProfile:
+    n_rows: int
+    n_cols: int
+    column_names: tuple[str, ...]
+    dtypes: tuple[str, ...]              # per-column dtype names (sampled), aligned to column_names
+    inferred_domain: str | None          # from a cheap detect_domain_detailed on the columns
+    domain_confidence: float             # 0.0 when no domain inferred
+```
+
+### `PipePlan` — frozen dataclass, portable (goldenpipe's `ExecutionPlan` analog)
+```python
+@dataclass(frozen=True)
+class PlannedStage:
+    name: str
+    config: dict          # per-stage config (e.g. {"domain": "finance"} for infer_schema)
+
+@dataclass(frozen=True)
+class PipePlan:
+    stages: tuple[PlannedStage, ...]
+    rule_name: str        # which rule fired (evidence) — or "default"
+    confidence: float     # 0..1
+    evidence: dict        # the signals that drove the decision (n_rows, domain, ...)
+```
+
+### `PipePlannerRule` + `plan_pipeline` — pure, deterministic
+```python
+Predicate = Callable[[PipeProfile], bool]
+Action    = Callable[[PipeProfile], PipePlan]
+
+@dataclass(frozen=True)
+class PipePlannerRule:
+    rule_name: str
+    predicate: Predicate
+    action: Action
+
+def plan_pipeline(profile: PipeProfile, rules: Sequence[PipePlannerRule] = DEFAULT_RULES) -> PipePlan:
+    for rule in rules:
+        if rule.predicate(profile):
+            return rule.action(profile)   # action stamps rule.rule_name
+    return _default_plan(profile)         # rule_name="default"
+```
+`plan_pipeline` + the rules + the structs are the pyo3-free-portable kernel — the
+thing that becomes `goldenpipe-core::plan_pipeline` in a later slice.
+
+## 4. The rule table (slice 1 — small, honest, real)
+
+Ordered; first match wins. All predicates read only cheap `PipeProfile` signals.
+
+| # | rule_name | predicate | action (plan) | confidence |
+| --- | --- | --- | --- | --- |
+| 1 | `pathological` | `n_rows <= 1` | `[scan, flow]` — skip dedupe (nothing to dedupe with ≤1 row); the proactive, plan-visible form of `row_count_gate` | `1.0` |
+| 2 | `confident_schema` | `domain_confidence >= 0.5` | `[infer_schema(domain=inferred_domain), scan, flow, dedupe]` — run schema inference (pinned to the detected domain) so downstream stages get typed columns | `domain_confidence` |
+| 3 | `default` (fallthrough) | — | `[scan, flow, dedupe]` — the current static shape (no infer_schema; low-value guessing when the domain isn't confident) | `0.7` |
+
+Rules only include a stage when the registry actually has it (checked at
+materialization, §5) — so a checkout missing `infer_schema` degrades to the
+`default` shape without error. `identity_resolve` (opt-in via identity opts) is
+appended at materialization exactly as today, orthogonal to the rule.
+
+> **Why these three:** they cover the genuinely new behavior worth prototyping —
+> the brain proactively **adds `infer_schema` when it will help** (confident
+> domain) and **skips it when it won't**, and reflects the tiny-data dedupe-skip
+> in the plan up front. That's a real capability the static `_auto_config` never
+> had, testable on cheap signals, without needing any stage to run first. More
+> rules (complexity/pair-count estimation, quality-driven flow tuning) are later
+> slices once the shape is proven.
+
+## 5. Host glue (stays Python; NOT ported to Rust)
+
+### `profile_context(ctx) -> PipeProfile`
+Builds the portable `PipeProfile` from the loaded context:
+- **Materialized df** (`ctx.df is not None`): `n_rows = len(df)`, `column_names`,
+  per-column `dtypes` (from `df.schema`), and a cheap
+  `infermap.detect_domain_detailed({"columns": column_names})` for
+  `inferred_domain`/`domain_confidence`. (InferMap is already a goldenpipe dep;
+  detect is column-name-only — no row scan.)
+- **Engine-resident** (`ctx.frame` set, df not materialized): build a minimal
+  profile from `ctx.metadata["input_rows"]` (n_rows) with `inferred_domain=None`,
+  `domain_confidence=0.0` — a **documented degradation** that avoids forcing
+  materialization just to plan. (Column names could come from a cheap engine
+  `DESCRIBE` in a later slice; slice 1 keeps it minimal.)
+
+### `plan_to_config(plan, available, identity_opts) -> PipelineConfig`
+Converts the portable `PipePlan` into the Pydantic `PipelineConfig`: for each
+`PlannedStage` whose `name` is in `available` (registry), emit
+`StageSpec(use=name, config=stage.config)`; append `identity_resolve` when
+identity opts are supplied and discoverable (unchanged from today); return
+`PipelineConfig(pipeline="auto", stages=[...])`.
+
+## 6. Wiring
+
+`_auto_config(self)` → `_auto_config(self, ctx)`:
+```python
+def _auto_config(self, ctx: PipeContext) -> PipelineConfig:
+    profile = profile_context(ctx)
+    plan = plan_pipeline(profile)
+    self._last_plan = plan            # surface for reporting/telemetry
+    return plan_to_config(plan, self._registry.list_all(), self._identity_opts)
+```
+Called in `run()` as `config = self._config or self._auto_config(ctx)` (ctx is
+already built + loaded at that point). An explicit user `config` still bypasses the
+planner entirely — **fully backward-compatible**. The `PipePlan` is stashed on the
+engine (`self._last_plan`) so a later slice can surface it (report/CLI/MCP);
+slice 1 does not add a new output surface.
+
+## 7. Testing (box-runnable — the point of Python-first)
+
+- **`plan_pipeline` unit tests** over synthetic `PipeProfile`s: each rule fires on
+  its inputs (pathological on n_rows=1; confident_schema on domain_confidence≥0.5
+  with a domain; default otherwise); the returned `PipePlan` has the right
+  `stages`, `rule_name`, `confidence`, and `evidence`. Pure + deterministic.
+- **`profile_context` tests**: a real Polars df → expected `PipeProfile` (n_rows,
+  columns, dtypes, and a domain detected for finance-like columns, cross-checking
+  the InferMap detect); the engine-resident path → the minimal degraded profile.
+- **`plan_to_config` tests**: a `PipePlan` → the expected `PipelineConfig`
+  (registry-availability filtering; identity_opts appended).
+- **Integration**: `MapEngine(...).run(df=...)` with the planner active produces a
+  plan that (a) includes `infer_schema` for a confident-domain df, (b) omits it +
+  skips dedupe for a 1-row df, and still runs end to end.
+
+## 8. Out of scope (later slices — honest)
+
+- **Confidence/refuse-on-RED** (`PipeNotConfidentError` analog + a
+  RED/AMBER/GREEN model + safe-default degradation). Slice 1 attaches a confidence
+  *score* but never refuses.
+- **The `goldenpipe-core` Rust port + TS-WASM parity** — the "harden and go
+  cross-surface" phase, done *after* the Python rules stabilize.
+- **Any signal that needs a stage to run first** (PII, quality findings) — stays
+  in the reactive `decisions.py` layer.
+- **New output surfaces** (CLI `--explain-plan`, MCP plan resource) — the plan is
+  stashed on the engine but not yet surfaced.
+- **Complexity/pair-count estimation, quality-driven flow tuning** — later rules.
+
+## 9. Risk assessment
+
+Low. It's additive + backward-compatible (explicit config bypasses it; missing
+stages degrade to the default shape). The decision core is small, pure, and
+box-testable — exactly the fast-iteration surface the Python-first phase wants.
+The one care point is keeping the portable core Polars/Pydantic-free (so the Rust
+port stays mechanical); the spec draws that boundary explicitly (§3 vs §5).
+
+## 10. Build environment constraints
+
+- **Box-runnable:** the entire slice is Python — `plan_pipeline`, the rules,
+  `profile_context`, `plan_to_config`, and their tests all run locally with the
+  goldenpipe venv (real TDD). `ruff check` touched files.
+- **Merge-queue repo:** `gh pr merge --auto --squash` without `--delete-branch`;
+  benzsevern gh account.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md
@@ -100,16 +100,29 @@ thing that becomes `goldenpipe-core::plan_pipeline` in a later slice.
 
 Ordered; first match wins. All predicates read only cheap `PipeProfile` signals.
 
-| # | rule_name | predicate | action (plan) | confidence |
-| --- | --- | --- | --- | --- |
-| 1 | `pathological` | `n_rows <= 1` | `[scan, flow]` — skip dedupe (nothing to dedupe with ≤1 row); the proactive, plan-visible form of `row_count_gate` | `1.0` |
-| 2 | `confident_schema` | `domain_confidence >= 0.5` | `[infer_schema(domain=inferred_domain), scan, flow, dedupe]` — run schema inference (pinned to the detected domain) so downstream stages get typed columns | `domain_confidence` |
-| 3 | `default` (fallthrough) | — | `[scan, flow, dedupe]` — the current static shape (no infer_schema; low-value guessing when the domain isn't confident) | `0.7` |
+**`PlannedStage.name` carries the EXACT registry name** — the dotted suite names
+`goldencheck.scan` / `goldenflow.transform` / `goldenmatch.dedupe`, and the bare
+`infer_schema`. (`plan_to_config` filters on `name in available`, so a shorthand
+like `scan` would be silently dropped → empty pipeline.)
 
-Rules only include a stage when the registry actually has it (checked at
-materialization, §5) — so a checkout missing `infer_schema` degrades to the
-`default` shape without error. `identity_resolve` (opt-in via identity opts) is
-appended at materialization exactly as today, orthogonal to the rule.
+| # | rule_name | predicate | action (plan `stages`) | confidence |
+| --- | --- | --- | --- | --- |
+| 1 | `pathological` | `n_rows <= 1` | `[goldencheck.scan, goldenflow.transform]` — skip dedupe (nothing to dedupe with ≤1 row); the proactive, plan-visible form of `row_count_gate` | `1.0` |
+| 2 | `confident_schema` | `domain_confidence >= 0.5` | `[infer_schema {domain: inferred_domain}, goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` — run schema inference (pinned to the detected domain, first, so downstream stages get typed columns) | `domain_confidence` |
+| 3 | `default` (fallthrough) | — | `[goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` — the current static shape (no infer_schema; low-value guessing when the domain isn't confident) | `0.7` |
+
+Rules only materialize a stage when the registry actually has it (`name in
+available`, §5). `identity_resolve` (opt-in via identity opts) is appended at
+materialization exactly as today, orthogonal to the rule. **Order matters**: the
+plan's stage order is authoritative (`StageSpec` carries no `needs` in the current
+`_auto_config`, so `Resolver.resolve` preserves plan order) — `infer_schema` is
+listed first in rule 2 so it runs before the stages that consume typed columns.
+
+> **`infer_schema` must be registered for rule 2 to do anything** (§6). It is NOT
+> in the registry today — the `goldenpipe.stages` entry-points list only
+> `goldencheck.scan` / `goldenflow.transform` / `goldenmatch.dedupe`. Slice 1
+> registers `infer_schema` (§6) or the flagship rule is inert (produces the same
+> plan as `default`).
 
 > **Why these three:** they cover the genuinely new behavior worth prototyping —
 > the brain proactively **adds `infer_schema` when it will help** (confident
@@ -125,14 +138,22 @@ appended at materialization exactly as today, orthogonal to the rule.
 Builds the portable `PipeProfile` from the loaded context:
 - **Materialized df** (`ctx.df is not None`): `n_rows = len(df)`, `column_names`,
   per-column `dtypes` (from `df.schema`), and a cheap
-  `infermap.detect_domain_detailed({"columns": column_names})` for
-  `inferred_domain`/`domain_confidence`. (InferMap is already a goldenpipe dep;
-  detect is column-name-only — no row scan.)
-- **Engine-resident** (`ctx.frame` set, df not materialized): build a minimal
-  profile from `ctx.metadata["input_rows"]` (n_rows) with `inferred_domain=None`,
-  `domain_confidence=0.0` — a **documented degradation** that avoids forcing
-  materialization just to plan. (Column names could come from a cheap engine
-  `DESCRIBE` in a later slice; slice 1 keeps it minimal.)
+  `infermap.detect_domain_detailed(ctx.df)` for the domain. **Detect reads only
+  `df.columns` (attribute access) — no row scan — but it needs an object with a
+  `.columns` attribute, NOT a `{"columns": [...]}` dict** (that raises
+  `AttributeError`). Pass `ctx.df` directly (a Polars df has `.columns`), or, to
+  keep the portable core independent, a `types.SimpleNamespace(columns=list(column_names))`.
+  Map the result: `inferred_domain = result.domain` (may be `None`);
+  `domain_confidence = result.score if result.domain is not None else 0.0`
+  (`DetectionResult` exposes `.score`, NOT `.confidence`, and reports a score even
+  on `tie`/`below_min_score` outcomes where `.domain is None` — hence the guard).
+- **Engine-resident** (`ctx.df is None`, i.e. the DuckDB path where `ctx.frame` is
+  a `DuckDBFrame` and the df is not materialized): build a minimal profile from
+  `ctx.metadata["input_rows"]` (n_rows) with `column_names=()`,
+  `inferred_domain=None`, `domain_confidence=0.0` — a **documented degradation**
+  that avoids forcing materialization just to plan. (The discriminator is
+  `ctx.df is None`; the `ctx.frame` property is never `None` when df is set.
+  Column names via a cheap engine `DESCRIBE` are a later slice.)
 
 ### `plan_to_config(plan, available, identity_opts) -> PipelineConfig`
 Converts the portable `PipePlan` into the Pydantic `PipelineConfig`: for each
@@ -142,6 +163,17 @@ identity opts are supplied and discoverable (unchanged from today); return
 `PipelineConfig(pipeline="auto", stages=[...])`.
 
 ## 6. Wiring
+
+**Register `infer_schema`** (blocker — it is discoverable nowhere today). Add it
+to `packages/python/goldenpipe/pyproject.toml`
+`[project.entry-points."goldenpipe.stages"]`:
+```toml
+infer_schema = "goldenpipe.stages.infer_schema:infer_schema_stage"
+```
+so `StageRegistry.discover()` includes it in `list_all()`. Being registered does
+NOT put it in any default pipeline — only rule 2 (`confident_schema`) plans it; the
+`default` rule still omits it. (The TS side registered `infer_schema` opt-in in
+#1520; this brings the Python registry to parity.)
 
 `_auto_config(self)` → `_auto_config(self, ctx)`:
 ```python

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_glue.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_glue.py
@@ -1,0 +1,61 @@
+"""Host glue for the auto-config brain (Polars/InferMap in; Pydantic out).
+
+NOT ported to Rust — the future `goldenpipe-core` kernel is the portable core
+(autoconfig_planner). This bracket does the impure extraction + materialization.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from goldenpipe.autoconfig_planner import PipePlan, PipeProfile
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import PipeContext
+
+
+def profile_context(ctx: PipeContext) -> PipeProfile:
+    """Build the portable PipeProfile from a loaded context (cheap, no row scan)."""
+    df = ctx.df
+    if df is None:
+        return PipeProfile(
+            n_rows=int(ctx.metadata.get("input_rows", 0)),
+            n_cols=0,
+            column_names=(),
+            dtypes=(),
+            inferred_domain=None,
+            domain_confidence=0.0,
+        )
+
+    column_names = tuple(df.columns)
+    dtypes = tuple(str(dt) for dt in df.dtypes)
+
+    from infermap import detect_domain_detailed
+
+    det = detect_domain_detailed(SimpleNamespace(columns=list(column_names)))
+    inferred_domain = det.domain
+    domain_confidence = det.score if det.domain is not None else 0.0
+
+    return PipeProfile(
+        n_rows=len(df),
+        n_cols=len(column_names),
+        column_names=column_names,
+        dtypes=dtypes,
+        inferred_domain=inferred_domain,
+        domain_confidence=domain_confidence,
+    )
+
+
+def plan_to_config(
+    plan: PipePlan,
+    available: Any,
+    identity_opts: dict | None,
+) -> PipelineConfig:
+    """Materialize a PipePlan into a Pydantic PipelineConfig, filtering by availability."""
+    specs: list[StageSpec] = [
+        StageSpec(use=s.name, config=dict(s.config))
+        for s in plan.stages
+        if s.name in available
+    ]
+    if identity_opts and "goldenmatch.identity_resolve" in available:
+        specs.append(StageSpec(use="goldenmatch.identity_resolve", config={**identity_opts}))
+    return PipelineConfig(pipeline="auto", stages=specs)

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner.py
@@ -1,0 +1,85 @@
+"""Plan-first auto-config decision core (portable — NO Polars/Pydantic).
+
+The pyo3-free-portable kernel: PipeProfile (in) -> PipePlan (out) via a pure
+rule table. Host glue (Polars profiling, Pydantic config) lives in
+`autoconfig_glue.py`. Mirrors goldenmatch's autoconfig_planner (PlannerRule +
+first-match plan) so the later `goldenpipe-core` Rust port is mechanical.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipeProfile:
+    """Cheap, up-front signals — no stage execution required."""
+    n_rows: int
+    n_cols: int
+    column_names: tuple[str, ...]
+    dtypes: tuple[str, ...]
+    inferred_domain: str | None
+    domain_confidence: float
+
+
+@dataclass(frozen=True)
+class PlannedStage:
+    name: str            # EXACT registry name (e.g. "goldencheck.scan", "infer_schema")
+    config: dict         # per-stage config
+
+
+@dataclass(frozen=True)
+class PipePlan:
+    stages: tuple[PlannedStage, ...]
+    rule_name: str
+    confidence: float
+    evidence: dict
+
+
+Predicate = Callable[[PipeProfile], bool]
+Action = Callable[[PipeProfile], "PipePlan"]
+
+
+@dataclass(frozen=True)
+class PipePlannerRule:
+    rule_name: str
+    predicate: Predicate
+    action: Action
+
+
+def default_evidence(p: PipeProfile) -> dict:
+    """Signal snapshot attached to every plan (evidence for humans/telemetry)."""
+    return {
+        "n_rows": p.n_rows,
+        "n_cols": p.n_cols,
+        "inferred_domain": p.inferred_domain,
+        "domain_confidence": p.domain_confidence,
+    }
+
+
+def _default_plan(p: PipeProfile) -> PipePlan:
+    """The current static shape: scan -> flow -> dedupe (no infer_schema)."""
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="default",
+        confidence=0.7,
+        evidence=default_evidence(p),
+    )
+
+
+def plan_pipeline(
+    profile: PipeProfile,
+    rules: Sequence[PipePlannerRule] | None = None,
+) -> PipePlan:
+    """First matching rule's action builds the plan; else the default shape."""
+    if rules is None:
+        from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES
+        rules = DEFAULT_RULES
+    for rule in rules:
+        if rule.predicate(profile):
+            return rule.action(profile)
+    return _default_plan(profile)

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
@@ -1,0 +1,64 @@
+"""Concrete planner rules for the goldenpipe auto-config brain (slice 1).
+
+Ordered; first match wins (see plan_pipeline). All predicates read only cheap
+PipeProfile signals. Portable — no Polars/Pydantic.
+"""
+from __future__ import annotations
+
+from goldenpipe.autoconfig_planner import (
+    PipePlan,
+    PipePlannerRule,
+    PipeProfile,
+    PlannedStage,
+    default_evidence,
+)
+
+_CONFIDENT_DOMAIN_THRESHOLD = 0.5
+
+
+def _is_pathological(p: PipeProfile) -> bool:
+    return p.n_rows <= 1
+
+
+def _pathological_plan(p: PipeProfile) -> PipePlan:
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+        ),
+        rule_name="pathological",
+        confidence=1.0,
+        evidence=default_evidence(p),
+    )
+
+
+rule_pathological = PipePlannerRule("pathological", _is_pathological, _pathological_plan)
+
+
+def _is_confident_schema(p: PipeProfile) -> bool:
+    return p.inferred_domain is not None and p.domain_confidence >= _CONFIDENT_DOMAIN_THRESHOLD
+
+
+def _confident_schema_plan(p: PipeProfile) -> PipePlan:
+    return PipePlan(
+        stages=(
+            PlannedStage("infer_schema", {"domain": p.inferred_domain}),
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="confident_schema",
+        confidence=p.domain_confidence,
+        evidence=default_evidence(p),
+    )
+
+
+rule_confident_schema = PipePlannerRule(
+    "confident_schema", _is_confident_schema, _confident_schema_plan,
+)
+
+
+DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
+    rule_pathological,
+    rule_confident_schema,
+)

--- a/packages/python/goldenpipe/goldenpipe/pipeline.py
+++ b/packages/python/goldenpipe/goldenpipe/pipeline.py
@@ -32,6 +32,10 @@ class Pipeline:
         # When the caller supplied an explicit PipelineConfig (YAML), the
         # YAML is authoritative and identity_opts is ignored.
         self._identity_opts = identity_opts
+        # Set by _plan_config on each run; exposes the last plan-first
+        # auto-config decision (rule_name, confidence, evidence) for
+        # introspection. None until the brain has planned at least once.
+        self._last_plan = None
 
     def run(
         self,
@@ -99,7 +103,7 @@ class Pipeline:
                 errors=["No source file or DataFrame provided"],
             )
 
-        config = self._config or self._auto_config()
+        config = self._config or self._plan_config(ctx)
 
         try:
             plan = Resolver.resolve(config, self._registry)
@@ -114,6 +118,29 @@ class Pipeline:
         runner = Runner(registry=self._registry)
         stages = runner.run(plan, ctx)
         return Reporter.build(ctx, stages)
+
+    def _plan_config(self, ctx: PipeContext) -> PipelineConfig:
+        """Plan-first auto-config: profile the loaded context, run the rule
+        table, and materialize the chosen plan into a PipelineConfig.
+
+        This is the "brain" (parity with GoldenMatch's controller): the shape
+        of the pipeline is DECIDED from the data + InferMap-inferred schema
+        rather than being the fixed scan/transform/dedupe list. The portable
+        decision core (``autoconfig_planner``) is kept free of Polars/Pydantic
+        for the later ``goldenpipe-core`` Rust port; this method is the host
+        glue bracket.
+        """
+        from goldenpipe.autoconfig_glue import plan_to_config, profile_context
+        from goldenpipe.autoconfig_planner import plan_pipeline
+
+        profile = profile_context(ctx)
+        plan = plan_pipeline(profile)
+        self._last_plan = plan
+        return plan_to_config(
+            plan,
+            self._registry.list_all(),
+            self._identity_opts,
+        )
 
     def _auto_config(self) -> PipelineConfig:
         available = self._registry.list_all()

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -54,6 +54,7 @@ Changelog = "https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/
 Author = "https://bensevern.dev"
 
 [project.entry-points."goldenpipe.stages"]
+"infer_schema" = "goldenpipe.stages.infer_schema:infer_schema_stage"
 "goldencheck.scan" = "goldenpipe.adapters.check:ScanStage"
 "goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
 "goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"

--- a/packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+++ b/packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
@@ -1,8 +1,22 @@
 """Emit cross-language parity fixtures for the goldenpipe TS port.
 
-Runs the Python ``goldenpipe.run`` (file path → full check→flow→dedupe chain)
-on small CSV fixtures and dumps the stable, cross-language-robust invariants of
-the resulting ``PipeResult`` to JSON under the TS package's fixtures dir.
+Runs the Python goldenpipe on small CSV fixtures and dumps the stable,
+cross-language-robust invariants of the resulting ``PipeResult`` to JSON under
+the TS package's fixtures dir.
+
+This fixture pins the **shared execution engine** -- the fixed
+check→flow→dedupe stage chain that BOTH the Python and TS surfaces implement
+identically. It deliberately does NOT go through ``goldenpipe.run`` (the public
+default), because ``run`` now flows through the Python-only auto-config *brain*
+(``Pipeline._plan_config``), which DECIDES the stage set from the data (e.g.
+drops dedupe for a single-row input). That decision layer is Python-only until
+it is ported to TS, so exercising it here would diverge the two surfaces by
+design and is not what this cross-surface fixture is for. The brain's decisions
+are covered directly by ``tests/test_autoconfig_glue.py``. When TS gains the
+brain, extend this fixture to cover the decision layer too.
+
+Concretely: we run the STATIC config from ``Pipeline._auto_config`` (the
+untouched pre-brain default chain), which is what the TS parity test also runs.
 
 The TS siblings are version-skewed from the Python ones, so we deliberately
 emit only the invariants that survive the skew:
@@ -22,6 +36,7 @@ import json
 from pathlib import Path
 
 import goldenpipe
+from goldenpipe.pipeline import Pipeline
 
 # Output dir: packages/typescript/goldenpipe/tests/fixtures/
 _HERE = Path(__file__).resolve()
@@ -74,11 +89,18 @@ def _row_count(artifact: object) -> int | None:
         return None
 
 
-def emit_case(case_id: str, csv_text: str, tmp_dir: Path) -> dict:
+def emit_case(
+    case_id: str,
+    csv_text: str,
+    tmp_dir: Path,
+    static_config: goldenpipe.PipelineConfig,
+) -> dict:
     csv_path = tmp_dir / f"{case_id}.csv"
     csv_path.write_text(csv_text)
 
-    result = goldenpipe.run(str(csv_path))
+    # Run the SHARED static chain (not goldenpipe.run, which uses the
+    # Python-only auto-config brain) -- see the module docstring.
+    result = Pipeline(config=static_config).run(source=str(csv_path))
 
     golden = result.artifacts.get("golden")
     unique = result.artifacts.get("unique")
@@ -102,11 +124,17 @@ def main() -> None:
     import tempfile
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    # The shared, cross-surface static chain: Pipeline._auto_config is the
+    # untouched pre-brain default (check→flow→dedupe [+identity]) that the TS
+    # parity test also runs. Build it once from a discovered registry.
+    static_config = Pipeline()._auto_config()
+
     cases: list[dict] = []
     with tempfile.TemporaryDirectory() as td:
         tmp_dir = Path(td)
         for case_id, csv_text in CASES:
-            cases.append(emit_case(case_id, csv_text, tmp_dir))
+            cases.append(emit_case(case_id, csv_text, tmp_dir, static_config))
 
     out_path = OUT_DIR / "pipe_parity.json"
     payload = {

--- a/packages/python/goldenpipe/tests/test_autoconfig_glue.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_glue.py
@@ -1,0 +1,59 @@
+import polars as pl
+from goldenpipe.autoconfig_glue import plan_to_config, profile_context
+from goldenpipe.autoconfig_planner import PipePlan, PlannedStage
+from goldenpipe.models.config import PipelineConfig
+from goldenpipe.models.context import PipeContext
+
+
+def test_profile_context_materialized_df_detects_finance():
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    ctx = PipeContext(df=df)
+    prof = profile_context(ctx)
+    assert prof.n_rows == 2
+    assert prof.n_cols == 2
+    assert prof.column_names == ("account_number", "currency")
+    assert prof.inferred_domain == "finance"
+    assert prof.domain_confidence > 0.0
+
+
+def test_profile_context_no_domain_gives_zero_confidence():
+    df = pl.DataFrame({"x": [1, 2], "y": [3, 4]})
+    prof = profile_context(PipeContext(df=df))
+    if prof.inferred_domain is None:
+        assert prof.domain_confidence == 0.0
+
+
+def test_profile_context_engine_resident_is_degraded():
+    ctx = PipeContext(df=None)
+    ctx.metadata["input_rows"] = 5000
+    prof = profile_context(ctx)
+    assert prof.n_rows == 5000
+    assert prof.column_names == ()
+    assert prof.inferred_domain is None
+    assert prof.domain_confidence == 0.0
+
+
+def test_plan_to_config_filters_by_availability_and_builds_stagespecs():
+    plan = PipePlan(
+        stages=(
+            PlannedStage("infer_schema", {"domain": "finance"}),
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("missing.stage", {}),
+        ),
+        rule_name="confident_schema", confidence=0.8, evidence={},
+    )
+    available = {"infer_schema": object(), "goldencheck.scan": object()}
+    cfg = plan_to_config(plan, available, identity_opts=None)
+    assert isinstance(cfg, PipelineConfig)
+    assert cfg.pipeline == "auto"
+    uses = [s.use for s in cfg.stages]
+    assert uses == ["infer_schema", "goldencheck.scan"]
+    assert cfg.stages[0].config == {"domain": "finance"}
+
+
+def test_plan_to_config_appends_identity_when_opts_and_available():
+    plan = PipePlan((PlannedStage("goldencheck.scan", {}),), "default", 0.7, {})
+    available = {"goldencheck.scan": object(), "goldenmatch.identity_resolve": object()}
+    cfg = plan_to_config(plan, available, identity_opts={"kinds": ["email"]})
+    assert [s.use for s in cfg.stages] == ["goldencheck.scan", "goldenmatch.identity_resolve"]
+    assert cfg.stages[-1].config == {"kinds": ["email"]}

--- a/packages/python/goldenpipe/tests/test_autoconfig_glue.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_glue.py
@@ -57,3 +57,87 @@ def test_plan_to_config_appends_identity_when_opts_and_available():
     cfg = plan_to_config(plan, available, identity_opts={"kinds": ["email"]})
     assert [s.use for s in cfg.stages] == ["goldencheck.scan", "goldenmatch.identity_resolve"]
     assert cfg.stages[-1].config == {"kinds": ["email"]}
+
+
+# --- Integration: _plan_config end-to-end through the brain -------------------
+
+from goldenpipe.engine.registry import StageRegistry  # noqa: E402
+from goldenpipe.models.context import PipeStatus, StageResult, StageStatus  # noqa: E402
+from goldenpipe.models.stage import stage  # noqa: E402
+from goldenpipe.pipeline import Pipeline  # noqa: E402
+
+
+def _stub_stage(name: str):
+    """A minimal always-succeeds Stage registered under a chosen name."""
+
+    @stage(name=name, produces=[], consumes=[])
+    def _run(ctx: PipeContext) -> StageResult:
+        return StageResult(status=StageStatus.SUCCESS)
+
+    return _run
+
+
+def _registry_with(*names: str) -> StageRegistry:
+    reg = StageRegistry()
+    for n in names:
+        reg.register(_stub_stage(n))
+    return reg
+
+
+def test_plan_config_confident_df_includes_infer_schema():
+    reg = _registry_with(
+        "infer_schema",
+        "goldencheck.scan",
+        "goldenflow.transform",
+        "goldenmatch.dedupe",
+    )
+    eng = Pipeline(registry=reg)
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    ctx = PipeContext(df=df)
+    cfg = eng._plan_config(ctx)
+    uses = [s.use for s in cfg.stages]
+    assert uses == [
+        "infer_schema",
+        "goldencheck.scan",
+        "goldenflow.transform",
+        "goldenmatch.dedupe",
+    ]
+    assert eng._last_plan.rule_name == "confident_schema"
+    assert cfg.stages[0].config == {"domain": "finance"}
+
+
+def test_plan_config_one_row_is_pathological_and_skips_dedupe():
+    reg = _registry_with(
+        "infer_schema",
+        "goldencheck.scan",
+        "goldenflow.transform",
+        "goldenmatch.dedupe",
+    )
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=pl.DataFrame({"x": [1]}))
+    cfg = eng._plan_config(ctx)
+    uses = [s.use for s in cfg.stages]
+    assert uses == ["goldencheck.scan", "goldenflow.transform"]
+    assert "goldenmatch.dedupe" not in uses
+    assert eng._last_plan.rule_name == "pathological"
+
+
+def test_plan_config_runs_end_to_end_and_preserves_order():
+    reg = _registry_with(
+        "infer_schema",
+        "goldencheck.scan",
+        "goldenflow.transform",
+        "goldenmatch.dedupe",
+    )
+    eng = Pipeline(registry=reg)
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    result = eng.run(df=df)
+    assert result.status == PipeStatus.SUCCESS
+    assert eng._last_plan.rule_name == "confident_schema"
+    ran = list(result.stages)
+    assert ran == [
+        "infer_schema",
+        "goldencheck.scan",
+        "goldenflow.transform",
+        "goldenmatch.dedupe",
+    ]

--- a/packages/python/goldenpipe/tests/test_autoconfig_planner.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_planner.py
@@ -45,3 +45,36 @@ def test_structs_are_frozen():
     p = _profile()
     with pytest.raises(dataclasses.FrozenInstanceError):
         p.n_rows = 5  # type: ignore[misc]
+
+
+from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES  # noqa: E402
+
+
+def test_rule_pathological_skips_dedupe():
+    plan = plan_pipeline(_profile(n_rows=1))
+    assert plan.rule_name == "pathological"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform",
+    )
+    assert plan.confidence == 1.0
+
+
+def test_rule_confident_schema_prepends_infer_schema():
+    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.8))
+    assert plan.rule_name == "confident_schema"
+    assert tuple(s.name for s in plan.stages) == (
+        "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+    assert plan.stages[0].config == {"domain": "finance"}
+    assert plan.confidence == 0.8
+
+
+def test_rule_weak_domain_is_default():
+    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.4))
+    assert plan.rule_name == "default"
+    assert all(s.name != "infer_schema" for s in plan.stages)
+
+
+def test_default_rules_is_the_module_table():
+    assert plan_pipeline(_profile(n_rows=1)).rule_name == "pathological"
+    assert len(DEFAULT_RULES) >= 2

--- a/packages/python/goldenpipe/tests/test_autoconfig_planner.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_planner.py
@@ -1,0 +1,47 @@
+from goldenpipe.autoconfig_planner import (
+    PipePlan,
+    PipePlannerRule,
+    PipeProfile,
+    PlannedStage,
+    plan_pipeline,
+)
+
+
+def _profile(**kw):
+    base = dict(n_rows=100, n_cols=3, column_names=("a", "b", "c"),
+                dtypes=("String", "Int64", "String"),
+                inferred_domain=None, domain_confidence=0.0)
+    base.update(kw)
+    return PipeProfile(**base)
+
+
+def test_plan_pipeline_first_match_wins_else_default():
+    fired = PipePlannerRule(
+        rule_name="fired",
+        predicate=lambda p: p.n_rows == 100,
+        action=lambda p: PipePlan(stages=(PlannedStage("x", {}),), rule_name="fired",
+                                  confidence=0.9, evidence={"n_rows": p.n_rows}),
+    )
+    plan = plan_pipeline(_profile(), rules=[fired])
+    assert plan.rule_name == "fired"
+    assert plan.stages == (PlannedStage("x", {}),)
+    assert plan.evidence == {"n_rows": 100}
+
+
+def test_plan_pipeline_falls_through_to_default():
+    never = PipePlannerRule("never", lambda p: False,
+                            lambda p: PipePlan((), "never", 0.0, {}))
+    plan = plan_pipeline(_profile(), rules=[never])
+    assert plan.rule_name == "default"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+
+
+def test_structs_are_frozen():
+    import dataclasses
+
+    import pytest
+    p = _profile()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.n_rows = 5  # type: ignore[misc]


### PR DESCRIPTION
## What

Gives GoldenPipe a plan-first auto-config **brain**, analogous to GoldenMatch's controller: instead of the fixed `scan -> transform -> dedupe` list, the pipeline shape is now **decided from the data** (+ the InferMap-inferred domain that `infer_schema` just landed on both surfaces) via a first-match rule table, with `rule_name` + confidence + evidence stamped on each decision.

This is **slice 1** of the Rust thesis workflow: prototype the feature in Python (fast iteration), harden to a pyo3-free `goldenpipe-core` later, then conform Python-native + TS-WASM to it. The decision core is deliberately kept free of Polars/Pydantic so it ports mechanically.

## Shape

- **`autoconfig_planner.py`** (portable core) -- `PipeProfile` / `PlannedStage` / `PipePlan` frozen dataclasses, `PipePlannerRule`, `plan_pipeline` first-match. No Polars, no Pydantic.
- **`autoconfig_planner_rules.py`** -- rule table: `pathological` (`n_rows <= 1` -> scan + transform, skip dedupe), `confident_schema` (`domain_confidence >= 0.5` -> infer_schema + scan + transform + dedupe), else the static default.
- **`autoconfig_glue.py`** (host bracket) -- `profile_context(ctx)` (Polars shape + `detect_domain_detailed`; engine-resident `ctx.df is None` -> degraded profile) and `plan_to_config(plan, available, identity_opts)` (filter by registry availability, append `identity_resolve`).
- **`pipeline.py`** -- new `_plan_config(ctx)` method wired into `run()`; stashes `_last_plan` for introspection. `_auto_config` is **untouched** (its `_planner_json` + test callers rely on the static default).
- **`pyproject.toml`** -- registers the `infer_schema` stage entry-point (parity with TS #1520; the `confident_schema` rule was otherwise inert).

## Tests

- 3 planner-core + 7 rule-table + 5 glue + 3 integration = **new tests all green** on the box (`_plan_config` decides confident_schema for a finance df, drops dedupe for a 1-row df, runs e2e with order preserved).
- Full goldenpipe suite: **200 passed**; the 5 remaining failures are pre-existing environmental breakage in the borrowed venv (goldenflow/goldenmatch mid-conflict + native-wheel parity), confirmed identical with these changes stashed out.

## Deferred (later slices)

- refuse-on-RED (`ControllerNotConfidentError` analogue) + confidence gating
- the `goldenpipe-core` Rust port + TS-WASM parity
- additional rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44