### PR TITLE
refactor(goldencheck): Polars-eviction R3 — port null_correlation/numeric_cross/temporal onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r3.md
+++ b/docs/superpowers/plans/2026-07-09-goldencheck-relation-ports-r3.md
@@ -1,0 +1,194 @@
+# GoldenCheck Polars Eviction — Relation Ports R3 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port `null_correlation` + `numeric_cross` + `temporal` off Polars onto the seam, adding 6 element-wise `Column` ops (`is_null`, `gt_mask`, `eq_mask`, `fill_null`, `sum`, `str_to_date`) — byte-identical, no version bump.
+
+**Architecture:** These three "two-column element-wise" relation profilers fully seam-route (no native kernel, no parity-locked raw-df helpers). Add the six ops; the violation pattern becomes `a.gt_mask(b).fill_null(False)` → `sum()` + `filter_by`; null-correlation uses `is_null()` + `eq_mask()`; temporal uses `str_to_date`.
+
+**Tech Stack:** Python 3.13, Polars (still a hard dep), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r3-design.md`
+
+---
+
+## Conventions (this plan runs in the `gc-r3` worktree, off fresh origin/main through R2)
+
+Branch `feat/goldencheck-relation-ports-r3`, worktree `D:\show_case\gc-r3`, off fresh `origin/main` (through R2 #1614 — the seam has `to_arrow`/`get`, `filter_by`, `eq`, `cast`, `dtype`, `drop_nulls`, `to_list`, `_neutral_dtype`). NOT stacked.
+
+**Test preamble** (run every test command from `/d/show_case/gc-r3`):
+```bash
+export PYTHONPATH="D:/show_case/gc-r3/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-r3
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical. Parity gates pass UNEDITED: `tests/relations/test_{null_correlation,numeric_cross,temporal}.py` (import only the Profiler classes; numeric_cross also imports the pure-Python `_find_max_pairs`, which is NOT changed). The import gate + full suite stay green. No version bump. Do NOT add new test FILES (append to `test_frame.py`). Commit per task; do NOT push.
+
+**Current seam** (`goldencheck/core/frame.py`): `Column` has `filter_by(mask: Column)` (reaches `mask._s`), scalar `eq(value)`, `cast`, `dtype` (neutral string), `drop_nulls`, `to_list`, etc. — but NO `is_null`/`gt_mask`/`eq_mask`/`fill_null`/`sum`/`str_to_date`. `Frame` has `columns`/`height`/`native`/`column()`.
+
+---
+
+## Task 1: Add `is_null` + `gt_mask` + `eq_mask` + `fill_null` + `sum` + `str_to_date` to the seam
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py`
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_column_is_null_and_sum():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": [1, None, 3, None]})).column("x")
+    mask = col.is_null()
+    assert mask.to_list() == [False, True, False, True]
+    assert int(mask.sum()) == 2   # sum of a bool column == count of True
+
+def test_column_gt_mask_and_eq_mask():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({"a": [5, 1, 9], "b": [3, 4, 9]}))
+    a = frame.column("a"); b = frame.column("b")
+    assert a.gt_mask(b).to_list() == (pl.Series([5, 1, 9]) > pl.Series([3, 4, 9])).to_list()
+    assert a.gt_mask(b).to_list() == [True, False, False]
+    assert a.eq_mask(b).to_list() == [False, False, True]
+
+def test_column_fill_null():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    # a > comparison with a null operand yields null; fill_null(False) clears it
+    frame = to_frame(pl.DataFrame({"a": [5, None, 9], "b": [3, 4, 9]}))
+    a = frame.column("a"); b = frame.column("b")
+    assert a.gt_mask(b).fill_null(False).to_list() == [True, False, False]
+
+def test_column_str_to_date():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"d": ["2020-01-02", "not-a-date", "2021-12-31"]})).column("d")
+    got = col.str_to_date("%Y-%m-%d", strict=False)
+    assert got.to_list() == pl.Series(["2020-01-02", "not-a-date", "2021-12-31"]).str.to_date(
+        format="%Y-%m-%d", strict=False
+    ).to_list()
+    # invalid parses -> null under strict=False
+    assert got.to_list()[1] is None
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PolarsColumn' object has no attribute 'is_null'`).
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "is_null_and_sum or gt_mask_and_eq_mask or fill_null or str_to_date" -v
+```
+
+- [ ] **Step 3: Implement.** Add to the `Column` Protocol (after the existing `get` line):
+```python
+    def is_null(self) -> Column: ...
+    def gt_mask(self, other: Column) -> Column: ...
+    def eq_mask(self, other: Column) -> Column: ...
+    def fill_null(self, value: Any) -> Column: ...
+    def sum(self) -> Any: ...
+    def str_to_date(self, fmt: str, *, strict: bool) -> Column: ...
+```
+Add to `PolarsColumn` (after its existing `get` method):
+```python
+    def is_null(self) -> PolarsColumn:
+        return PolarsColumn(self._s.is_null())
+
+    def gt_mask(self, other: Column) -> PolarsColumn:
+        return PolarsColumn(self._s > other._s)
+
+    def eq_mask(self, other: Column) -> PolarsColumn:
+        return PolarsColumn(self._s == other._s)
+
+    def fill_null(self, value: Any) -> PolarsColumn:
+        return PolarsColumn(self._s.fill_null(value))
+
+    def sum(self) -> Any:
+        return self._s.sum()
+
+    def str_to_date(self, fmt: str, *, strict: bool) -> PolarsColumn:
+        return PolarsColumn(self._s.str.to_date(format=fmt, strict=strict))
+```
+(`gt_mask`/`eq_mask` reach `other._s` — same pattern as `filter_by`. Everything delegates via `self._s.*`/`other._s` — no `pl.` symbol; import gate stays green. `Any` + `Column` already imported.)
+
+- [ ] **Step 4: Run → PASS**, import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean: `$PY -m ruff check packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-r3
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): add is_null/gt_mask/eq_mask/fill_null/sum/str_to_date to the Frame seam (PolarsColumn delegates)"
+```
+
+---
+
+## Task 2: Port null_correlation + numeric_cross + temporal, then verify
+
+**Files:** Modify (read EACH first):
+- `packages/python/goldencheck/goldencheck/relations/null_correlation.py`
+- `packages/python/goldencheck/goldencheck/relations/numeric_cross.py`
+- `packages/python/goldencheck/goldencheck/relations/temporal.py`
+
+**Shared for all 3:** remove `from goldencheck._polars_lazy import pl`; drop EVERY `pl.DataFrame`/`pl.Series` annotation (on `profile`, `_check_exceeds`, `_check_pair`, `_try_cast_to_date`, and the local `null_masks: dict[str, pl.Series]` annotation). Keep `to_frame`, `Finding`, `Severity`, and all pure-Python module bits. **Preserve every existing `try/except` block VERBATIM in structure** — only swap the op inside.
+
+- [ ] **Step 1: Port `null_correlation.py`.**
+  - `profile(self, frame)`: drop annotation; keep `frame = to_frame(frame)`; remove `df = frame.native`. `columns = frame.columns` (was `df.columns`); `n_rows = frame.height` (was `len(df)`). `if n_rows == 0 or len(columns) < 2: return findings` UNCHANGED.
+  - `null_masks = {col: frame.column(col).is_null() for col in columns}` (was `df[col].is_null()`; DROP the `: dict[str, pl.Series]` annotation on this local).
+  - `null_counts = {col: int(null_masks[col].sum()) for col in columns}` (DROP the `: dict[str, int]` annotation if present — harmless either way, but `pl` is gone so keep it clean). `null_masks[col].sum()` is now `Column.sum()`.
+  - In the `combinations` pair loop: `mask_a = null_masks[col_a]`; `mask_b = null_masks[col_b]`; `agreement = int(mask_a.eq_mask(mask_b).sum())` (was `int((mask_a == mask_b).sum())`). All thresholds, the `_UnionFind` grouping, `high_pairs`/`low_pairs` tiers, and both Finding bodies UNCHANGED.
+
+- [ ] **Step 2: Port `numeric_cross.py`.**
+  - Delete the `@lru_cache _numeric_dtypes()` helper + `from functools import lru_cache`. Add module constant near `_MAX_PAIRS`: `_NUMERIC = frozenset({"int", "uint", "float"})`.
+  - `profile(self, frame)`: drop annotation; `frame = to_frame(frame)`; remove `df = frame.native`. `max_pairs = _find_max_pairs(frame.columns)` (was `df.columns`). Loop: `result = self._check_exceeds(frame, value_col, max_col)` (was `(df, …)`).
+  - `_check_exceeds(self, frame, value_col, max_col)`: drop annotation.
+    - **Keep the `try/except Exception: return None`** around the two column pulls: `try: val_series = frame.column(value_col); max_series = frame.column(max_col) except Exception: return None` (was `df[value_col]`/`df[max_col]`).
+    - Numeric gate: `if val_series.dtype not in _NUMERIC or max_series.dtype not in _NUMERIC:` (was `not in _numeric_dtypes()`).
+    - **Keep the cast `try/except Exception: return None`** verbatim; inside it: `if val_series.dtype == "str": val_series = val_series.cast("float", strict=False)` (was `in (pl.Utf8, pl.String)` + `cast(pl.Float64, strict=False)`); same for `max_series`; then `if val_series.dtype not in _NUMERIC: return None` and `if max_series.dtype not in _NUMERIC: return None` (the original `_numeric_dtypes() + (pl.Float64,)` is redundant — Float64 ∈ `"float"` — so `_NUMERIC` is exact).
+    - **OUTSIDE the cast try/except:** `violation_mask = val_series.gt_mask(max_series).fill_null(False)` (was `(val_series > max_series).fill_null(False)`); `violation_count = int(violation_mask.sum())`.
+    - `if violation_count > 0:` block — `val_filtered = val_series.filter_by(violation_mask).to_list()[:3]` (was `.filter(violation_mask).head(3).to_list()`); `max_filtered = max_series.filter_by(violation_mask).to_list()[:3]`. The `zip`/`f"{v} exceeds {m}"` sample building + the ERROR Finding UNCHANGED.
+
+- [ ] **Step 3: Port `temporal.py`.**
+  - `_try_cast_to_date(col)`: drop `pl.Series` annotation. `if col.dtype == "str": return col.str_to_date("%Y-%m-%d", strict=False)` (was `if series.dtype == pl.Utf8 or series.dtype == pl.String: return series.str.to_date(format="%Y-%m-%d", strict=False)`); `return col` UNCHANGED.
+  - `profile(self, frame)`: drop annotation; `frame = to_frame(frame)`; remove `df = frame.native`. `kw_pairs = _find_date_pairs(frame.columns)`. Date-col detection loop: `for col_name in frame.columns: col = frame.column(col_name); if col.dtype in ("date", "datetime"): date_cols.append(col_name) elif col.dtype == "str":` then **keep the existing `try/except`**: `try: casted = col.str_to_date("%Y-%m-%d", strict=False); if len(casted.drop_nulls()) > 0: date_cols.append(col_name) except Exception: pass` (was `s.str.to_date(...)` + `casted.drop_nulls().len()`). The `<= 6` guard + `from itertools import combinations` + the `_check_pair(frame, col_a, col_b, confidence=0.4)` calls UNCHANGED. The keyword-pair loop calls `self._check_pair(frame, start_col, end_col, confidence=0.9)`.
+  - `_check_pair(self, frame, start_col, end_col, confidence)`: drop annotation. `start_series = frame.column(start_col)`; `end_series = frame.column(end_col)`. **Keep the `try: start_series = _try_cast_to_date(start_series); end_series = _try_cast_to_date(end_series) except Exception: return None`** (verbatim structure). `if start_series.dtype not in ("date", "datetime") or end_series.dtype not in ("date", "datetime"): return None`. `violation_mask = start_series.gt_mask(end_series).fill_null(False)`; `violation_count = violation_mask.sum()` (**RAW — no `int()`**, matching the original). `if violation_count > 0:` — `sample_starts = start_series.filter_by(violation_mask).cast("str").to_list()[:3]` (was `.filter(violation_mask).head(3).cast(pl.String).to_list()`); same for `sample_ends`. The `zip`/`f"{s} > {e}"` + the ERROR Finding (incl. `affected_rows=violation_count`) UNCHANGED.
+
+- [ ] **Step 4: Run the parity gates UNEDITED.**
+```bash
+cd /d/show_case/gc-r3 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/relations/test_null_correlation.py packages/python/goldencheck/tests/relations/test_numeric_cross.py packages/python/goldencheck/tests/relations/test_temporal.py -v
+```
+Expected: all pass, ZERO test edits. If a test fails, fix the PORT (likely a `gt_mask`/`fill_null` order or a dtype-string), never the test; report the assertion diff.
+
+- [ ] **Step 5: Confirm all 3 files polars-free.**
+```bash
+grep -REn "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/relations/null_correlation.py packages/python/goldencheck/goldencheck/relations/numeric_cross.py packages/python/goldencheck/goldencheck/relations/temporal.py || echo "all 3 polars-free"
+```
+
+- [ ] **Step 6: Final verification (whole batch).**
+```bash
+cd /d/show_case/gc-r3 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Expected: import gate green; full suite green (report exact passed/skipped counts). If any FAILURE, investigate + report which test (do NOT edit tests to pass).
+
+- [ ] **Step 7: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/relations/null_correlation.py packages/python/goldencheck/goldencheck/relations/numeric_cross.py packages/python/goldencheck/goldencheck/relations/temporal.py
+git commit -m "refactor(goldencheck): port null_correlation/numeric_cross/temporal onto the Frame seam (polars-free)"
+```
+
+---
+
+## Done criteria (R3 complete)
+- [ ] `Column` seam gained `is_null`/`gt_mask`/`eq_mask`/`fill_null`/`sum`/`str_to_date` (import gate green — no `pl.` refs).
+- [ ] `null_correlation`, `numeric_cross`, `temporal` are grep-clean of `polars`/`pl.` and route through the seam; every `try/except` preserved; `numeric_cross` wraps `int(sum())`, `temporal` keeps the raw scalar.
+- [ ] All 3 relation tests pass with ZERO edits.
+- [ ] Full suite green; `import goldencheck` loads zero Polars.
+- [ ] No scope creep: `_find_max_pairs`/`_find_date_pairs` untouched; R4 + the substrate backend + reader + deps flip untouched. Relation front is now R1–R3 seam-routed; only R4 (the decline pass) remains.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r3-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r3-design.md
@@ -1,0 +1,147 @@
+# GoldenCheck Polars eviction — Relation ports R3 (null_correlation + numeric_cross + temporal)
+
+Date: 2026-07-09
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` (through R2 #1614; the seam has the full column surface + `to_arrow`/`get` + `filter_by`/`eq`/`cast`)
+Parent program: goldencheck Polars eviction — relation front (see `2026-07-09-goldencheck-relation-ports-r1-design.md` for the R1–R4 roadmap)
+
+## Context
+
+R3 of the relation front — and the **cleanest** relation batch: `null_correlation`, `numeric_cross`,
+`temporal`. Unlike R2, these have **no native kernel and no parity-locked raw-df helpers**. Their tests
+import only the Profiler classes (`numeric_cross` also imports the pure-Python name-heuristic
+`_find_max_pairs`, which is untouched), so every helper is free to seam-route. They share a
+**two-column element-wise** shape: build a mask by comparing two columns (`a > b`, or null-mask
+`==`), count/sample the flagged rows.
+
+**Approach:** full seam-routing — add the six element-wise/aggregation ops these three need; no
+`frame.native` escape hatch required. Same "Polars as accelerator" model; byte-identical, no version
+bump.
+
+## Scope
+
+### In scope
+Port `null_correlation`, `numeric_cross`, `temporal` `profile()` methods + their internal helpers onto
+the seam, adding **6** `Column` methods (`is_null`, `gt_mask`, `eq_mask`, `fill_null`, `sum`,
+`str_to_date`) and a `_NUMERIC` neutral-string frozenset in `numeric_cross`. Byte-identical.
+
+### Explicitly NOT in scope
+`_find_max_pairs` / `_find_date_pairs` (pure-Python name heuristics over `list[str]` — untouched). R4
+(the decline pass). The Stage-2 non-Polars backend. The reader. The deps flip.
+
+### Success criteria
+- The three files are grep-clean of `polars`/`_polars_lazy`/`pl.`, routing through the seam.
+- Their existing tests (`tests/relations/test_{null_correlation,numeric_cross,temporal}.py`) pass
+  **unedited** (the parity gate).
+- Full suite green; `import goldencheck` still loads zero Polars.
+
+## The seam additions (`core/frame.py` — `Column`, PolarsColumn delegates)
+
+| Method | Signature | PolarsColumn impl | Used by |
+|---|---|---|---|
+| `is_null` | `is_null() -> Column` | `PolarsColumn(self._s.is_null())` | null_correlation (null masks) |
+| `gt_mask` | `gt_mask(other: Column) -> Column` | `PolarsColumn(self._s > other._s)` | numeric_cross, temporal (`a > b`) |
+| `eq_mask` | `eq_mask(other: Column) -> Column` | `PolarsColumn(self._s == other._s)` | null_correlation (mask agreement) |
+| `fill_null` | `fill_null(value: Any) -> Column` | `PolarsColumn(self._s.fill_null(value))` | numeric_cross, temporal |
+| `sum` | `sum() -> Any` | `self._s.sum()` | all three (callers wrap `int()` where the original did) |
+| `str_to_date` | `str_to_date(fmt: str, *, strict: bool) -> Column` | `PolarsColumn(self._s.str.to_date(format=fmt, strict=strict))` | temporal |
+
+- `gt_mask`/`eq_mask` are the first **column-vs-column** comparison ops — they take a `Column` and reach
+  `other._s`, mirroring `filter_by(mask: Column)`'s established pattern. Kept distinct from A2b's scalar
+  `eq(value)` (which compares against a Python scalar) rather than overloading it.
+- `sum()` returns the raw `self._s.sum()` (a Polars scalar). numeric_cross/null_correlation wrap
+  `int(...)` exactly as the originals did; temporal passes the raw scalar to `affected_rows` exactly as
+  the original did. Byte-identical either way.
+- None reference the `pl.` symbol (`self._s.*` / `other._s`), so the import gate stays green.
+
+## The 3 ports
+
+Each: drop `from goldencheck._polars_lazy import pl`; drop `pl.DataFrame`/`pl.Series` annotations
+(on `profile`, `_check_exceeds`, `_check_pair`, `_try_cast_to_date`). Keep `to_frame`, `Finding`,
+`Severity`, and all pure-Python module bits. The pure-Python heuristics `_find_max_pairs` /
+`_find_date_pairs` (over `list[str]`) are UNCHANGED (called with `frame.columns`).
+
+### null_correlation.py
+- `profile(self, frame)`: drop annotation; keep `frame = to_frame(frame)`; remove `df = frame.native`.
+  `columns = frame.columns`; `n_rows = frame.height` (was `len(df)`). `if n_rows == 0 or len(columns) < 2:
+  return findings` UNCHANGED.
+- `null_masks = {col: frame.column(col).is_null() for col in columns}` (was `df[col].is_null()`; values
+  are now Columns).
+- `null_counts = {col: int(null_masks[col].sum()) for col in columns}` (was `int(null_masks[col].sum())`
+  on a Series — now `Column.sum()`; byte-identical).
+- In the pair loop: `agreement = int(mask_a.eq_mask(mask_b).sum())` (was `int((mask_a == mask_b).sum())`)
+  where `mask_a = null_masks[col_a]`, `mask_b = null_masks[col_b]` (Columns). All thresholds, the
+  `_UnionFind` grouping, and both Finding bodies UNCHANGED.
+
+### numeric_cross.py
+- Delete the `@lru_cache _numeric_dtypes()` helper + `from functools import lru_cache`. Add module
+  constant `_NUMERIC = frozenset({"int", "uint", "float"})`.
+- `profile(self, frame)`: drop annotation; `frame = to_frame(frame)`; remove `df = frame.native`.
+  `max_pairs = _find_max_pairs(frame.columns)` (was `df.columns`). Loop calls
+  `self._check_exceeds(frame, value_col, max_col)` (was `(df, …)`).
+- `_check_exceeds(self, frame, value_col, max_col)`: drop annotation. `try: val_series =
+  frame.column(value_col); max_series = frame.column(max_col) except Exception: return None` (Columns
+  now; `frame.column` raises on a missing name exactly as `df[col]` did). Numeric gate: `if val_series.dtype
+  not in _NUMERIC or max_series.dtype not in _NUMERIC:` (was `not in _numeric_dtypes()`). String-cast
+  branch: `if val_series.dtype == "str": val_series = val_series.cast("float", strict=False)` (was
+  `in (pl.Utf8, pl.String)` + `cast(pl.Float64, strict=False)`); same for `max_series`; the re-check
+  `if val_series.dtype not in _NUMERIC: return None` (the original `_numeric_dtypes() + (pl.Float64,)` is
+  redundant — Float64 already ∈ numeric — so `_NUMERIC` is exact). `violation_mask =
+  val_series.gt_mask(max_series).fill_null(False)`; `violation_count = int(violation_mask.sum())`. Samples:
+  `val_filtered = val_series.filter_by(violation_mask).to_list()[:3]`; `max_filtered =
+  max_series.filter_by(violation_mask).to_list()[:3]` (was `.filter(mask).head(3).to_list()`). The
+  `zip`/`f"{v} exceeds {m}"` + the ERROR Finding UNCHANGED.
+
+### temporal.py
+- `_try_cast_to_date(col)`: drop `pl.Series` annotation. `if col.dtype == "str": return
+  col.str_to_date("%Y-%m-%d", strict=False)` (was `series.dtype == pl.Utf8 or pl.String` +
+  `series.str.to_date(format="%Y-%m-%d", strict=False)`); `return col` UNCHANGED.
+- `profile(self, frame)`: drop annotation; `frame = to_frame(frame)`; remove `df = frame.native`.
+  `kw_pairs = _find_date_pairs(frame.columns)`. Date-col detection loop: `for col_name in frame.columns:
+  col = frame.column(col_name); if col.dtype in ("date", "datetime"): date_cols.append(col_name) elif
+  col.dtype == "str": casted = col.str_to_date("%Y-%m-%d", strict=False); if len(casted.drop_nulls()) > 0:
+  date_cols.append(col_name)` (was `s.str.to_date(...)`; `casted.drop_nulls().len()` → `len(...)`). The
+  `<= 6` guard + `combinations` + `_check_pair(frame, …)` calls UNCHANGED.
+- `_check_pair(self, frame, start_col, end_col, confidence)`: drop annotation. `start_series =
+  frame.column(start_col)`; `end_series = frame.column(end_col)`. `_try_cast_to_date(start_series)`
+  (Column). `if start_series.dtype not in ("date", "datetime") or end_series.dtype not in ("date",
+  "datetime"): return None`. `violation_mask = start_series.gt_mask(end_series).fill_null(False)`;
+  `violation_count = violation_mask.sum()` (**raw, no `int()`** — matches the original). Samples:
+  `sample_starts = start_series.filter_by(violation_mask).cast("str").to_list()[:3]` (was
+  `.filter(mask).head(3).cast(pl.String).to_list()`); same for ends. The `zip`/`f"{s} > {e}"` + the ERROR
+  Finding (incl. `affected_rows=violation_count`) UNCHANGED.
+
+## Testing
+
+- **Seam unit tests** (`tests/core/test_frame.py` additions): `is_null()` on a null-containing column;
+  `gt_mask`/`eq_mask` between two columns == the raw `a._s > b._s` / `a._s == b._s` (compare `.to_list()`);
+  `fill_null(False)` on a mask with nulls; `sum()` on a bool column == `int(s.sum())`; `str_to_date` on a
+  `"%Y-%m-%d"` string column == `s.str.to_date(...)`.
+- **Parity gates (unedited):** the three `tests/relations/test_*.py` pass with ZERO edits.
+- **Regression:** full suite green (same counts + the new seam tests); import gate green; the three files
+  grep-clean of `polars`/`_polars_lazy`/`pl.`.
+
+## Risks
+
+- **`gt_mask`/`eq_mask` null semantics** — `self._s > other._s` yields `null` where either operand is
+  null (Polars three-valued). numeric_cross/temporal apply `.fill_null(False)` immediately (matching the
+  original), so nulls don't count as violations and `filter_by` excludes them. null_correlation's
+  `eq_mask` operates on `is_null()` masks (boolean, never null), so no fill needed — exactly as today.
+- **`_NUMERIC` frozenset** — byte-identical: `_numeric_dtypes()` = Int8-64 + UInt8-64 + Float32/64 →
+  `{"int","uint","float"}`; the `+ (pl.Float64,)` in the re-check is redundant (Float64 ∈ "float"). No
+  unsupported dtype collides into the set.
+- **temporal `.head(3).cast(String)` vs `.cast("str").to_list()[:3]`** — cast is element-wise and
+  order-preserving, so casting all filtered rows then slicing 3 yields the identical first-3 strings as
+  slicing 3 then casting. Byte-identical output (marginally more work when there are many violations —
+  same pattern already accepted for range_distribution's outlier samples).
+- **`sum()` raw scalar** — temporal's `affected_rows=violation_count` receives the raw Polars scalar
+  exactly as the original `violation_mask.sum()` produced; numeric_cross/null_correlation wrap `int()`.
+- **`frame.column(missing)` raise** — `PolarsFrame.column` does `self._df[name]`, which raises on a
+  missing name exactly as `df[col]` did, so `_check_exceeds`'s `try/except` behaves identically.
+- **Seam growth** — 6 methods, all general primitives (element-wise compare/agg/parse). The two-column
+  `gt_mask`/`eq_mask` follow the `filter_by(Column)` precedent. No task-shaped op (no `exceeds`,
+  no `null_agreement`).
+
+## Non-goals (YAGNI)
+R4; `_find_max_pairs`/`_find_date_pairs` changes; a `head(n)` seam op (use `.to_list()[:n]`); overloading
+scalar `eq` for columns; the Stage-2 backend; reader; deps flip.

--- a/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r3-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r3-design.md
@@ -141,6 +141,13 @@ Each: drop `from goldencheck._polars_lazy import pl`; drop `pl.DataFrame`/`pl.Se
 - **Seam growth** — 6 methods, all general primitives (element-wise compare/agg/parse). The two-column
   `gt_mask`/`eq_mask` follow the `filter_by(Column)` precedent. No task-shaped op (no `exceeds`,
   no `null_agreement`).
+- **Preserve every existing `try/except` block VERBATIM in structure** — only swap the op inside:
+  temporal's `_try_cast_to_date` call in `_check_pair` (the `try: … except Exception: return None`
+  around the two `_try_cast_to_date(...)` calls) and profile()'s date-detection string branch
+  (`try: casted = col.str_to_date(...) … except Exception: pass`); numeric_cross's `_check_exceeds`
+  `try: val_series = frame.column(value_col); … except Exception: return None` and the cast-branch
+  `try: … except Exception: return None` (with `violation_mask = …` staying OUTSIDE it). These guard
+  against exotic-dtype raises; byte-identical control flow requires keeping them.
 
 ## Non-goals (YAGNI)
 R4; `_find_max_pairs`/`_find_date_pairs` changes; a `head(n)` seam op (use `.to_list()[:n]`); overloading

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -44,6 +44,12 @@ class Column(Protocol):
     def value_counts_desc(self) -> list[tuple[Any, int]]: ...
     def eq(self, value: Any) -> Column: ...
     def filter_by(self, mask: Column) -> Column: ...
+    def is_null(self) -> Column: ...
+    def gt_mask(self, other: Column) -> Column: ...
+    def eq_mask(self, other: Column) -> Column: ...
+    def fill_null(self, value: Any) -> Column: ...
+    def sum(self) -> Any: ...
+    def str_to_date(self, fmt: str, *, strict: bool) -> Column: ...
 
 
 @runtime_checkable
@@ -174,6 +180,24 @@ class PolarsColumn:
 
     def filter_by(self, mask: Column) -> PolarsColumn:
         return PolarsColumn(self._s.filter(mask._s))
+
+    def is_null(self) -> PolarsColumn:
+        return PolarsColumn(self._s.is_null())
+
+    def gt_mask(self, other: Column) -> PolarsColumn:
+        return PolarsColumn(self._s > other._s)
+
+    def eq_mask(self, other: Column) -> PolarsColumn:
+        return PolarsColumn(self._s == other._s)
+
+    def fill_null(self, value: Any) -> PolarsColumn:
+        return PolarsColumn(self._s.fill_null(value))
+
+    def sum(self) -> Any:
+        return self._s.sum()
+
+    def str_to_date(self, fmt: str, *, strict: bool) -> PolarsColumn:
+        return PolarsColumn(self._s.str.to_date(format=fmt, strict=strict))
 
 
 class PolarsFrame:

--- a/packages/python/goldencheck/goldencheck/relations/null_correlation.py
+++ b/packages/python/goldencheck/goldencheck/relations/null_correlation.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 from itertools import combinations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
@@ -48,21 +47,20 @@ class NullCorrelationProfiler:
     def __init__(self, threshold: float = _DEFAULT_THRESHOLD) -> None:
         self.threshold = threshold
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
-        columns = df.columns
-        n_rows = len(df)
+        columns = frame.columns
+        n_rows = frame.height
 
         if n_rows == 0 or len(columns) < 2:
             return findings
 
         # Pre-compute null masks (True where null) as Polars Series
-        null_masks: dict[str, pl.Series] = {
-            col: df[col].is_null() for col in columns
+        null_masks = {
+            col: frame.column(col).is_null() for col in columns
         }
-        null_counts: dict[str, int] = {
+        null_counts = {
             col: int(null_masks[col].sum()) for col in columns
         }
 
@@ -86,7 +84,7 @@ class NullCorrelationProfiler:
             mask_b = null_masks[col_b]
 
             # Agreement: rows where both are null or both are non-null
-            agreement = int((mask_a == mask_b).sum())
+            agreement = int(mask_a.eq_mask(mask_b).sum())
             correlation = agreement / n_rows
 
             if correlation >= _HIGH_THRESHOLD:

--- a/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
+++ b/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
@@ -1,20 +1,10 @@
 """Numeric cross-column validation — detects value > max violations and age/DOB mismatches."""
 from __future__ import annotations
 
-from functools import lru_cache
-
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
-
-@lru_cache(maxsize=1)
-def _numeric_dtypes() -> tuple:
-    return (
-        pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-        pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-        pl.Float32, pl.Float64,
-    )
+_NUMERIC = frozenset({"int", "uint", "float"})
 
 # Heuristic pairs: (value_column_keyword, max_column_keyword)
 # The value column should be <= the max column
@@ -53,15 +43,14 @@ def _find_max_pairs(columns: list[str]) -> list[tuple[str, str]]:
 class NumericCrossColumnProfiler:
     """Detects rows where a numeric value exceeds a related maximum column."""
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
 
         # Value > Max checks
-        max_pairs = _find_max_pairs(df.columns)
+        max_pairs = _find_max_pairs(frame.columns)
         for value_col, max_col in max_pairs:
-            result = self._check_exceeds(df, value_col, max_col)
+            result = self._check_exceeds(frame, value_col, max_col)
             if result:
                 findings.append(result)
 
@@ -69,39 +58,39 @@ class NumericCrossColumnProfiler:
 
     def _check_exceeds(
         self,
-        df: pl.DataFrame,
+        frame,
         value_col: str,
         max_col: str,
     ) -> Finding | None:
         try:
-            val_series = df[value_col]
-            max_series = df[max_col]
+            val_series = frame.column(value_col)
+            max_series = frame.column(max_col)
         except Exception:
             return None
 
         # Both must be numeric
-        if val_series.dtype not in _numeric_dtypes() or max_series.dtype not in _numeric_dtypes():
+        if val_series.dtype not in _NUMERIC or max_series.dtype not in _NUMERIC:
             # Try casting strings to float
             try:
-                if val_series.dtype in (pl.Utf8, pl.String):
-                    val_series = val_series.cast(pl.Float64, strict=False)
-                if max_series.dtype in (pl.Utf8, pl.String):
-                    max_series = max_series.cast(pl.Float64, strict=False)
-                if val_series.dtype not in _numeric_dtypes() + (pl.Float64,):
+                if val_series.dtype == "str":
+                    val_series = val_series.cast("float", strict=False)
+                if max_series.dtype == "str":
+                    max_series = max_series.cast("float", strict=False)
+                if val_series.dtype not in _NUMERIC:
                     return None
-                if max_series.dtype not in _numeric_dtypes() + (pl.Float64,):
+                if max_series.dtype not in _NUMERIC:
                     return None
             except Exception:
                 return None
 
         # Find rows where value > max (ignoring nulls)
-        violation_mask = (val_series > max_series).fill_null(False)
+        violation_mask = val_series.gt_mask(max_series).fill_null(False)
         violation_count = int(violation_mask.sum())
 
         if violation_count > 0:
             sample_vals = []
-            val_filtered = val_series.filter(violation_mask).head(3).to_list()
-            max_filtered = max_series.filter(violation_mask).head(3).to_list()
+            val_filtered = val_series.filter_by(violation_mask).to_list()[:3]
+            max_filtered = max_series.filter_by(violation_mask).to_list()[:3]
             sample_vals = [f"{v} exceeds {m}" for v, m in zip(val_filtered, max_filtered)]
 
             return Finding(

--- a/packages/python/goldencheck/goldencheck/relations/temporal.py
+++ b/packages/python/goldencheck/goldencheck/relations/temporal.py
@@ -1,7 +1,6 @@
 """Temporal order profiler — checks that start-like date columns precede end-like columns."""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
@@ -62,47 +61,45 @@ def _find_date_pairs(columns: list[str]) -> list[tuple[str, str]]:
     return unique
 
 
-def _try_cast_to_date(series: pl.Series) -> pl.Series:
+def _try_cast_to_date(col):
     """Attempt to cast a series to Date if stored as strings."""
-    if series.dtype == pl.Utf8 or series.dtype == pl.String:
-        return series.str.to_date(format="%Y-%m-%d", strict=False)
-    return series
+    if col.dtype == "str":
+        return col.str_to_date("%Y-%m-%d", strict=False)
+    return col
 
 
 class TemporalOrderProfiler:
     """Checks that start-like date columns are <= end-like date columns."""
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
         findings: list[Finding] = []
 
         # Keyword-matched pairs (high confidence)
-        kw_pairs = _find_date_pairs(df.columns)
+        kw_pairs = _find_date_pairs(frame.columns)
         kw_pair_set: set[tuple[str, str]] = set(kw_pairs)
 
         checked_pairs: set[tuple[str, str]] = set()
 
         for start_col, end_col in kw_pairs:
             checked_pairs.add((start_col, end_col))
-            result = self._check_pair(df, start_col, end_col, confidence=0.9)
+            result = self._check_pair(frame, start_col, end_col, confidence=0.9)
             if result:
                 findings.append(result)
 
         # Any-date-pair fallback: find all Date-typed columns
         # Guard: skip if >10 date columns
         date_cols = []
-        for col in df.columns:
-            s = df[col]
-            dtype = s.dtype
-            if dtype in (pl.Date, pl.Datetime):
-                date_cols.append(col)
-            elif dtype in (pl.Utf8, pl.String):
+        for col_name in frame.columns:
+            col = frame.column(col_name)
+            if col.dtype in ("date", "datetime"):
+                date_cols.append(col_name)
+            elif col.dtype == "str":
                 # Try casting to check if it's a date column
                 try:
-                    casted = s.str.to_date(format="%Y-%m-%d", strict=False)
-                    if casted.drop_nulls().len() > 0:
-                        date_cols.append(col)
+                    casted = col.str_to_date("%Y-%m-%d", strict=False)
+                    if len(casted.drop_nulls()) > 0:
+                        date_cols.append(col_name)
                 except Exception:
                     pass
 
@@ -112,7 +109,7 @@ class TemporalOrderProfiler:
                 if (col_a, col_b) not in kw_pair_set and (col_b, col_a) not in kw_pair_set:
                     if (col_a, col_b) not in checked_pairs:
                         checked_pairs.add((col_a, col_b))
-                        result = self._check_pair(df, col_a, col_b, confidence=0.4)
+                        result = self._check_pair(frame, col_a, col_b, confidence=0.4)
                         if result:
                             findings.append(result)
 
@@ -120,13 +117,13 @@ class TemporalOrderProfiler:
 
     def _check_pair(
         self,
-        df: pl.DataFrame,
+        frame,
         start_col: str,
         end_col: str,
         confidence: float,
     ) -> Finding | None:
-        start_series = df[start_col]
-        end_series = df[end_col]
+        start_series = frame.column(start_col)
+        end_series = frame.column(end_col)
 
         # Attempt to cast to Date if stored as strings
         try:
@@ -135,16 +132,16 @@ class TemporalOrderProfiler:
         except Exception:
             return None
 
-        if start_series.dtype not in (pl.Date, pl.Datetime) or end_series.dtype not in (pl.Date, pl.Datetime):
+        if start_series.dtype not in ("date", "datetime") or end_series.dtype not in ("date", "datetime"):
             return None
 
         # Find rows where start > end (ignoring nulls)
-        violation_mask = (start_series > end_series).fill_null(False)
+        violation_mask = start_series.gt_mask(end_series).fill_null(False)
         violation_count = violation_mask.sum()
 
         if violation_count > 0:
-            sample_starts = start_series.filter(violation_mask).head(3).cast(pl.String).to_list()
-            sample_ends = end_series.filter(violation_mask).head(3).cast(pl.String).to_list()
+            sample_starts = start_series.filter_by(violation_mask).cast("str").to_list()[:3]
+            sample_ends = end_series.filter_by(violation_mask).cast("str").to_list()[:3]
             samples = [f"{s} > {e}" for s, e in zip(sample_starts, sample_ends)]
 
             return Finding(

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -221,3 +221,43 @@ def test_column_get():
     assert frame.column("s").get(1) == "b"
     # byte-identical to raw Series indexing (what df[c][r] does)
     assert frame.column("s").get(1) == pl.Series(["a", "b", "c"])[1]
+
+
+def test_column_is_null_and_sum():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"x": [1, None, 3, None]})).column("x")
+    mask = col.is_null()
+    assert mask.to_list() == [False, True, False, True]
+    assert int(mask.sum()) == 2   # sum of a bool column == count of True
+
+
+def test_column_gt_mask_and_eq_mask():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    frame = to_frame(pl.DataFrame({"a": [5, 1, 9], "b": [3, 4, 9]}))
+    a = frame.column("a"); b = frame.column("b")
+    assert a.gt_mask(b).to_list() == (pl.Series([5, 1, 9]) > pl.Series([3, 4, 9])).to_list()
+    assert a.gt_mask(b).to_list() == [True, False, False]
+    assert a.eq_mask(b).to_list() == [False, False, True]
+
+
+def test_column_fill_null():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    # a > comparison with a null operand yields null; fill_null(False) clears it
+    frame = to_frame(pl.DataFrame({"a": [5, None, 9], "b": [3, 4, 9]}))
+    a = frame.column("a"); b = frame.column("b")
+    assert a.gt_mask(b).fill_null(False).to_list() == [True, False, False]
+
+
+def test_column_str_to_date():
+    import polars as pl
+    from goldencheck.core.frame import to_frame
+    col = to_frame(pl.DataFrame({"d": ["2020-01-02", "not-a-date", "2021-12-31"]})).column("d")
+    got = col.str_to_date("%Y-%m-%d", strict=False)
+    assert got.to_list() == pl.Series(["2020-01-02", "not-a-date", "2021-12-31"]).str.to_date(
+        format="%Y-%m-%d", strict=False
+    ).to_list()
+    # invalid parses -> null under strict=False
+    assert got.to_list()[1] is None


### PR DESCRIPTION
R3 of the goldencheck relation-profiler eviction — the three **two-column element-wise** profilers. Byte-identical, no version bump. Follows R1 (#1612) + R2 (#1614). The cleanest relation batch: no native kernel, no parity-locked helpers, full seam-routing.

## Summary
- **Seam:** added 6 `Column` ops — `is_null`, `gt_mask(other)`/`eq_mask(other)` (first column-vs-column comparisons, following `filter_by`'s Column-taking pattern), `fill_null(value)`, `sum()` (raw), `str_to_date(fmt, *, strict)`.
- **Ports:** `null_correlation` (`is_null` masks + `eq_mask` agreement), `numeric_cross` (`gt_mask().fill_null(False)` + `filter_by` samples; `_numeric_dtypes()` -> `_NUMERIC` frozenset), `temporal` (`str_to_date` + `gt_mask().fill_null(False)`, raw `sum()` to match the original). Every `try/except` preserved verbatim.
- **All 3 files grep-clean of `polars`/`pl.`.**

## Test Plan
- [x] The 3 `tests/relations/test_*.py` pass **unedited** (parity gate) — 21 passed
- [x] 4 new seam unit tests in `tests/core/test_frame.py`
- [x] `tests/test_import_no_polars.py` green — `import goldencheck` loads zero Polars
- [x] Full suite: 756 passed / 6 skipped; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)