### PR TITLE
release(goldenflow): 1.17.0 — Polars-eviction Phases 2-3 columnar engine

### DIFF
--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.17.0 (2026-07-07)
+
+Polars-eviction Phases 2-3: a config's owned transforms now run entirely on the native/Arrow substrate (no Polars, no pyarrow) on both the whole-file CSV path and the in-memory path, byte-identical (data + manifest) to the Polars engine. Needs `goldenflow-native>=0.24.0`. Opt in with `GOLDENFLOW_ENGINE=columnar`; anything the columnar path does not cover declines to the Polars engine, so behavior is never wrong.
+
+- **Native CSV pipeline.** `goldenflow transform data.csv` (and `transform_file`) runs read -> transform -> write in ONE Rust call for an owned-transform config: the CSV is parsed into Rust-owned Arrow string columns, the owned chain runs, and the CSV is written back, with parallel read/write across record-boundary chunks. No `pl.DataFrame` is constructed.
+- **Native Arrow `Column` (pyarrow-free).** The in-memory columnar path holds columns as Rust-owned Arrow buffers ingested from Polars over the C-Data / PyCapsule interface (`__arrow_c_stream__`) -- pyarrow-free -- and runs the owned chain zero-copy.
+- **Auto-routed string chains.** A run auto-routes between the total (never-null) and nullable (`Option`-returning URL/company/email) fused chains.
+- **Numeric columnar execution.** A `string* parser f64*` config (the f64 parsers `currency_strip`/`percentage_normalize`/`comma_decimal`/`scientific_to_decimal`/`fraction_to_decimal` and the i64 parsers `to_integer`/`roman_to_int`/`ordinal_to_int`, plus the array ops `round`/`clamp`/`abs_value`/`fill_zero`) runs natively, with a Polars-matching f64 formatter so the output + manifest match Polars byte-for-byte. An f64 op promotes an Int64 column to Float64, exactly as Polars does.
+- **Multi-output splits.** `split_name`/`split_name_reverse` (-> `first_name`+`last_name`) and `split_address` (-> `street`+`city`+`state`+`zip`) append the fixed-name output columns, exactly as Polars' dataframe-mode `with_columns`.
+- **CSV empty-string fix.** The native CSV writer now quotes an empty-string value as `""` (distinct from a null empty field), matching Polars' `write_csv`, so any empty-string transform output round-trips correctly.
+- `goldenflow[native]` floor bumped to `goldenflow-native>=0.24.0` (the wheel carrying the columnar symbols).
+
 ## 1.16.0 (2026-07-06)
 
 Pillar-1 (evict Polars from the transform execution path): the fused columnar apply now covers a **third kernel shape** — the `Option`-returning URL / company / email families — so those chains fuse too. Needs `goldenflow-native>=0.14.0`.

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.16.0"
+__version__ = "1.17.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.16.0"
+version = "1.17.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"
@@ -48,7 +48,7 @@ agent = ["aiohttp>=3.14.0"]
 # Optional Rust/PyO3 acceleration runtime (mirrors goldenmatch[native]). Pulls
 # pyarrow for the zero-copy Series<->kernel bridge. Off by default at runtime --
 # see goldenflow.core._native_loader (GOLDENFLOW_NATIVE / _GATED_ON).
-native = ["goldenflow-native>=0.14.0", "pyarrow>=10"]
+native = ["goldenflow-native>=0.24.0", "pyarrow>=10"]
 all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
 
 [project.scripts]

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## goldenflow 1.17.0

Ships the Phase 2-3 Polars-eviction columnar work (all merged since 1.16.0) to PyPI. Owned transforms run entirely on the native/Arrow substrate (no Polars, no pyarrow) on both the CSV file path and the in-memory path, byte-identical (data + manifest) to the Polars engine.

- **Native CSV pipeline** (`transform_file`: read -> transform -> write in one Rust call, parallel read/write).
- **Native Arrow `Column`** (pyarrow-free C-Data interop) for the in-memory path.
- **Auto-routed** total/nullable string chains.
- **Numeric columnar execution** (f64 + i64 parsers + array ops, Polars-matching float formatter, i64->f64 promotion).
- **Multi-output splits** (`split_name`/`_reverse`/`split_address`).
- **CSV empty-string quoting fix** (`''` -> `""` like Polars `write_csv`).

Opt in with `GOLDENFLOW_ENGINE=columnar`; anything the columnar path does not cover declines to the Polars engine. Floor bumped to `goldenflow-native>=0.24.0` (published + verified to carry the columnar symbols).

Tag `goldenflow-v1.17.0` after merge -> `publish-goldenflow.yml` -> PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg