### PR TITLE
chore(golden-suite): 0.1.9 — bump goldenflow floor to >=2.0.0

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.9] - 2026-07-08
+
+### Changed
+- Bumped the goldenflow floor to **`goldenflow>=2.0.0`** (was `>=1.17.0`) and the
+  goldenflow-native floor to **`goldenflow-native>=0.26.0`** (was `>=0.24.0`), per the
+  lockstep policy. goldenflow 2.0.0 completes the Polars eviction: **Polars is no longer a
+  base dependency** — `pip install goldenflow` runs Polars-free by default on
+  goldenflow-native (now a base dep of goldenflow), and Polars moved to the optional
+  `goldenflow[polars]` backend. All 113 transforms + CSV/Parquet/Excel/DB read + zero-config
+  run without Polars. goldenflow-native 0.26.0 carries the full columnar surface
+  (`format_f64` + the numeric-input `AsFloat` parser).
+
 ## [0.1.8] - 2026-07-07
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.8"
+version = "0.1.9"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,14 +39,14 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
     "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
-    "goldenflow>=1.17.0",                # transform / standardize / normalize (>=1.17.0 = Polars-eviction columnar engine: CSV + in-memory, numeric + splits)
+    "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
     "goldenmatch-native>=0.1.12",       # >=0.1.12 carries perceptual + the current kernel surface
     "goldencheck-native>=0.1",
-    "goldenflow-native>=0.24.0",        # >=0.24.0 carries the Polars-eviction columnar symbols (transform_csv, numeric/split columnar)
+    "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
     "goldenanalysis-native>=0.1",
     # --- CLI (doctor / optimize) ---
     "typer>=0.12",


### PR DESCRIPTION
Lockstep with the **goldenflow 2.0.0** release (live on PyPI: https://pypi.org/project/goldenflow/2.0.0/). goldenflow `>=1.17.0 -> >=2.0.0`, goldenflow-native `>=0.24.0 -> >=0.26.0`. goldenflow 2.0.0 completes the Polars eviction (Polars-free by default; Polars -> `[polars]` extra; native is a base dep). Version `0.1.8 -> 0.1.9`. Deps-only meta-package; floor satisfiable in-workspace and on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)