### PR TITLE
feat(goldenflow-native): native Arrow Column via pyarrow-free C-Data interop (Phase 1b core)

### DIFF
--- a/packages/python/goldenflow/tests/engine/test_native_column.py
+++ b/packages/python/goldenflow/tests/engine/test_native_column.py
@@ -1,0 +1,76 @@
+"""Native Arrow ``Column`` (Polars-eviction Phase 1b) — the pyarrow-free C-Data
+substrate. Proves the native Column round-trips a Polars frame's Arrow buffers via
+``__arrow_c_stream__`` (ingest + egress) and applies the owned fused chain
+zero-copy, byte-identical to the Polars engine, WITHOUT importing pyarrow.
+"""
+from __future__ import annotations
+
+import sys
+
+import goldenflow  # noqa: F401
+import polars as pl
+import pytest
+from goldenflow.core._native_loader import native_module
+
+nm = native_module()
+_HAS_COLUMN = nm is not None and hasattr(nm, "Column")
+pytestmark = pytest.mark.skipif(
+    not _HAS_COLUMN, reason="native Column (arrow C-data) not built (pre-Phase-1b wheel)"
+)
+
+
+def _col(values: list):
+    return native_module().Column.from_arrow(pl.DataFrame({"c": values}))
+
+
+def test_ingest_egress_roundtrip_is_identity() -> None:
+    values = ["  A  ", "b", None, "café", "", "  X Y  "]
+    col = _col(values)
+    assert len(col) == len(values)
+    assert col.to_pylist() == values
+    # egress via __arrow_c_stream__ back into Polars -> identical
+    back = pl.from_arrow(col)
+    got = back.to_series(0) if isinstance(back, pl.DataFrame) else back
+    assert got.to_list() == values
+
+
+def test_apply_chain_matches_polars_engine() -> None:
+    from goldenflow import transform_df
+    from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+
+    values = ["  <b>John</b>  SMITH  ", "o'BRIEN, JR.", None, "café  éé", "  a  b  "]
+    ops = [("strip", []), ("lowercase", []), ("collapse_whitespace", []), ("remove_html_tags", [])]
+
+    col = _col(values)
+    out_col, changed = col.apply_chain(ops)
+    native_vals = out_col.to_pylist()
+
+    # reference: the Polars engine
+    cfg = GoldenFlowConfig(transforms=[TransformSpec(column="c", ops=[n for n, _ in ops])])
+    ref = transform_df(pl.DataFrame({"c": values}), config=cfg)
+    assert native_vals == ref.df["c"].to_list()
+    # affected counts match the manifest
+    assert [int(x) for x in changed] == [r.affected_rows for r in ref.manifest.records]
+
+
+def test_roundtrip_is_pyarrow_free() -> None:
+    """The whole ingest -> chain -> egress path must not import pyarrow — that is
+    the entire point (native ~5MB substrate, not native+pyarrow+polars ~80MB)."""
+    # pyarrow may already be present from an unrelated earlier import in the run;
+    # only assert the Column path itself doesn't newly require it.
+    had_pyarrow = "pyarrow" in sys.modules
+    col = _col(["  A  ", None, "b"])
+    out, _ = col.apply_chain([("strip", []), ("uppercase", [])])
+    _ = pl.from_arrow(out)
+    if not had_pyarrow:
+        assert "pyarrow" not in sys.modules, "Column C-data path pulled in pyarrow"
+
+
+def test_chunked_input_concatenates() -> None:
+    # a chunked Polars column (append creates chunks) still ingests as one array
+    s = pl.Series("c", ["  a  ", None])
+    s2 = pl.concat([s, pl.Series("c", ["B", "c "])], rechunk=False)
+    col = native_module().Column.from_arrow(s2.to_frame())
+    assert col.to_pylist() == ["  a  ", None, "B", "c "]
+    out, _ = col.apply_chain([("strip", []), ("lowercase", [])])
+    assert out.to_pylist() == ["a", None, "b", "c"]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -425,7 +425,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "arrow",
  "goldenflow-core",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]
@@ -24,7 +24,7 @@ pyo3 = { version = ">=0.28, <0.29", features = ["extension-module", "abi3-py311"
 # Arrow C Data Interface for zero-copy kernel input/output (Utf8 / LargeUtf8
 # string buffers in, string/int/bool buffers out). default features off — we
 # only read/build array buffers, no csv/ipc/json/compute.
-arrow = { version = "59", default-features = false, features = ["pyarrow"] }
+arrow = { version = "59", default-features = false, features = ["pyarrow", "ffi"] }
 # Dates are intentionally NOT a native kernel: GoldenFlow's Polars fast path
 # (str.to_date coalesce) already resolves the 4-digit-year formats in vectorized
 # Rust, and a per-row chrono parser would be slower while reintroducing the

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.16.0"
+version = "0.17.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.16.0"
+    __version__ = "0.17.0"

--- a/packages/rust/extensions/native-flow/src/column.rs
+++ b/packages/rust/extensions/native-flow/src/column.rs
@@ -1,0 +1,170 @@
+//! Native Arrow `Column` — Phase 1b of the Polars eviction. A Rust-owned Arrow
+//! array that ingests from / egresses to Python via the Arrow **C-Data /
+//! PyCapsule** interface (`__arrow_c_stream__`), so it needs **no pyarrow and no
+//! Polars** to hold or move Arrow buffers. Transforms run on it via the owned
+//! fused chain (Column -> Column, zero-copy), avoiding the per-transform
+//! `to_arrow`/`from_arrow` round-trip that couples the engine to Polars.
+//!
+//! Correctness is proven by parity (round-trip a Polars Series through `Column`);
+//! the speed win is a CI number (the dev box is too noisy to trust locally).
+
+use std::ffi::CString;
+use std::sync::Arc;
+
+use arrow::array::{make_array, Array, ArrayRef, LargeStringArray, StringArray};
+use arrow::compute::{cast, concat};
+use arrow::datatypes::{DataType, Field, Schema};
+use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+use arrow::record_batch::{RecordBatch, RecordBatchIterator, RecordBatchReader};
+use pyo3::exceptions::{PyTypeError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyList};
+
+use goldenflow_core::chain::{apply_chain, Kernel};
+
+const STREAM_NAME: &[u8] = b"arrow_array_stream";
+
+/// A Rust-owned Arrow column (one logical column, always a single contiguous
+/// array after ingest). Utf8 or LargeUtf8 for the owned string transform path.
+#[pyclass]
+pub struct Column {
+    array: ArrayRef,
+}
+
+impl Column {
+    fn new(array: ArrayRef) -> Self {
+        Column { array }
+    }
+}
+
+#[pymethods]
+impl Column {
+    /// Ingest a Python object exposing the Arrow C-stream interface (Polars
+    /// Series/DataFrame-column, or any `__arrow_c_stream__` producer) into a
+    /// Rust-owned array — zero-copy, pyarrow-free. Chunks are concatenated into
+    /// one contiguous array.
+    #[staticmethod]
+    fn from_arrow(py: Python, obj: &Bound<'_, PyAny>) -> PyResult<Column> {
+        let capsule_obj = obj.call_method0("__arrow_c_stream__")?;
+        let capsule = capsule_obj
+            .cast::<PyCapsule>()
+            .map_err(|_| PyTypeError::new_err("__arrow_c_stream__ did not return a PyCapsule"))?;
+        // Take ownership of the FFI stream (per the Arrow PyCapsule protocol: move
+        // it out, leaving a released/empty struct so the producer won't double-free).
+        #[allow(deprecated)] // pointer() is fine here; the checked variant's API churned
+        let ptr = capsule.pointer() as *mut FFI_ArrowArrayStream;
+        if ptr.is_null() {
+            return Err(PyValueError::new_err("null arrow_array_stream capsule"));
+        }
+        // Ingest is a one-time boundary op (not the hot loop), and the raw FFI
+        // pointer isn't Send, so run it under the GIL. `from_raw` performs the
+        // C-Data-interface move (the producer's release is transferred), so the
+        // capsule won't double-free.
+        let _ = py;
+        let reader = unsafe { ArrowArrayStreamReader::from_raw(ptr) }
+            .map_err(|e| PyValueError::new_err(format!("arrow stream import: {e}")))?;
+        let empty_type = reader.schema().field(0).data_type().clone();
+        let mut chunks: Vec<ArrayRef> = Vec::new();
+        for batch in reader {
+            let b = batch.map_err(|e| PyValueError::new_err(e.to_string()))?;
+            if b.num_columns() != 1 {
+                return Err(PyTypeError::new_err("expected a single-column stream"));
+            }
+            chunks.push(b.column(0).clone());
+        }
+        let array: ArrayRef = if chunks.len() == 1 {
+            chunks.into_iter().next().unwrap()
+        } else if chunks.is_empty() {
+            make_array(arrow::array::ArrayData::new_empty(&empty_type))
+        } else {
+            let refs: Vec<&dyn Array> = chunks.iter().map(|a| a.as_ref()).collect();
+            concat(&refs).map_err(|e| PyValueError::new_err(e.to_string()))?
+        };
+        // Polars 1.x exports strings as Utf8View; normalize to LargeUtf8 (what the
+        // owned chain + egress expect). Same materialization the `to_arrow` path
+        // already pays, but reached pyarrow-free.
+        let array = if matches!(array.data_type(), DataType::Utf8View) {
+            cast(&array, &DataType::LargeUtf8).map_err(|e| PyValueError::new_err(e.to_string()))?
+        } else {
+            array
+        };
+        Ok(Column::new(array))
+    }
+
+    fn __len__(&self) -> usize {
+        self.array.len()
+    }
+
+    /// Egress via the Arrow C-stream interface — the native Column IS an Arrow
+    /// producer, so `pl.from_arrow(column)` / any Arrow consumer imports it
+    /// zero-copy, pyarrow-free.
+    #[pyo3(signature = (requested_schema=None))]
+    fn __arrow_c_stream__<'py>(
+        &self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let _ = requested_schema; // we always export our own schema
+        let field = Field::new("", self.array.data_type().clone(), true);
+        let schema = Arc::new(Schema::new(vec![field]));
+        let batch = RecordBatch::try_new(schema.clone(), vec![self.array.clone()])
+            .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let reader = RecordBatchIterator::new(vec![Ok(batch)], schema);
+        let stream = FFI_ArrowArrayStream::new(Box::new(reader));
+        let name = CString::new(STREAM_NAME).unwrap();
+        let capsule = PyCapsule::new(py, stream, Some(name))?;
+        Ok(capsule.into_any())
+    }
+
+    /// Materialize as a Python `list[str | None]` (Utf8/LargeUtf8 only). Egress
+    /// helper for tests / the pure path; the zero-copy egress is
+    /// `__arrow_c_stream__`.
+    fn to_pylist<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyList>> {
+        let list = PyList::empty(py);
+        if let Some(a) = self.array.as_any().downcast_ref::<StringArray>() {
+            for v in a.iter() {
+                list.append(v)?;
+            }
+        } else if let Some(a) = self.array.as_any().downcast_ref::<LargeStringArray>() {
+            for v in a.iter() {
+                list.append(v)?;
+            }
+        } else {
+            return Err(PyTypeError::new_err(
+                "to_pylist requires a Utf8/LargeUtf8 column",
+            ));
+        }
+        Ok(list)
+    }
+
+    /// Apply a run of owned string kernels (`(name, params)` tuples) to this
+    /// column, returning `(new_column, per-kernel changed counts)`. Zero-copy
+    /// Column->Column: no Polars, no per-transform Arrow round-trip.
+    fn apply_chain(
+        &self,
+        py: Python,
+        ops: Vec<(String, Vec<String>)>,
+    ) -> PyResult<(Column, Vec<u64>)> {
+        let mut kernels = Vec::with_capacity(ops.len());
+        for (name, params) in &ops {
+            let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+            kernels.push(Kernel::from_op(name, &refs).ok_or_else(|| {
+                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
+            })?);
+        }
+        let (array, changed) = py.detach(|| -> PyResult<(ArrayRef, Vec<u64>)> {
+            if let Some(s) = self.array.as_any().downcast_ref::<StringArray>() {
+                let r = apply_chain(s, &kernels);
+                Ok((Arc::new(r.array) as ArrayRef, r.changed))
+            } else if let Some(s) = self.array.as_any().downcast_ref::<LargeStringArray>() {
+                let r = apply_chain(s, &kernels);
+                Ok((Arc::new(r.array) as ArrayRef, r.changed))
+            } else {
+                Err(PyTypeError::new_err(
+                    "Column.apply_chain requires a Utf8/LargeUtf8 column",
+                ))
+            }
+        })?;
+        Ok((Column::new(array), changed))
+    }
+}

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -15,6 +15,7 @@ mod address;
 mod autocorrect;
 mod categorical;
 mod chain;
+mod column;
 mod company;
 mod email;
 mod identifiers;
@@ -29,6 +30,7 @@ mod util;
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add_class::<column::Column>()?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_str_list, m)?)?;


### PR DESCRIPTION
**The Phase 1b linchpin — and it works.** A Rust-owned Arrow `Column` that ingests from / egresses to Python over the Arrow **C-Data / PyCapsule** interface (`__arrow_c_stream__`) with **no pyarrow and no Polars**, and applies the owned fused chain **zero-copy** (Column→Column, no per-transform `to_arrow`/`from_arrow`).

## Why it matters (weight)
`[native]` today = polars(~35MB) + pyarrow(~40MB) + native(~5MB) ≈ **80MB**, and the fused path's speed uses `to_arrow`/`from_arrow` which **require pyarrow**. This proves the native layer can hold + move Arrow buffers **pyarrow-free** → target is **native ~5MB alone**.

## What
`native-flow/src/column.rs` — `Column` pyclass:
- `from_arrow(obj)`: read the `arrow_array_stream` PyCapsule → arrow-rs `ArrowArrayStreamReader::from_raw` → concat chunks → one array (`unsafe` C-Data move). Polars 1.x exports `Utf8View`, normalized to `LargeUtf8` (same materialization the `to_arrow` path already pays, reached pyarrow-free).
- `apply_chain(ops)`: owned fused chain, zero-copy, GIL released.
- `__arrow_c_stream__`: egress as an `FFI_ArrowArrayStream` PyCapsule (the Column IS an Arrow producer; `pl.from_arrow` imports it pyarrow-free).
- arrow crate: +`ffi` feature (no new dep). native **0.16→0.17**.

## Verified by parity (not trust)
`tests/engine/test_native_column.py` (4 tests): ingest/egress round-trip is identity; `apply_chain` output **and** affected counts == the Polars engine; the whole path does **not import pyarrow**; chunked input concatenates. Correctness proven; the **speed number is deferred to CI** (the dev box gave 263–362ms for the same call) per the design doc's discipline for `unsafe` FFI.

## Next
Wire the columnar engine to hold/thread `Column` (zero-copy, replacing the list-marshaling path) — that's where the "beat Polars" wall-clock lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg