### PR TITLE
build(goldensuite-mcp): deployable image + railway.json for the single suite endpoint

### DIFF
--- a/packages/python/goldensuite-mcp/Dockerfile.mcp
+++ b/packages/python/goldensuite-mcp/Dockerfile.mcp
@@ -19,11 +19,13 @@ COPY . /app
 # Use uv for workspace-aware install; fall back to pip if uv isn't present.
 RUN pip install --no-cache-dir uv \
     && uv pip install --system --no-cache \
+        ./packages/python/goldencheck-types \
         ./packages/python/goldenmatch \
         ./packages/python/goldencheck \
         ./packages/python/goldenflow \
         ./packages/python/goldenpipe \
         ./packages/python/infermap \
+        ./packages/python/goldenanalysis \
         ./packages/python/goldensuite-mcp \
     && apt-get purge -y build-essential cmake gcc g++ \
     && apt-get autoremove -y \

--- a/packages/python/goldensuite-mcp/railway.json
+++ b/packages/python/goldensuite-mcp/railway.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "packages/python/goldensuite-mcp/Dockerfile.mcp"
+  },
+  "deploy": {
+    "startCommand": "goldensuite-mcp serve --transport http --port 8300",
+    "healthcheckPath": "/.well-known/mcp/server-card.json",
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 3
+  }
+}


### PR DESCRIPTION
## What

Makes `goldensuite-mcp` (the one-endpoint aggregator over the whole Golden Suite) deployable as a hosted service:
- **Dockerfile:** installs `goldencheck-types` (a `goldencheck` dep) and `goldenanalysis` (was in `dependencies` + has an adapter, but missing from the install list) from local monorepo paths, so the image gets **current** sub-package code, not stale PyPI.
- **railway.json:** pins a Dockerfile build with **repo-root context** (the image installs 6 sibling packages, so it needs the whole monorepo as context).

## Why

The hosted Golden Suite runs as 5 separate per-package MCP services, all frozen on their archived pre-fold repos. `goldensuite-mcp` already composes every sub-package's tools into one server (first-wins on name collisions) but was never deployed. This is the prep to host it as **the single suite endpoint** (public + free — its HTTP server has no auth gate by design), replacing the 5 stale services.

## Verified

Aggregator smoke tests pass (10/10) against current `main`; combined surface is ~88 tools after collision de-dup. The inline file ingestion (`upload_dataset` / `file_content`, PR #1613) flows through automatically since the suite aggregates `goldenmatch.TOOLS` + `gm.dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
