### PR TITLE
feat(goldenflow): 12 identifier *_validate bool scalars on the columnar path

### DIFF
--- a/packages/python/goldenflow/goldenflow/domains/healthcare.py
+++ b/packages/python/goldenflow/goldenflow/domains/healthcare.py
@@ -1,34 +1,20 @@
 from __future__ import annotations
 
-import re
-
 from goldenflow._polars_lazy import pl
 from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
 from goldenflow.domains.base import DomainPack
 from goldenflow.transforms import register_transform
 
+# NOTE: ``npi_validate`` is owned by goldenflow.transforms.identifiers (native-first +
+# a registered pure-Python ``scalar`` for the Polars-free columnar path + byte-parity
+# corpus). healthcare used to register its OWN ``npi_validate`` here, which clobbered
+# the core one whenever this domain loaded — dropping npi_validate off the columnar
+# path (the same class of bug as people_hr's ssn_mask). The domain now REFERENCES the
+# core ``npi_validate`` by name (see PACK.transforms). Behavior note: the core rejects
+# an NPI with embedded letters (e.g. ``"npi:1234567893"``) where the old domain copy
+# stripped all non-digits and accepted it — the core (canonical kernel) is stricter and
+# consistent with the rest of the identifier family.
 
-@register_transform(name="npi_validate", input_types=["string"], auto_apply=False, priority=50, mode="series")
-def npi_validate(series: pl.Series) -> pl.Series:
-    """Validate NPI numbers (10-digit, Luhn check)."""
-    def _validate(val):
-        if val is None:
-            return None
-        digits = re.sub(r"\D", "", str(val))
-        if len(digits) != 10:
-            return False
-        # Luhn check with prefix 80840
-        full = "80840" + digits
-        total = 0
-        for i, d in enumerate(reversed(full)):
-            n = int(d)
-            if i % 2 == 1:
-                n *= 2
-                if n > 9:
-                    n -= 9
-            total += n
-        return total % 10 == 0
-    return series.map_elements(_validate, return_dtype=pl.Boolean)
 
 @register_transform(name="icd10_format", input_types=["string"], auto_apply=False, priority=50, mode="series")
 def icd10_format(series: pl.Series) -> pl.Series:

--- a/packages/python/goldenflow/goldenflow/transforms/identifiers.py
+++ b/packages/python/goldenflow/goldenflow/transforms/identifiers.py
@@ -127,6 +127,8 @@ def _cc_mask_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_cc_validate_py,
+    scalar_dtype="bool",
 )
 def cc_validate(series: pl.Series) -> pl.Series:
     """Validate a payment-card number via the Luhn checksum."""
@@ -231,6 +233,8 @@ def _iban_format_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_iban_validate_py,
+    scalar_dtype="bool",
 )
 def iban_validate(series: pl.Series) -> pl.Series:
     """Validate an IBAN via structural checks + the ISO 7064 mod-97 check."""
@@ -342,6 +346,8 @@ def _isbn_normalize_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_isbn_validate_py,
+    scalar_dtype="bool",
 )
 def isbn_validate(series: pl.Series) -> pl.Series:
     """Validate an ISBN-10 or ISBN-13 via its checksum."""
@@ -406,6 +412,8 @@ def _ean_validate_py(val: str | None) -> bool | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_ean_validate_py,
+    scalar_dtype="bool",
 )
 def ean_validate(series: pl.Series) -> pl.Series:
     """Validate an EAN-8, UPC-A, or EAN-13 via its GTIN mod-10 checksum."""
@@ -465,6 +473,8 @@ def _swift_format_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_swift_validate_py,
+    scalar_dtype="bool",
 )
 def swift_validate(series: pl.Series) -> pl.Series:
     """Validate a SWIFT/BIC code via structural checks (length 8/11 +
@@ -641,6 +651,8 @@ def _vat_format_py(val: str | None) -> str | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_vat_validate_py,
+    scalar_dtype="bool",
 )
 def vat_validate(series: pl.Series) -> pl.Series:
     """Validate an EU VAT number: structural check (country prefix + length +
@@ -771,6 +783,8 @@ def _aba_validate_py(val: str | None) -> bool | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_aba_validate_py,
+    scalar_dtype="bool",
 )
 def aba_validate(series: pl.Series) -> pl.Series:
     """Validate a US ABA bank routing number: exactly 9 digits plus the
@@ -806,6 +820,8 @@ def _imei_validate_py(val: str | None) -> bool | None:
     auto_apply=False,
     priority=50,
     mode="series",
+    scalar=_imei_validate_py,
+    scalar_dtype="bool",
 )
 def imei_validate(series: pl.Series) -> pl.Series:
     """Validate an IMEI: exactly 15 digits plus the Luhn checksum."""
@@ -917,7 +933,9 @@ def _cc_brand_py(val: str | None) -> str | None:
 
 
 @register_transform(
-    name="isin_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series"
+    name="isin_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series",
+    scalar=_isin_validate_py,
+    scalar_dtype="bool",
 )
 def isin_validate(series: pl.Series) -> pl.Series:
     """Validate an ISIN (ISO 6166). Native-first over goldenflow-core."""
@@ -928,7 +946,9 @@ def isin_validate(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="cusip_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series"
+    name="cusip_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series",
+    scalar=_cusip_validate_py,
+    scalar_dtype="bool",
 )
 def cusip_validate(series: pl.Series) -> pl.Series:
     """Validate a CUSIP. Native-first over goldenflow-core."""
@@ -939,7 +959,9 @@ def cusip_validate(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="npi_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series"
+    name="npi_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series",
+    scalar=_npi_validate_py,
+    scalar_dtype="bool",
 )
 def npi_validate(series: pl.Series) -> pl.Series:
     """Validate a US NPI. Native-first over goldenflow-core."""
@@ -950,7 +972,9 @@ def npi_validate(series: pl.Series) -> pl.Series:
 
 
 @register_transform(
-    name="luhn_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series"
+    name="luhn_validate", input_types=["identifier", "string"], auto_apply=False, priority=50, mode="series",
+    scalar=_luhn_validate_py,
+    scalar_dtype="bool",
 )
 def luhn_validate(series: pl.Series) -> pl.Series:
     """Generic Luhn check-digit validation. Native-first over goldenflow-core."""

--- a/packages/python/goldenflow/tests/engine/test_columnar_identifier_validators.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_identifier_validators.py
@@ -1,0 +1,113 @@
+"""Phase 4d: the 12 checksummed-identifier ``*_validate`` transforms on the columnar path.
+
+The last clean identifier batch (the formatters landed in #1563). Each validator has a
+pure-Python reference (``_X_validate_py``) proven equal to the goldenflow-core Rust
+kernel by the byte-parity corpus; registering it as ``scalar=`` (``scalar_dtype="bool"``)
+makes it run on the Polars-free columnar path byte-identically to the Polars engine.
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+CASES = [
+    (["cc_validate"], ["4111111111111111", "1234", None]),
+    (["iban_validate"], ["GB82WEST12345698765432", "bad", None]),
+    (["isbn_validate"], ["9780306406157", "0306406152", "x", None]),
+    (["ean_validate"], ["4006381333931", "123", None]),
+    (["swift_validate"], ["DEUTDEFF", "nope", None]),
+    (["vat_validate"], ["DE123456789", "x", None]),
+    (["aba_validate"], ["021000021", "111", None]),
+    (["imei_validate"], ["490154203237518", "123", None]),
+    (["isin_validate"], ["US0378331005", "bad", None]),
+    (["cusip_validate"], ["037833100", "x", None]),
+    (["npi_validate"], ["1234567893", "111", None]),
+    (["luhn_validate"], ["4111111111111111", "1235", None]),
+    # mixed: a fused string kernel then the bool validator
+    (["strip", "cc_validate"], ["  4111111111111111 ", None]),
+]
+
+
+@pytest.mark.parametrize("ops,data", CASES)
+def test_validator_dict_equals_polars(ops, data) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built (pre-0.25 wheel)")
+    dd = {"c": data, "k": list(range(len(data)))}
+    cfg = _cfg([("c", ops)])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dd, config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(dd), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), f"{c} diverged for {ops}"
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("ops,data", CASES)
+def test_validator_columnar_engine_equals_polars(monkeypatch, ops, data) -> None:
+    """The GOLDENFLOW_ENGINE=columnar frame path matches value AND Boolean dtype."""
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    dd = {"c": data, "k": list(range(len(data)))}
+    df = pl.DataFrame(dd)
+    cfg = _cfg([("c", ops)])
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df), f"value/dtype diverged for {ops}"
+    assert got.df["c"].dtype == ref.df["c"].dtype == pl.Boolean
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+
+
+def test_validators_are_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="cc", ops=["cc_validate"]),
+                TransformSpec(column="ib", ops=["iban_validate"]),
+                TransformSpec(column="np", ops=["npi_validate"]),
+            ])
+            res = goldenflow.transform(
+                {"cc": ["4111111111111111", None], "ib": ["GB82WEST12345698765432", None],
+                 "np": ["1234567893", None], "k": [1, 2]},
+                config=cfg,
+            )
+            assert res.columns["cc"] == [True, None], res.columns["cc"]
+            assert res.columns["ib"] == [True, None], res.columns["ib"]
+            assert res.columns["np"] == [True, None], res.columns["np"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr


### PR DESCRIPTION
The last clean identifier batch after the formatters (#1563). Registers each checksummed-identifier validator's existing pure-Python reference (proven equal to the goldenflow-core Rust kernel by the byte-parity corpus) as `scalar=` / `scalar_dtype="bool"`: **cc, iban, isbn, ean, swift, vat, aba, imei, isin, cusip, npi, luhn**. They now run on the Polars-free columnar path byte-identically to the Polars engine (value + Boolean dtype + manifest).

## Also: a second domain-clobber fix
Dropped the duplicate `npi_validate` from `domains/healthcare.py` — the **same bug class** as the `people_hr` `ssn_mask` fix earlier this session. healthcare registered its own `npi_validate` (no native, no scalar) under the same name, so loading the healthcare domain knocked the core `npi_validate` off the columnar path. Surfaced by the new test running after `test_owned_kernel_boundary` (which imports every domain at collection time). The domain now references the core `npi_validate` by name.

**Behavior note:** the core rejects an NPI with embedded letters (`"npi:1234567893"`) where the old domain copy stripped all non-digits and accepted it — the canonical kernel is stricter and consistent with the rest of the identifier family.

## Coverage
This closes the identifier family on the columnar path (10 formatters via #1563 + these 12 validators). Remaining uncovered tail is only the deliberately-excluded data-dependent transforms (`category_*`, `category_auto_correct`, `merge_name`) and the numeric-input array ops.

## Tests
`tests/engine/test_columnar_identifier_validators.py` — dict==polars, `GOLDENFLOW_ENGINE=columnar` value+Boolean-dtype==polars, polars-free subprocess. Full engine+transforms+domains suite green (1919 pass). Pre-push grep confirmed no decline-test uses these validator names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)