### PR TITLE
feat(goldenflow): identifier formatters on the columnar path (Phase 4d wave 5)

### DIFF
--- a/packages/python/goldenflow/goldenflow/domains/people_hr.py
+++ b/packages/python/goldenflow/goldenflow/domains/people_hr.py
@@ -9,20 +9,12 @@ from goldenflow.transforms import register_transform
 
 _SSN_PATTERN = re.compile(r"^(\d{3})-?(\d{2})-?(\d{4})$")
 
-
-@register_transform(
-    name="ssn_mask", input_types=["ssn", "string"], auto_apply=False, priority=50, mode="series"
-)
-def ssn_mask(series: pl.Series) -> pl.Series:
-    def _mask(val: str | None) -> str | None:
-        if val is None:
-            return None
-        m = _SSN_PATTERN.match(val.strip())
-        if m:
-            return f"***-**-{m.group(3)}"
-        return val
-
-    return series.map_elements(_mask, return_dtype=pl.Utf8)
+# NOTE: ``ssn_mask`` is owned by goldenflow.transforms.identifiers (native-first +
+# a registered pure-Python ``scalar`` for the Polars-free columnar path + byte-parity
+# corpus). people_hr used to register its OWN ``ssn_mask`` here, which clobbered the
+# core one whenever this domain loaded — dropping ssn_mask off the columnar path and
+# masking the fact that two registrations existed. The domain now REFERENCES the core
+# ``ssn_mask`` by name (see PACK.transforms) instead of redefining it.
 
 
 @register_transform(

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -142,6 +142,7 @@ def cc_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_cc_format_py,
 )
 def cc_format(series: pl.Series) -> pl.Series:
     """Group a valid payment-card number (Amex 4-6-5, else 4-4-4-4...);
@@ -158,6 +159,7 @@ def cc_format(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_cc_mask_py,
 )
 def cc_mask(series: pl.Series) -> pl.Series:
     """Mask a payment-card number to stars + last 4 digits."""
@@ -244,6 +246,7 @@ def iban_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_iban_format_py,
 )
 def iban_format(series: pl.Series) -> pl.Series:
     """Group a valid IBAN into 4-char blocks; ``null`` for invalid input."""
@@ -354,6 +357,7 @@ def isbn_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_isbn_normalize_py,
 )
 def isbn_normalize(series: pl.Series) -> pl.Series:
     """Canonicalize a valid ISBN-10/13 to its 13-digit form; ``null`` for
@@ -477,6 +481,7 @@ def swift_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_swift_format_py,
 )
 def swift_format(series: pl.Series) -> pl.Series:
     """Normalize a valid SWIFT/BIC code to uppercase (spaces stripped);
@@ -654,6 +659,7 @@ def vat_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_vat_format_py,
 )
 def vat_format(series: pl.Series) -> pl.Series:
     """Normalize a valid EU VAT number to its compact uppercase form (prefix
@@ -679,6 +685,7 @@ def _ssn_format_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_ssn_format_py,
 )
 def ssn_format(series: pl.Series) -> pl.Series:
     """Normalize SSN to XXX-XX-XXXX format. Native-first over goldenflow-core."""
@@ -703,6 +710,7 @@ def _ssn_mask_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_ssn_mask_py,
 )
 def ssn_mask(series: pl.Series) -> pl.Series:
     """Mask SSN to ***-**-XXXX (last 4 visible). Native-first."""
@@ -727,6 +735,7 @@ def _ein_format_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_ein_format_py,
 )
 def ein_format(series: pl.Series) -> pl.Series:
     """Normalize EIN to XX-XXXXXXX format. Native-first."""
@@ -952,7 +961,7 @@ def luhn_validate(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="cc_brand", input_types=["identifier", "string"], auto_apply=False, priority=40, mode="series"
+    name="cc_brand", input_types=["identifier", "string"], auto_apply=False, priority=40, mode="series", scalar=_cc_brand_py
 )
 def cc_brand(series: pl.Series) -> pl.Series:
     """Detect the card brand (visa/mastercard/amex/...) or null. Native-first."""

--- a/packages/python/goldenflow/tests/domains/test_people_hr.py
+++ b/packages/python/goldenflow/tests/domains/test_people_hr.py
@@ -1,5 +1,9 @@
 import polars as pl
-from goldenflow.domains.people_hr import PACK, ssn_mask, ssn_validate
+from goldenflow.domains.people_hr import PACK, ssn_validate
+
+# ssn_mask is owned by transforms.identifiers now (people_hr references it by name,
+# no longer redefines it — see the note in people_hr.py).
+from goldenflow.transforms.identifiers import ssn_mask
 
 
 def test_pack_metadata():

--- a/packages/python/goldenflow/tests/engine/test_columnar_identifiers.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_identifiers.py
@@ -1,0 +1,84 @@
+"""Phase 4d wave 5: identifier FORMATTERS on the columnar path.
+
+The 10 owned str->str identifier formatters (ssn_format/ssn_mask/ein_format/
+cc_format/cc_mask/cc_brand/iban_format/isbn_normalize/swift_format/vat_format) run
+on the in-memory columnar path Polars-free via the `scalar=` mechanism -- their
+pure-Python scalar is byte-parity-equal to the native kernel the Polars engine uses.
+(The *_validate identifiers return bool and await the dtype-egress wiring.)
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+CASES = [
+    (["ssn_format"], "s", ["123456789", "123-45-6789", "bad", None]),
+    (["ssn_mask"], "s", ["123-45-6789", None]),
+    (["ein_format"], "e", ["123456789", None]),
+    (["cc_format"], "c", ["4111111111111111", None]),
+    (["cc_mask"], "c", ["4111111111111111", None]),
+    (["cc_brand"], "c", ["4111111111111111", "5500000000000004", None]),
+    (["iban_format"], "i", ["GB82WEST12345698765432", None]),
+    (["isbn_normalize"], "b", ["9780306406157", "0306406152", None]),
+    (["swift_format"], "w", ["DEUTDEFF", None]),
+    (["vat_format"], "v", ["DE123456789", None]),
+    (["strip", "ssn_format"], "s", ["  123456789 ", None]),
+]
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_identifier_formatters_columnar_equals_polars(ops, col, data) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {col: data, "k": list(range(len(data)))}
+    cfg = _cfg([(col, ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_identifier_formatters_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[TransformSpec(column="s", ops=["strip", "ssn_format"])])
+            res = goldenflow.transform({"s": ["  123456789 ", None], "k": [1, 2]}, config=cfg)
+            assert res.columns["s"] == ["123-45-6789", None], res.columns["s"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout


### PR DESCRIPTION
## Phase 4d wave 5 — identifier formatters (the biggest clean str batch)

Wires the **10 owned str→str identifier formatters** (`ssn_format`/`ssn_mask`/
`ein_format`/`cc_format`/`cc_mask`/`cc_brand`/`iban_format`/`isbn_normalize`/
`swift_format`/`vat_format`) with `scalar=`, so they run on the in-memory columnar path
**Polars-free** via the wave-1 mechanism — byte-identical (data + manifest) to the Polars
engine, including mixed chains (`strip → ssn_format`). Their pure-Python scalar is
byte-parity-equal to the native kernel the Polars engine uses, so the two paths agree.

The `*_validate` identifiers (cc/iban/isbn/swift/vat/aba/imei/isin/cusip/luhn/npi/ean)
return **bool** and await the dtype-egress wiring (from the int/bool wave).

Python-only, non-breaking. Gated by `tests/engine/test_columnar_identifiers.py`
(`transform(dict)` == `transform_df`, data + manifest; subprocess Polars-free). The
identifier parity corpus + engine suite green (1426).

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg