### PR TITLE
fix(ci): set ARROW_DEFAULT_MEMORY_POOL=system on goldengraph-pipeline

### DIFF
--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -28,6 +28,15 @@ jobs:
   pipeline:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # goldenmatch's ER pipeline (score_buckets / dedupe) allocates through pyarrow's
+    # bundled mimalloc on the polars / ThreadPoolExecutor worker threads it spawns;
+    # mimalloc's per-thread heap init SIGSEGVs (exit 139, core dumped) on this runner --
+    # the same crash the `rust` lane hit, whose #1627 fix note anticipated other
+    # pyarrow-invoking lanes needing it too (see packages/rust/extensions/CLAUDE.md).
+    # Force pyarrow onto the system memory pool (the documented Arrow remedy) for every
+    # gate that runs goldenmatch's pipeline.
+    env:
+      ARROW_DEFAULT_MEMORY_POOL: system
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable


### PR DESCRIPTION
## What and why

The standalone `goldengraph-pipeline` workflow is **red on `main`** (first failed on #1504's merge commit `e13c417f`). The "ER-quality ablation gate" step passes its pytest (4/4) but the `run_ablation` **script SIGSEGVs — exit 139, core dumped** — mid-`score_buckets`:

```
[score_buckets] t=0.08s: starting bucket_score with max_workers=4 path=find_fuzzy_matches
.../sh: line 3: 3336 Segmentation fault (core dumped) python -m erkgbench.qa_e2e.run_ablation ...
##[error]Process completed with exit code 139.
```

**Same root cause as the `rust` lane fix (#1627):** goldenmatch's ER pipeline (`score_buckets` / dedupe) allocates through **pyarrow's bundled mimalloc** on the polars / `ThreadPoolExecutor` worker threads it spawns, and mimalloc's per-thread heap init faults on this runner. #1627's own note (in `packages/rust/extensions/CLAUDE.md`) explicitly anticipated other pyarrow-invoking lanes needing the same remedy — this is that lane. Not caused by any code in #1504; it just runs goldenmatch's pipeline, which #1504's path filter re-triggered.

## Changes

- `.github/workflows/goldengraph-pipeline.yml`: set `ARROW_DEFAULT_MEMORY_POOL: system` (the documented Arrow knob) at the **job level**, so every capability gate that runs goldenmatch's pipeline (ablation / aggregation / temporal / scorecard / router / unified / tier / crossover) is covered — not just the one that crashed first.

## Testing

- CI-only change; no code touched.
- The workflow is `push`-triggered so it can't self-validate on the PR — I dispatched a `workflow_dispatch` run of it on this branch to confirm the fix greens the pipeline before merge.
- Remedy is the same one #1627 verified 20/20 clean with (vs 20/20 SIGSEGV without) on the identical crash.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a — CI env change)
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — CI-only)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (rationale inline; mirrors the documented #1627 remedy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x)_