### PR TITLE
docs(goldencheck-types): reflect 16 domain packs (4->16 rollout)

### DIFF
--- a/packages/python/goldencheck-types/CLAUDE.md
+++ b/packages/python/goldencheck-types/CLAUDE.md
@@ -18,7 +18,7 @@ goldencheck_types/
 ├── __init__.py     # public API: SchemaVersion, FieldType, InferredSchema, etc.
 ├── types.py        # Pydantic models. snake_case enforced via Field(alias=...) where needed.
 ├── loader.py       # YAML → FieldType. Single load_field_types(path) entrypoint.
-└── _domains/       # Bundled domain packs (healthcare.yml, finance.yml, ecommerce.yml)
+└── _domains/       # Bundled domain packs (16: generic + 15 industry verticals — synced byte-for-byte from the TS `domains/` canonical via scripts/sync_domain_packs.py)
 ```
 
 ## Schema versioning

--- a/packages/typescript/goldencheck-types/README.md
+++ b/packages/typescript/goldencheck-types/README.md
@@ -2,15 +2,29 @@
 
 Community-contributed semantic type definitions for [GoldenCheck](https://github.com/benseverndev-oss/goldencheck).
 
-Domain packs teach GoldenCheck about industry-specific column types, improving detection accuracy and reducing false positives.
+Domain packs teach GoldenCheck about industry-specific column types, improving detection accuracy and reducing false positives. The same packs also drive InferMap's `detect_domain` (which industry a dataset belongs to) and, through it, GoldenPipe's auto-config — a dataset that scores a domain confidently gets a schema-inference stage prepended.
 
 ## Available Domains
 
+15 industry packs (plus a `generic` fallback used when no domain matches):
+
 | Domain | Types | Description |
 |--------|-------|-------------|
-| [healthcare](domains/healthcare.yaml) | 10 | NPI, ICD codes, insurance IDs, patient demographics, CPT, DRG |
+| [automotive](domains/automotive.yaml) | 4 | Vehicles: VIN, license plate, registration, odometer, make/model |
+| [ecommerce](domains/ecommerce.yaml) | 9 | SKUs, order IDs, tracking numbers, product categories, shipping |
+| [education](domains/education.yaml) | 5 | Students, enrollment, courses, grades/GPA, terms, programs |
+| [energy](domains/energy.yaml) | 4 | Meters, consumption (kWh), tariffs, utility accounts |
 | [finance](domains/finance.yaml) | 8 | Account numbers, routing numbers, CUSIP/ISIN, currency, transactions |
-| [ecommerce](domains/ecommerce.yaml) | 9 | SKUs, order IDs, tracking numbers, categories, shipping |
+| [healthcare](domains/healthcare.yaml) | 10 | NPI, ICD codes, insurance IDs, patient demographics, CPT, DRG |
+| [hospitality](domains/hospitality.yaml) | 4 | Reservations, bookings, stays, rooms, guests |
+| [hr](domains/hr.yaml) | 11 | Employee IDs, job titles, departments, compensation, hire dates, status, org hierarchy, performance |
+| [insurance](domains/insurance.yaml) | 9 | Policies, claims, premiums, coverage, underwriting, beneficiaries |
+| [legal](domains/legal.yaml) | 4 | Cases, dockets, matters, parties, courts, jurisdictions |
+| [logistics](domains/logistics.yaml) | 5 | Shipments, tracking, carriers, freight, warehouses |
+| [manufacturing](domains/manufacturing.yaml) | 4 | Parts, work orders, batches/lots, BOM, quality |
+| [marketing](domains/marketing.yaml) | 5 | Leads, campaigns, pipeline, funnel metrics, attribution |
+| [real_estate](domains/real_estate.yaml) | 4 | Listings, properties, features (beds/baths/sqft), sale prices |
+| [telecom](domains/telecom.yaml) | 5 | Subscribers, device IDs (IMEI/IMSI/ICCID), usage, plans, network |
 
 ## Usage
 


### PR DESCRIPTION
## What

Doc sweep for the domain-pack rollout that took `goldencheck-types` from 4 to 16 packs (hr #1558; insurance/telecom/real_estate/education #1560; logistics/energy/automotive/legal/hospitality/manufacturing/marketing #1564).

Two surfaces enumerate this specific registry and were stale:
- **`packages/typescript/goldencheck-types/README.md`** — the Available-Domains table listed 3 packs; now lists all 15 industry packs (+ a note on the `generic` fallback), with type-counts and descriptions. Added one sentence noting these packs also drive InferMap `detect_domain` and GoldenPipe auto-config.
- **`packages/python/goldencheck-types/CLAUDE.md`** — the `_domains/` layout comment enumerated the old 3 packs; now states 16 and points at the sync script.

## Scope / deliberately NOT touched

These are **parallel** domain systems this rollout did not change, so their "3 domains" claims are correct as-is:
- goldencheck's own `semantic/domains/` (3 semantic packs for its scanner)
- InferMap's alias `dictionaries/` (3: healthcare/finance/ecommerce, `MapEngine(domains=)`)
- goldenflow's 5 transform domain packs

## Verification

- `scripts/sync_domain_packs.py --check` → `OK -- 16 domain pack(s) in sync`
- Docs-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)