### PR TITLE
feat(goldenpipe): brain TS + WASM parity (Slice C1)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-wasm-parity.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-wasm-parity.md
@@ -1,0 +1,426 @@
+# goldenpipe brain — TS + WASM parity (Slice C1) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the auto-config brain decision core to TypeScript and add the WASM faces, so the pure-TS brain (Leg A) and the Rust-core-via-WASM (Leg B) both reproduce the shared, already-committed vectors. Rust stays source of truth; TS conforms. TS `run()` is unchanged (C2 wires runtime).
+
+**Architecture:** New pure-TS `autoconfigPlanner.ts` mirrors `planner.rs`/`autoconfig_planner.py`; pure JSON bridges in `plannerJsonPure.ts` (Leg A); 3 `#[wasm_bindgen]` faces in `goldenpipe-wasm` + backend interface + loader wiring (Leg B); 3 cases added to each parity test.
+
+**Tech Stack:** TypeScript (vitest, CI-only — box OOMs), Rust wasm-bindgen (CI-only build; rustfmt local). Shared vectors: `packages/rust/extensions/goldenpipe-core/tests/vectors/{plan_pipeline,apply_scale_hints,band_of}.json`.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md`
+
+---
+
+## Environment & constraints
+
+- Repo `D:/show_case/gg-local-llm`, branch `feat/goldenpipe-brain-wasm-ts` (off fresh main, spec committed).
+- **Box CANNOT run vitest (OOM) or `cargo build`** — TS + wasm-Rust are written against this plan + the committed vectors and validated in CI. Verify TS by eye against the Python brain / the vectors.
+- **`rustfmt` the wasm `lib.rs` locally before pushing** (Task 1) — the only locally-runnable Rust check:
+  `RUSTFMT="D:/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin/rustfmt.exe"; "$RUSTFMT" --edition 2021 <file>`.
+- GitHub auth: `unset GH_TOKEN; gh auth switch --user benzsevern >/dev/null 2>&1; export GH_TOKEN=$(gh auth token --user benzsevern)`.
+- The 3 `pub fn *_json` the wasm faces delegate to already exist in `goldenpipe_core::json` (from #1545).
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `packages/rust/extensions/goldenpipe-wasm/src/lib.rs` | 3 `#[wasm_bindgen]` faces |
+| `packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts` | **new** — pure-TS brain |
+| `packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts` | 3 pure bridge fns + helpers |
+| `packages/typescript/goldenpipe/src/core/wasm/backend.ts` | 3 interface methods |
+| `packages/typescript/goldenpipe/src/core/wasm/loader.ts` | glue cast + 3 wirings |
+| `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts` | 3 Leg A cases |
+| `packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts` | 3 Leg B families |
+
+---
+
+### Task 1: goldenpipe-wasm brain faces (Rust, CI-gated; rustfmt local)
+
+**Files:** Modify `packages/rust/extensions/goldenpipe-wasm/src/lib.rs`.
+
+- [ ] **Step 1: Add the 3 faces** inside the `#[cfg(target_arch = "wasm32")] mod wasm { ... }` block, after `skip_if_falsy_json`, mirroring the existing 5:
+```rust
+    #[wasm_bindgen]
+    pub fn plan_pipeline_json(input: &str) -> String {
+        json::plan_pipeline_json(input)
+    }
+
+    #[wasm_bindgen]
+    pub fn apply_scale_hints_json(input: &str) -> String {
+        json::apply_scale_hints_json(input)
+    }
+
+    #[wasm_bindgen]
+    pub fn band_of_json(input: &str) -> String {
+        json::band_of_json(input)
+    }
+```
+
+- [ ] **Step 2: rustfmt (local) + verify**
+```bash
+RUSTFMT="D:/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin/rustfmt.exe"
+"$RUSTFMT" --edition 2021 packages/rust/extensions/goldenpipe-wasm/src/lib.rs
+"$RUSTFMT" --edition 2021 --check packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # expect no output
+grep -c "wasm_bindgen" packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # expect 8 (5 + 3)
+```
+
+- [ ] **Step 3: Commit**
+```bash
+git add packages/rust/extensions/goldenpipe-wasm/src/lib.rs
+git commit -m "feat(goldenpipe-wasm): brain faces (plan_pipeline/apply_scale_hints/band_of)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 2: pure-TS brain + pure bridges + Leg A (CI-gated; write against vectors)
+
+**Files:**
+- Create: `packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts`
+- Modify: `packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts`
+- Modify: `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts`
+
+- [ ] **Step 1: Create `autoconfigPlanner.ts`** — mirror `planner.rs`/`autoconfig_planner.py` EXACTLY. Internal fields camelCase; the JSON shape (emitted by the bridge in Step 2) is snake_case.
+```ts
+/**
+ * autoconfigPlanner.ts — pure-TS auto-config BRAIN (decision core), ported from
+ * autoconfig_planner.py / goldenpipe-core planner.rs. Rust is the source of
+ * truth; this is the SP3 TS fallback proven to reproduce the golden vectors.
+ * Pure: no InferMap/profiling (that is a PlannerInput the caller supplies).
+ */
+export interface PipeProfile {
+  nRows: number;
+  nCols: number;
+  columnNames: string[];
+  dtypes: string[];
+  inferredDomain: string | null;
+  domainConfidence: number;
+}
+export interface ComplexityProfile {
+  maxNullDensity: number;
+  meanNullDensity: number;
+}
+export interface PlannerInput {
+  runtime: PipeProfile;
+  complexity: ComplexityProfile;
+}
+export interface PlannedStage {
+  name: string;
+  config: Record<string, unknown>;
+}
+export interface PipePlan {
+  stages: PlannedStage[];
+  ruleName: string;
+  confidence: number;
+  evidence: Record<string, unknown>;
+}
+
+const RED_NULL_DENSITY = 0.6;
+const CONFIDENT_DOMAIN_THRESHOLD = 0.5;
+export const SCALE_ROUTE_MIN_ROWS = 1_000_000;
+const THROUGHPUT_RECALL_TARGET = 0.95;
+const GREEN_THRESHOLD = 0.7;
+const AMBER_THRESHOLD = 0.4;
+
+export function bandOf(confidence: number): "green" | "amber" | "red" {
+  if (confidence >= GREEN_THRESHOLD) return "green";
+  if (confidence >= AMBER_THRESHOLD) return "amber";
+  return "red";
+}
+
+function stage(name: string, config: Record<string, unknown> = {}): PlannedStage {
+  return { name, config };
+}
+
+function defaultDedupeStages(): PlannedStage[] {
+  return [stage("goldencheck.scan"), stage("goldenflow.transform"), stage("goldenmatch.dedupe")];
+}
+
+// Evidence keys are snake_case, in the exact Python/Rust order.
+function defaultEvidence(inp: PlannerInput): Record<string, unknown> {
+  return {
+    n_rows: inp.runtime.nRows,
+    n_cols: inp.runtime.nCols,
+    inferred_domain: inp.runtime.inferredDomain,
+    domain_confidence: inp.runtime.domainConfidence,
+    max_null_density: inp.complexity.maxNullDensity,
+    mean_null_density: inp.complexity.meanNullDensity,
+  };
+}
+
+export function planPipeline(inp: PlannerInput): PipePlan {
+  const r = inp.runtime;
+  if (r.nRows <= 1) {
+    return {
+      stages: [stage("goldencheck.scan"), stage("goldenflow.transform")],
+      ruleName: "pathological",
+      confidence: 1.0,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  if (r.inferredDomain !== null && r.domainConfidence >= CONFIDENT_DOMAIN_THRESHOLD) {
+    return {
+      stages: [
+        stage("infer_schema", { domain: r.inferredDomain }),
+        stage("goldencheck.scan"),
+        stage("goldenflow.transform"),
+        stage("goldenmatch.dedupe"),
+      ],
+      ruleName: "confident_schema",
+      confidence: r.domainConfidence,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  if (r.inferredDomain === null && inp.complexity.maxNullDensity > RED_NULL_DENSITY) {
+    return {
+      stages: defaultDedupeStages(),
+      ruleName: "low_confidence",
+      confidence: 0.3,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  return {
+    stages: defaultDedupeStages(),
+    ruleName: "default",
+    confidence: 0.7,
+    evidence: defaultEvidence(inp),
+  };
+}
+
+export function applyScaleHints(plan: PipePlan, runtime: PipeProfile): PipePlan {
+  const hasDedupe = plan.stages.some((s) => s.name === "goldenmatch.dedupe");
+  if (runtime.nRows < SCALE_ROUTE_MIN_ROWS || !hasDedupe) {
+    // No-op: return a NEW, structurally-identical plan (never mutate the input).
+    return {
+      stages: plan.stages.map((s) => ({ name: s.name, config: { ...s.config } })),
+      ruleName: plan.ruleName,
+      confidence: plan.confidence,
+      evidence: { ...plan.evidence },
+    };
+  }
+  const stages = plan.stages.map((s) =>
+    s.name === "goldenmatch.dedupe"
+      ? {
+          name: s.name,
+          config: {
+            ...s.config,
+            _dedupe_hints: { throughput: { recall_target: THROUGHPUT_RECALL_TARGET } },
+          },
+        }
+      : { name: s.name, config: { ...s.config } },
+  );
+  return {
+    stages,
+    ruleName: plan.ruleName,
+    confidence: plan.confidence,
+    evidence: { ...plan.evidence, scale_hinted: true },
+  };
+}
+```
+
+- [ ] **Step 2: Add the 3 pure bridge fns to `plannerJsonPure.ts`** (append at end). NOTE: this module already imports `PlannedStage` from `../engine/resolver.js` (the engine type) — do NOT import the brain's `PlannedStage`; type only on `PipePlan`/`PipeProfile`/`PlannerInput`.
+```ts
+import {
+  planPipeline,
+  applyScaleHints,
+  bandOf,
+  type PipePlan,
+  type PipeProfile,
+  type PlannerInput,
+} from "../autoconfigPlanner.js";
+
+// snake_case JSON shapes matching the golden vectors.
+interface ProfileJson {
+  n_rows: number;
+  n_cols: number;
+  column_names: string[];
+  dtypes: string[];
+  inferred_domain: string | null;
+  domain_confidence: number;
+}
+interface PlanJson {
+  stages: Array<{ name: string; config: Record<string, unknown> }>;
+  rule_name: string;
+  confidence: number;
+  evidence: Record<string, unknown>;
+}
+
+function profileFromJson(d: ProfileJson): PipeProfile {
+  return {
+    nRows: d.n_rows,
+    nCols: d.n_cols,
+    columnNames: d.column_names,
+    dtypes: d.dtypes,
+    inferredDomain: d.inferred_domain,
+    domainConfidence: d.domain_confidence,
+  };
+}
+
+function planFromJson(d: PlanJson): PipePlan {
+  return {
+    stages: d.stages.map((s) => ({ name: s.name, config: s.config })),
+    ruleName: d.rule_name,
+    confidence: d.confidence,
+    evidence: d.evidence,
+  };
+}
+
+function planToJson(plan: PipePlan): PlanJson {
+  return {
+    stages: plan.stages.map((s) => ({ name: s.name, config: s.config })),
+    rule_name: plan.ruleName,
+    confidence: plan.confidence,
+    evidence: plan.evidence,
+  };
+}
+
+export function planPipelineJsonPure(inputStr: string): string {
+  const arg = JSON.parse(inputStr) as {
+    runtime: ProfileJson;
+    complexity: { max_null_density: number; mean_null_density: number };
+  };
+  const inp: PlannerInput = {
+    runtime: profileFromJson(arg.runtime),
+    complexity: {
+      maxNullDensity: arg.complexity.max_null_density,
+      meanNullDensity: arg.complexity.mean_null_density,
+    },
+  };
+  return JSON.stringify(planToJson(planPipeline(inp)));
+}
+
+export function applyScaleHintsJsonPure(inputStr: string): string {
+  const arg = JSON.parse(inputStr) as { plan: PlanJson; runtime: ProfileJson };
+  return JSON.stringify(
+    planToJson(applyScaleHints(planFromJson(arg.plan), profileFromJson(arg.runtime))),
+  );
+}
+
+export function bandOfJsonPure(inputStr: string): string {
+  return JSON.stringify(bandOf(JSON.parse(inputStr) as number));
+}
+```
+
+- [ ] **Step 3: Add the 3 Leg A cases to `planner-parity.test.ts`** — extend the top import from `plannerJsonPure.js` with `planPipelineJsonPure, applyScaleHintsJsonPure, bandOfJsonPure`, and add to the `FAMILIES` array:
+```ts
+  ["plan_pipeline", planPipelineJsonPure],
+  ["apply_scale_hints", applyScaleHintsJsonPure],
+  ["band_of", bandOfJsonPure],
+```
+
+- [ ] **Step 4: Eyeball-verify against the vectors (no vitest on box).** Open `tests/vectors/plan_pipeline.json` + `apply_scale_hints.json` + `band_of.json` and hand-trace 1-2 cases through the TS logic: confirm the emitted shape (snake_case keys, `rule_name`, `_dedupe_hints`, `scale_hinted`, evidence six keys) matches an `expected`. Confirm no `PlannedStage` name clash (the brain type is NOT imported into plannerJsonPure.ts).
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts
+git commit -m "feat(goldenpipe-ts): pure-TS brain + Leg A parity (plan_pipeline/apply_scale_hints/band_of)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 3: backend interface + loader + Leg B (CI-gated)
+
+**Files:**
+- Modify: `packages/typescript/goldenpipe/src/core/wasm/backend.ts`
+- Modify: `packages/typescript/goldenpipe/src/core/wasm/loader.ts`
+- Modify: `packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts`
+
+- [ ] **Step 1: `backend.ts`** — add 3 methods to `interface PipeWasmBackend` (after `skipIfFalsyJson`):
+```ts
+  planPipelineJson(input: string): string;
+  applyScaleHintsJson(input: string): string;
+  bandOfJson(input: string): string;
+```
+
+- [ ] **Step 2: `loader.ts`** — (a) extend the inline `glue` cast type with the 3 snake_case exports, and (b) add the 3 return-object wirings:
+```ts
+    // in the `glue` cast type:
+    plan_pipeline_json: (s: string) => string;
+    apply_scale_hints_json: (s: string) => string;
+    band_of_json: (s: string) => string;
+```
+```ts
+    // in the returned backend object:
+    planPipelineJson: (s) => glue.plan_pipeline_json(s),
+    applyScaleHintsJson: (s) => glue.apply_scale_hints_json(s),
+    bandOfJson: (s) => glue.band_of_json(s),
+```
+
+- [ ] **Step 3: `planner-wasm-parity.test.ts`** — add to the `dispatch` map (inside `call`):
+```ts
+      plan_pipeline: b.planPipelineJson,
+      apply_scale_hints: b.applyScaleHintsJson,
+      band_of: b.bandOfJson,
+```
+and add the three names to the family loop array:
+```ts
+  for (const family of ["resolve", "apply_decision", "evaluate_builtin", "auto_config", "skip_if", "plan_pipeline", "apply_scale_hints", "band_of"]) {
+```
+
+- [ ] **Step 4: Eyeball-verify** the loader glue names (`plan_pipeline_json`) match the wasm exports from Task 1, and the backend method names (`planPipelineJson`) match the interface + the dispatch map.
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/typescript/goldenpipe/src/core/wasm/backend.ts packages/typescript/goldenpipe/src/core/wasm/loader.ts packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts
+git commit -m "feat(goldenpipe-ts): wasm backend brain faces + Leg B parity
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 4: Ship (CI gates TS + WASM)
+
+**Files:** none.
+
+- [ ] **Step 1: Final local checks**
+```bash
+RUSTFMT="D:/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin/rustfmt.exe"
+"$RUSTFMT" --edition 2021 --check packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # no output = clean
+git status --short   # only the 7 intended files across the 3 commits
+```
+(Cannot run vitest/tsc on the box — CI is the gate.)
+
+- [ ] **Step 2: Rebase + push + PR**
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern >/dev/null 2>&1; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q && git rebase origin/main
+git push -u origin feat/goldenpipe-brain-wasm-ts --force-with-lease
+gh pr create --repo benseverndev-oss/goldenmatch --base main --head feat/goldenpipe-brain-wasm-ts \
+  --title "feat(goldenpipe): brain TS + WASM parity (Slice C1)" \
+  --body "<summary: pure-TS autoconfigPlanner (planPipeline/applyScaleHints/bandOf) + pure bridges (Leg A) + 3 goldenpipe-wasm faces + backend/loader wiring (Leg B), both replaying the shared vectors from #1545. TS run() unchanged (C2 wires runtime + profiling parity). rustfmt clean on wasm lib.rs. CI-only verification (box can't vitest/cargo build).>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+- [ ] **Step 3: Watch the TS + goldenpipe_wasm jobs** (box can't run them locally, so watch the first CI run). Leg A runs in the `typescript`/goldenpipe TS test job; Leg B runs in the `goldenpipe_wasm` lane (builds the wasm artifact, un-skips the suite).
+```bash
+gh pr checks <PR#> --repo benseverndev-oss/goldenmatch
+# for a failing job, pull the vitest assertion or tsc error:
+gh run view <run-id> --repo benseverndev-oss/goldenmatch --log-failed | grep -iE "plan_pipeline|apply_scale|band_of|toEqual|expected|error TS|Expected|Received|assertion" | head -30
+```
+If red: common causes — a snake_case key typo (evidence key / `_dedupe_hints` / `scale_hinted`), a missing `glue` cast member (tsc), a family-name mismatch. Fix, rustfmt if Rust touched, commit, push, re-check. Iterate until the TS job and `goldenpipe_wasm` are green.
+
+- [ ] **Step 4: Arm auto-merge + STOP**
+```bash
+gh pr merge <PR#> --auto --squash   # WITHOUT --delete-branch; if 'strategy set by queue', run: gh pr merge <PR#> --auto
+```
+Then STOP.
+
+---
+
+## Cross-cutting reminders
+- **CI-only** for TS + wasm build; **rustfmt the wasm lib.rs locally** before every push (the #1545/#1546 lesson).
+- **snake_case JSON output** everywhere (vector contract): `n_rows`, `rule_name`, `_dedupe_hints`, `scale_hinted`, the six evidence keys.
+- **Do NOT import the brain's `PlannedStage`** into `plannerJsonPure.ts` (engine `PlannedStage` already imported) — type on `PipePlan` only.
+- **Extend the `glue` cast type** in loader.ts (not just the wiring) or tsc errors.
+- TS `run()` untouched; ViaWasm typed wrappers + profiling + pipe_parity are C2.

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-wasm-parity.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-wasm-parity.md
@@ -62,7 +62,7 @@
 RUSTFMT="D:/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin/rustfmt.exe"
 "$RUSTFMT" --edition 2021 packages/rust/extensions/goldenpipe-wasm/src/lib.rs
 "$RUSTFMT" --edition 2021 --check packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # expect no output
-grep -c "wasm_bindgen" packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # expect 8 (5 + 3)
+grep -cE "#\[wasm_bindgen\]" packages/rust/extensions/goldenpipe-wasm/src/lib.rs   # expect 8 (5 + 3 export attrs)
 ```
 
 - [ ] **Step 3: Commit**

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md
@@ -64,6 +64,12 @@ export function bandOfJsonPure(inputStr: string): string { return JSON.stringify
 
 `planPipelineJsonPure`: `const { runtime, complexity } = JSON.parse(inputStr)` (snake_case) → build `PlannerInput` → `planPipeline` → `planToJson`. `applyScaleHintsJsonPure`: parse `{plan, runtime}`, reconstruct typed `PipePlan` + `PipeProfile` from snake_case → `applyScaleHints` → `planToJson`.
 
+**Name-collision caveat:** `plannerJsonPure.ts` already imports `PlannedStage` from
+`../engine/resolver.js` (the ENGINE type: `{name, spec, config}`), which differs from the brain's
+`PlannedStage` (`{name, config}`). Do NOT import the brain's `PlannedStage` into this module under
+the same name — type the bridges on `PipePlan` only (they never need to name the brain's
+`PlannedStage`), or import it under an alias.
+
 ## 5. WASM Rust faces — `goldenpipe-wasm/src/lib.rs`
 
 Add three `#[wasm_bindgen]` faces inside the `cfg(target_arch = "wasm32")` module, delegating to the core (mirroring the existing 5):
@@ -91,15 +97,24 @@ Run `rustfmt` on this file locally before pushing.
   applyScaleHintsJson: (s) => glue.apply_scale_hints_json(s),
   bandOfJson: (s) => glue.band_of_json(s),
   ```
+  **Also extend the inline `glue` cast type** in `loader.ts` (it enumerates the current 5 exports)
+  with the 3 new snake_case members — otherwise `glue.plan_pipeline_json` is a `tsc` error:
+  ```ts
+  plan_pipeline_json: (s: string) => string;
+  apply_scale_hints_json: (s: string) => string;
+  band_of_json: (s: string) => string;
+  ```
 
 ## 7. Parity tests
 
-- **`tests/parity/planner-parity.test.ts`** (Leg A) — add to the `CASES` list:
-  `["plan_pipeline", planPipelineJsonPure]`, `["apply_scale_hints", applyScaleHintsJsonPure]`,
-  `["band_of", bandOfJsonPure]` (import the three from `plannerJsonPure.js`).
+- **`tests/parity/planner-parity.test.ts`** (Leg A) — add to the `FAMILIES` list (the actual
+  identifier; a `[name, pureFn]` tuple array): `["plan_pipeline", planPipelineJsonPure]`,
+  `["apply_scale_hints", applyScaleHintsJsonPure]`, `["band_of", bandOfJsonPure]` (import the three
+  from `plannerJsonPure.js`).
 - **`tests/parity/planner-wasm-parity.test.ts`** (Leg B) — add `plan_pipeline: b.planPipelineJson`,
-  `apply_scale_hints: b.applyScaleHintsJson`, `band_of: b.bandOfJson` to the backend-fn map, and
-  the three family names to the replay loop (`["resolve", ..., "plan_pipeline", "apply_scale_hints", "band_of"]`).
+  `apply_scale_hints: b.applyScaleHintsJson`, `band_of: b.bandOfJson` to the `dispatch`
+  (family→fn) map, and the three family names to the replay loop
+  (`["resolve", ..., "plan_pipeline", "apply_scale_hints", "band_of"]`).
 
 Both load vectors from `../../../../rust/extensions/goldenpipe-core/tests/vectors/${name}.json` (the same committed files) and assert `toEqual`.
 

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md
@@ -1,0 +1,126 @@
+# goldenpipe brain — TS + WASM parity (Slice C1) design
+
+**Status:** approved (design gate)
+**Date:** 2026-07-07
+**Builds on:** the goldenpipe-core Rust brain port (#1545) — `plan_pipeline`/`apply_scale_hints`/`band_of` + the hand-authored vectors (`plan_pipeline.json`, `apply_scale_hints.json`, `band_of.json`) already committed and gated by the Rust `golden_vectors.rs` + Python Leg A.
+**Sequenced before:** Slice C2 (TS runtime wiring + profiling parity + pipe_parity rework), which is a separate spec.
+
+## 1. Goal & scope
+
+Port the auto-config **brain decision core** to TypeScript and add the WASM faces, so the pure-TS brain **and** the same Rust core compiled to WASM both reproduce the shared vectors — mirroring the Rust port and the Python Leg A. Rust stays the source of truth; TS conforms.
+
+**In scope (C1):** pure-TS brain (`planPipeline`/`applyScaleHints`/`bandOf` + structs), pure JSON bridges, the 3 `goldenpipe-wasm` faces, the backend interface + loader wiring, and Leg A/Leg B parity cases.
+
+**Explicitly deferred to C2:** wiring TS `run()` to the brain, the TS profiling-parity layer (row count / InferMap domain / null density that must match Python's Polars/InferMap byte-for-byte), `enforce_confidence`, and the `pipe_parity` rework. **TS `run()` is unchanged** in C1 (still the static engine config). The typed `*ViaWasm` runtime wrappers (like `autoConfigViaWasm`) are also C2 — Leg B parity calls the backend's `*Json` methods directly, so C1 does not need them.
+
+## 2. Architecture
+
+Extend the existing two-leg TS parity harness (which already covers the engine layer) with the brain:
+
+- **Leg A** (`planner-parity.test.ts`, CI TS job) — the pure-TS bridge fns must reproduce the vectors.
+- **Leg B** (`planner-wasm-parity.test.ts`, `goldenpipe_wasm` CI lane) — the Rust-core-via-WASM `*Json` backend methods must reproduce the same vectors.
+
+Both replay the **same committed vectors** the Rust `golden_vectors.rs` and Python Leg A already meet. **TS is CI-only** (vitest OOMs the box) — the TS + wasm-Rust is written against the spec + vectors and validated in CI. `rustfmt` on the wasm `lib.rs` is runnable locally (per the #1545/#1546 lesson).
+
+**Numeric-type de-risk:** JS has a single `number` type, so the serde_json `1 != 1.0` trap does not apply — `JSON.parse("1.0")` and `JSON.parse("1")` both yield `1`, and vitest `toEqual` compares structurally. **Key-order** is NOT separately gated on the TS side (`toEqual` is order-insensitive); acceptable because TS is a consumer, not the source of truth — the Rust `json.rs` order test remains the canonical order guard. (Order matters only when TS *emits* config back to Python, which is C2's concern.)
+
+## 3. Pure-TS brain — `src/core/autoconfigPlanner.ts` (new)
+
+Mirror `autoconfig_planner.py` / `planner.rs` exactly. TS internal fields may be camelCase (idiomatic; the existing engine bridge maps camel→snake, e.g. `onError`→`on_error`), but **the serialized JSON MUST use the exact snake_case vector keys** (`n_rows`, `n_cols`, `column_names`, `dtypes`, `inferred_domain`, `domain_confidence`, `max_null_density`, `mean_null_density`, `rule_name`, `_dedupe_hints`, `scale_hinted`).
+
+```ts
+export interface PipeProfile {
+  nRows: number; nCols: number; columnNames: string[]; dtypes: string[];
+  inferredDomain: string | null; domainConfidence: number;
+}
+export interface ComplexityProfile { maxNullDensity: number; meanNullDensity: number; }
+export interface PlannerInput { runtime: PipeProfile; complexity: ComplexityProfile; }
+export interface PlannedStage { name: string; config: Record<string, unknown>; }
+export interface PipePlan {
+  stages: PlannedStage[]; ruleName: string; confidence: number;
+  evidence: Record<string, unknown>;
+}
+
+export const SCALE_ROUTE_MIN_ROWS = 1_000_000;
+// RED_NULL_DENSITY=0.6, CONFIDENT_DOMAIN_THRESHOLD=0.5, THROUGHPUT_RECALL_TARGET=0.95,
+// GREEN_THRESHOLD=0.7, AMBER_THRESHOLD=0.4
+
+export function bandOf(confidence: number): "green" | "amber" | "red" { /* >=0.7 / >=0.4 / else */ }
+export function planPipeline(inp: PlannerInput): PipePlan { /* pathological -> confident_schema -> low_confidence -> default */ }
+export function applyScaleHints(plan: PipePlan, runtime: PipeProfile): PipePlan { /* >= min rows && has dedupe -> hint */ }
+```
+
+Rules mirror Python/Rust: `pathological` (nRows<=1 → `[scan, transform]`, conf 1.0); `confident_schema` (`inferredDomain!==null && domainConfidence>=0.5` → `[infer_schema{domain}, scan, transform, dedupe]`, conf=domainConfidence); `low_confidence` (`inferredDomain===null && maxNullDensity>0.6` → `[scan, transform, dedupe]`, conf 0.3); `default` (conf 0.7). `defaultEvidence` fills the six snake_case keys in order. `applyScaleHints`: below `SCALE_ROUTE_MIN_ROWS` or no `goldenmatch.dedupe` stage → return the plan unchanged (a copy is fine; TS objects are mutable, so build a NEW plan and NEW stage/config/evidence objects — never mutate the input); else the dedupe stage's config gains `{"_dedupe_hints":{"throughput":{"recall_target":0.95}}}` and evidence gains `scale_hinted:true`.
+
+## 4. Pure JSON bridges — `src/core/wasm/plannerJsonPure.ts`
+
+Add three string→string fns (mirroring `skipIfFalsyJsonPure`/`autoConfigJsonPure`). They parse the vector `input`, call the typed brain, and serialize to the exact vector shape (snake_case keys). A small `planToJson(plan)` helper emits `{stages:[{name,config}], rule_name, confidence, evidence}`; a `profileFromJson`/`planFromJson` parse the snake_case input.
+
+```ts
+export function planPipelineJsonPure(inputStr: string): string { /* PlannerInput -> PipePlan */ }
+export function applyScaleHintsJsonPure(inputStr: string): string { /* {plan, runtime} -> PipePlan */ }
+export function bandOfJsonPure(inputStr: string): string { return JSON.stringify(bandOf(JSON.parse(inputStr) as number)); }
+```
+
+`planPipelineJsonPure`: `const { runtime, complexity } = JSON.parse(inputStr)` (snake_case) → build `PlannerInput` → `planPipeline` → `planToJson`. `applyScaleHintsJsonPure`: parse `{plan, runtime}`, reconstruct typed `PipePlan` + `PipeProfile` from snake_case → `applyScaleHints` → `planToJson`.
+
+## 5. WASM Rust faces — `goldenpipe-wasm/src/lib.rs`
+
+Add three `#[wasm_bindgen]` faces inside the `cfg(target_arch = "wasm32")` module, delegating to the core (mirroring the existing 5):
+```rust
+#[wasm_bindgen]
+pub fn plan_pipeline_json(input: &str) -> String { json::plan_pipeline_json(input) }
+#[wasm_bindgen]
+pub fn apply_scale_hints_json(input: &str) -> String { json::apply_scale_hints_json(input) }
+#[wasm_bindgen]
+pub fn band_of_json(input: &str) -> String { json::band_of_json(input) }
+```
+Run `rustfmt` on this file locally before pushing.
+
+## 6. Backend interface + loader
+
+- **`src/core/wasm/backend.ts`** — add to `interface PipeWasmBackend`:
+  ```ts
+  planPipelineJson(input: string): string;
+  applyScaleHintsJson(input: string): string;
+  bandOfJson(input: string): string;
+  ```
+- **`src/core/wasm/loader.ts`** — wire the glue (snake_case wasm exports):
+  ```ts
+  planPipelineJson: (s) => glue.plan_pipeline_json(s),
+  applyScaleHintsJson: (s) => glue.apply_scale_hints_json(s),
+  bandOfJson: (s) => glue.band_of_json(s),
+  ```
+
+## 7. Parity tests
+
+- **`tests/parity/planner-parity.test.ts`** (Leg A) — add to the `CASES` list:
+  `["plan_pipeline", planPipelineJsonPure]`, `["apply_scale_hints", applyScaleHintsJsonPure]`,
+  `["band_of", bandOfJsonPure]` (import the three from `plannerJsonPure.js`).
+- **`tests/parity/planner-wasm-parity.test.ts`** (Leg B) — add `plan_pipeline: b.planPipelineJson`,
+  `apply_scale_hints: b.applyScaleHintsJson`, `band_of: b.bandOfJson` to the backend-fn map, and
+  the three family names to the replay loop (`["resolve", ..., "plan_pipeline", "apply_scale_hints", "band_of"]`).
+
+Both load vectors from `../../../../rust/extensions/goldenpipe-core/tests/vectors/${name}.json` (the same committed files) and assert `toEqual`.
+
+## 8. Box constraints & gate
+
+- **Box CANNOT run vitest** (OOM) or `tsc` — TS + wasm-Rust written against spec + vectors, validated in CI (Leg A = TS test job; Leg B = `goldenpipe_wasm` lane). Verify TS by eye against the Python brain / vectors.
+- **`rustfmt` the wasm `lib.rs` locally** (the only locally-runnable Rust check; box can't `cargo build`).
+- The three vectors already exist + are Python/Rust-validated, so TS conforming is a pure CI check.
+
+## 9. Non-goals (C2 and beyond)
+
+- Wiring TS `run()` to the brain; the TS profiling-parity layer; `enforce_confidence`; the `pipe_parity` rework — all C2.
+- Typed `*ViaWasm` runtime wrappers in `plannerJson.ts` — C2 (runtime consumption).
+- Making TS the runtime path (it stays a parity-checked port; Rust is the source of truth).
+
+## 10. File touch list
+
+- `packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts` — **new** (typed brain + logic).
+- `packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts` — 3 pure bridge fns + helpers.
+- `packages/typescript/goldenpipe/src/core/wasm/backend.ts` — 3 interface methods.
+- `packages/typescript/goldenpipe/src/core/wasm/loader.ts` — 3 glue wirings.
+- `packages/rust/extensions/goldenpipe-wasm/src/lib.rs` — 3 `#[wasm_bindgen]` faces.
+- `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts` — 3 Leg A cases.
+- `packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts` — 3 Leg B families.

--- a/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
@@ -39,4 +39,19 @@ mod wasm {
     pub fn skip_if_falsy_json(input: &str) -> String {
         json::skip_if_falsy_json(input)
     }
+
+    #[wasm_bindgen]
+    pub fn plan_pipeline_json(input: &str) -> String {
+        json::plan_pipeline_json(input)
+    }
+
+    #[wasm_bindgen]
+    pub fn apply_scale_hints_json(input: &str) -> String {
+        json::apply_scale_hints_json(input)
+    }
+
+    #[wasm_bindgen]
+    pub fn band_of_json(input: &str) -> String {
+        json::band_of_json(input)
+    }
 }

--- a/packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts
+++ b/packages/typescript/goldenpipe/src/core/autoconfigPlanner.ts
@@ -1,0 +1,133 @@
+/**
+ * autoconfigPlanner.ts — pure-TS auto-config BRAIN (decision core), ported from
+ * autoconfig_planner.py / goldenpipe-core planner.rs. Rust is the source of
+ * truth; this is the SP3 TS fallback proven to reproduce the golden vectors.
+ * Pure: no InferMap/profiling (that is a PlannerInput the caller supplies).
+ */
+export interface PipeProfile {
+  nRows: number;
+  nCols: number;
+  columnNames: string[];
+  dtypes: string[];
+  inferredDomain: string | null;
+  domainConfidence: number;
+}
+export interface ComplexityProfile {
+  maxNullDensity: number;
+  meanNullDensity: number;
+}
+export interface PlannerInput {
+  runtime: PipeProfile;
+  complexity: ComplexityProfile;
+}
+export interface PlannedStage {
+  name: string;
+  config: Record<string, unknown>;
+}
+export interface PipePlan {
+  stages: PlannedStage[];
+  ruleName: string;
+  confidence: number;
+  evidence: Record<string, unknown>;
+}
+
+const RED_NULL_DENSITY = 0.6;
+const CONFIDENT_DOMAIN_THRESHOLD = 0.5;
+export const SCALE_ROUTE_MIN_ROWS = 1_000_000;
+const THROUGHPUT_RECALL_TARGET = 0.95;
+const GREEN_THRESHOLD = 0.7;
+const AMBER_THRESHOLD = 0.4;
+
+export function bandOf(confidence: number): "green" | "amber" | "red" {
+  if (confidence >= GREEN_THRESHOLD) return "green";
+  if (confidence >= AMBER_THRESHOLD) return "amber";
+  return "red";
+}
+
+function stage(name: string, config: Record<string, unknown> = {}): PlannedStage {
+  return { name, config };
+}
+
+function defaultDedupeStages(): PlannedStage[] {
+  return [stage("goldencheck.scan"), stage("goldenflow.transform"), stage("goldenmatch.dedupe")];
+}
+
+// Evidence keys are snake_case, in the exact Python/Rust order.
+function defaultEvidence(inp: PlannerInput): Record<string, unknown> {
+  return {
+    n_rows: inp.runtime.nRows,
+    n_cols: inp.runtime.nCols,
+    inferred_domain: inp.runtime.inferredDomain,
+    domain_confidence: inp.runtime.domainConfidence,
+    max_null_density: inp.complexity.maxNullDensity,
+    mean_null_density: inp.complexity.meanNullDensity,
+  };
+}
+
+export function planPipeline(inp: PlannerInput): PipePlan {
+  const r = inp.runtime;
+  if (r.nRows <= 1) {
+    return {
+      stages: [stage("goldencheck.scan"), stage("goldenflow.transform")],
+      ruleName: "pathological",
+      confidence: 1.0,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  if (r.inferredDomain !== null && r.domainConfidence >= CONFIDENT_DOMAIN_THRESHOLD) {
+    return {
+      stages: [
+        stage("infer_schema", { domain: r.inferredDomain }),
+        stage("goldencheck.scan"),
+        stage("goldenflow.transform"),
+        stage("goldenmatch.dedupe"),
+      ],
+      ruleName: "confident_schema",
+      confidence: r.domainConfidence,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  if (r.inferredDomain === null && inp.complexity.maxNullDensity > RED_NULL_DENSITY) {
+    return {
+      stages: defaultDedupeStages(),
+      ruleName: "low_confidence",
+      confidence: 0.3,
+      evidence: defaultEvidence(inp),
+    };
+  }
+  return {
+    stages: defaultDedupeStages(),
+    ruleName: "default",
+    confidence: 0.7,
+    evidence: defaultEvidence(inp),
+  };
+}
+
+export function applyScaleHints(plan: PipePlan, runtime: PipeProfile): PipePlan {
+  const hasDedupe = plan.stages.some((s) => s.name === "goldenmatch.dedupe");
+  if (runtime.nRows < SCALE_ROUTE_MIN_ROWS || !hasDedupe) {
+    return {
+      stages: plan.stages.map((s) => ({ name: s.name, config: { ...s.config } })),
+      ruleName: plan.ruleName,
+      confidence: plan.confidence,
+      evidence: { ...plan.evidence },
+    };
+  }
+  const stages = plan.stages.map((s) =>
+    s.name === "goldenmatch.dedupe"
+      ? {
+          name: s.name,
+          config: {
+            ...s.config,
+            _dedupe_hints: { throughput: { recall_target: THROUGHPUT_RECALL_TARGET } },
+          },
+        }
+      : { name: s.name, config: { ...s.config } },
+  );
+  return {
+    stages,
+    ruleName: plan.ruleName,
+    confidence: plan.confidence,
+    evidence: { ...plan.evidence, scale_hinted: true },
+  };
+}

--- a/packages/typescript/goldenpipe/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/backend.ts
@@ -18,6 +18,9 @@ export interface PipeWasmBackend {
   evaluateBuiltinJson(input: string): string;
   autoConfigJson(input: string): string;
   skipIfFalsyJson(input: string): string;
+  planPipelineJson(input: string): string;
+  applyScaleHintsJson(input: string): string;
+  bandOfJson(input: string): string;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenpipe/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/loader.ts
@@ -28,6 +28,9 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<PipeWasmBac
     evaluate_builtin_json: (s: string) => string;
     auto_config_json: (s: string) => string;
     skip_if_falsy_json: (s: string) => string;
+    plan_pipeline_json: (s: string) => string;
+    apply_scale_hints_json: (s: string) => string;
+    band_of_json: (s: string) => string;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -37,5 +40,8 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<PipeWasmBac
     evaluateBuiltinJson: (s) => glue.evaluate_builtin_json(s),
     autoConfigJson: (s) => glue.auto_config_json(s),
     skipIfFalsyJson: (s) => glue.skip_if_falsy_json(s),
+    planPipelineJson: (s) => glue.plan_pipeline_json(s),
+    applyScaleHintsJson: (s) => glue.apply_scale_hints_json(s),
+    bandOfJson: (s) => glue.band_of_json(s),
   };
 }

--- a/packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts
@@ -23,6 +23,14 @@ import {
 } from "../models.js";
 import type { StageRegistry } from "../engine/registry.js";
 import { computeAutoConfigPure } from "../pipeline.js";
+import {
+  planPipeline,
+  applyScaleHints,
+  bandOf,
+  type PipePlan,
+  type PipeProfile,
+  type PlannerInput,
+} from "../autoconfigPlanner.js";
 
 interface StubStage {
   info: StageInfo;
@@ -183,4 +191,74 @@ export function autoConfigJsonPure(inputStr: string): string {
 
 export function skipIfFalsyJsonPure(inputStr: string): string {
   return JSON.stringify(isFalsy(JSON.parse(inputStr)));
+}
+
+interface ProfileJson {
+  n_rows: number;
+  n_cols: number;
+  column_names: string[];
+  dtypes: string[];
+  inferred_domain: string | null;
+  domain_confidence: number;
+}
+interface PlanJson {
+  stages: Array<{ name: string; config: Record<string, unknown> }>;
+  rule_name: string;
+  confidence: number;
+  evidence: Record<string, unknown>;
+}
+
+function profileFromJson(d: ProfileJson): PipeProfile {
+  return {
+    nRows: d.n_rows,
+    nCols: d.n_cols,
+    columnNames: d.column_names,
+    dtypes: d.dtypes,
+    inferredDomain: d.inferred_domain,
+    domainConfidence: d.domain_confidence,
+  };
+}
+
+function planFromJson(d: PlanJson): PipePlan {
+  return {
+    stages: d.stages.map((s) => ({ name: s.name, config: s.config })),
+    ruleName: d.rule_name,
+    confidence: d.confidence,
+    evidence: d.evidence,
+  };
+}
+
+function planToJson(plan: PipePlan): PlanJson {
+  return {
+    stages: plan.stages.map((s) => ({ name: s.name, config: s.config })),
+    rule_name: plan.ruleName,
+    confidence: plan.confidence,
+    evidence: plan.evidence,
+  };
+}
+
+export function planPipelineJsonPure(inputStr: string): string {
+  const arg = JSON.parse(inputStr) as {
+    runtime: ProfileJson;
+    complexity: { max_null_density: number; mean_null_density: number };
+  };
+  const inp: PlannerInput = {
+    runtime: profileFromJson(arg.runtime),
+    complexity: {
+      maxNullDensity: arg.complexity.max_null_density,
+      meanNullDensity: arg.complexity.mean_null_density,
+    },
+  };
+  return JSON.stringify(planToJson(planPipeline(inp)));
+}
+
+export function applyScaleHintsJsonPure(inputStr: string): string {
+  const arg = JSON.parse(inputStr) as { plan: PlanJson; runtime: ProfileJson };
+  return JSON.stringify(
+    planToJson(applyScaleHints(planFromJson(arg.plan), profileFromJson(arg.runtime))),
+  );
+}
+
+export function bandOfJsonPure(inputStr: string): string {
+  return JSON.stringify(bandOf(JSON.parse(inputStr) as number));
 }

--- a/packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts
@@ -7,6 +7,9 @@ import {
   evaluateBuiltinJsonPure,
   autoConfigJsonPure,
   skipIfFalsyJsonPure,
+  planPipelineJsonPure,
+  applyScaleHintsJsonPure,
+  bandOfJsonPure,
 } from "../../src/core/wasm/plannerJsonPure.js";
 
 const VEC = (name: string) =>
@@ -25,6 +28,9 @@ const FAMILIES: Array<[string, (s: string) => string]> = [
   ["evaluate_builtin", evaluateBuiltinJsonPure],
   ["auto_config", autoConfigJsonPure],
   ["skip_if", skipIfFalsyJsonPure],
+  ["plan_pipeline", planPipelineJsonPure],
+  ["apply_scale_hints", applyScaleHintsJsonPure],
+  ["band_of", bandOfJsonPure],
 ];
 
 describe("Leg A — pure-TS planner == goldenpipe-core golden vectors", () => {

--- a/packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts
@@ -44,11 +44,14 @@ suite("Leg B — goldenpipe-wasm == golden vectors", () => {
       evaluate_builtin: b.evaluateBuiltinJson,
       auto_config: b.autoConfigJson,
       skip_if: b.skipIfFalsyJson,
+      plan_pipeline: b.planPipelineJson,
+      apply_scale_hints: b.applyScaleHintsJson,
+      band_of: b.bandOfJson,
     };
     return dispatch[family]!(input);
   };
 
-  for (const family of ["resolve", "apply_decision", "evaluate_builtin", "auto_config", "skip_if"]) {
+  for (const family of ["resolve", "apply_decision", "evaluate_builtin", "auto_config", "skip_if", "plan_pipeline", "apply_scale_hints", "band_of"]) {
     it(`${family} vectors`, () => {
       for (const { input, expected } of load(family)) {
         expect(JSON.parse(call(family, JSON.stringify(input)))).toEqual(expected);

--- a/packages/typescript/goldenpipe/tests/parity/reroute-agreement.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/reroute-agreement.test.ts
@@ -33,6 +33,9 @@ const fakeBackend = {
   evaluateBuiltinJson: pure.evaluateBuiltinJsonPure,
   autoConfigJson: pure.autoConfigJsonPure,
   skipIfFalsyJson: pure.skipIfFalsyJsonPure,
+  planPipelineJson: pure.planPipelineJsonPure,
+  applyScaleHintsJson: pure.applyScaleHintsJsonPure,
+  bandOfJson: pure.bandOfJsonPure,
 };
 
 /** A trivial stage with the given wiring; `run` is never invoked in these tests. */

--- a/packages/typescript/goldenpipe/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/wasm-backend.test.ts
@@ -11,6 +11,9 @@ const fake: PipeWasmBackend = {
   evaluateBuiltinJson: () => "null",
   autoConfigJson: () => "{}",
   skipIfFalsyJson: () => "true",
+  planPipelineJson: () => "{}",
+  applyScaleHintsJson: () => "{}",
+  bandOfJson: () => '"red"',
 };
 
 describe("PipeWasmBackend registry", () => {


### PR DESCRIPTION
## What

Ports the auto-config **brain decision core** to TypeScript and adds the WASM faces, so the pure-TS brain (Leg A) and the Rust-core-via-WASM (Leg B) both reproduce the shared vectors from #1545. Rust stays source of truth; TS conforms.

Slice C1 of the TS-consumer work. **TS `run()` is unchanged** — this is port + parity only.

## Shape

- **`src/core/autoconfigPlanner.ts`** (new) — pure-TS brain: `planPipeline`/`applyScaleHints`/`bandOf` + structs, mirroring `autoconfig_planner.py` / `planner.rs` exactly. Emits the snake_case vector JSON shape.
- **`plannerJsonPure.ts`** — 3 pure bridge fns (Leg A). Typed on `PipePlan` only (avoids the engine `PlannedStage` name clash).
- **`goldenpipe-wasm/src/lib.rs`** — 3 `#[wasm_bindgen]` faces delegating to `goldenpipe_core::json` (rustfmt clean).
- **`backend.ts` + `loader.ts`** — 3 `PipeWasmBackend` methods + glue cast + wiring.
- **`planner-parity` / `planner-wasm-parity` tests** — 3 cases each, replaying the same committed vectors the Rust `golden_vectors.rs` and Python Leg A already meet.

## Gate

- **Leg A** (pure-TS, TS test job) + **Leg B** (Rust-core-via-WASM, `goldenpipe_wasm` lane) both replay `plan_pipeline`/`apply_scale_hints`/`band_of` vectors. JS's single number type sidesteps the serde `1 != 1.0` trap; key-order isn't separately gated on TS (`toEqual` is structural) — the Rust `json.rs` order test remains the canonical order guard.

## Verification

- Eyeball-traced all 14 vector cases against the TS output (confident_schema `infer_schema{domain}`, apply_scale_hints at-scale `_dedupe_hints`/`scale_hinted`, band_of boundaries). `rustfmt --check` clean on the wasm `lib.rs`.
- CI-only for the rest (box can't run vitest/tsc/cargo build).

## Deferred (C2)

- Wiring TS `run()` to the brain; the TS profiling-parity layer (row count / InferMap domain / null density == Python); `enforce_confidence`; the `pipe_parity` rework; the typed `*ViaWasm` runtime wrappers.

Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-wasm-parity-design.md`
Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-wasm-parity.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44