### PR TITLE
feat(goldenmatch-native): match_fused orchestration + scale bench (fused-match increment 2)

### DIFF
--- a/.github/workflows/bench-match-fused.yml
+++ b/.github/workflows/bench-match-fused.yml
@@ -1,0 +1,137 @@
+# Fused Arrow-native match stage bench -- workflow_dispatch only.
+#
+# Measures `match_fused` (block+score+dedup+cluster in ONE Rust call) vs the
+# per-stage pipeline (Polars block + score_arrow + dedup_arrow + cc_arrow) at
+# scale, on a real box. Two axes the local (memory-starved) box can't measure:
+#   - peak RSS per path (does fusion avoid materializing the pairs list +
+#     per-block frames the pipeline builds?)
+#   - the 5M/10M shape where the materializing pipeline OOMs (exit 137) and the
+#     fused kernel survives at flat memory.
+# Each (path, n) runs in its OWN process so an OOM-kill of the pipeline doesn't
+# take down the fused run. Scoring forced parallel on BOTH
+# (GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS=0) so the dominant compute is held equal
+# and the delta is purely the fusion (grouping + eliminated conversions).
+#
+# Dispatch against the branch that has match_fused + the bench script:
+#   gh workflow run bench-match-fused.yml --ref main \
+#     -f source_ref=feat/native-block-formation-kernel
+name: bench-match-fused
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch/ref to build + bench (has match_fused + scripts/bench_match_fused_scale.py)"
+        required: true
+        default: "feat/native-block-formation-kernel"
+      row_counts:
+        description: "Space-separated row counts"
+        required: false
+        default: "1000000 5000000 10000000"
+      keycard:
+        description: "Avg rows per block (n/keycard distinct keys)"
+        required: false
+        default: "20"
+      runner:
+        description: "Runner label"
+        required: false
+        default: "large-new-64GB"
+      per_run_timeout:
+        description: "Hard per-run cap (s) so an OOM/hang can't blow the budget"
+        required: false
+        default: "1800"
+
+permissions:
+  contents: read
+
+jobs:
+  bench:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 120
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      POLARS_SKIP_CPU_CHECK: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (from source_ref)
+        run: uv run python scripts/build_native.py
+
+      - name: Run fused-vs-pipeline scale bench
+        working-directory: packages/python/goldenmatch
+        run: |
+          set +e
+          : > results.jsonl
+          for n in ${{ inputs.row_counts }}; do
+            for path in fused pipeline; do
+              echo "::group::n=$n path=$path"
+              out=$(GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS=0 \
+                timeout ${{ inputs.per_run_timeout }} \
+                uv run python scripts/bench_match_fused_scale.py \
+                  --path "$path" --n "$n" --keycard ${{ inputs.keycard }})
+              rc=$?
+              if [ $rc -eq 0 ]; then
+                echo "$out"
+                echo "$out" >> results.jsonl
+              else
+                # 124 = timeout; 137 = OOM-kill (SIGKILL); other = crash
+                echo "{\"path\":\"$path\",\"n\":$n,\"status\":\"FAIL\",\"exit\":$rc}" | tee -a results.jsonl
+              fi
+              echo "::endgroup::"
+            done
+          done
+
+      - name: Summarize
+        working-directory: packages/python/goldenmatch
+        run: |
+          uv run python - <<'PY'
+          import json
+          rows = [json.loads(l) for l in open("results.jsonl") if l.strip()]
+          by = {}
+          for r in rows:
+              by.setdefault(r["n"], {})[r["path"]] = r
+          print("\n=== fused vs pipeline (scoring forced parallel on both) ===")
+          hdr = f"{'n':>10} {'fused_wall':>10} {'pipe_wall':>10} {'speedup':>8} {'fused_rss':>10} {'pipe_rss':>10} {'rss_x':>7} {'parity':>8}"
+          print(hdr)
+          for n in sorted(by):
+              f = by[n].get("fused", {})
+              p = by[n].get("pipeline", {})
+              def g(d, k): return d.get(k)
+              fw, pw = g(f, "wall_s"), g(p, "wall_s")
+              fr, pr = g(f, "peak_rss_mb"), g(p, "peak_rss_mb")
+              speed = f"{pw/fw:.2f}x" if (fw and pw) else "-"
+              rssx = f"{pr/fr:.2f}x" if (fr and pr) else "-"
+              if "cluster_fp" in f and "cluster_fp" in p:
+                  parity = "PASS" if f["cluster_fp"] == p["cluster_fp"] else "FAIL"
+              else:
+                  parity = f"f={f.get('status','ok')}/p={p.get('status','ok')}"
+              def s(v, suf=""): return (f"{v}{suf}" if v is not None else "OOM/FAIL")
+              print(f"{n:>10} {s(fw,'s'):>10} {s(pw,'s'):>10} {speed:>8} {s(fr,'M'):>10} {s(pr,'M'):>10} {rssx:>7} {parity:>8}")
+          print("\nspeedup = pipeline_wall / fused_wall (>1 = fused faster)")
+          print("rss_x   = pipeline_rss  / fused_rss  (>1 = fused leaner)")
+          print("OOM/FAIL in a pipeline cell where fused succeeds = the scale win.")
+          PY
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always()
+        with:
+          name: bench-match-fused-results
+          path: packages/python/goldenmatch/results.jsonl

--- a/packages/python/goldenmatch/scripts/bench_match_fused_scale.py
+++ b/packages/python/goldenmatch/scripts/bench_match_fused_scale.py
@@ -1,0 +1,156 @@
+"""Scale bench for the fused Arrow-native match stage (increment 2/3).
+
+Runs ONE path (fused | pipeline) over a seeded synthetic dedupe frame and emits
+JSON: {wall_s, peak_rss_mb, n_clusters, cluster_fp}. The driver runs each path
+in its OWN process so (a) peak RSS is isolated per path and (b) an OOM-kill of
+the pipeline (exit 137) doesn't take down the fused run — the whole point of the
+scale test is the shape where the materializing pipeline dies and the fused
+kernel survives at flat memory.
+
+Both paths do IDENTICAL scoring (score_one) so the compute is held equal; the
+delta is the Polars group/materialize + the per-stage Arrow/py-list round trips
+that fusion removes. Force parallel scoring on both with
+GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS=0 for a fair many-core comparison.
+
+Usage:
+  python bench_match_fused_scale.py --path fused    --n 5000000 --keycard 20
+  python bench_match_fused_scale.py --path pipeline --n 5000000 --keycard 20
+"""
+import argparse
+import hashlib
+import json
+import os
+import random
+import sys
+import time
+
+os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+
+import polars as pl
+import pyarrow as pa
+import goldenmatch._native as native
+
+SCORER_IDS = [0]  # jaro_winkler
+WEIGHTS = [1.0]
+TOTAL_WEIGHT = 1.0
+THRESHOLD = 0.85
+
+
+def peak_rss_mb() -> float:
+    try:
+        import resource
+
+        kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return kb / 1024.0  # Linux ru_maxrss is KB
+    except Exception:
+        try:
+            import psutil
+
+            return psutil.Process().memory_info().rss / 1024.0 / 1024.0
+        except Exception:
+            return float("nan")
+
+
+def gen(n: int, keycard: int) -> pl.DataFrame:
+    rng = random.Random(11)
+    firsts = ["john", "jane", "mary", "mike", "sara", "dave", "lisa", "paul", "anna", "mark"]
+    lasts = ["smith", "jones", "brown", "davis", "moore", "clark", "hall", "young", "king", "wood"]
+    n_keys = max(1, n // keycard)
+    keys = [None] * n
+    names = [None] * n
+    for i in range(n):
+        keys[i] = f"blk{rng.randint(0, n_keys)}"
+        base = f"{rng.choice(firsts)} {rng.choice(lasts)}"
+        if rng.random() < 0.3:
+            base = base[:-1] + rng.choice("aeiou")
+        names[i] = base
+    return (
+        pl.DataFrame({"blk": keys, "name": names})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+
+
+def cluster_fp(clusters) -> str:
+    """Deterministic fingerprint of multi-member clusters (order-independent)."""
+    sets = sorted(
+        tuple(sorted(c)) for c in clusters if len(c) >= 2
+    )
+    h = hashlib.sha256()
+    for s in sets:
+        h.update(repr(s).encode())
+    return h.hexdigest()[:16], len(sets)
+
+
+def run_fused(df: pl.DataFrame):
+    row_ids = df.get_column("__row_id__").to_arrow()
+    key = df.get_column("blk").cast(pl.Utf8).to_arrow()
+    score = df.get_column("name").cast(pl.Utf8).to_arrow()
+    t0 = time.perf_counter()
+    clusters = native.match_fused(
+        row_ids, [key], [score], SCORER_IDS, WEIGHTS, TOTAL_WEIGHT, THRESHOLD
+    )
+    wall = time.perf_counter() - t0
+    return wall, clusters
+
+
+def run_pipeline(df: pl.DataFrame):
+    t0 = time.perf_counter()
+    keyed = df.with_columns(pl.col("blk").cast(pl.Utf8).alias("__bk__")).filter(
+        pl.col("__bk__").is_not_null()
+        & ~pl.col("__bk__").str.strip_chars().str.to_lowercase().is_in(["nan", "null", "none"])
+    )
+    counts = keyed.group_by("__bk__").agg(pl.len().alias("__n__"))
+    keep = counts.filter(pl.col("__n__") >= 2).select("__bk__")
+    keyed = keyed.join(keep, on="__bk__", how="inner").sort("__bk__")
+    sizes = keyed.group_by("__bk__", maintain_order=True).agg(pl.len().alias("__n__"))
+    block_sizes = sizes.get_column("__n__").to_list()
+
+    row_ids = keyed.get_column("__row_id__").to_arrow()
+    fields = [keyed.get_column("name").cast(pl.Utf8).to_arrow()]
+    pairs = native.score_block_pairs_arrow(
+        row_ids, fields, block_sizes, SCORER_IDS, WEIGHTS, TOTAL_WEIGHT, THRESHOLD
+    )
+    if pairs:
+        ia = pa.array([p[0] for p in pairs], type=pa.int64())
+        ib = pa.array([p[1] for p in pairs], type=pa.int64())
+        sc = pa.array([p[2] for p in pairs], type=pa.float64())
+    else:
+        ia = pa.array([], type=pa.int64())
+        ib = pa.array([], type=pa.int64())
+        sc = pa.array([], type=pa.float64())
+    da, db, ds = native.dedup_pairs_arrow(ia, ib, sc)
+    all_ids = df.get_column("__row_id__").to_arrow()
+    labels = native.connected_components_arrow(da, db, ds, all_ids)
+    wall = time.perf_counter() - t0
+    return wall, labels.to_pylist()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", choices=["fused", "pipeline"], required=True)
+    ap.add_argument("--n", type=int, required=True)
+    ap.add_argument("--keycard", type=int, default=20)
+    args = ap.parse_args()
+
+    df = gen(args.n, args.keycard)
+    if args.path == "fused":
+        wall, clusters = run_fused(df)
+    else:
+        wall, clusters = run_pipeline(df)
+    fp, n_clusters = cluster_fp(clusters)
+
+    print(json.dumps({
+        "path": args.path,
+        "n": args.n,
+        "keycard": args.keycard,
+        "wall_s": round(wall, 3),
+        "peak_rss_mb": round(peak_rss_mb(), 1),
+        "n_clusters": n_clusters,
+        "cluster_fp": fp,
+        "rayon_min_pairs": os.environ.get("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS", "default"),
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldenmatch/scripts/bench_match_fused_scale.py
+++ b/packages/python/goldenmatch/scripts/bench_match_fused_scale.py
@@ -21,14 +21,11 @@ import hashlib
 import json
 import os
 import random
-import sys
 import time
 
-os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
-
+import goldenmatch._native as native
 import polars as pl
 import pyarrow as pa
-import goldenmatch._native as native
 
 SCORER_IDS = [0]  # jaro_winkler
 WEIGHTS = [1.0]

--- a/packages/rust/extensions/native/src/block.rs
+++ b/packages/rust/extensions/native/src/block.rs
@@ -29,36 +29,47 @@ use crate::score::StrCol;
 /// ASCII sentinel, and the ASCII case-fold matches Polars' Unicode lowercase here).
 const SENTINELS: [&str; 3] = ["nan", "null", "none"];
 
-#[pyfunction]
-pub fn build_block_index_arrow(
+/// Validate + read the key columns to `StrCol`, checking equal lengths.
+pub(crate) fn read_key_cols(
     key_fields: Vec<PyArrowType<ArrayData>>,
-) -> PyResult<(PyArrowType<ArrayData>, Vec<usize>)> {
+    who: &str,
+) -> PyResult<(Vec<StrCol>, usize)> {
     if key_fields.is_empty() {
-        return Err(PyValueError::new_err(
-            "build_block_index_arrow: at least one key field required",
-        ));
+        return Err(PyValueError::new_err(format!(
+            "{who}: at least one key field required"
+        )));
     }
     let cols: Vec<StrCol> = key_fields
         .into_iter()
         .map(|p| StrCol::from_data(p.0))
         .collect::<PyResult<_>>()?;
-
     let n_rows = cols[0].len();
     for (i, c) in cols.iter().enumerate() {
         if c.len() != n_rows {
             return Err(PyValueError::new_err(format!(
-                "build_block_index_arrow: field {i} length {} != row count {n_rows}",
+                "{who}: field {i} length {} != row count {n_rows}",
                 c.len()
             )));
         }
     }
+    Ok((cols, n_rows))
+}
 
-    // Group rows by derived block key, preserving first-appearance order so the
-    // output is deterministic (order within a block doesn't affect the pair set).
-    // FxHash (not SipHash) since these keys are trusted, not adversarial, and the
-    // single-field path borrows `&str` straight from the Arrow buffer (no per-row
-    // String alloc) — both matter at 5M rows where std::HashMap<String> lost ~9x
-    // to Polars' SIMD group_by.
+/// Group row positions by derived block key, returning one position list per
+/// block that has `>= 2` members (singletons produce no candidate pairs), in
+/// first-appearance order (deterministic; within/among-block order doesn't
+/// affect the candidate-pair set). This is the shared core of
+/// `build_block_index_arrow` and the fused `match_fused` orchestration.
+///
+/// Byte-parity with `core/blocker.py::build_blocks`: key = concat(fields, "||");
+/// any-null field -> row dropped (Polars `concat_str` null semantics); a
+/// stripped+lowercased key in {nan,null,none} -> dropped.
+///
+/// FxHash (not SipHash) since these keys are trusted, not adversarial, and the
+/// single-field path borrows `&str` straight from the Arrow buffer (no per-row
+/// String alloc) — both matter at 5M rows where std::HashMap<String> lost ~9x
+/// to Polars' SIMD group_by.
+pub(crate) fn group_block_positions(cols: &[StrCol], n_rows: usize) -> Vec<Vec<i64>> {
     let mut groups: Vec<Vec<i64>> = Vec::new();
 
     if cols.len() == 1 {
@@ -70,7 +81,6 @@ pub fn build_block_index_arrow(
                 Some(s) => s,
                 None => continue, // null single-field key -> dropped
             };
-            // Sentinel drop: strip+lowercase(key) in {nan,null,none}.
             let stripped = key.trim();
             if SENTINELS.iter().any(|s| stripped.eq_ignore_ascii_case(s)) {
                 continue;
@@ -89,8 +99,6 @@ pub fn build_block_index_arrow(
         index.reserve(n_rows / 4);
         let mut key = String::new();
         'row: for r in 0..n_rows {
-            // concat_str yields null if ANY field is null (ignore_nulls=False
-            // default) -> is_not_null drops it, so a null field drops the row.
             key.clear();
             for (fi, col) in cols.iter().enumerate() {
                 match col.get(r) {
@@ -117,15 +125,24 @@ pub fn build_block_index_arrow(
         }
     }
 
+    groups.retain(|g| g.len() >= 2);
+    groups
+}
+
+#[pyfunction]
+pub fn build_block_index_arrow(
+    key_fields: Vec<PyArrowType<ArrayData>>,
+) -> PyResult<(PyArrowType<ArrayData>, Vec<usize>)> {
+    let (cols, n_rows) = read_key_cols(key_fields, "build_block_index_arrow")?;
+    let groups = group_block_positions(&cols, n_rows);
+
     let mut order = Int64Builder::with_capacity(n_rows);
-    let mut block_sizes: Vec<usize> = Vec::new();
+    let mut block_sizes: Vec<usize> = Vec::with_capacity(groups.len());
     for rows in &groups {
-        if rows.len() >= 2 {
-            for &r in rows {
-                order.append_value(r);
-            }
-            block_sizes.push(rows.len());
+        for &r in rows {
+            order.append_value(r);
         }
+        block_sizes.push(rows.len());
     }
 
     Ok((PyArrowType(order.finish().into_data()), block_sizes))

--- a/packages/rust/extensions/native/src/fused.rs
+++ b/packages/rust/extensions/native/src/fused.rs
@@ -1,0 +1,186 @@
+//! Fused Arrow-native match stage — block + score + dedup + cluster in ONE Rust
+//! call, zero intermediate Polars, zero per-stage Arrow re-conversion.
+//!
+//! This is increment 2 of the fused-match design
+//! (`docs/design/2026-07-08-fused-arrow-native-match-kernel.md`). Every stage it
+//! runs is an existing source-of-truth kernel:
+//!   - block formation: [`crate::block::group_block_positions`] (increment 1)
+//!   - scoring: `goldenmatch_score_core::score_one` (the exact per-pair weighted
+//!     average `score_block_pairs_arrow` uses — byte-identical scoring)
+//!   - dedup: `goldenmatch_graph_core::dedup_pairs_max_score`
+//!   - clustering: `goldenmatch_graph_core::connected_components`
+//!
+//! The bet (measured, not assumed): fusing them into one call removes the
+//! Polars group/materialize + the three Arrow round-trips between stages that
+//! capped every prior "Arrow everywhere" spike. `match_fused` returns the
+//! connected components (clusters); the caller compares them to the per-stage
+//! pipeline for byte-parity and times both.
+
+use arrow::array::{ArrayData, Int64Array};
+use arrow::datatypes::DataType;
+use arrow::pyarrow::PyArrowType;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use rayon::prelude::*;
+
+use goldenmatch_graph_core::{connected_components, dedup_pairs_max_score};
+use goldenmatch_score_core::score_one;
+
+use crate::block::{group_block_positions, read_key_cols};
+use crate::score::StrCol;
+
+/// Fused match: block (on `key_fields`) -> score (weighted `score_fields`) ->
+/// dedup -> connected-components cluster, one call. Byte-parity contract: the
+/// candidate pairs equal `build_blocks` + `score_block_pairs_arrow`, so the
+/// clusters equal the per-stage pipeline on a covered config.
+///
+/// Scoring is byte-identical to `score_block_pairs_arrow::score_span`: per pair,
+/// `score_sum += score_one(scorer_ids[f], a, b) * weights[f]` over fields where
+/// BOTH values are present, emit `(min, max, score_sum / total_weight)` when
+/// `weight_sum > 0 && combined >= threshold`.
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (
+    row_ids, key_fields, score_fields, scorer_ids, weights, total_weight, threshold,
+))]
+pub fn match_fused(
+    py: Python<'_>,
+    row_ids: PyArrowType<ArrayData>,
+    key_fields: Vec<PyArrowType<ArrayData>>,
+    score_fields: Vec<PyArrowType<ArrayData>>,
+    scorer_ids: Vec<u8>,
+    weights: Vec<f64>,
+    total_weight: f64,
+    threshold: f64,
+) -> PyResult<Vec<Vec<i64>>> {
+    let row_data = row_ids.0;
+    if row_data.data_type() != &DataType::Int64 {
+        return Err(PyValueError::new_err(format!(
+            "match_fused: row_ids must be int64, got {:?}",
+            row_data.data_type()
+        )));
+    }
+    let row_ids = Int64Array::from(row_data);
+    let n_rows = row_ids.len();
+
+    let (key_cols, key_n) = read_key_cols(key_fields, "match_fused key")?;
+    if key_n != n_rows {
+        return Err(PyValueError::new_err(format!(
+            "match_fused: key field length {key_n} != row count {n_rows}"
+        )));
+    }
+
+    let n_fields = score_fields.len();
+    if scorer_ids.len() != n_fields || weights.len() != n_fields {
+        return Err(PyValueError::new_err(format!(
+            "match_fused: scorer_ids ({}) / weights ({}) must match score_fields ({n_fields})",
+            scorer_ids.len(),
+            weights.len()
+        )));
+    }
+    let score_cols: Vec<StrCol> = score_fields
+        .into_iter()
+        .map(|p| StrCol::from_data(p.0))
+        .collect::<PyResult<_>>()?;
+    for (f, c) in score_cols.iter().enumerate() {
+        if c.len() != n_rows {
+            return Err(PyValueError::new_err(format!(
+                "match_fused: score field {f} length {} != row count {n_rows}",
+                c.len()
+            )));
+        }
+    }
+
+    let all_ids: Vec<i64> = row_ids.values().to_vec();
+
+    // Everything below is pure-Rust and touches no Python object -> release the
+    // GIL for the whole fused pipeline (mirrors score_block_pairs_arrow).
+    let clusters = py.detach(|| {
+        // 1. Block formation (positions per block, singletons already dropped).
+        let groups = group_block_positions(&key_cols, n_rows);
+
+        // 2. Gather row_ids + each score field into block-CONTIGUOUS order, once
+        //    (O(n)). The pipeline pays this via a Polars sort so scoring reads
+        //    contiguous memory; the fused kernel does the same gather in Rust so
+        //    the O(k^2) inner scoring loop has the same cache locality (scattered
+        //    per-position `.get()` in the hot loop cost ~1.4x at coarse/big-block
+        //    shapes — the gather removes it).
+        let n_blk: usize = groups.iter().map(|g| g.len()).sum();
+        let mut rid_sorted: Vec<i64> = Vec::with_capacity(n_blk);
+        let mut vals: Vec<Vec<Option<&str>>> =
+            (0..n_fields).map(|_| Vec::with_capacity(n_blk)).collect();
+        for block in &groups {
+            for &p in block {
+                let p = p as usize;
+                rid_sorted.push(all_ids[p]);
+                for f in 0..n_fields {
+                    vals[f].push(score_cols[f].get(p));
+                }
+            }
+        }
+
+        // 3. Score intra-block pairs over the contiguous block-sorted buffers.
+        //    Byte-identical to score_block_pairs_arrow::score_span, and the SAME
+        //    guarded-rayon posture (#688): sequential in the calling thread below
+        //    GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS candidate pairs, fan out to rayon
+        //    above it. Scoring is the dominant term (~57% of the stage), so this
+        //    is the hot path — both paths must be parallel to compare fairly.
+        let mut spans: Vec<(usize, usize)> = Vec::with_capacity(groups.len());
+        let mut off = 0usize;
+        for block in &groups {
+            spans.push((off, block.len()));
+            off += block.len();
+        }
+        let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
+            let mut local: Vec<(i64, i64, f64)> = Vec::new();
+            let end = offset + size;
+            for i in offset..end - 1 {
+                let ri = rid_sorted[i];
+                for j in (i + 1)..end {
+                    let rj = rid_sorted[j];
+                    let (a_id, b_id) = if ri < rj { (ri, rj) } else { (rj, ri) };
+                    let mut score_sum = 0.0_f64;
+                    let mut weight_sum = 0.0_f64;
+                    for f in 0..n_fields {
+                        if let (Some(a), Some(b)) = (vals[f][i], vals[f][j]) {
+                            score_sum += score_one(scorer_ids[f], a, b) * weights[f];
+                            weight_sum += weights[f];
+                        }
+                    }
+                    if weight_sum > 0.0 {
+                        let combined = score_sum / total_weight;
+                        if combined >= threshold {
+                            local.push((a_id, b_id, combined));
+                        }
+                    }
+                }
+            }
+            local
+        };
+        let total_pairs: u128 = spans
+            .iter()
+            .map(|&(_, s)| {
+                let s = s as u128;
+                s * (s - 1) / 2
+            })
+            .sum();
+        let rayon_min_pairs: u128 = std::env::var("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(20_000_000);
+        let pairs: Vec<(i64, i64, f64)> = if total_pairs >= rayon_min_pairs {
+            spans
+                .par_iter()
+                .flat_map_iter(|&(o, s)| score_span(o, s))
+                .collect()
+        } else {
+            spans.iter().flat_map(|&(o, s)| score_span(o, s)).collect()
+        };
+
+        // 4. Dedup (canonical (min,max), max score) + 5. connected components.
+        let deduped = dedup_pairs_max_score(&pairs);
+        connected_components(&deduped, &all_ids)
+    });
+
+    Ok(clusters)
+}

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -13,6 +13,7 @@ mod bloom;
 mod cluster;
 mod documents;
 mod featurize;
+mod fused;
 mod hash;
 mod pairs;
 mod perceptual;
@@ -36,6 +37,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pairs::candidate_pair_count, m)?)?;
     m.add_function(wrap_pyfunction!(pairs::block_histogram, m)?)?;
     m.add_function(wrap_pyfunction!(block::build_block_index_arrow, m)?)?;
+    m.add_function(wrap_pyfunction!(fused::match_fused, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_features, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_project, m)?)?;
     m.add_function(wrap_pyfunction!(score::jaro_winkler_similarity, m)?)?;


### PR DESCRIPTION
Increment 2 of the fused Arrow-native match kernel (design #1589; increment 1 = block-formation kernel, #1590 merged).

## What
`match_fused(row_ids, key_fields, score_fields, scorer_ids, weights, total_weight, threshold) -> clusters` — block + score + dedup + cluster in **one Rust call**, zero intermediate Polars, zero per-stage Arrow re-conversion. Every stage reuses an existing source-of-truth kernel:
- block formation → increment 1's `group_block_positions` (extracted here as a shared helper + `read_key_cols`)
- scoring → `score_core::score_one`, the exact weighted-average of `score_block_pairs_arrow` (byte-identical)
- dedup + cluster → `graph_core::{dedup_pairs_max_score, connected_components}`

Guarded rayon on the scoring span loop (same #688 posture as `score_block_pairs_arrow`); a one-time O(n) block-contiguous gather so the O(k²) scoring loop has the pipeline's cache locality.

## Parity
Clusters **byte-identical** to the per-stage pipeline (`build_blocks` + `score_block_pairs_arrow` + `dedup_pairs_arrow` + `connected_components_arrow`) on covered configs, verified over 100K–1M corpora (cluster fingerprint match).

## Measurement so far (honest)
Sequential wall, local box, min-of-3: **a wash** vs the per-stage pipeline (0.77–1.24x). Scoring dominates (~57%) and is identical in both paths, so fusion only saves the minority conversion slice. **This does not beat the pipeline on single-thread wall.**

But the value axis the design actually named is composability + not-materializing-at-scale, and local smoke already shows it: at 100K, **fused peak RSS 101MB vs pipeline 198MB (~2x leaner)**. The pipeline materializes the pairs-as-Python-list + block-sorted frames; the fused kernel keeps everything as Rust `Vec`s.

## What this PR sets up
`.github/workflows/bench-match-fused.yml` (workflow_dispatch, `large-new-64GB`) measures the two axes the memory-starved local box can't:
1. **peak RSS per path** at 1M/5M/10M (each run isolated in its own process)
2. **the scale where the materializing pipeline OOMs** (exit 137) while the fused kernel survives at flat memory
Scoring forced parallel on both (`GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS=0`) so the dominant compute is held equal.

Dispatch after merge: `gh workflow run bench-match-fused.yml --ref main -f source_ref=main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)