### PR TITLE
feat(mcp): GOLDENMATCH_MCP_ALLOW_PUBLIC opt-in for an open public server

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -309,6 +309,7 @@ When you expose any server (MCP, REST, A2A, web UI) on a non-loopback host, it i
 | Variable | Used by | Notes |
 |----------|---------|-------|
 | `GOLDENMATCH_MCP_TOKEN` | MCP server | Required on non-loopback binds. `/.well-known/` card stays public. |
+| `GOLDENMATCH_MCP_ALLOW_PUBLIC` | MCP server | Opt-out of the fail-closed default: set `1`/`true` to intentionally run an **open, unauthenticated public** MCP server (e.g. a showcase deployment) without `GOLDENMATCH_MCP_TOKEN`. Unset/`0` = fail closed (a non-loopback bind without a token is refused). A set `GOLDENMATCH_MCP_TOKEN` still takes precedence. |
 | `GOLDENMATCH_API_TOKEN` | REST API | Required on non-loopback binds (all except `/health`). |
 | `GOLDENMATCH_AGENT_TOKEN` | A2A agent | Required on non-loopback binds (except `/health` + agent card). |
 | `GOLDENMATCH_WEB_TOKEN` | Web UI | Required on non-loopback binds (except `/api/v1/healthz`). |

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1707,15 +1707,27 @@ def resolve_http_auth_token(host: str) -> str | None:
     ``GOLDENMATCH_MCP_TOKEN`` set, so an exposed server is never started
     unauthenticated by accident. Returns the token (or ``None`` for an
     intentionally-open loopback bind).
+
+    Escape hatch: set ``GOLDENMATCH_MCP_ALLOW_PUBLIC=1`` to intentionally
+    run an open, unauthenticated public server (e.g. a showcase deployment).
+    This opts out of the fail-closed default; a set ``GOLDENMATCH_MCP_TOKEN``
+    still takes precedence and is enforced when present.
     """
     import os
 
     token = os.environ.get("GOLDENMATCH_MCP_TOKEN")
     is_loopback = host in ("127.0.0.1", "localhost", "::1")
-    if not token and not is_loopback:
+    allow_public = os.environ.get("GOLDENMATCH_MCP_ALLOW_PUBLIC", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+    if not token and not is_loopback and not allow_public:
         raise RuntimeError(
             f"Refusing to start an unauthenticated MCP HTTP server on host {host!r}. "
-            "Set GOLDENMATCH_MCP_TOKEN, or bind to 127.0.0.1 for local use."
+            "Set GOLDENMATCH_MCP_TOKEN, bind to 127.0.0.1 for local use, or set "
+            "GOLDENMATCH_MCP_ALLOW_PUBLIC=1 to intentionally run an open public server."
         )
     return token
 

--- a/packages/python/goldenmatch/tests/test_wave0_surface.py
+++ b/packages/python/goldenmatch/tests/test_wave0_surface.py
@@ -147,6 +147,30 @@ class TestMcpFailClosed:
         monkeypatch.setenv("GOLDENMATCH_MCP_TOKEN", "secret")
         assert resolve_http_auth_token("0.0.0.0") == "secret"
 
+    def test_allow_public_flag_permits_public_without_token(self, monkeypatch):
+        from goldenmatch.mcp.server import resolve_http_auth_token
+
+        monkeypatch.delenv("GOLDENMATCH_MCP_TOKEN", raising=False)
+        monkeypatch.setenv("GOLDENMATCH_MCP_ALLOW_PUBLIC", "1")
+        # Opt-in escape hatch: an intentionally-open public server.
+        assert resolve_http_auth_token("0.0.0.0") is None
+
+    def test_allow_public_flag_does_not_override_a_set_token(self, monkeypatch):
+        from goldenmatch.mcp.server import resolve_http_auth_token
+
+        monkeypatch.setenv("GOLDENMATCH_MCP_TOKEN", "secret")
+        monkeypatch.setenv("GOLDENMATCH_MCP_ALLOW_PUBLIC", "1")
+        # The flag only relaxes the no-token case; a set token still applies.
+        assert resolve_http_auth_token("0.0.0.0") == "secret"
+
+    def test_allow_public_disabled_value_still_raises(self, monkeypatch):
+        from goldenmatch.mcp.server import resolve_http_auth_token
+
+        monkeypatch.delenv("GOLDENMATCH_MCP_TOKEN", raising=False)
+        monkeypatch.setenv("GOLDENMATCH_MCP_ALLOW_PUBLIC", "0")
+        with pytest.raises(RuntimeError, match="unauthenticated"):
+            resolve_http_auth_token("0.0.0.0")
+
 
 class TestA2aFailClosed:
     """0.5 -- same posture for the A2A agent server."""


### PR DESCRIPTION
## What

Adds an opt-in `GOLDENMATCH_MCP_ALLOW_PUBLIC` flag that lets the MCP HTTP server bind a **public** host without a token — a deliberate, reviewed opt-out of the Wave 0 fail-closed default, for intentionally-open showcase deployments.

## Why

The hosted showcase MCP server is meant to be publicly usable without auth. Wave 0 made an exposed bind fail-closed (`resolve_http_auth_token` raises on a non-loopback bind without `GOLDENMATCH_MCP_TOKEN`), which is the right default — but there was no way to *intentionally* run an open public server. This adds that escape hatch without weakening the default for anyone who doesn't set it.

## Behavior

- `GOLDENMATCH_MCP_ALLOW_PUBLIC` unset or `0`/`false` → **unchanged** (fail closed: public bind without a token is refused).
- `=1`/`true`/`yes`/`on` → a public bind without a token is allowed (open, unauthenticated).
- A set `GOLDENMATCH_MCP_TOKEN` **still takes precedence** and is enforced when present — the flag only relaxes the no-token case.

## Tests

`tests/test_wave0_surface.py::TestMcpFailClosed` gains three cases: flag permits public-without-token, flag does not override a set token, `=0` still raises. Existing fail-closed cases unchanged (16 pass).

## Docs

`docs-site/goldenmatch/tuning.mdx` documents the flag in the servers/security table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
