### PR TITLE
feat(goldenflow): scalar-chain columnar coverage, address family (Phase 4d wave 1)

### DIFF
--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -178,9 +178,23 @@ recovered by `[native]`.
   uncovered parity; pl.DataFrame-input TypeError; `to_polars()` bridge; subprocess
   polars-free check). `import goldenflow` stays Polars-free (columnar now loads at
   import for `ColumnarResult`, verified clean).
-- **4d — Transform signature port.** Rewrite the owned-family wrappers (one family at
-  a time) + the non-owned residual to dispatch on a `Column` instead of `pl.Series`/
-  `pl.Expr`. Gate: the existing per-family parity corpus, unchanged.
+- **4d — Transform signature port. IN PROGRESS (family by family).** Mechanism: a
+  transform registers an optional pure-Python `scalar` (`str|None -> value`, the SAME
+  per-element fn the Polars `series` path calls via `map_elements`), and the in-memory
+  columnar engine applies it op-by-op over a list — composing with owned Rust-kernel
+  ops in one chain — **Polars-free**. Byte-identical because, for owned families, the
+  native kernel (Polars engine) and the pure-Python scalar (columnar) are parity-gated
+  equal. The CSV path stays Rust-only (can't call a Python scalar): a scalar spec is
+  in-memory-ready but not file-ready. **Wave 1 (address):** `register_transform(scalar=)`
+  + `TransformInfo.scalar` + a scalar-chain tier in both in-memory paths
+  (`transform_columns_native` dict + `_transform_via_columns` frame); wired the 7
+  address transforms (`address_standardize`/`address_expand`/`state_abbreviate`/
+  `state_expand`/`zip_normalize`/`country_standardize`/`unit_normalize`). Gated by
+  `tests/engine/test_columnar_scalar_chain.py` (transform(dict) == transform_df ==
+  columnar-engine transform_df, data + manifest; in-memory-ready-not-file-ready;
+  subprocess Polars-free). Follow-on families (dates — the big non-owned one — needs
+  its closures un-nested to module-level scalars + int/str return handling;
+  identifiers/categorical/names remainder) are thin PRs on this mechanism.
 - **4e — I/O extras.** Native CSV is default; parquet/excel/scan/database move behind
   `[polars]`/`[parquet]` with graceful `ImportError`. Gate: fallback-path tests
   (mirror the existing cloud-connector pattern).

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -119,11 +119,37 @@ def _split_inmem_ok(nm) -> bool:
     )
 
 
-def _spec_ready(nm, spec, accepted: frozenset[str], numeric_ok: bool, split_ok: bool) -> bool:
+def _spec_scalar_ready(spec, accepted: frozenset[str]) -> bool:
+    """Phase 4d: a spec is *scalar-chain* runnable (in-memory only) iff every op is an
+    owned string kernel OR a transform with a registered pure-Python ``scalar``, AND at
+    least one op is scalar-only (else it's a pure owned-string run, handled by the
+    faster fused path). Applied op-by-op over a list -> Polars-free."""
+    has_scalar_op = False
+    for op_raw in spec.ops:
+        name, _params = parse_transform_name(op_raw)
+        info = get_transform(name)
+        if info is None:
+            return False
+        if name in accepted:
+            continue
+        if info.scalar is not None:
+            has_scalar_op = True
+            continue
+        return False
+    return has_scalar_op
+
+
+def _spec_ready(
+    nm, spec, accepted: frozenset[str], numeric_ok: bool, split_ok: bool, scalar_ok: bool = False
+) -> bool:
     """A spec is columnar-ready if it's an owned-string run, or — with native support
     — a valid NUMERIC (``string* parser f64*``) or SPLIT (``string* splitter``) shape
-    (validated by the native probes, the single source of truth)."""
+    (validated by the native probes, the single source of truth). ``scalar_ok`` (the
+    in-memory path only — the Rust CSV path can't call a Python scalar) also accepts a
+    scalar-chain spec (Phase 4d)."""
     if _spec_string_ready(spec, accepted):
+        return True
+    if scalar_ok and _spec_scalar_ready(spec, accepted):
         return True
     ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
     if numeric_ok and nm.columnar_numeric_ready(ops_spec):
@@ -147,7 +173,11 @@ def config_is_columnar_ready(config) -> bool:
     accepted = _accepted_string(nm)
     numeric_ok = _numeric_inmem_ok(nm)
     split_ok = _split_inmem_ok(nm)
-    return all(_spec_ready(nm, spec, accepted, numeric_ok, split_ok) for spec in config.transforms)
+    scalar_ok = native_columns_ready(nm)  # scalar-chain needs from_pylist (4b)
+    return all(
+        _spec_ready(nm, spec, accepted, numeric_ok, split_ok, scalar_ok)
+        for spec in config.transforms
+    )
 
 
 def columnar_file_ready(config) -> bool:
@@ -280,6 +310,36 @@ def _transform_via_columns(df, config, source, nm, pl):
             series = imported.to_series(0) if isinstance(imported, pl.DataFrame) else imported
             out_series.append(series.alias(spec.column))
             continue
+        # Scalar chain (Phase 4d): a spec with a scalar-only op. Apply op-by-op over a
+        # Python list (owned string ops native, scalar ops via the pure reference) and
+        # egress a pl.Series -- consistent with transform_columns_native (the dict path).
+        accepted = _accepted_string(nm)
+        if _spec_scalar_ready(spec, accepted):
+            cur = df[spec.column].cast(pl.Utf8).to_list()
+            total_rows = len(cur)
+            for name, params in ops:
+                before = _sample3(cur[:3])
+                if name in accepted:
+                    new = list(nm.apply_chain_str_list(cur, [(name, list(params))])[0])
+                    n_changed = sum(
+                        1 for b, a in zip(cur, new)
+                        if b is not None and a is not None and b != a
+                    )
+                else:
+                    fn = get_transform(name).scalar
+                    new = [fn(v) for v in cur]
+                    n_changed = sum(
+                        1 for b, a in zip(cur, new)
+                        if b is not None and a is not None and b != a
+                    )
+                after = _sample3(new[:3])
+                manifest.add_record(TransformRecord(
+                    column=spec.column, transform=name, affected_rows=n_changed,
+                    total_rows=total_rows, sample_before=before, sample_after=after,
+                ))
+                cur = new
+            out_series.append(pl.Series(spec.column, cur, dtype=pl.Utf8))
+            continue
         # Zero-copy, pyarrow-free ingest (a 1-column DataFrame -> a struct stream).
         col = nm.Column.from_arrow(df.select([spec.column]))
         total_rows = len(col)
@@ -405,6 +465,35 @@ def transform_columns_native(columns, config, source: str = "<dataframe>"):
                     total_rows=int(total), sample_before=list(before), sample_after=list(after),
                 ))
             out[spec.column] = num_col.to_pylist()
+            continue
+
+        # Scalar chain (Phase 4d): a spec with a scalar-only op runs op-by-op over the
+        # plain list -- owned string ops via the native list chain, scalar ops via the
+        # registered pure-Python reference (byte-identical to the native kernel the
+        # Polars engine uses, by the owned-kernel parity guarantee). Polars-free.
+        accepted = _accepted_string(nm)
+        if _spec_scalar_ready(spec, accepted):
+            cur = col_list
+            for name, params in ops:
+                before = _sample3(cur[:3])
+                if name in accepted:
+                    new, changed = nm.apply_chain_str_list(cur, [(name, list(params))])
+                    new = list(new)
+                    n_changed = int(changed[0])
+                else:
+                    fn = get_transform(name).scalar
+                    new = [fn(v) for v in cur]
+                    n_changed = sum(
+                        1 for b, a in zip(cur, new)
+                        if b is not None and a is not None and b != a
+                    )
+                after = _sample3(new[:3])
+                manifest.add_record(TransformRecord(
+                    column=spec.column, transform=name, affected_rows=n_changed,
+                    total_rows=total_rows, sample_before=before, sample_after=after,
+                ))
+                cur = new
+            out[spec.column] = cur
             continue
 
         # Owned string chain (auto-routed total/nullable): counts + 3-row replay.

--- a/packages/python/goldenflow/goldenflow/transforms/__init__.py
+++ b/packages/python/goldenflow/goldenflow/transforms/__init__.py
@@ -18,6 +18,14 @@ class TransformInfo:
     auto_apply: bool
     priority: int
     mode: Literal["expr", "series", "dataframe"]
+    # Phase 4d: the pure per-element reference `str|None -> value`. When present, the
+    # columnar in-memory engine can apply this transform over a plain list WITHOUT
+    # Polars (a scalar op composes into a Polars-free chain), so a config that mixes
+    # owned Rust kernels with scalar-only transforms still runs Polars-free. It is the
+    # SAME function the Polars `series`-mode path calls via `map_elements`, so a
+    # scalar-applied column is byte-identical to the Polars engine. `None` = no
+    # Polars-free path yet (the transform stays on the Polars engine).
+    scalar: Callable[[str | None], object] | None = None
 
 
 def register_transform(
@@ -27,6 +35,7 @@ def register_transform(
     auto_apply: bool = False,
     priority: int = 50,
     mode: Literal["expr", "series", "dataframe"] = "series",
+    scalar: Callable[[str | None], object] | None = None,
 ) -> Callable:
     """Decorator to register a transform function."""
 
@@ -38,6 +47,7 @@ def register_transform(
             auto_apply=auto_apply,
             priority=priority,
             mode=mode,
+            scalar=scalar,
         )
         return func
 

--- a/packages/python/goldenflow/goldenflow/transforms/address.py
+++ b/packages/python/goldenflow/goldenflow/transforms/address.py
@@ -147,7 +147,7 @@ def _address_standardize_series(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="expr"
+    name="address_standardize", input_types=["address"], auto_apply=False, priority=50, mode="expr", scalar=_address_standardize_py
 )
 def address_standardize(column: str) -> pl.Expr:
     """Replace full street suffixes (Street, Avenue...) with abbreviations.
@@ -176,7 +176,7 @@ def _address_expand_series(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="expr"
+    name="address_expand", input_types=["address"], auto_apply=False, priority=50, mode="expr", scalar=_address_expand_py
 )
 def address_expand(column: str) -> pl.Expr:
     """Replace street abbreviations (St, Ave...) with full forms.
@@ -212,7 +212,7 @@ def _state_abbreviate_series(series: pl.Series) -> pl.Series:
 
 @register_transform(
     name="state_abbreviate", input_types=["state", "string"], auto_apply=False, priority=50,
-    mode="expr",
+    mode="expr", scalar=_state_abbreviate_py,
 )
 def state_abbreviate(column: str) -> pl.Expr:
     """Normalize state name to a 2-letter abbreviation (unmatched -> original).
@@ -239,7 +239,7 @@ def _state_expand_series(series: pl.Series) -> pl.Series:
 
 @register_transform(
     name="state_expand", input_types=["state", "string"], auto_apply=False, priority=50,
-    mode="expr",
+    mode="expr", scalar=_state_expand_py,
 )
 def state_expand(column: str) -> pl.Expr:
     """Expand a 2-letter state abbreviation to its full name (unmatched -> original).
@@ -270,7 +270,7 @@ def _zip_normalize_series(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="expr"
+    name="zip_normalize", input_types=["zip"], auto_apply=True, priority=55, mode="expr", scalar=_zip_normalize_py
 )
 def zip_normalize(column: str) -> pl.Expr:
     """Normalize a US ZIP to 5-digit form (strip +4, zero-pad all-digit, preserve
@@ -297,6 +297,7 @@ def _country_standardize_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_country_standardize_py,
 )
 def country_standardize(series: pl.Series) -> pl.Series:
     """Normalize country names to ISO 3166-1 alpha-2 codes.
@@ -353,6 +354,7 @@ def _unit_normalize_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=45,
     mode="series",
+    scalar=_unit_normalize_py,
 )
 def unit_normalize(series: pl.Series) -> pl.Series:
     """Normalize unit/apartment/suite designations.

--- a/packages/python/goldenflow/tests/engine/test_columnar_scalar_chain.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_scalar_chain.py
@@ -1,0 +1,123 @@
+"""Phase 4d: scalar-chain columnar coverage (the transform-signature port).
+
+A transform that registers a pure-Python ``scalar`` (``str|None -> value``) can run on
+the in-memory columnar engine WITHOUT Polars -- applied op-by-op over a list, composing
+with owned Rust-kernel ops in the same chain. The pilot family is address
+(state_abbreviate / state_expand / address_standardize / address_expand /
+zip_normalize / country_standardize / unit_normalize): all str->str with byte-parity
+between the native kernel (used by the Polars engine) and the pure-Python scalar (used
+by the columnar path), so the two are byte-identical.
+
+The CSV path stays Rust-only (it can't call a Python scalar), so a scalar spec is
+in-memory-columnar-ready but NOT file-ready.
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+ADDRESS_CASES = [
+    ([("st", ["state_abbreviate"])], {"st": ["California", "TX", "New York", None, ""]}),
+    ([("st", ["state_expand"])], {"st": ["CA", "tx", None, "ZZ"]}),
+    ([("z", ["zip_normalize"])], {"z": ["12345-6789", "  90210 ", None, "bad"]}),
+    ([("a", ["address_standardize"])], {"a": ["123 Main Street", None, "5 Oak Ave"]}),
+    ([("a", ["address_expand"])], {"a": ["123 Main St", None]}),
+    ([("c", ["country_standardize"])], {"c": ["USA", "united states", None]}),
+    ([("u", ["unit_normalize"])], {"u": ["Apt 5", "#3", None]}),
+    # mixed: owned string kernels compose with a scalar op in one chain
+    ([("st", ["strip", "lowercase", "state_expand"])], {"st": ["  CA  ", "TX", None]}),
+    ([("a", ["strip", "address_standardize"])], {"a": ["  123 Main Street  ", None]}),
+]
+
+
+@pytest.mark.parametrize("specs,data", ADDRESS_CASES)
+def test_scalar_chain_transform_dict_equals_polars(specs, data) -> None:
+    """transform(dict) (Polars-free) == transform_df(pl.DataFrame) for address scalar
+    chains, data + manifest."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    data = {**data, "keep": list(range(len(next(iter(data.values())))))}
+    cfg = _cfg(specs)
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(data, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(data), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("specs,data", ADDRESS_CASES)
+def test_scalar_chain_columnar_engine_equals_polars(monkeypatch, specs, data) -> None:
+    """The GOLDENFLOW_ENGINE=columnar transform_df path also handles scalar chains."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    data = {**data, "keep": list(range(len(next(iter(data.values())))))}
+    df = pl.DataFrame(data)
+    cfg = _cfg(specs)
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df)
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+
+
+def test_scalar_spec_inmemory_ready_but_not_file_ready() -> None:
+    """A scalar spec runs on the in-memory columnar path but declines on the CSV path
+    (the Rust CSV kernel can't call a Python scalar)."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    cfg = _cfg([("st", ["state_expand"])])
+    assert columnar.config_is_columnar_ready(cfg) is True
+    assert columnar.columnar_file_ready(cfg) is False
+
+
+def test_scalar_chain_is_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="st", ops=["strip", "state_expand"]),
+                TransformSpec(column="a", ops=["address_standardize"]),
+            ])
+            res = goldenflow.transform(
+                {"st": ["  ca ", "TX", None], "a": ["123 Main Street", None, "5 Oak Ave"], "k": [1, 2, 3]},
+                config=cfg,
+            )
+            assert res.columns["st"] == ["California", "Texas", None], res.columns["st"]
+            assert res.columns["a"] == ["123 Main St", None, "5 Oak Ave"], res.columns["a"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout


### PR DESCRIPTION
## Phase 4d wave 1 — the transform-signature port (scalar chains)

The mechanism that ports transforms off the Polars signature: a transform registers a
pure-Python **`scalar`** (`str|None -> value`) so the in-memory columnar engine applies
it over a list **without Polars**, composing with owned Rust-kernel ops in the same
chain. This expands the Polars-free coverage beyond the owned fused/numeric/split shapes
to any transform with a scalar reference.

### How
- **Registry**: optional `scalar` on `register_transform` + `TransformInfo`. It's the
  **same** per-element fn the Polars `series`-mode path calls via `map_elements`, so a
  scalar-applied column is byte-identical to the Polars engine. For owned families the
  native kernel (Polars engine) and the pure-Python scalar (columnar) are
  **parity-gated equal**, so the two paths agree.
- **Columnar engine**: a `_spec_scalar_ready` tier (**in-memory only** — the Rust CSV
  path can't call a Python scalar, so a scalar spec is `config_is_columnar_ready` but
  **not** `columnar_file_ready`) + op-by-op scalar routing in **both** in-memory paths
  (`transform_columns_native` dict + `_transform_via_columns` frame): owned string ops
  via the native list chain, scalar ops via the pure reference. Manifest affected/samples
  match the Polars series-mode audit exactly.
- **Wave 1 family**: the 7 address transforms (`address_standardize`/`address_expand`/
  `state_abbreviate`/`state_expand`/`zip_normalize`/`country_standardize`/`unit_normalize`),
  all str→str with module-level `_py` scalars.

### Gate
`tests/engine/test_columnar_scalar_chain.py`: `transform(dict)` == `transform_df` ==
`GOLDENFLOW_ENGINE=columnar` `transform_df` (data + manifest, incl. mixed owned+scalar
chains); in-memory-ready-but-not-file-ready; subprocess Polars-free. `import goldenflow`
stays Polars-free. Full engine+transforms suite green (1757).

Python-only (no native change; `from_pylist` shipped in 0.25). **Non-breaking.**
Follow-on families (dates — the big non-owned one; identifiers/categorical/names
remainder) are thin PRs on this mechanism.

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg