### PR TITLE
feat(goldencheck): Polars-eviction Stage-2 S2.2 -- native regex kernel + PyColumn hard ops (encoding/format/pattern polars-free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2932,6 +2932,11 @@ jobs:
             uv.lock
             **/pyproject.toml
       - run: uv sync --all-packages
+      - name: Build goldencheck native (regex kernel, so hard-op checks run covered not skipped)
+        # No --offline: same idiom as the goldencheck_native lane. Mirrors goldenflow_nopolars'
+        # build-before-uninstall ordering. If this ever fails, the nopolars tests still pass --
+        # test_hard_checks_run_without_polars self-skips when native isn't enabled.
+        run: uv run python scripts/build_goldencheck_native.py
       - name: Uninstall polars (simulate the P4 base-deps flip)
         run: uv pip uninstall polars polars-runtime-32 polars-runtime-64 || true
       - name: Confirm polars is gone

--- a/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.2-native-hardops.md
+++ b/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.2-native-hardops.md
@@ -1,0 +1,578 @@
+# GoldenCheck Stage-2 S2.2 (native regex kernel + pure-Python value_counts + PyColumn.dtype) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `encoding_detection`, `format_detection`, and `pattern_consistency` run polars-free byte-identically via `scan_columns` — by adding a native Rust `regex` kernel (same engine as Polars), a pure-Python `value_counts_desc` with a shared deterministic total order, and a `PyColumn.dtype` that matches Polars' inference.
+
+**Architecture:** Three regex ops (`str_match_count`/`str_filter`/`str_replace_all`) get pyo3-free kernels in `goldencheck-core` (the `regex` crate — Polars uses the same crate, so byte-identical), wrapped by thin `#[pyfunction]` shims in `goldencheck-native`, gated through the existing `_native_loader` as a new `regex` component. `value_counts_desc` becomes pure Python (Counter + a shared null-safe `(count DESC, nulls-last, value ASC)` key applied to BOTH backends, de-flaking pattern_consistency). `PyColumn` gains `dtype` (str-gate-sufficient inference, byte-identical to `_neutral_dtype(pl.DataFrame(d)[c].dtype)`) + the 4 hard ops (regex ops native-guarded). `scan_columns` appends the 3 hard profilers when `native_enabled("regex")`, else skips-with-a-log.
+
+**Tech Stack:** Rust (`regex` crate, pyo3 abi3, `goldencheck-core`/`goldencheck-native`), Python 3.11+, pytest, maturin/cargo.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md` (read the PLANNING AMENDMENT at top — temporal + str_to_date are S2.3, NOT this plan).
+
+---
+
+## PRE-FLIGHT (before Task 1 — the branch must be on main-with-S2.1)
+
+S2.2 EXTENDS S2.1's `PyColumn`/`PyFrame`/`scan_columns` (`core/frame.py`, `engine/scanner.py`). The branch currently carries only the spec + this plan, off pre-S2.1 `origin/main`. Rebase onto main-with-S2.1 first:
+```bash
+cd /d/show_case/gc-s22
+git fetch origin main -q
+# Confirm S2.1 (#1630) landed — PyColumn + scan_columns must be on main:
+git show origin/main:packages/python/goldencheck/goldencheck/core/frame.py | grep -q "class PyColumn" \
+  && echo "S2.1 present on main" || echo "S2.1 NOT on main yet -- WAIT, do not proceed"
+git rebase origin/main
+```
+If S2.1 is NOT yet on main, STOP and wait — Tasks 3-6 edit files S2.1 created (`PyColumn`, `scan_columns`); a pre-S2.1 base cannot apply them.
+
+## Conventions (this plan runs in the `gc-s22` worktree)
+
+Branch `feat/goldencheck-stage2-s2.2-native-hardops`, worktree `D:\show_case\gc-s22`.
+
+**Python test preamble** (run test commands from `/d/show_case/gc-s22`):
+```bash
+export PYTHONPATH="D:/show_case/gc-s22/packages/python/goldencheck"
+export POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8
+PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe
+$PY -c "import goldencheck; print(goldencheck.__file__)"   # MUST be under gc-s22
+```
+Ruff (100-char): `$PY -m ruff check <paths>`.
+
+**Native build** (Task 2 onward — the parity tests need `goldencheck._native` importable in THIS worktree):
+```bash
+cd /d/show_case/gc-s22
+$PY scripts/build_goldencheck_native.py       # cargo build --release + drop the artifact
+# The script targets lib_native.so/.dylib. On WINDOWS cargo emits _native.dll and the
+# script may not place it — if `import goldencheck._native` still fails after the script,
+# copy the artifact manually:
+cp packages/rust/extensions/goldencheck-native/target/release/_native.dll \
+   packages/python/goldencheck/goldencheck/_native.pyd
+$PY -c "import goldencheck._native as n; print(n.__version__, [s for s in dir(n) if not s.startswith('_')])"
+```
+Verify each new symbol appears in that `dir()` list before relying on it. If the native build cannot be made to work locally on Windows, mark the affected Task's native-dependent test steps as CI-verified (the CI parity lane with `GOLDENCHECK_NATIVE=1` builds on Linux) and say so explicitly in the task report — do NOT claim a native path is verified when it was not built.
+
+**Rust build/lint discipline** (see @reference_rust_fmt_box_and_nonrequired_gate, @feedback_verify_rust_builds_explicitly): after Rust edits, `cargo build --release` from the crate dir and grep the output for `^error`; run `rustfmt` on the touched `.rs` files BY NAME (not `cargo fmt` — avoids whole-crate churn); `cargo clippy -p goldencheck-core` for the pyo3-free crate.
+
+**INVARIANTS:**
+- Byte-identical: each hard profiler produces IDENTICAL `Finding`s via the native-backed `PyColumn` path vs the `PolarsFrame` path (the parity gate). `Finding` is a plain `@dataclass` — compare with `==`.
+- Existing tests pass UNEDITED (regression gate): `encoding_detection`, `format_detection`, `pattern_consistency` test files + `tests/core/test_native_parity.py` + the S2.1 tests. If `value_counts_desc`'s new order changes a `pattern_consistency` assertion, that test relied on nondeterministic tie-order → investigate, do NOT loosen.
+- `import goldencheck` loads ZERO polars (the S2.1 import gate stays green). `scan_dataframe` (Polars path) unchanged except `value_counts_desc`'s deterministic secondary sort (guarded by the unedited-tests check).
+- Commit per task; do NOT push.
+
+**Seam facts (S1.1 backend, verified):** `PyColumn` implements only the 7 mechanical ops + NO dtype. `PolarsColumn.str_match_count` = `int(s.str.contains(pattern).sum())`; `.str_filter` = `s.filter(mask if matching else ~mask)`, `mask=s.str.contains(pattern)`; `.str_replace_all` = `s.str.replace_all(pattern, value)`; `.value_counts_desc` = `s.value_counts().sort("count", descending=True)` then `zip(vc[name].to_list(), vc["count"].to_list())`; `.dtype` = `_neutral_dtype(s.dtype)`. `_neutral_dtype` maps `pl.Utf8/String→"str"`, `Int*→"int"`, `UInt*→"uint"`, `Float*→"float"`, `Date→"date"`, `Datetime→"datetime"`, `Boolean→"bool"`, else `"other"`.
+
+**Loader facts:** `native_module()` returns the `_native` module or None; `native_enabled(component)` returns True iff not disabled AND all `_COMPONENT_SYMBOLS[component]` symbols are present. Add a `"regex"` entry to `_COMPONENT_SYMBOLS`. Env `GOLDENCHECK_NATIVE`: `0`=off, `1`=require, `auto`/unset=use-if-present.
+
+---
+
+## Task 1: `PyColumn.dtype` (str-gate-sufficient, byte-identical to Polars inference)
+
+The 3 hard profilers early-return on `col.dtype != "str"`. `PyColumn` has no `dtype`. This is FIRST because every later parity test depends on it.
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py` (add `dtype` property to `PyColumn`)
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Write the failing dtype-parity test** (append to `tests/core/test_frame.py`):
+```python
+def test_pycolumn_dtype_matches_polars_inference():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    datasets = [
+        {"s": ["a", "b", None, "c"]},         # str + null   -> "str"
+        {"s": ["a", "b", "c"]},               # str          -> "str"
+        {"i": [1, 2, None, 3]},               # int + null   -> "int"
+        {"f": [1.0, 2.5, 3.0]},               # float        -> "float"
+        {"b": [True, False, True]},           # bool         -> "bool"
+        {"n": [None, None]},                  # all-null      -> "other" (pl.Null)
+    ]
+    for d in datasets:
+        col = next(iter(d))
+        pol = PolarsFrame(pl.DataFrame(d)).column(col).dtype
+        pyf = PyFrame.from_columns(d).column(col).dtype
+        assert pyf == pol, (d, pyf, pol)
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PyColumn' object has no attribute 'dtype'`):
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k dtype_matches_polars -v
+```
+
+- [ ] **Step 3: Add the `dtype` property to `PyColumn`** in `core/frame.py` (place after `to_list`). Bool MUST be checked before int (`isinstance(True, int)` is True in Python):
+```python
+@property
+def dtype(self) -> str:
+    non_null = [v for v in self._v if v is not None]
+    if not non_null:
+        return "other"                      # Polars infers pl.Null -> _neutral_dtype -> "other"
+    first = non_null[0]
+    if isinstance(first, bool):
+        return "bool"
+    if isinstance(first, int):
+        return "int"
+    if isinstance(first, float):
+        return "float"
+    if isinstance(first, str):
+        return "str"
+    return "other"
+```
+Scope note (YAGNI): this classifies by the first non-null value — sufficient because `scan_columns` columns are homogeneous (like `pl.DataFrame(dict)`). Do NOT build a full type-inference engine; the parity test above is the contract on the covered corpus.
+
+- [ ] **Step 4: Run → PASS** + S1.1 import gate green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean on `core/frame.py` + `tests/core/test_frame.py`.
+
+- [ ] **Step 5: Commit.**
+```bash
+cd /d/show_case/gc-s22
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): S2.2 PyColumn.dtype -- str-gate inference byte-identical to Polars"
+```
+
+---
+
+## Task 2: native `regex` kernel (goldencheck-core pyo3-free + goldencheck-native shim + loader)
+
+**Files:**
+- Create: `packages/rust/extensions/goldencheck-core/src/regex.rs`
+- Modify: `packages/rust/extensions/goldencheck-core/src/lib.rs` (mod + re-export)
+- Modify: `packages/rust/extensions/goldencheck-core/Cargo.toml` (add `regex`)
+- Create: `packages/rust/extensions/goldencheck-native/src/regex.rs`
+- Modify: `packages/rust/extensions/goldencheck-native/src/lib.rs` (mod + register 3 fns)
+- Modify: `packages/python/goldencheck/goldencheck/core/_native_loader.py` (`_COMPONENT_SYMBOLS["regex"]`)
+- Test: `packages/rust/extensions/goldencheck-core/src/regex.rs` (inline `#[cfg(test)]`)
+
+- [ ] **Step 1: `goldencheck-core/Cargo.toml`** — add to `[dependencies]`:
+```toml
+# Same engine Polars uses for str.contains/replace_all, so regex ops are
+# byte-identical. Already resolved transitively (1.12.x) in the native lock.
+regex = "1"
+```
+
+- [ ] **Step 2: Write `goldencheck-core/src/regex.rs`** (pyo3-free; null = `None`, nulls never match, pass through on replace):
+```rust
+//! Pyo3-free regex kernels mirroring Polars' `str.contains` / `str.replace_all`
+//! (both back onto the `regex` crate, so these are byte-identical). Nulls (`None`)
+//! never match and pass through unchanged on replace.
+use regex::Regex;
+
+/// Count of non-null values matching `pattern` (mirrors `s.str.contains(p).sum()`).
+pub fn str_contains_count(values: &[Option<String>], pattern: &str) -> Result<usize, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values.iter().filter(|v| v.as_deref().is_some_and(|s| re.is_match(s))).count())
+}
+
+/// Three-valued match mask: `None` for a null element, else `Some(is_match)`.
+/// The Python seam excludes `None` unconditionally (Polars' `filter` drops null-mask rows).
+pub fn str_filter_mask(values: &[Option<String>], pattern: &str) -> Result<Vec<Option<bool>>, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values.iter().map(|v| v.as_deref().map(|s| re.is_match(s))).collect())
+}
+
+/// Element-wise `regex::replace_all` (mirrors `s.str.replace_all`); nulls pass through.
+pub fn str_replace_all(values: &[Option<String>], pattern: &str, replacement: &str) -> Result<Vec<Option<String>>, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values.iter().map(|v| v.as_deref().map(|s| re.replace_all(s, replacement).into_owned())).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn v(xs: &[Option<&str>]) -> Vec<Option<String>> { xs.iter().map(|x| x.map(String::from)).collect() }
+
+    #[test]
+    fn counts_non_null_matches() {
+        let data = v(&[Some("aXb"), Some("cd"), None, Some("X")]);
+        assert_eq!(str_contains_count(&data, "X").unwrap(), 2);
+    }
+    #[test]
+    fn mask_is_three_valued() {
+        let data = v(&[Some("X"), Some("y"), None]);
+        assert_eq!(str_filter_mask(&data, "X").unwrap(), vec![Some(true), Some(false), None]);
+    }
+    #[test]
+    fn replace_passes_nulls_through() {
+        let data = v(&[Some("a1b2"), None]);
+        assert_eq!(str_replace_all(&data, r"\d", "D").unwrap(), v(&[Some("aDbD"), None]));
+    }
+    #[test]
+    fn unicode_letter_class_matches_polars_semantics() {
+        // \p{L} is the class Polars uses; ASCII letters -> L, digits untouched.
+        let data = v(&[Some("Ab12")]);
+        assert_eq!(str_replace_all(&data, r"\p{L}", "L").unwrap(), v(&[Some("LL12")]));
+    }
+}
+```
+
+- [ ] **Step 3: `goldencheck-core/src/lib.rs`** — add `mod regex;` and `pub use regex::{str_contains_count, str_filter_mask, str_replace_all};` (mirror the existing `mod`/`pub use` block).
+
+- [ ] **Step 4: Build + test the core crate:**
+```bash
+cd /d/show_case/gc-s22/packages/rust/extensions/goldencheck-core
+cargo test --release 2>&1 | tee /tmp/gc_core_test.log; grep -E "^error|test result:" /tmp/gc_core_test.log
+```
+Expected: the 4 new tests pass, `test result: ok`. Then `rustfmt src/regex.rs` and `cargo clippy` (grep `^error`/`^warning: `).
+
+- [ ] **Step 5: Write `goldencheck-native/src/regex.rs`** (thin pyo3 shim; `Vec<Option<String>>` auto-converts from a Python `list[str|None]`):
+```rust
+//! PyO3 shims over `goldencheck_core::regex`. Input arrives as a Python
+//! `list[str | None]` (auto -> `Vec<Option<String>>`); a bad pattern -> ValueError.
+use goldencheck_core::{str_contains_count, str_filter_mask, str_replace_all};
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn str_contains_count(values: Vec<Option<String>>, pattern: &str) -> PyResult<usize> {
+    goldencheck_core::str_contains_count(&values, pattern).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+#[pyfunction]
+pub fn str_filter_mask(values: Vec<Option<String>>, pattern: &str) -> PyResult<Vec<Option<bool>>> {
+    goldencheck_core::str_filter_mask(&values, pattern).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+#[pyfunction]
+pub fn str_replace_all(values: Vec<Option<String>>, pattern: &str, replacement: &str) -> PyResult<Vec<Option<String>>> {
+    goldencheck_core::str_replace_all(&values, pattern, replacement).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+```
+(If Rust name-collision between the `use goldencheck_core::str_contains_count` import and the local `#[pyfunction] str_contains_count` is a problem, drop the `use` and fully-qualify as shown in the bodies. Prefer fully-qualified calls — remove the `use goldencheck_core::{...}` line.)
+
+- [ ] **Step 6: `goldencheck-native/src/lib.rs`** — add `mod regex;` (with the other `mod` lines) and inside `#[pymodule] fn _native`, register:
+```rust
+m.add_function(wrap_pyfunction!(regex::str_contains_count, m)?)?;
+m.add_function(wrap_pyfunction!(regex::str_filter_mask, m)?)?;
+m.add_function(wrap_pyfunction!(regex::str_replace_all, m)?)?;
+```
+
+- [ ] **Step 7: `_native_loader.py`** — add to `_COMPONENT_SYMBOLS`:
+```python
+    "regex": ("str_contains_count", "str_filter_mask", "str_replace_all"),
+```
+
+- [ ] **Step 8: Build the native ext + verify symbols:**
+```bash
+cd /d/show_case/gc-s22 && $PY scripts/build_goldencheck_native.py    # + Windows .dll->.pyd copy if needed (see preamble)
+$PY -c "import goldencheck._native as n; assert all(hasattr(n,s) for s in ('str_contains_count','str_filter_mask','str_replace_all')), dir(n); print('regex symbols present')"
+$PY -c "from goldencheck.core._native_loader import native_enabled; import os; os.environ['GOLDENCHECK_NATIVE']='auto'; print('regex enabled:', native_enabled('regex'))"
+```
+Expected: symbols present; `regex enabled: True`. (If the local Windows build fails, report it — this task's Python-facing verification then happens in the CI parity lane. Do not fake it.)
+
+- [ ] **Step 9: Commit.**
+```bash
+cd /d/show_case/gc-s22
+git add packages/rust/extensions/goldencheck-core packages/rust/extensions/goldencheck-native packages/python/goldencheck/goldencheck/core/_native_loader.py
+git commit -m "feat(goldencheck-native): S2.2 regex kernel (str_contains_count/filter_mask/replace_all) + loader gate"
+```
+
+---
+
+## Task 3: `PyColumn` hard ops (regex native-guarded) + `value_counts_desc` (pure-Python, both backends)
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/core/frame.py` (PyColumn ops, `_VC_KEY`, rewrite `PolarsColumn.value_counts_desc`, `NativeRequiredError`)
+- Test: `packages/python/goldencheck/tests/core/test_frame.py`
+
+- [ ] **Step 1: Write failing backend tests** (append to `tests/core/test_frame.py`). These need native built (Task 2):
+```python
+def test_pycolumn_regex_ops_match_polars():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    d = {"s": ["aX1", "bY2", None, "Z", "cc"]}
+    pol = PolarsFrame(pl.DataFrame(d)).column("s")
+    pyf = PyFrame.from_columns(d).column("s")
+    assert pyf.str_match_count(r"\d") == pol.str_match_count(r"\d")
+    assert pyf.str_filter(r"\d", matching=True).to_list() == pol.str_filter(r"\d", matching=True).to_list()
+    # matching=False MUST drop nulls (three-valued filter) -- the parity trap
+    assert pyf.str_filter(r"\d", matching=False).to_list() == pol.str_filter(r"\d", matching=False).to_list()
+    assert pyf.str_replace_all(r"\p{L}", "L").to_list() == pol.str_replace_all(r"\p{L}", "L").to_list()
+
+def test_value_counts_desc_deterministic_and_backend_identical():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    d = {"s": ["b", "a", "b", "a", "c", "b"]}   # counts b=3,a=2,c=1
+    pol = PolarsFrame(pl.DataFrame(d)).column("s").value_counts_desc()
+    pyf = PyFrame.from_columns(d).column("s").value_counts_desc()
+    assert pyf == pol
+    # tie case: a & b both 2 -> (count DESC, value ASC) => a before b, on BOTH backends
+    d2 = {"s": ["b", "a", "b", "a"]}
+    assert PolarsFrame(pl.DataFrame(d2)).column("s").value_counts_desc() == [("a", 2), ("b", 2)]
+    assert PyFrame.from_columns(d2).column("s").value_counts_desc() == [("a", 2), ("b", 2)]
+```
+
+- [ ] **Step 2: Run → FAIL** (`AttributeError: 'PyColumn' object has no attribute 'str_match_count'`):
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py -k "regex_ops_match or value_counts_desc_deterministic" -v
+```
+
+- [ ] **Step 3: Implement in `core/frame.py`.** Add at module level (near `_CAST_KIND`):
+```python
+class NativeRequiredError(RuntimeError):
+    """A covered hard op needs the native regex kernel. Install it with
+    `pip install goldencheck[native]` (or build it in-tree)."""
+
+
+def _VC_KEY(kv: tuple[Any, int]) -> tuple[int, bool, Any]:
+    value, count = kv
+    return (-count, value is None, value if value is not None else "")   # count DESC, nulls-last, value ASC
+```
+Add these methods to `PyColumn` (after `dtype`; needs `from collections import Counter` at top and `from goldencheck.core._native_loader import native_enabled, native_module`):
+```python
+def _regex_kernel():
+    if not native_enabled("regex"):
+        raise NativeRequiredError(
+            "goldencheck native regex kernel unavailable; the encoding/format/"
+            "pattern_consistency checks need `pip install goldencheck[native]`."
+        )
+    return native_module()
+
+# --- on PyColumn ---
+def str_match_count(self, pattern: str) -> int:
+    return _regex_kernel().str_contains_count(self._v, pattern)
+
+def str_filter(self, pattern: str, *, matching: bool) -> PyColumn:
+    mask = _regex_kernel().str_filter_mask(self._v, pattern)   # list[bool | None]
+    return PyColumn([v for v, m in zip(self._v, mask) if m is not None and m == matching])
+
+def str_replace_all(self, pattern: str, value: str) -> PyColumn:
+    return PyColumn(_regex_kernel().str_replace_all(self._v, pattern, value))
+
+def value_counts_desc(self) -> list[tuple[Any, int]]:
+    return sorted(Counter(self._v).items(), key=_VC_KEY)
+```
+(`_regex_kernel` is a module-level helper, not a method — define it at module scope.) Then **rewrite `PolarsColumn.value_counts_desc`** to use the SAME key:
+```python
+def value_counts_desc(self) -> list[tuple[Any, int]]:
+    vc = self._s.value_counts()
+    pairs = zip(vc[self._s.name].to_list(), vc["count"].to_list())   # (value, count)
+    return sorted(pairs, key=_VC_KEY)
+```
+
+- [ ] **Step 4: Run → PASS** + import gate + existing value_counts consumer tests green:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+$PY -m pytest packages/python/goldencheck/tests -k "pattern_consistency" -v   # value_counts consumer, must stay green UNEDITED
+```
+If a `pattern_consistency` test changed, a tie was reordered — investigate, don't loosen. Ruff clean.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/core/frame.py packages/python/goldencheck/tests/core/test_frame.py
+git commit -m "feat(goldencheck): S2.2 PyColumn regex ops (native-guarded) + deterministic value_counts_desc on both backends"
+```
+
+---
+
+## Task 4: expand `scan_columns` to the 3 hard profilers (native-gated)
+
+**Files:**
+- Modify: `packages/python/goldencheck/goldencheck/engine/scanner.py`
+- Test: `packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py` (new)
+
+- [ ] **Step 1: Write the byte-parity test** `tests/engine/test_scan_columns_hardops_parity.py` (needs native built):
+```python
+"""S2.2 byte-identity gate: encoding/format/pattern profilers produce identical Findings
+on the native-backed PyFrame vs PolarsFrame (polars present). Proves scan_columns' hard-op
+coverage == the Polars path, so the nopolars-lane assertions are trustworthy."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck import scan_columns
+from goldencheck.core.frame import PolarsFrame, PyFrame
+from goldencheck.core._native_loader import native_enabled
+from goldencheck.profilers.encoding_detection import EncodingDetectionProfiler
+from goldencheck.profilers.format_detection import FormatDetectionProfiler
+from goldencheck.profilers.pattern_consistency import PatternConsistencyProfiler
+
+pytestmark = pytest.mark.skipif(not native_enabled("regex"), reason="needs native regex kernel")
+
+def _datasets():
+    return [
+        {"email": [f"u{i}@x.com" for i in range(18)] + ["notanemail", "also bad"]},   # format: email + non-match
+        {"note": ["cafe", "café", "naïve", "plain", "x​zero"]},        # encoding: non-ascii + zero-width
+        {"code": ["AB-12", "CD-34", "EF-56", "X"]},                                    # pattern: skeleton LL-DD vs L
+        {"nums": [1, 2, 3]},                                                            # non-str -> all 3 early-return, no findings
+        {"phone": ["(555) 123-4567"] * 15 + ["555.111.2222"] * 3 + ["bad", None]},     # format phone + null (matching=False path)
+    ]
+
+@pytest.mark.parametrize("data", _datasets())
+def test_hard_profilers_backend_parity(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    pyf = PyFrame.from_columns(data)
+    for profiler in (EncodingDetectionProfiler(), FormatDetectionProfiler(), PatternConsistencyProfiler()):
+        for col in data:
+            assert profiler.profile(pol, col) == profiler.profile(pyf, col), (type(profiler).__name__, col)
+
+@pytest.mark.parametrize("data", _datasets())
+def test_scan_columns_includes_hard_checks(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    from goldencheck.engine.scanner import _MECHANICAL_PROFILERS, _HARD_PROFILERS
+    expected = []
+    for name in data:
+        for profiler in (*_MECHANICAL_PROFILERS, *_HARD_PROFILERS):
+            expected.extend(profiler.profile(pol, name))
+    assert scan_columns(data) == expected
+```
+
+- [ ] **Step 2: Run → FAIL** (`ImportError: cannot import name '_HARD_PROFILERS'`):
+```bash
+$PY -m pytest packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py -v
+```
+
+- [ ] **Step 3: Edit `scanner.py`.** Import the 3 profiler classes if not already imported (they are — used by `COLUMN_PROFILERS`), import `native_enabled` from `goldencheck.core._native_loader`, and replace the S2.1 `_COVERED_COLUMN_PROFILERS` block + `scan_columns` with:
+```python
+_MECHANICAL_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+_HARD_PROFILERS = [EncodingDetectionProfiler(), FormatDetectionProfiler(), PatternConsistencyProfiler()]
+
+
+def scan_columns(columns: dict[str, list]) -> list[Finding]:
+    """Polars-free reduced scan of the covered column checks over in-memory columns.
+    The mechanical checks (nullability/uniqueness/cardinality) always run; the regex
+    checks (encoding/format/pattern_consistency) run when the native regex kernel is
+    available (`pip install goldencheck[native]`) and are skipped-with-a-log otherwise.
+    Date/relational checks still need Polars -- use scan_dataframe for a full scan."""
+    frame = PyFrame.from_columns(columns)
+    profilers = list(_MECHANICAL_PROFILERS)
+    if native_enabled("regex"):
+        profilers += _HARD_PROFILERS
+    else:
+        logger.info(
+            "scan_columns: native regex kernel unavailable; skipping encoding/format/"
+            "pattern_consistency checks. Install with `pip install goldencheck[native]`."
+        )
+    findings: list[Finding] = []
+    for name in columns:
+        for profiler in profilers:
+            findings.extend(profiler.profile(frame, name))
+    return findings
+```
+Keep `scan_columns` in `__all__`. (The S2.1 name `_COVERED_COLUMN_PROFILERS` is removed; grep the package for other references first — there should be none outside scanner.py + its S2.1 parity test. If the S2.1 parity test `tests/engine/test_scan_columns_parity.py` imports `_COVERED_COLUMN_PROFILERS`, update that import to `_MECHANICAL_PROFILERS` — that is a test-infra rename, not a behavior change; the S2.1 assertions themselves stay.)
+
+- [ ] **Step 4: Run → PASS** (new parity test + S2.1 parity test + import gate):
+```bash
+$PY -m pytest packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py packages/python/goldencheck/tests/engine/test_scan_columns_parity.py packages/python/goldencheck/tests/test_import_no_polars.py -v
+```
+Ruff clean on scanner.py + the new test.
+
+- [ ] **Step 5: Commit.**
+```bash
+git add packages/python/goldencheck/goldencheck/engine/scanner.py packages/python/goldencheck/tests/engine/
+git commit -m "feat(goldencheck): S2.2 scan_columns runs encoding/format/pattern checks polars-free (native-gated)"
+```
+
+---
+
+## Task 5: nopolars-lane covered-scan + import-blocker (native present, polars absent)
+
+**Files:**
+- Modify: `packages/python/goldencheck/tests/nopolars/test_polars_absent.py`
+- Modify: `packages/python/goldencheck/tests/test_import_no_polars.py`
+
+- [ ] **Step 1: Add a hard-op covered-scan test** to `tests/nopolars/test_polars_absent.py` (append; the module is skipif'd when polars is present, so it runs only in the `goldencheck_nopolars` lane). Confirm `import sys` is at module top (S2.0 added it). Guard on native being present (the lane must have native built to exercise the hard checks):
+```python
+def test_hard_checks_run_without_polars() -> None:
+    import pytest
+    from goldencheck.core._native_loader import native_enabled
+    if not native_enabled("regex"):
+        pytest.skip("nopolars lane without native regex kernel; hard checks skip by design")
+    from goldencheck import scan_columns
+
+    findings = scan_columns({"email": [f"u{i}@x.com" for i in range(18)] + ["bad", "worse"]})
+    checks = {f.check for f in findings}
+    assert "format_detection" in checks       # regex ran polars-free
+    assert "polars" not in sys.modules
+```
+
+- [ ] **Step 2: Extend the import-blocker** in `tests/test_import_no_polars.py` — prove `scan_columns` runs the hard checks with polars unimportable + native present (REQUIRED suite). It must SKIP cleanly if native isn't importable in the subprocess:
+```python
+def test_scan_columns_hard_checks_with_polars_unimportable():
+    import importlib.util
+    if importlib.util.find_spec("goldencheck._native") is None and importlib.util.find_spec("goldencheck_native") is None:
+        import pytest
+        pytest.skip("native kernel not built; hard-op polars-free path is CI-parity-lane verified")
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "import os; os.environ['GOLDENCHECK_NATIVE']='auto'\n"
+        "from goldencheck import scan_columns\n"
+        "fs = scan_columns({'email': [f'u{i}@x.com' for i in range(18)] + ['bad','worse']})\n"
+        "checks = {f.check for f in fs}\n"
+        "assert 'format_detection' in checks, checks\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg_dir = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = pkg_dir + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+```
+
+- [ ] **Step 3: Run affected tests:**
+```bash
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py packages/python/goldencheck/tests/nopolars -v
+```
+Expected: import-gate tests pass (the new blocker test passes if native built, else skips cleanly); nopolars-module tests SKIP locally (polars present). Report which path (passed vs skipped) the native-dependent tests took.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add packages/python/goldencheck/tests/nopolars/test_polars_absent.py packages/python/goldencheck/tests/test_import_no_polars.py
+git commit -m "test(goldencheck): S2.2 covered-scan proof -- hard checks run polars-free with native (lane + blocker)"
+```
+
+---
+
+## Task 6: advisory CI lane builds native + final verification
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (the `goldencheck_nopolars` advisory job — build native so the hard-op checks actually run there)
+
+- [ ] **Step 1: Inspect the S2.0 `goldencheck_nopolars` job.** Read `.github/workflows/ci.yml`, find the `goldencheck_nopolars` job (added in S2.0 #1618). It uninstalls polars. For S2.2 its covered scan should also exercise the hard checks, which needs native built. Add a build step BEFORE the pytest step (mirror the pattern any existing native-parity lane uses to build `goldencheck._native`):
+```yaml
+      - name: Build goldencheck native (regex kernel)
+        run: uv run python scripts/build_goldencheck_native.py
+```
+Keep it advisory (`continue-on-error` / not in `ci-required`, exactly as S2.0 left it). If the job already builds native or a simpler wiring exists, match it — do NOT restructure the job. If building native in this lane proves heavy/flaky, leave the lane as-is (mechanical-only) and instead rely on the separate native-parity lane (`GOLDENCHECK_NATIVE=1`) for the hard-op parity — note the decision in the commit message. (Workflow-file edits force all CI jobs to re-run per repo CLAUDE.md — expected.)
+
+- [ ] **Step 2: Validate the workflow YAML parses** (a broken ci.yml = 0 jobs, per @feedback_ci_yaml_startup_failure):
+```bash
+$PY -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('ci.yml parses')"
+```
+
+- [ ] **Step 3: Final whole-batch verification.**
+```bash
+cd /d/show_case/gc-s22 && <python preamble> && <native build if not already>
+$PY -m pytest packages/python/goldencheck/tests/test_import_no_polars.py -v                    # import gate + blockers
+$PY -m pytest packages/python/goldencheck/tests/core/test_frame.py \
+              packages/python/goldencheck/tests/engine/test_scan_columns_parity.py \
+              packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py -v  # backend + parity
+$PY -m pytest packages/python/goldencheck/tests -k "encoding_detection or format_detection or pattern_consistency" -v  # existing profiler tests UNEDITED
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+cd packages/rust/extensions/goldencheck-core && cargo test --release 2>&1 | grep -E "^error|test result:"
+```
+Report exact pass/skip counts + confirm the existing profiler tests are green with ZERO edits. Do NOT run the full goldencheck suite locally (OOM risk per @feedback_avoid_full_suite_oom) — it runs in CI.
+
+- [ ] **Step 4: Commit.**
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci(goldencheck): S2.2 build native in the nopolars advisory lane so hard-op checks run"
+```
+
+---
+
+## Done criteria (S2.2 complete)
+- [ ] Native `regex` kernel (`str_contains_count`/`str_filter_mask`/`str_replace_all`) in `goldencheck-core` + `goldencheck-native` shim + `_COMPONENT_SYMBOLS["regex"]`; `native_enabled("regex")` True when built.
+- [ ] `PyColumn` has `dtype` (byte-identical to Polars inference on the covered corpus) + `str_match_count`/`str_filter` (three-valued mask)/`str_replace_all` (native-guarded, raise `NativeRequiredError` when absent) + pure-Python `value_counts_desc`.
+- [ ] `value_counts_desc` deterministic `(count DESC, nulls-last, value ASC)` on BOTH backends; existing `pattern_consistency` tests pass UNEDITED.
+- [ ] `scan_columns` runs encoding/format/pattern polars-free when native present, skips-with-log otherwise; byte-parity vs Polars proven per profiler across all finding branches (incl. the null + `matching=False` filter trap).
+- [ ] nopolars lane + import-blocker prove the hard checks run polars-free with native; both skip cleanly when native isn't built.
+- [ ] Existing suite green; `scan_dataframe` unchanged; `import goldencheck` loads zero Polars; Rust builds clean (`cargo test`/`clippy` no `^error`).
+- [ ] Scope: NO str_to_date, NO date-typed ops, NO temporal wiring (all S2.3). NO full type-inference engine.

--- a/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.2-native-hardops.md
+++ b/docs/superpowers/plans/2026-07-10-goldencheck-stage2-s2.2-native-hardops.md
@@ -55,7 +55,7 @@ Verify each new symbol appears in that `dir()` list before relying on it. If the
 
 **INVARIANTS:**
 - Byte-identical: each hard profiler produces IDENTICAL `Finding`s via the native-backed `PyColumn` path vs the `PolarsFrame` path (the parity gate). `Finding` is a plain `@dataclass` — compare with `==`.
-- Existing tests pass UNEDITED (regression gate): `encoding_detection`, `format_detection`, `pattern_consistency` test files + `tests/core/test_native_parity.py` + the S2.1 tests. If `value_counts_desc`'s new order changes a `pattern_consistency` assertion, that test relied on nondeterministic tie-order → investigate, do NOT loosen.
+- Existing PROFILER-BEHAVIOR tests pass UNEDITED (regression gate): `encoding_detection`, `format_detection`, `pattern_consistency` test files + `tests/core/test_native_parity.py`. If `value_counts_desc`'s new order changes a `pattern_consistency` assertion, that test relied on nondeterministic tie-order → investigate, do NOT loosen. (EXCEPTION — one deliberate test-infra edit: the S2.1 `test_scan_columns_parity.py::test_scan_columns_matches_polars_covered_output` MUST be updated to mirror `scan_columns`' new native gate — see Task 4 Step 3. That is not a behavior regression; it tracks `scan_columns`' expanded contract.)
 - `import goldencheck` loads ZERO polars (the S2.1 import gate stays green). `scan_dataframe` (Polars path) unchanged except `value_counts_desc`'s deterministic secondary sort (guarded by the unedited-tests check).
 - Commit per task; do NOT push.
 
@@ -219,7 +219,8 @@ Expected: the 4 new tests pass, `test result: ok`. Then `rustfmt src/regex.rs` a
 ```rust
 //! PyO3 shims over `goldencheck_core::regex`. Input arrives as a Python
 //! `list[str | None]` (auto -> `Vec<Option<String>>`); a bad pattern -> ValueError.
-use goldencheck_core::{str_contains_count, str_filter_mask, str_replace_all};
+//! NOTE: do NOT `use goldencheck_core::str_contains_count` etc. -- the shim fns
+//! share those names; the bodies call them fully-qualified to avoid an E0255 clash.
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 
@@ -238,7 +239,7 @@ pub fn str_replace_all(values: Vec<Option<String>>, pattern: &str, replacement: 
     goldencheck_core::str_replace_all(&values, pattern, replacement).map_err(|e| PyValueError::new_err(e.to_string()))
 }
 ```
-(If Rust name-collision between the `use goldencheck_core::str_contains_count` import and the local `#[pyfunction] str_contains_count` is a problem, drop the `use` and fully-qualify as shown in the bodies. Prefer fully-qualified calls — remove the `use goldencheck_core::{...}` line.)
+(The snippet above compiles as-is — the `#[pyfunction]` names are fully-qualified at the call site, no `use` of the core fns.)
 
 - [ ] **Step 6: `goldencheck-native/src/lib.rs`** — add `mod regex;` (with the other `mod` lines) and inside `#[pymodule] fn _native`, register:
 ```rust
@@ -275,8 +276,12 @@ git commit -m "feat(goldencheck-native): S2.2 regex kernel (str_contains_count/f
 - Modify: `packages/python/goldencheck/goldencheck/core/frame.py` (PyColumn ops, `_VC_KEY`, rewrite `PolarsColumn.value_counts_desc`, `NativeRequiredError`)
 - Test: `packages/python/goldencheck/tests/core/test_frame.py`
 
-- [ ] **Step 1: Write failing backend tests** (append to `tests/core/test_frame.py`). These need native built (Task 2):
+- [ ] **Step 1: Write failing backend tests** (append to `tests/core/test_frame.py`). The regex-ops test needs native built (Task 2), so it SKIPS cleanly when native is absent (a failed Windows build must not turn it red); the `value_counts_desc` test is pure-Python and needs no guard:
 ```python
+import pytest
+from goldencheck.core._native_loader import native_enabled
+
+@pytest.mark.skipif(not native_enabled("regex"), reason="needs native regex kernel")
 def test_pycolumn_regex_ops_match_polars():
     import polars as pl
     from goldencheck.core.frame import PolarsFrame, PyFrame
@@ -449,7 +454,23 @@ def scan_columns(columns: dict[str, list]) -> list[Finding]:
             findings.extend(profiler.profile(frame, name))
     return findings
 ```
-Keep `scan_columns` in `__all__`. (The S2.1 name `_COVERED_COLUMN_PROFILERS` is removed; grep the package for other references first — there should be none outside scanner.py + its S2.1 parity test. If the S2.1 parity test `tests/engine/test_scan_columns_parity.py` imports `_COVERED_COLUMN_PROFILERS`, update that import to `_MECHANICAL_PROFILERS` — that is a test-infra rename, not a behavior change; the S2.1 assertions themselves stay.)
+Keep `scan_columns` in `__all__`. The S2.1 name `_COVERED_COLUMN_PROFILERS` is removed; grep the package for references first (`grep -rn _COVERED_COLUMN_PROFILERS packages/python/goldencheck`) — there should be none outside scanner.py + the S2.1 parity test.
+
+**REQUIRED S2.1-test update (not just a rename — a real gate-mirror):** `tests/engine/test_scan_columns_parity.py::test_scan_columns_matches_polars_covered_output` builds `expected` from the covered profilers then asserts `scan_columns(data) == expected`. Since `scan_columns` now ALSO runs `_HARD_PROFILERS` when `native_enabled("regex")`, and the S2.1 datasets (the `email`/`phone` columns) DO trigger `pattern_consistency`, that assertion will FAIL when native is present unless `expected` mirrors the same gate. Update that test's `expected` loop to:
+```python
+from goldencheck.core._native_loader import native_enabled
+from goldencheck.engine.scanner import _MECHANICAL_PROFILERS, _HARD_PROFILERS
+# ...
+    covered = list(_MECHANICAL_PROFILERS)
+    if native_enabled("regex"):
+        covered += _HARD_PROFILERS
+    expected = []
+    for name in data:
+        for profiler in covered:
+            expected.extend(profiler.profile(pol, name))
+    assert scan_columns(data) == expected
+```
+The other S2.1 test (`test_covered_profilers_backend_parity`) instantiates the 3 mechanical profilers by name and does NOT call `scan_columns`, so it is unaffected — leave it. This test-infra update is necessitated by `scan_columns`' expanded contract; it is NOT a byte-identity regression (see the INVARIANTS nuance).
 
 - [ ] **Step 4: Run → PASS** (new parity test + S2.1 parity test + import gate):
 ```bash

--- a/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
@@ -5,6 +5,14 @@ Status: design — approved in brainstorming, pending spec review
 Base: fresh `origin/main` **after S2.1 #1630 merges** (the code tasks EXTEND S2.1's `PyColumn`/`PyFrame`/`scan_columns`, so the code branch must be rebased onto main-with-S2.1; this spec doc is a new file and carries no conflict).
 Parent program: goldencheck Polars eviction — Stage-2 (see `2026-07-10-goldencheck-stage2-s2.0-nopolars-lane-design.md` for the S2.0–S2.2/reader/P4 roadmap, and `...s2.1-pycolumn-backend-design.md` for the covered-subset backend this extends)
 
+## PLANNING AMENDMENT (2026-07-10) — S2.2 scope narrowed; temporal + str_to_date → S2.3
+
+Reading `relations/temporal.py` while writing the plan showed that wiring `temporal` polars-free needs far more than the `str_to_date` kernel: it calls `gt_mask`/`fill_null`/`sum`/`filter_by`/`cast("str")` on **date-typed** columns and requires the parsed result to report `dtype == "date"` (temporal.py:135). That is a whole date-typed backend surface, and `str_to_date` serves ONLY temporal. User confirmed the carve.
+
+**S2.2 (this spec, as executed) = regex kernel (3 ops) + pure-Python `value_counts_desc` + `PyColumn.dtype` + wire `encoding_detection` + `format_detection` + `pattern_consistency` into `scan_columns`.** These 3 profilers are clean — verified they use only `dtype` (str-gate), `drop_nulls`/`len`/`to_list`, the 3 regex ops, and `value_counts_desc`.
+
+**Deferred to S2.3:** the `str_to_date` chrono kernel, the date-typed `PyColumn` surface (`gt_mask`/`fill_null`/`sum`/`filter_by`/`cast`/`dtype=="date"`), and wiring `temporal`. Sections below that mention `date.rs`/`str_to_date`/`temporal` describe the S2.3 follow-up, not S2.2 — the **plan** (`2026-07-10-goldencheck-stage2-s2.2-native-hardops.md`) is the authoritative S2.2 task list. Native symbol naming follows the existing unprefixed convention (`str_contains_count`/`str_filter_mask`/`str_replace_all`), not the `gc_`-prefixed sketch below.
+
 ## Context
 
 S2.1 shipped the first covered non-Polars backend: a pure-Python `PyColumn`/`PyFrame` implementing the 7 *mechanical* dtype-free ops, so `nullability`/`uniqueness`/`cardinality` run polars-free byte-identically via a public `scan_columns(dict)`. S2.2 extends the covered subset to the **4 hard-op profilers** — `encoding_detection`, `format_detection`, `pattern_consistency`, `temporal` — by providing the ops they need without Polars. Pure-Python `re`/`strptime` **cannot** be byte-identical to Polars for the regex/date ops (different engines; the documented `\p{Nd}`-vs-`isdigit` gap), so the byte-identity mechanism is a **native Rust kernel that uses the SAME engine as Polars** (the `regex` crate; `chrono`). This is the goldenflow "covered-subset + byte-identical-or-decline" philosophy, one tier deeper.

--- a/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
@@ -1,0 +1,156 @@
+# GoldenCheck Polars eviction — Stage-2 S2.2 (native Rust kernels for the hard column-profiler ops)
+
+Date: 2026-07-10
+Status: design — approved in brainstorming, pending spec review
+Base: fresh `origin/main` **after S2.1 #1630 merges** (the code tasks EXTEND S2.1's `PyColumn`/`PyFrame`/`scan_columns`, so the code branch must be rebased onto main-with-S2.1; this spec doc is a new file and carries no conflict).
+Parent program: goldencheck Polars eviction — Stage-2 (see `2026-07-10-goldencheck-stage2-s2.0-nopolars-lane-design.md` for the S2.0–S2.2/reader/P4 roadmap, and `...s2.1-pycolumn-backend-design.md` for the covered-subset backend this extends)
+
+## Context
+
+S2.1 shipped the first covered non-Polars backend: a pure-Python `PyColumn`/`PyFrame` implementing the 7 *mechanical* dtype-free ops, so `nullability`/`uniqueness`/`cardinality` run polars-free byte-identically via a public `scan_columns(dict)`. S2.2 extends the covered subset to the **4 hard-op profilers** — `encoding_detection`, `format_detection`, `pattern_consistency`, `temporal` — by providing the ops they need without Polars. Pure-Python `re`/`strptime` **cannot** be byte-identical to Polars for the regex/date ops (different engines; the documented `\p{Nd}`-vs-`isdigit` gap), so the byte-identity mechanism is a **native Rust kernel that uses the SAME engine as Polars** (the `regex` crate; `chrono`). This is the goldenflow "covered-subset + byte-identical-or-decline" philosophy, one tier deeper.
+
+**Correction to prior program notes:** goldenflow-native has NO regex/date/value_counts kernels (only a phone kernel; it explicitly excludes dates). S2.2 is therefore the FIRST regex/date kernel in the Golden Suite — designed fresh, not ported from a goldenflow precedent.
+
+## The five hard ops (verified from source on the S2.1 branch)
+
+| Seam op | Profiler(s) | Polars call it replaces | S2.2 mechanism |
+|---|---|---|---|
+| `str_match_count(pattern)` | encoding_detection, format_detection | `int(s.str.contains(pattern).sum())` | **native regex kernel** |
+| `str_filter(pattern, *, matching)` | encoding_detection, format_detection | `s.filter(s.str.contains(pattern) [~])` | **native regex kernel** |
+| `str_replace_all(pattern, value)` | pattern_consistency | `s.str.replace_all(pattern, value)` | **native regex kernel** |
+| `str_to_date(fmt, *, strict)` | temporal | `s.str.to_date(format=fmt, strict=strict)` (always `fmt="%Y-%m-%d"`, `strict=False`) | **native chrono kernel** |
+| `value_counts_desc()` | pattern_consistency | `s.value_counts().sort("count", descending=True)` then zip | **pure Python (NO kernel)** — see below |
+
+### Why `value_counts_desc` needs NO Rust kernel (the tie-order hazard dissolved)
+
+Counting is engine-agnostic and exact — `collections.Counter(values)` produces the SAME counts as Polars `value_counts()`. The only "hard" part was the ORDER of equal-count entries, which Polars leaves implementation-defined (undocumented tie-break). `pattern_consistency` consumes this order load-bearingly: `pattern_counts[0]` is treated as the dominant pattern, and there is a top-5 minority cutoff — so at an exact skeleton-count tie, which pattern is "dominant" (and the emitted `Finding` fields) depends on tie-order.
+
+**Resolution:** define a deterministic **total order `(count DESC, value ASC)`** and apply it in `value_counts_desc` on BOTH backends (`PolarsColumn` and `PyColumn`). This makes the two byte-identical *by construction* and removes the latent nondeterminism `pattern_consistency` has today. Strictly an improvement; the existing `pattern_consistency` tests (run unedited) are the safety check.
+
+## Scope
+
+### In scope
+1. **Native crate:** new `goldencheck-core` kernel modules `regex.rs` (str_match_count / str_filter / str_replace_all) + `date.rs` (str_to_date), exposed as new `_native` pyfunctions in the `goldencheck-native` shim `lib.rs`. Add `regex` + `chrono` as DIRECT Cargo deps (both already resolve transitively in the lock).
+2. **Loader:** new `_COMPONENT_SYMBOLS` entries in `core/_native_loader.py` (`regex`, `str_to_date`) each probing their kernel symbol(s), gated by the existing `GOLDENCHECK_NATIVE` env (`0`/`1`/`auto`).
+3. **Backend:** extend `PyColumn` (S2.1) with the 5 hard ops:
+   - regex + date ops delegate to `_native` when the component is enabled; raise `NativeRequiredError` (a clear, typed error) when not — pure-Python `re`/`strptime` is DELIBERATELY not a fallback (would silently diverge).
+   - `value_counts_desc()` is pure Python on `PyColumn` (Counter + the `(count DESC, value ASC)` total order).
+   - `PolarsColumn.value_counts_desc()` gains the same secondary sort so the two match.
+   - `str_filter`/`str_replace_all`/`str_to_date` return a `PyColumn` (chainable, matching the Polars-backend return contract).
+4. **Coverage:** expand `scan_columns` — the 3 mechanical profilers run ALWAYS; the 4 hard-op profilers are appended to the covered scan **iff** their required kernels are enabled (`native_enabled(...)`), and skipped-with-a-`logger` line otherwise. Honest coverage matrix (below).
+5. **Parity tests:** per hard-op profiler, assert byte-identical `Finding`s from the native-backed `PyColumn` path vs the `PolarsFrame` path across data hitting each finding branch (the byte-identity gate). Plus a `value_counts_desc` backend-parity test. Existing profiler tests (incl. `pattern_consistency`'s and the 3 `_generalize_series` parity-locked tests) pass UNEDITED.
+6. **nopolars lane / import-blocker:** with polars unimportable + native present, the hard-op profilers run and produce findings (`"polars" not in sys.modules`).
+
+### Explicitly NOT in scope
+Wiring `PyFrame` into the main `scan_dataframe` (its Polars path is UNCHANGED); the other hard seam ops unused by these 4 profilers (`min`/`max`/`mean`/`std`/`diff`/`cast`/`dtype`/etc. — those serve already-ported relation profilers via the Polars accelerator and are out of the covered-column scan); a `dtype` op on `PyColumn` (pattern_consistency/temporal read `col.dtype` — see Open Question D); the non-Polars reader; the P4 deps-flip; any perf claim (kernels are for byte-identical polars-free COVERAGE, not speed).
+
+### Success criteria
+- The 4 hard-op profilers produce **byte-identical** Findings on the native-backed `PyColumn` path vs `PolarsFrame` (the parity gate), across data exercising every finding branch.
+- With polars genuinely absent + native present, the 4 hard-op profilers run via `scan_columns` and load zero Polars.
+- `value_counts_desc` is deterministic and identical on both backends; existing `pattern_consistency` tests pass unedited.
+- The existing full suite is green; `import goldencheck` still loads zero Polars; `scan_dataframe` (the Polars path) is byte-identical (unchanged).
+
+## Coverage matrix (the honest statement)
+
+| Environment | Mechanical 3 (nullability/uniqueness/cardinality) | Hard 4 (encoding/format/pattern/temporal) |
+|---|---|---|
+| polars present (normal) | run (Polars or PyColumn — both byte-identical) | run via Polars (unchanged) |
+| polars ABSENT + native present | run via PyColumn | **run via native-backed PyColumn (S2.2)** |
+| polars ABSENT + native ABSENT | run via PyColumn | **skipped-with-log** (native is required for byte-identity) |
+
+`scan_columns` never silently under-reports: when it skips the hard 4 (native absent), it emits a `logger.info` naming the skipped checks (mirrors the S2.0 "no silent caps" discipline).
+
+## Native crate design (`goldencheck-core` + `goldencheck-native`)
+
+Current `goldencheck-native` symbol surface (from `lib.rs`): `benford_leading_digits`, `composite_key_search`, `functional_dependency_holds`, `discover_functional_dependencies`, `discover_approximate_fds`, `fd_violation_rows`, `near_duplicate_value_clusters`. Deps: `pyo3`, `arrow` only.
+
+New kernels (take a Python `list[str | None]`; pyo3 handles list↔Vec):
+- `gc_str_contains_count(values, pattern) -> int` — count of non-null values matching `regex::Regex::new(pattern)` (mirrors `s.str.contains(pattern).sum()`; nulls do not match).
+- `gc_str_filter_mask(values, pattern) -> list[bool]` — per-element match mask (the seam builds the filtered `PyColumn` from the mask, keeping `matching`/`~matching` logic in Python and preserving null handling exactly like `s.filter`). *(Returning a mask, not the filtered list, keeps the Rust surface minimal and lets the seam handle the `matching` flag + null semantics.)*
+- `gc_str_replace_all(values, pattern, replacement) -> list[str | None]` — element-wise `Regex::replace_all` (nulls pass through as null; mirrors `s.str.replace_all`).
+- `gc_str_to_date(values, fmt) -> list[str | None]` — `chrono::NaiveDate::parse_from_str(v, fmt)`; parse failure → null (matches `strict=False`); success → ISO `%Y-%m-%d` string (the seam wraps into a date-typed `PyColumn`; temporal only needs ordering/non-null on the result — see Open Question D). Nulls pass through.
+
+Registration: add the 4 `m.add_function(...)` lines to `lib.rs`. Cargo: add `regex = "1"` (pin the minor to match Polars 1.40.1's bundled major where feasible — see Risks) and `chrono = { version = "0.4", default-features = false, features = ["std"] }`.
+
+**Regex flag parity:** the seam passes the raw pattern string straight through to `regex::Regex::new` with NO extra flags — Polars' `s.str.contains`/`replace_all` default to the same (Unicode-on, case-sensitive, no inline-flag injection). Any pattern the profilers use (`\p{L}`, `\d`, format/encoding character classes) compiles under the same syntax on both sides.
+
+## Backend design (`core/frame.py`)
+
+`PyColumn` gains (all guarded/typed):
+```python
+def str_match_count(self, pattern: str) -> int:
+    return _regex_kernel().gc_str_contains_count(self._v, pattern)  # raises NativeRequiredError if disabled
+
+def str_filter(self, pattern: str, *, matching: bool) -> PyColumn:
+    mask = _regex_kernel().gc_str_filter_mask(self._v, pattern)
+    return PyColumn([v for v, m in zip(self._v, mask) if m == matching])
+
+def str_replace_all(self, pattern: str, value: str) -> PyColumn:
+    return PyColumn(_regex_kernel().gc_str_replace_all(self._v, pattern, value))
+
+def str_to_date(self, fmt: str, *, strict: bool) -> PyColumn:
+    return PyColumn(_date_kernel().gc_str_to_date(self._v, fmt))   # strict handled below
+
+def value_counts_desc(self) -> list[tuple[Any, int]]:
+    counts = Counter(self._v)                       # engine-agnostic exact counts
+    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))   # (count DESC, value ASC)
+```
+- `_regex_kernel()`/`_date_kernel()` consult the loader (`native_enabled("regex")` / `"str_to_date"`); if disabled, raise `NativeRequiredError` with a message pointing at `pip install goldencheck[native]`.
+- `str_filter`'s `matching`/`~matching` + null handling stay in Python (mask-driven), exactly reproducing `s.filter(mask if matching else ~mask)` — nulls in `s` produce null in the contains-mask → excluded by both `matching` and `~matching`, matching Polars.
+- `str_to_date`'s `strict=False` is the only mode used; the kernel maps parse-failure to null (strict=True is unused — assert-or-`NotImplementedError` if ever passed True, YAGNI).
+- `PolarsColumn.value_counts_desc()` becomes: `vc = s.value_counts(); ... ; sorted(pairs, key=lambda kv: (-kv[1], kv[0]))` (same total order) so the two backends match by construction.
+
+`NativeRequiredError` is a new typed exception in `core/frame.py` (or `core/_native_loader.py`).
+
+## `scan_columns` coverage expansion (`engine/scanner.py`)
+
+```python
+_MECHANICAL_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+_HARD_PROFILERS = [EncodingDetectionProfiler(), FormatDetectionProfiler(),
+                   PatternConsistencyProfiler(), TemporalOrderProfiler()]  # names TBC at plan time
+
+def scan_columns(columns: dict[str, list]) -> list[Finding]:
+    frame = PyFrame.from_columns(columns)
+    profilers = list(_MECHANICAL_PROFILERS)
+    if native_enabled("regex") and native_enabled("str_to_date"):
+        profilers += _HARD_PROFILERS
+    else:
+        logger.info("scan_columns: native kernels unavailable; skipping hard-op checks "
+                    "(encoding/format/pattern_consistency/temporal). pip install goldencheck[native].")
+    findings = []
+    for name in columns:
+        for profiler in profilers:
+            findings.extend(profiler.profile(frame, name))
+    return findings
+```
+- Column-vs-relation shape: the mechanical + encoding/format/pattern profilers are `profile(frame, column, *, context=None)`; `temporal` is a `profile(frame)` relation profiler (Open Question C — how/whether it slots into the per-column loop, or runs once over the frame). Resolve at plan time.
+- Gating on BOTH `regex` and `str_to_date` is coarse; a finer split (run encoding/format/pattern when `regex` present even if `str_to_date` absent) is a plan-time refinement if cheap; default to the simple all-or-nothing hard-4 gate.
+
+## Testing
+
+### Byte-parity gate (polars PRESENT + native PRESENT)
+`tests/engine/test_scan_columns_hardops_parity.py` (new). For representative data per profiler, assert `profiler.profile(PolarsFrame(pl.DataFrame(d)), col) == profiler.profile(PyFrame.from_columns(d), col)` — identical Findings. Cover each finding branch (each encoding/format check; pattern_consistency dominant + minority + WARNING/<5% + top-5 cutoff; temporal ordered/unordered/unparseable). Plus a `value_counts_desc` backend-parity test incl. a tie case (proves deterministic identical order). `Finding` is a plain `@dataclass` → compare with `==`.
+
+### Existing tests unedited (the regression gate)
+`pattern_consistency`, `encoding_detection`, `format_detection`, `temporal` existing test files + the 3 `_generalize_series` parity tests pass with ZERO edits. If `value_counts_desc`'s new total order changes a `pattern_consistency` assertion, that test was relying on nondeterministic tie-order → investigate (do NOT loosen).
+
+### nopolars lane + import-blocker (native PRESENT)
+Extend `tests/nopolars/test_polars_absent.py` (skipif-when-polars-present) with a hard-op covered scan asserting the 4 checks fire polars-free (guarded by native availability). Extend `tests/test_import_no_polars.py` with a subprocess proving `scan_columns` runs the hard-op checks with polars UNIMPORTABLE + native present + `"polars" not in sys.modules`. (Whether the advisory `goldencheck_nopolars` CI lane also builds/installs native is a plan-time wiring decision — the required-suite import-blocker + the parity gate already prove correctness locally.)
+
+## Byte-identity anchors / risks
+
+- **regex-crate version drift** — Polars 1.40.1's bundled `regex` vs our pinned `regex` may differ on newly-assigned Unicode codepoints for `\p{L}`/`\d`. Pin `regex` to a version compatible with Polars' major; the parity corpus catches drift on tested characters. Low risk for realistic column data; the profilers already document a `\p{Nd}` corner that "doesn't appear in production column data."
+- **chrono vs Polars date parsing** — Polars `.str.to_date` is chrono under the hood; using chrono in the kernel guarantees the same engine. The kernel must use the SAME `fmt` (`%Y-%m-%d`) and the same failure→null semantics (`strict=False`). Verify: a corpus of valid, malformed (bad month/day, non-padded, trailing chars, empty) strings parses identically on both.
+- **value_counts total order touches `PolarsColumn`** — the safety check is that existing `pattern_consistency` tests pass unedited; if one ties, handle at plan time.
+- **`_generalize_series` untouched** — its 3 parity tests call raw Polars (not the seam), so they stay green; S2.2 does not modify it. The profiler hot path uses the seam `str_replace_all`, which the native kernel matches.
+- **`scan_dataframe` unchanged** — S2.2 touches only `scan_columns` + the backend + the native crate; the Polars scan path is untouched (the only behavioral change on the Polars side is `value_counts_desc`'s deterministic secondary sort, gated by the unedited-tests check).
+- **Native build for tests** — the parity gate needs `goldencheck._native` built in-tree (loader discover order). Plan documents the build step; CI parity runs where native is buildable.
+
+## Open questions (resolve at plan time)
+- **A. `str_filter` return shape** — mask-from-kernel + Python filter (chosen) vs kernel-returns-filtered-list. Mask keeps the Rust surface minimal and null/`matching` semantics in Python; confirm it exactly reproduces `s.filter`.
+- **B. `regex` pin** — exact version to match Polars 1.40.1's bundled major (inspect Polars' lock / the transitively-resolved `regex 1.12.3`).
+- **C. `temporal` in `scan_columns`** — it's a `profile(frame)` relation profiler, not per-column; how it slots into the covered scan (run once vs per-column) — or whether temporal is covered via a separate call. Possibly narrow S2.2's `scan_columns` expansion to the 3 per-column hard profilers (encoding/format/pattern) and cover temporal's `str_to_date` only at the backend+parity level, deferring its scan wiring.
+- **D. `col.dtype` on `PyColumn`** — pattern_consistency and temporal early-return on `col.dtype != "str"` / dtype checks. `PyColumn` has no `dtype` (S2.1 excluded it). Either add a minimal inferred `dtype` to `PyColumn` (all-str/all-None → "str"; else best-effort) sufficient for these profilers' gates, or have `scan_columns` infer per-column dtype. Must stay byte-identical to how the profilers branch on Polars dtype. This is the subtlest wiring point — resolve carefully at plan time; it may warrant its own task.
+
+## Non-goals (YAGNI)
+`strict=True` date parsing; regex flags beyond Polars' defaults; kernels for hard ops unused by these 4 profilers; `scan_dataframe` wiring; a NaN-aware anything; perf tuning; the reader; the deps-flip.

--- a/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldencheck-stage2-s2.2-native-hardops-design.md
@@ -42,7 +42,7 @@ Counting is engine-agnostic and exact — `collections.Counter(values)` produces
 6. **nopolars lane / import-blocker:** with polars unimportable + native present, the hard-op profilers run and produce findings (`"polars" not in sys.modules`).
 
 ### Explicitly NOT in scope
-Wiring `PyFrame` into the main `scan_dataframe` (its Polars path is UNCHANGED); the other hard seam ops unused by these 4 profilers (`min`/`max`/`mean`/`std`/`diff`/`cast`/`dtype`/etc. — those serve already-ported relation profilers via the Polars accelerator and are out of the covered-column scan); a `dtype` op on `PyColumn` (pattern_consistency/temporal read `col.dtype` — see Open Question D); the non-Polars reader; the P4 deps-flip; any perf claim (kernels are for byte-identical polars-free COVERAGE, not speed).
+Wiring `PyFrame` into the main `scan_dataframe` (its Polars path is UNCHANGED); the other hard seam ops unused by these 4 profilers (`min`/`max`/`mean`/`std`/`diff`/`cast`/etc. — those serve already-ported relation profilers via the Polars accelerator and are out of the covered-column scan); a FULL type-inference engine on `PyColumn` (only the minimal covered-corpus dtype the profilers gate on is in scope — see the required `PyColumn.dtype` section); the non-Polars reader; the P4 deps-flip; any perf claim (kernels are for byte-identical polars-free COVERAGE, not speed).
 
 ### Success criteria
 - The 4 hard-op profilers produce **byte-identical** Findings on the native-backed `PyColumn` path vs `PolarsFrame` (the parity gate), across data exercising every finding branch.
@@ -66,7 +66,7 @@ Current `goldencheck-native` symbol surface (from `lib.rs`): `benford_leading_di
 
 New kernels (take a Python `list[str | None]`; pyo3 handles list↔Vec):
 - `gc_str_contains_count(values, pattern) -> int` — count of non-null values matching `regex::Regex::new(pattern)` (mirrors `s.str.contains(pattern).sum()`; nulls do not match).
-- `gc_str_filter_mask(values, pattern) -> list[bool]` — per-element match mask (the seam builds the filtered `PyColumn` from the mask, keeping `matching`/`~matching` logic in Python and preserving null handling exactly like `s.filter`). *(Returning a mask, not the filtered list, keeps the Rust surface minimal and lets the seam handle the `matching` flag + null semantics.)*
+- `gc_str_filter_mask(values, pattern) -> list[bool | None]` — per-element **three-valued** match mask: `None` for a null input element, else `True`/`False`. This is required to reproduce Polars' three-valued `filter`: `mask = s.str.contains(pattern)` is null for null elements, and BOTH `s.filter(mask)` and `s.filter(~mask)` DROP null-mask rows. The seam excludes every `None`-mask element unconditionally and keeps a non-null element iff `bool == matching` (see backend). A two-valued `list[bool]` would wrongly INCLUDE nulls in the `matching=False` branch. *(Returning a mask, not the filtered list, keeps the Rust surface minimal and lets the seam handle the `matching` flag + null semantics.)*
 - `gc_str_replace_all(values, pattern, replacement) -> list[str | None]` — element-wise `Regex::replace_all` (nulls pass through as null; mirrors `s.str.replace_all`).
 - `gc_str_to_date(values, fmt) -> list[str | None]` — `chrono::NaiveDate::parse_from_str(v, fmt)`; parse failure → null (matches `strict=False`); success → ISO `%Y-%m-%d` string (the seam wraps into a date-typed `PyColumn`; temporal only needs ordering/non-null on the result — see Open Question D). Nulls pass through.
 
@@ -82,8 +82,8 @@ def str_match_count(self, pattern: str) -> int:
     return _regex_kernel().gc_str_contains_count(self._v, pattern)  # raises NativeRequiredError if disabled
 
 def str_filter(self, pattern: str, *, matching: bool) -> PyColumn:
-    mask = _regex_kernel().gc_str_filter_mask(self._v, pattern)
-    return PyColumn([v for v, m in zip(self._v, mask) if m == matching])
+    mask = _regex_kernel().gc_str_filter_mask(self._v, pattern)   # list[bool | None]
+    return PyColumn([v for v, m in zip(self._v, mask) if m is not None and m == matching])
 
 def str_replace_all(self, pattern: str, value: str) -> PyColumn:
     return PyColumn(_regex_kernel().gc_str_replace_all(self._v, pattern, value))
@@ -93,12 +93,19 @@ def str_to_date(self, fmt: str, *, strict: bool) -> PyColumn:
 
 def value_counts_desc(self) -> list[tuple[Any, int]]:
     counts = Counter(self._v)                       # engine-agnostic exact counts
-    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))   # (count DESC, value ASC)
+    return sorted(counts.items(), key=_VC_KEY)      # deterministic null-safe total order
 ```
+where the shared, **null-safe** total-order key (used on BOTH backends) is:
+```python
+def _VC_KEY(kv):                                    # (count DESC, nulls-last, value ASC)
+    value, count = kv
+    return (-count, value is None, value if value is not None else "")
+```
+`value is None` as the SECOND key sorts the single `None` group after all non-null groups at the same count, so the third element is never a `None`-vs-`str` comparison — a plain `(-count, value)` key would raise `TypeError` on Python 3 when a `None` skeleton coexists with string skeletons. (In practice `pattern_consistency` calls `col.drop_nulls()` BEFORE `str_replace_all`, so `value_counts_desc` receives a null-free column there — but the key must be null-safe anyway so touching `PolarsColumn.value_counts_desc` stays "strictly an improvement / never a new crash" for any caller.) `value_counts_desc`'s contract: **homogeneous, mutually-comparable non-null values (or `None`)** — holds for its sole caller (skeleton strings). Values are never mixed incomparable types.
 - `_regex_kernel()`/`_date_kernel()` consult the loader (`native_enabled("regex")` / `"str_to_date"`); if disabled, raise `NativeRequiredError` with a message pointing at `pip install goldencheck[native]`.
 - `str_filter`'s `matching`/`~matching` + null handling stay in Python (mask-driven), exactly reproducing `s.filter(mask if matching else ~mask)` — nulls in `s` produce null in the contains-mask → excluded by both `matching` and `~matching`, matching Polars.
 - `str_to_date`'s `strict=False` is the only mode used; the kernel maps parse-failure to null (strict=True is unused — assert-or-`NotImplementedError` if ever passed True, YAGNI).
-- `PolarsColumn.value_counts_desc()` becomes: `vc = s.value_counts(); ... ; sorted(pairs, key=lambda kv: (-kv[1], kv[0]))` (same total order) so the two backends match by construction.
+- `PolarsColumn.value_counts_desc()` becomes: `vc = s.value_counts(); pairs = zip(...); sorted(pairs, key=_VC_KEY)` (the SAME null-safe key) so the two backends match by construction.
 
 `NativeRequiredError` is a new typed exception in `core/frame.py` (or `core/_native_loader.py`).
 
@@ -146,11 +153,17 @@ Extend `tests/nopolars/test_polars_absent.py` (skipif-when-polars-present) with 
 - **`scan_dataframe` unchanged** — S2.2 touches only `scan_columns` + the backend + the native crate; the Polars scan path is untouched (the only behavioral change on the Polars side is `value_counts_desc`'s deterministic secondary sort, gated by the unedited-tests check).
 - **Native build for tests** — the parity gate needs `goldencheck._native` built in-tree (loader discover order). Plan documents the build step; CI parity runs where native is buildable.
 
+## `PyColumn.dtype` — a REQUIRED first design point (not deferrable)
+
+`pattern_consistency` (and the encoding/format profilers' str-gating) early-return on `col.dtype != "str"`; `PyColumn` has no `dtype` (S2.1 excluded it). Without it the hard profilers `AttributeError` and the parity gate can't pass, so this is load-bearing and must be the FIRST implementation task, not a parking-lot item.
+
+Requirement: `PyColumn` gains a `dtype` property returning the SAME neutral string the profilers branch on (`"str"`/`"int"`/`"float"`/…), inferred from the Python values, and **byte-identical to how `_neutral_dtype(pl.DataFrame(d)[col].dtype)` classifies the same `dict[str,list]`**. The plan must specify the inference rule (e.g. all-`str`-or-`None` → `"str"`; all-`int`-or-`None` → `"int"`; etc.) and PROVE it matches Polars' dtype inference over `dict[str,list]` for the covered column shapes (a dedicated parity test: for each dataset, `PyFrame.column(c).dtype == PolarsFrame(pl.DataFrame(d)).column(c).dtype`). This determines which columns even receive the hard profilers, so a divergence here silently changes which Findings fire. Scope the inference to exactly what the covered profilers gate on (str vs non-str primarily) — do NOT build a full type-inference engine (YAGNI); but it MUST agree with Polars on the covered corpus.
+
 ## Open questions (resolve at plan time)
-- **A. `str_filter` return shape** — mask-from-kernel + Python filter (chosen) vs kernel-returns-filtered-list. Mask keeps the Rust surface minimal and null/`matching` semantics in Python; confirm it exactly reproduces `s.filter`.
-- **B. `regex` pin** — exact version to match Polars 1.40.1's bundled major (inspect Polars' lock / the transitively-resolved `regex 1.12.3`).
-- **C. `temporal` in `scan_columns`** — it's a `profile(frame)` relation profiler, not per-column; how it slots into the covered scan (run once vs per-column) — or whether temporal is covered via a separate call. Possibly narrow S2.2's `scan_columns` expansion to the 3 per-column hard profilers (encoding/format/pattern) and cover temporal's `str_to_date` only at the backend+parity level, deferring its scan wiring.
-- **D. `col.dtype` on `PyColumn`** — pattern_consistency and temporal early-return on `col.dtype != "str"` / dtype checks. `PyColumn` has no `dtype` (S2.1 excluded it). Either add a minimal inferred `dtype` to `PyColumn` (all-str/all-None → "str"; else best-effort) sufficient for these profilers' gates, or have `scan_columns` infer per-column dtype. Must stay byte-identical to how the profilers branch on Polars dtype. This is the subtlest wiring point — resolve carefully at plan time; it may warrant its own task.
+- **A. `str_filter` null semantics (now specified as three-valued mask)** — the plan must include an explicit parity case with nulls in a `matching=False` filter to lock the three-valued behavior (the trap the two-valued mask fell into).
+- **B. `regex` pin** — exact version to match Polars 1.40.1's bundled major (inspect Polars' lock / the transitively-resolved `regex 1.12.3`). The pin only aligns majors (the kernel compiles its OWN `regex`, separate from Polars' bundled copy) — the parity corpus is the real guard.
+- **C. `temporal` in `scan_columns`** — it's a `profile(frame)` relation profiler, not per-column; how it slots into the covered scan (run once vs per-column). **Fallback decomposition:** if the wiring proves non-trivial, narrow S2.2's `scan_columns` expansion to the 3 per-column hard profilers (encoding/format/pattern) — which are the guaranteed deliverable — and cover temporal's `str_to_date` at the backend + parity level only (native kernel + byte-parity test), deferring its scan-loop wiring to a follow-up. encoding/format/pattern must not be blocked by temporal's shape.
+- **D. `str_to_date` result representation** — the kernel returns ISO `%Y-%m-%d` strings; this is sound for temporal's use ONLY because `%Y-%m-%d` sorts lexicographically identically to chronological date order (so ordering/`is_sorted`/min/max on the strings match the date-typed column). The plan must CONFIRM `temporal` does ordering / non-null only on the parsed result — NO date arithmetic (diffs, day-deltas). If temporal does arithmetic, the kernel must return date-typed values (or day-ordinals) instead — verify before building.
 
 ## Non-goals (YAGNI)
 `strict=True` date parsing; regex flags beyond Polars' defaults; kernels for hard ops unused by these 4 profilers; `scan_dataframe` wiring; a NaN-aware anything; perf tuning; the reader; the deps-flip.

--- a/packages/python/goldencheck/goldencheck/core/_native_loader.py
+++ b/packages/python/goldencheck/goldencheck/core/_native_loader.py
@@ -109,6 +109,7 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     "fuzzy_values": ("near_duplicate_value_clusters",),
     "approximate_fd": ("discover_approximate_fds", "fd_violation_rows"),
     "denial_constraint": ("denial_constraint_evidence",),
+    "regex": ("str_contains_count", "str_filter_mask", "str_replace_all"),
 }
 
 

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -7,9 +7,11 @@ caller may pass either a raw ``pl.DataFrame`` or an already-wrapped ``Frame``.
 """
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any, Protocol, runtime_checkable
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core._native_loader import native_enabled, native_module
 
 
 @runtime_checkable
@@ -82,6 +84,25 @@ def _neutral_dtype(dt: Any) -> str:
 
 
 _CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings only; resolved via getattr in cast()
+
+
+class NativeRequiredError(RuntimeError):
+    """A covered hard op needs the native regex kernel. Install it with
+    `pip install goldencheck[native]` (or build it in-tree)."""
+
+
+def _VC_KEY(kv: tuple[Any, int]) -> tuple[int, bool, Any]:
+    value, count = kv
+    return (-count, value is None, value if value is not None else "")   # count DESC, nulls-last, value ASC
+
+
+def _regex_kernel():
+    if not native_enabled("regex"):
+        raise NativeRequiredError(
+            "goldencheck native regex kernel unavailable; the encoding/format/"
+            "pattern_consistency checks need `pip install goldencheck[native]`."
+        )
+    return native_module()
 
 
 class PolarsColumn:
@@ -172,8 +193,9 @@ class PolarsColumn:
         return PolarsColumn(self._s.str.replace_all(pattern, value))
 
     def value_counts_desc(self) -> list[tuple[Any, int]]:
-        vc = self._s.value_counts().sort("count", descending=True)
-        return list(zip(vc[self._s.name].to_list(), vc["count"].to_list()))
+        vc = self._s.value_counts()
+        pairs = zip(vc[self._s.name].to_list(), vc["count"].to_list())   # (value, count)
+        return sorted(pairs, key=_VC_KEY)
 
     def eq(self, value: Any) -> PolarsColumn:
         return PolarsColumn(self._s == value)
@@ -269,6 +291,19 @@ class PyColumn:
         if isinstance(first, str):
             return "str"
         return "other"
+
+    def str_match_count(self, pattern: str) -> int:
+        return _regex_kernel().str_contains_count(self._v, pattern)
+
+    def str_filter(self, pattern: str, *, matching: bool) -> PyColumn:
+        mask = _regex_kernel().str_filter_mask(self._v, pattern)   # list[bool | None]
+        return PyColumn([v for v, m in zip(self._v, mask) if m is not None and m == matching])
+
+    def str_replace_all(self, pattern: str, value: str) -> PyColumn:
+        return PyColumn(_regex_kernel().str_replace_all(self._v, pattern, value))
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        return sorted(Counter(self._v).items(), key=_VC_KEY)
 
 
 class PyFrame:

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -254,6 +254,22 @@ class PyColumn:
     def to_list(self) -> list:
         return list(self._v)
 
+    @property
+    def dtype(self) -> str:
+        non_null = [v for v in self._v if v is not None]
+        if not non_null:
+            return "other"                      # Polars infers pl.Null -> _neutral_dtype -> "other"
+        first = non_null[0]
+        if isinstance(first, bool):
+            return "bool"
+        if isinstance(first, int):
+            return "int"
+        if isinstance(first, float):
+            return "float"
+        if isinstance(first, str):
+            return "str"
+        return "other"
+
 
 class PyFrame:
     """Pure-Python frame wrapping a ``dict[str, list]`` — no Polars import."""

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -245,8 +245,10 @@ class PolarsFrame:
 
 
 class PyColumn:
-    """Pure-Python column wrapping a ``list`` — the 7 mechanical, dtype-free ops
-    used by the simple column profilers (nullability/cardinality/uniqueness).
+    """Pure-Python column wrapping a ``list`` — the mechanical, dtype-free ops used
+    by the simple column profilers (nullability/cardinality/uniqueness), plus the
+    native-regex-backed string ops (str_match_count/str_filter/str_replace_all) and
+    eq/filter_by used by the hard profilers (encoding/format/pattern_consistency).
     Deliberately does NOT implement the full ``Column`` Protocol.
     """
 
@@ -304,6 +306,12 @@ class PyColumn:
 
     def value_counts_desc(self) -> list[tuple[Any, int]]:
         return sorted(Counter(self._v).items(), key=_VC_KEY)
+
+    def eq(self, value: Any) -> PyColumn:
+        return PyColumn([v == value if v is not None else None for v in self._v])
+
+    def filter_by(self, mask: PyColumn) -> PyColumn:
+        return PyColumn([v for v, m in zip(self._v, mask._v) if m])
 
 
 class PyFrame:

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -10,6 +10,7 @@ from goldencheck._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile
+from goldencheck.core._native_loader import native_enabled
 from goldencheck.core.frame import PyFrame
 from goldencheck.engine.confidence import apply_corroboration_boost
 from goldencheck.engine.reader import read_file
@@ -243,17 +244,28 @@ def _post_classification_checks(
     return new_findings
 
 
-_COVERED_COLUMN_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+_MECHANICAL_PROFILERS = [NullabilityProfiler(), UniquenessProfiler(), CardinalityProfiler()]
+_HARD_PROFILERS = [EncodingDetectionProfiler(), FormatDetectionProfiler(), PatternConsistencyProfiler()]
 
 
 def scan_columns(columns: dict[str, list]) -> list[Finding]:
-    """Polars-free reduced scan of the covered STRUCTURAL checks (nullability,
-    uniqueness, cardinality) over in-memory columns. The regex/format/encoding/
-    date/value-count checks need Polars -- use scan_dataframe for a full scan."""
+    """Polars-free reduced scan of the covered column checks over in-memory columns.
+    The mechanical checks (nullability/uniqueness/cardinality) always run; the regex
+    checks (encoding/format/pattern_consistency) run when the native regex kernel is
+    available (`pip install goldencheck[native]`) and are skipped-with-a-log otherwise.
+    Date/relational checks still need Polars -- use scan_dataframe for a full scan."""
     frame = PyFrame.from_columns(columns)
+    profilers = list(_MECHANICAL_PROFILERS)
+    if native_enabled("regex"):
+        profilers += _HARD_PROFILERS
+    else:
+        logger.info(
+            "scan_columns: native regex kernel unavailable; skipping encoding/format/"
+            "pattern_consistency checks. Install with `pip install goldencheck[native]`."
+        )
     findings: list[Finding] = []
     for name in columns:
-        for profiler in _COVERED_COLUMN_PROFILERS:
+        for profiler in profilers:
             findings.extend(profiler.profile(frame, name))
     return findings
 

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -312,3 +312,21 @@ def test_to_frame_pyframe_is_polars_free():
     env["POLARS_SKIP_CPU_CHECK"] = "1"
     r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stdout + r.stderr
+
+
+def test_pycolumn_dtype_matches_polars_inference():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    datasets = [
+        {"s": ["a", "b", None, "c"]},         # str + null   -> "str"
+        {"s": ["a", "b", "c"]},               # str          -> "str"
+        {"i": [1, 2, None, 3]},               # int + null   -> "int"
+        {"f": [1.0, 2.5, 3.0]},               # float        -> "float"
+        {"b": [True, False, True]},           # bool         -> "bool"
+        {"n": [None, None]},                  # all-null      -> "other" (pl.Null)
+    ]
+    for d in datasets:
+        col = next(iter(d))
+        pol = PolarsFrame(pl.DataFrame(d)).column(col).dtype
+        pyf = PyFrame.from_columns(d).column(col).dtype
+        assert pyf == pol, (d, pyf, pol)

--- a/packages/python/goldencheck/tests/core/test_frame.py
+++ b/packages/python/goldencheck/tests/core/test_frame.py
@@ -330,3 +330,34 @@ def test_pycolumn_dtype_matches_polars_inference():
         pol = PolarsFrame(pl.DataFrame(d)).column(col).dtype
         pyf = PyFrame.from_columns(d).column(col).dtype
         assert pyf == pol, (d, pyf, pol)
+
+
+import pytest
+from goldencheck.core._native_loader import native_enabled
+
+
+@pytest.mark.skipif(not native_enabled("regex"), reason="needs native regex kernel")
+def test_pycolumn_regex_ops_match_polars():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    d = {"s": ["aX1", "bY2", None, "Z", "cc"]}
+    pol = PolarsFrame(pl.DataFrame(d)).column("s")
+    pyf = PyFrame.from_columns(d).column("s")
+    assert pyf.str_match_count(r"\d") == pol.str_match_count(r"\d")
+    assert pyf.str_filter(r"\d", matching=True).to_list() == pol.str_filter(r"\d", matching=True).to_list()
+    # matching=False MUST drop nulls (three-valued filter) -- the parity trap
+    assert pyf.str_filter(r"\d", matching=False).to_list() == pol.str_filter(r"\d", matching=False).to_list()
+    assert pyf.str_replace_all(r"\p{L}", "L").to_list() == pol.str_replace_all(r"\p{L}", "L").to_list()
+
+
+def test_value_counts_desc_deterministic_and_backend_identical():
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame, PyFrame
+    d = {"s": ["b", "a", "b", "a", "c", "b"]}   # counts b=3,a=2,c=1
+    pol = PolarsFrame(pl.DataFrame(d)).column("s").value_counts_desc()
+    pyf = PyFrame.from_columns(d).column("s").value_counts_desc()
+    assert pyf == pol
+    # tie: a & b both 2 -> (count DESC, value ASC) => a before b, on BOTH backends
+    d2 = {"s": ["b", "a", "b", "a"]}
+    assert PolarsFrame(pl.DataFrame(d2)).column("s").value_counts_desc() == [("a", 2), ("b", 2)]
+    assert PyFrame.from_columns(d2).column("s").value_counts_desc() == [("a", 2), ("b", 2)]

--- a/packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py
+++ b/packages/python/goldencheck/tests/engine/test_scan_columns_hardops_parity.py
@@ -1,0 +1,45 @@
+"""S2.2 byte-identity gate: encoding/format/pattern profilers produce identical Findings
+on the native-backed PyFrame vs PolarsFrame (polars present). Proves scan_columns' hard-op
+coverage == the Polars path, so the nopolars-lane assertions are trustworthy."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck import scan_columns
+from goldencheck.core._native_loader import native_enabled
+from goldencheck.core.frame import PolarsFrame, PyFrame
+from goldencheck.profilers.encoding_detection import EncodingDetectionProfiler
+from goldencheck.profilers.format_detection import FormatDetectionProfiler
+from goldencheck.profilers.pattern_consistency import PatternConsistencyProfiler
+
+pytestmark = pytest.mark.skipif(not native_enabled("regex"), reason="needs native regex kernel")
+
+
+def _datasets():
+    return [
+        {"email": [f"u{i}@x.com" for i in range(18)] + ["notanemail", "also bad"]},
+        {"note": ["cafe", "café", "naïve", "plain", "x​zero"]},
+        {"code": ["AB-12", "CD-34", "EF-56", "X"]},
+        {"nums": [1, 2, 3]},
+        {"phone": ["(555) 123-4567"] * 15 + ["555.111.2222"] * 3 + ["bad", None]},
+    ]
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_hard_profilers_backend_parity(data):
+    pol = PolarsFrame(pl.DataFrame(data))
+    pyf = PyFrame.from_columns(data)
+    for profiler in (EncodingDetectionProfiler(), FormatDetectionProfiler(), PatternConsistencyProfiler()):
+        for col in data:
+            assert profiler.profile(pol, col) == profiler.profile(pyf, col), (type(profiler).__name__, col)
+
+
+@pytest.mark.parametrize("data", _datasets())
+def test_scan_columns_includes_hard_checks(data):
+    from goldencheck.engine.scanner import _HARD_PROFILERS, _MECHANICAL_PROFILERS
+    pol = PolarsFrame(pl.DataFrame(data))
+    expected = []
+    for name in data:
+        for profiler in (*_MECHANICAL_PROFILERS, *_HARD_PROFILERS):
+            expected.extend(profiler.profile(pol, name))
+    assert scan_columns(data) == expected

--- a/packages/python/goldencheck/tests/engine/test_scan_columns_parity.py
+++ b/packages/python/goldencheck/tests/engine/test_scan_columns_parity.py
@@ -8,7 +8,6 @@ import polars as pl
 import pytest
 from goldencheck import scan_columns
 from goldencheck.core.frame import PolarsFrame, PyFrame
-from goldencheck.engine.scanner import _COVERED_COLUMN_PROFILERS
 from goldencheck.profilers.cardinality import CardinalityProfiler
 from goldencheck.profilers.nullability import NullabilityProfiler
 from goldencheck.profilers.uniqueness import UniquenessProfiler
@@ -44,9 +43,14 @@ def test_covered_profilers_backend_parity(data):
 
 @pytest.mark.parametrize("data", _datasets())
 def test_scan_columns_matches_polars_covered_output(data):
+    from goldencheck.core._native_loader import native_enabled
+    from goldencheck.engine.scanner import _HARD_PROFILERS, _MECHANICAL_PROFILERS
     pol = PolarsFrame(pl.DataFrame(data))
+    covered = list(_MECHANICAL_PROFILERS)
+    if native_enabled("regex"):
+        covered += _HARD_PROFILERS
     expected = []
     for name in data:
-        for profiler in _COVERED_COLUMN_PROFILERS:
+        for profiler in covered:
             expected.extend(profiler.profile(pol, name))
     assert scan_columns(data) == expected

--- a/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
@@ -60,3 +60,16 @@ def test_covered_scan_columns_without_polars() -> None:
     assert "cardinality" in checks     # grade is low-cardinality
     assert "nullability" in checks     # note is entirely null
     assert "polars" not in sys.modules
+
+
+def test_hard_checks_run_without_polars() -> None:
+    import pytest
+    from goldencheck.core._native_loader import native_enabled
+    if not native_enabled("regex"):
+        pytest.skip("nopolars lane without native regex kernel; hard checks skip by design")
+    from goldencheck import scan_columns
+
+    findings = scan_columns({"email": [f"u{i}@x.com" for i in range(18)] + ["bad", "worse"]})
+    checks = {f.check for f in findings}
+    assert "format_detection" in checks       # regex ran polars-free
+    assert "polars" not in sys.modules

--- a/packages/python/goldencheck/tests/test_import_no_polars.py
+++ b/packages/python/goldencheck/tests/test_import_no_polars.py
@@ -43,6 +43,35 @@ def test_scan_columns_runs_with_polars_unimportable():
     assert r.returncode == 0, r.stdout + r.stderr
 
 
+def test_scan_columns_hard_checks_with_polars_unimportable():
+    import importlib.util
+    if (importlib.util.find_spec("goldencheck._native") is None
+            and importlib.util.find_spec("goldencheck_native") is None):
+        import pytest
+        pytest.skip("native kernel not built; hard-op polars-free path is CI-parity-lane verified")
+    code = (
+        "import sys, importlib.abc\n"
+        "class _B(importlib.abc.MetaPathFinder):\n"
+        "    def find_spec(self, n, path=None, target=None):\n"
+        "        if n=='polars' or n.startswith('polars.'):\n"
+        "            raise ModuleNotFoundError(n)\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _B())\n"
+        "import os; os.environ['GOLDENCHECK_NATIVE']='auto'\n"
+        "from goldencheck import scan_columns\n"
+        "fs = scan_columns({'email': [f'u{i}@x.com' for i in range(18)] + ['bad','worse']})\n"
+        "checks = {f.check for f in fs}\n"
+        "assert 'format_detection' in checks, checks\n"
+        "assert 'polars' not in sys.modules\n"
+    )
+    pkg_dir = str(Path(__file__).resolve().parents[1])
+    env = dict(os.environ)
+    env["PYTHONPATH"] = pkg_dir + os.pathsep + env.get("PYTHONPATH", "")
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    r = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True, env=env)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+
 def test_goldencheck_survives_polars_unimportable():
     # Simulate the P4 base-deps flip WITHOUT uninstalling: a meta_path finder makes
     # `polars` unimportable, then `import goldencheck` must still succeed (lazy proxy

--- a/packages/rust/extensions/goldencheck-core/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-core/Cargo.toml
@@ -20,6 +20,9 @@ name = "goldencheck_core"
 # is already in the dependency graph (pulled by the goldenmatch native stack),
 # so this adds no new crates.io fetch.
 rustc-hash = "2"
+# Same engine Polars uses for str.contains/replace_all, so regex ops are
+# byte-identical. Already resolved transitively (1.12.x) in the native lock.
+regex = "1"
 
 [dev-dependencies]
 # Property/parity checks for the Benford leading-digit extraction, plus the

--- a/packages/rust/extensions/goldencheck-core/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-core/src/lib.rs
@@ -20,6 +20,7 @@ mod benford;
 mod dc;
 mod fuzzy;
 mod keys;
+mod regex;
 
 pub use benford::benford_leading_digits;
 pub use dc::{dc_pair_evidence, dc_row_evidence, Pred};
@@ -28,3 +29,4 @@ pub use keys::{
     composite_key_search, discover_approximate_fds, discover_functional_dependencies,
     fd_violation_rows, functional_dependency_holds, tuple_distinct_count,
 };
+pub use regex::{str_contains_count, str_filter_mask, str_replace_all};

--- a/packages/rust/extensions/goldencheck-core/src/regex.rs
+++ b/packages/rust/extensions/goldencheck-core/src/regex.rs
@@ -1,0 +1,80 @@
+//! Pyo3-free regex kernels mirroring Polars' `str.contains` / `str.replace_all`
+//! (both back onto the `regex` crate, so these are byte-identical). Nulls (`None`)
+//! never match and pass through unchanged on replace.
+use regex::Regex;
+
+/// Count of non-null values matching `pattern` (mirrors `s.str.contains(p).sum()`).
+pub fn str_contains_count(values: &[Option<String>], pattern: &str) -> Result<usize, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values
+        .iter()
+        .filter(|v| v.as_deref().is_some_and(|s| re.is_match(s)))
+        .count())
+}
+
+/// Three-valued match mask: `None` for a null element, else `Some(is_match)`.
+/// The Python seam excludes `None` unconditionally (Polars' `filter` drops null-mask rows).
+pub fn str_filter_mask(
+    values: &[Option<String>],
+    pattern: &str,
+) -> Result<Vec<Option<bool>>, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values
+        .iter()
+        .map(|v| v.as_deref().map(|s| re.is_match(s)))
+        .collect())
+}
+
+/// Element-wise `regex::replace_all` (mirrors `s.str.replace_all`); nulls pass through.
+pub fn str_replace_all(
+    values: &[Option<String>],
+    pattern: &str,
+    replacement: &str,
+) -> Result<Vec<Option<String>>, regex::Error> {
+    let re = Regex::new(pattern)?;
+    Ok(values
+        .iter()
+        .map(|v| {
+            v.as_deref()
+                .map(|s| re.replace_all(s, replacement).into_owned())
+        })
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn v(xs: &[Option<&str>]) -> Vec<Option<String>> {
+        xs.iter().map(|x| x.map(String::from)).collect()
+    }
+
+    #[test]
+    fn counts_non_null_matches() {
+        let data = v(&[Some("aXb"), Some("cd"), None, Some("X")]);
+        assert_eq!(str_contains_count(&data, "X").unwrap(), 2);
+    }
+    #[test]
+    fn mask_is_three_valued() {
+        let data = v(&[Some("X"), Some("y"), None]);
+        assert_eq!(
+            str_filter_mask(&data, "X").unwrap(),
+            vec![Some(true), Some(false), None]
+        );
+    }
+    #[test]
+    fn replace_passes_nulls_through() {
+        let data = v(&[Some("a1b2"), None]);
+        assert_eq!(
+            str_replace_all(&data, r"\d", "D").unwrap(),
+            v(&[Some("aDbD"), None])
+        );
+    }
+    #[test]
+    fn unicode_letter_class_matches_polars_semantics() {
+        let data = v(&[Some("Ab12")]);
+        assert_eq!(
+            str_replace_all(&data, r"\p{L}", "L").unwrap(),
+            v(&[Some("LL12")])
+        );
+    }
+}

--- a/packages/rust/extensions/goldencheck-native/Cargo.lock
+++ b/packages/rust/extensions/goldencheck-native/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "goldencheck-core"
 version = "0.1.0"
 dependencies = [
+ "regex",
  "rustc-hash",
 ]
 

--- a/packages/rust/extensions/goldencheck-native/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-native/src/lib.rs
@@ -16,6 +16,7 @@ mod dc;
 mod fuzzy;
 mod keys;
 mod profile;
+mod regex;
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -28,5 +29,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(keys::fd_violation_rows, m)?)?;
     m.add_function(wrap_pyfunction!(fuzzy::near_duplicate_value_clusters, m)?)?;
     m.add_function(wrap_pyfunction!(dc::denial_constraint_evidence, m)?)?;
+    m.add_function(wrap_pyfunction!(regex::str_contains_count, m)?)?;
+    m.add_function(wrap_pyfunction!(regex::str_filter_mask, m)?)?;
+    m.add_function(wrap_pyfunction!(regex::str_replace_all, m)?)?;
     Ok(())
 }

--- a/packages/rust/extensions/goldencheck-native/src/regex.rs
+++ b/packages/rust/extensions/goldencheck-native/src/regex.rs
@@ -1,0 +1,21 @@
+//! PyO3 shims over `goldencheck_core::regex`. Input arrives as a Python
+//! `list[str | None]` (auto -> `Vec<Option<String>>`); a bad pattern -> ValueError.
+//! Do NOT `use goldencheck_core::str_contains_count` etc. -- the shim fns share
+//! those names; bodies call them fully-qualified to avoid an E0255 clash.
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+#[pyfunction]
+pub fn str_contains_count(values: Vec<Option<String>>, pattern: &str) -> PyResult<usize> {
+    goldencheck_core::str_contains_count(&values, pattern).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+#[pyfunction]
+pub fn str_filter_mask(values: Vec<Option<String>>, pattern: &str) -> PyResult<Vec<Option<bool>>> {
+    goldencheck_core::str_filter_mask(&values, pattern).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+#[pyfunction]
+pub fn str_replace_all(values: Vec<Option<String>>, pattern: &str, replacement: &str) -> PyResult<Vec<Option<String>>> {
+    goldencheck_core::str_replace_all(&values, pattern, replacement).map_err(|e| PyValueError::new_err(e.to_string()))
+}


### PR DESCRIPTION
## Summary

Stage-2 S2.2 of the goldencheck Polars-eviction program. Extends the S2.1 covered-subset backend so **encoding_detection, format_detection, and pattern_consistency** run byte-identically **without Polars**, via a native Rust `regex` kernel (the same engine Polars uses) + a pure-Python `value_counts_desc`. Builds on S2.1 (#1630).

## What changed

- **Native `regex` kernel** -- pyo3-free `goldencheck-core/src/regex.rs` (`str_contains_count` / `str_filter_mask` / `str_replace_all` via the `regex` crate; Polars' `str.contains`/`replace_all` use the same crate, so output is byte-identical) + a thin `goldencheck-native` pyo3 shim + a new `"regex"` component in `_native_loader`.
- **`PyColumn` hard ops** -- `str_match_count`, `str_filter` (three-valued mask: nulls dropped in BOTH branches, matching Polars' `s.filter(~mask)`), `str_replace_all` (native-guarded, `NativeRequiredError` when absent), `eq`/`filter_by`, and a required `dtype` property (byte-identical to Polars inference; bool-before-int, all-null -> `other`).
- **`value_counts_desc` = pure Python** (Counter) with a shared deterministic null-safe `(count DESC, nulls-last, value ASC)` key applied to BOTH backends -- makes them identical by construction AND removes the latent tie-order nondeterminism `pattern_consistency` had (Polars' native tie-break is undocumented).
- **`scan_columns`** now appends the 3 hard profilers when `native_enabled("regex")`, else skips-with-a-log (honest coverage matrix).
- **Byte-parity gate** (`test_scan_columns_hardops_parity.py`) -- the 3 profilers produce identical Findings on `PyFrame` vs `PolarsFrame` across 5 datasets (incl. the null + `matching=False` filter trap). The S2.1 `scan_columns` parity test is updated to mirror the new native gate.
- **nopolars lane + import-blocker** -- `scan_columns` runs the hard checks with polars unimportable + native present (verified: the import-blocker subprocess actually imported native and fired `format_detection`). The advisory `goldencheck_nopolars` CI lane now builds native so it exercises the real polars-free path.

## Scope note

`temporal` + `str_to_date` are carved to S2.3: reading `temporal.py` during planning showed it needs a whole date-typed backend surface (`gt_mask`/`fill_null`/`sum`/`filter_by`/`cast` on date columns + `dtype=="date"`) beyond the one date kernel, and `str_to_date` serves only temporal. S2.2 lands the 3 regex profilers fully.

## Test plan

- [x] Byte-parity: 5 datasets, backend parity + scan_columns-vs-Polars, all green; `PyColumn.eq`/`filter_by` added when the gate caught pattern_consistency needing them
- [x] `PyColumn.dtype` parity vs Polars inference (6 datasets)
- [x] `value_counts_desc` deterministic + identical both backends (incl. tie); existing `pattern_consistency` tests pass UNEDITED
- [x] Import gate green + import-blocker (hard checks run with polars unimportable, native present)
- [x] `cargo test` 22 passed (4 new) + clippy clean; ruff clean
- [ ] Full suite + advisory nopolars lane green in CI

Out of scope (roadmap): S2.3 = str_to_date chrono kernel + date-typed `PyColumn` surface + temporal; the non-Polars reader; P4 = the deps-flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h