### PR TITLE
feat(goldenmatch): fused match covers transforms — real configs collect the 2x single-box win

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -11,8 +11,13 @@ the boundary, which raises the row-count ceiling on a given box ~2x. It is NOT a
 speed win and must not be sold as one.
 
 Covered configs run native; everything else returns None so the caller keeps the
-existing pipeline (the columnar-decline pattern). Coverage grows over increments;
-this one ships the no-transform boundary the kernel can honor byte-for-byte.
+existing pipeline (the columnar-decline pattern). Transforms ARE covered: the
+block-key + score columns are derived host-side via the pipeline's own transform
+reference (`_build_block_key_expr` / `_get_transformed_values`) before the kernel
+groups/scores, so any configured transform (lowercase/strip/substring/soundex/…)
+is applied byte-identically. The derivation is an O(n) column pass — it does not
+reintroduce the O(k^2) block/pairs/dedup materialization the fusion removes, so
+the ~2x peak-RSS win (2x single-box capacity) holds.
 """
 
 from __future__ import annotations
@@ -35,20 +40,23 @@ _FUSED_SCORER_IDS: dict[str, int] = {
 
 
 def match_fused_ready(config: Any) -> bool:
-    """Conservative covered boundary for the fused kernel (grows over increments).
+    """Covered boundary for the fused kernel.
 
-    Covered: `static` single-key blocking with NO key transforms + exactly one
-    `weighted` matchkey whose fields all use a covered scorer with NO field
-    transforms + a threshold. The kernel groups/scores RAW column values (it
-    applies no transforms of its own), so "no transforms" is the byte-parity-safe
-    boundary this increment ships. Declines probabilistic / ANN / negative-
-    evidence / multi-pass / domain / LLM / PPRL to the existing pipeline.
+    Covered: `static` single-key blocking + exactly one `weighted` matchkey whose
+    fields all use a covered scorer + a threshold. **Transforms are covered** —
+    `run_match_fused_arrow` derives the block-key column via the same
+    `_build_block_key_expr` the pipeline's blocking uses (transform chain + "||"
+    concat) and the score columns via the scorer's own `_get_transformed_values`,
+    so any transform the pipeline applies is applied identically here (byte-parity
+    by construction; the kernel then groups/scores those derived values). Declines
+    probabilistic / ANN / negative-evidence / multi-pass / domain / LLM / PPRL to
+    the existing pipeline.
     """
     b = getattr(config, "blocking", None)
     if b is None or getattr(b, "strategy", "static") != "static":
         return False
     keys = getattr(b, "keys", None) or []
-    if len(keys) != 1 or keys[0].transforms:
+    if len(keys) != 1:
         return False
     if getattr(b, "ann_column", None):
         return False
@@ -65,7 +73,7 @@ def match_fused_ready(config: Any) -> bool:
     if mk.threshold is None or not mk.fields:
         return False
     for f in mk.fields:
-        if not f.field or f.transforms:
+        if not f.field:
             return False
         if f.scorer not in _FUSED_SCORER_IDS:
             return False
@@ -80,12 +88,6 @@ def _match_fused_symbol() -> Any | None:
     return getattr(mod, "match_fused", None)
 
 
-def _as_utf8(arr: Any) -> Any:
-    if arr.type in (pa.string(), pa.large_string()):
-        return arr
-    return arr.cast(pa.string())
-
-
 def run_match_fused_arrow(
     columns: Mapping[str, Any],
     config: Any,
@@ -98,21 +100,43 @@ def run_match_fused_arrow(
     ``None`` when the config is not covered OR the native kernel is absent, so
     the caller falls back to the existing pipeline.
 
-    ``columns`` maps field name -> pyarrow Array (any type; key + score fields
-    are cast to utf8). Row ids are 0..n in input order.
+    ``columns`` maps SOURCE field name -> pyarrow Array (the untransformed input
+    columns for every blocking + matchkey field). The block-key and score columns
+    are DERIVED here via the pipeline's own transform reference
+    (`_build_block_key_expr` for the key, `_get_transformed_values` for each score
+    field), so any configured transform is applied byte-identically before the
+    kernel groups/scores. Row ids are 0..n in input order.
     """
+    import polars as pl
+
+    from goldenmatch.core.blocker import _build_block_key_expr
+    from goldenmatch.core.scorer import _get_transformed_values
+
     fn = _match_fused_symbol()
     if fn is None or not match_fused_ready(config):
         return None
 
-    key_fields = list(config.blocking.keys[0].fields)
+    key_cfg = config.blocking.keys[0]
     mk = config.get_matchkeys()[0]
+    src_cols = list(dict.fromkeys([*key_cfg.fields, *[f.field for f in mk.fields]]))
 
-    n = n_rows if n_rows is not None else len(columns[key_fields[0]])
+    n = n_rows if n_rows is not None else len(columns[src_cols[0]])
+    # One O(n) pass to derive the transformed key + score columns, exactly as the
+    # pipeline would (blocking pre-casts every column to Utf8; mirror that). This
+    # does NOT reintroduce the block/pairs/dedup materialization the fusion
+    # eliminates -- it's a few string columns, not the O(k^2) match state.
+    frame = pl.DataFrame({c: columns[c] for c in src_cols}).cast(pl.Utf8)
+
+    block_key = (
+        frame.lazy().select(_build_block_key_expr(key_cfg)).collect().get_column("__block_key__")
+    )
+    key_arrs = [block_key.to_arrow()]  # already transformed + "||"-concatenated
+    score_arrs = [
+        pl.Series(f.field, _get_transformed_values(frame, f), dtype=pl.Utf8).to_arrow()
+        for f in mk.fields
+    ]
+
     row_ids = pa.array(range(n), type=pa.int64())
-
-    key_arrs = [_as_utf8(columns[f]) for f in key_fields]
-    score_arrs = [_as_utf8(columns[f.field]) for f in mk.fields]
     scorer_ids = [_FUSED_SCORER_IDS[f.scorer] for f in mk.fields]
     weights = [float(f.weight if f.weight is not None else 1.0) for f in mk.fields]
     total_weight = sum(weights)

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -46,16 +46,17 @@ def test_ready_true_on_covered_config():
     assert fused_match.match_fused_ready(_covered_config()) is True
 
 
-def test_ready_false_on_key_transform():
+def test_ready_true_with_key_transform():
+    # Transforms are covered — derived host-side via the pipeline reference.
     c = _covered_config()
-    c.blocking.keys[0].transforms = ["lowercase"]
-    assert fused_match.match_fused_ready(c) is False
+    c.blocking.keys[0].transforms = ["lowercase", "soundex"]
+    assert fused_match.match_fused_ready(c) is True
 
 
-def test_ready_false_on_field_transform():
+def test_ready_true_with_field_transform():
     c = _covered_config()
-    c.matchkeys[0].fields[0].transforms = ["strip"]
-    assert fused_match.match_fused_ready(c) is False
+    c.matchkeys[0].fields[0].transforms = ["lowercase", "strip"]
+    assert fused_match.match_fused_ready(c) is True
 
 
 def test_ready_false_on_uncovered_scorer():
@@ -84,8 +85,20 @@ def test_ready_false_on_missing_threshold():
 
 # ---- parity vs an independent brute oracle -----------------------------
 
-def _brute_clusters(keys, names, threshold):
+def _brute_clusters(keys, names, threshold, key_transforms=(), score_transforms=()):
+    """Independent oracle. Applies the SAME transforms via `apply_transforms`
+    (the per-value reference `_build_block_key_expr`/`_get_transformed_values`
+    fall back to), then blocks + scores + union-finds."""
+    from goldenmatch.utils.transforms import apply_transforms
+
     jw = native_module().jaro_winkler_similarity
+
+    def _xf(v, chain):
+        return apply_transforms(v, list(chain)) if chain else v
+
+    keys = [_xf(k, key_transforms) for k in keys]
+    names = [_xf(nm, score_transforms) for nm in names]
+
     blocks: dict[str, list[int]] = defaultdict(list)
     for i, k in enumerate(keys):
         if k is None:
@@ -106,6 +119,8 @@ def _brute_clusters(keys, names, threshold):
         for ai in range(len(members)):
             for bi in range(ai + 1, len(members)):
                 a, b = members[ai], members[bi]
+                if names[a] is None or names[b] is None:
+                    continue
                 if jw(names[a], names[b]) >= threshold:
                     ra, rb = find(a), find(b)
                     if ra != rb:
@@ -142,6 +157,44 @@ def test_run_match_fused_arrow_matches_brute_oracle():
     assert tbl is not None
     got = _table_to_clusters(tbl)
     want = _brute_clusters(keys, names, 0.85)
+    assert got == want
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_run_match_fused_arrow_matches_brute_oracle_with_transforms():
+    # Block key normalized by lowercase+strip (case/whitespace noise collapses into
+    # one block); score field normalized the same. Proves the host-side transform
+    # derivation is byte-faithful to the pipeline reference.
+    keys = [" Smith ", "smith", "SMITH", "jones", "Jones ", "lee"]
+    names = ["Jonathan", "jonathon ", " JONATHAN", "sarah", "SARAH", "solo"]
+    config = _covered_config(threshold=0.85)
+    config.blocking.keys[0].transforms = ["lowercase", "strip"]
+    config.matchkeys[0].fields[0].transforms = ["lowercase", "strip"]
+    columns = {"blk": pa.array(keys), "name": pa.array(names)}
+
+    tbl = fused_match.run_match_fused_arrow(columns, config)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    want = _brute_clusters(
+        keys, names, 0.85, key_transforms=["lowercase", "strip"], score_transforms=["lowercase", "strip"]
+    )
+    assert got == want
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_run_match_fused_arrow_soundex_block_key():
+    # soundex block key exercises the map_elements(apply_transforms) fallback path
+    # end to end (the common auto-config blocking transform).
+    keys = ["Smith", "Smyth", "Smithe", "Jones", "Jonez", "Zzzz"]
+    names = ["robert", "robbert", "roberto", "alice", "alicia", "solo"]
+    config = _covered_config(threshold=0.80)
+    config.blocking.keys[0].transforms = ["lowercase", "soundex"]
+    columns = {"blk": pa.array(keys), "name": pa.array(names)}
+
+    tbl = fused_match.run_match_fused_arrow(columns, config)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    want = _brute_clusters(keys, names, 0.80, key_transforms=["lowercase", "soundex"])
     assert got == want
 
 

--- a/packages/python/goldenpipe/goldenpipe/adapters/match.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/match.py
@@ -107,11 +107,13 @@ class FusedDedupeStage:
     CLUSTERS ONLY: it produces `clusters` + `cluster_assignments` (Arrow), NOT
     golden/unique/dupes (the fused kernel's declined scope -- golden records need
     the row payload, which stays the classic DedupeStage's job). Requires an
-    EXPLICIT covered config (`match_fused_ready`): static single-key blocking with
-    no key transforms + one weighted matchkey over covered scorers with no field
-    transforms. `validate()` raises a clear pointer to `goldenmatch.dedupe`
-    otherwise -- it never silently falls back, so a caller who asked for the
-    fused stage always gets the fused path or an explicit error.
+    EXPLICIT covered config (`match_fused_ready`): static single-key blocking +
+    one weighted matchkey over covered scorers with a threshold. Transforms
+    (lowercase/strip/substring/soundex/...) ARE covered -- derived host-side via
+    the pipeline's own transform reference before the kernel runs. `validate()`
+    raises a clear pointer to `goldenmatch.dedupe` for an uncovered config -- it
+    never silently falls back, so a caller who asked for the fused stage always
+    gets the fused path or an explicit error.
     """
 
     info = StageInfo(
@@ -149,9 +151,9 @@ class FusedDedupeStage:
         if not match_fused_ready(config):
             raise RuntimeError(
                 "config is not covered by the fused match kernel (needs static "
-                "single-key blocking with no key transforms + one weighted matchkey "
-                "over jaro_winkler/levenshtein/token_sort/exact with no field "
-                "transforms). Use the goldenmatch.dedupe stage for this config."
+                "single-key blocking + one weighted matchkey over "
+                "jaro_winkler/levenshtein/token_sort/exact with a threshold; "
+                "transforms are fine). Use the goldenmatch.dedupe stage for this config."
             )
 
     def run(self, ctx: PipeContext) -> StageResult:

--- a/packages/python/goldenpipe/tests/test_fused_dedupe_stage.py
+++ b/packages/python/goldenpipe/tests/test_fused_dedupe_stage.py
@@ -108,3 +108,36 @@ def test_run_emits_clusters_matching_brute_oracle():
 
     got = {frozenset(m) for m in ctx.artifacts["clusters"].values()}
     assert got == _brute(df, 0.85)
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_run_with_transforms_normalizes_then_clusters():
+    # Case/whitespace noise on both key and name; lowercase+strip collapses all
+    # three rows into one block + one identical name -> one cluster {0,1,2}.
+    df = pl.DataFrame({"blk": ["A", "a", " A "], "name": ["bob", "BOB ", " bob"]})
+    cfg = {
+        "blocking": {
+            "strategy": "static",
+            "keys": [{"fields": ["blk"], "transforms": ["lowercase", "strip"]}],
+        },
+        "matchkeys": [
+            {
+                "name": "mk",
+                "type": "weighted",
+                "threshold": 0.85,
+                "fields": [
+                    {
+                        "field": "name",
+                        "scorer": "jaro_winkler",
+                        "weight": 1.0,
+                        "transforms": ["lowercase", "strip"],
+                    }
+                ],
+            }
+        ],
+    }
+    ctx = PipeContext(df=df, stage_config=cfg)
+    stage = FusedDedupeStage()
+    stage.validate(ctx)  # transforms are covered -> no raise
+    stage.run(ctx)
+    assert {frozenset(m) for m in ctx.artifacts["clusters"].values()} == {frozenset({0, 1, 2})}


### PR DESCRIPTION
Broadens the fused Arrow-native match stage from the no-transform boundary to **configs with transforms** — the common real shape (blocking keys carry `lowercase`/`strip`/`substring`/`soundex`; match fields carry `lowercase`/`strip`). Follows the arc: block kernel #1590 → match_fused #1591 → Arrow entry #1594 → GoldenPipe stage #1595 → scale bench #1596.

## Why
The value of the fused stage is **~2x lower peak RSS → 2x single-box capacity** (measured in #1596: pipeline pegs at a 24G cap and plateaus while fused keeps scaling). But the no-transform boundary meant real auto-built configs (which all carry transforms) declined to the classic pipeline and never collected it. This extends coverage so they do.

## Approach — byte-parity by construction
Derive the transformed block-key + score columns **host-side via the pipeline's own transform reference**, then hand the derived Arrow to `match_fused` (kernel unchanged):
- block key → `_build_block_key_expr` (transform chain + `||` concat, incl. the `map_elements(apply_transforms)` soundex/metaphone fallback)
- score fields → the scorer's `_get_transformed_values`

Same code the pipeline uses → no Rust-reimplementation divergence risk. The derivation is one **O(n) column pass** — it does *not* reintroduce the O(k²) block/pairs/dedup materialization the fusion removes, so the ~2x peak-RSS win holds.

## Changes
- `match_fused_ready`: drop the no-transform gates; keep structural gates (static single key, one weighted matchkey, covered scorers, threshold, no NE/ANN).
- `run_match_fused_arrow`: derive key+score columns via the reference path.
- goldenpipe `FusedDedupeStage`: docstring + validate message updated.

## Tests
+2 goldenmatch (lowercase/strip parity + **soundex block key** via the map_elements fallback, both vs an independent `apply_transforms` brute oracle) = **11**; +1 goldenpipe (transforms config normalizes + clusters through the stage) = **4**. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)