### PR TITLE
feat(goldenflow): Polars-free public entry point transform() (Phase 4c)

### DIFF
--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -166,10 +166,18 @@ recovered by `[native]`.
   transforms data (covered configs) with Polars uninstalled — the Layer-3 milestone.
   `transform_columns_native` is a standalone core (not yet wired into the default
   `transform_df`); **4c** wires it behind the public entry point.
-- **4c — Polars-free public entry point.** Add `transform(data)` (D1a) accepting
-  path / dict / Arrow, returning a backend-agnostic result. `transform_df` becomes a
-  thin Polars-backend adapter. Gate: `transform(dict)` == `transform_df(pl.DataFrame)`
-  for the covered configs.
+- **4c — Polars-free public entry point. SHIPPED.** Added `goldenflow.transform(data,
+  config=None)` accepting a `dict[str, list]`, returning a `ColumnarResult`
+  (`.columns` dict + `.manifest`, opt-in `.to_polars()`). A covered config runs on the
+  4b native core with **Polars never imported**; an uncovered config (or `config=None`
+  zero-config) declines to the Polars engine via the existing `transform_df` (so it's
+  byte-identical), raising a clear `install goldenflow[polars]` if Polars is absent.
+  `transform_df(pl.DataFrame)` is unchanged for existing callers (D1a chosen —
+  non-breaking). Gate: `tests/engine/test_public_transform_polars_free.py`
+  (`transform(dict)` == `transform_df(pl.DataFrame)` for covered configs incl. splits;
+  uncovered parity; pl.DataFrame-input TypeError; `to_polars()` bridge; subprocess
+  polars-free check). `import goldenflow` stays Polars-free (columnar now loads at
+  import for `ColumnarResult`, verified clean).
 - **4d — Transform signature port.** Rewrite the owned-family wrappers (one family at
   a time) + the non-owned residual to dispatch on a `Column` instead of `pl.Series`/
   `pl.Expr`. Gate: the existing per-family parity corpus, unchanged.

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -38,6 +38,7 @@ from goldenflow.domains import load_domain
 
 # Domains
 from goldenflow.domains.base import DomainPack
+from goldenflow.engine.columnar import ColumnarResult
 from goldenflow.engine.differ import DiffResult, diff_dataframes
 
 # Engine
@@ -72,10 +73,24 @@ def transform_df(df, config=None):
     return engine.transform_df(df)
 
 
+def transform(data, config=None):
+    """Polars-free public entry point (Phase 4c): transform a ``dict[str, list]`` of
+    columns, returning a :class:`ColumnarResult` (``.columns`` dict + ``.manifest``,
+    with an opt-in ``.to_polars()``). A config the native columnar engine covers runs
+    with **Polars never imported**; an uncovered config (or ``config=None``
+    zero-config auto-detect) declines to the Polars engine, which needs
+    ``goldenflow[polars]`` (a clear ImportError if it's absent). The Polars-typed
+    ``transform_df`` remains for existing ``pl.DataFrame`` callers."""
+    from goldenflow.engine.columnar import transform_columns_public
+
+    return transform_columns_public(data, config)
+
+
 __all__ = [
     # Core engine
     "TransformEngine",
     "TransformResult",
+    "ColumnarResult",
     # Config schema
     "GoldenFlowConfig",
     "TransformSpec",
@@ -86,6 +101,7 @@ __all__ = [
     # Convenience functions
     "transform_file",
     "transform_df",
+    "transform",
     # Pure scalar canonicalizers
     "canonicalize",
     # Engine — manifest

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -28,6 +28,7 @@ the configs it accepts (gated by ``tests/engine/test_columnar_engine.py``).
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 
 from goldenflow.core._native_loader import native_module
 from goldenflow.engine.manifest import Manifest, TransformRecord
@@ -39,6 +40,24 @@ from goldenflow.transforms._chain import (
 )
 
 Column = list  # a column is a plain Python list (str | None)
+
+
+@dataclass
+class ColumnarResult:
+    """A **Polars-free** transform result (Phase 4c): the transformed data as a
+    ``dict[str, list]`` plus the audit :class:`Manifest`. The public
+    :func:`goldenflow.transform` returns this so a caller can run a covered config
+    with Polars uninstalled. ``to_polars()`` is an opt-in bridge for callers that
+    still want a ``pl.DataFrame`` (imports Polars on use)."""
+
+    columns: dict[str, list]
+    manifest: Manifest
+
+    def to_polars(self):
+        """Bridge to a ``pl.DataFrame`` (imports Polars — opt-in)."""
+        from goldenflow._polars_lazy import pl
+
+        return pl.DataFrame(self.columns)
 
 
 def columnar_engine_selected() -> bool:
@@ -285,6 +304,49 @@ def _transform_via_columns(df, config, source, nm, pl):
         out_series.append(series.alias(spec.column))
     out = df.with_columns(out_series) if out_series else df
     return out, manifest
+
+
+def transform_columns_public(data, config):
+    """Phase 4c public core: transform a ``dict[str, list]`` frame, returning a
+    :class:`ColumnarResult` (Polars-free). A covered config runs on the native
+    in-memory core with **Polars never imported**; anything else declines to the
+    Polars engine (which needs ``goldenflow[polars]`` — a clear ImportError if it's
+    absent). ``config=None`` (zero-config auto-detect) uses the Polars profiler, so it
+    also needs the extra.
+
+    This is the Polars-free public entry point the Rust-is-the-reference thesis wants:
+    a covered config is a first-class no-Polars API; the uncovered tail is where
+    Polars remains, loudly and optionally."""
+    if not isinstance(data, dict):
+        raise TypeError(
+            "transform() takes a dict[str, list] of columns; pass a pl.DataFrame to "
+            "transform_df() instead."
+        )
+
+    nm = native_module()
+    native_ok = nm is not None and native_columns_ready(nm)
+    if config is not None and native_ok and config_is_columnar_ready(config):
+        cols, manifest = transform_columns_native(data, config)
+        return ColumnarResult(columns=cols, manifest=manifest)
+
+    # Uncovered config (or zero-config auto-detect) -> the Polars engine, via the
+    # existing public transform_df so behavior is byte-identical (no reimplementation).
+    # Needs the optional [polars] backend; surface a clear, actionable error if absent.
+    try:
+        import goldenflow
+        from goldenflow._polars_lazy import pl
+
+        df = pl.DataFrame(data)
+        result = goldenflow.transform_df(df, config=config)
+    except ImportError as e:  # pragma: no cover - exercised only without polars
+        raise ImportError(
+            "This transform needs the Polars backend for the config given "
+            "(uncovered by the native columnar engine, or zero-config auto-detect). "
+            "Install it with: pip install goldenflow[polars]"
+        ) from e
+    return ColumnarResult(
+        columns=result.df.to_dict(as_series=False), manifest=result.manifest
+    )
 
 
 def native_columns_ready(nm) -> bool:

--- a/packages/python/goldenflow/tests/engine/test_public_transform_polars_free.py
+++ b/packages/python/goldenflow/tests/engine/test_public_transform_polars_free.py
@@ -1,0 +1,102 @@
+"""Phase 4c: the Polars-free public entry point ``goldenflow.transform``.
+
+``transform(dict[str, list], config)`` returns a ``ColumnarResult`` (``.columns`` +
+``.manifest``). A config the native columnar engine covers runs with Polars NEVER
+imported; an uncovered config declines to the Polars engine (byte-identical). The
+Polars-typed ``transform_df`` is unchanged for existing ``pl.DataFrame`` callers.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+@pytest.mark.parametrize(
+    "specs,data",
+    [
+        ([("name", ["strip", "lowercase"])], {"name": ["  Hi ", "BYE", None], "k": [1, 2, 3]}),
+        (
+            [("price", ["currency_strip", "round:1"])],
+            {"price": ["$1,234.56", "$0.5", None], "k": [1, 2, 3]},
+        ),
+        ([("name", ["split_name"])], {"name": ["John Smith", "Cher", None], "k": [1, 2, 3]}),
+    ],
+)
+def test_transform_dict_equals_transform_df(specs, data) -> None:
+    """transform(dict) == transform_df(pl.DataFrame) for covered configs."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    cfg = _cfg(specs)
+    res = goldenflow.transform(data, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(data), config=cfg)
+    assert list(res.columns.keys()) == ref.df.columns
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list()
+
+    def rows(m):
+        return [
+            (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+             tuple(r.sample_after or [])) for r in m.records
+        ]
+
+    assert rows(res.manifest) == rows(ref.manifest)
+
+
+def test_transform_uncovered_config_matches_polars() -> None:
+    """An uncovered config (phone_e164) declines to the Polars engine, byte-identical."""
+    cfg = _cfg([("p", ["strip", "phone_e164"])])
+    data = {"p": ["  212-555-0100 ", "bad"], "k": [1, 2]}
+    res = goldenflow.transform(data, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(data), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list()
+
+
+def test_transform_rejects_dataframe_input() -> None:
+    """A pl.DataFrame belongs to transform_df, not transform(dict)."""
+    with pytest.raises(TypeError, match="transform_df"):
+        goldenflow.transform(pl.DataFrame({"x": [1]}), config=_cfg([("x", ["strip"])]))
+
+
+def test_to_polars_bridge() -> None:
+    res = goldenflow.transform({"x": ["  a "], "k": [1]}, config=_cfg([("x", ["strip"])]))
+    df = res.to_polars()
+    assert df.shape == (1, 2)
+    assert df["x"].to_list() == ["a"]
+
+
+def test_transform_covered_is_polars_free() -> None:
+    """Subprocess: a covered transform() call imports no Polars."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[TransformSpec(column="x", ops=["strip", "lowercase"])])
+            res = goldenflow.transform({"x": ["  Hi ", "BYE"], "k": [1, 2]}, config=cfg)
+            assert res.columns["x"] == ["hi", "bye"], res.columns
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout


### PR DESCRIPTION
## Phase 4c — Polars-free public entry point

Adds **`goldenflow.transform(data, config=None)`** — the Polars-free public API on top
of the 4b execution core. Takes a `dict[str, list]` of columns, returns a
`ColumnarResult` (`.columns` dict + `.manifest`, with an opt-in `.to_polars()` bridge).

- A config the native columnar engine covers runs with **Polars never imported**
  (string / numeric / split), byte-identical to the Polars engine.
- An uncovered config (or `config=None` zero-config auto-detect) declines to the Polars
  engine **via the existing `transform_df`** — so it's byte-identical, no
  reimplementation — and raises a clear `pip install goldenflow[polars]` if Polars is
  absent (the graceful-degradation contract, D5).
- `transform_df(pl.DataFrame)` is **unchanged** for existing callers (D1a: the new entry
  point is additive, **non-breaking**). Passing a `pl.DataFrame` to `transform()` raises
  a `TypeError` pointing to `transform_df`.

`import goldenflow` stays Polars-free (it now loads `engine.columnar` for the
`ColumnarResult` export — verified clean via the 4a/4b subprocess guards).

### Gate
`tests/engine/test_public_transform_polars_free.py`: `transform(dict)` ==
`transform_df(pl.DataFrame)` for covered configs incl. splits, uncovered-config parity,
`pl.DataFrame`-input TypeError, the `to_polars()` bridge, and a subprocess polars-free
assertion. Full engine+transforms+public suite green (1760).

Non-breaking; lands under the current hard `polars` dep. Phase 4d ports the transform
signatures; 4e the I/O extras; 4f flips the default (2.0).

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg