### PR TITLE
fix(goldenflow): clamp with integer bounds no longer silently no-ops (pure-Python)

### DIFF
--- a/packages/python/goldenflow/goldenflow/transforms/numeric.py
+++ b/packages/python/goldenflow/goldenflow/transforms/numeric.py
@@ -319,6 +319,11 @@ def clamp(series: pl.Series, min_val: float = 0.0, max_val: float = 1.0) -> pl.S
     pure-Python fallback below is the value-exact reference this kernel
     replicates.
     """
+    # Coerce bounds to float: `clamp:0:100` parses to INT bounds, and the pure-Python
+    # path returns min_val/max_val for out-of-range cells -> an int into a Float64
+    # `map_elements` raises SchemaError (Int64 into Float64) -> clamp silently no-ops.
+    # The native path already takes f64 bounds, so this only fixes the fallback.
+    min_val, max_val = float(min_val), float(max_val)
     native = clamp_native(min_val, max_val)
     if native is not None:
         return native(series)

--- a/packages/python/goldenflow/tests/transforms/test_numeric.py
+++ b/packages/python/goldenflow/tests/transforms/test_numeric.py
@@ -50,6 +50,24 @@ def test_clamp():
     assert result.to_list() == [0.0, 0.0, 50.0, 100.0]
 
 
+def test_clamp_integer_bounds():
+    """INT bounds (e.g. from ``clamp:0:100`` param parsing) must not break the
+    pure-Python fallback -- it returned an int for out-of-range cells, tripping a
+    Float64 map_elements SchemaError -> clamp silently no-op'd (masked by native)."""
+    import os
+
+    prev = os.environ.get("GOLDENFLOW_NATIVE")
+    os.environ["GOLDENFLOW_NATIVE"] = "0"  # force the pure-Python path
+    try:
+        s = pl.Series("v", [-5.0, 0.0, 50.0, 150.0, None])
+        assert clamp(s, min_val=0, max_val=100).to_list() == [0.0, 0.0, 50.0, 100.0, None]
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENFLOW_NATIVE", None)
+        else:
+            os.environ["GOLDENFLOW_NATIVE"] = prev
+
+
 def test_to_integer():
     result = _apply_expr(
         to_integer, "v", ["42", "3.7", "100", "abc", None],


### PR DESCRIPTION
`clamp:0:100` parses to INT bounds; the pure-Python fallback returned `min_val`/`max_val` (ints) for out-of-range cells, tripping a Float64 `map_elements` `SchemaError` (Int64 into Float64) → the transform caught the exception and returned the frame **unchanged** (silent no-op). Masked whenever the native kernel is present (it takes f64 bounds); only bit a no-native install. Fix: coerce the bounds to `float` at the top (native path unaffected). Regression test forces `GOLDENFLOW_NATIVE=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)