### PR TITLE
feat(web): document-ingest REST endpoints (POST /api/v1/documents/{suggest-schema,ingest})

### DIFF
--- a/docs/superpowers/plans/2026-07-07-documents-rest.md
+++ b/docs/superpowers/plans/2026-07-07-documents-rest.md
@@ -1,0 +1,325 @@
+# Document Ingest REST Endpoint Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `POST /api/v1/documents/suggest-schema` and `POST /api/v1/documents/ingest` to the `[web]` FastAPI app — a thin HTTP surface over the shipped `goldenmatch.documents` functions.
+
+**Architecture:** One new router (`web/routers/documents.py`, `APIRouter(prefix="/api/v1")`) wired into `create_app`, inheriting the app's bearer-auth middleware. Multipart uploads are written to a temp dir (extension preserved), then the shipped `suggest_schema_from_file` / `ingest_documents` run in a `ThreadPoolExecutor` off the event loop. The router has zero extraction logic.
+
+**Tech Stack:** FastAPI, `python-multipart` (uploads), Polars, pytest + `fastapi.testclient`.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-documents-rest-design.md`
+
+---
+
+## Conventions for every task
+
+- **Worktree:** `D:/show_case/gm-docs-rest` (branch `feat/documents-rest`). Do NOT push, do NOT touch `main`.
+- **Test env** (from `packages/python/goldenmatch`):
+  ```bash
+  cd D:/show_case/gm-docs-rest/packages/python/goldenmatch
+  PY="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="D:/show_case/gm-docs-rest/packages/python/goldenmatch;D:/show_case/gm-docs-rest/packages/python/goldenflow"
+  export GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+  ```
+  (`GOLDENMATCH_NATIVE=0` forces the pure-Python documents path — this worktree has no built `_native`, and the HTTP tests don't exercise the kernel.)
+- **Prereq:** `"$PY" -c "import fastapi, multipart, PIL, fitz" 2>/dev/null || "$PY" -m pip install fastapi python-multipart pymupdf Pillow` (the shared venv already has fastapi/PIL/fitz from other work; `python-multipart` may be missing).
+- **Lint before each commit:** `"$PY" -m ruff check goldenmatch/web/routers/documents.py tests/web`.
+- **Commit trailers:** copy from `git log -1 --format=%B`. `git -c commit.gpgsign=false commit`.
+
+---
+
+## File structure (locked)
+
+| path | responsibility |
+|---|---|
+| `goldenmatch/web/routers/documents.py` | the two endpoints + the temp-file upload adapter |
+| `goldenmatch/web/app.py` (modify) | import + `include_router(documents_router.router)` |
+| `pyproject.toml` (modify) | add `python-multipart` to the `[web]` extra |
+| `tests/web/test_documents_router.py` | offline TestClient tests (FakeExtractor / stubbed suggest) |
+
+---
+
+## Task 1: Dependency + empty router wired into the app
+
+**Files:** Modify `pyproject.toml`, `goldenmatch/web/app.py`; Create `goldenmatch/web/routers/documents.py`; Test `tests/web/test_documents_router.py`
+
+- [ ] **Step 1: Failing test** — the app registers the two document routes:
+  ```python
+  from pathlib import Path
+  from fastapi.testclient import TestClient
+  from goldenmatch.web.app import create_app
+  from goldenmatch.web.state import AppState
+
+
+  def _client(tmp_path):
+      state = AppState(project_root=tmp_path, config_path=None,
+                       labels_path=tmp_path / "labels.jsonl")
+      return TestClient(create_app(state))
+
+
+  def test_document_routes_registered(tmp_path):
+      client = _client(tmp_path)
+      paths = {r.path for r in client.app.routes}
+      assert "/api/v1/documents/suggest-schema" in paths
+      assert "/api/v1/documents/ingest" in paths
+  ```
+- [ ] **Step 2: Run → fail.** `"$PY" -m pytest tests/web/test_documents_router.py -q` (routes missing).
+- [ ] **Step 3: Implement.**
+  - `pyproject.toml`: in the `[project.optional-dependencies]` `web = [...]` list, add `"python-multipart>=0.0.9"`.
+  - Create `goldenmatch/web/routers/documents.py`:
+    ```python
+    """POST /api/v1/documents/{suggest-schema,ingest} -- HTTP surface over goldenmatch.documents.
+
+    Thin adapter: multipart uploads -> temp files (extension preserved so loader.load_pages
+    routes PDF vs image) -> the shipped suggest_schema_from_file / ingest_documents (which run
+    through documents-core natively, pure-Python fallback otherwise). No extraction logic here.
+    """
+    from __future__ import annotations
+
+    import asyncio
+    import json
+    import tempfile
+    from concurrent.futures import ThreadPoolExecutor
+    from pathlib import Path
+
+    from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+    from goldenmatch.documents import ingest_documents
+    from goldenmatch.documents.config import resolve_extractor
+    from goldenmatch.documents.schema_io import schema_from_dict, schema_to_dict
+    from goldenmatch.documents.suggest import suggest_schema_from_file
+
+    router = APIRouter(prefix="/api/v1")
+    _executor = ThreadPoolExecutor(max_workers=2)
+
+
+    def _save_uploads(tmpdir: str, files: list[UploadFile]) -> list[str]:
+        paths: list[str] = []
+        for f in files:
+            suffix = Path(f.filename or "upload").suffix or ".bin"
+            p = Path(tmpdir) / f"doc{len(paths)}{suffix}"
+            p.write_bytes(f.file.read())
+            paths.append(str(p))
+        return paths
+
+
+    @router.post("/documents/suggest-schema")
+    async def suggest_schema_endpoint(
+        file: UploadFile = File(...),
+        backend: str = Form("vlm"),
+        model: str = Form("gpt-4o"),
+    ):
+        def work():
+            with tempfile.TemporaryDirectory() as td:
+                (path,) = _save_uploads(td, [file])
+                schema = suggest_schema_from_file(path, backend=backend, model=model)
+                return {"schema": schema_to_dict(schema)}
+        try:
+            return await asyncio.get_event_loop().run_in_executor(_executor, work)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+    @router.post("/documents/ingest")
+    async def ingest_endpoint(
+        files: list[UploadFile] | None = File(None),
+        schema: str = Form(...),
+        drop_empty: bool = Form(True),
+        backend: str = Form("vlm"),
+        model: str = Form("gpt-4o"),
+    ):
+        if not files:
+            raise HTTPException(status_code=400, detail="no files uploaded")
+        try:
+            target = schema_from_dict(json.loads(schema))
+        except (ValueError, json.JSONDecodeError) as e:
+            raise HTTPException(status_code=400, detail=f"invalid schema: {e}") from e
+
+        def work():
+            with tempfile.TemporaryDirectory() as td:
+                paths = _save_uploads(td, files)
+                extractor = resolve_extractor(backend, model)  # ValueError on bad backend/key
+                df, report = ingest_documents(paths, target, extractor=extractor,
+                                              drop_empty=drop_empty, return_report=True)
+                return {
+                    "records": df.to_dicts(),
+                    "report": {
+                        "n_files": report.n_files, "n_rows": report.n_rows,
+                        "errors": [{"file": f, "error": e} for (f, e) in report.errors],
+                    },
+                }
+        try:
+            return await asyncio.get_event_loop().run_in_executor(_executor, work)
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+    ```
+  - `goldenmatch/web/app.py`: with the other `from goldenmatch.web.routers import X as X_router` lines, add `from goldenmatch.web.routers import documents as documents_router`; with the other `app.include_router(...)` calls, add `app.include_router(documents_router.router)`.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `feat(web): document-ingest router scaffold + wiring + python-multipart`.
+
+---
+
+## Task 2: `suggest-schema` endpoint
+
+**Files:** Test `tests/web/test_documents_router.py` (add cases). Implementation already in place from Task 1 — these tests drive/verify it.
+
+- [ ] **Step 1: Failing test** — stub `suggest_schema_from_file` at the router module's reference so no live VLM call runs:
+  ```python
+  import io
+  import goldenmatch.web.routers.documents as docrouter
+  from goldenmatch.documents.types import Field, TargetSchema
+  from PIL import Image
+
+
+  def _png_bytes():
+      buf = io.BytesIO(); Image.new("RGB", (20, 20), "white").save(buf, format="PNG")
+      return buf.getvalue()
+
+
+  def test_suggest_schema_returns_schema(tmp_path, monkeypatch):
+      monkeypatch.setattr(docrouter, "suggest_schema_from_file",
+                          lambda path, **k: TargetSchema([Field("full_name"), Field("email", kind="email")]))
+      client = _client(tmp_path)
+      resp = client.post("/api/v1/documents/suggest-schema",
+                         files={"file": ("card.png", _png_bytes(), "image/png")})
+      assert resp.status_code == 200, resp.text
+      assert resp.json()["schema"]["fields"][0]["name"] == "full_name"
+  ```
+- [ ] **Step 2: Run → verify PASS** (implementation exists from Task 1). If it fails, fix the router. Also confirm the stub is hit (no network).
+- [ ] **Step 3: (no new impl expected)** — if a real gap surfaces, fix `documents.py`.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `test(web): suggest-schema endpoint`.
+
+---
+
+## Task 3: `ingest` endpoint
+
+**Files:** Test `tests/web/test_documents_router.py` (add cases).
+
+- [ ] **Step 1: Failing test** — inject a `FakeExtractor` by monkeypatching `resolve_extractor` at the router module's reference (upload a REAL png so `load_pages` succeeds; `FakeExtractor` returns canned rows):
+  ```python
+  import json
+  from goldenmatch.documents.extractor import FakeExtractor
+  from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+
+  SCHEMA = TargetSchema([Field("full_name"), Field("email")])
+
+
+  def test_ingest_returns_records_and_report(tmp_path, monkeypatch):
+      row = ExtractedRow.from_partial({"full_name": "Ada", "email": "ada@x.io"}, {},
+                                      SCHEMA, source_file="", source_page=0)
+      monkeypatch.setattr(docrouter, "resolve_extractor",
+                          lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+      client = _client(tmp_path)
+      resp = client.post(
+          "/api/v1/documents/ingest",
+          files=[("files", ("a.png", _png_bytes(), "image/png"))],
+          data={"schema": json.dumps({"fields": [{"name": "full_name"}, {"name": "email"}]})},
+      )
+      assert resp.status_code == 200, resp.text
+      body = resp.json()
+      assert body["report"]["n_rows"] == 1 and body["report"]["n_files"] == 1
+      rec = body["records"][0]
+      assert rec["full_name"] == "Ada" and rec["email"] == "ada@x.io"
+      # sidecar columns present for the dedupe_df exclude_columns handoff
+      assert "_source_file" in rec and "_source_page" in rec and "_extract_confidence" in rec
+  ```
+- [ ] **Step 2: Run → verify PASS** (impl from Task 1). Confirm no live call (FakeExtractor used).
+- [ ] **Step 3:** fix `documents.py` only if a real gap appears.
+- [ ] **Step 4: Run → pass.**
+- [ ] **Step 5: Commit** `test(web): ingest endpoint returns records + report`.
+
+---
+
+## Task 4: Error + auth contract
+
+**Files:** Test `tests/web/test_documents_router.py` (add cases).
+
+- [ ] **Step 1: Failing tests:**
+  ```python
+  def test_ingest_malformed_schema_400(tmp_path):
+      client = _client(tmp_path)
+      resp = client.post("/api/v1/documents/ingest",
+                         files=[("files", ("a.png", _png_bytes(), "image/png"))],
+                         data={"schema": "not json"})
+      assert resp.status_code == 400
+      assert "schema" in resp.json()["detail"].lower()
+
+
+  def test_ingest_no_files_400(tmp_path):
+      client = _client(tmp_path)
+      resp = client.post("/api/v1/documents/ingest",
+                         data={"schema": '{"fields":[{"name":"x"}]}'})
+      assert resp.status_code == 400  # optional files param -> handler's 400, not FastAPI 422
+
+
+  def test_auth_required_401_when_token_set(tmp_path, monkeypatch):
+      monkeypatch.setenv("GOLDENMATCH_WEB_TOKEN", "secret")  # middleware only enforces when set
+      client = _client(tmp_path)
+      resp = client.post("/api/v1/documents/ingest",
+                         files=[("files", ("a.png", _png_bytes(), "image/png"))],
+                         data={"schema": '{"fields":[{"name":"x"}]}'})
+      assert resp.status_code == 401
+  ```
+- [ ] **Step 2: Run → verify.** The malformed-schema and auth cases should pass with Task 1's code. For `no_files`: confirm the `files: ... | None = File(None)` default yields the handler's 400 (NOT a 422). If FastAPI still returns 422, adjust the param so the missing-field case reaches the handler (e.g. keep `File(None)` and ensure no other required-field 422 fires first).
+- [ ] **Step 3:** adjust `documents.py` if the no-files path returns 422 instead of 400.
+- [ ] **Step 4: Run → pass** (full file: `"$PY" -m pytest tests/web/test_documents_router.py -q`).
+- [ ] **Step 5: Commit** `test(web): document endpoints error + auth contract`.
+
+---
+
+## Task 5: Gated live smoke + README note
+
+**Files:** Test `tests/web/test_documents_router_live.py`; Modify `goldenmatch/documents/README.md`
+
+- [ ] **Step 1: Live smoke (skipped without a key):**
+  ```python
+  import io, os
+  import pytest
+  from PIL import Image, ImageDraw
+  from fastapi.testclient import TestClient
+  from goldenmatch.web.app import create_app
+  from goldenmatch.web.state import AppState
+
+  pytestmark = pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY_PERSONAL"),
+                                  reason="live VLM smoke; set OPENAI_API_KEY_PERSONAL")
+
+
+  def test_live_suggest_then_ingest(tmp_path):
+      img = Image.new("RGB", (400, 200), "white"); d = ImageDraw.Draw(img)
+      d.text((20, 40), "Ada Lovelace", fill="black"); d.text((20, 80), "ada@x.io", fill="black")
+      buf = io.BytesIO(); img.save(buf, format="PNG"); png = buf.getvalue()
+      client = TestClient(create_app(AppState(project_root=tmp_path, config_path=None,
+                                              labels_path=tmp_path / "labels.jsonl")))
+      s = client.post("/api/v1/documents/suggest-schema",
+                      files={"file": ("card.png", png, "image/png")})
+      assert s.status_code == 200 and s.json()["schema"]["fields"]
+  ```
+- [ ] **Step 2: Run → SKIPPED** (no key).
+- [ ] **Step 3: Append a "REST" section to `goldenmatch/documents/README.md`:**
+  ````markdown
+  ## REST (goldenmatch[web])
+
+  ```bash
+  # suggest a schema from a sample
+  curl -F file=@form.pdf localhost:8000/api/v1/documents/suggest-schema
+  # ingest a pile against a schema -> records + report JSON
+  curl -F files=@a.pdf -F files=@b.jpg -F schema='{"fields":[{"name":"full_name"},{"name":"email","kind":"email"}]}' \
+       localhost:8000/api/v1/documents/ingest
+  ```
+  Records carry `_source_file`/`_source_page`/`_extract_confidence`; pass them to
+  `dedupe_df(exclude_columns=...)`. Auth: set `GOLDENMATCH_WEB_TOKEN` and send `Authorization: Bearer`.
+  ````
+- [ ] **Step 4: Full suite + lint.** `"$PY" -m pytest tests/web/test_documents_router.py tests/web/test_documents_router_live.py -q` (live skipped) and ruff clean.
+- [ ] **Step 5: Commit** `docs(web): REST usage + gated live smoke`.
+
+---
+
+## Done-when
+
+- `tests/web/test_documents_router.py` green (live smoke skipped without a key), ruff clean.
+- `POST /api/v1/documents/suggest-schema` + `/ingest` registered, behind the bearer middleware,
+  returning the documented JSON shapes; records feed `dedupe_df(exclude_columns=[...])`.
+- `python-multipart` in the `[web]` extra.
+- Deferred (not here): async jobs, streaming, the Web UI frontend, rate limiting.

--- a/docs/superpowers/plans/2026-07-07-documents-rest.md
+++ b/docs/superpowers/plans/2026-07-07-documents-rest.md
@@ -116,7 +116,7 @@
                 schema = suggest_schema_from_file(path, backend=backend, model=model)
                 return {"schema": schema_to_dict(schema)}
         try:
-            return await asyncio.get_event_loop().run_in_executor(_executor, work)
+            return await asyncio.get_running_loop().run_in_executor(_executor, work)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
 
@@ -150,7 +150,7 @@
                     },
                 }
         try:
-            return await asyncio.get_event_loop().run_in_executor(_executor, work)
+            return await asyncio.get_running_loop().run_in_executor(_executor, work)
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
     ```

--- a/docs/superpowers/specs/2026-07-07-documents-rest-design.md
+++ b/docs/superpowers/specs/2026-07-07-documents-rest-design.md
@@ -58,8 +58,14 @@ under the hood), so REST inherits the fallback thesis for free.
   `suggest_schema_from_file` already raise `ValueError` at config time; map to 400).
 - A corrupt/unreadable individual file -> recorded in `report.errors`, response still **200**
   (batch-safe, already handled by `ingest_documents`).
-- No files / empty upload -> **400**.
+- No files / empty upload -> **400**. NOTE: declare `files` as OPTIONAL (`File(None)` / default `[]`)
+  and check length in the handler — a required `UploadFile` field makes FastAPI return its own
+  **422** before the handler runs, which wouldn't match this 400 contract.
 - Follow the existing routers' convention: raise `HTTPException(status_code=..., detail=...)`.
+- **`report.errors` serialization:** `IngestReport.errors` is `list[tuple[str, str]]` — map it
+  explicitly to `[{"file": f, "error": e} for (f, e) in report.errors]` (copy the exact mapping from
+  `mcp/document_tools.py::handle_document_tool`); a naive `dataclasses.asdict` would emit 2-element
+  arrays instead of the documented `{file, error}` objects.
 
 ## Testing (offline-first, matches repo)
 
@@ -68,7 +74,10 @@ under the hood), so REST inherits the fallback thesis for free.
   `TargetSchema`, so NO live VLM call runs in CI.
 - Cases: `suggest-schema` returns a schema dict; `ingest` returns records + report with the sidecar
   columns; a malformed `schema` field -> 400; no `file`/`files` -> 400; **auth required** -> 401
-  without the bearer token (proves the middleware wraps the new routes).
+  without the bearer token. NOTE: the bearer middleware only enforces when `GOLDENMATCH_WEB_TOKEN` is
+  set, so the 401 test must `monkeypatch.setenv("GOLDENMATCH_WEB_TOKEN", "secret")` (see the
+  precedent in `tests/test_wave1_http_hardening.py::TestWebAuthMiddleware`) — otherwise it silently
+  passes for the wrong reason.
 - One gated live smoke (`OPENAI_API_KEY_PERSONAL`), excluded from CI.
 - Tests need the `[web]` extra (fastapi + `python-multipart`) + `[documents]` (Pillow/pymupdf); CI
   already installs `[documents]` (from #1508) — the `[web]` install for this job must include

--- a/docs/superpowers/specs/2026-07-07-documents-rest-design.md
+++ b/docs/superpowers/specs/2026-07-07-documents-rest-design.md
@@ -1,0 +1,94 @@
+# Document Ingest REST endpoint — design
+
+**Goal.** Expose the shipped `goldenmatch.documents` capability over HTTP in the `[web]` FastAPI
+app: upload documents, get back records ready for `dedupe_df`, plus an AI-schema-suggestion
+endpoint. This is the foundational surface — the Web UI (next sub-project) and a possible TS client
+consume it.
+
+**Builds on:** Phase 1 (`ingest_documents`), Phase 2 (`suggest_schema_from_file`, `schema_io`),
+documents-core (native kernels) — all merged to main. The router adds NO extraction logic.
+
+## Decisions (settled in brainstorming)
+
+- **Synchronous v1:** POST files -> wait -> records/report JSON in the response. Mirrors the MCP
+  tool. Async jobs + streaming are deferred.
+- **Multipart uploads:** clients send file bytes (browser + programmatic); the router writes each to
+  a temp file preserving the extension (so `loader.load_pages` routes PDF vs image), then calls the
+  shipped Python. Needs `python-multipart` (add to the `[web]` extra).
+- **Reuse the app's bearer auth** (the `create_app` middleware wraps all routes) — no per-route auth.
+
+## Module + wiring
+
+- `goldenmatch/web/routers/documents.py` — `router = APIRouter(prefix="/api/v1")`, two endpoints.
+- `goldenmatch/web/app.py` (modify) — `from goldenmatch.web.routers import documents as documents_router`
+  + `app.include_router(documents_router.router)` (with the other `include_router` calls).
+- Blocking work (VLM calls / ingest) runs in a `ThreadPoolExecutor` off the event loop, mirroring
+  `autoconfig.py`'s pattern (endpoints are `async def`, delegate the sync body via
+  `loop.run_in_executor`).
+
+## Endpoints (under `/api/v1/documents`)
+
+**`POST /documents/suggest-schema`** — `multipart/form-data`:
+- `file`: one `UploadFile`.
+- `backend` (form, default `"vlm"`), `model` (form, default `"gpt-4o"`).
+- -> `200 {"schema": {"fields": [{"name","kind","hint"}, ...]}}` (from `schema_to_dict`).
+
+**`POST /documents/ingest`** — `multipart/form-data`:
+- `files`: `list[UploadFile]`.
+- `schema`: a JSON string of `{"fields":[...]}` (parsed via `schema_from_dict`).
+- `drop_empty` (form bool, default `true`), `backend`, `model`.
+- -> `200 {"records": [...], "report": {"n_files", "n_rows", "errors": [{"file","error"}]}}` — the
+  same shape as the MCP `documents_ingest` tool (`df.to_dicts()` + the `IngestReport`). Records carry
+  the schema columns + `_source_file`/`_source_page`/`_extract_confidence`; the response documents
+  that callers pass those three to `dedupe_df(exclude_columns=...)`.
+
+## Data flow
+
+`UploadFile`(s) -> write to a `tempfile.TemporaryDirectory`, each keeping its original suffix ->
+`ingest_documents(temp_paths, schema, backend=, model=, drop_empty=, return_report=True)` (or
+`suggest_schema_from_file(temp_path, backend=, model=)`) -> serialize -> JSON -> temp dir cleaned up
+in a `finally`. The extractor is resolved by the shipped `config.resolve_extractor` (native kernels
+under the hood), so REST inherits the fallback thesis for free.
+
+## Error handling
+
+- Missing/invalid `schema` JSON -> **400** with a clear message (catch the `ValueError` from
+  `schema_from_dict`).
+- No OpenAI key for the `vlm` backend / unknown backend -> **400** (the shipped `resolve_extractor` /
+  `suggest_schema_from_file` already raise `ValueError` at config time; map to 400).
+- A corrupt/unreadable individual file -> recorded in `report.errors`, response still **200**
+  (batch-safe, already handled by `ingest_documents`).
+- No files / empty upload -> **400**.
+- Follow the existing routers' convention: raise `HTTPException(status_code=..., detail=...)`.
+
+## Testing (offline-first, matches repo)
+
+- FastAPI `TestClient` against `create_app(...)`; monkeypatch `resolve_extractor` (at the reference
+  the router module imported) to a `FakeExtractor`, and `suggest_schema_from_file` to a canned
+  `TargetSchema`, so NO live VLM call runs in CI.
+- Cases: `suggest-schema` returns a schema dict; `ingest` returns records + report with the sidecar
+  columns; a malformed `schema` field -> 400; no `file`/`files` -> 400; **auth required** -> 401
+  without the bearer token (proves the middleware wraps the new routes).
+- One gated live smoke (`OPENAI_API_KEY_PERSONAL`), excluded from CI.
+- Tests need the `[web]` extra (fastapi + `python-multipart`) + `[documents]` (Pillow/pymupdf); CI
+  already installs `[documents]` (from #1508) — the `[web]` install for this job must include
+  `python-multipart`.
+
+## Dependencies
+
+- Add `python-multipart>=0.0.9` to the `[web]` optional-dependency extra (FastAPI `UploadFile`/`Form`
+  require it). Verify the web CI/test lane installs `[web]`.
+
+## Scope (YAGNI)
+
+**In:** the two sync endpoints + router + `create_app` wiring + `python-multipart` dep + offline
+tests. **Out:** async jobs, streaming/progress, the Web UI frontend (next surface), rate limiting,
+persistence of uploads.
+
+## Open risks
+
+- **Sync timeout on big batches:** a large upload (many docs x seconds each) can exceed a proxy/HTTP
+  timeout. Accepted for v1 (the async path is the documented next step); the response's `report`
+  still lets a client see partial success. Do NOT add a silent doc cap without surfacing it.
+- **Temp-file lifecycle:** ensure the `TemporaryDirectory` is cleaned even when `ingest_documents`
+  raises — use a `with`/`finally`.

--- a/packages/python/goldenmatch/goldenmatch/documents/README.md
+++ b/packages/python/goldenmatch/goldenmatch/documents/README.md
@@ -35,3 +35,16 @@ goldenmatch ingest-docs run inbox/*.pdf --schema schema.json --out records.csv
 
 - `documents_suggest_schema(sample_path)` → proposed schema JSON
 - `documents_ingest(paths, schema, out_path?)` → `{records, report}` (records ready for dedupe)
+
+## REST (goldenmatch[web])
+
+```bash
+# suggest a schema from a sample
+curl -F file=@form.pdf localhost:8000/api/v1/documents/suggest-schema
+# ingest a pile against a schema -> records + report JSON
+curl -F files=@a.pdf -F files=@b.jpg -F schema='{"fields":[{"name":"full_name"},{"name":"email","kind":"email"}]}' \
+     localhost:8000/api/v1/documents/ingest
+```
+
+Records carry `_source_file`/`_source_page`/`_extract_confidence`; pass them to
+`dedupe_df(exclude_columns=...)`. Auth: set `GOLDENMATCH_WEB_TOKEN` and send `Authorization: Bearer`.

--- a/packages/python/goldenmatch/goldenmatch/web/app.py
+++ b/packages/python/goldenmatch/goldenmatch/web/app.py
@@ -80,6 +80,7 @@ def create_app(state: AppState) -> FastAPI:
     from goldenmatch.web.routers import autoconfig as autoconfig_router
     from goldenmatch.web.routers import compare as compare_router
     from goldenmatch.web.routers import controller as controller_router
+    from goldenmatch.web.routers import documents as documents_router
     from goldenmatch.web.routers import domains as domains_router
     from goldenmatch.web.routers import evaluation as evaluation_router
     from goldenmatch.web.routers import identity as identity_router
@@ -116,6 +117,7 @@ def create_app(state: AppState) -> FastAPI:
     app.include_router(quality_router.router)
     app.include_router(controller_router.router)
     app.include_router(identity_router.router)
+    app.include_router(documents_router.router)
     app.include_router(suggest_router.router)
 
     if STATIC_DIR.exists() and any(STATIC_DIR.iterdir()):

--- a/packages/python/goldenmatch/goldenmatch/web/routers/documents.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/documents.py
@@ -1,0 +1,84 @@
+"""POST /api/v1/documents/{suggest-schema,ingest} -- HTTP surface over goldenmatch.documents.
+
+Thin adapter: multipart uploads -> temp files (extension preserved so loader.load_pages
+routes PDF vs image) -> the shipped suggest_schema_from_file / ingest_documents (which run
+through documents-core natively, pure-Python fallback otherwise). No extraction logic here.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+
+from goldenmatch.documents import ingest_documents
+from goldenmatch.documents.config import resolve_extractor
+from goldenmatch.documents.schema_io import schema_from_dict, schema_to_dict
+from goldenmatch.documents.suggest import suggest_schema_from_file
+
+router = APIRouter(prefix="/api/v1")
+_executor = ThreadPoolExecutor(max_workers=2)
+
+
+def _save_uploads(tmpdir: str, files: list[UploadFile]) -> list[str]:
+    paths: list[str] = []
+    for f in files:
+        suffix = Path(f.filename or "upload").suffix or ".bin"
+        p = Path(tmpdir) / f"doc{len(paths)}{suffix}"
+        p.write_bytes(f.file.read())
+        paths.append(str(p))
+    return paths
+
+
+@router.post("/documents/suggest-schema")
+async def suggest_schema_endpoint(
+    file: UploadFile = File(...),
+    backend: str = Form("vlm"),
+    model: str = Form("gpt-4o"),
+):
+    def work():
+        with tempfile.TemporaryDirectory() as td:
+            (path,) = _save_uploads(td, [file])
+            schema = suggest_schema_from_file(path, backend=backend, model=model)
+            return {"schema": schema_to_dict(schema)}
+    try:
+        return await asyncio.get_running_loop().run_in_executor(_executor, work)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post("/documents/ingest")
+async def ingest_endpoint(
+    files: list[UploadFile] | None = File(None),
+    schema: str = Form(...),
+    drop_empty: bool = Form(True),
+    backend: str = Form("vlm"),
+    model: str = Form("gpt-4o"),
+):
+    if not files:
+        raise HTTPException(status_code=400, detail="no files uploaded")
+    try:
+        target = schema_from_dict(json.loads(schema))
+    except (ValueError, json.JSONDecodeError) as e:
+        raise HTTPException(status_code=400, detail=f"invalid schema: {e}") from e
+
+    def work():
+        with tempfile.TemporaryDirectory() as td:
+            paths = _save_uploads(td, files)
+            extractor = resolve_extractor(backend, model)  # ValueError on bad backend/key
+            df, report = ingest_documents(paths, target, extractor=extractor,
+                                          drop_empty=drop_empty, return_report=True)
+            return {
+                "records": df.to_dicts(),
+                "report": {
+                    "n_files": report.n_files, "n_rows": report.n_rows,
+                    "errors": [{"file": f, "error": e} for (f, e) in report.errors],
+                },
+            }
+    try:
+        return await asyncio.get_running_loop().run_in_executor(_executor, work)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e

--- a/packages/python/goldenmatch/goldenmatch/web/routers/documents.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/documents.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
 from goldenmatch.documents import ingest_documents
-from goldenmatch.documents.config import resolve_extractor
+from goldenmatch.documents.config import resolve_api_key, resolve_extractor
 from goldenmatch.documents.schema_io import schema_from_dict, schema_to_dict
 from goldenmatch.documents.suggest import suggest_schema_from_file
 
@@ -39,15 +39,21 @@ async def suggest_schema_endpoint(
     backend: str = Form("vlm"),
     model: str = Form("gpt-4o"),
 ):
+    # Resolve config (backend + API key) up front so bad-request errors are 400; the executor
+    # body then only does I/O + the VLM call, whose failures surface as 500 (not mislabeled 400).
+    try:
+        if backend != "vlm":
+            raise ValueError(f"unsupported backend: {backend!r} (only 'vlm' is supported)")
+        resolve_api_key()
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
     def work():
         with tempfile.TemporaryDirectory() as td:
             (path,) = _save_uploads(td, [file])
             schema = suggest_schema_from_file(path, backend=backend, model=model)
             return {"schema": schema_to_dict(schema)}
-    try:
-        return await asyncio.get_running_loop().run_in_executor(_executor, work)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    return await asyncio.get_running_loop().run_in_executor(_executor, work)
 
 
 @router.post("/documents/ingest")
@@ -60,15 +66,20 @@ async def ingest_endpoint(
 ):
     if not files:
         raise HTTPException(status_code=400, detail="no files uploaded")
+    # Bad-request config (schema + backend/key) resolves up front -> 400. The executor body then
+    # runs only ingest I/O, whose internal failures surface as 500 rather than a mislabeled 400.
     try:
         target = schema_from_dict(json.loads(schema))
     except (ValueError, json.JSONDecodeError) as e:
         raise HTTPException(status_code=400, detail=f"invalid schema: {e}") from e
+    try:
+        extractor = resolve_extractor(backend, model)  # bad backend / missing key
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
 
     def work():
         with tempfile.TemporaryDirectory() as td:
             paths = _save_uploads(td, files)
-            extractor = resolve_extractor(backend, model)  # ValueError on bad backend/key
             df, report = ingest_documents(paths, target, extractor=extractor,
                                           drop_empty=drop_empty, return_report=True)
             return {
@@ -78,7 +89,4 @@ async def ingest_endpoint(
                     "errors": [{"file": f, "error": e} for (f, e) in report.errors],
                 },
             }
-    try:
-        return await asyncio.get_running_loop().run_in_executor(_executor, work)
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
+    return await asyncio.get_running_loop().run_in_executor(_executor, work)

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -196,6 +196,7 @@ web = [
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
     "httpx>=0.27",  # used by TestClient and tests
+    "python-multipart>=0.0.9",
 ]
 # Head-to-head accuracy panel (probabilistic vs Splink). Loads datasets via
 # splink_datasets (ships with splink) with a vendored-parquet fallback.

--- a/packages/python/goldenmatch/tests/web/test_documents_router.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router.py
@@ -60,3 +60,28 @@ def test_ingest_returns_records_and_report(tmp_path, monkeypatch):
     assert rec["full_name"] == "Ada" and rec["email"] == "ada@x.io"
     # sidecar columns present for the dedupe_df exclude_columns handoff
     assert "_source_file" in rec and "_source_page" in rec and "_extract_confidence" in rec
+
+
+def test_ingest_malformed_schema_400(tmp_path):
+    client = _client(tmp_path)
+    resp = client.post("/api/v1/documents/ingest",
+                       files=[("files", ("a.png", _png_bytes(), "image/png"))],
+                       data={"schema": "not json"})
+    assert resp.status_code == 400
+    assert "schema" in resp.json()["detail"].lower()
+
+
+def test_ingest_no_files_400(tmp_path):
+    client = _client(tmp_path)
+    resp = client.post("/api/v1/documents/ingest",
+                       data={"schema": '{"fields":[{"name":"x"}]}'})
+    assert resp.status_code == 400  # optional files param -> handler's 400, not FastAPI 422
+
+
+def test_auth_required_401_when_token_set(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_WEB_TOKEN", "secret")  # middleware only enforces when set
+    client = _client(tmp_path)
+    resp = client.post("/api/v1/documents/ingest",
+                       files=[("files", ("a.png", _png_bytes(), "image/png"))],
+                       data={"schema": '{"fields":[{"name":"x"}]}'})
+    assert resp.status_code == 401

--- a/packages/python/goldenmatch/tests/web/test_documents_router.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router.py
@@ -33,6 +33,7 @@ def test_document_routes_registered(tmp_path):
 
 
 def test_suggest_schema_returns_schema(tmp_path, monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY_PERSONAL", "sk-test")  # endpoint resolves config up front
     monkeypatch.setattr(docrouter, "suggest_schema_from_file",
                         lambda path, **k: TargetSchema([Field("full_name"), Field("email", kind="email")]))
     client = _client(tmp_path)
@@ -85,3 +86,20 @@ def test_auth_required_401_when_token_set(tmp_path, monkeypatch):
                        files=[("files", ("a.png", _png_bytes(), "image/png"))],
                        data={"schema": '{"fields":[{"name":"x"}]}'})
     assert resp.status_code == 401
+
+
+def test_ingest_internal_error_is_500_not_400(tmp_path, monkeypatch):
+    # config resolves fine, but ingest blows up internally -> must be 500, not a mislabeled 400
+    monkeypatch.setattr(docrouter, "resolve_extractor", lambda b, m: FakeExtractor([]))
+
+    def _boom(*a, **k):
+        raise ValueError("internal boom")
+
+    monkeypatch.setattr(docrouter, "ingest_documents", _boom)
+    state = AppState(project_root=tmp_path, config_path=None,
+                     labels_path=tmp_path / "labels.jsonl")
+    client = TestClient(create_app(state), raise_server_exceptions=False)
+    resp = client.post("/api/v1/documents/ingest",
+                       files=[("files", ("a.png", _png_bytes(), "image/png"))],
+                       data={"schema": json.dumps({"fields": [{"name": "x"}]})})
+    assert resp.status_code == 500

--- a/packages/python/goldenmatch/tests/web/test_documents_router.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
+import io
+
+import goldenmatch.web.routers.documents as docrouter
 from fastapi.testclient import TestClient
+from goldenmatch.documents.types import Field, TargetSchema
 from goldenmatch.web.app import create_app
 from goldenmatch.web.state import AppState
+from PIL import Image
 
 
 def _client(tmp_path):
@@ -11,8 +16,23 @@ def _client(tmp_path):
     return TestClient(create_app(state))
 
 
+def _png_bytes():
+    buf = io.BytesIO(); Image.new("RGB", (20, 20), "white").save(buf, format="PNG")
+    return buf.getvalue()
+
+
 def test_document_routes_registered(tmp_path):
     client = _client(tmp_path)
     paths = {r.path for r in client.app.routes}
     assert "/api/v1/documents/suggest-schema" in paths
     assert "/api/v1/documents/ingest" in paths
+
+
+def test_suggest_schema_returns_schema(tmp_path, monkeypatch):
+    monkeypatch.setattr(docrouter, "suggest_schema_from_file",
+                        lambda path, **k: TargetSchema([Field("full_name"), Field("email", kind="email")]))
+    client = _client(tmp_path)
+    resp = client.post("/api/v1/documents/suggest-schema",
+                       files={"file": ("card.png", _png_bytes(), "image/png")})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["schema"]["fields"][0]["name"] == "full_name"

--- a/packages/python/goldenmatch/tests/web/test_documents_router.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+from goldenmatch.web.app import create_app
+from goldenmatch.web.state import AppState
+
+
+def _client(tmp_path):
+    state = AppState(project_root=tmp_path, config_path=None,
+                     labels_path=tmp_path / "labels.jsonl")
+    return TestClient(create_app(state))
+
+
+def test_document_routes_registered(tmp_path):
+    client = _client(tmp_path)
+    paths = {r.path for r in client.app.routes}
+    assert "/api/v1/documents/suggest-schema" in paths
+    assert "/api/v1/documents/ingest" in paths

--- a/packages/python/goldenmatch/tests/web/test_documents_router.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import io
+import json
 
 import goldenmatch.web.routers.documents as docrouter
 from fastapi.testclient import TestClient
-from goldenmatch.documents.types import Field, TargetSchema
+from goldenmatch.documents.extractor import FakeExtractor
+from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
 from goldenmatch.web.app import create_app
 from goldenmatch.web.state import AppState
 from PIL import Image
+
+SCHEMA = TargetSchema([Field("full_name"), Field("email")])
 
 
 def _client(tmp_path):
@@ -36,3 +40,23 @@ def test_suggest_schema_returns_schema(tmp_path, monkeypatch):
                        files={"file": ("card.png", _png_bytes(), "image/png")})
     assert resp.status_code == 200, resp.text
     assert resp.json()["schema"]["fields"][0]["name"] == "full_name"
+
+
+def test_ingest_returns_records_and_report(tmp_path, monkeypatch):
+    row = ExtractedRow.from_partial({"full_name": "Ada", "email": "ada@x.io"}, {},
+                                    SCHEMA, source_file="", source_page=0)
+    monkeypatch.setattr(docrouter, "resolve_extractor",
+                        lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+    client = _client(tmp_path)
+    resp = client.post(
+        "/api/v1/documents/ingest",
+        files=[("files", ("a.png", _png_bytes(), "image/png"))],
+        data={"schema": json.dumps({"fields": [{"name": "full_name"}, {"name": "email"}]})},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["report"]["n_rows"] == 1 and body["report"]["n_files"] == 1
+    rec = body["records"][0]
+    assert rec["full_name"] == "Ada" and rec["email"] == "ada@x.io"
+    # sidecar columns present for the dedupe_df exclude_columns handoff
+    assert "_source_file" in rec and "_source_page" in rec and "_extract_confidence" in rec

--- a/packages/python/goldenmatch/tests/web/test_documents_router_live.py
+++ b/packages/python/goldenmatch/tests/web/test_documents_router_live.py
@@ -1,0 +1,22 @@
+import io
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from goldenmatch.web.app import create_app
+from goldenmatch.web.state import AppState
+from PIL import Image, ImageDraw
+
+pytestmark = pytest.mark.skipif(not os.environ.get("OPENAI_API_KEY_PERSONAL"),
+                                reason="live VLM smoke; set OPENAI_API_KEY_PERSONAL")
+
+
+def test_live_suggest_then_ingest(tmp_path):
+    img = Image.new("RGB", (400, 200), "white"); d = ImageDraw.Draw(img)
+    d.text((20, 40), "Ada Lovelace", fill="black"); d.text((20, 80), "ada@x.io", fill="black")
+    buf = io.BytesIO(); img.save(buf, format="PNG"); png = buf.getvalue()
+    client = TestClient(create_app(AppState(project_root=tmp_path, config_path=None,
+                                            labels_path=tmp_path / "labels.jsonl")))
+    s = client.post("/api/v1/documents/suggest-schema",
+                    files={"file": ("card.png", png, "image/png")})
+    assert s.status_code == 200 and s.json()["schema"]["fields"]


### PR DESCRIPTION
## Summary
The first of the four document-ingest surfaces on `documents-core`: an HTTP surface over the shipped `goldenmatch.documents`.

- **`POST /api/v1/documents/suggest-schema`** — multipart: one file -> `{"schema": {...}}` (a VLM proposes fields).
- **`POST /api/v1/documents/ingest`** — multipart: files + a `schema` field -> `{"records": [...], "report": {n_files, n_rows, errors[{file,error}]}}` (same shape as the MCP `documents_ingest` tool). Records carry `_source_file`/`_source_page`/`_extract_confidence` for `dedupe_df(exclude_columns=...)`.
- **Thin router** (`web/routers/documents.py`): multipart uploads -> temp files (extension preserved so the loader routes PDF vs image) -> `suggest_schema_from_file`/`ingest_documents` (which run through `documents-core` natively, pure-Python fallback otherwise). Blocking work runs off the event loop via a `ThreadPoolExecutor`. Reuses the app's bearer-auth middleware.
- **Status codes:** config (schema + backend/key) resolves up front -> **400** on bad request; genuine internal failures surface as **500** (not mislabeled 400).

## Test Plan
- [x] `pytest tests/web/test_documents_router.py` -> **7 passed, 1 skipped** (the skip is the gated live VLM smoke)
- [x] `ruff` clean; `from goldenmatch.web.app import create_app` imports clean
- [x] Covered: 200 happy paths, malformed schema -> 400, no files -> 400 (not FastAPI 422), 401 with `GOLDENMATCH_WEB_TOKEN` set, internal error -> 500

## Notes
- `python-multipart` added to the `[web]` extra. Spec + plan each reviewed; the implementation passed a combined spec + code-quality review, and the 400-vs-500 fix that review surfaced is included here.
- Deferred (later surfaces): async jobs, streaming, the Web UI frontend, then A2A + the TS client (which consumes `documents-core` via WASM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JThTtceZ9kStY5jWjwGk6v