### PR TITLE
feat(goldenflow): phonetic joins the fused chain (Phase 3 wave 1)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/_chain.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_chain.py
@@ -53,6 +53,10 @@ FUSABLE_KERNELS: frozenset[str] = frozenset(
         "nickname_standardize",
         "name_initials",
         "strip_middle",
+        # phonetic family (total string->string keys)
+        "soundex",
+        "double_metaphone_primary",
+        "double_metaphone_alt",
     }
 )
 

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -55,6 +55,9 @@ def test_native_list_binding_present() -> None:
         [("name", ["strip", "title_case", "name_proper"])],
         [("email", ["strip", "lowercase", "email_normalize"])],
         [("name", ["strip", "truncate:6"])],
+        # Phase 3 wave 1: phonetic joins the fused chain -> columnar-ready
+        [("name", ["strip", "lowercase", "soundex"])],
+        [("name", ["strip", "double_metaphone_primary"])],
     ],
 )
 def test_columnar_equals_polars(monkeypatch, specs) -> None:

--- a/packages/python/goldenflow/tests/engine/test_native_csv_io.py
+++ b/packages/python/goldenflow/tests/engine/test_native_csv_io.py
@@ -64,6 +64,7 @@ def _manifest_rows(manifest):
         [("name", ["strip", "title_case"]), ("email", ["strip", "lowercase"])],
         [("email", ["strip", "lowercase", "email_normalize"])],
         [("name", ["strip", "truncate:6"])],
+        [("name", ["strip", "lowercase", "soundex"])],  # Phase 3 wave 1: phonetic
     ],
 )
 def test_native_csv_equals_polars_engine(tmp_path, monkeypatch, specs) -> None:

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -46,7 +46,7 @@ use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 // NumericKernel/NullableKernel executors.
 #[cfg(feature = "arrow")]
 use crate::{company, numeric, url};
-use crate::{email, names, text};
+use crate::{email, names, phonetic, text};
 
 /// One owned, no-arg, total string→string kernel eligible for the fused chain.
 /// The name mapping (`from_name`) is the single source of truth the host's
@@ -80,6 +80,10 @@ pub enum Kernel {
     NicknameStandardize,
     NameInitials,
     StripMiddle,
+    // phonetic family (total string->string keys)
+    Soundex,
+    DoubleMetaphonePrimary,
+    DoubleMetaphoneAlt,
     // parameterized string->string (carry their args; total, never null)
     Truncate(usize),
     PadLeft(usize, char),
@@ -118,6 +122,9 @@ impl Kernel {
             "nickname_standardize" => Kernel::NicknameStandardize,
             "name_initials" => Kernel::NameInitials,
             "strip_middle" => Kernel::StripMiddle,
+            "soundex" => Kernel::Soundex,
+            "double_metaphone_primary" => Kernel::DoubleMetaphonePrimary,
+            "double_metaphone_alt" => Kernel::DoubleMetaphoneAlt,
             _ => return None,
         })
     }
@@ -181,6 +188,9 @@ impl Kernel {
         "nickname_standardize",
         "name_initials",
         "strip_middle",
+        "soundex",
+        "double_metaphone_primary",
+        "double_metaphone_alt",
     ];
 
     /// Append `s` transformed by this kernel into `out` (which the caller has
@@ -215,6 +225,9 @@ impl Kernel {
             Kernel::NicknameStandardize => out.push_str(&names::nickname_standardize(s)),
             Kernel::NameInitials => out.push_str(&names::name_initials(s)),
             Kernel::StripMiddle => out.push_str(&names::strip_middle(s)),
+            Kernel::Soundex => out.push_str(&phonetic::soundex(s)),
+            Kernel::DoubleMetaphonePrimary => out.push_str(&phonetic::double_metaphone_primary(s)),
+            Kernel::DoubleMetaphoneAlt => out.push_str(&phonetic::double_metaphone_alt(s)),
             Kernel::Truncate(n) => out.push_str(&text::truncate(s, n)),
             Kernel::PadLeft(w, p) => text::pad_left_into(s, w, p, out),
             Kernel::PadRight(w, p) => text::pad_right_into(s, w, p, out),

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "arrow",
  "csv",

--- a/packages/typescript/goldenflow/src/core/engine/_chain.ts
+++ b/packages/typescript/goldenflow/src/core/engine/_chain.ts
@@ -42,6 +42,9 @@ export const FUSABLE_KERNELS: ReadonlySet<string> = new Set([
   "nickname_standardize",
   "name_initials",
   "strip_middle",
+  "soundex",
+  "double_metaphone_primary",
+  "double_metaphone_alt",
 ]);
 
 /** The fused chain is active only when a WASM backend that exposes `applyChain`


### PR DESCRIPTION
## Phase 3 wave 1 — phonetic onto the columnar surface

> Stacked on #1534 (Phase 2b). The 2b commit shows here until #1534 merges, then this rebases to a single commit.

Phase 3 ports transforms onto the backend-agnostic columnar surface, one family at
a time. **Wave 1 = phonetic** (`soundex`, `double_metaphone_primary`,
`double_metaphone_alt`) — all total `fn(&str)->String` kernels — into the total
fused chain.

Because `config_is_columnar_ready` already accepts every `FUSABLE_KERNELS` op,
adding these three makes soundex/metaphone configs **columnar-ready with zero
columnar-engine changes**: `[strip, lowercase, soundex]` now runs **Polars-free**
(native Column path) and **pyarrow-free** (native CSV path), where before it
declined to the Polars engine.

### Changes
- **goldenflow-core `chain.rs`**: 3 `Kernel` variants + `apply_into` (calling the
  existing `goldenflow_core::phonetic` fns) + `from_name` + `ALL_NAMES`. Byte-identical
  to the per-transform soundex by construction (same fn). **goldenflow-core 0.10.0 →
  0.11.0** (wasm + native-flow `Cargo.lock`s bumped in lockstep).
- **Python `FUSABLE_KERNELS`** + **TS `FUSABLE_KERNELS`** mirror the three (the wasm
  fused chain picks them up automatically from the recompiled core).
- **Parity**: the fused-chain coverage guard stays green (native `fusable_kernel_names()`
  == Python `FUSABLE`); new columnar + native-CSV cases assert soundex/metaphone
  configs are byte-identical (data + manifest) to the Polars engine.

### Why phonetic first
It's the cleanest total-`fn(&str)->String` family available (company/url are
`Option`-returning → the nullable chain, a later wave). It joins the existing fused
machinery with no new columnar-engine logic, establishing the wave rhythm.

Design: `docs/design/2026-07-07-polars-eviction-plan.md` (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg