### PR TITLE
refactor(goldenflow): lazy Polars import — import goldenflow no longer loads Polars (Phase 4a)

### DIFF
--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -1,0 +1,210 @@
+# Phase 4 scoping: make Polars an optional accelerator
+
+**Date:** 2026-07-07 • **Status:** Scoping (not approved for build) • **Goal:**
+dependency weight / embeddability — a `pip install goldenflow` that does **not**
+pull Polars.
+
+This is the finish line of the Polars-eviction arc (Phases 0-3 shipped). It is a
+**restructure, not a config flip**, so this doc scopes it into staged, shippable,
+parity-gated sub-phases and surfaces the load-bearing decisions before any code.
+
+---
+
+## 1. Why (unchanged from the arc)
+
+Polars is a **mandatory** dependency (`polars>=1.0` in `pyproject.toml`). The goal is
+a lighter, more embeddable `goldenflow`: the default install runs the owned
+transforms on the native/Arrow substrate (already built, Phases 1-3), with Polars
+demoted to an **optional accelerator** (`goldenflow[polars]`) for its genuinely-fast
+bulk vectorized paths. Mirrors the **TypeScript port**, which is already fully
+Polars-free (`Row = Record<string, unknown>`, `Row[]`, pure-TS transforms + optional
+WASM) — Phase 4 brings that architecture to Python.
+
+> **Weight measured (4a).** On the dev env: **polars 7.8 MB**, its transitive
+> **numpy 23.4 MB**, **pyarrow 84.5 MB**. Reframing: (1) the DEFAULT install's Polars
+> cost is polars + numpy ≈ **31 MB** (numpy comes only via polars — confirmed gone
+> from `import goldenflow` after 4a); (2) the giant is **pyarrow (84.5 MB)**, but
+> pyarrow is only in the `[native]` extra, and Phases 1b-3 made the columnar path
+> **pyarrow-free** — so a **separate, larger win** is dropping `pyarrow>=10` from
+> `[native]` once the older `to_arrow`/`from_arrow` fused-apply path is migrated to
+> the pyarrow-free `Column` C-Data interop. Track that as **4g** (native-extra
+> pyarrow eviction); it may deliver more MB than the polars eviction itself.
+
+---
+
+## 2. Where we are (grounded in the current coupling)
+
+`import polars` appears in **34 modules** (top-level) + 4 lazy. The coupling has
+**three roles** (per the arc's analysis), at different stages of eviction:
+
+| Role | What it is | Status |
+|---|---|---|
+| **Substrate** | the in-memory columnar container (`pl.DataFrame`/`pl.Series`) the engine operates on | Native `Column` + native CSV frame exist (Phases 1b-3); in-memory path still *builds* a `pl.DataFrame` at the boundary |
+| **Wrapper** | transform bodies: `pl.col(c).map_batches(_series_fn)` around a native kernel / pure-Python fallback | Kernels are Polars-free (Rust core); the **wrapper + registration signatures are Polars-shaped** |
+| **I/O** | `read_csv`/`write_csv`/parquet/excel | Native CSV read+write shipped (Phase 2); parquet/excel still Polars |
+
+**The eager-import linchpin:** `import goldenflow` imports the transform registry,
+which imports every transform module (`address`/`dates`/`email`/…), each with a
+**top-level `import polars`**. So even a user who only touches the columnar path pays
+the Polars import at `import goldenflow`. **Nothing is Polars-optional until this
+chain is broken.**
+
+**Depth:** **274** transform functions are typed on `pl.Series`/`pl.Expr`/
+`pl.DataFrame`. For the **owned** transforms the real work is already in the Rust
+core (the signature is a thin `map_batches` wrapper); for the **non-owned** residual
+(`date_iso8601`/`phone_e164` via `dateutil`/`phonenumbers`, and the `dates` family
+which is a documented owned-kernel NO-GO) the body needs a *column*, not Polars
+specifically — but it's currently written against `pl.Series`.
+
+**Already an asset:** the **`Frame` seam** (`engine/frame.py`, Phase 0) is the
+abstraction point — a `Frame` Protocol + a `PolarsFrame` backend. Phase 4 adds a
+`NativeFrame` backend and routes the engine + public API through `Frame` without a
+hard Polars import. The seam means the engine internals largely don't change; the
+work is at the backend + transform-signature + I/O + public-API layers.
+
+---
+
+## 3. The load-bearing decisions (surface before building)
+
+These are genuine design choices, not settled. Each needs a call (recommendation
+given); they shape everything downstream.
+
+### D1 — The public API contract
+`transform_df(df: pl.DataFrame) -> pl.DataFrame` puts Polars **in the public
+signature**. Options:
+- **(a) Keep `transform_df` Polars-typed but lazy** — it works only when
+  `goldenflow[polars]` is installed; add a new Polars-free primary entry point
+  (`transform(data)`) that accepts a path / `dict[str, list]` / Arrow table / (if
+  present) a `pl.DataFrame`, returning a backend-agnostic `TransformResult`.
+- **(b) Redefine `transform_df` to accept/return the native `Frame`** and provide
+  `pl.DataFrame` interop only under the extra. Breaking change → a 2.0.
+- **Recommendation: (a).** Non-breaking for existing Polars users; the new entry
+  point is the Polars-free default. `transform_df` stays as a thin
+  Polars-backend adapter over the native path.
+
+### D2 — The default in-memory container
+What does a Polars-free user's data live in between transforms? Options: a native
+`Frame` over `dict[str, ArrowColumn]`; over `dict[str, list]` (the Phase-1 list
+path, simplest, slowest); or the native Arrow `Column` set (Phases 1b-3, fastest,
+pyarrow-free). **Recommendation:** native Arrow `Column` frame (already built +
+parity-proven), with the `dict[str, list]` path as the zero-dep fallback for
+platforms without the wheel.
+
+### D3 — The 274 Polars-typed transform signatures
+Owned transforms: rewrite the wrapper to dispatch on a `Column` (the kernel already
+exists) — mechanical, one family at a time, parity-gated (the pattern from Phase 3).
+Non-owned residual (`dates`, phone/date `map_elements`): these need a per-row Python
+lib; rewrite them to take a plain column (`list`/Arrow) instead of `pl.Series` — the
+body is unchanged, only the container type. **Decision:** do owned families first
+(they're already columnar-covered); the residual is a smaller, self-contained batch.
+
+### D4 — I/O under the extra
+Native CSV read+write shipped. Parquet/Excel/`scan_*`/database (`connectorx`) are
+Polars/pyarrow-specific. **Recommendation:** keep them behind `goldenflow[polars]` /
+`goldenflow[parquet]` extras with a graceful `ImportError` ("install
+goldenflow[parquet]"), exactly as the cloud connectors already do for `boto3`.
+
+### D5 — Graceful degradation contract
+A Polars-free user who invokes something not yet columnar-covered (a `dataframe`-mode
+transform outside the covered set, an `expr` combination, dedup/filter/rename frame
+ops) must get a **clear, actionable error** ("this needs goldenflow[polars]"), never
+a crash or silent wrong answer. This is the safety guarantee that lets us ship
+incrementally: coverage grows, and everything else declines *loudly*.
+
+---
+
+## 4. Target architecture
+
+```
+pip install goldenflow            -> native/Arrow substrate + pure-Python fallback, NO polars
+pip install goldenflow[native]    -> + the compiled goldenflow-native wheel (default fast path)
+pip install goldenflow[polars]    -> + polars, as an optional bulk-vectorized backend + parquet/excel I/O
+```
+
+- **`Frame`** is the engine's container; backends: `NativeFrame` (default),
+  `PolarsFrame` (optional), `ListFrame` (zero-dep fallback).
+- **Transforms** dispatch on a `Column`; owned families run the Rust kernel, the
+  residual runs its pure-Python body over the column.
+- **Public API:** a Polars-free `transform(...)` primary; `transform_df(pl.DataFrame)`
+  as an optional-backend adapter (D1a).
+- **`polars` moves to `[polars]`** — kept as a first-class optional accelerator, not
+  deleted (its bulk `str.*` path is genuinely faster on clean data).
+
+---
+
+## 5. Staged sub-phases (each shippable + parity-gated)
+
+The guardrail throughout: **no output change ever** (byte-identical, gated by the
+existing cross-surface + engine-parity corpus), and the default path may be slower —
+recovered by `[native]`.
+
+- **4a — Measure + lazy-import audit. SHIPPED.** Measured the weight (above). Added a
+  lazy Polars proxy (`goldenflow/_polars_lazy.py`) that imports Polars on first
+  attribute access, and routed all 22 eager-chain modules through it (swapped
+  `import polars as pl` → `from goldenflow._polars_lazy import pl`); also fixed the
+  one module-level dereference (`connectors/file.py`'s `{".csv": pl.read_csv}` reader
+  map, now resolved lazily by attribute name). Result: **`import goldenflow` loads no
+  polars/numpy/pyarrow** (537 → 384 modules), byte-identical behavior (Polars loads on
+  first actual use). Gated by `tests/test_lazy_polars_import.py` (subprocess asserts
+  `'polars' not in sys.modules` after `import goldenflow`, + a transparency check that
+  a real transform still works). Landed under the current hard `polars` dep (pure
+  refactor). This is the enabler for 4b-4f.
+- **4b — `NativeFrame` backend.** Add the native Arrow `Column` frame as a `Frame`
+  backend; route the columnar engine's in-memory path through it end-to-end (no
+  `pl.DataFrame` construction at the boundary — the residual from Phase 3d). Gate:
+  the columnar in-memory path builds no `pl.DataFrame`; byte-identical.
+- **4c — Polars-free public entry point.** Add `transform(data)` (D1a) accepting
+  path / dict / Arrow, returning a backend-agnostic result. `transform_df` becomes a
+  thin Polars-backend adapter. Gate: `transform(dict)` == `transform_df(pl.DataFrame)`
+  for the covered configs.
+- **4d — Transform signature port.** Rewrite the owned-family wrappers (one family at
+  a time) + the non-owned residual to dispatch on a `Column` instead of `pl.Series`/
+  `pl.Expr`. Gate: the existing per-family parity corpus, unchanged.
+- **4e — I/O extras.** Native CSV is default; parquet/excel/scan/database move behind
+  `[polars]`/`[parquet]` with graceful `ImportError`. Gate: fallback-path tests
+  (mirror the existing cloud-connector pattern).
+- **4f — Flip the default + move `polars` to `[polars]`.** Drop `polars>=1.0` from
+  `[project.dependencies]`; add the `[polars]` extra. Update the suite floors, docs,
+  `[all]`, and the golden-suite bundle. Gate: a **no-polars CI lane** (`pip install
+  goldenflow` in a clean env, run the covered surface, assert it works with
+  `'polars' not in sys.modules`). This is the only genuinely-breaking step and
+  is a **major version** (goldenflow 2.0) with a migration note.
+
+---
+
+## 6. Risks + non-goals
+
+- **Risk: coverage gaps become loud failures for Polars-free users.** Mitigated by D5
+  (graceful `ImportError`) + the fact that anything uncovered already declines to the
+  Polars engine today — under Phase 4 it declines to a clear "install
+  goldenflow[polars]" instead. The covered surface (Phases 1-3: string/phonetic/
+  nullable/numeric/splits, CSV + in-memory) is what runs Polars-free; the rest needs
+  the extra until ported.
+- **Risk: `transform_df` behavior drift.** Mitigated by keeping it a thin adapter over
+  the same native path the parity corpus already covers.
+- **Non-goal: speed.** The default path may regress; `[native]`/`[polars]` recover it.
+  Measure per sub-phase, don't block on it (same rule as the arc).
+- **Non-goal: dates.** The `dates` family stays a documented owned-kernel NO-GO
+  (`dateutil` fuzzy parsing is non-byte-portable); it runs on its pure-Python body
+  over a column under 4d, and needs `[polars]` only if the user wants the bulk fast
+  path.
+- **Non-goal: deleting Polars.** It stays a first-class optional accelerator.
+
+---
+
+## 7. Effort shape
+
+- **4a** (lazy-import) is the single highest-leverage step — mostly mechanical, lands
+  under the current hard dep, and is independently valuable (faster `import
+  goldenflow`). Do it first regardless of whether the full flip proceeds.
+- **4b-4c** are moderate (the Frame backend + one new entry point; the native pieces
+  exist).
+- **4d** is the long pole — 274 signatures, but mechanical + parity-gated, one family
+  per PR (the Phase-3 rhythm).
+- **4e-4f** are small but 4f is the breaking release (2.0) + suite lockstep + a
+  no-polars CI lane.
+
+**Recommendation:** approve **4a** now as a standalone (measure + kill the eager
+Polars import) — it's low-risk, independently valuable, and de-risks the rest by
+proving the import chain can be broken. Treat 4b-4f as a sequenced program gated on
+the 4a weight number actually justifying the 2.0.

--- a/packages/python/goldenflow/goldenflow/_polars_lazy.py
+++ b/packages/python/goldenflow/goldenflow/_polars_lazy.py
@@ -1,0 +1,50 @@
+"""Lazy Polars proxy — Phase 4a of the Polars eviction (make Polars optional).
+
+``from goldenflow._polars_lazy import pl`` gives a stand-in that imports Polars on
+the FIRST attribute access, not at import time. Every ``pl.col(...)`` /
+``pl.Series(...)`` / ``pl.Utf8`` runtime use in the transform + engine modules keeps
+working unchanged, but ``import goldenflow`` no longer eagerly imports Polars (the
+transform registry pulls every transform module, so a single top-level ``import
+polars`` anywhere in that chain loaded Polars for every user, including those who
+only touch the Polars-free columnar path).
+
+Safe because:
+- Type annotations are strings (`from __future__ import annotations` in every module
+  that uses the proxy), so signatures like ``-> pl.Expr`` never trigger the import.
+- There is no module-level ``pl.`` execution and no ``def f(x=pl.X)`` default arg
+  (audited), so nothing evaluates ``pl.`` at import time.
+- Attribute access returns the REAL Polars object (``pl.DataFrame`` is the actual
+  class), so ``isinstance(x, pl.DataFrame)`` and ``return_dtype=pl.Utf8`` behave
+  identically to a direct ``import polars as pl``.
+
+This lands while ``polars`` is still a hard dependency (a pure refactor, no behavior
+change); it is the enabler for later Phase-4 steps that move ``polars`` to an
+optional ``[polars]`` extra.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class _LazyPolars:
+    """A proxy that forwards attribute access to ``polars``, importing it on first
+    use and caching the module thereafter."""
+
+    __slots__ = ("_mod",)
+
+    def __init__(self) -> None:
+        self._mod: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        # `_mod` is a slot (set to None in __init__), so reading it here never
+        # re-enters __getattr__; only genuine polars attributes reach this path.
+        mod = self._mod
+        if mod is None:
+            import polars as _polars
+
+            self._mod = mod = _polars
+        return getattr(mod, name)
+
+
+pl = _LazyPolars()
+"""Module-level singleton — import as ``from goldenflow._polars_lazy import pl``."""

--- a/packages/python/goldenflow/goldenflow/connectors/file.py
+++ b/packages/python/goldenflow/goldenflow/connectors/file.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
-_READERS: dict[str, Callable] = {
-    ".csv": pl.read_csv,
-    ".parquet": pl.read_parquet,
-    ".json": pl.read_json,
+# Polars reader by suffix, resolved LAZILY at call time (a module-level
+# ``pl.read_csv`` reference would import Polars at module load, defeating the lazy
+# proxy — Phase 4a). Values are attribute names on the Polars module.
+_READER_NAMES: dict[str, str] = {
+    ".csv": "read_csv",
+    ".parquet": "read_parquet",
+    ".json": "read_json",
 }
 
 _WRITERS: dict[str, str] = {
@@ -30,10 +32,10 @@ def read_file(path: Path, **kwargs) -> pl.DataFrame:
             raise ImportError(
                 "openpyxl is required for Excel files: pip install goldenflow[excel]"
             )
-    reader = _READERS.get(suffix)
-    if reader is None:
+    reader_name = _READER_NAMES.get(suffix)
+    if reader_name is None:
         raise ValueError(f"Unsupported file format: {suffix}")
-    return reader(path, **kwargs)
+    return getattr(pl, reader_name)(path, **kwargs)
 
 
 def write_file(df: pl.DataFrame, path: Path, **kwargs) -> None:

--- a/packages/python/goldenflow/goldenflow/engine/differ.py
+++ b/packages/python/goldenflow/goldenflow/engine/differ.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
 
 @dataclass

--- a/packages/python/goldenflow/goldenflow/engine/frame.py
+++ b/packages/python/goldenflow/goldenflow/engine/frame.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import Any, Protocol, runtime_checkable
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
 
 @runtime_checkable

--- a/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
+++ b/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _PHONE_RE = re.compile(r"^[\+\(]?[\d][\d\(\)\-\.\s]{6,18}\d$")

--- a/packages/python/goldenflow/goldenflow/engine/transformer.py
+++ b/packages/python/goldenflow/goldenflow/engine/transformer.py
@@ -4,8 +4,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.config.schema import GoldenFlowConfig
 from goldenflow.connectors.file import read_file, write_file
 from goldenflow.engine.frame import Frame, to_frame

--- a/packages/python/goldenflow/goldenflow/mapping/schema_mapper.py
+++ b/packages/python/goldenflow/goldenflow/mapping/schema_mapper.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.config.schema import GoldenFlowConfig, MappingSpec
 from goldenflow.engine.profiler_bridge import profile_dataframe
 from goldenflow.mapping.name_similarity import name_similarity

--- a/packages/python/goldenflow/goldenflow/transforms/__init__.py
+++ b/packages/python/goldenflow/goldenflow/transforms/__init__.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
 # Global transform registry
 _REGISTRY: dict[str, TransformInfo] = {}

--- a/packages/python/goldenflow/goldenflow/transforms/_fastpath.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_fastpath.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import polars as pl
+from goldenflow._polars_lazy import pl
 
 _V = "__gf_v__"
 _I = "__gf_i__"

--- a/packages/python/goldenflow/goldenflow/transforms/_native.py
+++ b/packages/python/goldenflow/goldenflow/transforms/_native.py
@@ -15,8 +15,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.core._native_loader import native_enabled, native_module
 
 _DEFAULT_REGION = "US"

--- a/packages/python/goldenflow/goldenflow/transforms/address.py
+++ b/packages/python/goldenflow/goldenflow/transforms/address.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     address_expand_native,

--- a/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
+++ b/packages/python/goldenflow/goldenflow/transforms/auto_correct.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from collections import Counter
 from collections.abc import Iterable
 
-import polars as pl
 from rapidfuzz import fuzz
 
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import build_canonical_map_native
 

--- a/packages/python/goldenflow/goldenflow/transforms/categorical.py
+++ b/packages/python/goldenflow/goldenflow/transforms/categorical.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     boolean_normalize_native,

--- a/packages/python/goldenflow/goldenflow/transforms/company.py
+++ b/packages/python/goldenflow/goldenflow/transforms/company.py
@@ -6,8 +6,7 @@ byte-exact pure-Python references (byte-parity harness,
 """
 from __future__ import annotations
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     company_extract_legal_native,

--- a/packages/python/goldenflow/goldenflow/transforms/dates.py
+++ b/packages/python/goldenflow/goldenflow/transforms/dates.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from datetime import date, timedelta
 
-import polars as pl
 from dateutil import parser as dateutil_parser
 
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._fastpath import _V, apply_with_residual
 

--- a/packages/python/goldenflow/goldenflow/transforms/email.py
+++ b/packages/python/goldenflow/goldenflow/transforms/email.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     email_canonical_native,

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     aba_validate_native,

--- a/packages/python/goldenflow/goldenflow/transforms/names.py
+++ b/packages/python/goldenflow/goldenflow/transforms/names.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     has_initial_native,

--- a/packages/python/goldenflow/goldenflow/transforms/numeric.py
+++ b/packages/python/goldenflow/goldenflow/transforms/numeric.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import math
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     abs_value_native,

--- a/packages/python/goldenflow/goldenflow/transforms/phone.py
+++ b/packages/python/goldenflow/goldenflow/transforms/phone.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import phonenumbers
-import polars as pl
 
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._fastpath import _V, apply_with_residual
 from goldenflow.transforms._native import (

--- a/packages/python/goldenflow/goldenflow/transforms/phonetic.py
+++ b/packages/python/goldenflow/goldenflow/transforms/phonetic.py
@@ -5,8 +5,7 @@ byte-exact pure-Python reference (byte-parity harness).
 """
 from __future__ import annotations
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import double_metaphone_native, soundex_native
 

--- a/packages/python/goldenflow/goldenflow/transforms/text.py
+++ b/packages/python/goldenflow/goldenflow/transforms/text.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     collapse_whitespace_native,

--- a/packages/python/goldenflow/goldenflow/transforms/url.py
+++ b/packages/python/goldenflow/goldenflow/transforms/url.py
@@ -2,8 +2,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
-
+from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._native import (
     url_canonical_native,

--- a/packages/python/goldenflow/tests/test_lazy_polars_import.py
+++ b/packages/python/goldenflow/tests/test_lazy_polars_import.py
@@ -1,0 +1,61 @@
+"""Phase 4a guard: ``import goldenflow`` must NOT eagerly import Polars.
+
+The transform registry pulls every transform module at ``import goldenflow`` time,
+so a single top-level ``import polars`` anywhere in that chain loaded Polars for
+every user -- including those who only touch the Polars-free columnar path. Phase 4a
+routes all those modules through the lazy proxy (``goldenflow._polars_lazy``), so
+Polars loads only on first actual use. This test locks that in: a regression (a new
+top-level ``import polars as pl`` or a module-level ``pl.<attr>`` reference) would
+re-import Polars at load time and fail here.
+
+Run in a SUBPROCESS so it's a clean interpreter -- an in-process check is meaningless
+once any earlier test has imported Polars.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def _fresh_import_check(snippet: str) -> str:
+    """Run `snippet` in a clean interpreter and return its stdout (stripped)."""
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(snippet)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def test_import_goldenflow_does_not_load_polars() -> None:
+    result = _fresh_import_check(
+        """
+        import sys
+        import goldenflow  # noqa: F401
+        print("LOADED" if "polars" in sys.modules else "CLEAN")
+        """
+    )
+    assert result == "CLEAN", (
+        "import goldenflow eagerly imported Polars -- a module in the registry chain "
+        "has a top-level `import polars as pl` or a module-level `pl.<attr>` "
+        "reference. Route it through goldenflow._polars_lazy (Phase 4a)."
+    )
+
+
+def test_polars_loads_on_first_actual_use() -> None:
+    """The lazy proxy is transparent: a real transform still works (Polars loads on
+    first use), so the eviction of the EAGER import changes no behavior."""
+    result = _fresh_import_check(
+        """
+        import goldenflow
+        import polars as pl
+        from goldenflow import transform_df
+        from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+        cfg = GoldenFlowConfig(transforms=[TransformSpec(column="x", ops=["strip", "lowercase"])])
+        out = transform_df(pl.DataFrame({"x": ["  Hi ", "BYE"]}), config=cfg)
+        print(",".join(out.df["x"].to_list()))
+        """
+    )
+    assert result == "hi,bye"


### PR DESCRIPTION
## Phase 4a — lazy Polars import

First step of Phase 4 (make Polars an optional accelerator, per
`docs/design/2026-07-07-phase4-polars-optional-scoping.md`): break the eager Polars
import so **`import goldenflow` no longer pulls Polars** (or its transitive numpy).

The transform registry imports every transform module at load time, so a single
top-level `import polars` anywhere in that chain loaded Polars for *every* user —
including those who only touch the Polars-free columnar path.

### How
- **New `goldenflow/_polars_lazy.py`**: a proxy `pl` that imports Polars on first
  attribute access, cached thereafter. Type annotations are already strings
  (`from __future__ import annotations` everywhere), and there's no module-level `pl.`
  execution or `def f(x=pl.X)` default arg (audited) — so nothing triggers the import
  at load time; every `pl.col(...)`/`pl.Series(...)`/`pl.Utf8` runs at **call** time
  exactly as before. Attribute access returns the real Polars object, so
  `isinstance`/`return_dtype` behave identically.
- Routed all **22 eager-chain modules** (`transforms/*`, `engine/{differ,frame,
  profiler_bridge,transformer}`, `connectors/file`, `mapping/schema_mapper`) through
  the proxy.
- Fixed the one module-level dereference: `connectors/file.py` built
  `{".csv": pl.read_csv, ...}` at import time; now resolves the reader lazily by name.

### Result
`import goldenflow` loads **no polars / numpy / pyarrow** (537 → 384 modules),
**byte-identical** behavior (Polars loads on first actual use). Lands under the current
hard `polars` dep — a **pure refactor**, no dependency change yet.

Gated by `tests/test_lazy_polars_import.py` (subprocess: `polars not in sys.modules`
after `import goldenflow`, + a transparency check that a real transform still works).
Full transforms+engine suite green (1747; the lone `test_transform_with_splits` fail is
the pre-existing env-leak flake — passes isolated).

### Weight (measured, dev env)
polars 7.8 MB + transitive numpy 23.4 MB = **~31 MB** off the default import. Separately,
**pyarrow (84.5 MB, `[native]` only)** is the bigger prize for a later step (4g) — the
columnar path is already pyarrow-free.

Enabler for 4b–4f (Frame backend → Polars-free entry point → signature port → I/O extras
→ flip default). No breaking change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg