### PR TITLE
feat(goldenpipe): auto-config brain slice 2 (ComplexityProfile + refuse-on-RED)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain-slice2.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain-slice2.md
@@ -1,0 +1,964 @@
+# GoldenPipe auto-config brain — Slice 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the GoldenPipe auto-config brain a data-complexity signal, a confidence band, and a size-gated refuse-on-RED (`PipeNotConfidentError`) — the `ControllerNotConfidentError` analog that makes it decline instead of guess.
+
+**Architecture:** Extend the portable, Polars/Pydantic-free decision core (`autoconfig_planner.py`) with a `ComplexityProfile` + `PlannerInput` bundle and a pure `band_of` function; keep the impure profiling (`profile_complexity`) and the refuse-raise (`enforce_confidence`) in the host glue (`autoconfig_glue.py`). Wire both into `Pipeline._plan_config`. All decision logic stays plain-struct-in/plain-struct-out so the later `goldenpipe-core` Rust port is mechanical.
+
+**Tech Stack:** Python 3.12, Polars (glue only), pytest, ruff. No goldenflow/goldenmatch imports in the new code or its tests.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md`
+
+---
+
+## Environment (every test/ruff command in this plan)
+
+Native Windows Python. **PYTHONPATH uses `;` as separator — NOT `:`** (a `:`-joined path collapses to one malformed entry on native Windows Python and silently resolves `goldenpipe` to a *different* repo's installed copy).
+
+```bash
+cd "D:/show_case/gg-local-llm"
+INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+export PYTHONPATH="packages/python/goldenpipe;packages/python/infermap;packages/python/goldencheck-types"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+```
+
+- Run a test file: `"$INTERP" -m pytest <path> -q`
+- Ruff: `"$INTERP" -m ruff check <files>` (run `--fix` if it flags import order; harmless).
+- Branch is already `feat/goldenpipe-autoconfig-brain-slice2` off fresh `origin/main`, spec committed.
+
+## File Structure (what each touched file owns)
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `goldenpipe/autoconfig_planner.py` | Portable decision core (no Polars/Pydantic) | Add `ComplexityProfile`, `PlannerInput`, `band_of`; migrate `Predicate`/`Action`/`plan_pipeline`/`_default_plan`/`default_evidence` to `PlannerInput` |
+| `goldenpipe/errors.py` | goldenpipe-local exceptions | **New** — `PipeNotConfidentError` |
+| `goldenpipe/autoconfig_planner_rules.py` | Concrete rule table (portable) | Migrate signatures to `PlannerInput`; add `rule_low_confidence`; extend `DEFAULT_RULES` |
+| `goldenpipe/autoconfig_glue.py` | Impure host bracket (Polars in, Pydantic out, raises) | Add `profile_complexity`, `build_planner_input`, `enforce_confidence` |
+| `goldenpipe/pipeline.py` | Orchestrator | `_plan_config` builds `PlannerInput` + calls `enforce_confidence`; `run()` docstring notes the raise. `_auto_config` **untouched** |
+| `tests/test_autoconfig_planner.py` | Core tests | **Migrate** 6 `plan_pipeline` call sites + inline lambda to `PlannerInput`; add band/new-rule tests |
+| `tests/test_autoconfig_glue.py` | Glue + integration tests | Extend with `profile_complexity`, `enforce_confidence`, refuse integration |
+
+**Ordering note:** Changing `plan_pipeline`'s signature is atomic across the core, the rules module, and the test file — all three read the old `PipeProfile`-arg shape. **Task 1 migrates all three in one commit** so the suite is green at every commit. Task 3 then *additively* adds the `low_confidence` rule. Tasks 2–5 are otherwise additive. Task 6 adds the new planner tests; Task 7 the glue/integration tests; Task 8 ships. **No commit in this plan is red.**
+
+---
+
+### Task 1: Core structs + `band_of` + migrate planner signatures (core + rules + test, one green commit)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/autoconfig_planner.py`
+- Modify (migrate signatures only, NO new rule yet): `packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py`
+- Modify (migrate): `packages/python/goldenpipe/tests/test_autoconfig_planner.py`
+
+- [ ] **Step 1: Migrate the existing planner test to the new `PlannerInput` signature (RED)**
+
+The current tests call `plan_pipeline(_profile(...))` and use `lambda p: ...` predicates reading `PipeProfile` directly. Rewrite the top of `tests/test_autoconfig_planner.py` so every call goes through a `_planner_input()` helper and predicates read `inp.runtime.*`. Replace lines 1–47 (imports through `test_structs_are_frozen`) and update lines 53–80's `plan_pipeline(_profile(...))` calls to `plan_pipeline(_planner_input(...))`.
+
+Replace the import block + helpers + first three tests with:
+
+```python
+from goldenpipe.autoconfig_planner import (
+    ComplexityProfile,
+    PipePlan,
+    PipePlannerRule,
+    PipeProfile,
+    PlannedStage,
+    PlannerInput,
+    band_of,
+    plan_pipeline,
+)
+
+
+def _profile(**kw):
+    base = dict(n_rows=100, n_cols=3, column_names=("a", "b", "c"),
+                dtypes=("String", "Int64", "String"),
+                inferred_domain=None, domain_confidence=0.0)
+    base.update(kw)
+    return PipeProfile(**base)
+
+
+def _complexity(**kw):
+    base = dict(max_null_density=0.0, mean_null_density=0.0)
+    base.update(kw)
+    return ComplexityProfile(**base)
+
+
+def _planner_input(*, max_null_density=0.0, mean_null_density=0.0, **profile_kw):
+    return PlannerInput(
+        runtime=_profile(**profile_kw),
+        complexity=_complexity(max_null_density=max_null_density,
+                               mean_null_density=mean_null_density),
+    )
+
+
+def test_plan_pipeline_first_match_wins_else_default():
+    fired = PipePlannerRule(
+        rule_name="fired",
+        predicate=lambda inp: inp.runtime.n_rows == 100,
+        action=lambda inp: PipePlan(stages=(PlannedStage("x", {}),), rule_name="fired",
+                                    confidence=0.9, evidence={"n_rows": inp.runtime.n_rows}),
+    )
+    plan = plan_pipeline(_planner_input(), rules=[fired])
+    assert plan.rule_name == "fired"
+    assert plan.stages == (PlannedStage("x", {}),)
+    assert plan.evidence == {"n_rows": 100}
+
+
+def test_plan_pipeline_falls_through_to_default():
+    never = PipePlannerRule("never", lambda inp: False,
+                            lambda inp: PipePlan((), "never", 0.0, {}))
+    plan = plan_pipeline(_planner_input(), rules=[never])
+    assert plan.rule_name == "default"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+
+
+def test_structs_are_frozen():
+    import dataclasses
+
+    import pytest
+    inp = _planner_input()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        inp.runtime.n_rows = 5  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        inp.complexity.max_null_density = 0.5  # type: ignore[misc]
+```
+
+Then update the three later `plan_pipeline(_profile(...))` calls (currently lines 54, 63, 73, 79) to `plan_pipeline(_planner_input(...))`. Concretely:
+- `plan_pipeline(_profile(n_rows=1))` → `plan_pipeline(_planner_input(n_rows=1))` (two occurrences: `test_rule_pathological_skips_dedupe` and `test_default_rules_is_the_module_table`).
+- `plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.8))` → `plan_pipeline(_planner_input(inferred_domain="finance", domain_confidence=0.8))`.
+- `plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.4))` → `plan_pipeline(_planner_input(inferred_domain="finance", domain_confidence=0.4))`.
+
+- [ ] **Step 2: Run — verify it FAILS (ImportError: ComplexityProfile / PlannerInput / band_of don't exist)**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+```
+Expected: collection ImportError on `ComplexityProfile`.
+
+- [ ] **Step 3: Implement the core changes in `autoconfig_planner.py`**
+
+Add the two structs + `band_of` + thresholds, and migrate the signatures. The full migrated file:
+
+```python
+"""Plan-first auto-config decision core (portable — NO Polars/Pydantic).
+
+The pyo3-free-portable kernel: PlannerInput (in) -> PipePlan (out) via a pure
+rule table. Host glue (Polars profiling, Pydantic config, refuse-raise) lives in
+`autoconfig_glue.py`. Mirrors goldenmatch's controller (PlannerRule + first-match
+plan, RuntimeProfile + ComplexityProfile, traffic-light confidence) so the later
+`goldenpipe-core` Rust port is mechanical.
+"""
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PipeProfile:
+    """Cheap, up-front signals — no stage execution required."""
+    n_rows: int
+    n_cols: int
+    column_names: tuple[str, ...]
+    dtypes: tuple[str, ...]
+    inferred_domain: str | None
+    domain_confidence: float
+
+
+@dataclass(frozen=True)
+class ComplexityProfile:
+    """Data-derived signals from one columnar pass. Zeros = unknown
+    (engine-resident frame not profiled this slice)."""
+    max_null_density: float    # 0..1, worst column's null fraction
+    mean_null_density: float   # 0..1, mean across columns
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    """Everything a rule sees: cheap runtime signals + deeper complexity."""
+    runtime: PipeProfile
+    complexity: ComplexityProfile
+
+
+@dataclass(frozen=True)
+class PlannedStage:
+    name: str            # EXACT registry name (e.g. "goldencheck.scan", "infer_schema")
+    config: dict         # per-stage config
+
+
+@dataclass(frozen=True)
+class PipePlan:
+    stages: tuple[PlannedStage, ...]
+    rule_name: str
+    confidence: float
+    evidence: dict
+
+
+Predicate = Callable[["PlannerInput"], bool]
+Action = Callable[["PlannerInput"], "PipePlan"]
+
+
+@dataclass(frozen=True)
+class PipePlannerRule:
+    rule_name: str
+    predicate: Predicate
+    action: Action
+
+
+GREEN_THRESHOLD = 0.7
+AMBER_THRESHOLD = 0.4
+
+
+def band_of(confidence: float) -> str:
+    """Map a confidence float to a traffic-light band (Rust-portable strings)."""
+    if confidence >= GREEN_THRESHOLD:
+        return "green"
+    if confidence >= AMBER_THRESHOLD:
+        return "amber"
+    return "red"
+
+
+def default_evidence(inp: PlannerInput) -> dict:
+    """Signal snapshot attached to every plan (evidence for humans/telemetry)."""
+    return {
+        "n_rows": inp.runtime.n_rows,
+        "n_cols": inp.runtime.n_cols,
+        "inferred_domain": inp.runtime.inferred_domain,
+        "domain_confidence": inp.runtime.domain_confidence,
+        "max_null_density": inp.complexity.max_null_density,
+        "mean_null_density": inp.complexity.mean_null_density,
+    }
+
+
+def _default_plan(inp: PlannerInput) -> PipePlan:
+    """The current static shape: scan -> flow -> dedupe (no infer_schema)."""
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="default",
+        confidence=0.7,
+        evidence=default_evidence(inp),
+    )
+
+
+def plan_pipeline(
+    inp: PlannerInput,
+    rules: Sequence[PipePlannerRule] | None = None,
+) -> PipePlan:
+    """First matching rule's action builds the plan; else the default shape."""
+    if rules is None:
+        from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES
+        rules = DEFAULT_RULES
+    for rule in rules:
+        if rule.predicate(inp):
+            return rule.action(inp)
+    return _default_plan(inp)
+```
+
+NOTE: `default_evidence` now records `max_null_density` AND `mean_null_density` (so `mean` is not dead weight — resolves the spec-review nit). This changes the evidence dict shape; the migrated `test_plan_pipeline_first_match_wins_else_default` uses a custom rule with its own `evidence={"n_rows": ...}`, so it is unaffected.
+
+- [ ] **Step 4: Migrate `autoconfig_planner_rules.py` signatures ONLY (no new rule yet)**
+
+The rule predicates/actions still read the old `PipeProfile`-arg shape (`_is_pathological(p)` reads `p.n_rows`), which `PlannerInput` breaks. Migrate them to read `inp.runtime.*` so the suite stays green. Do NOT add `low_confidence` here — that is Task 3 (additive). Rewrite the file to:
+
+```python
+"""Concrete planner rules for the goldenpipe auto-config brain.
+
+Ordered; first match wins (see plan_pipeline). Predicates read PlannerInput
+(runtime + complexity). Portable — no Polars/Pydantic. Stage names are the EXACT
+dotted registry names (plan_to_config drops any name not in the registry).
+"""
+from __future__ import annotations
+
+from goldenpipe.autoconfig_planner import (
+    PipePlan,
+    PipePlannerRule,
+    PlannedStage,
+    PlannerInput,
+    default_evidence,
+)
+
+_CONFIDENT_DOMAIN_THRESHOLD = 0.5
+
+
+def _is_pathological(inp: PlannerInput) -> bool:
+    return inp.runtime.n_rows <= 1
+
+
+def _pathological_plan(inp: PlannerInput) -> PipePlan:
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+        ),
+        rule_name="pathological",
+        confidence=1.0,
+        evidence=default_evidence(inp),
+    )
+
+
+rule_pathological = PipePlannerRule("pathological", _is_pathological, _pathological_plan)
+
+
+def _is_confident_schema(inp: PlannerInput) -> bool:
+    r = inp.runtime
+    return r.inferred_domain is not None and r.domain_confidence >= _CONFIDENT_DOMAIN_THRESHOLD
+
+
+def _confident_schema_plan(inp: PlannerInput) -> PipePlan:
+    return PipePlan(
+        stages=(
+            PlannedStage("infer_schema", {"domain": inp.runtime.inferred_domain}),
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="confident_schema",
+        confidence=inp.runtime.domain_confidence,
+        evidence=default_evidence(inp),
+    )
+
+
+rule_confident_schema = PipePlannerRule(
+    "confident_schema", _is_confident_schema, _confident_schema_plan,
+)
+
+
+DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
+    rule_pathological,
+    rule_confident_schema,
+)
+```
+
+- [ ] **Step 5: Run — verify the WHOLE planner test file PASSES**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+```
+Expected: all pass (signatures consistent across core + rules + tests; no `low_confidence` yet, so no new-rule test yet — those come in Task 6).
+
+- [ ] **Step 6: Ruff + commit (green)**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git add packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git commit -m "feat(goldenpipe): ComplexityProfile + PlannerInput + band_of (core+rules)
+
+Migrate the decision core and rule table to a PlannerInput bundle (runtime +
+complexity) and add the traffic-light band_of. Atomic signature migration; the
+low_confidence rule is added additively next.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 2: `PipeNotConfidentError` (new errors module)
+
+**Files:**
+- Create: `packages/python/goldenpipe/goldenpipe/errors.py`
+- Test: `packages/python/goldenpipe/tests/test_errors.py`
+
+- [ ] **Step 1: Failing test**
+
+Create `tests/test_errors.py`:
+
+```python
+import pytest
+
+from goldenpipe.errors import PipeNotConfidentError
+
+
+def test_pipe_not_confident_is_an_exception():
+    with pytest.raises(PipeNotConfidentError):
+        raise PipeNotConfidentError("nope")
+
+
+def test_pipe_not_confident_carries_message():
+    err = PipeNotConfidentError("rule=low_confidence on 200000 rows")
+    assert "low_confidence" in str(err)
+```
+
+- [ ] **Step 2: Run — verify FAIL** (ImportError)
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_errors.py -q
+```
+
+- [ ] **Step 3: Implement `errors.py`**
+
+```python
+"""goldenpipe-local exceptions."""
+from __future__ import annotations
+
+
+class PipeNotConfidentError(RuntimeError):
+    """Raised by the auto-config brain when it cannot confidently plan a
+    pipeline for a large input (red confidence band at/above the row threshold).
+
+    Parallels goldenmatch's ``ControllerNotConfidentError``: refuse loudly
+    rather than run an expensive, likely-wrong pipeline. Supply an explicit
+    pipeline config (or reduce the input size) to proceed.
+    """
+```
+
+- [ ] **Step 4: Run — verify PASS**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_errors.py -q
+```
+Expected: 2 passed.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/errors.py packages/python/goldenpipe/tests/test_errors.py
+git add packages/python/goldenpipe/goldenpipe/errors.py packages/python/goldenpipe/tests/test_errors.py
+git commit -m "feat(goldenpipe): PipeNotConfidentError (refuse-on-RED exception)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 3: Add `rule_low_confidence` (additive — the RED source)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py`
+
+Signatures already migrated in Task 1. This task ONLY adds the new rule + constant + extends `DEFAULT_RULES`. Its tests land in Task 6 (kept together with the band tests), so this task's verification is "no regression."
+
+- [ ] **Step 1: Add the constant, rule, and extend the table**
+
+At the top constants, add `RED_NULL_DENSITY = 0.6` next to `_CONFIDENT_DOMAIN_THRESHOLD`. Before the `DEFAULT_RULES` tuple, add:
+
+```python
+def _is_low_confidence(inp: PlannerInput) -> bool:
+    # The sole RED source: no usable signal AND the data is mostly empty, so
+    # running the full dedupe pipeline is likely to produce garbage clusters.
+    return (
+        inp.runtime.inferred_domain is None
+        and inp.complexity.max_null_density > RED_NULL_DENSITY
+    )
+
+
+def _low_confidence_plan(inp: PlannerInput) -> PipePlan:
+    # Return the SAFE DEFAULT shape (so small inputs proceed) but tag it RED so
+    # the glue can refuse at scale.
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="low_confidence",
+        confidence=0.3,
+        evidence=default_evidence(inp),
+    )
+
+
+rule_low_confidence = PipePlannerRule(
+    "low_confidence", _is_low_confidence, _low_confidence_plan,
+)
+```
+
+Then extend `DEFAULT_RULES`, with the ordering rationale as a comment:
+
+```python
+# Order: positive rules first (a clear signal wins), then low_confidence (RED),
+# then plan_pipeline's plain default. Nothing shadows low_confidence — rules 1/2
+# require n_rows<=1 / domain-present, which the garbage case (domain None, high
+# null) does not satisfy.
+DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
+    rule_pathological,
+    rule_confident_schema,
+    rule_low_confidence,
+)
+```
+
+- [ ] **Step 2: Run — verify no regression** (existing planner tests still green; the new rule is not yet exercised by a test — that's Task 6)
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+```
+Expected: all pass. As a sanity smoke, confirm the rule is reachable:
+
+```bash
+"$INTERP" -c "import os; os.environ['POLARS_SKIP_CPU_CHECK']='1'
+from goldenpipe.autoconfig_planner import PlannerInput, PipeProfile, ComplexityProfile, plan_pipeline
+inp = PlannerInput(PipeProfile(200, 2, ('a','b'), ('String','Int64'), None, 0.0), ComplexityProfile(0.9, 0.5))
+print(plan_pipeline(inp).rule_name)"
+```
+Expected: prints `low_confidence`.
+
+- [ ] **Step 3: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+git add packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+git commit -m "feat(goldenpipe): add low_confidence rule (the RED source)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 4: Glue — `profile_complexity`, `build_planner_input`, `enforce_confidence`
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/autoconfig_glue.py`
+- Test: `packages/python/goldenpipe/tests/test_autoconfig_glue.py` (unit tests for the three functions)
+
+- [ ] **Step 1: Failing tests** — append to `tests/test_autoconfig_glue.py`:
+
+```python
+# --- Slice 2: complexity profiling + refuse ----------------------------------
+
+from goldenpipe.autoconfig_glue import (  # noqa: E402
+    build_planner_input,
+    enforce_confidence,
+    profile_complexity,
+)
+from goldenpipe.autoconfig_planner import PipePlan, PlannerInput  # noqa: E402
+from goldenpipe.errors import PipeNotConfidentError  # noqa: E402
+
+
+def test_profile_complexity_null_heavy_column():
+    df = pl.DataFrame({"a": [1, None, None, None], "b": [1, 2, 3, 4]})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.75      # column a: 3/4
+    assert comp.mean_null_density == 0.375     # (0.75 + 0.0) / 2
+
+
+def test_profile_complexity_no_nulls_is_zero():
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_profile_complexity_engine_resident_is_zero():
+    comp = profile_complexity(PipeContext(df=None))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_profile_complexity_empty_df_is_zero():
+    df = pl.DataFrame({"a": []})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_build_planner_input_bundles_runtime_and_complexity():
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    inp = build_planner_input(PipeContext(df=df))
+    assert isinstance(inp, PlannerInput)
+    assert inp.runtime.n_rows == 2
+    assert inp.runtime.inferred_domain == "finance"
+    assert inp.complexity.max_null_density == 0.0
+
+
+def _red_plan():
+    return PipePlan(stages=(), rule_name="low_confidence", confidence=0.3, evidence={})
+
+
+def _green_plan():
+    return PipePlan(stages=(), rule_name="default", confidence=0.7, evidence={})
+
+
+def test_enforce_confidence_red_at_scale_raises():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 100_000)
+    with pytest.raises(PipeNotConfidentError):
+        enforce_confidence(_red_plan(), runtime)
+
+
+def test_enforce_confidence_red_small_proceeds():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 99_999)
+    assert enforce_confidence(_red_plan(), runtime) is None
+
+
+def test_enforce_confidence_green_proceeds():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 100_000)
+    assert enforce_confidence(_green_plan(), runtime) is None
+```
+
+Add these imports/helpers near the top of the test file if not already present: `import pytest`, and a `_replace_n_rows` helper (PipeProfile is frozen — use `dataclasses.replace`):
+
+```python
+import dataclasses
+
+
+def _replace_n_rows(profile, n):
+    return dataclasses.replace(profile, n_rows=n)
+```
+
+- [ ] **Step 2: Run — verify FAIL** (ImportError on `profile_complexity`)
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+
+- [ ] **Step 3: Implement in `autoconfig_glue.py`**
+
+Add a module logger + the three functions. Insert imports at top: `import logging`, `from goldenpipe.autoconfig_planner import ComplexityProfile, PlannerInput, band_of`, `from goldenpipe.errors import PipeNotConfidentError`. Add after `profile_context`:
+
+```python
+logger = logging.getLogger(__name__)
+
+REFUSE_ROW_THRESHOLD = 100_000
+
+
+def profile_complexity(ctx: PipeContext) -> ComplexityProfile:
+    """One columnar pass for null density. Engine-resident or empty -> zeros
+    (unknown; not profiled this slice)."""
+    df = ctx.df
+    if df is None:
+        return ComplexityProfile(max_null_density=0.0, mean_null_density=0.0)
+    n_rows = len(df)
+    if n_rows == 0:
+        return ComplexityProfile(max_null_density=0.0, mean_null_density=0.0)
+    # null_count() -> a 1-row frame of per-column null counts.
+    counts = df.null_count().row(0)
+    fractions = [c / n_rows for c in counts]
+    return ComplexityProfile(
+        max_null_density=max(fractions),
+        mean_null_density=sum(fractions) / len(fractions),
+    )
+
+
+def build_planner_input(ctx: PipeContext) -> PlannerInput:
+    """Assemble the full decision input (runtime + complexity) from a context."""
+    return PlannerInput(
+        runtime=profile_context(ctx),
+        complexity=profile_complexity(ctx),
+    )
+
+
+def enforce_confidence(plan: PipePlan, runtime: PipeProfile) -> None:
+    """Refuse-on-RED (size-gated). Raises PipeNotConfidentError on a red-band
+    plan at/above the row threshold; warns and proceeds below it; no-op otherwise."""
+    if band_of(plan.confidence) != "red":
+        return
+    if runtime.n_rows >= REFUSE_ROW_THRESHOLD:
+        raise PipeNotConfidentError(
+            f"auto-config not confident (rule={plan.rule_name}, "
+            f"confidence={plan.confidence}) on {runtime.n_rows} rows; "
+            f"supply an explicit pipeline config or reduce the input size. "
+            f"evidence={plan.evidence}"
+        )
+    logger.warning(
+        "auto-config low confidence (rule=%s) on %d rows; proceeding on safe "
+        "default plan", plan.rule_name, runtime.n_rows,
+    )
+```
+
+Note: `df.null_count().row(0)` returns a tuple of per-column null counts (one row). Guard `n_rows == 0` avoids division by zero. `PipeProfile` is already imported at the top of the glue module (line 11); leave it.
+
+- [ ] **Step 4: Run — verify PASS**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expected: the slice-1 glue/integration tests + the 8 new tests all pass.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_glue.py packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git add packages/python/goldenpipe/goldenpipe/autoconfig_glue.py packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git commit -m "feat(goldenpipe): profile_complexity + build_planner_input + enforce_confidence
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 5: Wire the brain into `Pipeline._plan_config`
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/pipeline.py:122-143` (`_plan_config`) + `run()` docstring
+
+- [ ] **Step 1: Rewrite `_plan_config` (lines 122-143)**
+
+Replace the body (keep the method name/signature) with:
+
+```python
+    def _plan_config(self, ctx: PipeContext) -> PipelineConfig:
+        """Plan-first auto-config: profile the loaded context, run the rule
+        table, refuse if not confident at scale, and materialize the chosen
+        plan into a PipelineConfig.
+
+        This is the "brain" (parity with GoldenMatch's controller): the shape
+        of the pipeline is DECIDED from the data + InferMap-inferred schema, and
+        a red-confidence plan on a large input raises ``PipeNotConfidentError``
+        rather than running an expensive, likely-wrong pipeline. The portable
+        decision core (``autoconfig_planner``) is kept free of Polars/Pydantic
+        for the later ``goldenpipe-core`` Rust port; this method is the host
+        glue bracket.
+        """
+        from goldenpipe.autoconfig_glue import (
+            build_planner_input,
+            enforce_confidence,
+            plan_to_config,
+        )
+        from goldenpipe.autoconfig_planner import plan_pipeline
+
+        inp = build_planner_input(ctx)
+        plan = plan_pipeline(inp)
+        self._last_plan = plan
+        enforce_confidence(plan, inp.runtime)  # may raise PipeNotConfidentError
+        return plan_to_config(
+            plan,
+            self._registry.list_all(),
+            self._identity_opts,
+        )
+```
+
+- [ ] **Step 2: Update `run()`'s docstring** to note the raise. Find `def run(` (line 40) and add to its docstring a line:
+
+```
+        Raises:
+            PipeNotConfidentError: when auto-config (no explicit config) is not
+                confident on a large input (>= 100k rows). Pass an explicit
+                config to bypass the brain.
+```
+
+If `run()` currently has no docstring, add a one-line one plus the Raises block. Do NOT change `run()`'s logic — the `_plan_config` call at line 106 is already *before* the `Resolver.resolve` try-block, so the raise propagates out of `run()` (not swallowed into a FAILED PipeResult). Verify by reading lines 104-116.
+
+- [ ] **Step 3: `_auto_config` stays UNTOUCHED.** Confirm you did not modify `_auto_config` (line 145+). Its callers (`core/_planner_json.py`, `tests/test_pipeline.py`) rely on the static default.
+
+- [ ] **Step 4: Run the existing pipeline tests + slice-1 integration to verify no regression**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_pipeline.py packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expected: all pass (slice-1 integration tests exercising `_plan_config` still green — confident_schema df includes infer_schema, single-row skips dedupe, order preserved).
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/pipeline.py
+git add packages/python/goldenpipe/goldenpipe/pipeline.py
+git commit -m "feat(goldenpipe): _plan_config profiles complexity + refuses on RED at scale
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 6: New planner-core tests (bands + rules)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/tests/test_autoconfig_planner.py` (append)
+
+- [ ] **Step 1: Append tests**
+
+```python
+def test_band_of_boundaries():
+    assert band_of(0.7) == "green"
+    assert band_of(0.71) == "green"
+    assert band_of(0.69) == "amber"
+    assert band_of(0.4) == "amber"
+    assert band_of(0.39) == "red"
+    assert band_of(0.0) == "red"
+
+
+def test_rule_low_confidence_is_red_and_safe_default():
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.7))
+    assert plan.rule_name == "low_confidence"
+    assert plan.confidence == 0.3
+    assert band_of(plan.confidence) == "red"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+
+
+def test_low_confidence_not_shadowed_by_confident_schema():
+    # domain present -> confident_schema wins; domain absent + high null -> low_confidence.
+    with_domain = plan_pipeline(_planner_input(inferred_domain="finance",
+                                               domain_confidence=0.8, max_null_density=0.9))
+    assert with_domain.rule_name == "confident_schema"
+    no_domain = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.7))
+    assert no_domain.rule_name == "low_confidence"
+
+
+def test_low_confidence_only_above_null_threshold():
+    # domain absent but low null density -> falls through to default (not RED).
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.5))
+    assert plan.rule_name == "default"
+
+
+def test_default_evidence_records_null_density():
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.5,
+                                        mean_null_density=0.25))
+    assert plan.evidence["max_null_density"] == 0.5
+    assert plan.evidence["mean_null_density"] == 0.25
+```
+
+- [ ] **Step 2: Run — verify PASS**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+```
+Expected: all pass.
+
+- [ ] **Step 3: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git add packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git commit -m "test(goldenpipe): band_of + low_confidence rule coverage
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 7: Refuse integration tests (through `_plan_config`)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/tests/test_autoconfig_glue.py` (append)
+
+These use the slice-1 stub-registry pattern (`_registry_with`, `Pipeline(registry=reg)`) already present in the file. To hit `n_rows >= 100_000` cheaply, build a real 100k-row null-heavy DataFrame with NO detectable domain (generic column names).
+
+- [ ] **Step 1: Append integration tests**
+
+```python
+def _garbage_df(n_rows: int) -> pl.DataFrame:
+    # Generic column names (no domain) + a mostly-null column (max_null_density > 0.6).
+    import polars as pl
+    return pl.DataFrame({
+        "col_a": [None] * n_rows,             # 100% null -> max_null_density 1.0
+        "col_b": list(range(n_rows)),
+    })
+
+
+def test_plan_config_refuses_red_at_scale():
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=_garbage_df(100_000))
+    with pytest.raises(PipeNotConfidentError):
+        eng._plan_config(ctx)
+    assert eng._last_plan.rule_name == "low_confidence"
+
+
+def test_plan_config_red_below_threshold_proceeds():
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=_garbage_df(1_000))
+    cfg = eng._plan_config(ctx)                      # no raise
+    assert eng._last_plan.rule_name == "low_confidence"
+    assert [s.use for s in cfg.stages] == [
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    ]
+```
+
+Confirm `PipeContext`, `Pipeline`, `_registry_with`, `pytest`, and `PipeNotConfidentError` are imported in the file (slice-1 block + Task-4 block already import most; add any missing).
+
+- [ ] **Step 2: Run — verify PASS**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expected: all pass. (The 100k-row build is a trivial all-null + range frame; `null_count` over it is sub-second.)
+
+- [ ] **Step 3: Ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git add packages/python/goldenpipe/tests/test_autoconfig_glue.py
+git commit -m "test(goldenpipe): refuse-on-RED integration through _plan_config
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 8: Full suite + ship
+
+**Files:** none (verification + PR)
+
+- [ ] **Step 1: Run the three touched test files together**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py packages/python/goldenpipe/tests/test_autoconfig_glue.py packages/python/goldenpipe/tests/test_errors.py packages/python/goldenpipe/tests/test_pipeline.py -q
+```
+Expected: all pass.
+
+- [ ] **Step 2: Run the full goldenpipe suite (tolerate pre-existing env failures)**
+
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests -q -p no:cacheprovider --continue-on-collection-errors
+```
+Expected: the ONLY failures/errors are the pre-existing environmental ones from the borrowed goldenmatch venv — files that `import goldenflow`/`goldenmatch` (e.g. `test_engine_stage_v2.py`, `test_adapters.py::TestTransformStage`, `test_identity_cli.py`, `test_a2a.py`, `core/test_planner_parity.py::...resolve_json`). These are identical to slice-1's baseline. If UNSURE whether a failure is pre-existing, stash your changes and re-run the same nodeids:
+
+```bash
+git stash push -- packages/python/goldenpipe
+"$INTERP" -m pytest <suspect nodeids> -q -p no:cacheprovider --continue-on-collection-errors
+git stash pop
+```
+Every NEW test (planner, glue, errors) must pass. Do NOT touch goldenflow/goldenmatch to "fix" the environmental failures.
+
+- [ ] **Step 3: Ruff on all touched files**
+
+```bash
+"$INTERP" -m ruff check \
+  packages/python/goldenpipe/goldenpipe/autoconfig_planner.py \
+  packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py \
+  packages/python/goldenpipe/goldenpipe/autoconfig_glue.py \
+  packages/python/goldenpipe/goldenpipe/errors.py \
+  packages/python/goldenpipe/goldenpipe/pipeline.py \
+  packages/python/goldenpipe/tests/test_autoconfig_planner.py \
+  packages/python/goldenpipe/tests/test_autoconfig_glue.py \
+  packages/python/goldenpipe/tests/test_errors.py
+```
+Expected: All checks passed.
+
+- [ ] **Step 4: DO NOT touch `emit_ts_parity_fixtures.py`.** Cross-surface is deferred; the parity fixture stays aimed at the shared static engine (slice-1's fix). This slice adds no TS work and must not change the emitter or the committed `pipe_parity.json`.
+
+- [ ] **Step 5: Rebase onto fresh origin/main, push, PR, arm auto-merge, STOP**
+
+```bash
+cd "D:/show_case/gg-local-llm"
+unset GH_TOKEN; gh auth switch --user benzsevern >/dev/null 2>&1; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q && git rebase origin/main
+# resolve any conflicts (unlikely — new files + isolated _plan_config edit), then:
+git push -u origin feat/goldenpipe-autoconfig-brain-slice2 --force-with-lease
+gh pr create --repo benseverndev-oss/goldenmatch --base main \
+  --head feat/goldenpipe-autoconfig-brain-slice2 \
+  --title "feat(goldenpipe): auto-config brain slice 2 (ComplexityProfile + refuse-on-RED)" \
+  --body "<summary: ComplexityProfile (null density), band_of green/amber/red, size-gated refuse-on-RED via PipeNotConfidentError; low_confidence rule; _plan_config wired, _auto_config untouched, parity fixture untouched. Deferred: scale-hint merge, PII stage, Rust/TS port. New tests all green on box; remaining suite failures are the pre-existing borrowed-venv goldenflow/goldenmatch breakage (confirmed via stash-compare).>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+gh pr merge <PR#> --auto --squash   # WITHOUT --delete-branch (merge queue); if it says strategy set by queue, run: gh pr merge <PR#> --auto
+```
+Then STOP. Do not poll CI (merge queue lands it on green).
+
+---
+
+## Cross-cutting reminders
+
+- **PYTHONPATH `;` not `:`** on every command (native Windows Python).
+- **No goldenflow/goldenmatch imports** in the new code or its tests — that keeps every new test box-runnable despite the borrowed venv's mid-conflict goldenflow.
+- **`_auto_config` is untouched** — load-bearing for the `_planner_json` Rust parity bridge.
+- **Exact dotted stage names** in every `PlannedStage` (`plan_to_config` silently drops unknown names).
+- **DRY/YAGNI:** `mean_null_density` is carried + recorded in evidence but consumed by no rule this slice — deliberate seam for future signals, made non-dead via `default_evidence`.
+- Frequent commits (one per task). The suite is green at every commit EXCEPT the documented transient between Task 1 and Task 3 (atomic signature migration across core+rules).

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain-slice2.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain-slice2.md
@@ -48,7 +48,10 @@ export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
 **Files:**
 - Modify: `packages/python/goldenpipe/goldenpipe/autoconfig_planner.py`
 - Modify (migrate signatures only, NO new rule yet): `packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py`
+- Modify (migrate the ONE production reader of `plan_pipeline` in the same commit): `packages/python/goldenpipe/goldenpipe/pipeline.py:136-137`
 - Modify (migrate): `packages/python/goldenpipe/tests/test_autoconfig_planner.py`
+
+**Why pipeline.py is in Task 1:** `pipeline.py:137` (`plan_pipeline(profile)`) is the only non-test caller of `plan_pipeline`. Changing the signature to `PlannerInput` breaks it (the rules would dereference `profile.runtime.n_rows` on a bare `PipeProfile` → `AttributeError`), which errors `_plan_config` and the slice-1 integration tests in `test_autoconfig_glue.py`. So `_plan_config` is migrated here too — minimally, wrapping the profile in a `PlannerInput` with a zero `ComplexityProfile`. Task 5 later upgrades that to `build_planner_input` + `enforce_confidence` (which don't exist until Task 4).
 
 - [ ] **Step 1: Migrate the existing planner test to the new `PlannerInput` signature (RED)**
 
@@ -335,23 +338,51 @@ DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
 )
 ```
 
-- [ ] **Step 5: Run — verify the WHOLE planner test file PASSES**
+- [ ] **Step 5: Migrate the ONE production caller — `pipeline.py` `_plan_config` (lines 133-137)**
 
-```bash
-"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py -q
+Replace the profiling lines in `_plan_config` so it builds a `PlannerInput` (with a zero `ComplexityProfile` for now — Task 5 upgrades to `build_planner_input` + `enforce_confidence`). Change the imports + the two lines:
+
+```python
+        from goldenpipe.autoconfig_glue import plan_to_config, profile_context
+        from goldenpipe.autoconfig_planner import (
+            ComplexityProfile,
+            PlannerInput,
+            plan_pipeline,
+        )
+
+        inp = PlannerInput(
+            runtime=profile_context(ctx),
+            complexity=ComplexityProfile(max_null_density=0.0, mean_null_density=0.0),
+        )
+        plan = plan_pipeline(inp)
+        self._last_plan = plan
+        return plan_to_config(
+            plan,
+            self._registry.list_all(),
+            self._identity_opts,
+        )
 ```
-Expected: all pass (signatures consistent across core + rules + tests; no `low_confidence` yet, so no new-rule test yet — those come in Task 6).
 
-- [ ] **Step 6: Ruff + commit (green)**
+(Leave the docstring as-is for now; Task 5 rewrites it to mention the raise. Do NOT touch `_auto_config`.)
+
+- [ ] **Step 6: Run — verify BOTH planner tests AND the glue/integration tests pass**
 
 ```bash
-"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
-git add packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
-git commit -m "feat(goldenpipe): ComplexityProfile + PlannerInput + band_of (core+rules)
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_autoconfig_planner.py packages/python/goldenpipe/tests/test_autoconfig_glue.py -q
+```
+Expected: all pass. The glue file's slice-1 integration tests (`test_plan_config_*`) exercise `_plan_config` → they only pass because Step 5 migrated it. No `low_confidence` yet (Task 3); complexity is zeroed here (Task 5 wires real complexity).
 
-Migrate the decision core and rule table to a PlannerInput bundle (runtime +
-complexity) and add the traffic-light band_of. Atomic signature migration; the
-low_confidence rule is added additively next.
+- [ ] **Step 7: Ruff + commit (green)**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/goldenpipe/pipeline.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git add packages/python/goldenpipe/goldenpipe/autoconfig_planner.py packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py packages/python/goldenpipe/goldenpipe/pipeline.py packages/python/goldenpipe/tests/test_autoconfig_planner.py
+git commit -m "feat(goldenpipe): ComplexityProfile + PlannerInput + band_of (core+rules+wire)
+
+Migrate the decision core, rule table, and the one _plan_config caller to a
+PlannerInput bundle (runtime + complexity) and add the traffic-light band_of.
+Atomic signature migration (green); complexity is zeroed in _plan_config until
+Task 5 wires build_planner_input + enforce_confidence. low_confidence next.
 
 Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
 Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
@@ -689,11 +720,9 @@ Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
 ### Task 5: Wire the brain into `Pipeline._plan_config`
 
 **Files:**
-- Modify: `packages/python/goldenpipe/goldenpipe/pipeline.py:122-143` (`_plan_config`) + `run()` docstring
+- Modify: `packages/python/goldenpipe/goldenpipe/pipeline.py` (`_plan_config` + `run()` docstring)
 
-- [ ] **Step 1: Rewrite `_plan_config` (lines 122-143)**
-
-Replace the body (keep the method name/signature) with:
+- [ ] **Step 1: Rewrite `_plan_config`** — REPLACES the Task-1 inline `PlannerInput`/zero-`ComplexityProfile` version with the real `build_planner_input` (which now computes complexity) + `enforce_confidence` (which now exists, from Task 4). Keep the method name/signature; replace the body with:
 
 ```python
     def _plan_config(self, ctx: PipeContext) -> PipelineConfig:
@@ -841,7 +870,6 @@ These use the slice-1 stub-registry pattern (`_registry_with`, `Pipeline(registr
 ```python
 def _garbage_df(n_rows: int) -> pl.DataFrame:
     # Generic column names (no domain) + a mostly-null column (max_null_density > 0.6).
-    import polars as pl
     return pl.DataFrame({
         "col_a": [None] * n_rows,             # 100% null -> max_null_density 1.0
         "col_b": list(range(n_rows)),
@@ -961,4 +989,4 @@ Then STOP. Do not poll CI (merge queue lands it on green).
 - **`_auto_config` is untouched** — load-bearing for the `_planner_json` Rust parity bridge.
 - **Exact dotted stage names** in every `PlannedStage` (`plan_to_config` silently drops unknown names).
 - **DRY/YAGNI:** `mean_null_density` is carried + recorded in evidence but consumed by no rule this slice — deliberate seam for future signals, made non-dead via `default_evidence`.
-- Frequent commits (one per task). The suite is green at every commit EXCEPT the documented transient between Task 1 and Task 3 (atomic signature migration across core+rules).
+- Frequent commits (one per task). **The suite is green at every commit** — Task 1 migrates every reader of `plan_pipeline`'s new signature (core, rules, `_plan_config`, planner tests) in one commit; Task 3+ are additive.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md
@@ -1,0 +1,259 @@
+# GoldenPipe auto-config brain — Slice 2 design
+
+**Status:** approved (design gate)
+**Date:** 2026-07-07
+**Builds on:** Slice 1 (`docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md`) — the portable `autoconfig_planner` core, the rule table, `autoconfig_glue`, and `_plan_config` (default-on).
+
+## 1. Goal
+
+Make the GoldenPipe auto-config brain reason about *data complexity*, carry a
+*confidence band*, and *refuse* when it cannot plan well at scale — closing the
+gap between slice 1's "switch statement" and GoldenMatch's controller.
+
+Slice 1 decides *which* stages to run from cheap up-front signals (row count,
+InferMap-detected domain). Slice 2 adds:
+
+1. **ComplexityProfile** — deeper, data-derived signals (null density,
+   duplication hint) from one columnar pass.
+2. **Confidence bands** — every plan carries a green/amber/red band derived from
+   its confidence float.
+3. **Refuse-on-RED (size-gated)** — a red-band plan on a large input raises
+   `PipeNotConfidentError` instead of running an expensive, likely-wrong
+   pipeline. Below the threshold it warns and proceeds on the safe default.
+4. **One clean orchestration rule** — `weak_duplication_skip`: drop dedupe when
+   the data has no detectable duplication.
+
+This is a **Python prototype** per the Rust thesis: the decision core stays free
+of Polars/Pydantic so the later `goldenpipe-core` port is mechanical.
+
+## 2. Scope decisions (locked during brainstorming)
+
+- **Config scope = orchestration-level only.** The brain decides pipeline shape,
+  never a downstream stage's internals. This is load-bearing: `adapters/match.py`
+  treats an explicit dedupe `stage_config` as authoritative (Priority 1), which
+  **disables GoldenMatch's own auto-config**. So the brain must NOT hand-build a
+  `GoldenMatchConfig` — that would replace the controller (RuntimeProfile +
+  ComplexityProfile + 7-rule table) with a dumber config. GoldenMatch keeps
+  owning matchkeys / scorers / thresholds.
+- **Signals from one up-front columnar pass** (not two-phase re-planning, not a
+  redundant scan). On a **local** frame this is a full `null_count` / `n_unique`
+  pass (Arrow-backed, cheap — no sampling machinery). On an **engine-resident**
+  frame (`ctx.df is None`, e.g. `DuckDBFrame`) it profiles to **zeros**, the same
+  degraded contract slice-1's runtime profile already uses; we do not force
+  materialization just to profile.
+- **Refuse = size-gated raise**, mirroring GoldenMatch: red band AND
+  `n_rows >= 100_000` raises; red below the threshold warns and proceeds on the
+  safe default; non-red proceeds on the chosen plan.
+
+### 2.1 Explicitly deferred (each is its own slice)
+
+- **Scale-hint merge into GM auto-config.** Real scale routing (e.g. throughput
+  tier at large N) needs a `match.py` change so a brain *hint* MERGES with
+  GoldenMatch's auto-config instead of replacing it. Not this slice.
+- **PII/redact stage.** There is no registered PII stage to route to today
+  (PII handling is reactive via `decisions.py:pii_router`, which consumes
+  `goldencheck.scan` findings post-hoc). A net-new stage is its own design, so
+  `ComplexityProfile` does **not** carry PII signals this slice (YAGNI — no rule
+  would consume them).
+- **`goldenpipe-core` Rust port + TS-WASM parity.** Python leads; TS reconciles
+  later. The TS pipe-parity fixture stays aimed at the shared static engine
+  (slice-1's emitter fix), so this slice does not touch cross-surface parity.
+
+## 3. Portable decision core — `goldenpipe/autoconfig_planner.py`
+
+No Polars, no Pydantic. New/changed:
+
+```python
+@dataclass(frozen=True)
+class ComplexityProfile:
+    """Data-derived signals from one columnar pass. Zeros = unknown
+    (engine-resident frame not profiled this slice)."""
+    max_null_density: float    # 0..1, worst column's null fraction
+    mean_null_density: float   # 0..1, mean across columns
+    duplication_hint: float    # 0..1; ~0 = all-unique rows, ->1 = heavy dup
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    """Everything a rule sees: cheap runtime signals + deeper complexity."""
+    runtime: PipeProfile
+    complexity: ComplexityProfile
+
+
+GREEN_THRESHOLD = 0.7
+AMBER_THRESHOLD = 0.4
+
+
+def band_of(confidence: float) -> str:
+    """Map a confidence float to a traffic-light band (Rust-portable strings)."""
+    if confidence >= GREEN_THRESHOLD:
+        return "green"
+    if confidence >= AMBER_THRESHOLD:
+        return "amber"
+    return "red"
+```
+
+- `Predicate` / `Action` change from `Callable[[PipeProfile], ...]` to
+  `Callable[[PlannerInput], ...]`.
+- `plan_pipeline(inp: PlannerInput, rules=None) -> PipePlan` (was `profile`).
+- `_default_plan(inp)` and `default_evidence(inp)` migrate to read
+  `inp.runtime.*`; `default_evidence` additionally records
+  `max_null_density` and `duplication_hint` so the band is explainable.
+- `PipePlan` is unchanged (still `stages`, `rule_name`, `confidence`, `evidence`).
+  The band is *derived* via `band_of(plan.confidence)`, not stored — keeps the
+  core numeric and the Rust port trivial.
+
+## 4. Rules — `goldenpipe/autoconfig_planner_rules.py`
+
+Ordered, first-match. All predicates read `PlannerInput`. Order and rationale:
+
+| # | Rule | Predicate | Plan | Confidence |
+|---|------|-----------|------|-----------|
+| 1 | `pathological` (kept) | `runtime.n_rows <= 1` | scan, transform | 1.0 |
+| 2 | `confident_schema` (kept) | `domain is not None and domain_confidence >= 0.5` | infer_schema, scan, transform, dedupe | `domain_confidence` |
+| 3 | `weak_duplication_skip` (**new**) | `complexity.duplication_hint <= DUP_EPS and runtime.n_rows >= WEAK_DUP_MIN_ROWS` | scan, transform | 0.75 |
+| 4 | `low_confidence` (**new**) | `runtime.inferred_domain is None and complexity.max_null_density > RED_NULL_DENSITY` | scan, transform, dedupe (safe default) | 0.3 (RED) |
+| 5 | `default` (kept, in `plan_pipeline`) | — | scan, transform, dedupe | 0.7 |
+
+Constants (module-level, named): `DUP_EPS = 0.0` (exact-unique only — sampling
+could miss rare dups, so be conservative), `WEAK_DUP_MIN_ROWS = 1000` (don't
+bother skipping on tiny inputs), `RED_NULL_DENSITY = 0.6`.
+
+**Ordering rationale (documented in code):**
+- `confident_schema` before `weak_duplication_skip`: a strong positive schema
+  signal takes its full plan (with dedupe) even if this input happens to have no
+  dups. `weak_duplication_skip` therefore fires only for **non-confident-domain**
+  data with no duplication — the common "generic table, all unique" case where
+  skipping dedupe saves a needless pass at scale. GoldenMatch dedupe on a
+  zero-dup confident-domain input is fast and safe, so the minor inefficiency is
+  acceptable. Composable per-decision planning (so both `infer_schema` *and*
+  skip-dedupe could apply) is a deliberate future refactor, not this slice.
+- `low_confidence` is the sole RED source: no usable signal (`domain is None`)
+  **and** the data is mostly empty (`max_null_density > 0.6`) means running the
+  full dedupe pipeline is likely to produce garbage clusters. It still returns
+  the safe default plan (so small inputs proceed) but tags it RED so the glue can
+  refuse at scale.
+
+`DEFAULT_RULES = (rule_pathological, rule_confident_schema,
+rule_weak_duplication_skip, rule_low_confidence)`.
+
+## 5. Host glue — `goldenpipe/autoconfig_glue.py`
+
+- **`profile_complexity(ctx: PipeContext) -> ComplexityProfile`** — one pass:
+  - `ctx.df is None` (engine-resident or no data): return
+    `ComplexityProfile(0.0, 0.0, 0.0)` (unknown; not profiled this slice).
+  - Local frame: compute from `df` via Polars columnar aggregates —
+    `null_count()` per column → `max`/`mean` null density over `n_rows`;
+    `duplication_hint = 1 - df.n_unique() / n_rows` (whole-row distinctness).
+    Guard `n_rows == 0` → zeros.
+- **`profile_context`** is unchanged (still builds `PipeProfile`). A small
+  assembler builds `PlannerInput(runtime=profile_context(ctx),
+  complexity=profile_complexity(ctx))` — either a new
+  `build_planner_input(ctx)` helper here, or inline in `_plan_config`. (Plan
+  will pick one; keep `profile_context` and `profile_complexity` independently
+  testable.)
+- **`enforce_confidence(plan: PipePlan, runtime: PipeProfile) -> None`** —
+  ```python
+  if band_of(plan.confidence) == "red":
+      if runtime.n_rows >= REFUSE_ROW_THRESHOLD:
+          raise PipeNotConfidentError(
+              f"auto-config not confident (rule={plan.rule_name}, "
+              f"confidence={plan.confidence}) on {runtime.n_rows} rows; "
+              f"supply an explicit pipeline config or lower the input size. "
+              f"evidence={plan.evidence}"
+          )
+      logger.warning("auto-config low confidence (rule=%s) on %d rows; "
+                     "proceeding on safe default plan", plan.rule_name,
+                     runtime.n_rows)
+  ```
+  `REFUSE_ROW_THRESHOLD = 100_000`.
+- `plan_to_config` is unchanged.
+
+**`PipeNotConfidentError`** — a new goldenpipe-local exception (e.g. in
+`goldenpipe/errors.py` or alongside the glue). goldenpipe-local so the pipeline
+does not take a hard `goldenmatch` dependency just to name the error; the name
+parallels GoldenMatch's `ControllerNotConfidentError` for a consistent
+suite-wide story.
+
+## 6. Pipeline wiring — `goldenpipe/pipeline.py`
+
+`_plan_config(self, ctx)` becomes:
+
+```python
+from goldenpipe.autoconfig_glue import (
+    enforce_confidence, plan_to_config, profile_complexity, profile_context,
+)
+from goldenpipe.autoconfig_planner import PlannerInput, plan_pipeline
+
+inp = PlannerInput(
+    runtime=profile_context(ctx),
+    complexity=profile_complexity(ctx),
+)
+plan = plan_pipeline(inp)
+self._last_plan = plan
+enforce_confidence(plan, inp.runtime)   # may raise PipeNotConfidentError
+return plan_to_config(plan, self._registry.list_all(), self._identity_opts)
+```
+
+- The raise propagates out of `run()` (the `_plan_config` call is *before* the
+  `Resolver.resolve` try-block, so it is not swallowed into a FAILED
+  `PipeResult`). This matches GoldenMatch: refuse is loud, not a silent fallback.
+- `run()`'s docstring documents that it raises `PipeNotConfidentError` on
+  RED-at-scale.
+- `_auto_config` stays untouched (its `_planner_json` + `test_pipeline` callers
+  rely on the static default — same constraint as slice 1).
+
+## 7. Testing (all box-runnable pure Python)
+
+Interpreter `D:/show_case/goldenmatch/.venv/Scripts/python.exe`, `PYTHONPATH`
+with `;` separator, `POLARS_SKIP_CPU_CHECK=1`. `ruff check` all touched files.
+
+**Core (`tests/test_autoconfig_planner.py`, extend):**
+- `ComplexityProfile` / `PlannerInput` frozen.
+- `band_of` boundaries: 0.7→green, 0.69→amber, 0.4→amber, 0.39→red.
+- Each rule fires on a crafted `PlannerInput`, in order (first-match): pathological,
+  confident_schema, weak_duplication_skip (drops dedupe), low_confidence (RED
+  band, safe default stages), default. Confirm `weak_duplication_skip` does NOT
+  fire below `WEAK_DUP_MIN_ROWS` and does NOT fire when a confident domain
+  precedes it.
+
+**Glue (`tests/test_autoconfig_glue.py`, extend):**
+- `profile_complexity`: all-unique df → `duplication_hint == 0`; a df with
+  repeated rows → `duplication_hint > 0`; a df with null-heavy column →
+  `max_null_density` correct; `ctx.df is None` → zeros; `n_rows == 0` → zeros.
+- `enforce_confidence`: RED + `n_rows >= 100_000` raises `PipeNotConfidentError`;
+  RED + small warns and returns None; green/amber returns None.
+
+**Integration (`tests/test_autoconfig_glue.py`, extend, `_registry_with` helper):**
+- All-unique df (≥ `WEAK_DUP_MIN_ROWS`, no confident domain) → `_plan_config`
+  drops dedupe; `_last_plan.rule_name == "weak_duplication_skip"`.
+- Garbage df (no domain, `max_null_density > 0.6`) synthesized at
+  `n_rows >= 100_000` → `_plan_config` raises `PipeNotConfidentError`; the same
+  shape under the threshold → proceeds on the safe default and warns.
+- Existing slice-1 integration tests still pass (confident_schema includes
+  infer_schema; pathological skips dedupe; order preserved).
+
+## 8. Non-goals / limitations (documented)
+
+- Engine-resident (`DuckDBFrame`) inputs are not complexity-profiled this slice,
+  so they never trigger `weak_duplication_skip` or refuse-on-RED (complexity =
+  zeros → those rules can't fire). Acceptable; profiling engine frames without
+  forced materialization is future work tied to the scale-hint slice.
+- Rules return whole-plan lists (slice-1 pattern), so decisions don't compose
+  (a confident-domain no-dup input still dedupes). Documented trade-off;
+  composable planning is a future refactor.
+- No cross-surface (TS) work; no Rust port. Parity fixture untouched.
+
+## 9. File touch list
+
+- `goldenpipe/autoconfig_planner.py` — add `ComplexityProfile`, `PlannerInput`,
+  `band_of` + thresholds; migrate `Predicate`/`Action`/`plan_pipeline`/
+  `_default_plan`/`default_evidence` to `PlannerInput`.
+- `goldenpipe/autoconfig_planner_rules.py` — migrate rule signatures; add
+  `rule_weak_duplication_skip`, `rule_low_confidence`; extend `DEFAULT_RULES`.
+- `goldenpipe/autoconfig_glue.py` — add `profile_complexity`,
+  `enforce_confidence` (+ assembler); import `PipeNotConfidentError`.
+- `goldenpipe/errors.py` (new, or co-located) — `PipeNotConfidentError`.
+- `goldenpipe/pipeline.py` — `_plan_config` builds `PlannerInput`, calls
+  `enforce_confidence`; `run()` docstring notes the raise.
+- `tests/test_autoconfig_planner.py`, `tests/test_autoconfig_glue.py` — extend.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md
@@ -1,27 +1,24 @@
 # GoldenPipe auto-config brain — Slice 2 design
 
-**Status:** approved (design gate)
+**Status:** approved (design gate); revised after spec review (dropped the
+unsound `weak_duplication_skip` rule — see §2.2).
 **Date:** 2026-07-07
 **Builds on:** Slice 1 (`docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-design.md`) — the portable `autoconfig_planner` core, the rule table, `autoconfig_glue`, and `_plan_config` (default-on).
 
 ## 1. Goal
 
-Make the GoldenPipe auto-config brain reason about *data complexity*, carry a
-*confidence band*, and *refuse* when it cannot plan well at scale — closing the
-gap between slice 1's "switch statement" and GoldenMatch's controller.
+Give the GoldenPipe auto-config brain the one property that separates a
+controller from a lookup table: the ability to **refuse** when it cannot plan
+well at scale. Slice 1 decides *which* stages to run from cheap up-front signals
+(row count, InferMap-detected domain). Slice 2 adds:
 
-Slice 1 decides *which* stages to run from cheap up-front signals (row count,
-InferMap-detected domain). Slice 2 adds:
-
-1. **ComplexityProfile** — deeper, data-derived signals (null density,
-   duplication hint) from one columnar pass.
+1. **ComplexityProfile** — a data-derived signal (null density) from one
+   columnar pass. The struct is the home for future complexity signals.
 2. **Confidence bands** — every plan carries a green/amber/red band derived from
    its confidence float.
 3. **Refuse-on-RED (size-gated)** — a red-band plan on a large input raises
    `PipeNotConfidentError` instead of running an expensive, likely-wrong
    pipeline. Below the threshold it warns and proceeds on the safe default.
-4. **One clean orchestration rule** — `weak_duplication_skip`: drop dedupe when
-   the data has no detectable duplication.
 
 This is a **Python prototype** per the Rust thesis: the decision core stays free
 of Polars/Pydantic so the later `goldenpipe-core` port is mechanical.
@@ -36,9 +33,9 @@ of Polars/Pydantic so the later `goldenpipe-core` port is mechanical.
   ComplexityProfile + 7-rule table) with a dumber config. GoldenMatch keeps
   owning matchkeys / scorers / thresholds.
 - **Signals from one up-front columnar pass** (not two-phase re-planning, not a
-  redundant scan). On a **local** frame this is a full `null_count` / `n_unique`
-  pass (Arrow-backed, cheap — no sampling machinery). On an **engine-resident**
-  frame (`ctx.df is None`, e.g. `DuckDBFrame`) it profiles to **zeros**, the same
+  redundant scan). On a **local** frame this is a full per-column `null_count`
+  pass (a light Arrow-backed aggregate). On an **engine-resident** frame
+  (`ctx.df is None`, e.g. `DuckDBFrame`) it profiles to **zeros**, the same
   degraded contract slice-1's runtime profile already uses; we do not force
   materialization just to profile.
 - **Refuse = size-gated raise**, mirroring GoldenMatch: red band AND
@@ -59,6 +56,21 @@ of Polars/Pydantic so the later `goldenpipe-core` port is mechanical.
   later. The TS pipe-parity fixture stays aimed at the shared static engine
   (slice-1's emitter fix), so this slice does not touch cross-surface parity.
 
+### 2.2 Cut during spec review: `weak_duplication_skip`
+
+The design originally added a `weak_duplication_skip` rule that dropped dedupe
+when a `duplication_hint = 1 - n_unique()/n_rows` signal was ~0. **Removed.**
+`df.n_unique()` measures *whole-row exact* uniqueness, which is an unsound proxy
+for "no fuzzy duplicates": the whole job of `goldenmatch.dedupe` is finding
+near-duplicate entities among rows that are almost never byte-identical (a
+surrogate id column, a middle initial, or a typo all make rows exact-unique
+while the table is full of duplicate people). The rule would drop dedupe exactly
+on legitimate dedupe inputs. There is no cheap, sound up-front proxy for "no
+fuzzy dups" (a real estimate needs blocking/collision counting — dedupe's own
+job), so the rule and the `duplication_hint` signal are cut. This slice ships
+the sound refuse-core; a genuine skip signal, if one is ever found, is future
+work.
+
 ## 3. Portable decision core — `goldenpipe/autoconfig_planner.py`
 
 No Polars, no Pydantic. New/changed:
@@ -70,7 +82,6 @@ class ComplexityProfile:
     (engine-resident frame not profiled this slice)."""
     max_null_density: float    # 0..1, worst column's null fraction
     mean_null_density: float   # 0..1, mean across columns
-    duplication_hint: float    # 0..1; ~0 = all-unique rows, ->1 = heavy dup
 
 
 @dataclass(frozen=True)
@@ -95,63 +106,56 @@ def band_of(confidence: float) -> str:
 
 - `Predicate` / `Action` change from `Callable[[PipeProfile], ...]` to
   `Callable[[PlannerInput], ...]`.
-- `plan_pipeline(inp: PlannerInput, rules=None) -> PipePlan` (was `profile`).
+- `plan_pipeline(inp: PlannerInput, rules=None) -> PipePlan` (parameter renamed
+  from `profile`).
 - `_default_plan(inp)` and `default_evidence(inp)` migrate to read
-  `inp.runtime.*`; `default_evidence` additionally records
-  `max_null_density` and `duplication_hint` so the band is explainable.
-- `PipePlan` is unchanged (still `stages`, `rule_name`, `confidence`, `evidence`).
-  The band is *derived* via `band_of(plan.confidence)`, not stored — keeps the
-  core numeric and the Rust port trivial.
+  `inp.runtime.*`; `default_evidence` additionally records `max_null_density`
+  so the band is explainable.
+- `PipePlan` is unchanged (still `stages`, `rule_name`, `confidence`,
+  `evidence`). The band is *derived* via `band_of(plan.confidence)`, not stored —
+  keeps the core numeric and the Rust port trivial.
 
 ## 4. Rules — `goldenpipe/autoconfig_planner_rules.py`
 
-Ordered, first-match. All predicates read `PlannerInput`. Order and rationale:
+Ordered, first-match. All predicates read `PlannerInput`. **Stage names are the
+EXACT dotted registry names** (`plan_to_config` drops any `PlannedStage.name`
+not in the registry — the slice-1 inert-rule footgun). Reuse the exact tuples
+the shipped `_pathological_plan` / `_default_plan` already use.
 
-| # | Rule | Predicate | Plan | Confidence |
-|---|------|-----------|------|-----------|
-| 1 | `pathological` (kept) | `runtime.n_rows <= 1` | scan, transform | 1.0 |
-| 2 | `confident_schema` (kept) | `domain is not None and domain_confidence >= 0.5` | infer_schema, scan, transform, dedupe | `domain_confidence` |
-| 3 | `weak_duplication_skip` (**new**) | `complexity.duplication_hint <= DUP_EPS and runtime.n_rows >= WEAK_DUP_MIN_ROWS` | scan, transform | 0.75 |
-| 4 | `low_confidence` (**new**) | `runtime.inferred_domain is None and complexity.max_null_density > RED_NULL_DENSITY` | scan, transform, dedupe (safe default) | 0.3 (RED) |
-| 5 | `default` (kept, in `plan_pipeline`) | — | scan, transform, dedupe | 0.7 |
+| # | Rule | Predicate | Plan (exact names) | Confidence |
+|---|------|-----------|--------------------|-----------|
+| 1 | `pathological` (kept) | `runtime.n_rows <= 1` | `goldencheck.scan`, `goldenflow.transform` | 1.0 |
+| 2 | `confident_schema` (kept) | `runtime.inferred_domain is not None and runtime.domain_confidence >= 0.5` | `infer_schema`, `goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe` | `domain_confidence` |
+| 3 | `low_confidence` (**new, RED source**) | `runtime.inferred_domain is None and complexity.max_null_density > RED_NULL_DENSITY` | `goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe` (safe default) | 0.3 (RED) |
+| 4 | `default` (kept, in `plan_pipeline`) | — | `goldencheck.scan`, `goldenflow.transform`, `goldenmatch.dedupe` | 0.7 |
 
-Constants (module-level, named): `DUP_EPS = 0.0` (exact-unique only — sampling
-could miss rare dups, so be conservative), `WEAK_DUP_MIN_ROWS = 1000` (don't
-bother skipping on tiny inputs), `RED_NULL_DENSITY = 0.6`.
+Constant: `RED_NULL_DENSITY = 0.6` (module-level, named).
 
 **Ordering rationale (documented in code):**
-- `confident_schema` before `weak_duplication_skip`: a strong positive schema
-  signal takes its full plan (with dedupe) even if this input happens to have no
-  dups. `weak_duplication_skip` therefore fires only for **non-confident-domain**
-  data with no duplication — the common "generic table, all unique" case where
-  skipping dedupe saves a needless pass at scale. GoldenMatch dedupe on a
-  zero-dup confident-domain input is fast and safe, so the minor inefficiency is
-  acceptable. Composable per-decision planning (so both `infer_schema` *and*
-  skip-dedupe could apply) is a deliberate future refactor, not this slice.
 - `low_confidence` is the sole RED source: no usable signal (`domain is None`)
   **and** the data is mostly empty (`max_null_density > 0.6`) means running the
   full dedupe pipeline is likely to produce garbage clusters. It still returns
   the safe default plan (so small inputs proceed) but tags it RED so the glue can
   refuse at scale.
+- It sits after the positive rules (`pathological`, `confident_schema`) — a
+  clear positive signal wins — and before the plain `default`. With
+  `weak_duplication_skip` cut, nothing shadows it: the garbage case
+  (`domain None`, high null) reaches rule 3 and gets RED regardless of row
+  distinctness.
 
-`DEFAULT_RULES = (rule_pathological, rule_confident_schema,
-rule_weak_duplication_skip, rule_low_confidence)`.
+`DEFAULT_RULES = (rule_pathological, rule_confident_schema, rule_low_confidence)`.
 
 ## 5. Host glue — `goldenpipe/autoconfig_glue.py`
 
 - **`profile_complexity(ctx: PipeContext) -> ComplexityProfile`** — one pass:
-  - `ctx.df is None` (engine-resident or no data): return
-    `ComplexityProfile(0.0, 0.0, 0.0)` (unknown; not profiled this slice).
-  - Local frame: compute from `df` via Polars columnar aggregates —
-    `null_count()` per column → `max`/`mean` null density over `n_rows`;
-    `duplication_hint = 1 - df.n_unique() / n_rows` (whole-row distinctness).
-    Guard `n_rows == 0` → zeros.
-- **`profile_context`** is unchanged (still builds `PipeProfile`). A small
-  assembler builds `PlannerInput(runtime=profile_context(ctx),
-  complexity=profile_complexity(ctx))` — either a new
-  `build_planner_input(ctx)` helper here, or inline in `_plan_config`. (Plan
-  will pick one; keep `profile_context` and `profile_complexity` independently
-  testable.)
+  - `ctx.df is None` (engine-resident or no data) **or** `n_rows == 0`: return
+    `ComplexityProfile(0.0, 0.0)` (unknown; not profiled this slice).
+  - Local frame: `nulls = df.null_count()` (a 1-row per-column frame) → per-column
+    null fraction `count / n_rows`; `max_null_density = max(fractions)`,
+    `mean_null_density = mean(fractions)`.
+- **`build_planner_input(ctx) -> PlannerInput`** — assembles
+  `PlannerInput(runtime=profile_context(ctx), complexity=profile_complexity(ctx))`.
+  `profile_context` and `profile_complexity` stay independently testable.
 - **`enforce_confidence(plan: PipePlan, runtime: PipeProfile) -> None`** —
   ```python
   if band_of(plan.confidence) == "red":
@@ -159,7 +163,7 @@ rule_weak_duplication_skip, rule_low_confidence)`.
           raise PipeNotConfidentError(
               f"auto-config not confident (rule={plan.rule_name}, "
               f"confidence={plan.confidence}) on {runtime.n_rows} rows; "
-              f"supply an explicit pipeline config or lower the input size. "
+              f"supply an explicit pipeline config or reduce the input size. "
               f"evidence={plan.evidence}"
           )
       logger.warning("auto-config low confidence (rule=%s) on %d rows; "
@@ -169,11 +173,10 @@ rule_weak_duplication_skip, rule_low_confidence)`.
   `REFUSE_ROW_THRESHOLD = 100_000`.
 - `plan_to_config` is unchanged.
 
-**`PipeNotConfidentError`** — a new goldenpipe-local exception (e.g. in
-`goldenpipe/errors.py` or alongside the glue). goldenpipe-local so the pipeline
-does not take a hard `goldenmatch` dependency just to name the error; the name
-parallels GoldenMatch's `ControllerNotConfidentError` for a consistent
-suite-wide story.
+**`PipeNotConfidentError`** — a new goldenpipe-local exception (in
+`goldenpipe/errors.py`). goldenpipe-local so the pipeline does not take a hard
+`goldenmatch` dependency just to name the error; the name parallels GoldenMatch's
+`ControllerNotConfidentError` for a consistent suite-wide story.
 
 ## 6. Pipeline wiring — `goldenpipe/pipeline.py`
 
@@ -181,67 +184,74 @@ suite-wide story.
 
 ```python
 from goldenpipe.autoconfig_glue import (
-    enforce_confidence, plan_to_config, profile_complexity, profile_context,
+    build_planner_input, enforce_confidence, plan_to_config,
 )
-from goldenpipe.autoconfig_planner import PlannerInput, plan_pipeline
+from goldenpipe.autoconfig_planner import plan_pipeline
 
-inp = PlannerInput(
-    runtime=profile_context(ctx),
-    complexity=profile_complexity(ctx),
-)
+inp = build_planner_input(ctx)
 plan = plan_pipeline(inp)
 self._last_plan = plan
 enforce_confidence(plan, inp.runtime)   # may raise PipeNotConfidentError
 return plan_to_config(plan, self._registry.list_all(), self._identity_opts)
 ```
 
-- The raise propagates out of `run()` (the `_plan_config` call is *before* the
-  `Resolver.resolve` try-block, so it is not swallowed into a FAILED
-  `PipeResult`). This matches GoldenMatch: refuse is loud, not a silent fallback.
+- The raise propagates out of `run()`: `_plan_config` is called at
+  `pipeline.py:106`, *before* the `Resolver.resolve` try-block at line 108, so the
+  refuse is a loud exception, not a swallowed FAILED `PipeResult`. This matches
+  GoldenMatch: refuse is not a silent fallback. (Verified against shipped
+  `run()`.)
 - `run()`'s docstring documents that it raises `PipeNotConfidentError` on
   RED-at-scale.
-- `_auto_config` stays untouched (its `_planner_json` + `test_pipeline` callers
-  rely on the static default — same constraint as slice 1).
+- `_auto_config` stays untouched. It is `_auto_config(self)` (no `ctx`) and is
+  called by `core/_planner_json.py` (the goldenpipe-core Rust parity bridge) and
+  `tests/test_pipeline.py`; those rely on the static default. Same constraint as
+  slice 1.
 
 ## 7. Testing (all box-runnable pure Python)
 
 Interpreter `D:/show_case/goldenmatch/.venv/Scripts/python.exe`, `PYTHONPATH`
-with `;` separator, `POLARS_SKIP_CPU_CHECK=1`. `ruff check` all touched files.
+with `;` separator (Windows native), `POLARS_SKIP_CPU_CHECK=1`. `ruff check` all
+touched files. Core + glue + integration tests need only `polars` + `infermap`
+importable (the slice-1 `test_autoconfig_glue.py` pattern already relies on
+`infermap.detect_domain_detailed`); they do NOT import `goldenflow`/`goldenmatch`
+(the integration tests use a stub registry).
 
-**Core (`tests/test_autoconfig_planner.py`, extend):**
-- `ComplexityProfile` / `PlannerInput` frozen.
-- `band_of` boundaries: 0.7→green, 0.69→amber, 0.4→amber, 0.39→red.
-- Each rule fires on a crafted `PlannerInput`, in order (first-match): pathological,
-  confident_schema, weak_duplication_skip (drops dedupe), low_confidence (RED
-  band, safe default stages), default. Confirm `weak_duplication_skip` does NOT
-  fire below `WEAK_DUP_MIN_ROWS` and does NOT fire when a confident domain
-  precedes it.
+**Core (`tests/test_autoconfig_planner.py`, MIGRATE + extend):**
+- The existing tests call `plan_pipeline(_profile(...))` at six sites and use an
+  inline `lambda p: p.n_rows == 100` predicate reading `PipeProfile` directly.
+  All of these must be **migrated** to the new `PlannerInput` signature — add a
+  `_planner_input(**kw)` helper wrapping `runtime=_profile(...)` +
+  `complexity=ComplexityProfile(...)` and rewrite each call site + the lambda to
+  read `inp.runtime.*`.
+- New: `ComplexityProfile` / `PlannerInput` frozen; `band_of` boundaries
+  (0.7→green, 0.69→amber, 0.4→amber, 0.39→red); each rule fires in order
+  (pathological, confident_schema, low_confidence → RED band + safe-default
+  stages, default); `low_confidence` reachable for the garbage `PlannerInput`.
 
 **Glue (`tests/test_autoconfig_glue.py`, extend):**
-- `profile_complexity`: all-unique df → `duplication_hint == 0`; a df with
-  repeated rows → `duplication_hint > 0`; a df with null-heavy column →
-  `max_null_density` correct; `ctx.df is None` → zeros; `n_rows == 0` → zeros.
-- `enforce_confidence`: RED + `n_rows >= 100_000` raises `PipeNotConfidentError`;
-  RED + small warns and returns None; green/amber returns None.
+- `profile_complexity`: null-heavy column → correct `max_null_density`;
+  no-null df → zeros; `ctx.df is None` → zeros; `n_rows == 0` → zeros.
+- `enforce_confidence`: RED (`confidence=0.3`) + `n_rows >= 100_000` raises
+  `PipeNotConfidentError`; RED + small warns and returns None; green/amber
+  returns None.
 
 **Integration (`tests/test_autoconfig_glue.py`, extend, `_registry_with` helper):**
-- All-unique df (≥ `WEAK_DUP_MIN_ROWS`, no confident domain) → `_plan_config`
-  drops dedupe; `_last_plan.rule_name == "weak_duplication_skip"`.
-- Garbage df (no domain, `max_null_density > 0.6`) synthesized at
+- Garbage df (no detectable domain, `max_null_density > 0.6`) synthesized at
   `n_rows >= 100_000` → `_plan_config` raises `PipeNotConfidentError`; the same
-  shape under the threshold → proceeds on the safe default and warns.
+  shape under the threshold → proceeds on the safe default (`_last_plan.rule_name
+  == "low_confidence"`) and warns.
 - Existing slice-1 integration tests still pass (confident_schema includes
   infer_schema; pathological skips dedupe; order preserved).
 
 ## 8. Non-goals / limitations (documented)
 
-- Engine-resident (`DuckDBFrame`) inputs are not complexity-profiled this slice,
-  so they never trigger `weak_duplication_skip` or refuse-on-RED (complexity =
-  zeros → those rules can't fire). Acceptable; profiling engine frames without
-  forced materialization is future work tied to the scale-hint slice.
-- Rules return whole-plan lists (slice-1 pattern), so decisions don't compose
-  (a confident-domain no-dup input still dedupes). Documented trade-off;
-  composable planning is a future refactor.
+- Engine-resident (`DuckDBFrame`) inputs are not complexity-profiled this slice
+  (complexity = zeros → `low_confidence` can't fire → never refuses). Acceptable;
+  profiling engine frames without forced materialization is future work tied to
+  the scale-hint slice.
+- Rules return whole-plan lists (slice-1 pattern); decisions don't compose. Not a
+  problem for this rule set (all positive rules + one RED refuse), but noted as
+  the shape a future composable-planning refactor would change.
 - No cross-surface (TS) work; no Rust port. Parity fixture untouched.
 
 ## 9. File touch list
@@ -249,11 +259,15 @@ with `;` separator, `POLARS_SKIP_CPU_CHECK=1`. `ruff check` all touched files.
 - `goldenpipe/autoconfig_planner.py` — add `ComplexityProfile`, `PlannerInput`,
   `band_of` + thresholds; migrate `Predicate`/`Action`/`plan_pipeline`/
   `_default_plan`/`default_evidence` to `PlannerInput`.
-- `goldenpipe/autoconfig_planner_rules.py` — migrate rule signatures; add
-  `rule_weak_duplication_skip`, `rule_low_confidence`; extend `DEFAULT_RULES`.
+- `goldenpipe/autoconfig_planner_rules.py` — migrate rule signatures to
+  `PlannerInput`; add `rule_low_confidence` + `RED_NULL_DENSITY`; extend
+  `DEFAULT_RULES`.
 - `goldenpipe/autoconfig_glue.py` — add `profile_complexity`,
-  `enforce_confidence` (+ assembler); import `PipeNotConfidentError`.
-- `goldenpipe/errors.py` (new, or co-located) — `PipeNotConfidentError`.
+  `build_planner_input`, `enforce_confidence`; import `PipeNotConfidentError`.
+- `goldenpipe/errors.py` (new) — `PipeNotConfidentError`.
 - `goldenpipe/pipeline.py` — `_plan_config` builds `PlannerInput`, calls
   `enforce_confidence`; `run()` docstring notes the raise.
-- `tests/test_autoconfig_planner.py`, `tests/test_autoconfig_glue.py` — extend.
+- `tests/test_autoconfig_planner.py` — **migrate** the six `plan_pipeline` call
+  sites + inline lambda to `PlannerInput`; add new-rule / band tests.
+- `tests/test_autoconfig_glue.py` — extend with `profile_complexity`,
+  `enforce_confidence`, and refuse integration tests.

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_glue.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_glue.py
@@ -5,10 +5,18 @@ NOT ported to Rust — the future `goldenpipe-core` kernel is the portable core
 """
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any
 
-from goldenpipe.autoconfig_planner import PipePlan, PipeProfile
+from goldenpipe.autoconfig_planner import (
+    ComplexityProfile,
+    PipePlan,
+    PipeProfile,
+    PlannerInput,
+    band_of,
+)
+from goldenpipe.errors import PipeNotConfidentError
 from goldenpipe.models.config import PipelineConfig, StageSpec
 from goldenpipe.models.context import PipeContext
 
@@ -42,6 +50,55 @@ def profile_context(ctx: PipeContext) -> PipeProfile:
         dtypes=dtypes,
         inferred_domain=inferred_domain,
         domain_confidence=domain_confidence,
+    )
+
+
+logger = logging.getLogger(__name__)
+
+REFUSE_ROW_THRESHOLD = 100_000
+
+
+def profile_complexity(ctx: PipeContext) -> ComplexityProfile:
+    """One columnar pass for null density. Engine-resident or empty -> zeros
+    (unknown; not profiled this slice)."""
+    df = ctx.df
+    if df is None:
+        return ComplexityProfile(max_null_density=0.0, mean_null_density=0.0)
+    n_rows = len(df)
+    if n_rows == 0:
+        return ComplexityProfile(max_null_density=0.0, mean_null_density=0.0)
+    # null_count() -> a 1-row frame of per-column null counts.
+    counts = df.null_count().row(0)
+    fractions = [c / n_rows for c in counts]
+    return ComplexityProfile(
+        max_null_density=max(fractions),
+        mean_null_density=sum(fractions) / len(fractions),
+    )
+
+
+def build_planner_input(ctx: PipeContext) -> PlannerInput:
+    """Assemble the full decision input (runtime + complexity) from a context."""
+    return PlannerInput(
+        runtime=profile_context(ctx),
+        complexity=profile_complexity(ctx),
+    )
+
+
+def enforce_confidence(plan: PipePlan, runtime: PipeProfile) -> None:
+    """Refuse-on-RED (size-gated). Raises PipeNotConfidentError on a red-band
+    plan at/above the row threshold; warns and proceeds below it; no-op otherwise."""
+    if band_of(plan.confidence) != "red":
+        return
+    if runtime.n_rows >= REFUSE_ROW_THRESHOLD:
+        raise PipeNotConfidentError(
+            f"auto-config not confident (rule={plan.rule_name}, "
+            f"confidence={plan.confidence}) on {runtime.n_rows} rows; "
+            f"supply an explicit pipeline config or reduce the input size. "
+            f"evidence={plan.evidence}"
+        )
+    logger.warning(
+        "auto-config low confidence (rule=%s) on %d rows; proceeding on safe "
+        "default plan", plan.rule_name, runtime.n_rows,
     )
 
 

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner.py
@@ -1,9 +1,10 @@
 """Plan-first auto-config decision core (portable — NO Polars/Pydantic).
 
-The pyo3-free-portable kernel: PipeProfile (in) -> PipePlan (out) via a pure
-rule table. Host glue (Polars profiling, Pydantic config) lives in
-`autoconfig_glue.py`. Mirrors goldenmatch's autoconfig_planner (PlannerRule +
-first-match plan) so the later `goldenpipe-core` Rust port is mechanical.
+The pyo3-free-portable kernel: PlannerInput (in) -> PipePlan (out) via a pure
+rule table. Host glue (Polars profiling, Pydantic config, refuse-raise) lives in
+`autoconfig_glue.py`. Mirrors goldenmatch's controller (PlannerRule + first-match
+plan, RuntimeProfile + ComplexityProfile, traffic-light confidence) so the later
+`goldenpipe-core` Rust port is mechanical.
 """
 from __future__ import annotations
 
@@ -23,6 +24,21 @@ class PipeProfile:
 
 
 @dataclass(frozen=True)
+class ComplexityProfile:
+    """Data-derived signals from one columnar pass. Zeros = unknown
+    (engine-resident frame not profiled this slice)."""
+    max_null_density: float    # 0..1, worst column's null fraction
+    mean_null_density: float   # 0..1, mean across columns
+
+
+@dataclass(frozen=True)
+class PlannerInput:
+    """Everything a rule sees: cheap runtime signals + deeper complexity."""
+    runtime: PipeProfile
+    complexity: ComplexityProfile
+
+
+@dataclass(frozen=True)
 class PlannedStage:
     name: str            # EXACT registry name (e.g. "goldencheck.scan", "infer_schema")
     config: dict         # per-stage config
@@ -36,8 +52,8 @@ class PipePlan:
     evidence: dict
 
 
-Predicate = Callable[[PipeProfile], bool]
-Action = Callable[[PipeProfile], "PipePlan"]
+Predicate = Callable[["PlannerInput"], bool]
+Action = Callable[["PlannerInput"], "PipePlan"]
 
 
 @dataclass(frozen=True)
@@ -47,17 +63,32 @@ class PipePlannerRule:
     action: Action
 
 
-def default_evidence(p: PipeProfile) -> dict:
+GREEN_THRESHOLD = 0.7
+AMBER_THRESHOLD = 0.4
+
+
+def band_of(confidence: float) -> str:
+    """Map a confidence float to a traffic-light band (Rust-portable strings)."""
+    if confidence >= GREEN_THRESHOLD:
+        return "green"
+    if confidence >= AMBER_THRESHOLD:
+        return "amber"
+    return "red"
+
+
+def default_evidence(inp: PlannerInput) -> dict:
     """Signal snapshot attached to every plan (evidence for humans/telemetry)."""
     return {
-        "n_rows": p.n_rows,
-        "n_cols": p.n_cols,
-        "inferred_domain": p.inferred_domain,
-        "domain_confidence": p.domain_confidence,
+        "n_rows": inp.runtime.n_rows,
+        "n_cols": inp.runtime.n_cols,
+        "inferred_domain": inp.runtime.inferred_domain,
+        "domain_confidence": inp.runtime.domain_confidence,
+        "max_null_density": inp.complexity.max_null_density,
+        "mean_null_density": inp.complexity.mean_null_density,
     }
 
 
-def _default_plan(p: PipeProfile) -> PipePlan:
+def _default_plan(inp: PlannerInput) -> PipePlan:
     """The current static shape: scan -> flow -> dedupe (no infer_schema)."""
     return PipePlan(
         stages=(
@@ -67,12 +98,12 @@ def _default_plan(p: PipeProfile) -> PipePlan:
         ),
         rule_name="default",
         confidence=0.7,
-        evidence=default_evidence(p),
+        evidence=default_evidence(inp),
     )
 
 
 def plan_pipeline(
-    profile: PipeProfile,
+    inp: PlannerInput,
     rules: Sequence[PipePlannerRule] | None = None,
 ) -> PipePlan:
     """First matching rule's action builds the plan; else the default shape."""
@@ -80,6 +111,6 @@ def plan_pipeline(
         from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES
         rules = DEFAULT_RULES
     for rule in rules:
-        if rule.predicate(profile):
-            return rule.action(profile)
-    return _default_plan(profile)
+        if rule.predicate(inp):
+            return rule.action(inp)
+    return _default_plan(inp)

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
@@ -15,6 +15,7 @@ from goldenpipe.autoconfig_planner import (
 )
 
 _CONFIDENT_DOMAIN_THRESHOLD = 0.5
+RED_NULL_DENSITY = 0.6
 
 
 def _is_pathological(inp: PlannerInput) -> bool:
@@ -60,7 +61,41 @@ rule_confident_schema = PipePlannerRule(
 )
 
 
+def _is_low_confidence(inp: PlannerInput) -> bool:
+    # The sole RED source: no usable signal AND the data is mostly empty, so
+    # running the full dedupe pipeline is likely to produce garbage clusters.
+    return (
+        inp.runtime.inferred_domain is None
+        and inp.complexity.max_null_density > RED_NULL_DENSITY
+    )
+
+
+def _low_confidence_plan(inp: PlannerInput) -> PipePlan:
+    # Return the SAFE DEFAULT shape (so small inputs proceed) but tag it RED so
+    # the glue can refuse at scale.
+    return PipePlan(
+        stages=(
+            PlannedStage("goldencheck.scan", {}),
+            PlannedStage("goldenflow.transform", {}),
+            PlannedStage("goldenmatch.dedupe", {}),
+        ),
+        rule_name="low_confidence",
+        confidence=0.3,
+        evidence=default_evidence(inp),
+    )
+
+
+rule_low_confidence = PipePlannerRule(
+    "low_confidence", _is_low_confidence, _low_confidence_plan,
+)
+
+
+# Order: positive rules first (a clear signal wins), then low_confidence (RED),
+# then plan_pipeline's plain default. Nothing shadows low_confidence — rules 1/2
+# require n_rows<=1 / domain-present, which the garbage case (domain None, high
+# null) does not satisfy.
 DEFAULT_RULES: tuple[PipePlannerRule, ...] = (
     rule_pathological,
     rule_confident_schema,
+    rule_low_confidence,
 )

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
@@ -64,6 +64,15 @@ rule_confident_schema = PipePlannerRule(
 def _is_low_confidence(inp: PlannerInput) -> bool:
     # The sole RED source: no usable signal AND the data is mostly empty, so
     # running the full dedupe pipeline is likely to produce garbage clusters.
+    #
+    # Trip signal is the WORST column's null fraction (max, not mean): a single
+    # near-empty column is enough to make the row unreliable to match on. This
+    # is the more aggressive of the two metrics, so it is deliberately
+    # double-gated on `inferred_domain is None` -- a table with a detected
+    # domain is never refused on null density alone, which keeps the
+    # false-refuse blast radius narrow (a domain-less table with one optional
+    # mostly-null column is the only thing that trips it). Revisit toward `mean`
+    # if legitimate wide tables start getting refused.
     return (
         inp.runtime.inferred_domain is None
         and inp.complexity.max_null_density > RED_NULL_DENSITY

--- a/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
+++ b/packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py
@@ -1,26 +1,27 @@
-"""Concrete planner rules for the goldenpipe auto-config brain (slice 1).
+"""Concrete planner rules for the goldenpipe auto-config brain.
 
-Ordered; first match wins (see plan_pipeline). All predicates read only cheap
-PipeProfile signals. Portable — no Polars/Pydantic.
+Ordered; first match wins (see plan_pipeline). Predicates read PlannerInput
+(runtime + complexity). Portable — no Polars/Pydantic. Stage names are the EXACT
+dotted registry names (plan_to_config drops any name not in the registry).
 """
 from __future__ import annotations
 
 from goldenpipe.autoconfig_planner import (
     PipePlan,
     PipePlannerRule,
-    PipeProfile,
     PlannedStage,
+    PlannerInput,
     default_evidence,
 )
 
 _CONFIDENT_DOMAIN_THRESHOLD = 0.5
 
 
-def _is_pathological(p: PipeProfile) -> bool:
-    return p.n_rows <= 1
+def _is_pathological(inp: PlannerInput) -> bool:
+    return inp.runtime.n_rows <= 1
 
 
-def _pathological_plan(p: PipeProfile) -> PipePlan:
+def _pathological_plan(inp: PlannerInput) -> PipePlan:
     return PipePlan(
         stages=(
             PlannedStage("goldencheck.scan", {}),
@@ -28,28 +29,29 @@ def _pathological_plan(p: PipeProfile) -> PipePlan:
         ),
         rule_name="pathological",
         confidence=1.0,
-        evidence=default_evidence(p),
+        evidence=default_evidence(inp),
     )
 
 
 rule_pathological = PipePlannerRule("pathological", _is_pathological, _pathological_plan)
 
 
-def _is_confident_schema(p: PipeProfile) -> bool:
-    return p.inferred_domain is not None and p.domain_confidence >= _CONFIDENT_DOMAIN_THRESHOLD
+def _is_confident_schema(inp: PlannerInput) -> bool:
+    r = inp.runtime
+    return r.inferred_domain is not None and r.domain_confidence >= _CONFIDENT_DOMAIN_THRESHOLD
 
 
-def _confident_schema_plan(p: PipeProfile) -> PipePlan:
+def _confident_schema_plan(inp: PlannerInput) -> PipePlan:
     return PipePlan(
         stages=(
-            PlannedStage("infer_schema", {"domain": p.inferred_domain}),
+            PlannedStage("infer_schema", {"domain": inp.runtime.inferred_domain}),
             PlannedStage("goldencheck.scan", {}),
             PlannedStage("goldenflow.transform", {}),
             PlannedStage("goldenmatch.dedupe", {}),
         ),
         rule_name="confident_schema",
-        confidence=p.domain_confidence,
-        evidence=default_evidence(p),
+        confidence=inp.runtime.domain_confidence,
+        evidence=default_evidence(inp),
     )
 
 

--- a/packages/python/goldenpipe/goldenpipe/errors.py
+++ b/packages/python/goldenpipe/goldenpipe/errors.py
@@ -1,0 +1,12 @@
+"""goldenpipe-local exceptions."""
+from __future__ import annotations
+
+
+class PipeNotConfidentError(RuntimeError):
+    """Raised by the auto-config brain when it cannot confidently plan a
+    pipeline for a large input (red confidence band at/above the row threshold).
+
+    Parallels goldenmatch's ``ControllerNotConfidentError``: refuse loudly
+    rather than run an expensive, likely-wrong pipeline. Supply an explicit
+    pipeline config (or reduce the input size) to proceed.
+    """

--- a/packages/python/goldenpipe/goldenpipe/pipeline.py
+++ b/packages/python/goldenpipe/goldenpipe/pipeline.py
@@ -45,6 +45,13 @@ class Pipeline:
         duckdb_con=None,
         duckdb_table: str | None = None,
     ) -> PipeResult:
+        """Run the pipeline against a source file, DataFrame, or DuckDB table.
+
+        Raises:
+            PipeNotConfidentError: when auto-config (no explicit config) is not
+                confident on a large input (>= 100k rows). Pass an explicit
+                config to bypass the brain.
+        """
         ctx = PipeContext()
 
         if duckdb_con is not None and duckdb_table is not None:
@@ -121,28 +128,28 @@ class Pipeline:
 
     def _plan_config(self, ctx: PipeContext) -> PipelineConfig:
         """Plan-first auto-config: profile the loaded context, run the rule
-        table, and materialize the chosen plan into a PipelineConfig.
+        table, refuse if not confident at scale, and materialize the chosen
+        plan into a PipelineConfig.
 
         This is the "brain" (parity with GoldenMatch's controller): the shape
-        of the pipeline is DECIDED from the data + InferMap-inferred schema
-        rather than being the fixed scan/transform/dedupe list. The portable
+        of the pipeline is DECIDED from the data + InferMap-inferred schema, and
+        a red-confidence plan on a large input raises ``PipeNotConfidentError``
+        rather than running an expensive, likely-wrong pipeline. The portable
         decision core (``autoconfig_planner``) is kept free of Polars/Pydantic
         for the later ``goldenpipe-core`` Rust port; this method is the host
         glue bracket.
         """
-        from goldenpipe.autoconfig_glue import plan_to_config, profile_context
-        from goldenpipe.autoconfig_planner import (
-            ComplexityProfile,
-            PlannerInput,
-            plan_pipeline,
+        from goldenpipe.autoconfig_glue import (
+            build_planner_input,
+            enforce_confidence,
+            plan_to_config,
         )
+        from goldenpipe.autoconfig_planner import plan_pipeline
 
-        inp = PlannerInput(
-            runtime=profile_context(ctx),
-            complexity=ComplexityProfile(max_null_density=0.0, mean_null_density=0.0),
-        )
+        inp = build_planner_input(ctx)
         plan = plan_pipeline(inp)
         self._last_plan = plan
+        enforce_confidence(plan, inp.runtime)  # may raise PipeNotConfidentError
         return plan_to_config(
             plan,
             self._registry.list_all(),

--- a/packages/python/goldenpipe/goldenpipe/pipeline.py
+++ b/packages/python/goldenpipe/goldenpipe/pipeline.py
@@ -131,10 +131,17 @@ class Pipeline:
         glue bracket.
         """
         from goldenpipe.autoconfig_glue import plan_to_config, profile_context
-        from goldenpipe.autoconfig_planner import plan_pipeline
+        from goldenpipe.autoconfig_planner import (
+            ComplexityProfile,
+            PlannerInput,
+            plan_pipeline,
+        )
 
-        profile = profile_context(ctx)
-        plan = plan_pipeline(profile)
+        inp = PlannerInput(
+            runtime=profile_context(ctx),
+            complexity=ComplexityProfile(max_null_density=0.0, mean_null_density=0.0),
+        )
+        plan = plan_pipeline(inp)
         self._last_plan = plan
         return plan_to_config(
             plan,

--- a/packages/python/goldenpipe/tests/test_autoconfig_glue.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_glue.py
@@ -1,4 +1,5 @@
 import polars as pl
+import pytest
 from goldenpipe.autoconfig_glue import plan_to_config, profile_context
 from goldenpipe.autoconfig_planner import PipePlan, PlannedStage
 from goldenpipe.models.config import PipelineConfig
@@ -141,3 +142,83 @@ def test_plan_config_runs_end_to_end_and_preserves_order():
         "goldenflow.transform",
         "goldenmatch.dedupe",
     ]
+
+
+# --- Slice 2: complexity profiling + refuse ----------------------------------
+
+import dataclasses  # noqa: E402
+
+from goldenpipe.autoconfig_glue import (  # noqa: E402
+    build_planner_input,
+    enforce_confidence,
+    profile_complexity,
+)
+from goldenpipe.autoconfig_planner import PlannerInput  # noqa: E402
+from goldenpipe.errors import PipeNotConfidentError  # noqa: E402
+
+
+def _replace_n_rows(profile, n):
+    return dataclasses.replace(profile, n_rows=n)
+
+
+def test_profile_complexity_null_heavy_column():
+    df = pl.DataFrame({"a": [1, None, None, None], "b": [1, 2, 3, 4]})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.75      # column a: 3/4
+    assert comp.mean_null_density == 0.375     # (0.75 + 0.0) / 2
+
+
+def test_profile_complexity_no_nulls_is_zero():
+    df = pl.DataFrame({"a": [1, 2], "b": [3, 4]})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_profile_complexity_engine_resident_is_zero():
+    comp = profile_complexity(PipeContext(df=None))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_profile_complexity_empty_df_is_zero():
+    df = pl.DataFrame({"a": []})
+    comp = profile_complexity(PipeContext(df=df))
+    assert comp.max_null_density == 0.0
+    assert comp.mean_null_density == 0.0
+
+
+def test_build_planner_input_bundles_runtime_and_complexity():
+    df = pl.DataFrame({"account_number": ["A1", "A2"], "currency": ["USD", "EUR"]})
+    inp = build_planner_input(PipeContext(df=df))
+    assert isinstance(inp, PlannerInput)
+    assert inp.runtime.n_rows == 2
+    assert inp.runtime.inferred_domain == "finance"
+    assert inp.complexity.max_null_density == 0.0
+
+
+def _red_plan():
+    return PipePlan(stages=(), rule_name="low_confidence", confidence=0.3, evidence={})
+
+
+def _green_plan():
+    return PipePlan(stages=(), rule_name="default", confidence=0.7, evidence={})
+
+
+def test_enforce_confidence_red_at_scale_raises():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 100_000)
+    with pytest.raises(PipeNotConfidentError):
+        enforce_confidence(_red_plan(), runtime)
+
+
+def test_enforce_confidence_red_small_proceeds():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 99_999)
+    assert enforce_confidence(_red_plan(), runtime) is None
+
+
+def test_enforce_confidence_green_proceeds():
+    runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
+    runtime = _replace_n_rows(runtime, 100_000)
+    assert enforce_confidence(_green_plan(), runtime) is None

--- a/packages/python/goldenpipe/tests/test_autoconfig_glue.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_glue.py
@@ -222,3 +222,31 @@ def test_enforce_confidence_green_proceeds():
     runtime = profile_context(PipeContext(df=pl.DataFrame({"x": [1, 2]})))
     runtime = _replace_n_rows(runtime, 100_000)
     assert enforce_confidence(_green_plan(), runtime) is None
+
+
+def _garbage_df(n_rows: int) -> pl.DataFrame:
+    # Generic column names (no domain) + a mostly-null column (max_null_density > 0.6).
+    return pl.DataFrame({
+        "col_a": [None] * n_rows,             # 100% null -> max_null_density 1.0
+        "col_b": list(range(n_rows)),
+    })
+
+
+def test_plan_config_refuses_red_at_scale():
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=_garbage_df(100_000))
+    with pytest.raises(PipeNotConfidentError):
+        eng._plan_config(ctx)
+    assert eng._last_plan.rule_name == "low_confidence"
+
+
+def test_plan_config_red_below_threshold_proceeds():
+    reg = _registry_with("goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe")
+    eng = Pipeline(registry=reg)
+    ctx = PipeContext(df=_garbage_df(1_000))
+    cfg = eng._plan_config(ctx)                      # no raise
+    assert eng._last_plan.rule_name == "low_confidence"
+    assert [s.use for s in cfg.stages] == [
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    ]

--- a/packages/python/goldenpipe/tests/test_autoconfig_planner.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_planner.py
@@ -1,8 +1,11 @@
 from goldenpipe.autoconfig_planner import (
+    ComplexityProfile,
     PipePlan,
     PipePlannerRule,
     PipeProfile,
     PlannedStage,
+    PlannerInput,
+    band_of,  # noqa: F401 (imported for later slice; not yet exercised here)
     plan_pipeline,
 )
 
@@ -15,23 +18,37 @@ def _profile(**kw):
     return PipeProfile(**base)
 
 
+def _complexity(**kw):
+    base = dict(max_null_density=0.0, mean_null_density=0.0)
+    base.update(kw)
+    return ComplexityProfile(**base)
+
+
+def _planner_input(*, max_null_density=0.0, mean_null_density=0.0, **profile_kw):
+    return PlannerInput(
+        runtime=_profile(**profile_kw),
+        complexity=_complexity(max_null_density=max_null_density,
+                               mean_null_density=mean_null_density),
+    )
+
+
 def test_plan_pipeline_first_match_wins_else_default():
     fired = PipePlannerRule(
         rule_name="fired",
-        predicate=lambda p: p.n_rows == 100,
-        action=lambda p: PipePlan(stages=(PlannedStage("x", {}),), rule_name="fired",
-                                  confidence=0.9, evidence={"n_rows": p.n_rows}),
+        predicate=lambda inp: inp.runtime.n_rows == 100,
+        action=lambda inp: PipePlan(stages=(PlannedStage("x", {}),), rule_name="fired",
+                                    confidence=0.9, evidence={"n_rows": inp.runtime.n_rows}),
     )
-    plan = plan_pipeline(_profile(), rules=[fired])
+    plan = plan_pipeline(_planner_input(), rules=[fired])
     assert plan.rule_name == "fired"
     assert plan.stages == (PlannedStage("x", {}),)
     assert plan.evidence == {"n_rows": 100}
 
 
 def test_plan_pipeline_falls_through_to_default():
-    never = PipePlannerRule("never", lambda p: False,
-                            lambda p: PipePlan((), "never", 0.0, {}))
-    plan = plan_pipeline(_profile(), rules=[never])
+    never = PipePlannerRule("never", lambda inp: False,
+                            lambda inp: PipePlan((), "never", 0.0, {}))
+    plan = plan_pipeline(_planner_input(), rules=[never])
     assert plan.rule_name == "default"
     assert tuple(s.name for s in plan.stages) == (
         "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
@@ -42,16 +59,18 @@ def test_structs_are_frozen():
     import dataclasses
 
     import pytest
-    p = _profile()
+    inp = _planner_input()
     with pytest.raises(dataclasses.FrozenInstanceError):
-        p.n_rows = 5  # type: ignore[misc]
+        inp.runtime.n_rows = 5  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        inp.complexity.max_null_density = 0.5  # type: ignore[misc]
 
 
 from goldenpipe.autoconfig_planner_rules import DEFAULT_RULES  # noqa: E402
 
 
 def test_rule_pathological_skips_dedupe():
-    plan = plan_pipeline(_profile(n_rows=1))
+    plan = plan_pipeline(_planner_input(n_rows=1))
     assert plan.rule_name == "pathological"
     assert tuple(s.name for s in plan.stages) == (
         "goldencheck.scan", "goldenflow.transform",
@@ -60,7 +79,7 @@ def test_rule_pathological_skips_dedupe():
 
 
 def test_rule_confident_schema_prepends_infer_schema():
-    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.8))
+    plan = plan_pipeline(_planner_input(inferred_domain="finance", domain_confidence=0.8))
     assert plan.rule_name == "confident_schema"
     assert tuple(s.name for s in plan.stages) == (
         "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
@@ -70,11 +89,11 @@ def test_rule_confident_schema_prepends_infer_schema():
 
 
 def test_rule_weak_domain_is_default():
-    plan = plan_pipeline(_profile(inferred_domain="finance", domain_confidence=0.4))
+    plan = plan_pipeline(_planner_input(inferred_domain="finance", domain_confidence=0.4))
     assert plan.rule_name == "default"
     assert all(s.name != "infer_schema" for s in plan.stages)
 
 
 def test_default_rules_is_the_module_table():
-    assert plan_pipeline(_profile(n_rows=1)).rule_name == "pathological"
+    assert plan_pipeline(_planner_input(n_rows=1)).rule_name == "pathological"
     assert len(DEFAULT_RULES) >= 2

--- a/packages/python/goldenpipe/tests/test_autoconfig_planner.py
+++ b/packages/python/goldenpipe/tests/test_autoconfig_planner.py
@@ -5,7 +5,7 @@ from goldenpipe.autoconfig_planner import (
     PipeProfile,
     PlannedStage,
     PlannerInput,
-    band_of,  # noqa: F401 (imported for later slice; not yet exercised here)
+    band_of,
     plan_pipeline,
 )
 
@@ -97,3 +97,44 @@ def test_rule_weak_domain_is_default():
 def test_default_rules_is_the_module_table():
     assert plan_pipeline(_planner_input(n_rows=1)).rule_name == "pathological"
     assert len(DEFAULT_RULES) >= 2
+
+
+def test_band_of_boundaries():
+    assert band_of(0.7) == "green"
+    assert band_of(0.71) == "green"
+    assert band_of(0.69) == "amber"
+    assert band_of(0.4) == "amber"
+    assert band_of(0.39) == "red"
+    assert band_of(0.0) == "red"
+
+
+def test_rule_low_confidence_is_red_and_safe_default():
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.7))
+    assert plan.rule_name == "low_confidence"
+    assert plan.confidence == 0.3
+    assert band_of(plan.confidence) == "red"
+    assert tuple(s.name for s in plan.stages) == (
+        "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    )
+
+
+def test_low_confidence_not_shadowed_by_confident_schema():
+    # domain present -> confident_schema wins; domain absent + high null -> low_confidence.
+    with_domain = plan_pipeline(_planner_input(inferred_domain="finance",
+                                               domain_confidence=0.8, max_null_density=0.9))
+    assert with_domain.rule_name == "confident_schema"
+    no_domain = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.7))
+    assert no_domain.rule_name == "low_confidence"
+
+
+def test_low_confidence_only_above_null_threshold():
+    # domain absent but low null density -> falls through to default (not RED).
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.5))
+    assert plan.rule_name == "default"
+
+
+def test_default_evidence_records_null_density():
+    plan = plan_pipeline(_planner_input(inferred_domain=None, max_null_density=0.5,
+                                        mean_null_density=0.25))
+    assert plan.evidence["max_null_density"] == 0.5
+    assert plan.evidence["mean_null_density"] == 0.25

--- a/packages/python/goldenpipe/tests/test_errors.py
+++ b/packages/python/goldenpipe/tests/test_errors.py
@@ -1,0 +1,12 @@
+import pytest
+from goldenpipe.errors import PipeNotConfidentError
+
+
+def test_pipe_not_confident_is_an_exception():
+    with pytest.raises(PipeNotConfidentError):
+        raise PipeNotConfidentError("nope")
+
+
+def test_pipe_not_confident_carries_message():
+    err = PipeNotConfidentError("rule=low_confidence on 200000 rows")
+    assert "low_confidence" in str(err)


### PR DESCRIPTION
## What

Slice 2 of the GoldenPipe auto-config brain: it now reasons about data complexity, carries a confidence band, and **refuses** when it cannot plan well at scale -- the `ControllerNotConfidentError` analog that makes it a controller instead of a switch statement.

Builds on slice 1 (#1526). Python prototype per the Rust thesis; the decision core stays Polars/Pydantic-free for the later `goldenpipe-core` port.

## Shape

- **`ComplexityProfile`** (`max_null_density`, `mean_null_density`) from one `null_count` columnar pass. Engine-resident / empty frames profile to zeros (degraded, same contract as the runtime profile).
- **`PlannerInput`** bundle (`runtime` + `complexity`) -- rules now see both. `band_of(confidence)` -> green (>=0.7) / amber (>=0.4) / red.
- **`low_confidence` rule** (the sole RED source): `inferred_domain is None and max_null_density > 0.6` -> safe default plan tagged confidence 0.3 (RED). Ordered after the positive rules; nothing shadows it.
- **`enforce_confidence`** (glue): red band + `n_rows >= 100_000` raises `PipeNotConfidentError`; red below the threshold warns and proceeds on the safe default; green/amber proceed. Wired into `_plan_config`; the raise escapes `run()` (it's before the resolve try-block), matching GoldenMatch's no-silent-fallback contract.
- **`_auto_config` untouched** (its `_planner_json` Rust-parity + `test_pipeline` callers rely on the static default). Parity fixture untouched -- cross-surface deferred, Python leads.

## Tests

- 38 touched tests green on the box (12 planner incl. band/rule coverage, 18 glue incl. refuse integration -- garbage df >=100k raises, <100k warns+proceeds; 2 errors; slice-1 + pipeline still green).
- Full goldenpipe suite: 221 passed. The 1 failure (`test_planner_parity resolve_json`) + 2 a2a errors are pre-existing (native goldenpipe-core wheel skew / a2a setup) -- unrelated to autoconfig, run through `_auto_config` / no path this change touches.

## Deferred (own slices)

- Scale-hint merge into GM auto-config; PII/redact stage; the `goldenpipe-core` Rust port + TS-WASM parity.

## Cut during review

The originally-planned `weak_duplication_skip` rule was dropped -- whole-row exact-uniqueness is an unsound proxy for "no fuzzy duplicates" (it would drop dedupe precisely on legitimate dedupe inputs). Ships the sound refuse-core instead.

Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-autoconfig-brain-slice2-design.md`
Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-autoconfig-brain-slice2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44