### PR TITLE
feat(goldenpipe): FusedDedupeStage — opt-in Arrow-native match stage (fused-match increment 4)

### DIFF
--- a/packages/python/goldenpipe/goldenpipe/adapters/match.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/match.py
@@ -94,6 +94,94 @@ class DedupeStage:
         return StageResult(status=StageStatus.SUCCESS)
 
 
+class FusedDedupeStage:
+    """Opt-in Arrow-native fused match stage (memory/scale + composability).
+
+    Runs goldenmatch's `match_fused` kernel (block+score+dedup+cluster in ONE
+    FFI call) over the frame's columns as Arrow, with no intermediate
+    `pl.DataFrame`/pairs-list materialization. MEASURED (1M-10M): wall-neutral
+    vs the classic DedupeStage but ~2x lower peak RSS, byte-identical clusters --
+    so this is the stage a GoldenPipe chain places when it wants cluster
+    assignments at scale on a memory-constrained box, threaded as Arrow.
+
+    CLUSTERS ONLY: it produces `clusters` + `cluster_assignments` (Arrow), NOT
+    golden/unique/dupes (the fused kernel's declined scope -- golden records need
+    the row payload, which stays the classic DedupeStage's job). Requires an
+    EXPLICIT covered config (`match_fused_ready`): static single-key blocking with
+    no key transforms + one weighted matchkey over covered scorers with no field
+    transforms. `validate()` raises a clear pointer to `goldenmatch.dedupe`
+    otherwise -- it never silently falls back, so a caller who asked for the
+    fused stage always gets the fused path or an explicit error.
+    """
+
+    info = StageInfo(
+        name="goldenmatch.dedupe_fused",
+        produces=["clusters", "cluster_assignments"],
+        consumes=["df"],
+    )
+    rollback = None
+
+    def _config(self, ctx: PipeContext):
+        stage_cfg = ctx.stage_config
+        if not stage_cfg:
+            return None
+        from goldenmatch.config.schemas import GoldenMatchConfig
+
+        return GoldenMatchConfig(**stage_cfg)
+
+    def validate(self, ctx: PipeContext) -> None:
+        if not HAS_MATCH:
+            raise RuntimeError("GoldenMatch not installed. Run: pip install goldenpipe[match]")
+        from goldenmatch.core.fused_match import _match_fused_symbol, match_fused_ready
+
+        if _match_fused_symbol() is None:
+            raise RuntimeError(
+                "goldenmatch-native match_fused kernel unavailable. "
+                "Install goldenmatch[native] or use the goldenmatch.dedupe stage."
+            )
+        config = self._config(ctx)
+        if config is None:
+            raise RuntimeError(
+                "goldenmatch.dedupe_fused requires an explicit covered config in the "
+                "stage spec (auto-built configs carry transforms the fused kernel does "
+                "not cover). Supply one, or use the goldenmatch.dedupe stage."
+            )
+        if not match_fused_ready(config):
+            raise RuntimeError(
+                "config is not covered by the fused match kernel (needs static "
+                "single-key blocking with no key transforms + one weighted matchkey "
+                "over jaro_winkler/levenshtein/token_sort/exact with no field "
+                "transforms). Use the goldenmatch.dedupe stage for this config."
+            )
+
+    def run(self, ctx: PipeContext) -> StageResult:
+        from goldenmatch.core.fused_match import run_match_fused_arrow
+
+        config = self._config(ctx)
+        # Only the key + score columns cross as Arrow (one zero-copy view each);
+        # no whole-frame or intermediate re-materialization.
+        key_fields = list(config.blocking.keys[0].fields)
+        score_fields = [f.field for f in config.get_matchkeys()[0].fields]
+        needed = list(dict.fromkeys([*key_fields, *score_fields]))
+        columns = {c: ctx.df[c].to_arrow() for c in needed}
+
+        table = run_match_fused_arrow(columns, config, n_rows=ctx.df.height)
+        if table is None:  # defensive: validate() already gated coverage
+            raise RuntimeError("fused match declined a config validate() accepted")
+
+        ctx.artifacts["cluster_assignments"] = table
+        # Multi-member clusters as {cluster_id: [row_id, ...]} for downstream
+        # consumers (e.g. IdentityResolveStage reads `clusters`).
+        clusters: dict[int, list[int]] = {}
+        for rid, cid in zip(
+            table.column("__row_id__").to_pylist(),
+            table.column("__cluster_id__").to_pylist(),
+        ):
+            clusters.setdefault(cid, []).append(rid)
+        ctx.artifacts["clusters"] = {c: m for c, m in clusters.items() if len(m) >= 2}
+        return StageResult(status=StageStatus.SUCCESS)
+
+
 def _build_config_from_contexts(contexts: list, df) -> object | None:
     """Build a GoldenMatchConfig from pipeline column contexts.
 

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -58,6 +58,7 @@ Author = "https://bensevern.dev"
 "goldencheck.scan" = "goldenpipe.adapters.check:ScanStage"
 "goldenflow.transform" = "goldenpipe.adapters.flow:TransformStage"
 "goldenmatch.dedupe" = "goldenpipe.adapters.match:DedupeStage"
+"goldenmatch.dedupe_fused" = "goldenpipe.adapters.match:FusedDedupeStage"
 "goldenmatch.identity_resolve" = "goldenpipe.adapters.identity:IdentityResolveStage"
 "goldenanalysis.report" = "goldenpipe.adapters.analysis:AnalysisReportStage"
 

--- a/packages/python/goldenpipe/tests/test_fused_dedupe_stage.py
+++ b/packages/python/goldenpipe/tests/test_fused_dedupe_stage.py
@@ -1,0 +1,110 @@
+"""Increment 4: the opt-in Arrow-native FusedDedupeStage (GoldenPipe integration).
+
+Verifies the stage runs the fused match kernel over the frame's columns as Arrow
+and emits `clusters` + `cluster_assignments`, that it declines an uncovered config
+LOUDLY (never a silent fallback), and that its clusters match an independent
+brute-force oracle.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+
+import polars as pl
+import pytest
+
+pytest.importorskip("goldenmatch")
+
+from goldenmatch.core.fused_match import _match_fused_symbol  # noqa: E402
+from goldenpipe.adapters.match import FusedDedupeStage  # noqa: E402
+from goldenpipe.models.context import PipeContext, StageStatus  # noqa: E402
+
+_HAS_FUSED = _match_fused_symbol() is not None
+
+_COVERED_CFG = {
+    "blocking": {"strategy": "static", "keys": [{"fields": ["blk"]}]},
+    "matchkeys": [
+        {
+            "name": "mk",
+            "type": "weighted",
+            "threshold": 0.85,
+            "fields": [{"field": "name", "scorer": "jaro_winkler", "weight": 1.0}],
+        }
+    ],
+}
+
+
+def _frame():
+    keys = ["a", "a", "a", "b", "b", "c"]
+    names = ["jonathan", "jonathon", "michael", "sarah", "sarah", "lone"]
+    return pl.DataFrame({"blk": keys, "name": names})
+
+
+def _brute(df: pl.DataFrame, threshold: float):
+    from goldenmatch.core._native_loader import native_module
+
+    jw = native_module().jaro_winkler_similarity
+    keys = df["blk"].to_list()
+    names = df["name"].to_list()
+    blocks: dict[str, list[int]] = defaultdict(list)
+    for i, k in enumerate(keys):
+        blocks[str(k)].append(i)
+    parent = list(range(len(keys)))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for members in blocks.values():
+        for ai in range(len(members)):
+            for bi in range(ai + 1, len(members)):
+                a, b = members[ai], members[bi]
+                if jw(names[a], names[b]) >= threshold:
+                    ra, rb = find(a), find(b)
+                    if ra != rb:
+                        parent[ra] = rb
+    comps: dict[int, list[int]] = defaultdict(list)
+    for i in range(len(keys)):
+        comps[find(i)].append(i)
+    return {frozenset(v) for v in comps.values() if len(v) >= 2}
+
+
+def test_validate_declines_without_config():
+    ctx = PipeContext(df=_frame())
+    with pytest.raises(RuntimeError, match="explicit covered config"):
+        FusedDedupeStage().validate(ctx)
+
+
+def test_validate_declines_uncovered_config():
+    cfg = {
+        "blocking": {"strategy": "static", "keys": [{"fields": ["blk"]}]},
+        "matchkeys": [
+            {
+                "name": "mk",
+                "type": "weighted",
+                "threshold": 0.85,
+                "fields": [{"field": "name", "scorer": "soundex_match", "weight": 1.0}],
+            }
+        ],
+    }
+    ctx = PipeContext(df=_frame(), stage_config=cfg)
+    with pytest.raises(RuntimeError, match="not covered"):
+        FusedDedupeStage().validate(ctx)
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_run_emits_clusters_matching_brute_oracle():
+    df = _frame()
+    ctx = PipeContext(df=df, stage_config=_COVERED_CFG)
+    stage = FusedDedupeStage()
+    stage.validate(ctx)
+    res = stage.run(ctx)
+
+    assert res.status == StageStatus.SUCCESS
+    assert "cluster_assignments" in ctx.artifacts
+    assert ctx.artifacts["cluster_assignments"].num_rows == df.height  # one row per record
+
+    got = {frozenset(m) for m in ctx.artifacts["clusters"].values()}
+    assert got == _brute(df, 0.85)


### PR DESCRIPTION
Increment 4 (final) of the fused Arrow-native match kernel. Design #1589; #1590 block kernel, #1591 match_fused, #1594 Arrow entry — all merged.

## What
`goldenmatch.dedupe_fused` — a new GoldenPipe stage that threads the fused kernel into a pipeline: consumes the frame's key+score columns **as Arrow** (one zero-copy view each — no whole-frame or intermediate re-materialization), runs `run_match_fused_arrow` when the config is covered, and emits `clusters` + `cluster_assignments` (Arrow). This is the composability payoff the design named: a match stage a chain places with **no `pl.DataFrame` at the boundary**.

## Honest scope (per the measured verdict)
- **Clusters only** — not golden/unique/dupes. Golden records need the row payload materialized, which is the fused kernel's declined scope and stays the classic `goldenmatch.dedupe` stage's job.
- **Requires an explicit covered config** — auto-built configs carry transforms the kernel doesn't cover, so `validate()` raises a clear pointer to `goldenmatch.dedupe`. It **never silently falls back**: asking for the fused stage yields the fused path or an explicit error.
- Value case is **memory/scale (~2x lower peak RSS) + Arrow composability, not speed** (wall is a measured wash).

## Tests (3)
declines-without-config, declines-uncovered-config (loud), and run-emits-clusters-matching-an-independent-brute-oracle. Not an MCP/CLI/a2a surface (no `api_parity` manifest change); goldenpipe is not `native_symbols`-gated.

## Arc complete
block kernel (#1590) → match_fused (#1591) → Arrow entry (#1594) → GoldenPipe stage (this). The thesis landed as a **scale/composability capability** — byte-identical clusters at half the peak RSS behind one Arrow-in/out call — measured honestly, not sold as a speed win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)