### PR TITLE
refactor(goldencheck): Polars-eviction — port pattern_consistency onto the Frame seam (last column profiler)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a2b.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-profiler-ports-batch-a2b.md
@@ -1,0 +1,179 @@
+# GoldenCheck Polars Eviction — Profiler Ports Batch A2b Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `pattern_consistency` (the last column profiler) off Polars onto the `Frame`/`Column` seam by adding 4 `Column` methods (`str_replace_all`, `value_counts_desc`, `eq`, `filter_by`) — byte-identical, no version bump.
+
+**Architecture:** Add the string-generalization / histogram / cross-column-mask ops to the seam; `PolarsColumn` delegates each to the exact Polars call. Then rewrite `profile()` onto the seam, and make an annotation-only edit to the parity-gate-locked `_generalize_series` helper so the file goes grep-clean (its body + tests stay untouched).
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2b-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-batch-a2b` worktree, off fresh origin/main)
+
+Branch `feat/goldencheck-profiler-ports-batch-a2b`, worktree `D:\show_case\gc-batch-a2b`, off fresh `origin/main` (P0 #1605 + A #1606 + A2 #1607 + B #1608 + C #1610 all merged). NOT stacked.
+
+**Test preamble** (run every test command from `/d/show_case/gc-batch-a2b`):
+```bash
+export PYTHONPATH="D:/show_case/gc-batch-a2b/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-batch-a2b
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. The `pattern_consistency` existing test is the parity gate — it passes UNEDITED (both the profiler cases AND the three direct `_generalize`/`_generalize_series` tests). The import gate (`tests/test_import_no_polars.py`) + full suite stay green. No version bump. Do NOT add new test FILES (appending to the existing `test_frame.py` is fine — new files can shift pytest-split shard boundaries in CI). Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `Column` Protocol + `PolarsColumn` (wraps a `pl.Series` in `self._s`); has `dtype`/`cast`/`member_count`/`str_match_count`/`str_filter`/`min`/`max`/`mean`/`std`/`diff`/`is_sorted`/`count_gt`/`count_eq`/`filter_outside`/`slice`. Does NOT yet have `str_replace_all`/`value_counts_desc`/`eq`/`filter_by`.
+
+---
+
+## Task 1: Add `str_replace_all` + `value_counts_desc` + `eq` + `filter_by` to the seam
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py`
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_column_str_replace_all_chain():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", ["A1", "bc23", "Z9z"])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    # letters -> L, then digits -> D (letters first, matching _generalize_series)
+    got = col.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D").to_list()
+    assert got == s.str.replace_all(r"\p{L}", "L").str.replace_all(r"\d", "D").to_list()
+    assert got == ["LD", "LLDD", "LDL"]
+
+def test_column_value_counts_desc():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", ["a", "a", "a", "b", "b", "c"])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    got = col.value_counts_desc()
+    raw = s.value_counts().sort("count", descending=True)
+    assert got == list(zip(raw["x"].to_list(), raw["count"].to_list()))
+    assert got[0] == ("a", 3)   # most frequent first
+    assert all(isinstance(cnt, int) for _, cnt in got)
+
+def test_column_eq_and_filter_by():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({"val": ["keep1", "drop", "keep2"], "pat": ["A", "B", "A"]}))
+    val = frame.column("val")
+    pat = frame.column("pat")
+    # eq -> boolean mask; filter_by selects val rows where pat == "A"
+    assert val.filter_by(pat.eq("A")).to_list() == ["keep1", "keep2"]
+    # equivalence to the raw cross-column filter
+    assert val.filter_by(pat.eq("A")).to_list() == val._s.filter(pat._s == "A").to_list()
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PolarsColumn' object has no attribute 'str_replace_all'`).
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "str_replace_all_chain or value_counts_desc or eq_and_filter_by" -v
+```
+
+- [ ] **Step 3: Implement.** Add to the `Column` Protocol (after `slice`):
+```python
+    def str_replace_all(self, pattern: str, value: str) -> Column: ...
+    def value_counts_desc(self) -> list[tuple[Any, int]]: ...
+    def eq(self, value: Any) -> Column: ...
+    def filter_by(self, mask: Column) -> Column: ...
+```
+Add to `PolarsColumn` (after `slice`):
+```python
+    def str_replace_all(self, pattern: str, value: str) -> PolarsColumn:
+        return PolarsColumn(self._s.str.replace_all(pattern, value))
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        vc = self._s.value_counts().sort("count", descending=True)
+        return list(zip(vc[self._s.name].to_list(), vc["count"].to_list()))
+
+    def eq(self, value: Any) -> PolarsColumn:
+        return PolarsColumn(self._s == value)
+
+    def filter_by(self, mask: Column) -> PolarsColumn:
+        return PolarsColumn(self._s.filter(mask._s))
+```
+(Every method delegates via `self._s.*` / `mask._s` — no `pl.` symbol, so the import gate stays green. `Any` + `Column` are already available in `frame.py`. `value_counts_desc` uses `self._s.name` — the original column name, preserved through `drop_nulls`/`str.replace_all` — so `vc[self._s.name]` selects the value column exactly as the profiler's `pattern_counts[column]` did.)
+
+- [ ] **Step 4: Run → PASS**, import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean: `$PY -m ruff check packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-batch-a2b
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add str_replace_all/value_counts_desc/eq/filter_by to the Frame seam (PolarsColumn delegates)"
+```
+
+---
+
+## Task 2: Port `pattern_consistency` onto the seam + final verification
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py`
+
+- [ ] **Step 1: Read the file first.** Then rewrite `profile()` and make the two module edits below. Everything not called out stays byte-identical.
+
+  **`profile()` body:**
+  - Signature: `def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:` — **drop `frame: pl.DataFrame`**. Keep `frame = to_frame(frame)`.
+  - Remove `df = frame.native`; `col = frame.column(column)`.
+  - dtype gate: `if col.dtype != "str": return findings` (was `col.dtype not in (pl.Utf8, pl.String)`).
+  - `non_null = col.drop_nulls()`; `total = len(non_null)`; `if total == 0: return findings` UNCHANGED.
+  - Pattern generation via the seam: `patterns = non_null.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D")` (was `patterns = _generalize_series(non_null)`).
+  - Replace the comment block above it (the "Build pattern counts via vectorised regex ... map_elements(_generalize) ... #3 self-time hotspot" comment, currently ~4 lines) with a single accurate line: `# Generalise each value to its digit/letter skeleton, then tally the skeletons.` (the old comment references `map_elements`/`_generalize_series`, which `profile()` no longer calls — leaving it would be stale).
+  - Histogram: `pattern_counts = patterns.value_counts_desc()` (a `list[(pattern, count)]`). Remove the old `patterns.value_counts().sort(...)` expression. `n_patterns = len(pattern_counts)`; `if n_patterns <= 1: return findings` UNCHANGED.
+  - `dominant_pattern, dominant_count = pattern_counts[0]` (was `dominant_count = pattern_counts["count"][0]`; `dominant_pattern = pattern_counts[column][0]`).
+  - Minority loop: `for i in range(1, n_patterns):` → `minority_pattern, minority_count = pattern_counts[i]`; `minority_count = int(minority_count)`; `minority_pct = minority_count / total`; the `if minority_pct < MINORITY_THRESHOLD:` accumulation into `minority_candidates` UNCHANGED.
+  - `minority_candidates.sort(...)`, `MAX_PATTERNS = 5`, `emitted = ...[:MAX_PATTERNS]`, and the emit loop are UNCHANGED **except** the sample line: `sample_vals = non_null.filter_by(patterns.eq(minority_pattern)).to_list()[:5]` (was `mask = patterns == minority_pattern; sample_vals = non_null.filter(mask).head(5).to_list()`). All Findings (per-pattern + `msg_extra` structural-shift + the summary Finding), thresholds, severities, confidences, metadata UNCHANGED. Keep the trailing `return findings`.
+
+  **`_generalize_series` (annotation-only edit — body UNTOUCHED):**
+  - Change `def _generalize_series(s: pl.Series) -> pl.Series:` to `def _generalize_series(s):`. Do NOT touch the docstring or the body (`return s.str.replace_all(r"\p{L}", "L").str.replace_all(r"\d", "D")`). This keeps all three direct tests passing (they assert `.to_list()` behavior, not the annotation) while removing the only remaining `pl.` token.
+
+  **`_generalize` (pure-Python helper):** leave the FUNCTION untouched. Its docstring mentions `_generalize_series` — that's fine (no `pl.`/`polars` token). Optionally trim the "prefer `_generalize_series`" sentence for accuracy, but not required.
+
+  **Imports:** remove `from goldencheck._polars_lazy import pl` (no longer referenced anywhere in the module). Keep `to_frame`, `Finding`, `Severity`, `BaseProfiler`, and the `MINORITY_THRESHOLD`/`WARNING_THRESHOLD` constants.
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-batch-a2b && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/profilers/test_pattern_consistency.py -v
+```
+Expected: all pass, ZERO test edits — BOTH the `PatternConsistencyProfiler` cases AND `test_generalize_series_matches_python_loop` / `test_generalize_series_divergence_on_compat_digits` / `test_generalize_series_letters_before_digits_order`. If a test fails, fix the PORT (likely the `value_counts_desc` unpack or the `filter_by`/`eq` compose), never the test; report the assertion diff.
+
+- [ ] **Step 3: Confirm this file polars-free.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py || echo "pattern_consistency polars-free"
+```
+Expected: `pattern_consistency polars-free` (the capital-"Polars" mentions in the `_generalize_series` docstring do NOT match the lowercase pattern — that's fine).
+
+- [ ] **Step 4: Final verification (whole batch).**
+```bash
+cd /d/show_case/gc-batch-a2b && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite byte-identical
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Expected: import gate green; full suite green (report exact passed/skipped counts vs the fresh-main baseline + the 3 new seam tests); ruff clean. If the full suite has any FAILURES, investigate + report (do NOT edit tests to pass — a real failure means the port broke something).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
+git commit -m "refactor(goldencheck): port pattern_consistency onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (Batch A2b complete)
+- [ ] `Column` seam gained `str_replace_all`/`value_counts_desc`/`eq`/`filter_by` (PolarsColumn delegates; import gate green — no `pl.` refs).
+- [ ] `pattern_consistency` is polars-free (grep-clean) and routes `profile()` through the seam; `_generalize_series` kept (annotation-only edit) so its three direct tests pass unedited.
+- [ ] `test_pattern_consistency.py` passes with ZERO edits (profiler cases + all three helper tests — byte-identical).
+- [ ] Full suite green; `import goldencheck` loads zero Polars.
+- [ ] No scope creep: the 9 relation profilers, the substrate backend, reader, and deps flip untouched. **12 of ~13 column profilers now polars-free — the whole column-profiler front is done.**

--- a/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2b-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-profiler-ports-batch-a2b-design.md
@@ -1,0 +1,146 @@
+# GoldenCheck Polars eviction — Profiler ports Batch A2b (pattern_consistency: str_replace_all + value_counts + cross-column mask)
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (P0 #1605 + A #1606 + A2 #1607 + B #1608 + C #1610 all merged; the seam has `dtype`/`cast`/`member_count`/`str_match_count`/`str_filter`/`min`/`max`/`mean`/`std`/`diff`/`is_sorted`/`count_gt`/`count_eq`/`filter_outside`/`slice`)
+Parent program: goldencheck Polars eviction (see `2026-07-08-goldencheck-polars-eviction-p0-design.md`)
+
+## Context
+
+Continuing the goldencheck Polars eviction. `pattern_consistency` is the **last remaining column
+profiler** and the gnarliest port — deferred through Batches A/A2/B/C because it needs three ops no
+prior batch provided: a chainable vectorized `str_replace_all` (for the digit/letter
+generalization), a `value_counts` histogram, and a **cross-column mask filter** (sampling
+`non_null` rows by a mask computed on the derived `patterns` column). This batch designs those ops
+and ports the profiler. **11 of ~13 column profilers are polars-free; this makes 12 — the whole
+column-profiler front.**
+
+**Seam philosophy (unchanged):** the ops go on the `Column` seam; `PolarsColumn` delegates to the
+exact Polars call (byte-identical, no perf regression, Polars stays the fast path). Note this port
+buys **no perf** — `pattern_consistency` is already vectorized (`_generalize_series` + Polars
+`value_counts`); it is a pure byte-identical decoupling.
+
+## Scope
+
+### In scope
+Port `pattern_consistency`'s `profile()` onto the seam, adding **4** `Column` methods. Byte-identical,
+no version bump.
+
+### Explicitly NOT in scope
+The 9 relation profilers (some are the FD-mining/pivot decline-to-Polars tail). The Stage-2
+non-Polars backend. The reader. The deps flip.
+
+### Success criteria
+- `pattern_consistency` is polars-free (grep-clean of `polars`/`pl.`), routing through the seam.
+- Its existing test passes **unedited** (byte-identical — the parity gate). This includes the three
+  direct `_generalize_series` tests, which lock that helper's Polars-regex behavior.
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
+
+Four methods. Each `PolarsColumn` method delegates to the exact Polars call `pattern_consistency`
+uses today, so the port is byte-identical. **None reference the `pl.` symbol** (all `self._s.*` /
+`mask._s`), so the import gate stays green.
+
+| Method | Signature | PolarsColumn impl | Covers |
+|---|---|---|---|
+| `str_replace_all` | `str_replace_all(pattern: str, value: str) -> Column` | `PolarsColumn(self._s.str.replace_all(pattern, value))` | the `\p{L}`→`L`, `\d`→`D` generalization (chained) |
+| `value_counts_desc` | `value_counts_desc() -> list[tuple[Any, int]]` | `vc = self._s.value_counts().sort("count", descending=True); return list(zip(vc[self._s.name].to_list(), vc["count"].to_list()))` | the pattern histogram, most-frequent-first |
+| `eq` | `eq(value: Any) -> Column` | `PolarsColumn(self._s == value)` | the minority-pattern boolean mask |
+| `filter_by` | `filter_by(mask: Column) -> Column` | `PolarsColumn(self._s.filter(mask._s))` | sampling `non_null` rows by the `patterns` mask |
+
+- **`str_replace_all` is chainable** (returns a Column), so
+  `non_null.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D")` reproduces
+  `_generalize_series` exactly (letters-first, then digits — the ordering the helper documents).
+- **`value_counts_desc` bundles the sort.** Polars `value_counts()` order is not guaranteed and
+  `.sort("count", descending=True)` is not stable, so tie order is implementation-defined — but the
+  seam delegates the *identical* call chain, so the returned pair order is byte-identical to the
+  original. `self._s.name` is the original `column` (preserved through `drop_nulls` +
+  `str.replace_all`), so `vc[self._s.name]` selects the pattern column exactly as the original
+  `pattern_counts[column]` did. The "count" values come back as Python ints via `.to_list()`,
+  matching the original's `pattern_counts["count"][i]` (Polars integer indexing also yields a Python
+  int) — byte-identical in the f-strings and `affected_rows`.
+- **`eq` + `filter_by` are the raw boolean primitives** (declined for Batch B in favor of
+  count-shaped). They earn their place here: the sample pulls values from `non_null` using a mask
+  computed on the *different* `patterns` column, so no count-shaped op applies. `filter_by`'s
+  PolarsColumn impl reaches into `mask._s` — a backend-internal coupling (both are PolarsColumn in
+  the Polars backend); the Stage-2 substrate will implement its own `filter_by` over its own Column
+  type.
+
+## The port (`profilers/pattern_consistency.py`)
+
+`profile()` signature `def profile(self, frame, column: str, *, context: dict | None = None)` (drop
+the `frame: pl.DataFrame` annotation); keep `frame = to_frame(frame)`; remove `df = frame.native`;
+`col = frame.column(column)`.
+
+- dtype gate: `if col.dtype != "str": return findings` (was `col.dtype not in (pl.Utf8, pl.String)`).
+- `non_null = col.drop_nulls()`; `total = len(non_null)`; `if total == 0: return findings` UNCHANGED.
+- Pattern generation via the seam: `patterns = non_null.str_replace_all(r"\p{L}", "L")
+  .str_replace_all(r"\d", "D")` (was `patterns = _generalize_series(non_null)`).
+- Histogram: `pattern_counts = patterns.value_counts_desc()` (a `list[(pattern, count)]`) — replaces
+  `patterns.value_counts().sort("count", descending=True)` and its `["count"]`/`[column]` indexing.
+  `n_patterns = len(pattern_counts)`; `if n_patterns <= 1: return findings`.
+  `dominant_pattern, dominant_count = pattern_counts[0]`. The minority loop becomes
+  `for i in range(1, n_patterns): minority_pattern, minority_count = pattern_counts[i];
+  minority_count = int(minority_count); minority_pct = minority_count / total; ...` — same
+  thresholds, same `minority_candidates` accumulation, same rarest-first sort + `MAX_PATTERNS` cap.
+- Cross-column sample: `sample_vals = non_null.filter_by(patterns.eq(minority_pattern)).to_list()[:5]`
+  (was `mask = patterns == minority_pattern; non_null.filter(mask).head(5).to_list()`). Byte-identical
+  (`.head(5).to_list()` ≡ `.to_list()[:5]`; same filter, same order).
+- All Findings (the per-pattern detection + the structural-shift `msg_extra` + the summary Finding),
+  thresholds, severities, confidences, and metadata are UNCHANGED.
+
+### `_generalize_series` handling (chosen: drop annotations → grep-clean)
+
+`test_pattern_consistency.py` imports and directly tests `_generalize_series` (three tests, incl. one
+asserting its Polars-regex divergence on compat digits `²`/`³` — which a pure-Python port cannot
+reproduce). So the helper **cannot be removed or pure-Python-ported** — the parity gate locks it. It
+becomes a Polars helper used only by its own tests once `profile()` routes through the seam.
+
+To keep the file grep-clean: make a **minimal annotation-only edit** — change
+`def _generalize_series(s: pl.Series) -> pl.Series:` to `def _generalize_series(s):`; the body
+(`return s.str.replace_all(r"\p{L}", "L").str.replace_all(r"\d", "D")`) is **untouched**, so all three
+direct tests pass unedited. Then remove `from goldencheck._polars_lazy import pl` (no longer
+referenced — the dtype gate moved to `"str"` and the annotation is gone). `_generalize` (the pure-
+Python per-row helper) stays fully untouched. Optionally reword `_generalize`'s docstring reference to
+`_generalize_series` so it doesn't imply the profiler still calls it (cosmetic; not required for the
+gate — the docstrings contain no lowercase `polars` or `pl.` token).
+
+Result: no `pl` symbol anywhere in the module; the file is grep-clean; the import gate is trivially
+green; `_generalize_series`'s body still uses `s.str.replace_all` (a method on the passed-in Series,
+not the `pl` symbol) exactly as `PolarsColumn.str_replace_all` does.
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): `str_replace_all` chains
+  (`\p{L}`→L then `\d`→D) equal the raw `s.str.replace_all(...).str.replace_all(...)`;
+  `value_counts_desc()` equals the raw `s.value_counts().sort("count", descending=True)` zipped to
+  pairs (assert order + counts on a column with a clear majority + a tie-free minority);
+  `eq(value)` returns the boolean mask; `filter_by(mask)` selects the masked rows (compose
+  `a.filter_by(b.eq(x))` and compare to the raw `a.filter(b._s == x)`).
+- **Parity gate:** `test_pattern_consistency.py` passes with **zero edits** — both the
+  `PatternConsistencyProfiler` cases AND the three direct `_generalize`/`_generalize_series` tests.
+- **Regression:** full suite green (same counts + the new seam tests); import gate green; the ported
+  file grep-clean of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`value_counts_desc` tie order** — delegates the exact `.value_counts().sort("count",
+  descending=True)`, so any nondeterministic tie order is reproduced identically. `self._s.name` ==
+  the original `column`, so pattern-column selection matches. Count values are Python ints via
+  `.to_list()`, matching Polars integer indexing — byte-identical in f-strings + `affected_rows`.
+- **cross-column `filter_by`** — `non_null.filter_by(patterns.eq(p))` reproduces
+  `non_null.filter(patterns == p)` exactly (same mask, same order); `.to_list()[:5]` ≡
+  `.head(5).to_list()`.
+- **`_generalize_series` retained** — the parity gate requires it; the annotation-only edit keeps its
+  body + behavior identical (all three direct tests pass). The file is grep-clean because the body
+  uses `s.str.*` (no `pl` symbol) and the annotation is dropped.
+- **`str_replace_all` chaining order** — letters (`\p{L}`) first, then digits (`\d`), exactly as
+  `_generalize_series` documents (digits-first would misclassify the literal `D`s as letters). The
+  port preserves this order.
+- **Seam growth** — 4 methods, all general primitives (`str_replace_all`, `value_counts_desc`, `eq`,
+  `filter_by`). No task-shaped `generalize`/`pattern_histogram` op.
+
+## Non-goals (YAGNI)
+The 9 relation profilers; the Stage-2 non-Polars backend; reader; deps flip; any change to
+`_generalize` / `_generalize_series` behavior.

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -37,6 +37,10 @@ class Column(Protocol):
     def count_eq(self, value: Any) -> int: ...
     def filter_outside(self, lower: Any, upper: Any) -> Column: ...
     def slice(self, offset: int, length: int | None = None) -> Column: ...
+    def str_replace_all(self, pattern: str, value: str) -> Column: ...
+    def value_counts_desc(self) -> list[tuple[Any, int]]: ...
+    def eq(self, value: Any) -> Column: ...
+    def filter_by(self, mask: Column) -> Column: ...
 
 
 @runtime_checkable
@@ -143,6 +147,19 @@ class PolarsColumn:
 
     def slice(self, offset: int, length: int | None = None) -> PolarsColumn:
         return PolarsColumn(self._s.slice(offset, length))
+
+    def str_replace_all(self, pattern: str, value: str) -> PolarsColumn:
+        return PolarsColumn(self._s.str.replace_all(pattern, value))
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        vc = self._s.value_counts().sort("count", descending=True)
+        return list(zip(vc[self._s.name].to_list(), vc["count"].to_list()))
+
+    def eq(self, value: Any) -> PolarsColumn:
+        return PolarsColumn(self._s == value)
+
+    def filter_by(self, mask: Column) -> PolarsColumn:
+        return PolarsColumn(self._s.filter(mask._s))
 
 
 class PolarsFrame:

--- a/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
+++ b/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
@@ -1,7 +1,6 @@
 """Pattern consistency profiler — detects inconsistent string patterns within a column."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -32,7 +31,7 @@ def _generalize(value: str) -> str:
     return "".join(result)
 
 
-def _generalize_series(s: pl.Series) -> pl.Series:
+def _generalize_series(s):
     """Vectorised equivalent of ``_generalize`` for a Polars string Series.
 
     Pattern: letters (Unicode ``\\p{L}``) → ``L``, then decimal digits
@@ -59,13 +58,12 @@ def _generalize_series(s: pl.Series) -> pl.Series:
 
 
 class PatternConsistencyProfiler(BaseProfiler):
-    def profile(self, frame: pl.DataFrame, column: str, *, context: dict | None = None) -> list[Finding]:
+    def profile(self, frame, column: str, *, context: dict | None = None) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
+        col = frame.column(column)
         findings: list[Finding] = []
-        col = df[column]
 
-        if col.dtype not in (pl.Utf8, pl.String):
+        if col.dtype != "str":
             return findings
 
         non_null = col.drop_nulls()
@@ -73,29 +71,22 @@ class PatternConsistencyProfiler(BaseProfiler):
         if total == 0:
             return findings
 
-        # Build pattern counts via vectorised regex (Polars-native) instead
-        # of `map_elements(_generalize)`. ~10× faster on a 100K column; the
-        # Python UDF was the #3 self-time hotspot in the scale audit's
-        # cProfile of run_dedupe + auto_configure.
-        patterns = _generalize_series(non_null)
-        pattern_counts = (
-            patterns.value_counts()
-            .sort("count", descending=True)
-        )
+        # Generalise each value to its digit/letter skeleton, then tally the skeletons.
+        patterns = non_null.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D")
+        pattern_counts = patterns.value_counts_desc()
 
         n_patterns = len(pattern_counts)
         if n_patterns <= 1:
             # All values share the same pattern — no inconsistency
             return findings
 
-        dominant_count = pattern_counts["count"][0]
-        dominant_pattern = pattern_counts[column][0]
+        dominant_pattern, dominant_count = pattern_counts[0]
 
         # Collect all minority patterns (rarest first — already sorted ascending by reversing)
         minority_candidates = []
         for i in range(1, n_patterns):
-            minority_pattern = pattern_counts[column][i]
-            minority_count = int(pattern_counts["count"][i])
+            minority_pattern, minority_count = pattern_counts[i]
+            minority_count = int(minority_count)
             minority_pct = minority_count / total
 
             if minority_pct < MINORITY_THRESHOLD:
@@ -121,8 +112,7 @@ class PatternConsistencyProfiler(BaseProfiler):
                 severity = Severity.INFO
                 confidence = 0.5
             # Find sample values that match this minority pattern
-            mask = patterns == minority_pattern
-            sample_vals = non_null.filter(mask).head(5).to_list()
+            sample_vals = non_null.filter_by(patterns.eq(minority_pattern)).to_list()[:5]
 
             # Detect structural pattern shift (e.g., letter-first vs digit-first = mixed standards)
             dom_starts_alpha = dominant_pattern and dominant_pattern[0] == "L"

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -148,3 +148,36 @@ def test_column_cast_str():
     col = to_frame(pl.DataFrame({"x": [1, 2, 3]})).column("x")
     assert col.cast("str", strict=True).to_list() == pl.Series([1, 2, 3]).cast(pl.String).to_list()
     assert col.cast("str", strict=True).to_list() == ["1", "2", "3"]
+
+
+def test_column_str_replace_all_chain():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", ["A1", "bc23", "Z9z"])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    # letters -> L, then digits -> D (letters first, matching _generalize_series)
+    got = col.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D").to_list()
+    assert got == s.str.replace_all(r"\p{L}", "L").str.replace_all(r"\d", "D").to_list()
+    assert got == ["LD", "LLDD", "LDL"]
+
+def test_column_value_counts_desc():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    s = pl.Series("x", ["a", "a", "a", "b", "b", "c"])
+    col = to_frame(pl.DataFrame({"x": s})).column("x")
+    got = col.value_counts_desc()
+    raw = s.value_counts().sort("count", descending=True)
+    assert got == list(zip(raw["x"].to_list(), raw["count"].to_list()))
+    assert got[0] == ("a", 3)   # most frequent first
+    assert all(isinstance(cnt, int) for _, cnt in got)
+
+def test_column_eq_and_filter_by():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({"val": ["keep1", "drop", "keep2"], "pat": ["A", "B", "A"]}))
+    val = frame.column("val")
+    pat = frame.column("pat")
+    # eq -> boolean mask; filter_by selects val rows where pat == "A"
+    assert val.filter_by(pat.eq("A")).to_list() == ["keep1", "keep2"]
+    # equivalence to the raw cross-column filter
+    assert val.filter_by(pat.eq("A")).to_list() == val._s.filter(pat._s == "A").to_list()


### PR DESCRIPTION
Batch A2b of the goldencheck Polars eviction — the **last column profiler**. Byte-identical, no version bump. Follows P0 (#1605), A (#1606), A2 (#1607), B (#1608), C (#1610).

## Summary
- **Seam:** added 4 `Column` methods — `str_replace_all(pattern, value)` (chainable), `value_counts_desc()` (histogram, most-frequent-first, bundled sort so tie order is byte-identical), `eq(value)` (bool mask), `filter_by(mask)` (cross-column filter). `PolarsColumn` delegates each to the exact Polars call; none touch the `pl.` symbol.
- **Port:** `pattern_consistency` now routes `profile()` through the seam — the digit/letter generalization is `str_replace_all` chained, the histogram is `value_counts_desc()`, and the minority-pattern sampling is `non_null.filter_by(patterns.eq(p))` (a cross-column mask).
- **`_generalize_series` kept** (its 3 direct tests are part of the parity gate and assert Polars-regex divergence a pure-Python port can't reproduce) via an annotation-only edit, so the file still goes grep-clean.
- **12 of ~13 column profilers now polars-free — the whole column-profiler front is done.**

## Test Plan
- [x] `test_pattern_consistency.py` passes **unedited** — both the profiler cases AND all three `_generalize`/`_generalize_series` helper tests (parity gate)
- [x] 3 new seam unit tests in `tests/core/test_frame.py`
- [x] `tests/test_import_no_polars.py` green — `import goldencheck` loads zero Polars
- [x] Full suite: 749 passed / 6 skipped; ruff clean; pattern_consistency grep-clean of `polars`/`pl.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)