### PR TITLE
feat(goldenflow): phone/email_validate/name_script scalars on the columnar path

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/email.py
+++ b/packages/python/goldenflow/goldenflow/transforms/email.py
@@ -203,6 +203,8 @@ def email_extract_domain(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=60,
     mode="series",
+    scalar=_email_validate_py,
+    scalar_dtype="bool",
 )
 def email_validate(series: pl.Series) -> pl.Series:
     """Validate email format. Returns True/False/None.

--- a/packages/python/goldenflow/goldenflow/transforms/names.py
+++ b/packages/python/goldenflow/goldenflow/transforms/names.py
@@ -477,6 +477,7 @@ def _name_script_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_name_script_py,
 )
 def name_script(series: pl.Series) -> pl.Series:
     """Detect the dominant Unicode script in a name: ``Unknown`` for empty

--- a/packages/python/goldenflow/goldenflow/transforms/phone.py
+++ b/packages/python/goldenflow/goldenflow/transforms/phone.py
@@ -55,35 +55,73 @@ def _parse_phone(val: str | None) -> phonenumbers.PhoneNumber | None:
         return None
 
 
+# Module-level per-row references (Phase 4d scalar path). The fast path
+# (`apply_with_residual`) is parity-safe by construction -- every tier agrees with
+# these references on the rows it resolves -- so the engine's output equals applying
+# these row-by-row. Registering them as `scalar=` makes the phone family run on the
+# Polars-free columnar path byte-identically to the Polars engine (slower per-row
+# phonenumbers, recovered by [native]; only the columnar/Polars-free path uses this,
+# never the default fast path).
+def _phone_e164_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    parsed = _parse_phone(val)
+    if parsed is None:
+        return val  # preserve original on failure
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+
+
+def _phone_national_py(val: str | None) -> str | None:
+    if val is None:
+        return None
+    parsed = _parse_phone(val)
+    if parsed is None:
+        return val
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.NATIONAL)
+
+
+def _phone_validate_py(val: str | None) -> bool | None:
+    if val is None:
+        return None
+    parsed = _parse_phone(val)
+    if parsed is None:
+        return False
+    return phonenumbers.is_possible_number(parsed)
+
+
+def _phone_country_code_py(val: str | None) -> int | None:
+    if val is None:
+        return None
+    parsed = _parse_phone(val)
+    if parsed is None:
+        return None
+    return parsed.country_code
+
+
+def _phone_digits_py(val: str | None) -> str | None:
+    """Byte-exact reference for the corpus oracle: keep only ASCII digits
+    (matches the goldenflow-core `phone_digits` kernel; a Unicode digit is
+    dropped here, unlike Python `str.isdigit`)."""
+    if val is None:
+        return None
+    return "".join(c for c in val if c in "0123456789")
+
+
 @register_transform(
-    name="phone_e164", input_types=["phone"], auto_apply=True, priority=50, mode="series"
+    name="phone_e164", input_types=["phone"], auto_apply=True, priority=50, mode="series",
+    scalar=_phone_e164_py,
 )
 def phone_e164(series: pl.Series) -> pl.Series:
-    def _format(val: str | None) -> str | None:
-        if val is None:
-            return None
-        parsed = _parse_phone(val)
-        if parsed is None:
-            return val  # preserve original on failure
-        return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-
     return apply_with_residual(
-        series, _e164_fast_expr(), _format, pl.Utf8, native_fn=phone_e164_native()
+        series, _e164_fast_expr(), _phone_e164_py, pl.Utf8, native_fn=phone_e164_native()
     )
 
 
 @register_transform(
-    name="phone_national", input_types=["phone"], auto_apply=False, priority=50, mode="series"
+    name="phone_national", input_types=["phone"], auto_apply=False, priority=50, mode="series",
+    scalar=_phone_national_py,
 )
 def phone_national(series: pl.Series) -> pl.Series:
-    def _format(val: str | None) -> str | None:
-        if val is None:
-            return None
-        parsed = _parse_phone(val)
-        if parsed is None:
-            return val
-        return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.NATIONAL)
-
     # Native NANP national format, gated to the canonical "(NXX) NXX-XXXX" shape
     # (phone_national_native nulls the ambiguous leading-1 outputs so tier-3
     # Python settles them). No Polars fast expr -- a no-op lit + the Python
@@ -91,14 +129,15 @@ def phone_national(series: pl.Series) -> pl.Series:
     return apply_with_residual(
         series,
         pl.lit(None, dtype=pl.Utf8),
-        _format,
+        _phone_national_py,
         pl.Utf8,
         native_fn=phone_national_native(),
     )
 
 
 @register_transform(
-    name="phone_digits", input_types=["phone"], auto_apply=False, priority=50, mode="series"
+    name="phone_digits", input_types=["phone"], auto_apply=False, priority=50, mode="series",
+    scalar=_phone_digits_py,
 )
 def phone_digits(series: pl.Series) -> pl.Series:
     # Native-first over goldenflow-core (ASCII digit-strip); else the pure-Polars
@@ -112,28 +151,12 @@ def phone_digits(series: pl.Series) -> pl.Series:
     return series.cast(pl.Utf8).str.replace_all(r"\D", "")
 
 
-def _phone_digits_py(val: str | None) -> str | None:
-    """Byte-exact reference for the corpus oracle: keep only ASCII digits
-    (matches the goldenflow-core `phone_digits` kernel; a Unicode digit is
-    dropped here, unlike Python `str.isdigit`)."""
-    if val is None:
-        return None
-    return "".join(c for c in val if c in "0123456789")
-
-
 @register_transform(
-    name="phone_validate", input_types=["phone"], auto_apply=False, priority=60, mode="series"
+    name="phone_validate", input_types=["phone"], auto_apply=False, priority=60, mode="series",
+    scalar=_phone_validate_py, scalar_dtype="bool",
 )
 def phone_validate(series: pl.Series) -> pl.Series:
-    def _validate(val: str | None) -> bool | None:
-        if val is None:
-            return None
-        parsed = _parse_phone(val)
-        if parsed is None:
-            return False
-        return phonenumbers.is_possible_number(parsed)
-
-    return series.map_elements(_validate, return_dtype=pl.Boolean)
+    return series.map_elements(_phone_validate_py, return_dtype=pl.Boolean)
 
 
 @register_transform(
@@ -142,21 +165,14 @@ def phone_validate(series: pl.Series) -> pl.Series:
     auto_apply=False,
     priority=45,
     mode="series",
+    scalar=_phone_country_code_py,
+    scalar_dtype="int",
 )
 def phone_country_code(series: pl.Series) -> pl.Series:
     """Extract the country calling code as an integer."""
-
-    def _code(val: str | None) -> int | None:
-        if val is None:
-            return None
-        parsed = _parse_phone(val)
-        if parsed is None:
-            return None
-        return parsed.country_code
-
     native = phone_country_code_native()
     if native is None:
-        return series.map_elements(_code, return_dtype=pl.Int64)
+        return series.map_elements(_phone_country_code_py, return_dtype=pl.Int64)
     return apply_with_residual(
-        series, pl.lit(None, dtype=pl.Int64), _code, pl.Int64, native_fn=native
+        series, pl.lit(None, dtype=pl.Int64), _phone_country_code_py, pl.Int64, native_fn=native
     )

--- a/packages/python/goldenflow/tests/engine/test_columnar_engine.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_engine.py
@@ -159,14 +159,15 @@ def test_columnar_split_equals_polars(monkeypatch, ops, col, data) -> None:
 
 
 def test_columnar_declines_unsupported_config(monkeypatch) -> None:
-    """A config with a non-owned-string op (phone) or a frame-level op is NOT
-    columnar-ready; it falls through to the Polars engine (still correct)."""
+    """A config with a data-dependent op (category_auto_correct) or a frame-level op
+    is NOT columnar-ready; it falls through to the Polars engine (still correct)."""
     monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
-    # phone_e164 is not an owned string kernel -> declines
-    assert not columnar.config_is_columnar_ready(_cfg([("name", ["strip", "phone_e164"])]))
+    # category_auto_correct is data-dependent (whole-column frequency map), not a
+    # scalar or fused kernel -> declines (deliberately excluded from the columnar path)
+    assert not columnar.config_is_columnar_ready(_cfg([("name", ["strip", "category_auto_correct"])]))
     # a rename is a frame-level op -> declines
     cfg = GoldenFlowConfig(transforms=[TransformSpec(column="name", ops=["strip"])], renames={"name": "n"})
     assert not columnar.config_is_columnar_ready(cfg)
     # but it still produces correct output via the Polars fallback
-    out = transform_df(SAMPLE, config=_cfg([("name", ["strip", "phone_e164"])]))
-    assert out.df["name"].to_list()[0] == "<b>John</b>  SMITH!"  # strip applied
+    out = transform_df(SAMPLE, config=cfg)
+    assert out.df["n"].to_list()[0] == "<b>John</b>  SMITH!"  # strip applied, renamed

--- a/packages/python/goldenflow/tests/engine/test_columnar_scalar_families.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_scalar_families.py
@@ -1,0 +1,121 @@
+"""Phase 4d follow-on: the remaining clean scalar families on the columnar path.
+
+Wires the last non-#1563, non-data-dependent transforms onto the Polars-free columnar
+path via the ``scalar=`` mechanism:
+
+- **phone** (`phone_e164`/`phone_national`/`phone_digits`/`phone_validate`/
+  `phone_country_code`): the per-row `phonenumbers` reference is the SAME function the
+  fast path settles residual rows with, and the fast path is parity-safe by
+  construction (every tier agrees with the reference on rows it resolves), so the
+  scalar output is byte-identical to the Polars engine. Only the columnar/Polars-free
+  path uses the scalar; the default `transform_df` still runs the vectorized fast path.
+- **email_validate** (str -> bool) and **name_script** (str -> str): owned kernels whose
+  pure-Python reference is proven equal to the native kernel by the parity corpus.
+
+Covers three dtypes: str (e164/national/digits/name_script), bool (validate), int
+(country_code).
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+CASES = [
+    (["phone_e164"], "c", ["(415) 555-2671", "4155552671", "+44 20 7946 0958", "bad", None]),
+    (["phone_national"], "c", ["4155552671", "+14155552671", "nope", None]),
+    (["phone_digits"], "c", ["(415) 555-2671", "abc123", "", None]),
+    (["phone_validate"], "c", ["4155552671", "123", "bad", None]),
+    (["phone_country_code"], "c", ["+442079460958", "4155552671", "x", None]),
+    (["email_validate"], "c", ["a@b.com", "nope", "x@y.co.uk", None]),
+    (["name_script"], "c", ["John", "Иван", "Ω", "", None]),
+    # mixed chain: a fused kernel followed by a scalar
+    (["strip", "phone_e164"], "c", ["  4155552671 ", None]),
+    (["strip", "lowercase", "email_validate"], "c", ["  A@B.COM ", "  nope ", None]),
+]
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_scalar_family_dict_equals_polars(ops, col, data) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {col: data, "k": list(range(len(data)))}
+    cfg = _cfg([(col, ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged for {ops}"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("ops,col,data", CASES)
+def test_scalar_family_columnar_engine_equals_polars(monkeypatch, ops, col, data) -> None:
+    """The GOLDENFLOW_ENGINE=columnar frame path matches value AND dtype."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    dd = {col: data, "k": list(range(len(data)))}
+    df = pl.DataFrame(dd)
+    cfg = _cfg([(col, ops)])
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df), f"value/dtype diverged for {ops}"
+    assert got.df[col].dtype == ref.df[col].dtype
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+
+
+def test_scalar_families_are_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="p", ops=["phone_e164"]),
+                TransformSpec(column="cc", ops=["phone_country_code"]),
+                TransformSpec(column="e", ops=["email_validate"]),
+                TransformSpec(column="n", ops=["name_script"]),
+            ])
+            res = goldenflow.transform(
+                {"p": ["4155552671", None], "cc": ["+442079460958", None],
+                 "e": ["a@b.com", None], "n": ["John", None], "k": [1, 2]},
+                config=cfg,
+            )
+            assert res.columns["p"] == ["+14155552671", None], res.columns["p"]
+            assert res.columns["cc"] == [44, None], res.columns["cc"]
+            assert res.columns["e"] == [True, None], res.columns["e"]
+            assert res.columns["n"] == ["Latin", None], res.columns["n"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr

--- a/packages/python/goldenflow/tests/engine/test_public_transform_polars_free.py
+++ b/packages/python/goldenflow/tests/engine/test_public_transform_polars_free.py
@@ -60,9 +60,11 @@ def test_transform_dict_equals_transform_df(specs, data) -> None:
 
 
 def test_transform_uncovered_config_matches_polars() -> None:
-    """An uncovered config (phone_e164) declines to the Polars engine, byte-identical."""
-    cfg = _cfg([("p", ["strip", "phone_e164"])])
-    data = {"p": ["  212-555-0100 ", "bad"], "k": [1, 2]}
+    """An uncovered config (category_auto_correct is data-dependent, not on the
+    columnar path) declines to the Polars engine, byte-identical."""
+    cfg = _cfg([("p", ["strip", "category_auto_correct"])])
+    data = {"p": ["  Apple ", "apple", "APPLE", "bad"], "k": [1, 2, 3, 4]}
+    assert not columnar.config_is_columnar_ready(cfg)
     res = goldenflow.transform(data, config=cfg)
     ref = goldenflow.transform_df(pl.DataFrame(data), config=cfg)
     for c in ref.df.columns:


### PR DESCRIPTION
Widens the Polars-free columnar surface toward the 2.0 flip by wiring the remaining **clean** scalar families — the ones not blocked by #1563 (identifiers) and not deliberately excluded (caller-data-dependent `category_*`/`auto_correct`, multi-input `merge_name`).

## What
- **phone** (`phone_e164`/`phone_national`/`phone_digits`/`phone_validate`/`phone_country_code`): extract each transform's per-row `phonenumbers` reference to a module-level `_phone_*_py` and register it as `scalar=`. The fast path (`apply_with_residual`) is **parity-safe by construction** — every tier agrees with that reference on the rows it resolves — so the scalar output is byte-identical to the Polars engine. Only the columnar/Polars-free path uses the scalar; the default `transform_df` still runs the vectorized fast path, so **no speed regression** for existing users.
- **email_validate** (str -> bool) and **name_script** (str -> str): register the existing pure-Python reference (proven equal to the native kernel by the parity corpus) as `scalar=`, `scalar_dtype="bool"` for `email_validate`.

Covers str / bool / int dtypes and mixed fused-kernel + scalar chains (`strip` -> `phone_e164`).

## Coverage delta
Takes 7 more transforms columnar-ready. The remaining uncovered tail is: the 22 `identifiers` (blocked by #1563; the 12 `*_validate` are the next batch once it lands), the excluded data-dependent `category_*`/`category_auto_correct`, `merge_name` (multi-input), and the numeric-input array ops (`round`/`clamp`/`abs_value`/`fill_zero`, which run fine in-chain).

## Tests
`tests/engine/test_columnar_scalar_families.py` — dict == polars, `GOLDENFLOW_ENGINE=columnar` value+dtype == polars, and a polars-free subprocess assert (19 pass). The phone refactor leaves the existing engine / fast-path / parity suites green (`test_phone` + `test_fastpath_parity` + `test_native_parity` + `test_identifiers_parity` = 1431 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)