### PR TITLE
fix(parity): declare goldencheck denial-constraints CLI (unblocks merge queue)

### DIFF
--- a/parity/goldencheck.yaml
+++ b/parity/goldencheck.yaml
@@ -47,6 +47,7 @@ cli_commands:
   - watch
   python_only:
   - agent-serve
+  - denial-constraints
   - evaluate
   - history
   - init


### PR DESCRIPTION
## Summary
- The `denial-constraints` CLI command is on main but undeclared in `parity/goldencheck.yaml`, so `api_parity (goldencheck)` fails on every run that triggers the lane — kicking any merge-queue entry whose paths (or force_all) run it. One-line `python_only` declaration.
- Verified via the box-safe emitter: emitted CLI surface (19 commands) now exactly matches shared+python_only; zero undeclared, zero stale.

Known remaining queue blocker (separate issue, being diagnosed): goldenmatch-bridge `cargo test` SIGSEGV on the rust lane, suspected from #1566's FS-scoring threading inside the embedded interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wp3ZBqratCwFJKR55hbJTs