### PR TITLE
refactor(goldencheck): Polars-eviction — port type_inference + fuzzy_values onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a.md
@@ -1,0 +1,209 @@
+# GoldenCheck Polars Eviction — Profiler Ports Batch A Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `type_inference` and `fuzzy_values` off Polars onto the P0 `Frame`/`Column` seam by adding 3 delegating `Column` methods (`dtype`, `cast`, `member_count`) — byte-identical, no version bump.
+
+**Architecture:** Continue P0's eviction. Add the ops these two profilers need to the `Column` seam; `PolarsColumn` delegates each to the exact Polars call the profiler uses today (so results are byte-identical and Polars stays the fast path). Then rewrite the two profiler bodies to use `frame.column(col)` + the new seam methods, removing their `pl` imports. The non-Polars implementation of the seam ops arrives with the Stage-2 substrate backend — not here.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-batch-a` worktree, STACKED on P0)
+
+Branch `feat/goldencheck-profiler-ports-batch-a`, worktree `D:\show_case\gc-batch-a`, stacked on `feat/goldencheck-polars-eviction-p0` (the P0 seam is present). Rebase onto fresh `origin/main` once P0 (#1605) merges (`git rebase --onto origin/main <P0-tip>`).
+
+**Test preamble** (from `/d/show_case/gc-batch-a`):
+```bash
+export PYTHONPATH="D:/show_case/gc-batch-a/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-batch-a
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. The 2 profilers' existing tests are the parity gate — they pass UNEDITED. The import-graph gate (`tests/test_import_no_polars.py`) and full suite stay green. No version bump. Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `Column` = `{__len__, null_count, n_unique, drop_nulls, unique, sort, to_list}`; `Frame` = `{columns, height, native, column(name)}`; `PolarsColumn`/`PolarsFrame` backends; idempotent `to_frame()`.
+
+---
+
+## Task 1: Add `dtype`, `cast`, `member_count` to the seam
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/core/frame.py`; Test `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Write failing seam unit tests** (append to `tests/core/test_frame.py`):
+```python
+def test_column_dtype_neutral_mapping():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    f = to_frame(pl.DataFrame({
+        "s": ["a"], "i": pl.Series([1], dtype=pl.Int64), "u": pl.Series([1], dtype=pl.UInt32),
+        "f": [1.5], "b": [True],
+    }))
+    assert f.column("s").dtype == "str"
+    assert f.column("i").dtype == "int"
+    assert f.column("u").dtype == "uint"      # DISTINCT from int (byte-identity for type_inference)
+    assert f.column("f").dtype == "float"
+    assert f.column("b").dtype == "other"
+
+def test_column_cast_uncastable_to_null():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["1", "2", "oops"]})).column("x")
+    casted = col.cast("float", strict=False)
+    assert casted.null_count() == 1            # "oops" -> null
+    assert len(casted) - casted.null_count() == 2
+    assert to_frame(pl.DataFrame({"x": ["1", "2"]})).column("x").cast("int", strict=False).to_list() == [1, 2]
+
+def test_column_member_count():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a", "b", "a", "c", None]})).column("x")
+    assert col.member_count(["a", "c"]) == 3   # a,a,c ; matches int(s.is_in(v).sum())
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PolarsColumn' object has no attribute 'dtype'`). `$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "dtype or cast or member" -v`
+
+- [ ] **Step 3: Implement.** Add to the `Column` Protocol (after `to_list`):
+```python
+    @property
+    def dtype(self) -> str: ...
+    def cast(self, kind: str, *, strict: bool = False) -> Column: ...
+    def member_count(self, values: list) -> int: ...
+```
+Add a module-level dtype map + a cast-kind map (near the top, after imports — inside a function or as a lazily-built helper so no module-level `pl.` executes at import; the seam file itself is import-gate-sensitive):
+```python
+def _neutral_dtype(dt: Any) -> str:
+    if dt in (pl.Utf8, pl.String):
+        return "str"
+    if dt in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
+        return "int"
+    if dt in (pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64):
+        return "uint"
+    if dt in (pl.Float32, pl.Float64):
+        return "float"
+    if dt == pl.Date:
+        return "date"
+    if dt == pl.Datetime:
+        return "datetime"
+    return "other"
+
+_CAST_KIND = {"float": "Float64", "int": "Int64"}  # resolved to pl types lazily in cast()
+```
+(Both `_neutral_dtype` and the `cast` body reference `pl.` only INSIDE function bodies — never at module scope — so the import gate stays green.)
+Add to `PolarsColumn`:
+```python
+    @property
+    def dtype(self) -> str:
+        return _neutral_dtype(self._s.dtype)
+
+    def cast(self, kind: str, *, strict: bool = False) -> PolarsColumn:
+        pl_type = getattr(pl, _CAST_KIND[kind])
+        return PolarsColumn(self._s.cast(pl_type, strict=strict))
+
+    def member_count(self, values: list) -> int:
+        return int(self._s.is_in(values).sum())
+```
+(`__slots__` on PolarsColumn is `("_s",)` — a `@property` needs no slot, fine.)
+
+- [ ] **Step 4: Run → PASS.** Then the import gate must stay green (the new `pl.` refs are all in-function): `$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v`. Ruff clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-batch-a
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add dtype/cast/member_count to the Frame seam (PolarsColumn delegates)"
+```
+
+---
+
+## Task 2: Port `type_inference` onto the seam
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/type_inference.py`
+
+- [ ] **Step 1: Port the body.** Current state: `frame = to_frame(frame)`; `df = frame.native`; `col = df[column]`; `dtype = col.dtype`. Rewrite to use the seam:
+  - Remove `df = frame.native`; `col = frame.column(column)`; `dt = col.dtype`.
+  - `if dt == "str":` (was `dtype == pl.Utf8 or dtype == pl.String` — `"str"` covers both).
+  - `non_null = col.drop_nulls()`; `if len(non_null) == 0: return findings`.
+  - `cast_result = non_null.cast("float", strict=False)`; `numeric_count = len(non_null) - cast_result.null_count()` (byte-identical to `non_null.cast(pl.Float64, strict=False).is_not_null().sum()` — cast preserves length; both count non-nulls; both `int`).
+  - `int_cast = non_null.cast("int", strict=False)`; `int_count = len(non_null) - int_cast.null_count()`.
+  - The SHOULD_BE_STRING gate: `if dt in ("int", "float"):` (was signed-ints+floats only — `"int"` is signed, `"uint"` is EXCLUDED, so byte-identical; a `UInt` column is not flagged, same as today).
+  - Keep all thresholds/messages/Finding construction UNCHANGED.
+  - Remove `from goldencheck._polars_lazy import pl` (no longer referenced).
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-a && <preamble>
+ls packages/python/goldencheck/tests/profilers | grep -i "type_infer"
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_type_inference.py -v
+```
+Expected: all pass, ZERO test edits (byte-identical Findings). If a test fails, the port diverged — fix the PORT (likely the numeric-count or the dtype gate), never the test.
+
+- [ ] **Step 3: Confirm polars-free + import gate.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/profilers/type_inference.py || echo "type_inference polars-free"
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/type_inference.py
+git commit -m "refactor(goldencheck): port type_inference onto the Frame seam (polars-free)"
+```
+
+---
+
+## Task 3: Port `fuzzy_values` onto the seam + final verification
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py`
+
+- [ ] **Step 1: Port the body.** Current: `frame = to_frame(frame)`; `df = frame.native`; `df.height`; `col = df[column]`; `col.dtype != pl.Utf8`; `distinct = col.drop_nulls().unique()`; `distinct.len()`; `distinct.to_list()`; `col.is_in(variants).sum()`. Rewrite:
+  - Remove `df = frame.native`.
+  - `if frame.height < _MIN_ROWS: return []` (`Frame.height` exists).
+  - `col = frame.column(column)`; `if col.dtype != "str": return []` (was `!= pl.Utf8`; `"str"` covers Utf8/String, and `pl.Categorical → "other"` stays excluded, matching today).
+  - `distinct = col.drop_nulls().unique()`; `n_distinct = len(distinct)` (was `distinct.len()` — `__len__`); `values = distinct.to_list()`.
+  - Clustering block UNCHANGED (`values` is `list[str]`; native/`_python_clusters` untouched).
+  - `affected_rows=col.member_count(variants)` (was `int(col.is_in(variants).sum())`).
+  - Keep everything else (messages, metadata, `_python_clusters`, rapidfuzz import) UNCHANGED.
+  - Remove `from goldencheck._polars_lazy import pl` (no longer referenced).
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-a && <preamble>
+ls packages/python/goldencheck/tests/profilers | grep -i "fuzzy"
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_fuzzy_values.py -v
+```
+Expected: all pass, ZERO edits. Run BOTH lanes (native + fallback) since fuzzy has a native path:
+```bash
+GOLDENCHECK_NATIVE=1 $PY -m pytest packages/python/goldencheck/tests/profilers/test_fuzzy_values.py -q
+GOLDENCHECK_NATIVE=0 $PY -m pytest packages/python/goldencheck/tests/profilers/test_fuzzy_values.py -q
+```
+(If the native ext isn't built in this worktree, the native lane simply falls back — that's fine; report it.)
+
+- [ ] **Step 3: Final verification.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py || echo "fuzzy_values polars-free"
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite byte-identical
+```
+Expected: fuzzy_values polars-free; import gate green; full suite same pass/skip counts as the P0 baseline. Ruff clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+git commit -m "refactor(goldencheck): port fuzzy_values onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (Batch A complete)
+- [ ] `Column` seam gained `dtype`/`cast`/`member_count` (PolarsColumn delegates; import gate still green — all new `pl.` refs are in-function).
+- [ ] `type_inference` + `fuzzy_values` are polars-free (grep-clean) and route through the seam.
+- [ ] Both profilers' existing tests pass with ZERO edits (byte-identical Findings — the parity gate).
+- [ ] Full suite green (same counts); `import goldencheck` loads zero Polars.
+- [ ] No scope creep: `format_detection`/`encoding_detection` (Batch A2), `pattern_consistency`, Batches B/C, the substrate backend, reader, and deps flip are all untouched.

--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a.md
@@ -133,7 +133,7 @@ git commit -m "feat(goldencheck): add dtype/cast/member_count to the Frame seam 
   - `int_cast = non_null.cast("int", strict=False)`; `int_count = len(non_null) - int_cast.null_count()`.
   - The SHOULD_BE_STRING gate: `if dt in ("int", "float"):` (was signed-ints+floats only — `"int"` is signed, `"uint"` is EXCLUDED, so byte-identical; a `UInt` column is not flagged, same as today).
   - Keep all thresholds/messages/Finding construction UNCHANGED.
-  - Remove `from goldencheck._polars_lazy import pl` (no longer referenced).
+  - **Drop BOTH the `pl` import AND the `frame: pl.DataFrame` annotation** → `def profile(self, frame, column: str, *, context: dict | None = None)` (matching the P0-ported `nullability`/`cardinality`/`uniqueness`). Leaving `: pl.DataFrame` keeps a `pl` reference that the Step-3 polars-free grep flags.
 
 - [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
 ```bash
@@ -170,7 +170,7 @@ git commit -m "refactor(goldencheck): port type_inference onto the Frame seam (p
   - Clustering block UNCHANGED (`values` is `list[str]`; native/`_python_clusters` untouched).
   - `affected_rows=col.member_count(variants)` (was `int(col.is_in(variants).sum())`).
   - Keep everything else (messages, metadata, `_python_clusters`, rapidfuzz import) UNCHANGED.
-  - Remove `from goldencheck._polars_lazy import pl` (no longer referenced).
+  - **Drop BOTH the `pl` import AND the `frame: pl.DataFrame` annotation** → `def profile(self, frame, column: str, *, context: dict | None = None)` (matching the P0 profilers). Leaving `: pl.DataFrame` keeps a `pl` reference the Step-3 grep flags.
 
 - [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
 ```bash

--- a/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a-design.md
@@ -1,0 +1,109 @@
+# GoldenCheck Polars eviction — Profiler ports Batch A (dtype + string/cast/membership seam)
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: stacked on `feat/goldencheck-polars-eviction-p0` (P0 seam); rebase onto fresh `origin/main` once P0 (#1605) merges
+Parent program: goldencheck Polars eviction (see `2026-07-08-goldencheck-polars-eviction-p0-design.md`)
+
+## Context
+
+P0 (PR #1605) added the `Frame`/`Column` seam (`goldencheck/core/frame.py`, one `PolarsColumn`
+backend) and ported 3 profilers (nullability/cardinality/uniqueness) polars-free. `import
+goldencheck` loads zero Polars. This stage continues the incremental profiler ports.
+
+**Staging correction (discovered after P0):** the reader eviction is NOT next — `read_file`
+returns a `pl.DataFrame` and the scanner does Polars ops on it directly (`classify_columns`,
+`select`, `apply_rules`, drift), so a non-Polars reader requires the whole scan path to be
+Polars-free first. The reader is a *late* stage (goldenflow did its CSV path in Phase 4e). The real
+next increment is porting more profilers onto the seam.
+
+**Seam philosophy (decided):** operations Polars does today (`str.contains`, numeric `cast`,
+`is_in`) are added to the `Column` seam and `PolarsColumn` delegates to the exact Polars call —
+byte-identical, **no perf regression** (Polars stays the fast path), profiler decoupled from
+Polars. The *non-Polars* implementation of these ops arrives with the Stage-2 substrate backend;
+it is NOT this stage's concern. This is goldenflow's "Polars as accelerator" model and pushes the
+regex-vs-Python byte-identity risk to Stage 2 where it belongs.
+
+## Scope
+
+### In scope — port 4 profilers (the "dtype-only" batch)
+`type_inference`, `format_detection`, `encoding_detection`, `fuzzy_values`. Recon confirmed these
+need only a `dtype` accessor plus a few op-shaped seam methods (below); the rest of their logic is
+plain-Python thresholds + Finding construction.
+
+### Explicitly NOT in scope
+`pattern_consistency` (its `_generalize` is the #3 cProfile self-time hotspot at 100K rows — needs
+a vectorized `str.replace_all` + `value_counts` seam op; a later batch). Batch B (`freshness`,
+`range_distribution`, `sequence_detection` — need scalar stats min/max/mean/std). Batch C
+(`drift_detection` — positional slicing + stats + cast + is_in). The Stage-2 non-Polars backend.
+No reader, no deps flip.
+
+### Success criteria
+- The 4 profilers are polars-free (import no `pl`), routing through the seam.
+- Their existing tests pass **unedited** (byte-identical Findings — the parity gate).
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
+
+Five new `Column` methods (+ an optional `Frame.dtype(name)` thin wrapper). Each `PolarsColumn`
+method delegates to the exact Polars call the profiler uses today, so ports are byte-identical:
+
+| Method | Signature | PolarsColumn impl | Used by |
+|---|---|---|---|
+| `dtype` | `-> str` | neutral map (below) | all 4 (dtype gates) |
+| `cast` | `cast(kind: str, *, strict: bool = False) -> Column` | `PolarsColumn(self._s.cast(_pl(kind), strict=strict))` | type_inference |
+| `str_match_count` | `str_match_count(pattern: str) -> int` | `int(self._s.str.contains(pattern).sum())` | format, encoding |
+| `str_not_matching` | `str_not_matching(pattern: str, limit: int) -> list` | `self._s.filter(~self._s.str.contains(pattern)).head(limit).to_list()` | format, encoding |
+| `member_count` | `member_count(values: list) -> int` | `int(self._s.is_in(values).sum())` | fuzzy_values |
+
+**Neutral `dtype` mapping** (`PolarsColumn.dtype`): `pl.Utf8`/`pl.String → "str"`; `pl.Int8..Int64`,
+`pl.UInt8..UInt64 → "int"`; `pl.Float32/Float64 → "float"`; `pl.Date → "date"`; `pl.Datetime →
+"datetime"`; else `"other"`. Keeps int/float and date/datetime distinct (Batch A + later batches
+rely on it). `cast`'s `kind` accepts `"float"`/`"int"` mapped to `pl.Float64`/`pl.Int64`.
+
+`str_match_count`/`str_not_matching` operate on the column as-is; the profilers call them on a
+`drop_nulls()`'d Column (existing seam op), so null handling matches today's `non_null.str.contains`.
+
+## The 4 ports
+
+- **type_inference** — `frame.dtype/col.dtype` gate; for numeric-parse counting:
+  `casted = col.drop_nulls().cast("float", strict=False)`; `parseable = len(casted) - casted.null_count()`
+  (replaces `.cast(pl.Float64, strict=False).is_not_null().sum()`). Same for int.
+- **format_detection** — `col.dtype == "str"` gate; `match = col.drop_nulls().str_match_count(pat)`;
+  `samples = col.drop_nulls().str_not_matching(pat, 5)`. Replaces the `str.contains(...).sum()` +
+  `filter(~...).head(5).to_list()`.
+- **encoding_detection** — same shape as format_detection, its 4 patterns each via
+  `str_match_count` / `str_not_matching`.
+- **fuzzy_values** — `col.dtype == "str"` gate; distinct values via existing
+  `col.drop_nulls().unique().to_list()`; clustering unchanged (already `list[str]` through
+  `core/kernels.py`); `affected_rows = col.member_count(variants)` (replaces `is_in(variants).sum()`).
+
+Each ported file removes its `from goldencheck._polars_lazy import pl` import → polars-free.
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): each new `PolarsColumn` method equals
+  the raw Polars call it wraps (`dtype` mapping for each pl type; `cast` uncastable→null;
+  `str_match_count`/`str_not_matching` on a mixed column; `member_count`).
+- **Parity gate:** the 4 profilers' existing test files pass with ZERO edits (byte-identical). If a
+  test diverges, the port broke byte-identity — fix the port, never the test.
+- **Regression:** full suite green (same counts + these); import gate green; the 4 files grep-clean
+  of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`dtype` neutral-map lossiness** — mitigated: int/float and date/datetime kept distinct; Batch A
+  only needs str/int/float, later batches need date/datetime (present). If a profiler ever needs a
+  finer distinction (Int32 vs Int64, tz-aware Datetime), add it to the map then (YAGNI now).
+- **Seam growth** — 5 methods is proportionate to a 4-profiler batch; each is a one-line delegate.
+  Do NOT over-add (no `str_contains`→bool-Column + `filter` primitive algebra; the task-shaped
+  `str_match_count`/`str_not_matching` are what the profilers actually need).
+- **Byte-identity of the new ops** — by construction (PolarsColumn calls the same Polars method);
+  the parity tests are the proof. The regex-vs-Python risk is NOT here (Polars regex under the hood)
+  — it moves to Stage 2's non-Polars backend.
+- **Stacked base** — this branch stacks on unmerged P0; rebase onto fresh `origin/main` once P0
+  merges (`git rebase --onto origin/main <P0-tip>`), or land after P0.
+
+## Non-goals (YAGNI)
+pattern_consistency; Batches B/C; scalar stats / `.str`/`.dt` vectorized seam ops; the Stage-2
+non-Polars backend; reader; deps flip.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a-design.md
@@ -1,4 +1,4 @@
-# GoldenCheck Polars eviction — Profiler ports Batch A (dtype + string/cast/membership seam)
+# GoldenCheck Polars eviction — Profiler ports Batch A (dtype + cast + membership seam)
 
 Date: 2026-07-09
 Status: design — approved in brainstorming, pending spec review
@@ -26,12 +26,18 @@ regex-vs-Python byte-identity risk to Stage 2 where it belongs.
 
 ## Scope
 
-### In scope — port 4 profilers (the "dtype-only" batch)
-`type_inference`, `format_detection`, `encoding_detection`, `fuzzy_values`. Recon confirmed these
-need only a `dtype` accessor plus a few op-shaped seam methods (below); the rest of their logic is
-plain-Python thresholds + Finding construction.
+### In scope — port 2 profilers (narrowed after spec review)
+`type_inference` and `fuzzy_values`. Spec review found `format_detection` and `encoding_detection`
+each use a Polars op NOT covered by a simple seam addition and NOT expressible byte-identically
+without a string-predicate **filter/sampler** family: `format_detection` has a *cross-format* block
+`non_null.filter(~matchesA).str.contains(B).sum()` ("count rows not matching A that match B"), and
+`encoding_detection` samples the *matching* rows (`filter(mask).head(5)`), not the complement. Those
+two need a properly-designed positive+negative string sampler + a filtered-count op, worked out from
+a complete reading — a **separate follow-up batch** ("Batch A2"), NOT this one. `type_inference` and
+`fuzzy_values` port cleanly with a `dtype` accessor + `cast` + `member_count`, so Batch A ships them.
 
 ### Explicitly NOT in scope
+`format_detection`, `encoding_detection` (Batch A2 — need the string filter/sampler seam family).
 `pattern_consistency` (its `_generalize` is the #3 cProfile self-time hotspot at 100K rows — needs
 a vectorized `str.replace_all` + `value_counts` seam op; a later batch). Batch B (`freshness`,
 `range_distribution`, `sequence_detection` — need scalar stats min/max/mean/std). Batch C
@@ -39,71 +45,76 @@ a vectorized `str.replace_all` + `value_counts` seam op; a later batch). Batch B
 No reader, no deps flip.
 
 ### Success criteria
-- The 4 profilers are polars-free (import no `pl`), routing through the seam.
+- `type_inference` and `fuzzy_values` are polars-free (import no `pl`), routing through the seam.
 - Their existing tests pass **unedited** (byte-identical Findings — the parity gate).
 - Full suite green; `import goldencheck` still loads zero Polars.
 
 ## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
 
-Five new `Column` methods (+ an optional `Frame.dtype(name)` thin wrapper). Each `PolarsColumn`
+Three new `Column` methods (+ an optional `Frame.dtype(name)` thin wrapper). Each `PolarsColumn`
 method delegates to the exact Polars call the profiler uses today, so ports are byte-identical:
 
 | Method | Signature | PolarsColumn impl | Used by |
 |---|---|---|---|
-| `dtype` | `-> str` | neutral map (below) | all 4 (dtype gates) |
+| `dtype` | `-> str` | neutral map (below) | both (dtype gates) |
 | `cast` | `cast(kind: str, *, strict: bool = False) -> Column` | `PolarsColumn(self._s.cast(_pl(kind), strict=strict))` | type_inference |
-| `str_match_count` | `str_match_count(pattern: str) -> int` | `int(self._s.str.contains(pattern).sum())` | format, encoding |
-| `str_not_matching` | `str_not_matching(pattern: str, limit: int) -> list` | `self._s.filter(~self._s.str.contains(pattern)).head(limit).to_list()` | format, encoding |
 | `member_count` | `member_count(values: list) -> int` | `int(self._s.is_in(values).sum())` | fuzzy_values |
 
-**Neutral `dtype` mapping** (`PolarsColumn.dtype`): `pl.Utf8`/`pl.String → "str"`; `pl.Int8..Int64`,
-`pl.UInt8..UInt64 → "int"`; `pl.Float32/Float64 → "float"`; `pl.Date → "date"`; `pl.Datetime →
-"datetime"`; else `"other"`. Keeps int/float and date/datetime distinct (Batch A + later batches
-rely on it). `cast`'s `kind` accepts `"float"`/`"int"` mapped to `pl.Float64`/`pl.Int64`.
+**Neutral `dtype` mapping** (`PolarsColumn.dtype`): `pl.Utf8`/`pl.String → "str"`; `pl.Int8..Int64
+→ "int"`; `pl.UInt8..UInt64 → "uint"` (**kept DISTINCT from `int`** — see the byte-identity note);
+`pl.Float32/Float64 → "float"`; `pl.Date → "date"`; `pl.Datetime → "datetime"`; else `"other"`.
+`cast`'s `kind` accepts `"float"`/`"int"` mapped to `pl.Float64`/`pl.Int64`.
 
-`str_match_count`/`str_not_matching` operate on the column as-is; the profilers call them on a
-`drop_nulls()`'d Column (existing seam op), so null handling matches today's `non_null.str.contains`.
+**Byte-identity note (UInt):** `type_inference`'s "should-be-string" numeric gate is currently
+`dtype in (pl.Int8..Int64, pl.Float32/Float64)` — **signed ints + floats only, NO UInt**. So the map
+MUST keep `uint` distinct from `int`, and the port's numeric gate checks `dtype in ("int", "float")`
+(excluding `uint`) to stay byte-identical. Folding UInt→"int" would fire the warning on a `UInt`
+column the current code ignores.
 
-## The 4 ports
+## The 2 ports
 
-- **type_inference** — `frame.dtype/col.dtype` gate; for numeric-parse counting:
-  `casted = col.drop_nulls().cast("float", strict=False)`; `parseable = len(casted) - casted.null_count()`
-  (replaces `.cast(pl.Float64, strict=False).is_not_null().sum()`). Same for int.
-- **format_detection** — `col.dtype == "str"` gate; `match = col.drop_nulls().str_match_count(pat)`;
-  `samples = col.drop_nulls().str_not_matching(pat, 5)`. Replaces the `str.contains(...).sum()` +
-  `filter(~...).head(5).to_list()`.
-- **encoding_detection** — same shape as format_detection, its 4 patterns each via
-  `str_match_count` / `str_not_matching`.
-- **fuzzy_values** — `col.dtype == "str"` gate; distinct values via existing
-  `col.drop_nulls().unique().to_list()`; clustering unchanged (already `list[str]` through
-  `core/kernels.py`); `affected_rows = col.member_count(variants)` (replaces `is_in(variants).sum()`).
+- **type_inference** — `col.dtype` gate: `== "str"` (was `pl.Utf8`; note `pl.Utf8 is pl.String` in
+  current polars, so `"str"` covers both); the should-be-string numeric gate uses
+  `dtype in ("int", "float")` (signed+float only — NOT `uint`). For numeric-parse counting:
+  `casted = col.drop_nulls().cast("float", strict=False)`;
+  `parseable = len(casted) - casted.null_count()` (byte-identical to
+  `.cast(pl.Float64, strict=False).is_not_null().sum()` — both count non-nulls, cast preserves
+  length). Same for int.
+- **fuzzy_values** — `col.dtype == "str"` gate (`pl.Utf8`/`pl.String → "str"`; `pl.Categorical →
+  "other"`, excluded, matching today); distinct values via existing
+  `col.drop_nulls().unique().to_list()` + Python `len()`; clustering unchanged (already `list[str]`
+  through `core/kernels.py`); `affected_rows = col.member_count(variants)` (byte-identical to
+  `int(col.is_in(variants).sum())`, both on the full column).
 
 Each ported file removes its `from goldencheck._polars_lazy import pl` import → polars-free.
 
 ## Testing
 
 - **Seam unit tests** (`tests/core/test_frame.py` additions): each new `PolarsColumn` method equals
-  the raw Polars call it wraps (`dtype` mapping for each pl type; `cast` uncastable→null;
-  `str_match_count`/`str_not_matching` on a mixed column; `member_count`).
-- **Parity gate:** the 4 profilers' existing test files pass with ZERO edits (byte-identical). If a
-  test diverges, the port broke byte-identity — fix the port, never the test.
-- **Regression:** full suite green (same counts + these); import gate green; the 4 files grep-clean
+  the raw Polars call it wraps — `dtype` mapping for each pl type (incl. a `pl.UInt32` series →
+  `"uint"`, distinct from `int`); `cast("float"/"int", strict=False)` uncastable→null; `member_count`.
+- **Parity gate:** the `type_inference` + `fuzzy_values` existing test files pass with ZERO edits
+  (byte-identical). If a test diverges, the port broke byte-identity — fix the port, never the test.
+- **Regression:** full suite green (same counts); import gate green; the 2 ported files grep-clean
   of `polars`/`_polars_lazy`/`pl.`.
 
 ## Risks
 
-- **`dtype` neutral-map lossiness** — mitigated: int/float and date/datetime kept distinct; Batch A
-  only needs str/int/float, later batches need date/datetime (present). If a profiler ever needs a
-  finer distinction (Int32 vs Int64, tz-aware Datetime), add it to the map then (YAGNI now).
-- **Seam growth** — 5 methods is proportionate to a 4-profiler batch; each is a one-line delegate.
-  Do NOT over-add (no `str_contains`→bool-Column + `filter` primitive algebra; the task-shaped
-  `str_match_count`/`str_not_matching` are what the profilers actually need).
+- **`dtype` neutral-map lossiness** — mitigated: int/uint/float/date/datetime kept distinct (the
+  UInt distinction is byte-identity-load-bearing for `type_inference`; see the note above). If a
+  profiler ever needs a finer distinction (Int32 vs Int64, tz-aware Datetime, Boolean, Categorical),
+  add it to the map then (YAGNI now — Batch A needs only str/int/uint/float).
+- **Seam growth** — only 3 methods (dtype/cast/member_count), each a one-line delegate. The string
+  `str.contains`/filter/sampler ops that format/encoding need are DEFERRED to Batch A2 where they'll
+  be designed from a complete reading (positive+negative samplers + a cross-format filtered-count) —
+  NOT half-added here.
 - **Byte-identity of the new ops** — by construction (PolarsColumn calls the same Polars method);
-  the parity tests are the proof. The regex-vs-Python risk is NOT here (Polars regex under the hood)
-  — it moves to Stage 2's non-Polars backend.
+  the parity tests are the proof. The regex-vs-Python risk is NOT here (no string ops this batch);
+  it moves to Stage 2's non-Polars backend.
 - **Stacked base** — this branch stacks on unmerged P0; rebase onto fresh `origin/main` once P0
   merges (`git rebase --onto origin/main <P0-tip>`), or land after P0.
 
 ## Non-goals (YAGNI)
+`format_detection`, `encoding_detection` (Batch A2 — string filter/sampler seam family);
 pattern_consistency; Batches B/C; scalar stats / `.str`/`.dt` vectorized seam ops; the Stage-2
 non-Polars backend; reader; deps flip.

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -21,6 +21,10 @@ class Column(Protocol):
     def unique(self) -> Column: ...
     def sort(self) -> Column: ...
     def to_list(self) -> list: ...
+    @property
+    def dtype(self) -> str: ...
+    def cast(self, kind: str, *, strict: bool = False) -> Column: ...
+    def member_count(self, values: list) -> int: ...
 
 
 @runtime_checkable
@@ -32,6 +36,25 @@ class Frame(Protocol):
     @property
     def native(self) -> Any: ...
     def column(self, name: str) -> Column: ...
+
+
+def _neutral_dtype(dt: Any) -> str:
+    if dt in (pl.Utf8, pl.String):
+        return "str"
+    if dt in (pl.Int8, pl.Int16, pl.Int32, pl.Int64):
+        return "int"
+    if dt in (pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64):
+        return "uint"
+    if dt in (pl.Float32, pl.Float64):
+        return "float"
+    if dt == pl.Date:
+        return "date"
+    if dt == pl.Datetime:
+        return "datetime"
+    return "other"
+
+
+_CAST_KIND = {"float": "Float64", "int": "Int64"}   # strings only; resolved via getattr in cast()
 
 
 class PolarsColumn:
@@ -60,6 +83,17 @@ class PolarsColumn:
 
     def to_list(self) -> list:
         return self._s.to_list()
+
+    @property
+    def dtype(self) -> str:
+        return _neutral_dtype(self._s.dtype)
+
+    def cast(self, kind: str, *, strict: bool = False) -> PolarsColumn:
+        pl_type = getattr(pl, _CAST_KIND[kind])
+        return PolarsColumn(self._s.cast(pl_type, strict=strict))
+
+    def member_count(self, values: list) -> int:
+        return int(self._s.is_in(values).sum())
 
 
 class PolarsFrame:

--- a/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
+++ b/packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 from rapidfuzz.distance import Levenshtein as _RFLevenshtein
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
@@ -107,16 +106,15 @@ def _python_clusters(values: list[str], min_similarity: float) -> list[list[int]
 
 
 class FuzzyValuesProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        if df.height < _MIN_ROWS:
+        if frame.height < _MIN_ROWS:
             return []
-        col = df[column]
-        if col.dtype != pl.Utf8:
+        col = frame.column(column)
+        if col.dtype != "str":
             return []
         distinct = col.drop_nulls().unique()
-        n_distinct = distinct.len()
+        n_distinct = len(distinct)
         if n_distinct < _MIN_DISTINCT or n_distinct > _MAX_DISTINCT:
             return []
 
@@ -149,7 +147,7 @@ class FuzzyValuesProfiler(BaseProfiler):
                     f"like variants of one another: {', '.join(repr(v) for v in shown)}"
                     f"{' …' if len(variants) > len(shown) else ''}."
                 ),
-                affected_rows=int(col.is_in(variants).sum()),
+                affected_rows=col.member_count(variants),
                 sample_values=[str(v) for v in shown],
                 suggestion=(
                     "Standardize these to a single canonical value (casing/spelling), "

--- a/packages/python/goldencheck/goldencheck/profilers/type_inference.py
+++ b/packages/python/goldencheck/goldencheck/profilers/type_inference.py
@@ -1,29 +1,27 @@
 """Type inference profiler — detects mixed types and type mismatches."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 
 class TypeInferenceProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
-        dtype = col.dtype
-        if dtype == pl.Utf8 or dtype == pl.String:
+        col = frame.column(column)
+        dt = col.dtype
+        if dt == "str":
             non_null = col.drop_nulls()
             if len(non_null) == 0:
                 return findings
-            cast_result = non_null.cast(pl.Float64, strict=False)
-            numeric_count = cast_result.is_not_null().sum()
+            cast_result = non_null.cast("float", strict=False)
+            numeric_count = len(non_null) - cast_result.null_count()
             numeric_pct = numeric_count / len(non_null) if len(non_null) > 0 else 0
             if numeric_pct >= 0.8:
-                int_cast = non_null.cast(pl.Int64, strict=False)
-                int_count = int_cast.is_not_null().sum()
+                int_cast = non_null.cast("int", strict=False)
+                int_count = len(non_null) - int_cast.null_count()
                 int_pct = int_count / len(non_null)
                 type_name = "integer" if int_pct > 0.9 else "numeric"
                 non_numeric = len(non_null) - numeric_count
@@ -50,7 +48,7 @@ class TypeInferenceProfiler(BaseProfiler):
 
         # Check: integer/float column that should be string based on name
         SHOULD_BE_STRING = ["zip", "postal", "phone", "fax", "ssn", "npi", "id", "code", "sku"]
-        if dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64):
+        if dt in ("int", "float"):
             col_lower = column.lower()
             for hint in SHOULD_BE_STRING:
                 if hint in col_lower:

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -31,3 +31,34 @@ def test_to_frame_idempotent_and_rejects_other():
     import pytest
     with pytest.raises(TypeError):
         to_frame([1, 2, 3])                            # not a DataFrame/Frame
+
+
+def test_column_dtype_neutral_mapping():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    f = to_frame(pl.DataFrame({
+        "s": ["a"], "i": pl.Series([1], dtype=pl.Int64), "u": pl.Series([1], dtype=pl.UInt32),
+        "f": [1.5], "b": [True],
+    }))
+    assert f.column("s").dtype == "str"
+    assert f.column("i").dtype == "int"
+    assert f.column("u").dtype == "uint"      # DISTINCT from int (byte-identity for type_inference)
+    assert f.column("f").dtype == "float"
+    assert f.column("b").dtype == "other"
+
+
+def test_column_cast_uncastable_to_null():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["1", "2", "oops"]})).column("x")
+    casted = col.cast("float", strict=False)
+    assert casted.null_count() == 1            # "oops" -> null
+    assert len(casted) - casted.null_count() == 2
+    assert to_frame(pl.DataFrame({"x": ["1", "2"]})).column("x").cast("int", strict=False).to_list() == [1, 2]
+
+
+def test_column_member_count():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a", "b", "a", "c", None]})).column("x")
+    assert col.member_count(["a", "c"]) == 3   # a,a,c ; matches int(s.is_in(v).sum())


### PR DESCRIPTION
## Summary
Continues the goldencheck Polars eviction (follows P0 #1605, now merged). Ports **`type_inference`** and **`fuzzy_values`** off Polars onto the `Frame`/`Column` seam. **Byte-identical, no version bump.**

- Adds 3 delegating `Column` methods to `core/frame.py`: `dtype` (backend-neutral string — `str`/`int`/`uint`/`float`/`date`/`datetime`/`other`, with **`uint` kept distinct** from `int` — load-bearing for `type_inference`'s signed-only numeric gate), `cast(kind, *, strict=False)`, `member_count(values)`. `PolarsColumn` delegates each to the exact Polars call (fast path kept; the non-Polars impl arrives with the Stage-2 substrate). All new `pl.` refs are in-function, so `import goldencheck` still loads zero Polars.
- Ports the two profiler bodies onto the seam and removes their `pl` imports + `pl.DataFrame` annotations → **polars-free files**.

**Deferred:** `format_detection`/`encoding_detection` (Batch A2 — need a string filter/sampler seam family; a spec review found a cross-format `filter(~A).contains(B).sum()` block + a matching-vs-complement sample-direction mismatch this seam doesn't cover). `pattern_consistency` + Batches B/C later.

## Test plan
- [x] `tests/core/test_frame.py` — the 3 new seam methods equal the raw Polars calls (incl. `UInt32 → "uint"` distinct from `int`)
- [x] **Parity gate:** `test_type_inference.py` (8) + `test_fuzzy_values.py` (7, all 3 lanes incl. the real native kernel) pass UNEDITED — byte-identical Findings
- [x] `import goldencheck` loads zero Polars; both ported files grep-clean of `polars`/`pl.`
- [x] Full suite 737 passed / 6 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1XRtDNuLQncCEx6aUQTST