### PR TITLE
feat(goldenpipe): advisory repair-plan intelligence (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-07-goldenpipe-repair-plan-intelligence.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-repair-plan-intelligence.md
@@ -474,9 +474,12 @@ def test_attach_repair_plan_sets_artifact_and_reasoning():
     attach_repair_plan(ctx, findings, [Ctx("signup_date", "date")], df)
     plan = ctx.artifacts["repair_plan"]
     assert plan["repairs"][0]["suggested_transforms"] == ["date_validate"]
+    # reasoning is a dict[str,str] (Router writes ctx.reasoning["_router"]); we
+    # accumulate repair lines under one key, newline-joined.
+    assert "date_validate" in ctx.reasoning["repair_plan"]
 ```
 
-(Adjust `PipeContext` construction to its real signature — inspect `goldenpipe/models/context.py` first.)
+(Adjust `PipeContext` construction to its real signature — `goldenpipe/models/context.py`. NOTE: `ctx.reasoning` is `dict[str, str]` (context.py:49), NOT a list — the Router writes a single keyed string `ctx.reasoning["_router"]`. Do not call `.append` on it.)
 
 - [ ] **Step 2: Run to verify failure**
 
@@ -510,6 +513,14 @@ def sample_column(series, limit: int = _SAMPLE_LIMIT) -> list[str]:
     return out
 
 
+def _coarse_str(t) -> str:
+    # ColumnType is `str, Enum` with lowercase values, BUT str(ColumnType.EMAIL) ==
+    # "ColumnType.EMAIL" (NOT "email") — only .value gives "email". The context
+    # builder can also leave inferred_type a raw str (column_context.py backward-compat
+    # coercion), which has no .value. getattr handles both.
+    return getattr(t, "value", t)
+
+
 def build_column_inputs(contexts, df) -> list[dict]:
     cols = []
     names = set(df.columns)
@@ -518,7 +529,7 @@ def build_column_inputs(contexts, df) -> list[dict]:
             continue
         cols.append({
             "name": ctx.name,
-            "coarse_type": str(ctx.inferred_type),   # ColumnType is a str-enum -> "email" etc.
+            "coarse_type": _coarse_str(ctx.inferred_type),   # -> "email"/"date"/... not "ColumnType.EMAIL"
             "samples": sample_column(df[ctx.name]),
         })
     return cols
@@ -528,21 +539,19 @@ def attach_repair_plan(ctx, findings, contexts, df) -> dict:
     columns = build_column_inputs(contexts, df)
     plan = build_repair_plan(findings, columns)
     ctx.artifacts["repair_plan"] = plan
-    for item in plan["repairs"]:
-        line = (f"repair: {item['column']} ({item['check']}) -> "
-                f"{','.join(item['suggested_transforms'])} [{item['reason']}]")
-        _record_reasoning(ctx, line)
+    lines = [
+        f"repair: {item['column']} ({item['check']}) -> "
+        f"{','.join(item['suggested_transforms'])} [{item['reason']}]"
+        for item in plan["repairs"]
+    ]
+    if lines:
+        # ctx.reasoning is dict[str,str] (Router uses key "_router"); accumulate all
+        # repair lines under one key, newline-joined. Never .append (it's a dict).
+        ctx.reasoning["repair_plan"] = "\n".join(lines)
     return plan
-
-
-def _record_reasoning(ctx, line: str) -> None:
-    # Use whatever reasoning channel the ctx already exposes (inspect models/context.py:
-    # e.g. ctx.reasoning.append(line) or ctx.add_reasoning(line)). Kept in one helper
-    # so the exact call is easy to correct during implementation.
-    getattr(ctx, "reasoning", []).append(line)
 ```
 
-**Implementation note:** inspect `goldenpipe/models/context.py` for the real reasoning API and `ColumnContext.inferred_type`'s str value (Task 5 confirms), and correct `_record_reasoning` + the `str(ctx.inferred_type)` cast accordingly. `str(ColumnType.EMAIL)` must yield `"email"` — verify (the enum is `str, Enum` with lowercase values, so `.value` is `"email"`; use `ctx.inferred_type.value` if `str()` yields `ColumnType.EMAIL`).
+**Implementation note:** `ctx.reasoning` is `dict[str, str]` (`context.py:49`) — write the joined lines to `ctx.reasoning["repair_plan"]`, never `.append`. The `_coarse_str` helper is guarded because `str()`/f-string on a `ColumnType` yields `"ColumnType.EMAIL"`, not `"email"`. The box host test below uses a **string** stand-in for `inferred_type`, so it will NOT catch a bad enum cast — the real-`ColumnType` guard is the engine test in Task 5.
 
 - [ ] **Step 4: Run host tests to verify pass**
 
@@ -668,11 +677,11 @@ git commit -m "feat(goldenpipe-core): build_repair_plan kernel + golden-vector t
 - Modify: the engine module that builds ColumnContexts post-Check (find it in Step 1).
 - Test: extend `packages/python/goldenpipe/tests/test_repair_host.py` or add an engine-level test.
 
-- [ ] **Step 1: Locate the call site.** Grep for where `build_contexts_from_check` is called and where `findings` + the working DataFrame are both in scope:
+- [ ] **Step 1: Confirm the call site.** The site is `packages/python/goldenpipe/goldenpipe/adapters/check.py` (~lines 64-73), right after context build, where all three inputs are in scope: normalized `findings`, `ctx.artifacts["column_contexts"]` (the ColumnContext list), and `ctx.df` (the working DataFrame). Confirm exact names:
 
-Run: `grep -rn "build_contexts_from_check\|artifacts\[.findings.\]\|enrich_contexts_from_flow" packages/python/goldenpipe/goldenpipe --include=*.py`
+Run: `grep -n "findings\|column_contexts\|ctx.df\|build_contexts_from_check" packages/python/goldenpipe/goldenpipe/adapters/check.py`
 
-Confirm the reasoning API on `PipeContext` (`grep -n "reasoning\|def add_reason" packages/python/goldenpipe/goldenpipe/models/context.py`) and fix `repair_host._record_reasoning` to match.
+Confirm `ctx.reasoning` is `dict[str,str]` (`grep -n "reasoning" packages/python/goldenpipe/goldenpipe/models/context.py` → expect `reasoning: dict[str, str]`). The host glue already writes `ctx.reasoning["repair_plan"]` — no change needed there.
 
 - [ ] **Step 2: Write a failing engine-level assertion** that after a Check stage produces findings on a date column, `ctx.artifacts["repair_plan"]` exists with the expected item. (Use the smallest existing engine-test harness as a template — find one via `grep -rln "PipeContext()" packages/python/goldenpipe/tests`.)
 
@@ -680,11 +689,21 @@ Confirm the reasoning API on `PipeContext` (`grep -n "reasoning\|def add_reason"
 
 ```python
 from goldenpipe.repair_host import attach_repair_plan
-# ... where `findings`, `contexts`, and the working df are in scope:
-attach_repair_plan(ctx, findings, contexts, df)
+# In check.py after ctx.artifacts["findings"] and ctx.artifacts["column_contexts"]
+# are both set (just before `return StageResult(...)`):
+_findings = ctx.artifacts.get("findings", [])
+_contexts = ctx.artifacts.get("column_contexts", [])
+if ctx.df is not None and _findings and _contexts:
+    try:
+        attach_repair_plan(ctx, _findings, _contexts, ctx.df)
+    except Exception:
+        logger.exception("repair-plan attach failed; advisory artifact skipped")
 ```
 
-Guard it so a missing df or empty findings is a no-op (the pure fn already returns `{"repairs": []}`; ensure no exception if `df is None`).
+Wrapping in try/except mirrors the existing best-effort column-context build in
+check.py — repair-planning is advisory, so a failure must never break the stage.
+
+Guard it so a missing df / empty findings / empty contexts is a no-op (the pure fn already returns `{"repairs": []}`; the guard also avoids sampling when there's nothing to plan).
 
 - [ ] **Step 4: Run the engine test + the full repair test set (box)**
 
@@ -705,26 +724,30 @@ git commit -m "feat(goldenpipe): attach advisory repair_plan artifact in the eng
 
 **Files:**
 - Create: `packages/typescript/goldenpipe/src/core/repair.ts`
-- Modify: the TS json-face + `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts` (replay `build_repair_plan.json`).
+- Modify: `packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts` (the Leg-A pure json-face that `planner-parity.test.ts` imports) — add `buildRepairPlanJson`.
+- Modify: `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts` (replay `build_repair_plan.json`, Leg A pure).
+- Modify: `packages/typescript/goldenpipe/src/core/wasm/plannerJson.ts` (the wasm-backed json-face) + `packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts` — register `build_repair_plan` so the new wasm binding is exercised, not just compiled.
 - Modify: `packages/rust/extensions/goldenpipe-wasm/src/lib.rs` and `packages/rust/extensions/goldenpipe-native/src/lib.rs` (export `build_repair_plan_json` following the existing per-fn pattern).
 
 Box cannot run tsc/vitest or build wasm — mirror behavior, verify in CI.
 
 - [ ] **Step 1: Write `repair.ts`** mirroring `repair.py`: same ASCII predicates (use `c >= "0" && c <= "9"` etc., never `\d`), same detector order, same table, same `buildRepairPlan(findings, columns)` returning `{repairs: [...]}` with fields in the same order. Match the JS reason truncation to code points: `[...String(message)].slice(0, 80).join("")` (spread iterates by code point, matching Python `[:80]` on a str and Rust `.chars().take(80)`).
 
-- [ ] **Step 2: Add the TS json-face fn** `buildRepairPlanJson(s)` and register `build_repair_plan` in the parity test's vector list (mirror how `apply_decision`/`evaluate_builtin` are registered in `planner-parity.test.ts`).
+- [ ] **Step 2: Add the pure json-face fn** `buildRepairPlanJson(s)` to `src/core/wasm/plannerJsonPure.ts` and register `build_repair_plan` in the `planner-parity.test.ts` vector-family list (mirror how `apply_decision`/`evaluate_builtin` are registered there).
 
-- [ ] **Step 3: Export the shim fns.** In `goldenpipe-wasm/src/lib.rs` and `goldenpipe-native/src/lib.rs`, add a `build_repair_plan_json` binding following the exact pattern used for `apply_decision_json` (grep those files for `apply_decision_json` and copy the shape). rustfmt both.
+- [ ] **Step 3: Wire the wasm-backed face.** Add `buildRepairPlanJson` to `src/core/wasm/plannerJson.ts` (delegating to the wasm `build_repair_plan_json` export) and register `build_repair_plan` in `planner-wasm-parity.test.ts`, so the wasm binding is parity-tested against the same vectors (closes the "exported but untested" gap).
 
-- [ ] **Step 4: rustfmt the shims (box) + grep-verify**
+- [ ] **Step 4: Export the shim fns.** In `goldenpipe-wasm/src/lib.rs` and `goldenpipe-native/src/lib.rs`, add a `build_repair_plan_json` binding following the exact pattern used for `apply_decision_json` (grep those files for `apply_decision_json` and copy the shape). rustfmt both.
+
+- [ ] **Step 5: rustfmt the shims (box) + grep-verify**
 
 Run: `rustfmt --edition 2021 packages/rust/extensions/goldenpipe-wasm/src/lib.rs packages/rust/extensions/goldenpipe-native/src/lib.rs`
-Grep-verify each surface names `build_repair_plan_json`.
+Grep-verify each surface names `build_repair_plan_json`, and that both `plannerJsonPure.ts` and `wasm/plannerJson.ts` export `buildRepairPlanJson`.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 6: Commit**
 
 ```bash
-git add packages/typescript/goldenpipe/src/core/repair.ts <ts json-face> packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts packages/rust/extensions/goldenpipe-wasm/src/lib.rs packages/rust/extensions/goldenpipe-native/src/lib.rs
+git add packages/typescript/goldenpipe/src/core/repair.ts packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts packages/typescript/goldenpipe/src/core/wasm/plannerJson.ts packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts packages/rust/extensions/goldenpipe-wasm/src/lib.rs packages/rust/extensions/goldenpipe-native/src/lib.rs
 git commit -m "feat(goldenpipe): TS repair mirror + wasm/native json shims"
 ```
 

--- a/docs/superpowers/plans/2026-07-07-goldenpipe-repair-plan-intelligence.md
+++ b/docs/superpowers/plans/2026-07-07-goldenpipe-repair-plan-intelligence.md
@@ -1,0 +1,765 @@
+# GoldenPipe Repair-Plan Intelligence Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Phase-1 advisory `build_repair_plan` to the GoldenPipe brain that maps GoldenCheck findings to specific GoldenFlow transforms, keyed by `(check × value-level column type)`, emitted as a `repair_plan` artifact with zero change to executed stages.
+
+**Architecture:** A new pure kernel function `build_repair_plan(findings, columns)` lives in `goldenpipe-core` (Rust, source-of-truth-by-convention) and is mirrored byte-identically by a pure-Python module and a pure-TS module, all replaying one hand-authored golden-vector file. An in-kernel value-level fine-typer classifies each column from ≤20 sampled string values using **hand-rolled ASCII char-class matchers** (no regex crate — dependency-free and byte-identical across engines) plus a Luhn check for `credit_card`. A static `(check, type_tag) → [transforms]` table does the lookup. The pipeline host samples values, calls the function, and attaches the artifact + reasoning.
+
+**Tech Stack:** Rust (serde/serde_json, no regex), pure-Python mirror, pure-TS mirror, existing goldenpipe-core golden-vector parity harness.
+
+---
+
+## Box / environment constraints (read before executing)
+
+- **The box CANNOT `cargo build` (Rust) or run vitest/tsc (TS OOMs).** Both are CI-only. Rust and TS tasks are **write-against-spec, verify by grep/eye + CI**. Only the **pure-Python path is box-runnable** and is where real red→green TDD happens.
+- Because Rust can't run on the box, **the golden-vector file `build_repair_plan.json` is hand-authored** (its expected outputs are deterministic table lookups + ASCII classification, computed by hand from the spec). Python (box, Leg A) and Rust (CI) both assert against it — that IS the parity proof.
+- **rustfmt runs on the box** (formats without building): `rustfmt --edition 2021 <file>` on every touched `.rs` before commit.
+- Python invocation (native Windows, `;` PYTHONPATH separator):
+  ```bash
+  INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="packages/python/goldenpipe;packages/python/goldencheck;packages/python/infermap;packages/python/goldencheck-types"
+  export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+  ```
+  Run pytest as: `"$INTERP" -m pytest <path> -v`
+- `ruff check` every touched Python file before commit.
+- Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md`.
+- Reference the cross-surface skills where relevant: @superpowers:test-driven-development.
+
+---
+
+## File structure (decomposition)
+
+**Rust core (`packages/rust/extensions/goldenpipe-core/`):**
+- Create `src/repair.rs` — `TypeTag`, `ColumnInput`, `Finding`, `RepairItem`, `RepairPlan`, the fine-typer (`fine_type`), the mapping table (`lookup`), and `build_repair_plan`. One file, one responsibility (repair planning).
+- Modify `src/lib.rs` — add `pub mod repair;`.
+- Modify `src/json.rs` — add `build_repair_plan_json`.
+- Modify `tests/golden_vectors.rs` — add `vec_build_repair_plan`.
+- Create `tests/vectors/build_repair_plan.json` — the hand-authored parity contract.
+
+**Rust shims (CI-verified):**
+- Modify `packages/rust/extensions/goldenpipe-wasm/src/lib.rs` — export `build_repair_plan_json`.
+- Modify `packages/rust/extensions/goldenpipe-native/src/lib.rs` — export `build_repair_plan_json`.
+
+**Python (`packages/python/goldenpipe/goldenpipe/`):**
+- Create `repair.py` — the real pure-Python impl (fine-typer + table + `build_repair_plan`), mirroring `repair.rs` line-for-line in behavior.
+- Modify `core/_planner_json.py` — add `build_repair_plan_json`.
+- Modify `tests/core/test_planner_parity.py` — add `build_repair_plan` to Leg A + Leg B case lists.
+- Create `repair_host.py` — the sampling helper + `attach_repair_plan(ctx, findings, contexts, df)` host glue (kept separate from the pure kernel mirror so the pure module stays data-only).
+- Create `tests/test_repair_host.py` — box tests for sampling + artifact attachment.
+- Modify the engine call site that already builds ColumnContexts (identified in Task 5) to call `attach_repair_plan`.
+
+**TS (`packages/typescript/goldenpipe/`, CI-verified):**
+- Create `src/core/repair.ts` — mirror of `repair.rs`.
+- Modify the TS json-face module + `tests/parity/planner-parity.test.ts` to replay `build_repair_plan.json`.
+
+---
+
+## Canonical behavior reference (shared by all three surfaces)
+
+**Type tags.** Coarse (from host `ColumnContext`, lowercase string): `date`, `email`, `name`, `phone`, `zip`. Fine (from fine-typer): `iban`, `isin`, `swift`, `credit_card`, `cusip`, `npi`, `imei`, `ean`, `isbn`, `aba_routing`. Wildcard `*` used only in the table (never a resolved tag).
+
+**Fine-typer detector order (first firing wins).** Name-hint-gated group FIRST (they only fire on intentionally-named columns, so low false-positive), then value-distinctive group as fallback:
+1. `cusip` (name has `cusip`; value `^[0-9A-Z]{9}$`)
+2. `npi` (name has `npi`; value `^[0-9]{10}$`)
+3. `imei` (name has `imei` or `imsi`; value `^[0-9]{15}$`)
+4. `ean` (name has `ean`, `gtin`, or `barcode`; value `^[0-9]{8}$` or `^[0-9]{13}$`)
+5. `isbn` (name has `isbn`; value `^[0-9]{9}[0-9Xx]$` or `^[0-9]{13}$`)
+6. `aba_routing` (name has `routing` or `aba`; value `^[0-9]{9}$`)
+7. `iban` (value `^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$`, total length 15–34)
+8. `isin` (value `^[A-Z]{2}[0-9A-Z]{9}[0-9]$`, length 12)
+9. `swift` (value `^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$`, length 8 or 11)
+10. `credit_card` (value `^[0-9]{13,19}$` after stripping spaces/dashes, AND Luhn passes)
+
+Rationale for gated-first: a 13-digit `barcode` column resolves to `ean`, not `credit_card`; a `card_number` column (no gated hint matches) falls through to `credit_card`.
+
+**Firing rule.** For a detector, count non-empty samples whose value matches its value-predicate. It fires iff (name-hint satisfied when required) AND (matches × 2 > count of non-empty samples) — strict majority. Empty/whitespace samples are skipped in both numerator and denominator. Name-hint match is ASCII-lowercase substring of `name`.
+
+**Resolution.** `fine_type(name, samples)` returns the first firing fine tag, else `None`. `resolve_tag` = fine tag if present, else the coarse tag if it is one of the 5 known coarse tags (else `None` → column omitted / only `*` checks apply).
+
+**Mapping table (exact `(check, tag)` first, then `(check, "*")`, first-match).**
+Coarse:
+- `(encoding_detection, *)` → `["fix_mojibake", "normalize_unicode"]`
+- `(future_dated, date)`, `(temporal_order, date)`, `(stale_data, date)` → `["date_validate"]`
+- `(format_detection, date)` → `["date_parse"]`
+- `(format_detection, email)` → `["email_normalize"]`
+- `(pattern_consistency, email)` → `["email_canonical"]`
+- `(pattern_consistency, name)` → `["name_proper"]`
+- `(format_detection, phone)` → `["phone_validate"]`
+- `(pattern_consistency, phone)` → `["phone_national"]`
+- `(format_detection, zip)` → `["zip_normalize"]`
+
+Fine — BOTH `format_detection` and `pattern_consistency` map to the type's validator:
+- `iban`→`iban_validate`, `isin`→`isin_validate`, `swift`→`swift_validate`, `cusip`→`cusip_validate`, `npi`→`npi_validate`, `imei`→`imei_validate`, `ean`→`ean_validate`, `isbn`→`isbn_validate`, `credit_card`→`luhn_validate`, `aba_routing`→`aba_validate`.
+
+**build_repair_plan.** For each finding: resolve the finding's column tag from `columns`; look up `(check, tag)`; if a transform list exists, emit `RepairItem{column, check, type_tag, suggested_transforms, reason}`. `reason` = the finding's `message` truncated to 80 chars (Python `str(message)[:80]`). Findings whose column is absent from `columns`, whose tag is `None`, or whose `(check, tag)` misses → no item. Deterministic order = input findings order. Empty result → `RepairPlan{repairs: []}`.
+
+**JSON wire shape** (what `build_repair_plan_json` consumes/emits):
+- Input: `{"findings": [{"column","check","message","severity"}], "columns": [{"name","coarse_type","samples":[str]}]}`
+- Output: `{"repairs": [{"column","check","type_tag","suggested_transforms":[str],"reason"}]}`
+- Key order in each object is the struct field order above (serde preserve_order + Python dict insertion order + TS object literal order must agree).
+
+---
+
+## Task 1: Python pure kernel — fine-typer + table + build_repair_plan (box TDD, the correctness heart)
+
+**Files:**
+- Create: `packages/python/goldenpipe/goldenpipe/repair.py`
+- Test: `packages/python/goldenpipe/tests/test_repair_pure.py`
+
+Do Python FIRST: it is the only surface that runs on the box, so it is where real red→green happens. Rust (Task 4) mirrors it against the same hand-authored vectors.
+
+- [ ] **Step 1: Write failing tests for the fine-typer**
+
+Create `tests/test_repair_pure.py`:
+
+```python
+from goldenpipe.repair import fine_type, resolve_tag, build_repair_plan
+
+
+def test_iban_classifies_iban():
+    assert fine_type("account", ["GB82WEST12345698765432", "DE89370400440532013000"]) == "iban"
+
+def test_routing_9digit_is_not_iban_and_needs_name_for_aba():
+    # bare 9-digit, no name hint -> no fine tag
+    assert fine_type("col1", ["021000021", "011401533"]) is None
+    # with routing name hint -> aba_routing
+    assert fine_type("routing_number", ["021000021", "011401533"]) == "aba_routing"
+
+def test_credit_card_needs_luhn():
+    assert fine_type("card", ["4539578763621486", "4485275742308327"]) == "credit_card"   # valid Luhn
+    assert fine_type("card", ["4539578763621487", "1234567812345678"]) is None            # fail Luhn
+
+def test_barcode_resolves_ean_not_credit_card():
+    assert fine_type("barcode", ["4006381333931", "0012345678905"]) == "ean"
+
+def test_minority_match_does_not_fire():
+    # only 1 of 3 is an IBAN -> no majority
+    assert fine_type("account", ["GB82WEST12345698765432", "n/a", "unknown"]) is None
+
+def test_resolve_tag_prefers_fine_then_coarse_then_none():
+    assert resolve_tag("email_addr", "email", ["a@b.com"]) == "email"          # coarse, no fine
+    assert resolve_tag("iban", "string", ["GB82WEST12345698765432"]) == "iban" # fine wins
+    assert resolve_tag("misc", "string", ["hello"]) is None                    # neither
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_pure.py -v`
+Expected: FAIL — `ModuleNotFoundError: goldenpipe.repair`.
+
+- [ ] **Step 3: Implement `repair.py`**
+
+```python
+"""Pure repair-plan kernel — the SP2 mirror of goldenpipe-core/src/repair.rs.
+
+Deterministic, no I/O, no polars. Hand-rolled ASCII matchers (no regex) so the
+three surfaces are byte-identical by construction. See the design spec for the
+canonical behavior tables.
+"""
+from __future__ import annotations
+
+# ── coarse tags the host may supply ──────────────────────────────────────
+_COARSE = {"date", "email", "name", "phone", "zip"}
+
+# ── ASCII char-class primitives (no regex; \\d would diverge across engines) ─
+def _is_digit(c: str) -> bool:
+    return "0" <= c <= "9"
+
+def _is_upper(c: str) -> bool:
+    return "A" <= c <= "Z"
+
+def _is_alnum_upper(c: str) -> bool:
+    return _is_digit(c) or _is_upper(c)
+
+def _all(s: str, pred) -> bool:
+    return len(s) > 0 and all(pred(c) for c in s)
+
+# ── value predicates (detection shape, not full validation) ──────────────
+def _v_cusip(s: str) -> bool:
+    return len(s) == 9 and _all(s, _is_alnum_upper)
+
+def _v_npi(s: str) -> bool:
+    return len(s) == 10 and _all(s, _is_digit)
+
+def _v_imei(s: str) -> bool:
+    return len(s) == 15 and _all(s, _is_digit)
+
+def _v_ean(s: str) -> bool:
+    return len(s) in (8, 13) and _all(s, _is_digit)
+
+def _v_isbn(s: str) -> bool:
+    if len(s) == 13 and _all(s, _is_digit):
+        return True
+    return len(s) == 10 and _all(s[:9], _is_digit) and s[9] in "0123456789Xx"
+
+def _v_aba(s: str) -> bool:
+    return len(s) == 9 and _all(s, _is_digit)
+
+def _v_iban(s: str) -> bool:
+    if not (15 <= len(s) <= 34):
+        return False
+    return _is_upper(s[0]) and _is_upper(s[1]) and _is_digit(s[2]) and _is_digit(s[3]) and _all(s[4:], _is_alnum_upper)
+
+def _v_isin(s: str) -> bool:
+    return len(s) == 12 and _is_upper(s[0]) and _is_upper(s[1]) and _all(s[2:11], _is_alnum_upper) and _is_digit(s[11])
+
+def _v_swift(s: str) -> bool:
+    if len(s) not in (8, 11):
+        return False
+    return _all(s[:6], _is_upper) and _all(s[6:8], _is_alnum_upper) and (len(s) == 8 or _all(s[8:11], _is_alnum_upper))
+
+def _luhn_ok(s: str) -> bool:
+    d = [int(c) for c in s]
+    total, alt = 0, False
+    for x in reversed(d):
+        if alt:
+            x *= 2
+            if x > 9:
+                x -= 9
+        total += x
+        alt = not alt
+    return total % 10 == 0
+
+def _v_credit_card(s: str) -> bool:
+    t = s.replace(" ", "").replace("-", "")
+    return 13 <= len(t) <= 19 and _all(t, _is_digit) and _luhn_ok(t)
+
+# ── detectors: (tag, name_hints_or_None, value_predicate) in fixed order ──
+# name-gated group first (low false-positive), value-distinctive fallback second.
+_DETECTORS = [
+    ("cusip", ("cusip",), _v_cusip),
+    ("npi", ("npi",), _v_npi),
+    ("imei", ("imei", "imsi"), _v_imei),
+    ("ean", ("ean", "gtin", "barcode"), _v_ean),
+    ("isbn", ("isbn",), _v_isbn),
+    ("aba_routing", ("routing", "aba"), _v_aba),
+    ("iban", None, _v_iban),
+    ("isin", None, _v_isin),
+    ("swift", None, _v_swift),
+    ("credit_card", None, _v_credit_card),
+]
+
+
+def fine_type(name: str, samples: list[str]) -> str | None:
+    lname = name.lower()
+    nonempty = [s for s in samples if s and s.strip()]
+    if not nonempty:
+        return None
+    for tag, hints, pred in _DETECTORS:
+        if hints is not None and not any(h in lname for h in hints):
+            continue
+        matches = sum(1 for s in nonempty if pred(s))
+        if matches * 2 > len(nonempty):
+            return tag
+    return None
+
+
+def resolve_tag(name: str, coarse_type: str, samples: list[str]) -> str | None:
+    ft = fine_type(name, samples)
+    if ft is not None:
+        return ft
+    return coarse_type if coarse_type in _COARSE else None
+
+
+# ── mapping table: (check, tag) -> transforms; "*" tag = wildcard ─────────
+_VALIDATOR = {
+    "iban": "iban_validate", "isin": "isin_validate", "swift": "swift_validate",
+    "cusip": "cusip_validate", "npi": "npi_validate", "imei": "imei_validate",
+    "ean": "ean_validate", "isbn": "isbn_validate", "credit_card": "luhn_validate",
+    "aba_routing": "aba_validate",
+}
+_TABLE: dict[tuple[str, str], list[str]] = {
+    ("encoding_detection", "*"): ["fix_mojibake", "normalize_unicode"],
+    ("future_dated", "date"): ["date_validate"],
+    ("temporal_order", "date"): ["date_validate"],
+    ("stale_data", "date"): ["date_validate"],
+    ("format_detection", "date"): ["date_parse"],
+    ("format_detection", "email"): ["email_normalize"],
+    ("pattern_consistency", "email"): ["email_canonical"],
+    ("pattern_consistency", "name"): ["name_proper"],
+    ("format_detection", "phone"): ["phone_validate"],
+    ("pattern_consistency", "phone"): ["phone_national"],
+    ("format_detection", "zip"): ["zip_normalize"],
+}
+for _t, _v in _VALIDATOR.items():
+    _TABLE[("format_detection", _t)] = [_v]
+    _TABLE[("pattern_consistency", _t)] = [_v]
+
+
+def _lookup(check: str, tag: str | None) -> list[str] | None:
+    if tag is not None and (check, tag) in _TABLE:
+        return _TABLE[(check, tag)]
+    if (check, "*") in _TABLE:
+        return _TABLE[(check, "*")]
+    return None
+
+
+def build_repair_plan(findings: list[dict], columns: list[dict]) -> dict:
+    tags: dict[str, str | None] = {}
+    for c in columns:
+        tags[c["name"]] = resolve_tag(c["name"], c.get("coarse_type", ""), c.get("samples", []))
+
+    repairs = []
+    for f in findings:
+        col = f.get("column")
+        check = f.get("check", "")
+        # encoding wildcard can apply even to an omitted-tag column present in `columns`
+        if col not in tags:
+            continue
+        transforms = _lookup(check, tags[col])
+        if not transforms:
+            continue
+        repairs.append({
+            "column": col,
+            "check": check,
+            "type_tag": tags[col] if tags[col] is not None else "*",
+            "suggested_transforms": list(transforms),
+            "reason": str(f.get("message", ""))[:80],
+        })
+    return {"repairs": repairs}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_pure.py -v`
+Expected: PASS (all 6).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/repair.py packages/python/goldenpipe/tests/test_repair_pure.py
+git add packages/python/goldenpipe/goldenpipe/repair.py packages/python/goldenpipe/tests/test_repair_pure.py
+git commit -m "feat(goldenpipe): pure-Python repair-plan kernel (fine-typer + table)"
+```
+
+---
+
+## Task 2: Hand-author the golden-vector contract + wire the Python parity leg
+
+**Files:**
+- Create: `packages/rust/extensions/goldenpipe-core/tests/vectors/build_repair_plan.json`
+- Modify: `packages/python/goldenpipe/goldenpipe/core/_planner_json.py`
+- Modify: `packages/python/goldenpipe/tests/core/test_planner_parity.py`
+
+- [ ] **Step 1: Author the vector file** (each case `{input, expected}`; expected computed by hand from the canonical tables). Cover: an IBAN `pattern_consistency` → `iban_validate`; a `future_dated` date → `date_validate`; an `encoding_detection` on an omitted-tag column → `fix_mojibake,normalize_unicode`; a routing-number 9-digit `pattern_consistency` → `aba_validate`; a credit_card `format_detection` → `luhn_validate`; a no-map `unique` finding → no item; a finding on a column absent from `columns` → no item; an empty-findings case → `{"repairs":[]}`.
+
+```json
+[
+  {
+    "input": {
+      "findings": [{"column": "iban", "check": "pattern_consistency", "message": "3 values fail check-digit", "severity": "warning"}],
+      "columns": [{"name": "iban", "coarse_type": "string", "samples": ["GB82WEST12345698765432", "DE89370400440532013000"]}]
+    },
+    "expected": {"repairs": [{"column": "iban", "check": "pattern_consistency", "type_tag": "iban", "suggested_transforms": ["iban_validate"], "reason": "3 values fail check-digit"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "signup_date", "check": "future_dated", "message": "12 rows dated after today", "severity": "warning"}],
+      "columns": [{"name": "signup_date", "coarse_type": "date", "samples": ["2020-01-01", "2021-05-05"]}]
+    },
+    "expected": {"repairs": [{"column": "signup_date", "check": "future_dated", "type_tag": "date", "suggested_transforms": ["date_validate"], "reason": "12 rows dated after today"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "notes", "check": "encoding_detection", "message": "mojibake detected", "severity": "info"}],
+      "columns": [{"name": "notes", "coarse_type": "string", "samples": ["cafÃ©", "naÃ¯ve"]}]
+    },
+    "expected": {"repairs": [{"column": "notes", "check": "encoding_detection", "type_tag": "*", "suggested_transforms": ["fix_mojibake", "normalize_unicode"], "reason": "mojibake detected"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "routing_number", "check": "pattern_consistency", "message": "bad routing", "severity": "warning"}],
+      "columns": [{"name": "routing_number", "coarse_type": "string", "samples": ["021000021", "011401533"]}]
+    },
+    "expected": {"repairs": [{"column": "routing_number", "check": "pattern_consistency", "type_tag": "aba_routing", "suggested_transforms": ["aba_validate"], "reason": "bad routing"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "card", "check": "format_detection", "message": "spaced digits", "severity": "info"}],
+      "columns": [{"name": "card", "coarse_type": "string", "samples": ["4539578763621486", "4485275742308327"]}]
+    },
+    "expected": {"repairs": [{"column": "card", "check": "format_detection", "type_tag": "credit_card", "suggested_transforms": ["luhn_validate"], "reason": "spaced digits"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "id", "check": "unique", "message": "dupes", "severity": "warning"}],
+      "columns": [{"name": "id", "coarse_type": "string", "samples": ["a", "b"]}]
+    },
+    "expected": {"repairs": []}
+  },
+  {
+    "input": {
+      "findings": [{"column": "ghost", "check": "future_dated", "message": "x", "severity": "info"}],
+      "columns": []
+    },
+    "expected": {"repairs": []}
+  },
+  {
+    "input": {"findings": [], "columns": []},
+    "expected": {"repairs": []}
+  }
+]
+```
+
+Note the mojibake sample uses JSON `Ã©` escapes (the UTF-8 bytes of `é` mis-decoded) — this is finding-driven, the fine-typer never inspects these for classification (coarse `string` → no fine tag → the `*` wildcard applies).
+
+- [ ] **Step 2: Add `build_repair_plan_json` to `_planner_json.py`**
+
+At the end of the module (it must call the real `goldenpipe.repair`):
+
+```python
+from goldenpipe import repair as _repair  # add to import block
+
+
+def build_repair_plan_json(s: str) -> str:
+    arg = json.loads(s)
+    out = _repair.build_repair_plan(arg.get("findings", []), arg.get("columns", []))
+    return json.dumps(out)
+```
+
+- [ ] **Step 3: Add the vector to the Leg A + Leg B case lists in `test_planner_parity.py`**
+
+Add `("build_repair_plan", PJ.build_repair_plan_json)` to `_CASES`, and `("build_repair_plan", "build_repair_plan_json")` to the Leg B parametrize list.
+
+- [ ] **Step 4: Run the Leg A parity test (box)**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/core/test_planner_parity.py -k build_repair_plan -v`
+Expected: Leg A PASS. (Leg B native-wheel case is skip-guarded locally — confirm it SKIPs, does not fail.)
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/core/_planner_json.py packages/python/goldenpipe/tests/core/test_planner_parity.py
+git add packages/rust/extensions/goldenpipe-core/tests/vectors/build_repair_plan.json packages/python/goldenpipe/goldenpipe/core/_planner_json.py packages/python/goldenpipe/tests/core/test_planner_parity.py
+git commit -m "test(goldenpipe): repair-plan golden vectors + python parity leg"
+```
+
+---
+
+## Task 3: Host wiring — sampling helper + artifact attachment (box-testable)
+
+**Files:**
+- Create: `packages/python/goldenpipe/goldenpipe/repair_host.py`
+- Test: `packages/python/goldenpipe/tests/test_repair_host.py`
+
+Keep the polars-touching sampling glue OUT of the pure `repair.py` (which must stay data-only and box-parity-clean).
+
+- [ ] **Step 1: Write failing host tests**
+
+```python
+import polars as pl
+from goldenpipe.repair_host import sample_column, build_column_inputs, attach_repair_plan
+from goldenpipe.models.context import PipeContext
+
+
+def test_sample_column_first_n_nonnull_as_str():
+    s = pl.Series("c", [None, "a", "b", None, "c"])
+    assert sample_column(s, limit=2) == ["a", "b"]
+
+def test_build_column_inputs_from_contexts_and_df():
+    df = pl.DataFrame({"iban": ["GB82WEST12345698765432", "DE89370400440532013000"]})
+    class Ctx:  # minimal ColumnContext stand-in
+        def __init__(self, name, t): self.name, self.inferred_type = name, t
+    cols = build_column_inputs([Ctx("iban", "string")], df)
+    assert cols[0]["name"] == "iban" and cols[0]["coarse_type"] == "string"
+    assert cols[0]["samples"] == ["GB82WEST12345698765432", "DE89370400440532013000"]
+
+def test_attach_repair_plan_sets_artifact_and_reasoning():
+    df = pl.DataFrame({"signup_date": ["2020-01-01", "2021-05-05"]})
+    findings = [{"column": "signup_date", "check": "future_dated", "message": "12 rows after today", "severity": "warning"}]
+    class Ctx:
+        def __init__(self, name, t): self.name, self.inferred_type = name, t
+    ctx = PipeContext()  # adjust constructor per real signature
+    attach_repair_plan(ctx, findings, [Ctx("signup_date", "date")], df)
+    plan = ctx.artifacts["repair_plan"]
+    assert plan["repairs"][0]["suggested_transforms"] == ["date_validate"]
+```
+
+(Adjust `PipeContext` construction to its real signature — inspect `goldenpipe/models/context.py` first.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_host.py -v`
+Expected: FAIL — `ModuleNotFoundError: goldenpipe.repair_host`.
+
+- [ ] **Step 3: Implement `repair_host.py`**
+
+```python
+"""Host glue for repair-plan: sample polars columns, build ColumnInputs, call the
+pure kernel, attach the advisory artifact + reasoning. Advisory ONLY — never
+mutates the stage list."""
+from __future__ import annotations
+
+from goldenpipe.repair import build_repair_plan
+
+_SAMPLE_LIMIT = 20
+
+
+def sample_column(series, limit: int = _SAMPLE_LIMIT) -> list[str]:
+    out: list[str] = []
+    for v in series:                       # polars Series iterates values in row order
+        if v is None:
+            continue
+        s = str(v)
+        if s.strip() == "":
+            continue
+        out.append(s)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def build_column_inputs(contexts, df) -> list[dict]:
+    cols = []
+    names = set(df.columns)
+    for ctx in contexts:
+        if ctx.name not in names:
+            continue
+        cols.append({
+            "name": ctx.name,
+            "coarse_type": str(ctx.inferred_type),   # ColumnType is a str-enum -> "email" etc.
+            "samples": sample_column(df[ctx.name]),
+        })
+    return cols
+
+
+def attach_repair_plan(ctx, findings, contexts, df) -> dict:
+    columns = build_column_inputs(contexts, df)
+    plan = build_repair_plan(findings, columns)
+    ctx.artifacts["repair_plan"] = plan
+    for item in plan["repairs"]:
+        line = (f"repair: {item['column']} ({item['check']}) -> "
+                f"{','.join(item['suggested_transforms'])} [{item['reason']}]")
+        _record_reasoning(ctx, line)
+    return plan
+
+
+def _record_reasoning(ctx, line: str) -> None:
+    # Use whatever reasoning channel the ctx already exposes (inspect models/context.py:
+    # e.g. ctx.reasoning.append(line) or ctx.add_reasoning(line)). Kept in one helper
+    # so the exact call is easy to correct during implementation.
+    getattr(ctx, "reasoning", []).append(line)
+```
+
+**Implementation note:** inspect `goldenpipe/models/context.py` for the real reasoning API and `ColumnContext.inferred_type`'s str value (Task 5 confirms), and correct `_record_reasoning` + the `str(ctx.inferred_type)` cast accordingly. `str(ColumnType.EMAIL)` must yield `"email"` — verify (the enum is `str, Enum` with lowercase values, so `.value` is `"email"`; use `ctx.inferred_type.value` if `str()` yields `ColumnType.EMAIL`).
+
+- [ ] **Step 4: Run host tests to verify pass**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_host.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/repair_host.py packages/python/goldenpipe/tests/test_repair_host.py
+git add packages/python/goldenpipe/goldenpipe/repair_host.py packages/python/goldenpipe/tests/test_repair_host.py
+git commit -m "feat(goldenpipe): repair-plan host glue (sampling + artifact attach)"
+```
+
+---
+
+## Task 4: Rust core mirror (write-against-spec, CI-verified)
+
+**Files:**
+- Create: `packages/rust/extensions/goldenpipe-core/src/repair.rs`
+- Modify: `packages/rust/extensions/goldenpipe-core/src/lib.rs` (add `pub mod repair;`)
+- Modify: `packages/rust/extensions/goldenpipe-core/src/json.rs` (add `build_repair_plan_json`)
+- Modify: `packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs` (add `vec_build_repair_plan`)
+
+The box cannot build this — mirror `repair.py` behavior exactly, format with rustfmt, verify in CI.
+
+- [ ] **Step 1: Write `src/repair.rs`** — serde structs + hand-rolled matchers + Luhn + detector table (same order as Python) + `_lookup` + `build_repair_plan`. Structs:
+
+```rust
+//! Repair-plan kernel. Mirrors goldenpipe/repair.py EXACTLY (behavior-canonical
+//! by convention: Rust is the source of truth; the pure-Python/TS mirrors must
+//! reproduce these bytes). Hand-rolled ASCII matchers — NO regex crate — so all
+//! three surfaces agree on classification (`\d` would be Unicode in Rust/Python
+//! but ASCII in JS).
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct Finding {
+    pub column: Option<String>,
+    #[serde(default)]
+    pub check: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub severity: String,
+}
+
+#[derive(Deserialize)]
+pub struct ColumnInput {
+    pub name: String,
+    #[serde(default)]
+    pub coarse_type: String,
+    #[serde(default)]
+    pub samples: Vec<String>,
+}
+
+#[derive(Serialize)]
+pub struct RepairItem {
+    pub column: String,
+    pub check: String,
+    pub type_tag: String,
+    pub suggested_transforms: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(Serialize, Default)]
+pub struct RepairPlan {
+    pub repairs: Vec<RepairItem>,
+}
+```
+
+Implement `fine_type(name, samples) -> Option<&'static str>`, `resolve_tag`, `lookup(check, tag) -> Option<Vec<String>>`, and `build_repair_plan(findings, columns) -> RepairPlan`. Match Python's field/tag strings and the `reason` truncation: Rust `message.chars().take(80).collect()` (char-based, to match Python `[:80]` slicing on code points — note both slice by Unicode scalar, so use `.chars().take(80)` NOT byte slicing). `type_tag` for a wildcard-matched (omitted-tag) column serializes as `"*"` exactly like Python.
+
+Include `#[cfg(test)] mod tests` mirroring the Python unit cases (iban, routing-not-iban, credit_card Luhn, barcode→ean, minority-no-fire).
+
+- [ ] **Step 2: Add `pub mod repair;` to `lib.rs`** and the `build_repair_plan_json` wrapper to `json.rs`:
+
+```rust
+#[derive(Deserialize)]
+struct RepairIn {
+    #[serde(default)]
+    findings: Vec<crate::repair::Finding>,
+    #[serde(default)]
+    columns: Vec<crate::repair::ColumnInput>,
+}
+
+pub fn build_repair_plan_json(input: &str) -> String {
+    let arg: RepairIn = match serde_json::from_str(input) {
+        Ok(a) => a,
+        Err(e) => return parse_err(e),
+    };
+    serde_json::to_string(&crate::repair::build_repair_plan(&arg.findings, &arg.columns)).unwrap()
+}
+```
+
+- [ ] **Step 3: Add the golden-vector test entry** to `tests/golden_vectors.rs`:
+
+```rust
+#[test]
+fn vec_build_repair_plan() {
+    run("build_repair_plan", build_repair_plan_json);
+}
+```
+
+- [ ] **Step 4: rustfmt (box)**
+
+Run: `rustfmt --edition 2021 packages/rust/extensions/goldenpipe-core/src/repair.rs packages/rust/extensions/goldenpipe-core/src/json.rs packages/rust/extensions/goldenpipe-core/src/lib.rs packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs`
+Expected: exit 0, no diff surprises. **Do not** attempt `cargo build`/`cargo test` on the box — CI runs them.
+
+- [ ] **Step 5: Grep-verify wiring + commit**
+
+Verify by eye/grep: `pub mod repair` in lib.rs; `build_repair_plan_json` referenced in json.rs + golden_vectors.rs; struct field order matches the JSON wire shape.
+```bash
+git add packages/rust/extensions/goldenpipe-core/src/repair.rs packages/rust/extensions/goldenpipe-core/src/lib.rs packages/rust/extensions/goldenpipe-core/src/json.rs packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
+git commit -m "feat(goldenpipe-core): build_repair_plan kernel + golden-vector test"
+```
+
+---
+
+## Task 5: Wire the engine call site (box-testable integration)
+
+**Files:**
+- Modify: the engine module that builds ColumnContexts post-Check (find it in Step 1).
+- Test: extend `packages/python/goldenpipe/tests/test_repair_host.py` or add an engine-level test.
+
+- [ ] **Step 1: Locate the call site.** Grep for where `build_contexts_from_check` is called and where `findings` + the working DataFrame are both in scope:
+
+Run: `grep -rn "build_contexts_from_check\|artifacts\[.findings.\]\|enrich_contexts_from_flow" packages/python/goldenpipe/goldenpipe --include=*.py`
+
+Confirm the reasoning API on `PipeContext` (`grep -n "reasoning\|def add_reason" packages/python/goldenpipe/goldenpipe/models/context.py`) and fix `repair_host._record_reasoning` to match.
+
+- [ ] **Step 2: Write a failing engine-level assertion** that after a Check stage produces findings on a date column, `ctx.artifacts["repair_plan"]` exists with the expected item. (Use the smallest existing engine-test harness as a template — find one via `grep -rln "PipeContext()" packages/python/goldenpipe/tests`.)
+
+- [ ] **Step 3: Insert the call.** At the located site (after contexts + findings are available, before Match auto-config), add:
+
+```python
+from goldenpipe.repair_host import attach_repair_plan
+# ... where `findings`, `contexts`, and the working df are in scope:
+attach_repair_plan(ctx, findings, contexts, df)
+```
+
+Guard it so a missing df or empty findings is a no-op (the pure fn already returns `{"repairs": []}`; ensure no exception if `df is None`).
+
+- [ ] **Step 4: Run the engine test + the full repair test set (box)**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_pure.py packages/python/goldenpipe/tests/test_repair_host.py packages/python/goldenpipe/tests/core/test_planner_parity.py -k "repair or build_repair_plan" -v`
+Expected: PASS. Also run one broad existing engine test to prove **no executed-stage regression** (byte-identical-when-inactive): pick a pipeline test that asserts stage order/output and confirm it still passes unchanged.
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check <touched engine file> <touched test>
+git add <touched files>
+git commit -m "feat(goldenpipe): attach advisory repair_plan artifact in the engine"
+```
+
+---
+
+## Task 6: TS mirror + WASM/native shim exports (write-against-spec, CI-verified)
+
+**Files:**
+- Create: `packages/typescript/goldenpipe/src/core/repair.ts`
+- Modify: the TS json-face + `packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts` (replay `build_repair_plan.json`).
+- Modify: `packages/rust/extensions/goldenpipe-wasm/src/lib.rs` and `packages/rust/extensions/goldenpipe-native/src/lib.rs` (export `build_repair_plan_json` following the existing per-fn pattern).
+
+Box cannot run tsc/vitest or build wasm — mirror behavior, verify in CI.
+
+- [ ] **Step 1: Write `repair.ts`** mirroring `repair.py`: same ASCII predicates (use `c >= "0" && c <= "9"` etc., never `\d`), same detector order, same table, same `buildRepairPlan(findings, columns)` returning `{repairs: [...]}` with fields in the same order. Match the JS reason truncation to code points: `[...String(message)].slice(0, 80).join("")` (spread iterates by code point, matching Python `[:80]` on a str and Rust `.chars().take(80)`).
+
+- [ ] **Step 2: Add the TS json-face fn** `buildRepairPlanJson(s)` and register `build_repair_plan` in the parity test's vector list (mirror how `apply_decision`/`evaluate_builtin` are registered in `planner-parity.test.ts`).
+
+- [ ] **Step 3: Export the shim fns.** In `goldenpipe-wasm/src/lib.rs` and `goldenpipe-native/src/lib.rs`, add a `build_repair_plan_json` binding following the exact pattern used for `apply_decision_json` (grep those files for `apply_decision_json` and copy the shape). rustfmt both.
+
+- [ ] **Step 4: rustfmt the shims (box) + grep-verify**
+
+Run: `rustfmt --edition 2021 packages/rust/extensions/goldenpipe-wasm/src/lib.rs packages/rust/extensions/goldenpipe-native/src/lib.rs`
+Grep-verify each surface names `build_repair_plan_json`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/typescript/goldenpipe/src/core/repair.ts <ts json-face> packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts packages/rust/extensions/goldenpipe-wasm/src/lib.rs packages/rust/extensions/goldenpipe-native/src/lib.rs
+git commit -m "feat(goldenpipe): TS repair mirror + wasm/native json shims"
+```
+
+---
+
+## Task 7: Ship
+
+- [ ] **Step 1: Rebase onto fresh origin/main**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+Resolve any conflicts (most likely in `json.rs` import list, `golden_vectors.rs`, `lib.rs` mod list, `_planner_json.py` imports, and `test_planner_parity.py` case lists — keep BOTH sides' entries).
+
+- [ ] **Step 2: Re-run the box-runnable suite after rebase**
+
+Run: `"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_pure.py packages/python/goldenpipe/tests/test_repair_host.py packages/python/goldenpipe/tests/core/test_planner_parity.py -k "repair or build_repair_plan" -v`
+Expected: PASS.
+
+- [ ] **Step 3: Push + PR + arm auto-merge, then STOP**
+
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git push -u origin feat/goldenpipe-repair-plan
+gh pr create --base main --title "feat(goldenpipe): advisory repair-plan intelligence (Phase 1)" --body "<summary: kernel build_repair_plan + in-kernel fine-typer + host wiring; advisory only, byte-identical when inactive; spec + plan links>"
+# merge-queue repo: NO --delete-branch
+gh pr merge <N> --auto --squash
+```
+Then **STOP** — do not poll CI (merge-queue lands on green). Watch that CI covers: Rust `cargo test` (golden vectors incl. `vec_build_repair_plan`), Python `test_planner_parity` Leg A+B, TS parity, and the goldenpipe-core parity gate.
+
+---
+
+## Verification summary (what "done" means)
+
+- Box-green: `test_repair_pure.py`, `test_repair_host.py`, `test_planner_parity.py -k build_repair_plan` (Leg A), one existing engine test unchanged (no regression).
+- CI-green: Rust golden vectors (`vec_build_repair_plan`), Python Leg B (native wheel), TS parity, wasm build.
+- Advisory guarantee: no `Decision` emitted; executed-stage list byte-identical whether or not repair-planning runs (proved by the unchanged engine test).

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
@@ -2,7 +2,8 @@
 
 **Date:** 2026-07-07
 **Status:** Approved (brainstorming), pending implementation plan
-**Scope:** Phase 1 (advisory). Phase 2 (active config-injection) is designed-for but out of scope here.
+**Scope:** Phase 1 (advisory, with a value-level fine-typer). Phase 2 (active
+config-injection) is designed-for but out of scope here.
 
 ## Goal
 
@@ -23,31 +24,56 @@ a `future_dated` finding on a date column suggests `date_validate`; a
   changes **zero executed stages**. A pipeline's output is byte-identical
   whether or not repair-planning runs.
 
-## Approach (chosen: A)
+## Approach (chosen: A, with an in-kernel fine-typer)
 
 A static `(check, type_tag) -> [transforms]` table compiled into the kernel
-(exactly how decision rules already live there). A new pure kernel function does
-the lookups; the host resolves per-column types from machinery it already runs
-and passes them in as plain data. The kernel never sees a DataFrame or a
-classifier.
+(exactly how decision rules already live there). A new pure kernel function
+resolves each column's `type_tag` and does the lookups.
+
+Resolving `type_tag` needs a value-level signal: the domain packs and the coarse
+`ColumnContext` classifier cannot tell an IBAN from a routing number from a
+SWIFT code (the goldencheck-types finance pack groups all of these under coarse
+type keys like `routing_number`, and `iban` is not even a hint). Distinguishing
+them requires looking at the column's values. Because column values are just
+strings, the fine-typer runs **inside the kernel** (regex + structural checks
+are byte-identical across languages); the host's only new job is to **sample**
+values from the DataFrame it already holds and pass them in as JSON strings.
 
 Rejected alternatives:
 - **B — Python-only rule in `decisions.py`.** Fastest, but Python-only; TS/WASM
   would never get it. Violates the cross-surface constraint.
 - **C — repairs co-located in domain-pack YAML.** Elegant co-location and the
   packs already sync cross-surface, but only covers columns that matched a
-  domain type (coarse `date`/`email` on unmatched columns get nothing) and
-  bloats the pack schema. Worth revisiting for fine types later.
+  domain type, the pack type keys are too coarse to pick a specific validator
+  (`routing_number` covers routing/aba/swift/bic), and it bloats the pack
+  schema.
+- **Host-side fine-typer.** Would duplicate the regex/check-digit logic per
+  language and require its own parity gate. Keeping the fine-typer in the kernel
+  gives one implementation and one parity gate.
 
 ## Architecture
 
 ### New kernel function
 
 ```
-build_repair_plan(findings: [Finding], column_types: {col: TypeTag}) -> RepairPlan
+build_repair_plan(
+    findings: [Finding],
+    columns:  [ColumnInput],
+) -> RepairPlan
 ```
 
 Pure, deterministic, no I/O. Same functional shape as `apply_decision`.
+
+```
+ColumnInput { name: str, coarse_type: str, samples: [str] }   // samples: <=20 non-null, deterministic first-N
+Finding     { column, check, message, severity }              // existing shape from artifacts["findings"]
+```
+
+Per column the kernel: runs the fine-typer over `samples` -> a fine `type_tag`
+if a detector fires, else falls back to `coarse_type`, else omits the column (no
+tag -> only `*` wildcard checks can match). Then it does the `(check, type_tag)`
+lookups against the static table. All classification and mapping live in the
+kernel — one call, one parity gate.
 
 ### Data model (new serde structs in `goldenpipe-core/src/model.rs`, mirrored Python/TS)
 
@@ -58,9 +84,6 @@ RepairItem  { column, check, type_tag,
               reason }                        // human string, from the finding message
 ```
 
-`Finding` reuses the existing shape already in `artifacts["findings"]`:
-`{column, check, message, severity}`.
-
 `RepairPlan` is an **artifact**, never a `Decision`. It is attached to
 `ctx.artifacts["repair_plan"]`; it does not skip, insert, or abort any stage.
 The empty inserted-stage `config` seam in `router.rs` (an inserted `PlannedSpec`
@@ -70,10 +93,51 @@ suggested transforms — Phase 1 leaves it untouched.
 ### Data flow
 
 1. GoldenCheck scan -> `findings` (already in `artifacts["findings"]`).
-2. Host resolves `column_types` (see Type resolution).
-3. Host calls `build_repair_plan(findings, column_types)`.
-4. Kernel does `(check, type_tag)` lookups; emits `RepairPlan`.
+2. Host builds `ColumnInput`s: `name` and `coarse_type` from the existing
+   `ColumnContext`, `samples` = up to 20 deterministic first-N non-null values
+   from the DataFrame (cast to string).
+3. Host calls `build_repair_plan(findings, columns)`.
+4. Kernel fine-types each column, then does `(check, type_tag)` lookups; emits
+   `RepairPlan`.
 5. Host stores the artifact and appends one reasoning line per item.
+
+## The fine-typer (in-kernel)
+
+Per fine tag, a detector of the form `(name-hint, value-regex, optional
+check-digit)`. Value structure is the disambiguator; the name-hint gates the
+tags whose value shape is ambiguous with other fixed-length numeric ids.
+Detection stays structural (lean regex) — full check-digit validation is the
+GoldenFlow *validate* transform's job — **except** `credit_card`, where a Luhn
+pass is the disambiguator against arbitrary 13-19 digit numbers.
+
+A detector fires only if the majority of non-null samples match its value
+pattern (guards against a single coincidental match). Detectors are tried in a
+fixed order; first firing tag wins.
+
+### Fine vocabulary (v1)
+
+Value-distinctive (name-hint optional):
+
+| tag | value structure (detection, not full validation) |
+|---|---|
+| `iban` | `^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$`, length 15-34 |
+| `isin` | `^[A-Z]{2}[0-9A-Z]{9}[0-9]$` (12 chars) |
+| `swift` | `^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$` (8 or 11) |
+| `credit_card` | `^\d{13,19}$` (strip spaces/dashes) **and** Luhn passes |
+
+Name-hint required (value shape alone is ambiguous):
+
+| tag | name-hint (any of) | value structure |
+|---|---|---|
+| `cusip` | cusip | `^[0-9A-Z]{9}$` |
+| `npi` | npi | `^\d{10}$` |
+| `imei` | imei, imsi | `^\d{15}$` |
+| `ean` | ean, gtin, barcode | `^\d{8}$` or `^\d{13}$` |
+| `isbn` | isbn | `^\d{9}[\dX]$` or `^\d{13}$` |
+| `aba_routing` | routing, aba | `^\d{9}$` |
+
+`vat` is dropped from v1 — country-specific formats are too fuzzy for a lean
+detector.
 
 ## The mapping table
 
@@ -81,7 +145,9 @@ Static kernel data: a list of `(check, type_tag) -> [transforms]`. Lookup tries
 the exact `(check, type)` first, then `(check, "*")` wildcard. Ordered,
 deterministic, first-match wins.
 
-### Starter coverage (v1)
+### Coverage (v1)
+
+Coarse rows (tag from `ColumnContext.coarse_type`):
 
 | check | type_tag | suggested transforms |
 |---|---|---|
@@ -96,30 +162,24 @@ deterministic, first-match wins.
 | `format_detection` | `phone` | `phone_validate` |
 | `pattern_consistency` | `phone` | `phone_national` |
 | `format_detection` | `zip` | `zip_normalize` |
-| `format_detection` | `iban` | `iban_validate` |
-| `pattern_consistency` | `iban` | `iban_validate` |
-| `format_detection` | `cusip` | `cusip_validate` |
-| `pattern_consistency` | `cusip` | `cusip_validate` |
-| `format_detection` | `isin` | `isin_validate` |
-| `pattern_consistency` | `isin` | `isin_validate` |
-| `format_detection` | `npi` | `npi_validate` |
-| `pattern_consistency` | `npi` | `npi_validate` |
-| `format_detection` | `imei` | `imei_validate` |
-| `pattern_consistency` | `imei` | `imei_validate` |
-| `format_detection` | `ean` | `ean_validate` |
-| `pattern_consistency` | `ean` | `ean_validate` |
-| `format_detection` | `isbn` | `isbn_validate` |
-| `pattern_consistency` | `isbn` | `isbn_validate` |
-| `format_detection` | `credit_card` | `luhn_validate` |
-| `pattern_consistency` | `credit_card` | `luhn_validate` |
-| `format_detection` | `aba_routing` | `aba_validate` |
-| `pattern_consistency` | `aba_routing` | `aba_validate` |
-| `format_detection` | `swift` | `swift_validate` |
-| `pattern_consistency` | `swift` | `swift_validate` |
-| `format_detection` | `vat` | `vat_validate` |
-| `pattern_consistency` | `vat` | `vat_validate` |
 
-Every transform above is verified to exist in the GoldenFlow registry.
+Fine rows (tag from the in-kernel fine-typer); both `format_detection` and
+`pattern_consistency` map to the type's validator:
+
+| type_tag | suggested transform |
+|---|---|
+| `iban` | `iban_validate` |
+| `isin` | `isin_validate` |
+| `swift` | `swift_validate` |
+| `cusip` | `cusip_validate` |
+| `npi` | `npi_validate` |
+| `imei` | `imei_validate` |
+| `ean` | `ean_validate` |
+| `isbn` | `isbn_validate` |
+| `credit_card` | `luhn_validate` |
+| `aba_routing` | `aba_validate` |
+
+Every transform named above is verified to exist in the GoldenFlow registry.
 
 ### No-map policy (explicit, not an error)
 
@@ -137,29 +197,27 @@ produce **no** `RepairItem`: `unique`, `key_uniqueness_loss`, `duplicate_rows`,
 call, not a mechanical repair. The table is pure data, so promoting any no-map
 check later is a one-line addition plus a golden vector.
 
-## Type resolution (host side)
-
-A small per-language helper `resolve_type_tags(contexts, detect_result) ->
-{col: TypeTag}`. This is the only piece outside the kernel, because it reuses
-per-language machinery. Priority:
-
-1. **Domain-pack fine type** when InferMap detect ran and the column matched a
-   pack type (`iban`, `npi`, `vin`, ...).
-2. else **coarse `ColumnContext.inferred_type`** (`email`, `name`, `date`,
-   `phone`, `zip`, ...).
-3. else **omit** the column — no tag means it can only match `*` wildcard checks
-   such as `encoding_detection`.
-
-The kernel receives only the resolved `{col: tag}` dict, so parity is preserved.
-
 ## Error handling
 
-- No findings, unknown checks/types, or all-no-map -> `RepairPlan{repairs: []}`.
+- No findings, unknown checks/types, all-no-map, or empty samples ->
+  `RepairPlan{repairs: []}`.
 - Never raises, never blocks the pipeline.
-- Unknown `check` or `type_tag` is a silent no-match (forward-compatible with new
-  checks and new domain packs), not an error.
+- Unknown `check` or `coarse_type` is a silent no-match (forward-compatible with
+  new checks and new domain packs), not an error.
+- A column whose samples fire no fine detector falls back to its coarse tag; a
+  column with no coarse tag and no fine match is omitted.
 - `reason` is built from the finding's own `message`, truncated to the existing
   80-char finding-message convention.
+
+## Privacy / cost of value sampling
+
+Sampled values (possibly PII, e.g. card numbers) cross the planner boundary.
+Mitigations:
+- It is an **in-process** call — the data is already in host memory; nothing is
+  serialized to disk or network.
+- Samples are bounded (<=20 non-null values per column, deterministic first-N).
+- The fine-typer never logs raw values — reasoning lines carry only the derived
+  `type_tag` and the finding's own message.
 
 ## Surfacing (Phase 1, minimal)
 
@@ -171,14 +229,18 @@ The kernel receives only the resolved `{col: tag}` dict, so parity is preserved.
 ## Testing
 
 - **Rust golden vectors** (`goldenpipe-core/tests/golden_vectors.rs`): canonical
-  `(findings, column_types)` inputs -> exact `RepairPlan` JSON. Cross-surface
-  source of truth.
+  `(findings, columns)` inputs -> exact `RepairPlan` JSON. Cross-surface source
+  of truth.
+- **Fine-typer matrix** (positive + negative per fine tag): an IBAN sample
+  classifies as `iban`; a 9-digit routing number does **not** classify as
+  `iban`; a bare unnamed 9-digit column stays coarse (no fine tag); a 16-digit
+  number that fails Luhn is **not** `credit_card`. Parity-gated.
 - **Python + TS parity**: the same fixtures through each surface, asserted
   byte-identical against the golden JSON, wired into the existing goldenpipe-core
   parity gate.
-- **Box-runnable Python** unit tests for `resolve_type_tags` (coarse fallback,
-  fine-type priority, omit-on-unknown) and `build_repair_plan` via the pure
-  Python path — no Rust build needed on the box.
+- **Box-runnable Python** unit tests for the sampling helper (bounded, first-N,
+  null-skipping) and `build_repair_plan` via the pure Python path — no Rust
+  build needed on the box.
 - **Empty-plan-when-unused** test proves the byte-identical-when-inactive
   guarantee (a pipeline with no findings, or only no-map findings, emits an empty
   plan and unchanged executed stages).

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
@@ -114,6 +114,12 @@ A detector fires only if the majority of non-null samples match its value
 pattern (guards against a single coincidental match). Detectors are tried in a
 fixed order; first firing tag wins.
 
+**Cross-engine byte-identity:** every detector regex uses explicit ASCII
+character classes — `[0-9]`, never `\d`; `[0-9Xx]`, never `[\dX]`. `\d` is
+Unicode-digit by default in Python `re` and Rust `regex` but ASCII in JS, so a
+sample containing a non-ASCII digit would classify differently per surface and
+break the parity gate. Explicit classes are identical across all three engines.
+
 ### Fine vocabulary (v1)
 
 Value-distinctive (name-hint optional):
@@ -123,18 +129,18 @@ Value-distinctive (name-hint optional):
 | `iban` | `^[A-Z]{2}[0-9]{2}[A-Z0-9]{11,30}$`, length 15-34 |
 | `isin` | `^[A-Z]{2}[0-9A-Z]{9}[0-9]$` (12 chars) |
 | `swift` | `^[A-Z]{6}[A-Z0-9]{2}([A-Z0-9]{3})?$` (8 or 11) |
-| `credit_card` | `^\d{13,19}$` (strip spaces/dashes) **and** Luhn passes |
+| `credit_card` | `^[0-9]{13,19}$` (strip spaces/dashes) **and** Luhn passes |
 
 Name-hint required (value shape alone is ambiguous):
 
 | tag | name-hint (any of) | value structure |
 |---|---|---|
 | `cusip` | cusip | `^[0-9A-Z]{9}$` |
-| `npi` | npi | `^\d{10}$` |
-| `imei` | imei, imsi | `^\d{15}$` |
-| `ean` | ean, gtin, barcode | `^\d{8}$` or `^\d{13}$` |
-| `isbn` | isbn | `^\d{9}[\dX]$` or `^\d{13}$` |
-| `aba_routing` | routing, aba | `^\d{9}$` |
+| `npi` | npi | `^[0-9]{10}$` |
+| `imei` | imei, imsi | `^[0-9]{15}$` |
+| `ean` | ean, gtin, barcode | `^[0-9]{8}$` or `^[0-9]{13}$` |
+| `isbn` | isbn | `^[0-9]{9}[0-9Xx]$` or `^[0-9]{13}$` |
+| `aba_routing` | routing, aba | `^[0-9]{9}$` |
 
 `vat` is dropped from v1 — country-specific formats are too fuzzy for a lean
 detector.

--- a/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
+++ b/docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md
@@ -1,0 +1,197 @@
+# GoldenPipe Repair-Plan Intelligence — Design
+
+**Date:** 2026-07-07
+**Status:** Approved (brainstorming), pending implementation plan
+**Scope:** Phase 1 (advisory). Phase 2 (active config-injection) is designed-for but out of scope here.
+
+## Goal
+
+Turn GoldenCheck findings into specific, actionable GoldenFlow-transform
+remediations. Today the brain's Check-to-Flow decision is generic ("there are
+issues, route to Flow"). Repair-plan intelligence emits a per-column,
+per-finding plan naming the exact transform(s) that would fix each issue — e.g.
+a `future_dated` finding on a date column suggests `date_validate`; a
+`pattern_consistency` finding on an IBAN column suggests `iban_validate`.
+
+## Constraints
+
+- Must live in the pyo3-free `goldenpipe-core` kernel so it is **byte-identical
+  across Python / Rust / TS / WASM** (CI parity-gated), matching every other
+  brain decision.
+- Deterministic. No LLM in the hot path.
+- **Phase 1 is advisory only**: it emits an artifact and reasoning text and
+  changes **zero executed stages**. A pipeline's output is byte-identical
+  whether or not repair-planning runs.
+
+## Approach (chosen: A)
+
+A static `(check, type_tag) -> [transforms]` table compiled into the kernel
+(exactly how decision rules already live there). A new pure kernel function does
+the lookups; the host resolves per-column types from machinery it already runs
+and passes them in as plain data. The kernel never sees a DataFrame or a
+classifier.
+
+Rejected alternatives:
+- **B — Python-only rule in `decisions.py`.** Fastest, but Python-only; TS/WASM
+  would never get it. Violates the cross-surface constraint.
+- **C — repairs co-located in domain-pack YAML.** Elegant co-location and the
+  packs already sync cross-surface, but only covers columns that matched a
+  domain type (coarse `date`/`email` on unmatched columns get nothing) and
+  bloats the pack schema. Worth revisiting for fine types later.
+
+## Architecture
+
+### New kernel function
+
+```
+build_repair_plan(findings: [Finding], column_types: {col: TypeTag}) -> RepairPlan
+```
+
+Pure, deterministic, no I/O. Same functional shape as `apply_decision`.
+
+### Data model (new serde structs in `goldenpipe-core/src/model.rs`, mirrored Python/TS)
+
+```
+RepairPlan  { repairs: [RepairItem] }        // empty when nothing maps
+RepairItem  { column, check, type_tag,
+              suggested_transforms: [str],    // ordered, e.g. ["iban_validate"]
+              reason }                        // human string, from the finding message
+```
+
+`Finding` reuses the existing shape already in `artifacts["findings"]`:
+`{column, check, message, severity}`.
+
+`RepairPlan` is an **artifact**, never a `Decision`. It is attached to
+`ctx.artifacts["repair_plan"]`; it does not skip, insert, or abort any stage.
+The empty inserted-stage `config` seam in `router.rs` (an inserted `PlannedSpec`
+gets `config: Default::default()`) is where Phase 2 would later write the
+suggested transforms — Phase 1 leaves it untouched.
+
+### Data flow
+
+1. GoldenCheck scan -> `findings` (already in `artifacts["findings"]`).
+2. Host resolves `column_types` (see Type resolution).
+3. Host calls `build_repair_plan(findings, column_types)`.
+4. Kernel does `(check, type_tag)` lookups; emits `RepairPlan`.
+5. Host stores the artifact and appends one reasoning line per item.
+
+## The mapping table
+
+Static kernel data: a list of `(check, type_tag) -> [transforms]`. Lookup tries
+the exact `(check, type)` first, then `(check, "*")` wildcard. Ordered,
+deterministic, first-match wins.
+
+### Starter coverage (v1)
+
+| check | type_tag | suggested transforms |
+|---|---|---|
+| `encoding_detection` | `*` | `fix_mojibake`, `normalize_unicode` |
+| `future_dated` | `date` | `date_validate` |
+| `temporal_order` | `date` | `date_validate` |
+| `stale_data` | `date` | `date_validate` |
+| `format_detection` | `date` | `date_parse` |
+| `format_detection` | `email` | `email_normalize` |
+| `pattern_consistency` | `email` | `email_canonical` |
+| `pattern_consistency` | `name` | `name_proper` |
+| `format_detection` | `phone` | `phone_validate` |
+| `pattern_consistency` | `phone` | `phone_national` |
+| `format_detection` | `zip` | `zip_normalize` |
+| `format_detection` | `iban` | `iban_validate` |
+| `pattern_consistency` | `iban` | `iban_validate` |
+| `format_detection` | `cusip` | `cusip_validate` |
+| `pattern_consistency` | `cusip` | `cusip_validate` |
+| `format_detection` | `isin` | `isin_validate` |
+| `pattern_consistency` | `isin` | `isin_validate` |
+| `format_detection` | `npi` | `npi_validate` |
+| `pattern_consistency` | `npi` | `npi_validate` |
+| `format_detection` | `imei` | `imei_validate` |
+| `pattern_consistency` | `imei` | `imei_validate` |
+| `format_detection` | `ean` | `ean_validate` |
+| `pattern_consistency` | `ean` | `ean_validate` |
+| `format_detection` | `isbn` | `isbn_validate` |
+| `pattern_consistency` | `isbn` | `isbn_validate` |
+| `format_detection` | `credit_card` | `luhn_validate` |
+| `pattern_consistency` | `credit_card` | `luhn_validate` |
+| `format_detection` | `aba_routing` | `aba_validate` |
+| `pattern_consistency` | `aba_routing` | `aba_validate` |
+| `format_detection` | `swift` | `swift_validate` |
+| `pattern_consistency` | `swift` | `swift_validate` |
+| `format_detection` | `vat` | `vat_validate` |
+| `pattern_consistency` | `vat` | `vat_validate` |
+
+Every transform above is verified to exist in the GoldenFlow registry.
+
+### No-map policy (explicit, not an error)
+
+Structural / match / drift checks have no single-column transform remedy and
+produce **no** `RepairItem`: `unique`, `key_uniqueness_loss`, `duplicate_rows`,
+`near_duplicate_rows`, `fuzzy_duplicate_values`, `referential_integrity`,
+`functional_dependency`, `fd_violation`, `cross_column`,
+`cross_column_validation`, `composite_key`, `correlation_break`, `cardinality`,
+`benford_drift`, `distribution_drift`, `entropy_drift`, `type_drift`,
+`pattern_drift`, `new_correlation`, `new_pattern`, `null_correlation`,
+`nullability`, `required`, `range`, `range_distribution`, `bound_violation`,
+`sequence_detection`, `unmapped_column`, `identity_safe_pk`.
+
+`nullability`/`required` are deliberately no-map: filling nulls is a judgment
+call, not a mechanical repair. The table is pure data, so promoting any no-map
+check later is a one-line addition plus a golden vector.
+
+## Type resolution (host side)
+
+A small per-language helper `resolve_type_tags(contexts, detect_result) ->
+{col: TypeTag}`. This is the only piece outside the kernel, because it reuses
+per-language machinery. Priority:
+
+1. **Domain-pack fine type** when InferMap detect ran and the column matched a
+   pack type (`iban`, `npi`, `vin`, ...).
+2. else **coarse `ColumnContext.inferred_type`** (`email`, `name`, `date`,
+   `phone`, `zip`, ...).
+3. else **omit** the column — no tag means it can only match `*` wildcard checks
+   such as `encoding_detection`.
+
+The kernel receives only the resolved `{col: tag}` dict, so parity is preserved.
+
+## Error handling
+
+- No findings, unknown checks/types, or all-no-map -> `RepairPlan{repairs: []}`.
+- Never raises, never blocks the pipeline.
+- Unknown `check` or `type_tag` is a silent no-match (forward-compatible with new
+  checks and new domain packs), not an error.
+- `reason` is built from the finding's own `message`, truncated to the existing
+  80-char finding-message convention.
+
+## Surfacing (Phase 1, minimal)
+
+- `ctx.artifacts["repair_plan"]` on the pipeline result object.
+- One reasoning line per item on the existing reasoning-transparency channel,
+  e.g. `repair: signup_date (future_dated) -> date_validate [12 rows dated after today]`.
+- **No** new MCP tool or CLI flag in Phase 1 (YAGNI). Deferred to Phase 2.
+
+## Testing
+
+- **Rust golden vectors** (`goldenpipe-core/tests/golden_vectors.rs`): canonical
+  `(findings, column_types)` inputs -> exact `RepairPlan` JSON. Cross-surface
+  source of truth.
+- **Python + TS parity**: the same fixtures through each surface, asserted
+  byte-identical against the golden JSON, wired into the existing goldenpipe-core
+  parity gate.
+- **Box-runnable Python** unit tests for `resolve_type_tags` (coarse fallback,
+  fine-type priority, omit-on-unknown) and `build_repair_plan` via the pure
+  Python path — no Rust build needed on the box.
+- **Empty-plan-when-unused** test proves the byte-identical-when-inactive
+  guarantee (a pipeline with no findings, or only no-map findings, emits an empty
+  plan and unchanged executed stages).
+
+## Rollout
+
+Pure-additive. The planner runs and attaches the artifact unconditionally (it is
+advisory and cheap) but changes zero executed stages, so every existing
+pipeline's output is unchanged. No feature flag in Phase 1.
+
+## Phase 2 (out of scope, designed-for)
+
+Gated (`apply_repairs=True`) config-injection: the brain writes the suggested
+transforms into the `goldenflow.transform` stage's currently-empty inserted-stage
+`config`, so Flow applies exactly the brain's picks. Phase 1 proves the mapping
+is correct as advice before letting it drive execution.

--- a/packages/python/goldenpipe/goldenpipe/adapters/check.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/check.py
@@ -72,4 +72,14 @@ class ScanStage:
             logger.exception("Failed to build column contexts; downstream stages will auto-configure")
             ctx.artifacts["column_contexts"] = []
 
+        # Advisory repair-plan (never mutates the stage list; failures are non-fatal)
+        try:
+            from goldenpipe.repair_host import attach_repair_plan
+            _findings = ctx.artifacts.get("findings", [])
+            _contexts = ctx.artifacts.get("column_contexts", [])
+            if ctx.df is not None and _findings and _contexts:
+                attach_repair_plan(ctx, _findings, _contexts, ctx.df)
+        except Exception:
+            logger.exception("repair-plan attach failed; advisory artifact skipped")
+
         return StageResult(status=StageStatus.SUCCESS)

--- a/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
@@ -97,3 +97,7 @@ def apply_scale_hints_json(input: str) -> str:
 
 def band_of_json(input: str) -> str:
     return _native.band_of_json(input)
+
+
+def build_repair_plan_json(input: str) -> str:
+    return _native.build_repair_plan_json(input)

--- a/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
@@ -11,6 +11,7 @@ import json
 from typing import Any
 
 from goldenpipe import decisions as _dec
+from goldenpipe import repair as _repair
 from goldenpipe.autoconfig_planner import (
     ComplexityProfile,
     PipePlan,
@@ -210,3 +211,9 @@ def apply_scale_hints_json(input_str: str) -> str:
 
 def band_of_json(input_str: str) -> str:
     return json.dumps(band_of(json.loads(input_str)))
+
+
+def build_repair_plan_json(s: str) -> str:
+    arg = json.loads(s)
+    out = _repair.build_repair_plan(arg.get("findings", []), arg.get("columns", []))
+    return json.dumps(out)

--- a/packages/python/goldenpipe/goldenpipe/repair.py
+++ b/packages/python/goldenpipe/goldenpipe/repair.py
@@ -1,0 +1,167 @@
+"""Pure repair-plan kernel — the SP2 mirror of goldenpipe-core/src/repair.rs.
+
+Deterministic, no I/O, no polars. Hand-rolled ASCII matchers (no regex) so the
+three surfaces are byte-identical by construction. See the design spec for the
+canonical behavior tables.
+"""
+from __future__ import annotations
+
+# coarse tags the host may supply
+_COARSE = {"date", "email", "name", "phone", "zip"}
+
+# ASCII char-class primitives (no regex; \d would diverge across engines)
+def _is_digit(c: str) -> bool:
+    return "0" <= c <= "9"
+
+def _is_upper(c: str) -> bool:
+    return "A" <= c <= "Z"
+
+def _is_alnum_upper(c: str) -> bool:
+    return _is_digit(c) or _is_upper(c)
+
+def _all(s: str, pred) -> bool:
+    return len(s) > 0 and all(pred(c) for c in s)
+
+# value predicates (detection shape, not full validation)
+def _v_cusip(s: str) -> bool:
+    return len(s) == 9 and _all(s, _is_alnum_upper)
+
+def _v_npi(s: str) -> bool:
+    return len(s) == 10 and _all(s, _is_digit)
+
+def _v_imei(s: str) -> bool:
+    return len(s) == 15 and _all(s, _is_digit)
+
+def _v_ean(s: str) -> bool:
+    return len(s) in (8, 13) and _all(s, _is_digit)
+
+def _v_isbn(s: str) -> bool:
+    if len(s) == 13 and _all(s, _is_digit):
+        return True
+    return len(s) == 10 and _all(s[:9], _is_digit) and s[9] in "0123456789Xx"
+
+def _v_aba(s: str) -> bool:
+    return len(s) == 9 and _all(s, _is_digit)
+
+def _v_iban(s: str) -> bool:
+    if not (15 <= len(s) <= 34):
+        return False
+    return _is_upper(s[0]) and _is_upper(s[1]) and _is_digit(s[2]) and _is_digit(s[3]) and _all(s[4:], _is_alnum_upper)
+
+def _v_isin(s: str) -> bool:
+    return len(s) == 12 and _is_upper(s[0]) and _is_upper(s[1]) and _all(s[2:11], _is_alnum_upper) and _is_digit(s[11])
+
+def _v_swift(s: str) -> bool:
+    if len(s) not in (8, 11):
+        return False
+    return _all(s[:6], _is_upper) and _all(s[6:8], _is_alnum_upper) and (len(s) == 8 or _all(s[8:11], _is_alnum_upper))
+
+def _luhn_ok(s: str) -> bool:
+    d = [int(c) for c in s]
+    total, alt = 0, False
+    for x in reversed(d):
+        if alt:
+            x *= 2
+            if x > 9:
+                x -= 9
+        total += x
+        alt = not alt
+    return total % 10 == 0
+
+def _v_credit_card(s: str) -> bool:
+    t = s.replace(" ", "").replace("-", "")
+    return 13 <= len(t) <= 19 and _all(t, _is_digit) and _luhn_ok(t)
+
+# detectors: (tag, name_hints_or_None, value_predicate) in fixed order
+# name-gated group first (low false-positive), value-distinctive fallback second.
+_DETECTORS = [
+    ("cusip", ("cusip",), _v_cusip),
+    ("npi", ("npi",), _v_npi),
+    ("imei", ("imei", "imsi"), _v_imei),
+    ("ean", ("ean", "gtin", "barcode"), _v_ean),
+    ("isbn", ("isbn",), _v_isbn),
+    ("aba_routing", ("routing", "aba"), _v_aba),
+    ("iban", None, _v_iban),
+    ("isin", None, _v_isin),
+    ("swift", None, _v_swift),
+    ("credit_card", None, _v_credit_card),
+]
+
+
+def fine_type(name: str, samples: list[str]) -> str | None:
+    lname = name.lower()
+    nonempty = [s for s in samples if s and s.strip()]
+    if not nonempty:
+        return None
+    for tag, hints, pred in _DETECTORS:
+        if hints is not None and not any(h in lname for h in hints):
+            continue
+        matches = sum(1 for s in nonempty if pred(s))
+        if matches * 2 > len(nonempty):
+            return tag
+    return None
+
+
+def resolve_tag(name: str, coarse_type: str, samples: list[str]) -> str | None:
+    ft = fine_type(name, samples)
+    if ft is not None:
+        return ft
+    return coarse_type if coarse_type in _COARSE else None
+
+
+# mapping table: (check, tag) -> transforms; "*" tag = wildcard
+_VALIDATOR = {
+    "iban": "iban_validate", "isin": "isin_validate", "swift": "swift_validate",
+    "cusip": "cusip_validate", "npi": "npi_validate", "imei": "imei_validate",
+    "ean": "ean_validate", "isbn": "isbn_validate", "credit_card": "luhn_validate",
+    "aba_routing": "aba_validate",
+}
+_TABLE: dict[tuple[str, str], list[str]] = {
+    ("encoding_detection", "*"): ["fix_mojibake", "normalize_unicode"],
+    ("future_dated", "date"): ["date_validate"],
+    ("temporal_order", "date"): ["date_validate"],
+    ("stale_data", "date"): ["date_validate"],
+    ("format_detection", "date"): ["date_parse"],
+    ("format_detection", "email"): ["email_normalize"],
+    ("pattern_consistency", "email"): ["email_canonical"],
+    ("pattern_consistency", "name"): ["name_proper"],
+    ("format_detection", "phone"): ["phone_validate"],
+    ("pattern_consistency", "phone"): ["phone_national"],
+    ("format_detection", "zip"): ["zip_normalize"],
+}
+for _t, _v in _VALIDATOR.items():
+    _TABLE[("format_detection", _t)] = [_v]
+    _TABLE[("pattern_consistency", _t)] = [_v]
+
+
+def _lookup(check: str, tag: str | None) -> list[str] | None:
+    if tag is not None and (check, tag) in _TABLE:
+        return _TABLE[(check, tag)]
+    if (check, "*") in _TABLE:
+        return _TABLE[(check, "*")]
+    return None
+
+
+def build_repair_plan(findings: list[dict], columns: list[dict]) -> dict:
+    tags: dict[str, str | None] = {}
+    for c in columns:
+        tags[c["name"]] = resolve_tag(c["name"], c.get("coarse_type", ""), c.get("samples", []))
+
+    repairs = []
+    for f in findings:
+        col = f.get("column")
+        check = f.get("check", "")
+        # encoding wildcard can apply even to an omitted-tag column present in `columns`
+        if col not in tags:
+            continue
+        transforms = _lookup(check, tags[col])
+        if not transforms:
+            continue
+        repairs.append({
+            "column": col,
+            "check": check,
+            "type_tag": tags[col] if tags[col] is not None else "*",
+            "suggested_transforms": list(transforms),
+            "reason": str(f.get("message", ""))[:80],
+        })
+    return {"repairs": repairs}

--- a/packages/python/goldenpipe/goldenpipe/repair.py
+++ b/packages/python/goldenpipe/goldenpipe/repair.py
@@ -22,6 +22,12 @@ def _is_alnum_upper(c: str) -> bool:
 def _all(s: str, pred) -> bool:
     return len(s) > 0 and all(pred(c) for c in s)
 
+def _ascii_lower(s: str) -> str:
+    return "".join(chr(ord(c) + 32) if "A" <= c <= "Z" else c for c in s)
+
+def _is_ascii_ws(c: str) -> bool:
+    return c in " \t\n\r\f\v"
+
 # value predicates (detection shape, not full validation)
 def _v_cusip(s: str) -> bool:
     return len(s) == 9 and _all(s, _is_alnum_upper)
@@ -89,8 +95,8 @@ _DETECTORS = [
 
 
 def fine_type(name: str, samples: list[str]) -> str | None:
-    lname = name.lower()
-    nonempty = [s for s in samples if s and s.strip()]
+    lname = _ascii_lower(name)
+    nonempty = [s for s in samples if any(not _is_ascii_ws(c) for c in s)]
     if not nonempty:
         return None
     for tag, hints, pred in _DETECTORS:

--- a/packages/python/goldenpipe/goldenpipe/repair_host.py
+++ b/packages/python/goldenpipe/goldenpipe/repair_host.py
@@ -1,0 +1,58 @@
+"""Host glue for repair-plan: sample polars columns, build ColumnInputs, call the
+pure kernel, attach the advisory artifact + reasoning. Advisory ONLY — never
+mutates the stage list."""
+from __future__ import annotations
+
+from goldenpipe.repair import build_repair_plan
+
+_SAMPLE_LIMIT = 20
+
+
+def sample_column(series, limit: int = _SAMPLE_LIMIT) -> list[str]:
+    out: list[str] = []
+    for v in series:                       # polars Series iterates values in row order
+        if v is None:
+            continue
+        s = str(v)
+        if s.strip() == "":
+            continue
+        out.append(s)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _coarse_str(t) -> str:
+    # ColumnType is `str, Enum` with lowercase values, BUT str(ColumnType.EMAIL) ==
+    # "ColumnType.EMAIL" (NOT "email") — only .value gives "email". The context
+    # builder can also leave inferred_type a raw str (column_context.py coercion),
+    # which has no .value. getattr handles both.
+    return getattr(t, "value", t)
+
+
+def build_column_inputs(contexts, df) -> list[dict]:
+    cols = []
+    names = set(df.columns)
+    for ctx in contexts:
+        if ctx.name not in names:
+            continue
+        cols.append({
+            "name": ctx.name,
+            "coarse_type": _coarse_str(ctx.inferred_type),
+            "samples": sample_column(df[ctx.name]),
+        })
+    return cols
+
+
+def attach_repair_plan(ctx, findings, contexts, df) -> dict:
+    columns = build_column_inputs(contexts, df)
+    plan = build_repair_plan(findings, columns)
+    ctx.artifacts["repair_plan"] = plan
+    lines = [
+        f"repair: {item['column']} ({item['check']}) -> "
+        f"{','.join(item['suggested_transforms'])} [{item['reason']}]"
+        for item in plan["repairs"]
+    ]
+    if lines:
+        ctx.reasoning["repair_plan"] = "\n".join(lines)
+    return plan

--- a/packages/python/goldenpipe/tests/core/test_planner_parity.py
+++ b/packages/python/goldenpipe/tests/core/test_planner_parity.py
@@ -26,6 +26,7 @@ _CASES = [
     ("plan_pipeline", PJ.plan_pipeline_json),
     ("apply_scale_hints", PJ.apply_scale_hints_json),
     ("band_of", PJ.band_of_json),
+    ("build_repair_plan", PJ.build_repair_plan_json),
 ]
 
 
@@ -51,6 +52,7 @@ from goldenpipe.core import _native_loader as NL  # noqa: E402
         ("plan_pipeline", "plan_pipeline_json"),
         ("apply_scale_hints", "apply_scale_hints_json"),
         ("band_of", "band_of_json"),
+        ("build_repair_plan", "build_repair_plan_json"),
     ],
 )
 def test_native_wheel_matches_core_vectors(name, fn_name):

--- a/packages/python/goldenpipe/tests/test_repair_host.py
+++ b/packages/python/goldenpipe/tests/test_repair_host.py
@@ -1,0 +1,27 @@
+import polars as pl
+from goldenpipe.models.context import PipeContext
+from goldenpipe.repair_host import attach_repair_plan, build_column_inputs, sample_column
+
+
+def test_sample_column_first_n_nonnull_as_str():
+    s = pl.Series("c", [None, "a", "b", None, "c"])
+    assert sample_column(s, limit=2) == ["a", "b"]
+
+def test_build_column_inputs_from_contexts_and_df():
+    df = pl.DataFrame({"iban": ["GB82WEST12345698765432", "DE89370400440532013000"]})
+    class Ctx:  # minimal ColumnContext stand-in
+        def __init__(self, name, t): self.name, self.inferred_type = name, t
+    cols = build_column_inputs([Ctx("iban", "string")], df)
+    assert cols[0]["name"] == "iban" and cols[0]["coarse_type"] == "string"
+    assert cols[0]["samples"] == ["GB82WEST12345698765432", "DE89370400440532013000"]
+
+def test_attach_repair_plan_sets_artifact_and_reasoning():
+    df = pl.DataFrame({"signup_date": ["2020-01-01", "2021-05-05"]})
+    findings = [{"column": "signup_date", "check": "future_dated", "message": "12 rows after today", "severity": "warning"}]
+    class Ctx:
+        def __init__(self, name, t): self.name, self.inferred_type = name, t
+    ctx = PipeContext()
+    attach_repair_plan(ctx, findings, [Ctx("signup_date", "date")], df)
+    plan = ctx.artifacts["repair_plan"]
+    assert plan["repairs"][0]["suggested_transforms"] == ["date_validate"]
+    assert "date_validate" in ctx.reasoning["repair_plan"]

--- a/packages/python/goldenpipe/tests/test_repair_integration.py
+++ b/packages/python/goldenpipe/tests/test_repair_integration.py
@@ -1,0 +1,33 @@
+"""Integration tests for the advisory repair-plan wiring.
+
+Guards the real ``ColumnType`` enum path: ``attach_repair_plan`` must resolve
+``inferred_type`` via ``.value`` (``"date"``), NOT ``str(enum)``
+(``"ColumnType.DATE"``). A string stand-in cannot catch a bad enum cast, so
+these use a real ``ColumnContext`` with a real ``ColumnType``.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenpipe.models.column_context import ColumnContext, ColumnType
+from goldenpipe.models.context import PipeContext
+from goldenpipe.repair_host import attach_repair_plan
+
+
+def test_real_columntype_resolves_to_value_string():
+    df = pl.DataFrame({"signup_date": ["2020-01-01", "2021-05-05"]})
+    ctx = PipeContext()
+    cc = ColumnContext(name="signup_date", inferred_type=ColumnType.DATE)
+    findings = [{"column": "signup_date", "check": "future_dated", "message": "12 rows after today", "severity": "warning"}]
+    plan = attach_repair_plan(ctx, findings, [cc], df)
+    item = plan["repairs"][0]
+    assert item["suggested_transforms"] == ["date_validate"]
+    assert item["type_tag"] == "date"   # NOT "ColumnType.DATE"
+
+
+def test_nonrepairable_finding_empty_plan():
+    df = pl.DataFrame({"id": ["a", "b"]})
+    ctx = PipeContext()
+    cc = ColumnContext(name="id", inferred_type=ColumnType.STRING)
+    plan = attach_repair_plan(ctx, [{"column": "id", "check": "unique", "message": "dupes", "severity": "warning"}], [cc], df)
+    assert plan["repairs"] == []
+    assert "repair_plan" not in ctx.reasoning   # no lines written

--- a/packages/python/goldenpipe/tests/test_repair_pure.py
+++ b/packages/python/goldenpipe/tests/test_repair_pure.py
@@ -1,0 +1,27 @@
+from goldenpipe.repair import fine_type, resolve_tag
+
+
+def test_iban_classifies_iban():
+    assert fine_type("account", ["GB82WEST12345698765432", "DE89370400440532013000"]) == "iban"
+
+def test_routing_9digit_is_not_iban_and_needs_name_for_aba():
+    # bare 9-digit, no name hint -> no fine tag
+    assert fine_type("col1", ["021000021", "011401533"]) is None
+    # with routing name hint -> aba_routing
+    assert fine_type("routing_number", ["021000021", "011401533"]) == "aba_routing"
+
+def test_credit_card_needs_luhn():
+    assert fine_type("card", ["4539578763621486", "4485275742308327"]) == "credit_card"   # valid Luhn
+    assert fine_type("card", ["4539578763621487", "1234567812345678"]) is None            # fail Luhn
+
+def test_barcode_resolves_ean_not_credit_card():
+    assert fine_type("barcode", ["4006381333931", "0012345678905"]) == "ean"
+
+def test_minority_match_does_not_fire():
+    # only 1 of 3 is an IBAN -> no majority
+    assert fine_type("account", ["GB82WEST12345698765432", "n/a", "unknown"]) is None
+
+def test_resolve_tag_prefers_fine_then_coarse_then_none():
+    assert resolve_tag("email_addr", "email", ["a@b.com"]) == "email"          # coarse, no fine
+    assert resolve_tag("iban", "string", ["GB82WEST12345698765432"]) == "iban" # fine wins
+    assert resolve_tag("misc", "string", ["hello"]) is None                    # neither

--- a/packages/rust/extensions/goldenpipe-core/src/json.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/json.rs
@@ -118,6 +118,26 @@ pub fn band_of_json(input: &str) -> String {
     serde_json::to_string(band_of(x)).unwrap()
 }
 
+#[derive(Deserialize)]
+struct RepairIn {
+    #[serde(default)]
+    findings: Vec<crate::repair::Finding>,
+    #[serde(default)]
+    columns: Vec<crate::repair::ColumnInput>,
+}
+
+pub fn build_repair_plan_json(input: &str) -> String {
+    let arg: RepairIn = match serde_json::from_str(input) {
+        Ok(a) => a,
+        Err(e) => return parse_err(e),
+    };
+    serde_json::to_string(&crate::repair::build_repair_plan(
+        &arg.findings,
+        &arg.columns,
+    ))
+    .unwrap()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust/extensions/goldenpipe-core/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/lib.rs
@@ -12,5 +12,6 @@ pub mod decisions;
 pub mod json;
 pub mod model;
 pub mod planner;
+pub mod repair;
 pub mod resolve;
 pub mod router;

--- a/packages/rust/extensions/goldenpipe-core/src/repair.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/repair.rs
@@ -1,0 +1,368 @@
+//! Repair-plan kernel — the authoritative source for GoldenPipe's finding->transform
+//! suggestion mapping. The pure-Python (`goldenpipe/repair.py`) and pure-TS mirrors
+//! must reproduce these exact bytes.
+//!
+//! CODE-POINT SEMANTICS: every value predicate collects `s.chars()` into a `Vec<char>`
+//! and indexes/slices on code points, mirroring Python `len`/`s[i]`/`s[a:b]`. Byte
+//! indexing would diverge on non-ASCII input. No regex — hand-rolled ASCII matchers.
+use std::collections::HashMap;
+
+// ---- inputs / outputs (field order is the wire contract; serde preserves it) --------
+
+#[derive(serde::Deserialize)]
+pub struct Finding {
+    pub column: Option<String>,
+    #[serde(default)]
+    pub check: String,
+    #[serde(default)]
+    pub message: String,
+    #[serde(default)]
+    pub severity: String,
+}
+
+#[derive(serde::Deserialize)]
+pub struct ColumnInput {
+    pub name: String,
+    #[serde(default)]
+    pub coarse_type: String,
+    #[serde(default)]
+    pub samples: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct RepairItem {
+    pub column: String,
+    pub check: String,
+    pub type_tag: String,
+    pub suggested_transforms: Vec<String>,
+    pub reason: String,
+}
+
+#[derive(serde::Serialize, Default)]
+pub struct RepairPlan {
+    pub repairs: Vec<RepairItem>,
+}
+
+// ---- ASCII char-class primitives (no regex) -----------------------------------------
+
+fn is_digit(c: char) -> bool {
+    ('0'..='9').contains(&c)
+}
+
+fn is_upper(c: char) -> bool {
+    ('A'..='Z').contains(&c)
+}
+
+fn is_alnum_upper(c: char) -> bool {
+    is_digit(c) || is_upper(c)
+}
+
+/// Python `_all(s, pred)` = len > 0 and every char satisfies pred.
+fn all_pred(cs: &[char], pred: fn(char) -> bool) -> bool {
+    !cs.is_empty() && cs.iter().all(|&c| pred(c))
+}
+
+/// ASCII-only lower: map 'A'..='Z' -> +32, leave everything else (NOT Unicode lower).
+fn ascii_lower(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if ('A'..='Z').contains(&c) {
+                ((c as u32) + 32) as u8 as char
+            } else {
+                c
+            }
+        })
+        .collect()
+}
+
+fn is_ascii_ws(c: char) -> bool {
+    matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{000C}' | '\u{000B}')
+}
+
+// ---- value predicates (detection shape, not full validation) ------------------------
+
+fn v_cusip(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    cs.len() == 9 && all_pred(&cs, is_alnum_upper)
+}
+
+fn v_npi(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    cs.len() == 10 && all_pred(&cs, is_digit)
+}
+
+fn v_imei(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    cs.len() == 15 && all_pred(&cs, is_digit)
+}
+
+fn v_ean(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    (cs.len() == 8 || cs.len() == 13) && all_pred(&cs, is_digit)
+}
+
+fn v_isbn(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    if cs.len() == 13 && all_pred(&cs, is_digit) {
+        return true;
+    }
+    cs.len() == 10 && all_pred(&cs[..9], is_digit) && matches!(cs[9], '0'..='9' | 'X' | 'x')
+}
+
+fn v_aba(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    cs.len() == 9 && all_pred(&cs, is_digit)
+}
+
+fn v_iban(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    if !(15..=34).contains(&cs.len()) {
+        return false;
+    }
+    is_upper(cs[0])
+        && is_upper(cs[1])
+        && is_digit(cs[2])
+        && is_digit(cs[3])
+        && all_pred(&cs[4..], is_alnum_upper)
+}
+
+fn v_isin(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    cs.len() == 12
+        && is_upper(cs[0])
+        && is_upper(cs[1])
+        && all_pred(&cs[2..11], is_alnum_upper)
+        && is_digit(cs[11])
+}
+
+fn v_swift(s: &str) -> bool {
+    let cs: Vec<char> = s.chars().collect();
+    if cs.len() != 8 && cs.len() != 11 {
+        return false;
+    }
+    all_pred(&cs[..6], is_upper)
+        && all_pred(&cs[6..8], is_alnum_upper)
+        && (cs.len() == 8 || all_pred(&cs[8..11], is_alnum_upper))
+}
+
+/// Standard Luhn over digit chars; caller guarantees `s` is all digits (short-circuit).
+fn luhn_ok(s: &str) -> bool {
+    let mut total: i64 = 0;
+    let mut alt = false;
+    for c in s.chars().rev() {
+        let mut x = (c as u8 - b'0') as i64;
+        if alt {
+            x *= 2;
+            if x > 9 {
+                x -= 9;
+            }
+        }
+        total += x;
+        alt = !alt;
+    }
+    total % 10 == 0
+}
+
+fn v_credit_card(s: &str) -> bool {
+    let t: String = s.chars().filter(|&c| c != ' ' && c != '-').collect();
+    let cs: Vec<char> = t.chars().collect();
+    (13..=19).contains(&cs.len()) && all_pred(&cs, is_digit) && luhn_ok(&t)
+}
+
+// ---- detectors: (tag, name_hints_or_None, predicate) in FIXED order -----------------
+// name-gated group first (low false-positive), value-distinctive fallback second.
+type Pred = fn(&str) -> bool;
+const DETECTORS: &[(&str, Option<&[&str]>, Pred)] = &[
+    ("cusip", Some(&["cusip"]), v_cusip as Pred),
+    ("npi", Some(&["npi"]), v_npi as Pred),
+    ("imei", Some(&["imei", "imsi"]), v_imei as Pred),
+    ("ean", Some(&["ean", "gtin", "barcode"]), v_ean as Pred),
+    ("isbn", Some(&["isbn"]), v_isbn as Pred),
+    ("aba_routing", Some(&["routing", "aba"]), v_aba as Pred),
+    ("iban", None, v_iban as Pred),
+    ("isin", None, v_isin as Pred),
+    ("swift", None, v_swift as Pred),
+    ("credit_card", None, v_credit_card as Pred),
+];
+
+fn fine_type(name: &str, samples: &[String]) -> Option<&'static str> {
+    let lname = ascii_lower(name);
+    let nonempty: Vec<&str> = samples
+        .iter()
+        .map(|s| s.as_str())
+        .filter(|s| s.chars().any(|c| !is_ascii_ws(c)))
+        .collect();
+    if nonempty.is_empty() {
+        return None;
+    }
+    for &(tag, hints, pred) in DETECTORS.iter() {
+        if let Some(hs) = hints {
+            if !hs.iter().any(|h| lname.contains(h)) {
+                continue;
+            }
+        }
+        let matches = nonempty.iter().filter(|&&s| pred(s)).count();
+        if matches * 2 > nonempty.len() {
+            return Some(tag);
+        }
+    }
+    None
+}
+
+fn resolve_tag(name: &str, coarse_type: &str, samples: &[String]) -> Option<&'static str> {
+    if let Some(ft) = fine_type(name, samples) {
+        return Some(ft);
+    }
+    // _COARSE = {"date", "email", "name", "phone", "zip"}
+    match coarse_type {
+        "date" => Some("date"),
+        "email" => Some("email"),
+        "name" => Some("name"),
+        "phone" => Some("phone"),
+        "zip" => Some("zip"),
+        _ => None,
+    }
+}
+
+// ---- mapping table: (check, tag) -> transforms; "*" tag = wildcard -------------------
+
+/// Validator name for a fine type, or None if `tag` isn't a fine type.
+fn validator(tag: &str) -> Option<&'static str> {
+    Some(match tag {
+        "iban" => "iban_validate",
+        "isin" => "isin_validate",
+        "swift" => "swift_validate",
+        "cusip" => "cusip_validate",
+        "npi" => "npi_validate",
+        "imei" => "imei_validate",
+        "ean" => "ean_validate",
+        "isbn" => "isbn_validate",
+        "credit_card" => "luhn_validate",
+        "aba_routing" => "aba_validate",
+        _ => return None,
+    })
+}
+
+/// Exact (check, tag) row, or None. Mirrors `_TABLE` minus the wildcard entry. The
+/// fine-type validator rows exist for BOTH `format_detection` and `pattern_consistency`.
+fn exact_lookup(check: &str, tag: &str) -> Option<Vec<&'static str>> {
+    if check == "format_detection" || check == "pattern_consistency" {
+        if let Some(v) = validator(tag) {
+            return Some(vec![v]);
+        }
+    }
+    let row: &[&str] = match (check, tag) {
+        ("future_dated", "date") => &["date_validate"],
+        ("temporal_order", "date") => &["date_validate"],
+        ("stale_data", "date") => &["date_validate"],
+        ("format_detection", "date") => &["date_parse"],
+        ("format_detection", "email") => &["email_normalize"],
+        ("pattern_consistency", "email") => &["email_canonical"],
+        ("pattern_consistency", "name") => &["name_proper"],
+        ("format_detection", "phone") => &["phone_validate"],
+        ("pattern_consistency", "phone") => &["phone_national"],
+        ("format_detection", "zip") => &["zip_normalize"],
+        _ => return None,
+    };
+    Some(row.to_vec())
+}
+
+/// Python `_lookup`: exact (check, tag) first, then (check, "*"), else None.
+fn lookup(check: &str, tag: Option<&str>) -> Option<Vec<String>> {
+    if let Some(t) = tag {
+        if let Some(row) = exact_lookup(check, t) {
+            return Some(row.iter().map(|s| s.to_string()).collect());
+        }
+    }
+    // only wildcard row: ("encoding_detection", "*")
+    if check == "encoding_detection" {
+        return Some(vec![
+            "fix_mojibake".to_string(),
+            "normalize_unicode".to_string(),
+        ]);
+    }
+    None
+}
+
+pub fn build_repair_plan(findings: &[Finding], columns: &[ColumnInput]) -> RepairPlan {
+    // last insert wins on duplicate names (mirror Python dict)
+    let mut tags: HashMap<String, Option<&'static str>> = HashMap::new();
+    for c in columns {
+        tags.insert(
+            c.name.clone(),
+            resolve_tag(&c.name, &c.coarse_type, &c.samples),
+        );
+    }
+
+    let mut repairs: Vec<RepairItem> = Vec::new();
+    for f in findings {
+        // `col not in tags` — a None column, or a column absent from `columns`, is skipped.
+        // A column PRESENT with tag None is still "in tags" (wildcard can still apply).
+        let col = match &f.column {
+            Some(c) => c,
+            None => continue,
+        };
+        let tag = match tags.get(col) {
+            Some(t) => *t,
+            None => continue,
+        };
+        let transforms = match lookup(&f.check, tag) {
+            Some(t) if !t.is_empty() => t,
+            _ => continue,
+        };
+        repairs.push(RepairItem {
+            column: col.clone(),
+            check: f.check.clone(),
+            type_tag: tag.unwrap_or("*").to_string(),
+            suggested_transforms: transforms,
+            reason: f.message.chars().take(80).collect(),
+        });
+    }
+    RepairPlan { repairs }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ss(items: &[&str]) -> Vec<String> {
+        items.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn iban_by_value_majority() {
+        let s = ss(&["GB82WEST12345698765432", "DE89370400440532013000"]);
+        assert_eq!(fine_type("iban", &s), Some("iban"));
+    }
+
+    #[test]
+    fn bare_nine_digits_need_name_hint() {
+        let s = ss(&["021000021", "011401533"]);
+        // no routing/aba hint in the name -> no fine type
+        assert_eq!(fine_type("digits", &s), None);
+        // hinted name -> aba_routing
+        assert_eq!(fine_type("routing_number", &s), Some("aba_routing"));
+    }
+
+    #[test]
+    fn credit_card_luhn_pass_and_fail() {
+        let pass = ss(&["4539578763621486", "4485275742308327"]);
+        assert_eq!(fine_type("card", &pass), Some("credit_card"));
+        // flip the last check digit on both -> luhn fails -> no fine type
+        let fail = ss(&["4539578763621487", "4485275742308328"]);
+        assert_eq!(fine_type("card", &fail), None);
+    }
+
+    #[test]
+    fn barcode_thirteen_digits_is_ean() {
+        let s = ss(&["4006381333931", "0012345678905"]);
+        assert_eq!(fine_type("barcode", &s), Some("ean"));
+    }
+
+    #[test]
+    fn minority_iban_is_not_detected() {
+        // 1 of 3 valid -> matches*2 (2) not > 3 -> None
+        let s = ss(&["GB82WEST12345698765432", "not_an_iban", "12345"]);
+        assert_eq!(fine_type("iban", &s), None);
+    }
+}

--- a/packages/rust/extensions/goldenpipe-core/src/repair.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/repair.rs
@@ -46,11 +46,11 @@ pub struct RepairPlan {
 // ---- ASCII char-class primitives (no regex) -----------------------------------------
 
 fn is_digit(c: char) -> bool {
-    ('0'..='9').contains(&c)
+    c.is_ascii_digit()
 }
 
 fn is_upper(c: char) -> bool {
-    ('A'..='Z').contains(&c)
+    c.is_ascii_uppercase()
 }
 
 fn is_alnum_upper(c: char) -> bool {
@@ -66,7 +66,7 @@ fn all_pred(cs: &[char], pred: fn(char) -> bool) -> bool {
 fn ascii_lower(s: &str) -> String {
     s.chars()
         .map(|c| {
-            if ('A'..='Z').contains(&c) {
+            if c.is_ascii_uppercase() {
                 ((c as u32) + 32) as u8 as char
             } else {
                 c

--- a/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
+++ b/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
@@ -56,3 +56,7 @@ fn vec_apply_scale_hints() {
 fn vec_band_of() {
     run("band_of", band_of_json);
 }
+#[test]
+fn vec_build_repair_plan() {
+    run("build_repair_plan", build_repair_plan_json);
+}

--- a/packages/rust/extensions/goldenpipe-core/tests/vectors/build_repair_plan.json
+++ b/packages/rust/extensions/goldenpipe-core/tests/vectors/build_repair_plan.json
@@ -1,0 +1,55 @@
+[
+  {
+    "input": {
+      "findings": [{"column": "iban", "check": "pattern_consistency", "message": "3 values fail check-digit", "severity": "warning"}],
+      "columns": [{"name": "iban", "coarse_type": "string", "samples": ["GB82WEST12345698765432", "DE89370400440532013000"]}]
+    },
+    "expected": {"repairs": [{"column": "iban", "check": "pattern_consistency", "type_tag": "iban", "suggested_transforms": ["iban_validate"], "reason": "3 values fail check-digit"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "signup_date", "check": "future_dated", "message": "12 rows dated after today", "severity": "warning"}],
+      "columns": [{"name": "signup_date", "coarse_type": "date", "samples": ["2020-01-01", "2021-05-05"]}]
+    },
+    "expected": {"repairs": [{"column": "signup_date", "check": "future_dated", "type_tag": "date", "suggested_transforms": ["date_validate"], "reason": "12 rows dated after today"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "notes", "check": "encoding_detection", "message": "mojibake detected", "severity": "info"}],
+      "columns": [{"name": "notes", "coarse_type": "string", "samples": ["cafÃ©", "naÃ¯ve"]}]
+    },
+    "expected": {"repairs": [{"column": "notes", "check": "encoding_detection", "type_tag": "*", "suggested_transforms": ["fix_mojibake", "normalize_unicode"], "reason": "mojibake detected"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "routing_number", "check": "pattern_consistency", "message": "bad routing", "severity": "warning"}],
+      "columns": [{"name": "routing_number", "coarse_type": "string", "samples": ["021000021", "011401533"]}]
+    },
+    "expected": {"repairs": [{"column": "routing_number", "check": "pattern_consistency", "type_tag": "aba_routing", "suggested_transforms": ["aba_validate"], "reason": "bad routing"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "card", "check": "format_detection", "message": "spaced digits", "severity": "info"}],
+      "columns": [{"name": "card", "coarse_type": "string", "samples": ["4539578763621486", "4485275742308327"]}]
+    },
+    "expected": {"repairs": [{"column": "card", "check": "format_detection", "type_tag": "credit_card", "suggested_transforms": ["luhn_validate"], "reason": "spaced digits"}]}
+  },
+  {
+    "input": {
+      "findings": [{"column": "id", "check": "unique", "message": "dupes", "severity": "warning"}],
+      "columns": [{"name": "id", "coarse_type": "string", "samples": ["a", "b"]}]
+    },
+    "expected": {"repairs": []}
+  },
+  {
+    "input": {
+      "findings": [{"column": "ghost", "check": "future_dated", "message": "x", "severity": "info"}],
+      "columns": []
+    },
+    "expected": {"repairs": []}
+  },
+  {
+    "input": {"findings": [], "columns": []},
+    "expected": {"repairs": []}
+  }
+]

--- a/packages/rust/extensions/goldenpipe-native/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-native/src/lib.rs
@@ -36,6 +36,10 @@ fn apply_scale_hints_json(input: &str) -> String {
 fn band_of_json(input: &str) -> String {
     goldenpipe_core::json::band_of_json(input)
 }
+#[pyfunction]
+fn build_repair_plan_json(input: &str) -> String {
+    goldenpipe_core::json::build_repair_plan_json(input)
+}
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -48,5 +52,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(plan_pipeline_json, m)?)?;
     m.add_function(wrap_pyfunction!(apply_scale_hints_json, m)?)?;
     m.add_function(wrap_pyfunction!(band_of_json, m)?)?;
+    m.add_function(wrap_pyfunction!(build_repair_plan_json, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
@@ -54,4 +54,9 @@ mod wasm {
     pub fn band_of_json(input: &str) -> String {
         json::band_of_json(input)
     }
+
+    #[wasm_bindgen]
+    pub fn build_repair_plan_json(input: &str) -> String {
+        json::build_repair_plan_json(input)
+    }
 }

--- a/packages/typescript/goldenpipe/src/core/repair.ts
+++ b/packages/typescript/goldenpipe/src/core/repair.ts
@@ -14,13 +14,16 @@
 const COARSE = new Set(["date", "email", "name", "phone", "zip"]);
 
 // ASCII char-class primitives (no regex; \d would diverge across engines)
-function isDigit(c: string): boolean {
-  return c >= "0" && c <= "9";
+// Accept `string | undefined` because the repo's `noUncheckedIndexedAccess`
+// types `cs[i]` as possibly-undefined; length checks guarantee a real char at
+// runtime, and undefined -> false preserves byte-parity with Python/Rust.
+function isDigit(c: string | undefined): boolean {
+  return c !== undefined && c >= "0" && c <= "9";
 }
-function isUpper(c: string): boolean {
-  return c >= "A" && c <= "Z";
+function isUpper(c: string | undefined): boolean {
+  return c !== undefined && c >= "A" && c <= "Z";
 }
-function isAlnumUpper(c: string): boolean {
+function isAlnumUpper(c: string | undefined): boolean {
   return isDigit(c) || isUpper(c);
 }
 // `chars` is already a code-point array; nonempty + every char passes.
@@ -58,7 +61,8 @@ function vEan(s: string): boolean {
 function vIsbn(s: string): boolean {
   const cs = [...s];
   if (cs.length === 13 && allChars(cs, isDigit)) return true;
-  return cs.length === 10 && allChars(cs.slice(0, 9), isDigit) && "0123456789Xx".includes(cs[9]);
+  const c9 = cs[9];
+  return cs.length === 10 && allChars(cs.slice(0, 9), isDigit) && c9 !== undefined && "0123456789Xx".includes(c9);
 }
 function vAba(s: string): boolean {
   const cs = [...s];
@@ -95,11 +99,12 @@ function vSwift(s: string): boolean {
   );
 }
 function luhnOk(s: string): boolean {
-  const cs = [...s];
   let total = 0;
   let alt = false;
-  for (let i = cs.length - 1; i >= 0; i--) {
-    let x = cs[i].charCodeAt(0) - 48; // digit value; callers guarantee all-digit
+  // iterate right-to-left over code points (reverse() avoids indexed access,
+  // which noUncheckedIndexedAccess would type as possibly-undefined)
+  for (const c of [...s].reverse()) {
+    let x = c.charCodeAt(0) - 48; // digit value; callers guarantee all-digit
     if (alt) {
       x *= 2;
       if (x > 9) x -= 9;

--- a/packages/typescript/goldenpipe/src/core/repair.ts
+++ b/packages/typescript/goldenpipe/src/core/repair.ts
@@ -1,0 +1,247 @@
+/**
+ * repair.ts — pure-TS repair-plan kernel. The SP2 TS mirror of
+ * goldenpipe-core/src/repair.rs and goldenpipe/repair.py. Deterministic, no I/O,
+ * no regex; hand-rolled ASCII matchers so the three surfaces are byte-identical
+ * by construction.
+ *
+ * BYTE-PARITY NOTE: JS strings are UTF-16, so `s.length`/`s[i]` count code
+ * UNITS. Python `len`/indexing and Rust `.chars()` count code POINTS. Every
+ * predicate here first spreads to a code-point array (`const cs = [...s]`) and
+ * indexes/slices THAT — never the raw string.
+ */
+
+// coarse tags the host may supply
+const COARSE = new Set(["date", "email", "name", "phone", "zip"]);
+
+// ASCII char-class primitives (no regex; \d would diverge across engines)
+function isDigit(c: string): boolean {
+  return c >= "0" && c <= "9";
+}
+function isUpper(c: string): boolean {
+  return c >= "A" && c <= "Z";
+}
+function isAlnumUpper(c: string): boolean {
+  return isDigit(c) || isUpper(c);
+}
+// `chars` is already a code-point array; nonempty + every char passes.
+function allChars(chars: string[], pred: (c: string) => boolean): boolean {
+  return chars.length > 0 && chars.every(pred);
+}
+function asciiLower(s: string): string {
+  let out = "";
+  for (const c of s) {
+    out += c >= "A" && c <= "Z" ? String.fromCharCode(c.charCodeAt(0) + 32) : c;
+  }
+  return out;
+}
+function isAsciiWs(c: string): boolean {
+  return c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+}
+
+// value predicates (detection shape, not full validation)
+function vCusip(s: string): boolean {
+  const cs = [...s];
+  return cs.length === 9 && allChars(cs, isAlnumUpper);
+}
+function vNpi(s: string): boolean {
+  const cs = [...s];
+  return cs.length === 10 && allChars(cs, isDigit);
+}
+function vImei(s: string): boolean {
+  const cs = [...s];
+  return cs.length === 15 && allChars(cs, isDigit);
+}
+function vEan(s: string): boolean {
+  const cs = [...s];
+  return (cs.length === 8 || cs.length === 13) && allChars(cs, isDigit);
+}
+function vIsbn(s: string): boolean {
+  const cs = [...s];
+  if (cs.length === 13 && allChars(cs, isDigit)) return true;
+  return cs.length === 10 && allChars(cs.slice(0, 9), isDigit) && "0123456789Xx".includes(cs[9]);
+}
+function vAba(s: string): boolean {
+  const cs = [...s];
+  return cs.length === 9 && allChars(cs, isDigit);
+}
+function vIban(s: string): boolean {
+  const cs = [...s];
+  if (!(cs.length >= 15 && cs.length <= 34)) return false;
+  return (
+    isUpper(cs[0]) &&
+    isUpper(cs[1]) &&
+    isDigit(cs[2]) &&
+    isDigit(cs[3]) &&
+    allChars(cs.slice(4), isAlnumUpper)
+  );
+}
+function vIsin(s: string): boolean {
+  const cs = [...s];
+  return (
+    cs.length === 12 &&
+    isUpper(cs[0]) &&
+    isUpper(cs[1]) &&
+    allChars(cs.slice(2, 11), isAlnumUpper) &&
+    isDigit(cs[11])
+  );
+}
+function vSwift(s: string): boolean {
+  const cs = [...s];
+  if (!(cs.length === 8 || cs.length === 11)) return false;
+  return (
+    allChars(cs.slice(0, 6), isUpper) &&
+    allChars(cs.slice(6, 8), isAlnumUpper) &&
+    (cs.length === 8 || allChars(cs.slice(8, 11), isAlnumUpper))
+  );
+}
+function luhnOk(s: string): boolean {
+  const cs = [...s];
+  let total = 0;
+  let alt = false;
+  for (let i = cs.length - 1; i >= 0; i--) {
+    let x = cs[i].charCodeAt(0) - 48; // digit value; callers guarantee all-digit
+    if (alt) {
+      x *= 2;
+      if (x > 9) x -= 9;
+    }
+    total += x;
+    alt = !alt;
+  }
+  return total % 10 === 0;
+}
+function vCreditCard(s: string): boolean {
+  const t = [...s].filter((c) => c !== " " && c !== "-").join("");
+  const cs = [...t];
+  return cs.length >= 13 && cs.length <= 19 && allChars(cs, isDigit) && luhnOk(t);
+}
+
+// detectors: [tag, name_hints_or_null, value_predicate] in fixed order —
+// name-gated group first (low false-positive), value-distinctive fallback second.
+const DETECTORS: Array<[string, string[] | null, (s: string) => boolean]> = [
+  ["cusip", ["cusip"], vCusip],
+  ["npi", ["npi"], vNpi],
+  ["imei", ["imei", "imsi"], vImei],
+  ["ean", ["ean", "gtin", "barcode"], vEan],
+  ["isbn", ["isbn"], vIsbn],
+  ["aba_routing", ["routing", "aba"], vAba],
+  ["iban", null, vIban],
+  ["isin", null, vIsin],
+  ["swift", null, vSwift],
+  ["credit_card", null, vCreditCard],
+];
+
+function fineType(name: string, samples: string[]): string | null {
+  const lname = asciiLower(name);
+  const nonempty = samples.filter((s) => [...s].some((c) => !isAsciiWs(c)));
+  if (nonempty.length === 0) return null;
+  for (const [tag, hints, pred] of DETECTORS) {
+    if (hints !== null && !hints.some((h) => lname.includes(h))) continue;
+    let matches = 0;
+    for (const s of nonempty) if (pred(s)) matches++;
+    if (matches * 2 > nonempty.length) return tag;
+  }
+  return null;
+}
+
+function resolveTag(name: string, coarseType: string, samples: string[]): string | null {
+  const ft = fineType(name, samples);
+  if (ft !== null) return ft;
+  return COARSE.has(coarseType) ? coarseType : null;
+}
+
+// per-fine-tag validator; credit_card uses luhn_validate.
+const VALIDATOR: Record<string, string> = {
+  iban: "iban_validate",
+  isin: "isin_validate",
+  swift: "swift_validate",
+  cusip: "cusip_validate",
+  npi: "npi_validate",
+  imei: "imei_validate",
+  ean: "ean_validate",
+  isbn: "isbn_validate",
+  credit_card: "luhn_validate",
+  aba_routing: "aba_validate",
+};
+
+// mapping table: check -> tag -> transforms; tag "*" = wildcard. Nested (not a
+// concatenated string key) so there is no separator char in the source.
+const TABLE = new Map<string, Map<string, string[]>>();
+function tableSet(check: string, tag: string, transforms: string[]): void {
+  let byTag = TABLE.get(check);
+  if (byTag === undefined) {
+    byTag = new Map<string, string[]>();
+    TABLE.set(check, byTag);
+  }
+  byTag.set(tag, transforms);
+}
+tableSet("encoding_detection", "*", ["fix_mojibake", "normalize_unicode"]);
+tableSet("future_dated", "date", ["date_validate"]);
+tableSet("temporal_order", "date", ["date_validate"]);
+tableSet("stale_data", "date", ["date_validate"]);
+tableSet("format_detection", "date", ["date_parse"]);
+tableSet("format_detection", "email", ["email_normalize"]);
+tableSet("pattern_consistency", "email", ["email_canonical"]);
+tableSet("pattern_consistency", "name", ["name_proper"]);
+tableSet("format_detection", "phone", ["phone_validate"]);
+tableSet("pattern_consistency", "phone", ["phone_national"]);
+tableSet("format_detection", "zip", ["zip_normalize"]);
+for (const [tag, validator] of Object.entries(VALIDATOR)) {
+  tableSet("format_detection", tag, [validator]);
+  tableSet("pattern_consistency", tag, [validator]);
+}
+
+function lookup(check: string, tag: string | null): string[] | null {
+  const byTag = TABLE.get(check);
+  if (byTag === undefined) return null;
+  if (tag !== null && byTag.has(tag)) return byTag.get(tag)!;
+  if (byTag.has("*")) return byTag.get("*")!;
+  return null;
+}
+
+export interface Finding {
+  column?: string;
+  check?: string;
+  message?: string;
+  severity?: string;
+}
+export interface ColumnInput {
+  name: string;
+  coarse_type?: string;
+  samples?: string[];
+}
+export interface Repair {
+  column: string;
+  check: string;
+  type_tag: string;
+  suggested_transforms: string[];
+  reason: string;
+}
+export interface RepairPlan {
+  repairs: Repair[];
+}
+
+export function buildRepairPlan(findings: Finding[], columns: ColumnInput[]): RepairPlan {
+  const tags = new Map<string, string | null>();
+  for (const c of columns) {
+    tags.set(c.name, resolveTag(c.name, c.coarse_type ?? "", c.samples ?? []));
+  }
+
+  const repairs: Repair[] = [];
+  for (const f of findings) {
+    const col = f.column;
+    const check = f.check ?? "";
+    // encoding wildcard can apply even to an omitted-tag column present in `columns`
+    if (col === undefined || !tags.has(col)) continue;
+    const tag = tags.get(col)!;
+    const transforms = lookup(check, tag);
+    if (!transforms || transforms.length === 0) continue;
+    repairs.push({
+      column: col,
+      check,
+      type_tag: tag !== null ? tag : "*",
+      suggested_transforms: [...transforms],
+      reason: [...String(f.message ?? "")].slice(0, 80).join(""),
+    });
+  }
+  return { repairs };
+}

--- a/packages/typescript/goldenpipe/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/backend.ts
@@ -21,6 +21,7 @@ export interface PipeWasmBackend {
   planPipelineJson(input: string): string;
   applyScaleHintsJson(input: string): string;
   bandOfJson(input: string): string;
+  buildRepairPlanJson(input: string): string;
 }
 
 import { createBackendRegistry } from "goldenmatch-wasm-runtime";

--- a/packages/typescript/goldenpipe/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/loader.ts
@@ -31,6 +31,7 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<PipeWasmBac
     plan_pipeline_json: (s: string) => string;
     apply_scale_hints_json: (s: string) => string;
     band_of_json: (s: string) => string;
+    build_repair_plan_json: (s: string) => string;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -43,5 +44,6 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<PipeWasmBac
     planPipelineJson: (s) => glue.plan_pipeline_json(s),
     applyScaleHintsJson: (s) => glue.apply_scale_hints_json(s),
     bandOfJson: (s) => glue.band_of_json(s),
+    buildRepairPlanJson: (s) => glue.build_repair_plan_json(s),
   };
 }

--- a/packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts
+++ b/packages/typescript/goldenpipe/src/core/wasm/plannerJsonPure.ts
@@ -31,6 +31,7 @@ import {
   type PipeProfile,
   type PlannerInput,
 } from "../autoconfigPlanner.js";
+import { buildRepairPlan, type Finding, type ColumnInput } from "../repair.js";
 
 interface StubStage {
   info: StageInfo;
@@ -261,4 +262,9 @@ export function applyScaleHintsJsonPure(inputStr: string): string {
 
 export function bandOfJsonPure(inputStr: string): string {
   return JSON.stringify(bandOf(JSON.parse(inputStr) as number));
+}
+
+export function buildRepairPlanJsonPure(inputStr: string): string {
+  const arg = JSON.parse(inputStr) as { findings?: Finding[]; columns?: ColumnInput[] };
+  return JSON.stringify(buildRepairPlan(arg.findings ?? [], arg.columns ?? []));
 }

--- a/packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/planner-parity.test.ts
@@ -10,6 +10,7 @@ import {
   planPipelineJsonPure,
   applyScaleHintsJsonPure,
   bandOfJsonPure,
+  buildRepairPlanJsonPure,
 } from "../../src/core/wasm/plannerJsonPure.js";
 
 const VEC = (name: string) =>
@@ -31,6 +32,7 @@ const FAMILIES: Array<[string, (s: string) => string]> = [
   ["plan_pipeline", planPipelineJsonPure],
   ["apply_scale_hints", applyScaleHintsJsonPure],
   ["band_of", bandOfJsonPure],
+  ["build_repair_plan", buildRepairPlanJsonPure],
 ];
 
 describe("Leg A — pure-TS planner == goldenpipe-core golden vectors", () => {

--- a/packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/planner-wasm-parity.test.ts
@@ -47,11 +47,12 @@ suite("Leg B — goldenpipe-wasm == golden vectors", () => {
       plan_pipeline: b.planPipelineJson,
       apply_scale_hints: b.applyScaleHintsJson,
       band_of: b.bandOfJson,
+      build_repair_plan: b.buildRepairPlanJson,
     };
     return dispatch[family]!(input);
   };
 
-  for (const family of ["resolve", "apply_decision", "evaluate_builtin", "auto_config", "skip_if", "plan_pipeline", "apply_scale_hints", "band_of"]) {
+  for (const family of ["resolve", "apply_decision", "evaluate_builtin", "auto_config", "skip_if", "plan_pipeline", "apply_scale_hints", "band_of", "build_repair_plan"]) {
     it(`${family} vectors`, () => {
       for (const { input, expected } of load(family)) {
         expect(JSON.parse(call(family, JSON.stringify(input)))).toEqual(expected);

--- a/packages/typescript/goldenpipe/tests/parity/reroute-agreement.test.ts
+++ b/packages/typescript/goldenpipe/tests/parity/reroute-agreement.test.ts
@@ -36,6 +36,7 @@ const fakeBackend = {
   planPipelineJson: pure.planPipelineJsonPure,
   applyScaleHintsJson: pure.applyScaleHintsJsonPure,
   bandOfJson: pure.bandOfJsonPure,
+  buildRepairPlanJson: pure.buildRepairPlanJsonPure,
 };
 
 /** A trivial stage with the given wiring; `run` is never invoked in these tests. */

--- a/packages/typescript/goldenpipe/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/wasm-backend.test.ts
@@ -14,6 +14,7 @@ const fake: PipeWasmBackend = {
   planPipelineJson: () => "{}",
   applyScaleHintsJson: () => "{}",
   bandOfJson: () => '"red"',
+  buildRepairPlanJson: () => '{"repairs":[]}',
 };
 
 describe("PipeWasmBackend registry", () => {


### PR DESCRIPTION
## What

Adds a Phase-1 **advisory** repair-plan to the GoldenPipe brain: it maps GoldenCheck findings to specific GoldenFlow transforms, keyed by `(check × column type)`. A `future_dated` finding on a date column suggests `date_validate`; a `pattern_consistency` finding on an IBAN column suggests `iban_validate`.

New pure kernel `build_repair_plan(findings, columns)` in `goldenpipe-core` (Rust source-of-truth) mirrored byte-identically by pure-Python and pure-TS, all replaying one golden-vector file. An **in-kernel value-level fine-typer** classifies each column from <=20 sampled string values using hand-rolled ASCII matchers (no regex — byte-identical across engines) plus Luhn for `credit_card`. A static `(check, type_tag) -> [transforms]` table does the lookup.

## Advisory-only guarantee

Emits `ctx.artifacts["repair_plan"]` + one reasoning line per item. It never emits a `Decision` and never changes the executed-stage list — a pipeline's output is byte-identical whether or not repair-planning runs (proved by an unchanged Check-adapter regression test).

## Cross-surface

- Rust kernel + golden vectors (`vec_build_repair_plan`)
- Pure-Python mirror + host glue (sampling + artifact attach) + Check-adapter wiring
- TS mirror + pure & wasm parity registrations
- wasm + native (`#[pyfunction]`) shim exports + native-loader passthrough

Fine-typer is code-point-correct on all three surfaces (Python `[:80]` / Rust `.chars().take(80)` / JS `[...s]`; ASCII-only lower + whitespace).

## Verification

- Box-green (20 tests): pure kernel, host glue, real-`ColumnType` integration guard, Leg-A golden-vector parity.
- CI verifies: Rust golden vectors, Python native Leg B, TS pure + wasm parity, wasm build.

Spec: `docs/superpowers/specs/2026-07-07-goldenpipe-repair-plan-intelligence-design.md`
Plan: `docs/superpowers/plans/2026-07-07-goldenpipe-repair-plan-intelligence.md`

Phase 2 (out of scope): gated config-injection so the brain drives Flow directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)