### PR TITLE
chore(goldenflow): bump [native] floor to goldenflow-native>=0.26.0

### DIFF
--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -61,7 +61,7 @@ agent = ["aiohttp>=3.14.0"]
 # Optional Rust/PyO3 acceleration runtime (mirrors goldenmatch[native]). Pulls
 # pyarrow for the zero-copy Series<->kernel bridge. Off by default at runtime --
 # see goldenflow.core._native_loader (GOLDENFLOW_NATIVE / _GATED_ON).
-native = ["goldenflow-native>=0.24.0", "pyarrow>=10"]
+native = ["goldenflow-native>=0.26.0", "pyarrow>=10"]
 all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
 
 [project.scripts]


### PR DESCRIPTION
0.26.0 is live on PyPI (carries `format_f64` + the AsFloat numeric-input path from the zero-gap W4). Mandate the new baseline so `pip install goldenflow[native]` gets numeric-input columnar coverage instead of a silent decline on an older wheel. Resolves locally via the workspace path source (0.26.0 in-tree), from PyPI for published installs — no `uv sync` break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)