### PR TITLE
feat(goldenflow): nullable chain joins the columnar engine (Phase 3 wave 2)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -32,7 +32,11 @@ import os
 from goldenflow.core._native_loader import native_module
 from goldenflow.engine.manifest import Manifest, TransformRecord
 from goldenflow.transforms import get_transform, parse_transform_name
-from goldenflow.transforms._chain import FUSABLE_KERNELS, FUSABLE_PARAM_KERNELS
+from goldenflow.transforms._chain import (
+    FUSABLE_KERNELS,
+    FUSABLE_NULLABLE_KERNELS,
+    FUSABLE_PARAM_KERNELS,
+)
 
 Column = list  # a column is a plain Python list (str | None)
 
@@ -44,13 +48,19 @@ def columnar_engine_selected() -> bool:
 
 # The owned string kernels the columnar path can run natively (no-arg + param).
 _OWNED_STRING = FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
+# Owned Option-returning kernels (URL/company/email) — the nullable chain (Phase 3
+# wave 2). Accepted only when the native build auto-routes them (``chain_supports_
+# nullable``, native-flow 0.20+); a run may mix these with the total kernels.
+_OWNED_NULLABLE = FUSABLE_NULLABLE_KERNELS
 
 
 def config_is_columnar_ready(config) -> bool:
     """A config runs on the columnar engine iff EVERY op is an owned string kernel
-    (fusable) and there are no frame-level ops (splits/renames/drops/filters/dedup)
-    that Phase 1 doesn't handle yet. Otherwise the caller uses the Polars engine —
-    correctness first; coverage grows over the later phases."""
+    (total fusable, or — when the native build supports it — a nullable
+    URL/company/email kernel) and there are no frame-level ops
+    (splits/renames/drops/filters/dedup) that the columnar path doesn't handle yet.
+    Otherwise the caller uses the Polars engine — correctness first; coverage grows
+    over the phases."""
     if config.splits or config.renames or config.drop or config.filters or config.dedup:
         return False
     if not config.transforms:
@@ -58,10 +68,12 @@ def config_is_columnar_ready(config) -> bool:
     nm = native_module()
     if nm is None or not hasattr(nm, "apply_chain_str_list"):
         return False
+    nullable_ok = hasattr(nm, "chain_supports_nullable")
+    accepted = _OWNED_STRING | _OWNED_NULLABLE if nullable_ok else _OWNED_STRING
     for spec in config.transforms:
         for op_raw in spec.ops:
             name, _params = parse_transform_name(op_raw)
-            if name not in _OWNED_STRING:
+            if name not in accepted:
                 return False
             info = get_transform(name)
             if info is None:

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -58,6 +58,12 @@ def test_native_list_binding_present() -> None:
         # Phase 3 wave 1: phonetic joins the fused chain -> columnar-ready
         [("name", ["strip", "lowercase", "soundex"])],
         [("name", ["strip", "double_metaphone_primary"])],
+        # Phase 3 wave 2: nullable chain (URL/company/email Option-returning),
+        # incl. runs that MIX total + nullable kernels
+        [("email", ["strip", "lowercase", "email_extract_domain"])],
+        [("email", ["strip", "email_mask"])],
+        [("name", ["strip", "company_normalize"])],
+        [("name", ["strip", "url_normalize", "url_strip_www"])],
     ],
 )
 def test_columnar_equals_polars(monkeypatch, specs) -> None:

--- a/packages/python/goldenflow/tests/engine/test_native_csv_io.py
+++ b/packages/python/goldenflow/tests/engine/test_native_csv_io.py
@@ -65,6 +65,9 @@ def _manifest_rows(manifest):
         [("email", ["strip", "lowercase", "email_normalize"])],
         [("name", ["strip", "truncate:6"])],
         [("name", ["strip", "lowercase", "soundex"])],  # Phase 3 wave 1: phonetic
+        # Phase 3 wave 2: nullable chain (mixes total + Option-returning kernels)
+        [("email", ["strip", "lowercase", "email_extract_domain"])],
+        [("name", ["strip", "url_normalize"]), ("email", ["strip", "email_mask"])],
     ],
 )
 def test_native_csv_equals_polars_engine(tmp_path, monkeypatch, specs) -> None:

--- a/packages/rust/extensions/goldenflow-core/Cargo.toml
+++ b/packages/rust/extensions/goldenflow-core/Cargo.toml
@@ -8,7 +8,7 @@
 
 [package]
 name = "goldenflow-core"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/goldenflow-core/src/chain.rs
+++ b/packages/rust/extensions/goldenflow-core/src/chain.rs
@@ -41,12 +41,13 @@ use arrow_array::{Array, Float64Array, GenericStringArray, OffsetSizeTrait};
 #[cfg(feature = "arrow")]
 use arrow_buffer::{Buffer, OffsetBuffer, ScalarBuffer};
 
-// `email`/`names`/`text` back the arrow-free `Kernel` (via `apply_into`); the
-// `numeric`/`company`/`url` families are only reached by the arrow-gated
-// NumericKernel/NullableKernel executors.
+// `email`/`names`/`text`/`phonetic` back the arrow-free `Kernel` (via `apply_into`),
+// and `company`/`url` back the arrow-free `NullableKernel` (via `apply`) — all
+// available on every surface (WASM included). Only `numeric` (the f64 executor) is
+// arrow-only.
 #[cfg(feature = "arrow")]
-use crate::{company, numeric, url};
-use crate::{email, names, phonetic, text};
+use crate::numeric;
+use crate::{company, email, names, phonetic, text, url};
 
 /// One owned, no-arg, total string→string kernel eligible for the fused chain.
 /// The name mapping (`from_name`) is the single source of truth the host's
@@ -265,6 +266,39 @@ pub fn apply_chain_str(values: &[&str], kernels: &[Kernel]) -> (Vec<String>, Vec
             std::mem::swap(&mut cur, &mut next);
         }
         out.push(cur.clone());
+    }
+    (out, changed)
+}
+
+/// Arrow-FREE nullable string chain (the `Option`-returning URL/company/email
+/// families, mixable with total kernels wrapped as `Total`). Threads
+/// `Option<String>` per value: once a cell goes null it passes through the rest of
+/// the run. `changed[i]` matches the host's per-transform `(before != after).sum()`
+/// — a row is counted only when both before and after are non-null and differ
+/// (identical to the arrow [`apply_chain_nullable`], minus the offset buffers). For
+/// the non-arrow surfaces (WASM / the list bindings) that can't build a
+/// `GenericStringArray`.
+pub fn apply_chain_str_nullable(
+    values: &[Option<&str>],
+    kernels: &[NullableKernel],
+) -> (Vec<Option<String>>, Vec<u64>) {
+    let mut out = Vec::with_capacity(values.len());
+    let mut changed = vec![0u64; kernels.len()];
+    for &v in values {
+        let mut cur: Option<String> = v.map(str::to_string);
+        for (i, k) in kernels.iter().enumerate() {
+            let next = match &cur {
+                Some(s) => k.apply(s),
+                None => None,
+            };
+            if let (Some(b), Some(a)) = (&cur, &next) {
+                if b != a {
+                    changed[i] += 1;
+                }
+            }
+            cur = next;
+        }
+        out.push(cur);
     }
     (out, changed)
 }
@@ -499,7 +533,6 @@ impl NullableKernel {
 
     /// Apply to one present value, returning `None` when the kernel can't parse
     /// it (→ a null output cell). Total kernels always return `Some`.
-    #[cfg(feature = "arrow")]
     #[inline]
     fn apply(self, s: &str) -> Option<String> {
         match self {

--- a/packages/rust/extensions/goldenflow-wasm/Cargo.lock
+++ b/packages/rust/extensions/goldenflow-wasm/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "goldenflow-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "phonenumber",
 ]

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -437,7 +437,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "arrow",
  "csv",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.19.0"
+version = "0.20.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.19.0"
+    __version__ = "0.20.0"

--- a/packages/rust/extensions/native-flow/src/chain.rs
+++ b/packages/rust/extensions/native-flow/src/chain.rs
@@ -13,11 +13,62 @@
 use arrow::array::{make_array, Array, ArrayData, Float64Array, LargeStringArray, StringArray};
 use arrow::pyarrow::PyArrowType;
 use goldenflow_core::chain::{
-    apply_chain, apply_chain_f64, apply_chain_nullable, apply_chain_str, Kernel, NullableKernel,
-    NumericKernel,
+    apply_chain, apply_chain_f64, apply_chain_nullable, apply_chain_str, apply_chain_str_nullable,
+    Kernel, NullableKernel, NumericKernel,
 };
 use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
+
+/// A resolved run of chain ops: either ALL total string kernels (the zero-alloc
+/// fast path) or a run that contains at least one `Option`-returning
+/// URL/company/email kernel (the nullable path, into which total kernels fold as
+/// `Total`). The shared resolver so the list binding, the `Column`, and the CSV
+/// path all route the same way.
+pub enum ChainOps {
+    Total(Vec<Kernel>),
+    Nullable(Vec<NullableKernel>),
+}
+
+/// Resolve `ops` to a [`ChainOps`]: prefer the all-total fast path; fall back to
+/// the nullable chain if any op is `Option`-returning. Errors only if a name is
+/// not fusable at all.
+pub fn resolve_chain(ops: &[(String, Vec<String>)]) -> PyResult<ChainOps> {
+    let mut totals = Vec::with_capacity(ops.len());
+    let mut all_total = true;
+    for (name, params) in ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        match Kernel::from_op(name, &refs) {
+            Some(k) => totals.push(k),
+            None => {
+                all_total = false;
+                break;
+            }
+        }
+    }
+    if all_total {
+        return Ok(ChainOps::Total(totals));
+    }
+    let mut nks = Vec::with_capacity(ops.len());
+    for (name, params) in ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        nks.push(
+            NullableKernel::from_op(name, &refs).ok_or_else(|| {
+                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
+            })?,
+        );
+    }
+    Ok(ChainOps::Nullable(nks))
+}
+
+/// Capability probe: this build's `apply_chain_str_list` / `Column.apply_chain` /
+/// `transform_csv` AUTO-ROUTE `Option`-returning (URL/company/email) kernels
+/// (native-flow 0.20+). The host gates accepting nullable columnar configs on this
+/// symbol's presence — a pre-0.20 wheel lacks it, so those configs stay on the
+/// Polars engine (no hard error on a skewed wheel).
+#[pyfunction]
+pub fn chain_supports_nullable() -> bool {
+    true
+}
 
 /// The fusable kernel names the compiled chain supports (no-arg + parameterized),
 /// for the host's coverage guard (asserts Python `FUSABLE_KERNELS ∪
@@ -201,26 +252,27 @@ pub fn apply_chain_str_list(
     values: Vec<Option<String>>,
     ops: Vec<(String, Vec<String>)>,
 ) -> PyResult<(Vec<Option<String>>, Vec<u64>)> {
-    let mut kernels = Vec::with_capacity(ops.len());
-    for (name, params) in &ops {
-        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
-        kernels.push(
-            Kernel::from_op(name, &refs).ok_or_else(|| {
-                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
-            })?,
-        );
+    match resolve_chain(&ops)? {
+        ChainOps::Total(kernels) => {
+            // Thread only the non-null values (total kernels never null); nulls pass.
+            let non_null: Vec<&str> = values.iter().filter_map(|v| v.as_deref()).collect();
+            let (transformed, changed) = apply_chain_str(&non_null, &kernels);
+            // Scatter the transformed values back into their (non-null) positions.
+            let mut it = transformed.into_iter();
+            let out: Vec<Option<String>> = values
+                .iter()
+                .map(|v| {
+                    v.as_ref()
+                        .map(|_| it.next().expect("aligned with non-null count"))
+                })
+                .collect();
+            Ok((out, changed))
+        }
+        ChainOps::Nullable(kernels) => {
+            // A kernel may turn non-null -> null mid-run, so thread Options directly.
+            let opt_refs: Vec<Option<&str>> = values.iter().map(|v| v.as_deref()).collect();
+            let (out, changed) = apply_chain_str_nullable(&opt_refs, &kernels);
+            Ok((out, changed))
+        }
     }
-    // Thread only the non-null values (total kernels never null); nulls pass through.
-    let non_null: Vec<&str> = values.iter().filter_map(|v| v.as_deref()).collect();
-    let (transformed, changed) = apply_chain_str(&non_null, &kernels);
-    // Scatter the transformed values back into their (non-null) positions.
-    let mut it = transformed.into_iter();
-    let out: Vec<Option<String>> = values
-        .iter()
-        .map(|v| {
-            v.as_ref()
-                .map(|_| it.next().expect("aligned with non-null count"))
-        })
-        .collect();
-    Ok((out, changed))
 }

--- a/packages/rust/extensions/native-flow/src/column.rs
+++ b/packages/rust/extensions/native-flow/src/column.rs
@@ -20,7 +20,9 @@ use pyo3::exceptions::{PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyCapsule, PyList};
 
-use goldenflow_core::chain::{apply_chain, Kernel};
+use goldenflow_core::chain::{apply_chain, apply_chain_nullable};
+
+use crate::chain::{resolve_chain, ChainOps};
 
 const STREAM_NAME: &[u8] = b"arrow_array_stream";
 
@@ -145,24 +147,35 @@ impl Column {
         py: Python,
         ops: Vec<(String, Vec<String>)>,
     ) -> PyResult<(Column, Vec<u64>)> {
-        let mut kernels = Vec::with_capacity(ops.len());
-        for (name, params) in &ops {
-            let refs: Vec<&str> = params.iter().map(String::as_str).collect();
-            kernels.push(Kernel::from_op(name, &refs).ok_or_else(|| {
-                PyValueError::new_err(format!("not a fusable chain kernel: {name}"))
-            })?);
-        }
+        // Auto-route: an all-total run takes the zero-alloc fast chain; a run with
+        // any Option-returning (URL/company/email) kernel takes the nullable chain
+        // (total kernels fold in as Total). Byte-identical either way.
+        let chain = resolve_chain(&ops)?;
+        let err = || PyTypeError::new_err("Column.apply_chain requires a Utf8/LargeUtf8 column");
         let (array, changed) = py.detach(|| -> PyResult<(ArrayRef, Vec<u64>)> {
-            if let Some(s) = self.array.as_any().downcast_ref::<StringArray>() {
-                let r = apply_chain(s, &kernels);
-                Ok((Arc::new(r.array) as ArrayRef, r.changed))
-            } else if let Some(s) = self.array.as_any().downcast_ref::<LargeStringArray>() {
-                let r = apply_chain(s, &kernels);
-                Ok((Arc::new(r.array) as ArrayRef, r.changed))
-            } else {
-                Err(PyTypeError::new_err(
-                    "Column.apply_chain requires a Utf8/LargeUtf8 column",
-                ))
+            match &chain {
+                ChainOps::Total(ks) => {
+                    if let Some(s) = self.array.as_any().downcast_ref::<StringArray>() {
+                        let r = apply_chain(s, ks);
+                        Ok((Arc::new(r.array) as ArrayRef, r.changed))
+                    } else if let Some(s) = self.array.as_any().downcast_ref::<LargeStringArray>() {
+                        let r = apply_chain(s, ks);
+                        Ok((Arc::new(r.array) as ArrayRef, r.changed))
+                    } else {
+                        Err(err())
+                    }
+                }
+                ChainOps::Nullable(ks) => {
+                    if let Some(s) = self.array.as_any().downcast_ref::<StringArray>() {
+                        let r = apply_chain_nullable(s, ks);
+                        Ok((Arc::new(r.array) as ArrayRef, r.changed))
+                    } else if let Some(s) = self.array.as_any().downcast_ref::<LargeStringArray>() {
+                        let r = apply_chain_nullable(s, ks);
+                        Ok((Arc::new(r.array) as ArrayRef, r.changed))
+                    } else {
+                        Err(err())
+                    }
+                }
             }
         })?;
         Ok((Column::new(array), changed))

--- a/packages/rust/extensions/native-flow/src/csvio.rs
+++ b/packages/rust/extensions/native-flow/src/csvio.rs
@@ -13,10 +13,12 @@
 
 use arrow::array::{Array, LargeStringArray, LargeStringBuilder};
 use arrow::compute::concat;
-use pyo3::exceptions::{PyIOError, PyValueError};
+use pyo3::exceptions::PyIOError;
 use pyo3::prelude::*;
 
-use goldenflow_core::chain::{apply_chain, Kernel};
+use goldenflow_core::chain::{apply_chain, apply_chain_nullable, ChainResult};
+
+use crate::chain::{resolve_chain, ChainOps};
 
 /// Below this data-region size the CSV is parsed sequentially (parallel setup +
 /// concat isn't worth it). Override with `GOLDENFLOW_NATIVE_CSV_PARALLEL_MIN_BYTES`
@@ -274,10 +276,40 @@ fn write_csv(path: &str, names: &[String], columns: &[LargeStringArray]) -> Resu
     Ok(())
 }
 
-/// Read `in_path`, apply each spec's owned string chain (op-by-op, so the manifest
-/// carries per-op affected counts + before/after samples exactly like the Python
-/// columnar engine), write to `out_path`, and return the per-column manifest.
-/// Polars-free, pyarrow-free, one FFI crossing.
+/// Run a resolved chain over `col` and build the per-op manifest: ONE fused pass
+/// (`run_all` → the final array + per-op `changed` counts) plus a cheap 3-row
+/// replay (`run_one` applies just kernel `i`) for the before/after samples —
+/// byte-identical to running each op over the full column, at a fraction of the
+/// cost (N ops ⇒ 1 full pass, not N). Generic over the chain kind (total /
+/// nullable), which both return the same `ChainResult<i64>`.
+fn build_manifest<FAll, FOne>(
+    col: &LargeStringArray,
+    ops: &[(String, Vec<String>)],
+    total: u64,
+    run_all: FAll,
+    run_one: FOne,
+) -> (LargeStringArray, Vec<OpRecord>)
+where
+    FAll: FnOnce(&LargeStringArray) -> ChainResult<i64>,
+    FOne: Fn(&LargeStringArray, usize) -> ChainResult<i64>,
+{
+    let fused = run_all(col);
+    let mut head = LargeStringArray::from_iter(sample3(col));
+    let mut records: Vec<OpRecord> = Vec::with_capacity(ops.len());
+    for (i, (op, _)) in ops.iter().enumerate() {
+        let before = sample3(&head);
+        let replay = run_one(&head, i);
+        let after = sample3(&replay.array);
+        records.push((op.clone(), fused.changed[i], total, before, after));
+        head = replay.array;
+    }
+    (fused.array, records)
+}
+
+/// Read `in_path`, apply each spec's owned string chain (auto-routed total /
+/// nullable, so the manifest carries per-op affected counts + before/after samples
+/// exactly like the Python columnar engine), write to `out_path`, and return the
+/// per-column manifest. Polars-free, pyarrow-free, one FFI crossing.
 #[pyfunction]
 pub fn transform_csv(
     py: Python,
@@ -296,29 +328,26 @@ pub fn transform_csv(
                 continue; // column not in file — mirrors the Python `if col in df.columns`
             };
             let total = columns[idx].len() as u64;
-            let mut kernels = Vec::with_capacity(ops.len());
-            for (op, params) in ops {
-                let refs: Vec<&str> = params.iter().map(String::as_str).collect();
-                kernels.push(Kernel::from_op(op, &refs).ok_or_else(|| {
-                    PyValueError::new_err(format!("not a fusable chain kernel: {op}"))
-                })?);
-            }
-            // ONE fused pass over the whole column: the final array + per-op changed
-            // counts (apply_chain already returns changed[i] per kernel). The per-op
-            // before/after samples come from a cheap replay on just the first 3 rows —
-            // byte-identical to running each op over the full column, at a fraction of
-            // the cost (N ops => 1 full pass, not N).
-            let fused = apply_chain(&columns[idx], &kernels);
-            let mut head = LargeStringArray::from_iter(sample3(&columns[idx]));
-            let mut records: Vec<OpRecord> = Vec::with_capacity(ops.len());
-            for (i, (op, _)) in ops.iter().enumerate() {
-                let before = sample3(&head);
-                let replay = apply_chain(&head, std::slice::from_ref(&kernels[i]));
-                let after = sample3(&replay.array);
-                records.push((op.clone(), fused.changed[i], total, before, after));
-                head = replay.array;
-            }
-            columns[idx] = fused.array;
+            // Auto-route the run: all-total takes the zero-alloc fast chain; any
+            // Option-returning kernel takes the nullable chain. Both return the same
+            // ChainResult, so the fused-pass + 3-row-replay manifest logic is shared.
+            let (new_array, records) = match resolve_chain(ops)? {
+                ChainOps::Total(ks) => build_manifest(
+                    &columns[idx],
+                    ops,
+                    total,
+                    |c| apply_chain(c, &ks),
+                    |c, i| apply_chain(c, std::slice::from_ref(&ks[i])),
+                ),
+                ChainOps::Nullable(ks) => build_manifest(
+                    &columns[idx],
+                    ops,
+                    total,
+                    |c| apply_chain_nullable(c, &ks),
+                    |c, i| apply_chain_nullable(c, std::slice::from_ref(&ks[i])),
+                ),
+            };
+            columns[idx] = new_array;
             manifest.push((col_name.clone(), records));
         }
 

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -35,6 +35,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(chain::apply_chain_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_str_list, m)?)?;
+    m.add_function(wrap_pyfunction!(chain::chain_supports_nullable, m)?)?;
     m.add_function(wrap_pyfunction!(csvio::transform_csv, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_f64_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_nullable_arrow, m)?)?;


### PR DESCRIPTION
## Phase 3 wave 2 — the nullable chain

Brings the `Option`-returning **URL / company / email** families onto the columnar
surface, so configs mixing total + nullable kernels now run **Polars-free** (native
`Column`) and **pyarrow-free** (native CSV), where before they declined to Polars:
`url_normalize`/`_strip_tracking`/`_strip_www`/`_canonical`/`_extract_domain`,
`company_normalize`/`_strip_legal`/`_extract_legal`, `email_mask`/`_extract_domain`.

The nullable executor already existed in `goldenflow-core` (`apply_chain_nullable`).
Wave 2 unblocks the manifest sample-replay + the list path and auto-routes every
native entry point.

### Changes
- **goldenflow-core**: new **arrow-free** `apply_chain_str_nullable` (mirrors
  `apply_chain_str`, threads `Option`) + un-gate `NullableKernel::apply` and move
  `company`/`url` to unconditional imports, so the nullable chain is available on
  every surface (WASM included). **0.11.0 → 0.12.0.**
- **native-flow**: a shared `resolve_chain(ops) -> Total | Nullable`; `apply_chain_str_list`,
  `Column.apply_chain`, and `transform_csv` all auto-route — an all-total run takes
  the zero-alloc fast chain; any `Option`-returning op takes the nullable chain
  (total kernels folding in as `Total`). `transform_csv`'s fused-pass + 3-row-replay
  manifest logic is factored into a generic `build_manifest` shared by both. New
  `chain_supports_nullable` capability probe. **0.19.0 → 0.20.0** (wasm + native-flow
  `Cargo.lock`s bumped for core 0.12).
- **columnar engine**: `config_is_columnar_ready` accepts `FUSABLE_NULLABLE_KERNELS`
  **only when** the native build exposes `chain_supports_nullable` — a pre-0.20 wheel
  lacks it, so those configs stay on Polars (no hard error on wheel skew).

### Parity
Byte-identical by construction (same core kernels). New columnar + native-CSV cases
assert `email_extract_domain` / `email_mask` / `company_normalize` /
`url_normalize`+`url_strip_www` and **mixed total+nullable** runs are byte-identical
(data + manifest) to the Polars engine. Full transforms+engine suite green (1714
pass; the lone `test_transform_with_splits` fail is the pre-existing env-leak flake —
passes isolated, splits aren't columnar-ready).

### Coverage after wave 2
Total string (wave 0) + phonetic (wave 1) + nullable URL/company/email (wave 2) all
run on the columnar engine. Remaining Phase 3: the **f64 numeric chain** and the
multi-output `split_*`/`merge_name` families.

Design: `docs/design/2026-07-07-polars-eviction-plan.md` (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg