### PR TITLE
refactor(goldenmatch): Polars eviction W0 -- lazy-import linchpin + Frame seam scaffold

### DIFF
--- a/docs/design/2026-07-09-goldenmatch-polars-op-inventory.md
+++ b/docs/design/2026-07-09-goldenmatch-polars-op-inventory.md
@@ -129,7 +129,7 @@ and are otherwise expression-chain-dominated (W2/W3).
     `__getattr__` (PEP 562) so `from goldenmatch.core.scorer import
     PAIR_STREAM_SCHEMA` still resolves lazily for external consumers.
   - `identity/fingerprint_batch.py`: `_INT_UPCAST` (a tuple of dtypes) --
-    fixed via a cached function (`_int_upcast()`), same pattern as
+    fixed via a cached function (`_int_upcast_dtypes()`), same pattern as
     `indicators.py`.
 - All 112 swept files already had `from __future__ import annotations`
   (no additional forward-ref fixes needed as part of the sweep).

--- a/docs/design/2026-07-09-goldenmatch-polars-op-inventory.md
+++ b/docs/design/2026-07-09-goldenmatch-polars-op-inventory.md
@@ -1,0 +1,402 @@
+# goldenmatch Polars op inventory (W0 audit)
+
+This is the W0 audit deliverable of the Polars-eviction program. Spec:
+`docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md`.
+
+Regenerate the census with:
+
+```
+python scripts/audit_goldenmatch_polars_ops.py
+```
+
+Census generated 2026-07-09 at commit `e2494d491` (branch
+`feat/goldenmatch-polars-eviction-w0`). Scope: `packages/python/goldenmatch/goldenmatch/`
+(all 154 files still touching `pl` after the W0 proxy sweep). Totals across the
+whole package: **1,682** `pl.*` attribute uses, **1,401** curated relational
+method calls (upper bound -- see caveat in the script docstring).
+
+## Op families -> waves
+
+Judgment calls below are hand-written against the actual census numbers (see
+`## Generated census` for the raw tables). Counts combine the `pl.<fn>(...)`
+attribute form and the `.method(...)` bound-call form where both exist for the
+same op (e.g. `pl.read_csv` module fn vs `.read_csv()`/`.write_csv()` on a
+frame).
+
+### IO (`read_csv` / `scan_csv` / `read_parquet` / `write_*` / `read_excel`) -> W1 `io_arrow`
+Counts: `pl.read_csv` 41, `pl.scan_csv` 6, `.read_csv(...)` 1, `pl.read_parquet`
+5, `.read_parquet(...)` 2, `pl.read_excel` 3, `.write_csv(...)` 23,
+`.write_parquet(...)` 14. `pl.scan_parquet` (9) sits outside the curated
+method list (script gap -- `scan_parquet` wasn't added to `FRAME_METHODS`,
+only `scan_csv` was) so its true call-site count is undercounted here; treat
+`db/sync.py` and `core/chunked.py` (both IO-heavy in the table) as the
+verification targets for that specific gap.
+**Judgment: mechanical.** These are boundary reads/writes with well-defined
+Arrow equivalents (`pyarrow.csv`, `pyarrow.parquet`); no domain semantics to
+re-derive, just swap the call and re-verify byte-identical output on the
+existing fixtures.
+
+### Kernel boundary (`to_arrow`, `from_arrow`) -> already Arrow-shaped, W1 wiring
+Counts: `.to_arrow(...)` 67, `.from_arrow(...)` 18, `pl.from_arrow` 34 (52
+combined for the from-arrow direction).
+**Judgment: mechanical.** These calls exist specifically because the native
+kernels already speak Arrow -- the Polars frame is round-tripping through
+`pyarrow.Table` on both sides of the FFI boundary today. Removing Polars here
+means deleting the round-trip, not porting logic; lowest-risk, highest-value
+piece of W1.
+
+### Relational glue (`join`, `group_by`, `partition_by`, `unique`, `concat`) -> W2 seam ops
+Counts: `.join(...)` 194, `.group_by(...)` 50, `.groupby(...)` 1 (deprecated
+alias, one call site -- fold into the `group_by` port), `.partition_by(...)` 7,
+`.unique(...)` 36, `.concat(...)` 5 + `pl.concat` 35 (40 combined).
+**Judgment: needs-semantic-naming.** `join` is the single densest op
+(194 calls) and spans multiple join semantics (inner candidate-pair joins in
+`core/blocker.py`/`distributed/clustering.py`, left joins for enrichment in
+`core/golden.py`/`identity/resolve.py`, asof-adjacent lookups elsewhere) --
+the seam needs named variants (`Frame.join_inner`, `Frame.join_left`, etc.)
+rather than one generic passthrough, or the eviction just re-imports Polars'
+join-kwarg surface wholesale. `group_by`/`partition_by`/`concat` are more
+uniform and closer to mechanical once `join` sets the pattern.
+
+### Expression chains (`with_columns`, `select`, `filter`, `cast`, `concat_str`, `map_*`) -> W2/W3 semantic ops (named per call-site intent)
+Counts: `.with_columns(...)` 121, `.select(...)` 130, `.filter(...)` 123
+`cast` + 117 `filter`, `pl.concat_str` 6, `.map_elements(...)` 11,
+`.map_batches(...)` 30.
+**Judgment: needs-semantic-naming, and the hardest family.** These four verbs
+(`with_columns`/`select`/`filter`/`cast`) are Polars' general-purpose
+expression surface -- every call site embeds a different lambda/predicate, so
+there is no single seam signature that covers them. The W2/W3 work is to name
+each call site's *intent* (e.g. "add normalized-key column",
+"drop null-key rows", "cast identity columns to Utf8") as its own `Frame`
+method rather than exposing a raw expression builder. `map_elements` (Python
+row-apply, already the slow path in Polars itself) and `map_batches` (chunked
+numpy/arrow callback) are lower-volume but each needs a bespoke non-Polars
+callback-invocation shape -- flag these individually per call site rather than
+batching them into the generic expression-chain port.
+
+### Column reductions (`n_unique`, `null_count`, `value_counts`) -> W3 (goldencheck-proven seam ops)
+Counts: `.n_unique(...)` 39, `.null_count(...)` 14, `.value_counts(...)` 1.
+**Judgment: mechanical.** goldencheck's column-profiler front (P0/A/A2/B/C,
+see `project_goldencheck_polars_eviction` memory) already ported the
+equivalent reductions to pyo3-free Arrow kernels; W3 here is porting the same
+proven seam ops into goldenmatch rather than re-deriving them.
+
+### Distributed/tails usage -> W4
+Counts (all `distributed/*.py`, 11 files): 249 `pl.*` attrs, 237 relational
+method calls, overwhelmingly concentrated in `distributed/clustering.py`
+(172/167 -- by far the single densest file in the whole package).
+`distributed/scoring.py` (23/27) and `distributed/pipeline.py` (22/23) are a
+distant second/third. The remaining 8 distributed files are single digits to
+low teens.
+**Judgment: decline-shaped for `distributed/clustering.py` itself, mechanical
+for the rest.** `clustering.py`'s size and density (WCC / cluster-shuffle
+logic tied to Ray/GCS-backed distributed frames -- see
+`project_844_distributed_wcc` and `project_datafusion_spine` memory) makes it
+a poor W1-W3 candidate; it depends on distribution-aware frame semantics the
+earlier waves won't have built yet. Defer the whole file to W4 rather than
+partially porting it. The other 10 distributed files are thin enough to fold
+into W2/W3 alongside their non-distributed counterparts once the pattern is
+established, but are counted here under W4 for conservatism since they all
+import from `distributed/` and share fixtures with `clustering.py`.
+
+### Top-5 densest files and owning wave
+| file | pl.* uses | relational calls | wave |
+| --- | ---: | ---: | --- |
+| `distributed/clustering.py` | 172 | 167 | W4 |
+| `core/pipeline.py` | 98 | 132 | W2 (orchestrates the seam ops named above; ports once its callees port) |
+| `core/survivorship/native.py` | 87 | 50 | W2/W3 (correlated survivorship -- field_groups/conditional field_rules, see `project_correlated_survivorship_plan`; expression-chain-heavy) |
+| `core/blocker.py` | 50 | 63 | W1/W2 (blocking joins are the `join` seam's first proving ground -- candidate-pair inner joins, no distribution dependency) |
+| `core/golden.py` | 58 | 49 | W2/W3 (survivorship expression chains + enrichment joins; `golden_fused.py` at 41/12 is the Rust-fused sibling already partially ported per `project_fused_golden_kernel`) |
+
+Honorable mention: `core/scorer.py` (55/30) and `identity/fingerprint_batch.py`
+(43/8) both carry the module-`__getattr__`-cached dtype constants noted below
+and are otherwise expression-chain-dominated (W2/W3).
+
+## Module-level import-time hazards (W0 findings)
+
+- **2 dtype-set constants found by static recon**, both in
+  `core/indicators.py`:
+  - `_NON_IDENTITY_DTYPES = {pl.Boolean, pl.Date, pl.Datetime, pl.Time}` --
+    fixed by deferring behind `@lru_cache(maxsize=1)` as
+    `_non_identity_dtypes()` (commit `0e189ee51`).
+  - `_BOOLEAN_DTYPES = {pl.Boolean}` -- deleted as dead code (no call sites
+    referenced it).
+- **2 more found only by the runtime import-gate test** (static grep missed
+  both because they're multi-line / indirect literals, not a simple
+  `{pl.X, ...}` on one line):
+  - `core/scorer.py`: `PAIR_STREAM_SCHEMA` (a `dict[str, pl.DataType]`) --
+    fixed via a cached builder (`_pair_stream_schema()`) plus a module-level
+    `__getattr__` (PEP 562) so `from goldenmatch.core.scorer import
+    PAIR_STREAM_SCHEMA` still resolves lazily for external consumers.
+  - `identity/fingerprint_batch.py`: `_INT_UPCAST` (a tuple of dtypes) --
+    fixed via a cached function (`_int_upcast()`), same pattern as
+    `indicators.py`.
+- All 112 swept files already had `from __future__ import annotations`
+  (no additional forward-ref fixes needed as part of the sweep).
+- Zero `from polars import X` variants found anywhere in the package --
+  every module-level import was the `import polars as pl` form, which
+  simplified the proxy sweep to a single mechanical substitution
+  (`from goldenmatch._polars_lazy import pl`).
+
+**Lesson recorded:** static grep for `{pl\.` / `= {.*pl\.` patterns misses
+multi-line literals and anything built via a helper call
+(`_pair_stream_schema()`-style). The subprocess-based import-gate test (which
+actually imports `goldenmatch` with polars absent from `sys.modules` and
+asserts no `pl` symbol got touched at import time) is the authority on
+whether a module is import-time-safe -- treat static recon as a first pass,
+not a completeness guarantee.
+
+## Generated census
+
+<!-- BEGIN GENERATED: paste output of `python scripts/audit_goldenmatch_polars_ops.py` below verbatim -->
+
+# goldenmatch Polars op census (generated)
+
+| file | pl.* uses | relational method calls |
+| --- | ---: | ---: |
+| distributed/clustering.py | 172 | 167 |
+| core/pipeline.py | 98 | 132 |
+| core/survivorship/native.py | 87 | 50 |
+| core/blocker.py | 50 | 63 |
+| core/golden.py | 58 | 49 |
+| core/autoconfig.py | 43 | 56 |
+| core/scorer.py | 55 | 30 |
+| db/sync.py | 45 | 40 |
+| core/standardize.py | 44 | 18 |
+| identity/resolve.py | 45 | 11 |
+| core/golden_fused.py | 41 | 12 |
+| core/chunked.py | 25 | 27 |
+| identity/fingerprint_batch.py | 43 | 8 |
+| distributed/scoring.py | 23 | 27 |
+| core/matchkey.py | 33 | 15 |
+| core/domain.py | 36 | 10 |
+| core/autoconfig_controller.py | 36 | 9 |
+| core/golden_rules_refiner.py | 15 | 30 |
+| distributed/pipeline.py | 22 | 23 |
+| core/cluster.py | 7 | 37 |
+| core/indicators.py | 24 | 16 |
+| tui/engine.py | 19 | 20 |
+| core/autofix.py | 21 | 17 |
+| core/block_analyzer.py | 21 | 16 |
+| backends/score_buckets.py | 11 | 20 |
+| _api.py | 10 | 19 |
+| core/cluster_pairscores.py | 16 | 12 |
+| documents/assemble.py | 20 | 5 |
+| core/probabilistic.py | 13 | 11 |
+| core/smart_ingest.py | 22 | 2 |
+| core/suggest/adapter.py | 9 | 14 |
+| core/schema_match.py | 17 | 5 |
+| core/vector_store.py | 18 | 4 |
+| core/agent.py | 12 | 9 |
+| core/autoconfig_verify.py | 9 | 12 |
+| core/validate.py | 12 | 9 |
+| backends/datafusion_spine.py | 10 | 10 |
+| core/fused_match.py | 8 | 12 |
+| db/connector.py | 15 | 5 |
+| core/ingest.py | 12 | 6 |
+| core/memory/corrections.py | 10 | 8 |
+| core/domain_registry.py | 10 | 7 |
+| core/incremental.py | 7 | 9 |
+| core/profiler.py | 10 | 6 |
+| distributed/record_store.py | 10 | 6 |
+| core/blocking_pass_selection.py | 6 | 9 |
+| core/llm_extract.py | 8 | 7 |
+| cli/label.py | 7 | 7 |
+| core/quality.py | 12 | 2 |
+| core/vector_index.py | 10 | 4 |
+| core/api_connector.py | 13 | 0 |
+| core/config_optimizer.py | 8 | 5 |
+| core/learned_blocking.py | 3 | 10 |
+| pprl/autoconfig.py | 6 | 7 |
+| connectors/object_storage.py | 6 | 6 |
+| core/dashboard.py | 5 | 7 |
+| core/pairs.py | 0 | 12 |
+| db/hybrid_blocking.py | 7 | 5 |
+| identity/stitching.py | 5 | 7 |
+| cli/rollback.py | 4 | 7 |
+| connectors/sqlserver.py | 2 | 9 |
+| distributed/golden.py | 10 | 1 |
+| web/runs.py | 6 | 5 |
+| a2a/skills.py | 8 | 2 |
+| cli/anomalies.py | 5 | 5 |
+| cli/pprl.py | 4 | 6 |
+| core/transform.py | 4 | 6 |
+| db/connector_mysql.py | 7 | 3 |
+| db/connector_sqlserver.py | 7 | 3 |
+| mcp/server.py | 3 | 7 |
+| web/preview.py | 6 | 4 |
+| connectors/mongo.py | 6 | 3 |
+| connectors/postgres.py | 2 | 7 |
+| core/diff.py | 5 | 4 |
+| core/graph_er.py | 4 | 5 |
+| core/llm_scorer.py | 2 | 7 |
+| identity/store.py | 1 | 8 |
+| core/boost.py | 4 | 4 |
+| core/quality_exclusions.py | 4 | 4 |
+| core/screening.py | 5 | 3 |
+| core/streaming.py | 6 | 2 |
+| db/connector_snowflake.py | 7 | 1 |
+| pprl/protocol.py | 5 | 3 |
+| connectors/duckdb_source.py | 2 | 5 |
+| core/lineage.py | 3 | 4 |
+| distributed/identity_partition.py | 0 | 7 |
+| mcp/agent_tools.py | 5 | 2 |
+| tui/tabs/boost_tab.py | 4 | 3 |
+| connectors/mysql.py | 2 | 4 |
+| connectors/redshift.py | 2 | 4 |
+| core/blocking_candidates.py | 2 | 4 |
+| core/lsh_blocker.py | 3 | 3 |
+| core/perceptual_blocker.py | 3 | 3 |
+| core/rag_surface.py | 4 | 2 |
+| core/simhash_blocker.py | 3 | 3 |
+| distributed/transforms.py | 4 | 2 |
+| tui/tabs/matches_tab.py | 3 | 3 |
+| web/routers/run.py | 4 | 2 |
+| backends/duckdb_backend.py | 3 | 2 |
+| backends/ray_backend.py | 1 | 4 |
+| connectors/_sql_common.py | 4 | 1 |
+| connectors/hubspot.py | 2 | 3 |
+| core/frame.py | 1 | 4 |
+| core/match_one.py | 3 | 2 |
+| core/perceptual_autoconfig.py | 3 | 2 |
+| core/preview.py | 3 | 2 |
+| core/review_queue.py | 3 | 2 |
+| db/writer.py | 3 | 2 |
+| distributed/dataset.py | 1 | 4 |
+| web/routers/match.py | 5 | 0 |
+| api/server.py | 1 | 3 |
+| backends/datafusion_backend.py | 0 | 4 |
+| cli/autoconfig.py | 4 | 0 |
+| cli/evaluate.py | 2 | 2 |
+| cli/explain.py | 2 | 2 |
+| cli/main.py | 1 | 3 |
+| connectors/bigquery.py | 3 | 1 |
+| connectors/salesforce.py | 2 | 2 |
+| connectors/snowflake.py | 3 | 1 |
+| core/autoconfig_discriminative.py | 3 | 1 |
+| core/candidate_store.py | 1 | 3 |
+| core/config_critique.py | 2 | 2 |
+| core/llm_cluster.py | 1 | 3 |
+| core/report.py | 2 | 2 |
+| core/retrieval.py | 3 | 1 |
+| identity/survivorship.py | 2 | 2 |
+| snowflake/udfs.py | 2 | 2 |
+| cli/dedupe.py | 1 | 2 |
+| cli/incremental.py | 1 | 2 |
+| connectors/databricks.py | 2 | 1 |
+| core/evaluate.py | 1 | 2 |
+| core/merge_preview.py | 2 | 1 |
+| core/sensitivity.py | 1 | 2 |
+| distributed/indicators.py | 3 | 0 |
+| distributed/sample.py | 3 | 0 |
+| output/writer.py | 1 | 2 |
+| plugins/base.py | 3 | 0 |
+| connectors/base.py | 2 | 0 |
+| core/_hashing.py | 0 | 2 |
+| core/anomaly.py | 1 | 1 |
+| core/autoconfig_negative_evidence.py | 1 | 1 |
+| core/graph.py | 1 | 1 |
+| core/probabilistic_fast.py | 2 | 0 |
+| cli/review.py | 1 | 0 |
+| core/autoconfig_memory.py | 1 | 0 |
+| core/survivorship/groups.py | 1 | 0 |
+| core/survivorship/validate.py | 1 | 0 |
+| core/tf_tables.py | 1 | 0 |
+| distributed/identity.py | 1 | 0 |
+| web/routers/autoconfig.py | 1 | 0 |
+| web/routers/preview.py | 1 | 0 |
+| web/routers/quality.py | 1 | 0 |
+| web/routers/suggest.py | 1 | 0 |
+
+## pl.* attribute totals
+
+- `pl.DataFrame`: 600
+- `pl.col`: 308
+- `pl.Utf8`: 118
+- `pl.Int64`: 117
+- `pl.LazyFrame`: 75
+- `pl.Series`: 60
+- `pl.Expr`: 50
+- `pl.lit`: 49
+- `pl.read_csv`: 41
+- `pl.concat`: 35
+- `pl.from_arrow`: 34
+- `pl.len`: 23
+- `pl.Float64`: 23
+- `pl.when`: 15
+- `pl.Datetime`: 10
+- `pl.scan_parquet`: 9
+- `pl.String`: 9
+- `pl.DataType`: 7
+- `pl.scan_csv`: 6
+- `pl.concat_str`: 6
+- `pl.read_parquet`: 5
+- `pl.Boolean`: 5
+- `pl.element`: 5
+- `pl.coalesce`: 5
+- `pl.Int32`: 4
+- `pl.Float32`: 4
+- `pl.Null`: 4
+- `pl.from_dicts`: 4
+- `pl.read_excel`: 3
+- `pl.repeat`: 3
+- `pl.struct`: 3
+- `pl.Date`: 3
+- `pl.Time`: 3
+- `pl.exceptions`: 3
+- `pl.Categorical`: 2
+- `pl.Duration`: 2
+- `pl.Int8`: 2
+- `pl.Int16`: 2
+- `pl.UInt8`: 2
+- `pl.UInt16`: 2
+- `pl.UInt32`: 2
+- `pl.max_horizontal`: 2
+- `pl.Array`: 2
+- `pl.List`: 2
+- `pl.UInt64`: 2
+- `pl.int_range`: 2
+- `pl.from_pandas`: 1
+- `pl.scan_ndjson`: 1
+- `pl.read_json`: 1
+- `pl.min_horizontal`: 1
+- `pl.Binary`: 1
+- `pl.Decimal`: 1
+- `pl.Struct`: 1
+- `pl.Object`: 1
+- `pl.Enum`: 1
+
+## Relational method totals (upper bound; hand-verify per wave)
+
+- `.join(...)`: 194
+- `.select(...)`: 130
+- `.cast(...)`: 123
+- `.with_columns(...)`: 121
+- `.filter(...)`: 117
+- `.collect(...)`: 114
+- `.lazy(...)`: 97
+- `.to_arrow(...)`: 67
+- `.sort(...)`: 55
+- `.group_by(...)`: 50
+- `.n_unique(...)`: 39
+- `.unique(...)`: 36
+- `.is_in(...)`: 36
+- `.agg(...)`: 35
+- `.drop_nulls(...)`: 35
+- `.map_batches(...)`: 30
+- `.write_csv(...)`: 23
+- `.from_arrow(...)`: 18
+- `.null_count(...)`: 14
+- `.write_parquet(...)`: 14
+- `.map_elements(...)`: 11
+- `.rename(...)`: 11
+- `.partition_by(...)`: 7
+- `.replace_strict(...)`: 6
+- `.concat(...)`: 5
+- `.over(...)`: 5
+- `.hstack(...)`: 2
+- `.read_parquet(...)`: 2
+- `.value_counts(...)`: 1
+- `.vstack(...)`: 1
+- `.groupby(...)`: 1
+- `.read_csv(...)`: 1

--- a/docs/superpowers/plans/2026-07-09-goldenmatch-polars-eviction-w0.md
+++ b/docs/superpowers/plans/2026-07-09-goldenmatch-polars-eviction-w0.md
@@ -1,0 +1,748 @@
+# GoldenMatch Polars Eviction W0 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Wave 0 of the Polars eviction: `import goldenmatch` no longer loads Polars, a Frame/Column seam scaffold exists, and the op/dtype audits that size W1-W4 are checked in. Byte-identical behavior, no version bump, existing tests pass unedited.
+
+**Architecture:** A `_LazyPolars` proxy (goldenflow template + a `TYPE_CHECKING` dual-path so pyright keeps real Polars types) replaces all 112 module-level `import polars as pl` sites. Two module-level dtype-set constants in `core/indicators.py` become `lru_cache` functions so nothing evaluates `pl.` at import time. `core/frame.py` ships the Frame/Column Protocol scaffold with a delegating PolarsFrame backend (no call sites port in W0). An AST-based audit script generates the op inventory doc.
+
+**Tech Stack:** Python 3.11+, pytest, ruff, pyright. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md`
+
+**Working directory:** worktree `D:\show_case\goldenmatch\.worktrees\gm-polars-evict`, branch `feat/goldenmatch-polars-eviction-w0` (off fresh origin/main). All paths below are relative to `packages/python/goldenmatch/` unless they start with `docs/` or `scripts/` (repo root).
+
+**Test invocation (worktree + main .venv, Windows):** run from `packages/python/goldenmatch/` inside the worktree:
+
+```bash
+cd /d/show_case/goldenmatch/.worktrees/gm-polars-evict/packages/python/goldenmatch
+PYTHONPATH="D:\\show_case\\goldenmatch\\.worktrees\\gm-polars-evict\\packages\\python\\goldenmatch" \
+POLARS_SKIP_CPU_CHECK=1 GOLDENMATCH_NATIVE=0 \
+D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <target> -v --timeout=120
+```
+
+The `PYTHONPATH` prepend makes the worktree package shadow the editable install from the main checkout (PYTHONPATH entries precede site-packages .pth entries). Abbreviated below as `RUNPY -m pytest ...`.
+
+**Verified recon facts (do not re-derive):**
+- 112 files carry a column-0 `import polars as pl` line; there are ZERO `from polars import ...` or bare `import polars` module-level variants. Indented (function-local) `import polars as pl` / `as _pl` variants exist and are already lazy -- LEAVE THEM.
+- All 112 files already have `from __future__ import annotations` (the proxy's safety precondition; verified 2026-07-09).
+- Exactly 2 module-level `pl.` evaluations exist: `core/indicators.py:43` (`_BOOLEAN_DTYPES = {pl.Boolean}`) and `:44` (`_NON_IDENTITY_DTYPES = {pl.Boolean, pl.Date, pl.Datetime, pl.Time}`).
+- CI ruff for this package lints E9/F63/F7 only (import-order rules NOT enforced); pyright IS a required gate.
+
+---
+
+### Task 1: `_polars_lazy.py` proxy module
+
+**Files:**
+- Create: `goldenmatch/_polars_lazy.py`
+- Test: `tests/test_polars_lazy.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_polars_lazy.py
+"""The lazy-Polars proxy: real attributes, cached module, no import at module load."""
+from __future__ import annotations
+
+
+def test_proxy_returns_real_polars_attributes():
+    from goldenmatch._polars_lazy import pl
+    import polars as real_pl
+
+    assert pl.DataFrame is real_pl.DataFrame
+    assert pl.Utf8 is real_pl.Utf8
+
+
+def test_proxy_caches_module():
+    from goldenmatch._polars_lazy import _LazyPolars
+
+    proxy = _LazyPolars()
+    assert proxy._mod is None
+    _ = proxy.DataFrame
+    assert proxy._mod is not None
+    mod_after_first = proxy._mod
+    _ = proxy.Series
+    assert proxy._mod is mod_after_first
+
+
+def test_isinstance_works_through_proxy():
+    from goldenmatch._polars_lazy import pl
+
+    df = pl.DataFrame({"a": [1, 2]})
+    assert isinstance(df, pl.DataFrame)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RUNPY -m pytest tests/test_polars_lazy.py -v`
+Expected: FAIL / collection error with `ModuleNotFoundError: No module named 'goldenmatch._polars_lazy'`
+
+- [ ] **Step 3: Write the module**
+
+Adapted from `packages/python/goldenflow/goldenflow/_polars_lazy.py` (the proven template) with one deliberate addition: a `TYPE_CHECKING` dual-path so pyright resolves `pl` to the REAL polars module. goldenmatch's core (e.g. `pipeline.py`) depends on real Polars types for narrowing (`assert isinstance(x, pl.DataFrame)`); the plain proxy would silently degrade all of that to `Any`.
+
+```python
+# goldenmatch/_polars_lazy.py
+"""Lazy Polars proxy -- W0 of the Polars eviction (spec:
+docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md).
+
+``from goldenmatch._polars_lazy import pl`` gives a stand-in that imports Polars
+on the FIRST attribute access, not at import time. Every runtime ``pl.`` use in
+the swept modules keeps working unchanged, but ``import goldenmatch`` no longer
+eagerly imports Polars.
+
+Safe because (audited 2026-07-09):
+- All swept modules have ``from __future__ import annotations`` (string
+  annotations never trigger the import).
+- No module-level ``pl.`` execution remains (the two dtype-set constants in
+  core/indicators.py were converted to lru_cache functions in this wave) and no
+  ``def f(x=pl.X)`` default arg exists.
+- Attribute access returns the REAL Polars object, so ``isinstance(x,
+  pl.DataFrame)`` and dtype identity behave identically to ``import polars``.
+
+The ``TYPE_CHECKING`` branch makes pyright treat ``pl`` as the real module, so
+static narrowing across the package is unchanged (a deliberate divergence from
+the goldenflow/goldencheck template, which exposes ``Any``).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+class _LazyPolars:
+    """Forwards attribute access to ``polars``, importing it on first use."""
+
+    __slots__ = ("_mod",)
+
+    def __init__(self) -> None:
+        self._mod: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        # `_mod` is a slot (set in __init__), so reading it never re-enters
+        # __getattr__; only genuine polars attributes reach this path.
+        mod = self._mod
+        if mod is None:
+            import polars as _polars
+
+            self._mod = mod = _polars
+        return getattr(mod, name)
+
+
+if TYPE_CHECKING:
+    import polars as pl
+else:
+    pl = _LazyPolars()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `RUNPY -m pytest tests/test_polars_lazy.py -v`
+Expected: 3 PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/_polars_lazy.py packages/python/goldenmatch/tests/test_polars_lazy.py
+git commit -m "feat(goldenmatch): lazy-Polars proxy module (eviction W0)"
+```
+
+---
+
+### Task 2: Defer the two module-level dtype constants
+
+**Files:**
+- Modify: `goldenmatch/core/indicators.py:43-44` (+ every usage of the two names)
+- Test: `tests/test_indicators_dtype_defer.py`
+
+- [ ] **Step 1: Find every usage of the two constants**
+
+Run: `grep -rn "_BOOLEAN_DTYPES\|_NON_IDENTITY_DTYPES" packages/python/goldenmatch/goldenmatch/ packages/python/goldenmatch/tests/`
+Record every hit; all call sites change from `X` to `X()` in Step 3.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_indicators_dtype_defer.py
+"""The dtype-set constants must be lazy functions, not module-level pl. evaluations."""
+from __future__ import annotations
+
+
+def test_dtype_sets_are_functions_returning_expected_members():
+    import polars as pl
+
+    from goldenmatch.core.indicators import _boolean_dtypes, _non_identity_dtypes
+
+    assert _boolean_dtypes() == {pl.Boolean}
+    assert _non_identity_dtypes() == {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+    # lru_cache: same object back on the second call
+    assert _boolean_dtypes() is _boolean_dtypes()
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `RUNPY -m pytest tests/test_indicators_dtype_defer.py -v`
+Expected: FAIL with `ImportError: cannot import name '_boolean_dtypes'`
+
+- [ ] **Step 4: Convert the constants (the goldencheck lru_cache pattern)**
+
+In `goldenmatch/core/indicators.py`, replace lines 43-44:
+
+```python
+# BEFORE
+_BOOLEAN_DTYPES = {pl.Boolean}
+_NON_IDENTITY_DTYPES = {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+
+# AFTER (add `from functools import lru_cache` to the imports)
+@lru_cache(maxsize=1)
+def _boolean_dtypes() -> set:
+    """Deferred: evaluating pl.Boolean at module level would defeat _polars_lazy."""
+    return {pl.Boolean}
+
+
+@lru_cache(maxsize=1)
+def _non_identity_dtypes() -> set:
+    """Deferred: see _boolean_dtypes."""
+    return {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+```
+
+Update every usage found in Step 1 from `_BOOLEAN_DTYPES` -> `_boolean_dtypes()` and `_NON_IDENTITY_DTYPES` -> `_non_identity_dtypes()`.
+
+- [ ] **Step 5: Run the new test + the indicators tests**
+
+Run: `RUNPY -m pytest tests/test_indicators_dtype_defer.py tests/test_indicators.py -v`
+Expected: all PASS (if `tests/test_indicators.py` does not exist, run `RUNPY -m pytest tests/ -k indicator -v` instead)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/indicators.py packages/python/goldenmatch/tests/test_indicators_dtype_defer.py
+git commit -m "refactor(goldenmatch): defer module-level dtype-set constants (eviction W0)"
+```
+
+---
+
+### Task 3: The 112-file import sweep + the import gate
+
+**Files:**
+- Modify: all 112 files with a column-0 `import polars as pl` line
+- Test: `tests/test_lazy_import_gate.py`
+
+- [ ] **Step 1: Write the failing gate test**
+
+```python
+# tests/test_lazy_import_gate.py
+"""THE W0 gate: `import goldenmatch` must not load Polars.
+
+Subprocess-based so this test is immune to other tests having already imported
+polars into this process.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def test_import_goldenmatch_does_not_load_polars():
+    code = (
+        "import json, sys\n"
+        "import goldenmatch\n"
+        "print(json.dumps({'polars_loaded': 'polars' in sys.modules,"
+        " 'goldenmatch_file': goldenmatch.__file__}))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ},
+        check=True,
+    )
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload["polars_loaded"] is False, (
+        f"polars was imported eagerly by `import goldenmatch` "
+        f"(package at {payload['goldenmatch_file']}). Run "
+        f"`python -X importtime -c 'import goldenmatch' 2>&1 | grep polars` "
+        f"to find the offender."
+    )
+
+
+def test_polars_still_works_after_lazy_import():
+    """The proxy must not break real use: first pl. access imports polars fine."""
+    code = (
+        "import sys\n"
+        "import goldenmatch\n"
+        "from goldenmatch._polars_lazy import pl\n"
+        "df = pl.DataFrame({'a': [1]})\n"
+        "assert 'polars' in sys.modules\n"
+        "assert df.height == 1\n"
+        "print('OK')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, env={**os.environ}, check=True,
+    )
+    assert proc.stdout.strip().endswith("OK")
+```
+
+- [ ] **Step 2: Run gate test to verify it fails (pre-sweep baseline)**
+
+Run: `RUNPY -m pytest tests/test_lazy_import_gate.py::test_import_goldenmatch_does_not_load_polars -v`
+Expected: FAIL with `polars was imported eagerly` (the 112 top-level imports are still in place)
+
+- [ ] **Step 3: Execute the mechanical sweep**
+
+From the worktree root:
+
+```bash
+cd /d/show_case/goldenmatch/.worktrees/gm-polars-evict/packages/python/goldenmatch/goldenmatch
+grep -rlE "^import polars as pl$" --include=*.py . | while read -r f; do
+  sed -i 's/^import polars as pl$/from goldenmatch._polars_lazy import pl/' "$f"
+done
+```
+
+Then verify the sweep's completeness invariant -- ZERO column-0 polars imports remain anywhere in the package (the proxy module itself only has an indented, function-local import plus the indented TYPE_CHECKING one):
+
+```bash
+grep -rnE "^import polars|^from polars" --include=*.py . ; echo "exit=$?"
+```
+
+Expected: no output, `exit=1`.
+
+- [ ] **Step 4: Run the gate test**
+
+Run: `RUNPY -m pytest tests/test_lazy_import_gate.py -v`
+Expected: 2 PASS. If `test_import_goldenmatch_does_not_load_polars` still fails, an import-time evaluation remains somewhere. Diagnose with:
+
+```bash
+PYTHONPATH="D:\\show_case\\goldenmatch\\.worktrees\\gm-polars-evict\\packages\\python\\goldenmatch" \
+D:/show_case/goldenmatch/.venv/Scripts/python.exe -X importtime -c "import goldenmatch" 2>&1 | grep -B5 polars | head -30
+```
+
+Known candidate classes to check if this fires (recon found none, but the gate is the authority): (a) a Typer-decorated CLI function with a `pl.`-annotated parameter or return type (Typer resolves annotations at decoration time -- fix: change the annotation to a string the module never resolves, or restructure); (b) a Pydantic model field annotated with a `pl.` type (Pydantic evaluates annotations at class creation -- fix: `Any` + isinstance check); (c) a decorator argument or class-body default evaluating `pl.` at import.
+
+- [ ] **Step 5: Run the broad regression batches (targeted local; full suite is CI's job)**
+
+Run: `RUNPY -m pytest tests/test_cluster.py tests/test_golden.py tests/test_lineage.py tests/test_config.py tests/test_pipeline.py tests/test_api.py -v --timeout=120`
+Expected: all PASS (this is the documented torch-free core batch + the API surface)
+
+Run: `RUNPY -m pytest tests/test_polars_lazy.py tests/test_indicators_dtype_defer.py -v`
+Expected: all PASS (tasks 1-2 still green after the sweep)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /d/show_case/goldenmatch/.worktrees/gm-polars-evict
+git add -A packages/python/goldenmatch/goldenmatch packages/python/goldenmatch/tests/test_lazy_import_gate.py
+git commit -m "refactor(goldenmatch): sweep 112 module-level polars imports to the lazy proxy (eviction W0)"
+```
+
+---
+
+### Task 4: `core/frame.py` seam scaffold
+
+**Files:**
+- Create: `goldenmatch/core/frame.py`
+- Test: `tests/test_frame_seam.py`
+
+W0 ships the Protocols + the delegating Polars backend + `to_frame()` ONLY. No pipeline call site changes (that is W1+). The op set is deliberately minimal (YAGNI -- the Task 5 audit informs W1's expansion): Frame = {columns, height, native, column, to_arrow_columns}; Column = {__len__, null_count, n_unique, to_list, to_arrow}. `to_arrow_columns` exists because it IS the fused-kernel FFI boundary shape (`dict[str, pa.Array]`, what `run_match_fused_arrow` consumes today via `collected_df[c].to_arrow()`).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_frame_seam.py
+"""W0 Frame/Column seam scaffold: delegation parity vs raw Polars + to_frame idempotency."""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch.core.frame import Column, Frame, PolarsFrame, to_frame
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame({"name": ["ann", "bob", None, "ann"], "zip": [1, 2, 3, 1]})
+
+
+def test_to_frame_wraps_polars_dataframe():
+    frame = to_frame(_df())
+    assert isinstance(frame, PolarsFrame)
+    assert isinstance(frame, Frame)  # runtime_checkable Protocol
+
+
+def test_to_frame_is_idempotent():
+    frame = to_frame(_df())
+    assert to_frame(frame) is frame
+
+
+def test_frame_delegation_matches_raw_polars():
+    df = _df()
+    frame = to_frame(df)
+    assert frame.columns == df.columns
+    assert frame.height == df.height
+    assert frame.native is df
+
+
+def test_column_delegation_matches_raw_polars():
+    df = _df()
+    col = to_frame(df).column("name")
+    assert isinstance(col, Column)
+    assert len(col) == 4
+    assert col.null_count() == df["name"].null_count()
+    assert col.n_unique() == df["name"].n_unique()
+    assert col.to_list() == df["name"].to_list()
+
+
+def test_to_arrow_columns_matches_kernel_ffi_shape():
+    """to_arrow_columns must produce exactly what the fused kernels consume today."""
+    df = _df()
+    arrow_cols = to_frame(df).to_arrow_columns(["name", "zip"])
+    assert set(arrow_cols) == {"name", "zip"}
+    for name in ("name", "zip"):
+        assert arrow_cols[name].to_pylist() == df[name].to_arrow().to_pylist()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `RUNPY -m pytest tests/test_frame_seam.py -v`
+Expected: collection error, `ModuleNotFoundError: No module named 'goldenmatch.core.frame'`
+
+- [ ] **Step 3: Write the scaffold**
+
+```python
+# goldenmatch/core/frame.py
+"""Backend-neutral Frame/Column seam for the Polars eviction (W0 scaffold).
+
+Pipeline code will route through this instead of raw ``pl.DataFrame`` so call
+sites can migrate off Polars wave by wave (spec:
+docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md).
+W0 ships only the delegating Polars backend; the ArrowFrame backend arrives in
+W1. ``to_frame`` is idempotent so a caller may pass a raw ``pl.DataFrame`` or
+an already-wrapped ``Frame``.
+
+Op-set discipline: SEMANTIC operations only, added as call sites port -- never
+a Polars-expression clone. New ops require both backends plus a delegation-
+parity test.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from goldenmatch._polars_lazy import pl
+
+
+@runtime_checkable
+class Column(Protocol):
+    def __len__(self) -> int: ...
+    def null_count(self) -> int: ...
+    def n_unique(self) -> int: ...
+    def to_list(self) -> list: ...
+    def to_arrow(self) -> Any: ...
+
+
+@runtime_checkable
+class Frame(Protocol):
+    @property
+    def columns(self) -> list[str]: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def native(self) -> Any: ...
+    def column(self, name: str) -> Column: ...
+    def to_arrow_columns(self, names: list[str]) -> dict[str, Any]: ...
+
+
+class PolarsColumn:
+    """Delegates each op to the exact Polars call it replaces (byte-identical)."""
+
+    __slots__ = ("_s",)
+
+    def __init__(self, s: Any) -> None:
+        self._s = s
+
+    def __len__(self) -> int:
+        return len(self._s)
+
+    def null_count(self) -> int:
+        return self._s.null_count()
+
+    def n_unique(self) -> int:
+        return self._s.n_unique()
+
+    def to_list(self) -> list:
+        return self._s.to_list()
+
+    def to_arrow(self) -> Any:
+        return self._s.to_arrow()
+
+
+class PolarsFrame:
+    __slots__ = ("_df",)
+
+    def __init__(self, df: Any) -> None:
+        self._df = df
+
+    @property
+    def columns(self) -> list[str]:
+        return self._df.columns
+
+    @property
+    def height(self) -> int:
+        return self._df.height
+
+    @property
+    def native(self) -> Any:
+        return self._df
+
+    def column(self, name: str) -> PolarsColumn:
+        return PolarsColumn(self._df[name])
+
+    def to_arrow_columns(self, names: list[str]) -> dict[str, Any]:
+        # The fused-kernel FFI boundary: dict[str, pa.Array/ChunkedArray],
+        # exactly the `collected_df[c].to_arrow()` shape pipeline.py builds today.
+        return {n: self._df[n].to_arrow() for n in names}
+
+
+def to_frame(obj: Any) -> Frame:
+    """Idempotent coercion: raw ``pl.DataFrame`` or ``Frame`` -> ``Frame``."""
+    if isinstance(obj, PolarsFrame):
+        return obj
+    if isinstance(obj, pl.DataFrame):
+        return PolarsFrame(obj)
+    raise TypeError(f"to_frame expects a polars DataFrame or Frame, got {type(obj)!r}")
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `RUNPY -m pytest tests/test_frame_seam.py -v`
+Expected: 5 PASS
+
+- [ ] **Step 5: Verify the gate still holds (frame.py must not load polars at import)**
+
+Run: `RUNPY -m pytest tests/test_lazy_import_gate.py -v`
+Expected: 2 PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/core/frame.py packages/python/goldenmatch/tests/test_frame_seam.py
+git commit -m "feat(goldenmatch): Frame/Column seam scaffold with delegating Polars backend (eviction W0)"
+```
+
+---
+
+### Task 5: Op audit script + inventory doc
+
+**Files:**
+- Create: `scripts/audit_goldenmatch_polars_ops.py` (repo root `scripts/`)
+- Create: `docs/design/2026-07-09-goldenmatch-polars-op-inventory.md` (repo root `docs/`)
+
+This is the W0 deliverable that sizes W1-W4: an AST census of every `pl.<attr>` use and every method call on frame/series receivers in files that import polars, grouped per file, plus a hand-written summary mapping op families to waves. No tests (a read-only dev tool); the doc is the artifact.
+
+- [ ] **Step 1: Write the audit script**
+
+```python
+# scripts/audit_goldenmatch_polars_ops.py
+"""AST census of Polars usage in goldenmatch -- W0 op audit for the eviction.
+
+Emits markdown: per-file counts of (a) `pl.<attr>` attribute uses and (b) calls
+to a curated list of DataFrame/Series/LazyFrame relational methods. The curated
+list makes (b) high-signal: bare method names can collide with non-Polars
+objects, so treat per-file counts as an upper bound to hand-verify per wave.
+
+Usage: python scripts/audit_goldenmatch_polars_ops.py > /tmp/op_audit.md
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parents[1] / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+# Relational / frame-shaped methods whose ports define the W1-W4 seam ops.
+FRAME_METHODS = {
+    "join", "join_asof", "group_by", "groupby", "partition_by", "filter",
+    "with_columns", "select", "sort", "unique", "drop_nulls", "concat",
+    "explode", "pivot", "melt", "unpivot", "vstack", "hstack", "rename",
+    "cast", "lazy", "collect", "scan_csv", "read_csv", "read_parquet",
+    "write_csv", "write_parquet", "read_excel", "to_arrow", "from_arrow",
+    "agg", "over", "replace_strict", "value_counts", "n_unique",
+    "null_count", "is_in", "concat_str", "map_elements", "map_batches",
+}
+
+
+def audit_file(path: Path) -> tuple[Counter, Counter]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    pl_attrs: Counter = Counter()
+    methods: Counter = Counter()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == "pl":
+                pl_attrs[node.attr] += 1
+            elif node.attr in FRAME_METHODS:
+                methods[node.attr] += 1
+    return pl_attrs, methods
+
+
+def main() -> int:
+    rows = []
+    total_attrs: Counter = Counter()
+    total_methods: Counter = Counter()
+    for path in sorted(PKG.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "_polars_lazy import pl" not in text and "import polars" not in text:
+            continue
+        pl_attrs, methods = audit_file(path)
+        if not pl_attrs and not methods:
+            continue
+        rel = path.relative_to(PKG)
+        rows.append((str(rel), sum(pl_attrs.values()), sum(methods.values())))
+        total_attrs.update(pl_attrs)
+        total_methods.update(methods)
+
+    print("# goldenmatch Polars op census (generated)\n")
+    print("| file | pl.* uses | relational method calls |")
+    print("| --- | ---: | ---: |")
+    for rel, a, m in sorted(rows, key=lambda r: -(r[1] + r[2])):
+        print(f"| {rel} | {a} | {m} |")
+    print("\n## pl.* attribute totals\n")
+    for name, n in total_attrs.most_common():
+        print(f"- `pl.{name}`: {n}")
+    print("\n## Relational method totals (upper bound; hand-verify per wave)\n")
+    for name, n in total_methods.most_common():
+        print(f"- `.{name}(...)`: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+- [ ] **Step 2: Run it and sanity-check the output**
+
+Run (from the worktree root): `D:/show_case/goldenmatch/.venv/Scripts/python.exe scripts/audit_goldenmatch_polars_ops.py | head -40`
+Expected: a markdown table with 100+ rows; `core/pipeline.py`, `core/scorer.py`, `core/golden.py`, `core/blocker.py`, `distributed/clustering.py` near the top.
+
+- [ ] **Step 3: Write the inventory doc**
+
+Create `docs/design/2026-07-09-goldenmatch-polars-op-inventory.md` with:
+1. A header explaining this is the W0 audit deliverable of the eviction spec and how to regenerate (`python scripts/audit_goldenmatch_polars_ops.py`).
+2. The generated census output pasted verbatim under a `## Generated census` heading.
+3. A hand-written `## Op families -> waves` section that groups the observed usage into the spec's porting fronts, naming which wave owns each family:
+   - IO (`read_csv`/`scan_csv`/`read_parquet`/`write_*`/`read_excel`) -> W1 `io_arrow`
+   - Kernel boundary (`to_arrow`, `from_arrow`) -> already Arrow-shaped, W1 wiring
+   - Relational glue (`join`, `group_by`, `partition_by`, `unique`, `concat`) -> W2 seam ops
+   - Expression chains (`with_columns`, `select`, `filter`, `cast`, `concat_str`, `map_*`) -> W2/W3 semantic ops (named per call-site intent)
+   - Column reductions (`n_unique`, `null_count`, `value_counts`) -> W3 (goldencheck-proven seam ops)
+   - Distributed/tails usage -> W4
+4. A `## Module-level import-time hazards` section recording the W0 findings: exactly 2 dtype-set constants (fixed in this wave, `core/indicators.py`), all 112 files already carried `from __future__ import annotations`, zero `from polars import X` variants.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/audit_goldenmatch_polars_ops.py docs/design/2026-07-09-goldenmatch-polars-op-inventory.md
+git commit -m "docs(goldenmatch): W0 Polars op audit script + inventory (eviction W0)"
+```
+
+---
+
+### Task 6: Full W0 verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Lint + typecheck the touched surface**
+
+```bash
+cd /d/show_case/goldenmatch/.worktrees/gm-polars-evict
+D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check packages/python/goldenmatch/goldenmatch packages/python/goldenmatch/tests scripts/audit_goldenmatch_polars_ops.py
+D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pyright packages/python/goldenmatch/goldenmatch/_polars_lazy.py packages/python/goldenmatch/goldenmatch/core/frame.py packages/python/goldenmatch/goldenmatch/core/indicators.py 2>&1 | tail -5
+```
+
+Expected: ruff `All checks passed!`. Pyright: no NEW errors in the three files (local pyright shows pre-existing `reportMissingImports` noise absent on CI -- ignore exactly that class). The full-package pyright gate runs in CI.
+
+- [ ] **Step 2: Wider targeted test batches (spot the sweep's blast radius)**
+
+```bash
+RUNPY -m pytest tests/test_autoconfig_regressions.py tests/test_scorer.py tests/test_blocker.py -v --timeout=120 -x
+RUNPY -m pytest tests/test_lazy_import_gate.py tests/test_polars_lazy.py tests/test_frame_seam.py tests/test_indicators_dtype_defer.py -v
+```
+
+Expected: all PASS. (If a listed file does not exist under those names, substitute `-k autoconfig`, `-k scorer`, `-k blocker` selections.) Do NOT run the full suite locally (xdist OOMs the box; CI owns the full matrix).
+
+- [ ] **Step 3: The three W0 invariants, one command each**
+
+```bash
+# 1. Gate: import goldenmatch loads no polars (already tested; re-run standalone)
+RUNPY -m pytest tests/test_lazy_import_gate.py -q
+# 2. Sweep completeness: zero column-0 polars imports in the package
+grep -rnE "^import polars|^from polars" --include=*.py packages/python/goldenmatch/goldenmatch/ ; echo "exit=$?"   # expect exit=1
+# 3. Byte-identical intent: the diff contains ONLY import-line swaps, the indicators
+#    deferral, and new files
+git diff origin/main --stat | tail -5
+git diff origin/main -- packages/python/goldenmatch/goldenmatch/ | grep "^-" | grep -vE "^---|^-import polars as pl$|_BOOLEAN_DTYPES|_NON_IDENTITY_DTYPES" ; echo "exit=$?"   # expect exit=1 (no other deletions)
+```
+
+- [ ] **Step 4: Commit any stragglers**
+
+```bash
+git status --short   # expect clean; commit with a fix message if not
+```
+
+---
+
+### Task 7: PR + auto-merge
+
+**Files:** none
+
+- [ ] **Step 1: Push with the auth dance**
+
+```bash
+cd /d/show_case/goldenmatch/.worktrees/gm-polars-evict
+unset GH_TOKEN
+gh auth switch --user benzsevern
+git push -u origin feat/goldenmatch-polars-eviction-w0
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr create \
+  --title "refactor(goldenmatch): Polars eviction W0 -- lazy-import linchpin + Frame seam scaffold" \
+  --body "$(cat <<'EOF'
+## Summary
+- W0 of the Polars-eviction program (spec: docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md)
+- `import goldenmatch` no longer loads Polars: `_polars_lazy` proxy (goldenflow template + TYPE_CHECKING dual-path so pyright keeps real Polars types) swept across all 112 module-level import sites; the 2 module-level dtype-set constants in core/indicators.py deferred via lru_cache
+- `core/frame.py` Frame/Column seam scaffold with delegating PolarsFrame backend + idempotent `to_frame()` (no call sites ported -- that is W1+)
+- W0 audits checked in: `scripts/audit_goldenmatch_polars_ops.py` + `docs/design/2026-07-09-goldenmatch-polars-op-inventory.md`
+
+Byte-identical: no behavior change, no version bump, existing tests unedited.
+
+## Test plan
+- [x] New: tests/test_lazy_import_gate.py (subprocess gate: polars not in sys.modules after `import goldenmatch`)
+- [x] New: tests/test_polars_lazy.py, tests/test_frame_seam.py, tests/test_indicators_dtype_defer.py
+- [x] Targeted local batches green; full suite in CI
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Arm auto-merge and STOP (never poll CI)**
+
+```bash
+GH_TOKEN=$(gh auth token --user benzsevern) gh pr merge --auto --squash
+gh auth switch --user benzsevern-mjh
+```
+
+The merge queue runs the full goldenmatch matrix (the real parity gate: 1300+ tests unedited). Per standing SOP, do not poll; the queue reports.
+
+---
+
+## Out of scope for W0 (explicitly)
+
+- NO pipeline/controller call site moves onto the seam (W1+).
+- NO ArrowFrame backend, NO `GOLDENMATCH_FRAME` env var (W1).
+- NO pyproject dependency change -- `polars>=1.0` stays a base dep until W5.
+- NO CHANGELOG entry / docs-site change: zero user-visible behavior change.
+- Function-local `import polars as pl` / `as _pl` sites stay as-is (already lazy).

--- a/docs/superpowers/plans/2026-07-09-goldenmatch-polars-eviction-w0.md
+++ b/docs/superpowers/plans/2026-07-09-goldenmatch-polars-eviction-w0.md
@@ -157,25 +157,30 @@ git commit -m "feat(goldenmatch): lazy-Polars proxy module (eviction W0)"
 - [ ] **Step 1: Find every usage of the two constants**
 
 Run: `grep -rn "_BOOLEAN_DTYPES\|_NON_IDENTITY_DTYPES" packages/python/goldenmatch/goldenmatch/ packages/python/goldenmatch/tests/`
-Record every hit; all call sites change from `X` to `X()` in Step 3.
+Expected picture (pre-verified 2026-07-09; re-confirm with the grep): `_NON_IDENTITY_DTYPES` has exactly ONE usage beyond its definition (a membership check at `core/indicators.py:91`); `_BOOLEAN_DTYPES` has ZERO usages beyond its definition -- it is dead code and gets DELETED in Step 4, not converted. An "empty" grep result for `_BOOLEAN_DTYPES` usages is correct, not a mistake.
 
 - [ ] **Step 2: Write the failing test**
 
 ```python
 # tests/test_indicators_dtype_defer.py
-"""The dtype-set constants must be lazy functions, not module-level pl. evaluations."""
+"""The dtype-set constant must be a lazy function, not a module-level pl. evaluation."""
 from __future__ import annotations
 
 
-def test_dtype_sets_are_functions_returning_expected_members():
+def test_non_identity_dtypes_is_lazy_function_with_expected_members():
     import polars as pl
 
-    from goldenmatch.core.indicators import _boolean_dtypes, _non_identity_dtypes
+    from goldenmatch.core.indicators import _non_identity_dtypes
 
-    assert _boolean_dtypes() == {pl.Boolean}
     assert _non_identity_dtypes() == {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
     # lru_cache: same object back on the second call
-    assert _boolean_dtypes() is _boolean_dtypes()
+    assert _non_identity_dtypes() is _non_identity_dtypes()
+
+
+def test_dead_boolean_dtypes_constant_removed():
+    import goldenmatch.core.indicators as indicators
+
+    assert not hasattr(indicators, "_BOOLEAN_DTYPES")
 ```
 
 - [ ] **Step 3: Run test to verify it fails**
@@ -183,7 +188,7 @@ def test_dtype_sets_are_functions_returning_expected_members():
 Run: `RUNPY -m pytest tests/test_indicators_dtype_defer.py -v`
 Expected: FAIL with `ImportError: cannot import name '_boolean_dtypes'`
 
-- [ ] **Step 4: Convert the constants (the goldencheck lru_cache pattern)**
+- [ ] **Step 4: Delete the dead constant, defer the live one (the goldencheck lru_cache pattern)**
 
 In `goldenmatch/core/indicators.py`, replace lines 43-44:
 
@@ -192,20 +197,15 @@ In `goldenmatch/core/indicators.py`, replace lines 43-44:
 _BOOLEAN_DTYPES = {pl.Boolean}
 _NON_IDENTITY_DTYPES = {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
 
-# AFTER (add `from functools import lru_cache` to the imports)
-@lru_cache(maxsize=1)
-def _boolean_dtypes() -> set:
-    """Deferred: evaluating pl.Boolean at module level would defeat _polars_lazy."""
-    return {pl.Boolean}
-
-
+# AFTER (add `from functools import lru_cache` to the imports; _BOOLEAN_DTYPES is
+# deleted outright -- zero usages, dead code)
 @lru_cache(maxsize=1)
 def _non_identity_dtypes() -> set:
-    """Deferred: see _boolean_dtypes."""
+    """Deferred: evaluating pl dtypes at module level would defeat _polars_lazy."""
     return {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
 ```
 
-Update every usage found in Step 1 from `_BOOLEAN_DTYPES` -> `_boolean_dtypes()` and `_NON_IDENTITY_DTYPES` -> `_non_identity_dtypes()`.
+Update the single usage found in Step 1 (`core/indicators.py:91`) from `_NON_IDENTITY_DTYPES` -> `_non_identity_dtypes()`.
 
 - [ ] **Step 5: Run the new test + the indicators tests**
 
@@ -549,7 +549,9 @@ to a curated list of DataFrame/Series/LazyFrame relational methods. The curated
 list makes (b) high-signal: bare method names can collide with non-Polars
 objects, so treat per-file counts as an upper bound to hand-verify per wave.
 
-Usage: python scripts/audit_goldenmatch_polars_ops.py > /tmp/op_audit.md
+Usage: python scripts/audit_goldenmatch_polars_ops.py
+(stdout is markdown; paste under the '## Generated census' heading of
+docs/design/2026-07-09-goldenmatch-polars-op-inventory.md)
 """
 from __future__ import annotations
 
@@ -659,7 +661,7 @@ D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check packages/python/
 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pyright packages/python/goldenmatch/goldenmatch/_polars_lazy.py packages/python/goldenmatch/goldenmatch/core/frame.py packages/python/goldenmatch/goldenmatch/core/indicators.py 2>&1 | tail -5
 ```
 
-Expected: ruff `All checks passed!`. Pyright: no NEW errors in the three files (local pyright shows pre-existing `reportMissingImports` noise absent on CI -- ignore exactly that class). The full-package pyright gate runs in CI.
+Expected: ruff `All checks passed!`. Pyright: no NEW errors in the three files (local pyright shows pre-existing `reportMissingImports` noise absent on CI -- ignore exactly that class). `python -m pyright` is confirmed working in the main venv (used for the #1609 fix); if it ever goes missing, skip this step and let the required CI pyright gate cover it. The full-package pyright gate runs in CI.
 
 - [ ] **Step 2: Wider targeted test batches (spot the sweep's blast radius)**
 
@@ -712,7 +714,7 @@ GH_TOKEN=$(gh auth token --user benzsevern) gh pr create \
   --body "$(cat <<'EOF'
 ## Summary
 - W0 of the Polars-eviction program (spec: docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md)
-- `import goldenmatch` no longer loads Polars: `_polars_lazy` proxy (goldenflow template + TYPE_CHECKING dual-path so pyright keeps real Polars types) swept across all 112 module-level import sites; the 2 module-level dtype-set constants in core/indicators.py deferred via lru_cache
+- `import goldenmatch` no longer loads Polars: `_polars_lazy` proxy (goldenflow template + TYPE_CHECKING dual-path so pyright keeps real Polars types) swept across all 112 module-level import sites; core/indicators.py's live module-level dtype-set constant deferred via lru_cache (the dead one deleted)
 - `core/frame.py` Frame/Column seam scaffold with delegating PolarsFrame backend + idempotent `to_frame()` (no call sites ported -- that is W1+)
 - W0 audits checked in: `scripts/audit_goldenmatch_polars_ops.py` + `docs/design/2026-07-09-goldenmatch-polars-op-inventory.md`
 

--- a/docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md
@@ -1,0 +1,233 @@
+# GoldenMatch Polars Eviction -- Own the Rust/Arrow/Fusion Stack
+
+- **Date:** 2026-07-09
+- **Status:** Approved (design); implementation planned wave-by-wave
+- **Driver:** Full in-house ownership of the data plane (Arrow) and compute plane
+  (owned Rust kernels), mirroring the completed goldenflow and in-flight
+  goldencheck evictions. Secondary driver: install footprint (polars is ~130MB
+  of the base install).
+- **End state (user decision):** ZERO Polars anywhere in the goldenmatch
+  package -- not an optional `[polars]` accelerator extra, not a decline class.
+  Every module ports.
+
+## 1. Motivation and thesis
+
+GoldenMatch already owns its hot compute path in Rust over Arrow:
+
+- `match_fused` -- block + score + dedup + cluster in one FFI call; takes
+  `dict[str, pa.Array]` in, returns cluster ids. No Polars inside.
+- `golden_fused` -- clusters -> golden-record indices over Arrow. No Polars
+  inside.
+- `score-core`, `graph-core`, `fingerprint-core`, the goldenflow transform
+  kernels -- the scoring/standardize/transform layer largely exists in owned
+  Rust already.
+
+Polars' remaining role is glue between owned kernels: file IO, relational
+plumbing (joins/group_by/partition_by), and an expression long tail in the
+controller/profiling code. Each of those decomposes onto things we either
+already ship (pyarrow is a base dep and the kernel FFI boundary) or can own.
+
+The thesis: **Arrow is the data plane, owned Rust kernels are the compute
+plane, and Polars is replaceable glue.** This is the same "Rust is the
+reference" direction the suite committed to on 2026-07-01
+(`docs/design/2026-07-01-rust-is-the-reference-roadmap.md`), applied to the
+substrate itself.
+
+### Why goldenmatch is harder than goldenflow/goldencheck
+
+Those packages use Polars as a *calculator* (per-value transforms, per-column
+reductions), so a scalar-op seam sufficed. GoldenMatch uses Polars as a
+*relational engine*: exact matching is a self-join, blocking is a group_by,
+golden is a partition_by, ingest is a lazy scan. The counter-move is the fused
+kernel program (above) plus `pyarrow.compute` (which has hash joins and
+group_by) for the cold glue. The port is bigger -- 124 of 304 package files
+import polars; the densest are `distributed/clustering.py` (72 refs),
+`core/pipeline.py` (70), `core/scorer.py` (57), `core/golden.py` (55),
+`core/blocker.py` (44) -- but it is the same seam pattern, executed in waves.
+
+## 2. Decisions locked
+
+| Decision | Choice | Rationale |
+| --- | --- | --- |
+| End state | Zero Polars anywhere | Full ownership; no decline class, no accelerator tail. Everything ports; only ordering varies. |
+| Substrate | Owned Frame/Column seam backed by `pyarrow.Table` | The proven goldencheck/goldenflow pattern; port is mechanical file-by-file; substrate swappable later (e.g. arro3) without re-touching 124 files. |
+| Public API | Arrow-native results; semver major (v3.0.0) | Inputs stay polymorphic (any Arrow C stream object: polars, pandas, duckdb -- zero-copy, callers unchanged). `DedupeResult`/`MatchResult` frame fields become `pa.Table`. Polars users migrate with `pl.from_arrow(result.golden)` (zero-copy one-liner). The repo executed a clean 2.0.0 break before. |
+| Fallback contract | Pure-Python lane becomes Arrow + Python | Today's "pure-Python fallback" for the pipeline IS Polars. Post-eviction, no-wheel platforms run pyarrow.compute glue + Python scoring: correct but slower. Consistent with the reference-mode thesis (Rust reference, lossy fallback); the native wheel already covers win/mac/linux x86_64+aarch64. Documented plainly, not hidden. |
+
+Out of scope (explicitly retained): `pyarrow` (the data plane and kernel FFI
+boundary), `duckdb` (a feature backend, not glue), the TypeScript port (own
+engine), and any attempt to reproduce a Polars-style expression engine.
+
+## 3. Program shape: two arms, six waves
+
+The fused kernels are the existence proof but not the whole engine: they
+DECLINE to None on configs they do not cover (validators, plugins, LLM
+survivorship, adaptive, memory, identity, ...) and fall back to the classic
+pipeline -- which is Polars. So the program has two arms working toward each
+other:
+
+1. **Expand fusion downward** -- grow `match_fused`/`golden_fused` config
+   coverage so more runs never touch classic glue (continues the existing
+   fusion program).
+2. **Port the classic glue upward** -- move the remaining relational ops onto
+   the Frame seam, backed by `pyarrow.compute`, promoting measured hot spots
+   into owned kernels.
+
+### Waves
+
+Each wave ships independently, parity-gated, branched off fresh origin/main
+(one wave merges before the next branches -- the goldencheck stacking lesson).
+
+| Wave | Content | Polars status after |
+| --- | --- | --- |
+| W0 | Lazy-import linchpin (goldenflow's `_LazyPolars` proxy, all 124 imports) + `core/frame.py` seam scaffold with a delegating PolarsFrame backend | Present, but `import goldenmatch` no longer loads it |
+| W1 | Arrow IO (`core/io_arrow.py`: pyarrow csv/parquet; openpyxl direct for Excel) + the fused spine wired end-to-end on ArrowFrame, env-gated `GOLDENMATCH_FRAME=arrow` | Default engine still Polars |
+| W2 | Classic engine port: blocker/scorer/cluster/golden/standardize/matchkey onto seam ops; measured hot spots become kernels; fused coverage widened in parallel | Core engine dual-backend |
+| W3 | Controller/autoconfig front: profiling, indicators, complexity signals -- mostly column reductions (goldencheck-shaped; many map onto already-proven seam ops) | Controller dual-backend |
+| W4 | Tails: distributed (Ray `map_batches(batch_format="pyarrow")` -- Ray's object store is natively Arrow), chunked, db/identity, web, TUI engine, MCP/A2A handlers, in-repo downstream consumers | Polars unreferenced |
+| W5 | The flip: `polars` removed from dependencies, PolarsFrame + `GOLDENMATCH_FRAME` deleted, test assertions migrated to Arrow, ship v3.0.0 | ZERO |
+
+W0-W4 ship as 2.x minor releases; users see no behavior change (Polars remains
+the default backend, Arrow is env-gated experimental). W5 is the major.
+
+## 4. The Frame seam
+
+### 4.1 Semantic ops, never an expression DSL
+
+Pipeline Polars usage looks like
+`pl.col(x).cast(pl.Utf8).str.strip_chars() != ""` -- chains of a DSL the seam
+must NOT reproduce (rebuilding an expression engine is how this program dies).
+Instead, each call site's *intent* becomes one named op:
+
+- `frame.filter_nonnull_nonempty(col)`
+- `frame.concat_str(cols, sep)`
+- `frame.self_join_on(key)` (suffix semantics pinned to the exact-match join)
+- `frame.partition_by(col)`
+- `frame.group_by_len(keys)`
+- column-level: `col.cast_str()`, `col.null_count()`, `col.n_unique()`, ...
+
+Ops are derived from an **op audit of actual usage** (a W0 deliverable), not
+designed up front, and added wave-by-wave as call sites port -- exactly how the
+goldencheck seam grew (`str_match_count`, `value_counts_desc`, ...). Estimate
+40-80 semantic ops total; each is small, testable, and implemented twice.
+
+### 4.2 Two backends, differential CI, one dies at W5
+
+- **PolarsFrame** -- delegates each op to the exact Polars call it replaced
+  (byte-identical by construction). Default through W4; regression protection
+  for the existing 1300+ tests, which keep running UNEDITED against it.
+- **ArrowFrame** -- `pa.Table` + `pyarrow.compute`, with `to_arrow()` /
+  `to_arrow_columns()` as the kernel FFI boundary (the fused kernels already
+  consume `dict[str, pa.Array]`; that interface is unchanged).
+- Selection: `GOLDENMATCH_FRAME` env, default `polars` until W5. `to_frame()`
+  coercion is idempotent at every public entry point.
+- **Differential CI lane:** runs the suite's engine-relevant paths under both
+  backends and diffs canonicalized outputs (section 5). This is what makes each
+  wave safe to merge. Also records wall + peak RSS per backend.
+- At W5, PolarsFrame, the env var, and the differential lane are deleted
+  together; the test suite's assertions migrate to Arrow (acknowledged W5
+  work, not a hidden cost).
+
+### 4.3 Kernel-vs-glue routing rule
+
+Glue ops (join/group_by/filter/concat) start as `pyarrow.compute` behind the
+seam -- the cheapest correct implementation. Any op that regresses more than
+10% on the standing benches moves into `goldenmatch-native` as an owned Arrow
+kernel instead of shipping slow. W2 also widens fused-kernel config coverage,
+so a shrinking share of runs touches classic glue at all. End-state hot path:
+pyarrow IO -> fused kernels -> Arrow out, with pa.compute serving only
+cold/exotic configs.
+
+### 4.4 IO layer (`core/io_arrow.py`)
+
+`pyarrow.csv` / `pyarrow.parquet`; Excel goes through openpyxl directly
+(Polars was already delegating to it). Two known semantic gaps tracked as
+risks from day one:
+
+- Polars' `utf8-lossy` has no direct pyarrow equivalent -- dirty files
+  (Leipzig latin-1, junk rows) need a decode-with-replace strategy (read as
+  binary + errors="replace" decode pass, or pyarrow ReadOptions encoding where
+  sufficient).
+- Dtype inference differs between readers (Polars reads zips as Int64 -- a
+  documented gotcha call sites already `str()` around). Ingest parity gets its
+  own fixture corpus (section 5.1).
+
+Small consequences on the list: `DedupeResult._repr_html_` re-renders from
+Arrow; `write_csv`/`write_parquet` output paths move to pyarrow writers.
+
+## 5. Parity contract
+
+Byte-identity across engines is unattainable (row order, dtype inference,
+cluster-id assignment order), so the gate is **canonicalized equivalence**,
+pinned in dependency order:
+
+1. **Ingest parity FIRST.** A fixture corpus runs both readers over every
+   standard test file and diffs values + canonicalized dtypes. If the readers
+   disagree, nothing downstream is comparable; fixes land at the IO layer, not
+   papered over later.
+2. **Cluster partitions** compare as sets-of-frozensets of row ids
+   (order-free).
+3. **Golden records** compare as value maps keyed by sorted cluster members.
+4. **Scored pairs** compare as canonical `(min, max, score)` sets. Scores must
+   match exactly -- both backends feed the same kernels/rapidfuzz once ingest
+   parity holds.
+
+Pre-port outputs are frozen as serialized fixtures; the Arrow backend must
+reproduce them. The existing test suite runs unedited against the Polars
+backend through W4; the differential lane covers Arrow.
+
+## 6. Performance gates
+
+- The standing 100K zero-config <= 24s CI gate stays green on both backends.
+- The 1M and 25M benches re-run on every wave that touches engine ops.
+- The differential lane records peak RSS alongside wall (RSS is a tracked
+  workstream; Arrow should be leaner, but this is measured, not promised).
+- Binding rule: > 10% wall regression on any ported op -> owned kernel, not
+  shipped slow.
+- Named suspects to measure EARLY (W1/W2): exact-match self-join at 1M+
+  (Polars' join is excellent; `pa.Table.join`/Acero must prove itself),
+  blocking group_by, and the distributed columnar WCC (Phase B was
+  memory-tuned on Polars frames -- re-verify the 5M chain bench; Ray plasma is
+  natively Arrow so this is expected to get cleaner, but expected != measured).
+
+## 7. Risk register
+
+| Risk | Mitigation |
+| --- | --- |
+| Join null-key semantics differ between Polars and Acero | Dedicated semantics fixtures pinned before the exact-match port; behavior documented in the seam op's contract |
+| `utf8-lossy` dirty-CSV handling | decode-with-replace strategy in io_arrow; Leipzig latin-1 + junk-row files in the ingest parity corpus |
+| Dtype inference drift (Int64 zips etc.) | Ingest parity corpus is gate #1; canonicalization rules live in one module |
+| Module-level dtype constants break the lazy-import proxy | goldencheck hit 7; expect more here. W0 audit enumerates them; each becomes an lru_cache function (proven pattern) |
+| Polars expression long tail in controller/profiling | Semantic-op discipline (4.1); goldencheck already proved the column-reduction subset |
+| Ray/distributed re-port destabilizes the tuned WCC memory profile | Re-run the 5M chain bench as the W4 gate for that module |
+| In-repo downstream consumers (SQL-extensions bridge JSON->polars, goldenmatch-duckdb `.pl()`, goldenmatch-kg, dbt) | All port in W4; duckdb gets simpler (`.arrow()` is native); bridge converts JSON->Arrow |
+| Program size (124 files) | Wave/batch decomposition with per-batch merges, mirroring goldencheck (P0 + batches); no wave stacks on an unmerged predecessor |
+
+## 8. Rollout and versioning
+
+- **W0-W4:** 2.x minors. Polars default, Arrow env-gated experimental
+  (`GOLDENMATCH_FRAME=arrow`). No user-visible change.
+- **W5 = v3.0.0:**
+  - `polars` leaves the dependency list entirely.
+  - Results become `pa.Table`; migration guide is the `pl.from_arrow(...)`
+    one-liner; inputs unchanged (Arrow C stream protocol).
+  - Fallback-contract change documented plainly (no-wheel platforms:
+    correct-but-slower Arrow lane).
+  - Full docs sweep (tuning.mdx, api-quick-reference, README, examples,
+    CHANGELOG) per the rollout-docs-sweep discipline.
+  - golden-suite floor bump + release per the lockstep rule.
+- Version bumps follow the three-spot rule (pyproject.toml,
+  `goldenmatch/__init__.py`, CHANGELOG).
+
+## 9. Success criteria
+
+1. `pip install goldenmatch` (v3) installs and imports with no `polars`
+   distribution present; `python -c "import goldenmatch, sys; assert 'polars' not in sys.modules"` passes.
+2. `grep -r "import polars" packages/python/goldenmatch/goldenmatch/` returns
+   nothing.
+3. Differential fixtures: Arrow backend reproduces all frozen canonicalized
+   outputs (clusters, golden, pairs) from the Polars baseline.
+4. Perf: 100K zero-config gate green; 1M/25M benches within 10% of the Polars
+   baseline (or the offending op moved into a kernel).
+5. The fused spine (pyarrow IO -> match_fused -> golden_fused) is the default
+   covered-config path with zero Polars in the call stack.

--- a/docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md
+++ b/docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md
@@ -4,8 +4,8 @@
 - **Status:** Approved (design); implementation planned wave-by-wave
 - **Driver:** Full in-house ownership of the data plane (Arrow) and compute plane
   (owned Rust kernels), mirroring the completed goldenflow and in-flight
-  goldencheck evictions. Secondary driver: install footprint (polars is ~130MB
-  of the base install).
+  goldencheck evictions. Secondary driver: install footprint (~185MB, the
+  figure the sibling eviction programs use).
 - **End state (user decision):** ZERO Polars anywhere in the goldenmatch
   package -- not an optional `[polars]` accelerator extra, not a decline class.
   Every module ports.
@@ -80,8 +80,8 @@ Each wave ships independently, parity-gated, branched off fresh origin/main
 
 | Wave | Content | Polars status after |
 | --- | --- | --- |
-| W0 | Lazy-import linchpin (goldenflow's `_LazyPolars` proxy, all 124 imports) + `core/frame.py` seam scaffold with a delegating PolarsFrame backend | Present, but `import goldenmatch` no longer loads it |
-| W1 | Arrow IO (`core/io_arrow.py`: pyarrow csv/parquet; openpyxl direct for Excel) + the fused spine wired end-to-end on ArrowFrame, env-gated `GOLDENMATCH_FRAME=arrow` | Default engine still Polars |
+| W0 | Four deliverables: (1) lazy-import linchpin (goldenflow's `_LazyPolars` proxy, all 124 imports); (2) `core/frame.py` seam scaffold with a delegating PolarsFrame backend; (3) the semantic-op audit (section 4.1); (4) the module-level dtype-constant enumeration (section 7) | Present, but `import goldenmatch` no longer loads it |
+| W1 | Arrow IO (`core/io_arrow.py`: pyarrow csv/parquet; openpyxl direct for Excel) + the fused spine wired end-to-end on ArrowFrame, env-gated `GOLDENMATCH_FRAME=arrow`. The differential CI lane and the frozen pre-port parity fixtures (section 5) land HERE -- they are what makes the env-gated backend mergeable. Pre-W2, a config the fused kernels decline falls back to the Polars classic path with a logged notice, even under `GOLDENMATCH_FRAME=arrow` | Default engine still Polars |
 | W2 | Classic engine port: blocker/scorer/cluster/golden/standardize/matchkey onto seam ops; measured hot spots become kernels; fused coverage widened in parallel | Core engine dual-backend |
 | W3 | Controller/autoconfig front: profiling, indicators, complexity signals -- mostly column reductions (goldencheck-shaped; many map onto already-proven seam ops) | Controller dual-backend |
 | W4 | Tails: distributed (Ray `map_batches(batch_format="pyarrow")` -- Ray's object store is natively Arrow), chunked, db/identity, web, TUI engine, MCP/A2A handlers, in-repo downstream consumers | Polars unreferenced |

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -34,7 +34,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - DB tests (`test_db.py`, `test_reconcile.py`) need PostgreSQL — skip with `--ignore` if not available
 - `import torch` hangs on this machine — tests mocking GPU must patch `_has_cuda`/`_has_mps` at module level
 - `testing.postgresql` teardown errors on Windows (SIGINT) are harmless — tests still pass
-- CI workflow: `.github/workflows/ci.yml` -- test matrix (3.11/3.12/3.13), ruff lint (E9/F63/F7 only), smoke test. Ignores test_db, test_reconcile, test_mcp_and_watch
+- CI workflow: `.github/workflows/ci.yml` -- test matrix (3.11/3.12/3.13), ruff lint (the FULL root-pyproject select incl. import-sort `I` -- CI runs plain `ruff check packages/python/goldenmatch`; the old "E9/F63/F7 only" note was stale and nearly shipped 79 I001s in the W0 polars sweep), smoke test. Ignores test_db, test_reconcile, test_mcp_and_watch
 - Ray tests require `ray` optional dep -- use `pytest.mark.skipif(not HAS_RAY)` pattern
 - Windows drive letter tests must use `@pytest.mark.skipif(sys.platform != "win32")` -- Path.stem behaves differently on Linux
 - sdist includes benchmark datasets (can bloat to 500MB+) -- add large data dirs to `.gitignore` before building

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 # Imported at module level so tests can patch goldenmatch._api.auto_configure_df.
 # The lazy import guard inside each function is kept for cycle safety — this

--- a/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
+++ b/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
@@ -27,6 +27,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+__all__ = ["pl"]
+
 
 class _LazyPolars:
     """Forwards attribute access to ``polars``, importing it on first use."""

--- a/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
+++ b/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
@@ -7,12 +7,15 @@ on the FIRST attribute access, not at import time. Every runtime ``pl.`` use in
 the swept modules keeps working unchanged, but ``import goldenmatch`` no longer
 eagerly imports Polars.
 
-Safe because (audited 2026-07-09):
-- All swept modules have ``from __future__ import annotations`` (string
-  annotations never trigger the import).
-- No module-level ``pl.`` execution remains (the two dtype-set constants in
-  core/indicators.py were converted in this wave) and no ``def f(x=pl.X)``
-  default arg exists.
+The import-site sweep onto this proxy happens in a LATER W0 task; today this
+module has no consumers. Every module swept onto it must satisfy these FORWARD
+invariants (verified to hold for the planned sweep set as of 2026-07-09):
+- The module has ``from __future__ import annotations`` (string annotations
+  never trigger the import).
+- No module-level ``pl.`` execution (the two dtype-set constants in
+  core/indicators.py were handled in this wave: ``_NON_IDENTITY_DTYPES``
+  converted to a lazy ``lru_cache`` function, the dead ``_BOOLEAN_DTYPES``
+  deleted outright) and no ``def f(x=pl.X)`` default arg.
 - Attribute access returns the REAL Polars object, so ``isinstance(x,
   pl.DataFrame)`` and dtype identity behave identically to ``import polars``.
 

--- a/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
+++ b/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
@@ -1,0 +1,50 @@
+# goldenmatch/_polars_lazy.py
+"""Lazy Polars proxy -- W0 of the Polars eviction (spec:
+docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md).
+
+``from goldenmatch._polars_lazy import pl`` gives a stand-in that imports Polars
+on the FIRST attribute access, not at import time. Every runtime ``pl.`` use in
+the swept modules keeps working unchanged, but ``import goldenmatch`` no longer
+eagerly imports Polars.
+
+Safe because (audited 2026-07-09):
+- All swept modules have ``from __future__ import annotations`` (string
+  annotations never trigger the import).
+- No module-level ``pl.`` execution remains (the two dtype-set constants in
+  core/indicators.py were converted in this wave) and no ``def f(x=pl.X)``
+  default arg exists.
+- Attribute access returns the REAL Polars object, so ``isinstance(x,
+  pl.DataFrame)`` and dtype identity behave identically to ``import polars``.
+
+The ``TYPE_CHECKING`` branch makes pyright treat ``pl`` as the real module, so
+static narrowing across the package is unchanged (a deliberate divergence from
+the goldenflow/goldencheck template, which exposes ``Any``).
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+
+class _LazyPolars:
+    """Forwards attribute access to ``polars``, importing it on first use."""
+
+    __slots__ = ("_mod",)
+
+    def __init__(self) -> None:
+        self._mod: Any = None
+
+    def __getattr__(self, name: str) -> Any:
+        # `_mod` is a slot (set in __init__), so reading it never re-enters
+        # __getattr__; only genuine polars attributes reach this path.
+        mod = self._mod
+        if mod is None:
+            import polars as _polars
+
+            self._mod = mod = _polars
+        return getattr(mod, name)
+
+
+if TYPE_CHECKING:
+    import polars as pl
+else:
+    pl = _LazyPolars()

--- a/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
+++ b/packages/python/goldenmatch/goldenmatch/_polars_lazy.py
@@ -7,9 +7,9 @@ on the FIRST attribute access, not at import time. Every runtime ``pl.`` use in
 the swept modules keeps working unchanged, but ``import goldenmatch`` no longer
 eagerly imports Polars.
 
-The import-site sweep onto this proxy happens in a LATER W0 task; today this
-module has no consumers. Every module swept onto it must satisfy these FORWARD
-invariants (verified to hold for the planned sweep set as of 2026-07-09):
+All 112 module-level ``import polars as pl`` sites in the package are swept
+onto this proxy (landed in this same wave). Every module swept onto it must
+satisfy these invariants (verified to hold as of 2026-07-09):
 - The module has ``from __future__ import annotations`` (string annotations
   never trigger the import).
 - No module-level ``pl.`` execution (the two dtype-set constants in

--- a/packages/python/goldenmatch/goldenmatch/backends/duckdb_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/duckdb_backend.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -37,7 +37,6 @@ from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig
 from goldenmatch.core._native_loader import native_enabled, native_module
 from goldenmatch.core.bench import record_metrics, stage

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -36,7 +36,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig
 from goldenmatch.core._native_loader import native_enabled, native_module

--- a/packages/python/goldenmatch/goldenmatch/connectors/_sql_common.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/_sql_common.py
@@ -18,7 +18,7 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/_sql_common.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/_sql_common.py
@@ -19,7 +19,6 @@ from collections.abc import Iterable
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/base.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/base.py
@@ -5,7 +5,7 @@ import logging
 import os
 from abc import ABC, abstractmethod
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/bigquery.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/bigquery.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/bigquery.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/bigquery.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/databricks.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/databricks.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/databricks.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/databricks.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/duckdb_source.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/duckdb_source.py
@@ -53,7 +53,7 @@ import logging
 import os
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors._sql_common import (
     require_mode,

--- a/packages/python/goldenmatch/goldenmatch/connectors/duckdb_source.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/duckdb_source.py
@@ -54,7 +54,6 @@ import os
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors._sql_common import (
     require_mode,
     require_table,

--- a/packages/python/goldenmatch/goldenmatch/connectors/hubspot.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/hubspot.py
@@ -10,7 +10,6 @@ import logging
 import urllib.request
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/hubspot.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/hubspot.py
@@ -9,7 +9,7 @@ import json
 import logging
 import urllib.request
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
@@ -51,7 +51,6 @@ import os
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/mongo.py
@@ -50,7 +50,7 @@ import logging
 import os
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/mysql.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/mysql.py
@@ -39,7 +39,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors._sql_common import (
     df_to_rows,
     require_mode,

--- a/packages/python/goldenmatch/goldenmatch/connectors/mysql.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/mysql.py
@@ -38,7 +38,7 @@ import os
 from typing import Any
 from urllib.parse import urlparse
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors._sql_common import (
     df_to_rows,

--- a/packages/python/goldenmatch/goldenmatch/connectors/object_storage.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/object_storage.py
@@ -68,7 +68,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/object_storage.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/object_storage.py
@@ -67,7 +67,7 @@ import logging
 from typing import Any
 from urllib.parse import urlparse
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/postgres.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/postgres.py
@@ -44,7 +44,7 @@ import logging
 import os
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors._sql_common import (
     df_to_rows,

--- a/packages/python/goldenmatch/goldenmatch/connectors/postgres.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/postgres.py
@@ -45,7 +45,6 @@ import os
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors._sql_common import (
     df_to_rows,
     require_mode,

--- a/packages/python/goldenmatch/goldenmatch/connectors/redshift.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/redshift.py
@@ -47,7 +47,6 @@ import os
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors._sql_common import (
     df_to_rows,
     require_mode,

--- a/packages/python/goldenmatch/goldenmatch/connectors/redshift.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/redshift.py
@@ -46,7 +46,7 @@ import logging
 import os
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors._sql_common import (
     df_to_rows,

--- a/packages/python/goldenmatch/goldenmatch/connectors/salesforce.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/salesforce.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/salesforce.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/salesforce.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/snowflake.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/snowflake.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 

--- a/packages/python/goldenmatch/goldenmatch/connectors/snowflake.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/snowflake.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors.base import BaseConnector, ConnectorError
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/connectors/sqlserver.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/sqlserver.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import logging
 import os
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.connectors._sql_common import (
     df_to_rows,

--- a/packages/python/goldenmatch/goldenmatch/connectors/sqlserver.py
+++ b/packages/python/goldenmatch/goldenmatch/connectors/sqlserver.py
@@ -39,7 +39,6 @@ import logging
 import os
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.connectors._sql_common import (
     df_to_rows,
     require_mode,

--- a/packages/python/goldenmatch/goldenmatch/core/agent.py
+++ b/packages/python/goldenmatch/goldenmatch/core/agent.py
@@ -11,7 +11,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/agent.py
+++ b/packages/python/goldenmatch/goldenmatch/core/agent.py
@@ -10,7 +10,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.review_queue import ReviewQueue, gate_pairs
 

--- a/packages/python/goldenmatch/goldenmatch/core/anomaly.py
+++ b/packages/python/goldenmatch/goldenmatch/core/anomaly.py
@@ -14,7 +14,7 @@ import logging
 import re
 from collections import Counter
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/api_connector.py
+++ b/packages/python/goldenmatch/goldenmatch/core/api_connector.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldenmatch.config.schemas import StandardizationConfig

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -16,7 +16,7 @@ from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.autoconfig_history import RunHistory

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.autoconfig_history import RunHistory
 from goldenmatch.core.bench import stage

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -14,7 +14,7 @@ import os
 from difflib import SequenceMatcher
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 _IDENTITY_BASKET_TYPES = frozenset({"name", "multi_name", "email", "phone", "identifier"})
 # Basket types compared FUZZILY (a true duplicate's name is often corrupted --

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import (
     BlockingConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import (
     BlockingConfig,
     GoldenMatchConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/autofix.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autofix.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 # Strings that should be treated as null
 _NULL_STRINGS = frozenset({

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -7,7 +7,7 @@ import re
 from dataclasses import dataclass
 from itertools import combinations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.utils.transforms import apply_transforms
 

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from itertools import combinations
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.utils.transforms import apply_transforms
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
 from goldenmatch.core.complexity_profile import BlockingProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -7,7 +7,7 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
 from goldenmatch.core.complexity_profile import BlockingProfile

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -22,7 +22,7 @@ import logging
 import os
 from dataclasses import dataclass
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.quality_exclusions import ColumnProfile
 

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -23,7 +23,6 @@ import os
 from dataclasses import dataclass
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.quality_exclusions import ColumnProfile
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_pass_selection.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_pass_selection.py
@@ -32,7 +32,6 @@ from dataclasses import dataclass, field
 from itertools import combinations
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import BlockingKeyConfig
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_pass_selection.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_pass_selection.py
@@ -31,7 +31,7 @@ import random
 from dataclasses import dataclass, field
 from itertools import combinations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingKeyConfig
 

--- a/packages/python/goldenmatch/goldenmatch/core/boost.py
+++ b/packages/python/goldenmatch/goldenmatch/core/boost.py
@@ -11,10 +11,10 @@ import logging
 from pathlib import Path
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 from rapidfuzz.distance import JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.core.llm_labeler import (
     detect_context,
     detect_provider,

--- a/packages/python/goldenmatch/goldenmatch/core/boost.py
+++ b/packages/python/goldenmatch/goldenmatch/core/boost.py
@@ -11,7 +11,7 @@ import logging
 from pathlib import Path
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from rapidfuzz.distance import JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 

--- a/packages/python/goldenmatch/goldenmatch/core/chunked.py
+++ b/packages/python/goldenmatch/goldenmatch/core/chunked.py
@@ -18,7 +18,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 

--- a/packages/python/goldenmatch/goldenmatch/core/chunked.py
+++ b/packages/python/goldenmatch/goldenmatch/core/chunked.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from collections.abc import Iterable, Iterator
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 def _bucket_pairs(

--- a/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
@@ -31,7 +31,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.config_edits import (

--- a/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_optimizer.py
@@ -32,7 +32,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Protocol
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.config_edits import (
     _PERTURBABLE_TYPES,

--- a/packages/python/goldenmatch/goldenmatch/core/dashboard.py
+++ b/packages/python/goldenmatch/goldenmatch/core/dashboard.py
@@ -13,7 +13,7 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/diff.py
+++ b/packages/python/goldenmatch/goldenmatch/core/diff.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -13,7 +13,7 @@ import logging
 import re
 from dataclasses import dataclass, field
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.complexity_profile import DomainProfile as PublicDomainProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter

--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -14,7 +14,6 @@ import re
 from dataclasses import dataclass, field
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.complexity_profile import DomainProfile as PublicDomainProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -1,0 +1,99 @@
+"""Backend-neutral Frame/Column seam for the Polars eviction (W0 scaffold).
+
+Pipeline code will route through this instead of raw ``pl.DataFrame`` so call
+sites can migrate off Polars wave by wave (spec:
+docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md).
+W0 ships only the delegating Polars backend; the ArrowFrame backend arrives in
+W1. ``to_frame`` is idempotent so a caller may pass a raw ``pl.DataFrame`` or
+an already-wrapped ``Frame``.
+
+Op-set discipline: SEMANTIC operations only, added as call sites port -- never
+a Polars-expression clone. New ops require both backends plus a delegation-
+parity test.
+"""
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from goldenmatch._polars_lazy import pl
+
+
+@runtime_checkable
+class Column(Protocol):
+    def __len__(self) -> int: ...
+    def null_count(self) -> int: ...
+    def n_unique(self) -> int: ...
+    def to_list(self) -> list: ...
+    def to_arrow(self) -> Any: ...
+
+
+@runtime_checkable
+class Frame(Protocol):
+    @property
+    def columns(self) -> list[str]: ...
+    @property
+    def height(self) -> int: ...
+    @property
+    def native(self) -> Any: ...
+    def column(self, name: str) -> Column: ...
+    def to_arrow_columns(self, names: list[str]) -> dict[str, Any]: ...
+
+
+class PolarsColumn:
+    """Delegates each op to the exact Polars call it replaces (byte-identical)."""
+
+    __slots__ = ("_s",)
+
+    def __init__(self, s: Any) -> None:
+        self._s = s
+
+    def __len__(self) -> int:
+        return len(self._s)
+
+    def null_count(self) -> int:
+        return self._s.null_count()
+
+    def n_unique(self) -> int:
+        return self._s.n_unique()
+
+    def to_list(self) -> list:
+        return self._s.to_list()
+
+    def to_arrow(self) -> Any:
+        return self._s.to_arrow()
+
+
+class PolarsFrame:
+    __slots__ = ("_df",)
+
+    def __init__(self, df: Any) -> None:
+        self._df = df
+
+    @property
+    def columns(self) -> list[str]:
+        return self._df.columns
+
+    @property
+    def height(self) -> int:
+        return self._df.height
+
+    @property
+    def native(self) -> Any:
+        return self._df
+
+    def column(self, name: str) -> PolarsColumn:
+        return PolarsColumn(self._df[name])
+
+    def to_arrow_columns(self, names: list[str]) -> dict[str, Any]:
+        # The fused-kernel FFI boundary: dict[str, pa.Array/ChunkedArray],
+        # exactly the `collected_df[c].to_arrow()` shape pipeline.py builds today.
+        return {n: self._df[n].to_arrow() for n in names}
+
+
+def to_frame(obj: Any) -> Frame:
+    """Idempotent coercion: raw ``pl.DataFrame`` or ``Frame`` -> ``Frame``."""
+    if isinstance(obj, PolarsFrame):
+        return obj
+    if isinstance(obj, pl.DataFrame):
+        return PolarsFrame(obj)
+    raise TypeError(f"to_frame expects a polars DataFrame or Frame, got {type(obj)!r}")

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -8,7 +8,6 @@ from dataclasses import field as dataclass_field
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from dataclasses import field as dataclass_field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
@@ -14,7 +14,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
 
 _GOLDEN_STRATEGY_IDS = {

--- a/packages/python/goldenmatch/goldenmatch/core/graph.py
+++ b/packages/python/goldenmatch/goldenmatch/core/graph.py
@@ -13,7 +13,7 @@ import json
 import logging
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/graph_er.py
+++ b/packages/python/goldenmatch/goldenmatch/core/graph_er.py
@@ -30,7 +30,6 @@ import logging
 from dataclasses import dataclass, field
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.cluster import build_clusters
 from goldenmatch.core.pipeline import run_dedupe

--- a/packages/python/goldenmatch/goldenmatch/core/graph_er.py
+++ b/packages/python/goldenmatch/goldenmatch/core/graph_er.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.cluster import build_clusters

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -15,7 +15,6 @@ from functools import lru_cache
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.complexity_profile import (
     ColumnPrior,
     SparsityVerdict,

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -14,7 +14,7 @@ import time
 from functools import lru_cache
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.complexity_profile import (
     ColumnPrior,

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -42,9 +42,11 @@ _IDENTITY_NAME_PATTERNS = [
 ]
 
 @lru_cache(maxsize=1)
-def _non_identity_dtypes() -> set:
-    """Deferred: evaluating pl dtypes at module level would defeat _polars_lazy."""
-    return {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+def _non_identity_dtypes() -> frozenset:
+    """Deferred: evaluating pl dtypes at module level would defeat _polars_lazy
+    once this module is swept onto the proxy (today it still imports polars
+    directly; the sweep is a later W0 task)."""
+    return frozenset({pl.Boolean, pl.Date, pl.Datetime, pl.Time})
 
 
 def compute_column_priors(df: pl.DataFrame) -> dict[str, ColumnPrior]:

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+from functools import lru_cache
 from typing import Any
 
 import polars as pl
@@ -40,8 +41,10 @@ _IDENTITY_NAME_PATTERNS = [
     (re.compile(r"^(id|uuid|guid|user_id|account_id)$", re.I), 0.90),
 ]
 
-_BOOLEAN_DTYPES = {pl.Boolean}
-_NON_IDENTITY_DTYPES = {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+@lru_cache(maxsize=1)
+def _non_identity_dtypes() -> set:
+    """Deferred: evaluating pl dtypes at module level would defeat _polars_lazy."""
+    return {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
 
 
 def compute_column_priors(df: pl.DataFrame) -> dict[str, ColumnPrior]:
@@ -88,7 +91,7 @@ def compute_column_priors(df: pl.DataFrame) -> dict[str, ColumnPrior]:
 
 def _compute_identity_score(df: pl.DataFrame, col: str) -> float:
     """Identity-score heuristic. Name match > dtype match > cardinality."""
-    if df.schema.get(col) in _NON_IDENTITY_DTYPES:
+    if df.schema.get(col) in _non_identity_dtypes():
         return 0.0
     for pattern, score in _IDENTITY_NAME_PATTERNS:
         if pattern.match(col):

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -42,9 +42,9 @@ _IDENTITY_NAME_PATTERNS = [
 
 @lru_cache(maxsize=1)
 def _non_identity_dtypes() -> frozenset:
-    """Deferred: evaluating pl dtypes at module level would defeat _polars_lazy
-    once this module is swept onto the proxy (today it still imports polars
-    directly; the sweep is a later W0 task)."""
+    """Deferred: this module is swept onto _polars_lazy, so a module-level
+    ``pl.`` evaluation would trigger the polars import at package import time
+    and defeat the lazy proxy."""
     return frozenset({pl.Boolean, pl.Date, pl.Datetime, pl.Time})
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/ingest.py
@@ -7,7 +7,7 @@ import io
 import logging
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core._paths import safe_path
 

--- a/packages/python/goldenmatch/goldenmatch/core/ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/ingest.py
@@ -8,7 +8,6 @@ import logging
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core._paths import safe_path
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -14,7 +14,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core._logging import sanitize_for_log

--- a/packages/python/goldenmatch/goldenmatch/core/lineage.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lineage.py
@@ -15,7 +15,6 @@ from datetime import datetime
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core._logging import sanitize_for_log
 from goldenmatch.core._paths import safe_path

--- a/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
@@ -14,7 +14,7 @@ import json
 import logging
 from collections import defaultdict
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import LLMScorerConfig
 from goldenmatch.core.llm_budget import BudgetTracker

--- a/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
@@ -15,7 +15,6 @@ import logging
 from collections import defaultdict
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import LLMScorerConfig
 from goldenmatch.core.llm_budget import BudgetTracker
 

--- a/packages/python/goldenmatch/goldenmatch/core/llm_extract.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_extract.py
@@ -13,7 +13,7 @@ import logging
 import os
 import urllib.request
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
@@ -26,7 +26,7 @@ import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldenmatch.core.memory.store import MemoryStore

--- a/packages/python/goldenmatch/goldenmatch/core/lsh_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lsh_blocker.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig, LSHKeyConfig
 from goldenmatch.core import sketch

--- a/packages/python/goldenmatch/goldenmatch/core/lsh_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/lsh_blocker.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import BlockingConfig, LSHKeyConfig
 from goldenmatch.core import sketch
 

--- a/packages/python/goldenmatch/goldenmatch/core/match_one.py
+++ b/packages/python/goldenmatch/goldenmatch/core/match_one.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core.scorer import score_pair

--- a/packages/python/goldenmatch/goldenmatch/core/match_one.py
+++ b/packages/python/goldenmatch/goldenmatch/core/match_one.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core.scorer import score_pair
 

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core.complexity_profile import FieldStats, MatchkeyProfile

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core.complexity_profile import FieldStats, MatchkeyProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.memory.store import Correction, _canon_pair
 

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.memory.store import Correction, _canon_pair
 
 if TYPE_CHECKING:

--- a/packages/python/goldenmatch/goldenmatch/core/merge_preview.py
+++ b/packages/python/goldenmatch/goldenmatch/core/merge_preview.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 import re
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import (
     BlockingConfig,
     GoldenMatchConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import re
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import (
     BlockingConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import BlockingConfig, PerceptualKeyConfig
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig, PerceptualKeyConfig
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from goldenmatch.distributed.record_store import PreparedRecordStore
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig, GoldenRulesConfig
 from goldenmatch.core.autofix import auto_fix_dataframe
 from goldenmatch.core.bench import record_metric, record_metrics, stage

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from goldenmatch.core.cluster_pairscores import ClusterPairScores
     from goldenmatch.distributed.record_store import PreparedRecordStore
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig, GoldenRulesConfig
 from goldenmatch.core.autofix import auto_fix_dataframe

--- a/packages/python/goldenmatch/goldenmatch/core/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/core/preview.py
@@ -5,10 +5,10 @@ and score histograms using Rich tables and console capture.
 """
 from __future__ import annotations
 
-from goldenmatch._polars_lazy import pl
 from rich.console import Console
 from rich.table import Table
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.tui.engine import EngineStats
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/core/preview.py
@@ -5,7 +5,7 @@ and score histograms using Rich tables and console capture.
 """
 from __future__ import annotations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from rich.console import Console
 from rich.table import Table
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -21,8 +21,8 @@ from dataclasses import dataclass
 from itertools import combinations
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core.scorer import score_field
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from itertools import combinations
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import MatchkeyConfig
 from goldenmatch.core.scorer import score_field

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.backends.score_buckets import _resolve_score_pair_callable
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -34,7 +34,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.backends.score_buckets import _resolve_score_pair_callable
 
 if TYPE_CHECKING:

--- a/packages/python/goldenmatch/goldenmatch/core/profiler.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profiler.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from rich.panel import Panel
 from rich.table import Table
+
+from goldenmatch._polars_lazy import pl
 
 # ── Heuristic type detection helpers ────────────────────────────────────────
 

--- a/packages/python/goldenmatch/goldenmatch/core/profiler.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profiler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from rich.panel import Panel
 from rich.table import Table
 

--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
@@ -31,7 +31,7 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
@@ -32,7 +32,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.llm_canonicalize import CanonicalRecord, canonicalize_cluster
 from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records
 

--- a/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
+++ b/packages/python/goldenmatch/goldenmatch/core/rag_surface.py
@@ -31,7 +31,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.llm_canonicalize import CanonicalRecord, canonicalize_cluster
 from goldenmatch.core.retrieval import RetrievedRecord, retrieve_similar_records

--- a/packages/python/goldenmatch/goldenmatch/core/report.py
+++ b/packages/python/goldenmatch/goldenmatch/core/report.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.explainer import MatchExplanation, explain_pair
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/report.py
+++ b/packages/python/goldenmatch/goldenmatch/core/report.py
@@ -7,7 +7,7 @@ from collections import Counter
 from datetime import datetime
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.explainer import MatchExplanation, explain_pair
 

--- a/packages/python/goldenmatch/goldenmatch/core/retrieval.py
+++ b/packages/python/goldenmatch/goldenmatch/core/retrieval.py
@@ -24,7 +24,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.ann_blocker import ANNBlocker
 from goldenmatch.core.embedder import get_embedder

--- a/packages/python/goldenmatch/goldenmatch/core/retrieval.py
+++ b/packages/python/goldenmatch/goldenmatch/core/retrieval.py
@@ -25,7 +25,6 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.ann_blocker import ANNBlocker
 from goldenmatch.core.embedder import get_embedder
 

--- a/packages/python/goldenmatch/goldenmatch/core/schema_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/schema_match.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from rapidfuzz.fuzz import partial_ratio, ratio
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/schema_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/schema_match.py
@@ -12,8 +12,9 @@ from __future__ import annotations
 
 import logging
 
-from goldenmatch._polars_lazy import pl
 from rapidfuzz.fuzz import partial_ratio, ratio
+
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jellyfish
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from rapidfuzz.distance import JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 from rapidfuzz.process import cdist
@@ -1068,7 +1068,7 @@ def find_fuzzy_matches(
     # ``list[tuple]`` path (permanent opt-in, default). These two helpers
     # keep the branch bodies readable and the conversion in one place.
     def _emit_empty() -> list[tuple[int, int, float]] | pl.DataFrame:
-        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA) if _emit_dataframe else []
+        return pl.DataFrame(schema=_pair_stream_schema()) if _emit_dataframe else []
 
     def _emit_results(
         results: list[tuple[int, int, float]],
@@ -1315,7 +1315,7 @@ def find_fuzzy_matches(
             "id_a": ids_a if hasattr(ids_a, "astype") else np.asarray(ids_a, dtype=np.int64),
             "id_b": ids_b if hasattr(ids_b, "astype") else np.asarray(ids_b, dtype=np.int64),
             "score": scores if hasattr(scores, "astype") else np.asarray(scores, dtype=np.float64),
-        }, schema=PAIR_STREAM_SCHEMA)
+        }, schema=_pair_stream_schema())
     return [(int(a), int(b), float(s)) for a, b, s in zip(ids_a, ids_b, scores)]
 
 
@@ -1352,7 +1352,7 @@ def _score_one_block(
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()
         if len(sources_in_block) < 2:
-            return pl.DataFrame(schema=PAIR_STREAM_SCHEMA) if _emit_dataframe else []
+            return pl.DataFrame(schema=_pair_stream_schema()) if _emit_dataframe else []
 
     pairs = find_fuzzy_matches(
         block_df, mk,
@@ -1688,13 +1688,39 @@ def rerank_top_pairs(
 # Phase 1c. Spec: docs/superpowers/specs/2026-05-31-arrow-native-roadmap.md
 # (gitignored).
 
-PAIR_STREAM_SCHEMA: dict[str, pl.DataType] = {
-    "id_a": pl.Int64(),
-    "id_b": pl.Int64(),
-    "score": pl.Float64(),
-}
-"""Canonical pair-stream schema. ``id_a < id_b`` invariant maintained by the
-caller (legacy scorers already canonicalize via ``(min, max)``)."""
+_PAIR_STREAM_SCHEMA_CACHE: dict[str, pl.DataType] | None = None
+
+
+def _pair_stream_schema() -> dict[str, pl.DataType]:
+    """Canonical pair-stream schema. ``id_a < id_b`` invariant maintained by the
+    caller (legacy scorers already canonicalize via ``(min, max)``).
+
+    Built lazily -- not a module-level ``pl.`` literal -- so importing this
+    module doesn't import Polars eagerly (W0 polars-eviction gate). Cached
+    after the first call. The public ``PAIR_STREAM_SCHEMA`` name is still
+    importable (module ``__getattr__`` below) for external consumers (tests,
+    ``cluster.py``, ``pairs.py``) that expect a plain dict attribute.
+    """
+    global _PAIR_STREAM_SCHEMA_CACHE
+    if _PAIR_STREAM_SCHEMA_CACHE is None:
+        _PAIR_STREAM_SCHEMA_CACHE = {
+            "id_a": pl.Int64(),
+            "id_b": pl.Int64(),
+            "score": pl.Float64(),
+        }
+    return _PAIR_STREAM_SCHEMA_CACHE
+
+
+def __getattr__(name: str) -> dict[str, pl.DataType]:
+    """PEP 562 module attribute hook: resolves ``PAIR_STREAM_SCHEMA`` lazily
+    for ``from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA`` / attribute
+    access, without executing ``pl.Int64()`` etc. at module import time. Only
+    fires for names not already bound in the module's ``__dict__`` (i.e. not
+    for bare-name references inside this module's own functions, which call
+    ``_pair_stream_schema()`` directly above)."""
+    if name == "PAIR_STREAM_SCHEMA":
+        return _pair_stream_schema()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def pairs_list_to_df(pairs: list[tuple[int, int, float]]) -> pl.DataFrame:
@@ -1705,8 +1731,8 @@ def pairs_list_to_df(pairs: list[tuple[int, int, float]]) -> pl.DataFrame:
     without an ``if df.is_empty()`` guard at every call site.
     """
     if not pairs:
-        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
-    return pl.DataFrame(pairs, schema=PAIR_STREAM_SCHEMA, orient="row")
+        return pl.DataFrame(schema=_pair_stream_schema())
+    return pl.DataFrame(pairs, schema=_pair_stream_schema(), orient="row")
 
 
 def pairs_df_to_list(df: pl.DataFrame) -> list[tuple[int, int, float]]:
@@ -1797,7 +1823,7 @@ def _score_one_block_columnar(
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()
         if len(sources_in_block) < 2:
-            return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+            return pl.DataFrame(schema=_pair_stream_schema())
 
     pairs_df = find_fuzzy_matches_columnar(
         block_df, mk,
@@ -1873,7 +1899,7 @@ def score_blocks_columnar(
     if max_workers is None:
         max_workers = _DEFAULT_MAX_WORKERS
     if not blocks:
-        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+        return pl.DataFrame(schema=_pair_stream_schema())
 
     # Small block count: skip thread overhead (mirrors
     # score_blocks_parallel's <=2 branch).
@@ -1900,7 +1926,7 @@ def score_blocks_columnar(
                         matched_pairs.add((min(a, b), max(a, b)))
                 frames.append(df_pairs)
         if not frames:
-            return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+            return pl.DataFrame(schema=_pair_stream_schema())
         return pl.concat(frames)
 
     # Parallel path: ThreadPoolExecutor, mirroring score_blocks_parallel.
@@ -1945,7 +1971,7 @@ def score_blocks_columnar(
                 )
 
     if not frames:
-        return pl.DataFrame(schema=PAIR_STREAM_SCHEMA)
+        return pl.DataFrame(schema=_pair_stream_schema())
     return pl.concat(frames)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import jellyfish
 import numpy as np
-from goldenmatch._polars_lazy import pl
 from rapidfuzz.distance import JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 from rapidfuzz.process import cdist
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
 from goldenmatch.core._profile_helpers import (
     hartigan_dip,

--- a/packages/python/goldenmatch/goldenmatch/core/screening.py
+++ b/packages/python/goldenmatch/goldenmatch/core/screening.py
@@ -23,7 +23,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.match_one import match_one
 from goldenmatch.core.scorer import apply_transforms, score_field
 

--- a/packages/python/goldenmatch/goldenmatch/core/screening.py
+++ b/packages/python/goldenmatch/goldenmatch/core/screening.py
@@ -22,7 +22,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.match_one import match_one
 from goldenmatch.core.scorer import apply_transforms, score_field

--- a/packages/python/goldenmatch/goldenmatch/core/simhash_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/simhash_blocker.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig, SimHashKeyConfig
 from goldenmatch.core import sketch

--- a/packages/python/goldenmatch/goldenmatch/core/simhash_blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/simhash_blocker.py
@@ -16,8 +16,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import BlockingConfig, SimHashKeyConfig
 from goldenmatch.core import sketch
 

--- a/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
@@ -11,7 +11,6 @@ import statistics
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core._paths import safe_path
 
 # ---------------------------------------------------------------------------

--- a/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
+++ b/packages/python/goldenmatch/goldenmatch/core/smart_ingest.py
@@ -10,7 +10,7 @@ import re
 import statistics
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core._paths import safe_path
 

--- a/packages/python/goldenmatch/goldenmatch/core/standardize.py
+++ b/packages/python/goldenmatch/goldenmatch/core/standardize.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import re
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/streaming.py
+++ b/packages/python/goldenmatch/goldenmatch/core/streaming.py
@@ -28,7 +28,6 @@ from datetime import datetime
 from threading import Event
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.cluster import add_to_cluster
 from goldenmatch.core.match_one import match_one

--- a/packages/python/goldenmatch/goldenmatch/core/streaming.py
+++ b/packages/python/goldenmatch/goldenmatch/core/streaming.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from threading import Event
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core.cluster import add_to_cluster

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -41,9 +41,9 @@ import logging
 import os
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 import pyarrow as pa
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -41,7 +41,7 @@ import logging
 import os
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 import pyarrow as pa
 
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/groups.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/groups.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import re
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenGroupRule
 

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/groups.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/groups.py
@@ -5,7 +5,6 @@ import logging
 import re
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenGroupRule
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/native.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/native.py
@@ -6,7 +6,6 @@ strategy-by-strategy, each gated by a parity test in test_native_parity.py.
 from __future__ import annotations
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.golden import _is_internal, _stable_value_expr
 from goldenmatch.core.survivorship.conditions import select_conditional_strategy
 from goldenmatch.core.survivorship.validate import goldenflow_filter

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/native.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/native.py
@@ -5,7 +5,7 @@ strategy-by-strategy, each gated by a parity test in test_native_parity.py.
 """
 from __future__ import annotations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.golden import _is_internal, _stable_value_expr
 from goldenmatch.core.survivorship.conditions import select_conditional_strategy

--- a/packages/python/goldenmatch/goldenmatch/core/tf_tables.py
+++ b/packages/python/goldenmatch/goldenmatch/core/tf_tables.py
@@ -2,7 +2,7 @@
 weighted name scorer's data-driven downweight (#1207 PR2a)."""
 from __future__ import annotations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 def value_frequencies(

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/validate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/validate.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, field
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 @dataclass

--- a/packages/python/goldenmatch/goldenmatch/core/vector_index.py
+++ b/packages/python/goldenmatch/goldenmatch/core/vector_index.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.ann_blocker import ANNBlocker
 from goldenmatch.core.embedder import get_embedder

--- a/packages/python/goldenmatch/goldenmatch/core/vector_index.py
+++ b/packages/python/goldenmatch/goldenmatch/core/vector_index.py
@@ -36,8 +36,8 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.core.ann_blocker import ANNBlocker
 from goldenmatch.core.embedder import get_embedder
 from goldenmatch.core.retrieval import RetrievedRecord

--- a/packages/python/goldenmatch/goldenmatch/core/vector_store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/vector_store.py
@@ -36,8 +36,8 @@ import logging
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.core.embedder import get_embedder
 from goldenmatch.core.retrieval import RetrievedRecord
 

--- a/packages/python/goldenmatch/goldenmatch/core/vector_store.py
+++ b/packages/python/goldenmatch/goldenmatch/core/vector_store.py
@@ -36,7 +36,7 @@ import logging
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.embedder import get_embedder
 from goldenmatch.core.retrieval import RetrievedRecord

--- a/packages/python/goldenmatch/goldenmatch/db/connector.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/db/connector_mysql.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_mysql.py
@@ -15,7 +15,6 @@ from typing import Any
 from urllib.parse import urlparse
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.db.connector import DatabaseConnector
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/db/connector_mysql.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_mysql.py
@@ -14,7 +14,7 @@ from collections.abc import Iterator
 from typing import Any
 from urllib.parse import urlparse
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.db.connector import DatabaseConnector
 

--- a/packages/python/goldenmatch/goldenmatch/db/connector_snowflake.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_snowflake.py
@@ -16,7 +16,6 @@ from collections.abc import Iterator
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.db.connector import DatabaseConnector
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/db/connector_snowflake.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_snowflake.py
@@ -15,7 +15,7 @@ import os
 from collections.abc import Iterator
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.db.connector import DatabaseConnector
 

--- a/packages/python/goldenmatch/goldenmatch/db/connector_sqlserver.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_sqlserver.py
@@ -15,7 +15,6 @@ from collections.abc import Iterator
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.db.connector import DatabaseConnector
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/db/connector_sqlserver.py
+++ b/packages/python/goldenmatch/goldenmatch/db/connector_sqlserver.py
@@ -14,7 +14,7 @@ import logging
 from collections.abc import Iterator
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.db.connector import DatabaseConnector
 

--- a/packages/python/goldenmatch/goldenmatch/db/hybrid_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/db/hybrid_blocking.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import BlockingConfig
 from goldenmatch.db.ann_index import PersistentANNIndex

--- a/packages/python/goldenmatch/goldenmatch/db/hybrid_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/db/hybrid_blocking.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import logging
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import BlockingConfig
 from goldenmatch.db.ann_index import PersistentANNIndex
 from goldenmatch.db.blocking import build_blocking_query

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.db.connector import DatabaseConnector
 from goldenmatch.db.metadata import (

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -6,7 +6,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.db.connector import DatabaseConnector

--- a/packages/python/goldenmatch/goldenmatch/db/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/db/writer.py
@@ -6,7 +6,6 @@ import json
 import logging
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.db.connector import DatabaseConnector, _quote_ident
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/db/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/db/writer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.db.connector import DatabaseConnector, _quote_ident
 

--- a/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.core.complexity_profile import ColumnPrior, SparsityVerdict
 
 if TYPE_CHECKING:

--- a/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.complexity_profile import ColumnPrior, SparsityVerdict
 

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -18,7 +18,7 @@ import logging
 import os
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from ray.data import Dataset

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import duckdb
+
 from goldenmatch._polars_lazy import pl
 
 _TABLE_PREFIX = "prepared_"

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any, cast
 
 import duckdb
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 _TABLE_PREFIX = "prepared_"
 

--- a/packages/python/goldenmatch/goldenmatch/distributed/sample.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/sample.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from ray.data import Dataset

--- a/packages/python/goldenmatch/goldenmatch/distributed/transforms.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/transforms.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 Op = Literal["lower", "upper", "strip_punctuation", "strip", "nfkc"]
 

--- a/packages/python/goldenmatch/goldenmatch/documents/assemble.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/assemble.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.documents.types import (
     ExtractResult,
     IngestReport,

--- a/packages/python/goldenmatch/goldenmatch/documents/assemble.py
+++ b/packages/python/goldenmatch/goldenmatch/documents/assemble.py
@@ -1,7 +1,7 @@
 """Collapse per-document ExtractResults into one records DataFrame + a report."""
 from __future__ import annotations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.documents.types import (
     ExtractResult,

--- a/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import math
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 def _canonical_payload(payload: dict[str, Any]) -> dict[str, Any]:
@@ -40,11 +40,23 @@ def _canonical_payload(payload: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-# Integer dtypes that up-cast to Int64 without changing the canonical value.
-_INT_UPCAST = (
-    pl.Int8, pl.Int16, pl.Int32,
-    pl.UInt8, pl.UInt16, pl.UInt32,
-)
+_INT_UPCAST_CACHE: tuple[type, ...] | None = None
+
+
+def _int_upcast_dtypes() -> tuple[type, ...]:
+    """Integer dtypes that up-cast to Int64 without changing the canonical
+    value. Built lazily (not a module-level ``pl.`` tuple literal) so
+    importing this module doesn't import Polars eagerly (W0 polars-eviction
+    gate); cached after the first call."""
+    global _INT_UPCAST_CACHE
+    if _INT_UPCAST_CACHE is None:
+        _INT_UPCAST_CACHE = (
+            pl.Int8, pl.Int16, pl.Int32,
+            pl.UInt8, pl.UInt16, pl.UInt32,
+        )
+    return _INT_UPCAST_CACHE
+
+
 _I64_MAX = 2**63 - 1
 
 
@@ -132,7 +144,7 @@ def canonicalize_records_df(df: pl.DataFrame):
             )
         elif dtype == pl.Float32:
             exprs.append(pl.col(col).cast(pl.Float64))
-        elif isinstance(dtype, _INT_UPCAST) or dtype == pl.UInt64:
+        elif isinstance(dtype, _int_upcast_dtypes()) or dtype == pl.UInt64:
             # UInt64 handled here not in _INT_UPCAST: its overflow rows are already masked out above
             exprs.append(pl.col(col).cast(pl.Int64))
         elif isinstance(dtype, (pl.Categorical, pl.Enum)):

--- a/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
@@ -145,7 +145,7 @@ def canonicalize_records_df(df: pl.DataFrame):
         elif dtype == pl.Float32:
             exprs.append(pl.col(col).cast(pl.Float64))
         elif isinstance(dtype, _int_upcast_dtypes()) or dtype == pl.UInt64:
-            # UInt64 handled here not in _INT_UPCAST: its overflow rows are already masked out above
+            # UInt64 handled here not in _int_upcast_dtypes(): its overflow rows are already masked out above
             exprs.append(pl.col(col).cast(pl.Int64))
         elif isinstance(dtype, (pl.Categorical, pl.Enum)):
             exprs.append(pl.col(col).cast(pl.Utf8))

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldenmatch.config.schemas import MatchkeyConfig

--- a/packages/python/goldenmatch/goldenmatch/identity/stitching.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/stitching.py
@@ -35,7 +35,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldenmatch.config.schemas import ChannelStitchConfig

--- a/packages/python/goldenmatch/goldenmatch/identity/survivorship.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/survivorship.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import GoldenFieldRule
 from goldenmatch.core.golden import _is_internal, merge_field

--- a/packages/python/goldenmatch/goldenmatch/identity/survivorship.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/survivorship.py
@@ -28,7 +28,6 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import GoldenFieldRule
 from goldenmatch.core.golden import _is_internal, merge_field
 

--- a/packages/python/goldenmatch/goldenmatch/output/writer.py
+++ b/packages/python/goldenmatch/goldenmatch/output/writer.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 def write_output(

--- a/packages/python/goldenmatch/goldenmatch/plugins/base.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/base.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
+
 from goldenmatch._polars_lazy import pl
 
 

--- a/packages/python/goldenmatch/goldenmatch/plugins/base.py
+++ b/packages/python/goldenmatch/goldenmatch/plugins/base.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 from typing import Any, Protocol, runtime_checkable
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 @runtime_checkable

--- a/packages/python/goldenmatch/goldenmatch/pprl/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/pprl/autoconfig.py
@@ -11,7 +11,7 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.pprl.protocol import PPRLConfig
 

--- a/packages/python/goldenmatch/goldenmatch/pprl/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/pprl/autoconfig.py
@@ -11,8 +11,8 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.pprl.protocol import PPRLConfig
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
+++ b/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
@@ -16,8 +16,8 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
-from goldenmatch._polars_lazy import pl
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.core.cluster import build_clusters
 from goldenmatch.utils.transforms import bloom_clk_batch
 

--- a/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
+++ b/packages/python/goldenmatch/goldenmatch/pprl/protocol.py
@@ -16,7 +16,7 @@ import logging
 from dataclasses import dataclass
 
 import numpy as np
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.core.cluster import build_clusters
 from goldenmatch.utils.transforms import bloom_clk_batch

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 @dataclass

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widgets import Button, DataTable, Static
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.tui.engine import EngineResult
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from goldenmatch._polars_lazy import pl
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Static
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.tui.engine import EngineResult
 from goldenmatch.tui.widgets.threshold_slider import ThresholdSlider
 

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical

--- a/packages/python/goldenmatch/goldenmatch/web/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/web/preview.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import UTC, datetime
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,

--- a/packages/python/goldenmatch/goldenmatch/web/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/web/preview.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
-
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,
     MatchkeyConfig,

--- a/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
@@ -15,7 +15,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 
 from goldenmatch.config.schemas import (

--- a/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py
@@ -15,9 +15,9 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import (
     MatchkeyConfig,
     MatchkeyField,

--- a/packages/python/goldenmatch/goldenmatch/web/routers/match.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/match.py
@@ -21,7 +21,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/match.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/match.py
@@ -21,10 +21,10 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import GoldenMatchConfig, RulesPayload
 from goldenmatch.core.pipeline import run_match_df
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/preview.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import RulesPayload
 from goldenmatch.web.preview import run_preview
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/preview.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/quality.py
@@ -15,7 +15,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Query, Request
 
 log = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/web/routers/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/quality.py
@@ -15,8 +15,9 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Query, Request
+
+from goldenmatch._polars_lazy import pl
 
 log = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/run.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/run.py
@@ -32,7 +32,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/run.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/run.py
@@ -32,10 +32,10 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 
+from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,
     LLMScorerConfig,

--- a/packages/python/goldenmatch/goldenmatch/web/routers/suggest.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/suggest.py
@@ -19,8 +19,9 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
+
+from goldenmatch._polars_lazy import pl
 
 log = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/web/routers/suggest.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/suggest.py
@@ -19,7 +19,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 from fastapi import APIRouter, HTTPException, Request
 
 log = logging.getLogger(__name__)

--- a/packages/python/goldenmatch/goldenmatch/web/runs.py
+++ b/packages/python/goldenmatch/goldenmatch/web/runs.py
@@ -4,7 +4,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-import polars as pl
+from goldenmatch._polars_lazy import pl
 
 
 @dataclass(frozen=True)

--- a/packages/python/goldenmatch/tests/test_frame_seam.py
+++ b/packages/python/goldenmatch/tests/test_frame_seam.py
@@ -1,0 +1,48 @@
+# tests/test_frame_seam.py
+"""W0 Frame/Column seam scaffold: delegation parity vs raw Polars + to_frame idempotency."""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.frame import Column, Frame, PolarsFrame, to_frame
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame({"name": ["ann", "bob", None, "ann"], "zip": [1, 2, 3, 1]})
+
+
+def test_to_frame_wraps_polars_dataframe():
+    frame = to_frame(_df())
+    assert isinstance(frame, PolarsFrame)
+    assert isinstance(frame, Frame)  # runtime_checkable Protocol
+
+
+def test_to_frame_is_idempotent():
+    frame = to_frame(_df())
+    assert to_frame(frame) is frame
+
+
+def test_frame_delegation_matches_raw_polars():
+    df = _df()
+    frame = to_frame(df)
+    assert frame.columns == df.columns
+    assert frame.height == df.height
+    assert frame.native is df
+
+
+def test_column_delegation_matches_raw_polars():
+    df = _df()
+    col = to_frame(df).column("name")
+    assert isinstance(col, Column)
+    assert len(col) == 4
+    assert col.null_count() == df["name"].null_count()
+    assert col.n_unique() == df["name"].n_unique()
+    assert col.to_list() == df["name"].to_list()
+
+
+def test_to_arrow_columns_matches_kernel_ffi_shape():
+    """to_arrow_columns must produce exactly what the fused kernels consume today."""
+    df = _df()
+    arrow_cols = to_frame(df).to_arrow_columns(["name", "zip"])
+    assert set(arrow_cols) == {"name", "zip"}
+    for name in ("name", "zip"):
+        assert arrow_cols[name].to_pylist() == df[name].to_arrow().to_pylist()

--- a/packages/python/goldenmatch/tests/test_indicators_dtype_defer.py
+++ b/packages/python/goldenmatch/tests/test_indicators_dtype_defer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 def test_non_identity_dtypes_is_lazy_function_with_expected_members():
     import polars as pl
-
     from goldenmatch.core.indicators import _non_identity_dtypes
 
     assert _non_identity_dtypes() == {pl.Boolean, pl.Date, pl.Datetime, pl.Time}

--- a/packages/python/goldenmatch/tests/test_indicators_dtype_defer.py
+++ b/packages/python/goldenmatch/tests/test_indicators_dtype_defer.py
@@ -1,0 +1,19 @@
+# tests/test_indicators_dtype_defer.py
+"""The dtype-set constant must be a lazy function, not a module-level pl. evaluation."""
+from __future__ import annotations
+
+
+def test_non_identity_dtypes_is_lazy_function_with_expected_members():
+    import polars as pl
+
+    from goldenmatch.core.indicators import _non_identity_dtypes
+
+    assert _non_identity_dtypes() == {pl.Boolean, pl.Date, pl.Datetime, pl.Time}
+    # lru_cache: same object back on the second call
+    assert _non_identity_dtypes() is _non_identity_dtypes()
+
+
+def test_dead_boolean_dtypes_constant_removed():
+    import goldenmatch.core.indicators as indicators
+
+    assert not hasattr(indicators, "_BOOLEAN_DTYPES")

--- a/packages/python/goldenmatch/tests/test_lazy_import_gate.py
+++ b/packages/python/goldenmatch/tests/test_lazy_import_gate.py
@@ -1,0 +1,53 @@
+# tests/test_lazy_import_gate.py
+"""THE W0 gate: `import goldenmatch` must not load Polars.
+
+Subprocess-based so this test is immune to other tests having already imported
+polars into this process.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def test_import_goldenmatch_does_not_load_polars():
+    code = (
+        "import json, sys\n"
+        "import goldenmatch\n"
+        "print(json.dumps({'polars_loaded': 'polars' in sys.modules,"
+        " 'goldenmatch_file': goldenmatch.__file__}))\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env={**os.environ},
+        check=True,
+    )
+    payload = json.loads(proc.stdout.strip().splitlines()[-1])
+    assert payload["polars_loaded"] is False, (
+        f"polars was imported eagerly by `import goldenmatch` "
+        f"(package at {payload['goldenmatch_file']}). Run "
+        f"`python -X importtime -c 'import goldenmatch' 2>&1 | grep polars` "
+        f"to find the offender."
+    )
+
+
+def test_polars_still_works_after_lazy_import():
+    """The proxy must not break real use: first pl. access imports polars fine."""
+    code = (
+        "import sys\n"
+        "import goldenmatch\n"
+        "from goldenmatch._polars_lazy import pl\n"
+        "df = pl.DataFrame({'a': [1]})\n"
+        "assert 'polars' in sys.modules\n"
+        "assert df.height == 1\n"
+        "print('OK')\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, env={**os.environ}, check=True,
+    )
+    assert proc.stdout.strip().endswith("OK")

--- a/packages/python/goldenmatch/tests/test_polars_lazy.py
+++ b/packages/python/goldenmatch/tests/test_polars_lazy.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 
 def test_proxy_returns_real_polars_attributes():
-    from goldenmatch._polars_lazy import pl
     import polars as real_pl
+    from goldenmatch._polars_lazy import pl
 
     assert pl.DataFrame is real_pl.DataFrame
     assert pl.Utf8 is real_pl.Utf8

--- a/packages/python/goldenmatch/tests/test_polars_lazy.py
+++ b/packages/python/goldenmatch/tests/test_polars_lazy.py
@@ -1,0 +1,30 @@
+# tests/test_polars_lazy.py
+"""The lazy-Polars proxy: real attributes, cached module, no import at module load."""
+from __future__ import annotations
+
+
+def test_proxy_returns_real_polars_attributes():
+    from goldenmatch._polars_lazy import pl
+    import polars as real_pl
+
+    assert pl.DataFrame is real_pl.DataFrame
+    assert pl.Utf8 is real_pl.Utf8
+
+
+def test_proxy_caches_module():
+    from goldenmatch._polars_lazy import _LazyPolars
+
+    proxy = _LazyPolars()
+    assert proxy._mod is None
+    _ = proxy.DataFrame
+    assert proxy._mod is not None
+    mod_after_first = proxy._mod
+    _ = proxy.Series
+    assert proxy._mod is mod_after_first
+
+
+def test_isinstance_works_through_proxy():
+    from goldenmatch._polars_lazy import pl
+
+    df = pl.DataFrame({"a": [1, 2]})
+    assert isinstance(df, pl.DataFrame)

--- a/scripts/audit_goldenmatch_polars_ops.py
+++ b/scripts/audit_goldenmatch_polars_ops.py
@@ -1,0 +1,81 @@
+"""AST census of Polars usage in goldenmatch -- W0 op audit for the eviction.
+
+Emits markdown: per-file counts of (a) `pl.<attr>` attribute uses and (b) calls
+to a curated list of DataFrame/Series/LazyFrame relational methods. The curated
+list makes (b) high-signal: bare method names can collide with non-Polars
+objects, so treat per-file counts as an upper bound to hand-verify per wave.
+
+Usage: python scripts/audit_goldenmatch_polars_ops.py
+(stdout is markdown; paste under the '## Generated census' heading of
+docs/design/2026-07-09-goldenmatch-polars-op-inventory.md)
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from collections import Counter
+from pathlib import Path
+
+PKG = Path(__file__).resolve().parents[1] / "packages" / "python" / "goldenmatch" / "goldenmatch"
+
+# Relational / frame-shaped methods whose ports define the W1-W4 seam ops.
+FRAME_METHODS = {
+    "join", "join_asof", "group_by", "groupby", "partition_by", "filter",
+    "with_columns", "select", "sort", "unique", "drop_nulls", "concat",
+    "explode", "pivot", "melt", "unpivot", "vstack", "hstack", "rename",
+    "cast", "lazy", "collect", "scan_csv", "read_csv", "read_parquet",
+    "write_csv", "write_parquet", "read_excel", "to_arrow", "from_arrow",
+    "agg", "over", "replace_strict", "value_counts", "n_unique",
+    "null_count", "is_in", "concat_str", "map_elements", "map_batches",
+}
+
+
+def audit_file(path: Path) -> tuple[Counter, Counter]:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    pl_attrs: Counter = Counter()
+    methods: Counter = Counter()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute):
+            if isinstance(node.value, ast.Name) and node.value.id == "pl":
+                pl_attrs[node.attr] += 1
+            elif node.attr in FRAME_METHODS:
+                methods[node.attr] += 1
+    return pl_attrs, methods
+
+
+def main() -> int:
+    rows = []
+    total_attrs: Counter = Counter()
+    total_methods: Counter = Counter()
+    for path in sorted(PKG.rglob("*.py")):
+        text = path.read_text(encoding="utf-8")
+        if "_polars_lazy import pl" not in text and "import polars" not in text:
+            continue
+        try:
+            pl_attrs, methods = audit_file(path)
+        except SyntaxError as exc:
+            print(f"warning: skipping {path} ({exc})", file=sys.stderr)
+            continue
+        if not pl_attrs and not methods:
+            continue
+        rel = str(path.relative_to(PKG)).replace("\\", "/")
+        rows.append((rel, sum(pl_attrs.values()), sum(methods.values())))
+        total_attrs.update(pl_attrs)
+        total_methods.update(methods)
+
+    print("# goldenmatch Polars op census (generated)\n")
+    print("| file | pl.* uses | relational method calls |")
+    print("| --- | ---: | ---: |")
+    for rel, a, m in sorted(rows, key=lambda r: -(r[1] + r[2])):
+        print(f"| {rel} | {a} | {m} |")
+    print("\n## pl.* attribute totals\n")
+    for name, n in total_attrs.most_common():
+        print(f"- `pl.{name}`: {n}")
+    print("\n## Relational method totals (upper bound; hand-verify per wave)\n")
+    for name, n in total_methods.most_common():
+        print(f"- `.{name}(...)`: {n}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- W0 of the Polars-eviction program (spec: docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md, committed on this branch with the plan + op inventory)
- `import goldenmatch` no longer loads Polars: `_polars_lazy` proxy (goldenflow template + TYPE_CHECKING dual-path so pyright keeps real Polars types) swept across all 112 module-level import sites
- Four module-level `pl.` import-time evaluations neutralized: `core/indicators.py` dtype-set constant deferred via lru_cache frozenset (the dead one deleted), plus two the runtime gate caught that static recon missed -- `core/scorer.py` `PAIR_STREAM_SCHEMA` (cached builder + PEP 562 module `__getattr__`, external importers unchanged) and `identity/fingerprint_batch.py` `_INT_UPCAST` (cached function)
- `core/frame.py` Frame/Column seam scaffold with delegating PolarsFrame backend + idempotent `to_frame()` (no call sites ported -- that is W1+); `to_arrow_columns()` is the fused-kernel FFI boundary shape
- W0 audits checked in: `scripts/audit_goldenmatch_polars_ops.py` + `docs/design/2026-07-09-goldenmatch-polars-op-inventory.md` (1,682 pl.* uses / 1,401 relational calls across 154 files, mapped to waves W1-W4)
- Stale package-CLAUDE.md ruff note corrected (CI lints the full root select incl. import-sort I, not "E9/F63/F7 only" -- the sweep initially broke 79 I001s, all fixed)

Byte-identical: no behavior change, no dependency change, no version bump, existing tests unedited.

## Test plan
- [x] New subprocess gate: tests/test_lazy_import_gate.py (`import goldenmatch` leaves polars out of sys.modules; proxy still works on first touch)
- [x] New: tests/test_polars_lazy.py, tests/test_frame_seam.py, tests/test_indicators_dtype_defer.py
- [x] Targeted local batches green (164 core + 73 pipeline/api + 117 autoconfig/scorer/blocker + parity suites for the two hand-fixed hotspots); full suite in CI
- [x] ruff clean package-wide; per-task spec + quality reviews + final whole-branch review (READY TO MERGE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E1XRtDNuLQncCEx6aUQTST