### PR TITLE
feat(goldenmatch): fused match covers Fellegi-Sunter + multi-pass blocking

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -143,8 +143,12 @@ def run_match_fused_arrow(
     threshold = float(mk.threshold)
 
     clusters = fn(row_ids, key_arrs, score_arrs, scorer_ids, weights, total_weight, threshold)
+    return _clusters_to_table(clusters)
 
-    # clusters: list[list[int]] connected components (incl singletons).
+
+def _clusters_to_table(clusters: Any) -> Any:
+    """list[list[int]] connected components (incl singletons) -> pyarrow Table
+    (__row_id__, __cluster_id__), one row per record, stable id per component."""
     rid: list[int] = []
     cid: list[int] = []
     for c_id, comp in enumerate(clusters):
@@ -157,3 +161,102 @@ def run_match_fused_arrow(
             "__cluster_id__": pa.array(cid, type=pa.int64()),
         }
     )
+
+
+def match_fused_fs_ready(config: Any) -> bool:
+    """Covered boundary for the fused Fellegi-Sunter (probabilistic) path.
+
+    Covered: `static` single-key blocking + exactly one `probabilistic` matchkey
+    whose fields all use an FS-native scorer (`_NATIVE_FS_SCORER_IDS`). Transforms
+    covered (derived host-side). `run_match_fused_fs_arrow` takes a PRE-TRAINED
+    `EMResult` — training is the caller's O(n) model fit, unchanged.
+    """
+    b = getattr(config, "blocking", None)
+    if b is None or getattr(b, "strategy", "static") != "static":
+        return False
+    keys = getattr(b, "keys", None) or []
+    if len(keys) != 1 or getattr(b, "ann_column", None):
+        return False
+    get_mks = getattr(config, "get_matchkeys", None)
+    mks = get_mks() if callable(get_mks) else []
+    if len(mks) != 1 or getattr(mks[0], "type", None) != "probabilistic" or not mks[0].fields:
+        return False
+    from goldenmatch.core.probabilistic import _NATIVE_FS_SCORER_IDS
+
+    return all(f.field and f.scorer in _NATIVE_FS_SCORER_IDS for f in mks[0].fields)
+
+
+def _match_fused_fs_symbol() -> Any | None:
+    try:
+        return getattr(native_module(), "match_fused_fs", None)
+    except Exception:
+        return None
+
+
+def run_match_fused_fs_arrow(
+    columns: Mapping[str, Any],
+    config: Any,
+    em_result: Any,
+    n_rows: int | None = None,
+) -> Any | None:
+    """Fused Fellegi-Sunter match over Arrow columns, given a trained `EMResult`.
+
+    Byte-parity by construction: the block key is derived via
+    `_build_block_key_expr`, the score columns via `_field_values_for_block`, and
+    the FS kernel args (levels/partial_thresholds/match_weights/calibration/
+    thresholds) are assembled EXACTLY as `score_probabilistic_native` does — so
+    the fused kernel scores identically to the pipeline's native FS block scorer.
+    Returns a `(__row_id__, __cluster_id__)` Table, or None if uncovered / native
+    absent.
+    """
+    import polars as pl
+
+    from goldenmatch.core.blocker import _build_block_key_expr
+    from goldenmatch.core.probabilistic import (
+        _NATIVE_FS_SCORER_IDS,
+        _field_values_for_block,
+        _fs_calibration_mode,
+        compute_thresholds,
+        prior_weight,
+    )
+
+    fn = _match_fused_fs_symbol()
+    if fn is None or not match_fused_fs_ready(config):
+        return None
+
+    key_cfg = config.blocking.keys[0]
+    mk = config.get_matchkeys()[0]
+    src_cols = list(dict.fromkeys([*key_cfg.fields, *[f.field for f in mk.fields]]))
+    n = n_rows if n_rows is not None else len(columns[src_cols[0]])
+    frame = pl.DataFrame({c: columns[c] for c in src_cols}).cast(pl.Utf8)
+
+    block_key = (
+        frame.lazy().select(_build_block_key_expr(key_cfg)).collect().get_column("__block_key__")
+    )
+    key_arrs = [block_key.to_arrow()]
+
+    # FS kernel args — mirrors score_probabilistic_native exactly.
+    calibrated = _fs_calibration_mode() == "posterior"
+    prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
+    max_w = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
+    min_w = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    weight_range = max_w - min_w
+    if mk.link_threshold is not None:
+        link_threshold = float(mk.link_threshold)
+    else:
+        link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    scorer_ids = [_NATIVE_FS_SCORER_IDS[f.scorer] for f in mk.fields]
+    levels = [int(f.levels) for f in mk.fields]
+    partials = [float(f.partial_threshold) for f in mk.fields]
+    weights = [[float(w) for w in em_result.match_weights[f.field]] for f in mk.fields]
+    score_arrs = [
+        pl.Series(f.field, _field_values_for_block(frame, f, n), dtype=pl.Utf8).to_arrow()
+        for f in mk.fields
+    ]
+
+    row_ids = pa.array(range(n), type=pa.int64())
+    clusters = fn(
+        row_ids, key_arrs, score_arrs, scorer_ids, levels, partials, weights,
+        calibrated, prior_w, min_w, weight_range, link_threshold,
+    )
+    return _clusters_to_table(clusters)

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -60,24 +60,43 @@ def match_fused_ready(config: Any) -> bool:
         return False
     if getattr(b, "ann_column", None):
         return False
+    return _covered_weighted_matchkey(config) is not None
 
+
+def _covered_weighted_matchkey(config: Any) -> Any | None:
+    """The single covered `weighted` matchkey, or None. Covered = one weighted
+    matchkey, a threshold, every field named + on a covered scorer, no NE."""
     get_mks = getattr(config, "get_matchkeys", None)
     mks = get_mks() if callable(get_mks) else []
     if len(mks) != 1:
-        return False
+        return None
     mk = mks[0]
     if getattr(mk, "type", None) != "weighted":
-        return False
+        return None
     if getattr(mk, "negative_evidence", None):
-        return False
+        return None
     if mk.threshold is None or not mk.fields:
-        return False
+        return None
     for f in mk.fields:
-        if not f.field:
-            return False
-        if f.scorer not in _FUSED_SCORER_IDS:
-            return False
-    return True
+        if not f.field or f.scorer not in _FUSED_SCORER_IDS:
+            return None
+    return mk
+
+
+def match_fused_multipass_ready(config: Any) -> bool:
+    """Covered boundary for the fused MULTI-PASS blocking path: `multi_pass`
+    blocking with >=1 pass (each a real blocking key) + one covered weighted
+    matchkey. Each pass is run as a single-key fused match; their per-pass
+    clusters are union-find-merged (CC of the pass-pair union)."""
+    b = getattr(config, "blocking", None)
+    if b is None or getattr(b, "strategy", None) != "multi_pass":
+        return False
+    if getattr(b, "ann_column", None):
+        return False
+    passes = getattr(b, "passes", None) or []
+    if not passes or any(not getattr(p, "fields", None) for p in passes):
+        return False
+    return _covered_weighted_matchkey(config) is not None
 
 
 def _match_fused_symbol() -> Any | None:
@@ -161,6 +180,61 @@ def _clusters_to_table(clusters: Any) -> Any:
             "__cluster_id__": pa.array(cid, type=pa.int64()),
         }
     )
+
+
+def run_match_fused_multipass_arrow(
+    columns: Mapping[str, Any],
+    config: Any,
+    n_rows: int | None = None,
+) -> Any | None:
+    """Fused multi-pass blocking: run each pass as a single-key fused match, then
+    union-find-merge the per-pass clusters. Byte-parity with the pipeline's
+    multi-pass path: the final partition is the connected components of the union
+    of all passes' candidate pairs, which equals merging each pass's per-pass
+    clusters (every member of a pass-cluster is transitively connected). Returns a
+    `(__row_id__, __cluster_id__)` Table, or None if uncovered / native absent.
+    """
+    from goldenmatch.config.schemas import BlockingConfig, GoldenMatchConfig
+
+    if _match_fused_symbol() is None or not match_fused_multipass_ready(config):
+        return None
+
+    n = n_rows if n_rows is not None else len(next(iter(columns.values())))
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    mks = config.get_matchkeys()
+    for pass_cfg in config.blocking.passes:
+        single = GoldenMatchConfig(
+            blocking=BlockingConfig(strategy="static", keys=[pass_cfg]),
+            matchkeys=mks,
+        )
+        tbl = run_match_fused_arrow(columns, single, n_rows=n)
+        if tbl is None:
+            continue
+        groups: dict[int, list[int]] = {}
+        for r, c in zip(
+            tbl.column("__row_id__").to_pylist(), tbl.column("__cluster_id__").to_pylist()
+        ):
+            groups.setdefault(c, []).append(r)
+        for members in groups.values():
+            for m in members[1:]:
+                union(members[0], m)
+
+    comps: dict[int, list[int]] = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+    return _clusters_to_table(list(comps.values()))
 
 
 def match_fused_fs_ready(config: Any) -> bool:

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -286,3 +286,66 @@ def test_match_fused_fs_matches_pipeline_fs_block_scorer():
         comps[find(i)].append(i)
     want = {frozenset(v) for v in comps.values() if len(v) >= 2}
     assert got == want
+
+
+# ---- multi-pass blocking fused path ------------------------------------
+
+def _multipass_config():
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["blk1"])],
+            passes=[BlockingKeyConfig(fields=["blk1"]), BlockingKeyConfig(fields=["blk2"])],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="weighted",
+                threshold=0.85,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+            )
+        ],
+    )
+
+
+def test_multipass_ready_true_false():
+    assert fused_match.match_fused_multipass_ready(_multipass_config()) is True
+    assert fused_match.match_fused_multipass_ready(_covered_config()) is False  # static
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_multipass_merges_across_passes():
+    # pass1 blocks on blk1: {0,1}(a), {4,5}(z); pass2 on blk2: {0,2}(p), {3,4}(r).
+    # All names identical -> every intra-block pair merges; the union chains
+    # 0-1-2 (0-1 via pass1, 0-2 via pass2) and 3-4-5 (3-4 pass2, 4-5 pass1).
+    blk1 = ["a", "a", "x", "y", "z", "z"]
+    blk2 = ["p", "q", "p", "r", "r", "s"]
+    name = ["john"] * 6
+    config = _multipass_config()
+    columns = {"blk1": pa.array(blk1), "blk2": pa.array(blk2), "name": pa.array(name)}
+    tbl = fused_match.run_match_fused_multipass_arrow(columns, config)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    assert got == {frozenset({0, 1, 2}), frozenset({3, 4, 5})}
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused not built")
+def test_multipass_equals_single_pass_when_one_pass():
+    # A one-pass multi_pass config must equal the single-key fused result.
+    blk = ["a", "a", "a", "b", "b", "c"]
+    name = ["jonathan", "jonathon", "michael", "sarah", "sarah", "lone"]
+    columns = {"blk": pa.array(blk), "name": pa.array(name)}
+
+    single = _covered_config(threshold=0.85)
+    single.blocking.keys = [BlockingKeyConfig(fields=["blk"])]
+    mp = GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["blk"])],
+            passes=[BlockingKeyConfig(fields=["blk"])],
+        ),
+        matchkeys=single.matchkeys,
+    )
+    got_single = _table_to_clusters(fused_match.run_match_fused_arrow(columns, single))
+    got_mp = _table_to_clusters(fused_match.run_match_fused_multipass_arrow(columns, mp))
+    assert got_mp == got_single

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -202,3 +202,87 @@ def test_run_match_fused_arrow_declines_uncovered():
     c = _covered_config()
     c.matchkeys[0].fields[0].scorer = "soundex_match"
     assert fused_match.run_match_fused_arrow({"blk": pa.array(["a"]), "name": pa.array(["x"])}, c) is None
+
+
+# ---- Fellegi-Sunter (probabilistic) fused path -------------------------
+
+def _probabilistic_config():
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="probabilistic",
+                link_threshold=0.5,
+                fields=[
+                    MatchkeyField(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)
+                ],
+            )
+        ],
+    )
+
+
+def _em():
+    from goldenmatch.core.probabilistic import EMResult
+
+    # match_weights per level 0/1/2 (log2(m/u)); the only field that matters here.
+    return EMResult(
+        m_probs={"name": [0.1, 0.3, 0.6]},
+        u_probs={"name": [0.7, 0.2, 0.1]},
+        match_weights={"name": [-2.0, 0.585, 2.585]},
+        converged=True,
+        iterations=1,
+        proportion_matched=0.1,
+    )
+
+
+def test_fs_ready_true_on_probabilistic_false_on_weighted():
+    assert fused_match.match_fused_fs_ready(_probabilistic_config()) is True
+    assert fused_match.match_fused_fs_ready(_covered_config()) is False  # weighted
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused_fs not built")
+def test_match_fused_fs_matches_pipeline_fs_block_scorer():
+    import polars as pl
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.probabilistic import probabilistic_block_scorer
+
+    config = _probabilistic_config()
+    em = _em()
+    keys = ["a", "a", "a", "b", "b", "c"]
+    names = ["jonathan", "jonathon", "michael", "sarah", "sara", "solo"]
+    df = (
+        pl.DataFrame({"blk": keys, "name": names})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+
+    # fused FS
+    columns = {"blk": pa.array(keys), "name": pa.array(names)}
+    tbl = fused_match.run_match_fused_fs_arrow(columns, config, em)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+
+    # reference: the pipeline FS block path (same em -> same kernel FS math)
+    scorer = probabilistic_block_scorer(config.get_matchkeys()[0], em)
+    pairs = []
+    for br in build_blocks(df.lazy(), config.blocking):
+        g = br.df.collect() if hasattr(br.df, "collect") else br.df
+        pairs += scorer(g)
+    parent = list(range(df.height))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b, _s in pairs:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    comps = defaultdict(list)
+    for i in range(df.height):
+        comps[find(i)].append(i)
+    want = {frozenset(v) for v in comps.values() if len(v) >= 2}
+    assert got == want

--- a/packages/rust/extensions/native/src/fused.rs
+++ b/packages/rust/extensions/native/src/fused.rs
@@ -1,20 +1,18 @@
 //! Fused Arrow-native match stage — block + score + dedup + cluster in ONE Rust
 //! call, zero intermediate Polars, zero per-stage Arrow re-conversion.
 //!
-//! This is increment 2 of the fused-match design
-//! (`docs/design/2026-07-08-fused-arrow-native-match-kernel.md`). Every stage it
-//! runs is an existing source-of-truth kernel:
-//!   - block formation: [`crate::block::group_block_positions`] (increment 1)
-//!   - scoring: `goldenmatch_score_core::score_one` (the exact per-pair weighted
-//!     average `score_block_pairs_arrow` uses — byte-identical scoring)
-//!   - dedup: `goldenmatch_graph_core::dedup_pairs_max_score`
-//!   - clustering: `goldenmatch_graph_core::connected_components`
+//! Design: `docs/design/2026-07-08-fused-arrow-native-match-kernel.md`. Every
+//! stage is an existing source-of-truth kernel: block formation
+//! ([`crate::block::group_block_positions`]), scoring
+//! (`score_core::score_one`, or the Fellegi-Sunter `fs_level_from_sim` +
+//! `fs_normalize` shared with `score_block_pairs_fs`), dedup + clustering
+//! (`graph_core::{dedup_pairs_max_score, connected_components}`).
 //!
-//! The bet (measured, not assumed): fusing them into one call removes the
-//! Polars group/materialize + the three Arrow round-trips between stages that
-//! capped every prior "Arrow everywhere" spike. `match_fused` returns the
-//! connected components (clusters); the caller compares them to the per-stage
-//! pipeline for byte-parity and times both.
+//! `match_fused` = weighted-matchkey scoring; `match_fused_fs` = probabilistic
+//! (Fellegi-Sunter) scoring. Both share the block-formation + gather + dedup +
+//! cluster orchestration; only the per-pair scorer differs. The RSS win: no
+//! intermediate Polars frame / Python pairs-list is materialized — everything
+//! stays a Rust `Vec` behind one FFI crossing.
 
 use arrow::array::{ArrayData, Int64Array};
 use arrow::datatypes::DataType;
@@ -27,17 +25,119 @@ use goldenmatch_graph_core::{connected_components, dedup_pairs_max_score};
 use goldenmatch_score_core::score_one;
 
 use crate::block::{group_block_positions, read_key_cols};
-use crate::score::StrCol;
+use crate::score::{fs_level_from_sim, fs_normalize, StrCol};
 
-/// Fused match: block (on `key_fields`) -> score (weighted `score_fields`) ->
-/// dedup -> connected-components cluster, one call. Byte-parity contract: the
-/// candidate pairs equal `build_blocks` + `score_block_pairs_arrow`, so the
-/// clusters equal the per-stage pipeline on a covered config.
-///
-/// Scoring is byte-identical to `score_block_pairs_arrow::score_span`: per pair,
-/// `score_sum += score_one(scorer_ids[f], a, b) * weights[f]` over fields where
-/// BOTH values are present, emit `(min, max, score_sum / total_weight)` when
-/// `weight_sum > 0 && combined >= threshold`.
+/// Read + validate `row_ids` (Int64) and the score `field_arrays` (Utf8), shared
+/// by the weighted + FS entries.
+fn read_ids_and_fields(
+    who: &str,
+    row_ids: PyArrowType<ArrayData>,
+    score_fields: Vec<PyArrowType<ArrayData>>,
+    n_scorers: usize,
+) -> PyResult<(Int64Array, usize, Vec<StrCol>)> {
+    let row_data = row_ids.0;
+    if row_data.data_type() != &DataType::Int64 {
+        return Err(PyValueError::new_err(format!(
+            "{who}: row_ids must be int64, got {:?}",
+            row_data.data_type()
+        )));
+    }
+    let row_ids = Int64Array::from(row_data);
+    let n_rows = row_ids.len();
+    let n_fields = score_fields.len();
+    if n_scorers != n_fields {
+        return Err(PyValueError::new_err(format!(
+            "{who}: per-field param count ({n_scorers}) must match score_fields ({n_fields})"
+        )));
+    }
+    let score_cols: Vec<StrCol> = score_fields
+        .into_iter()
+        .map(|p| StrCol::from_data(p.0))
+        .collect::<PyResult<_>>()?;
+    for (f, c) in score_cols.iter().enumerate() {
+        if c.len() != n_rows {
+            return Err(PyValueError::new_err(format!(
+                "{who}: score field {f} length {} != row count {n_rows}",
+                c.len()
+            )));
+        }
+    }
+    Ok((row_ids, n_rows, score_cols))
+}
+
+/// Block-formation + gather into block-CONTIGUOUS order (once, O(n)). Returns the
+/// block-sorted row ids, the per-field block-sorted values (borrowed from the
+/// Arrow buffers), and the per-block `(offset, size)` spans. The contiguous
+/// layout gives the O(k^2) inner scoring loop the same cache locality the
+/// pipeline gets from its Polars sort.
+#[allow(clippy::type_complexity)]
+fn fused_gather<'a>(
+    key_cols: &[StrCol],
+    score_cols: &'a [StrCol],
+    n_rows: usize,
+    all_ids: &[i64],
+) -> (Vec<i64>, Vec<Vec<Option<&'a str>>>, Vec<(usize, usize)>) {
+    let groups = group_block_positions(key_cols, n_rows);
+    let n_blk: usize = groups.iter().map(|g| g.len()).sum();
+    let n_fields = score_cols.len();
+    let mut rid_sorted: Vec<i64> = Vec::with_capacity(n_blk);
+    let mut vals: Vec<Vec<Option<&str>>> =
+        (0..n_fields).map(|_| Vec::with_capacity(n_blk)).collect();
+    let mut spans: Vec<(usize, usize)> = Vec::with_capacity(groups.len());
+    let mut off = 0usize;
+    for block in &groups {
+        for &p in block {
+            let p = p as usize;
+            rid_sorted.push(all_ids[p]);
+            for (f, col) in score_cols.iter().enumerate() {
+                vals[f].push(col.get(p));
+            }
+        }
+        spans.push((off, block.len()));
+        off += block.len();
+    }
+    (rid_sorted, vals, spans)
+}
+
+/// Run a per-span scorer over the spans, with the #688 guarded-rayon posture:
+/// sequential in the calling thread below `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS`
+/// candidate pairs, fan out to rayon above it. Both paths walk spans in order, so
+/// the emitted pair sequence is identical either way.
+fn run_spans<F>(spans: &[(usize, usize)], score_span: F) -> Vec<(i64, i64, f64)>
+where
+    F: Fn(usize, usize) -> Vec<(i64, i64, f64)> + Sync + Send,
+{
+    let total_pairs: u128 = spans
+        .iter()
+        .map(|&(_, s)| {
+            let s = s as u128;
+            s * (s - 1) / 2
+        })
+        .sum();
+    let rayon_min_pairs: u128 = std::env::var("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20_000_000);
+    if total_pairs >= rayon_min_pairs {
+        spans
+            .par_iter()
+            .flat_map_iter(|&(o, s)| score_span(o, s))
+            .collect()
+    } else {
+        spans.iter().flat_map(|&(o, s)| score_span(o, s)).collect()
+    }
+}
+
+fn cluster_pairs(pairs: Vec<(i64, i64, f64)>, all_ids: &[i64]) -> Vec<Vec<i64>> {
+    let deduped = dedup_pairs_max_score(&pairs);
+    connected_components(&deduped, all_ids)
+}
+
+/// Fused weighted-matchkey match: block -> weighted-average score -> dedup ->
+/// connected-components cluster, one call. Scoring is byte-identical to
+/// `score_block_pairs_arrow`: per pair, `score_sum += score_one(id,a,b)*w[f]`
+/// over fields where BOTH values are present, emit `(min,max, score_sum/total_w)`
+/// when `weight_sum > 0 && combined >= threshold`.
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(signature = (
@@ -53,86 +153,26 @@ pub fn match_fused(
     total_weight: f64,
     threshold: f64,
 ) -> PyResult<Vec<Vec<i64>>> {
-    let row_data = row_ids.0;
-    if row_data.data_type() != &DataType::Int64 {
-        return Err(PyValueError::new_err(format!(
-            "match_fused: row_ids must be int64, got {:?}",
-            row_data.data_type()
-        )));
+    if weights.len() != scorer_ids.len() {
+        return Err(PyValueError::new_err(
+            "match_fused: weights must match scorer_ids",
+        ));
     }
-    let row_ids = Int64Array::from(row_data);
-    let n_rows = row_ids.len();
-
+    let (row_ids, n_rows, score_cols) =
+        read_ids_and_fields("match_fused", row_ids, score_fields, scorer_ids.len())?;
     let (key_cols, key_n) = read_key_cols(key_fields, "match_fused key")?;
     if key_n != n_rows {
         return Err(PyValueError::new_err(format!(
             "match_fused: key field length {key_n} != row count {n_rows}"
         )));
     }
-
-    let n_fields = score_fields.len();
-    if scorer_ids.len() != n_fields || weights.len() != n_fields {
-        return Err(PyValueError::new_err(format!(
-            "match_fused: scorer_ids ({}) / weights ({}) must match score_fields ({n_fields})",
-            scorer_ids.len(),
-            weights.len()
-        )));
-    }
-    let score_cols: Vec<StrCol> = score_fields
-        .into_iter()
-        .map(|p| StrCol::from_data(p.0))
-        .collect::<PyResult<_>>()?;
-    for (f, c) in score_cols.iter().enumerate() {
-        if c.len() != n_rows {
-            return Err(PyValueError::new_err(format!(
-                "match_fused: score field {f} length {} != row count {n_rows}",
-                c.len()
-            )));
-        }
-    }
-
     let all_ids: Vec<i64> = row_ids.values().to_vec();
+    let n_fields = score_cols.len();
 
-    // Everything below is pure-Rust and touches no Python object -> release the
-    // GIL for the whole fused pipeline (mirrors score_block_pairs_arrow).
-    let clusters = py.detach(|| {
-        // 1. Block formation (positions per block, singletons already dropped).
-        let groups = group_block_positions(&key_cols, n_rows);
-
-        // 2. Gather row_ids + each score field into block-CONTIGUOUS order, once
-        //    (O(n)). The pipeline pays this via a Polars sort so scoring reads
-        //    contiguous memory; the fused kernel does the same gather in Rust so
-        //    the O(k^2) inner scoring loop has the same cache locality (scattered
-        //    per-position `.get()` in the hot loop cost ~1.4x at coarse/big-block
-        //    shapes — the gather removes it).
-        let n_blk: usize = groups.iter().map(|g| g.len()).sum();
-        let mut rid_sorted: Vec<i64> = Vec::with_capacity(n_blk);
-        let mut vals: Vec<Vec<Option<&str>>> =
-            (0..n_fields).map(|_| Vec::with_capacity(n_blk)).collect();
-        for block in &groups {
-            for &p in block {
-                let p = p as usize;
-                rid_sorted.push(all_ids[p]);
-                for f in 0..n_fields {
-                    vals[f].push(score_cols[f].get(p));
-                }
-            }
-        }
-
-        // 3. Score intra-block pairs over the contiguous block-sorted buffers.
-        //    Byte-identical to score_block_pairs_arrow::score_span, and the SAME
-        //    guarded-rayon posture (#688): sequential in the calling thread below
-        //    GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS candidate pairs, fan out to rayon
-        //    above it. Scoring is the dominant term (~57% of the stage), so this
-        //    is the hot path — both paths must be parallel to compare fairly.
-        let mut spans: Vec<(usize, usize)> = Vec::with_capacity(groups.len());
-        let mut off = 0usize;
-        for block in &groups {
-            spans.push((off, block.len()));
-            off += block.len();
-        }
+    Ok(py.detach(|| {
+        let (rid_sorted, vals, spans) = fused_gather(&key_cols, &score_cols, n_rows, &all_ids);
         let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
-            let mut local: Vec<(i64, i64, f64)> = Vec::new();
+            let mut local = Vec::new();
             let end = offset + size;
             for i in offset..end - 1 {
                 let ri = rid_sorted[i];
@@ -157,30 +197,88 @@ pub fn match_fused(
             }
             local
         };
-        let total_pairs: u128 = spans
-            .iter()
-            .map(|&(_, s)| {
-                let s = s as u128;
-                s * (s - 1) / 2
-            })
-            .sum();
-        let rayon_min_pairs: u128 = std::env::var("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(20_000_000);
-        let pairs: Vec<(i64, i64, f64)> = if total_pairs >= rayon_min_pairs {
-            spans
-                .par_iter()
-                .flat_map_iter(|&(o, s)| score_span(o, s))
-                .collect()
-        } else {
-            spans.iter().flat_map(|&(o, s)| score_span(o, s)).collect()
+        let pairs = run_spans(&spans, score_span);
+        cluster_pairs(pairs, &all_ids)
+    }))
+}
+
+/// Fused Fellegi-Sunter match: block -> probabilistic score -> dedup -> cluster,
+/// one call. Scoring is byte-identical to `score_block_pairs_fs` (shares
+/// `fs_level_from_sim` + `fs_normalize`): per pair, per field map the similarity
+/// to a comparison `level` (null on either side -> level 0), sum
+/// `match_weights[f][level]`, normalize (calibrated posterior or linear), emit
+/// `(min,max, normalized)` when `normalized >= threshold`. `levels` /
+/// `partial_thresholds` / `match_weights` / `calibrated` / `prior_w` /
+/// `min_weight` / `weight_range` come from the host's EM-trained model.
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (
+    row_ids, key_fields, score_fields, scorer_ids, levels, partial_thresholds,
+    match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
+))]
+pub fn match_fused_fs(
+    py: Python<'_>,
+    row_ids: PyArrowType<ArrayData>,
+    key_fields: Vec<PyArrowType<ArrayData>>,
+    score_fields: Vec<PyArrowType<ArrayData>>,
+    scorer_ids: Vec<u8>,
+    levels: Vec<u8>,
+    partial_thresholds: Vec<f64>,
+    match_weights: Vec<Vec<f64>>,
+    calibrated: bool,
+    prior_w: f64,
+    min_weight: f64,
+    weight_range: f64,
+    threshold: f64,
+) -> PyResult<Vec<Vec<i64>>> {
+    let n = scorer_ids.len();
+    if levels.len() != n || partial_thresholds.len() != n || match_weights.len() != n {
+        return Err(PyValueError::new_err(
+            "match_fused_fs: scorer_ids/levels/partial_thresholds/match_weights must be same length",
+        ));
+    }
+    let (row_ids, n_rows, score_cols) =
+        read_ids_and_fields("match_fused_fs", row_ids, score_fields, n)?;
+    let (key_cols, key_n) = read_key_cols(key_fields, "match_fused_fs key")?;
+    if key_n != n_rows {
+        return Err(PyValueError::new_err(format!(
+            "match_fused_fs: key field length {key_n} != row count {n_rows}"
+        )));
+    }
+    let all_ids: Vec<i64> = row_ids.values().to_vec();
+    let n_fields = score_cols.len();
+
+    Ok(py.detach(|| {
+        let (rid_sorted, vals, spans) = fused_gather(&key_cols, &score_cols, n_rows, &all_ids);
+        let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
+            let mut local = Vec::new();
+            let end = offset + size;
+            for i in offset..end - 1 {
+                let ri = rid_sorted[i];
+                for j in (i + 1)..end {
+                    let rj = rid_sorted[j];
+                    let (a_id, b_id) = if ri < rj { (ri, rj) } else { (rj, ri) };
+                    let mut total_w = 0.0_f64;
+                    for f in 0..n_fields {
+                        let level = match (vals[f][i], vals[f][j]) {
+                            (Some(a), Some(b)) => {
+                                let sim = score_one(scorer_ids[f], a, b);
+                                fs_level_from_sim(sim, levels[f], partial_thresholds[f])
+                            }
+                            _ => 0, // null on either side -> disagree (level 0)
+                        };
+                        total_w += match_weights[f][level];
+                    }
+                    let normalized =
+                        fs_normalize(total_w, calibrated, prior_w, min_weight, weight_range);
+                    if normalized >= threshold {
+                        local.push((a_id, b_id, normalized));
+                    }
+                }
+            }
+            local
         };
-
-        // 4. Dedup (canonical (min,max), max score) + 5. connected components.
-        let deduped = dedup_pairs_max_score(&pairs);
-        connected_components(&deduped, &all_ids)
-    });
-
-    Ok(clusters)
+        let pairs = run_spans(&spans, score_span);
+        cluster_pairs(pairs, &all_ids)
+    }))
 }

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -38,6 +38,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(pairs::block_histogram, m)?)?;
     m.add_function(wrap_pyfunction!(block::build_block_index_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(fused::match_fused, m)?)?;
+    m.add_function(wrap_pyfunction!(fused::match_fused_fs, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_features, m)?)?;
     m.add_function(wrap_pyfunction!(featurize::char_ngram_project, m)?)?;
     m.add_function(wrap_pyfunction!(score::jaro_winkler_similarity, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -180,8 +180,29 @@ pub fn score_block_pairs(
 ///   2 levels: 1 if sim >= partial_threshold else 0
 ///   3 levels: 2 if sim >= 0.95, elif sim >= partial_threshold -> 1, else 0
 ///   N levels: count of k in 1..N with sim >= k/N (even spacing)
+/// Normalize a summed Fellegi-Sunter match weight to a [0,1] score. Shared by
+/// `score_block_pairs_fs` and the fused `match_fused_fs` so the two cannot drift.
+/// `calibrated` = posterior probability `1/(1+2^-(prior_w+w))`; else linear
+/// min-max over the observed weight range (0.5 when the range is degenerate).
+pub(crate) fn fs_normalize(
+    total_weight: f64,
+    calibrated: bool,
+    prior_w: f64,
+    min_weight: f64,
+    weight_range: f64,
+) -> f64 {
+    if calibrated {
+        let logodds = (prior_w + total_weight).clamp(-60.0, 60.0);
+        1.0 / (1.0 + 2.0_f64.powf(-logodds))
+    } else if weight_range > 0.0 {
+        ((total_weight - min_weight) / weight_range).clamp(0.0, 1.0)
+    } else {
+        0.5
+    }
+}
+
 #[inline]
-fn fs_level_from_sim(sim: f64, n_levels: u8, partial_threshold: f64) -> usize {
+pub(crate) fn fs_level_from_sim(sim: f64, n_levels: u8, partial_threshold: f64) -> usize {
     match n_levels {
         2 => usize::from(sim >= partial_threshold),
         3 => {
@@ -251,17 +272,6 @@ pub fn score_block_pairs_fs(
         offset += size;
     }
 
-    let normalize = |total_weight: f64| -> f64 {
-        if calibrated {
-            let logodds = (prior_w + total_weight).clamp(-60.0, 60.0);
-            1.0 / (1.0 + 2.0_f64.powf(-logodds))
-        } else if weight_range > 0.0 {
-            ((total_weight - min_weight) / weight_range).clamp(0.0, 1.0)
-        } else {
-            0.5
-        }
-    };
-
     py.detach(|| {
         spans
             .par_iter()
@@ -289,7 +299,13 @@ pub fn score_block_pairs_fs(
                                 };
                                 total_weight += match_weights[f][level];
                             }
-                            let normalized = normalize(total_weight);
+                            let normalized = fs_normalize(
+                                total_weight,
+                                calibrated,
+                                prior_w,
+                                min_weight,
+                                weight_range,
+                            );
                             if normalized >= threshold {
                                 local.push((pair_key.0, pair_key.1, normalized));
                             }


### PR DESCRIPTION
Completes the fused Arrow-native match stage's coverage of the common config shapes, so real auto-built configs collect the ~2x-single-box-capacity (2x lower peak RSS, byte-identical output) win. Follows: block kernel #1590, match_fused #1591, Arrow entry #1594, GoldenPipe stage #1595, scale bench #1596, transforms #1599.

## Fellegi-Sunter (probabilistic) matchkeys
`match_fused_fs` — FS scoring fused with block+dedup+cluster. **Byte-parity by construction**: the FS math is factored out of `score_block_pairs_fs` into shared `fs_level_from_sim` + `fs_normalize` (pub(crate)) that BOTH the existing FS block scorer and the fused branch call — they can't drift (the 26 Rust tests, incl. the existing FS parity suite, stay green — the refactor is behavior-identical). `run_match_fused_fs_arrow` assembles the kernel args exactly as `score_probabilistic_native`, takes a **pre-trained `EMResult`** (EM fit stays the caller's host step; EM is non-deterministic so the parity gate fixes the model). RSS/single-box win holds; wall vs the pipeline's FS path (#869 value-dedup/small-block-batching, which targets per-block FFI fan-out the fused single call sidesteps) is an open measurement.

## Multi-pass blocking
`run_match_fused_multipass_arrow` — pure Python orchestration over the single-pass fused entry, **zero kernel change**. Byte-parity by a clean graph argument: CC of the union of all passes' pairs == union-find-merge of each pass's per-pass clusters. Each pass runs fused (RSS win holds); transforms on pass keys covered.

## Dogfooded on real Febrl3 (5k records, 6,538 ground-truth pairs)
- weighted+transforms: **byte-identical** fused vs classic staged path
- FS: **byte-identical** fused vs pipeline FS scorer, F1 0.683 (P 0.86)
- multi-pass: recall 0.571 → 0.660 (the extra pass finds real matches)

## Tests
16 goldenmatch `test_fused_match` (weighted/transforms/FS/multi-pass parity + gates), 26 Rust native. Ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)