### PR TITLE
refactor(goldencheck): Polars-eviction P0 — lazy-import linchpin + Frame/Column seam

### DIFF
--- a/docs/superpowers/plans/2026-07-08-goldencheck-polars-eviction-p0.md
+++ b/docs/superpowers/plans/2026-07-08-goldencheck-polars-eviction-p0.md
@@ -42,8 +42,8 @@ Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (10
 | 7 modules with module-level dtype tuples | Modify | defer the constant so it's not evaluated at import |
 | `goldencheck/core/frame.py` | Create | `Frame`/`Column` Protocols + `PolarsFrame`/`PolarsColumn` + `to_frame()` |
 | `goldencheck/profilers/base.py` | Modify | `BaseProfiler.profile(df: pl.DataFrame …)` → `(frame: Frame …)` |
-| `goldencheck/engine/scanner.py` | Modify | wrap sample in `to_frame()`, pass `Frame` to profiler fan-outs |
-| 10 unported column profilers + 9 relation profilers | Modify | one-line `df = frame.native` shim |
+| `goldencheck/engine/scanner.py` | UNCHANGED | profiles coerce their own arg via `to_frame`; no scanner change |
+| 9 unported column profilers + 9 relation profilers | Modify | `frame = to_frame(frame)` + one-line `df = frame.native` shim |
 | `profilers/{nullability,cardinality,uniqueness}.py` | Modify | port bodies onto the `Column` seam |
 | `tests/core/test_frame.py`, `tests/test_import_no_polars.py` | Create | seam unit tests + import-graph gate |
 
@@ -232,25 +232,29 @@ def to_frame(native) -> Frame:
 
 ---
 
-## Task 4: Route `scanner.py` + all `profile()` methods through `Frame`
+## Task 4: Thread the `Frame` seam through every `profile()` via boundary-coercion
 
-**Files:** Modify `goldencheck/profilers/base.py`; Modify `goldencheck/engine/scanner.py`; Modify the 10 unported column profilers + 9 relation profilers (`df = frame.native` shim)
+**KEY DESIGN (from plan review):** ~20 existing test files call `profile(<raw pl.DataFrame>, column)` positionally, and `scanner.py:379` calls the out-of-scope `DenialConstraintProfiler().profile(target)` with a raw frame. So each `profile()` **coerces its first arg through the idempotent `to_frame()`** — `to_frame` accepts both a raw `pl.DataFrame` (test/denial callers) AND a `PolarsFrame`, so every caller keeps working with **zero test edits and zero scanner change**. Do NOT wrap anything in `scanner.py`; do NOT touch `scanner.py:379` (the denial profiler stays on raw Polars).
 
-- [ ] **Step 1: Change the signatures (two passes).**
-  - **Pass A — 13 column profilers (`BaseProfiler`):** in `profilers/base.py`, change `profile(self, df: pl.DataFrame, column, *, context=None)` → `profile(self, frame: Frame, column, *, context=None)` (import `Frame` from `goldencheck.core.frame`). In each of the 13 column profiler subclasses, change the signature the same way; for the 10 you are NOT porting in Task 5, add `df = frame.native` as the first body line (body unchanged). The 3 ported ones (nullability/cardinality/uniqueness) get their `frame:` signature here but are fully ported in Task 5 — for now give them `df = frame.native` too so this task stays byte-identical and self-contained.
-  - **Pass B — 9 relation profilers (`relations/*.py`, NOT `BaseProfiler`):** signature is `profile(self, df: pl.DataFrame)` (no column/context). Change `df` → `frame`, add `df = frame.native`. All 9 stay on `.native` in P0.
+**Counts (corrected):** `profilers/base.py` is the abstract `BaseProfiler` ABC (body `...`); there are **12** concrete column-profiler subclasses (`COLUMN_PROFILERS`, `scanner.py:44-60`) and **9** relation profilers (`relations/*.py`, do NOT inherit `BaseProfiler`, signature `profile(self, df)` — no column/context). = 21 concrete methods + the ABC signature.
 
-- [ ] **Step 2: Wrap the sample in `scanner.py`.** Find where `scanner.py` holds the sampled `pl.DataFrame` (`sample: pl.DataFrame`, ~line 84) and where it calls `profiler.profile(sample, col, ...)` / `relation.profile(sample)`. Wrap once: `frame = to_frame(sample)` (import `to_frame`), and pass `frame` to both fan-outs. (If other call sites construct profilers — `engine/scanner.py` `scan_dataframe`, the LLM path — thread `to_frame` there too. Grep `.profile(` across `goldencheck/` to find every call site.)
+**Files:** Modify `goldencheck/profilers/base.py`; the 12 column profilers; the 9 relation profilers. Do NOT modify `scanner.py`.
 
-- [ ] **Step 3: Run the FULL suite → byte-identical green.**
+- [ ] **Step 1: The ABC.** In `profilers/base.py`, change `profile(self, df: pl.DataFrame, column, *, context=None)` → `profile(self, frame, column, *, context=None)` (drop the now-unused `pl` import; optionally annotate `frame: "Frame | pl.DataFrame"` but the body is `...` so keep it simple). No `to_frame` here (abstract).
+
+- [ ] **Step 2: The 12 concrete column profilers.** For each, change the signature `df` → `frame` and make the FIRST body line `frame = to_frame(frame)` (import `from goldencheck.core.frame import to_frame`). For the **9** you are NOT porting in Task 5, then add `df = frame.native` and leave the body untouched. For the **3** to-be-ported (nullability/cardinality/uniqueness), also add `df = frame.native` here (clean byte-identical intermediate; Task 5 replaces it with the seam).
+
+- [ ] **Step 3: The 9 relation profilers.** Signature `profile(self, df)` → `profile(self, frame)`; first body line `frame = to_frame(frame)`; then `df = frame.native`; body untouched. Import `to_frame`.
+
+- [ ] **Step 4: Run the FULL suite → byte-identical green (tests UNEDITED).**
 ```bash
 cd /d/show_case/gc-polars-evict && <preamble>
 $PY -m pytest packages/python/goldencheck/tests -q
 $PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v   # still green
 ```
-Expected: same pass/skip counts as before (every profiler now takes a `Frame` but behaves identically via `.native`). Ruff clean.
+Expected: SAME pass/skip counts as before — every profiler coerces raw-`DataFrame` test callers via `to_frame`, behaves identically via `.native`. If ANY test errors with `AttributeError: 'DataFrame' object has no attribute 'native'/'column'`, a profiler is missing its `frame = to_frame(frame)` first line — fix it (do NOT edit the test). Ruff clean. Confirm `scanner.py` is unchanged (`git diff --stat packages/python/goldencheck/goldencheck/engine/scanner.py` → empty).
 
-- [ ] **Step 4: Commit.** `git add -A packages/python/goldencheck && git commit -m "refactor(goldencheck): route scanner + all profile() methods through the Frame seam (via .native)"`
+- [ ] **Step 5: Commit.** `git add -A packages/python/goldencheck && git commit -m "refactor(goldencheck): coerce profile() first arg through to_frame seam (via .native)"`
 
 ---
 
@@ -258,11 +262,11 @@ Expected: same pass/skip counts as before (every profiler now takes a `Frame` bu
 
 **Files:** Modify `profilers/nullability.py`, `cardinality.py`, `uniqueness.py`
 
-- [ ] **Step 1:** Port each body from `df[column]` → `frame.column(column)`, removing the `df = frame.native` shim (Task 4) and the now-unused `from goldencheck._polars_lazy import pl` import. The ops map 1:1:
-  - `nullability.py`: `col = frame.column(column)`; `total = len(col)`; `null_count = col.null_count()` — rest unchanged.
-  - `uniqueness.py`: `col = frame.column(column)`; `len(col)`; `non_null = col.drop_nulls()`; `len(non_null)`; `non_null.n_unique()` — rest unchanged.
-  - `cardinality.py`: `col = frame.column(column)`; `len(col)`; `col.n_unique()`; `col.drop_nulls().unique().sort().to_list()` — rest unchanged.
-  These profilers do NO dtype checks and had NO module-level `pl.` refs, so after porting they import no polars at all.
+- [ ] **Step 1:** Port each body. KEEP the `frame = to_frame(frame)` first line from Task 4 (it coerces raw-`DataFrame` test callers); REMOVE the `df = frame.native` shim and the now-unused `from goldencheck._polars_lazy import pl` import; replace `df[column]` with `frame.column(column)`. The ops map 1:1:
+  - `nullability.py`: `frame = to_frame(frame)`; `col = frame.column(column)`; `total = len(col)`; `null_count = col.null_count()` — rest unchanged.
+  - `uniqueness.py`: `frame = to_frame(frame)`; `col = frame.column(column)`; `len(col)`; `non_null = col.drop_nulls()`; `len(non_null)`; `non_null.n_unique()` — rest unchanged.
+  - `cardinality.py`: `frame = to_frame(frame)`; `col = frame.column(column)`; `len(col)`; `col.n_unique()`; `col.drop_nulls().unique().sort().to_list()` — rest unchanged.
+  These profilers do NO dtype checks and had NO module-level `pl.` refs, so after porting their only import from the seam is `to_frame` (no `pl`).
 
 - [ ] **Step 2: Run the 3 profilers' existing tests UNCHANGED → PASS (the parity gate).**
 ```bash
@@ -284,7 +288,7 @@ $PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v
 ## Done criteria (P0 complete)
 
 - [ ] `import goldencheck` loads zero Polars (`tests/test_import_no_polars.py` green).
-- [ ] `Frame`/`Column` seam exists (`core/frame.py`) with a `PolarsColumn` backend; `scanner.py` + all 22 `profile()` methods route through it.
+- [ ] `Frame`/`Column` seam exists (`core/frame.py`) with a `PolarsColumn` backend; all 21 concrete `profile()` methods (12 column + 9 relation) coerce their arg through `to_frame`; `scanner.py` is unchanged; the out-of-scope denial profiler (scanner.py:379) stays on raw Polars.
 - [ ] `nullability`/`cardinality`/`uniqueness` are ported onto the seam and import no polars; their existing tests pass with zero edits.
 - [ ] Full existing goldencheck suite green (same pass/skip counts) — byte-identical, no version bump.
 - [ ] No P1+ scope crept in (no reader eviction, no other profiler ports, no substrate/backend beyond PolarsColumn, no nopolars CI lane, no deps flip).

--- a/docs/superpowers/plans/2026-07-08-goldencheck-polars-eviction-p0.md
+++ b/docs/superpowers/plans/2026-07-08-goldencheck-polars-eviction-p0.md
@@ -1,0 +1,290 @@
+# GoldenCheck Polars Eviction — P0 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `import goldencheck` load zero Polars (lazy-import linchpin) and introduce a `Frame`/`Column` seam that `scanner.py` + the profilers route through, with 3 profilers ported onto it — all byte-identical, no behavior change.
+
+**Architecture:** Copy goldenflow's proven eviction P0: a `_LazyPolars` proxy so `import polars as pl` becomes lazy everywhere, plus deferring the 7 module-level dtype-tuple constants that would trigger an eager import. Then a minimal `goldencheck/core/frame.py` seam (`Frame`/`Column` Protocols + a single `PolarsColumn` backend) that the scan path uses instead of raw `pl.DataFrame`; the 3 simplest profilers migrate onto it while the other ~19 `profile()` methods reach through `frame.native` unchanged.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep in P0 — the *runtime* eviction is later stages), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-08-goldencheck-polars-eviction-p0-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-polars-evict` worktree)
+
+Branch `feat/goldencheck-polars-eviction-p0`, worktree `D:\show_case\gc-polars-evict`, off fresh `origin/main`. The repo-root `.venv` has `goldencheck` installed from the **main** tree, so tests MUST prepend the worktree package to `PYTHONPATH` (per `reference_py_worktree_test_native_skew`):
+
+**Test preamble** (from `/d/show_case/gc-polars-evict`):
+```bash
+export PYTHONPATH="D:/show_case/gc-polars-evict/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck, pathlib; print(goldencheck.__file__)"   # MUST be under gc-polars-evict
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**Reference to mirror (read it):** `packages/python/goldenflow/goldenflow/_polars_lazy.py` (the proxy to copy) and `packages/python/goldenflow/goldenflow/engine/frame.py` (the Frame Protocol shape).
+
+**Commit discipline:** conventional commits, one per task's final step. Do NOT push (a PR is a separate step after all tasks). All commits on `feat/goldencheck-polars-eviction-p0`.
+
+**INVARIANT:** every change in P0 is byte-identical. The existing goldencheck test suite is the regression gate — it must stay green at every task boundary. No version bump.
+
+---
+
+## File structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `goldencheck/_polars_lazy.py` | Create | `_LazyPolars` proxy (copy goldenflow's) |
+| ~49 modules `import polars as pl` | Modify | → `from goldencheck._polars_lazy import pl` |
+| 7 modules with module-level dtype tuples | Modify | defer the constant so it's not evaluated at import |
+| `goldencheck/core/frame.py` | Create | `Frame`/`Column` Protocols + `PolarsFrame`/`PolarsColumn` + `to_frame()` |
+| `goldencheck/profilers/base.py` | Modify | `BaseProfiler.profile(df: pl.DataFrame …)` → `(frame: Frame …)` |
+| `goldencheck/engine/scanner.py` | Modify | wrap sample in `to_frame()`, pass `Frame` to profiler fan-outs |
+| 10 unported column profilers + 9 relation profilers | Modify | one-line `df = frame.native` shim |
+| `profilers/{nullability,cardinality,uniqueness}.py` | Modify | port bodies onto the `Column` seam |
+| `tests/core/test_frame.py`, `tests/test_import_no_polars.py` | Create | seam unit tests + import-graph gate |
+
+---
+
+## Task 1: The `_LazyPolars` proxy
+
+**Files:** Create `packages/python/goldencheck/goldencheck/_polars_lazy.py`; Test `packages/python/goldencheck/tests/core/test_polars_lazy.py`
+
+- [ ] **Step 1: Write the failing test.**
+```python
+# tests/core/test_polars_lazy.py
+def test_lazy_proxy_returns_real_polars_objects():
+    from goldencheck._polars_lazy import pl
+    import polars as real_pl
+    assert pl.DataFrame is real_pl.DataFrame          # attribute access returns the REAL class
+    df = pl.DataFrame({"a": [1, 2]})
+    assert isinstance(df, real_pl.DataFrame)          # isinstance works
+    assert pl.Utf8 is real_pl.Utf8                    # dtype access works
+```
+
+- [ ] **Step 2: Run → FAIL** (`ModuleNotFoundError: goldencheck._polars_lazy`).
+
+- [ ] **Step 3: Create `_polars_lazy.py`** — copy `packages/python/goldenflow/goldenflow/_polars_lazy.py` VERBATIM, changing only the module docstring's `goldenflow`→`goldencheck` references. The class body (`_LazyPolars`, `__slots__=("_mod",)`, `__getattr__` importing polars on first access, `pl = _LazyPolars()`) is unchanged.
+
+- [ ] **Step 4: Run → PASS.** Ruff clean.
+
+- [ ] **Step 5: Commit.** `git add packages/python/goldencheck/goldencheck/_polars_lazy.py packages/python/goldencheck/tests/core/test_polars_lazy.py && git commit -m "feat(goldencheck): _LazyPolars proxy (lazy-import linchpin, copied from goldenflow)"`
+
+---
+
+## Task 2: Sweep the imports + defer the 7 module-level dtype constants
+
+**Files:** Modify ~49 files (`import polars as pl` → `from goldencheck._polars_lazy import pl`); Modify the 7 dtype-constant modules; Create `tests/test_import_no_polars.py`
+
+- [ ] **Step 1: Write the failing import-graph gate test.**
+```python
+# tests/test_import_no_polars.py  (the linchpin proof)
+import subprocess, sys
+
+def test_import_goldencheck_does_not_load_polars():
+    # Fresh interpreter: import goldencheck, assert polars was never imported.
+    code = "import goldencheck, sys; assert 'polars' not in sys.modules, sorted(m for m in sys.modules if 'polars' in m)"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    assert r.returncode == 0, r.stdout + r.stderr
+```
+(Run it via the worktree PY with PYTHONPATH set so the subprocess also sees the worktree — pass `env` with the same PYTHONPATH, or run from a shell that has it exported.)
+
+- [ ] **Step 2: Run → FAIL** (polars IS loaded — 49 eager imports + 7 module-level dtype tuples).
+
+- [ ] **Step 3a: Rewrite the import lines.** For every module under `goldencheck/goldencheck/**` that has `import polars as pl`, change it to `from goldencheck._polars_lazy import pl`. (Grep first: `grep -rl "^import polars as pl" packages/python/goldencheck/goldencheck`.) Confirm each has `from __future__ import annotations` at the top (the precondition — all do; the audit found zero default-arg dtypes). Do NOT change `tests/` files or the `_polars_lazy.py` proxy itself.
+
+- [ ] **Step 3b: Defer the 7 module-level dtype-tuple constants.** These are evaluated at import time and would trigger the eager import. For EACH, convert the module-level `X = (pl.Utf8, …)` into a lazily-evaluated form and update its in-module references. The 7:
+  - `profilers/sequence_detection.py:9` `INTEGER_DTYPES`
+  - `profilers/range_distribution.py:9-12`
+  - `profilers/drift_detection.py:9-12`
+  - `relations/numeric_cross.py:8-11` `NUMERIC_DTYPES`
+  - `relations/composite_key.py:36-41`
+  - `relations/approx_fd.py:33-37`
+  - `relations/functional_dependency.py:34-39` `_SUPPORTED`
+
+  Pattern per constant (module-level tuple → module-level function + `@lru_cache`, references become a call):
+  ```python
+  # before:
+  _SUPPORTED = (pl.Utf8, pl.Int8, pl.Int16, ...)
+  # ... later ... if series.dtype in _SUPPORTED:
+  # after:
+  from functools import lru_cache
+  @lru_cache(maxsize=1)
+  def _supported() -> tuple:
+      return (pl.Utf8, pl.Int8, pl.Int16, ...)
+  # ... later ... if series.dtype in _supported():
+  ```
+  (Read each file to get the exact tuple + all reference sites; update every reference in that module. `lru_cache` keeps it a one-time cost, matching the constant's semantics.)
+
+- [ ] **Step 4: Run the gate → PASS.** `'polars' not in sys.modules` after `import goldencheck`. Then run the FULL existing suite to confirm byte-identical behavior:
+```bash
+cd /d/show_case/gc-polars-evict && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v
+$PY -m pytest packages/python/goldencheck/tests -q    # full regression (may skip baseline/llm extras)
+```
+Expected: gate passes; full suite green (same pass/skip counts as before the sweep). Ruff clean.
+
+- [ ] **Step 5: Commit.** `git add -A packages/python/goldencheck && git commit -m "refactor(goldencheck): lazy Polars imports + defer 7 module-level dtype constants (import loads no polars)"`
+(Verify no stray artifact staged: `git status --short | grep -vE "\.py$"` should be empty-ish.)
+
+---
+
+## Task 3: The `Frame`/`Column` seam
+
+**Files:** Create `packages/python/goldencheck/goldencheck/core/frame.py`; Test `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Read `scanner.py`** to confirm exactly which `Frame`-level ops the scan path needs (`columns`, `height`, indexing) so the `Frame` Protocol covers them. Also read `goldenflow/engine/frame.py` for the Protocol style.
+
+- [ ] **Step 2: Write failing seam unit tests `tests/core/test_frame.py`.**
+```python
+import polars as pl
+from goldencheck.core.frame import to_frame, Frame, Column
+
+def _f():
+    return to_frame(pl.DataFrame({"a": [1, 1, 2, None], "b": ["x", "y", "x", "z"]}))
+
+def test_frame_basics():
+    f = _f()
+    assert set(f.columns) == {"a", "b"}
+    assert f.height == 4
+    assert f.native.shape == (4, 2)          # escape hatch = the pl.DataFrame
+
+def test_column_reductions_match_polars():
+    f = _f()
+    a = f.column("a")
+    assert len(a) == 4                        # __len__
+    assert a.null_count() == 1
+    assert a.drop_nulls().n_unique() == 2
+    assert a.drop_nulls().unique().sort().to_list() == [1, 2]
+    assert f.column("b").n_unique() == 3
+```
+
+- [ ] **Step 3: Run → FAIL.**
+
+- [ ] **Step 4: Implement `core/frame.py`.** Minimal Protocols + one Polars backend. Note: profilers use Python `len(col)`, so `Column` implements `__len__` (NOT a `.len()` method). No `dtype` in P0 (no ported profiler uses it — add in a later stage). Chained methods return wrappers that delegate, so parity is by construction.
+```python
+from __future__ import annotations
+from typing import Any, Protocol, runtime_checkable
+from goldencheck._polars_lazy import pl
+
+
+@runtime_checkable
+class Column(Protocol):
+    def __len__(self) -> int: ...
+    def null_count(self) -> int: ...
+    def n_unique(self) -> int: ...
+    def drop_nulls(self) -> "Column": ...
+    def unique(self) -> "Column": ...
+    def sort(self) -> "Column": ...
+    def to_list(self) -> list: ...
+
+
+@runtime_checkable
+class Frame(Protocol):
+    @property
+    def columns(self) -> list[str]: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def native(self) -> Any: ...
+    def column(self, name: str) -> Column: ...
+
+
+class PolarsColumn:
+    __slots__ = ("_s",)
+    def __init__(self, s) -> None: self._s = s
+    def __len__(self) -> int: return len(self._s)
+    def null_count(self) -> int: return self._s.null_count()
+    def n_unique(self) -> int: return self._s.n_unique()
+    def drop_nulls(self) -> "PolarsColumn": return PolarsColumn(self._s.drop_nulls())
+    def unique(self) -> "PolarsColumn": return PolarsColumn(self._s.unique())
+    def sort(self) -> "PolarsColumn": return PolarsColumn(self._s.sort())
+    def to_list(self) -> list: return self._s.to_list()
+
+
+class PolarsFrame:
+    __slots__ = ("_df",)
+    def __init__(self, df) -> None: self._df = df
+    @property
+    def columns(self) -> list[str]: return self._df.columns
+    @property
+    def height(self) -> int: return self._df.height
+    @property
+    def native(self): return self._df
+    def column(self, name: str) -> PolarsColumn: return PolarsColumn(self._df[name])
+
+
+def to_frame(native) -> Frame:
+    if isinstance(native, PolarsFrame):
+        return native
+    if isinstance(native, pl.DataFrame):
+        return PolarsFrame(native)
+    raise TypeError(f"to_frame() expects a polars.DataFrame (or PolarsFrame); got {type(native)!r}")
+```
+(Adjust `Frame` if Step 1 found scanner needs more, e.g. `dtype(name)` or row access — add only what's actually used.)
+
+- [ ] **Step 5: Run → PASS.** Ruff clean.
+
+- [ ] **Step 6: Commit.** `git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py && git commit -m "feat(goldencheck): Frame/Column seam with PolarsColumn backend (P0)"`
+
+---
+
+## Task 4: Route `scanner.py` + all `profile()` methods through `Frame`
+
+**Files:** Modify `goldencheck/profilers/base.py`; Modify `goldencheck/engine/scanner.py`; Modify the 10 unported column profilers + 9 relation profilers (`df = frame.native` shim)
+
+- [ ] **Step 1: Change the signatures (two passes).**
+  - **Pass A — 13 column profilers (`BaseProfiler`):** in `profilers/base.py`, change `profile(self, df: pl.DataFrame, column, *, context=None)` → `profile(self, frame: Frame, column, *, context=None)` (import `Frame` from `goldencheck.core.frame`). In each of the 13 column profiler subclasses, change the signature the same way; for the 10 you are NOT porting in Task 5, add `df = frame.native` as the first body line (body unchanged). The 3 ported ones (nullability/cardinality/uniqueness) get their `frame:` signature here but are fully ported in Task 5 — for now give them `df = frame.native` too so this task stays byte-identical and self-contained.
+  - **Pass B — 9 relation profilers (`relations/*.py`, NOT `BaseProfiler`):** signature is `profile(self, df: pl.DataFrame)` (no column/context). Change `df` → `frame`, add `df = frame.native`. All 9 stay on `.native` in P0.
+
+- [ ] **Step 2: Wrap the sample in `scanner.py`.** Find where `scanner.py` holds the sampled `pl.DataFrame` (`sample: pl.DataFrame`, ~line 84) and where it calls `profiler.profile(sample, col, ...)` / `relation.profile(sample)`. Wrap once: `frame = to_frame(sample)` (import `to_frame`), and pass `frame` to both fan-outs. (If other call sites construct profilers — `engine/scanner.py` `scan_dataframe`, the LLM path — thread `to_frame` there too. Grep `.profile(` across `goldencheck/` to find every call site.)
+
+- [ ] **Step 3: Run the FULL suite → byte-identical green.**
+```bash
+cd /d/show_case/gc-polars-evict && <preamble>
+$PY -m pytest packages/python/goldencheck/tests -q
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v   # still green
+```
+Expected: same pass/skip counts as before (every profiler now takes a `Frame` but behaves identically via `.native`). Ruff clean.
+
+- [ ] **Step 4: Commit.** `git add -A packages/python/goldencheck && git commit -m "refactor(goldencheck): route scanner + all profile() methods through the Frame seam (via .native)"`
+
+---
+
+## Task 5: Port `nullability`, `cardinality`, `uniqueness` onto the seam
+
+**Files:** Modify `profilers/nullability.py`, `cardinality.py`, `uniqueness.py`
+
+- [ ] **Step 1:** Port each body from `df[column]` → `frame.column(column)`, removing the `df = frame.native` shim (Task 4) and the now-unused `from goldencheck._polars_lazy import pl` import. The ops map 1:1:
+  - `nullability.py`: `col = frame.column(column)`; `total = len(col)`; `null_count = col.null_count()` — rest unchanged.
+  - `uniqueness.py`: `col = frame.column(column)`; `len(col)`; `non_null = col.drop_nulls()`; `len(non_null)`; `non_null.n_unique()` — rest unchanged.
+  - `cardinality.py`: `col = frame.column(column)`; `len(col)`; `col.n_unique()`; `col.drop_nulls().unique().sort().to_list()` — rest unchanged.
+  These profilers do NO dtype checks and had NO module-level `pl.` refs, so after porting they import no polars at all.
+
+- [ ] **Step 2: Run the 3 profilers' existing tests UNCHANGED → PASS (the parity gate).**
+```bash
+cd /d/show_case/gc-polars-evict && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_nullability.py packages/python/goldencheck/tests/profilers/test_cardinality.py packages/python/goldencheck/tests/profilers/test_uniqueness.py -v
+```
+Expected: all pass with ZERO test edits (byte-identical Findings). If a test file name differs, find it (`ls tests/profilers | grep -E "null|cardinal|uniq"`). Then the full suite + import gate:
+```bash
+$PY -m pytest packages/python/goldencheck/tests -q
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+
+- [ ] **Step 3: Confirm the 3 ported files are polars-free.** `grep -l "polars\|_polars_lazy\| pl\." packages/python/goldencheck/goldencheck/profilers/{nullability,cardinality,uniqueness}.py` → no matches (they now go entirely through the seam). Ruff clean.
+
+- [ ] **Step 4: Commit.** `git add packages/python/goldencheck/goldencheck/profilers/{nullability,cardinality,uniqueness}.py && git commit -m "refactor(goldencheck): port nullability/cardinality/uniqueness onto the Frame seam (polars-free)"`
+
+---
+
+## Done criteria (P0 complete)
+
+- [ ] `import goldencheck` loads zero Polars (`tests/test_import_no_polars.py` green).
+- [ ] `Frame`/`Column` seam exists (`core/frame.py`) with a `PolarsColumn` backend; `scanner.py` + all 22 `profile()` methods route through it.
+- [ ] `nullability`/`cardinality`/`uniqueness` are ported onto the seam and import no polars; their existing tests pass with zero edits.
+- [ ] Full existing goldencheck suite green (same pass/skip counts) — byte-identical, no version bump.
+- [ ] No P1+ scope crept in (no reader eviction, no other profiler ports, no substrate/backend beyond PolarsColumn, no nopolars CI lane, no deps flip).

--- a/docs/superpowers/specs/2026-07-08-goldencheck-polars-eviction-p0-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldencheck-polars-eviction-p0-design.md
@@ -52,8 +52,9 @@ substrate-agnostic (ships only `PolarsColumn`), so the choice is made when P2 po
    goldencheck._polars_lazy import pl`, and **defer every module-level `pl.` reference**.
 2. `goldencheck/core/frame.py` — `Frame` + `Column` Protocols + a `PolarsFrame`/`PolarsColumn`
    backend + `to_frame()` factory.
-3. Route `scanner.py` + `BaseProfiler.profile` (all ~13 profilers + relation profilers) through
-   `Frame` instead of raw `pl.DataFrame`.
+3. Route `scanner.py` + the profilers through `Frame` instead of raw `pl.DataFrame` — two passes:
+   the 13 `BaseProfiler` column profilers (`profile(df, column, *, context)`) and the 9
+   relation profilers (`profile(df)`, don't inherit `BaseProfiler`).
 4. Port 3 profilers (`nullability`, `cardinality`, `uniqueness`) onto the seam (byte-identical).
 5. An import-graph subprocess gate test.
 
@@ -76,16 +77,38 @@ imports polars on first attribute access) into `goldencheck/_polars_lazy.py`. Sw
 
 **The real work + top risk — module-level Polars references.** Function-body `pl.DataFrame(...)`
 is lazy for free (the function isn't run at import). But anything evaluated at *import* time
-triggers the proxy's import and defeats the linchpin — e.g. `_SUPPORTED = (pl.Utf8, pl.Int64, …)`
-dtype tuples in the profilers, a `pl.col(...)` in a module constant, a dtype in a default
-argument. The sweep must **grep for every `pl.` attribute access outside a `def`/method body** and
-defer each: move it into a function, a lazily-built cache (`@lru_cache`/module-level function), or
-a backend-neutral dtype string. The subprocess import-graph gate is what proves none were missed.
+triggers the proxy's import and defeats the linchpin. An audit of the ~90 `pl.<dtype>` references
+found the vast majority are inside function/method bodies (lazy-safe); the actual import-time
+killers are exactly **7 module-level dtype-tuple constants** (verified — no module-level
+`pl.col(...)` constant, no default-arg dtypes):
+- `profilers/sequence_detection.py:9` `INTEGER_DTYPES = (pl.Int8, …)`
+- `profilers/range_distribution.py:9-12`
+- `profilers/drift_detection.py:9-12`
+- `relations/numeric_cross.py:8-11` `NUMERIC_DTYPES`
+- `relations/composite_key.py:36-41`
+- `relations/approx_fd.py:33-37`
+- `relations/functional_dependency.py:34-39` `_SUPPORTED`
+
+The sweep is therefore genuinely mechanical: the 49 import-line rewrites + deferring these **7**
+constants (into a function or a lazily-built cache; these live in *unported* modules, so they're
+part of the lazy-import sweep, independent of the 3-profiler port). The subprocess import-graph
+gate proves none were missed.
+
+**Precondition to assert (goldenflow's proxy relies on it):** every swept module must have `from
+__future__ import annotations` (so `-> pl.Expr` annotations stay strings) and no `def f(x=pl.X)`
+default-arg dtypes. Both already hold across goldencheck (audited: zero default-arg dtypes) — the
+plan asserts it rather than assuming it.
 
 ## Component 2 — The `Frame`/`Column` seam (`goldencheck/core/frame.py`)
 
 Two minimal Protocols (mirroring goldenflow's `engine/frame.py`, plus a `Column` accessor
 goldencheck needs for its scalar reductions):
+
+The `Column` surface is exactly what the 3 P0 profilers use — verified against
+`nullability.py` (`len`, `null_count`), `uniqueness.py` (`len`, `drop_nulls`, `n_unique`), and
+`cardinality.py` (`len`, `n_unique`, and the chain `drop_nulls().unique().sort().to_list()`). So
+P0's `Column` is `{len, null_count, n_unique, drop_nulls, unique, sort, to_list}` plus `dtype` —
+**not** `value_counts`/`is_in` (no P0 profiler uses those; they arrive when later stages need them):
 
 ```python
 class Column(Protocol):
@@ -95,8 +118,8 @@ class Column(Protocol):
     def null_count(self) -> int: ...
     def n_unique(self) -> int: ...
     def drop_nulls(self) -> "Column": ...
-    def value_counts(self) -> list[tuple[object, int]]: ...
-    def is_in(self, values) -> "Column": ...
+    def unique(self) -> "Column": ...    # cardinality: drop_nulls().unique().sort().to_list()
+    def sort(self) -> "Column": ...
     def to_list(self) -> list: ...
 
 class Frame(Protocol):
@@ -118,22 +141,37 @@ the 3 ported profilers use; grow it as later stages port more. Backend-neutral `
 `pl.Date/Datetime -> "date"` (the exact mapping is defined here so ported profilers compare against
 strings, not `pl.` types — which also removes their module-level `pl.` dtype references).
 
-## Component 3 — Route `scanner.py` + `BaseProfiler` through the seam
+## Component 3 — Route `scanner.py` + the profilers through the seam (TWO signatures)
 
-`BaseProfiler.profile` signature changes from `df: pl.DataFrame` to `frame: Frame` for **all ~13
-profilers + the relation profilers**. For the 10 unported profilers this is a **one-line** change:
-`df = frame.native` at the top, body untouched. `scanner.py` wraps its sampled `pl.DataFrame` in a
-`PolarsFrame` once (`to_frame(sample)`) and passes the `Frame` everywhere. The seam threads through
-the whole scan immediately; bodies migrate one stage at a time. (Relation profilers take the
-`Frame` too and use `.native` until P2.)
+goldencheck has **two distinct `profile()` shapes** — the routing is two mechanical passes, not
+one:
+- **13 column profilers** inherit `BaseProfiler` (`profilers/base.py`): `profile(self, df:
+  pl.DataFrame, column: str, *, context: dict | None = None)`. Change `df: pl.DataFrame` → `frame:
+  Frame`. 10 unported ones get a one-line `df = frame.native` at the top, body untouched.
+- **9 relation profilers** (`relations/*.py`) do **NOT** inherit `BaseProfiler` and use a different
+  signature `profile(self, df: pl.DataFrame)` — whole frame, **no `column`, no `context`** (e.g.
+  `functional_dependency.py`). Change `df` → `frame`, add `df = frame.native` — all 9 stay on
+  `.native` in P0 (they're the FD-mining/pivot tail, ported or declined in P2).
+
+`scanner.py` (`sample: pl.DataFrame` at ~line 84) wraps the sample once via `to_frame(sample)` and
+passes the `Frame` to both fan-outs (`COLUMN_PROFILERS` ~44-60 and `RELATION_PROFILERS` ~62-81).
+The seam threads through the whole scan immediately; bodies migrate one stage at a time.
 
 ## Component 4 — Port `nullability`, `cardinality`, `uniqueness`
 
-These use only `null_count`/`n_unique`/`len`/`drop_nulls` (+ dtype checks). Port each body from
-`df[col].drop_nulls().n_unique()` → `frame.column(col).drop_nulls().n_unique()`, and dtype checks
-from `col.dtype == pl.Utf8` → `frame.dtype(col) == "str"`. Because `PolarsColumn` delegates to the
-same Polars calls, the ports are **byte-identical by construction** — the existing tests for these
+These three do **no dtype comparisons** and have **no module-level `pl.` references** — they use
+only the `Column` reductions above (`nullability`: `len`+`null_count`; `uniqueness`:
+`len`+`drop_nulls`+`n_unique`; `cardinality`: `len`+`n_unique`+`drop_nulls().unique().sort()
+.to_list()`). Port each body from `df[col]…` → `frame.column(col)…`. Because `PolarsColumn`
+delegates to the same Polars calls (and its chained methods return `PolarsColumn` wrappers that
+also delegate), the ports are **byte-identical by construction** — the existing tests for these
 three profilers pass with zero edits (the parity gate).
+
+(The backend-neutral `dtype`-string mapping defined in Component 2 is **infrastructure for later
+ports** — `type_inference`, `format_detection`, `sequence_detection`, etc. compare against `pl.`
+dtypes — not something the 3 P0 profilers use. The neutral collapse `int`/`date` is safe for P0
+precisely because the profilers needing Int32-vs-Float64 or Date-vs-Datetime distinctions aren't
+ported yet and reach through `.native`.)
 
 ## Testing
 
@@ -149,8 +187,10 @@ three profilers pass with zero edits (the parity gate).
 
 - **Module-level `pl.` references defeating the linchpin** (top risk) — mitigated by the
   grep-for-module-level-`pl.` sweep + the subprocess import-graph gate.
-- **The 13-profiler signature change** — broad but mechanical (one line per unported profiler);
-  parity tests guard against behavior drift.
+- **The signature change spans 22 `profile()` methods across TWO shapes** (13 `BaseProfiler`
+  column profilers `profile(df, column, *, context)` + 9 relation profilers `profile(df)`) — broad
+  but mechanical (one line per unported method); parity tests guard against behavior drift. Treat
+  them as two passes.
 - **Seam API incompleteness / over-design** — start minimal (only what the 3 profilers + scanner
   need); grow the `Column` Protocol as later stages port more. Do NOT model the pivot/`group_by`
   tail in P0 (those decline to `.native`/Polars until P2).

--- a/docs/superpowers/specs/2026-07-08-goldencheck-polars-eviction-p0-design.md
+++ b/docs/superpowers/specs/2026-07-08-goldencheck-polars-eviction-p0-design.md
@@ -1,0 +1,162 @@
+# GoldenCheck Polars eviction — Stage 1 (P0: lazy-import linchpin + Frame/Column seam)
+
+Date: 2026-07-08
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (goldencheck 1.4.1, denial-constraints #1601/#1602 merged)
+Parent program: "Evict Polars as a hard dependency from goldencheck" (5 stages; this is P0)
+
+## Context
+
+`goldencheck` is Polars-native: `polars>=1.0` is a **hard** dependency
+(`packages/python/goldencheck/pyproject.toml`), **49** modules `import polars`, and every
+profiler's `BaseProfiler.profile(self, df: pl.DataFrame, column, *, context)` operates on a
+`pl.DataFrame`. The sibling `goldenflow` already evicted Polars behind a lazy-import proxy + a
+`Frame` seam (`polars` → optional `[polars]` extra, ~185 MB installed weight removed, native
+Arrow substrate). The suite-wide direction (`docs/design/2026-07-01-rust-is-the-reference-roadmap.md`)
+lists check as a follower. This program brings the same eviction to goldencheck.
+
+**The driver is WEIGHT, not speed** (goldenflow measured ~185 MB; the eviction lets `import
+goldencheck` and the base install run without Polars). Polars stays as an optional accelerator.
+
+### What makes goldencheck a NARROWER eviction than goldenflow
+goldencheck's Polars use is overwhelmingly **eager per-column scalar reductions** (`null_count`,
+`n_unique`, `value_counts`, `cast`, `drop_nulls`) — **no lazy frames, no real joins
+(the 41 `.join(` hits are Python `str.join`), exactly one `.pivot()`** (`baseline/correlation.py`).
+And goldencheck **starts further along**: the native `goldencheck-core` crate, the
+`core/_native_loader.py` gate, and Polars-free `core/kernels.py` (plain-`Sequence`-typed) already
+exist — goldenflow had to build those.
+
+## The program (each stage its own spec → plan → build)
+
+Mirrors goldenflow's proven arc (seam → lazy-import → incremental ports → nopolars lane → flip):
+
+| Stage | Scope | goldenflow ref |
+|---|---|---|
+| **P0 (this spec)** | Lazy-import linchpin (`_polars_lazy.py` + 49-site sweep) **+** the `Frame`/`Column` seam (PolarsColumn backend only) routed through `scanner.py` + `BaseProfiler.profile`, with 3 profilers ported. Byte-identical, non-breaking. | #1525 + #1552 |
+| P1 | Reader Polars-free path (`engine/reader.py`: pyarrow CSV/Parquet + stdlib tail) | Phase 2 |
+| P2 | Incremental profiler ports + **decline-to-Polars** contract for the gnarly tail (`correlation.py` pivot, FD-mining `group_by`) | #1554-#1567 |
+| P3 | `nopolars` CI lane (uninstall polars, assert absent, run a Polars-free test dir) | #1568 |
+| P4 | The flip — `polars` → `[polars]` extra, deps-only, major version | #1586 |
+
+### The deferred decision (Stage 2, not P0)
+The **default substrate** that replaces Polars for ported reductions — pyarrow-backed `Column`
+(pyarrow is already a dep; easiest), a native `goldencheck-core` reduction, or a pure-Python
+`dict[str,list]` fallback (goldenflow's "correctness floor", ~3.3x slower). P0's seam is
+substrate-agnostic (ships only `PolarsColumn`), so the choice is made when P2 ports the runtime.
+
+## P0 scope
+
+### In scope
+1. `goldencheck/_polars_lazy.py` — a `_LazyPolars` proxy (port goldenflow's verbatim) that imports
+   Polars only on first attribute access; sweep all 49 `import polars as pl` → `from
+   goldencheck._polars_lazy import pl`, and **defer every module-level `pl.` reference**.
+2. `goldencheck/core/frame.py` — `Frame` + `Column` Protocols + a `PolarsFrame`/`PolarsColumn`
+   backend + `to_frame()` factory.
+3. Route `scanner.py` + `BaseProfiler.profile` (all ~13 profilers + relation profilers) through
+   `Frame` instead of raw `pl.DataFrame`.
+4. Port 3 profilers (`nullability`, `cardinality`, `uniqueness`) onto the seam (byte-identical).
+5. An import-graph subprocess gate test.
+
+### Explicitly NOT in P0
+Reader eviction (P1); porting the other ~10 profilers + the pivot/FD-`group_by` tail (P2); the
+full `nopolars` CI lane (P3); the deps flip (P4); choosing the non-Polars substrate (Stage 2).
+No behavior change, no version bump.
+
+### Success criteria
+- `python -c "import goldencheck, sys; assert 'polars' not in sys.modules"` passes.
+- The 3 ported profilers emit byte-identical `Finding`s (their existing tests pass with **zero**
+  edits).
+- Full existing test suite green (unported profilers/relations run via `frame.native`).
+
+## Component 1 — The lazy-import linchpin (`_polars_lazy.py`)
+
+Copy goldenflow's `packages/python/goldenflow/goldenflow/_polars_lazy.py` (`_LazyPolars` proxy,
+imports polars on first attribute access) into `goldencheck/_polars_lazy.py`. Sweep all 49
+`import polars as pl` sites to `from goldencheck._polars_lazy import pl`.
+
+**The real work + top risk — module-level Polars references.** Function-body `pl.DataFrame(...)`
+is lazy for free (the function isn't run at import). But anything evaluated at *import* time
+triggers the proxy's import and defeats the linchpin — e.g. `_SUPPORTED = (pl.Utf8, pl.Int64, …)`
+dtype tuples in the profilers, a `pl.col(...)` in a module constant, a dtype in a default
+argument. The sweep must **grep for every `pl.` attribute access outside a `def`/method body** and
+defer each: move it into a function, a lazily-built cache (`@lru_cache`/module-level function), or
+a backend-neutral dtype string. The subprocess import-graph gate is what proves none were missed.
+
+## Component 2 — The `Frame`/`Column` seam (`goldencheck/core/frame.py`)
+
+Two minimal Protocols (mirroring goldenflow's `engine/frame.py`, plus a `Column` accessor
+goldencheck needs for its scalar reductions):
+
+```python
+class Column(Protocol):
+    @property
+    def dtype(self) -> str: ...          # backend-neutral: "str"|"int"|"float"|"bool"|"date"
+    def len(self) -> int: ...
+    def null_count(self) -> int: ...
+    def n_unique(self) -> int: ...
+    def drop_nulls(self) -> "Column": ...
+    def value_counts(self) -> list[tuple[object, int]]: ...
+    def is_in(self, values) -> "Column": ...
+    def to_list(self) -> list: ...
+
+class Frame(Protocol):
+    @property
+    def columns(self) -> list[str]: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def native(self): ...                # escape hatch for not-yet-ported code
+    def dtype(self, name: str) -> str: ...
+    def column(self, name: str) -> Column: ...
+```
+
+Ship exactly one backend: `PolarsFrame(pl.DataFrame)` / `PolarsColumn(pl.Series)`, each method
+delegating to the identical Polars call (so parity is by construction). `to_frame(native) ->
+Frame` accepts a `pl.DataFrame` (later Arrow). **Keep the `Column` surface minimal** — only the ops
+the 3 ported profilers use; grow it as later stages port more. Backend-neutral `dtype` strings map
+`pl.Utf8 -> "str"`, `pl.Int* -> "int"`, `pl.Float* -> "float"`, `pl.Boolean -> "bool"`,
+`pl.Date/Datetime -> "date"` (the exact mapping is defined here so ported profilers compare against
+strings, not `pl.` types — which also removes their module-level `pl.` dtype references).
+
+## Component 3 — Route `scanner.py` + `BaseProfiler` through the seam
+
+`BaseProfiler.profile` signature changes from `df: pl.DataFrame` to `frame: Frame` for **all ~13
+profilers + the relation profilers**. For the 10 unported profilers this is a **one-line** change:
+`df = frame.native` at the top, body untouched. `scanner.py` wraps its sampled `pl.DataFrame` in a
+`PolarsFrame` once (`to_frame(sample)`) and passes the `Frame` everywhere. The seam threads through
+the whole scan immediately; bodies migrate one stage at a time. (Relation profilers take the
+`Frame` too and use `.native` until P2.)
+
+## Component 4 — Port `nullability`, `cardinality`, `uniqueness`
+
+These use only `null_count`/`n_unique`/`len`/`drop_nulls` (+ dtype checks). Port each body from
+`df[col].drop_nulls().n_unique()` → `frame.column(col).drop_nulls().n_unique()`, and dtype checks
+from `col.dtype == pl.Utf8` → `frame.dtype(col) == "str"`. Because `PolarsColumn` delegates to the
+same Polars calls, the ports are **byte-identical by construction** — the existing tests for these
+three profilers pass with zero edits (the parity gate).
+
+## Testing
+
+- **Import-graph gate:** a subprocess test asserting `'polars' not in sys.modules` after `import
+  goldencheck` (the linchpin proof).
+- **Parity:** the 3 ported profilers' existing tests pass unedited (byte-identical Findings).
+- **Seam unit tests:** each `PolarsColumn`/`PolarsFrame` op returns the same value as the raw Polars
+  call it wraps (null_count/n_unique/value_counts/drop_nulls/is_in/dtype-mapping).
+- **Regression:** the full existing goldencheck suite green (unported profilers/relations via
+  `frame.native`).
+
+## Risks
+
+- **Module-level `pl.` references defeating the linchpin** (top risk) — mitigated by the
+  grep-for-module-level-`pl.` sweep + the subprocess import-graph gate.
+- **The 13-profiler signature change** — broad but mechanical (one line per unported profiler);
+  parity tests guard against behavior drift.
+- **Seam API incompleteness / over-design** — start minimal (only what the 3 profilers + scanner
+  need); grow the `Column` Protocol as later stages port more. Do NOT model the pivot/`group_by`
+  tail in P0 (those decline to `.native`/Polars until P2).
+- **A relation profiler or engine module with a module-level Polars dtype constant** that the sweep
+  misses — the import gate catches it; fix by deferral.
+
+## Non-goals (YAGNI)
+Reader eviction; the other ~10 profiler ports; the pivot/FD-`group_by` decline-tail; the substrate
+choice; the `nopolars` CI lane; the deps flip. All later stages.

--- a/packages/python/goldencheck/goldencheck/_polars_lazy.py
+++ b/packages/python/goldencheck/goldencheck/_polars_lazy.py
@@ -1,0 +1,49 @@
+"""Lazy Polars proxy — Phase 0 of the Polars eviction (make Polars optional).
+
+``from goldencheck._polars_lazy import pl`` gives a stand-in that imports Polars on
+the FIRST attribute access, not at import time. Every ``pl.col(...)`` /
+``pl.Series(...)`` / ``pl.Utf8`` runtime use in the profiler + core modules keeps
+working unchanged, but ``import goldencheck`` no longer eagerly imports Polars (a
+single top-level ``import polars`` anywhere in that chain loaded Polars for every
+user, including those who only touch the Polars-free path).
+
+Safe because:
+- Type annotations are strings (`from __future__ import annotations` in every module
+  that uses the proxy), so signatures like ``-> pl.Expr`` never trigger the import.
+- There is no module-level ``pl.`` execution and no ``def f(x=pl.X)`` default arg
+  (audited), so nothing evaluates ``pl.`` at import time.
+- Attribute access returns the REAL Polars object (``pl.DataFrame`` is the actual
+  class), so ``isinstance(x, pl.DataFrame)`` and ``return_dtype=pl.Utf8`` behave
+  identically to a direct ``import polars as pl``.
+
+This lands while ``polars`` is still a hard dependency (a pure refactor, no behavior
+change); it is the enabler for later Phase-0 steps that move ``polars`` to an
+optional ``[polars]`` extra.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+class _LazyPolars:
+    """A proxy that forwards attribute access to ``polars``, importing it on first
+    use and caching the module thereafter."""
+
+    __slots__ = ("_mod",)
+
+    def __init__(self) -> None:
+        self._mod: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        # `_mod` is a slot (set to None in __init__), so reading it here never
+        # re-enters __getattr__; only genuine polars attributes reach this path.
+        mod = self._mod
+        if mod is None:
+            import polars as _polars
+
+            self._mod = mod = _polars
+        return getattr(mod, name)
+
+
+pl = _LazyPolars()
+"""Module-level singleton — import as ``from goldencheck._polars_lazy import pl``."""

--- a/packages/python/goldencheck/goldencheck/agent/intelligence.py
+++ b/packages/python/goldencheck/goldencheck/agent/intelligence.py
@@ -5,8 +5,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.engine.confidence import apply_confidence_downgrade
 from goldencheck.engine.sampler import maybe_sample
 from goldencheck.engine.scanner import scan_file

--- a/packages/python/goldencheck/goldencheck/baseline/__init__.py
+++ b/packages/python/goldencheck/goldencheck/baseline/__init__.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import BaselineProfile
 
 __all__ = ["create_baseline", "load_baseline"]

--- a/packages/python/goldencheck/goldencheck/baseline/constraints.py
+++ b/packages/python/goldencheck/goldencheck/baseline/constraints.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import FunctionalDependency, TemporalOrder
 
 __all__ = ["mine_constraints"]

--- a/packages/python/goldencheck/goldencheck/baseline/correlation.py
+++ b/packages/python/goldencheck/goldencheck/baseline/correlation.py
@@ -14,8 +14,7 @@ except ImportError as _err:  # pragma: no cover
         "Install them with: pip install 'goldencheck[baseline]'"
     ) from _err
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import CorrelationEntry
 
 if TYPE_CHECKING:

--- a/packages/python/goldencheck/goldencheck/baseline/patterns.py
+++ b/packages/python/goldencheck/goldencheck/baseline/patterns.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 import re
 from collections import Counter
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import PatternGrammar
 
 __all__ = ["induce_patterns", "_induce_column_grammars"]

--- a/packages/python/goldencheck/goldencheck/baseline/semantic.py
+++ b/packages/python/goldencheck/goldencheck/baseline/semantic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldencheck._polars_lazy import pl
 
 if TYPE_CHECKING:
     pass

--- a/packages/python/goldencheck/goldencheck/baseline/statistical.py
+++ b/packages/python/goldencheck/goldencheck/baseline/statistical.py
@@ -15,8 +15,7 @@ except ImportError as _err:  # pragma: no cover
         "Install them with: pip install 'goldencheck[baseline]'"
     ) from _err
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import StatProfile
 from goldencheck.core._native_loader import native_enabled, native_module
 

--- a/packages/python/goldencheck/goldencheck/cell_quality.py
+++ b/packages/python/goldencheck/goldencheck/cell_quality.py
@@ -25,8 +25,7 @@ from __future__ import annotations
 
 import datetime as _dt
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.profilers.fuzzy_values import _MAX_DISTINCT as _FUZZY_MAX_DISTINCT
 from goldencheck.profilers.fuzzy_values import (

--- a/packages/python/goldencheck/goldencheck/cli/demo_data.py
+++ b/packages/python/goldencheck/goldencheck/cli/demo_data.py
@@ -5,7 +5,7 @@ import random
 import tempfile
 from pathlib import Path
 
-import polars as pl
+from goldencheck._polars_lazy import pl
 
 
 def generate_demo_csv(path: Path | None = None) -> Path:

--- a/packages/python/goldencheck/goldencheck/cli/main.py
+++ b/packages/python/goldencheck/goldencheck/cli/main.py
@@ -6,12 +6,12 @@ import sys
 from contextlib import contextmanager
 from pathlib import Path
 
-import polars as pl
 import typer
 from rich.console import Console
 from typer.core import TyperGroup
 
 from goldencheck import __version__
+from goldencheck._polars_lazy import pl
 from goldencheck.config.loader import load_config
 from goldencheck.config.writer import save_config
 from goldencheck.engine.confidence import apply_confidence_downgrade

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -1,0 +1,94 @@
+"""Backend-neutral Frame/Column seam for the Polars eviction (P0).
+
+Profilers route through this instead of a raw ``pl.DataFrame`` so their bodies can
+migrate off Polars one at a time. P0 ships only the Polars-backed backend; the
+native/Arrow backend arrives in a later stage. ``to_frame`` is idempotent so a
+caller may pass either a raw ``pl.DataFrame`` or an already-wrapped ``Frame``.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from goldencheck._polars_lazy import pl
+
+
+@runtime_checkable
+class Column(Protocol):
+    def __len__(self) -> int: ...
+    def null_count(self) -> int: ...
+    def n_unique(self) -> int: ...
+    def drop_nulls(self) -> Column: ...
+    def unique(self) -> Column: ...
+    def sort(self) -> Column: ...
+    def to_list(self) -> list: ...
+
+
+@runtime_checkable
+class Frame(Protocol):
+    @property
+    def columns(self) -> list[str]: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def native(self) -> Any: ...
+    def column(self, name: str) -> Column: ...
+
+
+class PolarsColumn:
+    __slots__ = ("_s",)
+
+    def __init__(self, s: Any) -> None:
+        self._s = s
+
+    def __len__(self) -> int:
+        return len(self._s)
+
+    def null_count(self) -> int:
+        return self._s.null_count()
+
+    def n_unique(self) -> int:
+        return self._s.n_unique()
+
+    def drop_nulls(self) -> PolarsColumn:
+        return PolarsColumn(self._s.drop_nulls())
+
+    def unique(self) -> PolarsColumn:
+        return PolarsColumn(self._s.unique())
+
+    def sort(self) -> PolarsColumn:
+        return PolarsColumn(self._s.sort())
+
+    def to_list(self) -> list:
+        return self._s.to_list()
+
+
+class PolarsFrame:
+    __slots__ = ("_df",)
+
+    def __init__(self, df: Any) -> None:
+        self._df = df
+
+    @property
+    def columns(self) -> list[str]:
+        return self._df.columns
+
+    @property
+    def height(self) -> int:
+        return self._df.height
+
+    @property
+    def native(self) -> Any:
+        return self._df
+
+    def column(self, name: str) -> PolarsColumn:
+        return PolarsColumn(self._df[name])
+
+
+def to_frame(native: Any) -> Frame:
+    if isinstance(native, PolarsFrame):
+        return native
+    if isinstance(native, pl.DataFrame):
+        return PolarsFrame(native)
+    raise TypeError(
+        f"to_frame() expects a polars.DataFrame (or PolarsFrame); got {type(native)!r}"
+    )

--- a/packages/python/goldencheck/goldencheck/denial/mine.py
+++ b/packages/python/goldencheck/goldencheck/denial/mine.py
@@ -57,8 +57,7 @@ from __future__ import annotations
 import random
 from dataclasses import dataclass
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.denial.constants import (
     DEFAULT_EPS,
     DEFAULT_SAMPLE,

--- a/packages/python/goldencheck/goldencheck/denial/predicates.py
+++ b/packages/python/goldencheck/goldencheck/denial/predicates.py
@@ -22,8 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.denial.constants import MAX_LITERAL_CARD, MAX_PREDICATES, MIN_SUPPORT
 from goldencheck.denial.models import Op, Predicate
 

--- a/packages/python/goldencheck/goldencheck/denial/validate.py
+++ b/packages/python/goldencheck/goldencheck/denial/validate.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 import random
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.denial.constants import VALIDATION_SAMPLE
 from goldencheck.denial.models import Predicate
 from goldencheck.denial.predicates import encode_columns, predicate_holds

--- a/packages/python/goldencheck/goldencheck/drift/detector.py
+++ b/packages/python/goldencheck/goldencheck/drift/detector.py
@@ -14,8 +14,7 @@ try:
 except ImportError:
     _SCIPY_AVAILABLE = False
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.baseline.correlation import _cramers_v
 from goldencheck.baseline.models import BaselineProfile
 from goldencheck.baseline.patterns import _induce_column_grammars

--- a/packages/python/goldencheck/goldencheck/engine/db_scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/db_scanner.py
@@ -5,8 +5,7 @@ import logging
 import tempfile
 from pathlib import Path
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.engine.confidence import apply_confidence_downgrade
 from goldencheck.engine.scanner import scan_file
 from goldencheck.models.finding import Finding

--- a/packages/python/goldencheck/goldencheck/engine/differ.py
+++ b/packages/python/goldencheck/goldencheck/engine/differ.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.models.profile import DatasetProfile
 

--- a/packages/python/goldencheck/goldencheck/engine/fixer.py
+++ b/packages/python/goldencheck/goldencheck/engine/fixer.py
@@ -5,8 +5,7 @@ import re
 import unicodedata
 from dataclasses import dataclass, field
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding
 
 __all__ = ["apply_fixes", "FixReport", "FixEntry"]

--- a/packages/python/goldencheck/goldencheck/engine/reader.py
+++ b/packages/python/goldencheck/goldencheck/engine/reader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import polars as pl
+from goldencheck._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 SUPPORTED_EXTENSIONS = {".csv", ".parquet", ".xlsx", ".xls"}

--- a/packages/python/goldencheck/goldencheck/engine/referential.py
+++ b/packages/python/goldencheck/goldencheck/engine/referential.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.engine.reader import read_file
 from goldencheck.models.finding import Finding, Severity
 

--- a/packages/python/goldencheck/goldencheck/engine/sampler.py
+++ b/packages/python/goldencheck/goldencheck/engine/sampler.py
@@ -1,7 +1,7 @@
 """Smart sampling for large datasets."""
 from __future__ import annotations
 
-import polars as pl
+from goldencheck._polars_lazy import pl
 
 
 def maybe_sample(df: pl.DataFrame, max_rows: int = 100_000) -> pl.DataFrame:

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldencheck._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile

--- a/packages/python/goldencheck/goldencheck/engine/validator.py
+++ b/packages/python/goldencheck/goldencheck/engine/validator.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.config.schema import ColumnRule, GoldenCheckConfig
 from goldencheck.engine.reader import read_file
 from goldencheck.models.finding import Finding, Severity

--- a/packages/python/goldencheck/goldencheck/functional_dependencies.py
+++ b/packages/python/goldencheck/goldencheck/functional_dependencies.py
@@ -17,8 +17,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.relations import approx_fd as _afd
 from goldencheck.relations import functional_dependency as _fd

--- a/packages/python/goldencheck/goldencheck/llm/rule_generator.py
+++ b/packages/python/goldencheck/goldencheck/llm/rule_generator.py
@@ -6,9 +6,9 @@ import logging
 import os
 from pathlib import Path
 
-import polars as pl
 from pydantic import BaseModel
 
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldencheck/goldencheck/llm/sample_block.py
+++ b/packages/python/goldencheck/goldencheck/llm/sample_block.py
@@ -5,8 +5,7 @@ import logging
 import random
 from collections import defaultdict
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldencheck/goldencheck/profilers/base.py
+++ b/packages/python/goldencheck/goldencheck/profilers/base.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding
 
 

--- a/packages/python/goldencheck/goldencheck/profilers/base.py
+++ b/packages/python/goldencheck/goldencheck/profilers/base.py
@@ -9,5 +9,5 @@ from goldencheck.models.finding import Finding
 
 class BaseProfiler(ABC):
     @abstractmethod
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
         ...

--- a/packages/python/goldencheck/goldencheck/profilers/cardinality.py
+++ b/packages/python/goldencheck/goldencheck/profilers/cardinality.py
@@ -1,7 +1,6 @@
 """Cardinality profiler — detects low-cardinality columns that may be enum candidates."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -11,11 +10,10 @@ ENUM_MIN_ROWS = 50
 
 
 class CardinalityProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
         total = len(col)
         unique_count = col.n_unique()
 

--- a/packages/python/goldencheck/goldencheck/profilers/cardinality.py
+++ b/packages/python/goldencheck/goldencheck/profilers/cardinality.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -10,7 +11,9 @@ ENUM_MIN_ROWS = 50
 
 
 class CardinalityProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         total = len(col)

--- a/packages/python/goldencheck/goldencheck/profilers/cardinality.py
+++ b/packages/python/goldencheck/goldencheck/profilers/cardinality.py
@@ -1,8 +1,7 @@
 """Cardinality profiler — detects low-cardinality columns that may be enum candidates."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
@@ -1,16 +1,20 @@
 """Drift detection profiler — detects distribution drift between first and second half of data."""
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
-NUMERIC_DTYPES = (
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64,
-)
+
+@lru_cache(maxsize=1)
+def _numeric_dtypes() -> tuple:
+    return (
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Float32, pl.Float64,
+    )
 
 # Minimum row count to attempt drift detection (small samples are unreliable)
 MIN_ROWS = 1000
@@ -45,10 +49,10 @@ class DriftDetectionProfiler(BaseProfiler):
         non_null = col.drop_nulls()
         if len(non_null) > 0:
             unique_pct = non_null.n_unique() / len(non_null)
-            if unique_pct > 0.90 and col.dtype not in NUMERIC_DTYPES:
+            if unique_pct > 0.90 and col.dtype not in _numeric_dtypes():
                 return findings
 
-        is_numeric = col.dtype in NUMERIC_DTYPES
+        is_numeric = col.dtype in _numeric_dtypes()
 
         if is_numeric:
             # Numeric drift: compare means

--- a/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -29,7 +30,9 @@ CATEGORICAL_DRIFT_EXTREME = 0.50    # >50% new categories â†’ WARNING; 20-50% â†
 
 
 class DriftDetectionProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         total = len(col)

--- a/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
@@ -1,8 +1,7 @@
 """Encoding detection profiler — detects encoding anomalies in string columns."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -26,7 +27,9 @@ CONTROL_CHAR_PATTERN = r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]"
 
 
 class EncodingDetectionProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
 

--- a/packages/python/goldencheck/goldencheck/profilers/format_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/format_detection.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -17,7 +18,9 @@ FORMATS = [
 
 
 class FormatDetectionProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
 

--- a/packages/python/goldencheck/goldencheck/profilers/format_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/format_detection.py
@@ -1,8 +1,7 @@
 """Format detection profiler — detects email, phone, and URL patterns in string columns."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/freshness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/freshness.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import datetime as _dt
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -38,7 +39,9 @@ def _looks_like_update_column(name: str) -> bool:
 
 
 class FreshnessProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         col = df[column]
         is_datetime = col.dtype == pl.Datetime
         is_date = col.dtype == pl.Date

--- a/packages/python/goldencheck/goldencheck/profilers/freshness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/freshness.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 import datetime as _dt
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+++ b/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
@@ -22,9 +22,9 @@ old pure-Python DP), so the two paths agree.
 """
 from __future__ import annotations
 
-import polars as pl
 from rapidfuzz.distance import Levenshtein as _RFLevenshtein
 
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler

--- a/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+++ b/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
@@ -26,6 +26,7 @@ from rapidfuzz.distance import Levenshtein as _RFLevenshtein
 
 from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -106,7 +107,9 @@ def _python_clusters(values: list[str], min_similarity: float) -> list[list[int]
 
 
 class FuzzyValuesProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         if df.height < _MIN_ROWS:
             return []
         col = df[column]

--- a/packages/python/goldencheck/goldencheck/profilers/nullability.py
+++ b/packages/python/goldencheck/goldencheck/profilers/nullability.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class NullabilityProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         total = len(col)

--- a/packages/python/goldencheck/goldencheck/profilers/nullability.py
+++ b/packages/python/goldencheck/goldencheck/profilers/nullability.py
@@ -1,18 +1,16 @@
 """Nullability profiler — detects required vs. optional columns."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class NullabilityProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
         total = len(col)
         null_count = col.null_count()
         null_pct = null_count / total if total > 0 else 0

--- a/packages/python/goldencheck/goldencheck/profilers/nullability.py
+++ b/packages/python/goldencheck/goldencheck/profilers/nullability.py
@@ -1,8 +1,7 @@
 """Nullability profiler — detects required vs. optional columns."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
+++ b/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -58,7 +59,9 @@ def _generalize_series(s: pl.Series) -> pl.Series:
 
 
 class PatternConsistencyProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
 

--- a/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
+++ b/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
@@ -1,8 +1,7 @@
 """Pattern consistency profiler — detects inconsistent string patterns within a column."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
+++ b/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -18,7 +19,9 @@ def _numeric_dtypes() -> tuple:
 
 
 class RangeDistributionProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         dtype = col.dtype

--- a/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
+++ b/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
@@ -1,16 +1,20 @@
 """Range and distribution profiler — detects outliers and reports min/max for numeric columns."""
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
-NUMERIC_DTYPES = (
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64,
-)
+
+@lru_cache(maxsize=1)
+def _numeric_dtypes() -> tuple:
+    return (
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Float32, pl.Float64,
+    )
 
 
 class RangeDistributionProfiler(BaseProfiler):
@@ -18,7 +22,7 @@ class RangeDistributionProfiler(BaseProfiler):
         findings: list[Finding] = []
         col = df[column]
         dtype = col.dtype
-        is_numeric = dtype in NUMERIC_DTYPES
+        is_numeric = dtype in _numeric_dtypes()
 
         # Chain: if type inference flagged as mostly numeric, cast and run
         if not is_numeric and context and context.get(column, {}).get("mostly_numeric"):
@@ -27,7 +31,7 @@ class RangeDistributionProfiler(BaseProfiler):
         elif not is_numeric:
             return findings
 
-        non_null = col.drop_nulls() if is_numeric and dtype in NUMERIC_DTYPES else col
+        non_null = col.drop_nulls() if is_numeric and dtype in _numeric_dtypes() else col
         total = len(non_null)
         if total < 2:
             return findings

--- a/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
@@ -1,15 +1,19 @@
 """Sequence gap detection profiler — detects gaps in sequential integer columns."""
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
-INTEGER_DTYPES = (
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-)
+
+@lru_cache(maxsize=1)
+def _integer_dtypes() -> tuple:
+    return (
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+    )
 
 # Minimum fraction of consecutive diffs == 1 to consider column sequential.
 # We use this threshold on columns where the values increment exactly by 1 most of the time.
@@ -23,7 +27,7 @@ class SequenceDetectionProfiler(BaseProfiler):
         findings: list[Finding] = []
         col = df[column]
 
-        if col.dtype not in INTEGER_DTYPES:
+        if col.dtype not in _integer_dtypes():
             return findings
 
         non_null = col.drop_nulls()

--- a/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
@@ -23,7 +24,9 @@ SEQUENTIAL_THRESHOLD = 0.90
 
 
 class SequenceDetectionProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
 

--- a/packages/python/goldencheck/goldencheck/profilers/type_inference.py
+++ b/packages/python/goldencheck/goldencheck/profilers/type_inference.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class TypeInferenceProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         dtype = col.dtype

--- a/packages/python/goldencheck/goldencheck/profilers/type_inference.py
+++ b/packages/python/goldencheck/goldencheck/profilers/type_inference.py
@@ -1,8 +1,7 @@
 """Type inference profiler — detects mixed types and type mismatches."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
@@ -2,12 +2,15 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class UniquenessProfiler(BaseProfiler):
-    def profile(self, df: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         col = df[column]
         total = len(col)

--- a/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
@@ -1,8 +1,7 @@
 """Uniqueness profiler — detects primary key candidates and duplicates."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 

--- a/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/uniqueness.py
@@ -1,18 +1,16 @@
 """Uniqueness profiler — detects primary key candidates and duplicates."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class UniquenessProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
         total = len(col)
         non_null = col.drop_nulls()
         unique_count = non_null.n_unique() if len(non_null) > 0 else 0

--- a/packages/python/goldencheck/goldencheck/relations/age_validation.py
+++ b/packages/python/goldencheck/goldencheck/relations/age_validation.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 import datetime
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
 # Words that contain "age" but are NOT age columns

--- a/packages/python/goldencheck/goldencheck/relations/age_validation.py
+++ b/packages/python/goldencheck/goldencheck/relations/age_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import datetime
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 # Words that contain "age" but are NOT age columns
@@ -37,7 +38,9 @@ def _try_parse_dates(series: pl.Series) -> pl.Series:
 class AgeValidationProfiler:
     """Cross-validates age columns against date-of-birth columns."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
 
         age_cols = [c for c in df.columns if _is_age_column(c)]

--- a/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
@@ -22,6 +22,7 @@ this profiler is the deterministic normalize-and-group tier.
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _SEP = "\x1f"  # unit separator -- won't appear in normal data
@@ -52,7 +53,9 @@ def _exact_signature(df: pl.DataFrame) -> pl.Series:
 class ApproxDuplicateProfiler:
     """Dataset-level relation profiler: exact + near-duplicate rows."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         n_rows = df.height
         if n_rows < 2 or df.width == 0:
             return []

--- a/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
@@ -21,8 +21,7 @@ this profiler is the deterministic normalize-and-group tier.
 """
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
 _SEP = "\x1f"  # unit separator -- won't appear in normal data

--- a/packages/python/goldencheck/goldencheck/relations/approx_fd.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_fd.py
@@ -20,8 +20,9 @@ grouping columns qualify.
 """
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
 
@@ -30,19 +31,23 @@ _MIN_CONFIDENCE = 0.95
 _MIN_AVG_GROUP = 3  # must match goldencheck_core::MIN_AVG_GROUP
 _MAX_CANDIDATES = 12
 _MAX_FINDINGS = 8
-_SUPPORTED = (
-    pl.Utf8,
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Boolean,
-)
+
+
+@lru_cache(maxsize=1)
+def _supported() -> tuple:
+    return (
+        pl.Utf8,
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Boolean,
+    )
 
 
 def _select_candidates(df: pl.DataFrame) -> list[str]:
     scored: list[tuple[int, str]] = []
     for col in df.columns:
         series = df[col]
-        if series.dtype not in _SUPPORTED:
+        if series.dtype not in _supported():
             continue
         nu = series.n_unique()
         if nu <= 1:

--- a/packages/python/goldencheck/goldencheck/relations/approx_fd.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_fd.py
@@ -24,6 +24,7 @@ from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _MIN_ROWS = 100
@@ -115,7 +116,9 @@ def _discover_python(cols_ids: list[list[int]], n_rows: int, min_conf: float) ->
 class ApproximateFDProfiler:
     """Dataset-level relation profiler: near-FD violations (likely errors)."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         n_rows = df.height
         if n_rows < _MIN_ROWS or df.width < 2:
             return []

--- a/packages/python/goldencheck/goldencheck/relations/composite_key.py
+++ b/packages/python/goldencheck/goldencheck/relations/composite_key.py
@@ -23,6 +23,7 @@ from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 # A key wider than this is rarely a meaningful natural key and the search space
@@ -109,7 +110,9 @@ def _python_search(
 class CompositeKeyProfiler:
     """Dataset-level relation profiler: discover minimal composite keys."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         n_rows = df.height
         if n_rows < 2 or df.width < 2:
             return []

--- a/packages/python/goldencheck/goldencheck/relations/composite_key.py
+++ b/packages/python/goldencheck/goldencheck/relations/composite_key.py
@@ -19,8 +19,9 @@ information, not a violation.
 """
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
 
@@ -33,13 +34,15 @@ MAX_REPORTED_KEYS = 3
 
 # Dtypes the native interner supports; we restrict the Python path to the same
 # set so the two are parity-comparable on identical inputs.
-_SUPPORTED = (
-    pl.Utf8,
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64,
-    pl.Boolean,
-)
+@lru_cache(maxsize=1)
+def _supported() -> tuple:
+    return (
+        pl.Utf8,
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Float32, pl.Float64,
+        pl.Boolean,
+    )
 
 
 def _select_candidates(df: pl.DataFrame, n_rows: int) -> list[str]:
@@ -47,7 +50,7 @@ def _select_candidates(df: pl.DataFrame, n_rows: int) -> list[str]:
     scored: list[tuple[int, str]] = []
     for col in df.columns:
         series = df[col]
-        if series.dtype not in _SUPPORTED:
+        if series.dtype not in _supported():
             continue
         nu = series.n_unique()
         if nu <= 1:  # constant column can never help form a key

--- a/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
+++ b/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
@@ -26,6 +26,7 @@ from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _MIN_ROWS = 50          # enough support that a strict FD isn't a small-sample fluke
@@ -86,7 +87,9 @@ def _discover_python(df: pl.DataFrame, cols: list[str], n_rows: int) -> list[tup
 class FunctionalDependencyProfiler:
     """Dataset-level relation profiler: discover strict single-column FDs."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         n_rows = df.height
         if n_rows < _MIN_ROWS or df.width < 2:
             return []

--- a/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
+++ b/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
@@ -22,8 +22,9 @@ reports a bounded number of findings.
 """
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
 
@@ -31,12 +32,15 @@ _MIN_ROWS = 50          # enough support that a strict FD isn't a small-sample f
 _MAX_CANDIDATES = 12    # bound the O(k^2) pair space
 _MAX_FINDINGS = 10
 
-_SUPPORTED = (
-    pl.Utf8,
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Boolean,
-)
+
+@lru_cache(maxsize=1)
+def _supported() -> tuple:
+    return (
+        pl.Utf8,
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Boolean,
+    )
 
 
 def _select_candidates(df: pl.DataFrame, n_rows: int) -> list[str]:
@@ -45,7 +49,7 @@ def _select_candidates(df: pl.DataFrame, n_rows: int) -> list[str]:
     scored: list[tuple[int, str]] = []
     for col in df.columns:
         series = df[col]
-        if series.dtype not in _SUPPORTED:
+        if series.dtype not in _supported():
             continue
         nu = series.n_unique()
         if nu <= 1:

--- a/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
+++ b/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
@@ -26,6 +26,7 @@ Heuristic for a "PK candidate":
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 # Column-name prefixes/substrings that imply "this is data the user
@@ -120,7 +121,9 @@ class IdentitySafePkProfiler:
     Graph without explicit `source_pk_column`.
     """
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         if df.width == 0:
             return []
 

--- a/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
+++ b/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
@@ -25,8 +25,7 @@ Heuristic for a "PK candidate":
 """
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
 # Column-name prefixes/substrings that imply "this is data the user

--- a/packages/python/goldencheck/goldencheck/relations/null_correlation.py
+++ b/packages/python/goldencheck/goldencheck/relations/null_correlation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from itertools import combinations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _DEFAULT_THRESHOLD = 0.90
@@ -47,7 +48,9 @@ class NullCorrelationProfiler:
     def __init__(self, threshold: float = _DEFAULT_THRESHOLD) -> None:
         self.threshold = threshold
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
         columns = df.columns
         n_rows = len(df)

--- a/packages/python/goldencheck/goldencheck/relations/null_correlation.py
+++ b/packages/python/goldencheck/goldencheck/relations/null_correlation.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from itertools import combinations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
 _DEFAULT_THRESHOLD = 0.90

--- a/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
+++ b/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 
@@ -52,7 +53,9 @@ def _find_max_pairs(columns: list[str]) -> list[tuple[str, str]]:
 class NumericCrossColumnProfiler:
     """Detects rows where a numeric value exceeds a related maximum column."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
 
         # Value > Max checks

--- a/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
+++ b/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
@@ -1,15 +1,19 @@
 """Numeric cross-column validation — detects value > max violations and age/DOB mismatches."""
 from __future__ import annotations
 
-import polars as pl
+from functools import lru_cache
 
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
-NUMERIC_DTYPES = (
-    pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-    pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-    pl.Float32, pl.Float64,
-)
+
+@lru_cache(maxsize=1)
+def _numeric_dtypes() -> tuple:
+    return (
+        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+        pl.Float32, pl.Float64,
+    )
 
 # Heuristic pairs: (value_column_keyword, max_column_keyword)
 # The value column should be <= the max column
@@ -73,16 +77,16 @@ class NumericCrossColumnProfiler:
             return None
 
         # Both must be numeric
-        if val_series.dtype not in NUMERIC_DTYPES or max_series.dtype not in NUMERIC_DTYPES:
+        if val_series.dtype not in _numeric_dtypes() or max_series.dtype not in _numeric_dtypes():
             # Try casting strings to float
             try:
                 if val_series.dtype in (pl.Utf8, pl.String):
                     val_series = val_series.cast(pl.Float64, strict=False)
                 if max_series.dtype in (pl.Utf8, pl.String):
                     max_series = max_series.cast(pl.Float64, strict=False)
-                if val_series.dtype not in NUMERIC_DTYPES + (pl.Float64,):
+                if val_series.dtype not in _numeric_dtypes() + (pl.Float64,):
                     return None
-                if max_series.dtype not in NUMERIC_DTYPES + (pl.Float64,):
+                if max_series.dtype not in _numeric_dtypes() + (pl.Float64,):
                     return None
             except Exception:
                 return None

--- a/packages/python/goldencheck/goldencheck/relations/temporal.py
+++ b/packages/python/goldencheck/goldencheck/relations/temporal.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 # Pairs of (start-pattern, end-pattern) — matched against lowercased column names
@@ -71,7 +72,9 @@ def _try_cast_to_date(series: pl.Series) -> pl.Series:
 class TemporalOrderProfiler:
     """Checks that start-like date columns are <= end-like date columns."""
 
-    def profile(self, df: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+        frame = to_frame(frame)
+        df = frame.native
         findings: list[Finding] = []
 
         # Keyword-matched pairs (high confidence)

--- a/packages/python/goldencheck/goldencheck/relations/temporal.py
+++ b/packages/python/goldencheck/goldencheck/relations/temporal.py
@@ -1,8 +1,7 @@
 """Temporal order profiler — checks that start-like date columns precede end-like columns."""
 from __future__ import annotations
 
-import polars as pl
-
+from goldencheck._polars_lazy import pl
 from goldencheck.models.finding import Finding, Severity
 
 # Pairs of (start-pattern, end-pattern) — matched against lowercased column names

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -6,8 +6,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import polars as pl
 import yaml
+
+from goldencheck._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -1,0 +1,33 @@
+import polars as pl
+from goldencheck.core.frame import Column, Frame, to_frame
+
+
+def _f():
+    return to_frame(pl.DataFrame({"a": [1, 1, 2, None], "b": ["x", "y", "x", "z"]}))
+
+
+def test_frame_basics():
+    f = _f()
+    assert set(f.columns) == {"a", "b"}
+    assert f.height == 4
+    assert f.native.shape == (4, 2)                 # escape hatch = the pl.DataFrame
+    assert isinstance(f, Frame)                       # runtime_checkable
+
+
+def test_column_reductions_match_polars():
+    f = _f()
+    a = f.column("a")
+    assert isinstance(a, Column)
+    assert len(a) == 4                                # __len__
+    assert a.null_count() == 1
+    assert a.drop_nulls().n_unique() == 2
+    assert a.drop_nulls().unique().sort().to_list() == [1, 2]
+    assert f.column("b").n_unique() == 3
+
+
+def test_to_frame_idempotent_and_rejects_other():
+    f = _f()
+    assert to_frame(f) is f                           # PolarsFrame passes through unchanged
+    import pytest
+    with pytest.raises(TypeError):
+        to_frame([1, 2, 3])                            # not a DataFrame/Frame

--- a/packages/python/goldencheck/tests/core/test_polars_lazy.py
+++ b/packages/python/goldencheck/tests/core/test_polars_lazy.py
@@ -1,0 +1,8 @@
+def test_lazy_proxy_returns_real_polars_objects():
+    import polars as real_pl
+    from goldencheck._polars_lazy import pl
+
+    assert pl.DataFrame is real_pl.DataFrame          # attribute access returns the REAL class
+    df = pl.DataFrame({"a": [1, 2]})
+    assert isinstance(df, real_pl.DataFrame)          # isinstance works
+    assert pl.Utf8 is real_pl.Utf8                    # dtype access works

--- a/packages/python/goldencheck/tests/test_import_no_polars.py
+++ b/packages/python/goldencheck/tests/test_import_no_polars.py
@@ -1,14 +1,18 @@
 import os
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_import_goldencheck_does_not_load_polars():
     code = ("import goldencheck, sys; "
             "bad=[m for m in sys.modules if m=='polars' or m.startswith('polars.')]; "
             "assert not bad, bad")
+    # Anchor the subprocess PYTHONPATH to THIS package dir (…/packages/python/goldencheck),
+    # so the gate tests this checkout's goldencheck regardless of worktree/CWD.
+    pkg_dir = str(Path(__file__).resolve().parents[1])
     env = dict(os.environ)
-    env["PYTHONPATH"] = r"D:/show_case/gc-polars-evict/packages/python/goldencheck"
+    env["PYTHONPATH"] = pkg_dir + os.pathsep + env.get("PYTHONPATH", "")
     env["POLARS_SKIP_CPU_CHECK"] = "1"
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stdout + r.stderr

--- a/packages/python/goldencheck/tests/test_import_no_polars.py
+++ b/packages/python/goldencheck/tests/test_import_no_polars.py
@@ -1,0 +1,14 @@
+import os
+import subprocess
+import sys
+
+
+def test_import_goldencheck_does_not_load_polars():
+    code = ("import goldencheck, sys; "
+            "bad=[m for m in sys.modules if m=='polars' or m.startswith('polars.')]; "
+            "assert not bad, bad")
+    env = dict(os.environ)
+    env["PYTHONPATH"] = r"D:/show_case/gc-polars-evict/packages/python/goldencheck"
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr


### PR DESCRIPTION
## Summary
Stage 1 (P0) of evicting **Polars as a hard dependency** from goldencheck (driver: ~185 MB install weight; mirrors goldenflow's completed eviction). **Byte-identical, no version bump, no behavior change** — Polars stays a hard dep in P0; the runtime eviction + deps flip are later stages.

- **Lazy-import linchpin** — `_LazyPolars` proxy (copied from goldenflow) + swept 48 `import polars as pl` → `from goldencheck._polars_lazy import pl` + deferred the 7 module-level dtype-tuple constants (`@lru_cache`). Result: **`import goldencheck` loads zero Polars** (gated by `tests/test_import_no_polars.py`).
- **`Frame`/`Column` seam** (`core/frame.py`) — minimal Protocols + a `PolarsColumn` backend + idempotent `to_frame()`. `Column` = `{__len__, null_count, n_unique, drop_nulls, unique, sort, to_list}` (no dtype — added when a later port needs it).
- **Coercion routing** — all 21 `profile()` methods (12 column + 9 relation) coerce their first arg via `to_frame()`. Scanner is unchanged; the ~20 tests that pass a raw `pl.DataFrame` stay unedited (idempotent coercion).
- **3 profilers ported polars-free** — `nullability`/`cardinality`/`uniqueness` now go through the seam; their existing tests pass with zero edits (the parity gate).

The 5-stage program: **P0 (this)** → P1 reader Polars-free → P2 remaining profiler ports + decline-to-Polars tail → P3 `nopolars` CI lane → P4 the deps flip (`polars` → `[polars]` extra).

## Test plan
- [x] `tests/test_import_no_polars.py` — subprocess asserts no `polars`/`polars.*` in `sys.modules` after `import goldencheck` (→ `[]`)
- [x] `tests/core/test_frame.py`, `test_polars_lazy.py` — seam + proxy unit tests
- [x] **Full suite 734 passed / 6 skipped — byte-identical before and after** (measured via `git stash`); the 3 ported profilers' tests pass UNEDITED
- [x] Scope: `polars>=1.0` still a HARD dep (no P4 flip), no version bump, scanner/reader/CLI unchanged except the import-line sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1XRtDNuLQncCEx6aUQTST