### PR TITLE
feat(goldenpipe): compiler SP2 — field-level provenance from the IR

### DIFF
--- a/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-provenance.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-provenance.md
@@ -1,0 +1,365 @@
+# GoldenPipe Compiler SP2 — Field-Level Provenance — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the SP1 `CompiledPipeline` into a field-level lineage report (per column: Check ops → ordered Flow transforms → matching role), via a pure `provenance` kernel function + a Match-capture enrichment that makes blocking-key/scorer roles real. Non-perf, net-new, additive.
+
+**Architecture:** A pure `provenance(CompiledPipeline) → {fields, unmapped}` in the `goldenpipe-core` kernel (Rust + Python mirror + golden vectors), same pattern as `lower`. The host enriches `capture.py`'s Match branch (normalize the real `GoldenMatchConfig`'s nested `blocking`/`matchkeys` into flat `{keys, scorer}` so `Partition.keys`/`PairScore.scorer` name real columns) and adds a `field_lineage` wrapper + `format_lineage`.
+
+**Tech Stack:** Python (goldenpipe compiler + goldenmatch config), Rust (serde_json), the existing goldenpipe-core golden-vector infra.
+
+---
+
+## Box / environment constraints
+
+- **Python is box-runnable** (real red→green). Rust is CI-only (write-against-spec + rustfmt + grep/eye).
+- Python env (`;` PYTHONPATH; **includes goldenmatch** for the config shapes):
+  ```bash
+  INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="packages/python/goldenpipe;packages/python/goldencheck;packages/python/infermap;packages/python/goldencheck-types;packages/python/goldenflow;packages/python/goldenmatch"
+  export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 GOLDENMATCH_AUTOCONFIG_MEMORY=0
+  ```
+  `cd "D:/show_case/gg-local-llm"` each Bash call. `ruff check` touched Python.
+- **Depends on SP1** (`goldenpipe/compiler/{ir,capture,compiled_runner}.py` + `goldenpipe-core/src/ir.rs`). SP1 is PR #1592 (in the merge queue). Task 6 (ship) rebases onto merged `main`.
+- Spec: `docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md`. @superpowers:test-driven-development per Python task.
+
+## Canonical shapes (verified against `goldenmatch/config/schemas.py`)
+
+`GoldenMatchConfig.model_dump()` nests (NO top-level `keys`/`scorer`):
+- `blocking.keys: [ {fields: [str], ...} ]`, `blocking.passes: [ {fields:[str]} ] | None`, `blocking.sub_block_keys: [ {fields:[str]} ] | None` — the **blocking column names** (union all three; `multi_pass` puts recall columns in `passes`).
+- `matchkeys: [ {fields: [ {field: str|None, columns: [str]|None, ...} ], ...} ]` — the **scorer column names** (`field`, plus `columns` for `record_embedding`).
+
+Enrichment output (what `lower`'s match branch reads): `{"keys": [str], "scorer": {"columns": [str]}}`.
+
+## File structure
+
+- Modify `packages/python/goldenpipe/goldenpipe/compiler/capture.py` — add `_normalize_match_config` + apply it in the Match branch.
+- Create `packages/python/goldenpipe/goldenpipe/compiler/provenance.py` — pure `provenance` (Python kernel mirror).
+- Create `packages/python/goldenpipe/goldenpipe/compiler/lineage.py` — host `field_lineage` + `format_lineage`.
+- Modify `packages/python/goldenpipe/goldenpipe/core/_planner_json.py` — `provenance_json`.
+- Modify `packages/python/goldenpipe/tests/core/test_planner_parity.py` — register `provenance`.
+- Create `packages/rust/extensions/goldenpipe-core/tests/vectors/provenance.json`.
+- Rust: `goldenpipe-core/src/provenance.rs`, `lib.rs`, `json.rs`, `tests/golden_vectors.rs`; shims `goldenpipe-wasm/src/lib.rs`, `goldenpipe-native/src/lib.rs`; `_native_loader.py`.
+- Tests: `tests/compiler/test_match_enrich.py`, `test_provenance.py`, `test_lineage.py`.
+
+---
+
+## Task 1: Match-capture enrichment (box TDD)
+
+**Files:** Modify `goldenpipe/compiler/capture.py`; Test `tests/compiler/test_match_enrich.py`.
+
+Normalize a `GoldenMatchConfig`-shaped dict (from either the explicit stage config or `_build_config_from_contexts(...).model_dump()`) into flat `{keys, scorer}` so the IR's `Partition`/`PairScore` name real columns.
+
+- [ ] **Step 1: Write failing test** `tests/compiler/test_match_enrich.py`:
+
+```python
+from goldenpipe.compiler.capture import _normalize_match_config
+
+
+def test_blocking_keys_union_keys_and_passes():
+    cfg = {
+        "blocking": {
+            "keys": [{"fields": ["last_name"]}],
+            "passes": [{"fields": ["last_name"]}, {"fields": ["email"]}],
+            "sub_block_keys": None,
+        },
+        "matchkeys": [{"fields": [{"field": "email"}, {"field": "first_name"}]}],
+    }
+    out = _normalize_match_config(cfg)
+    assert out["keys"] == ["email", "last_name"]  # union, sorted, deduped
+    assert out["scorer"] == {"columns": ["email", "first_name"]}  # matchkey field refs, first-seen order
+
+
+def test_embedding_columns_and_missing_fields_graceful():
+    cfg = {"blocking": {"keys": [], "passes": None}, "matchkeys": [{"fields": [{"columns": ["name_a", "name_b"]}]}]}
+    out = _normalize_match_config(cfg)
+    assert out["keys"] == []
+    assert out["scorer"] == {"columns": ["name_a", "name_b"]}
+
+
+def test_empty_config_is_empty():
+    assert _normalize_match_config({}) == {"keys": [], "scorer": {"columns": []}}
+```
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Implement.** Add to `capture.py`:
+
+```python
+def _normalize_match_config(cfg: dict) -> dict:
+    """Flatten a GoldenMatchConfig-shaped dict into {keys, scorer:{columns}} — the
+    column names the IR's Partition/PairScore need. Blocking column names come from
+    blocking.keys/passes/sub_block_keys[].fields (union); scorer column names from
+    matchkeys[].fields[].field (+ .columns for record_embedding)."""
+    blocking = cfg.get("blocking") or {}
+    key_cols: set[str] = set()
+    for group in ("keys", "passes", "sub_block_keys"):
+        for bk in (blocking.get(group) or []):
+            for f in (bk.get("fields") or []):
+                if isinstance(f, str):
+                    key_cols.add(f)
+    scorer_cols: list[str] = []
+    seen: set[str] = set()
+    for mk in (cfg.get("matchkeys") or []):
+        for f in (mk.get("fields") or []):
+            refs = []
+            if f.get("field"):
+                refs.append(f["field"])
+            refs.extend(f.get("columns") or [])
+            for c in refs:
+                if c not in seen:
+                    seen.add(c)
+                    scorer_cols.append(c)
+    return {"keys": sorted(key_cols), "scorer": {"columns": scorer_cols}}
+```
+
+Then in the Match branch, apply it to BOTH paths (explicit + contexts):
+```python
+    if name == "goldenmatch.dedupe":
+        raw = dict(cfg) if cfg else _match_config_from_ctx(ctx)
+        return "match", _normalize_match_config(raw), resolved
+```
+(Keep `_match_config_from_ctx` returning the `.model_dump()` dict; the normalize step now runs on its output. The explicit `cfg` path is also a GoldenMatchConfig-shaped dict, normalized identically.)
+
+- [ ] **Step 4: Run to verify PASS (3 tests).**
+
+- [ ] **Step 5: Confirm no SP1 regression + ruff + commit.**
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/compiler/ -q   # SP1 capture/equivalence still green
+"$INTERP" -m ruff check packages/python/goldenpipe/goldenpipe/compiler/capture.py packages/python/goldenpipe/tests/compiler/test_match_enrich.py
+git add packages/python/goldenpipe/goldenpipe/compiler/capture.py packages/python/goldenpipe/tests/compiler/test_match_enrich.py && git commit -m "feat(goldenpipe): enrich Match capture with real blocking/scorer columns (SP2)"
+```
+NOTE: the SP1 equivalence gate asserts only Match node KINDS present (not `Partition.keys` contents) — so populated keys won't break it. If it does, STOP and report (unexpected).
+
+---
+
+## Task 2: Pure `provenance` (box TDD)
+
+**Files:** Create `goldenpipe/compiler/provenance.py`; Test `tests/compiler/test_provenance.py`.
+
+- [ ] **Step 1: Write failing tests** `tests/compiler/test_provenance.py`:
+
+```python
+from goldenpipe.compiler.provenance import provenance
+
+
+def _cp(nodes):
+    return {"nodes": nodes, "edges": []}
+
+
+def _n(kind, nid, stage="s", resolved=False, **rest):
+    return {"kind": kind, "id": nid, "origin_stage": stage, "resolved": resolved, **rest}
+
+
+def test_column_gets_checks_and_ordered_transforms():
+    cp = _cp([
+        _n("Scan", 0, column="email", ops=["pattern_consistency"]),
+        _n("Map", 1, column="email", op="email_normalize"),
+        _n("Map", 2, column="email", op="email_canonical"),
+    ])
+    out = provenance(cp)
+    f = next(x for x in out["fields"] if x["column"] == "email")
+    assert f["checks"] == ["pattern_consistency"]
+    assert f["transforms"] == ["email_normalize", "email_canonical"]  # node-id order
+    assert f["node_ids"] == [0, 1, 2]
+
+
+def test_blocking_and_scorer_roles():
+    cp = _cp([
+        _n("Map", 0, column="last_name", op="name_proper"),
+        _n("Partition", 1, keys=["last_name"]),
+        _n("PairScore", 2, scorer={"columns": ["email", "last_name"]}),
+    ])
+    out = provenance(cp)
+    ln = {x["column"]: x for x in out["fields"]}
+    assert ln["last_name"]["blocking_key"] is True
+    assert ln["last_name"]["scorer_input"] is True
+    assert ln["email"]["scorer_input"] is True
+    assert ln["email"]["blocking_key"] is False
+
+
+def test_source_connected_barrier_are_unmapped_notes():
+    cp = _cp([_n("Source", 0, produces=["df"]), _n("Connected", 1, method={"name": "cc"}), _n("Barrier", 2, raw_config={})])
+    out = provenance(cp)
+    assert out["fields"] == []
+    kinds = [u["kind"] for u in out["unmapped"]]
+    assert kinds == ["Source", "Connected", "Barrier"]
+
+
+def test_empty_pipeline():
+    assert provenance({"nodes": [], "edges": []}) == {"fields": [], "unmapped": []}
+```
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Implement `provenance.py`:**
+
+```python
+"""Pure field-level provenance over the SP1 IR — the mirror of
+goldenpipe-core/src/provenance.rs. provenance(CompiledPipeline) -> {fields, unmapped}."""
+from __future__ import annotations
+
+_COLUMN_KINDS = {"Scan", "Map"}
+
+
+def provenance(compiled: dict) -> dict:
+    nodes = compiled.get("nodes", [])
+    fields: dict[str, dict] = {}
+    order: list[str] = []
+    unmapped: list[dict] = []
+    blocking: set[str] = set()
+    scorer: set[str] = set()
+
+    def field(col: str) -> dict:
+        if col not in fields:
+            fields[col] = {
+                "column": col, "origin": "source", "checks": [], "transforms": [],
+                "blocking_key": False, "scorer_input": False, "node_ids": [],
+            }
+            order.append(col)
+        return fields[col]
+
+    for n in nodes:  # nodes already in id order from lower()
+        kind = n.get("kind")
+        if kind == "Scan":
+            f = field(n["column"]); f["checks"].extend(n.get("ops", [])); f["node_ids"].append(n["id"])
+        elif kind == "Map":
+            f = field(n["column"]); f["transforms"].append(n["op"]); f["node_ids"].append(n["id"])
+        elif kind == "Partition":
+            for k in (n.get("keys") or []):
+                blocking.add(k)
+        elif kind == "PairScore":
+            for c in ((n.get("scorer") or {}).get("columns") or []):
+                scorer.add(c)
+        else:  # Source / Connected / Barrier
+            unmapped.append({"node_id": n["id"], "kind": kind, "note": _note(kind)})
+
+    # apply blocking/scorer roles (create a field entry if a key/scorer col has no Scan/Map)
+    for col in list(blocking) + list(scorer):
+        field(col)
+    for col, f in fields.items():
+        f["blocking_key"] = col in blocking
+        f["scorer_input"] = col in scorer
+
+    return {"fields": [fields[c] for c in order], "unmapped": unmapped}
+
+
+def _note(kind: str) -> str:
+    return {"Source": "data loaded", "Connected": "clustering", "Barrier": "opaque stage"}.get(kind, kind)
+```
+
+Note ordering: `blocking`/`scorer` roles are applied after the node scan, and a blocking/scorer-only column (no Scan/Map) is appended in `list(blocking)+list(scorer)` iteration order — since Python `set` order is nondeterministic, sort those for determinism: change to `for col in sorted(blocking | scorer): field(col)`. (Update the implementation to `sorted(blocking | scorer)`.)
+
+- [ ] **Step 4: Run to verify PASS (4 tests).** Confirm the field order is deterministic (first-seen for Scan/Map columns, then sorted for role-only columns).
+
+- [ ] **Step 5: ruff + commit** (`feat(goldenpipe): pure field-level provenance over the IR (SP2)`).
+
+---
+
+## Task 3: Golden vectors + Python parity leg (box)
+
+**Files:** Create `goldenpipe-core/tests/vectors/provenance.json`; Modify `core/_planner_json.py`, `tests/core/test_planner_parity.py`.
+
+- [ ] **Step 1: Author `provenance.json`** — `{input: CompiledPipeline, expected: {fields, unmapped}}` cases mirroring the unit tests (Scan+Map column; blocking+scorer roles; Source/Connected/Barrier unmapped; empty). Compute `expected` by hand from provenance.py.
+
+- [ ] **Step 2: Add `provenance_json`** to `_planner_json.py`:
+```python
+def provenance_json(s: str) -> str:
+    from goldenpipe.compiler.provenance import provenance
+    return json.dumps(provenance(json.loads(s)))
+```
+
+- [ ] **Step 3: Register** `("provenance", PJ.provenance_json)` in `_CASES` (Leg A) and `("provenance", "provenance_json")` in the Leg B list of `test_planner_parity.py`.
+
+- [ ] **Step 4: Run Leg A** — `"$INTERP" -m pytest packages/python/goldenpipe/tests/core/test_planner_parity.py -k provenance -v` → Leg A PASS; Leg B fails on the stale wheel (expected — CI handles it; report which).
+
+- [ ] **Step 5: ruff + commit** (`test(goldenpipe): provenance golden vectors + python parity leg (SP2)`).
+
+---
+
+## Task 4: Host `field_lineage` + `format_lineage` + real-pipeline test (box)
+
+**Files:** Create `goldenpipe/compiler/lineage.py`; Test `tests/compiler/test_lineage.py`.
+
+- [ ] **Step 1: Write failing tests** `tests/compiler/test_lineage.py`:
+- A `format_lineage` unit test (structured lineage → the expected human string).
+- A **real-pipeline** test: reuse the equivalence-gate fixture helpers (`_tiny_people_df`, `_write_csv`, `_read_source`, `_registry`, `_plan` from `tests/compiler/test_equivalence.py` — import them), `compile_and_run` the full `load→check→flow→match` (contexts path), call `field_lineage(compiled)`, and assert: `email`'s `transforms` are non-empty and match the `manifest.records` transforms for `email`; and the `blocking_key` columns equal the columns in the resolved config's `blocking.keys`/`passes` (recompute via `_build_config_from_contexts` on the same contexts, or read them off the compiled `Partition` node). Keep assertions to what the contexts path deterministically produces.
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Implement `lineage.py`:**
+```python
+"""Host lineage: compute field-level provenance from a compiled pipeline (via the
+pure kernel) and render it human-readable."""
+from __future__ import annotations
+
+from goldenpipe.compiler.provenance import provenance
+
+
+def field_lineage(compiled: dict) -> dict:
+    return provenance(compiled or {"nodes": [], "edges": []})
+
+
+def format_lineage(lineage: dict) -> str:
+    lines = []
+    for f in lineage.get("fields", []):
+        parts = []
+        if f["checks"]:
+            parts.append(f"checks[{','.join(f['checks'])}]")
+        if f["transforms"]:
+            parts.append(f"transforms[{','.join(f['transforms'])}]")
+        roles = [r for r, on in (("blocking-key", f["blocking_key"]), ("scorer-input", f["scorer_input"])) if on]
+        if roles:
+            parts.append(",".join(roles))
+        lines.append(f"{f['column']}: " + " -> ".join(parts) if parts else f"{f['column']}: (no ops)")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run to verify PASS.** Report what the real-pipeline lineage showed for `email` (checks/transforms/roles) — a sanity artifact.
+
+- [ ] **Step 5: ruff + commit** (`feat(goldenpipe): field_lineage host wrapper + format_lineage (SP2)`).
+
+---
+
+## Task 5: Rust kernel mirror + shims (write-against-spec, CI-verified)
+
+**Files:** Create `goldenpipe-core/src/provenance.rs`; Modify `src/lib.rs`, `src/json.rs`, `tests/golden_vectors.rs`; shims `goldenpipe-wasm/src/lib.rs`, `goldenpipe-native/src/lib.rs`; `_native_loader.py`.
+
+Mirror `provenance.py` exactly, building output as `serde_json::Value` objects by hand for byte-parity (key order `column, origin, checks, transforms, blocking_key, scorer_input, node_ids`). Follow the SP1 `ir.rs`/`lower_json` pattern precisely (the recently-shipped reference).
+
+- [ ] **Step 1: Read** `src/ir.rs` (the by-hand `serde_json::Map` build + the no-temporary `.into_iter().flatten()` iterator form), `src/json.rs` (`lower_json` wrapper + `parse_err`), `tests/golden_vectors.rs` (`run`/`vec_*`), and grep `lower_json` in the two shim `lib.rs` + `_native_loader.py`.
+
+- [ ] **Step 2: Write `src/provenance.rs`** — `pub fn provenance(compiled: &serde_json::Value) -> serde_json::Value` reproducing the Python: iterate `nodes` (already id-ordered), accumulate per-column `checks`/`transforms`/`node_ids` (first-seen column order), collect `blocking`/`scorer` sets, emit `unmapped` for Source/Connected/Barrier, apply roles, and — CRITICAL for parity — append role-only columns in **sorted** order (matching Python's `sorted(blocking | scorer)`). Field object key order exactly `column, origin, checks, transforms, blocking_key, scorer_input, node_ids`. Add `#[cfg(test)] mod tests` with ~2 cases. rustfmt.
+
+- [ ] **Step 3: `lib.rs` `pub mod provenance;`; `json.rs` `provenance_json`** (parse a `CompiledPipeline` JSON → call `provenance` → to_string), mirroring `lower_json`.
+
+- [ ] **Step 4: `tests/golden_vectors.rs` `#[test] fn vec_provenance() { run("provenance", provenance_json); }`.**
+
+- [ ] **Step 5: Shims** — `provenance_json` in `goldenpipe-wasm/src/lib.rs` (`#[wasm_bindgen]`) and `goldenpipe-native/src/lib.rs` (`#[pyfunction]` + `wrap_pyfunction!(provenance_json, m)` registration — verify the registration line), + `_native_loader.py` passthrough. rustfmt.
+
+- [ ] **Step 6: rustfmt + grep-verify** (`pub mod provenance`, `provenance_json` reachable, native registration present, key order matches Python). No cargo. Commit (`feat(goldenpipe-core): provenance kernel + json + shims (SP2)`).
+
+---
+
+## Task 6: Ship
+
+- [ ] **Step 1: Gate on SP1 merged.** `gh pr view 1592 --json state -q .state`. If not MERGED, WAIT (SP2 stacks on SP1's IR + capture). Once merged:
+- [ ] **Step 2: Rebase onto merged main** — `git fetch origin && git rebase --onto origin/main <last-SP1-commit>` (drop SP1 commits now in main; keep the SP2 doc + code commits). Resolve conflicts in `capture.py` (SP2 edits the Match branch SP1 created), `json.rs`/`_planner_json.py`/`test_planner_parity.py`/`golden_vectors.rs`/`_native_loader.py` (keep both `lower*`+`provenance*` entries). Re-run the box suite:
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/compiler/ packages/python/goldenpipe/tests/core/test_planner_parity.py -k "provenance or lineage or match_enrich or compiler" -q
+```
+- [ ] **Step 3: Push + PR + arm auto-merge, STOP.**
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git push -u origin feat/goldenpipe-compiler-provenance
+gh pr create --base main --title "feat(goldenpipe): compiler SP2 — field-level provenance" --body "<summary: provenance(IR)->field lineage kernel + Match-capture enrichment (real blocking/scorer cols); non-perf net-new; additive. Links spec+plan. Note: SP2 of the compiler program; pivoted from fusion after measurement showed perf levers already covered.>"
+gh pr merge <N> --auto --squash   # merge-queue: NO --delete-branch
+```
+Watch CI: Rust `vec_provenance`, Python `test_planner_parity` Leg A+B, the SP2 compiler tests.
+
+---
+
+## Verification summary
+- Box-green: `test_match_enrich`, `test_provenance`, `test_lineage` (incl. real-pipeline), `test_planner_parity -k provenance` Leg A, SP1 `tests/compiler/` unchanged (equivalence gate still green — enrichment only touches recorded IR configs).
+- CI-green: Rust `vec_provenance`, Python Leg B, + all above.
+- Additive: `provenance`/`field_lineage` are read-only; the only existing-behavior edit is `capture.py`'s Match branch (recorded IR configs), which the equivalence gate (kind-only Match assertion) tolerates.

--- a/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-provenance.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-provenance.md
@@ -77,6 +77,13 @@ def test_embedding_columns_and_missing_fields_graceful():
     assert out["scorer"] == {"columns": ["name_a", "name_b"]}
 
 
+def test_record_embedding_sentinel_is_skipped():
+    # record_embedding sets field="__record__" (not a real column) + real columns
+    cfg = {"matchkeys": [{"fields": [{"field": "__record__", "columns": ["full_name"]}]}]}
+    out = _normalize_match_config(cfg)
+    assert out["scorer"] == {"columns": ["full_name"]}  # __record__ filtered out
+
+
 def test_empty_config_is_empty():
     assert _normalize_match_config({}) == {"keys": [], "scorer": {"columns": []}}
 ```
@@ -107,9 +114,12 @@ def _normalize_match_config(cfg: dict) -> dict:
                 refs.append(f["field"])
             refs.extend(f.get("columns") or [])
             for c in refs:
-                if c not in seen:
-                    seen.add(c)
-                    scorer_cols.append(c)
+                # skip the record_embedding sentinel (MatchkeyField sets field="__record__"
+                # for a whole-record scorer) — it is not a real column.
+                if c == "__record__" or c in seen:
+                    continue
+                seen.add(c)
+                scorer_cols.append(c)
     return {"keys": sorted(key_cols), "scorer": {"columns": scorer_cols}}
 ```
 
@@ -234,8 +244,11 @@ def provenance(compiled: dict) -> dict:
         else:  # Source / Connected / Barrier
             unmapped.append({"node_id": n["id"], "kind": kind, "note": _note(kind)})
 
-    # apply blocking/scorer roles (create a field entry if a key/scorer col has no Scan/Map)
-    for col in list(blocking) + list(scorer):
+    # apply blocking/scorer roles. A key/scorer-only column (no Scan/Map) gets a field
+    # entry; append those in SORTED order — Python set iteration is nondeterministic and
+    # would flake the golden-vector / Rust-parity comparison. (Do NOT use list(blocking)
+    # + list(scorer) here.)
+    for col in sorted(blocking | scorer):
         field(col)
     for col, f in fields.items():
         f["blocking_key"] = col in blocking
@@ -248,7 +261,9 @@ def _note(kind: str) -> str:
     return {"Source": "data loaded", "Connected": "clustering", "Barrier": "opaque stage"}.get(kind, kind)
 ```
 
-Note ordering: `blocking`/`scorer` roles are applied after the node scan, and a blocking/scorer-only column (no Scan/Map) is appended in `list(blocking)+list(scorer)` iteration order — since Python `set` order is nondeterministic, sort those for determinism: change to `for col in sorted(blocking | scorer): field(col)`. (Update the implementation to `sorted(blocking | scorer)`.)
+`node_ids` deliberately lists only the **column-bearing** Scan/Map nodes (blocking/scorer
+participation is the `blocking_key`/`scorer_input` boolean flags, not node ids) — keep it
+that way so the Python and Rust mirrors stay simple and identical.
 
 - [ ] **Step 4: Run to verify PASS (4 tests).** Confirm the field order is deterministic (first-seen for Scan/Map columns, then sorted for role-only columns).
 
@@ -283,7 +298,9 @@ def provenance_json(s: str) -> str:
 
 - [ ] **Step 1: Write failing tests** `tests/compiler/test_lineage.py`:
 - A `format_lineage` unit test (structured lineage → the expected human string).
-- A **real-pipeline** test: reuse the equivalence-gate fixture helpers (`_tiny_people_df`, `_write_csv`, `_read_source`, `_registry`, `_plan` from `tests/compiler/test_equivalence.py` — import them), `compile_and_run` the full `load→check→flow→match` (contexts path), call `field_lineage(compiled)`, and assert: `email`'s `transforms` are non-empty and match the `manifest.records` transforms for `email`; and the `blocking_key` columns equal the columns in the resolved config's `blocking.keys`/`passes` (recompute via `_build_config_from_contexts` on the same contexts, or read them off the compiled `Partition` node). Keep assertions to what the contexts path deterministically produces.
+- A **real-pipeline** test: reuse the equivalence-gate fixture helpers (`_tiny_people_df`, `_write_csv`, `_read_source`, `_registry`, `_plan` from `tests/compiler/test_equivalence.py` — import them), `compile_and_run` the full `load→check→flow→match` (contexts path), call `field_lineage(compiled)`, and assert:
+  - `email`'s `transforms` match the `manifest.records` transforms for `email` (from `compiled_ctx.artifacts["manifest"]`) — a real fidelity check.
+  - **`blocking_key` columns == the compiled `Partition` node's `keys`** (read the `Partition` node out of `compiled["nodes"]` and compare the set of `blocking_key=True` columns to `set(partition["keys"])`). This asserts lineage matches the recorded plan WITHOUT assuming blocking is non-empty — if the fixture's classification yields `auto_suggest`/empty keys (`adapters/match.py`), both sides are empty and the assertion still holds honestly. Inspect the actual `column_contexts`/`Partition` node rather than assuming a particular column blocks.
 
 - [ ] **Step 2: Run to verify FAIL.**
 

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md
@@ -1,0 +1,154 @@
+# GoldenPipe Compiler — SP2: Field-Level Provenance from the IR — Design
+
+**Date:** 2026-07-08
+**Status:** Approved (brainstorming), pending implementation plan
+**Program:** GoldenPipe compiler (SP1 IR walking skeleton shipped, PR #1592). This is
+**sub-project 2**. It is deliberately **NOT** a performance sub-project (see below).
+
+## Why non-performance (the measured pivot)
+
+The original SP2 plan was cross-stage columnar fusion. Measurement + code inspection
+refuted every compiler *performance* lever on the core ER workload:
+- **Columnar fusion** — the columnar stages (Check `Scan` + Flow `Map`) are ~8% of
+  wall time on a 20k-row ER pipeline (Check 5.1% / Flow 3.0% / **Match 91.9%**), and
+  Match dominates *more* at scale. goldenflow already fuses Map chains within a stage.
+- **Auto-config opt-out** — measured ~3.7% of Match, and GoldenPipe already does it
+  (`adapters/match.py` builds an explicit config from Check's `column_contexts` via
+  `_build_config_from_contexts` and passes it to `dedupe_df`, skipping GoldenMatch's
+  internal auto-config controller).
+- **Emit Match to a scale engine** — already exists as goldenmatch `backend=` targets
+  (`backends/datafusion_backend.py`, `duckdb_backend.py`, `score_duckdb.py`, the `sail/`
+  and `distributed/` packages).
+
+Every performance lever is already covered by goldenflow (fusion), GoldenPipe
+(opt-out), or goldenmatch (scale backends). SP1's real value was never speed — it is
+the portable, inspectable, cross-surface whole-*pipeline* plan. SP2 delivers a value
+that only the IR can provide and that the suite lacks: **field-level provenance.**
+
+## Goal
+
+Turn a `CompiledPipeline` (SP1's IR) into a **field-level lineage report**: for each
+column the pipeline touches, its journey through the plan — Check ops, ordered Flow
+transforms, and matching role (blocking key / scorer input). A pure, deterministic
+`provenance(CompiledPipeline) -> lineage` kernel function + a host wrapper that
+attaches it, plus a human-readable explain string.
+
+**Net-new (verified):** no cross-stage field provenance exists in the suite —
+goldenmatch's `explain_pair`/`explain_cluster` explain *record pairs*; goldenpipe's
+`reasoning` explains *stages*; this explains *fields end-to-end*. Only the IR holds the
+per-column op graph across Check→Flow→Match.
+
+**Value:** compliance/audit ("how was this golden field derived?"), debugging bad
+merges ("which transform normalized the blocking key that caused this merge?"), and
+trust (show the full column journey).
+
+## The `FieldLineage` shape
+
+```
+provenance(CompiledPipeline) -> { "fields": [FieldLineage], "unmapped": [PipelineNote] }
+
+FieldLineage {
+  column: str,
+  origin: "source" | "derived",   // "source" for all in SP1's op set (no column-creating
+                                  // op yet; splits/renames mark "derived" later — kept fwd-compat)
+  checks: [str],                  // ops from Scan nodes on this column (Check)
+  transforms: [str],             // ops from Map nodes on this column, IN ORDER (Flow)
+  blocking_key: bool,             // column ∈ any Partition.keys (Match blocking)
+  scorer_input: bool,             // column referenced by any PairScore.scorer (Match scoring)
+  node_ids: [int]                 // the IR nodes that mention this column (traceability)
+}
+
+PipelineNote { node_id: int, kind: str, note: str }   // Source / Connected / Barrier
+```
+
+## Derivation (pure, single pass over nodes)
+
+- `Source` → a `PipelineNote` ("data loaded"); does not itself name columns.
+- `Scan{column, ops}` → `checks[column] += ops`; record `node_id`.
+- `Map{column, op}` → `transforms[column].append(op)` (iterate nodes in id order so the
+  transform chain is ordered); record `node_id`.
+- `Partition{keys}` → `blocking_key[k] = true` for each `k in keys`.
+- `PairScore{scorer}` → resolve the scorer config's referenced columns → `scorer_input[c] = true`.
+- `Connected` / `Barrier` → `PipelineNote` (clustering method / opaque stage).
+- Column set = union of every named column; emit one `FieldLineage` per column,
+  deterministic order (first-seen). Columns are matched by exact string.
+
+`provenance` is a total pure function of the `CompiledPipeline` JSON; unknown node
+kinds contribute a `PipelineNote` rather than erroring.
+
+## Prerequisite — enrich the Match capture (fix SP1's placeholder)
+
+SP1 captured Match nodes as placeholders (`GoldenMatchConfig.model_dump()` did not map
+to `keys`/`scorer`, so `Partition.keys` was empty). For `blocking_key`/`scorer_input`
+to be real, `capture.py`'s Match branch must normalize the real `GoldenMatchConfig`
+into `{keys, scorer}`:
+- `keys` = the blocking key column names, from the config's `matchkeys` / `blocking`
+  fields.
+- `scorer` = the scorer spec with its referenced column names (best-effort from the
+  config; a coarse record is acceptable — provenance only needs the column refs).
+
+**Contained:** this changes only the *recorded IR node configs*, not execution. The
+SP1 equivalence gate compares *execution* artifacts (df/findings/profile/manifest/
+clusters/golden) — untouched. `lower`'s match branch already handles populated
+`keys`/`scorer` (the existing `lower.json` vectors cover it). So the enrichment cannot
+break the equivalence gate.
+
+## Host wiring
+
+- `field_lineage(compiled) -> lineage` — a thin host wrapper calling the kernel
+  `provenance`. The caller invokes it on the `compile_and_run` result; **no coupling to
+  execution** (opt-in, read-only).
+- `format_lineage(lineage) -> str` — host-side presentation (e.g.
+  `email: checks[pattern_consistency] -> transforms[email_normalize] -> blocking-key, scorer-input`).
+  The **structured** lineage is the cross-surface parity contract; the human string
+  stays host Python (presentation, like reasoning lines).
+
+## Kernel / host split (for the plan)
+
+- **Kernel** (`goldenpipe-core`, Rust; Python pure mirror): `provenance` (build lineage
+  objects as `serde_json::Value` by hand for byte-parity key order, like `lower`),
+  `provenance_json` wrapper, `tests/vectors/provenance.json` golden vectors, wasm +
+  native shim exports, `_native_loader.py` passthrough.
+- **Host** (Python, box-runnable): the `capture.py` Match enrichment, `field_lineage`
+  wrapper, `format_lineage`, and the real-pipeline lineage test.
+
+## Scope boundary
+
+**Column/plan-level, NOT row-level.** Provenance answers "how is field X *treated* by
+the plan" (its transform chain + matching role), not "which row's value survived into
+golden record R" (row-level survivorship needs the Match *output*, not the IR
+structure). Row/cluster-level provenance is a clean future increment.
+
+Also out of scope: no execution change, no new fusion/emit, no TS host (the kernel
+`provenance` + Python mirror ship; a TS mirror is a later increment like SP1's).
+
+## Error handling
+
+- `provenance` is total: empty pipeline → `{fields: [], unmapped: []}`; unknown node
+  kind → a `PipelineNote`, never raises.
+- `field_lineage` on a `None`/empty compiled plan → empty lineage.
+- The Match-capture enrichment degrades gracefully: if a config field is absent, the
+  corresponding `keys`/`scorer` entry is empty (no crash) — provenance then reports
+  `blocking_key: false` for that column, honestly reflecting the recorded plan.
+
+## Testing
+
+- **Kernel golden vectors** (`provenance.json`, replayed Rust + Python mirror via
+  `test_planner_parity`): Scan+Map column → `checks`+ordered `transforms`; a
+  `Partition`-key column → `blocking_key: true`; a scorer-referenced column →
+  `scorer_input: true`; `Source`/`Connected` → `unmapped` notes; a Map-only column (no
+  check); empty pipeline → empty.
+- **Match-capture enrichment** (box): construct a `GoldenMatchConfig`, run the Match
+  capture branch, assert real `{keys, scorer}` extracted (not the empty placeholder).
+- **Real-pipeline lineage** (box): reuse the equivalence-gate fixture, `compile_and_run`
+  the full `load→check→flow→match`, call `field_lineage(compiled)`, assert `email`'s
+  `transforms` match what `manifest.records` actually applied and `blocking_key` columns
+  match the resolved match config — proving lineage reflects the *actual* plan.
+- **`format_lineage`** host test.
+
+## Rollout
+
+Pure-additive, opt-in. Zero execution change (classic runner + `compile_and_run`
+untouched). The only edit to existing behavior is the `capture.py` Match enrichment,
+which only affects recorded IR node configs; the equivalence gate stays green. No new
+kernel symbols depended on by existing paths.

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md
@@ -78,20 +78,42 @@ kinds contribute a `PipelineNote` rather than erroring.
 
 ## Prerequisite — enrich the Match capture (fix SP1's placeholder)
 
-SP1 captured Match nodes as placeholders (`GoldenMatchConfig.model_dump()` did not map
-to `keys`/`scorer`, so `Partition.keys` was empty). For `blocking_key`/`scorer_input`
-to be real, `capture.py`'s Match branch must normalize the real `GoldenMatchConfig`
-into `{keys, scorer}`:
-- `keys` = the blocking key column names, from the config's `matchkeys` / `blocking`
-  fields.
-- `scorer` = the scorer spec with its referenced column names (best-effort from the
-  config; a coarse record is acceptable — provenance only needs the column refs).
+SP1 captured Match nodes as placeholders (`GoldenMatchConfig.model_dump()` has top-level
+`matchkeys`/`blocking`, NOT `keys`/`scorer`, so `lower`'s match branch produced an empty
+`Partition.keys`). For `blocking_key`/`scorer_input` to be real, `capture.py`'s Match
+branch normalizes the real `GoldenMatchConfig` into `{keys, scorer}` via **two distinct
+nested walks** (the column names are nested, not top-level):
+- **`keys` (→ Partition.keys) = the BLOCKING column names**, from `blocking.*`. Union
+  the `fields` lists across `blocking.keys[].fields` AND `blocking.passes[].fields`
+  (and `sub_block_keys[].fields` if present) — `multi_pass` (the default from
+  `_build_config_from_contexts`) puts recall columns in `passes`, so reading only
+  `blocking.keys` would miss later-pass columns. `BlockingKeyConfig.fields: list[str]`.
+- **`scorer` (→ PairScore.scorer refs) = the MATCHKEY column names**, from
+  `matchkeys[].fields[].field` (note the `.column` alias; `.columns` for
+  `record_embedding`). A coarse record naming the referenced columns is enough —
+  provenance only needs the column refs.
+- `method` (Connected) is deliberately left unset — `Connected` becomes a
+  `PipelineNote`, not a column-bearing lineage entry, so a null `method` is harmless.
 
 **Contained:** this changes only the *recorded IR node configs*, not execution. The
 SP1 equivalence gate compares *execution* artifacts (df/findings/profile/manifest/
-clusters/golden) — untouched. `lower`'s match branch already handles populated
-`keys`/`scorer` (the existing `lower.json` vectors cover it). So the enrichment cannot
-break the equivalence gate.
+clusters/golden) and asserts only Match node *kinds* present (never `Partition.keys`
+contents) — so `[] → real columns` cannot break it. `lower`'s match branch already
+handles populated `keys`/`scorer` (the existing `lower.json` vectors cover it), so no
+`lower` change and no vector change.
+
+**Fidelity honesty — provenance reflects the CONTEXTS path.** `capture.py` re-runs
+`_build_config_from_contexts(column_contexts, df)` to obtain the config. This equals
+what GoldenMatch actually executed ONLY on the **Priority-2 path** (the match adapter
+used the same contexts-derived config — `adapters/match.py`). If a run used Priority-1
+(explicit stage config) or Priority-3 (bare `_dedupe(df)` auto-configure), GoldenMatch
+chose blocking/matchkeys at *runtime* and they are absent from `column_contexts` →
+capture records `{}` → provenance honestly reports `blocking_key: false` (honest, not
+wrong — the recorded plan genuinely lacks that info). SP2's real-pipeline test uses the
+contexts path (its `check→match` fixture populates `column_contexts`), where the
+matching-role IS faithful. Also: `_build_config_from_contexts` can itself emit
+`BlockingConfig(keys=[], auto_suggest=True)` for some shapes — a legitimately hollow
+`keys` case that provenance reports honestly.
 
 ## Host wiring
 
@@ -140,10 +162,12 @@ Also out of scope: no execution change, no new fusion/emit, no TS host (the kern
   check); empty pipeline → empty.
 - **Match-capture enrichment** (box): construct a `GoldenMatchConfig`, run the Match
   capture branch, assert real `{keys, scorer}` extracted (not the empty placeholder).
-- **Real-pipeline lineage** (box): reuse the equivalence-gate fixture, `compile_and_run`
-  the full `load→check→flow→match`, call `field_lineage(compiled)`, assert `email`'s
-  `transforms` match what `manifest.records` actually applied and `blocking_key` columns
-  match the resolved match config — proving lineage reflects the *actual* plan.
+- **Real-pipeline lineage** (box): reuse the equivalence-gate fixture (its `check→match`
+  pipeline populates `column_contexts` → the Priority-2 path), `compile_and_run` the full
+  `load→check→flow→match`, call `field_lineage(compiled)`, assert `email`'s `transforms`
+  match what `manifest.records` actually applied AND that the `blocking_key` columns match
+  the columns in the contexts-derived config's `blocking.keys`/`blocking.passes`. On the
+  contexts path the matching-role is faithful; the test asserts it there.
 - **`format_lineage`** host test.
 
 ## Rollout

--- a/packages/python/goldenpipe/goldenpipe/compiler/capture.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/capture.py
@@ -46,10 +46,39 @@ def capture_stage(planned, ctx, result):
         return "scan", {"columns": [{"column": c, "ops": by_col[c]} for c in order]}, resolved
 
     if name == "goldenmatch.dedupe":
-        concrete = dict(cfg) if cfg else _match_config_from_ctx(ctx)
-        return "match", concrete, resolved
+        raw = dict(cfg) if cfg else _match_config_from_ctx(ctx)
+        return "match", _normalize_match_config(raw), resolved
 
     return "barrier", dict(cfg), False
+
+
+def _normalize_match_config(cfg: dict) -> dict:
+    """Flatten a GoldenMatchConfig-shaped dict into {keys, scorer:{columns}} — the
+    column names the IR's Partition/PairScore need. Blocking column names come from
+    blocking.keys/passes/sub_block_keys[].fields (union); scorer column names from
+    matchkeys[].fields[].field (+ .columns for record_embedding)."""
+    blocking = cfg.get("blocking") or {}
+    key_cols: set[str] = set()
+    for group in ("keys", "passes", "sub_block_keys"):
+        for bk in (blocking.get(group) or []):
+            for f in (bk.get("fields") or []):
+                if isinstance(f, str):
+                    key_cols.add(f)
+    scorer_cols: list[str] = []
+    seen: set[str] = set()
+    for mk in (cfg.get("matchkeys") or []):
+        for f in (mk.get("fields") or []):
+            refs = []
+            if f.get("field"):
+                refs.append(f["field"])
+            refs.extend(f.get("columns") or [])
+            for c in refs:
+                # skip the record_embedding sentinel (field="__record__", not a real column)
+                if c == "__record__" or c in seen:
+                    continue
+                seen.add(c)
+                scorer_cols.append(c)
+    return {"keys": sorted(key_cols), "scorer": {"columns": scorer_cols}}
 
 
 def _profile_columns(profile) -> list[str]:

--- a/packages/python/goldenpipe/goldenpipe/compiler/lineage.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/lineage.py
@@ -1,0 +1,24 @@
+"""Host lineage: compute field-level provenance from a compiled pipeline (via the
+pure kernel) and render it human-readable."""
+from __future__ import annotations
+
+from goldenpipe.compiler.provenance import provenance
+
+
+def field_lineage(compiled: dict) -> dict:
+    return provenance(compiled or {"nodes": [], "edges": []})
+
+
+def format_lineage(lineage: dict) -> str:
+    lines = []
+    for f in lineage.get("fields", []):
+        parts = []
+        if f["checks"]:
+            parts.append(f"checks[{','.join(f['checks'])}]")
+        if f["transforms"]:
+            parts.append(f"transforms[{','.join(f['transforms'])}]")
+        roles = [r for r, on in (("blocking-key", f["blocking_key"]), ("scorer-input", f["scorer_input"])) if on]
+        if roles:
+            parts.append(",".join(roles))
+        lines.append(f"{f['column']}: " + " -> ".join(parts) if parts else f"{f['column']}: (no ops)")
+    return "\n".join(lines)

--- a/packages/python/goldenpipe/goldenpipe/compiler/provenance.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/provenance.py
@@ -1,0 +1,54 @@
+"""Pure field-level provenance over the SP1 IR — the mirror of
+goldenpipe-core/src/provenance.rs. provenance(CompiledPipeline) -> {fields, unmapped}."""
+from __future__ import annotations
+
+
+def provenance(compiled: dict) -> dict:
+    nodes = compiled.get("nodes", [])
+    fields: dict[str, dict] = {}
+    order: list[str] = []
+    unmapped: list[dict] = []
+    blocking: set[str] = set()
+    scorer: set[str] = set()
+
+    def field(col: str) -> dict:
+        if col not in fields:
+            fields[col] = {
+                "column": col, "origin": "source", "checks": [], "transforms": [],
+                "blocking_key": False, "scorer_input": False, "node_ids": [],
+            }
+            order.append(col)
+        return fields[col]
+
+    for n in nodes:  # nodes already in id order from lower()
+        kind = n.get("kind")
+        if kind == "Scan":
+            f = field(n["column"])
+            f["checks"].extend(n.get("ops", []))
+            f["node_ids"].append(n["id"])
+        elif kind == "Map":
+            f = field(n["column"])
+            f["transforms"].append(n["op"])
+            f["node_ids"].append(n["id"])
+        elif kind == "Partition":
+            for k in (n.get("keys") or []):
+                blocking.add(k)
+        elif kind == "PairScore":
+            for c in ((n.get("scorer") or {}).get("columns") or []):
+                scorer.add(c)
+        else:  # Source / Connected / Barrier
+            unmapped.append({"node_id": n["id"], "kind": kind, "note": _note(kind)})
+
+    # role-only columns (no Scan/Map) appended in SORTED order — set iteration is
+    # nondeterministic and would flake golden-vector / Rust-parity.
+    for col in sorted(blocking | scorer):
+        field(col)
+    for col, f in fields.items():
+        f["blocking_key"] = col in blocking
+        f["scorer_input"] = col in scorer
+
+    return {"fields": [fields[c] for c in order], "unmapped": unmapped}
+
+
+def _note(kind: str) -> str:
+    return {"Source": "data loaded", "Connected": "clustering", "Barrier": "opaque stage"}.get(kind, kind)

--- a/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_native_loader.py
@@ -105,3 +105,7 @@ def build_repair_plan_json(input: str) -> str:
 
 def lower_json(input: str) -> str:
     return _native.lower_json(input)
+
+
+def provenance_json(input: str) -> str:
+    return _native.provenance_json(input)

--- a/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
+++ b/packages/python/goldenpipe/goldenpipe/core/_planner_json.py
@@ -226,3 +226,8 @@ def lower_json(s: str) -> str:
         a["origin_stage"], a["kind_hint"], a.get("concrete", {}), a.get("next_id", 0), a.get("resolved", False)
     )
     return json.dumps({"nodes": nodes, "next_id": nid})
+
+
+def provenance_json(s: str) -> str:
+    from goldenpipe.compiler.provenance import provenance
+    return json.dumps(provenance(json.loads(s)))

--- a/packages/python/goldenpipe/tests/compiler/test_lineage.py
+++ b/packages/python/goldenpipe/tests/compiler/test_lineage.py
@@ -1,0 +1,60 @@
+import polars as pl
+from goldenpipe.compiler.compiled_runner import compile_and_run
+from goldenpipe.compiler.lineage import field_lineage, format_lineage
+from goldenpipe.engine.registry import StageRegistry
+from goldenpipe.engine.resolver import Resolver
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import PipeContext
+
+
+def _fixture_csv(tmp_path):
+    surnames = ["Smith", "Jones", "Brown", "Garcia", "Lee", "Nguyen", "Patel", "Khan", "Diaz", "Okafor", "Wong", "Ali"]
+    first = ["John", "Jane", "Bob", "Alice", "Carlos", "Mei", "Raj", "Sara", "Luis", "Ada", "Wei", "Omar"]
+    rows = []
+    for i in range(len(surnames)):
+        rows.append({
+            "first_name": f"  {first[i]} " if i % 3 == 0 else first[i],
+            "email": (f"{first[i]}.{surnames[i]}@Example.COM " if i % 2 == 0 else f"{first[i].lower()}.{surnames[i].lower()}@example.com"),
+            "last_name": surnames[i],
+        })
+    rows.append({"first_name": "John ", "email": " JOHN.SMITH@example.com", "last_name": "Smith"})
+    rows.append({"first_name": "Jane", "email": "jane.jones@EXAMPLE.com ", "last_name": "Jones"})
+    p = tmp_path / "people.csv"
+    pl.DataFrame(rows).write_csv(p)
+    return str(p)
+
+
+def _plan(stages, registry):
+    specs = [StageSpec(use=s) for s in stages]
+    return Resolver.resolve(PipelineConfig(pipeline="lin", stages=specs), registry)
+
+
+def test_format_lineage_string():
+    lin = {"fields": [
+        {"column": "email", "origin": "source", "checks": ["pattern_consistency"], "transforms": ["email_normalize"], "blocking_key": False, "scorer_input": True, "node_ids": [0, 1]},
+    ], "unmapped": []}
+    assert format_lineage(lin) == "email: checks[pattern_consistency] -> transforms[email_normalize] -> scorer-input"
+
+
+def test_real_pipeline_lineage(tmp_path):
+    reg = StageRegistry(); reg.discover()
+    csv = _fixture_csv(tmp_path)
+    plan = _plan(["goldencheck.scan", "goldenflow.transform", "goldenmatch.dedupe"], reg)
+    ctx = PipeContext(df=pl.read_csv(csv, ignore_errors=True, encoding="utf8-lossy"))
+    ctx.metadata["source"] = csv
+    _, compiled = compile_and_run(plan, ctx, reg)
+
+    lin = field_lineage(compiled)
+    by_col = {f["column"]: f for f in lin["fields"]}
+
+    # email's transforms match the manifest records for email (real fidelity vs what ran)
+    manifest = ctx.artifacts["manifest"]
+    email_transforms = [r.transform for r in manifest.records if r.column == "email"]
+    assert by_col.get("email", {}).get("transforms", []) == email_transforms
+
+    # blocking_key columns == the compiled Partition node's keys (honest; no assume-nonempty)
+    partition = next((n for n in compiled["nodes"] if n["kind"] == "Partition"), None)
+    assert partition is not None
+    blocked = {c for c, f in by_col.items() if f["blocking_key"]}
+    assert blocked == set(partition["keys"])
+    print("LINEAGE:\n" + format_lineage(lin))  # sanity artifact (-s to see)

--- a/packages/python/goldenpipe/tests/compiler/test_lineage.py
+++ b/packages/python/goldenpipe/tests/compiler/test_lineage.py
@@ -50,11 +50,13 @@ def test_real_pipeline_lineage(tmp_path):
     # email's transforms match the manifest records for email (real fidelity vs what ran)
     manifest = ctx.artifacts["manifest"]
     email_transforms = [r.transform for r in manifest.records if r.column == "email"]
+    assert email_transforms, "fixture should dirty email so goldenflow emits transforms"
     assert by_col.get("email", {}).get("transforms", []) == email_transforms
 
     # blocking_key columns == the compiled Partition node's keys (honest; no assume-nonempty)
     partition = next((n for n in compiled["nodes"] if n["kind"] == "Partition"), None)
     assert partition is not None
     blocked = {c for c, f in by_col.items() if f["blocking_key"]}
+    assert blocked, "fixture should yield a non-empty blocking key"
     assert blocked == set(partition["keys"])
     print("LINEAGE:\n" + format_lineage(lin))  # sanity artifact (-s to see)

--- a/packages/python/goldenpipe/tests/compiler/test_match_enrich.py
+++ b/packages/python/goldenpipe/tests/compiler/test_match_enrich.py
@@ -1,0 +1,32 @@
+from goldenpipe.compiler.capture import _normalize_match_config
+
+
+def test_blocking_keys_union_keys_and_passes():
+    cfg = {
+        "blocking": {
+            "keys": [{"fields": ["last_name"]}],
+            "passes": [{"fields": ["last_name"]}, {"fields": ["email"]}],
+            "sub_block_keys": None,
+        },
+        "matchkeys": [{"fields": [{"field": "email"}, {"field": "first_name"}]}],
+    }
+    out = _normalize_match_config(cfg)
+    assert out["keys"] == ["email", "last_name"]  # union, sorted, deduped
+    assert out["scorer"] == {"columns": ["email", "first_name"]}  # matchkey field refs, first-seen order
+
+
+def test_embedding_columns_and_missing_fields_graceful():
+    cfg = {"blocking": {"keys": [], "passes": None}, "matchkeys": [{"fields": [{"columns": ["name_a", "name_b"]}]}]}
+    out = _normalize_match_config(cfg)
+    assert out["keys"] == []
+    assert out["scorer"] == {"columns": ["name_a", "name_b"]}
+
+
+def test_record_embedding_sentinel_is_skipped():
+    cfg = {"matchkeys": [{"fields": [{"field": "__record__", "columns": ["full_name"]}]}]}
+    out = _normalize_match_config(cfg)
+    assert out["scorer"] == {"columns": ["full_name"]}  # __record__ filtered out
+
+
+def test_empty_config_is_empty():
+    assert _normalize_match_config({}) == {"keys": [], "scorer": {"columns": []}}

--- a/packages/python/goldenpipe/tests/compiler/test_provenance.py
+++ b/packages/python/goldenpipe/tests/compiler/test_provenance.py
@@ -1,0 +1,47 @@
+from goldenpipe.compiler.provenance import provenance
+
+
+def _cp(nodes):
+    return {"nodes": nodes, "edges": []}
+
+
+def _n(kind, nid, stage="s", resolved=False, **rest):
+    return {"kind": kind, "id": nid, "origin_stage": stage, "resolved": resolved, **rest}
+
+
+def test_column_gets_checks_and_ordered_transforms():
+    cp = _cp([
+        _n("Scan", 0, column="email", ops=["pattern_consistency"]),
+        _n("Map", 1, column="email", op="email_normalize"),
+        _n("Map", 2, column="email", op="email_canonical"),
+    ])
+    out = provenance(cp)
+    f = next(x for x in out["fields"] if x["column"] == "email")
+    assert f["checks"] == ["pattern_consistency"]
+    assert f["transforms"] == ["email_normalize", "email_canonical"]
+    assert f["node_ids"] == [0, 1, 2]
+
+
+def test_blocking_and_scorer_roles():
+    cp = _cp([
+        _n("Map", 0, column="last_name", op="name_proper"),
+        _n("Partition", 1, keys=["last_name"]),
+        _n("PairScore", 2, scorer={"columns": ["email", "last_name"]}),
+    ])
+    out = provenance(cp)
+    ln = {x["column"]: x for x in out["fields"]}
+    assert ln["last_name"]["blocking_key"] is True
+    assert ln["last_name"]["scorer_input"] is True
+    assert ln["email"]["scorer_input"] is True
+    assert ln["email"]["blocking_key"] is False
+
+
+def test_source_connected_barrier_are_unmapped_notes():
+    cp = _cp([_n("Source", 0, produces=["df"]), _n("Connected", 1, method={"name": "cc"}), _n("Barrier", 2, raw_config={})])
+    out = provenance(cp)
+    assert out["fields"] == []
+    assert [u["kind"] for u in out["unmapped"]] == ["Source", "Connected", "Barrier"]
+
+
+def test_empty_pipeline():
+    assert provenance({"nodes": [], "edges": []}) == {"fields": [], "unmapped": []}

--- a/packages/python/goldenpipe/tests/core/test_planner_parity.py
+++ b/packages/python/goldenpipe/tests/core/test_planner_parity.py
@@ -28,6 +28,7 @@ _CASES = [
     ("band_of", PJ.band_of_json),
     ("build_repair_plan", PJ.build_repair_plan_json),
     ("lower", PJ.lower_json),
+    ("provenance", PJ.provenance_json),
 ]
 
 
@@ -55,6 +56,7 @@ from goldenpipe.core import _native_loader as NL  # noqa: E402
         ("band_of", "band_of_json"),
         ("build_repair_plan", "build_repair_plan_json"),
         ("lower", "lower_json"),
+        ("provenance", "provenance_json"),
     ],
 )
 def test_native_wheel_matches_core_vectors(name, fn_name):

--- a/packages/rust/extensions/goldenpipe-core/src/json.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/json.rs
@@ -170,6 +170,14 @@ pub fn lower_json(input: &str) -> String {
     serde_json::json!({ "nodes": nodes, "next_id": next_id }).to_string()
 }
 
+pub fn provenance_json(input: &str) -> String {
+    let compiled: Value = match serde_json::from_str(input) {
+        Ok(v) => v,
+        Err(e) => return parse_err(e),
+    };
+    crate::provenance::provenance(&compiled).to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/packages/rust/extensions/goldenpipe-core/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod ir;
 pub mod json;
 pub mod model;
 pub mod planner;
+pub mod provenance;
 pub mod repair;
 pub mod resolve;
 pub mod router;

--- a/packages/rust/extensions/goldenpipe-core/src/provenance.rs
+++ b/packages/rust/extensions/goldenpipe-core/src/provenance.rs
@@ -1,0 +1,187 @@
+//! Field-level provenance over the SP1 IR — the reference twin of
+//! goldenpipe/compiler/provenance.py. Builds the `{fields, unmapped}` result as
+//! serde_json Value objects by hand so the emitted JSON (key set + ORDER, via
+//! preserve_order) is byte-identical to the Python dicts. Field key order is
+//! exactly column, origin, checks, transforms, blocking_key, scorer_input,
+//! node_ids; unmapped key order is node_id, kind, note.
+use serde_json::{json, Map, Value};
+use std::collections::{BTreeSet, HashMap};
+
+pub fn provenance(compiled: &Value) -> Value {
+    let mut order: Vec<String> = Vec::new();
+    let mut idx: HashMap<String, usize> = HashMap::new();
+    let mut checks: Vec<Vec<Value>> = Vec::new();
+    let mut transforms: Vec<Vec<Value>> = Vec::new();
+    let mut node_ids: Vec<Vec<Value>> = Vec::new();
+    let mut unmapped: Vec<Value> = Vec::new();
+    // BTreeSet keeps the union sorted, matching Python `sorted(blocking | scorer)`.
+    let mut blocking: BTreeSet<String> = BTreeSet::new();
+    let mut scorer: BTreeSet<String> = BTreeSet::new();
+
+    // Inline get-or-create returning the field index for `col` (a closure would
+    // need &mut captures of every accumulator — the borrow checker rejects that).
+    macro_rules! ensure {
+        ($col:expr) => {{
+            let c = $col;
+            match idx.get(c) {
+                Some(&i) => i,
+                None => {
+                    let i = order.len();
+                    order.push(c.to_string());
+                    idx.insert(c.to_string(), i);
+                    checks.push(Vec::new());
+                    transforms.push(Vec::new());
+                    node_ids.push(Vec::new());
+                    i
+                }
+            }
+        }};
+    }
+
+    for n in compiled
+        .get("nodes")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let kind = n.get("kind").and_then(Value::as_str).unwrap_or("");
+        match kind {
+            "Scan" => {
+                let col = n.get("column").and_then(Value::as_str).unwrap_or("");
+                let i = ensure!(col);
+                for op in n.get("ops").and_then(Value::as_array).into_iter().flatten() {
+                    checks[i].push(op.clone());
+                }
+                if let Some(id) = n.get("id") {
+                    node_ids[i].push(id.clone());
+                }
+            }
+            "Map" => {
+                let col = n.get("column").and_then(Value::as_str).unwrap_or("");
+                let i = ensure!(col);
+                if let Some(op) = n.get("op") {
+                    transforms[i].push(op.clone());
+                }
+                if let Some(id) = n.get("id") {
+                    node_ids[i].push(id.clone());
+                }
+            }
+            "Partition" => {
+                for k in n
+                    .get("keys")
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(s) = k.as_str() {
+                        blocking.insert(s.to_string());
+                    }
+                }
+            }
+            "PairScore" => {
+                for c in n
+                    .get("scorer")
+                    .and_then(|s| s.get("columns"))
+                    .and_then(Value::as_array)
+                    .into_iter()
+                    .flatten()
+                {
+                    if let Some(s) = c.as_str() {
+                        scorer.insert(s.to_string());
+                    }
+                }
+            }
+            // Source / Connected / Barrier (and any unknown kind -> the kind itself).
+            other => {
+                let note = match other {
+                    "Source" => "data loaded",
+                    "Connected" => "clustering",
+                    "Barrier" => "opaque stage",
+                    _ => other,
+                };
+                let mut m = Map::new();
+                m.insert(
+                    "node_id".into(),
+                    n.get("id").cloned().unwrap_or(Value::Null),
+                );
+                m.insert("kind".into(), Value::from(other));
+                m.insert("note".into(), Value::from(note));
+                unmapped.push(Value::Object(m));
+            }
+        }
+    }
+
+    // Role-only columns (no Scan/Map) in sorted union order (BTreeSet union is sorted).
+    for col in blocking.union(&scorer) {
+        let _ = ensure!(col.as_str());
+    }
+
+    let mut fields: Vec<Value> = Vec::new();
+    for col in &order {
+        let i = idx[col];
+        let mut m = Map::new();
+        m.insert("column".into(), Value::from(col.clone()));
+        m.insert("origin".into(), Value::from("source"));
+        m.insert(
+            "checks".into(),
+            Value::Array(std::mem::take(&mut checks[i])),
+        );
+        m.insert(
+            "transforms".into(),
+            Value::Array(std::mem::take(&mut transforms[i])),
+        );
+        m.insert("blocking_key".into(), Value::from(blocking.contains(col)));
+        m.insert("scorer_input".into(), Value::from(scorer.contains(col)));
+        m.insert(
+            "node_ids".into(),
+            Value::Array(std::mem::take(&mut node_ids[i])),
+        );
+        fields.push(Value::Object(m));
+    }
+
+    json!({ "fields": fields, "unmapped": unmapped })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_and_map_build_one_field() {
+        let compiled = json!({"nodes": [
+            {"kind": "Scan", "id": 0, "column": "email", "ops": ["pattern_consistency"]},
+            {"kind": "Map", "id": 1, "column": "email", "op": "email_normalize"}
+        ]});
+        assert_eq!(
+            provenance(&compiled),
+            json!({
+                "fields": [{
+                    "column": "email", "origin": "source",
+                    "checks": ["pattern_consistency"], "transforms": ["email_normalize"],
+                    "blocking_key": false, "scorer_input": false, "node_ids": [0, 1]
+                }],
+                "unmapped": []
+            })
+        );
+    }
+
+    #[test]
+    fn partition_and_pairscore_mark_roles_sorted() {
+        let compiled = json!({"nodes": [
+            {"kind": "Partition", "id": 0, "keys": ["last_name"]},
+            {"kind": "PairScore", "id": 1, "scorer": {"columns": ["email", "last_name"]}}
+        ]});
+        assert_eq!(
+            provenance(&compiled),
+            json!({
+                "fields": [
+                    {"column": "email", "origin": "source", "checks": [], "transforms": [],
+                     "blocking_key": false, "scorer_input": true, "node_ids": []},
+                    {"column": "last_name", "origin": "source", "checks": [], "transforms": [],
+                     "blocking_key": true, "scorer_input": true, "node_ids": []}
+                ],
+                "unmapped": []
+            })
+        );
+    }
+}

--- a/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
+++ b/packages/rust/extensions/goldenpipe-core/tests/golden_vectors.rs
@@ -64,3 +64,7 @@ fn vec_build_repair_plan() {
 fn vec_lower() {
     run("lower", lower_json);
 }
+#[test]
+fn vec_provenance() {
+    run("provenance", provenance_json);
+}

--- a/packages/rust/extensions/goldenpipe-core/tests/vectors/provenance.json
+++ b/packages/rust/extensions/goldenpipe-core/tests/vectors/provenance.json
@@ -1,0 +1,39 @@
+[
+  {
+    "input": {"nodes": [
+      {"kind": "Scan", "id": 0, "origin_stage": "goldencheck.scan", "resolved": true, "column": "email", "ops": ["pattern_consistency"]},
+      {"kind": "Map", "id": 1, "origin_stage": "goldenflow.transform", "resolved": true, "column": "email", "op": "email_normalize"},
+      {"kind": "Map", "id": 2, "origin_stage": "goldenflow.transform", "resolved": true, "column": "email", "op": "email_canonical"}
+    ], "edges": []},
+    "expected": {"fields": [
+      {"column": "email", "origin": "source", "checks": ["pattern_consistency"], "transforms": ["email_normalize", "email_canonical"], "blocking_key": false, "scorer_input": false, "node_ids": [0, 1, 2]}
+    ], "unmapped": []}
+  },
+  {
+    "input": {"nodes": [
+      {"kind": "Map", "id": 0, "origin_stage": "goldenflow.transform", "resolved": true, "column": "last_name", "op": "name_proper"},
+      {"kind": "Partition", "id": 1, "origin_stage": "goldenmatch.dedupe", "resolved": true, "keys": ["last_name"]},
+      {"kind": "PairScore", "id": 2, "origin_stage": "goldenmatch.dedupe", "resolved": true, "scorer": {"columns": ["email", "last_name"]}}
+    ], "edges": []},
+    "expected": {"fields": [
+      {"column": "last_name", "origin": "source", "checks": [], "transforms": ["name_proper"], "blocking_key": true, "scorer_input": true, "node_ids": [0]},
+      {"column": "email", "origin": "source", "checks": [], "transforms": [], "blocking_key": false, "scorer_input": true, "node_ids": []}
+    ], "unmapped": []}
+  },
+  {
+    "input": {"nodes": [
+      {"kind": "Source", "id": 0, "origin_stage": "load", "resolved": false, "produces": ["df"]},
+      {"kind": "Connected", "id": 1, "origin_stage": "goldenmatch.dedupe", "resolved": true, "method": {"name": "cc"}},
+      {"kind": "Barrier", "id": 2, "origin_stage": "infer_schema", "resolved": false, "raw_config": {}}
+    ], "edges": []},
+    "expected": {"fields": [], "unmapped": [
+      {"node_id": 0, "kind": "Source", "note": "data loaded"},
+      {"node_id": 1, "kind": "Connected", "note": "clustering"},
+      {"node_id": 2, "kind": "Barrier", "note": "opaque stage"}
+    ]}
+  },
+  {
+    "input": {"nodes": [], "edges": []},
+    "expected": {"fields": [], "unmapped": []}
+  }
+]

--- a/packages/rust/extensions/goldenpipe-native/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-native/src/lib.rs
@@ -44,6 +44,10 @@ fn build_repair_plan_json(input: &str) -> String {
 fn lower_json(input: &str) -> String {
     goldenpipe_core::json::lower_json(input)
 }
+#[pyfunction]
+fn provenance_json(input: &str) -> String {
+    goldenpipe_core::json::provenance_json(input)
+}
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -58,5 +62,6 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(band_of_json, m)?)?;
     m.add_function(wrap_pyfunction!(build_repair_plan_json, m)?)?;
     m.add_function(wrap_pyfunction!(lower_json, m)?)?;
+    m.add_function(wrap_pyfunction!(provenance_json, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldenpipe-wasm/src/lib.rs
@@ -64,4 +64,9 @@ mod wasm {
     pub fn lower_json(input: &str) -> String {
         json::lower_json(input)
     }
+
+    #[wasm_bindgen]
+    pub fn provenance_json(input: &str) -> String {
+        json::provenance_json(input)
+    }
 }


### PR DESCRIPTION
## What

Sub-project 2 of the GoldenPipe compiler. Turns the SP1 `CompiledPipeline` (IR) into a **field-level lineage report** — for each column: its Check ops, ordered Flow transforms, and matching role (blocking key / scorer input). A pure `provenance(CompiledPipeline) -> {fields, unmapped}` kernel function (Rust + Python mirror + golden vectors) + a Match-capture enrichment that makes the matching-role real, + `field_lineage`/`format_lineage` host helpers.

## Why non-perf (the measured pivot)

Originally SP2 was a fusion pass. Measurement refuted **every** compiler *performance* lever on the ER workload: columnar fusion ~8% of wall (Match is 92%); auto-config opt-out ~4% *and already done* by GoldenPipe; and emit-to-scale **already exists** as goldenmatch `backend=datafusion/duckdb/sail`. So SP2 delivers a value the suite genuinely lacks — cross-stage field provenance (goldenmatch explains *pairs*, goldenpipe explains *stages*; nothing explains *fields end-to-end*).

## How it works

- **Match-capture enrichment** — normalize the real `GoldenMatchConfig` nested `blocking.keys/passes[].fields` → `Partition.keys` and `matchkeys[].fields[].field` → `PairScore.scorer` (SP1 left these empty placeholders). Only touches recorded IR configs; the SP1 equivalence gate (kind-only Match assertion) stays green.
- **Pure `provenance`** — single pass over the IR nodes; deterministic (role-only columns emitted `sorted`); cross-surface golden-vector'd.
- **Real-pipeline proof** — on a real check→flow→match run, `email`'s transforms match the manifest exactly and `blocking_key` columns equal the compiled `Partition` node's keys.

## Verification

- Box-green (35 tests): match-enrich, provenance, field_lineage (incl. the self-defending real-pipeline proof), Leg-A parity, SP1 compiler suite unchanged.
- CI verifies: Rust `vec_provenance`, Python native Leg B, wasm build.

Spec: `docs/superpowers/specs/2026-07-08-goldenpipe-compiler-provenance-design.md`
Plan: `docs/superpowers/plans/2026-07-08-goldenpipe-compiler-provenance.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)