### PR TITLE
release(golden-suite): 0.1.8 — lockstep to goldenflow 1.17.0 + native 0.24.0

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.8] - 2026-07-07
+
+### Changed
+- Bumped the goldenflow floor to **`goldenflow>=1.17.0`** (was `>=1.16.0`) and the
+  goldenflow-native floor to **`goldenflow-native>=0.24.0`** (was `>=0.15.0`), per the
+  lockstep policy. goldenflow 1.17.0 + goldenflow-native 0.24.0 ship the Polars-eviction
+  columnar engine (Phases 2-3): owned transforms run on the native/Arrow substrate (no
+  Polars, no pyarrow) on both the whole-file CSV path and the in-memory path, covering
+  string, phonetic, nullable URL/company/email, numeric (f64 + i64 parsers + array ops
+  with a Polars-matching float formatter), and multi-output splits — byte-identical (data
+  + manifest) to the Polars engine, opt-in via `GOLDENFLOW_ENGINE=columnar`.
+
 ## [0.1.7] - 2026-07-07
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.7"
+version = "0.1.8"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.16.0",                # transform / standardize / normalize (>=1.16.0 = nullable URL/company/email fused apply)
+    "goldenflow>=1.17.0",                # transform / standardize / normalize (>=1.17.0 = Polars-eviction columnar engine: CSV + in-memory, numeric + splits)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.15.0",
+    "goldenflow-native>=0.24.0",        # >=0.24.0 carries the Polars-eviction columnar symbols (transform_csv, numeric/split columnar)
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
## golden-suite 0.1.8

Bumps the goldenflow floor to **`>=1.17.0`** (was `>=1.16.0`) and the goldenflow-native
floor to **`>=0.24.0`** (was `>=0.15.0`), per the lockstep policy, now that both members
are on PyPI. Together they ship the Polars-eviction columnar engine (Phases 2-3): owned
transforms run on the native/Arrow substrate (no Polars, no pyarrow) on both the CSV file
path and the in-memory path — string, phonetic, nullable URL/company/email, numeric (f64 +
i64 parsers + array ops), and multi-output splits — byte-identical to the Polars engine,
opt-in via `GOLDENFLOW_ENGINE=columnar`.

Deps-only meta-package; no code change. Both floors are satisfiable on PyPI (goldenflow
1.17.0 + goldenflow-native 0.24.0 both live).

Tag `golden-suite-v0.1.8` after merge -> `publish-golden-suite.yml` -> PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg