### PR TITLE
style(goldenpipe-core): rustfmt planner.rs + json.rs (unblock crate fmt gate)

### DIFF
--- a/packages/rust/extensions/goldenpipe-core/src/json.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/json.rs
@@ -9,7 +9,9 @@ use serde_json::{json, Value};
 use crate::config::{auto_config, skip_if_falsy};
 use crate::decisions::evaluate_builtin;
 use crate::model::{CtxSubset, Decision, JsonMap, PipelineConfig, PlannedSpec, StageInfo};
-use crate::planner::{apply_scale_hints, band_of, plan_pipeline, PipePlan, PipeProfile, PlannerInput};
+use crate::planner::{
+    apply_scale_hints, band_of, plan_pipeline, PipePlan, PipeProfile, PlannerInput,
+};
 use crate::resolve::resolve;
 use crate::router::apply_decision;
 

--- a/packages/rust/extensions/goldenpipe-core/src/planner.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/planner.rs
@@ -60,7 +60,10 @@ pub fn band_of(confidence: f64) -> &'static str {
 }
 
 fn stage(name: &str, config: JsonMap) -> PlannedStage {
-    PlannedStage { name: name.to_string(), config }
+    PlannedStage {
+        name: name.to_string(),
+        config,
+    }
 }
 
 fn default_evidence(inp: &PlannerInput) -> JsonMap {
@@ -70,9 +73,18 @@ fn default_evidence(inp: &PlannerInput) -> JsonMap {
     m.insert("n_rows".into(), json!(inp.runtime.n_rows));
     m.insert("n_cols".into(), json!(inp.runtime.n_cols));
     m.insert("inferred_domain".into(), json!(inp.runtime.inferred_domain));
-    m.insert("domain_confidence".into(), json!(inp.runtime.domain_confidence));
-    m.insert("max_null_density".into(), json!(inp.complexity.max_null_density));
-    m.insert("mean_null_density".into(), json!(inp.complexity.mean_null_density));
+    m.insert(
+        "domain_confidence".into(),
+        json!(inp.runtime.domain_confidence),
+    );
+    m.insert(
+        "max_null_density".into(),
+        json!(inp.complexity.max_null_density),
+    );
+    m.insert(
+        "mean_null_density".into(),
+        json!(inp.complexity.mean_null_density),
+    );
     m
 }
 
@@ -148,7 +160,10 @@ pub fn apply_scale_hints(plan: &PipePlan, runtime: &PipeProfile) -> PipePlan {
                     "_dedupe_hints".into(),
                     json!({"throughput": {"recall_target": THROUGHPUT_RECALL_TARGET}}),
                 );
-                PlannedStage { name: s.name.clone(), config: cfg }
+                PlannedStage {
+                    name: s.name.clone(),
+                    config: cfg,
+                }
             } else {
                 s.clone()
             }
@@ -178,7 +193,10 @@ mod tests {
                 inferred_domain: domain.map(|s| s.to_string()),
                 domain_confidence: dc,
             },
-            complexity: ComplexityProfile { max_null_density: max_null, mean_null_density: 0.0 },
+            complexity: ComplexityProfile {
+                max_null_density: max_null,
+                mean_null_density: 0.0,
+            },
         }
     }
 
@@ -191,18 +209,36 @@ mod tests {
 
     #[test]
     fn rules_fire_in_order() {
-        assert_eq!(plan_pipeline(&inp(1, None, 0.0, 0.0)).rule_name, "pathological");
-        assert_eq!(plan_pipeline(&inp(100, Some("finance"), 0.8, 0.0)).rule_name, "confident_schema");
-        assert_eq!(plan_pipeline(&inp(200000, None, 0.0, 0.7)).rule_name, "low_confidence");
-        assert_eq!(plan_pipeline(&inp(100, None, 0.0, 0.0)).rule_name, "default");
-        assert_eq!(plan_pipeline(&inp(100, Some("finance"), 0.4, 0.0)).rule_name, "default");
+        assert_eq!(
+            plan_pipeline(&inp(1, None, 0.0, 0.0)).rule_name,
+            "pathological"
+        );
+        assert_eq!(
+            plan_pipeline(&inp(100, Some("finance"), 0.8, 0.0)).rule_name,
+            "confident_schema"
+        );
+        assert_eq!(
+            plan_pipeline(&inp(200000, None, 0.0, 0.7)).rule_name,
+            "low_confidence"
+        );
+        assert_eq!(
+            plan_pipeline(&inp(100, None, 0.0, 0.0)).rule_name,
+            "default"
+        );
+        assert_eq!(
+            plan_pipeline(&inp(100, Some("finance"), 0.4, 0.0)).rule_name,
+            "default"
+        );
     }
 
     #[test]
     fn scale_hint_applies_and_noops() {
         let plan = plan_pipeline(&inp(100, None, 0.0, 0.0));
         let hinted = apply_scale_hints(&plan, &inp(1_000_000, None, 0.0, 0.0).runtime);
-        assert_eq!(hinted.evidence.get("scale_hinted"), Some(&Value::Bool(true)));
+        assert_eq!(
+            hinted.evidence.get("scale_hinted"),
+            Some(&Value::Bool(true))
+        );
         let below = apply_scale_hints(&plan, &inp(999_999, None, 0.0, 0.0).runtime);
         assert!(below.evidence.get("scale_hinted").is_none());
     }


### PR DESCRIPTION
Follow-up to #1545 (brain port). That PR merged via the queue on the required `rust` (`cargo test`) job; the `goldenpipe_native`/`goldenpipe_wasm` `fmt + clippy` checks are non-required, so their `cargo fmt --check` failure did not block the merge and the unformatted `planner.rs`/`json.rs` landed on main. `cargo fmt --check` runs over the whole crate, so this now fails the fmt gate for any future goldenpipe-core PR.

Ran `rustfmt` 1.94.0 in place — pure formatting (wraps the long `use` import and the long test `assert_eq!` lines). No logic change; the `rust` job was already green on #1545.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44