### PR TITLE
fix(ci): run the rust lane's bridge tests process-isolated (nextest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2265,9 +2265,25 @@ jobs:
             packages/rust/extensions/autoconfig-core
             packages/rust/extensions/suggest-core
             packages/rust/extensions/goldenflow-core
-      - run: cargo test --workspace
-        # Bridge tests now hard-require goldenmatch (installed above) -- a Python
+      # The bridge tests embed CPython (pyo3, initialized ONCE per process) and run
+      # goldenmatch's polars-heavy auto_configure_df. Under a single `cargo test`
+      # binary all 43 tests share that one persistent interpreter; after ~3 autoconfig
+      # runs the accumulated polars/native state corrupts it and the binary SIGSEGVs
+      # (deterministic, goldenmatch-version-independent, NOT test concurrency -- it
+      # crashes single-threaded too; every test passes in isolation). This only bit
+      # the full-matrix merge_group runs that exercise this lane, evicting ci.yml/rust-
+      # touching PRs from the queue. nextest runs each test in its OWN process, so the
+      # interpreter never accumulates that state; non-bridge members ride it for free.
+      - name: Install cargo-nextest
+        run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ~/.cargo/bin
+      - run: cargo nextest run --workspace
+        # Bridge tests hard-require goldenmatch (installed above) -- a Python
         # import/marshalling failure fails the lane instead of silently skipping.
+        env:
+          GOLDENMATCH_BRIDGE_REQUIRE_PY: "1"
+      - run: cargo test --workspace --doc
+        # nextest does not run doctests; run them separately. Each doctest is its own
+        # process, so the embedded-interpreter accumulation above cannot occur here.
         env:
           GOLDENMATCH_BRIDGE_REQUIRE_PY: "1"
       - run: cargo clippy --workspace -- -D warnings


### PR DESCRIPTION
## What and why

The `rust` CI lane deterministically **SIGSEGVs**, which evicts every `ci.yml`/Rust-touching PR from the merge queue. The full-matrix `merge_group` runs this lane; path-filtered PRs skip it (which is why #1498/#1522/#1566 merged fine while **#1618 / #1504 / #1603 keep getting evicted with `CI_FAILURE`**). The breakage was latent because the lane only runs on Rust-path changes or the full matrix.

**Root cause:** the `goldenmatch-bridge` test binary embeds CPython (pyo3, initialized once per process) and runs goldenmatch's polars-heavy `auto_configure_df`. All 43 bridge tests share that single persistent interpreter; after ~3 autoconfig runs the accumulated polars/native state corrupts it and the binary crashes with `signal: 11`.

Verified during diagnosis:
- **Deterministic** — reproduced 12/12 locally and across the queue's `merge_group` runs.
- **Not test concurrency** — crashes under `--test-threads=1` too.
- **Not a goldenmatch regression** — 2.6.0 / 2.7.0 / 2.8.0 all crash identically.
- **Not polars thread count** — `POLARS_MAX_THREADS=1` still crashes.
- **Every bridge test passes in isolation** — 46/46 with one process per test.

## Changes

- `.github/workflows/ci.yml` (`rust` lane): replace `cargo test --workspace` with `cargo nextest run --workspace`. nextest runs each test in its own process, so the embedded interpreter never accumulates the corrupting state. Added a nextest install step (official `get.nexte.st` installer) and a separate `cargo test --workspace --doc` step (nextest does not run doctests; each doctest is already its own process). Non-bridge workspace members are unaffected and get the isolation for free.

## Testing

- Faithful local repro of the lane (py3.12 venv, goldenmatch from PyPI, pinned `PYO3_PYTHON`): `cargo test -p goldenmatch-bridge` SIGSEGVs 12/12.
- `cargo nextest run -p goldenmatch-bridge` → **46 passed, 0 crashes** (twice). Per-process isolation of every test → 46/46 pass.
- ci.yml re-validated: parses, job count unchanged (57), `rust` job intact.
- This PR itself touches `ci.yml`, so the merge queue runs the full matrix — it self-validates the fix in the real lane.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (CI-lane change; validated by reproducing the crash and the nextest fix locally)
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — CI-only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (rationale documented inline in `ci.yml`)

Note: the nextest install uses the official `curl … get.nexte.st` installer rather than a SHA-pinned action, to avoid introducing a new third-party action dependency. Happy to switch to a pinned `taiki-e/install-action` if you prefer that convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x)_