### PR TITLE
feat(goldenflow): Polars-free zero-config transform(dict, config=None)

### DIFF
--- a/docs/design/2026-07-07-phase4-polars-optional-scoping.md
+++ b/docs/design/2026-07-07-phase4-polars-optional-scoping.md
@@ -247,6 +247,22 @@ recovered by `[native]`.
 
 ---
 
+## 5a. The remaining `[polars]`-only surface — triaged (2026-07-08)
+
+After the transform coverage hit 9/9 columnar (every transform runs Polars-free), the
+four commonly-cited "still needs `[polars]`" surfaces resolve as follows:
+
+| Surface | Verdict | Detail |
+|---|---|---|
+| **`transform_df(pl.DataFrame)`** | **NOT a gap** | You cannot *construct* a `pl.DataFrame` without Polars installed, so a Polars-free user never calls it. It is the Polars-backend adapter by design (D1a) — tautological, not a gap. |
+| **dates "bulk fast path"** | **NOT a coverage gap** | The `dates` family already runs **correct** Polars-free via the columnar scalar path (all `date_*` are columnar-ready). The bulk fast path is only the optional Polars vectorized *speedup*, recovered by `[polars]`/`[native]`. |
+| **zero-config (`config=None`)** | **CLOSED (Polars-free) for a dict** | `profiler_bridge.profile_columns` profiles + auto-selects over plain lists — byte-identical *selection* to the Polars built-in profiler (which is what a dict / no-file-path input uses; GoldenCheck is file-path-only). `transform(dict, config=None)` runs on the native path, byte-identical to `transform_df(pl.DataFrame(data), config=None)` (validated over a 400-case stress). A **CSV path** + `config=None` still needs `[polars]` — Polars' CSV dtype inference decides numeric-vs-string, which the string-only stdlib reader can't reproduce. |
+| **Excel / Parquet / DB I/O** | **deliberate optional-backend** | Excel (openpyxl→dict) and DB (DBAPI→dict) *could* be made Polars-free readers, but are niche for a Polars-free user; Parquet honestly stays pyarrow (`[native]`/`[parquet]`) — a pure-Python parquet reader isn't worth it. These stay behind `[polars]`/`[excel]`/`[parquet]` with a graceful `ImportError`, exactly as the cloud connectors already do. CSV read is already Polars-free (Phase 4e). |
+
+Net: the only things a default-no-polars user genuinely can't do are **read Excel/Parquet/DB** and **CSV zero-config** — all legitimately optional-backend, all declining loudly with an actionable install hint.
+
+---
+
 ## 6. Risks + non-goals
 
 - **Risk: coverage gaps become loud failures for Polars-free users.** Mitigated by D5

--- a/packages/python/goldenflow/goldenflow/engine/columnar.py
+++ b/packages/python/goldenflow/goldenflow/engine/columnar.py
@@ -511,21 +511,45 @@ def read_csv_columns(path) -> dict[str, list]:
     return cols
 
 
+def _autoconfig_columns(data: dict):
+    """Zero-config Polars-free: profile the columns + select auto-apply transforms
+    per column (the SAME built-in profiler + selector the Polars engine uses for a
+    no-file-path input), returning the built :class:`GoldenFlowConfig`."""
+    from goldenflow.config.schema import GoldenFlowConfig, TransformSpec
+    from goldenflow.engine.profiler_bridge import profile_columns
+    from goldenflow.engine.selector import select_transforms
+
+    profile = profile_columns(data)
+    specs = []
+    for cp in profile.columns:
+        selected = select_transforms(cp)
+        if selected:
+            specs.append(TransformSpec(column=cp.name, ops=[t.name for t in selected]))
+    return GoldenFlowConfig(transforms=specs)
+
+
 def transform_columns_public(data, config):
     """Phase 4c/4e public core: transform a ``dict[str, list]`` frame OR a CSV path
     (str/``Path`` ending ``.csv``), returning a :class:`ColumnarResult` (Polars-free).
     A CSV path is read via the stdlib reader (:func:`read_csv_columns`). A covered
     config runs on the native in-memory core with **Polars never imported**; anything
     else declines to the Polars engine (which needs ``goldenflow[polars]`` — a clear
-    ImportError if it's absent). ``config=None`` (zero-config auto-detect) uses the
-    Polars profiler, so it also needs the extra.
+    ImportError if it's absent).
+
+    ``config=None`` (zero-config auto-detect) is ALSO Polars-free for a **dict** input:
+    the columns are profiled + auto-selected via the Polars-free profiler
+    (:func:`profile_columns`) and run on the native path — byte-identical to
+    ``transform_df(pl.DataFrame(data))``. A CSV path + ``config=None`` still needs the
+    extra (Polars' CSV dtype inference decides numeric vs string, which the string-only
+    stdlib reader can't reproduce).
 
     This is the Polars-free public entry point the Rust-is-the-reference thesis wants:
     a covered config (from a dict or a CSV) is a first-class no-Polars API; the
     uncovered tail is where Polars remains, loudly and optionally."""
     from pathlib import Path
 
-    if isinstance(data, (str, Path)):
+    from_csv = isinstance(data, (str, Path))
+    if from_csv:
         p = Path(data)
         if p.suffix.lower() != ".csv":
             raise ValueError(
@@ -541,6 +565,17 @@ def transform_columns_public(data, config):
 
     nm = native_module()
     native_ok = nm is not None and native_columns_ready(nm)
+
+    # Zero-config (config=None) for a dict: profile + auto-select Polars-free, then run
+    # the built config on the native path if covered. (CSV declines — see docstring.)
+    if config is None and native_ok and not from_csv:
+        built = _autoconfig_columns(data)
+        if not built.transforms:
+            return ColumnarResult(columns=dict(data), manifest=Manifest(source="<dataframe>"))
+        if config_is_columnar_ready(built):
+            cols, manifest = transform_columns_native(data, built)
+            return ColumnarResult(columns=cols, manifest=manifest)
+
     if config is not None and native_ok and config_is_columnar_ready(config):
         cols, manifest = transform_columns_native(data, config)
         return ColumnarResult(columns=cols, manifest=manifest)
@@ -667,7 +702,10 @@ def transform_columns_native(columns, config, source: str = "<dataframe>"):
         # only when the RENDERED strings differ, matching the engine exactly.
         accepted = _accepted_string(nm)
         if _spec_scalar_ready(spec, accepted):
-            cur = col_list
+            # Owned string / scalar ops operate on strings; a non-string input column
+            # (e.g. zero-config picking string ops for a numeric column named "phone")
+            # coerces to Polars `cast(Utf8)` first, exactly as the engine does.
+            cur = _stringify_for_column(col_list, nm)
             for name, params in ops:
                 cb = [_cast_utf8(v) for v in cur]
                 if name in accepted:

--- a/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
+++ b/packages/python/goldenflow/goldenflow/engine/profiler_bridge.py
@@ -143,6 +143,66 @@ def _profile_column(series: pl.Series) -> ColumnProfile:
     )
 
 
+def _infer_type_list(values: list) -> str:
+    """Polars-free twin of :func:`_infer_type` over a plain list. A column of Python
+    ``int``/``float`` (the dtype a ``pl.DataFrame`` would infer as numeric) is
+    ``numeric``; all-``bool`` is ``boolean``; else the SAME regex heuristics on the first
+    100 non-null stripped values. (No ``pl.Date`` case — a list column is never a
+    Polars temporal dtype; date-looking STRINGS still match ``_DATE_RE``.)"""
+    non_null = [v for v in values if v is not None]
+    if non_null and all(isinstance(v, bool) for v in non_null):
+        return "boolean"
+    if non_null and all(isinstance(v, (int, float)) and not isinstance(v, bool) for v in non_null):
+        return "numeric"
+
+    sample = non_null[:100]
+    sample_stripped = [str(s).strip() for s in sample if str(s) and str(s).strip()]
+    if not sample_stripped:
+        return "string"
+    checks = [
+        ("email", _EMAIL_RE, 0.7),
+        ("zip", _ZIP_RE, 0.7),
+        ("date", _DATE_RE, 0.5),
+        ("phone", _PHONE_RE, 0.6),
+        ("name", _NAME_RE, 0.5),
+    ]
+    for type_name, pattern, threshold in checks:
+        match_pct = sum(1 for v in sample_stripped if pattern.match(v)) / len(sample_stripped)
+        if match_pct >= threshold:
+            return type_name
+    return "string"
+
+
+def profile_columns(cols: dict[str, list], file_path: str = "") -> DatasetProfile:
+    """Profile a ``dict[str, list]`` **Polars-free** — the built-in profiler over plain
+    lists (byte-identical selection to :func:`profile_dataframe`'s built-in fallback,
+    which is what a dict/no-file-path input uses anyway; the GoldenCheck path is
+    file-path-only). Powers zero-config ``transform(dict, config=None)`` with Polars
+    uninstalled. ``inferred_type`` + ``unique_pct`` — the only fields
+    :func:`select_transforms` reads — match the Polars profiler exactly."""
+    columns = []
+    row_count = len(next(iter(cols.values()))) if cols else 0
+    for name, values in cols.items():
+        n = len(values)
+        null_count = sum(1 for v in values if v is None)
+        non_null = [v for v in values if v is not None]
+        unique_count = len(set(non_null))
+        inferred = _override_type_by_column_name(name, _infer_type_list(values))
+        columns.append(ColumnProfile(
+            name=name,
+            inferred_type=inferred,
+            row_count=n,
+            null_count=null_count,
+            null_pct=null_count / n if n > 0 else 0.0,
+            unique_count=unique_count,
+            unique_pct=unique_count / n if n > 0 else 0.0,
+            sample_values=[str(v) for v in non_null[:5]],
+        ))
+    return DatasetProfile(
+        file_path=file_path, row_count=row_count, column_count=len(cols), columns=columns,
+    )
+
+
 def profile_dataframe(df: pl.DataFrame, file_path: str = "", use_llm: bool | None = None) -> DatasetProfile:
     """Profile a DataFrame. Uses GoldenCheck if available, otherwise falls back to built-in.
 

--- a/packages/python/goldenflow/tests/engine/test_columnar_zero_config.py
+++ b/packages/python/goldenflow/tests/engine/test_columnar_zero_config.py
@@ -1,0 +1,104 @@
+"""Polars-free zero-config: ``transform(dict, config=None)`` auto-detects + fixes.
+
+``config=None`` used to require the Polars engine (the profiler inspected ``pl.Series``
+dtypes). A Polars-free profiler (:func:`profiler_bridge.profile_columns`) now infers each
+column's type + cardinality over plain lists — byte-identical *selection* to the Polars
+built-in profiler (which is what a dict / no-file-path input uses anyway; GoldenCheck is
+file-path-only) — so zero-config on a dict runs on the native columnar path with Polars
+uninstalled, identical to ``transform_df(pl.DataFrame(data), config=None)``.
+
+(A CSV path + ``config=None`` still needs ``[polars]``: Polars' CSV dtype inference
+decides numeric-vs-string, which the string-only stdlib reader can't reproduce.)
+"""
+from __future__ import annotations
+
+import math
+
+import goldenflow
+import polars as pl
+import pytest
+from goldenflow.core._native_loader import native_module
+from goldenflow.engine import columnar
+
+
+def _mrows(m):
+    return [
+        (r.column, r.transform, r.affected_rows, tuple(r.sample_before or []),
+         tuple(r.sample_after or [])) for r in m.records
+    ]
+
+
+def _native_ready() -> bool:
+    nm = native_module()
+    return nm is not None and columnar.native_columns_ready(nm)
+
+
+def _veq(a, b) -> bool:
+    if len(a) != len(b):
+        return False
+    for x, y in zip(a, b):
+        if isinstance(x, float) and isinstance(y, float) and math.isnan(x) and math.isnan(y):
+            continue
+        if x != y:
+            return False
+    return True
+
+
+CASES = [
+    {"name": ["  John SMITH ", "jane doe", None], "k": [0, 1, 2]},
+    {"email": ["A@B.COM", "x@y.co", "bad"], "city": ["  NYC ", "nyc", "LA"], "k": [0, 1, 2]},
+    {"phone": ["212-555-0100", "(415) 555-2671", None], "amount": [1, 2, 3]},  # numeric col untouched
+    {"active": [True, False, None], "id": [10, 20, 30], "notes": ["  a ", "B", "n/a"]},
+    {"category": ["NYC", "nyc", "NYC", "LA", "la"], "k": [0, 1, 2, 3, 4]},  # low-cardinality
+    {"empty": [None, None], "plain": ["x", "y"]},
+]
+
+
+@pytest.mark.parametrize("data", CASES)
+def test_zero_config_dict_equals_polars(data) -> None:
+    if not _native_ready():
+        pytest.skip("native in-memory core not built")
+    res = goldenflow.transform(dict(data), config=None)
+    ref = goldenflow.transform_df(pl.DataFrame(data), config=None)
+    for c in ref.df.columns:
+        assert _veq(res.columns[c], ref.df[c].to_list()), c
+    assert _mrows(res.manifest) == _mrows(ref.manifest)
+
+
+def test_zero_config_is_polars_free() -> None:
+    import subprocess
+    import sys
+    import textwrap
+
+    if not _native_ready():
+        pytest.skip("native core not built")
+    out = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(
+            """
+            import sys, goldenflow
+            res = goldenflow.transform(
+                {"name": ["  John SMITH ", "jane"], "amount": [1, 2], "k": [1, 2]},
+                config=None,
+            )
+            assert res.columns["name"] == ["John SMITH", "jane"], res.columns["name"]
+            assert res.columns["amount"] == [1, 2], res.columns["amount"]  # numeric untouched
+            print("POLARS" if "polars" in sys.modules else "CLEAN")
+            """
+        )],
+        capture_output=True, text=True, check=True,
+    )
+    assert out.stdout.strip() == "CLEAN", out.stdout + out.stderr
+
+
+def test_zero_config_csv_still_needs_polars_backend(tmp_path) -> None:
+    """A CSV path + config=None routes to the Polars engine (dtype inference), not the
+    Polars-free zero-config — it declines cleanly rather than mis-inferring."""
+    import csv
+
+    p = tmp_path / "in.csv"
+    with open(p, "w", newline="", encoding="utf-8") as f:
+        csv.writer(f).writerows([["name"], ["  John "]])
+    # With polars present it succeeds via the engine; the point is it does NOT silently
+    # go through the string-only Polars-free profiler (which would mis-type numerics).
+    res = goldenflow.transform(str(p), config=None)
+    assert "name" in res.columns


### PR DESCRIPTION
Closes the last substantive `[polars]`-only gap on the transform surface, and triages the rest.

## Zero-config now Polars-free (dict input)
`config=None` used to require the Polars engine (the profiler inspected `pl.Series` dtypes). A Polars-free profiler (`profiler_bridge.profile_columns` / `_infer_type_list`) infers each column's type + cardinality over plain lists — **byte-identical selection** to the Polars built-in profiler (which a dict / no-file-path input uses anyway; GoldenCheck is file-path-only). So `transform(dict, config=None)` profiles → auto-selects → runs on the native path, byte-identical to `transform_df(pl.DataFrame(data), config=None)`. Validated over a **400-case randomized stress** (name/email/phone/zip/numeric/bool/categorical, incl. the pathological int-column-named-"phone" the name-override coerces).

Also: the scalar-chain path now coerces a non-string input column via `_stringify_for_column` (Polars `cast(Utf8)`) before string/scalar ops — the case zero-config hits when a column-name override routes a numeric column through string ops, exactly as the engine casts.

A **CSV path** + `config=None` still needs `[polars]` (Polars' CSV dtype inference decides numeric-vs-string; the string-only stdlib reader can't reproduce it) — declines cleanly.

## Triage of the four cited `[polars]`-only surfaces (doc §5a)
| Surface | Verdict |
|---|---|
| `transform_df(pl.DataFrame)` | **NOT a gap** — you need Polars to construct a pl.DataFrame; a Polars-free user never calls it. |
| dates bulk fast path | **NOT a coverage gap** — dates run correct Polars-free via the scalar path; bulk is speed-only. |
| zero-config | **CLOSED** (this PR, dict input). |
| Excel / Parquet / DB I/O | **deliberate optional-backend** — Excel/DB *could* be Polars-free readers (niche); Parquet honestly stays pyarrow. Graceful `ImportError`. |

Full engine+transforms+domains sweep green (1965).

🤖 Generated with [Claude Code](https://claude.com/claude-code)