### PR TITLE
feat(goldenflow): transform() reads a CSV path Polars-free (Phase 4e)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -392,21 +392,53 @@ def _transform_via_columns(df, config, source, nm, pl):
     return out, manifest
 
 
+def read_csv_columns(path) -> dict[str, list]:
+    """Read a CSV into a ``dict[str, list]`` — **Polars-free, pyarrow-free** (stdlib
+    ``csv``). Every field is a string; an empty field maps to ``None`` — cell-identical
+    to ``pl.read_csv(path, infer_schema_length=0)`` (Phase 4e: a covered CSV pipeline
+    with Polars uninstalled). Quoting/embedded newlines are handled by the csv module."""
+    import csv
+
+    with open(path, newline="", encoding="utf-8") as f:
+        reader = csv.reader(f)
+        try:
+            header = next(reader)
+        except StopIteration:
+            return {}
+        cols: dict[str, list] = {h: [] for h in header}
+        for row in reader:
+            for i, h in enumerate(header):
+                v = row[i] if i < len(row) else ""
+                cols[h].append(v if v != "" else None)
+    return cols
+
+
 def transform_columns_public(data, config):
-    """Phase 4c public core: transform a ``dict[str, list]`` frame, returning a
-    :class:`ColumnarResult` (Polars-free). A covered config runs on the native
-    in-memory core with **Polars never imported**; anything else declines to the
-    Polars engine (which needs ``goldenflow[polars]`` — a clear ImportError if it's
-    absent). ``config=None`` (zero-config auto-detect) uses the Polars profiler, so it
-    also needs the extra.
+    """Phase 4c/4e public core: transform a ``dict[str, list]`` frame OR a CSV path
+    (str/``Path`` ending ``.csv``), returning a :class:`ColumnarResult` (Polars-free).
+    A CSV path is read via the stdlib reader (:func:`read_csv_columns`). A covered
+    config runs on the native in-memory core with **Polars never imported**; anything
+    else declines to the Polars engine (which needs ``goldenflow[polars]`` — a clear
+    ImportError if it's absent). ``config=None`` (zero-config auto-detect) uses the
+    Polars profiler, so it also needs the extra.
 
     This is the Polars-free public entry point the Rust-is-the-reference thesis wants:
-    a covered config is a first-class no-Polars API; the uncovered tail is where
-    Polars remains, loudly and optionally."""
-    if not isinstance(data, dict):
+    a covered config (from a dict or a CSV) is a first-class no-Polars API; the
+    uncovered tail is where Polars remains, loudly and optionally."""
+    from pathlib import Path
+
+    if isinstance(data, (str, Path)):
+        p = Path(data)
+        if p.suffix.lower() != ".csv":
+            raise ValueError(
+                f"transform() reads .csv paths Polars-free; {p.suffix or 'this'} needs "
+                "transform_df() / read_file() with goldenflow[polars]."
+            )
+        data = read_csv_columns(p)
+    elif not isinstance(data, dict):
         raise TypeError(
-            "transform() takes a dict[str, list] of columns; pass a pl.DataFrame to "
-            "transform_df() instead."
+            "transform() takes a dict[str, list] of columns or a .csv path; pass a "
+            "pl.DataFrame to transform_df() instead."
         )
 
     nm = native_module()

--- a/packages/python/goldenflow/tests/engine/test_columnar_csv_path.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_csv_path.py
@@ -1,0 +1,113 @@
+"""Phase 4e: ``transform()`` accepts a CSV path Polars-free.
+
+The public ``transform()`` already runs a covered config over a ``dict[str, list]``
+with Polars never imported. This closes the read side: hand it a ``.csv`` path and the
+stdlib-``csv`` reader (:func:`goldenflow.engine.columnar.read_csv_columns`) ingests it
+into the same ``dict`` shape — cell-identical to ``pl.read_csv(infer_schema_length=0)``
+(every field a string; empty -> ``None``). So the full read -> transform -> result flow
+works with ``goldenflow[polars]`` uninstalled.
+"""
+from __future__ import annotations
+
+import csv
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+def _write_csv(path, rows):
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        for r in rows:
+            w.writerow(["" if v is None else v for v in r])
+
+
+def test_read_csv_columns_matches_polars(tmp_path) -> None:
+    p = tmp_path / "in.csv"
+    _write_csv(p, [
+        ["name", "note", "empty"],
+        ["  John SMITH ", 'has,comma', ""],
+        ["jane", 'line\nbreak', "x"],
+        ["", "trailing", ""],
+    ])
+    got = columnar.read_csv_columns(p)
+    ref = pl.read_csv(p, infer_schema_length=0)
+    assert list(got.keys()) == ref.columns
+    for c in ref.columns:
+        assert got[c] == ref[c].to_list(), f"{c} diverged"
+
+
+def test_read_csv_columns_empty_file(tmp_path) -> None:
+    p = tmp_path / "empty.csv"
+    p.write_text("", encoding="utf-8")
+    assert columnar.read_csv_columns(p) == {}
+
+
+def test_transform_csv_path_equals_dict_and_polars(tmp_path) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    p = tmp_path / "in.csv"
+    _write_csv(p, [
+        ["name", "price", "dob"],
+        ["  John SMITH ", "$1,234.50", "2000-03-15"],
+        ["jane", "$0.5", "1990"],
+        ["", "", "bad"],
+    ])
+    cfg = GoldenFlowConfig(transforms=[
+        TransformSpec(column="name", ops=["strip", "lowercase"]),
+        TransformSpec(column="price", ops=["currency_strip", "round:1"]),
+        TransformSpec(column="dob", ops=["date_iso8601"]),
+    ])
+    assert columnar.config_is_columnar_ready(cfg)
+    from_path = goldenflow.transform(p, config=cfg)
+    from_dict = goldenflow.transform(columnar.read_csv_columns(p), config=cfg)
+    ref = goldenflow.transform_df(pl.read_csv(p, infer_schema_length=0), config=cfg)
+    for c in ref.df.columns:
+        assert from_path.columns[c] == ref.df[c].to_list(), f"{c} diverged"
+        assert from_path.columns[c] == from_dict.columns[c]
+
+
+def test_transform_non_csv_path_rejected(tmp_path) -> None:
+    p = tmp_path / "in.parquet"
+    p.write_bytes(b"")
+    cfg = GoldenFlowConfig(transforms=[TransformSpec(column="a", ops=["strip"])])
+    with pytest.raises(ValueError, match="csv"):
+        goldenflow.transform(p, config=cfg)
+
+
+def test_transform_csv_path_is_polars_free(tmp_path) -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    p = tmp_path / "in.csv"
+    _write_csv(p, [["name", "price"], ["  Hi ", "$1234.50"], ["JANE", "$0.5"]])
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            f"""
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="name", ops=["strip", "lowercase"]),
+                TransformSpec(column="price", ops=["currency_strip"]),
+            ])
+            res = goldenflow.transform(r"{p}", config=cfg)
+            assert res.columns["name"] == ["hi", "jane"], res.columns["name"]
+            assert res.columns["price"] == [1234.5, 0.5], res.columns["price"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr


### PR DESCRIPTION
Phase 4e of the GoldenFlow Polars-eviction arc. Closes the **read** side of the Polars-free pipeline.

## What
`transform()` already ran a covered config over a `dict[str, list]` with Polars never imported (Phase 4c). This adds a `.csv` **path** as an accepted input:

- New `columnar.read_csv_columns(path)` — stdlib-`csv` reader, **Polars-free, pyarrow-free**. Every field is a string; empty -> `None`. Cell-identical to `pl.read_csv(path, infer_schema_length=0)` (verified in the test, including embedded commas/newlines and empty-vs-null).
- `transform_columns_public` accepts `str`/`Path` ending `.csv` (reads via the stdlib reader), still accepts a `dict`. A non-`.csv` path raises a clear `ValueError` pointing at `transform_df()` / `read_file()` with `goldenflow[polars]`.

Net: the full **read CSV -> transform -> result** flow works with `goldenflow[polars]` uninstalled for any covered config.

## Tests (`tests/engine/test_columnar_csv_path.py`)
- `read_csv_columns` == `pl.read_csv(infer_schema_length=0)` cell-for-cell (commas, newlines, empty->null)
- empty file -> `{}`
- `transform(csv_path)` == `transform(dict)` == `transform_df(pl.read_csv(...))` for a covered config (strip/lowercase/currency_strip/round/date_iso8601)
- non-`.csv` path rejected
- subprocess assert: `transform(csv_path)` runs with **`polars` never imported**

🤖 Generated with [Claude Code](https://claude.com/claude-code)