### PR TITLE
bench(goldenmatch): memory-capped throughput bench for the fused match stage

### DIFF
--- a/.github/workflows/bench-match-fused-memcap.yml
+++ b/.github/workflows/bench-match-fused-memcap.yml
@@ -1,0 +1,147 @@
+# Memory-capped throughput bench for the fused match stage -- workflow_dispatch.
+#
+# Tests the "RSS -> speed" hypothesis: under a FIXED cgroup RAM cap, does fused's
+# ~2x lower per-job working set let it sustain ~2x the concurrent dedup jobs
+# before the cap OOM-kills it -> ~2x aggregate throughput? This is the
+# MEMORY-BOUND regime the earlier 64GB wall bench (CPU-bound, a wash) couldn't
+# show. Each (path, workers) runs W concurrent dedup PROCESSES (no GIL confound)
+# inside `systemd-run -p MemoryMax=<cap>`; OOM-kill at the cap is the RSS signal.
+# The path that fits more workers before the cap has the higher throughput
+# ceiling at that RAM budget.
+#
+# Dispatch after this lands on main:
+#   gh workflow run bench-match-fused-memcap.yml --ref main -f source_ref=main
+name: bench-match-fused-memcap
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch/ref to build + bench (has match_fused + the memcap script)"
+        required: true
+        default: "main"
+      cap:
+        description: "cgroup MemoryMax (e.g. 24G) -- the fixed RAM ceiling"
+        required: false
+        default: "24G"
+      n:
+        description: "Rows per concurrent dedup job (sized so working set > interpreter base)"
+        required: false
+        default: "5000000"
+      workers:
+        description: "Space-separated worker counts to sweep"
+        required: false
+        default: "2 4 6 8 10 12"
+      runner:
+        description: "Runner label (physical RAM must exceed the cap; cores >= max workers)"
+        required: false
+        default: "large-new-64GB"
+      per_run_timeout:
+        description: "Hard per-run cap (s)"
+        required: false
+        default: "1200"
+
+permissions:
+  contents: read
+
+jobs:
+  memcap:
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 120
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      POLARS_SKIP_CPU_CHECK: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.source_ref }}
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (from source_ref)
+        run: uv run python scripts/build_native.py
+
+      - name: Sweep workers under a fixed RAM cap
+        working-directory: packages/python/goldenmatch
+        run: |
+          set +e
+          : > memcap.jsonl
+          PY=$(uv run python -c "import sys;print(sys.executable)")
+          echo "python: $PY  cap: ${{ inputs.cap }}  n: ${{ inputs.n }}"
+          for p in fused pipeline; do
+            for w in ${{ inputs.workers }}; do
+              echo "::group::path=$p workers=$w cap=${{ inputs.cap }}"
+              out=$(sudo systemd-run --scope --quiet \
+                    -p MemoryMax=${{ inputs.cap }} -p MemorySwapMax=0 \
+                    --setenv=POLARS_SKIP_CPU_CHECK=1 \
+                    --setenv=GOLDENMATCH_AUTOCONFIG_MEMORY=0 \
+                    -- timeout ${{ inputs.per_run_timeout }} \
+                    "$PY" scripts/bench_match_fused_memcap.py --path "$p" --n ${{ inputs.n }} --workers "$w")
+              rc=$?
+              if [ $rc -eq 0 ] && [ -n "$out" ]; then
+                echo "$out"; echo "$out" >> memcap.jsonl
+              else
+                # non-zero = OOM-kill at the cap (or timeout). This is the ceiling signal.
+                echo "{\"path\":\"$p\",\"n\":${{ inputs.n }},\"workers\":$w,\"status\":\"OOM_OR_FAIL\",\"exit\":$rc}" | tee -a memcap.jsonl
+              fi
+              echo "::endgroup::"
+            done
+          done
+
+      - name: Summarize
+        working-directory: packages/python/goldenmatch
+        run: |
+          uv run python - <<'PY'
+          import json
+          rows = [json.loads(l) for l in open("memcap.jsonl") if l.strip()]
+          by = {}
+          for r in rows:
+              by.setdefault(r["path"], {})[r["workers"]] = r
+          print(f"\n=== memory-capped throughput (fixed RAM cap; W concurrent dedup jobs) ===")
+          for path in ("fused", "pipeline"):
+              d = by.get(path, {})
+              print(f"\n{path}:")
+              best = 0
+              best_w = None
+              for w in sorted(d):
+                  r = d[w]
+                  if r.get("status") == "ok":
+                      tp = r["rows_per_s"]
+                      peak = r.get("cgroup_peak_mb")
+                      print(f"  W={w:>3}  rows/s={tp:>12,}  peak={peak}MB  (total {r['total_rows']:,} rows)")
+                      if tp > best:
+                          best, best_w = tp, w
+                  else:
+                      print(f"  W={w:>3}  OOM/FAIL at the cap (ceiling)")
+              if best_w is not None:
+                  print(f"  -> peak sustained throughput: {best:,} rows/s at W={best_w}")
+              by[path]["_best"] = best
+          fb = by.get("fused", {}).get("_best", 0)
+          pb = by.get("pipeline", {}).get("_best", 0)
+          print("\n=== VERDICT ===")
+          if pb and fb:
+              print(f"peak throughput at the cap: fused {fb:,} rows/s vs pipeline {pb:,} rows/s = {fb/pb:.2f}x")
+              print("(>1 = fused converts its RSS headroom into throughput in the memory-bound regime)")
+          else:
+              print(f"fused_best={fb} pipeline_best={pb} (one path OOM'd at every W -- widen the sweep or cap)")
+          PY
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        if: always()
+        with:
+          name: bench-match-fused-memcap-results
+          path: packages/python/goldenmatch/memcap.jsonl

--- a/packages/python/goldenmatch/scripts/bench_match_fused_memcap.py
+++ b/packages/python/goldenmatch/scripts/bench_match_fused_memcap.py
@@ -1,0 +1,142 @@
+"""Memory-capped throughput bench for the fused match stage (the "RSS -> speed"
+experiment). Ben's hypothesis: fused's ~2x lower peak RSS lets you run ~2x the
+concurrent dedup jobs under a fixed RAM ceiling -> ~2x throughput, in the
+MEMORY-BOUND regime the earlier (CPU-bound, 64GB) wall bench couldn't show.
+
+This runs W concurrent dedup jobs (each on its own N-row frame) in separate
+PROCESSES -- true parallelism, no GIL confound -- and reports aggregate
+throughput (rows/s). Run it under a cgroup memory cap (the workflow wraps it in
+`systemd-run -p MemoryMax=...`); the OOM-kill at the cap is the RSS signal. The
+path that sustains more workers before the cap kills it has the higher
+throughput ceiling at that RAM budget.
+
+Per-job N is sized so the per-job working set dominates the per-process
+interpreter+lib base (~0.5 GB), so the delta measured is working set, not base.
+
+Usage (under a cap):
+  systemd-run --scope -p MemoryMax=24G -p MemorySwapMax=0 -- \
+    python bench_match_fused_memcap.py --path fused --n 5000000 --workers 8
+"""
+
+import argparse
+import json
+import os
+import random
+import time
+from concurrent.futures import ProcessPoolExecutor
+
+SCORER_IDS = [0]  # jaro_winkler
+WEIGHTS = [1.0]
+TOTAL_WEIGHT = 1.0
+THRESHOLD = 0.85
+
+
+def _gen(n: int, keycard: int, seed: int):
+    rng = random.Random(seed)
+    firsts = ["john", "jane", "mary", "mike", "sara", "dave", "lisa", "paul", "anna", "mark"]
+    lasts = ["smith", "jones", "brown", "davis", "moore", "clark", "hall", "young", "king", "wood"]
+    import polars as pl
+
+    n_keys = max(1, n // keycard)
+    keys = [f"blk{rng.randint(0, n_keys)}" for _ in range(n)]
+    names = []
+    for _ in range(n):
+        base = f"{rng.choice(firsts)} {rng.choice(lasts)}"
+        if rng.random() < 0.3:
+            base = base[:-1] + rng.choice("aeiou")
+        names.append(base)
+    return (
+        pl.DataFrame({"blk": keys, "name": names})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+
+
+def _job(args):
+    """One dedup job in its own process. Returns rows processed + cluster count."""
+    path, n, keycard, seed = args
+    os.environ.setdefault("POLARS_SKIP_CPU_CHECK", "1")
+    import goldenmatch._native as native
+    import polars as pl
+    import pyarrow as pa
+
+    df = _gen(n, keycard, seed)
+    if path == "fused":
+        row_ids = df.get_column("__row_id__").to_arrow()
+        key = df.get_column("blk").cast(pl.Utf8).to_arrow()
+        score = df.get_column("name").cast(pl.Utf8).to_arrow()
+        clusters = native.match_fused(
+            row_ids, [key], [score], SCORER_IDS, WEIGHTS, TOTAL_WEIGHT, THRESHOLD
+        )
+        cnt = sum(1 for c in clusters if len(c) >= 2)
+    else:
+        keyed = df.with_columns(pl.col("blk").cast(pl.Utf8).alias("__bk__")).filter(
+            pl.col("__bk__").is_not_null()
+            & ~pl.col("__bk__").str.strip_chars().str.to_lowercase().is_in(["nan", "null", "none"])
+        )
+        counts = keyed.group_by("__bk__").agg(pl.len().alias("__n__"))
+        keep = counts.filter(pl.col("__n__") >= 2).select("__bk__")
+        keyed = keyed.join(keep, on="__bk__", how="inner").sort("__bk__")
+        sizes = keyed.group_by("__bk__", maintain_order=True).agg(pl.len().alias("__n__"))
+        block_sizes = sizes.get_column("__n__").to_list()
+        row_ids = keyed.get_column("__row_id__").to_arrow()
+        fields = [keyed.get_column("name").cast(pl.Utf8).to_arrow()]
+        pairs = native.score_block_pairs_arrow(
+            row_ids, fields, block_sizes, SCORER_IDS, WEIGHTS, TOTAL_WEIGHT, THRESHOLD
+        )
+        if pairs:
+            ia = pa.array([p[0] for p in pairs], type=pa.int64())
+            ib = pa.array([p[1] for p in pairs], type=pa.int64())
+            sc = pa.array([p[2] for p in pairs], type=pa.float64())
+        else:
+            ia = pa.array([], type=pa.int64())
+            ib = pa.array([], type=pa.int64())
+            sc = pa.array([], type=pa.float64())
+        da, db, ds = native.dedup_pairs_arrow(ia, ib, sc)
+        all_ids = df.get_column("__row_id__").to_arrow()
+        labels = native.connected_components_arrow(da, db, ds, all_ids).to_pylist()
+        cnt = sum(1 for c in labels if len(c) >= 2)
+    return n, cnt
+
+
+def _cgroup_peak_mb():
+    """Best-effort peak RSS of this process's cgroup (systemd scope), MB."""
+    try:
+        with open("/proc/self/cgroup") as fh:
+            rel = fh.read().strip().split(":")[-1]
+        path = f"/sys/fs/cgroup{rel}/memory.peak"
+        with open(path) as fh:
+            return round(int(fh.read().strip()) / 1024 / 1024, 1)
+    except Exception:
+        return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--path", choices=["fused", "pipeline"], required=True)
+    ap.add_argument("--n", type=int, required=True)
+    ap.add_argument("--keycard", type=int, default=20)
+    ap.add_argument("--workers", type=int, required=True)
+    args = ap.parse_args()
+
+    jobs = [(args.path, args.n, args.keycard, 11 + i) for i in range(args.workers)]
+    t0 = time.perf_counter()
+    with ProcessPoolExecutor(max_workers=args.workers) as ex:
+        results = list(ex.map(_job, jobs))
+    wall = time.perf_counter() - t0
+    total_rows = sum(r[0] for r in results)
+
+    print(json.dumps({
+        "path": args.path,
+        "n": args.n,
+        "workers": args.workers,
+        "total_rows": total_rows,
+        "wall_s": round(wall, 3),
+        "rows_per_s": round(total_rows / wall) if wall > 0 else None,
+        "cgroup_peak_mb": _cgroup_peak_mb(),
+        "status": "ok",
+    }))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The experiment that tests Ben's "RSS -> speed" thesis in the regime where it should hold.

## Why
The 10M/64GB wall bench was CPU-bound (scoring saturated all cores, identical kernel both paths) → a wash. Ben's insight: fused's ~2x lower per-job working set should convert to speed in the **memory-bound** regime — under a fixed RAM ceiling, fused fits ~2x the concurrent dedup jobs before OOM → ~2x aggregate throughput.

## How
`scripts/bench_match_fused_memcap.py` runs W concurrent dedup jobs (separate **processes** — no GIL confound) and reports rows/s + cgroup peak. `.github/workflows/bench-match-fused-memcap.yml` (workflow_dispatch, `large-new-64GB`) sweeps W under a **fixed cgroup RAM cap** (`systemd-run -p MemoryMax=24G -p MemorySwapMax=0`) for both paths; the OOM-kill at the cap is the RSS signal. Per-job N (default 5M) is sized so the working set dominates the ~0.5GB interpreter base, so the delta measured is working set. Summary prints peak sustained throughput per path + the ratio.

## Verdict shape
If fused sustains ~2x the workers before the cap → ~2x throughput at the same RAM budget = the speedup claim, honestly earned in the memory-bound regime (the one the wall bench couldn't reach). Both job paths validated locally to produce identical clusters (8646 @ 40k).

Dispatch after merge: `gh workflow run bench-match-fused-memcap.yml --ref main -f source_ref=main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)