### PR TITLE
feat(goldenflow): multi-output splits on the columnar engine (Phase 3 wave 3e)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -89,13 +89,37 @@ def _numeric_inmem_ok(nm) -> bool:
     )
 
 
+def _split_inmem_ok(nm) -> bool:
+    """The in-memory Column path can run a split spec when the kernel exposes the
+    shape probe AND the Column returns the source + output columns (``apply_split``,
+    native-flow 0.24+). Skew-safe: an older wheel lacks it -> split declines to
+    Polars in-memory."""
+    col_cls = getattr(nm, "Column", None)
+    return hasattr(nm, "columnar_split_ready") and col_cls is not None and hasattr(
+        col_cls, "apply_split"
+    )
+
+
+def _spec_ready(nm, spec, accepted: frozenset[str], numeric_ok: bool, split_ok: bool) -> bool:
+    """A spec is columnar-ready if it's an owned-string run, or — with native support
+    — a valid NUMERIC (``string* parser f64*``) or SPLIT (``string* splitter``) shape
+    (validated by the native probes, the single source of truth)."""
+    if _spec_string_ready(spec, accepted):
+        return True
+    ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
+    if numeric_ok and nm.columnar_numeric_ready(ops_spec):
+        return True
+    if split_ok and nm.columnar_split_ready(ops_spec):
+        return True
+    return False
+
+
 def config_is_columnar_ready(config) -> bool:
     """A config runs on the IN-MEMORY columnar engine iff EVERY spec is an owned
-    string run (total fusable, or — when supported — a nullable URL/company/email
-    kernel) OR — Phase 3 wave 3d — a valid NUMERIC shape (``string* parser f64*``,
-    via the native ``columnar_numeric_ready`` probe + ``Column.apply_numeric``), and
-    there are no frame-level ops. Otherwise the caller uses the Polars engine —
-    correctness first; coverage grows over the phases."""
+    string run, a NUMERIC shape (wave 3d, via ``Column.apply_numeric``), or a SPLIT
+    shape (wave 3e, via ``Column.apply_split``), with no frame-level ops. Otherwise
+    the caller uses the Polars engine — correctness first; coverage grows over the
+    phases."""
     if _frame_level_blocked(config) or not config.transforms:
         return False
     nm = native_module()
@@ -103,23 +127,16 @@ def config_is_columnar_ready(config) -> bool:
         return False
     accepted = _accepted_string(nm)
     numeric_ok = _numeric_inmem_ok(nm)
-    for spec in config.transforms:
-        if _spec_string_ready(spec, accepted):
-            continue
-        ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
-        if numeric_ok and nm.columnar_numeric_ready(ops_spec):
-            continue
-        return False
-    return True
+    split_ok = _split_inmem_ok(nm)
+    return all(_spec_ready(nm, spec, accepted, numeric_ok, split_ok) for spec in config.transforms)
 
 
 def columnar_file_ready(config) -> bool:
     """True when the native whole-file CSV path can run this config: no frame-level
-    ops, and every spec is either an owned-string run OR — Phase 3 wave 3b — a valid
-    NUMERIC shape (``string* parser f64*``, validated by the native
-    ``columnar_numeric_ready`` probe, the single source of truth so host and kernel
-    never disagree). When true, a CSV runs read->transform->write entirely in Rust —
-    no ``pl.DataFrame``, no Polars, no pyarrow."""
+    ops, and every spec is an owned-string run OR a valid NUMERIC (``string* parser
+    f64*``) or SPLIT (``string* splitter``) shape, validated by the native probes
+    (the single source of truth). When true, a CSV runs read->transform->write
+    entirely in Rust — no ``pl.DataFrame``, no Polars, no pyarrow."""
     if _frame_level_blocked(config) or not config.transforms:
         return False
     nm = native_module()
@@ -127,14 +144,8 @@ def columnar_file_ready(config) -> bool:
         return False
     accepted = _accepted_string(nm)
     numeric_ok = hasattr(nm, "columnar_numeric_ready")
-    for spec in config.transforms:
-        if _spec_string_ready(spec, accepted):
-            continue
-        ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
-        if numeric_ok and nm.columnar_numeric_ready(ops_spec):
-            continue
-        return False
-    return True
+    split_ok = hasattr(nm, "columnar_split_ready")
+    return all(_spec_ready(nm, spec, accepted, numeric_ok, split_ok) for spec in config.transforms)
 
 
 def transform_file(in_path, out_path, config, source: str | None = None) -> Manifest:
@@ -197,12 +208,39 @@ def _transform_via_columns(df, config, source, nm, pl):
     No list marshaling, no pyarrow."""
     manifest = Manifest(source=source)
     numeric_ok = _numeric_inmem_ok(nm)
+    split_ok = _split_inmem_ok(nm)
     out_series = []
+
+    def _add_records(column, records):
+        for name, affected, total, before, after in records:
+            manifest.add_record(TransformRecord(
+                column=column,
+                transform=name,
+                affected_rows=int(affected),
+                total_rows=int(total),
+                sample_before=list(before),
+                sample_after=list(after),
+            ))
+
+    def _egress(col):
+        imported = pl.from_arrow(col)
+        return imported.to_series(0) if isinstance(imported, pl.DataFrame) else imported
+
     for spec in config.transforms:
         if spec.column not in df.columns:
             continue
         ops = [parse_transform_name(op) for op in spec.ops]
         ops_spec = [(n, list(p)) for n, p in ops]
+        # Split spec (string* splitter): the source column keeps its (string-ops)
+        # value and the fixed-name output columns are appended -- exactly Polars'
+        # dataframe-mode with_columns. Cast to Utf8 first (the split reads strings).
+        if split_ok and nm.columnar_split_ready(ops_spec):
+            col = nm.Column.from_arrow(df.select([pl.col(spec.column).cast(pl.Utf8)]))
+            src_col, new_cols, records = col.apply_split(ops_spec)
+            _add_records(spec.column, records)
+            out_series.append(_egress(src_col).alias(spec.column))
+            out_series.extend(_egress(c).alias(name) for name, c in new_cols)
+            continue
         # Numeric spec (string* parser f64*): cast the column to Utf8 (Polars' numeric
         # transforms cast to Utf8 internally, so this matches even a non-string input)
         # and run the numeric plan, egressing the RAW numeric array (Int64/Float64) as

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -124,6 +124,40 @@ def test_columnar_numeric_equals_polars(monkeypatch, ops, data) -> None:
     assert _manifest_rows(columnar_out) == _manifest_rows(polars_out)
 
 
+@pytest.mark.parametrize(
+    "ops,col,data",
+    [
+        (["split_name"], "name", ["John Smith", "Mary Jane Doe", "Cher", None, "", "o'Brien"]),
+        (["strip", "split_name"], "name", ["  John Smith  ", "Mary Doe", None, ""]),
+        (["split_name_reverse"], "name", ["Smith, John", "Doe, Mary", None, ""]),
+        (["split_address"], "addr", ["123 Main St, Springfield, IL 62704", "5 Oak Ave", None, ""]),
+        (["strip", "lowercase", "split_address"], "addr", ["  123 Main St, Reno, NV 89501 ", None]),
+    ],
+)
+def test_columnar_split_equals_polars(monkeypatch, ops, col, data) -> None:
+    """Phase 3 wave 3e: multi-output splits (split_name/_reverse/split_address) run on
+    the in-memory Column path — the source column keeps its value and the fixed-name
+    output columns are appended, byte-identical to the Polars engine (frame + manifest)."""
+    nm = native_module()
+    if nm is None or not hasattr(nm, "columnar_split_ready") or not hasattr(
+        getattr(nm, "Column", object), "apply_split"
+    ):
+        pytest.skip("native split not built (pre-0.24 wheel)")
+    df = pl.DataFrame({col: data, "keep": list(range(len(data)))})
+    cfg = _cfg([(col, ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    polars_out = transform_df(df, config=cfg)
+
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    columnar_out = transform_df(df, config=cfg)
+
+    assert columnar_out.df.columns == polars_out.df.columns, "split output schema diverged"
+    assert columnar_out.df.equals(polars_out.df), "split output frame diverged"
+    assert _manifest_rows(columnar_out) == _manifest_rows(polars_out)
+
+
 def test_columnar_declines_unsupported_config(monkeypatch) -> None:
     """A config with a non-owned-string op (phone) or a frame-level op is NOT
     columnar-ready; it falls through to the Polars engine (still correct)."""

--- a/packages/python/goldenflow/tests/engine/test_native_csv_io.py
+++ b/packages/python/goldenflow/tests/engine/test_native_csv_io.py
@@ -183,6 +183,52 @@ def test_native_csv_i64_equals_polars(tmp_path, monkeypatch, ops, rows) -> None:
     assert _manifest_rows(manifest) == _manifest_rows(ref.manifest)
 
 
+@pytest.mark.parametrize(
+    "ops,col,data",
+    [
+        (["split_name"], "name", ["John Smith", "Cher", "", None, "o'Brien"]),
+        (["strip", "split_name"], "name", ["  John Smith  ", "Mary Doe", None]),
+        (["split_name_reverse"], "name", ["Smith, John", "Doe, Mary", None, ""]),
+        (["split_address"], "addr", ["123 Main St, Reno, NV 89501", "5 Oak Ave", None, ""]),
+    ],
+)
+def test_native_csv_split_equals_polars(tmp_path, monkeypatch, ops, col, data) -> None:
+    """Phase 3 wave 3e: splits on the CSV path add the fixed-name output columns; the
+    output CSV (parsed back) + manifest are byte-identical to the Polars engine. This
+    also exercises the empty-string quoting fix (split_name's last='' for a single-word
+    name must survive the CSV round-trip as '', not null)."""
+    if not columnar.columnar_file_ready(_cfg([(col, ops)])):
+        pytest.skip("native split not built (pre-0.24 wheel)")
+    inp = tmp_path / "in.csv"
+    _write_2col(inp, col, data)
+    cfg = _cfg([(col, ops)])
+
+    out = tmp_path / "out.csv"
+    manifest = columnar.transform_file(inp, out, cfg, source=str(inp))
+
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = transform_df(pl.read_csv(inp, infer_schema_length=0), config=cfg)
+
+    got = pl.read_csv(out, infer_schema_length=0)
+    assert got.columns == ref.df.columns
+    for c in got.columns:
+        assert got[c].to_list() == ref.df[c].cast(pl.Utf8).to_list(), f"{c} diverged"
+    assert _manifest_rows(manifest) == _manifest_rows(ref.manifest)
+
+
+def test_native_csv_quotes_empty_string_like_polars(tmp_path) -> None:
+    """The native writer quotes an empty-string VALUE as `\"\"` (distinct from a null
+    empty field), matching Polars — so `strip('   ') -> ''` round-trips as '' not null."""
+    inp = tmp_path / "in.csv"
+    _write_2col(inp, "x", ["   ", "keep", None])  # row0 -> strip -> '' (empty string)
+    out = tmp_path / "out.csv"
+    columnar.transform_file(inp, out, _cfg([("x", ["strip"])]))
+    raw = out.read_text(encoding="utf-8").splitlines()
+    assert raw[1].startswith('""'), f'empty string not quoted: {raw[1]!r}'
+    back = pl.read_csv(out, infer_schema_length=0)
+    assert back["x"].to_list() == ["", "keep", None]  # '' preserved, null stays null
+
+
 def test_native_csv_path_is_pyarrow_free(tmp_path) -> None:
     """The transform_csv call must not pull in pyarrow — the whole weight thesis."""
     inp = tmp_path / "in.csv"

--- a/packages/rust/extensions/native-flow/Cargo.lock
+++ b/packages/rust/extensions/native-flow/Cargo.lock
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "goldenflow-native"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "arrow",
  "csv",

--- a/packages/rust/extensions/native-flow/Cargo.toml
+++ b/packages/rust/extensions/native-flow/Cargo.toml
@@ -5,7 +5,7 @@
 
 [package]
 name = "goldenflow-native"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native-flow/pyproject.toml
+++ b/packages/rust/extensions/native-flow/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenflow-native"
-version = "0.23.0"
+version = "0.24.0"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenflow"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
+++ b/packages/rust/extensions/native-flow/python/goldenflow_native/__init__.py
@@ -18,4 +18,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenflow-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.23.0"
+    __version__ = "0.24.0"

--- a/packages/rust/extensions/native-flow/src/column.rs
+++ b/packages/rust/extensions/native-flow/src/column.rs
@@ -25,8 +25,12 @@ use goldenflow_core::chain::{apply_chain, apply_chain_nullable};
 use crate::chain::{resolve_chain, ChainOps};
 use crate::csvio::OpRecord;
 use crate::numeric_columnar::{resolve_numeric, run_numeric_column};
+use crate::split_columnar::{resolve_split, run_split_column};
 
 const STREAM_NAME: &[u8] = b"arrow_array_stream";
+
+/// `apply_split` result: `(source_column, [(output_name, output_column)], records)`.
+type SplitCols = (Column, Vec<(String, Column)>, Vec<OpRecord>);
 
 /// A Rust-owned Arrow column (one logical column, always a single contiguous
 /// array after ingest). Utf8 or LargeUtf8 for the owned string transform path.
@@ -207,5 +211,28 @@ impl Column {
             })?;
         let (numcol, records) = py.detach(|| run_numeric_column(arr, &plan));
         Ok((Column::new(numcol.into_array()), records))
+    }
+
+    /// In-memory multi-output path (Phase 3 wave 3e): run a split config
+    /// (`string* splitter`) over this string column, returning the source `Column`
+    /// (unchanged by the split, only its string ops applied), the fixed-name output
+    /// `Column`s to add to the frame, and the per-op manifest records. Each Column
+    /// egresses via `__arrow_c_stream__`.
+    fn apply_split(&self, py: Python, ops: Vec<(String, Vec<String>)>) -> PyResult<SplitCols> {
+        let plan = resolve_split(&ops)
+            .ok_or_else(|| PyValueError::new_err("not a split columnar config"))?;
+        let arr = self
+            .array
+            .as_any()
+            .downcast_ref::<LargeStringArray>()
+            .ok_or_else(|| {
+                PyTypeError::new_err("Column.apply_split requires a Utf8/LargeUtf8 column")
+            })?;
+        let (src, new_cols, records) = py.detach(|| run_split_column(arr, &plan));
+        let new = new_cols
+            .into_iter()
+            .map(|(n, a)| (n, Column::new(Arc::new(a))))
+            .collect();
+        Ok((Column::new(Arc::new(src)), new, records))
     }
 }

--- a/packages/rust/extensions/native-flow/src/csvio.rs
+++ b/packages/rust/extensions/native-flow/src/csvio.rs
@@ -199,23 +199,41 @@ fn read_csv(path: &str) -> Result<(Vec<String>, Vec<LargeStringArray>), String> 
     Ok((names, columns))
 }
 
-/// Serialize rows `[start, end)` of `columns` to an in-memory CSV byte buffer
-/// (no header) via the `csv` crate — null -> empty field, RFC4180 quoting.
-fn write_region(columns: &[LargeStringArray], start: usize, end: usize) -> Result<Vec<u8>, String> {
-    let mut w = csv::WriterBuilder::new()
-        .has_headers(false)
-        .from_writer(Vec::<u8>::new());
-    for row in start..end {
-        for c in columns {
-            let field = if c.is_null(row) { "" } else { c.value(row) };
-            w.write_field(field)
-                .map_err(|e| format!("write row {row}: {e}"))?;
+/// Append one CSV field to `out`, matching Polars' `write_csv` quoting EXACTLY:
+/// a null cell is an empty field (no quotes); a NON-null cell is quoted iff it is
+/// the empty string (so `""` round-trips as `""`, distinct from a null empty field)
+/// OR it contains a delimiter / quote / newline, with `"` escaped as `""`.
+fn write_csv_field(out: &mut Vec<u8>, field: Option<&str>) {
+    let Some(s) = field else { return }; // null -> empty field
+    let needs_quote = s.is_empty() || s.bytes().any(|b| matches!(b, b',' | b'"' | b'\n' | b'\r'));
+    if needs_quote {
+        out.push(b'"');
+        for b in s.bytes() {
+            if b == b'"' {
+                out.push(b'"');
+            }
+            out.push(b);
         }
-        w.write_record(std::iter::empty::<&[u8]>())
-            .map_err(|e| format!("end row {row}: {e}"))?;
+        out.push(b'"');
+    } else {
+        out.extend_from_slice(s.as_bytes());
     }
-    w.into_inner()
-        .map_err(|e| format!("finish write buffer: {e}"))
+}
+
+/// Serialize rows `[start, end)` of `columns` to an in-memory CSV byte buffer (no
+/// header) — Polars-matching quoting, `\n` terminator.
+fn write_region(columns: &[LargeStringArray], start: usize, end: usize) -> Result<Vec<u8>, String> {
+    let mut out = Vec::new();
+    for row in start..end {
+        for (i, c) in columns.iter().enumerate() {
+            if i > 0 {
+                out.push(b',');
+            }
+            write_csv_field(&mut out, (!c.is_null(row)).then(|| c.value(row)));
+        }
+        out.push(b'\n');
+    }
+    Ok(out)
 }
 
 /// Write `(column_names, columns)` back to a CSV file — null -> empty field,
@@ -228,16 +246,15 @@ fn write_csv(path: &str, names: &[String], columns: &[LargeStringArray]) -> Resu
     let nrows = columns.first().map_or(0, |c| c.len());
     let value_bytes: usize = columns.iter().map(|c| c.values().len()).sum();
 
-    // Header (one buffer; picks up the same quoting rules as the data).
-    let mut header = csv::WriterBuilder::new()
-        .has_headers(false)
-        .from_writer(Vec::<u8>::new());
-    header
-        .write_record(names)
-        .map_err(|e| format!("write header: {e}"))?;
-    let header = header
-        .into_inner()
-        .map_err(|e| format!("finish header buffer: {e}"))?;
+    // Header (same quoting rules as the data).
+    let mut header = Vec::new();
+    for (i, n) in names.iter().enumerate() {
+        if i > 0 {
+            header.push(b',');
+        }
+        write_csv_field(&mut header, Some(n));
+    }
+    header.push(b'\n');
 
     let nthreads = std::thread::available_parallelism().map_or(1, |n| n.get());
     let bufs: Vec<Vec<u8>> = if nthreads <= 1 || value_bytes < parallel_min_bytes() {
@@ -318,16 +335,28 @@ pub fn transform_csv(
     specs: Vec<ColumnSpec>,
 ) -> PyResult<Vec<ColumnManifest>> {
     py.detach(|| -> PyResult<Vec<ColumnManifest>> {
-        let (names, mut columns) =
+        let (mut names, mut columns) =
             read_csv(in_path).map_err(|e| PyIOError::new_err(format!("read CSV: {e}")))?;
-        let idx_of = |name: &str| names.iter().position(|n| n == name);
 
         let mut manifest: Vec<ColumnManifest> = Vec::with_capacity(specs.len());
+        // Split outputs (fixed-name columns to add) accumulate here and are appended
+        // AFTER all specs, so they land after the original columns (as Polars does).
+        let mut extra: Vec<(String, LargeStringArray)> = Vec::new();
         for (col_name, ops) in &specs {
-            let Some(idx) = idx_of(col_name) else {
+            let Some(idx) = names.iter().position(|n| n == col_name) else {
                 continue; // column not in file — mirrors the Python `if col in df.columns`
             };
             let total = columns[idx].len() as u64;
+            // Split shape (`string* splitter`) transforms the source in place and ADDS
+            // the fixed-name output columns (source itself unchanged by the split).
+            if let Some(plan) = crate::split_columnar::resolve_split(ops) {
+                let (src, new_cols, records) =
+                    crate::split_columnar::run_split_column(&columns[idx], &plan);
+                columns[idx] = src;
+                extra.extend(new_cols);
+                manifest.push((col_name.clone(), records));
+                continue;
+            }
             // Numeric shape (`string* parser f64*`) runs the string->f64->string
             // path (formatting via the Polars-matching float formatter); otherwise
             // auto-route the string run total vs nullable.
@@ -361,6 +390,17 @@ pub fn transform_csv(
             };
             columns[idx] = new_array;
             manifest.push((col_name.clone(), records));
+        }
+
+        // Append the split output columns (or replace an existing same-name column,
+        // matching Polars' `with_columns` semantics).
+        for (name, arr) in extra {
+            if let Some(pos) = names.iter().position(|n| *n == name) {
+                columns[pos] = arr;
+            } else {
+                names.push(name);
+                columns.push(arr);
+            }
         }
 
         write_csv(out_path, &names, &columns)

--- a/packages/rust/extensions/native-flow/src/lib.rs
+++ b/packages/rust/extensions/native-flow/src/lib.rs
@@ -25,6 +25,7 @@ mod numeric;
 mod numeric_columnar;
 mod phone;
 mod phonetic;
+mod split_columnar;
 mod text;
 mod url;
 mod util;
@@ -41,6 +42,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
         numeric_columnar::columnar_numeric_ready,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(split_columnar::columnar_split_ready, m)?)?;
     m.add_function(wrap_pyfunction!(csvio::transform_csv, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_f64_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(chain::apply_chain_nullable_arrow, m)?)?;

--- a/packages/rust/extensions/native-flow/src/split_columnar.rs
+++ b/packages/rust/extensions/native-flow/src/split_columnar.rs
@@ -1,0 +1,190 @@
+//! Multi-output (split) columnar execution — Phase 3 wave 3e. A config of shape
+//! `[string ops] -> [one splitter]` (`split_name`/`split_name_reverse` ->
+//! `first_name`+`last_name`; `split_address` -> `street`+`city`+`state`+`zip`) runs
+//! natively: the leading string ops transform the source column in place, then the
+//! terminal splitter ADDS the fixed-name output columns (the source column itself is
+//! unchanged by the split, exactly as Polars' `df.with_columns(...)` dataframe-mode
+//! transform does). Byte-identical (data + manifest) to the Polars engine.
+//!
+//! Manifest: the string ops record as usual; the splitter records the SOURCE column
+//! (unchanged by the split -> affected 0, before == after == the post-string-ops
+//! source), matching how the engine audits a dataframe-mode transform.
+
+use arrow::array::{Array, LargeStringArray};
+use pyo3::prelude::*;
+
+use goldenflow_core::address;
+use goldenflow_core::chain::{apply_chain_nullable, NullableKernel};
+use goldenflow_core::names;
+
+use crate::csvio::OpRecord;
+
+/// `(source_column, [(output_name, output_column)], per-op records)`.
+type SplitResult = (
+    LargeStringArray,
+    Vec<(String, LargeStringArray)>,
+    Vec<OpRecord>,
+);
+
+/// Host gate: is this a config the native split path can run? (A valid
+/// `string* splitter` shape.) The single source of truth the Python
+/// `config_is_columnar_ready` / `columnar_file_ready` call.
+#[pyfunction]
+pub fn columnar_split_ready(ops: Vec<(String, Vec<String>)>) -> bool {
+    resolve_split(&ops).is_some()
+}
+
+/// A terminal 1 -> N splitter and its fixed output column names.
+#[derive(Clone, Copy)]
+enum Splitter {
+    Name,
+    NameReverse,
+    Address,
+}
+
+impl Splitter {
+    fn from_name(name: &str) -> Option<Splitter> {
+        Some(match name {
+            "split_name" => Splitter::Name,
+            "split_name_reverse" => Splitter::NameReverse,
+            "split_address" => Splitter::Address,
+            _ => return None,
+        })
+    }
+
+    fn output_names(self) -> &'static [&'static str] {
+        match self {
+            Splitter::Name | Splitter::NameReverse => &["first_name", "last_name"],
+            Splitter::Address => &["street", "city", "state", "zip"],
+        }
+    }
+
+    /// Split `col` into the output columns (one `LargeStringArray` per output name).
+    /// A null input cell yields null in every output.
+    fn split(self, col: &LargeStringArray) -> Vec<LargeStringArray> {
+        let n = self.output_names().len();
+        let mut outs: Vec<Vec<Option<String>>> = vec![Vec::with_capacity(col.len()); n];
+        for i in 0..col.len() {
+            if col.is_null(i) {
+                for o in outs.iter_mut() {
+                    o.push(None);
+                }
+                continue;
+            }
+            let s = col.value(i);
+            match self {
+                Splitter::Name => {
+                    let (f, l) = names::split_name(s);
+                    outs[0].push(Some(f));
+                    outs[1].push(Some(l));
+                }
+                Splitter::NameReverse => {
+                    let (f, l) = names::split_name_reverse(s);
+                    outs[0].push(Some(f));
+                    outs[1].push(Some(l));
+                }
+                Splitter::Address => {
+                    let (street, city, state, zip) = address::split_address(s);
+                    outs[0].push(Some(street));
+                    outs[1].push(city);
+                    outs[2].push(state);
+                    outs[3].push(zip);
+                }
+            }
+        }
+        outs.into_iter().map(LargeStringArray::from).collect()
+    }
+}
+
+/// A resolved split plan: leading string ops + one terminal splitter.
+pub struct SplitPlan {
+    string_ops: Vec<(String, NullableKernel)>,
+    splitter: (String, Splitter),
+}
+
+/// Resolve `ops` to a [`SplitPlan`] iff they form `string* splitter` with the
+/// splitter as the LAST op. `None` if there is no splitter (not a split config) or
+/// the shape is invalid (an op after the splitter, a non-fusable string op, etc.).
+pub fn resolve_split(ops: &[(String, Vec<String>)]) -> Option<SplitPlan> {
+    let mut string_ops = Vec::new();
+    let mut splitter: Option<(String, Splitter)> = None;
+    let last = ops.len().checked_sub(1)?;
+    for (i, (name, params)) in ops.iter().enumerate() {
+        if let Some(s) = Splitter::from_name(name) {
+            if i != last {
+                return None; // a splitter must be terminal
+            }
+            splitter = Some((name.clone(), s));
+        } else {
+            let refs: Vec<&str> = params.iter().map(String::as_str).collect();
+            match NullableKernel::from_op(name, &refs) {
+                Some(k) => string_ops.push((name.clone(), k)),
+                None => return None,
+            }
+        }
+    }
+    Some(SplitPlan {
+        string_ops,
+        splitter: splitter?,
+    })
+}
+
+fn str_opts(arr: &LargeStringArray) -> Vec<Option<String>> {
+    (0..arr.len())
+        .map(|i| (!arr.is_null(i)).then(|| arr.value(i).to_string()))
+        .collect()
+}
+
+fn head3(v: &[Option<String>]) -> Vec<Option<String>> {
+    v.iter().take(3).cloned().collect()
+}
+
+/// Execute a [`SplitPlan`] over one string column, returning `(source_column,
+/// [(output_name, output_column)], records)`: the source column after the string
+/// ops (the split leaves it unchanged), the fixed-name output columns to add, and
+/// the per-op manifest records (string ops as usual; the splitter records the
+/// unchanged source -> affected 0). Byte-identical to the Polars engine.
+pub fn run_split_column(input: &LargeStringArray, plan: &SplitPlan) -> SplitResult {
+    let total = input.len() as u64;
+    let mut records: Vec<OpRecord> = Vec::with_capacity(plan.string_ops.len() + 1);
+
+    // String phase (fused; 3-row replay for samples).
+    let str_kernels: Vec<NullableKernel> = plan.string_ops.iter().map(|(_, k)| *k).collect();
+    let src: LargeStringArray = if str_kernels.is_empty() {
+        input.clone()
+    } else {
+        let fused = apply_chain_nullable(input, &str_kernels);
+        let mut head = LargeStringArray::from_iter(str_opts(input).into_iter().take(3));
+        for (i, (name, _)) in plan.string_ops.iter().enumerate() {
+            let before = head3(&str_opts(&head));
+            let replay = apply_chain_nullable(&head, std::slice::from_ref(&str_kernels[i]));
+            let after = head3(&str_opts(&replay.array));
+            records.push((name.clone(), fused.changed[i], total, before, after));
+            head = replay.array;
+        }
+        fused.array
+    };
+
+    // The split adds columns but leaves the source unchanged -> a no-op audit record
+    // on the source column (before == after == the post-string-ops source).
+    let src_head = head3(&str_opts(&src));
+    records.push((
+        plan.splitter.0.clone(),
+        0,
+        total,
+        src_head.clone(),
+        src_head,
+    ));
+
+    let arrays = plan.splitter.1.split(&src);
+    let new_cols: Vec<(String, LargeStringArray)> = plan
+        .splitter
+        .1
+        .output_names()
+        .iter()
+        .map(|s| s.to_string())
+        .zip(arrays)
+        .collect();
+
+    (src, new_cols, records)
+}


### PR DESCRIPTION
## Phase 3 wave 3e — multi-output splits

The multi-output transforms `split_name`/`split_name_reverse` (→ `first_name` +
`last_name`) and `split_address` (→ `street`+`city`+`state`+`zip`) now run on **both**
columnar paths. A config of shape `string* splitter` transforms the source column in
place and **appends** the fixed-name output columns — exactly Polars' dataframe-mode
`df.with_columns(...)` — byte-identical (schema + data + manifest) to the Polars engine.

### How
- **native-flow `split_columnar.rs`**: `Splitter` (over `goldenflow_core::names::split_name`/
  `split_name_reverse` + `address::split_address`) + `resolve_split` (validates the
  `string* splitter` shape, splitter terminal) + `run_split_column`, returning the source
  column (unchanged by the split, only its string ops applied), the fixed-name output
  columns, and per-op records (the splitter records the unchanged source → affected 0,
  matching the engine's dataframe-mode audit). `transform_csv` appends the outputs
  (replacing a same-name column, like `with_columns`); new `Column.apply_split` does the
  in-memory path. `columnar_split_ready` is the single-source shape probe. **native-flow
  0.23.0 → 0.24.0.**
- **columnar engine**: `config_is_columnar_ready` + `columnar_file_ready` accept a split
  spec via the probe (in-memory needs `Column.apply_split`; CSV needs `transform_csv`),
  refactored to a shared `_spec_ready` helper. `_transform_via_columns` casts to Utf8 and
  appends the split output series.

### Fix (a pre-existing Phase 2 writer gap this surfaced)
The native CSV writer now **quotes an empty-string value as `""`** (distinct from a null
empty field), matching Polars' `write_csv` — so `split_name`'s `last=''` for a single-word
name (and *any* empty-string transform output) survives the CSV round-trip as `''`, not
null. The writer is now a direct Polars-matching field writer (empty/special-char quoting,
`"`→`""`), replacing the csv-crate Writer (the reader is unchanged).

### Parity
5 in-memory + 4 CSV split cases + an empty-string-quoting regression, all byte-identical
(schema + data + manifest) to the Polars engine. Full engine + fused suite green (138).
`merge_name` is intentionally **not** included (a bare op needs config for the second
column, so it doesn't fit the single-column columnar model).

Design: `docs/design/2026-07-07-polars-eviction-plan.md` (Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg