### PR TITLE
feat(a2a): document-ingest skills (documents_suggest_schema, documents_ingest)

### DIFF
--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ER Agent"
-description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 38 skills, confidence-gated review queue, and Python API."
+description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 40 skills, confidence-gated review queue, and Python API."
 keywords: ["agent", "A2A", "entity resolution", "autonomous", "review queue", "MCP"]
 ---
 

--- a/docs/superpowers/plans/2026-07-07-documents-a2a.md
+++ b/docs/superpowers/plans/2026-07-07-documents-a2a.md
@@ -1,0 +1,168 @@
+# Document Ingest A2A Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add two A2A skills (`documents_suggest_schema`, `documents_ingest`) to the goldenmatch agent server, delegating to the existing MCP `handle_document_tool`.
+
+**Architecture:** Two `_SKILLS` agent-card entries in `a2a/server.py` + one `dispatch_skill` branch in `a2a/skills.py` that routes both ids to `handle_document_tool` (returns a dict, the A2A contract). Plus the two CI-enforced bookkeeping updates: the parity manifest and the hard-coded skill count. Pure Python; path-based.
+
+**Tech Stack:** Python, aiohttp (a2a extra), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-documents-a2a-design.md`
+
+---
+
+## Conventions for every task
+
+- **Worktree:** `D:/show_case/gm-docs-a2a` (branch `feat/documents-a2a`). Do NOT push, do NOT touch `main`. Never `git stash` (it is shared across all worktrees).
+- **Test env** (from `packages/python/goldenmatch`):
+  ```bash
+  cd D:/show_case/gm-docs-a2a/packages/python/goldenmatch
+  PY="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="D:/show_case/gm-docs-a2a/packages/python/goldenmatch;D:/show_case/gm-docs-a2a/packages/python/goldenflow"
+  export GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+  ```
+  Prereq: `"$PY" -c "import aiohttp, mcp, PIL, fitz" 2>/dev/null || "$PY" -m pip install aiohttp "mcp>=1.0" pymupdf Pillow` (the shared venv should already have these).
+- **Lint before each commit:** `"$PY" -m ruff check goldenmatch/a2a tests/test_a2a.py`.
+- **Commit trailers:** copy from `git log -1 --format=%B`. `git -c commit.gpgsign=false commit`.
+
+---
+
+## File structure (locked)
+
+| path | change |
+|---|---|
+| `goldenmatch/a2a/server.py` | add 2 entries to `_SKILLS` (closes ~line 325) |
+| `goldenmatch/a2a/skills.py` | add 1 branch to `dispatch_skill` (before the terminal `raise`, ~line 466) |
+| `tests/test_a2a.py` | bump `test_agent_card_has_38_skills` -> 40; add card-lists + 2 dispatch tests |
+| `parity/goldenmatch.yaml` (repo root) | add both ids to `a2a_skills.python_only` (sorted, after `configure`) |
+| `README.md` (pkg), `llms.txt` (pkg), `docs/llms.txt` (repo) | bump "38 skills" -> "40 skills" |
+
+---
+
+## Task 1: Skill-card entries + count bump
+
+**Files:** Modify `goldenmatch/a2a/server.py`, `tests/test_a2a.py`, `packages/python/goldenmatch/README.md`, `packages/python/goldenmatch/llms.txt`, `docs/llms.txt`
+
+- [ ] **Step 1: Write/adjust the failing tests** in `tests/test_a2a.py`:
+  - Rename `test_agent_card_has_38_skills` -> `test_agent_card_has_40_skills`, change the final assert to `== 40`, and append to its docstring: `"; document ingest added documents_suggest_schema / documents_ingest (38->40)."`.
+  - Add a new test:
+    ```python
+    def test_agent_card_lists_document_skills():
+        from goldenmatch.a2a.server import build_agent_card
+        ids = {s["id"] for s in build_agent_card("http://localhost:8080")["skills"]}
+        assert {"documents_suggest_schema", "documents_ingest"} <= ids
+    ```
+- [ ] **Step 2: Run -> fail.** `"$PY" -m pytest tests/test_a2a.py::test_agent_card_has_40_skills tests/test_a2a.py::test_agent_card_lists_document_skills -q` (count is 38, ids absent).
+- [ ] **Step 3: Implement.** In `goldenmatch/a2a/server.py`, add these two entries to `_SKILLS` (before the closing `]` at ~line 325):
+  ```python
+      {
+          "id": "documents_suggest_schema",
+          "name": "Suggest Document Schema",
+          "description": "Propose an extraction schema from a sample document (PDF/image).",
+          "inputModes": ["application/json"],
+          "outputModes": ["application/json"],
+      },
+      {
+          "id": "documents_ingest",
+          "name": "Ingest Documents",
+          "description": "Extract records from documents against a schema; records ready for dedupe.",
+          "inputModes": ["application/json"],
+          "outputModes": ["application/json"],
+      },
+  ```
+  Then bump the doc surfaces (grep to confirm the exact wording first — `grep -rn "38 skills" ..`):
+  `packages/python/goldenmatch/README.md`, `packages/python/goldenmatch/llms.txt`, `docs/llms.txt` — change "38 skills" -> "40 skills".
+- [ ] **Step 4: Run -> pass** (both tests green).
+- [ ] **Step 5: Commit** `feat(a2a): advertise documents_suggest_schema + documents_ingest skills (38->40)`.
+
+---
+
+## Task 2: Dispatch branch + dispatch tests
+
+**Files:** Modify `goldenmatch/a2a/skills.py`, `tests/test_a2a.py`
+
+- [ ] **Step 1: Failing tests** in `tests/test_a2a.py` (near the other `dispatch_skill` tests). Use a real temp PNG so `load_pages` succeeds; a `FakeExtractor` returns canned rows so no live VLM runs:
+  ```python
+  def test_dispatch_documents_ingest(tmp_path, monkeypatch):
+      import io
+      from PIL import Image
+      import goldenmatch.mcp.document_tools as dt
+      from goldenmatch.documents.extractor import FakeExtractor
+      from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+      from goldenmatch.a2a.skills import dispatch_skill
+
+      p = tmp_path / "a.png"
+      Image.new("RGB", (20, 20), "white").save(p)
+      schema = TargetSchema([Field("full_name"), Field("email")])
+      row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {},
+                                      schema, source_file="", source_page=0)
+      monkeypatch.setattr(dt, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+      out = dispatch_skill("documents_ingest", {
+          "paths": [str(p)],
+          "schema": {"fields": [{"name": "full_name"}, {"name": "email"}]},
+      })
+      assert out["report"]["n_rows"] == 1
+      assert out["records"][0]["full_name"] == "Ada"
+
+
+  def test_dispatch_documents_suggest_schema(tmp_path, monkeypatch):
+      import goldenmatch.mcp.document_tools as dt
+      from goldenmatch.documents.types import Field, TargetSchema
+      from goldenmatch.a2a.skills import dispatch_skill
+      from PIL import Image
+
+      p = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(p)
+      monkeypatch.setattr(dt, "suggest_schema_from_file",
+                          lambda path, **k: TargetSchema([Field("full_name"), Field("email", kind="email")]))
+      out = dispatch_skill("documents_suggest_schema", {"sample_path": str(p)})
+      assert out["schema"]["fields"][0]["name"] == "full_name"
+  ```
+  (Monkeypatch `resolve_extractor`/`suggest_schema_from_file` on `document_tools` because that is the module `handle_document_tool` calls them from.)
+- [ ] **Step 2: Run -> fail** (dispatch raises `Unknown skill`).
+- [ ] **Step 3: Implement.** In `goldenmatch/a2a/skills.py`, add just before the terminal `raise ValueError(f"Unknown skill: {skill_id}")` (~line 466):
+  ```python
+      if skill_id in ("documents_ingest", "documents_suggest_schema"):
+          from goldenmatch.mcp.document_tools import handle_document_tool
+          return handle_document_tool(skill_id, params)
+  ```
+- [ ] **Step 4: Run -> pass.** Also re-run the whole a2a file: `"$PY" -m pytest tests/test_a2a.py -q` (all green, no count regressions).
+- [ ] **Step 5: Commit** `feat(a2a): dispatch document skills to the MCP handler`.
+
+---
+
+## Task 3: Parity manifest declaration
+
+**Files:** Modify `parity/goldenmatch.yaml` (repo root)
+
+- [ ] **Step 1:** In `parity/goldenmatch.yaml`, under `a2a_skills:` -> `python_only:`, insert (sorted — after `configure`, before `identity_audit`):
+  ```yaml
+    - documents_ingest
+    - documents_suggest_schema
+  ```
+- [ ] **Step 2: Validate** the YAML + placement:
+  ```bash
+  "$PY" -c "import yaml; d=yaml.safe_load(open('parity/goldenmatch.yaml'))['a2a_skills']['python_only']; assert 'documents_ingest' in d and 'documents_suggest_schema' in d; print('ok, sorted:', d==sorted(d))"
+  ```
+  (The full `scripts/check_api_parity.py goldenmatch` gate needs the built TS surface and can't run locally — CI verifies it. The manifest edit is the fix; these two ids were the `undeclared_py_only` failure mode for MCP in #1515, now pre-empted for a2a.)
+- [ ] **Step 3: Commit** `chore(parity): declare document a2a skills as python_only`.
+
+---
+
+## Task 4: Full local verification
+
+- [ ] **Step 1:** `"$PY" -m pytest tests/test_a2a.py -q` — all green (count is 40, both dispatch tests pass, no regressions).
+- [ ] **Step 2:** `"$PY" -m ruff check goldenmatch/a2a tests/test_a2a.py` — clean.
+- [ ] **Step 3:** `grep -rn "38 skills" packages/ docs/ 2>/dev/null` returns NOTHING (all bumped).
+- [ ] **Step 4:** any lint fixups -> commit `chore(a2a): lint`.
+
+---
+
+## Done-when
+
+- `documents_suggest_schema` + `documents_ingest` advertised in the agent card + dispatched to
+  `handle_document_tool`; `dispatch_skill` returns the records/report and schema dicts.
+- Skill count bumped 38 -> 40 in the test AND all three doc surfaces; no stray "38 skills" left.
+- Both ids declared in `a2a_skills.python_only` in `parity/goldenmatch.yaml`.
+- `tests/test_a2a.py` green, ruff clean.
+- Deferred: TS A2A side (TS surface), uploads, new AgentSession methods.

--- a/docs/superpowers/plans/2026-07-07-documents-a2a.md
+++ b/docs/superpowers/plans/2026-07-07-documents-a2a.md
@@ -71,8 +71,9 @@
           "outputModes": ["application/json"],
       },
   ```
-  Then bump the doc surfaces (grep to confirm the exact wording first — `grep -rn "38 skills" ..`):
-  `packages/python/goldenmatch/README.md`, `packages/python/goldenmatch/llms.txt`, `docs/llms.txt` — change "38 skills" -> "40 skills".
+  Then bump the doc surfaces (grep the WHOLE repo first: `grep -rn "38 skills" packages/ docs/ docs-site/`):
+  `packages/python/goldenmatch/README.md`, `packages/python/goldenmatch/llms.txt`, `docs/llms.txt`,
+  AND `docs-site/goldenmatch/agent.mdx` (frontmatter description) — change "38 skills" -> "40 skills".
 - [ ] **Step 4: Run -> pass** (both tests green).
 - [ ] **Step 5: Commit** `feat(a2a): advertise documents_suggest_schema + documents_ingest skills (38->40)`.
 
@@ -153,7 +154,7 @@
 
 - [ ] **Step 1:** `"$PY" -m pytest tests/test_a2a.py -q` — all green (count is 40, both dispatch tests pass, no regressions).
 - [ ] **Step 2:** `"$PY" -m ruff check goldenmatch/a2a tests/test_a2a.py` — clean.
-- [ ] **Step 3:** `grep -rn "38 skills" packages/ docs/ 2>/dev/null` returns NOTHING (all bumped).
+- [ ] **Step 3:** `grep -rn "38 skills" packages/ docs/ docs-site/ 2>/dev/null` returns NOTHING (all four bumped).
 - [ ] **Step 4:** any lint fixups -> commit `chore(a2a): lint`.
 
 ---

--- a/docs/superpowers/specs/2026-07-07-documents-a2a-design.md
+++ b/docs/superpowers/specs/2026-07-07-documents-a2a-design.md
@@ -69,10 +69,11 @@ schema); the A2A server's existing dispatch wraps a raising skill into a failed-
 - `test_dispatch_documents_suggest_schema`: monkeypatch `suggest_schema_from_file` -> a canned
   `TargetSchema`; assert `{"schema": {...}}`.
 - `test_agent_card_lists_document_skills`: `build_agent_card()` includes both ids.
-- Update the existing `test_agent_card_has_38_skills` (rename/rebump to 40) — and **grep the whole
-  suite + `server.py` for any other hard-coded `38` skill-count literal** (the #1515 count-enumeration
-  lesson: a count change must be chased across every assertion + docstring, not just the feature's
-  own test).
+- Update the existing `test_agent_card_has_38_skills` (rename/rebump to 40) — and **grep the WHOLE
+  REPO for any other hard-coded `38` skill-count literal** (the #1515 count-enumeration lesson). This
+  is NOT just the test suite: confirmed doc surfaces also carry "38 skills" and go stale silently
+  (they won't red CI): `packages/python/goldenmatch/README.md` (~line 182), `packages/python/
+  goldenmatch/llms.txt` (~line 11), `docs/llms.txt` (~line 8). Bump all of them to 40 in the same PR.
 - No live calls in CI.
 
 ## Parity manifest (`parity/goldenmatch.yaml`)

--- a/docs/superpowers/specs/2026-07-07-documents-a2a-design.md
+++ b/docs/superpowers/specs/2026-07-07-documents-a2a-design.md
@@ -1,0 +1,95 @@
+# Document Ingest A2A skills — design
+
+**Goal.** Expose document ingest as two agent-to-agent (A2A) skills so other agents can suggest a
+schema from and extract records from documents. Thin surface over the shipped MCP handler.
+
+**Builds on:** the MCP `handle_document_tool` (Phase 2) + `goldenmatch.documents` (which runs through
+documents-core natively). All merged to main. Frontend-independent; pure Python.
+
+## Decisions (settled in brainstorming)
+
+- **Two skills, same ids as the MCP tools** (no cross-surface naming divergence — the api_parity work
+  deliberately reconciled such splits): `documents_suggest_schema`, `documents_ingest`.
+- **Path-based** (A2A is stateless HTTP with no file upload): callers pass server-accessible paths,
+  exactly like the MCP tools.
+- **Delegate to the MCP handler** (`handle_document_tool`) so the JSON contract, config->400 mapping,
+  and native-fallback behavior are the single source of truth — no duplicated logic.
+
+## Components / files
+
+| path | change |
+|---|---|
+| `goldenmatch/a2a/server.py` | add two `_SKILLS` entries (`{id, name, description, inputModes, outputModes}`) |
+| `goldenmatch/a2a/skills.py` | add one `dispatch_skill` branch delegating both ids to `handle_document_tool` |
+| `parity/goldenmatch.yaml` | add both ids to `a2a_skills.python_only` (sorted) |
+| `tests/test_a2a.py` | bump the hard-coded skill-count assertion (38 -> 40); add dispatch tests |
+
+## Skill card entries (`_SKILLS`)
+
+```python
+{"id": "documents_suggest_schema", "name": "Suggest Document Schema",
+ "description": "Propose an extraction schema from a sample document (PDF/image).",
+ "inputModes": ["application/json"], "outputModes": ["application/json"]},
+{"id": "documents_ingest", "name": "Ingest Documents",
+ "description": "Extract records from documents against a schema; records ready for dedupe.",
+ "inputModes": ["application/json"], "outputModes": ["application/json"]},
+```
+
+## Dispatch (`skills.py`)
+
+Add near the other branches in `dispatch_skill(skill_id, params, allow_pprl=False)`:
+```python
+if skill_id in ("documents_ingest", "documents_suggest_schema"):
+    from goldenmatch.mcp.document_tools import handle_document_tool
+    return handle_document_tool(skill_id, params)
+```
+(Other skills delegate to `AgentSession`; documents has no session method, so it routes to the MCP
+handler — the closest existing single source of truth. `handle_document_tool` returns a plain dict,
+which is exactly what `dispatch_skill` returns.)
+
+## Contract
+
+- `documents_suggest_schema {sample_path, backend?, model?}` -> `{"schema": {"fields": [...]}}`.
+- `documents_ingest {paths, schema, backend?, model?, drop_empty?}` -> `{"records": [...], "report":
+  {"n_files","n_rows","errors":[{"file","error"}]}}`. Records carry the schema columns +
+  `_source_file`/`_source_page`/`_extract_confidence`.
+
+## Error handling
+
+`handle_document_tool` raises `ValueError` on bad config (missing key / bad backend / malformed
+schema); the A2A server's existing dispatch wraps a raising skill into a failed-task/error response
+(mirror the current behavior for the other skills — no new error path needed here).
+
+## Testing (offline)
+
+- `test_dispatch_documents_ingest`: monkeypatch `resolve_extractor` (at the reference
+  `document_tools` uses) to a `FakeExtractor`; call `dispatch_skill("documents_ingest", {paths:[...],
+  schema:{...}})`; assert `records`/`report` shape. Use a real tiny image temp file so `load_pages`
+  succeeds (FakeExtractor returns canned rows).
+- `test_dispatch_documents_suggest_schema`: monkeypatch `suggest_schema_from_file` -> a canned
+  `TargetSchema`; assert `{"schema": {...}}`.
+- `test_agent_card_lists_document_skills`: `build_agent_card()` includes both ids.
+- Update the existing `test_agent_card_has_38_skills` (rename/rebump to 40) — and **grep the whole
+  suite + `server.py` for any other hard-coded `38` skill-count literal** (the #1515 count-enumeration
+  lesson: a count change must be chased across every assertion + docstring, not just the feature's
+  own test).
+- No live calls in CI.
+
+## Parity manifest (`parity/goldenmatch.yaml`)
+
+Add `documents_ingest` and `documents_suggest_schema` to `a2a_skills.python_only` (TS A2A has no
+document skills yet), sorted (they land after `configure`). Without this the `api_parity` a2a gate
+fails `undeclared_py_only` (the #1515 gotcha). These same ids are already declared under
+`mcp_tools.python_only` from Phase 2 — the a2a surface is a separate partition and needs its own
+entries.
+
+## Scope (YAGNI)
+
+**In:** 2 skill-card entries + the dispatch branch + the parity declaration + the count-test bump +
+dispatch/card tests. **Out:** file upload (path-based by design), streaming, the TS A2A side (part of
+the TS surface later), any new `AgentSession` method.
+
+## Open risks
+
+- **Count-assertion drift:** `test_agent_card_has_38_skills` (and any `"38 skills"` docstring) MUST be
+  updated to 40, or CI reds on a count mismatch — same failure mode as #1515's `len(TOOLS)==74`.

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -179,7 +179,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 
 ### Integration
 - **REST API + MCP Server** — 68 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
-- **A2A Agent** — 38 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
+- **A2A Agent** — 40 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
 - **Enterprise connectors** — Snowflake, Databricks, BigQuery, HubSpot, Salesforce

--- a/packages/python/goldenmatch/docs/llms.txt
+++ b/packages/python/goldenmatch/docs/llms.txt
@@ -5,7 +5,7 @@
 ## Interfaces
 - MCP Server: `goldenmatch mcp-serve` (16 agent tools + 24 data tools + 7 memory tools + 7 identity tools = 54 total)
 - Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (54 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (38 skills advertised in the agent card)
+- A2A Server: `goldenmatch agent-serve --port 8200` (40 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch autoconfig`, `goldenmatch match`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` -- `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, `AgentSession.autoconfigure()`, `add_correction()`, `learn()`, `memory_stats()`, `get_memory()`, ~106 exports
 - TypeScript / Edge: `npm install goldenmatch` -- same API in browsers, Cloudflare Workers, Vercel Edge, Deno; optional WASM via `await enableWasm()` swaps in the Rust score-core kernel (pure-TS stays the default + byte-identical fallback); `enableSuggestWasm()` brings the config-suggestion "healer" (`dedupe({ suggest, heal })`) to TS via the suggest-core kernel (graceful-empty without it)

--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -322,6 +322,20 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    {
+        "id": "documents_suggest_schema",
+        "name": "Suggest Document Schema",
+        "description": "Propose an extraction schema from a sample document (PDF/image).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "documents_ingest",
+        "name": "Ingest Documents",
+        "description": "Extract records from documents against a schema; records ready for dedupe.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -463,6 +463,10 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
 
         return {"suggestions": serialize_suggestions(suggestions, verified=True)}
 
+    if skill_id in ("documents_ingest", "documents_suggest_schema"):
+        from goldenmatch.mcp.document_tools import handle_document_tool
+        return handle_document_tool(skill_id, params)
+
     raise ValueError(f"Unknown skill: {skill_id}")
 
 

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -8,7 +8,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 ## Interfaces
 - MCP Server: `goldenmatch mcp-serve` (16 agent tools + 24 data tools + 7 memory tools + 7 identity tools = 54 total)
 - Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (54 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (38 skills advertised in the agent card)
+- A2A Server: `goldenmatch agent-serve --port 8200` (40 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~101 exports
 - TypeScript / Edge: `npm install goldenmatch` — same API in browsers, Cloudflare Workers, Vercel Edge, Deno; optional WASM via `await enableWasm()` swaps in the Rust score-core kernel, and `enableSuggestWasm()` brings the config-suggestion "healer" (`dedupe({suggest, heal})`) to TS via suggest-core (pure-TS stays the default + byte-identical fallback)

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -35,18 +35,19 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_38_skills():
+def test_agent_card_has_40_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
     (18->19); the MCP tool-coverage parity pass added 12 (19->31); #1089 added
     retrieve_similar (31->32); Agent Memory #1075/#1078 added identity_claim /
     identity_resolve_conflict / identity_audit (32->35); #1078 tamper-evidence
     added identity_audit_seal / identity_audit_verify (35->37); the healer added
-    review_config (37->38)."""
+    review_config (37->38); document ingest added documents_suggest_schema /
+    documents_ingest (38->40)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 38
+    assert len(card["skills"]) == 40
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "retrieve_similar" in ids
@@ -65,6 +66,12 @@ def test_agent_card_has_38_skills():
         "sensitivity", "incremental", "identity_show", "list_runs", "rollback",
         "list_corrections", "learn_thresholds", "memory_stats",
     } <= ids
+
+
+def test_agent_card_lists_document_skills():
+    from goldenmatch.a2a.server import build_agent_card
+    ids = {s["id"] for s in build_agent_card("http://localhost:8080")["skills"]}
+    assert {"documents_suggest_schema", "documents_ingest"} <= ids
 
 
 def test_agent_card_skills_have_modes():

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -357,6 +357,40 @@ def test_dispatch_memory_loop(tmp_path):
     assert stats["total_corrections"] == 1
 
 
+def test_dispatch_documents_ingest(tmp_path, monkeypatch):
+    import goldenmatch.mcp.document_tools as dt
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.documents.extractor import FakeExtractor
+    from goldenmatch.documents.types import ExtractedRow, ExtractResult, Field, TargetSchema
+    from PIL import Image
+
+    p = tmp_path / "a.png"
+    Image.new("RGB", (20, 20), "white").save(p)
+    schema = TargetSchema([Field("full_name"), Field("email")])
+    row = ExtractedRow.from_partial({"full_name": "Ada", "email": "a@x.io"}, {},
+                                    schema, source_file="", source_page=0)
+    monkeypatch.setattr(dt, "resolve_extractor", lambda b, m: FakeExtractor([ExtractResult(rows=[row])]))
+    out = dispatch_skill("documents_ingest", {
+        "paths": [str(p)],
+        "schema": {"fields": [{"name": "full_name"}, {"name": "email"}]},
+    })
+    assert out["report"]["n_rows"] == 1
+    assert out["records"][0]["full_name"] == "Ada"
+
+
+def test_dispatch_documents_suggest_schema(tmp_path, monkeypatch):
+    import goldenmatch.mcp.document_tools as dt
+    from goldenmatch.a2a.skills import dispatch_skill
+    from goldenmatch.documents.types import Field, TargetSchema
+    from PIL import Image
+
+    p = tmp_path / "s.png"; Image.new("RGB", (10, 10), "white").save(p)
+    monkeypatch.setattr(dt, "suggest_schema_from_file",
+                        lambda path, **k: TargetSchema([Field("full_name"), Field("email", kind="email")]))
+    out = dispatch_skill("documents_suggest_schema", {"sample_path": str(p)})
+    assert out["schema"]["fields"][0]["name"] == "full_name"
+
+
 def test_agent_card_has_quality_and_transform_skills():
     from goldenmatch.a2a.server import build_agent_card
 

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -200,6 +200,8 @@ a2a_skills:
   - analyze_blocking
   - compare_clusters
   - configure
+  - documents_ingest
+  - documents_suggest_schema
   - identity_audit
   - identity_audit_seal
   - identity_audit_verify


### PR DESCRIPTION
## Summary
The third document-ingest surface: two A2A agent-card skills over the shipped MCP handler, so other agents can suggest a schema from and extract records from documents.

- **`documents_suggest_schema`** / **`documents_ingest`** added to `_SKILLS`; `dispatch_skill` delegates both to the existing `handle_document_tool` — one JSON-contract source of truth (config->400 mapping + native-fallback inherited for free). Path-based (A2A is stateless HTTP, no upload).
- **Same ids as the MCP tools** — no cross-surface naming divergence.
- **Bookkeeping (CI-enforced):** declared both ids in `parity/goldenmatch.yaml` `a2a_skills.python_only`; bumped the hard-coded skill count **38 -> 40** across the test assertion + 4 doc surfaces (`README`, both `llms.txt`, `docs-site/goldenmatch/agent.mdx`).

## Test Plan
- [x] `pytest tests/test_a2a.py` -> **44 passed** (2 new dispatch tests with a FakeExtractor / stubbed suggest, a card-lists-both-skills test, and the count assertion at 40)
- [x] `ruff` clean; parity YAML valid (both ids declared + sorted); `grep "38 skills"` returns nothing

## Notes
- Delegation target `handle_document_tool` was code-reviewed in the documents-core PR; this surface adds no new logic.
- Deferred: the TS A2A side (part of the TS surface), uploads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JThTtceZ9kStY5jWjwGk6v