### PR TITLE
docs(goldenflow): sweep surfaces for the Polars eviction (Phase 4)

### DIFF
--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,26 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-07-08 -- GoldenFlow: Polars eviction FUNCTIONALLY COMPLETE (Phase 4, extends ADR 0034)
+- The "Great Polars Eviction" (ADR 0034) is done on the transform + I/O surface. `import
+  goldenflow` imports no Polars; the public `transform(data, config)` runs the native/Arrow
+  substrate by DEFAULT (no `GOLDENFLOW_ENGINE=columnar` opt-in), and ALL 113 transforms are
+  columnar (9/9 gaps closed) via a `scalar=`/`scalar_dtype`/`scalar_factory` registry
+  mechanism + 3 new columnar op-shapes (multi-input `merge_name`, flag-only
+  `initial_expand`, whole-column `category_auto_correct`) + a synthetic-`AsFloat`
+  numeric-INPUT path. `transform()` reads `.csv`/`.parquet`/`.xlsx` + any DBAPI connection
+  Polars-free; zero-config (`config=None`) is Polars-free too.
+- LOAD-BEARING DECISIONS (design doc `docs/design/2026-07-07-phase4-polars-optional-scoping.md`
+  §5a): (1) `transform()` is the Polars-free primary, `transform_df(pl.DataFrame)` the
+  optional Polars-backend adapter (tautological — needs Polars to hold a pl.DataFrame);
+  (2) CSV zero-config OWNS its inference (profiles columns as text, `"01234"` stays a zip)
+  — an intentional `pl.read_csv` divergence, dates-style. New extras `[polars]`/`[parquet]`;
+  `goldenflow-native` republished 0.26.0 (adds `format_f64` + AsFloat). Weight win measured
+  ~185 MB installed / ~35 MB wheel.
+- REMAINING: only the 2.0 major that drops `polars` from base deps -> `[polars]` (fully
+  de-risked: `[polars]` extra + `goldenflow_nopolars` CI lane staged, polars-absent
+  validated).
+
 ## 2026-07-06 -- GoldenFlow: fused columnar apply, Pillar-1 execution fusion, default-on (ADR 0034)
 - First real step of the "Great Polars Eviction": fuse a column's run of owned no-arg
   total string→string kernels (25: text/email/name) into ONE native Arrow pass instead

--- a/docs-site/goldenflow/overview.mdx
+++ b/docs-site/goldenflow/overview.mdx
@@ -92,6 +92,23 @@ config = GoldenFlowConfig(transforms=[
 result = goldenflow.transform_df(df, config=config)
 ```
 
+## Polars-free `transform()`
+
+`goldenflow.transform()` runs the same transforms on the native/Arrow substrate with
+**Polars never imported**. It takes a `dict[str, list]` or a file path
+(`.csv` / `.parquet` / `.xlsx`), and returns a `ColumnarResult` (`.columns` +
+`.manifest`, with an opt-in `.to_polars()`):
+
+```python
+result = goldenflow.transform({"phone": ["212-555-0100"]}, config=config)
+result = goldenflow.transform("customers.parquet", config=config)  # pyarrow, no Polars
+result = goldenflow.transform("customers.csv", config=None)        # zero-config, Polars-free
+```
+
+`transform_df(pl.DataFrame)` stays as the Polars-backend adapter. Install optional
+backends with `pip install goldenflow[polars]` (bulk-vectorized backend + `pl.read_*`)
+or `goldenflow[parquet]` (pyarrow, for Polars-free Parquet read).
+
 ## Schema mapping
 
 ```python

--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## [Unreleased]
+
+Polars-eviction Phase 4: the columnar path is now the **default** for the public
+`transform()` entry point (no `GOLDENFLOW_ENGINE=columnar` opt-in needed), and it runs
+**Polars-free** end to end. `import goldenflow` no longer imports Polars; every one of the
+113 transforms runs on the native/Arrow substrate, byte-identical to the Polars engine.
+The remaining work is the 2.0 major that moves `polars` out of the base dependencies.
+
+- **Polars-free public `transform()`.** `goldenflow.transform(data, config=...)` accepts a
+  `dict[str, list]` OR a file path and returns a `ColumnarResult` (`.columns` + `.manifest`,
+  with an opt-in `.to_polars()` bridge) — with **Polars never imported** for a covered
+  config. `transform_df(pl.DataFrame)` stays as the Polars-backend adapter (it needs a
+  `pl.DataFrame`, which needs Polars).
+- **Every transform on the columnar path (9/9 gaps closed).** A `scalar=` / `scalar_dtype`
+  / `scalar_factory` registry mechanism plus new columnar op-shapes (multi-input
+  `merge_name`, flag-only `initial_expand`, whole-column `category_auto_correct`, and a
+  synthetic-coerce numeric-INPUT path for `round`/`clamp`/`abs_value`/`fill_zero`) bring the
+  full transform surface onto the Polars-free path. Owned by `goldenflow-native>=0.26.0`
+  (adds `format_f64` + the numeric-input `AsFloat` parser).
+- **Polars-free file readers.** `transform("<x>.csv")` (stdlib csv), `"<x>.parquet"`
+  (pyarrow `to_pydict`, byte-identical to `pl.read_parquet`), and `"<x>.xlsx"` (openpyxl)
+  all read without Polars. `connectors.database.read_database_columns(conn, query)` reads
+  any PEP-249 (DBAPI) connection into a dict, no connectorx/polars.
+- **Polars-free zero-config.** `transform(data, config=None)` profiles + auto-selects over
+  plain lists (`profiler_bridge.profile_columns`), Polars-free. For a **dict / Parquet /
+  Excel** input it is byte-identical to `transform_df(..., config=None)`; for **CSV** it
+  profiles columns *as text* (so `"01234"` stays a zip, not `1234`) — an intentional
+  data-cleaning-correct divergence from `pl.read_csv`'s numeric coercion.
+- **New extras.** `goldenflow[polars]` (the optional Polars bulk-vectorized backend +
+  `transform_df` + `pl.read_*` I/O) and `goldenflow[parquet]` (pyarrow, for Polars-free
+  Parquet read). `goldenflow[native]` floor bumped to `goldenflow-native>=0.26.0`.
+
 ## 1.17.0 (2026-07-07)
 
 Polars-eviction Phases 2-3: a config's owned transforms now run entirely on the native/Arrow substrate (no Polars, no pyarrow) on both the whole-file CSV path and the in-memory path, byte-identical (data + manifest) to the Polars engine. Needs `goldenflow-native>=0.24.0`. Opt in with `GOLDENFLOW_ENGINE=columnar`; anything the columnar path does not cover declines to the Polars engine, so behavior is never wrong.

--- a/packages/python/goldenflow/CLAUDE.md
+++ b/packages/python/goldenflow/CLAUDE.md
@@ -550,6 +550,35 @@ Hosted on Railway, registered on Smithery:
 - **Railway project:** `golden-suite-mcp` (service: `goldenflow-mcp`, port 8150)
 - **Local HTTP:** `goldenflow mcp-serve --transport http --port 8150`
 
+## Polars eviction — FUNCTIONALLY COMPLETE (Phase 4, 2026-07-08)
+
+The columnar path (`engine/columnar.py`) is the DEFAULT for the public `transform()` and
+runs **Polars-free**: `import goldenflow` imports no Polars, all 113 transforms + CSV/
+Parquet/Excel/DB read + dict/file zero-config run without Polars. Only the 2.0 base-deps
+flip remains (drop `polars` from `[project.dependencies]` -> the `[polars]` extra).
+- **`transform(data, config)`** (Polars-free primary) takes a `dict[str, list]` or a path
+  (`.csv`/`.parquet`/`.xlsx`) -> `ColumnarResult`. Readers: `read_csv_columns` (stdlib
+  csv), `read_parquet_columns` (pyarrow `to_pydict`), `read_excel_columns` (openpyxl),
+  `connectors.database.read_database_columns` (any DBAPI). `transform_df(pl.DataFrame)` is
+  the Polars-backend adapter (tautologically needs Polars).
+- **Coverage mechanism.** `register_transform(scalar=, scalar_dtype=, scalar_factory=)`
+  covers per-element str/int/bool/float/parameterized; `_apply_special` covers the 3
+  odd shapes (multi-input `merge_name`, flag-only `initial_expand`, whole-column
+  `category_auto_correct`); numeric-INPUT (`round`/`clamp`/`abs_value`/`fill_zero`) via a
+  synthetic `AsFloat` parser in native-flow. Needs `goldenflow-native>=0.26.0` (adds
+  `format_f64` + AsFloat).
+- **CSV zero-config OWNS its inference** (a deliberate `pl.read_csv` divergence, like the
+  dates fix): profiles CSV columns AS TEXT so `"01234"` stays a zip, not `1234`. Cleaned
+  text values match `transform_df(pl.read_csv)`; numeric columns keep their string dtype.
+- **When adding a transform, wire it onto the columnar path** (scalar / fused kernel /
+  special-shape) or it silently declines to `[polars]`. And **grep `domains/` for a
+  same-name registration** — a domain pack re-registering a core name clobbers its
+  scalar/native (see `feedback_domain_pack_reregister_clobber`).
+- **Latent bug (pre-existing, masked by native):** `clamp:0:100` with INTEGER bounds
+  errors in the PURE-PYTHON path (`SchemaError` Int64->Float64 in `map_elements`) ->
+  clamp silently no-ops; only bites a no-native install. One-line fix: `float()` the
+  bounds in `transforms/numeric.py::clamp`.
+
 ## Gotchas
 
 - `utf8-lossy` encoding on CSV reads (streaming.py, cli/main.py, api/server.py)

--- a/packages/python/goldenflow/README.md
+++ b/packages/python/goldenflow/README.md
@@ -547,6 +547,39 @@ goldenflow learn data.csv -o config.yaml
 
 ## Python API
 
+### Polars-free `transform()` (the default path)
+
+`goldenflow.transform()` runs on the native/Arrow substrate with **Polars never
+imported** — `import goldenflow` loads no Polars, and every one of the 113 transforms
+runs Polars-free. It accepts a `dict[str, list]` or a file path (`.csv` / `.parquet` /
+`.xlsx`) and returns a `ColumnarResult` (`.columns` + `.manifest`):
+
+```python
+import goldenflow
+from goldenflow import GoldenFlowConfig, TransformSpec
+
+cfg = GoldenFlowConfig(transforms=[TransformSpec(column="phone", ops=["phone_e164"])])
+
+result = goldenflow.transform({"phone": ["212-555-0100"], "id": [1]}, config=cfg)
+result = goldenflow.transform("customers.parquet", config=cfg)   # pyarrow, no Polars
+result = goldenflow.transform("customers.csv", config=None)      # zero-config auto-detect
+result.columns      # dict[str, list] — the cleaned data
+result.to_polars()  # opt-in bridge to a pl.DataFrame (imports Polars on use)
+
+# From a database — any PEP-249 (DBAPI) connection, no connectorx/polars:
+import sqlite3
+from goldenflow.connectors.database import read_database_columns
+cols = read_database_columns(sqlite3.connect("app.db"), "SELECT * FROM customers")
+result = goldenflow.transform(cols, config=cfg)
+```
+
+`transform_df(pl.DataFrame)` remains the Polars-backend adapter (it needs a
+`pl.DataFrame`, which needs Polars). Install the optional backends with
+`pip install goldenflow[polars]` (bulk-vectorized backend + `pl.read_*` I/O) or
+`goldenflow[parquet]` (pyarrow, for Polars-free Parquet read).
+
+### `transform_df` / `transform_file`
+
 ```python
 import goldenflow
 

--- a/packages/python/goldenflow/llms.txt
+++ b/packages/python/goldenflow/llms.txt
@@ -7,7 +7,7 @@
 - Remote MCP: https://goldenflow-mcp-production.up.railway.app/mcp/ (10 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenflow)
 - A2A Server: `goldenflow agent-serve --port 8150` (6 skills)
 - CLI: `goldenflow transform`, `goldenflow map`, + 12 more commands
-- Python API: `from goldenflow import transform_file, transform_df`
+- Python API: `from goldenflow import transform, transform_df, transform_file`. `transform(data, config)` is Polars-free (native/Arrow substrate; `import goldenflow` imports no Polars) and takes a `dict[str, list]` or a `.csv`/`.parquet`/`.xlsx` path; `transform_df(pl.DataFrame)` is the optional Polars-backend adapter (`pip install goldenflow[polars]`).
 - REST API: `goldenflow serve` on port 8000
 - SQL (DuckDB): `goldenflow-duckdb` — compiled zero-Python DuckDB extension, 98 transforms as `goldenflow_<kernel>` SQL functions (release tag `goldenflow-duckdb-v*`, loads on DuckDB >= 1.3.0)
 


### PR DESCRIPTION
Rollout-docs-sweep for the Polars-eviction arc — documents the Polars-free `transform()` surface everywhere. All **additions** (nothing removed; the 2.0 flip hasn't landed).

- **CHANGELOG** `[Unreleased]`: Polars-free `transform()`, CSV/Parquet/Excel/DB readers, zero-config, `[polars]`/`[parquet]` extras, `native>=0.26.0`.
- **README** + **docs-site/goldenflow/overview.mdx**: new *Polars-free `transform()`* section (dict / .csv / .parquet / .xlsx / DBAPI; `transform_df` is the Polars-backend adapter).
- **llms.txt**: Python API line now lists `transform` (Polars-free) alongside `transform_df`.
- **CLAUDE.md**: durable eviction gotchas (coverage mechanism, CSV-owns-inference, the `clamp` int-bounds pure-Python latent bug, grep `domains/` for clobbers).
- **context-network/meta/updates.md**: dated entry (extends ADR 0034).

Doc consistency gate green (the lone orphan FAIL is the documented Windows backslash-slug false-positive — 0 orphans on Linux).

🤖 Generated with [Claude Code](https://claude.com/claude-code)