### PR TITLE
refactor(goldencheck): Polars-eviction — port drift_detection onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-c.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-c.md
@@ -1,0 +1,148 @@
+# GoldenCheck Polars Eviction — Profiler Ports Batch C Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `drift_detection` off Polars onto the `Frame`/`Column` seam by adding 1 positional `slice` method and 1 `cast` kind (`"str"`) — byte-identical, no version bump.
+
+**Architecture:** Add positional `slice` to the seam (`PolarsColumn` delegates to `self._s.slice`) and extend `_CAST_KIND` with `"str": "String"` so `cast("str")` works. Then rewrite `drift_detection`'s body onto the seam — the two halves become `slice(0, mid)`/`slice(mid)`, `mean`/`std` reuse Batch B's ops, and the categorical `is_in().sum()` reuses Batch A's `member_count`. Remove the `pl` import and `_numeric_dtypes()` helper.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-c-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-batch-c` worktree, off fresh origin/main)
+
+Branch `feat/goldencheck-profiler-ports-batch-c`, worktree `D:\show_case\gc-batch-c`, off fresh `origin/main` (P0 #1605 + A #1606 + A2 #1607 + B #1608 all merged — the seam has `dtype`/`cast`/`member_count`/`min`/`max`/`mean`/`std`/`diff`/`is_sorted`/`count_gt`/`count_eq`/`filter_outside`). NOT stacked.
+
+**Test preamble** (run every test command from `/d/show_case/gc-batch-c`):
+```bash
+export PYTHONPATH="D:/show_case/gc-batch-c/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-batch-c
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. The `drift_detection` existing test is the parity gate — it passes UNEDITED. The import gate (`tests/test_import_no_polars.py`) + full suite stay green. No version bump. Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `Column` Protocol + `PolarsColumn` (wraps a `pl.Series` in `self._s`); `_CAST_KIND = {"float": "Float64", "int": "Int64"}`; `cast(self, kind, *, strict=False)` does `getattr(pl, _CAST_KIND[kind])`; `member_count(values)` = `int(self._s.is_in(values).sum())`; `mean`/`std` present. There is NO `slice` yet.
+
+---
+
+## Task 1: Add positional `slice` + the `"str"` cast kind to the seam
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py`
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_column_slice_positional_halves():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", [10, 20, 30, 40, 50])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    mid = 5 // 2   # 2
+    # first half == s[:mid], second half == s[mid:]
+    assert col.slice(0, mid).to_list() == s.slice(0, mid).to_list() == [10, 20]
+    assert col.slice(mid).to_list() == s.slice(mid).to_list() == [30, 40, 50]
+    # slice(mid) with no length runs to the end (matches s[mid:])
+    assert col.slice(mid).to_list() == s[mid:].to_list()
+
+def test_column_cast_str():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": [1, 2, 3]})).column("x")
+    assert col.cast("str", strict=True).to_list() == pl.Series([1, 2, 3]).cast(pl.String).to_list()
+    assert col.cast("str", strict=True).to_list() == ["1", "2", "3"]
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PolarsColumn' object has no attribute 'slice'` and a `KeyError: 'str'` from `_CAST_KIND`).
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "slice_positional or cast_str" -v
+```
+
+- [ ] **Step 3: Implement.**
+  - Add to the `Column` Protocol (after `filter_outside`):
+```python
+    def slice(self, offset: int, length: int | None = None) -> Column: ...
+```
+  - Extend the `_CAST_KIND` module constant:
+```python
+_CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings only; resolved via getattr in cast()
+```
+  - Add to `PolarsColumn` (after `filter_outside`):
+```python
+    def slice(self, offset: int, length: int | None = None) -> PolarsColumn:
+        return PolarsColumn(self._s.slice(offset, length))
+```
+  (`slice` delegates via `self._s.slice` — no `pl.` symbol; `cast("str")` resolves through the existing `getattr(pl, "String")` path. Import gate stays green.)
+
+- [ ] **Step 4: Run → PASS**, and the import gate stays green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean: `$PY -m ruff check packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-batch-c
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add positional slice + str cast-kind to the Frame seam (PolarsColumn delegates)"
+```
+
+---
+
+## Task 2: Port `drift_detection` onto the seam + final verification
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/drift_detection.py`
+
+- [ ] **Step 1: Read the file first**, then rewrite:
+  - Signature: `def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:` — **drop `frame: pl.DataFrame`**. Keep `frame = to_frame(frame)`.
+  - Remove `df = frame.native`; use `col = frame.column(column)`.
+  - `total = len(col)`; `if total < MIN_ROWS: return findings` UNCHANGED.
+  - `mid = total // 2`; `first_half = col.slice(0, mid).drop_nulls()`; `second_half = col.slice(mid).drop_nulls()` (was `col[:mid].drop_nulls()` / `col[mid:].drop_nulls()`).
+  - `if len(first_half) == 0 or len(second_half) == 0: return findings` UNCHANGED.
+  - High-cardinality skip: `non_null = col.drop_nulls()`; `if len(non_null) > 0:` `unique_pct = non_null.n_unique() / len(non_null)`; `if unique_pct > 0.90 and col.dtype not in ("int", "uint", "float"): return findings` (was `col.dtype not in _numeric_dtypes()`).
+  - `is_numeric = col.dtype in ("int", "uint", "float")` (was `col.dtype in _numeric_dtypes()`).
+  - **Numeric path:** `mean1 = first_half.mean()`; `mean2 = second_half.mean()`; `std1 = first_half.std()` (via seam). The `if mean1 is None or mean2 is None or std1 is None or std1 == 0: return findings` guard, `deviation = abs(mean2 - mean1) / std1`, the `DRIFT_STDDEV_*` thresholds, severity, and the numeric-drift Finding are ALL UNCHANGED.
+  - **Categorical path (else):** `cats_first = set(first_half.cast("str", strict=True).to_list())`; `cats_second = set(second_half.cast("str", strict=True).to_list())` (was `first_half.cast(pl.String).to_list()`). `new_cats = cats_second - cats_first`; the `if new_cats:` block, `new_cat_pct`, `CATEGORICAL_DRIFT_*` thresholds, `sample_new = sorted(new_cats)[:10]` are ALL UNCHANGED. Replace `new_cat_mask = second_half.cast(pl.String).is_in(list(new_cats)); affected = int(new_cat_mask.sum())` with a single line: `affected = second_half.cast("str", strict=True).member_count(list(new_cats))` (`member_count` delegates to exactly `int(self._s.is_in(values).sum())`). The categorical-drift Finding UNCHANGED.
+  - Remove `from goldencheck._polars_lazy import pl`; DELETE the `@lru_cache _numeric_dtypes()` helper AND `from functools import lru_cache`. Keep `to_frame`, `Finding`, `Severity`, `BaseProfiler`, and the `MIN_ROWS`/`DRIFT_*`/`CATEGORICAL_*` module constants.
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-c && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_drift_detection.py -v
+```
+Expected: all pass, ZERO edits (byte-identical — both numeric-drift and categorical-drift branches). If a test fails, fix the PORT (most likely a `slice` offset or the `cast("str")` compose), never the test; report the assertion diff.
+
+- [ ] **Step 3: Confirm this file polars-free.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\.|lru_cache" packages/python/goldencheck/goldencheck/profilers/drift_detection.py || echo "drift_detection polars-free"
+```
+
+- [ ] **Step 4: Final verification (whole batch).**
+```bash
+cd /d/show_case/gc-batch-c && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite byte-identical
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Expected: import gate green; full suite green (same pass/skip counts as the fresh-main baseline + the 2 new seam tests); ruff clean. If the full suite has any FAILURES, investigate + report (do NOT edit tests to pass — a real failure means the port broke something).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/drift_detection.py
+git commit -m "refactor(goldencheck): port drift_detection onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (Batch C complete)
+- [ ] `Column` seam gained `slice` (Protocol stub + PolarsColumn impl) and `_CAST_KIND` gained `"str"` (import gate green — no `pl.` refs).
+- [ ] `drift_detection` is polars-free (grep-clean) and routes through the seam.
+- [ ] `drift_detection`'s existing test passes with ZERO edits (byte-identical — both numeric + categorical drift branches).
+- [ ] Full suite green; `import goldencheck` loads zero Polars.
+- [ ] No scope creep: `pattern_consistency` (A2b), the relation profilers, the substrate backend, reader, and deps flip untouched. 11 of ~13 column profilers now polars-free.

--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-c.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-c.md
@@ -99,7 +99,7 @@ git commit -m "feat(goldencheck): add positional slice + str cast-kind to the Fr
 
 **Files:** Modify `packages/python/goldencheck/goldencheck/profilers/drift_detection.py`
 
-- [ ] **Step 1: Read the file first**, then rewrite:
+- [ ] **Step 1: Read the file first**, then rewrite (this is an in-place edit — keep the `findings: list[Finding] = []` init and the trailing `return findings`; only change the lines called out below):
   - Signature: `def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:` — **drop `frame: pl.DataFrame`**. Keep `frame = to_frame(frame)`.
   - Remove `df = frame.native`; use `col = frame.column(column)`.
   - `total = len(col)`; `if total < MIN_ROWS: return findings` UNCHANGED.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-c-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-c-design.md
@@ -1,0 +1,112 @@
+# GoldenCheck Polars eviction — Profiler ports Batch C (drift_detection: positional slice + str cast)
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (P0 #1605 + Batch A #1606 + Batch A2 #1607 + Batch B #1608 all merged; the Frame/Column seam has `dtype`/`cast`/`member_count`/`str_match_count`/`str_filter`/`min`/`max`/`mean`/`std`/`diff`/`is_sorted`/`count_gt`/`count_eq`/`filter_outside`)
+Parent program: goldencheck Polars eviction (see `2026-07-08-goldencheck-polars-eviction-p0-design.md`)
+
+## Context
+
+Continuing the goldencheck Polars eviction. Batch B ported the scalar-reduction profilers and added
+`min`/`max`/`mean`/`std` (among others). This batch ports the single remaining
+**scalar-stats-dependent** profiler, `drift_detection`, which reuses Batch B's `mean`/`std` and
+Batch A's `member_count`, and needs only ONE genuinely new seam op — positional `slice` — plus one
+new `cast` kind (`"str"`). **10 of ~13 column profilers are polars-free; this makes 11.**
+
+**Seam philosophy (unchanged):** the op goes on the `Column` seam; `PolarsColumn` delegates to the
+exact Polars call (byte-identical, no perf regression, Polars stays the fast path). The non-Polars
+implementation arrives with the Stage-2 substrate backend — not here.
+
+## Scope
+
+### In scope
+Port `drift_detection` onto the seam, adding **1** `Column` method (`slice`) and **1** `cast` kind
+(`"str"`). Byte-identical, no version bump.
+
+### Explicitly NOT in scope
+`pattern_consistency` (Batch A2b — needs chainable `str_replace_all` + `value_counts` + a
+cross-column mask filter; the gnarliest port, and already vectorized so it buys no perf). The 9
+relation profilers. The Stage-2 non-Polars backend. The reader. The deps flip.
+
+### Success criteria
+- `drift_detection` is polars-free (import no `pl`), routing through the seam.
+- Its existing test passes **unedited** (byte-identical Findings — the parity gate).
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
+
+One new method + one new `cast` kind. Each `PolarsColumn` method delegates to the exact Polars call
+`drift_detection` uses today, so the port is byte-identical. **Neither references the `pl.` symbol
+at method scope** (all `self._s.*`), so the import gate stays trivially green.
+
+| Method / change | Signature | PolarsColumn impl | Used by |
+|---|---|---|---|
+| `slice` | `slice(offset: int, length: int \| None = None) -> Column` | `PolarsColumn(self._s.slice(offset, length))` | drift (the two halves) |
+| `cast` kind `"str"` | (existing `cast(kind, *, strict=False)`) | `_CAST_KIND` gains `"str": "String"` → `getattr(pl, "String")` | drift (categorical path) |
+
+- **Positional halves:** `col[:mid] ≡ self._s.slice(0, mid)`; `col[mid:] ≡ self._s.slice(mid)` (=
+  `self._s.slice(mid, None)`, offset to end). Polars `Series.__getitem__` with a slice delegates to
+  `.slice` internally, so values + order are identical.
+- **`cast("str")`:** `_CAST_KIND["str"] = "String"`; the existing `cast` body
+  (`getattr(pl, _CAST_KIND[kind])`) resolves it to `pl.String`. `pl.String` is the alias of
+  `pl.Utf8`. Because the original calls `cast(pl.String)` with Polars' **default `strict=True`**, the
+  port passes `strict=True` explicitly (the seam default is `strict=False`; for a String target the
+  distinction is immaterial — casting any dtype to String never fails — but we keep it faithful).
+
+## The port (`profilers/drift_detection.py`)
+
+Signature `def profile(self, frame, column: str, *, context: dict | None = None)` (drop the
+`frame: pl.DataFrame` annotation — matches P0/A/A2/B); keep `frame = to_frame(frame)`; remove
+`df = frame.native`; `col = frame.column(column)`; remove `from goldencheck._polars_lazy import pl`;
+delete the `@lru_cache _numeric_dtypes()` helper AND `from functools import lru_cache`.
+
+- `total = len(col)`; `if total < MIN_ROWS: return findings` UNCHANGED.
+- `mid = total // 2`; `first_half = col.slice(0, mid).drop_nulls()`;
+  `second_half = col.slice(mid).drop_nulls()` (was `col[:mid].drop_nulls()` / `col[mid:].drop_nulls()`).
+- `if len(first_half) == 0 or len(second_half) == 0: return findings` UNCHANGED.
+- High-cardinality skip: `non_null = col.drop_nulls()`; `if len(non_null) > 0:`
+  `unique_pct = non_null.n_unique() / len(non_null)`;
+  `if unique_pct > 0.90 and col.dtype not in ("int", "uint", "float"): return findings`
+  (was `col.dtype not in _numeric_dtypes()`).
+- `is_numeric = col.dtype in ("int", "uint", "float")` (was `col.dtype in _numeric_dtypes()`).
+- **Numeric path:** `mean1 = first_half.mean()`; `mean2 = second_half.mean()`;
+  `std1 = first_half.std()` (all via seam). The `None`/`std1 == 0` guard, `deviation`, thresholds,
+  severity, and the numeric-drift Finding are UNCHANGED.
+- **Categorical path:** `cats_first = set(first_half.cast("str", strict=True).to_list())`;
+  `cats_second = set(second_half.cast("str", strict=True).to_list())` (was `cast(pl.String)`).
+  `new_cats = cats_second - cats_first`; the `new_cat_pct` threshold, `sample_new = sorted(new_cats)
+  [:10]` are UNCHANGED. `affected = second_half.cast("str", strict=True).member_count(list(new_cats))`
+  (was `int(second_half.cast(pl.String).is_in(list(new_cats)).sum())` — `member_count` already
+  delegates to exactly `int(self._s.is_in(values).sum())`). The categorical-drift Finding UNCHANGED.
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): `slice(0, mid)` / `slice(mid)` equal
+  the raw `s.slice(0, mid)` / `s.slice(mid)` (compare `.to_list()`), and match Python slicing
+  `s[:mid]` / `s[mid:]`; `cast("str")` on an int column yields the string values (compare `.to_list()`
+  to `s.cast(pl.String).to_list()`).
+- **Parity gate:** `test_drift_detection.py` passes with **zero edits** (byte-identical Findings —
+  both the numeric-drift and categorical-drift branches).
+- **Regression:** full suite green (same counts + the new seam tests); import gate green
+  (`tests/test_import_no_polars.py`); the ported file grep-clean of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`slice` byte-identity** — `s[:mid]`/`s[mid:]` delegate to `Series.slice` under the hood; the
+  seam op calls `.slice` directly with the same offsets, so values + order are identical. The
+  `slice(mid)` (no length) form correctly runs to the end, matching `s[mid:]`.
+- **`cast("str")` strictness** — the port passes `strict=True` to mirror the original
+  `cast(pl.String)` default; for a String target the result is identical regardless, so this is
+  belt-and-suspenders faithfulness, not a behavior change.
+- **`member_count` reuse** — `second_half.cast("str").member_count(list(new_cats))` delegates to
+  `int(self._s.is_in(values).sum())`, byte-identical to the original
+  `int(second_half.cast(pl.String).is_in(list(new_cats)).sum())`. `is_in` on a String column with a
+  `list(new_cats)` of Python strings is unchanged.
+- **Seam growth** — only 1 method + 1 cast-kind. `slice` is a general positional primitive (offset +
+  optional length), not a task-shaped `first_half`/`second_half` op.
+- **`n_unique` / `.dt` etc.** — no new op needed; `n_unique`, `drop_nulls`, `to_list`, `__len__`,
+  `mean`, `std`, `member_count` all pre-exist.
+
+## Non-goals (YAGNI)
+`pattern_consistency` (Batch A2b); the relation profilers; a `value_counts` / `str_replace_all` seam
+op; the Stage-2 non-Polars backend; reader; deps flip.

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -36,6 +36,7 @@ class Column(Protocol):
     def count_gt(self, value: Any) -> int: ...
     def count_eq(self, value: Any) -> int: ...
     def filter_outside(self, lower: Any, upper: Any) -> Column: ...
+    def slice(self, offset: int, length: int | None = None) -> Column: ...
 
 
 @runtime_checkable
@@ -65,7 +66,7 @@ def _neutral_dtype(dt: Any) -> str:
     return "other"
 
 
-_CAST_KIND = {"float": "Float64", "int": "Int64"}   # strings only; resolved via getattr in cast()
+_CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings only; resolved via getattr in cast()
 
 
 class PolarsColumn:
@@ -139,6 +140,9 @@ class PolarsColumn:
 
     def filter_outside(self, lower: Any, upper: Any) -> PolarsColumn:
         return PolarsColumn(self._s.filter((self._s < lower) | (self._s > upper)))
+
+    def slice(self, offset: int, length: int | None = None) -> PolarsColumn:
+        return PolarsColumn(self._s.slice(offset, length))
 
 
 class PolarsFrame:

--- a/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
@@ -1,21 +1,9 @@
 """Drift detection profiler — detects distribution drift between first and second half of data."""
 from __future__ import annotations
 
-from functools import lru_cache
-
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
-
-
-@lru_cache(maxsize=1)
-def _numeric_dtypes() -> tuple:
-    return (
-        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-        pl.Float32, pl.Float64,
-    )
 
 # Minimum row count to attempt drift detection (small samples are unreliable)
 MIN_ROWS = 1000
@@ -30,19 +18,18 @@ CATEGORICAL_DRIFT_EXTREME = 0.50    # >50% new categories → WARNING; 20-50% �
 
 
 class DriftDetectionProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        col = df[column]
+        col = frame.column(column)
         total = len(col)
 
         if total < MIN_ROWS:
             return findings
 
         mid = total // 2
-        first_half = col[:mid].drop_nulls()
-        second_half = col[mid:].drop_nulls()
+        first_half = col.slice(0, mid).drop_nulls()
+        second_half = col.slice(mid).drop_nulls()
 
         if len(first_half) == 0 or len(second_half) == 0:
             return findings
@@ -52,10 +39,10 @@ class DriftDetectionProfiler(BaseProfiler):
         non_null = col.drop_nulls()
         if len(non_null) > 0:
             unique_pct = non_null.n_unique() / len(non_null)
-            if unique_pct > 0.90 and col.dtype not in _numeric_dtypes():
+            if unique_pct > 0.90 and col.dtype not in ("int", "uint", "float"):
                 return findings
 
-        is_numeric = col.dtype in _numeric_dtypes()
+        is_numeric = col.dtype in ("int", "uint", "float")
 
         if is_numeric:
             # Numeric drift: compare means
@@ -85,8 +72,8 @@ class DriftDetectionProfiler(BaseProfiler):
                 ))
         else:
             # Categorical drift: look for new categories in second half
-            cats_first = set(first_half.cast(pl.String).to_list())
-            cats_second = set(second_half.cast(pl.String).to_list())
+            cats_first = set(first_half.cast("str", strict=True).to_list())
+            cats_second = set(second_half.cast("str", strict=True).to_list())
             new_cats = cats_second - cats_first
 
             if new_cats:
@@ -95,8 +82,7 @@ class DriftDetectionProfiler(BaseProfiler):
                 if new_cat_pct > CATEGORICAL_DRIFT_THRESHOLD:
                     sample_new = sorted(new_cats)[:10]
                     # Count rows in second half that contain new categories
-                    new_cat_mask = second_half.cast(pl.String).is_in(list(new_cats))
-                    affected = int(new_cat_mask.sum())
+                    affected = second_half.cast("str", strict=True).member_count(list(new_cats))
                     # >50% new categories → WARNING (extreme); 20-50% → INFO
                     severity = Severity.WARNING if new_cat_pct > CATEGORICAL_DRIFT_EXTREME else Severity.INFO
                     findings.append(Finding(

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -128,3 +128,23 @@ def test_column_filter_outside():
     # values < 5 or > 50 -> [1, 100], original order preserved
     assert col.filter_outside(5, 50).to_list() == s.filter((s < 5) | (s > 50)).to_list()
     assert col.filter_outside(5, 50).to_list() == [1, 100]
+
+
+def test_column_slice_positional_halves():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", [10, 20, 30, 40, 50])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    mid = 5 // 2   # 2
+    # first half == s[:mid], second half == s[mid:]
+    assert col.slice(0, mid).to_list() == s.slice(0, mid).to_list() == [10, 20]
+    assert col.slice(mid).to_list() == s.slice(mid).to_list() == [30, 40, 50]
+    # slice(mid) with no length runs to the end (matches s[mid:])
+    assert col.slice(mid).to_list() == s[mid:].to_list()
+
+def test_column_cast_str():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": [1, 2, 3]})).column("x")
+    assert col.cast("str", strict=True).to_list() == pl.Series([1, 2, 3]).cast(pl.String).to_list()
+    assert col.cast("str", strict=True).to_list() == ["1", "2", "3"]


### PR DESCRIPTION
Batch C of the goldencheck Polars eviction (driver = install **weight** ~185MB, not speed). Byte-identical, no version bump. Follows P0 (#1605), A (#1606), A2 (#1607), B (#1608).

## Summary
- **Seam:** added a positional `slice(offset, length=None)` method (`PolarsColumn` delegates to `self._s.slice`) and a `"str"` cast kind (`_CAST_KIND["str"] = "String"`, resolved via the existing `getattr(pl, ...)` path). Neither references the `pl.` symbol at method scope, so the import gate stays green.
- **Port:** `drift_detection` now routes through the seam — the two temporal halves are `slice(0, mid)`/`slice(mid)`, the numeric path reuses Batch B's `mean`/`std`, and the categorical `int(cast(pl.String).is_in(new_cats).sum())` collapses to Batch A's `member_count`. Dropped the `pl` import + `_numeric_dtypes()` lru_cache helper.
- **11 of ~13 column profilers now polars-free.**

## Test Plan
- [x] `test_drift_detection.py` passes **unedited** (parity gate — byte-identical numeric + categorical drift Findings)
- [x] 2 new seam unit tests in `tests/core/test_frame.py`
- [x] `tests/test_import_no_polars.py` green — `import goldencheck` loads zero Polars
- [x] Full suite: 746 passed / 6 skipped; ruff clean; drift_detection grep-clean of `polars`/`pl.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)