### PR TITLE
feat(goldenflow): dtype-aware scalar egress — int/bool columnar (Phase 4d wave 4)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -231,6 +231,21 @@ def _sample3(col: Column) -> list:
     return list(col[:3])
 
 
+def _cast_utf8(v):
+    """Format a scalar value the way Polars' ``cast(Utf8)`` does — the reference for
+    the columnar scalar path's manifest samples + affected counts (Phase 4d
+    dtype-egress). ``None`` stays null; a ``bool`` renders ``"true"``/``"false"``; an
+    ``int`` renders ``str(int)``; a ``str`` is itself. (No scalar returns a float —
+    numerics run the dedicated parser path, not the scalar chain.)"""
+    if v is None:
+        return None
+    if v is True:
+        return "true"
+    if v is False:
+        return "false"
+    return str(v)
+
+
 def transform(df, config, source: str = "<dataframe>"):
     """Apply an owned-string ``config`` to ``df`` (a ``pl.DataFrame``), preferring
     the native Arrow ``Column`` path (zero-copy, pyarrow-free) and falling back to
@@ -312,33 +327,35 @@ def _transform_via_columns(df, config, source, nm, pl):
             continue
         # Scalar chain (Phase 4d): a spec with a scalar-only op. Apply op-by-op over a
         # Python list (owned string ops native, scalar ops via the pure reference) and
-        # egress a pl.Series -- consistent with transform_columns_native (the dict path).
+        # egress a correctly-TYPED pl.Series -- consistent with the dict path, but the
+        # frame needs the real dtype (str/int/bool) so a numeric/bool result column
+        # matches the Polars engine (incl. the all-null edge, where value inference
+        # can't tell Boolean-null from Int64-null). Samples/counts use _cast_utf8.
         accepted = _accepted_string(nm)
+        dtype_map = {"str": pl.Utf8, "int": pl.Int64, "bool": pl.Boolean, "float": pl.Float64}
         if _spec_scalar_ready(spec, accepted):
             cur = df[spec.column].cast(pl.Utf8).to_list()
             total_rows = len(cur)
+            last_dtype = "str"
             for name, params in ops:
-                before = _sample3(cur[:3])
+                cb = [_cast_utf8(v) for v in cur]
                 if name in accepted:
                     new = list(nm.apply_chain_str_list(cur, [(name, list(params))])[0])
-                    n_changed = sum(
-                        1 for b, a in zip(cur, new)
-                        if b is not None and a is not None and b != a
-                    )
+                    last_dtype = "str"
                 else:
-                    fn = get_transform(name).scalar
-                    new = [fn(v) for v in cur]
-                    n_changed = sum(
-                        1 for b, a in zip(cur, new)
-                        if b is not None and a is not None and b != a
-                    )
-                after = _sample3(new[:3])
+                    info = get_transform(name)
+                    new = [info.scalar(v) for v in cur]
+                    last_dtype = info.scalar_dtype
+                cn = [_cast_utf8(v) for v in new]
+                n_changed = sum(
+                    1 for b, a in zip(cb, cn) if b is not None and a is not None and b != a
+                )
                 manifest.add_record(TransformRecord(
                     column=spec.column, transform=name, affected_rows=n_changed,
-                    total_rows=total_rows, sample_before=before, sample_after=after,
+                    total_rows=total_rows, sample_before=cb[:3], sample_after=cn[:3],
                 ))
                 cur = new
-            out_series.append(pl.Series(spec.column, cur, dtype=pl.Utf8))
+            out_series.append(pl.Series(spec.column, cur, dtype=dtype_map[last_dtype]))
             continue
         # Zero-copy, pyarrow-free ingest (a 1-column DataFrame -> a struct stream).
         col = nm.Column.from_arrow(df.select([spec.column]))
@@ -470,30 +487,30 @@ def transform_columns_native(columns, config, source: str = "<dataframe>"):
         # Scalar chain (Phase 4d): a spec with a scalar-only op runs op-by-op over the
         # plain list -- owned string ops via the native list chain, scalar ops via the
         # registered pure-Python reference (byte-identical to the native kernel the
-        # Polars engine uses, by the owned-kernel parity guarantee). Polars-free.
+        # Polars engine uses, by the owned-kernel parity guarantee). Polars-free. The
+        # manifest samples + affected counts compare Polars' cast(Utf8) forms
+        # (_cast_utf8), so a dtype-changing op (e.g. "true" -> bool True) counts a row
+        # only when the RENDERED strings differ, matching the engine exactly.
         accepted = _accepted_string(nm)
         if _spec_scalar_ready(spec, accepted):
             cur = col_list
             for name, params in ops:
-                before = _sample3(cur[:3])
+                cb = [_cast_utf8(v) for v in cur]
                 if name in accepted:
-                    new, changed = nm.apply_chain_str_list(cur, [(name, list(params))])
-                    new = list(new)
-                    n_changed = int(changed[0])
+                    new = list(nm.apply_chain_str_list(cur, [(name, list(params))])[0])
                 else:
                     fn = get_transform(name).scalar
                     new = [fn(v) for v in cur]
-                    n_changed = sum(
-                        1 for b, a in zip(cur, new)
-                        if b is not None and a is not None and b != a
-                    )
-                after = _sample3(new[:3])
+                cn = [_cast_utf8(v) for v in new]
+                n_changed = sum(
+                    1 for b, a in zip(cb, cn) if b is not None and a is not None and b != a
+                )
                 manifest.add_record(TransformRecord(
                     column=spec.column, transform=name, affected_rows=n_changed,
-                    total_rows=total_rows, sample_before=before, sample_after=after,
+                    total_rows=total_rows, sample_before=cb[:3], sample_after=cn[:3],
                 ))
                 cur = new
-            out[spec.column] = cur
+            out[spec.column] = cur  # raw Python values (int/bool/str) -> dict result
             continue
 
         # Owned string chain (auto-routed total/nullable): counts + 3-row replay.

--- a/packages/python/goldenflow/goldenflow/transforms/__init__.py
+++ b/packages/python/goldenflow/goldenflow/transforms/__init__.py
@@ -26,6 +26,12 @@ class TransformInfo:
     # scalar-applied column is byte-identical to the Polars engine. `None` = no
     # Polars-free path yet (the transform stays on the Polars engine).
     scalar: Callable[[str | None], object] | None = None
+    # Phase 4d dtype-egress: the value dtype the ``scalar`` returns, so the columnar
+    # engine can (a) egress a correctly-typed column (str/int/bool/float) and (b)
+    # format manifest samples + affected counts like Polars' ``cast(Utf8)`` (a bool
+    # renders "true"/"false", an int str(int)). Only ``str`` fit the pre-egress
+    # mechanism; ``int``/``bool``/``float`` need this tag.
+    scalar_dtype: Literal["str", "int", "bool", "float"] = "str"
 
 
 def register_transform(
@@ -36,6 +42,7 @@ def register_transform(
     priority: int = 50,
     mode: Literal["expr", "series", "dataframe"] = "series",
     scalar: Callable[[str | None], object] | None = None,
+    scalar_dtype: Literal["str", "int", "bool", "float"] = "str",
 ) -> Callable:
     """Decorator to register a transform function."""
 
@@ -48,6 +55,7 @@ def register_transform(
             priority=priority,
             mode=mode,
             scalar=scalar,
+            scalar_dtype=scalar_dtype,
         )
         return func
 

--- a/packages/python/goldenflow/goldenflow/transforms/categorical.py
+++ b/packages/python/goldenflow/goldenflow/transforms/categorical.py
@@ -73,7 +73,8 @@ def _category_normalize_key_series(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="boolean_normalize", input_types=["boolean", "string"], auto_apply=False, priority=50, mode="series"
+    name="boolean_normalize", input_types=["boolean", "string"], auto_apply=False, priority=50,
+    mode="series", scalar=_boolean_normalize_py, scalar_dtype="bool",
 )
 def boolean_normalize(series: pl.Series) -> pl.Series:
     """Parse loose boolean-ish strings (yes/no/y/n/1/0/true/false/t/f).

--- a/packages/python/goldenflow/goldenflow/transforms/dates.py
+++ b/packages/python/goldenflow/goldenflow/transforms/dates.py
@@ -75,6 +75,37 @@ def _extract_day_of_week_py(val: str | None) -> str | None:
     return _DAY_NAMES[d.weekday()] if d is not None else None
 
 
+# int/bool-returning date references (Phase 4d dtype-egress). Deterministic via
+# _parse_date; the SAME per-element fn the Polars `series` path applies -> the
+# columnar engine egresses a real Int64/Boolean column, byte-identical.
+def _extract_year_py(val: str | None) -> int | None:
+    d = _parse_date(val)
+    return d.year if d else None
+
+
+def _extract_month_py(val: str | None) -> int | None:
+    d = _parse_date(val)
+    return d.month if d else None
+
+
+def _extract_day_py(val: str | None) -> int | None:
+    d = _parse_date(val)
+    return d.day if d else None
+
+
+def _extract_quarter_py(val: str | None) -> int | None:
+    d = _parse_date(val)
+    return (d.month - 1) // 3 + 1 if d else None
+
+
+def _date_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    if not val.strip():
+        return False
+    return _parse_date(val) is not None
+
+
 _YEAR_ONLY_RE = r"^\s*\d{4}\s*$"
 
 # Formats the vectorized fast path resolves entirely in Polars/Rust. Each is
@@ -217,17 +248,12 @@ def datetime_iso8601(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=35,
     mode="series",
+    scalar=_extract_year_py,
+    scalar_dtype="int",
 )
 def extract_year(series: pl.Series) -> pl.Series:
     """Extract the year as an integer."""
-
-    def _year(val: str | None) -> int | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.year if d else None
-
-    return series.map_elements(_year, return_dtype=pl.Int64)
+    return series.map_elements(_extract_year_py, return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -236,17 +262,12 @@ def extract_year(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=35,
     mode="series",
+    scalar=_extract_month_py,
+    scalar_dtype="int",
 )
 def extract_month(series: pl.Series) -> pl.Series:
     """Extract the month as an integer (1-12)."""
-
-    def _month(val: str | None) -> int | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.month if d else None
-
-    return series.map_elements(_month, return_dtype=pl.Int64)
+    return series.map_elements(_extract_month_py, return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -280,17 +301,12 @@ _DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
     auto_apply=False,
     priority=35,
     mode="series",
+    scalar=_extract_day_py,
+    scalar_dtype="int",
 )
 def extract_day(series: pl.Series) -> pl.Series:
     """Extract the day of month as an integer (1-31)."""
-
-    def _day(val: str | None) -> int | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        return d.day if d else None
-
-    return series.map_elements(_day, return_dtype=pl.Int64)
+    return series.map_elements(_extract_day_py, return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -299,19 +315,12 @@ def extract_day(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=35,
     mode="series",
+    scalar=_extract_quarter_py,
+    scalar_dtype="int",
 )
 def extract_quarter(series: pl.Series) -> pl.Series:
     """Extract the quarter (1-4) from a date."""
-
-    def _quarter(val: str | None) -> int | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        if d is None:
-            return None
-        return (d.month - 1) // 3 + 1
-
-    return series.map_elements(_quarter, return_dtype=pl.Int64)
+    return series.map_elements(_extract_quarter_py, return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -333,15 +342,9 @@ def extract_day_of_week(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=60,
     mode="series",
+    scalar=_date_validate_py,
+    scalar_dtype="bool",
 )
 def date_validate(series: pl.Series) -> pl.Series:
     """Validate if value is a parseable date. Returns True/False/None."""
-
-    def _validate(val: str | None) -> bool | None:
-        if val is None:
-            return None
-        if not val.strip():
-            return False
-        return _parse_date(val) is not None
-
-    return series.map_elements(_validate, return_dtype=pl.Boolean)
+    return series.map_elements(_date_validate_py, return_dtype=pl.Boolean)

--- a/packages/python/goldenflow/tests/engine/test_columnar_dtype_egress.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_dtype_egress.py
@@ -1,0 +1,115 @@
+"""Phase 4d dtype-egress: int/bool-returning scalars on the columnar path.
+
+The scalar mechanism egressed only ``str`` results. This extension adds a
+``scalar_dtype`` tag ("str"/"int"/"bool"/"float") so a scalar transform can egress a
+correctly-typed column and format manifest samples/affected counts like Polars'
+``cast(Utf8)`` (bool -> "true"/"false", int -> str(int)). Unlocks:
+- categorical ``boolean_normalize`` (bool),
+- dates ``date_validate`` (bool) + ``extract_year``/``extract_month``/``extract_day``/
+  ``extract_quarter`` (int),
+all running Polars-free, byte-identical (frame value+dtype AND manifest) to the Polars
+engine.
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+CASES = [
+    (["boolean_normalize"], "b", ["yes", "no", "TRUE", "f", "1", "maybe", None]),
+    (["date_validate"], "d", ["2020-03-15", "not a date", "", None, "1995"]),
+    (["extract_year"], "d", ["2020-03-15", "March 1995", None, "bad"]),
+    (["extract_month"], "d", ["2020-03-15", None, "bad"]),
+    (["extract_day"], "d", ["2020-03-15", "March 5, 2021", None]),
+    (["extract_quarter"], "d", ["2020-08-15", "2020-01-01", None]),
+    # mixed: an owned string op then a dtype-changing scalar
+    (["strip", "boolean_normalize"], "b", ["  yes ", "NO", None]),
+    (["strip", "extract_year"], "d", ["  2020-03-15 ", "1995", None]),
+    # all-null / all-unparseable -> the typed-null egress edge
+    (["boolean_normalize"], "b", ["x", "y", None]),
+    (["extract_year"], "d", ["bad", None]),
+]
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_dtype_scalar_dict_equals_polars(ops, col, data) -> None:
+    """transform(dict) (Polars-free) == transform_df, values + manifest."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {col: data, "k": list(range(len(data)))}
+    cfg = _cfg([(col, ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_dtype_scalar_columnar_engine_equals_polars(monkeypatch, ops, col, data) -> None:
+    """The GOLDENFLOW_ENGINE=columnar frame path egresses the correct dtype
+    (Boolean/Int64), matching the Polars engine including .dtype and the all-null edge."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    dd = {col: data, "k": list(range(len(data)))}
+    df = pl.DataFrame(dd)
+    cfg = _cfg([(col, ops)])
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df)
+    assert got.df[col].dtype == ref.df[col].dtype
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+
+
+def test_dtype_scalar_is_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="b", ops=["strip", "boolean_normalize"]),
+                TransformSpec(column="d", ops=["extract_year"]),
+            ])
+            res = goldenflow.transform(
+                {"b": ["  yes ", "no", None], "d": ["2020-03-15", "1995", None], "k": [1, 2, 3]},
+                config=cfg,
+            )
+            assert res.columns["b"] == [True, False, None], res.columns["b"]
+            assert res.columns["d"] == [2020, 1995, None], res.columns["d"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout


### PR DESCRIPTION
## Phase 4d wave 4 — dtype-aware scalar egress

Extends the scalar mechanism (which egressed only **str**) to **int-** and
**bool-**returning transforms, unlocking the whole non-parameterized int/bool tail in
one piece:
- categorical **`boolean_normalize`** (bool)
- dates **`date_validate`** (bool) + **`extract_year`/`extract_month`/`extract_day`/
  `extract_quarter`** (int)

all now run on the Polars-free columnar path, byte-identical to the Polars engine
(frame **value + dtype** and manifest).

### How
- **Registry**: a `scalar_dtype` tag (`"str"`/`"int"`/`"bool"`/`"float"`) on
  `register_transform` + `TransformInfo`, so the columnar engine knows a scalar's egress
  type.
- **Columnar engine**: a `_cast_utf8` formatter renders values the way Polars'
  `cast(Utf8)` does (`bool → "true"/"false"`, `int → str(int)`, `str → itself`,
  `None → None`) — **load-bearing** for a dtype-changing op: `boolean_normalize`
  (`"true" → True`) must count a row affected only when the *rendered strings* differ
  (`"true" == "true"` → 0), not the raw values (`"true" != True` → would wrongly count
  every row). Both in-memory scalar branches (dict + frame) use it for samples/counts;
  the frame path egresses a correctly-typed `pl.Series` via `scalar_dtype` (handles the
  all-null column edge that value-inference can't).
- Wired the 6 transforms with `scalar=` + `scalar_dtype`; un-nested the `extract_*` /
  `date_validate` closures to module-level references (single source, no
  engine/columnar divergence).

### Gate
`tests/engine/test_columnar_dtype_egress.py`: `transform(dict)` == `transform_df` ==
`GOLDENFLOW_ENGINE=columnar` `transform_df` (values + **dtype** + manifest); the all-null
typed-egress edge; subprocess Polars-free. Full transforms+engine suite green (1790).

Python-only, non-breaking. Parameterized scalars (`age_from_dob`, `date_shift` — the
`fn(val)` signature has no param slot) remain the last deferred scalar shape.

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg