### PR TITLE
refactor(goldencheck): Polars-eviction R1 — port identity_safe_pk onto the Frame seam (relation front begins)

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r1.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r1.md
@@ -59,6 +59,8 @@ def test_column_dtype_bool_and_repr():
     assert frame.column("s").dtype_repr() == "String"
 ```
 
+(Note: the `dtype_repr()` string assertions `"String"`/`"Int64"` are Polars-version-sensitive — modern Polars renders the string dtype as `"String"`; if this suite's Polars renders `"Utf8"`, reconcile the TEST literal, not the port. This never touches the parity gate — `identity_safe_pk`'s tests only exercise the float/boolean disqualifier paths.)
+
 - [ ] **Step 2: Run → FAIL** (`AssertionError: 'other' == 'bool'` and/or `AttributeError: ... no attribute 'dtype_repr'`).
 ```bash
 $PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "dtype_bool_and_repr" -v

--- a/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r1.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r1.md
@@ -1,0 +1,161 @@
+# GoldenCheck Polars Eviction — Relation Ports R1 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `identity_safe_pk` (the first relation profiler) off Polars onto the `Frame`/`Column` seam by adding `Column.dtype_repr()` + a `pl.Boolean → "bool"` neutral-dtype-map entry — byte-identical, no version bump.
+
+**Architecture:** Add a `dtype_repr()` display op (so the `unsuitable dtype (Float64)` reason renders byte-identically) and a `"bool"` category to the neutral dtype map (so the `== pl.Boolean` check becomes `dtype == "bool"`). Then rewrite `identity_safe_pk`'s `profile()` + its `_column_qualifies_as_pk` helper onto the seam, removing the `pl` import.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r1-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-r1` worktree, off fresh origin/main)
+
+Branch `feat/goldencheck-relation-ports-r1`, worktree `D:\show_case\gc-r1`, off fresh `origin/main` (P0 #1605 + A #1606 + A2 #1607 + B #1608 + C #1610 + A2b #1611 all merged — the whole column-profiler front is seam-routed). NOT stacked.
+
+**Test preamble** (run every test command from `/d/show_case/gc-r1`):
+```bash
+export PYTHONPATH="D:/show_case/gc-r1/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-r1
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. The `identity_safe_pk` existing test is the parity gate — it passes UNEDITED. The import gate (`tests/test_import_no_polars.py`) + full suite stay green. No version bump. Do NOT add new test FILES (appending to the existing `test_frame.py` is fine — new files can shift pytest-split shard boundaries in CI). Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `_neutral_dtype(dt)` maps `pl.Utf8`/`pl.String → "str"`, `pl.Int* → "int"`, `pl.UInt* → "uint"`, `pl.Float32/Float64 → "float"`, `pl.Date → "date"`, `pl.Datetime → "datetime"`, else `"other"` (Boolean currently falls to `"other"`). `Column` has `dtype` (returns the neutral string) + ~26 ops but NO `dtype_repr`. `Frame` has `columns` (list[str]), `height` (int), `native`, `column(name)`.
+
+---
+
+## Task 1: Add `dtype_repr()` + the `"bool"` neutral-dtype-map entry
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py`
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_column_dtype_bool_and_repr():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({
+        "b": [True, False, True],
+        "f": [1.0, 2.0, 3.0],
+        "i": [1, 2, 3],
+        "s": ["a", "b", "c"],
+    }))
+    # neutral dtype: Boolean now maps to "bool" (was "other"); float unchanged
+    assert frame.column("b").dtype == "bool"
+    assert frame.column("f").dtype == "float"
+    # dtype_repr renders the raw Polars dtype string, byte-identical to str(dtype)
+    assert frame.column("f").dtype_repr() == str(pl.Series([1.0]).dtype)   # "Float64"
+    assert frame.column("f").dtype_repr() == "Float64"
+    assert frame.column("b").dtype_repr() == "Boolean"
+    assert frame.column("i").dtype_repr() == "Int64"
+    assert frame.column("s").dtype_repr() == "String"
+```
+
+- [ ] **Step 2: Run → FAIL** (`AssertionError: 'other' == 'bool'` and/or `AttributeError: ... no attribute 'dtype_repr'`).
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "dtype_bool_and_repr" -v
+```
+
+- [ ] **Step 3: Implement.**
+  - In `_neutral_dtype`, add a `pl.Boolean` branch **before** the final `return "other"`:
+```python
+    if dt == pl.Boolean:
+        return "bool"
+    return "other"
+```
+  (Place it after the existing `pl.Datetime → "datetime"` branch; it uses the already-imported lazy `pl` proxy, so no new import-time Polars access.)
+  - Add to the `Column` Protocol (after the existing `dtype` property — `dtype_repr` is a plain method, NOT a `@property`):
+```python
+    def dtype_repr(self) -> str: ...
+```
+  - Add to `PolarsColumn` (next to its `dtype` property):
+```python
+    def dtype_repr(self) -> str:
+        return str(self._s.dtype)
+```
+  (`str(self._s.dtype)` — no `pl.` symbol; import gate stays green.)
+
+- [ ] **Step 4: Run → PASS**, import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean: `$PY -m ruff check packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-r1
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add Column.dtype_repr() + map pl.Boolean -> 'bool' in the Frame seam"
+```
+
+---
+
+## Task 2: Port `identity_safe_pk` onto the seam + final verification
+
+**Files:** Modify `packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py`
+
+- [ ] **Step 1: Read the file first.** Then rewrite the two functions below; everything not called out (the module docstring, `_VALUE_COLUMN_PATTERNS`, `_PK_NAME_PATTERNS`, `_looks_like_value_column`, `_looks_like_pk_column`, both Finding bodies) stays byte-identical.
+
+  **A) `_column_qualifies_as_pk` (module helper — the test does NOT import it, so the signature change is free):**
+  - Signature: `def _column_qualifies_as_pk(frame, column: str) -> tuple[bool, str]:` (was `def _column_qualifies_as_pk(df: pl.DataFrame, column: str,) -> tuple[bool, str]:` — rename the first param `df` → `frame`, drop its `pl.DataFrame` annotation).
+  - The `if _looks_like_value_column(column): return False, "value-shaped name (email/name/address/etc.)"` guard UNCHANGED (it comes first).
+  - `col = frame.column(column)` (was `col = df[column]`).
+  - **Remove** the `dtype = col.dtype` line. Dtype disqualifier: `if col.dtype in ("float", "bool"): return False, f"unsuitable dtype ({col.dtype_repr()})"` (was `dtype = col.dtype` then `if dtype.is_float() or dtype == pl.Boolean: return False, f"unsuitable dtype ({dtype})"`). Note `col.dtype` here is the neutral string ("float"/"bool"), and `col.dtype_repr()` renders the raw Polars dtype ("Float64"/"Boolean") — byte-identical to the original `{dtype}` interpolation.
+  - `n_rows = len(col)`; `if n_rows == 0: return False, "empty sample"` UNCHANGED.
+  - `n_nulls = col.null_count()`; `if n_nulls > 0: return False, f"{n_nulls} null value(s)"` UNCHANGED.
+  - `if col.n_unique() != n_rows: return False, "non-unique values"` UNCHANGED.
+  - `return True, "stable unique non-null"` UNCHANGED.
+
+  **B) `IdentitySafePkProfiler.profile` (the param is ALREADY named `frame`):**
+  - Signature: `def profile(self, frame) -> list[Finding]:` — **drop the `frame: pl.DataFrame` annotation**. Keep `frame = to_frame(frame)`.
+  - **Remove** the local `df = frame.native`.
+  - `if len(frame.columns) == 0: return []` (was `if df.width == 0: return []`).
+  - Loop: `for column in frame.columns:` (was `for column in df.columns:`); call `_column_qualifies_as_pk(frame, column)` (was `(df, column)`). The candidate/disqualifier/named-PK-disqualifier accumulation UNCHANGED.
+  - `if candidates: return []` UNCHANGED.
+  - Named-PK-disqualifier Finding: `affected_rows=frame.height` (was `affected_rows=len(df)`). Everything else in that Finding UNCHANGED.
+  - Generic `__dataset__` Finding: `sample_cols = ", ".join(frame.columns[:5])` (was `df.columns[:5]`); `if len(frame.columns) > 5: sample_cols += ", ..."` (was `if df.width > 5:`); `affected_rows=frame.height` (was `len(df)`). Everything else UNCHANGED.
+  - Remove `from goldencheck._polars_lazy import pl`. Keep `to_frame`, `Finding`, `Severity`.
+
+- [ ] **Step 2: Run the existing test UNEDITED (parity gate).**
+```bash
+cd /d/show_case/gc-r1 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/relations/test_identity_safe_pk.py -v
+```
+Expected: all 10 pass, ZERO test edits (clean-PK, uuid, no-PK, named-PK-nulls, named-PK-dups, value-column, float, boolean, empty-DF, multiple-candidates). If a test fails, fix the PORT (likely the dtype-string check or a `frame.columns`/`frame.height` substitution), never the test; report the assertion diff.
+
+- [ ] **Step 3: Confirm this file polars-free.**
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py || echo "identity_safe_pk polars-free"
+```
+
+- [ ] **Step 4: Final verification (whole batch).**
+```bash
+cd /d/show_case/gc-r1 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite byte-identical
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Expected: import gate green; full suite green (report exact passed/skipped counts vs the fresh-main baseline + the new seam test); ruff clean. If the full suite has any FAILURES, investigate + report (do NOT edit tests to pass — a real failure means the port broke something, OR the `"bool"` map change affected another profiler — check which test failed).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
+git commit -m "refactor(goldencheck): port identity_safe_pk onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (R1 complete)
+- [ ] `Column` seam gained `dtype_repr()`; `_neutral_dtype` maps `pl.Boolean → "bool"` (import gate green — no `pl.` refs at method scope).
+- [ ] `identity_safe_pk` is polars-free (grep-clean) and routes `profile()` + `_column_qualifies_as_pk` through the seam.
+- [ ] `test_identity_safe_pk.py` passes with ZERO edits (all 10 tests — byte-identical).
+- [ ] Full suite green (the `"bool"` re-map did not disturb any other profiler); `import goldencheck` loads zero Polars.
+- [ ] No scope creep: R2/R3/R4 profilers, the substrate backend, reader, and deps flip untouched. First relation profiler is now seam-routed; R2 (`Frame.select(cols).n_unique()`) is next.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r1-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r1-design.md
@@ -82,8 +82,9 @@ R2/R3/R4 and their profilers. The Stage-2 non-Polars backend. The reader. The de
   `f"({dtype})"`). `n_rows = len(col)`; `n_nulls = col.null_count()`; `col.n_unique() != n_rows` — all
   existing Column ops. The empty/null/non-unique reason strings + the qualifies-True string are pure
   Python, UNCHANGED.
-- **`profile(self, df)` → `profile(self, frame)`**: drop `df: pl.DataFrame`; keep `frame = to_frame(frame)`;
-  remove `df = frame.native`. `if len(frame.columns) == 0: return []` (was `df.width == 0`). Loop
+- **`profile(self, frame)`**: the param is ALREADY named `frame` (annotated `pl.DataFrame`) — drop the
+  `pl.DataFrame` annotation; keep `frame = to_frame(frame)`; remove the local `df = frame.native`.
+  `if len(frame.columns) == 0: return []` (was `df.width == 0`). Loop
   `for column in frame.columns:` (was `df.columns`) calling `_column_qualifies_as_pk(frame, column)`.
   `affected_rows=frame.height` (was `len(df)`, both = row count). `sample_cols = ", ".join(frame.columns[:5])`;
   `if len(frame.columns) > 5:` (was `df.width > 5`). Both Findings (the named-PK-disqualifier WARNING and

--- a/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r1-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r1-design.md
@@ -1,0 +1,123 @@
+# GoldenCheck Polars eviction — Relation ports R1 (identity_safe_pk) + relation-front roadmap
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (P0 #1605 + A #1606 + A2 #1607 + B #1608 + C #1610 + A2b #1611 all merged; the whole **column-profiler** front is seam-routed)
+Parent program: goldencheck Polars eviction (see `2026-07-08-goldencheck-polars-eviction-p0-design.md`)
+
+## Context
+
+The column-profiler front is complete (12/13 column profilers polars-free through the `Frame`/`Column`
+seam). This opens the **relation-profiler** front: the 9 dataset-level profilers under
+`goldencheck/relations/` (plus `baseline/correlation.py` and the `functional_dependencies.py` bridge),
+which take a whole `pl.DataFrame` (`profile(self, df)`, not `BaseProfiler`, no `column` arg).
+
+**Key finding (reframes the value):** these profilers are **already import-gate-safe** — P0's
+package-wide sweep converted them to `from goldencheck._polars_lazy import pl` (lazy) with deferred
+dtype tuples, and they already `import to_frame`. `import goldencheck` loads zero Polars today. So this
+front is **not** about the import gate. It is about **seam-decoupling** the portable profilers (route
+their `pl.` bodies through the seam so the eventual Stage-2 substrate can back them, and they go
+grep-clean) and **formally declining** the gnarly tail. Routing a body through the seam buys nothing at
+runtime until the substrate exists (PolarsColumn just delegates to Polars) — the value is completing
+the seam surface (it defines exactly which Frame-level ops the substrate must implement) and drawing the
+Polars-only boundary in code. Same "Polars as accelerator" model as [[project_goldenflow_polars_eviction]].
+
+This spec designs **R1** (the first, easiest sub-batch: `identity_safe_pk`) and locks the R1–R4
+decomposition as the roadmap.
+
+## The relation-front roadmap (R1–R4)
+
+Grouped by shared seam need (each is its own spec→plan→execute cycle):
+
+| Sub-batch | Profilers | Seam work | Bucket |
+|---|---|---|---|
+| **R1** (this spec) | `identity_safe_pk` | per-column reductions (mostly existing ops) + `pl.Boolean → "bool"` in the neutral map + `Column.dtype_repr()` | EASY |
+| **R2** | `composite_key`, `functional_dependency`, `approx_fd` (+ the `functional_dependencies` bridge) | `Frame.select(cols).n_unique()` (multi-column distinct-row count) + an Arrow-export escape hatch for their native-kernel paths | EASY/MED |
+| **R3** | `null_correlation`, `numeric_cross`, `temporal` | two-column element-wise ops (`col_a` vs `col_b` comparison → mask, null-mask agreement count, `fill_null`, filter-other-by-mask) + str→date parse | MEDIUM |
+| **R4 (DECLINE)** | `age_validation`, `approx_duplicate`, `baseline/correlation` | keep raw-Polars bodies (already lazy-safe); formally mark **Polars-accelerator-only** + document the decline (expression trees / `group_by`+`join` / `pivot`+numpy/scipy — not substrate-portable) | HARD |
+
+R4 is mostly a documentation/decline pass, not a port. Only R1–R3 add seam ops.
+
+## Scope (R1 only)
+
+### In scope
+Port `identity_safe_pk`'s `profile()` (and its module helper `_column_qualifies_as_pk`) onto the seam,
+adding **1** `Column` method (`dtype_repr`) and **1** neutral-dtype-map entry (`"bool"`).
+Byte-identical, no version bump.
+
+### Explicitly NOT in scope
+R2/R3/R4 and their profilers. The Stage-2 non-Polars backend. The reader. The deps flip.
+
+### Success criteria
+- `identity_safe_pk` is polars-free (grep-clean of `polars`/`pl.`), routing through the seam.
+- Its existing test (`tests/relations/test_identity_safe_pk.py`) passes **unedited** (the parity gate).
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py`)
+
+| Change | Where | Impl | Why |
+|---|---|---|---|
+| `"bool"` category | `_neutral_dtype` | add `if dt == pl.Boolean: return "bool"` (before `else "other"`) | the disqualifier check `dtype == pl.Boolean` becomes `col.dtype == "bool"` |
+| `dtype_repr()` | `Column` Protocol + `PolarsColumn` | `PolarsColumn`: `str(self._s.dtype)` | the reason string `f"unsuitable dtype ({dtype})"` must still render `"Float64"`/`"Boolean"` byte-identically |
+
+- **`"bool"` re-map is behavior-neutral for existing profilers** — verified: no ported profiler branches
+  on `col.dtype == "other"` or `"bool"`; every profiler gates on *positive* categories
+  (str/int/uint/float/date/datetime), so a Boolean column stays skipped exactly as when it mapped to
+  `"other"` (e.g. drift's `dtype not in ("int","uint","float")` skip is unchanged). Only
+  `identity_safe_pk` reads `"bool"`.
+- **`dtype_repr()` is a display op** (returns the backend's dtype string). For the Polars backend it is
+  `str(self._s.dtype)` = `"Float64"`/`"Boolean"`/… — byte-identical to the original `f"({dtype})"`. A
+  future substrate implements its own repr; this is a backend-local display string, deliberately not a
+  neutral category (the neutral category is `dtype`).
+- Neither change references the `pl.` symbol at method scope (`_neutral_dtype` already imports the lazy
+  `pl` proxy at module scope, unchanged; `dtype_repr` uses only `self._s.dtype`), so the import gate
+  stays green.
+
+## The port (`relations/identity_safe_pk.py`)
+
+- **`_column_qualifies_as_pk(df, column)` → `_column_qualifies_as_pk(frame, column)`** (the test does NOT
+  import this helper, so the signature change is free): drop the `df: pl.DataFrame` annotation;
+  `col = frame.column(column)`; dtype check `if col.dtype in ("float", "bool"):` (was
+  `if dtype.is_float() or dtype == pl.Boolean:`); reason `f"unsuitable dtype ({col.dtype_repr()})"` (was
+  `f"({dtype})"`). `n_rows = len(col)`; `n_nulls = col.null_count()`; `col.n_unique() != n_rows` — all
+  existing Column ops. The empty/null/non-unique reason strings + the qualifies-True string are pure
+  Python, UNCHANGED.
+- **`profile(self, df)` → `profile(self, frame)`**: drop `df: pl.DataFrame`; keep `frame = to_frame(frame)`;
+  remove `df = frame.native`. `if len(frame.columns) == 0: return []` (was `df.width == 0`). Loop
+  `for column in frame.columns:` (was `df.columns`) calling `_column_qualifies_as_pk(frame, column)`.
+  `affected_rows=frame.height` (was `len(df)`, both = row count). `sample_cols = ", ".join(frame.columns[:5])`;
+  `if len(frame.columns) > 5:` (was `df.width > 5`). Both Findings (the named-PK-disqualifier WARNING and
+  the generic `__dataset__` WARNING) — severity/check/column/message/affected_rows/sample_values/suggestion/
+  confidence — UNCHANGED.
+- Remove `from goldencheck._polars_lazy import pl`. Keep `to_frame`, `Finding`, `Severity`, and the
+  `_VALUE_COLUMN_PATTERNS`/`_PK_NAME_PATTERNS`/`_looks_like_value_column`/`_looks_like_pk_column` module bits
+  (all pure Python, no `pl`).
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): `_neutral_dtype`/`dtype` maps a `pl.Boolean`
+  Series → `"bool"` (and a Float column still → `"float"`); `dtype_repr()` returns `str(s.dtype)`
+  (`"Float64"`, `"Boolean"`, `"Int64"`, `"String"`).
+- **Parity gate:** `tests/relations/test_identity_safe_pk.py` passes with **zero edits** (all 10 tests —
+  clean-PK, uuid, no-PK, named-PK-with-nulls, named-PK-with-dups, value-column, float, boolean, empty-DF,
+  multiple-candidates).
+- **Regression:** full suite green (same counts + the new seam tests); import gate green; the ported file
+  grep-clean of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`"bool"` neutral-map change touches a SHARED file** (`_neutral_dtype`) used by every ported profiler.
+  Mitigated: verified no profiler branches on `"other"`/`"bool"`; Boolean stays skipped by all positive-
+  category gates. The seam unit test pins the new mapping; the full suite is the regression proof.
+- **`dtype_repr` byte-identity** — `str(self._s.dtype)` equals the original `f"({dtype})"` interpolation
+  (both call `str()` on the same Polars dtype). Reachable only via the untested named-PK-disqualified-by-
+  dtype path; held strict per the session's byte-identity discipline.
+- **`_column_qualifies_as_pk` signature change** — safe: the test imports only `IdentitySafePkProfiler`,
+  not the helper.
+- **`df.width` → `len(frame.columns)`** — `width` == column count == `len(columns)`; byte-identical for the
+  empty-DF (`pl.DataFrame()` → `columns == []`) and the `> 5` cases.
+- **Seam growth** — 1 method + 1 map entry. `dtype_repr` is a general display primitive; no task-shaped op.
+
+## Non-goals (YAGNI)
+R2/R3/R4 profilers; `Frame.width` (use `len(columns)`); `Frame.select().n_unique()` (R2); two-column
+element-wise ops (R3); the Stage-2 non-Polars backend; reader; deps flip.

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -23,6 +23,7 @@ class Column(Protocol):
     def to_list(self) -> list: ...
     @property
     def dtype(self) -> str: ...
+    def dtype_repr(self) -> str: ...
     def cast(self, kind: str, *, strict: bool = False) -> Column: ...
     def member_count(self, values: list) -> int: ...
     def str_match_count(self, pattern: str) -> int: ...
@@ -67,6 +68,8 @@ def _neutral_dtype(dt: Any) -> str:
         return "date"
     if dt == pl.Datetime:
         return "datetime"
+    if dt == pl.Boolean:
+        return "bool"
     return "other"
 
 
@@ -103,6 +106,9 @@ class PolarsColumn:
     @property
     def dtype(self) -> str:
         return _neutral_dtype(self._s.dtype)
+
+    def dtype_repr(self) -> str:
+        return str(self._s.dtype)
 
     def cast(self, kind: str, *, strict: bool = False) -> PolarsColumn:
         pl_type = getattr(pl, _CAST_KIND[kind])

--- a/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
+++ b/packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py
@@ -25,7 +25,6 @@ Heuristic for a "PK candidate":
 """
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
@@ -82,10 +81,7 @@ def _looks_like_pk_column(name: str) -> bool:
     return False
 
 
-def _column_qualifies_as_pk(
-    df: pl.DataFrame,
-    column: str,
-) -> tuple[bool, str]:
+def _column_qualifies_as_pk(frame, column: str) -> tuple[bool, str]:
     """Return (qualifies, why_or_disqualifier).
 
     A column qualifies as a stable PK candidate when:
@@ -97,10 +93,9 @@ def _column_qualifies_as_pk(
     """
     if _looks_like_value_column(column):
         return False, "value-shaped name (email/name/address/etc.)"
-    col = df[column]
-    dtype = col.dtype
-    if dtype.is_float() or dtype == pl.Boolean:
-        return False, f"unsuitable dtype ({dtype})"
+    col = frame.column(column)
+    if col.dtype in ("float", "bool"):
+        return False, f"unsuitable dtype ({col.dtype_repr()})"
     n_rows = len(col)
     if n_rows == 0:
         return False, "empty sample"
@@ -121,18 +116,17 @@ class IdentitySafePkProfiler:
     Graph without explicit `source_pk_column`.
     """
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        if df.width == 0:
+        if len(frame.columns) == 0:
             return []
 
         candidates: list[str] = []
         disqualifiers: dict[str, str] = {}
         named_pk_disqualifiers: dict[str, str] = {}
 
-        for column in df.columns:
-            qualifies, reason = _column_qualifies_as_pk(df, column)
+        for column in frame.columns:
+            qualifies, reason = _column_qualifies_as_pk(frame, column)
             if qualifies:
                 candidates.append(column)
             else:
@@ -162,7 +156,7 @@ class IdentitySafePkProfiler:
                     f"will fall back to payload-hash record_ids, which "
                     f"silently collide on duplicate raw rows."
                 ),
-                affected_rows=len(df),
+                affected_rows=frame.height,
                 sample_values=[],
                 suggestion=(
                     f"Either fix the column ('{target}' should be "
@@ -176,8 +170,8 @@ class IdentitySafePkProfiler:
 
         # No named-PK column either. Generic warning -- treat as
         # dataset-level (no specific column anchor).
-        sample_cols = ", ".join(df.columns[:5])
-        if df.width > 5:
+        sample_cols = ", ".join(frame.columns[:5])
+        if len(frame.columns) > 5:
             sample_cols += ", ..."
         return [Finding(
             severity=Severity.WARNING,
@@ -188,7 +182,7 @@ class IdentitySafePkProfiler:
                 f"({sample_cols}) have nulls, duplicates, or look "
                 "like editable value columns (email/name/address)."
             ),
-            affected_rows=len(df),
+            affected_rows=frame.height,
             sample_values=[],
             suggestion=(
                 "If feeding this dataset to goldenmatch's Identity "

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -44,7 +44,7 @@ def test_column_dtype_neutral_mapping():
     assert f.column("i").dtype == "int"
     assert f.column("u").dtype == "uint"      # DISTINCT from int (byte-identity for type_inference)
     assert f.column("f").dtype == "float"
-    assert f.column("b").dtype == "other"
+    assert f.column("b").dtype == "bool"
 
 
 def test_column_cast_uncastable_to_null():
@@ -181,3 +181,23 @@ def test_column_eq_and_filter_by():
     assert val.filter_by(pat.eq("A")).to_list() == ["keep1", "keep2"]
     # equivalence to the raw cross-column filter
     assert val.filter_by(pat.eq("A")).to_list() == val._s.filter(pat._s == "A").to_list()
+
+
+def test_column_dtype_bool_and_repr():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({
+        "b": [True, False, True],
+        "f": [1.0, 2.0, 3.0],
+        "i": [1, 2, 3],
+        "s": ["a", "b", "c"],
+    }))
+    # neutral dtype: Boolean now maps to "bool" (was "other"); float unchanged
+    assert frame.column("b").dtype == "bool"
+    assert frame.column("f").dtype == "float"
+    # dtype_repr renders the raw Polars dtype string, byte-identical to str(dtype)
+    assert frame.column("f").dtype_repr() == str(pl.Series([1.0]).dtype)   # "Float64"
+    assert frame.column("f").dtype_repr() == "Float64"
+    assert frame.column("b").dtype_repr() == "Boolean"
+    assert frame.column("i").dtype_repr() == "Int64"
+    assert frame.column("s").dtype_repr() == "String"


### PR DESCRIPTION
R1 of the goldencheck Polars eviction — the first **relation profiler** (dataset-level, `profile(df)`-shaped). Byte-identical, no version bump. Follows the completed column-profiler front (P0/A/A2/B/C/A2b, #1605-#1611).

## Summary
- **Seam:** added `Column.dtype_repr()` (raw Polars dtype string, so the `unsuitable dtype (Float64)` reason renders byte-identically) and mapped `pl.Boolean -> "bool"` in the neutral dtype map (was `"other"`; grep-verified behavior-neutral for every other profiler, which all gate on positive categories).
- **Port:** `identity_safe_pk` now routes `profile()` + `_column_qualifies_as_pk` through the seam (`frame.columns`/`frame.height`/`frame.column()`, `col.dtype in ("float","bool")`, `col.dtype_repr()`), dropping its `pl` import.
- **Roadmap:** this is R1 of a 4-part relation front. Note the relation profilers were ALREADY import-gate-safe (P0 swept them) — this front is seam-decoupling + drawing the Polars-only boundary, not the import gate. R2 (`Frame.select(cols).n_unique()`), R3 (two-column element-wise ops), R4 (formally decline age_validation/approx_duplicate/correlation) follow.

## Test Plan
- [x] `test_identity_safe_pk.py` passes **unedited** — all 10 tests (parity gate)
- [x] 1 new seam unit test in `tests/core/test_frame.py` (+ the intentional Boolean-map assertion update in the existing seam test)
- [x] `tests/test_import_no_polars.py` green — `import goldencheck` loads zero Polars
- [x] Full suite: 750 passed / 6 skipped; ruff clean; identity_safe_pk grep-clean of `polars`/`pl.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)