### PR TITLE
feat(goldenmatch): Arrow-native fused match entry + gate (fused-match increment 3)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -1,0 +1,135 @@
+"""Fused Arrow-native match stage -- opt-in scale/composability entry.
+
+`match_fused` (goldenmatch-native) runs block + score + dedup + cluster in ONE
+FFI call, holding every intermediate as a Rust `Vec` instead of a Polars frame
+or a Python pairs-list. MEASURED (`bench-match-fused`, 1M-10M on a 64GB box,
+scoring parallel on both paths): **wall-neutral** vs the per-stage pipeline
+(1.00-1.10x) but **~2x lower peak RSS** (2.73 GB vs 5.19 GB at 10M), clusters
+byte-identical. So this is a MEMORY/scale + composability entry -- a single
+Arrow-in -> Arrow-out match stage GoldenPipe can thread with no `pl.DataFrame` at
+the boundary, which raises the row-count ceiling on a given box ~2x. It is NOT a
+speed win and must not be sold as one.
+
+Covered configs run native; everything else returns None so the caller keeps the
+existing pipeline (the columnar-decline pattern). Coverage grows over increments;
+this one ships the no-transform boundary the kernel can honor byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pyarrow as pa
+
+from goldenmatch.core._native_loader import native_module
+
+# score_one ids -- mirror backends.score_buckets._NATIVE_SCORER_IDS exactly so
+# the fused entry scores identically to the per-stage arrow scorer.
+_FUSED_SCORER_IDS: dict[str, int] = {
+    "jaro_winkler": 0,
+    "levenshtein": 1,
+    "token_sort": 2,
+    "exact": 3,
+}
+
+
+def match_fused_ready(config: Any) -> bool:
+    """Conservative covered boundary for the fused kernel (grows over increments).
+
+    Covered: `static` single-key blocking with NO key transforms + exactly one
+    `weighted` matchkey whose fields all use a covered scorer with NO field
+    transforms + a threshold. The kernel groups/scores RAW column values (it
+    applies no transforms of its own), so "no transforms" is the byte-parity-safe
+    boundary this increment ships. Declines probabilistic / ANN / negative-
+    evidence / multi-pass / domain / LLM / PPRL to the existing pipeline.
+    """
+    b = getattr(config, "blocking", None)
+    if b is None or getattr(b, "strategy", "static") != "static":
+        return False
+    keys = getattr(b, "keys", None) or []
+    if len(keys) != 1 or keys[0].transforms:
+        return False
+    if getattr(b, "ann_column", None):
+        return False
+
+    get_mks = getattr(config, "get_matchkeys", None)
+    mks = get_mks() if callable(get_mks) else []
+    if len(mks) != 1:
+        return False
+    mk = mks[0]
+    if getattr(mk, "type", None) != "weighted":
+        return False
+    if getattr(mk, "negative_evidence", None):
+        return False
+    if mk.threshold is None or not mk.fields:
+        return False
+    for f in mk.fields:
+        if not f.field or f.transforms:
+            return False
+        if f.scorer not in _FUSED_SCORER_IDS:
+            return False
+    return True
+
+
+def _match_fused_symbol() -> Any | None:
+    try:
+        mod = native_module()
+    except Exception:
+        return None
+    return getattr(mod, "match_fused", None)
+
+
+def _as_utf8(arr: Any) -> Any:
+    if arr.type in (pa.string(), pa.large_string()):
+        return arr
+    return arr.cast(pa.string())
+
+
+def run_match_fused_arrow(
+    columns: Mapping[str, Any],
+    config: Any,
+    n_rows: int | None = None,
+) -> Any | None:
+    """Run the fused match stage over Arrow columns.
+
+    Returns a pyarrow Table ``(__row_id__ int64, __cluster_id__ int64)`` -- one
+    row per input record, a stable cluster id per connected component -- or
+    ``None`` when the config is not covered OR the native kernel is absent, so
+    the caller falls back to the existing pipeline.
+
+    ``columns`` maps field name -> pyarrow Array (any type; key + score fields
+    are cast to utf8). Row ids are 0..n in input order.
+    """
+    fn = _match_fused_symbol()
+    if fn is None or not match_fused_ready(config):
+        return None
+
+    key_fields = list(config.blocking.keys[0].fields)
+    mk = config.get_matchkeys()[0]
+
+    n = n_rows if n_rows is not None else len(columns[key_fields[0]])
+    row_ids = pa.array(range(n), type=pa.int64())
+
+    key_arrs = [_as_utf8(columns[f]) for f in key_fields]
+    score_arrs = [_as_utf8(columns[f.field]) for f in mk.fields]
+    scorer_ids = [_FUSED_SCORER_IDS[f.scorer] for f in mk.fields]
+    weights = [float(f.weight if f.weight is not None else 1.0) for f in mk.fields]
+    total_weight = sum(weights)
+    threshold = float(mk.threshold)
+
+    clusters = fn(row_ids, key_arrs, score_arrs, scorer_ids, weights, total_weight, threshold)
+
+    # clusters: list[list[int]] connected components (incl singletons).
+    rid: list[int] = []
+    cid: list[int] = []
+    for c_id, comp in enumerate(clusters):
+        for r in comp:
+            rid.append(r)
+            cid.append(c_id)
+    return pa.table(
+        {
+            "__row_id__": pa.array(rid, type=pa.int64()),
+            "__cluster_id__": pa.array(cid, type=pa.int64()),
+        }
+    )

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -1,0 +1,151 @@
+"""Increment 3: the fused Arrow-native match entry (goldenmatch.core.fused_match).
+
+Gate tests for `match_fused_ready` (covered boundary) + a parity test of
+`run_match_fused_arrow` against an INDEPENDENT brute-force oracle (block by key
+with the same null/sentinel drop, score with jaro_winkler, union-find) -- so the
+entry's marshaling (scorer id, weight, threshold, column selection, block-key
+semantics) is proven correct end to end, not just kernel-vs-kernel.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import pyarrow as pa
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core import fused_match
+from goldenmatch.core._native_loader import native_module
+
+_HAS_FUSED = fused_match._match_fused_symbol() is not None
+
+
+def _covered_config(threshold: float = 0.85) -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="weighted",
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+                threshold=threshold,
+            )
+        ],
+    )
+
+
+# ---- gate ---------------------------------------------------------------
+
+def test_ready_true_on_covered_config():
+    assert fused_match.match_fused_ready(_covered_config()) is True
+
+
+def test_ready_false_on_key_transform():
+    c = _covered_config()
+    c.blocking.keys[0].transforms = ["lowercase"]
+    assert fused_match.match_fused_ready(c) is False
+
+
+def test_ready_false_on_field_transform():
+    c = _covered_config()
+    c.matchkeys[0].fields[0].transforms = ["strip"]
+    assert fused_match.match_fused_ready(c) is False
+
+
+def test_ready_false_on_uncovered_scorer():
+    c = _covered_config()
+    c.matchkeys[0].fields[0].scorer = "soundex_match"
+    assert fused_match.match_fused_ready(c) is False
+
+
+def test_ready_false_on_multi_pass_blocking():
+    c = _covered_config()
+    c.blocking.strategy = "multi_pass"
+    assert fused_match.match_fused_ready(c) is False
+
+
+def test_ready_false_on_two_blocking_keys():
+    c = _covered_config()
+    c.blocking.keys.append(BlockingKeyConfig(fields=["name"]))
+    assert fused_match.match_fused_ready(c) is False
+
+
+def test_ready_false_on_missing_threshold():
+    c = _covered_config()
+    c.matchkeys[0].threshold = None
+    assert fused_match.match_fused_ready(c) is False
+
+
+# ---- parity vs an independent brute oracle -----------------------------
+
+def _brute_clusters(keys, names, threshold):
+    jw = native_module().jaro_winkler_similarity
+    blocks: dict[str, list[int]] = defaultdict(list)
+    for i, k in enumerate(keys):
+        if k is None:
+            continue
+        if str(k).strip().lower() in ("nan", "null", "none"):
+            continue
+        blocks[str(k)].append(i)
+
+    parent = list(range(len(keys)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for members in blocks.values():
+        for ai in range(len(members)):
+            for bi in range(ai + 1, len(members)):
+                a, b = members[ai], members[bi]
+                if jw(names[a], names[b]) >= threshold:
+                    ra, rb = find(a), find(b)
+                    if ra != rb:
+                        parent[ra] = rb
+
+    comps: dict[int, list[int]] = defaultdict(list)
+    for i in range(len(keys)):
+        comps[find(i)].append(i)
+    return {frozenset(v) for v in comps.values() if len(v) >= 2}
+
+
+def _table_to_clusters(tbl):
+    comps: dict[int, list[int]] = defaultdict(list)
+    for r, c in zip(tbl.column("__row_id__").to_pylist(), tbl.column("__cluster_id__").to_pylist()):
+        comps[c].append(r)
+    return {frozenset(v) for v in comps.values() if len(v) >= 2}
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_run_match_fused_arrow_matches_brute_oracle():
+    # Blocks form on `blk`; near-duplicate names cross the jaro_winkler threshold.
+    keys = ["a", "a", "a", "b", "b", "c", None, "NULL", "nan", "d", "d"]
+    names = [
+        "jonathan", "jonathon", "michael",   # blk a: jonathan~jonathon merge, michael alone
+        "sarah", "sarah",                    # blk b: exact merge
+        "lone",                              # blk c: singleton
+        "dropme1", "dropme2", "dropme3",     # null / NULL / nan keys dropped
+        "kevin", "kevni",                    # blk d: near-dup merge
+    ]
+    config = _covered_config(threshold=0.85)
+    columns = {"blk": pa.array(keys), "name": pa.array(names)}
+
+    tbl = fused_match.run_match_fused_arrow(columns, config)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    want = _brute_clusters(keys, names, 0.85)
+    assert got == want
+
+
+def test_run_match_fused_arrow_declines_uncovered():
+    c = _covered_config()
+    c.matchkeys[0].fields[0].scorer = "soundex_match"
+    assert fused_match.run_match_fused_arrow({"blk": pa.array(["a"]), "name": pa.array(["x"])}, c) is None


### PR DESCRIPTION
Increment 3 of the fused Arrow-native match kernel (design #1589; #1590 block kernel + #1591 match_fused, both merged).

## What
`goldenmatch/core/fused_match.py` — the **Arrow-in → Arrow-out public entry** over `match_fused`, the seam GoldenPipe threads with no `pl.DataFrame` at the boundary:
- **`match_fused_ready(config) -> bool`** — conservative covered boundary: `static` single-key blocking with no key transforms + one `weighted` matchkey whose fields all use a covered scorer (`jaro_winkler`/`levenshtein`/`token_sort`/`exact`) with no field transforms + a threshold. Everything else declines to the existing pipeline (the columnar-decline pattern). Coverage grows over increments; this ships the no-transform boundary the kernel honors byte-for-byte.
- **`run_match_fused_arrow(columns, config) -> pa.Table | None`** — marshals config → kernel args (scorer ids mirror `score_buckets._NATIVE_SCORER_IDS`), calls `match_fused`, returns `(__row_id__, __cluster_id__)`; `None` when uncovered or native absent so the caller keeps the pipeline.

## Framing (per the measured verdict)
`bench-match-fused` (1M–10M, 64GB): wall-neutral (1.00–1.10x) but **~2x lower peak RSS** (2.73 GB vs 5.19 GB at 10M), clusters byte-identical. This is a **memory/scale + composability** entry, **not a speed win**, and the module docstring says so.

## Scope discipline
Deliberately **not** added to `goldenmatch.__all__` / MCP / CLI — no cross-language surface-parity manifest change; reachable via `goldenmatch.core.fused_match`. Wiring into GoldenPipe is increment 4.

## Tests (9/9)
Parity of `run_match_fused_arrow` vs an **independent brute-force oracle** (block + `jaro_winkler` + union-find with the same null/sentinel drop) — proves the marshaling end to end, not just kernel-vs-kernel — plus 7 `match_fused_ready` gate cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)