### PR TITLE
feat(goldenflow): stage Phase 4f (polars-optional) behind a proof lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
       analysis_native: ${{ steps.filter.outputs.analysis_native }}
       infermap_native: ${{ steps.filter.outputs.infermap_native }}
       native_flow: ${{ steps.filter.outputs.native_flow }}
+      goldenflow_nopolars: ${{ steps.filter.outputs.goldenflow_nopolars }}
       goldenflow_duckdb: ${{ steps.filter.outputs.goldenflow_duckdb }}
       goldenpipe_native: ${{ steps.filter.outputs.goldenpipe_native }}
       goldenembed: ${{ steps.filter.outputs.goldenembed }}
@@ -655,6 +656,19 @@ jobs:
               - 'packages/python/goldenflow/goldenflow/transforms/_fastpath.py'
               - 'packages/python/goldenflow/tests/transforms/test_native_parity.py'
               - 'packages/python/goldenflow/tests/transforms/test_fastpath_parity.py'
+              - 'packages/python/goldenflow/scripts/build_native.py'
+            goldenflow_nopolars:
+              # Phase 4f (Polars eviction) proof lane: builds the native in-memory
+              # core, then installs goldenflow with polars UNINSTALLED and runs the
+              # polars-absent covered-path tests (tests/nopolars). Proves `import
+              # goldenflow` + covered transform() work with polars gone, so the 2.0
+              # base-deps flip is already de-risked. Advisory (not ci-required).
+              - 'packages/rust/extensions/native-flow/**'
+              - 'packages/rust/extensions/goldenflow-core/**'
+              - 'packages/rust/extensions/Cargo.toml'
+              - 'packages/python/goldenflow/goldenflow/**'
+              - 'packages/python/goldenflow/tests/nopolars/**'
+              - 'packages/python/goldenflow/pyproject.toml'
               - 'packages/python/goldenflow/scripts/build_native.py'
             goldenflow_duckdb:
               # goldenflow-duckdb: the compiled zero-Python DuckDB extension over
@@ -2751,6 +2765,47 @@ jobs:
             packages/python/goldenflow/tests/transforms/test_phone.py \
             packages/python/goldenflow/tests/transforms/test_dates.py \
             -v
+
+  # Phase 4f (Polars eviction) proof lane. Builds the native in-memory core, then
+  # UNINSTALLS polars and runs the polars-absent covered-path tests. This is the
+  # living proof that `import goldenflow` + a covered config's transform() work with
+  # polars gone — so the 2.0 major that moves `polars` out of the base deps is already
+  # de-risked. Advisory (NOT in ci-required); a red here means the polars-free surface
+  # regressed (a module grew a top-level `import polars`, or a covered transform now
+  # needs the Polars engine), not that main is broken.
+  goldenflow_nopolars:
+    needs: changes
+    if: needs.changes.outputs.goldenflow_nopolars == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native-flow
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+      - run: uv sync --all-packages
+      - name: Build native in-memory core into the package
+        run: uv run python packages/python/goldenflow/scripts/build_native.py
+      - name: Uninstall polars (simulate the 2.0 base-deps flip)
+        # The covered config path runs on the native in-memory core alone; polars is
+        # the OPTIONAL Polars engine for the uncovered tail. Remove it (and its split
+        # runtime) so the tests below prove the polars-absent surface for real. NO
+        # pyarrow either — the covered in-memory path is pyarrow-free.
+        run: uv pip uninstall polars polars-runtime-32 polars-runtime-64 || true
+      - name: Confirm polars is gone
+        run: uv run --no-sync python -c "import importlib.util,sys; sys.exit(0 if importlib.util.find_spec('polars') is None else 'polars still present')"
+      - name: Polars-absent covered-path proof (tests/nopolars)
+        # --no-sync so uv doesn't reinstall polars before the run; --noconftest so the
+        # polars-importing parent tests/conftest.py isn't collected (the nopolars tests
+        # are self-contained, only the builtin tmp_path fixture).
+        run: uv run --no-sync python -m pytest packages/python/goldenflow/tests/nopolars --noconftest -v
 
   # goldenpipe planner kernel: pyo3-free goldenpipe-core is the REFERENCE. This lane
   # is goldenpipe-core's ONLY CI coverage (it had no consumer to hang a lane on before

--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -214,15 +214,36 @@ recovered by `[native]`.
   `age_from_dob`) await dtype-aware scalar egress (a later wave). Remaining clean
   families (categorical, identifiers formatters, names remainder) are thin
   `scalar=`-wiring PRs.
-- **4e — I/O extras.** Native CSV is default; parquet/excel/scan/database move behind
-  `[polars]`/`[parquet]` with graceful `ImportError`. Gate: fallback-path tests
-  (mirror the existing cloud-connector pattern).
-- **4f — Flip the default + move `polars` to `[polars]`.** Drop `polars>=1.0` from
-  `[project.dependencies]`; add the `[polars]` extra. Update the suite floors, docs,
-  `[all]`, and the golden-suite bundle. Gate: a **no-polars CI lane** (`pip install
-  goldenflow` in a clean env, run the covered surface, assert it works with
-  `'polars' not in sys.modules`). This is the only genuinely-breaking step and
-  is a **major version** (goldenflow 2.0) with a migration note.
+- **4e — I/O extras. SHIPPED (read side, PR #1567).** `transform()` now accepts a
+  `.csv` **path** via a stdlib-`csv` reader (`columnar.read_csv_columns`), cell-identical
+  to `pl.read_csv(infer_schema_length=0)` (every field a string, empty -> `None`,
+  quoting/embedded-newline handled). So the full **read CSV -> transform -> result**
+  flow works Polars-free for a covered config; a non-`.csv` path raises a clear
+  `ValueError`. (parquet/excel/scan/database stay behind `[polars]` with graceful
+  `ImportError` — the existing cloud-connector pattern; no change needed there yet.)
+- **4f — Flip the default + move `polars` to `[polars]`. PROTOTYPED (staged, not
+  flipped).** The breaking bits are staged and de-risked so the shape is visible before
+  the 2.0 commit:
+  - **Measured weight delta (clean-room, §7a below): ~185 MB installed / ~35 MB wheel**,
+    and polars pulls **no numpy, no pyarrow** — those are `[native]`/other-package
+    costs, not base. That number justifies the 2.0.
+  - **Validated the end state for real:** with polars **genuinely uninstalled**,
+    `import goldenflow` succeeds (polars never enters `sys.modules`), the native
+    in-memory core is ready, covered `transform()` (dict + CSV path) produces correct
+    output, and touching the lazy proxy raises a clean `ModuleNotFoundError`.
+  - **`[polars]` extra added now** (additive, non-breaking — base still has `polars`,
+    so `goldenflow[polars]` resolves today as a forward-compatible no-op).
+  - **`goldenflow_nopolars` CI lane added** (advisory, not `ci-required`): builds the
+    native core, `uv pip uninstall polars`, runs `tests/nopolars/test_polars_absent.py`
+    (imports polars nowhere; asserts covered outputs vs hardcoded literals the parity
+    corpus already proves equal the Polars engine). It `skipif`s OUT of the normal
+    suite (5 skipped where polars is present; 5 pass where absent), so it's inert
+    except in its own lane — and it's already green, so the flip is pre-proven.
+  - **Remaining to actually flip (the 2.0 PR):** delete `polars>=1.0` from
+    `[project.dependencies]` (it stays in `[polars]`), add `polars` to `[all]`, bump to
+    `2.0.0`, migration note, suite floors + golden-suite lockstep. Only genuinely-breaking
+    step; hold until the covered surface is judged wide enough (dates bulk path + the
+    remaining `*_validate`/name families still need `[polars]` or their scalar wiring).
 
 ---
 
@@ -245,6 +266,29 @@ recovered by `[native]`.
 - **Non-goal: deleting Polars.** It stays a first-class optional accelerator.
 
 ---
+
+## 7a. Measured weight delta (4f prototype, 2026-07-07)
+
+Clean-room, fresh venv on Windows/py3.12:
+
+| Step | site-packages size |
+|---|---|
+| empty venv | 12 MB |
+| `pip install polars` | 197 MB |
+| **delta (polars + polars-runtime-32)** | **~185 MB installed** |
+
+- `pip install polars` pulled **only** `polars` + `polars-runtime-32` — **no numpy, no
+  pyarrow** (both are polars *extras*: `polars[numpy]`, `polars[pyarrow]`). goldenflow's
+  base code imports neither directly (only the `[native]` path touches pyarrow). So the
+  numpy (41 MB) + pyarrow (85 MB) seen in a full dev venv are NOT base-goldenflow costs.
+- Wheel download is ~35 MB; installed (uncompressed) is ~185 MB. The 2.0 flip removes
+  that from the default `pip install goldenflow`.
+
+**Polars-absent validation (the shape is real, not theoretical):** a base-minus-polars
+venv + the in-tree native core runs `import goldenflow` and covered `transform()`
+(dict + CSV path) correctly with `'polars' not in sys.modules`; the lazy proxy raises a
+clean `ModuleNotFoundError` on the uncovered tail. Locked by the `goldenflow_nopolars`
+CI lane (`tests/nopolars/`).
 
 ## 7. Effort shape
 

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -20,6 +20,15 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
 ]
+# Phase 4f (Polars eviction) is STAGED, not yet flipped. `polars` is still a base
+# dependency here; the 2.0 major will MOVE it to the `[polars]` extra below so a
+# default `pip install goldenflow` drops the ~185 MB installed polars footprint and
+# the covered config path runs on the native in-memory core alone. The `[polars]`
+# extra already exists so `goldenflow[polars]` resolves today (currently a no-op —
+# polars is in base — but forward-compatible), and the `goldenflow_nopolars` CI lane
+# proves `import goldenflow` + covered transforms work with polars uninstalled. When
+# the 2.0 flip lands: delete `polars>=1.0` from this list (it stays in `[polars]`),
+# add `polars` to `all`, bump to 2.0.0. See docs/design for the measured shape.
 dependencies = [
     "polars>=1.0",
     "pydantic>=2.7",
@@ -38,6 +47,10 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6", "httpx>=0.27", "python-multipart>=0.0.20"]
 check = ["goldencheck>=1.0"]
+# Phase 4f: the Polars engine (transform_df, zero-config profiling, non-covered
+# transforms, Excel/Parquet/DB connectors). Currently redundant with the base dep;
+# becomes load-bearing when 2.0 drops polars from the base `dependencies`.
+polars = ["polars>=1.0"]
 excel = ["openpyxl>=3.1"]
 db = ["connectorx>=0.3"]
 mcp = ["mcp>=1.0"]

--- a/packages/python/goldenflow/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldenflow/tests/nopolars/test_polars_absent.py
@@ -1,0 +1,120 @@
+"""Phase 4f prototype: goldenflow works with **polars genuinely uninstalled**.
+
+This is the living proof for the Polars-eviction end state. Every other Polars-free
+test in the suite still ``import polars`` to compare a covered result against the
+``transform_df`` reference, so none of them can run in a polars-absent interpreter.
+This module imports polars NOWHERE — it asserts covered outputs against hardcoded
+literals (the byte-parity corpus already proves those literals equal the Polars
+engine) — so it is the one module that can run under a base install with ``polars``
+moved to the ``[polars]`` extra.
+
+It is ``skipif``'d OUT of the normal suite (where polars IS present), so it is inert
+there and only executes in the dedicated ``goldenflow_nopolars`` CI lane (and any
+local run where polars is absent). When 4f flips ``polars`` out of the base deps for
+the 2.0 major, this lane is already green — it de-risks the breaking bump.
+"""
+from __future__ import annotations
+
+import importlib.util
+
+import pytest
+
+_HAS_POLARS = importlib.util.find_spec("polars") is not None
+
+pytestmark = pytest.mark.skipif(
+    _HAS_POLARS,
+    reason="polars-absent proof — only runs where polars is NOT installed (the 4f lane)",
+)
+
+
+def test_import_goldenflow_without_polars() -> None:
+    import sys
+
+    import goldenflow  # must not raise, must not import polars
+
+    assert "polars" not in sys.modules
+    # sanity: the public covered entry points exist
+    assert hasattr(goldenflow, "transform")
+    assert hasattr(goldenflow, "transform_df")  # exists; needs [polars] to run
+
+
+def test_native_core_is_ready_without_polars() -> None:
+    from goldenflow.core._native_loader import native_module
+    from goldenflow.engine import columnar
+
+    nm = native_module()
+    if nm is None or not columnar.native_columns_ready(nm):
+        pytest.skip("native in-memory core not built (the covered path needs it)")
+
+
+def _cfg(specs):
+    from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _need_native():
+    from goldenflow.core._native_loader import native_module
+    from goldenflow.engine import columnar
+
+    nm = native_module()
+    if nm is None or not columnar.native_columns_ready(nm):
+        pytest.skip("native in-memory core not built")
+
+
+def test_covered_transform_dict_without_polars() -> None:
+    import sys
+
+    import goldenflow
+
+    _need_native()
+    cfg = _cfg([
+        ("name", ["strip", "lowercase"]),
+        ("price", ["currency_strip", "round:1"]),
+        ("dob", ["date_iso8601"]),
+        ("flag", ["boolean_normalize"]),
+    ])
+    res = goldenflow.transform(
+        {
+            "name": ["  John SMITH ", "jane", None],
+            "price": ["$1,234.50", "$0.5", ""],
+            "dob": ["2000-03-15", "1990", "bad"],
+            "flag": ["yes", "no", "maybe"],
+            "k": [1, 2, 3],
+        },
+        config=cfg,
+    )
+    assert res.columns["name"] == ["john smith", "jane", None]
+    assert res.columns["price"] == [1234.5, 0.5, None]
+    assert res.columns["dob"] == ["2000-03-15", "1990-01-01", "bad"]
+    assert res.columns["flag"] == [True, False, None]
+    assert "polars" not in sys.modules
+
+
+def test_covered_transform_csv_path_without_polars(tmp_path) -> None:
+    import csv
+    import sys
+
+    import goldenflow
+
+    _need_native()
+    p = tmp_path / "in.csv"
+    with open(p, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["name", "price"])
+        w.writerow(["  Hi ", "$1234.50"])
+        w.writerow(["JANE", "$0.5"])
+    cfg = _cfg([("name", ["strip", "lowercase"]), ("price", ["currency_strip"])])
+    res = goldenflow.transform(p, config=cfg)
+    assert res.columns["name"] == ["hi", "jane"]
+    assert res.columns["price"] == [1234.5, 0.5]
+    assert "polars" not in sys.modules
+
+
+def test_uncovered_path_raises_clean_error_without_polars() -> None:
+    """Touching the lazy Polars proxy with polars absent surfaces a plain
+    ``ModuleNotFoundError`` (the uncovered tail is loudly, optionally Polars)."""
+    from goldenflow._polars_lazy import pl
+
+    with pytest.raises(ModuleNotFoundError):
+        _ = pl.DataFrame  # attribute access triggers the deferred import


### PR DESCRIPTION
Prototypes the GoldenFlow 2.0 Polars-eviction flip **without the breaking change** — so the shape is visible and pre-proven before we commit to the major bump. Nothing here changes the default install: `polars` stays a base dep.

## Measured weight delta (clean-room, fresh venv)
| Step | site-packages |
|---|---|
| empty venv | 12 MB |
| `pip install polars` | 197 MB |
| **delta** | **~185 MB installed** (~35 MB wheel) |

`pip install polars` pulled **only** `polars` + `polars-runtime-32` — **no numpy, no pyarrow** (both are polars *extras*). goldenflow base imports neither directly, so the numpy/pyarrow in a dev venv are `[native]`/other-package costs, not base. That ~185 MB is what the 2.0 flip removes from a default `pip install goldenflow`.

## Validated the end state for real
With polars **genuinely uninstalled** (base-minus-polars venv + in-tree native core):
- `import goldenflow` succeeds, `polars` never enters `sys.modules`
- native in-memory core ready; covered `transform()` (dict + CSV path) correct
- touching the lazy proxy raises a clean `ModuleNotFoundError`

## What's staged here (all additive / non-breaking)
- **`[polars]` extra** in `pyproject.toml` — resolves today as a forward-compat no-op (base still has polars). The 2.0 PR deletes the base dep; the extra stays.
- **`tests/nopolars/test_polars_absent.py`** — imports polars nowhere; asserts covered outputs vs hardcoded literals the parity corpus already proves equal the Polars engine. `skipif`'d out when polars is present (inert: 5 skipped in the normal suite) and runs when absent (5 pass).
- **`goldenflow_nopolars` CI lane** (advisory, **not** `ci-required`) — builds the native core, `uv pip uninstall polars`, runs the polars-absent tests. Living proof the flip is safe.

## Still to do for the actual 2.0 (a later PR)
Delete `polars>=1.0` from `[project.dependencies]` (stays in `[polars]`), add `polars` to `[all]`, bump `2.0.0` + migration note, suite floors + golden-suite lockstep. Hold until the covered surface is judged wide enough (dates bulk path + remaining `*_validate`/name families still need `[polars]` or scalar wiring).

Design doc: `docs/design/2026-07-07-phase4-polars-optional-scoping.md` (§4f + §7a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)