### PR TITLE
feat(goldenpipe): repair-plan Phase 2 — gated active application

### DIFF
--- a/docs/superpowers/plans/2026-07-08-goldenpipe-repair-plan-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-repair-plan-phase2.md
@@ -1,0 +1,656 @@
+# GoldenPipe Repair-Plan Phase 2 (Gated Active Application) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When `apply_repairs` is on, make the `goldenflow.transform` adapter apply the Phase-1 repair plan's *fixer* transforms to the flagged columns; byte-identical when off.
+
+**Architecture:** Pure host-side (no `goldenpipe-core` kernel change). A curated FIXERS allowlist + a `repair_transform_specs` converter turn the `repair_plan` artifact into `GoldenFlowConfig.transforms`; the Flow adapter merges them surgically and runs. Cross-surface: Python (`repair_host.py` + `flow.py`) and TS (new `repairHost.ts` producer + `check.ts` wiring + `flow.ts` consumer — Phase 1 wired the producer only in Python).
+
+**Tech Stack:** Python (polars/goldenflow), TypeScript (goldenflow-js), existing goldenpipe adapters.
+
+---
+
+## Box / environment constraints (read before executing)
+
+- **Python is box-runnable** (this is where real red→green TDD happens). TS **cannot** run on the box (tsc/vitest OOM) → write-against-spec + eyeball + CI-verify.
+- Python invocation (native Windows, `;` PYTHONPATH separator — note **goldenflow is added** for Flow tests):
+  ```bash
+  INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="packages/python/goldenpipe;packages/python/goldencheck;packages/python/infermap;packages/python/goldencheck-types;packages/python/goldenflow"
+  export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+  ```
+  Run pytest: `"$INTERP" -m pytest <path> -v`. `cd "D:/show_case/gg-local-llm"` each Bash call (cwd resets).
+- `ruff check` every touched Python file before commit.
+- **TS strict-mode traps** (Phase 1 CI bit us here): `noUncheckedIndexedAccess` types `arr[i]` as `T | undefined`; a typed interface object missing a member fails tsc. Phase 2 touches `flow.ts`/`check.ts`/`repairHost.ts` (NOT the wasm backend), so lower risk — but guard indexed access and don't add members to shared interfaces.
+- Spec: `docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md`.
+- @superpowers:test-driven-development for each Python task.
+
+## Canonical shared facts
+
+**FIXERS allowlist (identical Python/TS, host policy):**
+`fix_mojibake, normalize_unicode, date_parse, email_normalize, email_canonical, name_proper, phone_national, zip_normalize`.
+Everything else in a `suggested_transforms` list (all `*_validate`) is an **assertion** → skipped (returning bool would overwrite the column).
+
+**repair_plan artifact shape:** `{"repairs": [{"column","check","type_tag","suggested_transforms":[str],"reason"}]}`.
+
+**TransformSpec:** `{"column": str, "ops": [str]}` (both surfaces). `GoldenFlowConfig.transforms: [TransformSpec]`.
+
+**transform_df is either/or:** non-empty `transforms` → explicit mode (auto-detect OFF); empty → auto-detect.
+
+**Host config asymmetry:**
+- Python `flow.py`: `_transform(ctx.df, **stage_cfg)`; base `GoldenFlowConfig` lives at `stage_config["config"]`; applying path calls `transform_df(df, config=merged)` directly.
+- TS `flow.ts`: `new TransformEngine(stageConfig)`; base config IS `stageConfig`; transforms at `stageConfig.transforms`.
+
+---
+
+## File structure
+
+- Modify `packages/python/goldenpipe/goldenpipe/repair_host.py` — add `FIXERS`, `repair_transform_specs`, `merge_transforms`.
+- Modify `packages/python/goldenpipe/goldenpipe/adapters/flow.py` — gate + surgical merge + apply.
+- Test `packages/python/goldenpipe/tests/test_repair_apply.py` (new) — converter + merge (box).
+- Test `packages/python/goldenpipe/tests/test_flow_apply.py` (new) — flow adapter gate/merge (box, monkeypatch `_transform`).
+- Create `packages/typescript/goldenpipe/src/core/repairHost.ts` — producer glue + FIXERS + `repairTransformSpecs` + `mergeTransforms`.
+- Modify `packages/typescript/goldenpipe/src/core/adapters/check.ts` — wire `attachRepairPlan`.
+- Modify `packages/typescript/goldenpipe/src/core/adapters/flow.ts` — gate + merge + apply.
+- Test `packages/typescript/goldenpipe/tests/unit/repair-apply.test.ts` (new) — CI-only.
+
+---
+
+## Task 1: Python converter — FIXERS + repair_transform_specs + merge_transforms (box TDD)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/repair_host.py`
+- Test: `packages/python/goldenpipe/tests/test_repair_apply.py`
+
+- [ ] **Step 1: Write the failing test** `tests/test_repair_apply.py`:
+
+```python
+from goldenpipe.repair_host import FIXERS, repair_transform_specs, merge_transforms
+
+
+def _plan(*items):
+    return {"repairs": list(items)}
+
+
+def test_fixer_only_grouped_and_deduped():
+    plan = _plan(
+        {"column": "email", "check": "format_detection", "suggested_transforms": ["email_normalize"], "reason": "x"},
+        {"column": "email", "check": "pattern_consistency", "suggested_transforms": ["email_canonical", "email_normalize"], "reason": "y"},
+    )
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == [{"column": "email", "ops": ["email_normalize", "email_canonical"]}]  # dedup, order preserved
+    assert skipped == []
+
+
+def test_assertion_ops_are_skipped_not_applied():
+    plan = _plan(
+        {"column": "iban", "check": "pattern_consistency", "suggested_transforms": ["iban_validate"], "reason": "bad"},
+        {"column": "signup", "check": "future_dated", "suggested_transforms": ["date_validate"], "reason": "future"},
+    )
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == []
+    assert {"column": "iban", "op": "iban_validate"} in skipped
+    assert {"column": "signup", "op": "date_validate"} in skipped
+
+
+def test_mixed_item_keeps_fixer_skips_assertion():
+    # a column flagged for both a fixer and an assertion
+    plan = _plan({"column": "dob", "check": "format_detection", "suggested_transforms": ["date_parse", "date_validate"], "reason": "z"})
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == [{"column": "dob", "ops": ["date_parse"]}]
+    assert skipped == [{"column": "dob", "op": "date_validate"}]
+
+
+def test_fixers_membership():
+    assert "email_normalize" in FIXERS and "iban_validate" not in FIXERS
+
+
+def test_merge_user_first_then_repair_deduped():
+    user = [{"column": "email", "ops": ["email_lowercase"]}, {"column": "name", "ops": ["strip"]}]
+    repair = [{"column": "email", "ops": ["email_normalize", "email_lowercase"]}, {"column": "zip", "ops": ["zip_normalize"]}]
+    merged = merge_transforms(user, repair)
+    assert merged == [
+        {"column": "email", "ops": ["email_lowercase", "email_normalize"]},  # user-first, dup dropped
+        {"column": "name", "ops": ["strip"]},
+        {"column": "zip", "ops": ["zip_normalize"]},
+    ]
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `cd "D:/show_case/gg-local-llm" && "$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_apply.py -v`
+Expected: FAIL — `ImportError: cannot import name 'FIXERS'`.
+
+- [ ] **Step 3: Append to `repair_host.py`** (do NOT touch the existing Phase-1 functions):
+
+```python
+# ── Phase 2: active application (fixer allowlist + config conversion) ─────
+# FIXERS are transforms that CLEAN in place. Everything else the kernel can
+# suggest is a *_validate ASSERTION that returns a boolean series — applying it
+# as a column op would overwrite the column with True/False, so it is skipped.
+# Host policy, kept identical in repairHost.ts (NOT the parity-gated kernel).
+FIXERS = frozenset({
+    "fix_mojibake", "normalize_unicode", "date_parse", "email_normalize",
+    "email_canonical", "name_proper", "phone_national", "zip_normalize",
+})
+
+
+def repair_transform_specs(plan: dict) -> tuple[list[dict], list[dict]]:
+    """repair_plan -> (specs, skipped). specs = [{column, ops}] fixer ops grouped
+    per column, deduped, order-preserving. skipped = [{column, op}] assertion ops."""
+    by_col: dict[str, list[str]] = {}
+    order: list[str] = []
+    skipped: list[dict] = []
+    for item in plan.get("repairs", []):
+        col = item["column"]
+        for op in item.get("suggested_transforms", []):
+            if op in FIXERS:
+                if col not in by_col:
+                    by_col[col] = []
+                    order.append(col)
+                if op not in by_col[col]:
+                    by_col[col].append(op)
+            else:
+                skipped.append({"column": col, "op": op})
+    specs = [{"column": c, "ops": by_col[c]} for c in order]
+    return specs, skipped
+
+
+def merge_transforms(user: list[dict], repair: list[dict]) -> list[dict]:
+    """Per-column merge, user ops first then repair ops, dedup exact dupes,
+    preserving first-seen column + op order."""
+    by_col: dict[str, list[str]] = {}
+    order: list[str] = []
+    for spec in list(user) + list(repair):
+        col = spec["column"]
+        if col not in by_col:
+            by_col[col] = []
+            order.append(col)
+        by_col[col].extend(spec.get("ops") or [])
+    result = []
+    for col in order:
+        seen: set[str] = set()
+        ops: list[str] = []
+        for op in by_col[col]:
+            if op not in seen:
+                seen.add(op)
+                ops.append(op)
+        result.append({"column": col, "ops": ops})
+    return result
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `cd "D:/show_case/gg-local-llm" && "$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_apply.py -v`
+Expected: PASS (5).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/repair_host.py packages/python/goldenpipe/tests/test_repair_apply.py
+cd "D:/show_case/gg-local-llm" && git add packages/python/goldenpipe/goldenpipe/repair_host.py packages/python/goldenpipe/tests/test_repair_apply.py && git commit -m "feat(goldenpipe): repair-plan fixer allowlist + config conversion (Phase 2)"
+```
+
+---
+
+## Task 2: Python flow.py — gated surgical application (box TDD)
+
+**Files:**
+- Modify: `packages/python/goldenpipe/goldenpipe/adapters/flow.py`
+- Test: `packages/python/goldenpipe/tests/test_flow_apply.py`
+
+Test strategy: **monkeypatch `goldenpipe.adapters.flow._transform`** with a spy that records the `config=` it receives and returns a minimal result object. This tests Phase 2's gate/merge/pop logic deterministically without depending on goldenflow's actual transform execution (Task 1 + goldenflow's own suite cover the transforms).
+
+- [ ] **Step 1: Write the failing test** `tests/test_flow_apply.py`:
+
+```python
+import types
+import pytest
+from goldenpipe.models.context import PipeContext, StageStatus
+
+
+class _SpyResult:
+    def __init__(self):
+        self.df = "DF_OUT"
+        self.manifest = types.SimpleNamespace(records=[])
+
+
+def _install_spy(monkeypatch):
+    calls = {}
+    def spy(df, config=None, **kw):
+        calls["df"] = df
+        calls["config"] = config
+        calls["kw"] = kw
+        return _SpyResult()
+    import goldenpipe.adapters.flow as flowmod
+    monkeypatch.setattr(flowmod, "_transform", spy)
+    monkeypatch.setattr(flowmod, "HAS_FLOW", True)
+    return calls
+
+
+def _ctx(stage_config=None, repair_plan=None):
+    ctx = PipeContext(df="DF_IN")
+    ctx.stage_config = stage_config or {}
+    if repair_plan is not None:
+        ctx.artifacts["repair_plan"] = repair_plan
+    return ctx
+
+
+def _run(ctx):
+    from goldenpipe.adapters.flow import TransformStage
+    return TransformStage().run(ctx)
+
+
+def test_gate_off_no_config_calls_autodetect(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    _run(_ctx())
+    # existing behavior: transform_df(df) with no config kwarg
+    assert calls["config"] is None and calls["kw"] == {}
+
+
+def test_gate_off_with_user_config_unchanged(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    _run(_ctx(stage_config={"config": {"transforms": [{"column": "a", "ops": ["strip"]}]}}))
+    # gate absent -> old splat path: transform_df(df, config={...})
+    assert calls["config"] == {"transforms": [{"column": "a", "ops": ["strip"]}]}
+
+
+def test_gate_on_injects_fixer_specs(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "email", "check": "format_detection", "suggested_transforms": ["email_normalize"], "reason": "x"}]}
+    _run(_ctx(stage_config={"apply_repairs": True}, repair_plan=plan))
+    assert calls["config"] == {"transforms": [{"column": "email", "ops": ["email_normalize"]}]}
+
+
+def test_gate_on_all_assertion_falls_through_to_autodetect(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "iban", "check": "pattern_consistency", "suggested_transforms": ["iban_validate"], "reason": "b"}]}
+    ctx = _ctx(stage_config={"apply_repairs": True}, repair_plan=plan)
+    _run(ctx)
+    # no fixer specs, no user transforms -> do NOT flip to explicit; auto-detect
+    assert calls["config"] is None
+    # the assertion skip is recorded
+    assert "iban_validate" in ctx.reasoning.get("repair_skipped", "")
+
+
+def test_gate_on_merges_user_and_repair(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "email", "check": "pattern_consistency", "suggested_transforms": ["email_canonical"], "reason": "y"}]}
+    sc = {"apply_repairs": True, "config": {"transforms": [{"column": "email", "ops": ["email_lowercase"]}]}}
+    _run(_ctx(stage_config=sc, repair_plan=plan))
+    assert calls["config"] == {"transforms": [{"column": "email", "ops": ["email_lowercase", "email_canonical"]}]}
+
+
+def test_gate_pop_does_not_mutate_ctx_stage_config(monkeypatch):
+    _install_spy(monkeypatch)
+    sc = {"apply_repairs": True}
+    ctx = _ctx(stage_config=sc, repair_plan={"repairs": []})
+    _run(ctx)
+    assert sc == {"apply_repairs": True}  # original dict untouched (copied before pop)
+```
+
+- [ ] **Step 2: Run to verify FAIL**
+
+Run: `cd "D:/show_case/gg-local-llm" && "$INTERP" -m pytest packages/python/goldenpipe/tests/test_flow_apply.py -v`
+Expected: FAIL (current flow.py splats `apply_repairs` → the spy gets `apply_repairs` in kw / or wrong config).
+
+- [ ] **Step 3: Rewrite `flow.py` `run()`** (keep imports, `validate`, manifest/enrich tail unchanged). Replace the top of `run`:
+
+```python
+    def run(self, ctx: PipeContext) -> StageResult:
+        cfg = dict(ctx.stage_config or {})           # COPY: ctx.stage_config IS StageSpec.config
+        apply = cfg.pop("apply_repairs", False)       # pop even when False (never leak to transform_df)
+
+        if apply:
+            result = self._run_with_repairs(ctx, cfg)
+        elif cfg:
+            result = _transform(ctx.df, **cfg)
+        else:
+            result = _transform(ctx.df)
+
+        if hasattr(result, "df"):
+            ctx.df = result.df
+        if hasattr(result, "manifest"):
+            ctx.artifacts["manifest"] = result.manifest
+            if "column_contexts" in ctx.artifacts:
+                try:
+                    from goldenpipe.models.column_context import enrich_contexts_from_flow
+                    enrich_contexts_from_flow(ctx.artifacts["column_contexts"], result.manifest)
+                except Exception:
+                    logger.exception("Failed to enrich column contexts from flow manifest")
+
+        return StageResult(status=StageStatus.SUCCESS)
+
+    def _run_with_repairs(self, ctx: PipeContext, cfg: dict):
+        """apply_repairs is on: merge the repair plan's fixer transforms into the
+        base GoldenFlowConfig and run explicit mode. Falls through to the normal
+        path when there is nothing to apply (keeps auto-detect / byte-identity)."""
+        from goldenpipe.repair_host import repair_transform_specs, merge_transforms
+
+        plan = ctx.artifacts.get("repair_plan")
+        specs, skipped = repair_transform_specs(plan) if plan else ([], [])
+        base = dict(cfg.get("config") or {})
+        user_transforms = list(base.get("transforms") or [])
+
+        if not specs and not user_transforms:
+            if skipped:
+                ctx.reasoning["repair_skipped"] = "; ".join(f"{s['column']}:{s['op']}" for s in skipped)
+            # nothing to inject -> behave exactly like the gate-off path
+            return _transform(ctx.df, **cfg) if cfg else _transform(ctx.df)
+
+        base["transforms"] = merge_transforms(user_transforms, specs)
+        if skipped:
+            ctx.reasoning["repair_skipped"] = "; ".join(f"{s['column']}:{s['op']}" for s in skipped)
+        logger.info("Applying %d repair transform spec(s); skipped %d assertion(s)", len(specs), len(skipped))
+        return _transform(ctx.df, config=base)
+```
+
+- [ ] **Step 4: Run to verify PASS**
+
+Run: `cd "D:/show_case/gg-local-llm" && "$INTERP" -m pytest packages/python/goldenpipe/tests/test_flow_apply.py packages/python/goldenpipe/tests/test_adapters.py -v`
+Expected: new file PASS (6); `test_adapters.py` still PASS (no regression).
+
+- [ ] **Step 5: ruff + commit**
+
+```bash
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/adapters/flow.py packages/python/goldenpipe/tests/test_flow_apply.py
+cd "D:/show_case/gg-local-llm" && git add packages/python/goldenpipe/goldenpipe/adapters/flow.py packages/python/goldenpipe/tests/test_flow_apply.py && git commit -m "feat(goldenpipe): gated active repair application in flow adapter (Phase 2)"
+```
+
+---
+
+## Task 3: TS producer — repairHost.ts (write + CI-verify)
+
+**Files:**
+- Create: `packages/typescript/goldenpipe/src/core/repairHost.ts`
+
+Mirror `repair_host.py`, reusing the existing `repair.ts` kernel. **Do not reimplement `buildRepairPlan`.** TS `ColumnContext.inferredType` is already a lowercase string (no `.value` dance). TS df is `Row[]` (array of objects), so sampling reads `row[colName]`.
+
+- [ ] **Step 1: Write `repairHost.ts`**
+
+```ts
+/**
+ * repairHost.ts — TS producer glue for the repair plan (mirror of
+ * goldenpipe/repair_host.py). Samples column values from the row array, builds
+ * ColumnInputs, calls the pure repair.ts kernel, attaches the advisory artifact.
+ * Also holds the Phase-2 FIXERS allowlist + config conversion (host policy,
+ * identical to repair_host.py — NOT the parity-gated kernel).
+ */
+import { buildRepairPlan } from "./repair.js";
+import type { ColumnContext } from "./columnContext.js";
+import type { PipeContext, Row } from "./models.js";
+import type { TransformSpec } from "goldenflow/core";
+
+const SAMPLE_LIMIT = 20;
+
+export function sampleColumn(rows: Row[], col: string, limit = SAMPLE_LIMIT): string[] {
+  const out: string[] = [];
+  for (const row of rows) {
+    const v = (row as Record<string, unknown>)[col];
+    if (v === null || v === undefined) continue;
+    const s = String(v);
+    if (s.trim() === "") continue;
+    out.push(s);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+export function buildColumnInputs(contexts: ColumnContext[], rows: Row[]): Array<{ name: string; coarse_type: string; samples: string[] }> {
+  const names = new Set<string>(rows.length > 0 ? Object.keys(rows[0] as object) : []);
+  const cols: Array<{ name: string; coarse_type: string; samples: string[] }> = [];
+  for (const ctx of contexts) {
+    if (!names.has(ctx.name)) continue;
+    cols.push({ name: ctx.name, coarse_type: ctx.inferredType, samples: sampleColumn(rows, ctx.name) });
+  }
+  return cols;
+}
+
+interface RepairItem {
+  column: string;
+  check: string;
+  type_tag: string;
+  suggested_transforms: string[];
+  reason: string;
+}
+
+export function attachRepairPlan(
+  ctx: PipeContext,
+  findings: unknown[],
+  contexts: ColumnContext[],
+  rows: Row[],
+): { repairs: RepairItem[] } {
+  const columns = buildColumnInputs(contexts, rows);
+  const plan = JSON.parse(buildRepairPlanJsonLocal(findings, columns)) as { repairs: RepairItem[] };
+  ctx.artifacts["repair_plan"] = plan;
+  const lines = plan.repairs.map(
+    (item) => `repair: ${item.column} (${item.check}) -> ${item.suggested_transforms.join(",")} [${item.reason}]`,
+  );
+  if (lines.length > 0) ctx.reasoning["repair_plan"] = lines.join("\n");
+  return plan;
+}
+
+// buildRepairPlan takes (findings, columns) and returns the object directly.
+function buildRepairPlanJsonLocal(findings: unknown[], columns: unknown[]): string {
+  return JSON.stringify(buildRepairPlan(findings as never, columns as never));
+}
+
+// ── FIXERS allowlist + conversion (identical to repair_host.py) ──────────
+export const FIXERS: ReadonlySet<string> = new Set([
+  "fix_mojibake", "normalize_unicode", "date_parse", "email_normalize",
+  "email_canonical", "name_proper", "phone_national", "zip_normalize",
+]);
+
+export function repairTransformSpecs(plan: { repairs: RepairItem[] } | undefined): {
+  specs: TransformSpec[];
+  skipped: Array<{ column: string; op: string }>;
+} {
+  const byCol = new Map<string, string[]>();
+  const order: string[] = [];
+  const skipped: Array<{ column: string; op: string }> = [];
+  for (const item of plan?.repairs ?? []) {
+    const col = item.column;
+    for (const op of item.suggested_transforms ?? []) {
+      if (FIXERS.has(op)) {
+        let ops = byCol.get(col);
+        if (ops === undefined) { ops = []; byCol.set(col, ops); order.push(col); }
+        if (!ops.includes(op)) ops.push(op);
+      } else {
+        skipped.push({ column: col, op });
+      }
+    }
+  }
+  const specs: TransformSpec[] = order.map((c) => ({ column: c, ops: byCol.get(c) ?? [] }));
+  return { specs, skipped };
+}
+
+export function mergeTransforms(user: readonly TransformSpec[], repair: readonly TransformSpec[]): TransformSpec[] {
+  const byCol = new Map<string, string[]>();
+  const order: string[] = [];
+  for (const spec of [...user, ...repair]) {
+    let ops = byCol.get(spec.column);
+    if (ops === undefined) { ops = []; byCol.set(spec.column, ops); order.push(spec.column); }
+    ops.push(...spec.ops);
+  }
+  return order.map((col) => {
+    const seen = new Set<string>();
+    const ops: string[] = [];
+    for (const op of byCol.get(col) ?? []) if (!seen.has(op)) { seen.add(op); ops.push(op); }
+    return { column: col, ops };
+  });
+}
+```
+
+**Note for implementer:** check `repair.ts`'s exact export signature for `buildRepairPlan` — it takes `(findings, columns)` and returns `{repairs: [...]}`. If its param types are strict, adapt the `as never` casts to the real exported types rather than `never`. Confirm `Row` is exported from `models.js` and `TransformSpec` from `goldenflow/core` (grep the existing `flow.ts` import line — it imports `GoldenFlowConfig` from `goldenflow/core`; add `TransformSpec` there).
+
+- [ ] **Step 2: Grep-verify + commit** (no tsc on box)
+
+Verify: `buildRepairPlan` import path matches how other core files import repair (`./repair.js`); `Row`/`ColumnContext`/`PipeContext` import paths match `flow.ts`/`check.ts`; no raw `arr[i]` indexed access without a guard (the only index is `rows[0]` guarded by `rows.length > 0` — under `noUncheckedIndexedAccess` `Object.keys(rows[0] as object)` needs `rows[0]` non-undefined; guard with `rows.length > 0 ? Object.keys(rows[0] as object) : []` — already done, but confirm tsc-acceptable, else use `const first = rows[0]; ... first ? Object.keys(first) : []`).
+
+```bash
+cd "D:/show_case/gg-local-llm" && git add packages/typescript/goldenpipe/src/core/repairHost.ts && git commit -m "feat(goldenpipe): TS repair producer + fixer conversion (Phase 2)"
+```
+
+---
+
+## Task 4: TS check.ts — wire attachRepairPlan (write + CI-verify)
+
+**Files:**
+- Modify: `packages/typescript/goldenpipe/src/core/adapters/check.ts`
+
+- [ ] **Step 1: Read `check.ts`** around the `ctx.artifacts["column_contexts"] = ...` assignment (near line 83) and the final `return { status: StageStatus.SUCCESS }` (near 88).
+
+- [ ] **Step 2: Insert the attach call** immediately before the final `return`, mirroring `check.py` (advisory, non-fatal):
+
+```ts
+    // Advisory repair-plan (Phase 1 producer, TS side). Never throws.
+    try {
+      const { attachRepairPlan } = await import("../repairHost.js");
+      const rp_findings = (ctx.artifacts["findings"] as unknown[]) ?? [];
+      const rp_contexts = (ctx.artifacts["column_contexts"] as ColumnContext[]) ?? [];
+      if (ctx.df && rp_findings.length > 0 && rp_contexts.length > 0) {
+        attachRepairPlan(ctx, rp_findings, rp_contexts, ctx.df);
+      }
+    } catch {
+      /* advisory: never break the scan stage */
+    }
+```
+
+Confirm `ColumnContext` is already imported in `check.ts` (it uses `buildContextsFromCheck`); if not, add the type import. Prefer a top-of-file `import { attachRepairPlan } from "../repairHost.js";` if the file's style uses static imports (check whether `check.ts` uses dynamic `await import` elsewhere; match the file — a static import is simpler if the module graph allows it. repairHost imports repair.ts + goldenflow/core types only, no cycle with check.ts, so a static import is safe).
+
+- [ ] **Step 3: Grep-verify + commit**
+
+Verify the insertion is inside `run` after `column_contexts` is set, before `return`. Confirm no `noUncheckedIndexedAccess` issue (the `?? []` guards cover it).
+
+```bash
+cd "D:/show_case/gg-local-llm" && git add packages/typescript/goldenpipe/src/core/adapters/check.ts && git commit -m "feat(goldenpipe): attach advisory repair_plan in TS check adapter (Phase 2)"
+```
+
+---
+
+## Task 5: TS flow.ts — gated active application (write + CI-verify)
+
+**Files:**
+- Modify: `packages/typescript/goldenpipe/src/core/adapters/flow.ts`
+- Test: `packages/typescript/goldenpipe/tests/unit/repair-apply.test.ts` (new, CI-only)
+
+TS asymmetry: `stageConfig` IS the `GoldenFlowConfig`; transforms at `stageConfig.transforms` (NOT nested under `"config"`).
+
+- [ ] **Step 1: Rewrite the config-building block of `flow.ts` `run()`.** Replace:
+
+```ts
+    const stageCfg = ctx.stageConfig;
+    const config =
+      stageCfg && Object.keys(stageCfg).length > 0
+        ? (stageCfg as Partial<GoldenFlowConfig>)
+        : undefined;
+```
+
+with:
+
+```ts
+    const rawCfg: Record<string, unknown> = { ...(ctx.stageConfig ?? {}) };
+    const apply = rawCfg["apply_repairs"] === true;
+    delete rawCfg["apply_repairs"];
+
+    let config: Partial<GoldenFlowConfig> | undefined;
+    if (apply) {
+      const { repairTransformSpecs, mergeTransforms } = await import("../repairHost.js");
+      const plan = ctx.artifacts["repair_plan"] as { repairs: never[] } | undefined;
+      const { specs, skipped } = repairTransformSpecs(plan as never);
+      const userTransforms = (rawCfg["transforms"] as TransformSpec[] | undefined) ?? [];
+      if (skipped.length > 0) {
+        ctx.reasoning["repair_skipped"] = skipped.map((s) => `${s.column}:${s.op}`).join("; ");
+      }
+      if (specs.length > 0 || userTransforms.length > 0) {
+        config = { ...rawCfg, transforms: mergeTransforms(userTransforms, specs) } as Partial<GoldenFlowConfig>;
+      } else {
+        config = Object.keys(rawCfg).length > 0 ? (rawCfg as Partial<GoldenFlowConfig>) : undefined;
+      }
+    } else {
+      config = Object.keys(rawCfg).length > 0 ? (rawCfg as Partial<GoldenFlowConfig>) : undefined;
+    }
+```
+
+Add `TransformSpec` to the existing `import type { GoldenFlowConfig } from "goldenflow/core";` line → `import type { GoldenFlowConfig, TransformSpec } from "goldenflow/core";`. The rest of `run()` (engine construction, `ctx.df = ...`, enrich) stays unchanged.
+
+- [ ] **Step 2: Write the CI-only test** `tests/unit/repair-apply.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { repairTransformSpecs, mergeTransforms, FIXERS } from "../../src/core/repairHost.js";
+
+describe("repairTransformSpecs", () => {
+  it("keeps fixers grouped+deduped, skips assertions", () => {
+    const plan = { repairs: [
+      { column: "email", check: "format_detection", type_tag: "email", suggested_transforms: ["email_normalize"], reason: "x" },
+      { column: "iban", check: "pattern_consistency", type_tag: "iban", suggested_transforms: ["iban_validate"], reason: "b" },
+    ] };
+    const { specs, skipped } = repairTransformSpecs(plan as never);
+    expect(specs).toEqual([{ column: "email", ops: ["email_normalize"] }]);
+    expect(skipped).toEqual([{ column: "iban", op: "iban_validate" }]);
+  });
+  it("FIXERS excludes validators", () => {
+    expect(FIXERS.has("email_normalize")).toBe(true);
+    expect(FIXERS.has("iban_validate")).toBe(false);
+  });
+  it("merges user-first then repair, deduped", () => {
+    const merged = mergeTransforms(
+      [{ column: "email", ops: ["email_lowercase"] }],
+      [{ column: "email", ops: ["email_normalize", "email_lowercase"] }],
+    );
+    expect(merged).toEqual([{ column: "email", ops: ["email_lowercase", "email_normalize"] }]);
+  });
+});
+```
+
+- [ ] **Step 3: Grep-verify + commit** (no tsc/vitest on box; CI runs them)
+
+Verify: `TransformSpec` imported; `apply_repairs` deleted from `rawCfg` before use; no unguarded indexed access; the dynamic `await import("../repairHost.js")` matches the file (flow.ts `run` is already `async`).
+
+```bash
+cd "D:/show_case/gg-local-llm" && git add packages/typescript/goldenpipe/src/core/adapters/flow.ts packages/typescript/goldenpipe/tests/unit/repair-apply.test.ts && git commit -m "feat(goldenpipe): gated active repair application in TS flow adapter (Phase 2)"
+```
+
+---
+
+## Task 6: Ship (Phase-1 dependency handling)
+
+- [ ] **Step 1: Check whether Phase 1 (#1577) merged**
+
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+gh pr view 1577 --json state -q .state
+```
+
+- [ ] **Step 2a: If MERGED** — rebase Phase 2 onto fresh main so only Phase-2 commits remain:
+
+```bash
+git fetch origin
+git rebase origin/main
+# Phase-1 commits are now in main and drop out of the range; resolve any conflicts
+# (unlikely — Phase 2 touches different lines). Re-run the box suite:
+export PYTHONPATH="packages/python/goldenpipe;packages/python/goldencheck;packages/python/infermap;packages/python/goldencheck-types;packages/python/goldenflow"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+"$INTERP" -m pytest packages/python/goldenpipe/tests/test_repair_apply.py packages/python/goldenpipe/tests/test_flow_apply.py packages/python/goldenpipe/tests/test_adapters.py -q
+```
+
+- [ ] **Step 2b: If NOT merged** — keep Phase 2 stacked on `feat/goldenpipe-repair-plan`; the PR will target `main` but contain both waves until Phase 1 lands (note this in the PR body). Prefer to WAIT for Phase 1 to merge, then do 2a, to avoid a stacked-PR squash-closure (see repo CLAUDE.md). If waiting isn't viable, open the PR and note the dependency.
+
+- [ ] **Step 3: Push + PR + arm auto-merge, then STOP**
+
+```bash
+git push
+gh pr create --base main --title "feat(goldenpipe): repair-plan Phase 2 — gated active application" --body "<summary: apply_repairs gate; flow adapter applies fixer transforms from the Phase-1 repair_plan; fixer-only (validators skipped as bool-destructive); cross-surface; byte-identical when off. Links to spec + plan. Note Phase-1 dependency if stacked.>"
+# merge-queue repo: NO --delete-branch
+gh pr merge <N> --auto --squash
+```
+Then **STOP** — do not poll CI. Watch that CI covers: python goldenpipe (test_repair_apply, test_flow_apply, test_adapters) + typescript (repair-apply.test.ts, tsc).
+
+---
+
+## Verification summary
+
+- Box-green: `test_repair_apply.py` (converter/merge), `test_flow_apply.py` (gate/pop/merge/fall-through via `_transform` spy), `test_adapters.py` (no regression).
+- CI-green: TS `repair-apply.test.ts`, `tsc` over the modified `flow.ts`/`check.ts` + new `repairHost.ts`.
+- Byte-identical-when-off: `test_gate_off_*` assert the exact pre-Phase-2 `_transform` call; gate-off path in both adapters is structurally unchanged.

--- a/docs/superpowers/plans/2026-07-08-goldenpipe-repair-plan-phase2.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-repair-plan-phase2.md
@@ -421,18 +421,16 @@ export function attachRepairPlan(
   rows: Row[],
 ): { repairs: RepairItem[] } {
   const columns = buildColumnInputs(contexts, rows);
-  const plan = JSON.parse(buildRepairPlanJsonLocal(findings, columns)) as { repairs: RepairItem[] };
+  // buildRepairPlan returns a typed RepairPlan structurally identical to
+  // {repairs: RepairItem[]}; call it directly (no JSON round-trip). If repair.ts
+  // exports Finding/ColumnInput, use those instead of the casts.
+  const plan = buildRepairPlan(findings as never, columns as never) as unknown as { repairs: RepairItem[] };
   ctx.artifacts["repair_plan"] = plan;
   const lines = plan.repairs.map(
     (item) => `repair: ${item.column} (${item.check}) -> ${item.suggested_transforms.join(",")} [${item.reason}]`,
   );
   if (lines.length > 0) ctx.reasoning["repair_plan"] = lines.join("\n");
   return plan;
-}
-
-// buildRepairPlan takes (findings, columns) and returns the object directly.
-function buildRepairPlanJsonLocal(findings: unknown[], columns: unknown[]): string {
-  return JSON.stringify(buildRepairPlan(findings as never, columns as never));
 }
 
 // ── FIXERS allowlist + conversion (identical to repair_host.py) ──────────
@@ -500,7 +498,14 @@ cd "D:/show_case/gg-local-llm" && git add packages/typescript/goldenpipe/src/cor
 
 - [ ] **Step 1: Read `check.ts`** around the `ctx.artifacts["column_contexts"] = ...` assignment (near line 83) and the final `return { status: StageStatus.SUCCESS }` (near 88).
 
-- [ ] **Step 2: Insert the attach call** immediately before the final `return`, mirroring `check.py` (advisory, non-fatal):
+- [ ] **Step 2: Add the `ColumnContext` type import** at the top of `check.ts` (the reviewer confirmed it is NOT currently imported — omitting this is a `TS2304` in CI):
+
+```ts
+import type { ColumnContext } from "../columnContext.js";
+```
+(Merge into an existing `columnContext.js` import line if one exists.)
+
+- [ ] **Step 3: Insert the attach call** immediately before the final `return`, mirroring `check.py` (advisory, non-fatal):
 
 ```ts
     // Advisory repair-plan (Phase 1 producer, TS side). Never throws.
@@ -516,9 +521,9 @@ cd "D:/show_case/gg-local-llm" && git add packages/typescript/goldenpipe/src/cor
     }
 ```
 
-Confirm `ColumnContext` is already imported in `check.ts` (it uses `buildContextsFromCheck`); if not, add the type import. Prefer a top-of-file `import { attachRepairPlan } from "../repairHost.js";` if the file's style uses static imports (check whether `check.ts` uses dynamic `await import` elsewhere; match the file — a static import is simpler if the module graph allows it. repairHost imports repair.ts + goldenflow/core types only, no cycle with check.ts, so a static import is safe).
+Prefer a top-of-file `import { attachRepairPlan } from "../repairHost.js";` if the file's style uses static imports (check whether `check.ts` uses dynamic `await import` elsewhere; match the file — a static import is simpler if the module graph allows it. repairHost imports repair.ts + goldenflow/core types only, no cycle with check.ts, so a static import is safe).
 
-- [ ] **Step 3: Grep-verify + commit**
+- [ ] **Step 4: Grep-verify + commit**
 
 Verify the insertion is inside `run` after `column_contexts` is set, before `return`. Confirm no `noUncheckedIndexedAccess` issue (the `?? []` guards cover it).
 

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md
@@ -1,0 +1,160 @@
+# GoldenPipe Repair-Plan Intelligence — Phase 2 (Gated Active Application) — Design
+
+**Date:** 2026-07-08
+**Status:** Approved (brainstorming), pending implementation plan
+**Depends on:** Phase 1 (PR #1577, branch `feat/goldenpipe-repair-plan`) — must be green/merged before Phase 2 implementation. Phase 2 builds on Phase 1's `repair_plan` artifact.
+
+## Goal
+
+When a gate (`apply_repairs`) is on, make the GoldenPipe brain actually apply the
+Phase-1 repair suggestions: the `goldenflow.transform` adapter reads the advisory
+`repair_plan` artifact and applies the suggested **fixer** transforms to the
+flagged columns. When the gate is off, behavior is byte-identical to Phase 1.
+
+## Constraints
+
+- **No kernel change.** The Phase-1 `goldenpipe-core` kernel already produces the
+  `repair_plan` artifact. Phase 2 is entirely host-side (Flow/Check adapters).
+  This fits "planner is in the kernel; execution is a per-language host."
+- **Byte-identical when the gate is off.**
+- **Cross-surface** (Python + TS), consistent with Phase 1.
+
+## Approach (chosen: Flow adapter reads the artifact)
+
+The `goldenflow.transform` adapter, when `apply_repairs` is on, reads the
+`repair_plan` artifact (already in `ctx.artifacts["repair_plan"]`), converts the
+suggested transforms to a `GoldenFlowConfig` (`transforms: [{column, ops}]`), and
+runs. Rejected: extending the kernel `Decision` model to carry a config payload
+(the Phase-1 "inserted-stage config seam" sketch) — heavier (cross-surface kernel
+change + parity gate) and unnecessary since the pipeline already contains the Flow
+stage and the artifact already exists.
+
+## Safety model — fixer-only application (the crux)
+
+GoldenFlow transforms split into two kinds:
+- **Fixers** — return the cleaned column value (in-place clean). Safe to auto-apply.
+- **Assertions** — the `*_validate` transforms return a **boolean** series
+  (`scalar_dtype="bool"`). Applied as a column op they **overwrite** the column
+  with `True`/`False`, destroying the data.
+
+Phase 1's mapping suggested validators (`iban_validate`, `date_validate`, …) as
+advice for check-digit / format findings. As advice that is correct; as an
+auto-applied column op it is destructive. So Phase 2 applies **only fixers** and
+**skips assertions**, logging each skip.
+
+Note: goldenflow's own `auto_apply` flag is **not** the discriminator — genuine
+fixers (`fix_mojibake`, `date_parse`, `email_normalize`, `name_proper`) are all
+`auto_apply=False`. The discriminator is the return type (fixer value vs bool).
+Phase 2 uses a curated allowlist, not runtime registry introspection.
+
+**FIXERS allowlist (host policy, identical Python/TS):**
+```
+fix_mojibake, normalize_unicode, date_parse, email_normalize,
+email_canonical, name_proper, phone_national, zip_normalize
+```
+Everything else in a `suggested_transforms` list (all `*_validate`) is an
+assertion → skipped + logged.
+
+**Honest consequence:** the fine-identifier findings (IBAN/CUSIP/NPI/…
+check-digit failures) contribute **nothing** to active application — a malformed
+identifier has no safe automatic fix, so it stays flagged. Phase 2's value is
+targeted auto-cleaning (mojibake, email/name/phone/zip/date normalization) **only
+on columns the checker flagged** — more surgical than goldenflow's blanket
+zero-config auto-detect.
+
+## The gate
+
+`apply_repairs: true` as a key in the `goldenflow.transform` stage's config. The
+adapter **pops** it before building the `transform_df` call, so it never leaks
+into `GoldenFlowConfig`. Declarative, per-pipeline, local to the acting stage.
+Absent/false → the existing code path runs untouched.
+
+## Merge / auto-detect semantics — surgical (replace)
+
+`transform_df` is either/or: non-empty `config.transforms` → **explicit** mode;
+empty → **auto-detect** mode (there is no clean "auto-detect plan + merge" API).
+
+When `apply_repairs` is on:
+- Build repair specs from the artifact (fixers only, grouped by column, dedup
+  preserving order).
+- **If there are ≥1 fixer specs or the stage already had user-declared
+  transforms:** run explicit mode.
+  - No user transforms → `config.transforms = [repair fixer specs]` (auto-detect
+    is bypassed for that run — the documented consequence).
+  - User transforms present → per column: `user ops ++ repair ops`, deduping
+    exact duplicates (user-first). Columns only in repairs get their own spec.
+- **If there are zero fixer specs** (all-assertion plan) **and no user
+  transforms:** inject nothing — the stage runs auto-detect exactly as before (do
+  NOT flip to explicit-empty).
+
+## Data flow
+
+1. Check stage produces `findings` + `column_contexts` and (Phase-1 producer)
+   attaches `repair_plan` to `ctx.artifacts` (Python already; TS added here).
+2. Flow adapter `run()`: `apply = stage_config.pop("apply_repairs", False)`.
+3. If `apply` and `repair_plan` present: `specs, skipped = repair_transform_specs(repair_plan)`.
+4. Build the merged `GoldenFlowConfig` per the surgical rules; log `skipped`
+   (assertion ops) into the manifest/reasoning.
+5. `transform_df(df, config=merged)` (or the existing path when not applying).
+
+## Components
+
+### Python (box-testable)
+- `goldenpipe/repair_host.py` — add:
+  - `FIXERS: frozenset[str]` (the allowlist above).
+  - `repair_transform_specs(repair_plan: dict) -> tuple[list[dict], list[dict]]`:
+    returns `(specs, skipped)` where `specs = [{"column", "ops"}]` (fixers only,
+    grouped, deduped) and `skipped = [{"column", "op"}]` for logging.
+- `goldenpipe/adapters/flow.py` — pop the gate; when applying, build the merged
+  config (surgical) and call `transform_df(df, config=...)`; record skipped
+  assertions. The existing non-applying path is unchanged.
+
+### TS (CI-only)
+- `src/core/repairHost.ts` — **new**: mirror `repair_host.py`'s producer glue
+  (`sampleColumn`, `buildColumnInputs`, `attachRepairPlan`) so the TS pipeline
+  produces the artifact (Phase-1 gap), plus the identical `FIXERS` +
+  `repairTransformSpecs`.
+- `src/core/adapters/check.ts` — wire `attachRepairPlan` (mirror `check.py`).
+- `src/core/adapters/flow.ts` — the consumer (gate + merge + apply), mirror of
+  `flow.py`.
+
+The `FIXERS` set is host policy (not the parity-gated kernel), defined
+identically in both hosts; a code comment cross-references, and this spec is the
+single source of the list.
+
+## Error handling
+
+- Gate off / no artifact → existing path, byte-identical.
+- All-assertion repair plan + no user transforms → inject nothing (auto-detect
+  keeps running; never flip to explicit-empty).
+- `transform_df` errors on an injected fixer → propagate (the user opted into
+  applying; failures must be visible). The spec conversion/merge never raises.
+
+## Testing
+
+### Python (box)
+- `repair_transform_specs`: mixed fixer+assertion item → specs contain only
+  fixers, grouped/deduped; assertion-only item → empty specs + skipped entry.
+- flow.py gate **off** → identical to today (no config injected; auto-detect
+  path unchanged).
+- flow.py gate **on** + fixer repair (e.g. `email_normalize`) → column
+  transformed, manifest shows it.
+- flow.py gate **on** + assertion-only (`iban_validate`) → no injection, column
+  **not** bool-replaced, auto-detect still runs.
+- flow.py gate **on** + user transforms + repair → merged user-first, deduped.
+
+### TS (CI-only)
+- `repairHost.ts` produce + `check.ts` attach integration (artifact appears).
+- `flow.ts` gate-off identity + gate-on fixer apply.
+
+## Rollout
+
+Opt-in via `apply_repairs` in the Flow stage config. Default off → byte-identical.
+No new kernel symbols, no parity-gate changes.
+
+## Out of scope
+
+- Kernel `Decision`-carried config injection (rejected approach).
+- Applying assertion transforms to a derived `<col>_is_valid` column (the
+  `{column, ops}` schema has no per-op output-column routing).
+- Auto-detect + repairs augmentation (two-pass) — rejected in favor of surgical.

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md
@@ -65,9 +65,38 @@ zero-config auto-detect.
 ## The gate
 
 `apply_repairs: true` as a key in the `goldenflow.transform` stage's config. The
-adapter **pops** it before building the `transform_df` call, so it never leaks
+adapter removes it before building the `transform_df` call, so it never leaks
 into `GoldenFlowConfig`. Declarative, per-pipeline, local to the acting stage.
 Absent/false → the existing code path runs untouched.
+
+**Copy before mutate (important):** `ctx.stage_config` is the SAME object as the
+`StageSpec.config` Pydantic field (`resolver.py` → `PlannedStage(config=spec.config)`;
+`runner.py` → `ctx.stage_config = planned.config`). Popping in place would corrupt
+a re-run of the same `PipelineConfig`. The adapter must copy first —
+`cfg = dict(ctx.stage_config or {})` then `apply = cfg.pop("apply_repairs", False)`
+— matching the sibling `adapters/identity.py` pattern.
+
+## Host config shapes (Python vs TS asymmetry)
+
+The two hosts pass stage config to GoldenFlow differently; Phase 2 must respect
+each:
+- **Python** — `flow.py` today does `_transform(ctx.df, **stage_cfg)`, and
+  `transform_df(df, config=None)` accepts only `config`. So the base
+  `GoldenFlowConfig` lives at `stage_config["config"]` (a dict). User transforms,
+  when present, are at `stage_config["config"]["transforms"]`. In practice the
+  brain planner passes `{}` (empty → auto-detect); a populated flow config is a
+  valid-but-currently-unexercised path.
+- **TS** — `flow.ts` does `new TransformEngine(stageConfig as GoldenFlowConfig)`.
+  The base config IS `stageConfig` itself; user transforms are at
+  `stageConfig.transforms`.
+
+**Applying path builds config explicitly (avoids the `**splat` fragility).** When
+`apply_repairs` is on, the adapter does NOT splat — it extracts the per-surface
+base config, merges the repair specs, and calls `transform_df(df, config=merged)`
+(Python) / `new TransformEngine(merged)` (TS) directly. The gate-off path is left
+exactly as today (byte-identical). The primary and fully-tested path is
+gate-on + empty base config (inject repair fixers); the user-transforms-present
+merge is a documented defensive case.
 
 ## Merge / auto-detect semantics — surgical (replace)
 
@@ -75,27 +104,37 @@ Absent/false → the existing code path runs untouched.
 empty → **auto-detect** mode (there is no clean "auto-detect plan + merge" API).
 
 When `apply_repairs` is on:
+- Extract the per-surface base config (`stage_config["config"]` in Python,
+  `stageConfig` in TS, with the gate key removed) and its existing
+  `transforms` (`[]` if none).
 - Build repair specs from the artifact (fixers only, grouped by column, dedup
   preserving order).
-- **If there are ≥1 fixer specs or the stage already had user-declared
+- **If there are ≥1 fixer specs or the base already had user-declared
   transforms:** run explicit mode.
-  - No user transforms → `config.transforms = [repair fixer specs]` (auto-detect
+  - No user transforms → `merged.transforms = [repair fixer specs]` (auto-detect
     is bypassed for that run — the documented consequence).
   - User transforms present → per column: `user ops ++ repair ops`, deduping
     exact duplicates (user-first). Columns only in repairs get their own spec.
+  - Call `transform_df(df, config=merged)` (Python) / `new TransformEngine(merged)`
+    (TS) directly — not via `**splat`.
 - **If there are zero fixer specs** (all-assertion plan) **and no user
-  transforms:** inject nothing — the stage runs auto-detect exactly as before (do
-  NOT flip to explicit-empty).
+  transforms:** inject nothing — fall through to the existing gate-off path so the
+  stage runs auto-detect exactly as before (do NOT flip to explicit-empty).
 
 ## Data flow
 
 1. Check stage produces `findings` + `column_contexts` and (Phase-1 producer)
    attaches `repair_plan` to `ctx.artifacts` (Python already; TS added here).
-2. Flow adapter `run()`: `apply = stage_config.pop("apply_repairs", False)`.
+2. Flow adapter `run()`: `cfg = dict(ctx.stage_config or {})` (COPY),
+   `apply = cfg.pop("apply_repairs", False)`.
 3. If `apply` and `repair_plan` present: `specs, skipped = repair_transform_specs(repair_plan)`.
-4. Build the merged `GoldenFlowConfig` per the surgical rules; log `skipped`
-   (assertion ops) into the manifest/reasoning.
-5. `transform_df(df, config=merged)` (or the existing path when not applying).
+   If `specs` is empty and the base has no user transforms → fall through to the
+   existing gate-off path (auto-detect unchanged).
+4. Otherwise build the merged `GoldenFlowConfig` per the surgical rules from the
+   per-surface base config; log `skipped` (assertion ops) into the
+   manifest/reasoning.
+5. `transform_df(df, config=merged)` / `new TransformEngine(merged)` directly (or
+   the existing splat/engine path unchanged when not applying).
 
 ## Components
 
@@ -113,7 +152,8 @@ When `apply_repairs` is on:
 - `src/core/repairHost.ts` — **new**: mirror `repair_host.py`'s producer glue
   (`sampleColumn`, `buildColumnInputs`, `attachRepairPlan`) so the TS pipeline
   produces the artifact (Phase-1 gap), plus the identical `FIXERS` +
-  `repairTransformSpecs`.
+  `repairTransformSpecs`. It imports the EXISTING `src/core/repair.ts` kernel
+  (`buildRepairPlan`) — do NOT reimplement the kernel.
 - `src/core/adapters/check.ts` — wire `attachRepairPlan` (mirror `check.py`).
 - `src/core/adapters/flow.ts` — the consumer (gate + merge + apply), mirror of
   `flow.py`.

--- a/packages/python/goldenpipe/goldenpipe/adapters/flow.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/flow.py
@@ -25,18 +25,20 @@ class TransformStage:
             raise RuntimeError("GoldenFlow not installed. Run: pip install goldenpipe[flow]")
 
     def run(self, ctx: PipeContext) -> StageResult:
-        stage_cfg = ctx.stage_config
-        if stage_cfg:
-            logger.info("Passing stage config to GoldenFlow transform")
-            result = _transform(ctx.df, **stage_cfg)
+        cfg = dict(ctx.stage_config or {})           # COPY: ctx.stage_config IS StageSpec.config
+        apply = cfg.pop("apply_repairs", False)       # pop even when False (never leak to transform_df)
+
+        if apply:
+            result = self._run_with_repairs(ctx, cfg)
+        elif cfg:
+            result = _transform(ctx.df, **cfg)
         else:
             result = _transform(ctx.df)
+
         if hasattr(result, "df"):
             ctx.df = result.df
         if hasattr(result, "manifest"):
             ctx.artifacts["manifest"] = result.manifest
-
-            # Enrich column contexts with transform information (best-effort)
             if "column_contexts" in ctx.artifacts:
                 try:
                     from goldenpipe.models.column_context import enrich_contexts_from_flow
@@ -45,3 +47,26 @@ class TransformStage:
                     logger.exception("Failed to enrich column contexts from flow manifest")
 
         return StageResult(status=StageStatus.SUCCESS)
+
+    def _run_with_repairs(self, ctx: PipeContext, cfg: dict):
+        """apply_repairs is on: merge the repair plan's fixer transforms into the
+        base GoldenFlowConfig and run explicit mode. Falls through to the normal
+        path when there is nothing to apply (keeps auto-detect / byte-identity)."""
+        from goldenpipe.repair_host import merge_transforms, repair_transform_specs
+
+        plan = ctx.artifacts.get("repair_plan")
+        specs, skipped = repair_transform_specs(plan) if plan else ([], [])
+        base = dict(cfg.get("config") or {})
+        user_transforms = list(base.get("transforms") or [])
+
+        if not specs and not user_transforms:
+            if skipped:
+                ctx.reasoning["repair_skipped"] = "; ".join(f"{s['column']}:{s['op']}" for s in skipped)
+            # nothing to inject -> behave exactly like the gate-off path
+            return _transform(ctx.df, **cfg) if cfg else _transform(ctx.df)
+
+        base["transforms"] = merge_transforms(user_transforms, specs)
+        if skipped:
+            ctx.reasoning["repair_skipped"] = "; ".join(f"{s['column']}:{s['op']}" for s in skipped)
+        logger.info("Applying %d repair transform spec(s); skipped %d assertion(s)", len(specs), len(skipped))
+        return _transform(ctx.df, config=base)

--- a/packages/python/goldenpipe/goldenpipe/repair_host.py
+++ b/packages/python/goldenpipe/goldenpipe/repair_host.py
@@ -56,3 +56,58 @@ def attach_repair_plan(ctx, findings, contexts, df) -> dict:
     if lines:
         ctx.reasoning["repair_plan"] = "\n".join(lines)
     return plan
+
+
+# ── Phase 2: active application (fixer allowlist + config conversion) ─────
+# FIXERS are transforms that CLEAN in place. Everything else the kernel can
+# suggest is a *_validate ASSERTION that returns a boolean series — applying it
+# as a column op would overwrite the column with True/False, so it is skipped.
+# Host policy, kept identical in repairHost.ts (NOT the parity-gated kernel).
+FIXERS = frozenset({
+    "fix_mojibake", "normalize_unicode", "date_parse", "email_normalize",
+    "email_canonical", "name_proper", "phone_national", "zip_normalize",
+})
+
+
+def repair_transform_specs(plan: dict) -> tuple[list[dict], list[dict]]:
+    """repair_plan -> (specs, skipped). specs = [{column, ops}] fixer ops grouped
+    per column, deduped, order-preserving. skipped = [{column, op}] assertion ops."""
+    by_col: dict[str, list[str]] = {}
+    order: list[str] = []
+    skipped: list[dict] = []
+    for item in plan.get("repairs", []):
+        col = item["column"]
+        for op in item.get("suggested_transforms", []):
+            if op in FIXERS:
+                if col not in by_col:
+                    by_col[col] = []
+                    order.append(col)
+                if op not in by_col[col]:
+                    by_col[col].append(op)
+            else:
+                skipped.append({"column": col, "op": op})
+    specs = [{"column": c, "ops": by_col[c]} for c in order]
+    return specs, skipped
+
+
+def merge_transforms(user: list[dict], repair: list[dict]) -> list[dict]:
+    """Per-column merge, user ops first then repair ops, dedup exact dupes,
+    preserving first-seen column + op order."""
+    by_col: dict[str, list[str]] = {}
+    order: list[str] = []
+    for spec in list(user) + list(repair):
+        col = spec["column"]
+        if col not in by_col:
+            by_col[col] = []
+            order.append(col)
+        by_col[col].extend(spec.get("ops") or [])
+    result = []
+    for col in order:
+        seen: set[str] = set()
+        ops: list[str] = []
+        for op in by_col[col]:
+            if op not in seen:
+                seen.add(op)
+                ops.append(op)
+        result.append({"column": col, "ops": ops})
+    return result

--- a/packages/python/goldenpipe/tests/test_flow_apply.py
+++ b/packages/python/goldenpipe/tests/test_flow_apply.py
@@ -1,0 +1,79 @@
+import types
+
+from goldenpipe.models.context import PipeContext
+
+
+class _SpyResult:
+    def __init__(self):
+        self.df = "DF_OUT"
+        self.manifest = types.SimpleNamespace(records=[])
+
+
+def _install_spy(monkeypatch):
+    calls = {}
+    def spy(df, config=None, **kw):
+        calls["df"] = df
+        calls["config"] = config
+        calls["kw"] = kw
+        return _SpyResult()
+    import goldenpipe.adapters.flow as flowmod
+    monkeypatch.setattr(flowmod, "_transform", spy)
+    monkeypatch.setattr(flowmod, "HAS_FLOW", True)
+    return calls
+
+
+def _ctx(stage_config=None, repair_plan=None):
+    ctx = PipeContext(df="DF_IN")
+    ctx.stage_config = stage_config or {}
+    if repair_plan is not None:
+        ctx.artifacts["repair_plan"] = repair_plan
+    return ctx
+
+
+def _run(ctx):
+    from goldenpipe.adapters.flow import TransformStage
+    return TransformStage().run(ctx)
+
+
+def test_gate_off_no_config_calls_autodetect(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    _run(_ctx())
+    assert calls["config"] is None and calls["kw"] == {}
+
+
+def test_gate_off_with_user_config_unchanged(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    _run(_ctx(stage_config={"config": {"transforms": [{"column": "a", "ops": ["strip"]}]}}))
+    assert calls["config"] == {"transforms": [{"column": "a", "ops": ["strip"]}]}
+
+
+def test_gate_on_injects_fixer_specs(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "email", "check": "format_detection", "suggested_transforms": ["email_normalize"], "reason": "x"}]}
+    _run(_ctx(stage_config={"apply_repairs": True}, repair_plan=plan))
+    assert calls["config"] == {"transforms": [{"column": "email", "ops": ["email_normalize"]}]}
+
+
+def test_gate_on_all_assertion_falls_through_to_autodetect(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "iban", "check": "pattern_consistency", "suggested_transforms": ["iban_validate"], "reason": "b"}]}
+    ctx = _ctx(stage_config={"apply_repairs": True}, repair_plan=plan)
+    _run(ctx)
+    assert calls["config"] is None
+    assert "iban_validate" in ctx.reasoning.get("repair_skipped", "")
+
+
+def test_gate_on_merges_user_and_repair(monkeypatch):
+    calls = _install_spy(monkeypatch)
+    plan = {"repairs": [{"column": "email", "check": "pattern_consistency", "suggested_transforms": ["email_canonical"], "reason": "y"}]}
+    sc = {"apply_repairs": True, "config": {"transforms": [{"column": "email", "ops": ["email_lowercase"]}]}}
+    _run(_ctx(stage_config=sc, repair_plan=plan))
+    assert calls["config"] == {"transforms": [{"column": "email", "ops": ["email_lowercase", "email_canonical"]}]}
+
+
+def test_gate_pop_does_not_mutate_ctx_stage_config(monkeypatch):
+    _install_spy(monkeypatch)
+    sc = {"apply_repairs": True}
+    ctx = _ctx(stage_config=sc, repair_plan={"repairs": []})
+    _run(ctx)
+    assert sc == {"apply_repairs": True}

--- a/packages/python/goldenpipe/tests/test_repair_apply.py
+++ b/packages/python/goldenpipe/tests/test_repair_apply.py
@@ -1,0 +1,49 @@
+from goldenpipe.repair_host import FIXERS, merge_transforms, repair_transform_specs
+
+
+def _plan(*items):
+    return {"repairs": list(items)}
+
+
+def test_fixer_only_grouped_and_deduped():
+    plan = _plan(
+        {"column": "email", "check": "format_detection", "suggested_transforms": ["email_normalize"], "reason": "x"},
+        {"column": "email", "check": "pattern_consistency", "suggested_transforms": ["email_canonical", "email_normalize"], "reason": "y"},
+    )
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == [{"column": "email", "ops": ["email_normalize", "email_canonical"]}]  # dedup, order preserved
+    assert skipped == []
+
+
+def test_assertion_ops_are_skipped_not_applied():
+    plan = _plan(
+        {"column": "iban", "check": "pattern_consistency", "suggested_transforms": ["iban_validate"], "reason": "bad"},
+        {"column": "signup", "check": "future_dated", "suggested_transforms": ["date_validate"], "reason": "future"},
+    )
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == []
+    assert {"column": "iban", "op": "iban_validate"} in skipped
+    assert {"column": "signup", "op": "date_validate"} in skipped
+
+
+def test_mixed_item_keeps_fixer_skips_assertion():
+    # a column flagged for both a fixer and an assertion
+    plan = _plan({"column": "dob", "check": "format_detection", "suggested_transforms": ["date_parse", "date_validate"], "reason": "z"})
+    specs, skipped = repair_transform_specs(plan)
+    assert specs == [{"column": "dob", "ops": ["date_parse"]}]
+    assert skipped == [{"column": "dob", "op": "date_validate"}]
+
+
+def test_fixers_membership():
+    assert "email_normalize" in FIXERS and "iban_validate" not in FIXERS
+
+
+def test_merge_user_first_then_repair_deduped():
+    user = [{"column": "email", "ops": ["email_lowercase"]}, {"column": "name", "ops": ["strip"]}]
+    repair = [{"column": "email", "ops": ["email_normalize", "email_lowercase"]}, {"column": "zip", "ops": ["zip_normalize"]}]
+    merged = merge_transforms(user, repair)
+    assert merged == [
+        {"column": "email", "ops": ["email_lowercase", "email_normalize"]},  # user-first, dup dropped
+        {"column": "name", "ops": ["strip"]},
+        {"column": "zip", "ops": ["zip_normalize"]},
+    ]

--- a/packages/typescript/goldenpipe/src/core/adapters/check.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/check.ts
@@ -18,9 +18,11 @@ import type { PipeContext, Stage, StageResult } from "../models.js";
 import { StageStatus } from "../models.js";
 import {
   buildContextsFromCheck,
+  type ColumnContext,
   type ColumnProfileLike,
   type FindingLike,
 } from "../columnContext.js";
+import { attachRepairPlan } from "../repairHost.js";
 
 interface NormalizedFinding {
   severity: string;
@@ -83,6 +85,17 @@ export const ScanStage: Stage = {
       ctx.artifacts["column_contexts"] = buildContextsFromCheck(findingLikes, profileLikes);
     } catch {
       ctx.artifacts["column_contexts"] = [];
+    }
+
+    // Advisory repair-plan (Phase 1 producer, TS side). Never throws.
+    try {
+      const rp_findings = (ctx.artifacts["findings"] as NormalizedFinding[]) ?? [];
+      const rp_contexts = (ctx.artifacts["column_contexts"] as ColumnContext[]) ?? [];
+      if (ctx.df && rp_findings.length > 0 && rp_contexts.length > 0) {
+        attachRepairPlan(ctx, rp_findings, rp_contexts, ctx.df);
+      }
+    } catch {
+      /* advisory: never break the scan stage */
     }
 
     return { status: StageStatus.SUCCESS };

--- a/packages/typescript/goldenpipe/src/core/adapters/flow.ts
+++ b/packages/typescript/goldenpipe/src/core/adapters/flow.ts
@@ -11,10 +11,11 @@
  */
 
 import { TransformEngine } from "goldenflow/core";
-import type { GoldenFlowConfig } from "goldenflow/core";
+import type { GoldenFlowConfig, TransformSpec } from "goldenflow/core";
 import type { PipeContext, Stage, StageResult, Row } from "../models.js";
 import { StageStatus } from "../models.js";
 import { enrichContextsFromFlow, type ColumnContext, type ManifestRecordLike } from "../columnContext.js";
+import { repairTransformSpecs, mergeTransforms } from "../repairHost.js";
 
 export const TransformStage: Stage = {
   info: { name: "goldenflow.transform", produces: ["df", "manifest"], consumes: ["df"] },
@@ -27,11 +28,26 @@ export const TransformStage: Stage = {
 
   async run(ctx: PipeContext): Promise<StageResult> {
     const rows = (ctx.df ?? []) as Row[];
-    const stageCfg = ctx.stageConfig;
-    const config =
-      stageCfg && Object.keys(stageCfg).length > 0
-        ? (stageCfg as Partial<GoldenFlowConfig>)
-        : undefined;
+    const rawCfg: Record<string, unknown> = { ...(ctx.stageConfig ?? {}) };
+    const apply = rawCfg["apply_repairs"] === true;
+    delete rawCfg["apply_repairs"];
+
+    let config: Partial<GoldenFlowConfig> | undefined;
+    if (apply) {
+      const plan = ctx.artifacts["repair_plan"] as Parameters<typeof repairTransformSpecs>[0];
+      const { specs, skipped } = repairTransformSpecs(plan);
+      const userTransforms = (rawCfg["transforms"] as TransformSpec[] | undefined) ?? [];
+      if (skipped.length > 0) {
+        ctx.reasoning["repair_skipped"] = skipped.map((s) => `${s.column}:${s.op}`).join("; ");
+      }
+      if (specs.length > 0 || userTransforms.length > 0) {
+        config = { ...rawCfg, transforms: mergeTransforms(userTransforms, specs) } as Partial<GoldenFlowConfig>;
+      } else {
+        config = Object.keys(rawCfg).length > 0 ? (rawCfg as Partial<GoldenFlowConfig>) : undefined;
+      }
+    } else {
+      config = Object.keys(rawCfg).length > 0 ? (rawCfg as Partial<GoldenFlowConfig>) : undefined;
+    }
 
     const engine = new TransformEngine(config);
     const result = engine.transformDf(rows);

--- a/packages/typescript/goldenpipe/src/core/repairHost.ts
+++ b/packages/typescript/goldenpipe/src/core/repairHost.ts
@@ -1,0 +1,99 @@
+/**
+ * repairHost.ts — TS producer glue for the repair plan (mirror of
+ * goldenpipe/repair_host.py). Samples column values from the row array, builds
+ * ColumnInputs, calls the pure repair.ts kernel, attaches the advisory artifact.
+ * Also holds the Phase-2 FIXERS allowlist + config conversion (host policy,
+ * identical to repair_host.py — NOT the parity-gated kernel).
+ */
+import { buildRepairPlan } from "./repair.js";
+import type { ColumnInput, Finding, RepairPlan } from "./repair.js";
+import type { ColumnContext } from "./columnContext.js";
+import type { PipeContext, Row } from "./models.js";
+import type { TransformSpec } from "goldenflow/core";
+
+const SAMPLE_LIMIT = 20;
+
+export function sampleColumn(rows: Row[], col: string, limit = SAMPLE_LIMIT): string[] {
+  const out: string[] = [];
+  for (const row of rows) {
+    const v = (row as Record<string, unknown>)[col];
+    if (v === null || v === undefined) continue;
+    const s = String(v);
+    if (s.trim() === "") continue;
+    out.push(s);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+export function buildColumnInputs(contexts: ColumnContext[], rows: Row[]): ColumnInput[] {
+  const first = rows.length > 0 ? rows[0] : undefined;
+  const names = new Set<string>(first ? Object.keys(first as object) : []);
+  const cols: ColumnInput[] = [];
+  for (const ctx of contexts) {
+    if (!names.has(ctx.name)) continue;
+    cols.push({ name: ctx.name, coarse_type: ctx.inferredType, samples: sampleColumn(rows, ctx.name) });
+  }
+  return cols;
+}
+
+export function attachRepairPlan(
+  ctx: PipeContext,
+  findings: Finding[],
+  contexts: ColumnContext[],
+  rows: Row[],
+): RepairPlan {
+  const columns = buildColumnInputs(contexts, rows);
+  const plan = buildRepairPlan(findings, columns);
+  ctx.artifacts["repair_plan"] = plan;
+  const lines = plan.repairs.map(
+    (item) => `repair: ${item.column} (${item.check}) -> ${item.suggested_transforms.join(",")} [${item.reason}]`,
+  );
+  if (lines.length > 0) ctx.reasoning["repair_plan"] = lines.join("\n");
+  return plan;
+}
+
+// ── FIXERS allowlist + conversion (identical to repair_host.py) ──────────
+export const FIXERS: ReadonlySet<string> = new Set([
+  "fix_mojibake", "normalize_unicode", "date_parse", "email_normalize",
+  "email_canonical", "name_proper", "phone_national", "zip_normalize",
+]);
+
+export function repairTransformSpecs(plan: RepairPlan | undefined): {
+  specs: TransformSpec[];
+  skipped: Array<{ column: string; op: string }>;
+} {
+  const byCol = new Map<string, string[]>();
+  const order: string[] = [];
+  const skipped: Array<{ column: string; op: string }> = [];
+  for (const item of plan?.repairs ?? []) {
+    const col = item.column;
+    for (const op of item.suggested_transforms ?? []) {
+      if (FIXERS.has(op)) {
+        let ops = byCol.get(col);
+        if (ops === undefined) { ops = []; byCol.set(col, ops); order.push(col); }
+        if (!ops.includes(op)) ops.push(op);
+      } else {
+        skipped.push({ column: col, op });
+      }
+    }
+  }
+  const specs: TransformSpec[] = order.map((c) => ({ column: c, ops: byCol.get(c) ?? [] }));
+  return { specs, skipped };
+}
+
+export function mergeTransforms(user: readonly TransformSpec[], repair: readonly TransformSpec[]): TransformSpec[] {
+  const byCol = new Map<string, string[]>();
+  const order: string[] = [];
+  for (const spec of [...user, ...repair]) {
+    let ops = byCol.get(spec.column);
+    if (ops === undefined) { ops = []; byCol.set(spec.column, ops); order.push(spec.column); }
+    ops.push(...spec.ops);
+  }
+  return order.map((col) => {
+    const seen = new Set<string>();
+    const ops: string[] = [];
+    for (const op of byCol.get(col) ?? []) if (!seen.has(op)) { seen.add(op); ops.push(op); }
+    return { column: col, ops };
+  });
+}

--- a/packages/typescript/goldenpipe/tests/unit/repair-apply.test.ts
+++ b/packages/typescript/goldenpipe/tests/unit/repair-apply.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { repairTransformSpecs, mergeTransforms, FIXERS } from "../../src/core/repairHost.js";
+
+describe("repairTransformSpecs", () => {
+  it("keeps fixers grouped+deduped, skips assertions", () => {
+    const plan = { repairs: [
+      { column: "email", check: "format_detection", type_tag: "email", suggested_transforms: ["email_normalize"], reason: "x" },
+      { column: "iban", check: "pattern_consistency", type_tag: "iban", suggested_transforms: ["iban_validate"], reason: "b" },
+    ] };
+    const { specs, skipped } = repairTransformSpecs(plan as never);
+    expect(specs).toEqual([{ column: "email", ops: ["email_normalize"] }]);
+    expect(skipped).toEqual([{ column: "iban", op: "iban_validate" }]);
+  });
+  it("FIXERS excludes validators", () => {
+    expect(FIXERS.has("email_normalize")).toBe(true);
+    expect(FIXERS.has("iban_validate")).toBe(false);
+  });
+  it("merges user-first then repair, deduped", () => {
+    const merged = mergeTransforms(
+      [{ column: "email", ops: ["email_lowercase"] }],
+      [{ column: "email", ops: ["email_normalize", "email_lowercase"] }],
+    );
+    expect(merged).toEqual([{ column: "email", ops: ["email_lowercase", "email_normalize"] }]);
+  });
+});


### PR DESCRIPTION
## What

Phase 2 of repair-plan intelligence: when `apply_repairs: true` is set on the `goldenflow.transform` stage, the Flow adapter reads the Phase-1 `repair_plan` artifact and **applies** the suggested transforms to the flagged columns. **No kernel change** — pure host-side (Check/Flow adapters).

## Safety: fixer-only application

The repair suggestions mix **fixers** (clean in place) and **validators** (`*_validate`, which return a *boolean* series — applied as a column op they'd overwrite the column with True/False, destroying data). Phase 2 applies **only the 8 fixers** (`fix_mojibake, normalize_unicode, date_parse, email_normalize, email_canonical, name_proper, phone_national, zip_normalize`) and **skips validators** (logged to `reasoning.repair_skipped`). Honest consequence: fine-identifier check-digit findings have no safe auto-fix, so they stay flagged.

## Semantics

- **Gate off / absent → byte-identical** to today (proven: gate-off tests assert the exact pre-change `transform_df` call).
- **Surgical merge:** injecting repair transforms flips the stage to explicit mode (auto-detect off for that run). User-declared transforms are preserved (per-column `user ops ++ repair ops`, deduped). All-assertion + no user transforms → inject nothing (auto-detect preserved).
- Gate popped from a **copy** of stage config (`ctx.stage_config` IS the `StageSpec.config` object — in-place mutation would corrupt re-runs).

## Cross-surface

Phase 1 wired the artifact *producer* only in Python, so this also adds the **TS producer** (`repairHost.ts` + `check.ts` wiring) plus the TS consumer (`flow.ts`). Python nests config under `stage_config["config"]`; TS treats `stageConfig` as the config directly — handled per surface.

## Verification

- Box-green (29 tests): converter/merge (`test_repair_apply`), flow gate/merge/pop/fall-through via a `_transform` spy (`test_flow_apply`), Phase-1 host/integration + `test_adapters` (no regression).
- CI verifies: TS `repair-apply.test.ts` + tsc over `flow.ts`/`check.ts`/`repairHost.ts`.

Spec: `docs/superpowers/specs/2026-07-08-goldenpipe-repair-plan-phase2-design.md`
Plan: `docs/superpowers/plans/2026-07-08-goldenpipe-repair-plan-phase2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)