### PR TITLE
feat(mcp): inline file ingestion for the remote server (upload_dataset + file_content)

### DIFF
--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: "MCP Server"
-description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 69 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
+description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 75 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
 keywords: ["mcp", "claude desktop", "model context protocol", "entity resolution", "learning memory"]
 ---
 
-GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 69 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
+GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 75 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
 
 <Tip>
   Looking for AI-to-AI autonomy? See the [ER Agent (A2A)](/goldenmatch/agent) page for agent framework integration (LangChain, CrewAI, AutoGen).
@@ -36,6 +36,30 @@ Add to your `claude_desktop_config.json`:
 ```
 
 Or browse on Smithery: [https://smithery.ai/servers/benzsevern/goldenmatch](https://smithery.ai/servers/benzsevern/goldenmatch)
+
+### Using local files with the remote server
+
+The hosted server resolves `file_path` on the **server's** filesystem, so your local paths (`C:\Users\...`, `/home/...`) aren't visible to it. Feed it a local file two ways, neither of which hosts your data anywhere:
+
+- **Inline `file_content`** — every file-taking tool (`analyze_data`, `auto_configure`, `agent_deduplicate`, `scan_quality`, `schema_match`, `pprl_link`, ...) accepts `file_content` as an alternative to `file_path`. Send it base64-encoded (default), or set `encoding: "text"` for raw text (e.g. CSV/JSON). The server writes it to a temp file and runs the tool on it.
+
+  ```json
+  {
+    "name": "analyze_data",
+    "arguments": { "file_content": "<base64 of your CSV>", "filename": "customers.csv" }
+  }
+  ```
+
+- **`upload_dataset`** — upload the bytes once and reuse the returned server path across many calls:
+
+  ```json
+  { "name": "upload_dataset", "arguments": { "file_content": "<base64>", "filename": "customers.csv" } }
+  // -> { "path": "/data/goldenmatch-uploads/<id>-customers.csv", "bytes": 8369635, "filename": "customers.csv" }
+  ```
+
+  Pass that `path` as `file_path` to `analyze_data`, `agent_deduplicate`, etc.
+
+Uploads are ephemeral scratch: capped at 64 MB (`GOLDENMATCH_MCP_MAX_UPLOAD_BYTES`), reaped after 24 h (`GOLDENMATCH_MCP_UPLOAD_TTL`), and written under the server's `GOLDENMATCH_ALLOWED_ROOT` so the [path sandbox](#path-sandbox) still applies. For datasets larger than the cap, pass a public `http(s)://` URL as `file_path` — the server reads those directly.
 
 ## Local Server
 

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -314,6 +314,8 @@ When you expose any server (MCP, REST, A2A, web UI) on a non-loopback host, it i
 | `GOLDENMATCH_WEB_TOKEN` | Web UI | Required on non-loopback binds (except `/api/v1/healthz`). |
 | `GOLDENMATCH_API_CORS_ORIGINS` | REST API | Comma-separated allow-list; replaces wildcard CORS. |
 | `GOLDENMATCH_ALLOWED_ROOT` | All file-taking surfaces | Opt-in path sandbox. When set, every user-supplied path must resolve under this root or the call is rejected. Recommended for deployed/shared instances (e.g. the Railway MCP server sets it to `/data`). Unset = no containment (correct local-first default). |
+| `GOLDENMATCH_MCP_MAX_UPLOAD_BYTES` | MCP server (inline upload) | Max decoded size for `file_content` / `upload_dataset` inline uploads. Default `67108864` (64 MB). Over the cap the call is rejected — pass a public `http(s)://` URL as `file_path` for larger datasets. |
+| `GOLDENMATCH_MCP_UPLOAD_TTL` | MCP server (inline upload) | Age in seconds after which an inline-uploaded temp file is reaped. Default `86400` (24 h). Uploaded paths are ephemeral scratch; re-upload if you need one older than this. |
 
 **Storage / persistence:**
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -1271,7 +1271,16 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-69 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+75 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+
+### Local files with the remote server
+
+The hosted server resolves `file_path` on the *server's* filesystem, so a remote client's local paths (`C:\...`, `/home/...`) aren't visible to it. Two ways to feed it a local file without hosting it anywhere:
+
+- **Inline `file_content`** — every file-taking tool (`analyze_data`, `auto_configure`, `agent_deduplicate`, `scan_quality`, `schema_match`, ...) accepts `file_content` (base64 by default, or raw with `encoding: "text"`) as an alternative to `file_path`. The server materializes it to a temp file and proceeds.
+- **`upload_dataset`** — upload the bytes once (`upload_dataset(file_content, filename)`) and get back a server path to reuse across any number of tool calls.
+
+Uploads are ephemeral scratch, capped at 64 MB (`GOLDENMATCH_MCP_MAX_UPLOAD_BYTES`) and reaped after 24 h (`GOLDENMATCH_MCP_UPLOAD_TTL`). For larger datasets, pass a public `http(s)://` URL as `file_path` instead — the server reads those directly.
 
 ## Architecture
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/_ingest.py
@@ -1,0 +1,122 @@
+"""Inline file ingestion for the MCP server.
+
+Turns a caller-supplied (file_path | file_content) pair into a concrete
+server-side path. `file_content` is decoded (base64 default, text opt-in),
+size-checked, and written under an uploads dir that honors
+GOLDENMATCH_ALLOWED_ROOT so the existing `core._paths.safe_path` guard
+still accepts the resulting path on network-exposed deployments.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import os
+import re
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+_MAX_BYTES_ENV = "GOLDENMATCH_MCP_MAX_UPLOAD_BYTES"
+_TTL_ENV = "GOLDENMATCH_MCP_UPLOAD_TTL"
+_ROOT_ENV = "GOLDENMATCH_ALLOWED_ROOT"
+_DEFAULT_MAX_BYTES = 64 * 1024 * 1024
+_DEFAULT_TTL = 86_400
+_UPLOAD_SUBDIR = "goldenmatch-uploads"
+_WS = re.compile(rb"\s+")
+_UNSAFE = re.compile(r"[^A-Za-z0-9._-]")
+
+
+def _max_bytes() -> int:
+    raw = os.environ.get(_MAX_BYTES_ENV)
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return _DEFAULT_MAX_BYTES
+
+
+def _ttl() -> int:
+    raw = os.environ.get(_TTL_ENV)
+    if raw:
+        try:
+            return int(raw)
+        except ValueError:
+            pass
+    return _DEFAULT_TTL
+
+
+def _uploads_dir() -> str:
+    root = os.environ.get(_ROOT_ENV)
+    base = root if root else tempfile.gettempdir()
+    d = Path(base) / _UPLOAD_SUBDIR
+    d.mkdir(parents=True, exist_ok=True)
+    return str(d)
+
+
+def _safe_filename(name: str | None) -> str:
+    if not name:
+        return "upload.csv"
+    base = os.path.basename(str(name)).replace("..", "")
+    cleaned = _UNSAFE.sub("", base).lstrip(".")
+    return cleaned or "upload.csv"
+
+
+def _reap(uploads_dir: str | os.PathLike, *, ttl: int) -> None:
+    cutoff = time.time() - ttl
+    try:
+        for entry in os.scandir(uploads_dir):
+            try:
+                if entry.is_file() and entry.stat().st_mtime < cutoff:
+                    os.remove(entry.path)
+            except OSError:
+                continue
+    except OSError:
+        return
+
+
+def _decode(content: str, encoding: str) -> bytes:
+    if encoding == "text":
+        return content.encode("utf-8")
+    if encoding == "base64":
+        stripped = _WS.sub(b"", content.encode("ascii", "ignore"))
+        try:
+            return base64.b64decode(stripped, validate=True)
+        except (binascii.Error, ValueError) as exc:
+            raise ValueError(
+                "file_content is not valid base64; set encoding='text' for "
+                "raw text"
+            ) from exc
+    raise ValueError("encoding must be 'base64' or 'text'")
+
+
+def resolve_input_source(
+    *,
+    file_path: str | None,
+    file_content: str | None,
+    filename: str | None = None,
+    encoding: str = "base64",
+) -> str:
+    """Return a concrete server path for (file_path | file_content).
+
+    Exactly one of file_path/file_content must be non-empty.
+    """
+    if file_content:
+        data = _decode(file_content, encoding)
+        cap = _max_bytes()
+        if len(data) > cap:
+            raise ValueError(
+                f"file_content ({len(data)} bytes) exceeds the "
+                f"{cap}-byte cap ({_MAX_BYTES_ENV}); pass a public http(s) "
+                f"URL as file_path for larger datasets"
+            )
+        uploads = _uploads_dir()
+        _reap(uploads, ttl=_ttl())
+        dest = Path(uploads) / f"{uuid.uuid4().hex}-{_safe_filename(filename)}"
+        dest.write_bytes(data)
+        return str(dest)
+    if file_path:
+        return file_path
+    raise ValueError("provide file_path or file_content")

--- a/packages/python/goldenmatch/goldenmatch/mcp/_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/_ingest.py
@@ -120,3 +120,74 @@ def resolve_input_source(
     if file_path:
         return file_path
     raise ValueError("provide file_path or file_content")
+
+
+# (path_param, content_param, name_param). A side with no content and no
+# path is left untouched (optional side). encoding is read from a shared
+# "encoding" arg (default base64) across all sides of a call.
+INGEST_PARAMS: dict[str, list[tuple[str, str, str]]] = {
+    "analyze_data": [("file_path", "file_content", "filename")],
+    "auto_configure": [("file_path", "file_content", "filename")],
+    "agent_deduplicate": [("file_path", "file_content", "filename")],
+    "suggest_pprl": [("file_path", "file_content", "filename")],
+    "scan_quality": [("file_path", "file_content", "filename")],
+    "fix_quality": [("file_path", "file_content", "filename")],
+    "run_transforms": [("file_path", "file_content", "filename")],
+    "sensitivity": [("file_path", "file_content", "filename")],
+    "certify_recall": [("file_path", "file_content", "filename")],
+    "retrieve_similar": [("file_path", "file_content", "filename")],
+    "agent_compare_strategies": [
+        ("file_path", "file_content", "filename"),
+        ("ground_truth", "ground_truth_content", "ground_truth_name"),
+    ],
+    "agent_match_sources": [
+        ("file_a", "file_a_content", "file_a_name"),
+        ("file_b", "file_b_content", "file_b_name"),
+    ],
+    "incremental": [
+        ("base_file", "base_file_content", "base_file_name"),
+        ("new_records", "new_records_content", "new_records_name"),
+    ],
+    "pprl_link": [
+        ("file_a", "file_a_content", "file_a_name"),
+        ("file_b", "file_b_content", "file_b_name"),
+    ],
+    "schema_match": [
+        ("file_a", "file_a_content", "file_a_name"),
+        ("file_b", "file_b_content", "file_b_name"),
+    ],
+    "compare_clusters": [
+        ("clusters_a_path", "clusters_a_content", "clusters_a_name"),
+        ("clusters_b_path", "clusters_b_content", "clusters_b_name"),
+    ],
+}
+
+
+def resolve_ingest_args(name: str, args: dict) -> dict | None:
+    """Resolve inline content params for tool *name* in place.
+
+    For each (path, content, name) side of the tool, if content is present
+    it is materialized and args[path] is rewritten with the server path.
+    A side with neither content nor an existing path is left untouched
+    (supports optional sides). Returns None on success, or an
+    ``{"error": str}`` dict if any side fails to resolve.
+    """
+    sides = INGEST_PARAMS.get(name)
+    if not sides:
+        return None
+    encoding = args.get("encoding", "base64")
+    for path_param, content_param, name_param in sides:
+        content = args.get(content_param)
+        if not content:
+            continue  # no inline content for this side; leave path as-is
+        try:
+            resolved = resolve_input_source(
+                file_path=None,
+                file_content=content,
+                filename=args.get(name_param),
+                encoding=encoding,
+            )
+        except ValueError as exc:
+            return {"error": str(exc)}
+        args[path_param] = resolved
+    return None

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -415,6 +415,39 @@ AGENT_TOOLS = [
             "required": ["file_path", "query", "column"],
         },
     ),
+    Tool(
+        name="upload_dataset",
+        description=(
+            "Upload a local file's bytes to the server and get back a "
+            "server-side path to reuse across other tools (analyze_data, "
+            "auto_configure, agent_deduplicate, ...). No hosting needed. "
+            "Send base64 (default) or raw text via `encoding`. Uploaded "
+            "files are ephemeral scratch, reaped after "
+            "GOLDENMATCH_MCP_UPLOAD_TTL (default 24h); re-upload if you "
+            "need a path older than that. Max size "
+            "GOLDENMATCH_MCP_MAX_UPLOAD_BYTES (default 64MB) -- above it, "
+            "pass a public http(s) URL as file_path instead."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "file_content": {
+                    "type": "string",
+                    "description": "File bytes, base64-encoded (or raw text with encoding='text')",
+                },
+                "filename": {
+                    "type": "string",
+                    "description": "Original filename (extension preserved for format sniffing)",
+                },
+                "encoding": {
+                    "type": "string",
+                    "enum": ["base64", "text"],
+                    "description": "Encoding of file_content (default base64)",
+                },
+            },
+            "required": ["file_content", "filename"],
+        },
+    ),
 ]
 
 _AGENT_TOOL_NAMES = frozenset(t.name for t in AGENT_TOOLS)
@@ -473,6 +506,26 @@ def _dispatch(
     dataset: str | None = None,
 ) -> dict:
     """Dispatch to the appropriate handler by tool name."""
+
+    from goldenmatch.mcp import _ingest
+
+    if name == "upload_dataset":
+        path = _ingest.resolve_input_source(
+            file_path=None,
+            file_content=args["file_content"],
+            filename=args.get("filename"),
+            encoding=args.get("encoding", "base64"),
+        )
+        import os as _os
+        return {
+            "path": path,
+            "bytes": _os.path.getsize(path),
+            "filename": _ingest._safe_filename(args.get("filename")),
+        }
+
+    _ingest_err = _ingest.resolve_ingest_args(name, args)
+    if _ingest_err is not None:
+        return _ingest_err
 
     if name == "analyze_data":
         session = session_cls()

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -100,8 +100,14 @@ AGENT_TOOLS = [
             "type": "object",
             "properties": {
                 "file_path": {"type": "string"},
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -118,8 +124,14 @@ AGENT_TOOLS = [
                 "file_path": {"type": "string"},
                 "constraints": {"type": "object"},
                 "exclude_columns": _EXCLUDE_COLUMNS_SCHEMA,
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -143,8 +155,14 @@ AGENT_TOOLS = [
                 "file_path": {"type": "string"},
                 "config": {"type": "object"},
                 "exclude_columns": _EXCLUDE_COLUMNS_SCHEMA,
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -157,8 +175,13 @@ AGENT_TOOLS = [
                 "file_b": {"type": "string"},
                 "config": {"type": "object"},
                 "exclude_columns": _EXCLUDE_COLUMNS_SCHEMA,
+                "file_a_content": {"type": "string", "description": "Alternative to file_a: base64/text bytes"},
+                "file_a_name": {"type": "string"},
+                "file_b_content": {"type": "string", "description": "Alternative to file_b: base64/text bytes"},
+                "file_b_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_a", "file_b"],
+            "required": [],
         },
     ),
     Tool(
@@ -221,8 +244,16 @@ AGENT_TOOLS = [
             "properties": {
                 "file_path": {"type": "string"},
                 "ground_truth": {"type": "string"},
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "ground_truth_content": {"type": "string", "description": "Alternative to ground_truth: base64/text bytes"},
+                "ground_truth_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -232,8 +263,14 @@ AGENT_TOOLS = [
             "type": "object",
             "properties": {
                 "file_path": {"type": "string"},
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -254,8 +291,14 @@ AGENT_TOOLS = [
                     "type": "string",
                     "description": "Optional domain hint (healthcare, finance, ecommerce)",
                 },
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -286,8 +329,14 @@ AGENT_TOOLS = [
                     "type": "string",
                     "description": "Optional path to save the fixed CSV. If omitted, returns summary only.",
                 },
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -309,8 +358,14 @@ AGENT_TOOLS = [
                     "type": "string",
                     "description": "Optional path to save the transformed CSV. If omitted, returns summary only.",
                 },
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -338,8 +393,14 @@ AGENT_TOOLS = [
                     "type": "integer",
                     "description": "Optional: randomly sample N records before sweeping",
                 },
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path", "sweep"],
+            "required": ["sweep"],
         },
     ),
     Tool(
@@ -357,8 +418,13 @@ AGENT_TOOLS = [
                 "new_records": {"type": "string", "description": "New records file to match in"},
                 "config": {"type": "string", "description": "Optional config YAML path"},
                 "threshold": {"type": "number", "description": "Optional threshold override"},
+                "base_file_content": {"type": "string", "description": "Alternative to base_file: base64/text bytes"},
+                "base_file_name": {"type": "string"},
+                "new_records_content": {"type": "string", "description": "Alternative to new_records: base64/text bytes"},
+                "new_records_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["base_file", "new_records"],
+            "required": [],
         },
     ),
     Tool(
@@ -375,8 +441,14 @@ AGENT_TOOLS = [
             "type": "object",
             "properties": {
                 "file_path": {"type": "string", "description": "Dataset to dedupe + certify"},
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -411,8 +483,14 @@ AGENT_TOOLS = [
                     "type": "object",
                     "description": "Optional {column: value} equality pre-filter applied before embedding",
                 },
+                "file_content": {
+                    "type": "string",
+                    "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
+                },
+                "filename": {"type": "string", "description": "Original filename when using file_content"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["file_path", "query", "column"],
+            "required": ["query", "column"],
         },
     ),
     Tool(

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -422,6 +422,11 @@ _BASE_TOOLS = [
                     "type": "string",
                     "description": "Path to party B's CSV file",
                 },
+                "file_a_content": {"type": "string", "description": "Alternative to file_a: base64/text bytes"},
+                "file_a_name": {"type": "string"},
+                "file_b_content": {"type": "string", "description": "Alternative to file_b: base64/text bytes"},
+                "file_b_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
                 "fields": {
                     "type": "array",
                     "items": {"type": "string"},
@@ -437,7 +442,7 @@ _BASE_TOOLS = [
                     "default": "high",
                 },
             },
-            "required": ["file_a", "file_b", "fields"],
+            "required": ["fields"],
         },
     ),
     Tool(
@@ -491,8 +496,13 @@ _BASE_TOOLS = [
             "properties": {
                 "clusters_a_path": {"type": "string", "description": "Baseline clusters JSON"},
                 "clusters_b_path": {"type": "string", "description": "Comparison clusters JSON"},
+                "clusters_a_content": {"type": "string", "description": "Alternative to clusters_a_path: base64/text bytes (JSON, use encoding='text')"},
+                "clusters_a_name": {"type": "string"},
+                "clusters_b_content": {"type": "string", "description": "Alternative to clusters_b_path: base64/text bytes (JSON, use encoding='text')"},
+                "clusters_b_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
             },
-            "required": ["clusters_a_path", "clusters_b_path"],
+            "required": [],
         },
     ),
     Tool(
@@ -508,9 +518,14 @@ _BASE_TOOLS = [
             "properties": {
                 "file_a": {"type": "string"},
                 "file_b": {"type": "string"},
+                "file_a_content": {"type": "string", "description": "Alternative to file_a: base64/text bytes"},
+                "file_a_name": {"type": "string"},
+                "file_b_content": {"type": "string", "description": "Alternative to file_b: base64/text bytes"},
+                "file_b_name": {"type": "string"},
+                "encoding": {"type": "string", "enum": ["base64", "text"], "description": "Encoding of *_content (default base64)"},
                 "min_score": {"type": "number", "default": 0.5},
             },
-            "required": ["file_a", "file_b"],
+            "required": [],
         },
     ),
     Tool(
@@ -935,6 +950,10 @@ def create_server(file_paths: list[str] | None = None, config_path: str | None =
 
 def _handle_tool(name: str, args: dict) -> dict:
     """Dispatch tool calls."""
+    from goldenmatch.mcp import _ingest
+    _ingest_err = _ingest.resolve_ingest_args(name, args)
+    if _ingest_err is not None:
+        return _ingest_err
     if name == "get_stats":
         return _tool_get_stats()
     elif name == "find_duplicates":
@@ -1752,7 +1771,7 @@ async def run_server_http(
     async def server_card(request):
         return JSONResponse({
             "name": "GoldenMatch",
-            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 74 MCP tools for matching, semantic retrieval, explaining, reviewing, evaluating, blocking analysis, config critique, config healing, lineage, data quality, transforms, identity graph, distributed-routing config, and privacy-preserving linkage. Built on Polars. 97.2% F1 on DBLP-ACM.",
+            "description": "Entity resolution toolkit — deduplicate records, match across datasets, and create golden records using fuzzy, probabilistic, and LLM-powered scoring. Zero-config mode auto-detects your data. 75 MCP tools for matching, semantic retrieval, explaining, reviewing, evaluating, blocking analysis, config critique, config healing, lineage, data quality, transforms, identity graph, distributed-routing config, privacy-preserving linkage, and inline file upload. Built on Polars. 97.2% F1 on DBLP-ACM.",
             "homepage": "https://github.com/benseverndev-oss/goldenmatch",
             "iconUrl": "https://avatars.githubusercontent.com/u/192581748"
         })

--- a/packages/python/goldenmatch/tests/test_mcp_ingest.py
+++ b/packages/python/goldenmatch/tests/test_mcp_ingest.py
@@ -71,6 +71,20 @@ def test_oversized_raises(tmp_path, monkeypatch):
         )
 
 
+def test_size_cap_measures_decoded_not_encoded_bytes(tmp_path, monkeypatch):
+    # Pin the guarantee that the cap is on DECODED bytes: 6 raw bytes
+    # base64-encode to 8 chars. With cap=7, decoded (6) is under and must
+    # succeed; a buggy check on the encoded length (8) would wrongly reject.
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    monkeypatch.setenv("GOLDENMATCH_MCP_MAX_UPLOAD_BYTES", "7")
+    raw = b"x" * 6
+    assert len(_b64(raw)) == 8  # encoded length exceeds the cap
+    path = _ingest.resolve_input_source(
+        file_path=None, file_content=_b64(raw), filename="d.csv"
+    )
+    assert Path(path).read_bytes() == raw
+
+
 def test_invalid_base64_hints_text(tmp_path, monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
     with pytest.raises(ValueError, match="base64"):

--- a/packages/python/goldenmatch/tests/test_mcp_ingest.py
+++ b/packages/python/goldenmatch/tests/test_mcp_ingest.py
@@ -1,0 +1,111 @@
+import base64
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from goldenmatch.mcp import _ingest
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def test_base64_roundtrip_writes_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    raw = b"a,b\n1,2\n"
+    path = _ingest.resolve_input_source(
+        file_path=None, file_content=_b64(raw), filename="d.csv"
+    )
+    assert Path(path).read_bytes() == raw
+    assert Path(path).suffix == ".csv"
+    # Under the allowed root so safe_path will accept it.
+    assert Path(path).resolve().is_relative_to(tmp_path.resolve())
+
+
+def test_newline_wrapped_base64_decodes(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    raw = b"x" * 200
+    wrapped = "\n".join(
+        _b64(raw)[i : i + 76] for i in range(0, len(_b64(raw)), 76)
+    )
+    path = _ingest.resolve_input_source(
+        file_path=None, file_content=wrapped, filename="d.csv"
+    )
+    assert Path(path).read_bytes() == raw
+
+
+def test_text_encoding_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    path = _ingest.resolve_input_source(
+        file_path=None, file_content="a,b\n1,2\n", filename="d.csv", encoding="text"
+    )
+    assert Path(path).read_text() == "a,b\n1,2\n"
+
+
+def test_uploads_dir_falls_back_to_tempdir_when_root_unset(tmp_path, monkeypatch):
+    monkeypatch.delenv("GOLDENMATCH_ALLOWED_ROOT", raising=False)
+    monkeypatch.setattr(_ingest.tempfile, "gettempdir", lambda: str(tmp_path))
+    d = _ingest._uploads_dir()
+    assert Path(d).resolve().is_relative_to(tmp_path.resolve())
+
+
+def test_passthrough_file_path_unchanged():
+    assert _ingest.resolve_input_source(
+        file_path="/data/x.csv", file_content=None
+    ) == "/data/x.csv"
+
+
+def test_neither_source_raises():
+    with pytest.raises(ValueError, match="file_path or file_content"):
+        _ingest.resolve_input_source(file_path=None, file_content=None)
+
+
+def test_oversized_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    monkeypatch.setenv("GOLDENMATCH_MCP_MAX_UPLOAD_BYTES", "8")
+    with pytest.raises(ValueError, match="exceeds"):
+        _ingest.resolve_input_source(
+            file_path=None, file_content=_b64(b"x" * 100), filename="d.csv"
+        )
+
+
+def test_invalid_base64_hints_text(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    with pytest.raises(ValueError, match="base64"):
+        _ingest.resolve_input_source(
+            file_path=None, file_content="not*valid*b64*!!", filename="d.csv"
+        )
+
+
+def test_bad_encoding_value(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    with pytest.raises(ValueError, match="encoding"):
+        _ingest.resolve_input_source(
+            file_path=None, file_content="x", filename="d.csv", encoding="hex"
+        )
+
+
+@pytest.mark.parametrize(
+    "raw,expected_suffix",
+    [("../../etc/passwd", ""), ("a b.csv", ".csv"), ("weirdé.parquet", ".parquet")],
+)
+def test_safe_filename_traversal_and_ext(raw, expected_suffix):
+    safe = _ingest._safe_filename(raw)
+    assert "/" not in safe and "\\" not in safe and ".." not in safe
+    if expected_suffix:
+        assert safe.endswith(expected_suffix)
+
+
+def test_reaper_deletes_aged_keeps_fresh(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_MCP_UPLOAD_TTL", "1")
+    old = tmp_path / "old.csv"
+    old.write_text("x")
+    new = tmp_path / "new.csv"
+    new.write_text("y")
+    past = time.time() - 10
+    os.utime(old, (past, past))
+    _ingest._reap(tmp_path, ttl=1)
+    assert not old.exists()
+    assert new.exists()

--- a/packages/python/goldenmatch/tests/test_mcp_ingest.py
+++ b/packages/python/goldenmatch/tests/test_mcp_ingest.py
@@ -4,7 +4,6 @@ import time
 from pathlib import Path
 
 import pytest
-
 from goldenmatch.mcp import _ingest
 
 

--- a/packages/python/goldenmatch/tests/test_mcp_ingest.py
+++ b/packages/python/goldenmatch/tests/test_mcp_ingest.py
@@ -109,3 +109,46 @@ def test_reaper_deletes_aged_keeps_fresh(tmp_path, monkeypatch):
     _ingest._reap(tmp_path, ttl=1)
     assert not old.exists()
     assert new.exists()
+
+
+def test_resolve_ingest_args_rewrites_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    args = {"file_content": _b64(b"a,b\n1,2\n"), "filename": "d.csv"}
+    err = _ingest.resolve_ingest_args("analyze_data", args)
+    assert err is None
+    assert "file_path" in args and Path(args["file_path"]).exists()
+
+
+def test_resolve_ingest_args_two_sided(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    args = {
+        "file_a_content": _b64(b"a\n1\n"),
+        "file_b_content": _b64(b"b\n2\n"),
+        "fields": ["a"],
+    }
+    err = _ingest.resolve_ingest_args("schema_match", args)
+    assert err is None
+    assert Path(args["file_a"]).exists() and Path(args["file_b"]).exists()
+
+
+def test_resolve_ingest_args_unknown_tool_noop():
+    args = {"foo": 1}
+    assert _ingest.resolve_ingest_args("get_stats", args) is None
+    assert args == {"foo": 1}
+
+
+def test_resolve_ingest_args_optional_side_skipped(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    # compare_strategies: only the dataset side supplied, ground_truth omitted
+    args = {"file_content": _b64(b"a\n1\n"), "filename": "d.csv"}
+    err = _ingest.resolve_ingest_args("agent_compare_strategies", args)
+    assert err is None
+    assert Path(args["file_path"]).exists()
+    assert "ground_truth" not in args  # untouched when neither path nor content
+
+
+def test_resolve_ingest_args_bad_content_returns_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    args = {"file_content": "not*b64*!!"}
+    err = _ingest.resolve_ingest_args("analyze_data", args)
+    assert err is not None and "error" in err

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,7 +16,7 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_69():
+def test_total_tool_count_is_77():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -23,12 +23,12 @@ def test_total_tool_count_is_69():
     from goldenmatch.mcp.routing_tools import ROUTING_TOOLS
     from goldenmatch.mcp.server import _BASE_TOOLS, TOOLS
 
-    assert len(AGENT_TOOLS) == 18   # +1 retrieve_similar (#1089)
+    assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
     assert len(_BASE_TOOLS) == 31   # 26 + 5 cross-language naming aliases (#1451)
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 76   # 71 (69 + documents_ingest/documents_suggest_schema) + 5 aliases
+    assert len(TOOLS) == 77   # 71 (69 + documents_ingest/documents_suggest_schema) + 5 aliases + upload_dataset
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))

--- a/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
+++ b/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
@@ -74,7 +74,7 @@ def test_schema_match_inline_both_sides(tmp_path, monkeypatch):
         "file_a_content": _b64(a), "file_b_content": _b64(b),
     })
     assert "error" not in res
-    assert "matches" in res or "mapping" in res or isinstance(res, dict)
+    assert "mappings" in res
 
 
 def test_server_schemas_expose_content_params():

--- a/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
+++ b/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
@@ -57,3 +57,31 @@ def test_agent_schemas_expose_content_params():
         # path param must not be in required anymore
         for path_param, _c, _n in sides:
             assert path_param not in t.inputSchema.get("required", [])
+
+
+from goldenmatch.mcp.server import _handle_tool, TOOLS
+
+
+def _call_server(name, args):
+    return _handle_tool(name, args)
+
+
+def test_schema_match_inline_both_sides(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    a = b"first_name,last_name,zip\nJOHN,SMITH,10001\n"
+    b = b"fname,lname,postal\nJOHN,SMITH,10001\n"
+    res = _call_server("schema_match", {
+        "file_a_content": _b64(a), "file_b_content": _b64(b),
+    })
+    assert "error" not in res
+    assert "matches" in res or "mapping" in res or isinstance(res, dict)
+
+
+def test_server_schemas_expose_content_params():
+    by_name = {t.name: t for t in TOOLS}
+    server_side = {"pprl_link", "schema_match", "compare_clusters"}
+    for tool in server_side:
+        props = by_name[tool].inputSchema["properties"]
+        for path_param, content_param, _n in INGEST_PARAMS[tool]:
+            assert content_param in props
+            assert path_param not in by_name[tool].inputSchema.get("required", [])

--- a/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
+++ b/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
@@ -21,3 +21,39 @@ def test_upload_dataset_returns_path(tmp_path, monkeypatch):
     res = _call("upload_dataset", {"file_content": _b64(raw), "filename": "p.csv"})
     assert "path" in res and res["bytes"] == len(raw)
     assert Path(res["path"]).read_bytes() == raw
+
+
+import pytest
+
+from goldenmatch.mcp._ingest import INGEST_PARAMS
+from goldenmatch.mcp.agent_tools import AGENT_TOOLS
+
+_PERSON_CSV = (
+    "first_name,last_name,city,zip\n"
+    "JOHN,SMITH,NEW YORK,10001\n"
+    "JON,SMITH,NEW YORK,10001\n"
+    "MARY,JONES,BOSTON,02108\n"
+)
+
+
+@pytest.mark.parametrize("tool", ["analyze_data", "scan_quality"])
+def test_inline_file_content_dispatch(tool, tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    res = _call(tool, {"file_content": _b64(_PERSON_CSV.encode()), "filename": "p.csv"})
+    assert "error" not in res or "goldencheck" in json.dumps(res).lower()
+    # analyze_data must return a profile; scan_quality may report missing
+    # optional dep — both are non-crash outcomes.
+
+
+def test_agent_schemas_expose_content_params():
+    by_name = {t.name: t for t in AGENT_TOOLS}
+    for tool, sides in INGEST_PARAMS.items():
+        t = by_name.get(tool)
+        if t is None:
+            continue  # server-side tool, checked in Task 5
+        props = t.inputSchema["properties"]
+        for path_param, content_param, name_param in sides:
+            assert content_param in props, f"{tool} missing {content_param}"
+        # path param must not be in required anymore
+        for path_param, _c, _n in sides:
+            assert path_param not in t.inputSchema.get("required", [])

--- a/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
+++ b/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
@@ -3,7 +3,10 @@ import base64
 import json
 from pathlib import Path
 
-from goldenmatch.mcp.agent_tools import handle_agent_tool
+import pytest
+from goldenmatch.mcp._ingest import INGEST_PARAMS
+from goldenmatch.mcp.agent_tools import AGENT_TOOLS, handle_agent_tool
+from goldenmatch.mcp.server import TOOLS, _handle_tool
 
 
 def _b64(data: bytes) -> str:
@@ -22,11 +25,6 @@ def test_upload_dataset_returns_path(tmp_path, monkeypatch):
     assert "path" in res and res["bytes"] == len(raw)
     assert Path(res["path"]).read_bytes() == raw
 
-
-import pytest
-
-from goldenmatch.mcp._ingest import INGEST_PARAMS
-from goldenmatch.mcp.agent_tools import AGENT_TOOLS
 
 _PERSON_CSV = (
     "first_name,last_name,city,zip\n"
@@ -57,9 +55,6 @@ def test_agent_schemas_expose_content_params():
         # path param must not be in required anymore
         for path_param, _c, _n in sides:
             assert path_param not in t.inputSchema.get("required", [])
-
-
-from goldenmatch.mcp.server import _handle_tool, TOOLS
 
 
 def _call_server(name, args):

--- a/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
+++ b/packages/python/goldenmatch/tests/test_mcp_upload_and_inline.py
@@ -1,0 +1,23 @@
+# tests/test_mcp_upload_and_inline.py
+import base64
+import json
+from pathlib import Path
+
+from goldenmatch.mcp.agent_tools import handle_agent_tool
+
+
+def _b64(data: bytes) -> str:
+    return base64.b64encode(data).decode("ascii")
+
+
+def _call(name, args):
+    out = handle_agent_tool(name, args)
+    return json.loads(out[0].text)
+
+
+def test_upload_dataset_returns_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(tmp_path))
+    raw = b"first_name,last_name,zip\nJOHN,SMITH,10001\n"
+    res = _call("upload_dataset", {"file_content": _b64(raw), "filename": "p.csv"})
+    assert "path" in res and res["bytes"] == len(raw)
+    assert Path(res["path"]).read_bytes() == raw

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -157,7 +157,7 @@ def test_memory_tools_op_error_returns_structured_error(tmp_path, monkeypatch):
 
 
 def test_server_card_description_count():
-    """server.py description string advertises 69 MCP tools."""
+    """server.py description string advertises 75 MCP tools."""
     server_path = (
         Path(__file__).resolve().parent.parent / "goldenmatch" / "mcp" / "server.py"
     )

--- a/packages/python/goldenmatch/tests/test_memory_tools.py
+++ b/packages/python/goldenmatch/tests/test_memory_tools.py
@@ -164,4 +164,4 @@ def test_server_card_description_count():
     text = server_path.read_text(encoding="utf-8")
     match = re.search(r"(\d+) MCP tools", text)
     assert match is not None
-    assert int(match.group(1)) == 74   # 69 + 5 cross-language naming aliases (#1451)
+    assert int(match.group(1)) == 75   # 69 + 5 cross-language naming aliases (#1451) + upload_dataset

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -121,6 +121,7 @@ mcp_tools:
   - shatter_cluster
   - test_domain
   - unmerge_record
+  - upload_dataset
   ts_only:
   - build_clusters
   - find_exact_matches


### PR DESCRIPTION
## What

Lets a remote MCP client hand the GoldenMatch server a local file's bytes **inline** — no hosting, no public URL. Closes the gap where the hosted Railway server could only read server-side `file_path`s or `http(s)://` URLs, so a client's local files (and any private data in them) had nowhere to go.

## Why

Dogfooding the remote server on a local CSV returned `No such file or directory` for a local path; only a public URL worked. Putting private data on a public URL is a non-starter. This adds a hosting-free path.

## How

- **`mcp/_ingest.py`** (new) — one shared resolver: decodes `file_content` (base64 default, `encoding: "text"` for raw; whitespace-stripped so wrapped base64 works), enforces a 64 MB decoded-byte cap, writes under an uploads dir **rooted at `GOLDENMATCH_ALLOWED_ROOT`** so the existing `safe_path` guard still accepts it, and reaps files older than 24 h. Plus an `INGEST_PARAMS` map + `resolve_ingest_args` choke point.
- **`upload_dataset` tool** — upload bytes once, get a server path back, reuse it across any tool.
- **Inline `file_content`** on every input-file tool (agent-side + `pprl_link`/`schema_match`/`compare_clusters`), resolved at a single choke point at the top of each dispatcher — handlers unchanged. `file_path`-only calls are byte-identical.
- Excluded (by design): `evaluate` (needs a loaded run on the stateless server), `lineage`/`analyze_blocking` (no dataset input), `output_path` writes, config YAML.

## Guardrails

64 MB cap (`GOLDENMATCH_MCP_MAX_UPLOAD_BYTES`), 24 h TTL (`GOLDENMATCH_MCP_UPLOAD_TTL`), filename sanitized to a traversal-safe basename, uploads contained under the path sandbox. Over the cap, the `http(s)://` URL path remains the escape hatch.

## Tests

New `test_mcp_ingest.py` (resolver: base64 roundtrip, newline-wrapped base64, text, allowed-root rooting, decoded-vs-encoded cap, traversal filename, reaper) and `test_mcp_upload_and_inline.py` (`upload_dataset` roundtrip, inline dispatch, two-sided `schema_match`, schema completeness). Tool-count assertions + server card updated (74→75 tools). Full targeted MCP suite green.

## Docs

README "Remote MCP Server" section + `docs-site/goldenmatch/mcp.mdx` document `upload_dataset` and inline `file_content` (also fixes pre-existing 69/74 count drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
