### PR TITLE
feat(goldenflow): Polars-free columnar engine (Phase 1) for owned string transforms

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -1,0 +1,114 @@
+"""Columnar (Polars-free) transform execution — Phase 1 of the Polars eviction
+(docs/design/2026-07-07-polars-eviction-plan.md).
+
+Applies a config's OWNED string transforms to plain Python-list columns via the
+native arrow-free fused chain (``apply_chain_str_list``) with **zero Polars, zero
+pyarrow, zero Arrow** — the proof that the owned transform path runs on the
+native/Arrow substrate alone. Non-owned / non-string / multi-column transforms are
+not handled here yet (Phase 3); a config that needs them declines to the Polars
+engine, so behavior is never wrong — only the fully-owned-string path is
+Polars-free today.
+
+Enabled with ``GOLDENFLOW_ENGINE=columnar``. Byte-identical to the Polars engine
+for the configs it accepts (gated by ``tests/engine/test_columnar_engine.py``).
+
+PERFORMANCE NOTE (measured, honest): this LIST substrate is the correctness
+foundation + a zero-dependency fallback, but it is currently ~3.3× SLOWER than the
+Polars engine at scale — the cost is the Python-list marshaling
+(``Polars→list→Rust→list→Polars``), not the kernels. "Lighter AND faster" (the
+project's bar) needs the columns held as **Arrow buffers threaded zero-copy through
+the native kernels** (the chosen native/Arrow substrate), which avoids the per-
+element Python round-trip entirely — that is Phase 1b, layered on this correctness
+proof. The list path stays as the pure-Python fallback for platforms without the
+native wheel.
+"""
+from __future__ import annotations
+
+import os
+
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine.manifest import Manifest, TransformRecord
+from goldenflow.transforms import get_transform, parse_transform_name
+from goldenflow.transforms._chain import FUSABLE_KERNELS, FUSABLE_PARAM_KERNELS
+
+Column = list  # a column is a plain Python list (str | None)
+
+
+def columnar_engine_selected() -> bool:
+    """True when ``GOLDENFLOW_ENGINE=columnar`` opts into the Polars-free path."""
+    return os.environ.get("GOLDENFLOW_ENGINE", "").lower() == "columnar"
+
+
+# The owned string kernels the columnar path can run natively (no-arg + param).
+_OWNED_STRING = FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
+
+
+def config_is_columnar_ready(config) -> bool:
+    """A config runs on the columnar engine iff EVERY op is an owned string kernel
+    (fusable) and there are no frame-level ops (splits/renames/drops/filters/dedup)
+    that Phase 1 doesn't handle yet. Otherwise the caller uses the Polars engine —
+    correctness first; coverage grows over the later phases."""
+    if config.splits or config.renames or config.drop or config.filters or config.dedup:
+        return False
+    if not config.transforms:
+        return False
+    nm = native_module()
+    if nm is None or not hasattr(nm, "apply_chain_str_list"):
+        return False
+    for spec in config.transforms:
+        for op_raw in spec.ops:
+            name, _params = parse_transform_name(op_raw)
+            if name not in _OWNED_STRING:
+                return False
+            info = get_transform(name)
+            if info is None:
+                return False
+    return True
+
+
+def _sample3(col: Column) -> list:
+    """First 3 values, null-preserving — mirrors the Polars engine's
+    ``series.head(3).cast(Utf8).to_list()`` (a string column casts to itself, nulls
+    stay ``None``). The columnar path only runs on string columns, so no coercion."""
+    return list(col[:3])
+
+
+def transform_columns(
+    columns: dict[str, Column],
+    config,
+    source: str = "<dataframe>",
+) -> tuple[dict[str, Column], Manifest]:
+    """Apply ``config``'s owned string transforms to ``columns`` (dict of Python
+    lists) entirely via the native arrow-free chain — no Polars. Returns the new
+    columns + the audit manifest, byte-identical to the Polars engine."""
+    nm = native_module()
+    manifest = Manifest(source=source)
+    columns = dict(columns)  # shallow copy; we replace whole columns
+
+    for spec in config.transforms:
+        if spec.column not in columns:
+            continue
+        ops = [parse_transform_name(op) for op in spec.ops]  # [(name, params)]
+        col = columns[spec.column]
+        total_rows = len(col)
+        # One native pass over the whole run (owned string kernels only here).
+        new_col, changed = nm.apply_chain_str_list(col, [(n, list(p)) for n, p in ops])
+        new_col = list(new_col)
+        # Per-op audit: exact affected counts from the kernel + a head(3) replay
+        # through the same native chain for before/after samples.
+        sample = col[:3]
+        for (name, params), n_changed in zip(ops, changed):
+            before = _sample3(sample)
+            sample = list(nm.apply_chain_str_list(sample, [(name, list(params))])[0])
+            after = _sample3(sample)
+            manifest.add_record(TransformRecord(
+                column=spec.column,
+                transform=name,
+                affected_rows=int(n_changed),
+                total_rows=total_rows,
+                sample_before=before,
+                sample_after=after,
+            ))
+        columns[spec.column] = new_col
+
+    return columns, manifest

--- a/packages/python/goldenflow/goldenflow/engine/transformer.py
+++ b/packages/python/goldenflow/goldenflow/engine/transformer.py
@@ -71,6 +71,20 @@ class TransformEngine:
         """Transform a DataFrame. The public API takes/returns ``pl.DataFrame``; the
         engine operates on a backend-agnostic :class:`Frame` internally (the seam for
         making Polars optional — see the Polars-eviction design doc)."""
+        # Phase 1: the columnar (Polars-free) engine. When opted in via
+        # GOLDENFLOW_ENGINE=columnar AND the config is fully owned-string, the
+        # transform EXECUTION runs on the native arrow-free chain with no Polars
+        # (only the boundary column extract/assemble touches it — Phase 2 removes
+        # that). Byte-identical to the Polars engine; anything it can't handle yet
+        # declines here and falls through to the Polars path.
+        from goldenflow.engine import columnar as _columnar
+        if _columnar.columnar_engine_selected() and _columnar.config_is_columnar_ready(self.config):
+            names = [s.column for s in self.config.transforms if s.column in df.columns]
+            cols = {c: df[c].to_list() for c in names}
+            new_cols, manifest = _columnar.transform_columns(cols, self.config, source=source)
+            out = df.with_columns([pl.Series(n, v) for n, v in new_cols.items()])
+            return TransformResult(df=out, manifest=manifest)
+
         manifest = Manifest(source=source)
         frame: Frame = to_frame(df)
 

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -1,0 +1,92 @@
+"""Columnar (Polars-free) engine — Phase 1 parity gate.
+
+The ``GOLDENFLOW_ENGINE=columnar`` path executes owned string transforms via the
+native arrow-free chain with NO Polars. It must be byte-identical to the Polars
+engine — same output frame AND same audit manifest — for every config it accepts.
+"""
+from __future__ import annotations
+
+import goldenflow  # noqa: F401 -- import-time transform registration
+import polars as pl
+import pytest
+from goldenflow import transform_df
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _manifest_rows(result) -> list[tuple]:
+    return [
+        (
+            r.column,
+            r.transform,
+            r.affected_rows,
+            tuple(r.sample_before or []),
+            tuple(r.sample_after or []),
+        )
+        for r in result.manifest.records
+    ]
+
+
+def _cfg(specs: list[tuple[str, list[str]]]) -> GoldenFlowConfig:
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+SAMPLE = pl.DataFrame({
+    "name": ["  <b>John</b>  SMITH!  ", "o'BRIEN, jr.  123", None, "café  éé  #7", "", "  a   b  "],
+    "email": ["  JOHN@X.COM ", "MARY@Y.com  ", None, "b@z.io", "", "q@a.com"],
+    "keep_int": [1, 2, 3, 4, 5, 6],
+})
+
+
+def test_native_list_binding_present() -> None:
+    nm = native_module()
+    if nm is None or not hasattr(nm, "apply_chain_str_list"):
+        pytest.skip("native arrow-free list chain not built (pre-columnar wheel)")
+    assert hasattr(nm, "apply_chain_str_list")
+
+
+@pytest.mark.parametrize(
+    "specs",
+    [
+        [("name", ["strip", "lowercase"])],
+        [("name", ["strip", "lowercase", "collapse_whitespace", "remove_punctuation"])],
+        [("name", ["remove_html_tags", "strip", "collapse_whitespace"]), ("email", ["strip", "lowercase"])],
+        [("name", ["strip", "title_case", "name_proper"])],
+        [("email", ["strip", "lowercase", "email_normalize"])],
+        [("name", ["strip", "truncate:6"])],
+    ],
+)
+def test_columnar_equals_polars(monkeypatch, specs) -> None:
+    nm = native_module()
+    if nm is None or not hasattr(nm, "apply_chain_str_list"):
+        pytest.skip("native arrow-free list chain not built")
+
+    cfg = _cfg(specs)
+    # config must actually be accepted by the columnar engine (else this proves nothing)
+    assert columnar.config_is_columnar_ready(cfg)
+
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)  # Polars engine
+    polars_out = transform_df(SAMPLE, config=cfg)
+
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")  # Polars-free path
+    columnar_out = transform_df(SAMPLE, config=cfg)
+
+    assert columnar_out.df.equals(polars_out.df), "columnar output frame diverged"
+    assert _manifest_rows(columnar_out) == _manifest_rows(polars_out), "columnar manifest diverged"
+    # untransformed column + its dtype are preserved
+    assert columnar_out.df["keep_int"].to_list() == [1, 2, 3, 4, 5, 6]
+
+
+def test_columnar_declines_unsupported_config(monkeypatch) -> None:
+    """A config with a non-owned-string op (phone) or a frame-level op is NOT
+    columnar-ready; it falls through to the Polars engine (still correct)."""
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    # phone_e164 is not an owned string kernel -> declines
+    assert not columnar.config_is_columnar_ready(_cfg([("name", ["strip", "phone_e164"])]))
+    # a rename is a frame-level op -> declines
+    cfg = GoldenFlowConfig(transforms=[TransformSpec(column="name", ops=["strip"])], renames={"name": "n"})
+    assert not columnar.config_is_columnar_ready(cfg)
+    # but it still produces correct output via the Polars fallback
+    out = transform_df(SAMPLE, config=_cfg([("name", ["strip", "phone_e164"])]))
+    assert out.df["name"].to_list()[0] == "<b>John</b>  SMITH!"  # strip applied

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.15.0"
+version = "0.16.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.15.0"
+    __version__ = "0.16.0"

--- a/packages/rust/extensions/native-flow/src/chain.rs
+++ b/packages/rust/extensions/native-flow/src/chain.rs
@@ -13,7 +13,8 @@
 use arrow::array::{make_array, Array, ArrayData, Float64Array, LargeStringArray, StringArray};
 use arrow::pyarrow::PyArrowType;
 use goldenflow_core::chain::{
-    apply_chain, apply_chain_f64, apply_chain_nullable, Kernel, NullableKernel, NumericKernel,
+    apply_chain, apply_chain_f64, apply_chain_nullable, apply_chain_str, Kernel, NullableKernel,
+    NumericKernel,
 };
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
@@ -187,4 +188,39 @@ pub fn apply_chain_nullable_arrow(
             "fused nullable apply requires a Utf8 or LargeUtf8 array",
         ))
     }
+}
+
+/// Arrow-FREE fused string chain over a Python list — the columnar-engine path
+/// that needs no pyarrow, no Polars, no Arrow. Each op is a `(name, params)` tuple
+/// (owned no-arg + parameterized string kernels; `Kernel::from_op`). Nulls (`None`)
+/// pass through unchanged and are NOT counted; non-null values are threaded through
+/// the chain (`goldenflow_core::chain::apply_chain_str`). Returns
+/// `(values, per-kernel changed counts)` — the list analogue of `apply_chain_ops_arrow`.
+#[pyfunction]
+pub fn apply_chain_str_list(
+    values: Vec<Option<String>>,
+    ops: Vec<(String, Vec<String>)>,
+) -> PyResult<(Vec<Option<String>>, Vec<u64>)> {
+    let mut kernels = Vec::with_capacity(ops.len());
+    for (name, params) in &ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        kernels.push(
+            Kernel::from_op(name, &refs).ok_or_else(|| {
+                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
+            })?,
+        );
+    }
+    // Thread only the non-null values (total kernels never null); nulls pass through.
+    let non_null: Vec<&str> = values.iter().filter_map(|v| v.as_deref()).collect();
+    let (transformed, changed) = apply_chain_str(&non_null, &kernels);
+    // Scatter the transformed values back into their (non-null) positions.
+    let mut it = transformed.into_iter();
+    let out: Vec<Option<String>> = values
+        .iter()
+        .map(|v| {
+            v.as_ref()
+                .map(|_| it.next().expect("aligned with non-null count"))
+        })
+        .collect();
+    Ok((out, changed))
 }

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -31,6 +31,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(chain::apply_chain_str_list, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_f64_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_nullable_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::fusable_kernel_names, m)?)?;


### PR DESCRIPTION
**Phase 1** of the Polars eviction: the owned string transform path now executes with **zero Polars, zero pyarrow, zero Arrow**.

## What
- **native-flow**: `apply_chain_str_list(values: list[str|None], ops) -> (values, changed)` — a pyo3 wrapper over the arrow-free `apply_chain_str` (built for WASM). Nulls pass through; per-kernel affected counts. native **0.16.0**.
- **engine/columnar.py**: applies owned string transforms via that binding, Polars-free, byte-identical manifest (exact counts + head(3) replay). `GOLDENFLOW_ENGINE=columnar` opts in; `config_is_columnar_ready` accepts only fully-owned-string configs, everything else declines to the Polars engine — **correctness first**.
- `transform_df` routes to it behind the flag; public API unchanged.

## Byte-identical
`tests/engine/test_columnar_engine.py` (columnar == polars output **and** manifest over 6 configs) + full suite **1694 pass**.

## Honest measurement (the "lighter AND faster" bar)
The LIST substrate is **~3.3× slower** than Polars at 2M rows — the cost is Python-list marshaling (`Polars→list→Rust→list→Polars`), **not** the kernels. So this is the **correctness foundation + a zero-dep fallback**, not the perf substrate. "Lighter AND faster" needs the columns held as **Arrow buffers threaded zero-copy** through the native kernels (the chosen native/Arrow substrate) — **Phase 1b**, layered on this proof. Logged, not hidden: the bar is to beat Polars, and the list path doesn't yet.

Roadmap unchanged (design doc): this is P1's correctness half; P1b = Arrow-native substrate for the perf; P2 I/O; P3 port transform signatures; P4 flip default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg