### PR TITLE
fix(autoconfig): zip name is authoritative (ZIP+4 misclassified as phone -> exact matchkey over-merge)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -399,10 +399,13 @@ def profile_columns(
             data_type, data_confidence = _classify_by_data(values)
 
             # Combine: name heuristics are authoritative for structural types
-            # (date, geo) because data profiling frequently misclassifies them
-            # (e.g., ISO dates look like phone numbers, city names look like person names).
+            # (date, geo, zip) because data profiling frequently misclassifies them
+            # (e.g., ISO dates look like phone numbers, city names look like person
+            # names, and ZIP+4 codes like '10001-3904' look like phone numbers).
+            # A zip misclassified as phone would back an exact matchkey and
+            # over-merge same-address records, so trust the name.
             # For other types, Phase 2 (data) wins when it contradicts Phase 1 (name).
-            _name_authoritative = {"date", "geo", "identifier", "numeric", "year"}
+            _name_authoritative = {"date", "geo", "identifier", "numeric", "year", "zip"}
             if name_type and name_type in _name_authoritative:
                 # Name pattern is authoritative for date/geo — trust it
                 col_type = name_type

--- a/packages/python/goldenmatch/tests/test_autoconfig.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig.py
@@ -132,6 +132,19 @@ class TestProfileColumns:
         profiles = profile_columns(df)
         assert all(p.name != "__row_id__" for p in profiles)
 
+    def test_zip_plus_four_stays_zip(self):
+        """ZIP+4 ('10001-3904') is phone-shaped to the data profiler; the 'zip'
+        NAME must win. Otherwise col_type='phone' backs an exact matchkey and
+        over-merges same-practice colleagues. Regression for the colleague
+        over-merge surfaced by the labeled DERM ER test."""
+        df = pl.DataFrame({
+            "zip": ["10001-3904", "07675-2600", "98109-4324", "33324-7005",
+                    "10001-3904", "60601-1234"],
+            "name": ["a", "b", "c", "d", "e", "f"],
+        })
+        types = {p.name: p.col_type for p in profile_columns(df)}
+        assert types["zip"] == "zip", f"ZIP+4 misclassified as {types['zip']!r}"
+
 
 class TestIdentifierNotOverridden:
     """Identifier columns should not be overridden by phone/zip data profiling."""

--- a/packages/rust/extensions/autoconfig-core/golden/classifier_vectors.json
+++ b/packages/rust/extensions/autoconfig-core/golden/classifier_vectors.json
@@ -250,7 +250,7 @@
     "expected": {
       "name": "zip_code",
       "dtype": "String",
-      "col_type": "identifier",
+      "col_type": "zip",
       "confidence": 0.9,
       "null_rate": 0.0,
       "cardinality_ratio": 1.0,

--- a/packages/rust/extensions/autoconfig-core/src/classify.rs
+++ b/packages/rust/extensions/autoconfig-core/src/classify.rs
@@ -480,13 +480,22 @@ pub fn classify_by_data(values: &[std::string::String]) -> (ColType, f64) {
 // ── Task B4: classify_columns ─────────────────────────────────────────────────
 
 /// Column types where the name heuristic overrides data profiling.
-/// Python: `name_authoritative = {Date, Geo, Identifier, Numeric, Year}`.
-const NAME_AUTHORITATIVE: &[ColType] =
-    &[ColType::Date, ColType::Geo, ColType::Identifier, ColType::Numeric, ColType::Year];
+/// Python: `name_authoritative = {Date, Geo, Identifier, Numeric, Year, Zip}`.
+/// Zip is authoritative because ZIP+4 codes ('10001-3904') look phone-shaped to
+/// the data profiler; a zip misclassified as phone would back an exact matchkey
+/// and over-merge same-address records.
+const NAME_AUTHORITATIVE: &[ColType] = &[
+    ColType::Date,
+    ColType::Geo,
+    ColType::Identifier,
+    ColType::Numeric,
+    ColType::Year,
+    ColType::Zip,
+];
 
 /// Port of `autoconfig.py::profile_columns` merge-precedence logic (lines 350-368).
 ///
-/// Authoritative set: `{Date, Geo, Identifier, Numeric, Year}`.
+/// Authoritative set: `{Date, Geo, Identifier, Numeric, Year, Zip}`.
 /// `needs_llm_escalation` implements the predicate from `_llm_classify_columns`
 /// (line 401-405 in autoconfig.py):
 ///   `(confidence < 0.8 || col_type in {String, Numeric})

--- a/packages/typescript/goldenmatch/tests/parity/fixtures/autoconfig/classifier_vectors.json
+++ b/packages/typescript/goldenmatch/tests/parity/fixtures/autoconfig/classifier_vectors.json
@@ -250,7 +250,7 @@
     "expected": {
       "name": "zip_code",
       "dtype": "String",
-      "col_type": "identifier",
+      "col_type": "zip",
       "confidence": 0.9,
       "null_rate": 0.0,
       "cardinality_ratio": 1.0,


### PR DESCRIPTION
## What

A column named `zip` / `zip_code` / `postal_code` is correctly name-classified as `zip`, but **ZIP+4** values like `10001-3904` look phone-shaped to the data profiler. Because `zip` was missing from `_name_authoritative`, the phone data-guess won → `col_type="phone"` → an `exact(zip)` matchkey → **over-merged same-address records**.

Fix: add `zip` to the name-authoritative set. Python (`autoconfig.py`) + Rust (`autoconfig-core/src/classify.rs`). The TS port already treated `zip` as authoritative, so this **aligns** Python/Rust with TS (removes a latent cross-lang divergence), it doesn't create one.

## Why it matters

`zip` is a structural/geo sibling of `geo` (already authoritative). Per the documented rule, `col_type in ('zip','geo')` must never back an exact matchkey — but that only holds if zip is *classified* as zip. ZIP+4 data silently defeated it.

## Impact (labeled DERM ER test, 250 rows / 138 entities)

| | before | after |
|---|---|---|
| Recall | 0.894 | **1.000** |
| F1 | 0.847 | **0.890** |

All nickname / typo / truncation variants now recovered; `city`/`state`/`country` still correctly skip exact matchkeys. No autoconfig regressions (214 passed, 2 skipped; native parity 7/7).

Surfaced by dogfooding a labeled ER benchmark. (A separate, deeper precision issue — same-practice colleagues sharing `phone`/`address` — remains and is tracked; this PR is the classification root-cause.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
