### PR TITLE
feat(goldenflow)!: 2.0 — Polars is no longer a base dependency

### DIFF
--- a/packages/python/goldenflow/CHANGELOG.md
+++ b/packages/python/goldenflow/CHANGELOG.md
@@ -1,12 +1,33 @@
 # Changelog
 
-## [Unreleased]
+## 2.0.0 (2026-07-08)
 
-Polars-eviction Phase 4: the columnar path is now the **default** for the public
-`transform()` entry point (no `GOLDENFLOW_ENGINE=columnar` opt-in needed), and it runs
-**Polars-free** end to end. `import goldenflow` no longer imports Polars; every one of the
-113 transforms runs on the native/Arrow substrate, byte-identical to the Polars engine.
-The remaining work is the 2.0 major that moves `polars` out of the base dependencies.
+**BREAKING — Polars is no longer a base dependency.** `pip install goldenflow` no longer
+pulls Polars (dropping ~185 MB installed); it now runs **Polars-free by default** on
+`goldenflow-native` (the ~5 MB abi3 kernel, now a base dependency). Every one of the 113
+transforms, all file/DB readers, and zero-config run without Polars, byte-identical to the
+Polars engine. Polars becomes an **optional bulk-vectorized backend** — `pip install
+goldenflow[polars]`.
+
+### Migration
+
+- **If you use `transform_df(pl.DataFrame)`, `read_file`, `write_file`, or otherwise pass
+  Polars objects:** `pip install goldenflow[polars]`. You already have Polars installed to
+  construct a `pl.DataFrame`, so in practice this is only a dependency-declaration change.
+- **New code should prefer `goldenflow.transform(data, config=...)`** — the Polars-free
+  primary. It takes a `dict[str, list]` or a `.csv` / `.parquet` / `.xlsx` path and returns
+  a `ColumnarResult` (`.columns` + `.manifest`, with an opt-in `.to_polars()` bridge).
+- **`goldenflow-native` is now installed by default** (was the `[native]` extra). A bare
+  install works out of the box, Polars-free. The `[native]` extra now only adds `pyarrow`
+  (the zero-copy Series bridge for the Polars fused-numeric fast path); it still resolves
+  for back-compat.
+- **Parquet read** needs `goldenflow[parquet]` (pyarrow); **Excel** needs
+  `goldenflow[excel]` (openpyxl); **CSV/DB** read Polars-free out of the box.
+- **CSV zero-config** (`transform("<x>.csv", config=None)`) now profiles columns *as text*
+  (so `"01234"` stays a zip, not `1234`) — an intentional, data-cleaning-correct divergence
+  from `pl.read_csv`'s numeric coercion. Cleaned text values are unchanged.
+
+### Details
 
 - **Polars-free public `transform()`.** `goldenflow.transform(data, config=...)` accepts a
   `dict[str, list]` OR a file path and returns a `ColumnarResult` (`.columns` + `.manifest`,

--- a/packages/python/goldenflow/goldenflow/__init__.py
+++ b/packages/python/goldenflow/goldenflow/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.17.0"
+__version__ = "2.0.0"
 
 import goldenflow.notebook  # noqa: F401 — register Jupyter _repr_html_ methods
 import goldenflow.transforms.address  # noqa: F401

--- a/packages/python/goldenflow/pyproject.toml
+++ b/packages/python/goldenflow/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldenflow"
-version = "1.17.0"
+version = "2.0.0"
 description = "Data transformation toolkit — standardize, reshape, and normalize messy data before it hits your pipeline."
 readme = "README.md"
 license = "MIT"
@@ -20,17 +20,15 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Typing :: Typed",
 ]
-# Phase 4f (Polars eviction) is STAGED, not yet flipped. `polars` is still a base
-# dependency here; the 2.0 major will MOVE it to the `[polars]` extra below so a
-# default `pip install goldenflow` drops the ~185 MB installed polars footprint and
-# the covered config path runs on the native in-memory core alone. The `[polars]`
-# extra already exists so `goldenflow[polars]` resolves today (currently a no-op —
-# polars is in base — but forward-compatible), and the `goldenflow_nopolars` CI lane
-# proves `import goldenflow` + covered transforms work with polars uninstalled. When
-# the 2.0 flip lands: delete `polars>=1.0` from this list (it stays in `[polars]`),
-# add `polars` to `all`, bump to 2.0.0. See docs/design for the measured shape.
+# 2.0 (Polars eviction FLIPPED): `polars` is NO LONGER a base dependency -- it moved to
+# the `[polars]` extra (the optional bulk-vectorized backend + `transform_df` + `pl.read_*`
+# I/O). A default `pip install goldenflow` drops the ~185 MB installed polars footprint and
+# runs the covered path on `goldenflow-native` (the ~5 MB abi3 kernel, now a BASE dep so the
+# Polars-free columnar path works out of the box -- it needs no pyarrow). The
+# `goldenflow_nopolars` CI lane proves `import goldenflow` + transforms work with polars
+# uninstalled. See docs/design/2026-07-07-phase4-polars-optional-scoping.md.
 dependencies = [
-    "polars>=1.0",
+    "goldenflow-native>=0.26.0",
     "pydantic>=2.7",
     "typer>=0.12",
     "rich>=13.0",
@@ -47,9 +45,9 @@ dependencies = [
 [project.optional-dependencies]
 dev = ["pytest>=8.0", "pytest-cov>=5.0", "ruff>=0.6", "httpx>=0.27", "python-multipart>=0.0.20"]
 check = ["goldencheck>=1.0"]
-# Phase 4f: the Polars engine (transform_df, zero-config profiling, non-covered
-# transforms, Excel/Parquet/DB connectors). Currently redundant with the base dep;
-# becomes load-bearing when 2.0 drops polars from the base `dependencies`.
+# The optional Polars backend: `transform_df(pl.DataFrame)`, zero-config profiling of a
+# pl.DataFrame, the bulk-vectorized fast path, and Polars `read_*` I/O. NOT needed for the
+# default Polars-free path (native + the stdlib/pyarrow/openpyxl readers cover it).
 polars = ["polars>=1.0"]
 excel = ["openpyxl>=3.1"]
 # Polars-free Parquet read (pyarrow only, no polars) for transform("<path>.parquet").
@@ -60,11 +58,11 @@ llm = ["anthropic>=0.30", "openai>=1.30"]
 s3 = ["boto3>=1.34"]
 gcs = ["google-cloud-storage>=2.14"]
 agent = ["aiohttp>=3.14.0"]
-# Optional Rust/PyO3 acceleration runtime (mirrors goldenmatch[native]). Pulls
-# pyarrow for the zero-copy Series<->kernel bridge. Off by default at runtime --
-# see goldenflow.core._native_loader (GOLDENFLOW_NATIVE / _GATED_ON).
-native = ["goldenflow-native>=0.26.0", "pyarrow>=10"]
-all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs]"]
+# `goldenflow-native` is now a BASE dep (the default Polars-free kernel). This extra
+# additionally pulls pyarrow for the zero-copy Series<->kernel bridge used by the Polars
+# fused-numeric fast path; kept for back-compat (`goldenflow[native]` still resolves).
+native = ["pyarrow>=10"]
+all = ["goldenflow[check,excel,db,mcp,agent,s3,gcs,polars,parquet,native]"]
 
 [project.scripts]
 goldenflow = "goldenflow.cli.main:app"

--- a/packages/python/goldenflow/server.json
+++ b/packages/python/goldenflow/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenFlow",
   "description": "Standardize, reshape, and normalize messy data — CSV, Excel, Parquet, S3, databases.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenflow/",
-  "version": "1.17.0",
+  "version": "2.0.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenflow",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenflow",
-      "version": "1.17.0",
+      "version": "2.0.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
**BREAKING.** The Polars eviction, flipped. `pip install goldenflow` no longer pulls Polars (drops ~185 MB installed) — it runs **Polars-free by default** on `goldenflow-native` (the ~5 MB abi3 kernel, now a **base dependency** so a bare install works out of the box, pyarrow-free). Polars moves to the `[polars]` extra (optional bulk-vectorized backend + `transform_df` + `pl.read_*` I/O).

All 113 transforms + CSV/Parquet/Excel/DB read + dict/file zero-config run without Polars, byte-identical to the Polars engine — the whole Phase-4 arc (#1552–#1583).

### Changes
- **pyproject**: drop `polars>=1.0` from base `dependencies`, add `goldenflow-native>=0.26.0`. `[native]` extra now only adds pyarrow (back-compat). `[all]` includes polars/parquet/native.
- **version 1.17.0 → 2.0.0** (pyproject + `__init__.__version__` + server.json ×2, lockstep — version_consistency gate green).
- **CHANGELOG 2.0.0** with the BREAKING migration note.

### Migration
Anyone using `transform_df(pl.DataFrame)` / `read_file` / Polars objects: `pip install goldenflow[polars]` (you already have Polars to build a `pl.DataFrame`, so it's a declaration change). New code should prefer the Polars-free `goldenflow.transform(data, config)`.

### Default-install contract (chosen)
Native in base deps (per decision) so a bare install functions out of the box Polars-free. Trade-off: needs a prebuilt abi3 wheel (available for linux x86_64/aarch64, windows x64, macos x86_64/aarch64).

### Notes
No `uv.lock` change needed (goldenflow-native is already a workspace member; CI syncs non-locked). Full engine+transforms sweep green (1947). The `goldenflow_nopolars` CI lane (staged in #1568) proves the without-polars path.

**Follow-up (post-merge, sequenced):** tag `goldenflow-v2.0.0` → PyPI, THEN golden-suite lockstep (bump goldenflow floor `>=2.0.0` + cut golden-suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)