### PR TITLE
feat(goldencheck): Polars-eviction Stage-2 S2.1 — pure-Python PyColumn/PyFrame backend + scan_columns

### DIFF
--- a/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend.md
+++ b/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend.md
@@ -1,0 +1,370 @@
+# GoldenCheck Stage-2 S2.1 (pure-Python PyColumn/PyFrame backend + scan_columns) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the first non-Polars backend — a pure-Python `PyColumn`/`PyFrame` — so nullability/cardinality/uniqueness run byte-identically without Polars, plus a public `scan_columns(dict)` entry + byte-parity/nopolars tests.
+
+**Architecture:** `PyColumn` wraps a `list`, `PyFrame` a `dict[str,list]`, implementing the 7 mechanical ops the 3 covered profilers use. `to_frame` is reordered so a `PyFrame` never touches the `pl` symbol. `scan_columns` runs the 3 covered profilers over a `PyFrame`. A byte-parity test (PolarsFrame vs PyFrame) is the byte-identity gate; the nopolars lane runs `scan_columns` polars-free.
+
+**Tech Stack:** Python 3.13 (stdlib only for the backend), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend-design.md`
+
+---
+
+## PRE-FLIGHT (do this BEFORE Task 1 — the branch must be on main-with-S2.0)
+
+The S2.1 code MODIFIES S2.0's `tests/nopolars/test_polars_absent.py` (Task 3), so the branch must sit on a `main` that already has S2.0 (#1618). At the start of execution:
+```bash
+cd /d/show_case/gc-s21
+git fetch origin main -q
+# Confirm S2.0 landed (tests/nopolars/ + the lane exist on main):
+git show origin/main:packages/python/goldencheck/tests/nopolars/test_polars_absent.py >/dev/null 2>&1 && echo "S2.0 present on main" || echo "S2.0 NOT on main yet -- WAIT, do not proceed"
+```
+If S2.0 is present, rebase this branch onto fresh main (it currently carries only the spec + this plan, so the rebase is trivial):
+```bash
+git rebase origin/main
+```
+If S2.0 is NOT yet on main, STOP and wait — do not start Task 1 (Task 3 would create/conflict on `tests/nopolars/`).
+
+## Conventions (this plan runs in the `gc-s21` worktree)
+
+Branch `feat/goldencheck-stage2-s2.1-pycolumn-backend`, worktree `D:\show_case\gc-s21`.
+
+**Test preamble** (run every test command from `/d/show_case/gc-s21`):
+```bash
+export PYTHONPATH="D:/show_case/gc-s21/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-s21
+```
+Run tests: `$PY -m pytest packages/python/goldencheck/tests/<path> -v`. Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**INVARIANT:** byte-identical covered profilers (PyFrame == PolarsFrame). `scan_dataframe` (the polars path) is UNCHANGED. The full suite + import gate stay green; `import goldencheck` loads zero Polars. `Finding` is a plain `@dataclass` — compare `Finding`/`list[Finding]` with `==` directly (no normalized-tuple fallback needed). Commit per task; do NOT push.
+
+**Current seam** (`core/frame.py`): `Column`/`Frame` Protocols + `PolarsColumn`/`PolarsFrame`; `to_frame` currently does `isinstance(native, PolarsFrame)` then `isinstance(native, pl.DataFrame)` (the latter TOUCHES `pl`). No `PyColumn`/`PyFrame` yet.
+
+---
+
+## Task 1: `PyColumn` / `PyFrame` backend + `to_frame` reorder
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py`
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Append failing seam tests** to `tests/core/test_frame.py`:
+```python
+def test_pycolumn_mechanical_ops():
+    from goldencheck.core.frame import PyColumn
+    c = PyColumn([3, 1, None, 1, 2])
+    assert len(c) == 5
+    assert c.null_count() == 1
+    assert c.n_unique() == 4                       # {3,1,None,2}
+    assert c.drop_nulls().to_list() == [3, 1, 1, 2]
+    assert c.drop_nulls().unique().sort().to_list() == [1, 2, 3]
+    assert c.to_list() == [3, 1, None, 1, 2]
+
+def test_pyframe_surface_and_from_columns():
+    from goldencheck.core.frame import PyFrame, to_frame
+    f = PyFrame.from_columns({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert f.columns == ["a", "b"]
+    assert f.height == 3
+    assert f.native == {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+    assert f.column("a").to_list() == [1, 2, 3]
+    # to_frame is idempotent on a PyFrame and does NOT require polars
+    assert to_frame(f) is f
+    # empty frame
+    assert PyFrame.from_columns({}).height == 0
+    assert PyFrame.from_columns({}).columns == []
+
+def test_to_frame_pyframe_is_polars_free():
+    # Building/using a PyFrame must not load polars.
+    import subprocess, sys, os
+    from pathlib import Path
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "from goldencheck.core.frame import PyFrame, to_frame\n"
+        "f = to_frame(PyFrame.from_columns({'a':[1,None,2]}))\n"
+        "assert f.column('a').null_count()==1\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ); env["PYTHONPATH"] = pkg + os.pathsep + env.get("PYTHONPATH","")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+```
+
+- [ ] **Step 2: Run → FAIL** (`ImportError: cannot import name 'PyColumn'`).
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "pycolumn or pyframe or to_frame_pyframe" -v
+```
+
+- [ ] **Step 3: Implement in `core/frame.py`.** Add `PyColumn` + `PyFrame` (place them ABOVE `to_frame`, after `PolarsFrame`). Each op returns a `PyColumn` where the Protocol says `-> Column` (so chaining works):
+```python
+class PyColumn:
+    __slots__ = ("_v",)
+
+    def __init__(self, values: list) -> None:
+        self._v = values
+
+    def __len__(self) -> int:
+        return len(self._v)
+
+    def null_count(self) -> int:
+        return sum(1 for v in self._v if v is None)
+
+    def n_unique(self) -> int:
+        return len(set(self._v))
+
+    def drop_nulls(self) -> PyColumn:
+        return PyColumn([v for v in self._v if v is not None])
+
+    def unique(self) -> PyColumn:
+        return PyColumn(list(set(self._v)))
+
+    def sort(self) -> PyColumn:
+        return PyColumn(sorted(self._v))
+
+    def to_list(self) -> list:
+        return list(self._v)
+
+
+class PyFrame:
+    __slots__ = ("_cols",)
+
+    def __init__(self, cols: dict[str, list]) -> None:
+        self._cols = cols
+
+    @classmethod
+    def from_columns(cls, cols: dict[str, list]) -> PyFrame:
+        return cls(cols)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._cols.keys())
+
+    @property
+    def height(self) -> int:
+        return len(next(iter(self._cols.values()))) if self._cols else 0
+
+    @property
+    def native(self) -> Any:
+        return self._cols
+
+    def column(self, name: str) -> PyColumn:
+        return PyColumn(self._cols[name])
+```
+Then **reorder `to_frame`** so the frame fast-paths come first (NO `pl` access for a PyFrame):
+```python
+def to_frame(native: Any) -> Frame:
+    if isinstance(native, (PolarsFrame, PyFrame)):
+        return native
+    if isinstance(native, pl.DataFrame):
+        return PolarsFrame(native)
+    raise TypeError(
+        f"to_frame() expects a polars.DataFrame, PolarsFrame, or PyFrame; got {type(native)!r}"
+    )
+```
+(`PyColumn` implements only the 7 mechanical ops — it deliberately does NOT satisfy the full `Column` Protocol; that's fine, the 3 covered profilers use only these 7. Do NOT add the other ops — YAGNI/out-of-scope.)
+
+- [ ] **Step 4: Run → PASS**, import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean: `$PY -m ruff check packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-s21
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): S2.1 pure-Python PyColumn/PyFrame backend + polars-free to_frame reorder"
+```
+
+---
+
+## Task 2: `scan_columns` + export + byte-parity test
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/engine/scanner.py`
+- Modify: `packages/python/goldencheck/goldencheck/__init__.py`
+- Test: `packages/python/goldencheck/tests/engine/test_scan_columns_parity.py` (new)
+
+- [ ] **Step 1: Add `scan_columns` to `scanner.py`.** Near `scan_dataframe`, add a covered-profiler list + the entry (import `PyFrame` from `core.frame`; the 3 profiler classes are already imported in scanner.py):
+```python
+from goldencheck.core.frame import PyFrame  # add to the existing core.frame import if present
+
+_COVERED_COLUMN_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+
+
+def scan_columns(columns: dict[str, list]) -> list[Finding]:
+    """Polars-free reduced scan of the covered STRUCTURAL checks (nullability,
+    uniqueness, cardinality) over in-memory columns. The regex/format/encoding/
+    date/value-count checks need Polars -- use scan_dataframe for a full scan."""
+    frame = PyFrame.from_columns(columns)
+    findings: list[Finding] = []
+    for name in columns:
+        for profiler in _COVERED_COLUMN_PROFILERS:
+            findings.extend(profiler.profile(frame, name))
+    return findings
+```
+(If scanner.py already `from goldencheck.core.frame import to_frame`, extend that line to also import `PyFrame`. `Finding` is already imported there.)
+
+- [ ] **Step 2: Export from `__init__.py`.** Add `scan_columns` to the `from goldencheck.engine.scanner import ...` line and to `__all__`.
+
+- [ ] **Step 3: Write the byte-parity test** `tests/engine/test_scan_columns_parity.py`:
+```python
+"""S2.1 byte-identity gate: the covered profilers produce identical Findings on the
+pure-Python PyFrame backend and the Polars PolarsFrame backend (run with polars
+present). This proves scan_columns(dict) == the Polars covered-check output, so the
+polars-absent nopolars-lane literals are trustworthy."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck import scan_columns
+from goldencheck.core.frame import PolarsFrame, PyFrame
+from goldencheck.engine.scanner import _COVERED_COLUMN_PROFILERS
+from goldencheck.profilers.cardinality import CardinalityProfiler
+from goldencheck.profilers.nullability import NullabilityProfiler
+from goldencheck.profilers.uniqueness import UniquenessProfiler
+
+# Data exercising each covered finding branch. NOTE: floats are NaN-FREE on purpose --
+# PyColumn.sort/n_unique assume no NaN (Polars sorts NaN last; Python does not). Do NOT
+# add NaN to any column here.
+def _datasets():
+    return [
+        {"pk": list(range(120)),                                   # 100% unique -> PK finding
+         "grade": ["A", "B", "C"] * 40,                            # low cardinality enum
+         "note": [None] * 120,                                     # entirely null
+         "score": [float(i % 7) for i in range(120)]},             # clean floats, low card
+        {"user_id": [1, 1, 2, 3] * 30,                             # identifier w/ dups (near-unique? no)
+         "email": [f"u{i}" for i in range(120)],                   # 100% unique non-id
+         "opt": ([1] * 114) + [None] * 6},                         # ~5% nulls in sizeable col
+        {"x": [1, 2, 3]},                                          # tiny frame (<10, <50) -> few/no findings
+    ]
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_covered_profilers_backend_parity(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    pyf = PyFrame.from_columns(data)
+    for profiler in (NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()):
+        for col in data:
+            assert profiler.profile(pol, col) == profiler.profile(pyf, col), (profiler, col)
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_scan_columns_matches_polars_covered_output(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    expected = []
+    for name in data:
+        for profiler in _COVERED_COLUMN_PROFILERS:
+            expected.extend(profiler.profile(pol, name))
+    assert scan_columns(data) == expected
+```
+
+- [ ] **Step 4: Run → PASS** + import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/engine/test_scan_columns_parity.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+If a parity assertion FAILS, a PyColumn op diverges from Polars on that data — fix the PORT/backend (or narrow the data if it's a genuine unsupported edge like NaN), never loosen the assertion. Ruff clean on the 3 files.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/engine/scanner.py packages/python/goldencheck/goldencheck/__init__.py packages/python/goldencheck/tests/engine/test_scan_columns_parity.py
+git commit -m "feat(goldencheck): S2.1 public scan_columns() -- polars-free covered structural scan"
+```
+
+---
+
+## Task 3: nopolars covered-scan assertions + final verification
+
+**Files:**
+- Modify: `packages/python/goldencheck/tests/nopolars/test_polars_absent.py` (S2.0's module)
+- Modify: `packages/python/goldencheck/tests/test_import_no_polars.py` (extend the import-blocker)
+
+- [ ] **Step 1: Add a covered-scan test to `tests/nopolars/test_polars_absent.py`** (append; the module is `skipif`'d when polars is present, so this runs only in the `goldencheck_nopolars` lane):
+```python
+def test_covered_scan_columns_without_polars() -> None:
+    from goldencheck import scan_columns
+
+    findings = scan_columns({
+        "pk": list(range(120)),
+        "grade": ["A", "B", "C"] * 40,
+        "note": [None] * 120,
+    })
+    checks = sorted({f.check for f in findings})
+    # covered structural checks fire; nothing polars-only ran
+    assert "uniqueness" in checks      # pk is 100% unique
+    assert "cardinality" in checks     # grade is low-cardinality
+    assert "nullability" in checks     # note is entirely null
+    assert "polars" not in sys.modules
+```
+(Use the exact literal checks the S2.1 byte-parity test validated. If you want value-level literal asserts, copy expected Finding fields from a parity-test run — but the `check`-set + polars-not-loaded assertions are sufficient and robust.)
+
+- [ ] **Step 2: Extend the import-blocker** in `tests/test_import_no_polars.py` — add a test proving `scan_columns` runs end-to-end with polars unimportable (REQUIRED suite):
+```python
+def test_scan_columns_runs_with_polars_unimportable():
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "from goldencheck import scan_columns\n"
+        "fs = scan_columns({'pk': list(range(120)), 'note': [None]*120})\n"
+        "checks = {f.check for f in fs}\n"
+        "assert 'uniqueness' in checks and 'nullability' in checks, checks\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg_dir = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = pkg_dir + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+```
+
+- [ ] **Step 3: Run the affected tests + verify polars-free:**
+```bash
+cd /d/show_case/gc-s21 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py packages/python/goldencheck/tests/nopolars -v
+```
+Expected: import gate tests pass (incl. the new scan_columns-blocked test); nopolars 3 skipped (polars present locally). Confirm `scan_columns`'s covered path is polars-free:
+```bash
+grep -nE "polars|_polars_lazy|[^a-z]pl\." packages/python/goldencheck/goldencheck/core/frame.py | grep -iE "PyColumn|PyFrame" || echo "(PyColumn/PyFrame reference no pl -- check by reading: their bodies use only stdlib)"
+```
+
+- [ ] **Step 4: Final verification (whole batch).**
+```bash
+cd /d/show_case/gc-s21 && <preamble>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v      # import gate + 2 new blocker tests green
+$PY -m pytest packages/python/goldencheck/tests -q                               # full suite
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Expected: import gate green; full suite green (report exact passed/skipped counts vs baseline + the new tests); ruff clean. `scan_dataframe` behavior unchanged (no test regressions).
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/tests/nopolars/test_polars_absent.py packages/python/goldencheck/tests/test_import_no_polars.py
+git commit -m "test(goldencheck): S2.1 covered-scan proof -- scan_columns runs polars-free (lane + blocker)"
+```
+
+---
+
+## Done criteria (S2.1 complete)
+- [ ] `PyColumn`/`PyFrame` (7 mechanical ops) in `core/frame.py`; `to_frame` reordered so a `PyFrame` never touches `pl` (import gate green).
+- [ ] Public `scan_columns(dict) -> list[Finding]` runs the 3 covered profilers on a `PyFrame`; exported from `__init__.py`.
+- [ ] Byte-parity test proves the 3 covered profilers produce identical Findings on `PyFrame` vs `PolarsFrame`, and `scan_columns(d)` == the Polars covered output.
+- [ ] The nopolars lane runs a REAL covered scan (`scan_columns`) polars-free; the import-blocker proves it in the required suite.
+- [ ] Full suite green; `scan_dataframe` unchanged; `import goldencheck` loads zero Polars.
+- [ ] No scope creep: no dtype/stats/regex/date ops on PyColumn, no `scan_dataframe` wiring, no reader, no deps-flip. S2.2 (new Rust kernels for the hard ops) is next.

--- a/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend.md
+++ b/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend.md
@@ -196,9 +196,9 @@ git commit -m "feat(goldencheck): S2.1 pure-Python PyColumn/PyFrame backend + po
 - Modify: `packages/python/goldencheck/goldencheck/__init__.py`
 - Test: `packages/python/goldencheck/tests/engine/test_scan_columns_parity.py` (new)
 
-- [ ] **Step 1: Add `scan_columns` to `scanner.py`.** Near `scan_dataframe`, add a covered-profiler list + the entry (import `PyFrame` from `core.frame`; the 3 profiler classes are already imported in scanner.py):
+- [ ] **Step 1: Add `scan_columns` to `scanner.py`.** Near `scan_dataframe`, add a covered-profiler list + the entry. `scanner.py` does NOT currently import from `core.frame`, so add a new import line `from goldencheck.core.frame import PyFrame` (the 3 profiler classes + `Finding` are already imported there). Also add `"scan_columns"` to `scanner.py`'s module-level `__all__` (currently `["scan_file", "scan_file_with_llm", "scan_dataframe"]`).
 ```python
-from goldencheck.core.frame import PyFrame  # add to the existing core.frame import if present
+from goldencheck.core.frame import PyFrame  # new import — scanner.py has no core.frame import yet
 
 _COVERED_COLUMN_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
 
@@ -247,6 +247,9 @@ def _datasets():
         {"user_id": [1, 1, 2, 3] * 30,                             # identifier w/ dups (near-unique? no)
          "email": [f"u{i}" for i in range(120)],                   # 100% unique non-id
          "opt": ([1] * 114) + [None] * 6},                         # ~5% nulls in sizeable col
+        # Exercise the WARNING branches the spec calls out:
+        {"account_id": list(range(119)) + [0],                     # 119 unique of 120, name has 'id' + 1 dup -> uniqueness WARNING
+         "phone": ([f"p{i}" for i in range(118)]) + [None, None]}, # 118/120 non-null (>95%), total>=100 -> nullability WARNING
         {"x": [1, 2, 3]},                                          # tiny frame (<10, <50) -> few/no findings
     ]
 
@@ -290,7 +293,7 @@ git commit -m "feat(goldencheck): S2.1 public scan_columns() -- polars-free cove
 - Modify: `packages/python/goldencheck/tests/nopolars/test_polars_absent.py` (S2.0's module)
 - Modify: `packages/python/goldencheck/tests/test_import_no_polars.py` (extend the import-blocker)
 
-- [ ] **Step 1: Add a covered-scan test to `tests/nopolars/test_polars_absent.py`** (append; the module is `skipif`'d when polars is present, so this runs only in the `goldencheck_nopolars` lane):
+- [ ] **Step 1: Add a covered-scan test to `tests/nopolars/test_polars_absent.py`** (append; the module is `skipif`'d when polars is present, so this runs only in the `goldencheck_nopolars` lane). **First open the file and confirm `import sys` is present at module top (S2.0 added it — but verify; if absent, add it) since the test below uses `sys.modules`.** Then append:
 ```python
 def test_covered_scan_columns_without_polars() -> None:
     from goldencheck import scan_columns

--- a/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.1-pycolumn-backend-design.md
@@ -1,0 +1,164 @@
+# GoldenCheck Polars eviction — Stage-2 S2.1 (covered pure-Python Column/Frame backend + scan_columns)
+
+Date: 2026-07-10
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` **after S2.0 #1618 merges** (the code tasks MODIFY S2.0's `tests/nopolars/` scaffold, so the code branch must be rebased onto main-with-S2.0; this spec doc is a new file and carries no conflict).
+Parent program: goldencheck Polars eviction — Stage-2 (see `2026-07-10-goldencheck-stage2-s2.0-nopolars-lane-design.md` for the S2.0–S2.2/reader/P4 roadmap)
+
+## Context
+
+S2.0 shipped the nopolars scaffold + advisory lane (import-survival + clean-decline, **no covered
+scan** — goldencheck had no non-Polars backend). S2.1 ships the **first covered non-Polars backend**: a
+pure-Python `Column`/`Frame` so the three *mechanical* column profilers run polars-free, byte-identically,
+plus a public `scan_columns(dict)` entry and the covered-scan assertions the S2.0 lane deferred.
+
+**Why these three are cleanly coverable (verified from source):** `nullability`, `cardinality`,
+`uniqueness` use only a tiny, **dtype-free** op set — `__len__`, `null_count`, `n_unique`, `drop_nulls`,
+`unique`, `sort`, `to_list` — and none call `dtype`/`cast`/regex/date/stats. Every one of those 7 ops is
+byte-identical to Polars on a pure-Python `dict[str,list]` backend for homogeneous, null-as-`None`,
+non-NaN columns (see byte-identity anchors). This is the goldenflow "covered-subset" pattern: run the
+covered checks on the pure-Python backend, leave the rest to Polars.
+
+## Scope
+
+### In scope
+1. **`PyColumn` / `PyFrame`** (pure-Python, `dict[str,list]`) in `core/frame.py` implementing the 7
+   mechanical `Column` ops + the `Frame` surface + `PyFrame.from_columns(dict)`.
+2. **`to_frame` reorder** so the `PolarsFrame`/`PyFrame` fast-paths are checked BEFORE `pl.DataFrame`
+   (so `to_frame(py_frame)` never touches the `pl` symbol) + a `PyFrame` passthrough.
+3. **`scan_columns(columns: dict[str, list]) -> list[Finding]`** — a public, polars-free reduced scan
+   that runs the covered profilers (`Nullability`, `Uniqueness`, `Cardinality`) per column on a
+   `PyFrame`. Exported from `goldencheck/__init__.py`.
+4. **A byte-parity test** (normal suite, polars present): each covered profiler yields identical
+   `Finding`s on `PolarsFrame` vs `PyFrame` for representative data; `scan_columns(d)` equals the covered
+   profilers run over `PyFrame.from_columns(d)`.
+5. **Covered-scan assertions in `tests/nopolars/`** (S2.0's module): `scan_columns({...})` runs
+   polars-free + asserts Findings; the import-blocker path asserts `scan_columns` works with polars
+   unimportable.
+
+### Explicitly NOT in scope
+`dtype`/`cast` (type_inference); `min`/`max`/`mean`/`std` (range/sequence/drift — float-precision
+byte-identity risk); the regex/date/value_counts profilers; wiring `PyFrame` into the main
+`scan_dataframe` scanner (its polars scan path is UNCHANGED — no byte-identity surface touched); the
+non-Polars reader (S2.2+/reader); the deps-flip.
+
+### Success criteria
+- The 3 covered profilers produce **byte-identical** Findings on `PyFrame` vs `PolarsFrame` (the parity
+  gate).
+- `scan_columns(dict)` runs with polars genuinely absent (the nopolars lane) + with polars unimportable
+  (the import-blocker), producing the covered Findings and loading zero polars.
+- The existing full suite is green; `import goldencheck` still loads zero Polars; `scan_dataframe` (the
+  polars path) is byte-identical (unchanged).
+
+## The backend (`core/frame.py`)
+
+### `PyColumn` (wraps a plain `list`, `__slots__ = ("_v",)`)
+| Op | Impl | Polars equivalent it matches |
+|---|---|---|
+| `__len__` | `len(self._v)` | `len(s)` |
+| `null_count` | `sum(1 for v in self._v if v is None)` | `s.null_count()` (null == `None`; NaN is NOT null) |
+| `n_unique` | `len(set(self._v))` | `s.n_unique()` (counts null as ONE distinct — matches `len({...,None})`) |
+| `drop_nulls` | `PyColumn([v for v in self._v if v is not None])` | `s.drop_nulls()` |
+| `unique` | `PyColumn(list(dict.fromkeys(self._v)))` OR `list(set(...))` | `s.unique()` (order unspecified in Polars; callers `.sort()` after) |
+| `sort` | `PyColumn(sorted(self._v))` | `s.sort()` (homogeneous column → same order) |
+| `to_list` | `list(self._v)` | `s.to_list()` |
+
+`unique`'s order does not matter (the only caller, `cardinality`, does `drop_nulls().unique().sort()`);
+use whichever is simplest — `sorted` is applied downstream so `list(set(...))` is fine. (If a future
+caller needs `unique()` order to match Polars, revisit — YAGNI now.)
+
+### `PyFrame` (wraps a `dict[str, list]`, `__slots__ = ("_cols",)`)
+- `from_columns(cols: dict[str, list]) -> PyFrame` classmethod (or `PyFrame(cols)`).
+- `columns -> list[str]` = `list(self._cols.keys())`.
+- `height -> int` = `len(next(iter(self._cols.values())))` if non-empty else `0`.
+- `native -> dict` = `self._cols`.
+- `column(name) -> PyColumn` = `PyColumn(self._cols[name])`.
+- Assumes equal-length columns (like `pl.DataFrame(dict)`); ragged input is caller error (do NOT add
+  validation unless a test needs it — YAGNI).
+
+### `to_frame` reorder (byte-identical for existing callers)
+```python
+def to_frame(native):
+    if isinstance(native, (PolarsFrame, PyFrame)):   # fast-paths first; NO pl access
+        return native
+    if isinstance(native, pl.DataFrame):             # pl touched ONLY for raw polars input
+        return PolarsFrame(native)
+    raise TypeError(...)
+```
+The `PolarsFrame` passthrough + the `pl.DataFrame → PolarsFrame` path are unchanged for existing callers;
+the ONLY change is the new `PyFrame` passthrough and that a `PyFrame` never reaches the `pl.DataFrame`
+check. This is what makes `to_frame(py_frame)` polars-free.
+
+## `scan_columns` (`engine/scanner.py`, exported from `__init__.py`)
+
+```python
+_COVERED_COLUMN_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+
+def scan_columns(columns: dict[str, list]) -> list[Finding]:
+    """Polars-free reduced scan of the covered STRUCTURAL checks (nullability,
+    uniqueness, cardinality) over in-memory columns. The regex/format/encoding/
+    date/value-count checks need Polars -- use scan_dataframe for a full scan."""
+    frame = PyFrame.from_columns(columns)
+    findings: list[Finding] = []
+    for name in columns:                      # dict order
+        for profiler in _COVERED_COLUMN_PROFILERS:
+            findings.extend(profiler.profile(frame, name))
+    return findings
+```
+- Deterministic order: columns in dict-insertion order × the fixed covered-profiler order.
+- Return type `list[Finding]` (NOT the `(findings, DatasetProfile)` tuple `scan_dataframe` returns — this
+  is a deliberately reduced, polars-free entry; it does NOT reproduce classification / denial / sampling
+  / DatasetProfile, all of which are polars-coupled and out of scope).
+- Export `scan_columns` from `goldencheck/__init__.py` + add to `__all__`.
+- The three covered profilers accept `*, context=None` and ignore it; `scan_columns` passes no context
+  (matches their default).
+
+## Testing
+
+### Byte-parity test (normal suite — polars PRESENT — the byte-identity gate)
+`tests/engine/test_scan_columns_parity.py` (new file). For representative data
+`d = {"id": [1,2,3,4,...], "cat": ["a","a","b",None,...], "val": [1.0,2.0,3.0,...], "flag": [...]}`
+covering int / str+null / clean float:
+- For each covered profiler P and each column: `assert P.profile(PolarsFrame(pl.DataFrame(d)), col) ==
+  P.profile(PyFrame.from_columns(d), col)` (backend parity — identical `Finding`s). Relies on
+  `Finding.__eq__`; if `Finding` is not directly comparable, compare a normalized tuple of its fields.
+- `assert scan_columns(d) == [f for name in d for P in covered for f in P.profile(PolarsFrame(pl.DataFrame(d)), name)]`
+  (scan_columns == the covered profilers over the SAME data; proves the wrapper + the backend agree with
+  Polars).
+- Include cases that exercise each finding branch (all-null, 0-null≥10-rows, low-cardinality enum,
+  100%-unique PK, near-unique identifier-with-dups) so parity is proven where the profilers actually emit.
+
+### nopolars lane (polars ABSENT — extends S2.0's `tests/nopolars/test_polars_absent.py`)
+- `test_covered_scan_columns_without_polars()`: `from goldencheck import scan_columns`; run
+  `scan_columns({...})` over data that triggers known findings; assert the returned Findings against
+  **hardcoded literals** (the parity test above proves those literals == the Polars path); assert
+  `"polars" not in sys.modules` after. (Mirrors goldenflow's covered-path assertions.)
+- Extend the import-blocker subprocess test (S2.0's `test_goldencheck_survives_polars_unimportable` in
+  `tests/test_import_no_polars.py`) OR add a sibling: with `polars` blocked, `scan_columns({...})`
+  returns findings AND `"polars" not in sys.modules` (proves the covered path is genuinely polars-free
+  end-to-end, in the REQUIRED suite).
+
+## Byte-identity anchors / risks
+
+- **null = `None`** — Polars null round-trips as Python `None` in `.to_list()`; the covered profilers see
+  nulls only via `null_count`/`drop_nulls`/`n_unique`, all of which treat `None` exactly as Polars treats
+  null. NaN is a distinct float value (NOT null) in both — the covered set does not special-case NaN.
+- **`n_unique` counts null as ONE** — `pl.Series([1,1,None]).n_unique() == 2`; `len({1,1,None}) == 2`.
+  Matches for `cardinality` (full-column `n_unique`) and `uniqueness` (post-`drop_nulls`, no nulls).
+- **`sort` on homogeneous columns** — `sorted(list)` matches `s.sort()` for int/str/clean-float columns
+  (columns are homogeneous, so no mixed-type `TypeError`). **The one edge is float NaN**: Polars sorts
+  NaN last; Python `sorted` with NaN is position-undefined. The covered set **assumes no NaN**; the
+  parity test uses clean floats and does NOT include NaN. Documented — if a NaN-bearing low-cardinality
+  float column ever needs coverage, that is a follow-up (add a NaN-aware `sort`), not S2.1.
+- **`to_frame` reorder** — byte-identical for existing callers (the `PolarsFrame`/`pl.DataFrame` paths are
+  unchanged); the reorder matters only so a `PyFrame` never touches `pl.DataFrame`. Existing tests + the
+  import gate are the proof.
+- **`scan_dataframe` unchanged** — S2.1 does NOT wire `PyFrame` into the main scanner; the polars scan
+  path is untouched (no byte-identity surface). `scan_columns` is a separate, additive entry.
+- **`Finding` equality** — the parity test depends on comparing `Finding`s; confirm `Finding` supports
+  `==` (dataclass/pydantic) or compare normalized field tuples. (Verify at plan time.)
+
+## Non-goals (YAGNI)
+`dtype`/`cast`/stats/regex/date/value_counts ops on `PyColumn`; wiring `PyFrame` into `scan_dataframe`;
+`PyColumn.unique()` order matching Polars; ragged-column validation; the reader; the deps-flip; a
+NaN-aware sort.

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -31,7 +31,7 @@ from goldencheck.engine.differ import (
 )
 from goldencheck.engine.fixer import FixEntry, FixReport, apply_fixes
 from goldencheck.engine.reader import read_file
-from goldencheck.engine.scanner import scan_dataframe, scan_file, scan_file_with_llm
+from goldencheck.engine.scanner import scan_columns, scan_dataframe, scan_file, scan_file_with_llm
 from goldencheck.engine.triage import TriageResult, auto_triage
 
 # Engine: validator, confidence, triage, fixer, differ, reader
@@ -66,6 +66,7 @@ def __getattr__(name: str):
 __all__ = [
     # Core
     "scan_dataframe",
+    "scan_columns",
     "scan_file",
     "scan_file_with_llm",
     "cell_quality",

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -222,11 +222,72 @@ class PolarsFrame:
         return PolarsColumn(self._df[name])
 
 
+class PyColumn:
+    """Pure-Python column wrapping a ``list`` — the 7 mechanical, dtype-free ops
+    used by the simple column profilers (nullability/cardinality/uniqueness).
+    Deliberately does NOT implement the full ``Column`` Protocol.
+    """
+
+    __slots__ = ("_v",)
+
+    def __init__(self, values: list) -> None:
+        self._v = values
+
+    def __len__(self) -> int:
+        return len(self._v)
+
+    def null_count(self) -> int:
+        return sum(1 for v in self._v if v is None)
+
+    def n_unique(self) -> int:
+        return len(set(self._v))
+
+    def drop_nulls(self) -> PyColumn:
+        return PyColumn([v for v in self._v if v is not None])
+
+    def unique(self) -> PyColumn:
+        return PyColumn(list(set(self._v)))
+
+    def sort(self) -> PyColumn:
+        return PyColumn(sorted(self._v))
+
+    def to_list(self) -> list:
+        return list(self._v)
+
+
+class PyFrame:
+    """Pure-Python frame wrapping a ``dict[str, list]`` — no Polars import."""
+
+    __slots__ = ("_cols",)
+
+    def __init__(self, cols: dict[str, list]) -> None:
+        self._cols = cols
+
+    @classmethod
+    def from_columns(cls, cols: dict[str, list]) -> PyFrame:
+        return cls(cols)
+
+    @property
+    def columns(self) -> list[str]:
+        return list(self._cols.keys())
+
+    @property
+    def height(self) -> int:
+        return len(next(iter(self._cols.values()))) if self._cols else 0
+
+    @property
+    def native(self) -> Any:
+        return self._cols
+
+    def column(self, name: str) -> PyColumn:
+        return PyColumn(self._cols[name])
+
+
 def to_frame(native: Any) -> Frame:
-    if isinstance(native, PolarsFrame):
+    if isinstance(native, (PolarsFrame, PyFrame)):
         return native
     if isinstance(native, pl.DataFrame):
         return PolarsFrame(native)
     raise TypeError(
-        f"to_frame() expects a polars.DataFrame (or PolarsFrame); got {type(native)!r}"
+        f"to_frame() expects a polars.DataFrame, PolarsFrame, or PyFrame; got {type(native)!r}"
     )

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -10,6 +10,7 @@ from goldencheck._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile
+from goldencheck.core.frame import PyFrame
 from goldencheck.engine.confidence import apply_corroboration_boost
 from goldencheck.engine.reader import read_file
 from goldencheck.engine.sampler import maybe_sample
@@ -39,7 +40,7 @@ from goldencheck.relations.temporal import TemporalOrderProfiler
 
 logger = logging.getLogger(__name__)
 
-__all__ = ["scan_file", "scan_file_with_llm", "scan_dataframe"]
+__all__ = ["scan_file", "scan_file_with_llm", "scan_dataframe", "scan_columns"]
 
 COLUMN_PROFILERS = [
     TypeInferenceProfiler(),
@@ -240,6 +241,21 @@ def _post_classification_checks(
             ))
 
     return new_findings
+
+
+_COVERED_COLUMN_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+
+
+def scan_columns(columns: dict[str, list]) -> list[Finding]:
+    """Polars-free reduced scan of the covered STRUCTURAL checks (nullability,
+    uniqueness, cardinality) over in-memory columns. The regex/format/encoding/
+    date/value-count checks need Polars -- use scan_dataframe for a full scan."""
+    frame = PyFrame.from_columns(columns)
+    findings: list[Finding] = []
+    for name in columns:
+        for profiler in _COVERED_COLUMN_PROFILERS:
+            findings.extend(profiler.profile(frame, name))
+    return findings
 
 
 def scan_dataframe(

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -261,3 +261,54 @@ def test_column_str_to_date():
     ).to_list()
     # invalid parses -> null under strict=False
     assert got.to_list()[1] is None
+
+
+def test_pycolumn_mechanical_ops():
+    from goldencheck.core.frame import PyColumn
+    c = PyColumn([3, 1, None, 1, 2])
+    assert len(c) == 5
+    assert c.null_count() == 1
+    assert c.n_unique() == 4                       # {3,1,None,2}
+    assert c.drop_nulls().to_list() == [3, 1, 1, 2]
+    assert c.drop_nulls().unique().sort().to_list() == [1, 2, 3]
+    assert c.to_list() == [3, 1, None, 1, 2]
+
+
+def test_pyframe_surface_and_from_columns():
+    from goldencheck.core.frame import PyFrame, to_frame
+    f = PyFrame.from_columns({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+    assert f.columns == ["a", "b"]
+    assert f.height == 3
+    assert f.native == {"a": [1, 2, 3], "b": ["x", "y", "z"]}
+    assert f.column("a").to_list() == [1, 2, 3]
+    # to_frame is idempotent on a PyFrame and does NOT require polars
+    assert to_frame(f) is f
+    # empty frame
+    assert PyFrame.from_columns({}).height == 0
+    assert PyFrame.from_columns({}).columns == []
+
+
+def test_to_frame_pyframe_is_polars_free():
+    # Building/using a PyFrame must not load polars.
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "from goldencheck.core.frame import PyFrame, to_frame\n"
+        "f = to_frame(PyFrame.from_columns({'a':[1,None,2]}))\n"
+        "assert f.column('a').null_count()==1\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ); env["PYTHONPATH"] = pkg + os.pathsep + env.get("PYTHONPATH","")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr

--- a/packages/python/goldencheck/tests/engine/test_scan_columns_parity.py
+++ b/packages/python/goldencheck/tests/engine/test_scan_columns_parity.py
@@ -1,0 +1,52 @@
+"""S2.1 byte-identity gate: the covered profilers produce identical Findings on the
+pure-Python PyFrame backend and the Polars PolarsFrame backend (run with polars
+present). This proves scan_columns(dict) == the Polars covered-check output, so the
+polars-absent nopolars-lane literals are trustworthy."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck import scan_columns
+from goldencheck.core.frame import PolarsFrame, PyFrame
+from goldencheck.engine.scanner import _COVERED_COLUMN_PROFILERS
+from goldencheck.profilers.cardinality import CardinalityProfiler
+from goldencheck.profilers.nullability import NullabilityProfiler
+from goldencheck.profilers.uniqueness import UniquenessProfiler
+
+
+# Data exercising each covered finding branch. NOTE: floats are NaN-FREE on purpose --
+# PyColumn.sort/n_unique assume no NaN (Polars sorts NaN last; Python does not). Do NOT
+# add NaN to any column here.
+def _datasets():
+    return [
+        {"pk": list(range(120)),                                   # 100% unique -> PK finding
+         "grade": ["A", "B", "C"] * 40,                            # low cardinality enum
+         "note": [None] * 120,                                     # entirely null
+         "score": [float(i % 7) for i in range(120)]},             # clean floats, low card
+        {"user_id": [1, 1, 2, 3] * 30,                             # identifier w/ dups (near-unique? no)
+         "email": [f"u{i}" for i in range(120)],                   # 100% unique non-id
+         "opt": ([1] * 114) + [None] * 6},                         # ~5% nulls in sizeable col
+        # Exercise the WARNING branches the spec calls out:
+        {"account_id": list(range(119)) + [0],                     # 119 unique of 120, name has 'id' + 1 dup -> uniqueness WARNING
+         "phone": ([f"p{i}" for i in range(118)]) + [None, None]}, # 118/120 non-null (>95%), total>=100 -> nullability WARNING
+        {"x": [1, 2, 3]},                                          # tiny frame (<10, <50) -> few/no findings
+    ]
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_covered_profilers_backend_parity(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    pyf = PyFrame.from_columns(data)
+    for profiler in (NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()):
+        for col in data:
+            assert profiler.profile(pol, col) == profiler.profile(pyf, col), (profiler, col)
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_scan_columns_matches_polars_covered_output(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    expected = []
+    for name in data:
+        for profiler in _COVERED_COLUMN_PROFILERS:
+            expected.extend(profiler.profile(pol, name))
+    assert scan_columns(data) == expected

--- a/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
@@ -44,3 +44,19 @@ def test_uncovered_path_raises_clean_error_without_polars() -> None:
 
     with pytest.raises(ModuleNotFoundError):
         _ = pl.DataFrame
+
+
+def test_covered_scan_columns_without_polars() -> None:
+    from goldencheck import scan_columns
+
+    findings = scan_columns({
+        "pk": list(range(120)),
+        "grade": ["A", "B", "C"] * 40,
+        "note": [None] * 120,
+    })
+    checks = sorted({f.check for f in findings})
+    # covered structural checks fire; nothing polars-only ran
+    assert "uniqueness" in checks      # pk is 100% unique
+    assert "cardinality" in checks     # grade is low-cardinality
+    assert "nullability" in checks     # note is entirely null
+    assert "polars" not in sys.modules

--- a/packages/python/goldencheck/tests/test_import_no_polars.py
+++ b/packages/python/goldencheck/tests/test_import_no_polars.py
@@ -18,6 +18,31 @@ def test_import_goldencheck_does_not_load_polars():
     assert r.returncode == 0, r.stdout + r.stderr
 
 
+def test_scan_columns_runs_with_polars_unimportable():
+    # S2.1: prove the covered scan (scan_columns) runs end-to-end with polars unimportable,
+    # not just that the module imports (test_goldencheck_survives_polars_unimportable above).
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "from goldencheck import scan_columns\n"
+        "fs = scan_columns({'pk': list(range(120)), 'note': [None]*120})\n"
+        "checks = {f.check for f in fs}\n"
+        "assert 'uniqueness' in checks and 'nullability' in checks, checks\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg_dir = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = pkg_dir + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
 def test_goldencheck_survives_polars_unimportable():
     # Simulate the P4 base-deps flip WITHOUT uninstalling: a meta_path finder makes
     # `polars` unimportable, then `import goldencheck` must still succeed (lazy proxy


### PR DESCRIPTION
## Summary

Stage-2 S2.1 of the goldencheck Polars-eviction program: the **first covered non-Polars backend**. Ships a pure-Python `PyColumn`/`PyFrame` so the three *mechanical* column profilers (nullability / uniqueness / cardinality) run byte-identically without Polars, plus a public `scan_columns(dict)` entry and the covered-scan assertions the S2.0 nopolars lane deferred.

Builds on S2.0 (#1618, nopolars scaffold + advisory lane).

## What changed

- **`PyColumn` / `PyFrame`** (`core/frame.py`) — pure-Python (`list` / `dict[str,list]`) backend implementing only the 7 mechanical, dtype-free ops the covered profilers use (`__len__`, `null_count`, `n_unique`, `drop_nulls`, `unique`, `sort`, `to_list` + the `Frame` surface). Deliberately does NOT satisfy the full `Column` Protocol (YAGNI).
- **`to_frame` reorder** — `isinstance(native, (PolarsFrame, PyFrame))` is checked BEFORE `pl.DataFrame`, so a `PyFrame` never touches the `pl` symbol. This is what makes the covered path genuinely polars-free. Byte-identical for existing callers (the PolarsFrame + pl.DataFrame branches are unchanged).
- **`scan_columns(columns: dict[str,list]) -> list[Finding]`** (`engine/scanner.py`, exported from `__init__.py`) — a polars-free reduced scan running the 3 covered structural profilers over a `PyFrame`. `scan_dataframe` (the Polars path) is UNCHANGED.
- **Byte-parity gate** (`tests/engine/test_scan_columns_parity.py`) — proves the 3 covered profilers yield identical `Finding`s on `PyFrame` vs `PolarsFrame`, and `scan_columns(d)` == the Polars covered output. Passed on the first run with zero backend fixes.
- **nopolars lane + import-blocker** — a covered-scan test in the `goldencheck_nopolars` lane + a required-suite import-blocker proving `scan_columns` runs end-to-end with polars unimportable.

## Byte-identity notes

- null = `None`; `n_unique` counts null as one distinct (matches Polars); `sort` = `sorted()` for homogeneous columns. Float **NaN** is the one excluded edge (Polars sorts NaN last, Python does not) — the covered set + parity datasets are NaN-free by design.

## Test plan

- [x] Byte-parity: 8 parametrized cases (backend parity + scan_columns-vs-Polars), all green, no backend fix needed
- [x] Import gate green (`import goldencheck` loads zero polars) + new blocker test (`scan_columns` runs with polars unimportable)
- [x] nopolars lane covered-scan test (skipped locally where polars present; runs in CI's advisory lane)
- [x] `core/frame.py` seam tests + ruff clean across `goldencheck` + `tests`
- [ ] Full suite green in CI

Out of scope (roadmap): S2.2 = new goldencheck-native Rust kernels for the hard ops (regex/date/value_counts); the non-Polars reader; P4 = the deps-flip (`polars` → `[polars]` extra) where the ~185MB weight payoff lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h