### PR TITLE
feat(goldenflow): numeric on the in-memory Column path (Phase 3 wave 3d)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -78,20 +78,39 @@ def _spec_string_ready(spec, accepted: frozenset[str]) -> bool:
     return True
 
 
+def _numeric_inmem_ok(nm) -> bool:
+    """The in-memory Column path can run a numeric spec when the kernel exposes the
+    shape probe AND the Column egresses a raw numeric array (``apply_numeric``,
+    native-flow 0.23+). Skew-safe: an older wheel lacks it -> numeric declines to
+    Polars in-memory, no hard error."""
+    col_cls = getattr(nm, "Column", None)
+    return hasattr(nm, "columnar_numeric_ready") and col_cls is not None and hasattr(
+        col_cls, "apply_numeric"
+    )
+
+
 def config_is_columnar_ready(config) -> bool:
-    """A config runs on the IN-MEMORY columnar engine iff EVERY op is an owned string
-    kernel (total fusable, or — when the native build supports it — a nullable
-    URL/company/email kernel) and there are no frame-level ops. Numeric configs are
-    NOT accepted here (the in-memory Column path is string-only); the CSV path takes
-    them (see :func:`columnar_file_ready`). Otherwise the caller uses the Polars
-    engine — correctness first; coverage grows over the phases."""
+    """A config runs on the IN-MEMORY columnar engine iff EVERY spec is an owned
+    string run (total fusable, or — when supported — a nullable URL/company/email
+    kernel) OR — Phase 3 wave 3d — a valid NUMERIC shape (``string* parser f64*``,
+    via the native ``columnar_numeric_ready`` probe + ``Column.apply_numeric``), and
+    there are no frame-level ops. Otherwise the caller uses the Polars engine —
+    correctness first; coverage grows over the phases."""
     if _frame_level_blocked(config) or not config.transforms:
         return False
     nm = native_module()
     if nm is None or not hasattr(nm, "apply_chain_str_list"):
         return False
     accepted = _accepted_string(nm)
-    return all(_spec_string_ready(spec, accepted) for spec in config.transforms)
+    numeric_ok = _numeric_inmem_ok(nm)
+    for spec in config.transforms:
+        if _spec_string_ready(spec, accepted):
+            continue
+        ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
+        if numeric_ok and nm.columnar_numeric_ready(ops_spec):
+            continue
+        return False
+    return True
 
 
 def columnar_file_ready(config) -> bool:
@@ -177,12 +196,33 @@ def _transform_via_columns(df, config, source, nm, pl):
     C-Data interface, run the owned chain on the Rust-held Arrow buffer, egress back.
     No list marshaling, no pyarrow."""
     manifest = Manifest(source=source)
+    numeric_ok = _numeric_inmem_ok(nm)
     out_series = []
     for spec in config.transforms:
         if spec.column not in df.columns:
             continue
         ops = [parse_transform_name(op) for op in spec.ops]
         ops_spec = [(n, list(p)) for n, p in ops]
+        # Numeric spec (string* parser f64*): cast the column to Utf8 (Polars' numeric
+        # transforms cast to Utf8 internally, so this matches even a non-string input)
+        # and run the numeric plan, egressing the RAW numeric array (Int64/Float64) as
+        # a real numeric column. The manifest records come straight from the kernel.
+        if numeric_ok and nm.columnar_numeric_ready(ops_spec):
+            col = nm.Column.from_arrow(df.select([pl.col(spec.column).cast(pl.Utf8)]))
+            num_col, records = col.apply_numeric(ops_spec)
+            for name, affected, total, before, after in records:
+                manifest.add_record(TransformRecord(
+                    column=spec.column,
+                    transform=name,
+                    affected_rows=int(affected),
+                    total_rows=int(total),
+                    sample_before=list(before),
+                    sample_after=list(after),
+                ))
+            imported = pl.from_arrow(num_col)
+            series = imported.to_series(0) if isinstance(imported, pl.DataFrame) else imported
+            out_series.append(series.alias(spec.column))
+            continue
         # Zero-copy, pyarrow-free ingest (a 1-column DataFrame -> a struct stream).
         col = nm.Column.from_arrow(df.select([spec.column]))
         total_rows = len(col)

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -87,6 +87,43 @@ def test_columnar_equals_polars(monkeypatch, specs) -> None:
     assert columnar_out.df["keep_int"].to_list() == [1, 2, 3, 4, 5, 6]
 
 
+@pytest.mark.parametrize(
+    "ops,data",
+    [
+        (["currency_strip"], ["  $1,234.50 ", "$0.5", "10", "", None, "bad"]),
+        (["strip", "currency_strip"], ["  $1,234.50 ", "$0.5", "", None, "bad"]),
+        (["currency_strip", "round:1"], ["$1,234.56", "$0.5", "", None]),
+        (["percentage_normalize"], ["50%", "12.5%", "", None, "3"]),
+        (["to_integer"], ["  42 ", "1,000", "-5", "", None, "3.9"]),
+        (["to_integer", "abs_value"], ["42", "-5", "", None]),  # Int64 -> Float64
+        (["roman_to_int"], ["IV", "XII", "", None, "bad"]),
+        (["currency_strip"], [1.5, 2.0, None, 3.25]),  # already-numeric input
+    ],
+)
+def test_columnar_numeric_equals_polars(monkeypatch, ops, data) -> None:
+    """Phase 3 wave 3d: numeric configs run on the IN-MEMORY Column path too — the
+    result egresses as a real Int64/Float64 column (compared by value + dtype),
+    byte-identical to the Polars engine incl. the manifest."""
+    nm = native_module()
+    if nm is None or not hasattr(nm, "columnar_numeric_ready") or not hasattr(
+        getattr(nm, "Column", object), "apply_numeric"
+    ):
+        pytest.skip("native in-memory numeric not built (pre-0.23 wheel)")
+    df = pl.DataFrame({"x": data, "keep": list(range(len(data)))})
+    cfg = _cfg([("x", ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    polars_out = transform_df(df, config=cfg)
+
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    columnar_out = transform_df(df, config=cfg)
+
+    assert columnar_out.df.equals(polars_out.df), "numeric in-memory frame diverged"
+    assert columnar_out.df["x"].dtype == polars_out.df["x"].dtype
+    assert _manifest_rows(columnar_out) == _manifest_rows(polars_out)
+
+
 def test_columnar_declines_unsupported_config(monkeypatch) -> None:
     """A config with a non-owned-string op (phone) or a frame-level op is NOT
     columnar-ready; it falls through to the Polars engine (still correct)."""

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "arrow",
  "csv",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.22.0"
+version = "0.23.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.22.0"
+    __version__ = "0.23.0"

--- a/packages/rust/extensions/native-flow/src/column.rs
+++ b/packages/rust/extensions/native-flow/src/column.rs
@@ -23,6 +23,8 @@ use pyo3::types::{PyCapsule, PyList};
 use goldenflow_core::chain::{apply_chain, apply_chain_nullable};
 
 use crate::chain::{resolve_chain, ChainOps};
+use crate::csvio::OpRecord;
+use crate::numeric_columnar::{resolve_numeric, run_numeric_column};
 
 const STREAM_NAME: &[u8] = b"arrow_array_stream";
 
@@ -179,5 +181,31 @@ impl Column {
             }
         })?;
         Ok((Column::new(array), changed))
+    }
+
+    /// In-memory numeric path (Phase 3 wave 3d): run a numeric config
+    /// (`string* parser f64*`) over this string column and return a `Column` holding
+    /// the RAW numeric result (Int64 / Float64) — egressed via `__arrow_c_stream__`
+    /// as an Arrow column of that dtype, so the in-memory frame gets a real numeric
+    /// column compared BY VALUE — plus the per-op manifest records (which still carry
+    /// the formatted before/after samples). The caller casts the input to Utf8 first
+    /// (Polars' numeric transforms cast to Utf8 internally, so this matches even for
+    /// an already-numeric input column).
+    fn apply_numeric(
+        &self,
+        py: Python,
+        ops: Vec<(String, Vec<String>)>,
+    ) -> PyResult<(Column, Vec<OpRecord>)> {
+        let plan = resolve_numeric(&ops)
+            .ok_or_else(|| PyValueError::new_err("not a numeric columnar config"))?;
+        let arr = self
+            .array
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .ok_or_else(|| {
+                PyTypeError::new_err("Column.apply_numeric requires a Utf8/LargeUtf8 column")
+            })?;
+        let (numcol, records) = py.detach(|| run_numeric_column(arr, &plan));
+        Ok((Column::new(numcol.into_array()), records))
     }
 }

--- a/packages/rust/extensions/native-flow/src/csvio.rs
+++ b/packages/rust/extensions/native-flow/src/csvio.rs
@@ -332,9 +332,11 @@ pub fn transform_csv(
             // path (formatting via the Polars-matching float formatter); otherwise
             // auto-route the string run total vs nullable.
             if let Some(plan) = crate::numeric_columnar::resolve_numeric(ops) {
-                let (new_array, records) =
+                let (numcol, records) =
                     crate::numeric_columnar::run_numeric_column(&columns[idx], &plan);
-                columns[idx] = new_array;
+                // CSV output is text: format the numeric result (f64 via the
+                // Polars-matching formatter, i64 as a plain integer).
+                columns[idx] = LargeStringArray::from_iter(numcol.fmt());
                 manifest.push((col_name.clone(), records));
                 continue;
             }

--- a/packages/rust/extensions/native-flow/src/numeric_columnar.rs
+++ b/packages/rust/extensions/native-flow/src/numeric_columnar.rs
@@ -95,18 +95,28 @@ impl NumericParser {
 /// A parsed numeric column: Int64 (from an integer parser, until an f64 op
 /// promotes it) or Float64. `cast(Utf8)` — for `affected`/samples — is a plain
 /// integer for I64, the Polars-matching float format for F64.
-enum NumCol {
+pub enum NumCol {
     I64(Int64Array),
     F64(Float64Array),
 }
 
 impl NumCol {
-    fn fmt(&self) -> Vec<Option<String>> {
+    /// `cast(Utf8)` per cell — the CSV output + the manifest before/after strings.
+    pub fn fmt(&self) -> Vec<Option<String>> {
         match self {
             NumCol::I64(a) => (0..a.len())
                 .map(|i| (!a.is_null(i)).then(|| a.value(i).to_string()))
                 .collect(),
             NumCol::F64(a) => fmt_f64(a),
+        }
+    }
+
+    /// The RAW numeric array (Int64 / Float64) for the in-memory path, which egresses
+    /// it as an Arrow column of the matching dtype (compared by value, not formatted).
+    pub fn into_array(self) -> arrow::array::ArrayRef {
+        match self {
+            NumCol::I64(a) => std::sync::Arc::new(a),
+            NumCol::F64(a) => std::sync::Arc::new(a),
         }
     }
 
@@ -202,13 +212,11 @@ fn head3(v: &[Option<String>]) -> Vec<Option<String>> {
     v.iter().take(3).cloned().collect()
 }
 
-/// Execute a [`NumericPlan`] over one string column, returning the formatted output
-/// column (f64 rendered exactly as Polars' write_csv would) and the per-op manifest
-/// records — all byte-identical to the Polars engine.
-pub fn run_numeric_column(
-    input: &LargeStringArray,
-    plan: &NumericPlan,
-) -> (LargeStringArray, Vec<OpRecord>) {
+/// Execute a [`NumericPlan`] over one string column, returning the raw numeric
+/// result column ([`NumCol`], Int64/Float64) and the per-op manifest records — all
+/// byte-identical to the Polars engine. The CSV path formats the `NumCol` to string
+/// (`.fmt()`); the in-memory path egresses its raw array (`.into_array()`).
+pub fn run_numeric_column(input: &LargeStringArray, plan: &NumericPlan) -> (NumCol, Vec<OpRecord>) {
     let total = input.len() as u64;
     let mut records: Vec<OpRecord> =
         Vec::with_capacity(plan.string_ops.len() + 1 + plan.f64_ops.len());
@@ -258,8 +266,9 @@ pub fn run_numeric_column(
         cur = NumCol::F64(next_arr);
         cur_fmt = next_fmt;
     }
+    let _ = cur_fmt; // the final formatting is the caller's concern (CSV) — keep raw
 
-    (LargeStringArray::from_iter(cur_fmt), records)
+    (cur, records)
 }
 
 /// Host gate: is this a config the native numeric columnar path can run? (A valid


### PR DESCRIPTION
## Phase 3 wave 3d — numeric on the in-memory Column path

Numeric configs (`string* parser f64*`) now run on the **in-memory** columnar engine
(`transform_df`) too, not just the CSV path. The result egresses as a real
**Int64/Float64** Arrow column (compared by value + dtype), byte-identical to the
Polars engine including the manifest.

### How
- **native-flow**: `run_numeric_column` now returns the raw `NumCol` (Int64/Float64)
  + records; the CSV path formats it to text (`.fmt()`), the in-memory path egresses
  its raw array (`NumCol::into_array()`). New `Column.apply_numeric` runs the plan and
  returns a `Column` wrapping the numeric array (egressed via `__arrow_c_stream__` as
  that dtype) + the per-op records. **native-flow 0.22.0 → 0.23.0.**
- **columnar engine**: `config_is_columnar_ready` (in-memory) accepts a numeric spec
  via the native probe + the `Column.apply_numeric` capability (skew-safe: an older
  wheel lacks it → numeric declines to Polars). `_transform_via_columns` casts the
  column to Utf8 first — Polars' numeric transforms cast to Utf8 internally, so this
  matches even an **already-numeric** input column (verified: `currency_strip` on an
  f64 column).

### Parity
8 in-memory numeric cases (f64/i64 parsers, i64→f64 promotion, already-numeric input,
string-only regression) assert byte-identical frame (value + dtype) + manifest vs the
Polars engine. Full engine + fused suite green (128).

Design: `docs/design/2026-07-07-polars-eviction-plan.md` (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg