### PR TITLE
feat(goldenflow): own deterministic date semantics + dates columnar (Phase 4d wave 2)

### DIFF
--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -192,9 +192,28 @@ recovered by `[native]`.
   `state_expand`/`zip_normalize`/`country_standardize`/`unit_normalize`). Gated by
   `tests/engine/test_columnar_scalar_chain.py` (transform(dict) == transform_df ==
   columnar-engine transform_df, data + manifest; in-memory-ready-not-file-ready;
-  subprocess Polars-free). Follow-on families (dates — the big non-owned one — needs
-  its closures un-nested to module-level scalars + int/str return handling;
-  identifiers/categorical/names remainder) are thin PRs on this mechanism.
+  subprocess Polars-free).
+  **Wave 2 (dates) — "own the source of truth."** Dates first looked *unportable*:
+  `date_iso8601("1995")` = `"1995-01-01"` (its year-string fast path) but the pure
+  `dateutil` scalar = `"1995-07-07"` — dateutil fills a missing month/day with
+  **today**, a latent non-determinism bug AND inconsistent with the fast path. Rather
+  than treat the (buggy, non-deterministic) Polars-engine output as the oracle, we
+  OWNED the semantics: pin the fill to **Jan 1** (`dates._DEFAULT_DATE`,
+  `dateutil.parse(val, default=…)`). That (1) fixes the non-determinism, (2) makes the
+  residual agree with the fast path, and (3) makes the date scalars byte-reproducible →
+  the str-returning date transforms (`date_iso8601`/`date_parse`/`date_us`/`date_eu`/
+  `datetime_iso8601`/`extract_day_of_week`) run on the columnar path via the wave-1
+  `scalar=` mechanism (no engine change — just registering the scalars). **Intentional
+  (bug-fixing) output change** for partial-date inputs (non-deterministic before);
+  `test_fastpath_parity.py` references updated to the deterministic spec (now assert
+  engine == owned scalar). Gated by `tests/transforms/test_dates_deterministic.py`.
+  Known separate edge (out of scope): an ambiguous "Month Year" partial (`"March 1995"`)
+  hits a pre-existing Polars `to_date(strict=False)` looseness in the fast path
+  (`"0095-03-19"`) where the columnar scalar is *more* correct. The int/bool-returning
+  date transforms (`extract_year`/…/`date_validate`) + parameterized (`date_shift`/
+  `age_from_dob`) await dtype-aware scalar egress (a later wave). Remaining clean
+  families (categorical, identifiers formatters, names remainder) are thin
+  `scalar=`-wiring PRs.
 - **4e — I/O extras.** Native CSV is default; parquet/excel/scan/database move behind
   `[polars]`/`[parquet]` with graceful `ImportError`. Gate: fallback-path tests
   (mirror the existing cloud-connector pattern).

--- a/packages/python/goldenflow/goldenflow/transforms/dates.py
+++ b/packages/python/goldenflow/goldenflow/transforms/dates.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 
 from dateutil import parser as dateutil_parser
 
@@ -8,14 +8,71 @@ from goldenflow._polars_lazy import pl
 from goldenflow.transforms import register_transform
 from goldenflow.transforms._fastpath import _V, apply_with_residual
 
+# DETERMINISTIC fill for date fields absent from the input (Phase 4d / "own the
+# source of truth"). dateutil's default fills missing fields from `datetime.now()`,
+# so `parse("March 1995")` returned a DIFFERENT day on every run -- a latent
+# non-determinism bug, and inconsistent with GoldenFlow's own year-string fast path
+# (which already fills month/day with 1: "1995" -> "1995-01-01"). We pin the fill to
+# **month/day = 1, time = 00:00:00** so partial dates are deterministic AND agree
+# with the fast path. Only partial-date inputs (which were non-deterministic anyway)
+# change; fully-specified dates are unaffected. This is what makes the date family
+# byte-reproducible and therefore portable to the native/columnar path.
+_DEFAULT_DATE = datetime(2000, 1, 1, 0, 0, 0)
+
 
 def _parse_date(val: str | None) -> date | None:
     if not val:
         return None
     try:
-        return dateutil_parser.parse(val).date()
+        return dateutil_parser.parse(val, default=_DEFAULT_DATE).date()
     except (ValueError, OverflowError):
         return None
+
+
+# --------------------------------------------------------------------------- #
+# Module-level per-element references (Phase 4d). Deterministic (see _parse_date /
+# _DEFAULT_DATE), so they are the SAME fn the Polars `series` path applies AND the
+# owned reference the native/columnar path runs -- byte-identical, Polars-free.
+# Registered via `scalar=` so the in-memory columnar engine can run the date family
+# over a list. The str-returning date transforms are wired this wave; the
+# int/bool-returning ones (extract_year/…/date_validate) await dtype-aware egress.
+# --------------------------------------------------------------------------- #
+def _date_iso8601_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    return d.isoformat() if d else val
+
+
+def _date_us_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    return d.strftime("%m/%d/%Y") if d else val
+
+
+def _date_eu_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    return d.strftime("%d/%m/%Y") if d else val
+
+
+def _datetime_iso8601_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    try:
+        dt = dateutil_parser.parse(val, default=_DEFAULT_DATE)
+        return dt.strftime("%Y-%m-%dT%H:%M:%S")
+    except (ValueError, OverflowError):
+        return val
+
+
+def _extract_day_of_week_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    return _DAY_NAMES[d.weekday()] if d is not None else None
 
 
 _YEAR_ONLY_RE = r"^\s*\d{4}\s*$"
@@ -58,7 +115,8 @@ def _parsed_date_expr() -> pl.Expr:
 
 
 @register_transform(
-    name="date_iso8601", input_types=["date"], auto_apply=True, priority=50, mode="series"
+    name="date_iso8601", input_types=["date"], auto_apply=True, priority=50, mode="series",
+    scalar=_date_iso8601_py,
 )
 def date_iso8601(series: pl.Series) -> pl.Series:
     # Fast path A: numeric column (the inferred "date" type matched a column
@@ -84,48 +142,34 @@ def date_iso8601(series: pl.Series) -> pl.Series:
         if non_null.len() > 0 and bool(non_null.str.contains(_YEAR_ONLY_RE).all()):
             return series.str.strip_chars() + "-01-01"
 
-    def _fmt(val: str | None) -> str | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.isoformat() if d else val
-
     # Vectorized fast path: parse the well-formed common formats in Rust and
-    # strftime to ISO; only rows the fast path can't resolve hit dateutil.
+    # strftime to ISO; only rows the fast path can't resolve hit the deterministic
+    # per-row reference (_date_iso8601_py).
     fast_iso = _parsed_date_expr().dt.strftime("%Y-%m-%d")
-    return apply_with_residual(series, fast_iso, _fmt, pl.Utf8)
+    return apply_with_residual(series, fast_iso, _date_iso8601_py, pl.Utf8)
 
 
 @register_transform(
-    name="date_us", input_types=["date"], auto_apply=False, priority=50, mode="series"
+    name="date_us", input_types=["date"], auto_apply=False, priority=50, mode="series",
+    scalar=_date_us_py,
 )
 def date_us(series: pl.Series) -> pl.Series:
-    def _fmt(val: str | None) -> str | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.strftime("%m/%d/%Y") if d else val
-
     fast = _parsed_date_expr().dt.strftime("%m/%d/%Y")
-    return apply_with_residual(series, fast, _fmt, pl.Utf8)
+    return apply_with_residual(series, fast, _date_us_py, pl.Utf8)
 
 
 @register_transform(
-    name="date_eu", input_types=["date"], auto_apply=False, priority=50, mode="series"
+    name="date_eu", input_types=["date"], auto_apply=False, priority=50, mode="series",
+    scalar=_date_eu_py,
 )
 def date_eu(series: pl.Series) -> pl.Series:
-    def _fmt(val: str | None) -> str | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.strftime("%d/%m/%Y") if d else val
-
     fast = _parsed_date_expr().dt.strftime("%d/%m/%Y")
-    return apply_with_residual(series, fast, _fmt, pl.Utf8)
+    return apply_with_residual(series, fast, _date_eu_py, pl.Utf8)
 
 
 @register_transform(
-    name="date_parse", input_types=["date"], auto_apply=False, priority=55, mode="series"
+    name="date_parse", input_types=["date"], auto_apply=False, priority=55, mode="series",
+    scalar=_date_iso8601_py,
 )
 def date_parse(series: pl.Series) -> pl.Series:
     """Auto-detect format and normalize to ISO 8601."""
@@ -137,7 +181,7 @@ def date_parse(series: pl.Series) -> pl.Series:
 )
 def age_from_dob(series: pl.Series, reference_date: str | None = None) -> pl.Series:
     ref = (
-        dateutil_parser.parse(reference_date).date()
+        dateutil_parser.parse(reference_date, default=_DEFAULT_DATE).date()
         if reference_date
         else date.today()
     )
@@ -160,20 +204,11 @@ def age_from_dob(series: pl.Series, reference_date: str | None = None) -> pl.Ser
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_datetime_iso8601_py,
 )
 def datetime_iso8601(series: pl.Series) -> pl.Series:
     """Parse to ISO 8601 datetime (with time component)."""
-
-    def _fmt(val: str | None) -> str | None:
-        if val is None:
-            return None
-        try:
-            dt = dateutil_parser.parse(val)
-            return dt.strftime("%Y-%m-%dT%H:%M:%S")
-        except (ValueError, OverflowError):
-            return val
-
-    return series.map_elements(_fmt, return_dtype=pl.Utf8)
+    return series.map_elements(_datetime_iso8601_py, return_dtype=pl.Utf8)
 
 
 @register_transform(
@@ -285,19 +320,11 @@ def extract_quarter(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=35,
     mode="series",
+    scalar=_extract_day_of_week_py,
 )
 def extract_day_of_week(series: pl.Series) -> pl.Series:
     """Extract the day of week name (Monday, Tuesday, etc.)."""
-
-    def _dow(val: str | None) -> str | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        if d is None:
-            return None
-        return _DAY_NAMES[d.weekday()]
-
-    return series.map_elements(_dow, return_dtype=pl.Utf8)
+    return series.map_elements(_extract_day_of_week_py, return_dtype=pl.Utf8)
 
 
 @register_transform(

--- a/packages/python/goldenflow/tests/transforms/test_dates_deterministic.py
+++ b/packages/python/goldenflow/tests/transforms/test_dates_deterministic.py
@@ -1,0 +1,105 @@
+"""Phase 4d: dates are now DETERMINISTIC (owned source of truth) + columnar.
+
+The date family used to fill missing fields via dateutil's default = ``today``, so
+``date_iso8601("March 1995")`` returned a different day on every run -- a latent
+non-determinism bug, and inconsistent with the year-string fast path (which fills
+month/day with 1). We pinned the fill to Jan 1 (`_DEFAULT_DATE`), which:
+1. makes partial dates deterministic,
+2. makes the residual agree with the fast path, and
+3. makes the date scalars byte-reproducible -> the str-returning date transforms run
+   on the Polars-free columnar path (via the wave-1 `scalar=` mechanism).
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+from goldenflow.transforms.dates import (
+    _date_iso8601_py,
+    date_iso8601,
+)
+
+
+def test_partial_dates_are_deterministic() -> None:
+    """A missing month/day fills to 1, not today -- stable across calls, and matching
+    the year-string fast path."""
+    assert _date_iso8601_py("March 1995") == "1995-03-01"
+    assert _date_iso8601_py("March 1995") == _date_iso8601_py("March 1995")
+    # year-only agrees with the vectorized fast path (both -> -01-01)
+    assert _date_iso8601_py("1995") == "1995-01-01"
+    assert date_iso8601(pl.Series(["1995"])).to_list()[0] == "1995-01-01"
+    # fully-specified dates are unaffected
+    assert _date_iso8601_py("2020-03-15") == "2020-03-15"
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+# str-returning date transforms + a mixed chain. Inputs where the vectorized fast path
+# and the deterministic scalar agree (full dates, year-only, invalid passthrough,
+# fast-returns-null partials) -- the common cases. (An ambiguous "Month Year" partial
+# like "March 1995" hits a SEPARATE pre-existing fast-path looseness where the columnar
+# scalar is actually more correct; that's out of scope here.)
+DATE_CASES = [
+    (["date_iso8601"], ["2020-03-15", "March 5, 2021", "1995", "invalid", None, "2023/01/05"]),
+    (["date_us"], ["2020-03-15", "1995", None, "bad"]),
+    (["date_eu"], ["2020-03-15", "1995", None, "bad"]),
+    (["date_parse"], ["2020-03-15", "March 5, 2021", "1995", None]),
+    (["datetime_iso8601"], ["2020-03-15", "March 5, 2021", None, "invalid"]),
+    (["extract_day_of_week"], ["2020-03-15", "2021-01-01", None, "bad"]),
+    (["strip", "date_iso8601"], ["  2020-03-15 ", "1995", None]),
+]
+
+
+@pytest.mark.parametrize("ops,data", DATE_CASES)
+def test_dates_columnar_equals_polars(ops, data) -> None:
+    """transform(dict) (Polars-free) == transform_df(pl.DataFrame), data + manifest."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {"d": data, "k": list(range(len(data)))}
+    cfg = _cfg([("d", ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_dates_columnar_is_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[TransformSpec(column="d", ops=["strip", "date_iso8601"])])
+            res = goldenflow.transform({"d": ["  2020-03-15 ", "1995", None], "k": [1, 2, 3]}, config=cfg)
+            assert res.columns["d"] == ["2020-03-15", "1995-01-01", None], res.columns["d"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout

--- a/packages/python/goldenflow/tests/transforms/test_fastpath_parity.py
+++ b/packages/python/goldenflow/tests/transforms/test_fastpath_parity.py
@@ -13,39 +13,42 @@ import random
 import phonenumbers
 import polars as pl
 from dateutil import parser as dateutil_parser
-from goldenflow.transforms.dates import date_eu, date_iso8601, date_us
+from goldenflow.transforms.dates import (
+    _DEFAULT_DATE,
+    _date_eu_py,
+    _date_iso8601_py,
+    _date_us_py,
+    date_eu,
+    date_iso8601,
+    date_us,
+)
 from goldenflow.transforms.phone import phone_digits, phone_e164
 
-# --- references: the original per-row implementations ------------------------
+# --- references: the OWNED deterministic per-row implementations --------------
+# The date family is now the deterministic source of truth (missing fields fill to
+# Jan 1 via _DEFAULT_DATE, not dateutil's non-deterministic today-fill). The parity
+# references ARE those owned scalars, so the vectorized fast path is checked against
+# the same deterministic reference the columnar/native path runs.
 
 def _ref_parse_date(val):
     if not val:
         return None
     try:
-        return dateutil_parser.parse(val).date()
+        return dateutil_parser.parse(val, default=_DEFAULT_DATE).date()
     except (ValueError, OverflowError):
         return None
 
 
 def _ref_iso(val):
-    if val is None:
-        return None
-    d = _ref_parse_date(val)
-    return d.isoformat() if d else val
+    return _date_iso8601_py(val)
 
 
 def _ref_us(val):
-    if val is None:
-        return None
-    d = _ref_parse_date(val)
-    return d.strftime("%m/%d/%Y") if d else val
+    return _date_us_py(val)
 
 
 def _ref_eu(val):
-    if val is None:
-        return None
-    d = _ref_parse_date(val)
-    return d.strftime("%d/%m/%Y") if d else val
+    return _date_eu_py(val)
 
 
 def _ref_e164(val):


### PR DESCRIPTION
## Phase 4d wave 2 — own the date semantics, then port dates

Ports the date family to the Polars-free columnar path by **owning the date semantics**
instead of treating the Polars engine's (buggy, non-deterministic) output as the oracle.

### The blocker
`date_iso8601("1995")` → `"1995-01-01"` (its vectorized year-string fast path), but the
pure `dateutil` scalar → `"1995-07-07"` — dateutil fills a missing month/day with
**today**. That's a latent **non-determinism bug** (different output every run) *and*
inconsistent with the fast path (which fills with 1).

### The fix — pick our source of truth and own it
Pin the fill to **Jan 1** (`dates._DEFAULT_DATE` + `dateutil.parse(val, default=…)`). This
simultaneously:
1. **fixes the non-determinism**, `"March 1995"` → `"1995-03-01"` always;
2. makes the residual **agree with the fast path**;
3. makes the date scalars **byte-reproducible** → the str-returning date transforms
   (`date_iso8601`/`date_parse`/`date_us`/`date_eu`/`datetime_iso8601`/`extract_day_of_week`)
   run on the columnar path via the wave-1 `scalar=` mechanism — no engine change, just
   un-nesting each closure to a module-level `_date_*_py` and registering `scalar=`.

### Intentional output change
This is a **bug-fixing** change for partial-date inputs (which were non-deterministic
anyway — nobody could depend on "today"). `test_fastpath_parity.py` references are updated
to the deterministic spec: they now assert the vectorized engine **==** the owned scalar
reference. Gated by `tests/transforms/test_dates_deterministic.py` (determinism +
engine/fast-path agreement + columnar parity + subprocess Polars-free). All date tests
green (35).

### Known separate edge (out of scope)
An ambiguous "Month Year" partial like `"March 1995"` hits a pre-existing Polars
`to_date(strict=False)` looseness in the *fast path* (`"0095-03-19"`) where the columnar
scalar is actually **more** correct (`"1995-03-01"`). That's a fast-path fix, not a
dates-port concern. The int/bool-returning date transforms (`extract_year`/…/`date_validate`)
+ parameterized (`date_shift`/`age_from_dob`) await dtype-aware scalar egress (a later wave).

Python-only, non-breaking (aside from the deterministic date bug fix). Full transforms+engine
suite green (1776; lone `test_transform_with_splits` fail is the pre-existing env-leak flake).

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg