### PR TITLE
feat(goldenpipe): end-to-end field lineage (compiler SP3)

### DIFF
--- a/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-e2e-lineage.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-e2e-lineage.md
@@ -1,0 +1,282 @@
+# GoldenPipe Compiler SP3 — End-to-End Field Lineage — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface goldenmatch's existing golden-provenance as a GoldenPipe artifact + stitch it with SP2's field-lineage into an end-to-end per-golden-field journey (pre-match Flow-clean × post-match survivorship).
+
+**Architecture:** Host-only Python (no kernel/Rust — needs the Match execution output). Part A: the match adapter calls goldenmatch's `golden_provenance_for_run(result.dupes, clusters, result.config.golden_rules)` and attaches `ctx.artifacts["golden_provenance"]`. Part B: `end_to_end_lineage(compiled, golden_provenance)` joins SP2 `field_lineage` with the provenance on column name. Additive, byte-identical (None when survivorship inactive).
+
+**Tech Stack:** Python (goldenpipe compiler host + goldenmatch lineage). Reuses goldenmatch's provenance engine wholesale.
+
+---
+
+## Box / environment constraints
+
+- **Python is box-runnable** (real red→green). No Rust, no cross-surface, no kernel.
+  ```bash
+  INTERP="D:/show_case/goldenmatch/.venv/Scripts/python.exe"
+  export PYTHONPATH="packages/python/goldenpipe;packages/python/goldencheck;packages/python/infermap;packages/python/goldencheck-types;packages/python/goldenflow;packages/python/goldenmatch"
+  export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 GOLDENMATCH_AUTOCONFIG_MEMORY=0
+  ```
+  `cd "D:/show_case/gg-local-llm"` each Bash call. `ruff check` touched Python.
+- SP2 is merged into `main`; this branch is off fresh `main` so `goldenpipe/compiler/{lineage,provenance,ir,capture}.py` are present.
+- Spec: `docs/superpowers/specs/2026-07-08-goldenpipe-compiler-e2e-lineage-design.md`.
+
+## Verified shapes (from the code)
+
+- SP2 `field_lineage(compiled) -> {"fields":[{column, checks, transforms, blocking_key, scorer_input, ...}], "unmapped":...}` (importable from `goldenpipe.compiler.lineage`).
+- goldenmatch `golden_provenance_for_run(data_df, clusters, rules) -> list[ClusterProvenance] | None` (fail-open; None for non-survivorship / no multi-member clusters). `ClusterProvenance` dataclass: `cluster_id`, `fields: dict[str, FieldProvenance]`. `FieldProvenance`: `value, source_row_id, strategy, confidence, ...`.
+- Match adapter `DedupeStage.run` (`adapters/match.py`): sets `ctx.artifacts["clusters"]`/`["dupes"]` (lines ~71-78) before `return StageResult(SUCCESS)` (line ~94). `result.dupes` carries `__row_id__` (Int64); `result.config.golden_rules` is the `GoldenRulesConfig | None`.
+- `_survivorship_active` (True only for `field_groups` / list-form `field_rules` / `when`/`validate_with`) — default & auto-config pipelines → `None`.
+
+## File structure
+
+- Create `packages/python/goldenpipe/goldenpipe/compiler/e2e.py` — `end_to_end_lineage`, `format_end_to_end`, `surface_golden_provenance`.
+- Modify `packages/python/goldenpipe/goldenpipe/adapters/match.py` — call `surface_golden_provenance` in `DedupeStage.run`.
+- Tests: `tests/compiler/test_e2e.py`, `test_e2e_surface.py`, `test_e2e_integration.py`.
+
+---
+
+## Task 1: The stitch — `end_to_end_lineage` + `format_end_to_end` (box TDD)
+
+**Files:** Create `goldenpipe/compiler/e2e.py`; Test `tests/compiler/test_e2e.py`.
+
+- [ ] **Step 1: Write the failing test** `tests/compiler/test_e2e.py`:
+
+```python
+from types import SimpleNamespace
+
+from goldenpipe.compiler.e2e import end_to_end_lineage, format_end_to_end
+
+
+def _cp(nodes):
+    return {"nodes": nodes, "edges": []}
+
+
+def _n(kind, nid, **rest):
+    return {"kind": kind, "id": nid, "origin_stage": "s", "resolved": False, **rest}
+
+
+def test_stitch_combines_survivorship_and_plan():
+    compiled = _cp([
+        _n("Scan", 0, column="email", ops=["pattern_consistency"]),
+        _n("Map", 1, column="email", op="email_normalize"),
+        _n("Partition", 2, keys=["email"]),
+    ])
+    fp = SimpleNamespace(value="j@x.com", source_row_id=24, strategy="conditional", confidence=1.0)
+    cp = SimpleNamespace(cluster_id=1, fields={"email": fp})
+    out = end_to_end_lineage(compiled, [cp])
+    assert len(out["entries"]) == 1
+    e = out["entries"][0]
+    assert e["source_row_id"] == 24 and e["strategy"] == "conditional"          # goldenmatch
+    assert e["transforms"] == ["email_normalize"] and e["blocking_key"] is True  # SP2 (email is a Partition key)
+    assert e["checks"] == ["pattern_consistency"]
+
+
+def test_none_provenance_degrades_with_note():
+    out = end_to_end_lineage({"nodes": [], "edges": []}, None)
+    assert out["entries"] == []
+    assert "survivorship inactive" in out["notes"][0]
+
+
+def test_column_without_sp2_lineage_gets_empty_plan():
+    fp = SimpleNamespace(value="x", source_row_id=3, strategy="conditional", confidence=0.9)
+    cp = SimpleNamespace(cluster_id=1, fields={"phone": fp})
+    out = end_to_end_lineage({"nodes": [], "edges": []}, [cp])
+    e = out["entries"][0]
+    assert e["source_row_id"] == 3 and e["transforms"] == [] and e["blocking_key"] is False
+
+
+def test_format_end_to_end():
+    out = {"entries": [{
+        "cluster_id": 1, "column": "email", "value": "j@x.com", "source_row_id": 24,
+        "strategy": "conditional", "survivor_confidence": 1.0, "checks": [],
+        "transforms": ["email_normalize"], "blocking_key": False, "scorer_input": True,
+    }], "notes": []}
+    assert format_end_to_end(out) == (
+        "cluster 1 email = 'j@x.com' (row 24 via conditional); pre-match transforms[email_normalize], scorer-input"
+    )
+```
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Implement `e2e.py`** (the stitch + format; `surface_golden_provenance` is added in Task 2 — you may stub it or add it now):
+
+```python
+"""End-to-end field lineage (SP3): stitch SP2 field-lineage (pre-match Flow-clean +
+matching role, from the IR) with goldenmatch's golden-provenance (post-match
+survivorship) into one per-golden-field journey. Host-only — needs the Match output."""
+from __future__ import annotations
+
+from goldenpipe.compiler.lineage import field_lineage
+
+
+def end_to_end_lineage(compiled: dict, golden_provenance: list | None) -> dict:
+    """Join SP2 field-lineage with goldenmatch ClusterProvenance on column name.
+    Returns {entries, notes}. None/empty provenance -> [] + a note (plan-only view)."""
+    if not golden_provenance:
+        return {"entries": [], "notes": ["survivorship inactive — use field_lineage(compiled) for the plan-only view"]}
+    by_col = {f["column"]: f for f in field_lineage(compiled).get("fields", [])}
+    entries = []
+    for cp in golden_provenance:
+        cid = getattr(cp, "cluster_id", None)
+        for col, fp in (getattr(cp, "fields", None) or {}).items():
+            plan = by_col.get(col, {})
+            entries.append({
+                "cluster_id": cid,
+                "column": col,
+                "value": getattr(fp, "value", None),
+                "source_row_id": getattr(fp, "source_row_id", None),
+                "strategy": getattr(fp, "strategy", None),
+                "survivor_confidence": getattr(fp, "confidence", None),
+                "checks": list(plan.get("checks", [])),
+                "transforms": list(plan.get("transforms", [])),
+                "blocking_key": bool(plan.get("blocking_key", False)),
+                "scorer_input": bool(plan.get("scorer_input", False)),
+            })
+    return {"entries": entries, "notes": []}
+
+
+def format_end_to_end(result: dict) -> str:
+    lines = []
+    for e in result.get("entries", []):
+        pre = []
+        if e["transforms"]:
+            pre.append(f"transforms[{','.join(e['transforms'])}]")
+        pre.extend(r for r, on in (("blocking-key", e["blocking_key"]), ("scorer-input", e["scorer_input"])) if on)
+        pre_s = ("; pre-match " + ", ".join(pre)) if pre else ""
+        lines.append(f"cluster {e['cluster_id']} {e['column']} = {e['value']!r} (row {e['source_row_id']} via {e['strategy']}){pre_s}")
+    for n in result.get("notes", []):
+        lines.append(f"# {n}")
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run to verify PASS (4 tests).**
+- [ ] **Step 5: ruff + commit** (`feat(goldenpipe): end-to-end field lineage stitch (SP3)`).
+
+---
+
+## Task 2: Surface goldenmatch provenance in the Match adapter (box TDD)
+
+**Files:** Modify `goldenpipe/compiler/e2e.py` (add `surface_golden_provenance`) + `goldenpipe/adapters/match.py`; Test `tests/compiler/test_e2e_surface.py`.
+
+- [ ] **Step 1: Write the failing test** `tests/compiler/test_e2e_surface.py` (monkeypatch goldenmatch's entry so the WIRING is tested deterministically — no full dedupe needed):
+
+```python
+from types import SimpleNamespace
+
+from goldenpipe.compiler.e2e import surface_golden_provenance
+
+
+def test_surface_passes_dupes_clusters_rules_and_returns_provenance(monkeypatch):
+    calls = {}
+    def fake(data_df, clusters, rules):
+        calls["args"] = (data_df, clusters, rules)
+        return ["PROV"]
+    monkeypatch.setattr("goldenmatch.core.lineage.golden_provenance_for_run", fake)
+    result = SimpleNamespace(dupes="DUPES_DF", config=SimpleNamespace(golden_rules="RULES"))
+    out = surface_golden_provenance(result, {1: {"members": [0, 1], "size": 2}})
+    assert out == ["PROV"]
+    assert calls["args"] == ("DUPES_DF", {1: {"members": [0, 1], "size": 2}}, "RULES")
+
+
+def test_surface_none_when_no_rules():
+    result = SimpleNamespace(dupes="DUPES_DF", config=SimpleNamespace(golden_rules=None))
+    assert surface_golden_provenance(result, {1: {"members": [0, 1]}}) is None
+
+
+def test_surface_none_when_no_dupes_or_clusters():
+    result = SimpleNamespace(dupes=None, config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result, {1: {}}) is None
+    result2 = SimpleNamespace(dupes="DF", config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result2, None) is None
+
+
+def test_surface_fail_open_on_error(monkeypatch):
+    def boom(*a): raise RuntimeError("x")
+    monkeypatch.setattr("goldenmatch.core.lineage.golden_provenance_for_run", boom)
+    result = SimpleNamespace(dupes="DF", config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result, {1: {"members": [0, 1]}}) is None
+```
+
+- [ ] **Step 2: Run to verify FAIL.**
+
+- [ ] **Step 3: Add `surface_golden_provenance` to `e2e.py`:**
+
+```python
+def surface_golden_provenance(result, clusters):
+    """Reuse goldenmatch's golden_provenance_for_run to rebuild ClusterProvenance from a
+    finished DedupeResult. Returns list|None (None when survivorship inactive, no dupes/
+    clusters/rules, or any error — fail-open). data_df=result.dupes (carries __row_id__);
+    rules=result.config.golden_rules."""
+    try:
+        from goldenmatch.core.lineage import golden_provenance_for_run
+        cfg = getattr(result, "config", None)
+        rules = getattr(cfg, "golden_rules", None) if cfg is not None else None
+        dupes = getattr(result, "dupes", None)
+        if dupes is None or not clusters or rules is None:
+            return None
+        return golden_provenance_for_run(dupes, clusters, rules)
+    except Exception:
+        return None
+```
+
+- [ ] **Step 4: Wire into `DedupeStage.run` in `adapters/match.py`.** Immediately BEFORE the final `return StageResult(status=StageStatus.SUCCESS)` (after the `dupes`/`clusters`/`scored_pairs` artifact assignments, ~line 93), add:
+```python
+        # SP3: surface goldenmatch's golden-record provenance (survivorship audit) as an
+        # advisory pipeline artifact. None (byte-identical) unless survivorship is active.
+        from goldenpipe.compiler.e2e import surface_golden_provenance
+        ctx.artifacts["golden_provenance"] = surface_golden_provenance(result, ctx.artifacts.get("clusters"))
+```
+`surface_golden_provenance` is itself fail-open, so no extra try/except is needed here — it returns None on any problem. Confirm `result` is in scope at that point (it is — the artifact assignments above use it).
+
+- [ ] **Step 5: Run to verify PASS + no regression.**
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/compiler/test_e2e_surface.py packages/python/goldenpipe/tests/test_adapters.py -q
+```
+Expected: surface tests pass; `test_adapters` unchanged (the new artifact is additive; a default config yields None).
+
+- [ ] **Step 6: ruff + commit** (`feat(goldenpipe): surface goldenmatch golden-provenance in match adapter (SP3)`).
+
+---
+
+## Task 3: Real-pipeline end-to-end proof (box)
+
+**Files:** Test `tests/compiler/test_e2e_integration.py`.
+
+- [ ] **Step 1: Write the integration test.** Build a tiny fixture + a **survivorship-ACTIVE** explicit match config (so `golden_provenance` populates). Study `goldenmatch/config/schemas.py` for `GoldenRulesConfig` + `FieldGroupConfig` (or list-form `field_rules`) — the config MUST trip `_survivorship_active` (`field_groups`, OR list-form conditional `field_rules`, OR a rule with `when`/`validate_with`). Run the full `load→check→flow→match` with that config, then:
+  - Assert `ctx.artifacts["golden_provenance"]` is not None (Part A surfaced it).
+  - `compile_and_run` the same plan to get `compiled`; `end_to_end_lineage(compiled, ctx.artifacts["golden_provenance"])` → assert at least one entry carries **both** `source_row_id` (from goldenmatch) **and** a non-empty `transforms` for a Flow-transformed column (from SP2).
+
+  **Fallback (if standing up an active config on a tiny fixture proves fiddly):** keep the assertion to "golden_provenance is not None AND end_to_end_lineage yields ≥1 entry with a source_row_id" — the Task-1 unit test already carries the join fidelity; this test's job is proving Part-A surfacing produces real provenance end-to-end. Do NOT weaken to a monkeypatched provenance here (Task 2 covers wiring; this must exercise the REAL goldenmatch lineage path). If you genuinely cannot get `_survivorship_active` true on a tiny fixture after a real effort, report BLOCKED with what you tried (the exact config + why golden_provenance stayed None) rather than faking it.
+
+  Env: `GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_AUTOCONFIG_MEMORY=0`; tiny fixture, soundex-spread surnames.
+
+- [ ] **Step 2: Run to verify PASS.** Report the printed end-to-end lineage for the survivorship-active field (source_row_id + transforms) — the SP3 headline artifact.
+
+- [ ] **Step 3: ruff + commit** (`test(goldenpipe): real-pipeline end-to-end lineage proof (SP3)`).
+
+---
+
+## Task 4: Ship
+
+- [ ] **Step 1:** SP2 (#1597) is already merged; this branch is off fresh `main`. `git fetch origin && git rebase origin/main` (resolve any conflict in `adapters/match.py`).
+- [ ] **Step 2:** Re-run the box suite:
+```bash
+"$INTERP" -m pytest packages/python/goldenpipe/tests/compiler/ packages/python/goldenpipe/tests/test_adapters.py -q
+```
+Expected: green (SP1/SP2 compiler tests + the 3 SP3 test files + adapters no-regression).
+- [ ] **Step 3:** Push + PR + arm auto-merge, then **STOP** (no CI polling):
+```bash
+unset GH_TOKEN; gh auth switch --user benzsevern; export GH_TOKEN=$(gh auth token --user benzsevern)
+git push -u origin feat/goldenpipe-compiler-e2e-lineage
+gh pr create --base main --title "feat(goldenpipe): compiler SP3 — end-to-end field lineage" --body "<summary: surface goldenmatch golden-provenance in the match adapter + stitch with SP2 field-lineage into a per-golden-field journey (pre-match Flow-clean x post-match survivorship). Host-only, reuses goldenmatch's lineage engine wholesale; additive/byte-identical (None when survivorship inactive). Links spec+plan. Note SP3 of the compiler program.>"
+gh pr merge <N> --auto --squash   # merge-queue: NO --delete-branch
+```
+Watch CI: python (goldenpipe) — the SP3 tests + adapters.
+
+---
+
+## Verification summary
+- Box-green: `test_e2e` (stitch join, None-degrade, format), `test_e2e_surface` (adapter wiring, fail-open, None cases), `test_e2e_integration` (real goldenmatch provenance + stitch), `test_adapters` (no regression — additive artifact).
+- Additive/byte-identical: `golden_provenance` is a new artifact key, `None` for default/auto pipelines (survivorship gate narrow); the stitch + format are opt-in host functions. No kernel, no cross-surface, no execution change.

--- a/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-e2e-lineage.md
+++ b/docs/superpowers/plans/2026-07-08-goldenpipe-compiler-e2e-lineage.md
@@ -244,11 +244,26 @@ Expected: surface tests pass; `test_adapters` unchanged (the new artifact is add
 
 **Files:** Test `tests/compiler/test_e2e_integration.py`.
 
-- [ ] **Step 1: Write the integration test.** Build a tiny fixture + a **survivorship-ACTIVE** explicit match config (so `golden_provenance` populates). Study `goldenmatch/config/schemas.py` for `GoldenRulesConfig` + `FieldGroupConfig` (or list-form `field_rules`) — the config MUST trip `_survivorship_active` (`field_groups`, OR list-form conditional `field_rules`, OR a rule with `when`/`validate_with`). Run the full `load→check→flow→match` with that config, then:
-  - Assert `ctx.artifacts["golden_provenance"]` is not None (Part A surfaced it).
-  - `compile_and_run` the same plan to get `compiled`; `end_to_end_lineage(compiled, ctx.artifacts["golden_provenance"])` → assert at least one entry carries **both** `source_row_id` (from goldenmatch) **and** a non-empty `transforms` for a Flow-transformed column (from SP2).
+- [ ] **Step 1: Write the integration test.** Build a tiny fixture + a **survivorship-ACTIVE** explicit match config so `golden_provenance` populates.
 
-  **Fallback (if standing up an active config on a tiny fixture proves fiddly):** keep the assertion to "golden_provenance is not None AND end_to_end_lineage yields ≥1 entry with a source_row_id" — the Task-1 unit test already carries the join fidelity; this test's job is proving Part-A surfacing produces real provenance end-to-end. Do NOT weaken to a monkeypatched provenance here (Task 2 covers wiring; this must exercise the REAL goldenmatch lineage path). If you genuinely cannot get `_survivorship_active` true on a tiny fixture after a real effort, report BLOCKED with what you tried (the exact config + why golden_provenance stayed None) rather than faking it.
+  **CRITICAL (from review): the stitch reads only `ClusterProvenance.fields` (the SCALAR survivorship branch), NOT `.groups`.** Group-member columns land in `cp.groups`, which SP3 does not read. So the Flow-transformed column you assert on (`email`) MUST be a **scalar** column (not a group member) — then `build_resolution_order` adds it as a scalar unit and it appears in `cp.fields` with a `source_row_id`. Trip `_survivorship_active` via `field_groups` on *other* columns.
+
+  **Concrete minimal config** (verified to trip `_survivorship_active` via the `field_groups` branch, no `when:`-predicate risk):
+  ```python
+  from goldenmatch.config.schemas import GoldenRulesConfig, GoldenGroupRule  # confirm exact names
+  golden_rules = GoldenRulesConfig(
+      default_strategy="most_complete",
+      field_groups=[GoldenGroupRule(name="loc", columns=["city", "state"], strategy="most_complete")],
+  )
+  # pass on the match StageSpec: config=GoldenMatchConfig(matchkeys=..., blocking=..., golden_rules=golden_rules)
+  ```
+  **Fixture columns:** `email` (dirty → Flow-transformed, SCALAR — the column you assert), `city`+`state` (the ≥2-column group), a name column for blocking (soundex-spread surnames), and real duplicates (so there's a multi-member cluster). Confirm `GoldenGroupRule`/`GoldenRulesConfig` exact names + required fields against `goldenmatch/config/schemas.py`.
+
+  Run the full `load→check→flow→match` with that config, then:
+  - Assert `ctx.artifacts["golden_provenance"]` is not None (Part A surfaced it).
+  - `compile_and_run` the same plan to get `compiled`; `end_to_end_lineage(compiled, ctx.artifacts["golden_provenance"])` → assert at least one entry for the **scalar `email` column** carries **both** `source_row_id` (from goldenmatch `cp.fields`) **and** non-empty `transforms` (from SP2).
+
+  **Fallback (if the active config is still fiddly):** keep the assertion to "golden_provenance is not None AND end_to_end_lineage yields ≥1 entry with a source_row_id" — the Task-1 unit test carries the join fidelity; this test's job is proving Part-A surfacing produces REAL provenance end-to-end. Do NOT weaken to a monkeypatched provenance here (Task 2 covers wiring; this must exercise the REAL goldenmatch lineage path). If you genuinely cannot get `_survivorship_active` true after a real effort, report BLOCKED with the exact config + why `golden_provenance` stayed None — do not fake it.
 
   Env: `GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_AUTOCONFIG_MEMORY=0`; tiny fixture, soundex-spread surnames.
 

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-e2e-lineage-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-e2e-lineage-design.md
@@ -1,0 +1,143 @@
+# GoldenPipe Compiler — SP3: End-to-End Field Lineage (Flow-clean × Match-survivorship) — Design
+
+**Date:** 2026-07-08
+**Status:** Approved (brainstorming), pending implementation plan
+**Program:** GoldenPipe compiler. SP1 (IR walking skeleton, PR #1592) + SP2 (field-level
+provenance, PR #1597) shipped. This is **sub-project 3**.
+
+## Why this shape (the measured pivot — again)
+
+The literal ask was "row/cluster-level provenance." Code inspection shows goldenmatch
+**already has a complete row/cluster/survivorship lineage system**, exposed via its
+public API, CLI, MCP server, and web router:
+- `core/golden.py`: `FieldProvenance{value, source_row_id, strategy, confidence,
+  candidates, condition, validator, dropped_invalid}`, `GroupProvenance` (correlated
+  survivorship), `ClusterProvenance{cluster_id, cluster_quality, cluster_confidence,
+  fields: dict[str, FieldProvenance], groups}`, `GoldenRecordResult.provenance`.
+- `core/lineage.py`: `build_lineage`, `golden_provenance_for_run`, `save_lineage`,
+  `load_lineage`, FS scoring waterfalls, NL renderers.
+
+So "build row/cluster provenance" would **rebuild `lineage.py`** — the exact dead end
+this program has hit repeatedly (fusion, auto-config opt-out, emit-to-scale all already
+existed too). The **only** net-new sliver: goldenmatch's lineage runs on the *post-Flow*
+data — it knows survivorship + matching but has **no knowledge of what Flow cleaned each
+column before matching**. SP2 has the transform lineage but no row-level survivor. Only
+the *compiler* sees both. SP3 stitches them.
+
+## Goal
+
+Two host-only pieces:
+1. **Surface** goldenmatch's existing golden-provenance as a GoldenPipe pipeline
+   artifact (the match adapter drops it today).
+2. **Stitch** it with SP2's field-lineage into an **end-to-end field journey**: for each
+   golden field, `source row → pre-match Flow transforms/checks → matching role →
+   survivorship (which row's value won, via what strategy)`.
+
+Net-new because it joins the *pre-match cleaning* (GoldenPipe/goldenflow) with the
+*post-match survivorship* (goldenmatch) — a view neither engine produces alone.
+
+## Non-goals
+
+- **No reimplementation** of survivorship / cluster / pair provenance — reuse
+  goldenmatch's `golden_provenance_for_run` and `ClusterProvenance`/`FieldProvenance`
+  wholesale.
+- **No kernel / Rust / cross-surface.** SP3 needs the Match *execution output*, so it is
+  entirely host-side Python (unlike SP1/SP2's pure IR kernel functions).
+- **No execution change.** Additive artifact + opt-in stitch.
+- No row/cluster provenance UI/CLI (goldenmatch already has those).
+
+## Architecture
+
+### Part A — surface goldenmatch provenance (match adapter)
+
+In `adapters/match.py`, after dedupe produces `clusters`/`golden`, call goldenmatch's
+public, fail-open entry:
+```
+golden_provenance_for_run(data_df, clusters, rules) -> list[ClusterProvenance] | None
+```
+- `data_df` = the source frame carrying `__row_id__` (the frame dedupe scored — the same
+  one whose row ids the clusters' `members` reference).
+- `clusters` = the `clusters` artifact (dict `{cluster_id: {members, size, ...}}`).
+- `rules` = the survivorship rules from the match `GoldenMatchConfig` the adapter used
+  (the field-rules / survivorship config; the adapter already holds the config).
+
+Attach `ctx.artifacts["golden_provenance"]` = the returned list (or `None`).
+
+**Additive + byte-identical:** `golden_provenance_for_run` is fail-open (returns `None`
+on any error), returns `None` for non-survivorship configs (`_survivorship_active` is
+false) and when there are no multi-member clusters. So a default pipeline is unchanged;
+the artifact simply appears when survivorship is active. Wrap the call in try/except so a
+lineage failure never breaks the match stage (mirror the adapter's existing best-effort
+enrichment pattern).
+
+### Part B — the stitch (compiler host)
+
+New `goldenpipe/compiler/e2e.py`:
+```
+end_to_end_lineage(compiled: dict, golden_provenance: list | None) -> dict
+    -> { "entries": [EndToEndField], "notes": [str] }
+
+EndToEndField {
+    cluster_id: int,
+    column: str,
+    # survivorship (from goldenmatch FieldProvenance)
+    value, source_row_id: int, strategy: str, survivor_confidence: float,
+    # plan lineage (from SP2 field_lineage)
+    checks: [str], transforms: [str], blocking_key: bool, scorer_input: bool,
+}
+```
+
+**Join = column name.** Compute `field_lineage(compiled)` (SP2) once → a `{column: {checks,
+transforms, blocking_key, scorer_input}}` lookup. For each `ClusterProvenance` cp, for
+each `(column, fp)` in `cp.fields`, emit an entry merging `fp`'s survivorship with the
+SP2 lookup for that column (defaults `[]`/`False` when the column has no SP2 lineage —
+e.g. an untransformed column). Entry order: cluster order, then `cp.fields` order.
+
+- `golden_provenance is None` → `{"entries": [], "notes": ["survivorship inactive — use
+  field_lineage(compiled) for the plan-only view"]}`.
+- `format_end_to_end(result) -> str` — host presentation, one line per entry, e.g.
+  `cluster 1 email = 'j@x.com' (row 24 via most_complete); pre-match transforms[email_normalize], scorer-input`.
+
+`ClusterProvenance`/`FieldProvenance` are dataclasses; the stitch reads them directly
+(in-process). No serialization needed; goldenmatch's `_serialize_provenance` is available
+if a caller wants JSON.
+
+## Error handling
+
+- Part A: try/except around `golden_provenance_for_run`; on failure attach `None` and
+  log (never break the stage). Missing `clusters`/config → `None`.
+- Part B: `end_to_end_lineage(compiled, None)` → empty entries + note. A `ClusterProvenance`
+  missing `fields` → no entries for it (no crash). A column in provenance absent from SP2
+  lineage → entry with empty `checks`/`transforms`, `blocking_key=False` (honest).
+- The stitch never raises on well-formed inputs; it reads dataclass attributes that
+  goldenmatch always populates.
+
+## Testing
+
+- **Unit stitch** (box): a hand-built `compiled` (email `Scan`/`Map` + `Partition` naming
+  email) + a synthetic `ClusterProvenance(cluster_id=1, fields={"email": FieldProvenance(
+  value="j@x.com", source_row_id=24, strategy="most_complete", confidence=1.0)})` →
+  exactly one entry combining both halves (`source_row_id=24` AND `transforms=[...]`).
+  And `golden_provenance=None` → `entries:[]` + the note.
+- **`format_end_to_end`** unit (structured → expected string).
+- **Real-pipeline proof** (box): a pipeline **with survivorship rules** so
+  `golden_provenance` populates — `compile_and_run` the full `load→check→flow→match`,
+  run Part-A surfacing (call `golden_provenance_for_run` with the run's frame/clusters/
+  rules), stitch, and assert a golden field's entry carries **both** `source_row_id`
+  (goldenmatch) **and** the `email` `transforms` (SP2). If standing up a survivorship
+  config on a tiny fixture proves heavy, the unit test carries the join proof and the
+  real-pipeline test asserts Part-A produces a non-`None` provenance + a non-empty stitch.
+
+## Rollout
+
+Pure-additive, host-only. Part A surfaces a new `golden_provenance` artifact (`None`
+when survivorship inactive → byte-identical default pipeline). Part B (`end_to_end_lineage`,
+`format_end_to_end`) is an opt-in host function callers invoke on the `compile_and_run`
+result. No kernel, no cross-surface, no execution change, no new kernel symbols.
+
+## Scope boundary
+
+SP3 is the **column/field-level** end-to-end journey (per golden field: its survivor row
++ pre-match transforms + matching role). It does NOT re-expose goldenmatch's cluster/pair
+NL explanations or its lineage CLI/MCP (those exist). It adds exactly the cross-engine
+stitch the compiler is uniquely positioned to produce.

--- a/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-e2e-lineage-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldenpipe-compiler-e2e-lineage-design.md
@@ -55,20 +55,33 @@ public, fail-open entry:
 ```
 golden_provenance_for_run(data_df, clusters, rules) -> list[ClusterProvenance] | None
 ```
-- `data_df` = the source frame carrying `__row_id__` (the frame dedupe scored — the same
-  one whose row ids the clusters' `members` reference).
-- `clusters` = the `clusters` artifact (dict `{cluster_id: {members, size, ...}}`).
-- `rules` = the survivorship rules from the match `GoldenMatchConfig` the adapter used
-  (the field-rules / survivorship config; the adapter already holds the config).
+Inputs (VERIFIED against the real code — do NOT use the naive `ctx.df`/`config` sources):
+- `data_df` = **`result.dupes`** — the frame carrying `__row_id__` (Int64) + value columns
+  for the multi-member members that `clusters[*].members` reference. `ctx.df` does NOT
+  carry `__row_id__` (goldenmatch adds it internally via `_add_row_ids` *after* the
+  adapter hands off the frame), so passing `ctx.df` makes the internal
+  `multi_df.join(data_df, on="__row_id__")` fail → fail-open → the artifact would be
+  **perpetually `None`**. `result.dupes` is dtype-correct and already surfaced as
+  `ctx.artifacts["dupes"]`.
+- `clusters` = the `clusters` artifact (dict `{cluster_id: {members, size, ...}}`) from
+  the classic `DedupeStage`. (The `FusedDedupeStage` sets `clusters = {cid: [row_ids]}` —
+  a list, incompatible with `golden_provenance_for_run`'s `cinfo.get("size"/"members")`;
+  SP3 is a silent no-op there, which is fine — the fused stage produces no golden.)
+- `rules` = **`result.config.golden_rules`** (a `GoldenRulesConfig`, or `None`).
+  `DedupeResult.config` is the *resolved* config present on ALL adapter paths (including
+  Priority-0 throughput and Priority-3 auto-config, where the adapter holds no local
+  `config`). Do NOT use the `GoldenMatchConfig` the adapter built — it's unavailable on
+  those branches, and the survivorship rules live at `.golden_rules`, not top-level.
 
 Attach `ctx.artifacts["golden_provenance"]` = the returned list (or `None`).
 
 **Additive + byte-identical:** `golden_provenance_for_run` is fail-open (returns `None`
-on any error), returns `None` for non-survivorship configs (`_survivorship_active` is
-false) and when there are no multi-member clusters. So a default pipeline is unchanged;
-the artifact simply appears when survivorship is active. Wrap the call in try/except so a
-lineage failure never breaks the match stage (mirror the adapter's existing best-effort
-enrichment pattern).
+on any error), builds only new frames (no mutation of `data_df`/`clusters`), returns
+`None` for non-survivorship configs and single-member-only clusters, and
+`golden_provenance` is a NEW artifact key (the adapter + downstream `IdentityResolveStage`
+read only `clusters`/`scored_pairs`/`matchkey_used`, never `golden_provenance`). So a
+default pipeline is unchanged. Wrap the call in try/except so a lineage failure never
+breaks the match stage (mirror the adapter's existing best-effort enrichment pattern).
 
 ### Part B — the stitch (compiler host)
 
@@ -93,10 +106,20 @@ each `(column, fp)` in `cp.fields`, emit an entry merging `fp`'s survivorship wi
 SP2 lookup for that column (defaults `[]`/`False` when the column has no SP2 lineage —
 e.g. an untransformed column). Entry order: cluster order, then `cp.fields` order.
 
+**Join-key limitation (documented, honest):** the join matches goldenmatch's golden
+column names (post-Flow) to SP2's IR column names. If Flow **renamed** or **split** a
+column (`name` → `first_name`/`last_name`), the golden column won't match an SP2 IR
+column, so the entry carries empty `checks`/`transforms` (`blocking_key=False`) — the
+pre-match half is honestly absent for exactly the columns Flow reshaped most. SP1's IR op
+set has no column-creating op today, so in practice this is limited to explicit split/
+rename configs; note it as a known gap rather than silently implying full coverage.
+
 - `golden_provenance is None` → `{"entries": [], "notes": ["survivorship inactive — use
   field_lineage(compiled) for the plan-only view"]}`.
-- `format_end_to_end(result) -> str` — host presentation, one line per entry, e.g.
-  `cluster 1 email = 'j@x.com' (row 24 via most_complete); pre-match transforms[email_normalize], scorer-input`.
+- `format_end_to_end(result) -> str` — host presentation, one line per entry. The
+  `strategy` is whatever survivorship strategy actually won (a survivorship-active one,
+  e.g. a conditional/group rule — NOT `most_complete`, which is inactive), e.g.
+  `cluster 1 email = 'j@x.com' (row 24 via conditional:corporate_domain); pre-match transforms[email_normalize], scorer-input`.
 
 `ClusterProvenance`/`FieldProvenance` are dataclasses; the stitch reads them directly
 (in-process). No serialization needed; goldenmatch's `_serialize_provenance` is available
@@ -120,13 +143,20 @@ if a caller wants JSON.
   exactly one entry combining both halves (`source_row_id=24` AND `transforms=[...]`).
   And `golden_provenance=None` → `entries:[]` + the note.
 - **`format_end_to_end`** unit (structured → expected string).
-- **Real-pipeline proof** (box): a pipeline **with survivorship rules** so
-  `golden_provenance` populates — `compile_and_run` the full `load→check→flow→match`,
-  run Part-A surfacing (call `golden_provenance_for_run` with the run's frame/clusters/
-  rules), stitch, and assert a golden field's entry carries **both** `source_row_id`
-  (goldenmatch) **and** the `email` `transforms` (SP2). If standing up a survivorship
-  config on a tiny fixture proves heavy, the unit test carries the join proof and the
-  real-pipeline test asserts Part-A produces a non-`None` provenance + a non-empty stitch.
+- **Real-pipeline proof** (box): a pipeline with an explicit **survivorship-ACTIVE**
+  golden-rules config so `golden_provenance` populates. The config MUST trip
+  `_survivorship_active` — i.e. `golden_rules` with `field_groups`, OR a list-form
+  (conditional) `field_rules`, OR a rule carrying `when`/`validate_with`. A plain
+  `most_complete` / dict `field_rules` will NOT (→ `None`). Pass it as the explicit match
+  stage config (`StageSpec(use="goldenmatch.dedupe", config=<GoldenMatchConfig with
+  golden_rules>)`). Then `compile_and_run`, run Part-A surfacing (via `result.dupes` +
+  `clusters` + `result.config.golden_rules`), stitch, and assert a golden field's entry
+  carries **both** `source_row_id` (goldenmatch) **and** the `email` `transforms` (SP2).
+  **The unit stitch test is the PRIMARY join proof** (deterministic, synthetic
+  provenance); the real-pipeline test's job is to prove Part-A surfacing yields non-`None`
+  provenance + a non-empty stitch on a genuinely-active config — if the tiny-fixture
+  survivorship setup is fiddly, keep the real-pipeline assertion to "non-None + stitched",
+  not a specific survivor value.
 
 ## Rollout
 

--- a/packages/python/goldenpipe/goldenpipe/adapters/match.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/match.py
@@ -91,6 +91,10 @@ class DedupeStage:
         )
         if mks:
             ctx.artifacts["matchkey_used"] = mks[0].name
+        # SP3: surface goldenmatch's golden-record provenance (survivorship audit) as an
+        # advisory pipeline artifact. None (byte-identical) unless survivorship is active.
+        from goldenpipe.compiler.e2e import surface_golden_provenance
+        ctx.artifacts["golden_provenance"] = surface_golden_provenance(result, ctx.artifacts.get("clusters"))
         return StageResult(status=StageStatus.SUCCESS)
 
 

--- a/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
@@ -32,6 +32,23 @@ def end_to_end_lineage(compiled: dict, golden_provenance: list | None) -> dict:
     return {"entries": entries, "notes": []}
 
 
+def surface_golden_provenance(result, clusters):
+    """Reuse goldenmatch's golden_provenance_for_run to rebuild ClusterProvenance from a
+    finished DedupeResult. Returns list|None — None when survivorship inactive, no dupes/
+    clusters/rules, or any error (fail-open). data_df=result.dupes (carries __row_id__);
+    rules=result.config.golden_rules."""
+    try:
+        from goldenmatch.core.lineage import golden_provenance_for_run
+        cfg = getattr(result, "config", None)
+        rules = getattr(cfg, "golden_rules", None) if cfg is not None else None
+        dupes = getattr(result, "dupes", None)
+        if dupes is None or not clusters or rules is None:
+            return None
+        return golden_provenance_for_run(dupes, clusters, rules)
+    except Exception:
+        return None
+
+
 def format_end_to_end(result: dict) -> str:
     lines = []
     for e in result.get("entries", []):

--- a/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
@@ -1,0 +1,46 @@
+"""End-to-end field lineage (SP3): stitch SP2 field-lineage (pre-match Flow-clean +
+matching role, from the IR) with goldenmatch's golden-provenance (post-match
+survivorship) into one per-golden-field journey. Host-only — needs the Match output."""
+from __future__ import annotations
+
+from goldenpipe.compiler.lineage import field_lineage
+
+
+def end_to_end_lineage(compiled: dict, golden_provenance: list | None) -> dict:
+    """Join SP2 field-lineage with goldenmatch ClusterProvenance on column name.
+    Returns {entries, notes}. None/empty provenance -> [] + a note (plan-only view)."""
+    if not golden_provenance:
+        return {"entries": [], "notes": ["survivorship inactive — use field_lineage(compiled) for the plan-only view"]}
+    by_col = {f["column"]: f for f in field_lineage(compiled).get("fields", [])}
+    entries = []
+    for cp in golden_provenance:
+        cid = getattr(cp, "cluster_id", None)
+        for col, fp in (getattr(cp, "fields", None) or {}).items():
+            plan = by_col.get(col, {})
+            entries.append({
+                "cluster_id": cid,
+                "column": col,
+                "value": getattr(fp, "value", None),
+                "source_row_id": getattr(fp, "source_row_id", None),
+                "strategy": getattr(fp, "strategy", None),
+                "survivor_confidence": getattr(fp, "confidence", None),
+                "checks": list(plan.get("checks", [])),
+                "transforms": list(plan.get("transforms", [])),
+                "blocking_key": bool(plan.get("blocking_key", False)),
+                "scorer_input": bool(plan.get("scorer_input", False)),
+            })
+    return {"entries": entries, "notes": []}
+
+
+def format_end_to_end(result: dict) -> str:
+    lines = []
+    for e in result.get("entries", []):
+        pre = []
+        if e["transforms"]:
+            pre.append(f"transforms[{','.join(e['transforms'])}]")
+        pre.extend(r for r, on in (("blocking-key", e["blocking_key"]), ("scorer-input", e["scorer_input"])) if on)
+        pre_s = ("; pre-match " + ", ".join(pre)) if pre else ""
+        lines.append(f"cluster {e['cluster_id']} {e['column']} = {e['value']!r} (row {e['source_row_id']} via {e['strategy']}){pre_s}")
+    for n in result.get("notes", []):
+        lines.append(f"# {n}")
+    return "\n".join(lines)

--- a/packages/python/goldenpipe/tests/compiler/test_e2e.py
+++ b/packages/python/goldenpipe/tests/compiler/test_e2e.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+
+from goldenpipe.compiler.e2e import end_to_end_lineage, format_end_to_end
+
+
+def _cp(nodes):
+    return {"nodes": nodes, "edges": []}
+
+
+def _n(kind, nid, **rest):
+    return {"kind": kind, "id": nid, "origin_stage": "s", "resolved": False, **rest}
+
+
+def test_stitch_combines_survivorship_and_plan():
+    compiled = _cp([
+        _n("Scan", 0, column="email", ops=["pattern_consistency"]),
+        _n("Map", 1, column="email", op="email_normalize"),
+        _n("Partition", 2, keys=["email"]),
+    ])
+    fp = SimpleNamespace(value="j@x.com", source_row_id=24, strategy="conditional", confidence=1.0)
+    cp = SimpleNamespace(cluster_id=1, fields={"email": fp})
+    out = end_to_end_lineage(compiled, [cp])
+    assert len(out["entries"]) == 1
+    e = out["entries"][0]
+    assert e["source_row_id"] == 24 and e["strategy"] == "conditional"
+    assert e["transforms"] == ["email_normalize"] and e["blocking_key"] is True
+    assert e["checks"] == ["pattern_consistency"]
+
+
+def test_none_provenance_degrades_with_note():
+    out = end_to_end_lineage({"nodes": [], "edges": []}, None)
+    assert out["entries"] == []
+    assert "survivorship inactive" in out["notes"][0]
+
+
+def test_column_without_sp2_lineage_gets_empty_plan():
+    fp = SimpleNamespace(value="x", source_row_id=3, strategy="conditional", confidence=0.9)
+    cp = SimpleNamespace(cluster_id=1, fields={"phone": fp})
+    out = end_to_end_lineage({"nodes": [], "edges": []}, [cp])
+    e = out["entries"][0]
+    assert e["source_row_id"] == 3 and e["transforms"] == [] and e["blocking_key"] is False
+
+
+def test_format_end_to_end():
+    out = {"entries": [{
+        "cluster_id": 1, "column": "email", "value": "j@x.com", "source_row_id": 24,
+        "strategy": "conditional", "survivor_confidence": 1.0, "checks": [],
+        "transforms": ["email_normalize"], "blocking_key": False, "scorer_input": True,
+    }], "notes": []}
+    assert format_end_to_end(out) == (
+        "cluster 1 email = 'j@x.com' (row 24 via conditional); pre-match transforms[email_normalize], scorer-input"
+    )

--- a/packages/python/goldenpipe/tests/compiler/test_e2e_integration.py
+++ b/packages/python/goldenpipe/tests/compiler/test_e2e_integration.py
@@ -1,0 +1,123 @@
+"""SP3 real-pipeline integration proof: run a full load->check->flow->match pipeline
+with a survivorship-ACTIVE goldenmatch config so goldenmatch actually produces
+ClusterProvenance, then stitch SP2 field-lineage with that provenance and assert an
+entry carries BOTH source_row_id (goldenmatch survivorship) AND transforms (SP2
+Flow-clean). No mocks -- this exercises real goldenmatch lineage end-to-end."""
+from __future__ import annotations
+
+import polars as pl
+
+# Real goldenmatch config schema (verified against goldenmatch/config/schemas.py).
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenGroupRule,
+    GoldenMatchConfig,
+    GoldenRulesConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenpipe.compiler.compiled_runner import compile_and_run
+from goldenpipe.compiler.e2e import end_to_end_lineage, format_end_to_end
+from goldenpipe.engine.registry import StageRegistry
+from goldenpipe.engine.resolver import Resolver
+from goldenpipe.models.config import PipelineConfig, StageSpec
+from goldenpipe.models.context import PipeContext
+
+
+def _fixture_csv(tmp_path) -> str:
+    """~14 rows. Surnames are soundex-spread (avoids blocking/scoring hang). `email`
+    is DIRTY (MixedCase + surrounding whitespace) so GoldenFlow auto-detect transforms
+    it -- and it is a SCALAR column (NOT in a field_group), so it lands in
+    ClusterProvenance.fields (the branch the stitch reads). Three duplicate PAIRS
+    (same first+last, same city/state) form multi-member clusters; survivorship needs
+    at least one cluster of size >= 2."""
+    rows = [
+        # cluster A: Robert Smith / Boston MA (dup pair)
+        {"first_name": "Robert", "last_name": "Smith", "email": "  RObert.Smith@Example.COM ", "city": "Boston", "state": "MA"},
+        {"first_name": "Robert", "last_name": "Smith", "email": "robert.smith@example.com", "city": "Boston", "state": "MA"},
+        # cluster B: Maria Garcia / Miami FL (dup pair)
+        {"first_name": "Maria", "last_name": "Garcia", "email": " Maria.Garcia@Mail.Com  ", "city": "Miami", "state": "FL"},
+        {"first_name": "Maria", "last_name": "Garcia", "email": "maria.garcia@mail.com", "city": "Miami", "state": "FL"},
+        # cluster C: James Johnson / Chicago IL (dup pair)
+        {"first_name": "James", "last_name": "Johnson", "email": "JAMES.johnson@Work.org ", "city": "Chicago", "state": "IL"},
+        {"first_name": "James", "last_name": "Johnson", "email": "james.johnson@work.org", "city": "Chicago", "state": "IL"},
+        # singletons -- soundex-spread surnames
+        {"first_name": "William", "last_name": "Williams", "email": "  William.W@Example.com", "city": "Dallas", "state": "TX"},
+        {"first_name": "Brian", "last_name": "Brown", "email": "Brian.Brown@Mail.com ", "city": "Denver", "state": "CO"},
+        {"first_name": "Jennifer", "last_name": "Jones", "email": " Jen.Jones@Work.org", "city": "Seattle", "state": "WA"},
+        {"first_name": "Michael", "last_name": "Miller", "email": "Michael.Miller@Example.com  ", "city": "Portland", "state": "OR"},
+        {"first_name": "David", "last_name": "Davis", "email": "  David.Davis@Mail.com", "city": "Phoenix", "state": "AZ"},
+        {"first_name": "Linda", "last_name": "Lopez", "email": "Linda.Lopez@Work.org ", "city": "Austin", "state": "TX"},
+        {"first_name": "Karen", "last_name": "Wilson", "email": " Karen.Wilson@Example.com ", "city": "Atlanta", "state": "GA"},
+        {"first_name": "Nancy", "last_name": "Nguyen", "email": "Nancy.Nguyen@Mail.com", "city": "Reno", "state": "NV"},
+    ]
+    df = pl.DataFrame(rows)
+    csv_path = tmp_path / "e2e_people.csv"
+    df.write_csv(str(csv_path))
+    return str(csv_path)
+
+
+def _match_config() -> GoldenMatchConfig:
+    """Survivorship-ACTIVE config. `golden_rules.field_groups=[loc:(city,state)]` trips
+    _survivorship_active (the field_groups branch) with no when:-predicate risk. `email`
+    stays a SCALAR golden field (default most_complete) so it lands in cp.fields."""
+    golden_rules = GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_groups=[
+            GoldenGroupRule(name="loc", columns=["city", "state"], strategy="most_complete"),
+        ],
+    )
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="fuzzy_name",
+                type="weighted",
+                threshold=0.85,
+                fields=[
+                    MatchkeyField(field="last_name", scorer="jaro_winkler", weight=1.0,
+                                  transforms=["lowercase", "strip"]),
+                    MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0,
+                                  transforms=["lowercase", "strip"]),
+                ],
+            ),
+        ],
+        blocking=BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["last_name"], transforms=["lowercase", "soundex"])],
+            max_block_size=500,
+            skip_oversized=True,
+        ),
+        golden_rules=golden_rules,
+    )
+
+
+def test_end_to_end_lineage_real_pipeline(tmp_path):
+    reg = StageRegistry()
+    reg.discover()
+    csv = _fixture_csv(tmp_path)
+
+    gm_config = _match_config()
+    stages = [
+        StageSpec(use="goldencheck.scan"),
+        StageSpec(use="goldenflow.transform"),
+        # match adapter does GoldenMatchConfig(**stage_config) -> pass the field kwargs
+        StageSpec(use="goldenmatch.dedupe", config=gm_config.model_dump()),
+    ]
+    plan = Resolver.resolve(PipelineConfig(pipeline="e2e", stages=stages), reg)
+    ctx = PipeContext(df=pl.read_csv(csv, ignore_errors=True, encoding="utf8-lossy"))
+    ctx.metadata["source"] = csv
+    _, compiled = compile_and_run(plan, ctx, reg)
+
+    prov = ctx.artifacts.get("golden_provenance")
+    assert prov is not None, "survivorship-active config should surface golden_provenance"
+
+    out = end_to_end_lineage(compiled, prov)
+    print("E2E LINEAGE:\n" + format_end_to_end(out))
+
+    # the scalar email entry must carry BOTH source_row_id (goldenmatch) AND
+    # transforms (SP2 Flow-clean).
+    email_entries = [e for e in out["entries"] if e["column"] == "email"]
+    assert email_entries, "email should appear in cp.fields (scalar survivorship)"
+    e = email_entries[0]
+    assert e["source_row_id"] is not None
+    assert e["transforms"], "email was Flow-transformed -> SP2 transforms should be non-empty"

--- a/packages/python/goldenpipe/tests/compiler/test_e2e_surface.py
+++ b/packages/python/goldenpipe/tests/compiler/test_e2e_surface.py
@@ -1,0 +1,38 @@
+from types import SimpleNamespace
+
+from goldenpipe.compiler.e2e import surface_golden_provenance
+
+
+def test_surface_passes_dupes_clusters_rules_and_returns_provenance(monkeypatch):
+    calls = {}
+    def fake(data_df, clusters, rules):
+        calls["args"] = (data_df, clusters, rules)
+        return ["PROV"]
+    monkeypatch.setattr("goldenmatch.core.lineage.golden_provenance_for_run", fake)
+    result = SimpleNamespace(dupes="DUPES_DF", config=SimpleNamespace(golden_rules="RULES"))
+    out = surface_golden_provenance(result, {1: {"members": [0, 1], "size": 2}})
+    assert out == ["PROV"]
+    assert calls["args"] == ("DUPES_DF", {1: {"members": [0, 1], "size": 2}}, "RULES")
+
+
+def test_surface_none_when_no_rules():
+    result = SimpleNamespace(dupes="DUPES_DF", config=SimpleNamespace(golden_rules=None))
+    assert surface_golden_provenance(result, {1: {"members": [0, 1]}}) is None
+
+
+def test_surface_none_when_no_dupes():
+    result = SimpleNamespace(dupes=None, config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result, {1: {"members": [0, 1]}}) is None
+
+
+def test_surface_none_when_no_clusters():
+    result = SimpleNamespace(dupes="DF", config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result, None) is None
+
+
+def test_surface_fail_open_on_error(monkeypatch):
+    def boom(*a):
+        raise RuntimeError("x")
+    monkeypatch.setattr("goldenmatch.core.lineage.golden_provenance_for_run", boom)
+    result = SimpleNamespace(dupes="DF", config=SimpleNamespace(golden_rules="RULES"))
+    assert surface_golden_provenance(result, {1: {"members": [0, 1]}}) is None


### PR DESCRIPTION
## What

SP3 of the GoldenPipe fuse-and-emit compiler program: end-to-end field lineage. Joins SP2's plan-level field lineage (per column: checks / transforms / blocking-key / scorer-input, from the IR) with goldenmatch's existing golden-record survivorship provenance (which source row's value won each field) into ONE row-level view.

Net-new, honestly scoped: goldenmatch already ships row/cluster/survivorship provenance (core/lineage.py). This does NOT rebuild it. It STITCHES the two halves that nothing connected before: what pre-match cleaning happened to a field (Flow, which goldenmatch never sees) + which row survived it (goldenmatch).

## How

- `goldenpipe/compiler/e2e.py`: `end_to_end_lineage(compiled, golden_provenance)` joins SP2 `field_lineage` with goldenmatch `ClusterProvenance.fields` on column name; `format_end_to_end` renders it; `surface_golden_provenance(result, clusters)` is a fail-open helper that pulls goldenmatch's `golden_provenance_for_run` from a completed dedupe result.
- Match adapter records `ctx.artifacts["golden_provenance"]` after a classic dedupe (additive; None when survivorship inactive; nothing else reads it).
- Host-only, no kernel: this needs Match EXECUTION output (clusters/golden), not just the static IR, so unlike SP1/SP2 it is not a pyo3-free kernel function.

## Tests

- `tests/compiler/test_e2e.py`, `test_e2e_surface.py`: unit (stitch + fail-open surfacing).
- `tests/compiler/test_e2e_integration.py`: REAL load->check->flow->match pipeline with a survivorship-active config; asserts a scalar email field carries BOTH source_row_id (goldenmatch survivorship) AND transforms (SP2 Flow-clean) in one entry. No mocks.

Additive + opt-in throughout; classic runner path byte-identical.