### PR TITLE
feat(goldenflow): caller-data categorical transforms on the columnar path (zero-gap W1)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/categorical.py
+++ b/packages/python/goldenflow/goldenflow/transforms/categorical.py
@@ -125,12 +125,60 @@ def null_standardize(series: pl.Series) -> pl.Series:
     return series.map_elements(_null_standardize_py, return_dtype=pl.Utf8)
 
 
+def _category_passthrough(val: str | None) -> str | None:
+    """Columnar scalar for ``category_standardize``: identity. The variant->canonical
+    mapping is a dict passed only via the direct API (``category_standardize(series,
+    mapping=...)``) — there is NO config/ops-string channel for a dict, so through the
+    config-driven columnar path this transform is a no-op, exactly as the Polars engine
+    is (``mapping=None`` -> ``return series``). Wiring identity makes the config case
+    columnar-ready and byte-identical; the mapping-carrying direct call still runs the
+    Polars body."""
+    return val
+
+
+def _category_from_file_factory(params: list[str]):
+    """Columnar scalar factory for ``category_from_file:<path>``. Loads the
+    variant->canonical mapping Polars-free (stdlib ``csv`` / ``yaml``) ONCE, then returns
+    a per-element closure byte-identical to the Polars engine: ``mapping.get(trim+lower
+    key, original)``. No path (or an unknown suffix) -> identity, matching the engine's
+    ``if not lookup_path: return series``."""
+    import csv
+    from pathlib import Path
+
+    lookup_path = params[0] if params else None
+    if not lookup_path:
+        return _category_passthrough
+    p = Path(lookup_path)
+    mapping: dict[str, str] = {}
+    if p.suffix == ".csv":
+        with open(p, newline="", encoding="utf-8") as f:
+            for row in csv.DictReader(f):
+                mapping[row["variant"].lower()] = row["canonical"]
+    elif p.suffix in (".yaml", ".yml"):
+        import yaml
+        with open(p) as f:
+            raw = yaml.safe_load(f) or {}
+        for canonical, variants in raw.items():
+            for v in variants:
+                mapping[v.lower()] = canonical
+    else:
+        return _category_passthrough
+
+    def _apply(val: str | None) -> str | None:
+        if val is None:
+            return None
+        return mapping.get(_category_normalize_key_py(val), val)
+
+    return _apply
+
+
 @register_transform(
     name="category_standardize",
     input_types=["string"],
     auto_apply=False,
     priority=45,
     mode="series",
+    scalar=_category_passthrough,
 )
 def category_standardize(
     series: pl.Series, mapping: dict[str, list[str]] | None = None
@@ -164,6 +212,7 @@ def category_standardize(
     auto_apply=False,
     priority=45,
     mode="series",
+    scalar_factory=_category_from_file_factory,
 )
 def category_from_file(
     series: pl.Series, lookup_path: str | None = None

--- a/packages/python/goldenflow/tests/engine/test_columnar_category_mapping.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_category_mapping.py
@@ -1,0 +1,115 @@
+"""Zero-gap Wave 1: the caller-data categorical transforms on the columnar path.
+
+- ``category_standardize`` takes a variant->canonical dict only via the direct API
+  (there is no config/ops-string channel for a dict), so through the config-driven
+  columnar path it is a no-op — identical to the Polars engine's ``mapping=None ->
+  return series``. Wired as an identity scalar.
+- ``category_from_file:<path>`` loads the mapping from a CSV/YAML file; wired as a
+  ``scalar_factory`` that reads the file Polars-free (stdlib csv/yaml) once and applies
+  ``mapping.get(trim+lower key, original)`` per element — byte-identical to the engine.
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+def _write_map_csv(path):
+    path.write_text(
+        "variant,canonical\nnyc,New York\nla,Los Angeles\nsf,San Francisco\n",
+        encoding="utf-8",
+    )
+
+
+def _write_map_yaml(path):
+    path.write_text(
+        "New York:\n  - nyc\n  - ny\nLos Angeles:\n  - la\n", encoding="utf-8"
+    )
+
+
+DATA = {"c": ["NYC", " la ", "SF", "Boston", None], "k": [0, 1, 2, 3, 4]}
+
+
+def test_category_standardize_identity_columnar() -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    cfg = _cfg([("c", ["category_standardize"])])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dict(DATA), config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(DATA), config=cfg)
+    assert res.columns["c"] == ref.df["c"].to_list()
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+@pytest.mark.parametrize("ext,writer", [("csv", _write_map_csv), ("yaml", _write_map_yaml)])
+def test_category_from_file_columnar_equals_polars(monkeypatch, tmp_path, ext, writer) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    # relative path: the ':' op-delimiter would split a Windows drive path (engine and
+    # columnar mangle it identically, but a relative name avoids the ambiguity entirely)
+    monkeypatch.chdir(tmp_path)
+    writer(tmp_path / f"map.{ext}")
+    for ops in ([f"category_from_file:map.{ext}"], ["strip", f"category_from_file:map.{ext}"]):
+        cfg = _cfg([("c", ops)])
+        assert columnar.config_is_columnar_ready(cfg)
+        res = goldenflow.transform(dict(DATA), config=cfg)
+        ref = goldenflow.transform_df(pl.DataFrame(DATA), config=cfg)
+        assert res.columns["c"] == ref.df["c"].to_list(), ops
+        assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_category_from_file_no_path_is_identity() -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    cfg = _cfg([("c", ["category_from_file"])])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dict(DATA), config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(DATA), config=cfg)
+    assert res.columns["c"] == ref.df["c"].to_list()
+
+
+def test_category_from_file_columnar_is_polars_free(monkeypatch, tmp_path) -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    _write_map_csv(tmp_path / "map.csv")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, os, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            os.chdir(sys.argv[1])
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="c", ops=["category_from_file:map.csv"]),
+            ])
+            res = goldenflow.transform({"c": ["NYC", "la", None], "k": [1, 2, 3]}, config=cfg)
+            assert res.columns["c"] == ["New York", "Los Angeles", None], res.columns["c"]
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        ), str(tmp_path)],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr


### PR DESCRIPTION
First wave toward **zero columnar gaps before 2.0** (closes 2 of 9).

- `category_standardize` — its variant→canonical dict arrives only via the direct API (no config/ops-string channel for a dict), so via the config-driven columnar path it's a no-op, identical to the Polars engine's `mapping=None -> return series`. Wired as an identity scalar.
- `category_from_file:<path>` — wired as a `scalar_factory` that loads the mapping file **Polars-free** (stdlib csv/yaml) once and applies `mapping.get(trim+lower key, original)` per element, byte-identical to the engine (which used `pl.read_csv`). No path → identity.

Tests: identity, CSV+YAML mapping (value + manifest == polars), no-path identity, polars-free subprocess. Full engine+transforms+domains suite green (1924 pass).

Remaining gaps after this: 4 numeric-input ops (round/clamp/abs_value/fill_zero), merge_name (multi-input), category_auto_correct (whole-column), initial_expand (flag-recording) — sequenced as follow-on waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)