### PR TITLE
feat(goldenpipe): TS run() uses the brain (Slice C2 — runtime wiring)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-runtime.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-runtime.md
@@ -288,7 +288,8 @@ Leave `computeAutoConfig`/`computeAutoConfigPure` defined (orphaned wrapper is f
 - [ ] **Step 3: Rework the Python emitter** `scripts/emit_ts_parity_fixtures.py`. Re-aim from the static config to `goldenpipe.run()`:
   - In `emit_case`: drop the `static_config` param; change the run line to `result = goldenpipe.run(str(csv_path))`.
   - In `main`: drop `static_config = Pipeline()._auto_config()` and pass-through; call `emit_case(case_id, csv_text, tmp_dir)`.
-  - Update the module docstring + the `emit_case` comment: it now emits the BRAIN path (`goldenpipe.run`), so single_row → pathological (drops dedupe); the fixture is the cross-surface brain contract (Python run() == TS run()).
+  - **DELETE the now-unused import** `from goldenpipe.pipeline import Pipeline` (line ~39) — after the rework `Pipeline` has zero uses, and root `pyproject.toml` ruff config selects `F` (→ `F401`), so a dangling import FAILS the `ruff check` gate in Step 4 / Task 3. Keep `import goldenpipe` (still used: `goldenpipe.run`, `goldenpipe.__version__`).
+  - Update the module docstring + the `emit_case` comment (they describe the STATIC path): it now emits the BRAIN path (`goldenpipe.run`), so single_row → pathological (drops dedupe); the fixture is the cross-surface brain contract (Python run() == TS run()).
 
 - [ ] **Step 4: Regenerate the fixture (BOX-runnable — verify here)**
 ```bash
@@ -327,6 +328,8 @@ describe("planConfig (brain wiring)", () => {
 ```
 
 - [ ] **Step 6: Eyeball-verify** run() builds config before the resolve try (throw propagates); `planConfig` imports resolve; the fixture single_row change is consistent with the pathological unit test. (CI gates the TS.)
+
+- [ ] **Step 6b: Audit other run()-driven tests stay green.** Switching `run()` to the brain changes behavior for any zero-config test whose input the brain routes differently. Verified safe during review: `tests/e2e/pipeline-e2e.test.ts` drives `runDf(rows)` zero-config and asserts the exact chain `[load, goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` — its samples are person columns (`first_name,last_name,email,city,state`, 5 & 3 rows) → domain None + >1 row + no nulls → brain picks `default` = the same chain. Grep for any OTHER `runDf(`/`run(` zero-config test asserting a stage list on a single-row or domain-detecting input; if one exists and would now diverge, update it in THIS commit (or flag). Expected: only `pipe_parity.json`'s single_row changes.
 
 - [ ] **Step 7: Commit (atomic)**
 ```bash

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-runtime.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-runtime.md
@@ -1,0 +1,395 @@
+# goldenpipe brain — TS runtime wiring (Slice C2) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make TS `goldenpipe.run()` plan-first auto-config (default-on) — a TS profiling layer builds the same `PlannerInput` as Python, `planConfig` runs the brain, and the `pipe_parity` fixture is re-aimed at the brain so Python `run()` == TS `run()`.
+
+**Architecture:** New `autoconfigGlue.ts` (profiling + enforce + planToConfig, mirroring Python `autoconfig_glue.py`) + `errors.ts`; `pipeline.ts` gains `planConfig` and `run()` calls it; the Python emitter re-aims from static config to `goldenpipe.run()` and the fixture regenerates. Rust brain is source of truth; TS conforms via the C1 vectors + this run-level parity.
+
+**Tech Stack:** TypeScript (vitest, CI-only — box OOMs), Python (emitter — box-runnable). Domain detection = InferMap cross-surface-gated `detectDomainDetailed`.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md`
+
+---
+
+## Environment & constraints
+
+- Repo `D:/show_case/gg-local-llm`, branch `feat/goldenpipe-brain-ts-runtime` (off fresh main, spec committed).
+- **TS is CI-only** (vitest/tsc OOM the box) — TS written against the spec + Python mirror, verified by eye + CI. **The Python emitter + fixture regen IS box-runnable** (Task 2 verifies on the box).
+- Python emitter env: `INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"`, `PYTHONPATH="packages/python/goldenpipe;packages/python/infermap;packages/python/goldencheck-types"`, `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8`.
+- GitHub auth: `unset GH_TOKEN; gh auth switch --user benzsevern >/dev/null 2>&1; export GH_TOKEN=$(gh auth token --user benzsevern)`.
+- **No `Math.max(...spread)`** — the `ts-no-spread-math-min-max` ast-grep rule is error-severity and runs on every PR. Use loop-max.
+
+## File Structure
+
+| File | Change |
+|------|--------|
+| `packages/typescript/goldenpipe/src/core/errors.ts` | **new** — `PipeNotConfidentError` |
+| `packages/typescript/goldenpipe/src/core/autoconfigGlue.ts` | **new** — profiling + enforce + planToConfig |
+| `packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts` | **new** — glue + planConfig unit tests |
+| `packages/typescript/goldenpipe/src/core/pipeline.ts` | `planConfig` + `run()` switch |
+| `packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py` | re-aim static → `goldenpipe.run()` |
+| `packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json` | regenerated (single_row golden changes) |
+
+**Ordering (green at every commit):** Task 1 (errors + glue + glue-unit-tests) is self-contained. **Task 2 is one atomic commit** — the `run()` switch and the fixture regen are coupled (the fixture *is* the expected TS output), so wiring `run()` to the brain (single_row drops dedupe) and regenerating the fixture must land together, or the pipe-parity test fails between commits. Task 3 ships.
+
+---
+
+### Task 1: `errors.ts` + `autoconfigGlue.ts` + glue unit tests
+
+**Files:**
+- Create: `packages/typescript/goldenpipe/src/core/errors.ts`
+- Create: `packages/typescript/goldenpipe/src/core/autoconfigGlue.ts`
+- Create: `packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts`
+
+- [ ] **Step 1: `errors.ts`**
+```ts
+/** goldenpipe-local exceptions. */
+export class PipeNotConfidentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PipeNotConfidentError";
+  }
+}
+```
+
+- [ ] **Step 2: `autoconfigGlue.ts`** — the impure host bracket, mirroring `autoconfig_glue.py`. Verify field names against `autoconfigPlanner.ts` (nRows/nCols/columnNames/dtypes/inferredDomain/domainConfidence; maxNullDensity/meanNullDensity; ruleName) and the `models.ts` signatures (`makeStageSpec({use, config})`, `makePipelineConfig({pipeline, stages})`, `Row` from `./index.js`, `StageRegistry.listAll()`).
+```ts
+/**
+ * autoconfigGlue.ts — impure host bracket for the auto-config brain
+ * (InferMap detect + Row[] profiling in; PipelineConfig out; refuse-on-RED).
+ * TS analogue of goldenpipe/autoconfig_glue.py. The pure decision core is
+ * autoconfigPlanner.ts.
+ */
+import type { Row } from "./index.js";
+import {
+  planPipeline,
+  applyScaleHints,
+  bandOf,
+  type PipeProfile,
+  type ComplexityProfile,
+  type PlannerInput,
+  type PipePlan,
+} from "./autoconfigPlanner.js";
+import { detectDomainDetailed } from "infermap";
+import { PipeNotConfidentError } from "./errors.js";
+import { makePipelineConfig, makeStageSpec, type PipelineConfig } from "./models.js";
+import type { StageRegistry } from "./engine/registry.js";
+
+export const REFUSE_ROW_THRESHOLD = 100_000;
+
+export function profileContext(rows: readonly Row[]): PipeProfile {
+  if (rows.length === 0) {
+    return {
+      nRows: 0, nCols: 0, columnNames: [], dtypes: [],
+      inferredDomain: null, domainConfidence: 0,
+    };
+  }
+  const columnNames = Object.keys(rows[0]!);
+  const det = detectDomainDetailed({ columns: columnNames });
+  return {
+    nRows: rows.length,
+    nCols: columnNames.length,
+    columnNames,
+    dtypes: [],                       // unused by any rule; never emitted
+    inferredDomain: det.domain,
+    domainConfidence: det.domain !== null ? det.score : 0,
+  };
+}
+
+export function profileComplexity(rows: readonly Row[]): ComplexityProfile {
+  const nRows = rows.length;
+  if (nRows === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const columnNames = Object.keys(rows[0]!);
+  if (columnNames.length === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const fractions = columnNames.map((c) => {
+    let nulls = 0;
+    for (const r of rows) {
+      const v = r[c];
+      if (v === null || v === undefined) nulls++;
+    }
+    return nulls / nRows;
+  });
+  // Loop-max, NOT Math.max(...spread) (ts-no-spread-math-min-max is error-severity).
+  let maxNullDensity = 0;
+  for (const f of fractions) if (f > maxNullDensity) maxNullDensity = f;
+  return {
+    maxNullDensity,
+    meanNullDensity: fractions.reduce((a, b) => a + b, 0) / fractions.length,
+  };
+}
+
+export function buildPlannerInput(rows: readonly Row[]): PlannerInput {
+  return { runtime: profileContext(rows), complexity: profileComplexity(rows) };
+}
+
+export function enforceConfidence(plan: PipePlan, runtime: PipeProfile): void {
+  if (bandOf(plan.confidence) !== "red") return;
+  if (runtime.nRows >= REFUSE_ROW_THRESHOLD) {
+    throw new PipeNotConfidentError(
+      `auto-config not confident (rule=${plan.ruleName}, confidence=${plan.confidence}) ` +
+        `on ${runtime.nRows} rows; supply an explicit pipeline config or reduce the input size. ` +
+        `evidence=${JSON.stringify(plan.evidence)}`,
+    );
+  }
+  // Low confidence below the threshold: proceed on the safe default plan.
+}
+
+export function planToConfig(
+  plan: PipePlan,
+  available: Record<string, unknown>,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const stages = plan.stages
+    .filter((s) => s.name in available)
+    .map((s) => makeStageSpec({ use: s.name, config: s.config }));
+  const IDENTITY = "goldenmatch.identity_resolve";
+  if (Object.keys(identityOpts).length > 0 && IDENTITY in available) {
+    stages.push(makeStageSpec({ use: IDENTITY, config: identityOpts }));
+  }
+  return makePipelineConfig({ pipeline: "auto", stages });
+}
+```
+If `Row`'s value type makes `r[c]` a type error, use the actual `Row` index type (it is `Record<string, unknown>`-like — confirm in `models.ts`/`index.ts`).
+
+- [ ] **Step 3: `autoconfig-glue.test.ts`** — the glue unit tests (planConfig tests come in Task 2):
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  profileContext,
+  profileComplexity,
+  enforceConfidence,
+} from "../../src/core/autoconfigGlue.js";
+import { PipeNotConfidentError } from "../../src/core/errors.js";
+import type { PipePlan, PipeProfile } from "../../src/core/autoconfigPlanner.js";
+
+const financeRows = [
+  { account_number: "A1", currency: "USD" },
+  { account_number: "A2", currency: "EUR" },
+];
+const personRows = [
+  { first_name: "John", last_name: "Smith", email: "j@x.co" },
+  { first_name: "Jane", last_name: "Doe", email: "d@x.co" },
+];
+
+describe("profileContext", () => {
+  it("detects finance domain from columns", () => {
+    const p = profileContext(financeRows);
+    expect(p.nRows).toBe(2);
+    expect(p.columnNames).toEqual(["account_number", "currency"]);
+    expect(p.inferredDomain).toBe("finance");
+    expect(p.domainConfidence).toBe(1.0);
+  });
+  it("person columns detect no domain", () => {
+    const p = profileContext(personRows);
+    expect(p.inferredDomain).toBeNull();
+    expect(p.domainConfidence).toBe(0);
+  });
+  it("empty rows -> zeros", () => {
+    const p = profileContext([]);
+    expect(p.nRows).toBe(0);
+    expect(p.inferredDomain).toBeNull();
+  });
+});
+
+describe("profileComplexity", () => {
+  it("computes null density from explicit nulls", () => {
+    const rows = [
+      { a: 1, b: null },
+      { a: null, b: null },
+      { a: 3, b: 4 },
+      { a: 4, b: undefined },
+    ];
+    const c = profileComplexity(rows);
+    // a: 1/4 null = 0.25 ; b: 3/4 null = 0.75
+    expect(c.maxNullDensity).toBe(0.75);
+    expect(c.meanNullDensity).toBeCloseTo(0.5, 10);
+  });
+  it("no nulls -> zeros", () => {
+    expect(profileComplexity(personRows)).toEqual({ maxNullDensity: 0, meanNullDensity: 0 });
+  });
+  it("empty -> zeros", () => {
+    expect(profileComplexity([])).toEqual({ maxNullDensity: 0, meanNullDensity: 0 });
+  });
+});
+
+function redPlan(): PipePlan {
+  return { stages: [], ruleName: "low_confidence", confidence: 0.3, evidence: {} };
+}
+function greenPlan(): PipePlan {
+  return { stages: [], ruleName: "default", confidence: 0.7, evidence: {} };
+}
+function profile(nRows: number): PipeProfile {
+  return { nRows, nCols: 0, columnNames: [], dtypes: [], inferredDomain: null, domainConfidence: 0 };
+}
+
+describe("enforceConfidence", () => {
+  it("RED at scale throws", () => {
+    expect(() => enforceConfidence(redPlan(), profile(100_000))).toThrow(PipeNotConfidentError);
+  });
+  it("RED below threshold proceeds", () => {
+    expect(() => enforceConfidence(redPlan(), profile(99_999))).not.toThrow();
+  });
+  it("green proceeds", () => {
+    expect(() => enforceConfidence(greenPlan(), profile(100_000))).not.toThrow();
+  });
+});
+```
+
+- [ ] **Step 4: Eyeball-verify** field names against `autoconfigPlanner.ts` (the `PipeProfile`/`ComplexityProfile`/`PipePlan` interfaces) and that `detectDomainDetailed({columns})` returns `.domain`/`.score`. Confirm no `Math.max(...spread)` remains. (Cannot run vitest on the box — CI gates it.)
+
+- [ ] **Step 5: Commit**
+```bash
+git add packages/typescript/goldenpipe/src/core/errors.ts packages/typescript/goldenpipe/src/core/autoconfigGlue.ts packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
+git commit -m "feat(goldenpipe-ts): auto-config profiling glue + PipeNotConfidentError
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 2: wire `planConfig` into `run()` + emitter rework + fixture regen (ONE atomic commit)
+
+**Files:**
+- Modify: `packages/typescript/goldenpipe/src/core/pipeline.ts`
+- Modify: `packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py`
+- Modify (regenerated): `packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json`
+- Modify: `packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts` (append planConfig tests)
+
+Why atomic: switching `run()` to the brain makes single_row drop dedupe; the committed fixture must reflect that in the same commit, or the pipe-parity test fails.
+
+- [ ] **Step 1: `pipeline.ts` — add `planConfig`** (after the `computeAutoConfig` block). Add imports at top: `buildPlannerInput, enforceConfidence, planToConfig` from `./autoconfigGlue.js`; `planPipeline, applyScaleHints` from `./autoconfigPlanner.js`.
+```ts
+/**
+ * planConfig — the brain path (pure-TS; mirrors Python _plan_config). Profiles
+ * the rows, runs the rule table + scale hints, refuses if not confident at
+ * scale, and materializes the chosen plan into a PipelineConfig.
+ */
+export function planConfig(
+  rows: readonly Row[],
+  registry: StageRegistry,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const inp = buildPlannerInput(rows);
+  let plan = planPipeline(inp);
+  plan = applyScaleHints(plan, inp.runtime);
+  enforceConfidence(plan, inp.runtime); // may throw PipeNotConfidentError
+  return planToConfig(plan, registry.listAll(), identityOpts);
+}
+```
+
+- [ ] **Step 2: `run()` — switch to `planConfig`.** Change the config line (keep it BEFORE the `Resolver.resolve` try, so a thrown `PipeNotConfidentError` propagates out of `run()`):
+```ts
+    const config = this.config ?? planConfig([...rows], this.registry, this.identityOpts);
+```
+Leave `computeAutoConfig`/`computeAutoConfigPure` defined (orphaned wrapper is fine — public API; `computeAutoConfigPure` still backs the engine `auto_config` parity). Do NOT change `DEFAULT_STAGE_ORDER`.
+
+- [ ] **Step 3: Rework the Python emitter** `scripts/emit_ts_parity_fixtures.py`. Re-aim from the static config to `goldenpipe.run()`:
+  - In `emit_case`: drop the `static_config` param; change the run line to `result = goldenpipe.run(str(csv_path))`.
+  - In `main`: drop `static_config = Pipeline()._auto_config()` and pass-through; call `emit_case(case_id, csv_text, tmp_dir)`.
+  - Update the module docstring + the `emit_case` comment: it now emits the BRAIN path (`goldenpipe.run`), so single_row → pathological (drops dedupe); the fixture is the cross-surface brain contract (Python run() == TS run()).
+
+- [ ] **Step 4: Regenerate the fixture (BOX-runnable — verify here)**
+```bash
+INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+export PYTHONPATH="packages/python/goldenpipe;packages/python/infermap;packages/python/goldencheck-types"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+"$INTERP" packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+```
+Then eyeball `packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json`: `single_row` stages must now be `[load, goldencheck.scan, goldenflow.transform]` (NO dedupe); `people_dupes` + `all_unique` unchanged (`[load, scan, flow, dedupe]`), all `status: "success"`. (Verified on the box during design.) Confirm `ruff check` passes on the emitter:
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+```
+
+- [ ] **Step 5: Append planConfig unit tests** to `autoconfig-glue.test.ts`:
+```ts
+import { planConfig } from "../../src/core/pipeline.js";
+import { buildDefaultRegistry } from "../../src/core/adapters/index.js";
+
+describe("planConfig (brain wiring)", () => {
+  it("confident_schema prepends infer_schema", () => {
+    const rows = [
+      { account_number: "A1", currency: "USD" },
+      { account_number: "A2", currency: "EUR" },
+    ];
+    const cfg = planConfig(rows, buildDefaultRegistry(), {});
+    expect(cfg.stages.map((s) => s.use)).toEqual([
+      "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    ]);
+  });
+  it("single row is pathological (drops dedupe)", () => {
+    const rows = [{ first_name: "Solo", last_name: "Person", email: "s@x.co" }];
+    const cfg = planConfig(rows, buildDefaultRegistry(), {});
+    expect(cfg.stages.map((s) => s.use)).toEqual(["goldencheck.scan", "goldenflow.transform"]);
+  });
+});
+```
+
+- [ ] **Step 6: Eyeball-verify** run() builds config before the resolve try (throw propagates); `planConfig` imports resolve; the fixture single_row change is consistent with the pathological unit test. (CI gates the TS.)
+
+- [ ] **Step 7: Commit (atomic)**
+```bash
+git add packages/typescript/goldenpipe/src/core/pipeline.ts packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
+git commit -m "feat(goldenpipe-ts): run() uses the brain (plan-first auto-config) + re-aim pipe_parity
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+---
+
+### Task 3: Ship (CI gates TS; box verified the emitter/fixture)
+
+**Files:** none.
+
+- [ ] **Step 1: Local checks**
+```bash
+INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+export PYTHONPATH="packages/python/goldenpipe;packages/python/infermap;packages/python/goldencheck-types"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+"$INTERP" -m ruff check packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+# Re-run the emitter and confirm git sees NO diff (fixture already regenerated in Task 2):
+"$INTERP" packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+git status --short   # pipe_parity.json should NOT reappear as modified
+```
+(If the emitter re-run dirties the fixture, the committed fixture is stale — re-add.)
+
+- [ ] **Step 2: Rebase + push + PR**
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern >/dev/null 2>&1; export GH_TOKEN=$(gh auth token --user benzsevern)
+git fetch origin main -q && git rebase origin/main
+git push -u origin feat/goldenpipe-brain-ts-runtime --force-with-lease
+gh pr create --repo benseverndev-oss/goldenmatch --base main --head feat/goldenpipe-brain-ts-runtime \
+  --title "feat(goldenpipe): TS run() uses the brain (Slice C2 — runtime wiring)" \
+  --body "<summary: TS autoconfigGlue (profileContext via cross-surface InferMap detect + profileComplexity null density + enforceConfidence refuse + planToConfig); pipeline.planConfig; run() switches to the brain (default-on); emitter re-aimed at goldenpipe.run() so pipe_parity is the Python-run()==TS-run() brain contract (single_row now pathological). Unit tests cover confident_schema/pathological/null-density/refuse. Rust brain is source of truth; TS conforms. Emitter+fixture box-verified; TS CI-gated. Deferred: null-heavy pipe_parity fixture (parseCsv '' vs Polars null), WASM-routed runtime.>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44"
+```
+
+- [ ] **Step 3: Watch the TS + freshness jobs** (box can't run vitest). Key jobs: `typescript` (unit tests + tsc + the reworked pipe-parity test) and `ts_parity_freshness` (re-runs the emitter, compares the fixture).
+```bash
+gh pr checks <PR#> --repo benseverndev-oss/goldenmatch
+# for a failing job:
+gh run view <run-id> --repo benseverndev-oss/goldenmatch --log-failed | grep -iE "planConfig|profileContext|profileComplexity|pipe_parity|single_row|infer_schema|toEqual|error TS|Expected|Received|DRIFT|STALE" | head -30
+```
+Likely causes if red: a field-name slip (tsc), the `Math.max` spread (ast-grep — shouldn't be present), a fixture mismatch (freshness gate — the committed fixture must equal a fresh-install emitter run; person fixtures have no infer_schema/entry-point dependency so this should match), or the confident_schema unit test if the finance columns don't score ≥0.5 (they score 1.0 — verified). Fix, commit, push, re-check.
+
+- [ ] **Step 4: Arm auto-merge + STOP**
+```bash
+gh pr merge <PR#> --auto --squash   # WITHOUT --delete-branch; if 'strategy set by queue', run: gh pr merge <PR#> --auto
+```
+Then STOP.
+
+---
+
+## Cross-cutting reminders
+- **TS CI-only** (vitest OOMs box); **Python emitter + fixture regen box-runnable** (Task 2 verifies).
+- **Loop-max, never `Math.max(...spread)`** (ast-grep error gate).
+- **`run()` builds config before the resolve try** — refuse propagates out (rejects the promise), matching Python.
+- **`computeAutoConfigPure` stays live** (engine auto_config parity); `computeAutoConfig` wrapper orphans harmlessly — leave it.
+- **Task 2 is atomic** — run() switch + emitter + fixture regen + planConfig tests in one commit (coupled).
+- **Domain via `detectDomainDetailed({columns})`** — columns-only, byte-identical to Python.
+- Deferred: null-heavy pipe_parity fixture; WASM-routed runtime brain.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md
@@ -1,0 +1,193 @@
+# goldenpipe brain — TS runtime wiring (Slice C2) design
+
+**Status:** approved (design gate)
+**Date:** 2026-07-07
+**Builds on:** C1 (#1548) — the pure-TS brain (`planPipeline`/`applyScaleHints`/`bandOf` + structs in `autoconfigPlanner.ts`) and its Leg A/B vector parity. This slice wires that brain into TS `run()`.
+
+## 1. Goal
+
+Make TS `goldenpipe.run()` plan-first auto-config (default-on), so TS users get the same brain-decided pipeline as Python. Rust brain stays the source of truth; TS conforms via the C1 vectors (decision core, already gated) + new run-level parity (profiling + wiring) here.
+
+## 2. What the profiling parity actually requires (de-risked)
+
+The brain needs a `PlannerInput` built from the TS `Row[]`, matching Python's `build_planner_input`. The pieces and their parity status:
+
+- **n_rows** = `rows.length` == Python `len(df)`. Trivial.
+- **columns** = `Object.keys(rows[0])` (header order) == Python `df.columns`. `parseCsv` builds row objects in header order, so this matches. Empty input (`rows.length === 0`) → zeros (mirrors Python `df is None`).
+- **domain / confidence** = `detectDomainDetailed({ columns }).score`. InferMap's `detect_domain` is **byte-identical across Python/native/TS/WASM** (its own cross-surface Rust cutover) and reads **only column names** — the exact columns-only input Python passes (`SimpleNamespace(columns=list(column_names))` → `[str(c) for c in df.columns]`). Pure-TS `detectDomainDetailed` is byte-identical to `infermap-core::detect_domain`. So domain parity is already solved; C2 just wires it (`{ columns }` input, `.score`, domain-null → confidence 0).
+- **null density** = per-column null count / n_rows. Deterministic. **Null-semantics subtlety (documented, load-bearing):** `parseCsv` maps an empty CSV cell to `""`, NOT null/undefined (`csv.ts:23`). Polars `read_csv` maps it to null. So for a CSV-loaded row, an empty cell counts as null in Python but not in TS. This does not affect the person pipe_parity fixtures (they have zero empty cells → both see zero nulls → agree). It is exactly why a **null-heavy pipe_parity fixture is deferred** (§8) — it would need reconciling `parseCsv` `""` with Polars null. TS `profileComplexity` defines null as `value === null || value === undefined` (an absent key reads as `undefined`); a targeted unit test covers it with explicit-null `Row[]` (not CSV-derived).
+
+Net: the only genuinely new parity risk (null density) is unobservable in the current pipe_parity path and is covered by a unit test with controlled inputs.
+
+## 3. Components
+
+### 3.1 `src/core/errors.ts` (new)
+```ts
+export class PipeNotConfidentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PipeNotConfidentError";
+  }
+}
+```
+Mirrors Python `errors.PipeNotConfidentError`. TS-local (no goldenmatch dep).
+
+### 3.2 `src/core/autoconfigGlue.ts` (new) — the impure host bracket, mirroring `autoconfig_glue.py`
+```ts
+import type { Row } from "./index.js";
+import {
+  planPipeline, applyScaleHints, bandOf,
+  type PipeProfile, type ComplexityProfile, type PlannerInput, type PipePlan,
+} from "./autoconfigPlanner.js";
+import { detectDomainDetailed } from "infermap";
+import { PipeNotConfidentError } from "./errors.js";
+import { makePipelineConfig, makeStageSpec, type PipelineConfig } from "./models.js";
+import type { StageRegistry } from "./engine/registry.js";
+
+export const REFUSE_ROW_THRESHOLD = 100_000;
+
+export function profileContext(rows: readonly Row[]): PipeProfile {
+  if (rows.length === 0) {
+    return { nRows: 0, nCols: 0, columnNames: [], dtypes: [],
+             inferredDomain: null, domainConfidence: 0 };
+  }
+  const columnNames = Object.keys(rows[0]!);
+  const det = detectDomainDetailed({ columns: columnNames });
+  return {
+    nRows: rows.length,
+    nCols: columnNames.length,
+    columnNames,
+    dtypes: [],                            // dtypes unused by any rule / never emitted
+    inferredDomain: det.domain,
+    domainConfidence: det.domain !== null ? det.score : 0,
+  };
+}
+
+export function profileComplexity(rows: readonly Row[]): ComplexityProfile {
+  const nRows = rows.length;
+  if (nRows === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const columnNames = Object.keys(rows[0]!);
+  if (columnNames.length === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const fractions = columnNames.map((c) => {
+    let nulls = 0;
+    for (const r of rows) {
+      const v = r[c];
+      if (v === null || v === undefined) nulls++;
+    }
+    return nulls / nRows;
+  });
+  return {
+    maxNullDensity: Math.max(...fractions),
+    meanNullDensity: fractions.reduce((a, b) => a + b, 0) / fractions.length,
+  };
+}
+
+export function buildPlannerInput(rows: readonly Row[]): PlannerInput {
+  return { runtime: profileContext(rows), complexity: profileComplexity(rows) };
+}
+
+export function enforceConfidence(plan: PipePlan, runtime: PipeProfile): void {
+  if (bandOf(plan.confidence) !== "red") return;
+  if (runtime.nRows >= REFUSE_ROW_THRESHOLD) {
+    throw new PipeNotConfidentError(
+      `auto-config not confident (rule=${plan.ruleName}, confidence=${plan.confidence}) ` +
+      `on ${runtime.nRows} rows; supply an explicit pipeline config or reduce the input size.`,
+    );
+  }
+  // Low confidence below the threshold: proceed on the safe default plan.
+  // (console.warn parity with Python's logger.warning is optional.)
+}
+
+export function planToConfig(
+  plan: PipePlan,
+  available: Record<string, unknown>,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const stages = plan.stages
+    .filter((s) => s.name in available)
+    .map((s) => makeStageSpec({ use: s.name, config: s.config }));
+  const IDENTITY = "goldenmatch.identity_resolve";
+  if (Object.keys(identityOpts).length > 0 && IDENTITY in available) {
+    stages.push(makeStageSpec({ use: IDENTITY, config: identityOpts }));
+  }
+  return makePipelineConfig({ pipeline: "auto", stages });
+}
+```
+Notes:
+- `Math.max(...fractions)` is safe here (column counts are tiny — never the 65K-element spread the ast-grep rule guards). If the repo's `ts-no-spread-math-min-max` rule flags it, use a loop-max instead.
+- `dtypes: []` — no rule reads dtypes and they never appear in any emitted output (plan/evidence/pipe_parity), so an empty array is faithful. (Python fills real Polars dtypes but they are equally unused downstream.)
+
+### 3.3 `pipeline.ts` — `planConfig` + `run()` switch
+```ts
+// NEW: the brain path (pure-TS; mirrors Python _plan_config).
+export function planConfig(
+  rows: readonly Row[],
+  registry: StageRegistry,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const inp = buildPlannerInput(rows);
+  let plan = planPipeline(inp);
+  plan = applyScaleHints(plan, inp.runtime);
+  enforceConfidence(plan, inp.runtime);       // may throw PipeNotConfidentError
+  return planToConfig(plan, registry.listAll(), identityOpts);
+}
+```
+In `run()`, change the config line from `computeAutoConfig(...)` to `planConfig(...)`, keeping it **before** the `Resolver.resolve` try-block so a `PipeNotConfidentError` propagates out of `run()` (rejects the promise) rather than becoming a FAILED result — matching Python (raise out of `run()`):
+```ts
+const config = this.config ?? planConfig([...rows], this.registry, this.identityOpts);
+```
+- **`computeAutoConfig` / `computeAutoConfigPure` stay untouched** — they remain the static engine config used by the `auto_config` Leg A/B parity (`autoConfigJsonPure` / `autoConfigViaWasm`). This mirrors Python keeping `_auto_config` alongside the new `_plan_config`. `DEFAULT_STAGE_ORDER` (the static scan/flow/dedupe list) is unchanged.
+- **Pure-TS runtime** — `planConfig` calls `planPipeline` + `detectDomainDetailed` directly (both byte-identical to core), NOT the WASM backend. WASM-routed runtime is deferred (§8); it would add async + backend plumbing for zero behavioral difference.
+
+### 3.4 `runDf` parity
+`runDf(rows, config?)` (the in-memory entry the pipe_parity test drives) constructs a `Pipeline` and calls `run()`, so it inherits the brain automatically. Confirm `runDf`'s zero-config path reaches `planConfig` (it should, via `run()`).
+
+## 4. pipe_parity rework
+
+`scripts/emit_ts_parity_fixtures.py` currently emits from `Pipeline(config=static_config).run(source=path)` (slice-1's static-engine aim). **Re-aim it at `goldenpipe.run(path)`** (the brain default). Effect on the 3 committed fixtures:
+- `single_row` (1 row) → `pathological` → `[load, scan, flow]` (drops dedupe). **Golden changes.**
+- `people_dupes` / `all_unique` (person columns → domain None, low null) → `default` → `[load, scan, flow, dedupe]`. **Unchanged.**
+
+All three are **box-emittable** (person columns → no infer_schema, no domain, and they dedupe cleanly). Regenerate `pipe_parity.json` on the box via the emitter and eyeball the single_row change. The TS `pipe-parity.test.ts` mechanism is unchanged (`runDf(parseCsv(input_csv))` now goes through the brain); its goldens update from the regenerated fixture.
+
+The CI `ts_parity_freshness` gate re-runs the emitter and compares — so the committed fixture must match what a fresh-install emitter produces. Person fixtures have no infer_schema/entry-point dependency, so box-regeneration == CI-regeneration here.
+
+## 5. TS unit tests (`tests/unit/autoconfig-glue.test.ts`, new)
+
+The brain paths pipe_parity can't observe:
+- **`profileContext`** — person-column rows → `inferredDomain: null`; finance-column rows (`account_number`, `currency`) → `inferredDomain: "finance"`, `domainConfidence > 0`. (Proves the columns-only detect wiring + `.score`.)
+- **`profileComplexity`** — a `Row[]` with explicit `null`/`undefined` values → hand-computed `maxNullDensity` / `meanNullDensity`. (Covers the null-density definition directly, since pipe_parity can't.)
+- **`enforceConfidence`** — a RED plan (`confidence: 0.3`) at `nRows >= 100_000` throws `PipeNotConfidentError`; below the threshold returns; green/amber returns.
+- **`planConfig` confident_schema** — finance-column rows through `planConfig(rows, buildDefaultRegistry(), {})` → stages `[infer_schema, goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` (`buildDefaultRegistry` registers `InferSchemaStage`, so it survives `planToConfig`'s availability filter).
+- **`planConfig` pathological** — a single-row `Row[]` → stages `[goldencheck.scan, goldenflow.transform]` (dedupe dropped).
+
+## 6. Testing summary
+
+- **Box-runnable:** the Python emitter rework + `pipe_parity.json` regeneration + eyeballing (person fixtures, no infer_schema/dedupe wrinkle). Verify `goldenpipe.run(path)` on each fixture CSV produces the expected brain stages on the box.
+- **CI-only:** all TS (vitest OOMs the box) — the unit tests + the reworked pipe-parity test. The `ts_parity_freshness` gate re-verifies the fixture.
+
+## 7. Parity story (complete picture after C2)
+
+| Layer | Gate |
+|-------|------|
+| Decision core (planPipeline/applyScaleHints/bandOf) | C1 vectors (Rust `golden_vectors.rs` + TS Leg A/B + Python Leg A) |
+| Domain detection | InferMap cross-surface detect parity (byte-identical) |
+| Null density | TS `profileComplexity` unit test (controlled inputs) |
+| Run-level (brain-decided stages) | pipe_parity: Python `run()` == TS `run()` |
+
+## 8. Non-goals / deferred
+
+- **Null-heavy pipe_parity fixture** — needs reconciling `parseCsv` `""` vs Polars null (§2). Deferred; `profileComplexity` unit test covers the logic meanwhile.
+- **WASM-routed runtime brain** — `planConfig` is pure-TS; routing `planPipeline`/detect through the WASM backend when enabled is deferred (zero behavioral difference; adds async plumbing).
+- **`_last_plan` introspection surface** on the TS `Pipeline` — optional; not required for parity. (Add only if a consumer needs it.)
+- Making TS the runtime source of truth — Rust stays canonical.
+
+## 9. File touch list
+
+- `packages/typescript/goldenpipe/src/core/errors.ts` — **new** (`PipeNotConfidentError`).
+- `packages/typescript/goldenpipe/src/core/autoconfigGlue.ts` — **new** (profiling + enforce + planToConfig).
+- `packages/typescript/goldenpipe/src/core/pipeline.ts` — add `planConfig`; `run()` calls it (before the resolve try); `computeAutoConfig` untouched.
+- `packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py` — re-aim from static config to `goldenpipe.run()`.
+- `packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json` — regenerated (single_row golden changes).
+- `packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts` — **new** (unit coverage).
+- (Verify) `packages/typescript/goldenpipe/tests/parity/pipe-parity.test.ts` — mechanism unchanged; goldens update from the fixture.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md
@@ -76,8 +76,14 @@ export function profileComplexity(rows: readonly Row[]): ComplexityProfile {
     }
     return nulls / nRows;
   });
+  // Loop-max (NOT Math.max(...spread)) — the repo's `ts-no-spread-math-min-max`
+  // ast-grep rule is error-severity and runs on every PR (see infer.ts for the
+  // same pattern). fractions is column-count-sized so the spread would be
+  // runtime-safe, but the lint fires regardless.
+  let maxNullDensity = 0;
+  for (const f of fractions) if (f > maxNullDensity) maxNullDensity = f;
   return {
-    maxNullDensity: Math.max(...fractions),
+    maxNullDensity,
     meanNullDensity: fractions.reduce((a, b) => a + b, 0) / fractions.length,
   };
 }
@@ -91,7 +97,8 @@ export function enforceConfidence(plan: PipePlan, runtime: PipeProfile): void {
   if (runtime.nRows >= REFUSE_ROW_THRESHOLD) {
     throw new PipeNotConfidentError(
       `auto-config not confident (rule=${plan.ruleName}, confidence=${plan.confidence}) ` +
-      `on ${runtime.nRows} rows; supply an explicit pipeline config or reduce the input size.`,
+      `on ${runtime.nRows} rows; supply an explicit pipeline config or reduce the input size. ` +
+      `evidence=${JSON.stringify(plan.evidence)}`,
     );
   }
   // Low confidence below the threshold: proceed on the safe default plan.
@@ -114,7 +121,7 @@ export function planToConfig(
 }
 ```
 Notes:
-- `Math.max(...fractions)` is safe here (column counts are tiny — never the 65K-element spread the ast-grep rule guards). If the repo's `ts-no-spread-math-min-max` rule flags it, use a loop-max instead.
+- Null density uses a **loop-max**, not `Math.max(...fractions)` — the `ts-no-spread-math-min-max` ast-grep rule is error-severity and runs on every PR (see `infer.ts` for the same loop pattern).
 - `dtypes: []` — no rule reads dtypes and they never appear in any emitted output (plan/evidence/pipe_parity), so an empty array is faithful. (Python fills real Polars dtypes but they are equally unused downstream.)
 
 ### 3.3 `pipeline.ts` — `planConfig` + `run()` switch
@@ -136,7 +143,8 @@ In `run()`, change the config line from `computeAutoConfig(...)` to `planConfig(
 ```ts
 const config = this.config ?? planConfig([...rows], this.registry, this.identityOpts);
 ```
-- **`computeAutoConfig` / `computeAutoConfigPure` stay untouched** — they remain the static engine config used by the `auto_config` Leg A/B parity (`autoConfigJsonPure` / `autoConfigViaWasm`). This mirrors Python keeping `_auto_config` alongside the new `_plan_config`. `DEFAULT_STAGE_ORDER` (the static scan/flow/dedupe list) is unchanged.
+- **`computeAutoConfigPure` stays live** — the `auto_config` Leg A/B parity calls it **directly** via `autoConfigJsonPure` (`plannerJsonPure.ts`), independent of `run()`. `DEFAULT_STAGE_ORDER` (the static scan/flow/dedupe list) is unchanged. This mirrors Python keeping `_auto_config` alongside the new `_plan_config`.
+- **`computeAutoConfig` (the WASM-guarded wrapper) + `autoConfigViaWasm`**: after `run()` switches to `planConfig`, `computeAutoConfig`'s only caller is gone, so it (and transitively `autoConfigViaWasm`) become orphaned exported functions. **Leave them exported** (public API surface; unused exports are not a lint failure) — do NOT delete them in this slice. Just don't claim they back the parity.
 - **Pure-TS runtime** — `planConfig` calls `planPipeline` + `detectDomainDetailed` directly (both byte-identical to core), NOT the WASM backend. WASM-routed runtime is deferred (§8); it would add async + backend plumbing for zero behavioral difference.
 
 ### 3.4 `runDf` parity
@@ -155,10 +163,10 @@ The CI `ts_parity_freshness` gate re-runs the emitter and compares — so the co
 ## 5. TS unit tests (`tests/unit/autoconfig-glue.test.ts`, new)
 
 The brain paths pipe_parity can't observe:
-- **`profileContext`** — person-column rows → `inferredDomain: null`; finance-column rows (`account_number`, `currency`) → `inferredDomain: "finance"`, `domainConfidence > 0`. (Proves the columns-only detect wiring + `.score`.)
+- **`profileContext`** — person-column rows → `inferredDomain: null`; finance-column rows with **exactly `["account_number", "currency"]`** (verified on the box: `detectDomainDetailed({columns}).score === 1.0`, well above the 0.5 confident threshold) → `inferredDomain: "finance"`, `domainConfidence === 1.0`. Use these exact columns so this test and the `planConfig` confident_schema test below cannot disagree (a weaker finance column set could score between 0 and 0.5 and land on `default`).
 - **`profileComplexity`** — a `Row[]` with explicit `null`/`undefined` values → hand-computed `maxNullDensity` / `meanNullDensity`. (Covers the null-density definition directly, since pipe_parity can't.)
 - **`enforceConfidence`** — a RED plan (`confidence: 0.3`) at `nRows >= 100_000` throws `PipeNotConfidentError`; below the threshold returns; green/amber returns.
-- **`planConfig` confident_schema** — finance-column rows through `planConfig(rows, buildDefaultRegistry(), {})` → stages `[infer_schema, goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` (`buildDefaultRegistry` registers `InferSchemaStage`, so it survives `planToConfig`'s availability filter).
+- **`planConfig` confident_schema** — rows with columns `["account_number", "currency"]` (score 1.0) through `planConfig(rows, buildDefaultRegistry(), {})` → stages `[infer_schema, goldencheck.scan, goldenflow.transform, goldenmatch.dedupe]` (`buildDefaultRegistry` registers `InferSchemaStage`, so it survives `planToConfig`'s availability filter). Use ≥2 rows so `pathological` doesn't fire first.
 - **`planConfig` pathological** — a single-row `Row[]` → stages `[goldencheck.scan, goldenflow.transform]` (dedupe dropped).
 
 ## 6. Testing summary

--- a/packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
+++ b/packages/python/goldenpipe/scripts/emit_ts_parity_fixtures.py
@@ -4,19 +4,14 @@ Runs the Python goldenpipe on small CSV fixtures and dumps the stable,
 cross-language-robust invariants of the resulting ``PipeResult`` to JSON under
 the TS package's fixtures dir.
 
-This fixture pins the **shared execution engine** -- the fixed
-check→flow→dedupe stage chain that BOTH the Python and TS surfaces implement
-identically. It deliberately does NOT go through ``goldenpipe.run`` (the public
-default), because ``run`` now flows through the Python-only auto-config *brain*
-(``Pipeline._plan_config``), which DECIDES the stage set from the data (e.g.
-drops dedupe for a single-row input). That decision layer is Python-only until
-it is ported to TS, so exercising it here would diverge the two surfaces by
-design and is not what this cross-surface fixture is for. The brain's decisions
-are covered directly by ``tests/test_autoconfig_glue.py``. When TS gains the
-brain, extend this fixture to cover the decision layer too.
-
-Concretely: we run the STATIC config from ``Pipeline._auto_config`` (the
-untouched pre-brain default chain), which is what the TS parity test also runs.
+This fixture pins the **brain path** -- ``goldenpipe.run()``, which flows
+through the auto-config brain (``Pipeline._plan_config``) that DECIDES the
+stage set from the data (e.g. drops dedupe for a single-row input). Both the
+Python and TS surfaces now implement the same rule table + scale hints
+(TS: ``planConfig`` in ``pipeline.ts``), so running the real public entry
+point on both sides is exactly what this cross-surface fixture is for: the
+fixture pins Python ``run()`` output; the TS parity test asserts TS
+``run()`` reaches the same stage set on the same inputs.
 
 The TS siblings are version-skewed from the Python ones, so we deliberately
 emit only the invariants that survive the skew:
@@ -36,7 +31,6 @@ import json
 from pathlib import Path
 
 import goldenpipe
-from goldenpipe.pipeline import Pipeline
 
 # Output dir: packages/typescript/goldenpipe/tests/fixtures/
 _HERE = Path(__file__).resolve()
@@ -93,14 +87,12 @@ def emit_case(
     case_id: str,
     csv_text: str,
     tmp_dir: Path,
-    static_config: goldenpipe.PipelineConfig,
 ) -> dict:
     csv_path = tmp_dir / f"{case_id}.csv"
     csv_path.write_text(csv_text)
 
-    # Run the SHARED static chain (not goldenpipe.run, which uses the
-    # Python-only auto-config brain) -- see the module docstring.
-    result = Pipeline(config=static_config).run(source=str(csv_path))
+    # Run the BRAIN path (the public default) -- see the module docstring.
+    result = goldenpipe.run(str(csv_path))
 
     golden = result.artifacts.get("golden")
     unique = result.artifacts.get("unique")
@@ -125,16 +117,11 @@ def main() -> None:
 
     OUT_DIR.mkdir(parents=True, exist_ok=True)
 
-    # The shared, cross-surface static chain: Pipeline._auto_config is the
-    # untouched pre-brain default (check→flow→dedupe [+identity]) that the TS
-    # parity test also runs. Build it once from a discovered registry.
-    static_config = Pipeline()._auto_config()
-
     cases: list[dict] = []
     with tempfile.TemporaryDirectory() as td:
         tmp_dir = Path(td)
         for case_id, csv_text in CASES:
-            cases.append(emit_case(case_id, csv_text, tmp_dir, static_config))
+            cases.append(emit_case(case_id, csv_text, tmp_dir))
 
     out_path = OUT_DIR / "pipe_parity.json"
     payload = {

--- a/packages/typescript/goldencheck-types/src/loader.ts
+++ b/packages/typescript/goldencheck-types/src/loader.ts
@@ -25,7 +25,16 @@ function domainsDir(): string {
   }
   // Resolve relative to this file. In dev (src/) we go up one to find domains/;
   // in dist/ we also go up one (dist/loader.js -> ../domains).
-  const here = path.dirname(url.fileURLToPath(import.meta.url));
+  //
+  // Bundle-safe across ESM and CJS: the CJS build (dist/index.cjs, which the
+  // goldenpipe CLI bundle `require`s) has NO valid `import.meta.url` — it
+  // resolves to undefined and `fileURLToPath(undefined)` throws. `__dirname` is
+  // defined in CJS; in ESM it is undeclared so `typeof __dirname` is "undefined"
+  // (no throw) and we fall back to `import.meta.url`, which is valid there.
+  const here =
+    typeof __dirname !== "undefined"
+      ? __dirname
+      : path.dirname(url.fileURLToPath(import.meta.url));
   return path.resolve(here, "..", "domains");
 }
 

--- a/packages/typescript/goldenpipe/src/core/autoconfigGlue.ts
+++ b/packages/typescript/goldenpipe/src/core/autoconfigGlue.ts
@@ -1,0 +1,93 @@
+/**
+ * autoconfigGlue.ts — impure host bracket for the auto-config brain
+ * (InferMap detect + Row[] profiling in; PipelineConfig out; refuse-on-RED).
+ * TS analogue of goldenpipe/autoconfig_glue.py. The pure decision core is
+ * autoconfigPlanner.ts.
+ */
+import type { Row } from "./index.js";
+import {
+  planPipeline,
+  applyScaleHints,
+  bandOf,
+  type PipeProfile,
+  type ComplexityProfile,
+  type PlannerInput,
+  type PipePlan,
+} from "./autoconfigPlanner.js";
+import { detectDomainDetailed } from "infermap";
+import { PipeNotConfidentError } from "./errors.js";
+import { makePipelineConfig, makeStageSpec, type PipelineConfig } from "./models.js";
+import type { StageRegistry } from "./engine/registry.js";
+
+export const REFUSE_ROW_THRESHOLD = 100_000;
+
+export function profileContext(rows: readonly Row[]): PipeProfile {
+  if (rows.length === 0) {
+    return {
+      nRows: 0, nCols: 0, columnNames: [], dtypes: [],
+      inferredDomain: null, domainConfidence: 0,
+    };
+  }
+  const columnNames = Object.keys(rows[0]!);
+  const det = detectDomainDetailed({ columns: columnNames });
+  return {
+    nRows: rows.length,
+    nCols: columnNames.length,
+    columnNames,
+    dtypes: [],
+    inferredDomain: det.domain,
+    domainConfidence: det.domain !== null ? det.score : 0,
+  };
+}
+
+export function profileComplexity(rows: readonly Row[]): ComplexityProfile {
+  const nRows = rows.length;
+  if (nRows === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const columnNames = Object.keys(rows[0]!);
+  if (columnNames.length === 0) return { maxNullDensity: 0, meanNullDensity: 0 };
+  const fractions = columnNames.map((c) => {
+    let nulls = 0;
+    for (const r of rows) {
+      const v = r[c];
+      if (v === null || v === undefined) nulls++;
+    }
+    return nulls / nRows;
+  });
+  // Loop-max, NOT Math.max(...spread) (ts-no-spread-math-min-max is error-severity).
+  let maxNullDensity = 0;
+  for (const f of fractions) if (f > maxNullDensity) maxNullDensity = f;
+  return {
+    maxNullDensity,
+    meanNullDensity: fractions.reduce((a, b) => a + b, 0) / fractions.length,
+  };
+}
+
+export function buildPlannerInput(rows: readonly Row[]): PlannerInput {
+  return { runtime: profileContext(rows), complexity: profileComplexity(rows) };
+}
+
+export function enforceConfidence(plan: PipePlan, runtime: PipeProfile): void {
+  if (bandOf(plan.confidence) !== "red") return;
+  if (runtime.nRows >= REFUSE_ROW_THRESHOLD) {
+    throw new PipeNotConfidentError(
+      `auto-config not confident (rule=${plan.ruleName}, confidence=${plan.confidence}) ` +
+        `on ${runtime.nRows} rows; supply an explicit pipeline config or reduce the input size. ` +
+        `evidence=${JSON.stringify(plan.evidence)}`,
+    );
+  }
+}
+
+export function planToConfig(
+  plan: PipePlan,
+  available: Record<string, unknown>,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const stages = plan.stages
+    .filter((s) => s.name in available)
+    .map((s) => makeStageSpec({ use: s.name, config: s.config }));
+  const IDENTITY = "goldenmatch.identity_resolve";
+  if (Object.keys(identityOpts).length > 0 && IDENTITY in available) {
+    stages.push(makeStageSpec({ use: IDENTITY, config: identityOpts }));
+  }
+  return makePipelineConfig({ pipeline: "auto", stages });
+}

--- a/packages/typescript/goldenpipe/src/core/autoconfigGlue.ts
+++ b/packages/typescript/goldenpipe/src/core/autoconfigGlue.ts
@@ -6,8 +6,6 @@
  */
 import type { Row } from "./index.js";
 import {
-  planPipeline,
-  applyScaleHints,
   bandOf,
   type PipeProfile,
   type ComplexityProfile,
@@ -17,7 +15,6 @@ import {
 import { detectDomainDetailed } from "infermap";
 import { PipeNotConfidentError } from "./errors.js";
 import { makePipelineConfig, makeStageSpec, type PipelineConfig } from "./models.js";
-import type { StageRegistry } from "./engine/registry.js";
 
 export const REFUSE_ROW_THRESHOLD = 100_000;
 

--- a/packages/typescript/goldenpipe/src/core/errors.ts
+++ b/packages/typescript/goldenpipe/src/core/errors.ts
@@ -1,0 +1,7 @@
+/** goldenpipe-local exceptions. */
+export class PipeNotConfidentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PipeNotConfidentError";
+  }
+}

--- a/packages/typescript/goldenpipe/src/core/pipeline.ts
+++ b/packages/typescript/goldenpipe/src/core/pipeline.ts
@@ -18,6 +18,8 @@ import { Reporter } from "./engine/reporter.js";
 import { buildDefaultRegistry } from "./adapters/index.js";
 import { getPipeWasmBackend } from "./wasm/backend.js";
 import { autoConfigViaWasm } from "./wasm/plannerJson.js";
+import { buildPlannerInput, enforceConfidence, planToConfig } from "./autoconfigGlue.js";
+import { planPipeline, applyScaleHints } from "./autoconfigPlanner.js";
 
 const DEFAULT_STAGE_ORDER = [
   "goldencheck.scan",
@@ -51,7 +53,7 @@ export class Pipeline {
       metadata: { source, input_rows: rows.length },
     });
 
-    const config = this.config ?? computeAutoConfig(this.registry, this.identityOpts);
+    const config = this.config ?? planConfig([...rows], this.registry, this.identityOpts);
 
     let plan;
     try {
@@ -99,6 +101,23 @@ export function computeAutoConfigPure(
     stages.push(makeStageSpec({ use: IDENTITY_STAGE, config: identityOpts }));
   }
   return makePipelineConfig({ pipeline: "auto", stages });
+}
+
+/**
+ * planConfig — the brain path (pure-TS; mirrors Python _plan_config). Profiles
+ * the rows, runs the rule table + scale hints, refuses if not confident at
+ * scale, and materializes the chosen plan into a PipelineConfig.
+ */
+export function planConfig(
+  rows: readonly Row[],
+  registry: StageRegistry,
+  identityOpts: Record<string, unknown>,
+): PipelineConfig {
+  const inp = buildPlannerInput(rows);
+  let plan = planPipeline(inp);
+  plan = applyScaleHints(plan, inp.runtime);
+  enforceConfidence(plan, inp.runtime); // may throw PipeNotConfidentError
+  return planToConfig(plan, registry.listAll(), identityOpts);
 }
 
 /**

--- a/packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json
+++ b/packages/typescript/goldenpipe/tests/fixtures/pipe_parity.json
@@ -1,6 +1,6 @@
 {
   "_comment": "Cross-language parity goldens emitted by scripts/emit_ts_parity_fixtures.py. Only skew-robust invariants are asserted by the TS parity test.",
-  "python_version": "1.2.0",
+  "python_version": "1.3.0",
   "cases": [
     {
       "id": "people_dupes",
@@ -46,15 +46,11 @@
         {
           "name": "goldenflow.transform",
           "status": "success"
-        },
-        {
-          "name": "goldenmatch.dedupe",
-          "status": "success"
         }
       ],
       "skipped": [],
       "golden_count": null,
-      "unique_count": 1
+      "unique_count": null
     },
     {
       "id": "all_unique",

--- a/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  profileContext,
+  profileComplexity,
+  enforceConfidence,
+} from "../../src/core/autoconfigGlue.js";
+import { PipeNotConfidentError } from "../../src/core/errors.js";
+import type { PipePlan, PipeProfile } from "../../src/core/autoconfigPlanner.js";
+
+const financeRows = [
+  { account_number: "A1", currency: "USD" },
+  { account_number: "A2", currency: "EUR" },
+];
+const personRows = [
+  { first_name: "John", last_name: "Smith", email: "j@x.co" },
+  { first_name: "Jane", last_name: "Doe", email: "d@x.co" },
+];
+
+describe("profileContext", () => {
+  it("detects finance domain from columns", () => {
+    const p = profileContext(financeRows);
+    expect(p.nRows).toBe(2);
+    expect(p.columnNames).toEqual(["account_number", "currency"]);
+    expect(p.inferredDomain).toBe("finance");
+    expect(p.domainConfidence).toBe(1.0);
+  });
+  it("person columns detect no domain", () => {
+    const p = profileContext(personRows);
+    expect(p.inferredDomain).toBeNull();
+    expect(p.domainConfidence).toBe(0);
+  });
+  it("empty rows -> zeros", () => {
+    const p = profileContext([]);
+    expect(p.nRows).toBe(0);
+    expect(p.inferredDomain).toBeNull();
+  });
+});
+
+describe("profileComplexity", () => {
+  it("computes null density from explicit nulls", () => {
+    const rows = [
+      { a: 1, b: null },
+      { a: null, b: null },
+      { a: 3, b: 4 },
+      { a: 4, b: undefined },
+    ];
+    const c = profileComplexity(rows);
+    expect(c.maxNullDensity).toBe(0.75);
+    expect(c.meanNullDensity).toBeCloseTo(0.5, 10);
+  });
+  it("no nulls -> zeros", () => {
+    expect(profileComplexity(personRows)).toEqual({ maxNullDensity: 0, meanNullDensity: 0 });
+  });
+  it("empty -> zeros", () => {
+    expect(profileComplexity([])).toEqual({ maxNullDensity: 0, meanNullDensity: 0 });
+  });
+});
+
+function redPlan(): PipePlan {
+  return { stages: [], ruleName: "low_confidence", confidence: 0.3, evidence: {} };
+}
+function greenPlan(): PipePlan {
+  return { stages: [], ruleName: "default", confidence: 0.7, evidence: {} };
+}
+function profile(nRows: number): PipeProfile {
+  return { nRows, nCols: 0, columnNames: [], dtypes: [], inferredDomain: null, domainConfidence: 0 };
+}
+
+describe("enforceConfidence", () => {
+  it("RED at scale throws", () => {
+    expect(() => enforceConfidence(redPlan(), profile(100_000))).toThrow(PipeNotConfidentError);
+  });
+  it("RED below threshold proceeds", () => {
+    expect(() => enforceConfidence(redPlan(), profile(99_999))).not.toThrow();
+  });
+  it("green proceeds", () => {
+    expect(() => enforceConfidence(greenPlan(), profile(100_000))).not.toThrow();
+  });
+});

--- a/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
@@ -87,13 +87,15 @@ describe("planConfig (brain wiring)", () => {
       { account_number: "A2", currency: "EUR" },
     ];
     const cfg = planConfig(rows, buildDefaultRegistry(), {});
-    expect(cfg.stages.map((s) => s.use)).toEqual([
+    expect(cfg.stages.map((s) => (typeof s === "string" ? s : s.use))).toEqual([
       "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
     ]);
   });
   it("single row is pathological (drops dedupe)", () => {
     const rows = [{ first_name: "Solo", last_name: "Person", email: "s@x.co" }];
     const cfg = planConfig(rows, buildDefaultRegistry(), {});
-    expect(cfg.stages.map((s) => s.use)).toEqual(["goldencheck.scan", "goldenflow.transform"]);
+    expect(cfg.stages.map((s) => (typeof s === "string" ? s : s.use))).toEqual([
+      "goldencheck.scan", "goldenflow.transform",
+    ]);
   });
 });

--- a/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/autoconfig-glue.test.ts
@@ -6,6 +6,8 @@ import {
 } from "../../src/core/autoconfigGlue.js";
 import { PipeNotConfidentError } from "../../src/core/errors.js";
 import type { PipePlan, PipeProfile } from "../../src/core/autoconfigPlanner.js";
+import { planConfig } from "../../src/core/pipeline.js";
+import { buildDefaultRegistry } from "../../src/core/adapters/index.js";
 
 const financeRows = [
   { account_number: "A1", currency: "USD" },
@@ -75,5 +77,23 @@ describe("enforceConfidence", () => {
   });
   it("green proceeds", () => {
     expect(() => enforceConfidence(greenPlan(), profile(100_000))).not.toThrow();
+  });
+});
+
+describe("planConfig (brain wiring)", () => {
+  it("confident_schema prepends infer_schema", () => {
+    const rows = [
+      { account_number: "A1", currency: "USD" },
+      { account_number: "A2", currency: "EUR" },
+    ];
+    const cfg = planConfig(rows, buildDefaultRegistry(), {});
+    expect(cfg.stages.map((s) => s.use)).toEqual([
+      "infer_schema", "goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe",
+    ]);
+  });
+  it("single row is pathological (drops dedupe)", () => {
+    const rows = [{ first_name: "Solo", last_name: "Person", email: "s@x.co" }];
+    const cfg = planConfig(rows, buildDefaultRegistry(), {});
+    expect(cfg.stages.map((s) => s.use)).toEqual(["goldencheck.scan", "goldenflow.transform"]);
   });
 });


### PR DESCRIPTION
## What

Wires the ported TS brain (C1, #1548) into TS `goldenpipe.run()` so TS gets plan-first auto-config default-on, matching Python. Rust brain stays source of truth; TS conforms via the C1 vectors (decision core) + this run-level parity (profiling + wiring).

Final slice of the cross-surface auto-config arc.

## Shape

- **`autoconfigGlue.ts`** (new) — the impure host bracket mirroring Python `autoconfig_glue.py`:
  - `profileContext(rows)` — n_rows/columns + domain via `detectDomainDetailed({ columns })`. InferMap's `detect_domain` is **byte-identical cross-surface** (its own Rust cutover) and reads only column names — the exact columns-only input Python passes. So domain parity is already solved.
  - `profileComplexity(rows)` — per-column null density (loop-max, not `Math.max(...spread)` — the ast-grep rule is error-severity).
  - `buildPlannerInput`, `enforceConfidence` (throws `PipeNotConfidentError` on RED band ≥100k), `planToConfig`.
- **`errors.ts`** (new) — `PipeNotConfidentError`.
- **`pipeline.ts`** — `planConfig(rows, registry, identityOpts)` = profile → planPipeline → applyScaleHints → enforce → materialize. `run()` switches to it (before the resolve try, so refuse propagates). `computeAutoConfigPure` stays for the engine `auto_config` parity.
- **Emitter re-aim** — `emit_ts_parity_fixtures.py` now emits from `goldenpipe.run()` (the brain), so `pipe_parity` is the **Python-run() == TS-run()** brain contract. `single_row` → `pathological` (drops dedupe); `people_dupes`/`all_unique` → `default` (unchanged, person columns detect domain=None). Box-verified.

## Tests

- **Unit** (`autoconfig-glue.test.ts`): `profileContext` finance→domain / person→null; `profileComplexity` null-density hand-computed; `enforceConfidence` refuse ≥100k; `planConfig` confident_schema (finance → `[infer_schema, scan, flow, dedupe]`) + pathological (single row drops dedupe).
- **pipe_parity** (reworked): TS `runDf` now goes through the brain; goldens track the brain path.
- Box-verified: the Python emitter + fixture regen (person fixtures, no infer_schema/dedupe wrinkle); re-running the emitter produces no diff. TS is CI-gated (vitest OOMs the box).

## Parity story (complete)

| Layer | Gate |
|-------|------|
| Decision core | C1 vectors (Rust cargo test + TS Leg A/B + Python Leg A) |
| Domain detection | InferMap cross-surface detect parity |
| Null density | `profileComplexity` unit test |
| Run-level (brain-decided stages) | pipe_parity: Python `run()` == TS `run()` |

## Deferred

- **Null-heavy pipe_parity fixture** — `parseCsv` maps an empty cell to `""`, Polars maps it to null; reconciling that is deferred (person fixtures have zero empty cells → both see zero nulls → agree; the null-density unit test covers the logic).
- **WASM-routed runtime brain** — `planConfig` is pure-TS (byte-identical to core); routing through the WASM backend adds async plumbing for zero behavioral difference.

Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-brain-ts-runtime-design.md`
Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-brain-ts-runtime.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2g8Snk1Akef5z3yZdtt44