### PR TITLE
feat(goldenflow): merge_name + initial_expand on the columnar path (zero-gap W2)

### DIFF
--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -147,6 +147,50 @@ def _scalar_fn(info, params):
     return info.scalar
 
 
+# Zero-gap: transforms that are neither per-element scalars, numeric parsers, nor
+# splits — a multi-INPUT merge (``merge_name``: two columns -> one) and a flag-only op
+# (``initial_expand``: value identity + flagged rows into the manifest errors). They run
+# Polars-free over plain lists, byte-identical to the Polars engine. In-memory only
+# (like the scalar chain) — the Rust CSV path never sees them.
+_SPECIAL_OPS = frozenset({"merge_name", "initial_expand"})
+
+
+def _spec_special_ready(spec) -> str | None:
+    """A single-op spec whose op is a special in-memory columnar transform. Returns the
+    op name, else ``None``. Single-op only — these don't compose into a chain."""
+    if len(spec.ops) != 1:
+        return None
+    name, _ = parse_transform_name(spec.ops[0])
+    return name if name in _SPECIAL_OPS else None
+
+
+def _apply_special(name: str, cols: dict, column: str):
+    """Pure-Python (Polars-free) application of a special transform over ``cols`` (a
+    ``dict[str, list]`` of the current columns). Returns ``(new_columns, affected,
+    flagged_rows)``: ``new_columns`` are columns to set/append; the SOURCE column is
+    left unchanged (both ops are identity on it), so ``affected`` is always 0 —
+    matching the engine's ``(before != after).sum()`` on the source column."""
+    src = cols[column]
+    if name == "merge_name":
+        from goldenflow.transforms.names import _merge_name_py
+
+        # merge_name reads first (``column``) + ``last_name`` -> appends ``full_name``;
+        # if there is no last_name column the engine returns the frame unchanged.
+        last = cols.get("last_name")
+        new = (
+            {"full_name": [_merge_name_py(f, l) for f, l in zip(src, last)]}
+            if last is not None
+            else {}
+        )
+        return new, 0, []
+    if name == "initial_expand":
+        from goldenflow.transforms.names import _has_initial_py
+
+        flagged = [i for i, v in enumerate(src) if _has_initial_py(v)]
+        return {}, 0, flagged
+    raise ValueError(f"not a special columnar op: {name}")
+
+
 def _spec_ready(
     nm, spec, accepted: frozenset[str], numeric_ok: bool, split_ok: bool, scalar_ok: bool = False
 ) -> bool:
@@ -158,6 +202,8 @@ def _spec_ready(
     if _spec_string_ready(spec, accepted):
         return True
     if scalar_ok and _spec_scalar_ready(spec, accepted):
+        return True
+    if scalar_ok and _spec_special_ready(spec):
         return True
     ops_spec = [(n, list(p)) for n, p in (parse_transform_name(o) for o in spec.ops)]
     if numeric_ok and nm.columnar_numeric_ready(ops_spec):
@@ -303,6 +349,25 @@ def _transform_via_columns(df, config, source, nm, pl):
             continue
         ops = [parse_transform_name(op) for op in spec.ops]
         ops_spec = [(n, list(p)) for n, p in ops]
+        # Special (multi-input merge / flag-only): apply Polars-free over column lists;
+        # source column stays as-is (identity), appended outputs go into out_series.
+        special = _spec_special_ready(spec)
+        if special:
+            cols = {c: df[c].to_list() for c in df.columns}
+            new_cols, affected, flagged = _apply_special(special, cols, spec.column)
+            for row_idx in flagged:
+                manifest.add_error(
+                    column=spec.column, transform=special, row=row_idx,
+                    error="Flagged for review",
+                )
+            before = df[spec.column].head(3).cast(pl.Utf8).to_list()
+            manifest.add_record(TransformRecord(
+                column=spec.column, transform=special, affected_rows=affected,
+                total_rows=df.height, sample_before=before, sample_after=before,
+            ))
+            for k, v in new_cols.items():
+                out_series.append(pl.Series(k, v))
+            continue
         # Split spec (string* splitter): the source column keeps its (string-ops)
         # value and the fixed-name output columns are appended -- exactly Polars'
         # dataframe-mode with_columns. Cast to Utf8 first (the split reads strings).
@@ -499,6 +564,26 @@ def transform_columns_native(columns, config, source: str = "<dataframe>"):
         ops_spec = [(n, list(p)) for n, p in ops]
         col_list = out[spec.column]
         total_rows = len(col_list)
+
+        # Special (multi-input merge / flag-only): Polars-free over plain lists, source
+        # column identity so the manifest samples are before==after and affected==0.
+        special = _spec_special_ready(spec)
+        if special:
+            new_cols, affected, flagged = _apply_special(special, out, spec.column)
+            for k, v in new_cols.items():
+                out[k] = v
+            for row_idx in flagged:
+                manifest.add_error(
+                    column=spec.column, transform=special, row=row_idx,
+                    error="Flagged for review",
+                )
+            cb = [_cast_utf8(v) for v in out[spec.column][:3]]
+            manifest.add_record(TransformRecord(
+                column=spec.column, transform=special, affected_rows=affected,
+                total_rows=total_rows, sample_before=cb, sample_after=cb,
+            ))
+            continue
+
         col = nm.Column.from_pylist(col_list)
 
         # Split (string* splitter): source kept, fixed-name outputs appended.

--- a/packages/python/goldenflow/tests/engine/test_columnar_special.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_special.py
@@ -1,0 +1,126 @@
+"""Zero-gap Wave 2: the two special-shape transforms on the columnar path.
+
+- ``merge_name`` — multi-INPUT (reads the source column + ``last_name``, appends
+  ``full_name``). mode=dataframe; identity on the source column.
+- ``initial_expand`` — flag-only (value identity + flagged rows recorded as manifest
+  ERRORS via the ``has_initial`` predicate).
+
+Both run Polars-free over plain lists (references ``_merge_name_py`` / ``_has_initial_py``
+proven equal to the goldenflow-core kernels) and are byte-identical to the Polars engine:
+values, appended columns, manifest records AND errors.
+"""
+from __future__ import annotations
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _cfg(specs):
+    return GoldenFlowConfig(transforms=[TransformSpec(column=c, ops=o) for c, o in specs])
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _errs(m):
+    return [(e.column, e.transform, e.row, e.error) for e in m.errors]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+MERGE = {"first_name": ["John", "Jane", None, "Al"], "last_name": ["Smith", None, "Doe", "Roe"],
+         "k": [0, 1, 2, 3]}
+INIT = {"name": ["John A. Smith", "Jane Doe", "R. J. Brown", None], "k": [0, 1, 2, 3]}
+
+
+def test_merge_name_dict_equals_polars() -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    cfg = _cfg([("first_name", ["merge_name"])])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dict(MERGE), config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(MERGE), config=cfg)
+    for c in ref.df.columns:
+        assert res.columns[c] == ref.df[c].to_list(), c
+    assert "full_name" in res.columns
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_merge_name_no_last_name_is_noop() -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    data = {"first_name": ["John", "Jane"], "k": [0, 1]}
+    cfg = _cfg([("first_name", ["merge_name"])])
+    res = goldenflow.transform(dict(data), config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(data), config=cfg)
+    assert ("full_name" in res.columns) == ("full_name" in ref.df.columns)
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_initial_expand_dict_equals_polars() -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    cfg = _cfg([("name", ["initial_expand"])])
+    assert columnar.config_is_columnar_ready(cfg)
+    res = goldenflow.transform(dict(INIT), config=cfg)
+    ref = goldenflow.transform_df(pl.DataFrame(INIT), config=cfg)
+    assert res.columns["name"] == ref.df["name"].to_list()
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+    assert _errs(res.manifest) == _errs(ref.manifest)  # flagged rows match
+
+
+@pytest.mark.parametrize("data,col,op", [(MERGE, "first_name", "merge_name"), (INIT, "name", "initial_expand")])
+def test_special_columnar_engine_equals_polars(monkeypatch, data, col, op) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    df = pl.DataFrame(data)
+    cfg = _cfg([(col, [op])])
+    monkeypatch.delenv("GOLDENFLOW_ENGINE", raising=False)
+    ref = goldenflow.transform_df(df, config=cfg)
+    monkeypatch.setenv("GOLDENFLOW_ENGINE", "columnar")
+    got = goldenflow.transform_df(df, config=cfg)
+    assert got.df.equals(ref.df)
+    assert _mrows(got.manifest) == _mrows(ref.manifest)
+    assert _errs(got.manifest) == _errs(ref.manifest)
+
+
+def test_special_are_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+            cfg = GoldenFlowConfig(transforms=[
+                TransformSpec(column="first_name", ops=["merge_name"]),
+                TransformSpec(column="nm", ops=["initial_expand"]),
+            ])
+            res = goldenflow.transform(
+                {"first_name": ["John", None], "last_name": ["Smith", "Doe"],
+                 "nm": ["A. B. Cee", "plain"], "k": [1, 2]},
+                config=cfg,
+            )
+            assert res.columns["full_name"] == ["John Smith", "Doe"], res.columns["full_name"]
+            assert [e.row for e in res.manifest.errors] == [0], res.manifest.errors
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr


### PR DESCRIPTION
Second zero-gap wave (4/9 closed). The two special-shape transforms that don't fit the scalar/numeric/split mechanisms, closed Polars-free via a shared `_apply_special` hook in both the dict and frame columnar paths (readiness gated under `scalar_ok`, in-memory only).

- **merge_name** — multi-INPUT: reads the source column + `last_name`, appends `full_name` via `_merge_name_py`; source column identity (affected 0). No `last_name` → no-op, matching the engine.
- **initial_expand** — flag-only: value identity, flagged rows (`has_initial` predicate) recorded as manifest **errors**, exactly like the engine.

Byte-identical to the Polars engine — values, appended columns, manifest records **and errors** — on both the dict path and `GOLDENFLOW_ENGINE=columnar`. New `test_columnar_special.py` (incl. polars-free subprocess). Full engine+transforms+domains suite green (1930 pass).

Remaining gaps: `category_auto_correct` (whole-column) + the 4 numeric-input ops (round/clamp/abs_value/fill_zero — need a native-flow Rust kernel + wheel republish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)