### PR TITLE
docs(documents): surface the document-ingest capability across doc surfaces

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -56,6 +56,7 @@
               {
                 "group": "Features",
                 "pages": [
+                  "goldenmatch/documents",
                   "goldenmatch/auto-config",
                   "goldenmatch/config-suggestions",
                   "goldenmatch/scoring",

--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -59,7 +59,7 @@ Add to `claude_desktop_config.json`:
 }
 ```
 
-## Agent Capabilities (38 Skills)
+## Agent Capabilities (40 Skills)
 
 <Note>
 **Cross-language skill ids.** The TypeScript and Python A2A servers share

--- a/docs-site/goldenmatch/documents.mdx
+++ b/docs-site/goldenmatch/documents.mdx
@@ -1,0 +1,126 @@
+---
+title: "Document ingest"
+description: "Run GoldenMatch on unstructured input — extract matchable records from PDFs and images, then dedupe them."
+keywords: ["document ingest", "pdf", "image", "unstructured", "extraction", "vlm", "ocr", "records"]
+---
+
+GoldenMatch does not require structured data. Point it at a pile of PDFs or images
+(business cards, intake forms, invoices, receipts, scanned directories) and it extracts
+structured records against a schema you control, then hands them straight to the ER
+pipeline. One vision call per page classifies and extracts: a form or card becomes one
+row, a table becomes N rows.
+
+## Install
+
+Document ingest is an optional extra (adds `pymupdf` + `Pillow` for PDF rasterization and
+image loading):
+
+```bash
+pip install "goldenmatch[documents]"
+```
+
+The default backend calls an OpenAI vision model (`gpt-4o`). Set an API key — the personal
+key is preferred so a work-scoped key is never used by accident:
+
+```bash
+export OPENAI_API_KEY_PERSONAL=sk-...   # or OPENAI_API_KEY
+```
+
+`import goldenmatch.documents` and the MCP server both degrade gracefully when the extra or
+the key is absent — nothing else in GoldenMatch requires them.
+
+## The two-step workflow
+
+You own the target schema. The recommended flow is: let a vision model **propose** a schema
+from one representative document, **review** it, then **ingest** the whole batch against it.
+
+### Python
+
+```python
+from goldenmatch.documents import ingest_documents
+from goldenmatch.documents.suggest import suggest_schema_from_file
+from goldenmatch import dedupe_df
+
+# 1. Propose a schema from a sample document (review before trusting it).
+schema = suggest_schema_from_file("samples/card.png")
+
+# 2. Extract every document into one Polars DataFrame.
+df = ingest_documents(["cards/*.png", "forms/intake.pdf"], schema)
+
+# 3. Hand the records to the ER pipeline. Exclude the provenance sidecars so they
+#    are never treated as match fields.
+result = dedupe_df(
+    df,
+    exclude_columns=["_source_file", "_source_page", "_extract_confidence"],
+)
+```
+
+Every extracted row carries three sidecar columns: `_source_file`, `_source_page`, and
+`_extract_confidence`. Pass `return_report=True` to `ingest_documents` to also get an
+`IngestReport` (`n_files`, `n_rows`, and per-file `errors` — a bad file is recorded and the
+batch continues rather than aborting).
+
+You can define a schema by hand instead of suggesting one:
+
+```python
+from goldenmatch.documents import TargetSchema, Field
+
+schema = TargetSchema([
+    Field("full_name"),
+    Field("email", kind="email"),
+    Field("phone", kind="phone"),
+    Field("company"),
+])
+```
+
+`kind` (`text` | `email` | `phone` | `address` | `date` | `number`) and an optional `hint`
+guide the extractor. Fields absent from a given document come back null.
+
+### CLI
+
+```bash
+# Propose a schema, write it for review
+goldenmatch ingest-docs suggest-schema samples/card.png --out schema.json
+
+# Ingest documents against the reviewed schema
+goldenmatch ingest-docs run cards/*.png --schema schema.json --out records.csv
+```
+
+`run` writes `.csv` or `.parquet`. Both commands take `--backend` (default `vlm`) and
+`--model` (default `gpt-4o`).
+
+## Other surfaces
+
+The same capability is exposed everywhere GoldenMatch runs:
+
+| Surface | Entry points |
+| --- | --- |
+| **MCP** (Claude Desktop / Code) | tools `documents_suggest_schema`, `documents_ingest` |
+| **A2A** (agent-to-agent) | skills `documents_suggest_schema`, `documents_ingest` |
+| **REST** | `POST /api/v1/documents/suggest-schema`, `POST /api/v1/documents/ingest` |
+| **Web UI** | the `/documents` "Ingest" page — upload, AI-suggest a schema, edit it, extract, review + export |
+| **TypeScript** | the deterministic `documents-core` kernels (schema/parse/prompt/normalize) via `goldenmatch/core/documents-wasm`, byte-parity with Python |
+
+MCP, A2A, and REST are **path-based** (the caller passes server-accessible file paths or, for
+REST/Web, uploads); the Web UI handles browser uploads.
+
+## How it works
+
+- **VLM-first, one call per page.** A single vision call classifies the document and extracts
+  fields in one shot. The backend is a pluggable `Extractor` seam behind an injectable
+  transport, so the stack is fully offline-testable (swap in a `FakeExtractor`).
+- **Rust kernel = single source of truth.** Schema validation, response parsing, prompt
+  building, and record normalization live in the `documents-core` Rust crate, bound to Python
+  (native) and TypeScript (WASM). Pure-Python is a byte-identical fallback.
+- **Tables fan out.** A document containing several records (a roster, a directory) yields one
+  row per record; a single-entity document (a card, a form) yields one row.
+
+## Notes and limits
+
+- Extraction quality tracks the vision model. On clean documents it is near-perfect and never
+  fabricates a value for a field that is absent; on genuinely hard inputs (unusual proper
+  nouns, heavy scan degradation) it can misread — those errors are the model's ceiling, not the
+  pipeline's.
+- `kind: date` / `kind: number` are advisory hints to the extractor, not post-hoc coercion.
+- Each page is one vision API call; cost and latency scale with page count. Ingest is
+  parallel-safe across files.

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -84,12 +84,34 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 
 ## Why GoldenMatch?
 
+- **Runs on unstructured input** — extract matchable records from PDFs and images (cards, forms, invoices, scanned directories) against a schema you control, then dedupe them. `pip install goldenmatch[documents]`; see [Document ingest](https://docs.bensevern.dev/goldenmatch/documents).
 - **Zero-config that beats hand-tuned** — the introspective controller auto-detects columns, picks scorers, iterates on complexity signals, and converges on a defensible config. No training data, no rules to write. (v1.8.0)
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
 - **68 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
+
+### Run on unstructured input (document ingest)
+
+GoldenMatch doesn't require structured data. Extract records from PDFs/images against a
+schema you control, then dedupe them (`pip install "goldenmatch[documents]"`, set
+`OPENAI_API_KEY_PERSONAL`):
+
+```python
+from goldenmatch.documents import ingest_documents
+from goldenmatch.documents.suggest import suggest_schema_from_file
+from goldenmatch import dedupe_df
+
+schema = suggest_schema_from_file("samples/card.png")   # propose, then review
+df = ingest_documents(["cards/*.png", "forms/intake.pdf"], schema)
+result = dedupe_df(df, exclude_columns=["_source_file", "_source_page", "_extract_confidence"])
+```
+
+Also available as `goldenmatch ingest-docs {suggest-schema, run}` (CLI), the
+`documents_suggest_schema` / `documents_ingest` MCP tools and A2A skills,
+`POST /api/v1/documents/{suggest-schema, ingest}` (REST), and the `/documents` Web UI page.
+Full guide: [Document ingest](https://docs.bensevern.dev/goldenmatch/documents).
 
 ### Auto-config & scale safeguards
 

--- a/packages/python/goldenmatch/docs/llms.txt
+++ b/packages/python/goldenmatch/docs/llms.txt
@@ -16,9 +16,13 @@
 
 Every interface above returns the same JSON shape from `goldenmatch.web.controller_telemetry.serialize_telemetry`: `{stop_reason, health, scoring, blocking, cluster, column_priors, decisions, committed_matchkeys, negative_evidence}`. Write one parser, reuse across web / TUI / CLI / SQL / MCP / A2A / REST.
 
+## Document ingest (run on unstructured input)
+GoldenMatch doesn't require structured data. Extract matchable records from PDFs/images against a schema you control, then dedupe them: `suggest_schema_from_file(sample)` proposes a schema (review it), `ingest_documents(paths, schema)` returns a DataFrame -> `dedupe_df(df, exclude_columns=["_source_file","_source_page","_extract_confidence"])`. Python `from goldenmatch.documents import ingest_documents`; CLI `goldenmatch ingest-docs {suggest-schema, run}`; MCP tools + A2A skills `documents_suggest_schema` / `documents_ingest`; REST `POST /api/v1/documents/{suggest-schema, ingest}`; Web UI `/documents`. Needs `goldenmatch[documents]` + an OpenAI vision key (`OPENAI_API_KEY_PERSONAL`, default `gpt-4o`). Docs: https://docs.bensevern.dev/goldenmatch/documents
+
 ## Install
 - `pip install goldenmatch` (native acceleration ships by default on common platforms)
 - TypeScript: `npm install goldenmatch`
+- Document ingest (PDF/image -> records): `pip install goldenmatch[documents]`
 - Quality scanning: `pip install goldenmatch[quality]`
 - Data transforms: `pip install goldenmatch[transform]`
 - Embeddings: `pip install goldenmatch[embeddings]`

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -15,8 +15,12 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - REST API: `goldenmatch serve` on port 8000
 - SQL: Postgres (pgrx extension) + DuckDB UDFs — dedupe / match / score / auto-config + telemetry / identity graph
 
+## Document ingest (run on unstructured input)
+GoldenMatch doesn't require structured data. Extract matchable records from PDFs/images (cards, forms, invoices, scanned directories) against a schema you control, then dedupe them. Two-step: `suggest_schema_from_file(sample)` proposes a schema (review it), `ingest_documents(paths, schema)` returns a DataFrame -> `dedupe_df(df, exclude_columns=["_source_file","_source_page","_extract_confidence"])`. Python: `from goldenmatch.documents import ingest_documents`. CLI: `goldenmatch ingest-docs {suggest-schema, run}`. MCP tools + A2A skills: `documents_suggest_schema`, `documents_ingest`. REST: `POST /api/v1/documents/{suggest-schema, ingest}`. Web UI: `/documents`. Needs `goldenmatch[documents]` + an OpenAI vision key (`OPENAI_API_KEY_PERSONAL`; default `gpt-4o`). Docs: https://docs.bensevern.dev/goldenmatch/documents
+
 ## Install
 - `pip install goldenmatch` (native acceleration ships by default on common platforms)
+- Document ingest (PDF/image -> records): `pip install goldenmatch[documents]`
 - TypeScript: `npm install goldenmatch`
 - Quality scanning: `pip install goldenmatch[quality]`
 - Data transforms: `pip install goldenmatch[transform]`


### PR DESCRIPTION
## Summary

The document-ingest rollout (6 merged PRs: #1508 #1515 #1528 #1533 #1539 #1544 + TS #1549) shipped the feature — GoldenMatch now runs on unstructured PDFs/images — but never surfaced it in any user- or agent-facing discovery doc. This closes that gap (end-of-rollout doc sweep).

- **New `docs-site/goldenmatch/documents.mdx`** — canonical guide: install the `[documents]` extra + key, the two-step suggest → review → ingest workflow, and every surface's entry points (Python, CLI, MCP, A2A, REST, Web UI, TS kernels). Added to the Features nav.
- **Package README** — a "runs on unstructured input" bullet in *Why GoldenMatch?* plus a short Document-ingest section with a code snippet.
- **`llms.txt` (package + docs)** — a capability paragraph so agents discover it, plus the `goldenmatch[documents]` extra in Install.
- **`agent.mdx`** — fixed a stale section header (`38 Skills` → `40 Skills`); the A2A rollout bumped the frontmatter to 40 but missed the header.

All API/CLI/tool/endpoint names verified against the merged code. No code changes, no count edits to the MCP-tool/A2A-skill totals (left as-is to avoid drift).

## Test Plan
- [ ] docs.json validates; `goldenmatch/documents` renders in the Features nav
- [ ] No stray "38 skills" left on any live doc surface (only historical plan/spec docs retain it, correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)