### PR TITLE
fix(agent): reasoning payload honors exclude_columns (cosmetic leak)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/agent.py
+++ b/packages/python/goldenmatch/goldenmatch/core/agent.py
@@ -330,6 +330,30 @@ def _decision_to_config(decision: StrategyDecision) -> Any:
 # ── Agent session ────────────────────────────────────────────────────────────
 
 
+def _reasoning_frame(df: pl.DataFrame, config: Any = None) -> pl.DataFrame:
+    """Drop caller-excluded columns before profiling for the ``reasoning`` payload.
+
+    The ``reasoning`` explanation is profiled separately from the actual
+    pipeline. Without this, columns the caller excluded (``exclude_columns`` on
+    the MCP tools -> ``_RUNTIME_EXCLUDE_COLUMNS``, ``config.exclude_columns``,
+    env force-exclude) still surface in ``fuzzy_fields``/``strong_ids`` -- a
+    misleading explanation that lists columns the dedup never matched on.
+    Reuses the pipeline's own resolver so the explanation matches reality.
+    force_include (rescue) columns are never dropped.
+    """
+    try:
+        from goldenmatch.core.autoconfig import (
+            _resolve_effective_exclusion_overrides,
+        )
+
+        force_exclude, force_include = _resolve_effective_exclusion_overrides(config)
+        keep = set(force_include)
+        drop = [c for c in force_exclude if c not in keep and c in df.columns]
+        return df.drop(drop) if drop else df
+    except Exception:
+        return df
+
+
 class AgentSession:
     """Stateful session for autonomous entity resolution.
 
@@ -427,7 +451,7 @@ class AgentSession:
         df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         self.data = df
 
-        profile = profile_for_agent(df)
+        profile = profile_for_agent(_reasoning_frame(df))
         decision = select_strategy(profile, allow_pprl=allow_pprl)
         alternatives = build_alternatives(decision, profile)
 
@@ -486,7 +510,7 @@ class AgentSession:
         # See PR #169: routing the default path through dedupe_df()'s
         # AutoConfigController gives us the v1.7-v1.12 telemetry that the
         # legacy `_decision_to_config(decision)` heuristic does not.
-        profile = profile_for_agent(df)
+        profile = profile_for_agent(_reasoning_frame(df, config))
         decision = select_strategy(profile, allow_pprl=allow_pprl)
 
         if config is not None:

--- a/packages/python/goldenmatch/tests/test_agent.py
+++ b/packages/python/goldenmatch/tests/test_agent.py
@@ -350,6 +350,55 @@ class TestAgentSession:
         result = session.deduplicate(tmp_csv, config=cfg)
         assert result["results"] is not None
 
+    def test_deduplicate_reasoning_honors_runtime_exclude(self, tmp_path):
+        """reasoning.fuzzy_fields must not surface columns the caller excluded.
+
+        Regression for the cosmetic leak where the `reasoning` payload was
+        profiled from the full frame while the pipeline (via
+        `_RUNTIME_EXCLUDE_COLUMNS`) correctly dropped the excluded columns —
+        making the explanation list columns that were never matched on.
+        """
+        from goldenmatch.config.schemas import (
+            GoldenMatchConfig,
+            MatchkeyConfig,
+            MatchkeyField,
+        )
+        from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+
+        # Values chosen so every string column is a fuzzy_candidate
+        # (uniqueness < 0.90, avg_length > 3): this hits the branch that lists
+        # all string columns as fuzzy_fields, where the leak manifests.
+        df = pl.DataFrame({
+            "name": ["John Smith", "John Smith", "Mary Jones", "Mary Jones"],
+            "city": ["New York", "New York", "Boston", "Boston"],
+            "secret_label": ["ENTITY001", "ENTITY001", "ENTITY002", "ENTITY002"],
+        })
+        path = tmp_path / "d.csv"
+        df.write_csv(path)
+
+        # Explicit config keeps dedupe fast + avoids any model bootstrap; the
+        # reasoning profile still runs regardless of config.
+        cfg = GoldenMatchConfig(matchkeys=[
+            MatchkeyConfig(
+                name="exact_name",
+                type="exact",
+                fields=[MatchkeyField(field="name", transforms=["lowercase", "strip"])],
+            ),
+        ])
+        session = AgentSession()
+        token = _RUNTIME_EXCLUDE_COLUMNS.set(["secret_label"])
+        try:
+            result = session.deduplicate(str(path), config=cfg)
+        finally:
+            _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+        fuzzy = result["reasoning"]["fuzzy_fields"]
+        assert "secret_label" not in fuzzy, (
+            f"excluded column leaked into reasoning.fuzzy_fields: {fuzzy}"
+        )
+        # A normal string column is still surfaced (the profile still works).
+        assert "name" in fuzzy or "city" in fuzzy
+
     def test_match_sources(self, tmp_csv, tmp_csv_b):
         session = AgentSession()
         result = session.match_sources(tmp_csv, tmp_csv_b)


### PR DESCRIPTION
## What

`AgentSession.deduplicate` / `analyze` built the `reasoning` explanation by profiling the **full** frame, so caller-excluded columns still showed up in `reasoning.fuzzy_fields` / `strong_ids` — even though the actual pipeline correctly dropped them from the committed config.

## Why it matters

The `agent_deduplicate` MCP tool accepts `exclude_columns` and applies it functionally (via `_RUNTIME_EXCLUDE_COLUMNS`), but the `reasoning` payload ignored it. Result: the explanation lists columns the dedup never matched on. Caught while dogfooding a labeled ER test file — the ground-truth label column (`true_entity_id`) appeared in `reasoning.fuzzy_fields`, which *looked* like the label had leaked into matching (it hadn't; `committed_matchkeys` were clean). Misleading output.

## Fix

New `_reasoning_frame()` drops the caller-excluded columns before profiling for `reasoning`, reusing the pipeline's own `_resolve_effective_exclusion_overrides` (config.exclude_columns + `_RUNTIME_EXCLUDE_COLUMNS` + env force-exclude, honoring force_include rescue). So the explanation matches what was actually matched on. Root-cause fix, not a display patch — the reasoning now sees the same columns the pipeline does.

## Tests

`test_agent.py::TestAgentSession::test_deduplicate_reasoning_honors_runtime_exclude` reproduces the leak (all string columns land in the `fuzzy` branch; excluded column previously appeared) and asserts it's gone while legit columns remain. Full agent suite green (43).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
