### PR TITLE
feat(goldenflow): numeric columnar execution on the CSV path (Phase 3 wave 3b)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -54,43 +54,68 @@ _OWNED_STRING = FUSABLE_KERNELS | FUSABLE_PARAM_KERNELS
 _OWNED_NULLABLE = FUSABLE_NULLABLE_KERNELS
 
 
+def _frame_level_blocked(config) -> bool:
+    """Frame-level ops (splits/renames/drops/filters/dedup) the columnar path
+    doesn't handle yet — any of them forces the Polars engine."""
+    return bool(
+        config.splits or config.renames or config.drop or config.filters or config.dedup
+    )
+
+
+def _accepted_string(nm) -> frozenset[str]:
+    """The owned string kernels this native build accepts: total + parameterized,
+    plus the nullable URL/company/email family when it auto-routes them (0.20+)."""
+    if hasattr(nm, "chain_supports_nullable"):
+        return _OWNED_STRING | _OWNED_NULLABLE
+    return _OWNED_STRING
+
+
+def _spec_string_ready(spec, accepted: frozenset[str]) -> bool:
+    for op_raw in spec.ops:
+        name, _params = parse_transform_name(op_raw)
+        if name not in accepted or get_transform(name) is None:
+            return False
+    return True
+
+
 def config_is_columnar_ready(config) -> bool:
-    """A config runs on the columnar engine iff EVERY op is an owned string kernel
-    (total fusable, or — when the native build supports it — a nullable
-    URL/company/email kernel) and there are no frame-level ops
-    (splits/renames/drops/filters/dedup) that the columnar path doesn't handle yet.
-    Otherwise the caller uses the Polars engine — correctness first; coverage grows
-    over the phases."""
-    if config.splits or config.renames or config.drop or config.filters or config.dedup:
-        return False
-    if not config.transforms:
+    """A config runs on the IN-MEMORY columnar engine iff EVERY op is an owned string
+    kernel (total fusable, or — when the native build supports it — a nullable
+    URL/company/email kernel) and there are no frame-level ops. Numeric configs are
+    NOT accepted here (the in-memory Column path is string-only); the CSV path takes
+    them (see :func:`columnar_file_ready`). Otherwise the caller uses the Polars
+    engine — correctness first; coverage grows over the phases."""
+    if _frame_level_blocked(config) or not config.transforms:
         return False
     nm = native_module()
     if nm is None or not hasattr(nm, "apply_chain_str_list"):
         return False
-    nullable_ok = hasattr(nm, "chain_supports_nullable")
-    accepted = _OWNED_STRING | _OWNED_NULLABLE if nullable_ok else _OWNED_STRING
-    for spec in config.transforms:
-        for op_raw in spec.ops:
-            name, _params = parse_transform_name(op_raw)
-            if name not in accepted:
-                return False
-            info = get_transform(name)
-            if info is None:
-                return False
-    return True
+    accepted = _accepted_string(nm)
+    return all(_spec_string_ready(spec, accepted) for spec in config.transforms)
 
 
 def columnar_file_ready(config) -> bool:
-    """True when the native whole-file CSV path (Phase 2) can run this config:
-    the config is columnar-ready (fully owned-string, no frame-level ops) AND the
-    native kernel exposes ``transform_csv``. When true, a CSV runs
-    read->transform->write entirely in Rust — no ``pl.DataFrame``, no Polars, no
-    pyarrow."""
-    if not config_is_columnar_ready(config):
+    """True when the native whole-file CSV path can run this config: no frame-level
+    ops, and every spec is either an owned-string run OR — Phase 3 wave 3b — a valid
+    NUMERIC shape (``string* parser f64*``, validated by the native
+    ``columnar_numeric_ready`` probe, the single source of truth so host and kernel
+    never disagree). When true, a CSV runs read->transform->write entirely in Rust —
+    no ``pl.DataFrame``, no Polars, no pyarrow."""
+    if _frame_level_blocked(config) or not config.transforms:
         return False
     nm = native_module()
-    return nm is not None and hasattr(nm, "transform_csv")
+    if nm is None or not hasattr(nm, "transform_csv") or not hasattr(nm, "apply_chain_str_list"):
+        return False
+    accepted = _accepted_string(nm)
+    numeric_ok = hasattr(nm, "columnar_numeric_ready")
+    for spec in config.transforms:
+        if _spec_string_ready(spec, accepted):
+            continue
+        ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
+        if numeric_ok and nm.columnar_numeric_ready(ops_spec):
+            continue
+        return False
+    return True
 
 
 def transform_file(in_path, out_path, config, source: str | None = None) -> Manifest:

--- a/packages/python/goldenflow/tests/engine/test_native_csv_io.py
+++ b/packages/python/goldenflow/tests/engine/test_native_csv_io.py
@@ -99,6 +99,46 @@ def test_native_csv_equals_polars_engine(tmp_path, monkeypatch, specs) -> None:
     assert _manifest_rows(manifest) == _manifest_rows(ref.manifest)
 
 
+@pytest.mark.parametrize(
+    "ops",
+    [
+        ["currency_strip"],
+        ["strip", "currency_strip"],
+        ["currency_strip", "round:1"],
+        ["currency_strip", "abs_value"],
+        ["currency_strip", "round:0", "clamp:0:100"],
+        ["currency_strip", "fill_zero"],
+        ["percentage_normalize"],
+        ["comma_decimal"],
+        ["scientific_to_decimal"],
+    ],
+)
+def test_native_csv_numeric_equals_polars(tmp_path, monkeypatch, ops) -> None:
+    """Phase 3 wave 3b: numeric configs (string* parser f64*) run string->f64->string
+    on the native CSV path, byte-identical (data + manifest) to the Polars engine.
+    The f64 output is formatted via the Polars-matching formatter (wave 3a)."""
+    if not columnar.columnar_file_ready(_cfg([("price", ops)])):
+        pytest.skip("native numeric columnar not built (pre-0.21 wheel)")
+    # 2-column CSV so empty fields are unambiguous (a lone empty single-column line
+    # is null-vs-blank ambiguous between readers).
+    rows = ["  $1,234.50 ", "$0.5", "10", "", "bad", "-$3.00", "0", "1000000", "12.5%", "1.5e3"]
+    lines = ["price,keep"] + [f'"{v}",k{i}' for i, v in enumerate(rows)]
+    inp = tmp_path / "in.csv"
+    inp.write_bytes(("\n".join(lines) + "\n").encode("utf-8"))
+    cfg = _cfg([("price", ops)])
+
+    out = tmp_path / "out.csv"
+    manifest = columnar.transform_file(inp, out, cfg, source=str(inp))
+
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = transform_df(pl.read_csv(inp, infer_schema_length=0), config=cfg)
+
+    got = pl.read_csv(out, infer_schema_length=0)
+    for col in got.columns:
+        assert got[col].to_list() == ref.df[col].cast(pl.Utf8).to_list(), f"{col} diverged"
+    assert _manifest_rows(manifest) == _manifest_rows(ref.manifest)
+
+
 def test_native_csv_path_is_pyarrow_free(tmp_path) -> None:
     """The transform_csv call must not pull in pyarrow — the whole weight thesis."""
     inp = tmp_path / "in.csv"

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "arrow",
  "csv",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.20.0"
+version = "0.21.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.20.0"
+    __version__ = "0.21.0"

--- a/packages/rust/extensions/native-flow/src/csvio.rs
+++ b/packages/rust/extensions/native-flow/src/csvio.rs
@@ -28,7 +28,7 @@ const DEFAULT_PARALLEL_MIN_BYTES: usize = 512 * 1024;
 /// One per-op audit record: `(op, affected_rows, total_rows, sample_before,
 /// sample_after)`. Samples are the null-preserving first 3 values, mirroring the
 /// Python columnar engine's `series.head(3).cast(Utf8).to_list()`.
-type OpRecord = (String, u64, u64, Vec<Option<String>>, Vec<Option<String>>);
+pub type OpRecord = (String, u64, u64, Vec<Option<String>>, Vec<Option<String>>);
 /// Manifest for one transformed column: `(column, [OpRecord])`.
 type ColumnManifest = (String, Vec<OpRecord>);
 
@@ -328,6 +328,16 @@ pub fn transform_csv(
                 continue; // column not in file — mirrors the Python `if col in df.columns`
             };
             let total = columns[idx].len() as u64;
+            // Numeric shape (`string* parser f64*`) runs the string->f64->string
+            // path (formatting via the Polars-matching float formatter); otherwise
+            // auto-route the string run total vs nullable.
+            if let Some(plan) = crate::numeric_columnar::resolve_numeric(ops) {
+                let (new_array, records) =
+                    crate::numeric_columnar::run_numeric_column(&columns[idx], &plan);
+                columns[idx] = new_array;
+                manifest.push((col_name.clone(), records));
+                continue;
+            }
             // Auto-route the run: all-total takes the zero-alloc fast chain; any
             // Option-returning kernel takes the nullable chain. Both return the same
             // ChainResult, so the fused-pass + 3-row-replay manifest logic is shared.

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -22,6 +22,7 @@ mod email;
 mod identifiers;
 mod names;
 mod numeric;
+mod numeric_columnar;
 mod phone;
 mod phonetic;
 mod text;
@@ -36,6 +37,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(chain::apply_chain_ops_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_str_list, m)?)?;
     m.add_function(wrap_pyfunction!(chain::chain_supports_nullable, m)?)?;
+    m.add_function(wrap_pyfunction!(
+        numeric_columnar::columnar_numeric_ready,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(csvio::transform_csv, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_f64_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_nullable_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/numeric_columnar.rs
+++ b/packages/rust/extensions/native-flow/src/numeric_columnar.rs
@@ -1,0 +1,205 @@
+//! Numeric columnar execution — Phase 3 wave 3b. Runs a numeric config on a string
+//! column entirely natively: `[string ops] -> [one f64 parser] -> [f64 ops]`,
+//! formatting the f64 result back to string via the Polars-matching
+//! `float_to_polars_string` (wave 3a) so the CSV output + manifest are
+//! byte-identical to the Polars engine.
+//!
+//! Parity model (from `engine/transformer.py`): every op's `affected` is
+//! `(before.cast(Utf8) != after.cast(Utf8)).sum()` with null comparisons excluded,
+//! and samples are `head(3).cast(Utf8)`. For a string cell cast(Utf8) is itself;
+//! for an f64 cell it is `float_to_polars_string`. So the whole manifest is
+//! computed by formatting each state and comparing — which also makes a
+//! `-0.0 -> 0.0` change count (the formats differ) exactly as Polars does, even
+//! though raw `==` would call them equal.
+//!
+//! Scope: the f64 parsers (`currency_strip`/`percentage_normalize`/`comma_decimal`/
+//! `scientific_to_decimal`/`fraction_to_decimal`) + the f64 array ops
+//! (`round`/`clamp`/`abs_value`/`fill_zero`). The i64 parsers (`to_integer`/
+//! `roman_to_int`/`ordinal_to_int`, which yield an Int64 column with different
+//! formatting) are a later increment.
+
+use arrow::array::{Array, Float64Array, Float64Builder, LargeStringArray};
+use pyo3::prelude::*;
+
+use goldenflow_core::chain::{
+    apply_chain_f64, apply_chain_nullable, NullableKernel, NumericKernel,
+};
+use goldenflow_core::float_fmt::float_to_polars_string;
+use goldenflow_core::numeric;
+
+use crate::csvio::OpRecord;
+
+/// A string -> f64 parser (the dtype transition). f64-valued only.
+#[derive(Clone, Copy)]
+enum NumericParser {
+    CurrencyStrip,
+    PercentageNormalize,
+    CommaDecimal,
+    ScientificToDecimal,
+    FractionToDecimal,
+}
+
+impl NumericParser {
+    fn from_name(name: &str) -> Option<NumericParser> {
+        Some(match name {
+            "currency_strip" => NumericParser::CurrencyStrip,
+            "percentage_normalize" => NumericParser::PercentageNormalize,
+            "comma_decimal" => NumericParser::CommaDecimal,
+            "scientific_to_decimal" => NumericParser::ScientificToDecimal,
+            "fraction_to_decimal" => NumericParser::FractionToDecimal,
+            _ => return None,
+        })
+    }
+
+    fn parse(self, s: &str) -> Option<f64> {
+        match self {
+            NumericParser::CurrencyStrip => numeric::currency_strip(s),
+            NumericParser::PercentageNormalize => numeric::percentage_normalize(s),
+            NumericParser::CommaDecimal => numeric::comma_decimal(s),
+            NumericParser::ScientificToDecimal => numeric::scientific_to_decimal(s),
+            NumericParser::FractionToDecimal => numeric::fraction_to_decimal(s),
+        }
+    }
+}
+
+/// A resolved numeric column plan: optional leading string ops, exactly one f64
+/// parser (the transition), optional trailing f64 array ops.
+pub struct NumericPlan {
+    string_ops: Vec<(String, NullableKernel)>,
+    parser: (String, NumericParser),
+    f64_ops: Vec<(String, NumericKernel)>,
+}
+
+/// Resolve `ops` to a [`NumericPlan`] iff they form a valid numeric shape:
+/// `string* parser f64*`. Returns `None` if there is no f64 parser (not a numeric
+/// config → the string chains handle it) or the shape is invalid (a string op after
+/// the transition, a second parser, an f64 op before the parser, etc.).
+pub fn resolve_numeric(ops: &[(String, Vec<String>)]) -> Option<NumericPlan> {
+    let mut string_ops = Vec::new();
+    let mut parser: Option<(String, NumericParser)> = None;
+    let mut f64_ops = Vec::new();
+    for (name, params) in ops {
+        let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+        if parser.is_none() {
+            if let Some(p) = NumericParser::from_name(name) {
+                parser = Some((name.clone(), p));
+            } else if let Some(k) = NullableKernel::from_op(name, &refs) {
+                string_ops.push((name.clone(), k));
+            } else {
+                return None;
+            }
+        } else if let Some(k) = NumericKernel::from_op(name, &refs) {
+            f64_ops.push((name.clone(), k));
+        } else {
+            return None;
+        }
+    }
+    Some(NumericPlan {
+        string_ops,
+        parser: parser?,
+        f64_ops,
+    })
+}
+
+fn str_opts(arr: &LargeStringArray) -> Vec<Option<String>> {
+    (0..arr.len())
+        .map(|i| (!arr.is_null(i)).then(|| arr.value(i).to_string()))
+        .collect()
+}
+
+fn fmt_f64(arr: &Float64Array) -> Vec<Option<String>> {
+    (0..arr.len())
+        .map(|i| (!arr.is_null(i)).then(|| float_to_polars_string(arr.value(i))))
+        .collect()
+}
+
+/// `(before.cast(Utf8) != after.cast(Utf8)).sum()` — rows where both are non-null
+/// and the formatted strings differ.
+fn affected(before: &[Option<String>], after: &[Option<String>]) -> u64 {
+    before
+        .iter()
+        .zip(after)
+        .filter(|(b, a)| matches!((b, a), (Some(b), Some(a)) if b != a))
+        .count() as u64
+}
+
+fn head3(v: &[Option<String>]) -> Vec<Option<String>> {
+    v.iter().take(3).cloned().collect()
+}
+
+/// Execute a [`NumericPlan`] over one string column, returning the formatted output
+/// column (f64 rendered exactly as Polars' write_csv would) and the per-op manifest
+/// records — all byte-identical to the Polars engine.
+pub fn run_numeric_column(
+    input: &LargeStringArray,
+    plan: &NumericPlan,
+) -> (LargeStringArray, Vec<OpRecord>) {
+    let total = input.len() as u64;
+    let mut records: Vec<OpRecord> =
+        Vec::with_capacity(plan.string_ops.len() + 1 + plan.f64_ops.len());
+
+    // --- string phase (fused one pass; per-op affected from the fused counts, 3-row
+    // replay for samples — the same shape as the string columnar path) ---
+    let str_kernels: Vec<NullableKernel> = plan.string_ops.iter().map(|(_, k)| *k).collect();
+    let str_col: LargeStringArray = if str_kernels.is_empty() {
+        input.clone()
+    } else {
+        let fused = apply_chain_nullable(input, &str_kernels);
+        let mut head = LargeStringArray::from_iter(str_opts(input).into_iter().take(3));
+        for (i, (name, _)) in plan.string_ops.iter().enumerate() {
+            let before = head3(&str_opts(&head));
+            let replay = apply_chain_nullable(&head, std::slice::from_ref(&str_kernels[i]));
+            let after = head3(&str_opts(&replay.array));
+            records.push((name.clone(), fused.changed[i], total, before, after));
+            head = replay.array;
+        }
+        fused.array
+    };
+
+    // --- parser: string -> f64 (null in / unparseable -> null) ---
+    let mut builder = Float64Builder::with_capacity(str_col.len());
+    for i in 0..str_col.len() {
+        match (!str_col.is_null(i))
+            .then(|| str_col.value(i))
+            .and_then(|s| plan.parser.1.parse(s))
+        {
+            Some(f) => builder.append_value(f),
+            None => builder.append_null(),
+        }
+    }
+    let mut cur_arr = builder.finish();
+    let before_fmt = str_opts(&str_col);
+    let mut cur_fmt = fmt_f64(&cur_arr);
+    records.push((
+        plan.parser.0.clone(),
+        affected(&before_fmt, &cur_fmt),
+        total,
+        head3(&before_fmt),
+        head3(&cur_fmt),
+    ));
+
+    // --- f64 array ops (op-by-op so `affected` uses the formatted comparison) ---
+    for (name, kernel) in &plan.f64_ops {
+        let next_arr = apply_chain_f64(&cur_arr, std::slice::from_ref(kernel)).array;
+        let next_fmt = fmt_f64(&next_arr);
+        records.push((
+            name.clone(),
+            affected(&cur_fmt, &next_fmt),
+            total,
+            head3(&cur_fmt),
+            head3(&next_fmt),
+        ));
+        cur_arr = next_arr;
+        cur_fmt = next_fmt;
+    }
+
+    (LargeStringArray::from_iter(cur_fmt), records)
+}
+
+/// Host gate: is this a config the native numeric columnar path can run? (A valid
+/// `string* parser f64*` shape.) The single source of truth the Python
+/// `config_is_columnar_ready` calls, so host and kernel never disagree.
+#[pyfunction]
+pub fn columnar_numeric_ready(ops: Vec<(String, Vec<String>)>) -> bool {
+    resolve_numeric(&ops).is_some()
+}


### PR DESCRIPTION
## Phase 3 wave 3b — numeric columnar execution

Wires wave 3a's Polars-matching float formatter (#1538) into a numeric execution
path. A config of shape **`string* parser f64*`** (a leading owned-string run, one
f64 parser, trailing f64 array ops) now runs entirely natively on the CSV file path
— `string → f64 parse → f64 chain → format back` — **Polars-free and pyarrow-free**,
byte-identical (data + manifest) to the Polars engine.

Unlocks price/percentage/decimal cleaning: `[currency_strip]`, `[strip, currency_strip,
round:2]`, `[percentage_normalize]`, `[comma_decimal]`, `[currency_strip, clamp:0:100]`.

### How
- **native-flow `numeric_columnar.rs`**: `NumericParser` (the f64 parsers) +
  `resolve_numeric` (validates the `string*`/`parser`/`f64*` shape) +
  `run_numeric_column`. The manifest is computed **exactly** as the engine does —
  `affected = (before.cast(Utf8) != after.cast(Utf8)).sum()` (nulls excluded),
  samples `head(3).cast(Utf8)` — by **formatting each state** via
  `float_to_polars_string` and comparing. That makes a `-0.0→0.0` change count (the
  formats differ) just like Polars, even though raw `==` says equal. `transform_csv`
  tries the numeric plan first, else the string chains. `columnar_numeric_ready(ops)`
  is the single-source-of-truth shape probe. **native-flow 0.20.0 → 0.21.0.**
- **columnar engine**: `columnar_file_ready` (CSV path) accepts a numeric spec via
  the native probe; `config_is_columnar_ready` (in-memory Column path) stays
  string-only (the f64 Column is a later increment), so numeric runs columnar on
  files and declines to Polars in-memory — both correct.

### Scope
f64 parsers (`currency_strip`/`percentage_normalize`/`comma_decimal`/
`scientific_to_decimal`/`fraction_to_decimal`) + f64 array ops
(`round`/`clamp`/`abs_value`/`fill_zero`). The i64 parsers (`to_integer`/
`roman_to_int`/`ordinal_to_int` → Int64, different formatting) are a later increment.

### Parity
9 numeric cases (parser-only, string-prefix+parser, parser+f64 ops incl. params, all
three f64 parsers) assert byte-identical data + manifest vs the Polars engine. Full
engine + fused suite green (114).

Design: `docs/design/2026-07-07-polars-eviction-plan.md` (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg