### PR TITLE
feat(autoconfig): facility full-name negative-evidence lever (opt-in) -- stops colleague over-merge on company data

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -578,6 +578,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_BLOCKING_PRUNE_PASSES` / `_PASS_MIN_WEAKPOS` | `0` / `1` | Weak-positive multi-pass pruning. |
 | `GOLDENMATCH_QUALITY_AWARE_BLOCKING` | `0` | Add fuzzy passes for noisy columns (GoldenCheck door #1). |
 | `GOLDENMATCH_FD_NEGATIVE_EVIDENCE` | `0` | FD-driven negative evidence (GoldenCheck door #3). |
+| `GOLDENMATCH_FACILITY_NAME_NE` | `0` | On company/location-mode data (shared phone/address/company demoted because the sharers don't co-agree on the person name), add the person full name (first+last) as `token_sort` negative evidence so distinct colleagues at one facility don't fuse. Opt-in; only fires when facility mode is detected, so person datasets (e.g. Febrl) are unaffected even when set. |
 | `GOLDENMATCH_QUALITY_GATED_REVIEW` | `0` | Downgrade auto-merge on low-quality records. |
 
 ### Probabilistic / Fellegi-Sunter (advanced)

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -197,9 +197,20 @@ class NegativeEvidenceField(BaseModel):
     scorer: str
     threshold: float = Field(ge=0.0, le=1.0)
     penalty: float = Field(ge=0.0, le=1.0)
+    # When set, ``field`` is a SYNTHESIZED column the pipeline materializes
+    # before scoring by space-joining ``derive_from`` (e.g. a person full name
+    # from ['first_name', 'last_name']). Lets an NE score a composite the raw
+    # frame doesn't carry -- used by the facility full-name NE lever so a
+    # token_sort on the whole name can tell distinct colleagues apart from
+    # nickname/typo duplicates. None => ``field`` must already exist.
+    derive_from: list[str] | None = None
 
     @model_validator(mode="after")
     def _validate_transforms_and_scorer(self) -> NegativeEvidenceField:
+        if self.derive_from is not None and len(self.derive_from) < 2:
+            raise ValueError(
+                "derive_from must name at least 2 source columns to concatenate"
+            )
         for t in self.transforms:
             if t not in VALID_SIMPLE_TRANSFORMS:
                 raise ValueError(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -29,6 +29,7 @@ from goldenmatch.config.schemas import (
     MatchkeyConfig,
     MatchkeyField,
     MemoryConfig,
+    NegativeEvidenceField,
     OutputConfig,
 )
 from goldenmatch.core.autoconfig_discriminative import (
@@ -1343,7 +1344,80 @@ def build_matchkeys(
                 fields=fields,
             ))
 
+    _promote_facility_fullname_ne(matchkeys, skipped_exact, _person_name_basket)
     return matchkeys
+
+
+_GIVEN_NAME_RE = re.compile(r"(first[_ ]?name|given[_ ]?name|fname|^first$|forename)", re.I)
+_FAMILY_NAME_RE = re.compile(r"(last[_ ]?name|surname|lname|family[_ ]?name)", re.I)
+_PERSON_FULLNAME_COL = "__gm_person_fullname__"
+
+
+def _facility_name_ne_enabled() -> bool:
+    return os.environ.get("GOLDENMATCH_FACILITY_NAME_NE", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _promote_facility_fullname_ne(
+    matchkeys: list[MatchkeyConfig],
+    skipped_exact: list[tuple[str, str]],
+    person_name_basket: list[tuple[str, bool]],
+) -> None:
+    """Opt-in (``GOLDENMATCH_FACILITY_NAME_NE=1``): on company/location-mode
+    data, add the person FULL NAME as negative evidence on weighted matchkeys.
+
+    Rationale: when a workplace attribute (phone/address/company) was demoted
+    because the records sharing it do NOT co-agree on the person name
+    (``should_demote_attribute_field``), the weighted matchkey still carries
+    address/company (deliberately -- load-bearing for corruption-heavy recall),
+    so two distinct colleagues at one clinic can still fuse. A full-name NE
+    penalises a merge when the whole name is clearly different.
+
+    Full name, not the given name: ``jaro_winkler`` on a given name alone can't
+    separate colleagues (jw(mark,laura)=0.63) from nicknames (jw(robert,bob)=0.50).
+    ``token_sort`` on the concatenated name separates cleanly -- colleagues
+    0.48-0.60, every duplicate flavour (nickname 0.76 / truncation 0.71 / typo
+    0.92) at/above 0.65 -- and is corruption-safe (febrl3's typo'd names stay
+    high, so its true duplicates are never penalised). The full name is a
+    synthesized column (``NegativeEvidenceField.derive_from``) materialized by
+    ``precompute_matchkey_transforms``.
+    """
+    if not _facility_name_ne_enabled():
+        return
+    facility_mode = any(
+        "group-attribute" in reason or "facility" in reason
+        for _col, reason in skipped_exact
+    )
+    if not facility_mode:
+        return
+    name_cols = [c for c, _flag in person_name_basket]
+    if len(name_cols) < 2:
+        return
+    family = next((c for c in name_cols if _FAMILY_NAME_RE.search(c)), None)
+    given = next((c for c in name_cols if _GIVEN_NAME_RE.search(c)), None)
+    sources = [given, family] if (given and family) else name_cols[:2]
+    for mk in matchkeys:
+        if mk.type != "weighted":
+            continue
+        if any(n.field == _PERSON_FULLNAME_COL for n in (mk.negative_evidence or [])):
+            continue
+        ne = list(mk.negative_evidence or [])
+        ne.append(NegativeEvidenceField(
+            field=_PERSON_FULLNAME_COL,
+            transforms=["lowercase", "strip"],
+            scorer="token_sort",
+            threshold=0.65,
+            penalty=0.5,
+            derive_from=sources,
+        ))
+        mk.negative_evidence = ne
+        logger.info(
+            "auto-config[facility]: promoted full-name negative evidence "
+            "(token_sort on %s) on weighted matchkey '%s' -- clearly-different "
+            "colleagues at a shared facility should not fuse.",
+            sources, mk.name,
+        )
 
 
 # ── Strong-identifier blocking-union (#1207) ──────────────────────────────

--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -343,6 +343,10 @@ def precompute_matchkey_transforms(
         is the new caller in the NE fast-path widening, 2026-05-29)."""
         if getattr(field_obj, "scorer", None) == "record_embedding":
             return
+        # A derived NE column whose sources were absent (see derive_from block
+        # above) never got materialized -- skip its xform rather than raise.
+        if field_obj.field not in df.columns:
+            return
         sig = _xform_sig(field_obj)
         if sig in seen or sig in df.columns:
             return
@@ -357,6 +361,31 @@ def precompute_matchkey_transforms(
                 [apply_transforms(v, field_obj.transforms) if v is not None else None
                  for v in values],
             ))
+
+    # Materialize any SYNTHESIZED NE columns (NegativeEvidenceField.derive_from)
+    # before their xform signatures are computed below. A derived NE field
+    # (e.g. a person full name from ['first_name','last_name']) is not in the
+    # raw frame, so space-join the sources into it first; the NE xform loop and
+    # the per-pair scorer then read it like any other column. Missing sources
+    # => skip (the NE no-ops safely rather than raising).
+    _derived_exprs: list[pl.Expr] = []
+    _seen_derived: set[str] = set()
+    for mk in matchkeys:
+        for ne in (getattr(mk, "negative_evidence", None) or []):
+            src = getattr(ne, "derive_from", None)
+            if not src or ne.field in df.columns or ne.field in _seen_derived:
+                continue
+            if not all(c in df.columns for c in src):
+                continue
+            _seen_derived.add(ne.field)
+            _derived_exprs.append(
+                pl.concat_str(
+                    [pl.col(c).cast(pl.Utf8).fill_null("") for c in src],
+                    separator=" ",
+                ).alias(ne.field)
+            )
+    if _derived_exprs:
+        df = df.with_columns(_derived_exprs)
 
     for mk in matchkeys:
         for field in mk.fields:

--- a/packages/python/goldenmatch/tests/test_facility_fullname_ne.py
+++ b/packages/python/goldenmatch/tests/test_facility_fullname_ne.py
@@ -1,0 +1,105 @@
+"""Facility full-name negative-evidence lever (opt-in GOLDENMATCH_FACILITY_NAME_NE).
+
+On company/location-mode data (a workplace attribute demoted because its
+shared-value records don't co-agree on the person name), promote the person
+FULL NAME as token_sort negative evidence so distinct colleagues at one facility
+don't fuse. The full name is a synthesized column (NegativeEvidenceField.derive_from).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+from goldenmatch.core.matchkey import precompute_matchkey_transforms
+
+
+class TestDeriveFromSchema:
+    def test_derive_from_requires_two_sources(self):
+        with pytest.raises(ValueError, match="at least 2"):
+            NegativeEvidenceField(
+                field="__gm_person_fullname__", scorer="token_sort",
+                threshold=0.65, penalty=0.5, derive_from=["first_name"],
+            )
+
+    def test_derive_from_two_sources_ok(self):
+        ne = NegativeEvidenceField(
+            field="__gm_person_fullname__", scorer="token_sort",
+            threshold=0.65, penalty=0.5, derive_from=["first_name", "last_name"],
+        )
+        assert ne.derive_from == ["first_name", "last_name"]
+
+    def test_derive_from_default_none(self):
+        ne = NegativeEvidenceField(field="phone", scorer="exact", threshold=0.5, penalty=0.5)
+        assert ne.derive_from is None
+
+
+class TestDerivedColumnMaterialization:
+    def test_precompute_materializes_full_name(self):
+        df = pl.DataFrame({
+            "first_name": ["John", "Jane"],
+            "last_name": ["Smith", "Doe"],
+            "zip": ["10001", "20002"],
+        })
+        mk = MatchkeyConfig(
+            name="k", type="exact", fields=[MatchkeyField(field="zip")],
+            negative_evidence=[NegativeEvidenceField(
+                field="__gm_person_fullname__", scorer="token_sort",
+                threshold=0.65, penalty=0.5, derive_from=["first_name", "last_name"],
+            )],
+        )
+        out = precompute_matchkey_transforms(df, [mk])
+        assert "__gm_person_fullname__" in out.columns
+        assert out["__gm_person_fullname__"].to_list() == ["John Smith", "Jane Doe"]
+
+    def test_missing_source_is_safe_noop(self):
+        # last_name absent -> derived column skipped, no raise
+        df = pl.DataFrame({"first_name": ["John"], "zip": ["1"]})
+        mk = MatchkeyConfig(
+            name="k", type="exact", fields=[MatchkeyField(field="zip")],
+            negative_evidence=[NegativeEvidenceField(
+                field="__gm_person_fullname__", scorer="token_sort",
+                threshold=0.65, penalty=0.5, derive_from=["first_name", "last_name"],
+            )],
+        )
+        out = precompute_matchkey_transforms(df, [mk])
+        assert "__gm_person_fullname__" not in out.columns
+
+
+class TestFacilityPromotion:
+    def _weighted_mk(self):
+        return MatchkeyConfig(
+            name="fuzzy_match", type="weighted", threshold=0.8,
+            fields=[MatchkeyField(field="address1", scorer="jaro_winkler", weight=1.0),
+                    MatchkeyField(field="first_name", scorer="jaro_winkler", weight=1.0)],
+        )
+
+    def test_promoted_when_flag_on_and_facility_mode(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FACILITY_NAME_NE", "1")
+        from goldenmatch.core.autoconfig import _promote_facility_fullname_ne
+        mks = [self._weighted_mk()]
+        skipped = [("phone", "group-attribute: shared facility value, not identity")]
+        basket = [("first_name", True), ("last_name", True)]
+        _promote_facility_fullname_ne(mks, skipped, basket)
+        ne = mks[0].negative_evidence or []
+        assert any(n.field == "__gm_person_fullname__" and n.scorer == "token_sort"
+                   and n.derive_from == ["first_name", "last_name"] for n in ne)
+
+    def test_not_promoted_when_flag_off(self, monkeypatch):
+        monkeypatch.delenv("GOLDENMATCH_FACILITY_NAME_NE", raising=False)
+        from goldenmatch.core.autoconfig import _promote_facility_fullname_ne
+        mks = [self._weighted_mk()]
+        skipped = [("phone", "group-attribute: shared facility value, not identity")]
+        _promote_facility_fullname_ne(mks, skipped, [("first_name", True), ("last_name", True)])
+        assert not (mks[0].negative_evidence or [])
+
+    def test_not_promoted_without_facility_mode(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FACILITY_NAME_NE", "1")
+        from goldenmatch.core.autoconfig import _promote_facility_fullname_ne
+        mks = [self._weighted_mk()]
+        skipped = [("email", "cardinality_ratio 0.2 < 0.50")]  # not a facility reason
+        _promote_facility_fullname_ne(mks, skipped, [("first_name", True), ("last_name", True)])
+        assert not (mks[0].negative_evidence or [])


### PR DESCRIPTION
## What

An opt-in lever (`GOLDENMATCH_FACILITY_NAME_NE=1`) that stops **company/location-mode** data from fusing distinct colleagues who share a facility's phone/address.

When auto-config demotes a workplace attribute (phone/address/company) because its shared-value records **don't co-agree on the person name** (`should_demote_attribute_field` — the existing facility detector), the *weighted* matchkey still carries address+company (deliberately — load-bearing for corruption-heavy recall like Febrl3). So two different doctors at one clinic can still merge. This adds the **person full name** as `token_sort` negative evidence, penalising a merge when the whole name is clearly different.

## Why full name (not given name)

`jaro_winkler` on a given name can't separate colleagues from nicknames: `jw(mark,laura)=0.63` overlaps `jw(robert,bob)=0.50`. `token_sort` on the concatenated name separates cleanly:

| | colleagues | nickname dup | truncation dup | typo dup |
|---|---|---|---|---|
| full-name token_sort | 0.48–0.60 | 0.76 | 0.71 | 0.92 |

Threshold 0.65 penalises only clearly-different names; every duplicate flavour (incl. Febrl3-style typos) stays above.

## How

- **`NegativeEvidenceField.derive_from`** — a synthesized full-name column (`first`+`last`) materialized in `precompute_matchkey_transforms`, so a single-field `token_sort` NE can score the whole name. Missing sources → safe no-op.
- **Facility promotion** in `build_matchkeys`, gated by facility-mode detection **and** the opt-in flag.
- Both scorer backends (`find_fuzzy_matches`, `bucket`) already apply single-field NE with `token_sort`.

## Verification

- **Labeled DERM facility benchmark:** precision **0.936→1.000**, F1 **0.967→0.990**, facility over-merge **11/52 → 0/52**. (3 truncated-surname FN — `MARY M.` vs `MARY MCDANIEL` — a rare edge; net F1 still up.)
- **Febrl3:** **unchanged** (P/R/F1 0.999/0.983/0.991 with flag on OR off) — it never triggers facility mode, so the NE is never promoted. This is the safety property: the lever only touches company/location data.
- **Default OFF is byte-identical.** New unit tests (`test_facility_fullname_ne.py`, 8) + touched suites green (test_autoconfig / test_scorer / test_matchkey / NE suites: 246 passed).

Depends conceptually on #1624 (zip classification) for the cleanest DERM baseline, but is functionally independent. Flag documented in `tuning.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s
