### PR TITLE
fix(goldencheck): require both approximate_fd native symbols in the loader probe

### DIFF
--- a/packages/python/goldencheck/goldencheck/core/_native_loader.py
+++ b/packages/python/goldencheck/goldencheck/core/_native_loader.py
@@ -94,21 +94,27 @@ def native_enabled(component: str) -> bool:
     return _native is not None and _has_symbol(component)
 
 
-# Component name -> the native symbol that backs it. A component is only usable
-# when its symbol is actually present on the loaded module.
-_COMPONENT_SYMBOLS: dict[str, str] = {
-    "benford": "benford_leading_digits",
-    "composite_keys": "composite_key_search",
-    "functional_dependencies": "discover_functional_dependencies",
-    "fuzzy_values": "near_duplicate_value_clusters",
-    "approximate_fd": "discover_approximate_fds",
+# Component name -> the native symbol(s) that back it. A component is only usable
+# when ALL its symbols are present on the loaded module. Most components need one
+# symbol; ``approximate_fd`` needs two -- its call site (``relations/approx_fd.py``)
+# calls BOTH ``discover_approximate_fds`` and ``fd_violation_rows``, so a stale
+# wheel carrying only the former would pass a single-symbol probe, run the first
+# call, then ``AttributeError`` on the second and fall fully back to Python -- a
+# silent redundant native pass (the goldenmatch #688 footgun). Requiring every
+# symbol makes such a wheel cleanly decline up front.
+_COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
+    "benford": ("benford_leading_digits",),
+    "composite_keys": ("composite_key_search",),
+    "functional_dependencies": ("discover_functional_dependencies",),
+    "fuzzy_values": ("near_duplicate_value_clusters",),
+    "approximate_fd": ("discover_approximate_fds", "fd_violation_rows"),
 }
 
 
 def _has_symbol(component: str) -> bool:
     if _native is None:
         return False
-    symbol = _COMPONENT_SYMBOLS.get(component)
-    if symbol is None:
+    symbols = _COMPONENT_SYMBOLS.get(component)
+    if not symbols:
         return False
-    return hasattr(_native, symbol)
+    return all(hasattr(_native, s) for s in symbols)

--- a/packages/python/goldencheck/tests/test_native_loader_reference.py
+++ b/packages/python/goldencheck/tests/test_native_loader_reference.py
@@ -52,3 +52,24 @@ def test_env_one_requires_native(monkeypatch):
     monkeypatch.setenv("GOLDENCHECK_NATIVE", "1")
     with pytest.raises(RuntimeError):
         nl.native_enabled("benford")
+
+
+def test_approximate_fd_requires_both_symbols(monkeypatch):
+    """``approximate_fd``'s call site (relations/approx_fd.py) uses BOTH
+    ``discover_approximate_fds`` and ``fd_violation_rows``. A wheel carrying only
+    the first must cleanly decline, not pass the probe and then AttributeError on
+    the second call and silently fall back mid-run (the goldenmatch #688 footgun)."""
+    class FakeNativeOnlyDiscover:
+        discover_approximate_fds = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNativeOnlyDiscover)
+    monkeypatch.delenv("GOLDENCHECK_NATIVE", raising=False)
+    # Missing fd_violation_rows -> the component is not usable natively.
+    assert nl.native_enabled("approximate_fd") is False
+
+    class FakeNativeBoth:
+        discover_approximate_fds = staticmethod(lambda *a, **k: None)
+        fd_violation_rows = staticmethod(lambda *a, **k: None)
+
+    monkeypatch.setattr(nl, "_native", FakeNativeBoth)
+    assert nl.native_enabled("approximate_fd") is True


### PR DESCRIPTION
## Summary
- `goldencheck/core/_native_loader.py`: `_COMPONENT_SYMBOLS` values are now tuples of **all** native symbols a component needs, and `_has_symbol` requires **every** one present.
- Fixes an `approximate_fd` capability-probe gap: its call site (`relations/approx_fd.py`) calls **both** `discover_approximate_fds` and `fd_violation_rows`, but the probe only checked the first. A stale wheel carrying `discover_approximate_fds` without `fd_violation_rows` would pass the probe, run the first native call, then `AttributeError` on the second and fall fully back to Python — a silent redundant native pass (the goldenmatch #688 footgun).
- The other four components map to single-element tuples (behavior unchanged).

No behavior change on a current/correct wheel: main's native module registers both `discover_approximate_fds` and `fd_violation_rows` (`goldencheck-native/src/lib.rs`), so `native_enabled("approximate_fd")` stays `True`.

## Test plan
- [x] `tests/test_native_loader_reference.py` 6/6 pass, incl. new `test_approximate_fd_requires_both_symbols` (only-`discover_approximate_fds` fake → declines; both-symbol fake → enabled)
- [x] `ruff check` clean on both files
- [x] Verified main's pymodule exports both symbols (no regression on a real wheel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1XRtDNuLQncCEx6aUQTST