### PR TITLE
refactor(goldencheck): Polars-eviction — port format_detection + encoding_detection onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a2.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a2.md
@@ -1,0 +1,165 @@
+# GoldenCheck Polars Eviction — Profiler Ports Batch A2 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `format_detection` and `encoding_detection` off Polars onto the `Frame`/`Column` seam by adding 2 composable `Column` methods (`str_match_count`, `str_filter`) — byte-identical, no version bump.
+
+**Architecture:** Add the string ops these two profilers need to the seam; `PolarsColumn` delegates each to the exact Polars call (byte-identical, Polars stays the fast path). `str_filter` returns a Column, so it composes: the cross-format count is `str_filter(A, matching=False).str_match_count(B)` and the samples are `str_filter(p, matching=...).to_list()[:5]`. Then rewrite the two profiler bodies onto the seam, removing their `pl` imports. Non-Polars impl of the seam ops comes with the Stage-2 substrate — not here.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-batch-a2` worktree, off fresh origin/main)
+
+Branch `feat/goldencheck-profiler-ports-batch-a2`, worktree `D:\show_case\gc-batch-a2`, off fresh `origin/main` (P0 #1605 + Batch A #1606 both merged — the seam has `dtype`/`cast`/`member_count`). NOT stacked.
+
+**Test preamble** (from `/d/show_case/gc-batch-a2`):
+```bash
+export PYTHONPATH="D:/show_case/gc-batch-a2/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-batch-a2
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. The 2 profilers' existing tests are the parity gate — they pass UNEDITED. The import gate (`tests/test_import_no_polars.py`) + full suite stay green. No version bump. Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `Column` = `{__len__, null_count, n_unique, drop_nulls, unique, sort, to_list, dtype, cast, member_count}`; `PolarsColumn` wraps a `pl.Series` in `self._s`. `PolarsFrame.column(name) -> PolarsColumn(self._df[name])`.
+
+---
+
+## Task 1: Add `str_match_count` + `str_filter` to the seam
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/core/frame.py`; Test `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_column_str_match_count():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a@b.com", "nope", "c@d.org"]})).column("x")
+    assert col.str_match_count(r"@") == 2
+    assert col.str_match_count(r"^z") == 0
+
+def test_column_str_filter_matching_and_complement():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a@b", "nope", "c@d"]})).column("x")
+    assert col.str_filter(r"@", matching=True).to_list() == ["a@b", "c@d"]      # matching rows
+    assert col.str_filter(r"@", matching=False).to_list() == ["nope"]           # complement
+    # composition: filter to non-matching-A, then count matching-B (cross-format shape)
+    col2 = to_frame(pl.DataFrame({"x": ["http://x", "e@f.com", "plain"]})).column("x")
+    assert col2.str_filter(r"^https?://", matching=False).str_match_count(r"@") == 1
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PolarsColumn' object has no attribute 'str_match_count'`). `$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "str_match or str_filter" -v`
+
+- [ ] **Step 3: Implement.** Add to the `Column` Protocol (after `member_count`):
+```python
+    def str_match_count(self, pattern: str) -> int: ...
+    def str_filter(self, pattern: str, *, matching: bool) -> Column: ...
+```
+Add to `PolarsColumn`:
+```python
+    def str_match_count(self, pattern: str) -> int:
+        return int(self._s.str.contains(pattern).sum())
+
+    def str_filter(self, pattern: str, *, matching: bool) -> PolarsColumn:
+        mask = self._s.str.contains(pattern)
+        return PolarsColumn(self._s.filter(mask if matching else ~mask))
+```
+(Both reference `self._s.str.contains` / `self._s.filter` — no `pl.` symbol, so the import gate is trivially safe.)
+
+- [ ] **Step 4: Run → PASS**, and the import gate stays green: `$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v`. Ruff clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-batch-a2
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add str_match_count/str_filter to the Frame seam (PolarsColumn delegates)"
+```
+
+---
+
+## Task 2: Port `format_detection` onto the seam
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/format_detection.py`
+
+- [ ] **Step 1: Port the body.** Read the file first. Rewrite:
+  - Signature: `def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:` — **drop the `frame: pl.DataFrame` annotation** (keep `frame = to_frame(frame)`).
+  - Remove `df = frame.native` (no longer referenced); `col = frame.column(column)`.
+  - `if col.dtype != "str": return findings` (was `col.dtype not in (pl.Utf8, pl.String)`).
+  - `non_null = col.drop_nulls()`; `total = len(non_null)`; `if total == 0: return findings`.
+  - Per format loop: `match_count = non_null.str_match_count(pattern)`; `match_pct = match_count / total` (UNCHANGED).
+  - Detection Finding UNCHANGED. `non_match_count = total - match_count`.
+  - `if non_match_count > 0:` block — `sample = non_null.str_filter(pattern, matching=False).to_list()[:5]` (was `non_null.filter(~matches).head(5).to_list()`); the non-matching Finding UNCHANGED.
+  - Cross-format loop — KEEP its inner `if non_match_count > 0:` guard VERBATIM (control-flow byte-identity); inside:
+    `wrong_fmt_count = non_null.str_filter(pattern, matching=False).str_match_count(other_pattern)`
+    (was `non_null.filter(~matches).str.contains(other_pattern).sum()`). The ERROR Finding UNCHANGED.
+  - Remove `from goldencheck._polars_lazy import pl`. Keep `to_frame`. The `FORMATS`/`EMAIL_REGEX`/etc. module constants are plain strings — leave them.
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-a2 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_format_detection.py -v
+```
+Expected: all pass, ZERO edits (byte-identical Findings, including the cross-format ERROR + the non-matching samples). If a test fails, fix the PORT (check `str_filter` direction + the cross-format compose), never the test; report the assertion diff.
+
+- [ ] **Step 3: Confirm polars-free + import gate.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/profilers/format_detection.py || echo "format_detection polars-free"
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/format_detection.py
+git commit -m "refactor(goldencheck): port format_detection onto the Frame seam (polars-free)"
+```
+
+---
+
+## Task 3: Port `encoding_detection` onto the seam + final verification
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/encoding_detection.py`
+
+- [ ] **Step 1: Port the body.** Read the file first. Rewrite:
+  - Signature: `def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:` — drop `frame: pl.DataFrame`.
+  - Remove `df = frame.native`; `col = frame.column(column)`.
+  - `if col.dtype != "str": return findings`; `non_null = col.drop_nulls()`; `total = len(non_null)`; `if total == 0: return findings`.
+  - For EACH of the 4 checks (zero-width, smart-quotes, non-ASCII, control): `count = non_null.str_match_count(PATTERN)` (was `mask = non_null.str.contains(PATTERN); count = mask.sum()`); `if count > 0: sample = non_null.str_filter(PATTERN, matching=True).to_list()[:5]` (was `non_null.filter(mask).head(5).to_list()` — **matching**, positive). Each Finding UNCHANGED (incl. the `repr(v)` sample rendering).
+  - Remove `from goldencheck._polars_lazy import pl`. The `*_PATTERN` module constants are plain strings — leave them.
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-a2 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_encoding_detection.py -v
+```
+Expected: all pass, ZERO edits (byte-identical — the samples are the MATCHING rows via `matching=True`). If a test fails, fix the PORT (most likely `matching` direction), never the test.
+
+- [ ] **Step 3: Final verification.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/profilers/encoding_detection.py || echo "encoding_detection polars-free"
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite byte-identical
+```
+Expected: encoding_detection polars-free; import gate green; full suite green (same pass/skip counts as the fresh-main baseline + the 2 new seam tests). Ruff clean.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
+git commit -m "refactor(goldencheck): port encoding_detection onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (Batch A2 complete)
+- [ ] `Column` seam gained `str_match_count`/`str_filter` (PolarsColumn delegates; import gate green — no `pl.` refs).
+- [ ] `format_detection` + `encoding_detection` are polars-free (grep-clean) and route through the seam.
+- [ ] Both profilers' existing tests pass with ZERO edits (byte-identical — incl. format's cross-format ERROR + non-matching samples, and encoding's MATCHING samples).
+- [ ] Full suite green; `import goldencheck` loads zero Polars.
+- [ ] No scope creep: `pattern_consistency`, Batches B/C, the relation profilers, the substrate backend, reader, and deps flip untouched. 7 of ~13 column profilers now polars-free.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2-design.md
@@ -1,0 +1,113 @@
+# GoldenCheck Polars eviction — Profiler ports Batch A2 (str_match_count + str_filter seam)
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (P0 #1605 + Batch A #1606 both merged; the Frame/Column seam + dtype/cast/member_count are present)
+Parent program: goldencheck Polars eviction (see `2026-07-08-goldencheck-polars-eviction-p0-design.md`)
+
+## Context
+
+Continuing the goldencheck Polars eviction. P0 built the `Frame`/`Column` seam; Batch A ported
+`nullability`/`cardinality`/`uniqueness` (P0) + `type_inference`/`fuzzy_values` (adding `dtype`,
+`cast`, `member_count`). 5 of ~13 column profilers are polars-free. This batch ports the two
+**string-format** profilers that Batch A deferred: `format_detection` and `encoding_detection`.
+
+Batch A's spec review flagged why they were deferred: `format_detection` has a **cross-format**
+block `non_null.filter(~matchesA).str.contains(B).sum()` ("count values not matching A that match
+B"), and `encoding_detection` samples the **matching** rows (`filter(mask).head(5)`), not the
+complement — neither expressible byte-identically with Batch A's seam. This batch designs the
+string-op seam family from a complete reading of both files.
+
+**Seam philosophy (unchanged from Batch A):** the ops go on the `Column` seam; `PolarsColumn`
+delegates to the exact Polars call (byte-identical, no perf regression, Polars stays the fast
+path). The non-Polars implementation arrives with the Stage-2 substrate backend — not here.
+
+## Scope
+
+### In scope
+Port `format_detection` and `encoding_detection` onto the seam, adding **2** composable `Column`
+methods. Byte-identical, no version bump.
+
+### Explicitly NOT in scope
+`pattern_consistency` (its `_generalize` is a cProfile hotspot — needs a vectorized
+`str.replace_all` + `value_counts` seam op; a later batch). Batch B (`freshness`,
+`range_distribution`, `sequence_detection` — scalar stats). Batch C (`drift_detection`). The
+relation profilers. The Stage-2 non-Polars backend. The reader. The deps flip.
+
+### Success criteria
+- `format_detection` + `encoding_detection` are polars-free (import no `pl`), routing through the seam.
+- Their existing tests pass **unedited** (byte-identical Findings — the parity gate).
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
+
+Two composable methods (`PolarsColumn` delegates each to the exact Polars call):
+
+| Method | Signature | PolarsColumn impl | Covers |
+|---|---|---|---|
+| `str_match_count` | `str_match_count(pattern: str) -> int` | `int(self._s.str.contains(pattern).sum())` | every `.str.contains(p).sum()` count |
+| `str_filter` | `str_filter(pattern: str, *, matching: bool) -> Column` | `matching`: `PolarsColumn(self._s.filter(self._s.str.contains(pattern)))`; else `PolarsColumn(self._s.filter(~self._s.str.contains(pattern)))` | the matching/non-matching row sets |
+
+`str_filter` returns a full `PolarsColumn`, so it composes with existing seam ops (`to_list`,
+`str_match_count`). New `pl.` refs are all in-function → import gate stays green.
+
+**Composition covers all three cases (byte-identical):**
+- **count matching:** `col.str_match_count(pat)` = `non_null.str.contains(pat).sum()` (as `int`).
+- **sample matching** (encoding): `col.str_filter(pat, matching=True).to_list()[:5]` =
+  `non_null.filter(mask).head(5).to_list()` (`.head(5).to_list()` ≡ `.to_list()[:5]`, same first-5).
+- **sample non-matching** (format): `col.str_filter(A, matching=False).to_list()[:5]` =
+  `non_null.filter(~matches).head(5).to_list()`.
+- **cross-format count** (format): `col.str_filter(A, matching=False).str_match_count(B)` =
+  `non_null.filter(~matches).str.contains(B).sum()`.
+
+Note: this recomputes `str.contains` where the original reused a `matches` mask — deterministic, so
+byte-identical (Batch A's review already accepted this for format). Perf: PolarsColumn still runs
+Polars vectorized `str.contains`/`filter`, so no regression vs today.
+
+## The 2 ports
+
+Both currently start `frame = to_frame(frame)`; `df = frame.native`; `col = df[column]`;
+`col.dtype not in (pl.Utf8, pl.String)` → `return`; `non_null = col.drop_nulls()`; `total = len(non_null)`.
+
+- **format_detection** — `col = frame.column(column)`; `if col.dtype != "str": return`;
+  `non_null = col.drop_nulls()`; `total = len(non_null)`. Per format:
+  `match_count = non_null.str_match_count(pattern)`; `if non_match_count > 0:
+  sample = non_null.str_filter(pattern, matching=False).to_list()[:5]`; cross-format:
+  `wrong_fmt_count = non_null.str_filter(pattern, matching=False).str_match_count(other_pattern)`.
+  All thresholds/messages/Findings UNCHANGED.
+- **encoding_detection** — same dtype gate + `non_null`; per pattern:
+  `count = non_null.str_match_count(PATTERN)`; `if count > 0:
+  sample = non_null.str_filter(PATTERN, matching=True).to_list()[:5]`. All UNCHANGED.
+
+Each port: signature `def profile(self, frame, column: str, *, context=None)` (drop the
+`frame: pl.DataFrame` annotation — matches P0/Batch-A profilers); remove
+`from goldencheck._polars_lazy import pl` → polars-free.
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): `str_match_count` on a mixed column
+  == `int(s.str.contains(p).sum())`; `str_filter(p, matching=True)`/`(matching=False)` return the
+  matching / non-matching values (compare `.to_list()` to the raw `s.filter(mask)`/`filter(~mask)`);
+  `str_filter(A, matching=False).str_match_count(B)` == the cross-format raw expression.
+- **Parity gate:** `test_format_detection.py` + `test_encoding_detection.py` pass **unedited**
+  (byte-identical Findings). If a test diverges, the port broke byte-identity — fix the port.
+- **Regression:** full suite green (same counts); import gate green; the 2 ported files grep-clean
+  of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`.head(5).to_list()` vs `.to_list()[:5]`** — byte-identical (both first-5 in order); confirmed
+  equivalent for a Polars Series. If any profiler used `.head(n)` for a non-slice reason (it does
+  not — both just sample 5), revisit.
+- **`str.contains` recomputation** — deterministic → byte-identical; PolarsColumn keeps it
+  vectorized (no perf regression). The regex-vs-Python risk is NOT here (Polars regex under the
+  hood) — it moves to Stage 2's non-Polars backend.
+- **`.sum()` type** — `str_match_count` wraps in `int(...)`; the profilers use the count in
+  arithmetic (`/ total`) + `affected_rows` (an int field), so the value is byte-identical.
+- **Seam growth** — only 2 methods, both composable primitives (not task-shaped over-specific ops).
+  Do NOT add a bespoke `not_matching_match_count(A,B)` — `str_filter(A, matching=False)
+  .str_match_count(B)` composes it from the two general methods.
+
+## Non-goals (YAGNI)
+`pattern_consistency`; Batches B/C; the relation profilers; scalar-stats / `.dt` seam ops; the
+Stage-2 non-Polars backend; reader; deps flip.

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -25,6 +25,8 @@ class Column(Protocol):
     def dtype(self) -> str: ...
     def cast(self, kind: str, *, strict: bool = False) -> Column: ...
     def member_count(self, values: list) -> int: ...
+    def str_match_count(self, pattern: str) -> int: ...
+    def str_filter(self, pattern: str, *, matching: bool) -> Column: ...
 
 
 @runtime_checkable
@@ -94,6 +96,13 @@ class PolarsColumn:
 
     def member_count(self, values: list) -> int:
         return int(self._s.is_in(values).sum())
+
+    def str_match_count(self, pattern: str) -> int:
+        return int(self._s.str.contains(pattern).sum())
+
+    def str_filter(self, pattern: str, *, matching: bool) -> PolarsColumn:
+        mask = self._s.str.contains(pattern)
+        return PolarsColumn(self._s.filter(mask if matching else ~mask))
 
 
 class PolarsFrame:

--- a/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
@@ -1,7 +1,6 @@
 """Encoding detection profiler — detects encoding anomalies in string columns."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -27,13 +26,12 @@ CONTROL_CHAR_PATTERN = r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]"
 
 
 class EncodingDetectionProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
 
-        if col.dtype not in (pl.Utf8, pl.String):
+        if col.dtype != "str":
             return findings
 
         non_null = col.drop_nulls()
@@ -42,10 +40,9 @@ class EncodingDetectionProfiler(BaseProfiler):
             return findings
 
         # 1. Zero-width Unicode characters (confidence: 0.8 — almost always wrong)
-        zw_mask = non_null.str.contains(ZERO_WIDTH_PATTERN)
-        zw_count = zw_mask.sum()
+        zw_count = non_null.str_match_count(ZERO_WIDTH_PATTERN)
         if zw_count > 0:
-            sample = non_null.filter(zw_mask).head(5).to_list()
+            sample = non_null.str_filter(ZERO_WIDTH_PATTERN, matching=True).to_list()[:5]
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column=column,
@@ -61,10 +58,9 @@ class EncodingDetectionProfiler(BaseProfiler):
             ))
 
         # 2. Smart/curly quotes (confidence: 0.6 — could be intentional)
-        sq_mask = non_null.str.contains(SMART_QUOTES_PATTERN)
-        sq_count = sq_mask.sum()
+        sq_count = non_null.str_match_count(SMART_QUOTES_PATTERN)
         if sq_count > 0:
-            sample = non_null.filter(sq_mask).head(5).to_list()
+            sample = non_null.str_filter(SMART_QUOTES_PATTERN, matching=True).to_list()[:5]
             findings.append(Finding(
                 severity=Severity.INFO,
                 column=column,
@@ -80,12 +76,11 @@ class EncodingDetectionProfiler(BaseProfiler):
             ))
 
         # 3. Non-ASCII characters (confidence: 0.5 — could be valid international text)
-        na_mask = non_null.str.contains(NON_ASCII_PATTERN)
-        na_count = na_mask.sum()
+        na_count = non_null.str_match_count(NON_ASCII_PATTERN)
         if na_count > 0:
             # Only flag if zero-width chars were NOT already found for the same rows
             # (avoid duplicate noise), but still report non-ASCII separately
-            sample = non_null.filter(na_mask).head(5).to_list()
+            sample = non_null.str_filter(NON_ASCII_PATTERN, matching=True).to_list()[:5]
             findings.append(Finding(
                 severity=Severity.INFO,
                 column=column,
@@ -101,10 +96,9 @@ class EncodingDetectionProfiler(BaseProfiler):
             ))
 
         # 4. Control characters (confidence: 0.8 — rarely valid in data)
-        ctrl_mask = non_null.str.contains(CONTROL_CHAR_PATTERN)
-        ctrl_count = ctrl_mask.sum()
+        ctrl_count = non_null.str_match_count(CONTROL_CHAR_PATTERN)
         if ctrl_count > 0:
-            sample = non_null.filter(ctrl_mask).head(5).to_list()
+            sample = non_null.str_filter(CONTROL_CHAR_PATTERN, matching=True).to_list()[:5]
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column=column,

--- a/packages/python/goldencheck/goldencheck/profilers/format_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/format_detection.py
@@ -1,7 +1,6 @@
 """Format detection profiler — detects email, phone, and URL patterns in string columns."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -18,13 +17,12 @@ FORMATS = [
 
 
 class FormatDetectionProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
 
-        if col.dtype not in (pl.Utf8, pl.String):
+        if col.dtype != "str":
             return findings
 
         non_null = col.drop_nulls()
@@ -33,8 +31,7 @@ class FormatDetectionProfiler(BaseProfiler):
             return findings
 
         for fmt_name, pattern in FORMATS:
-            matches = non_null.str.contains(pattern)
-            match_count = matches.sum()
+            match_count = non_null.str_match_count(pattern)
             match_pct = match_count / total
 
             if match_pct > 0.70:
@@ -50,8 +47,7 @@ class FormatDetectionProfiler(BaseProfiler):
                 ))
                 non_match_count = total - match_count
                 if non_match_count > 0:
-                    non_matching = non_null.filter(~matches)
-                    sample = non_matching.head(5).to_list()
+                    sample = non_null.str_filter(pattern, matching=False).to_list()[:5]
                     # Non-matching findings inherit same confidence as detection
                     findings.append(Finding(
                         severity=Severity.WARNING,
@@ -74,8 +70,7 @@ class FormatDetectionProfiler(BaseProfiler):
                 }
                 for other_fmt, other_pattern in CROSS_FORMAT_CHECKS.get(fmt_name, []):
                     if non_match_count > 0:
-                        wrong_fmt_matches = non_null.filter(~matches).str.contains(other_pattern)
-                        wrong_fmt_count = wrong_fmt_matches.sum()
+                        wrong_fmt_count = non_null.str_filter(pattern, matching=False).str_match_count(other_pattern)
                         if wrong_fmt_count > 0:
                             wrong_pct = wrong_fmt_count / total
                             findings.append(Finding(

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -62,3 +62,21 @@ def test_column_member_count():
     from goldencheck.core.frame import to_frame
     col = to_frame(pl.DataFrame({"x": ["a", "b", "a", "c", None]})).column("x")
     assert col.member_count(["a", "c"]) == 3   # a,a,c ; matches int(s.is_in(v).sum())
+
+
+def test_column_str_match_count():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a@b.com", "nope", "c@d.org"]})).column("x")
+    assert col.str_match_count(r"@") == 2
+    assert col.str_match_count(r"^z") == 0
+
+
+def test_column_str_filter_matching_and_complement():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": ["a@b", "nope", "c@d"]})).column("x")
+    assert col.str_filter(r"@", matching=True).to_list() == ["a@b", "c@d"]
+    assert col.str_filter(r"@", matching=False).to_list() == ["nope"]
+    col2 = to_frame(pl.DataFrame({"x": ["http://x", "e@f.com", "plain"]})).column("x")
+    assert col2.str_filter(r"^https?://", matching=False).str_match_count(r"@") == 1


### PR DESCRIPTION
## Summary
Continues the goldencheck Polars eviction (follows P0 #1605 + Batch A #1606, both merged). Ports **`format_detection`** and **`encoding_detection`** off Polars onto the `Frame`/`Column` seam. **Byte-identical, no version bump.**

- Adds 2 composable `Column` methods to `core/frame.py`: `str_match_count(pattern) -> int` (= `int(s.str.contains(p).sum())`) and `str_filter(pattern, *, matching: bool) -> Column` (= `s.filter(mask)` / `s.filter(~mask)`). `PolarsColumn` delegates each (byte-identical, Polars stays the fast path). No `pl.` symbol in either method → import gate stays green.
- These resolve the two cases Batch A couldn't express byte-identically (a spec review had deferred them): `format_detection`'s cross-format count `filter(~A).contains(B).sum()` → `str_filter(A, matching=False).str_match_count(B)`; `encoding_detection` samples the **matching** rows → `str_filter(P, matching=True).to_list()[:5]`.
- Both profiler bodies now route through the seam; `pl` imports + `pl.DataFrame` annotations removed → **polars-free files**.

## Test plan
- [x] `tests/core/test_frame.py` — the 2 new seam methods equal the raw Polars calls (incl. the `str_filter(A,False).str_match_count(B)` composition)
- [x] **Parity gate:** `test_format_detection.py` (4, incl. the cross-format ERROR) + `test_encoding_detection.py` (8, matching-row samples) pass UNEDITED — byte-identical Findings
- [x] `import goldencheck` loads zero Polars; both ported files grep-clean of `polars`/`pl.`
- [x] Full suite 739 passed / 6 skipped

7 of ~13 column profilers now polars-free. Remaining: `pattern_consistency` + Batch B (`freshness`/`range_distribution`/`sequence_detection`) + Batch C (`drift_detection`), then the relation profilers, the Stage-2 non-Polars substrate backend, the reader (late), and the deps flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1XRtDNuLQncCEx6aUQTST