### PR TITLE
feat(goldenflow): parameterized scalars on the columnar path (Phase 4d wave 6)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -132,11 +132,19 @@ def _spec_scalar_ready(spec, accepted: frozenset[str]) -> bool:
             return False
         if name in accepted:
             continue
-        if info.scalar is not None:
+        if info.scalar is not None or info.scalar_factory is not None:
             has_scalar_op = True
             continue
         return False
     return has_scalar_op
+
+
+def _scalar_fn(info, params):
+    """The per-element scalar for a transform: a parameterized ``scalar_factory``
+    bound to ``params`` (Phase 4d), else the plain ``scalar``."""
+    if info.scalar_factory is not None:
+        return info.scalar_factory(list(params))
+    return info.scalar
 
 
 def _spec_ready(
@@ -344,7 +352,8 @@ def _transform_via_columns(df, config, source, nm, pl):
                     last_dtype = "str"
                 else:
                     info = get_transform(name)
-                    new = [info.scalar(v) for v in cur]
+                    fn = _scalar_fn(info, params)
+                    new = [fn(v) for v in cur]
                     last_dtype = info.scalar_dtype
                 cn = [_cast_utf8(v) for v in new]
                 n_changed = sum(
@@ -499,7 +508,7 @@ def transform_columns_native(columns, config, source: str = "<dataframe>"):
                 if name in accepted:
                     new = list(nm.apply_chain_str_list(cur, [(name, list(params))])[0])
                 else:
-                    fn = get_transform(name).scalar
+                    fn = _scalar_fn(get_transform(name), params)
                     new = [fn(v) for v in cur]
                 cn = [_cast_utf8(v) for v in new]
                 n_changed = sum(

--- a/packages/python/goldenflow/goldenflow/transforms/__init__.py
+++ b/packages/python/goldenflow/goldenflow/transforms/__init__.py
@@ -32,6 +32,11 @@ class TransformInfo:
     # renders "true"/"false", an int str(int)). Only ``str`` fit the pre-egress
     # mechanism; ``int``/``bool``/``float`` need this tag.
     scalar_dtype: Literal["str", "int", "bool", "float"] = "str"
+    # Phase 4d parameterized shape: a factory `params -> fn(val)` for transforms whose
+    # per-element reference depends on the op's params (e.g. `date_shift:7`,
+    # `age_from_dob:2024-01-01`). The columnar engine builds the scalar from the spec's
+    # params; ``scalar`` (no params) and ``scalar_factory`` are mutually exclusive.
+    scalar_factory: Callable[[list[str]], Callable[[str | None], object]] | None = None
 
 
 def register_transform(
@@ -43,6 +48,7 @@ def register_transform(
     mode: Literal["expr", "series", "dataframe"] = "series",
     scalar: Callable[[str | None], object] | None = None,
     scalar_dtype: Literal["str", "int", "bool", "float"] = "str",
+    scalar_factory: Callable[[list[str]], Callable[[str | None], object]] | None = None,
 ) -> Callable:
     """Decorator to register a transform function."""
 
@@ -56,6 +62,7 @@ def register_transform(
             mode=mode,
             scalar=scalar,
             scalar_dtype=scalar_dtype,
+            scalar_factory=scalar_factory,
         )
         return func
 

--- a/packages/python/goldenflow/goldenflow/transforms/dates.py
+++ b/packages/python/goldenflow/goldenflow/transforms/dates.py
@@ -106,6 +106,40 @@ def _date_validate_py(val: str | None) -> bool | None:
     return _parse_date(val) is not None
 
 
+# Parameterized references (Phase 4d): a per-element fn bound to the op's params. The
+# same logic the Polars `series` path runs, single-sourced so engine == columnar.
+def _date_shift_scalar(val: str | None, days: int) -> str | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    if d is None:
+        return val
+    return (d + timedelta(days=days)).isoformat()
+
+
+def _date_shift_factory(params: list[str]):
+    days = int(params[0]) if params else 0
+    return lambda v: _date_shift_scalar(v, days)
+
+
+def _age_scalar(val: str | None, ref: date) -> int | None:
+    if val is None:
+        return None
+    d = _parse_date(val)
+    if d is None:
+        return None
+    return ref.year - d.year - ((ref.month, ref.day) < (d.month, d.day))
+
+
+def _age_from_dob_factory(params: list[str]):
+    ref = (
+        dateutil_parser.parse(params[0], default=_DEFAULT_DATE).date()
+        if params and params[0]
+        else date.today()
+    )
+    return lambda v: _age_scalar(v, ref)
+
+
 _YEAR_ONLY_RE = r"^\s*\d{4}\s*$"
 
 # Formats the vectorized fast path resolves entirely in Polars/Rust. Each is
@@ -208,7 +242,8 @@ def date_parse(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="age_from_dob", input_types=["date"], auto_apply=False, priority=40, mode="series"
+    name="age_from_dob", input_types=["date"], auto_apply=False, priority=40, mode="series",
+    scalar_factory=_age_from_dob_factory, scalar_dtype="int",
 )
 def age_from_dob(series: pl.Series, reference_date: str | None = None) -> pl.Series:
     ref = (
@@ -216,17 +251,7 @@ def age_from_dob(series: pl.Series, reference_date: str | None = None) -> pl.Ser
         if reference_date
         else date.today()
     )
-
-    def _age(val: str | None) -> int | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        if d is None:
-            return None
-        age = ref.year - d.year - ((ref.month, ref.day) < (d.month, d.day))
-        return age
-
-    return series.map_elements(_age, return_dtype=pl.Int64)
+    return series.map_elements(lambda v: _age_scalar(v, ref), return_dtype=pl.Int64)
 
 
 @register_transform(
@@ -276,20 +301,12 @@ def extract_month(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=30,
     mode="series",
+    scalar_factory=_date_shift_factory,
+    scalar_dtype="str",
 )
 def date_shift(series: pl.Series, days: int = 0) -> pl.Series:
     """Shift dates by a number of days (positive = forward, negative = backward)."""
-
-    def _shift(val: str | None) -> str | None:
-        if val is None:
-            return None
-        d = _parse_date(val)
-        if d is None:
-            return val
-        shifted = d + timedelta(days=days)
-        return shifted.isoformat()
-
-    return series.map_elements(_shift, return_dtype=pl.Utf8)
+    return series.map_elements(lambda v: _date_shift_scalar(v, days), return_dtype=pl.Utf8)
 
 
 _DAY_NAMES = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]

--- a/packages/python/goldenflow/tests/engine/test_columnar_parameterized_scalar.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_parameterized_scalar.py
@@ -1,0 +1,103 @@
+"""Phase 4d wave 6: parameterized scalars on the columnar path.
+
+Some transforms' per-element reference depends on the op's params (``date_shift:7``,
+``age_from_dob:2024-01-01``). A ``scalar_factory`` (params -> fn(val)) on the registry
+lets the columnar engine build the scalar from the spec's params, so these run
+Polars-free byte-identical to the Polars engine. This is the last non-excluded scalar
+shape (after str, int, and bool returns).
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+CASES = [
+    (["date_shift:7"], "d", ["2020-03-15", "1995", None, "bad"]),
+    (["date_shift:-30"], "d", ["2020-03-15", None]),
+    (["date_shift"], "d", ["2020-03-15", None]),  # no param -> days=0
+    (["age_from_dob:2024-01-01"], "d", ["2000-03-15", "1990-06-20", None, "bad"]),
+    (["strip", "date_shift:1"], "d", ["  2020-03-15 ", None]),
+    (["strip", "age_from_dob:2024-06-01"], "d", ["  2000-01-01 ", None]),
+]
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_parameterized_scalar_dict_equals_polars(ops, col, data) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {col: data, "k": list(range(len(data)))}
+    cfg = _cfg([(col, ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_parameterized_scalar_columnar_engine_equals_polars(monkeypatch, ops, col, data) -> None:
+    """The GOLDENFLOW_ENGINE=columnar frame path matches too (value + dtype)."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    dd = {col: data, "k": list(range(len(data)))}
+    df = pl.DataFrame(dd)
+    cfg = _cfg([(col, ops)])
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df)
+    assert got.df[col].dtype == ref.df[col].dtype
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+
+
+def test_parameterized_scalar_is_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="d", ops=["date_shift:7"]),
+                TransformSpec(column="b", ops=["age_from_dob:2024-01-01"]),
+            ])
+            res = goldenflow.transform(
+                {"d": ["2020-03-15", None], "b": ["2000-03-15", None], "k": [1, 2]},
+                config=cfg,
+            )
+            assert res.columns["d"] == ["2020-03-22", None], res.columns["d"]
+            assert res.columns["b"] == [23, None], res.columns["b"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout


### PR DESCRIPTION
## Phase 4d wave 6 — parameterized scalars (the last scalar shape)

Transforms whose per-element reference depends on the op's **params** (`date_shift:7`,
`age_from_dob:2024-01-01`) now run on the Polars-free columnar path, byte-identical to
the Polars engine. This is the last non-excluded scalar shape (after str, int, and bool
returns).

### How
- **Registry**: a `scalar_factory` (`params -> fn(val)`) on `register_transform` +
  `TransformInfo`. The columnar engine builds the per-op scalar from the spec's params;
  `scalar` (no params) and `scalar_factory` are mutually exclusive.
- **Engine**: a shared `_scalar_fn(info, params)` helper — factory-bound when
  `scalar_factory` is set, else the plain `scalar`. `_spec_scalar_ready` accepts a
  `scalar_factory` op; both in-memory scalar branches (dict + frame) use the helper.
  Composes with owned string ops (`strip → date_shift:1`) and dtype egress
  (`age_from_dob → Int64`).
- **dates**: `date_shift` (str) + `age_from_dob` (int) wired via factories; per-element
  logic **single-sourced** (`_date_shift_scalar` / `_age_scalar`) so the Polars-engine
  body and the columnar factory share one implementation (no divergence).

### Gate
`tests/engine/test_columnar_parameterized_scalar.py`: `transform(dict)` == `transform_df`
== `GOLDENFLOW_ENGINE=columnar` `transform_df` (value + dtype + manifest); no-param
default; mixed chains; subprocess Polars-free. Full transforms+engine suite green (1811).

### Milestone
With this, the scalar mechanism covers **every shape** (str/int/bool returns +
parameterized). The only transforms still off the columnar path are the **deliberately
excluded** ones: data-dependent `category_*` (caller-supplied mappings) and multi-input
`merge_name`.

Design: `docs/design/2026-07-07-phase4-polars-optional-scoping.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FYFLbXeAk9UBHv7T3hFBtg