### PR TITLE
feat(goldensuite-mcp): suite_find_tools discovery meta-tool

### DIFF
--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -11,6 +11,13 @@
   Filtering is **list-only** — every hidden tool stays callable by exact name via
   `dispatch`. The set lives in `CURATED_TOOLS` in `server.py`. (README: "Curated
   tool listing".)
+- **`suite_find_tools` discovery meta-tool** — a curated tool that searches the
+  full catalog (name + package + description + inputSchema), optionally filtered by
+  `query` (keyword) or `package`, so a client can discover any of the ~80 hidden
+  tools and then call it by exact name. This is the progressive-disclosure
+  complement to the curated listing (small default surface + one search tool)
+  rather than collapsing everything into overloaded god-tools. It does not list
+  itself. (README: "Discovering hidden tools".)
 
 ## 0.3.0 (2026-06-24)
 

--- a/packages/python/goldensuite-mcp/README.md
+++ b/packages/python/goldensuite-mcp/README.md
@@ -64,6 +64,26 @@ GOLDENSUITE_MCP_TOOLS=upload_dataset,agent_deduplicate,scan goldensuite-mcp serv
 
 The curated set lives in `CURATED_TOOLS` in `goldensuite_mcp/server.py`.
 
+### Discovering hidden tools (`suite_find_tools`)
+
+Because the curated listing hides ~80 tools, the default surface includes one
+discovery tool, **`suite_find_tools`**, so a client can find and reach the rest
+without switching to `full`:
+
+```jsonc
+// find everything data-quality related
+suite_find_tools({ "query": "quality" })
+// list one package's whole surface
+suite_find_tools({ "package": "goldenmatch" })
+// -> [{ name, package, description, inputSchema }, ...]
+```
+
+It returns each matching tool's name, package, description, and input schema.
+Call any returned tool by its exact `name` — hidden tools dispatch normally, they
+just aren't listed. (`suite_find_tools` does not list itself.) This keeps the
+default surface small while leaving the full ~105-tool catalog one search away,
+instead of collapsing everything into a few overloaded `action`-style god-tools.
+
 ## Claude Desktop / Claude Code config
 
 ```json

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -58,6 +58,8 @@ CURATED_TOOLS: frozenset[str] = frozenset({
     "apply",
     # goldenanalysis -- read-only run analysis
     "analyze_frame", "detect_regressions",
+    # discovery meta-tool -- how a client reaches the ~80 non-headline tools
+    "suite_find_tools",
 })
 
 
@@ -194,6 +196,80 @@ _SUITE_ORDER: list[tuple[str, Callable[[], tuple[list[Tool], Callable[[str, dict
 
 
 # ---------------------------------------------------------------------------
+# Discovery meta-tool
+# ---------------------------------------------------------------------------
+# `list_tools` shows only the curated headline set by default (see above), which
+# leaves the long tail undiscoverable even though every tool stays callable by
+# exact name. `suite_find_tools` closes that gap: it returns the FULL catalog
+# (name + package + description + inputSchema), optionally filtered by keyword or
+# package, so a client can find a hidden tool and then call it directly. This is
+# the progressive-disclosure pattern -- a small default surface plus one search
+# tool -- rather than collapsing everything into overloaded god-tools.
+
+_FIND_TOOLS_NAME = "suite_find_tools"
+
+_FIND_TOOLS_TOOL = Tool(
+    name=_FIND_TOOLS_NAME,
+    description=(
+        "Search the full Golden Suite tool catalog. list_tools shows only a curated "
+        "headline subset by default; use this to discover the complete set (~105 tools "
+        "across goldenmatch, goldencheck, goldenflow, goldenpipe, infermap, "
+        "goldenanalysis), then call any returned tool by its exact `name` (hidden tools "
+        "are fully callable, just not listed). Returns each tool's name, package, "
+        "description, and inputSchema."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Case-insensitive substring matched against tool name and description. Omit to list everything.",
+            },
+            "package": {
+                "type": "string",
+                "enum": [name for name, _ in _SUITE_ORDER],
+                "description": "Restrict results to one sub-package.",
+            },
+        },
+        "required": [],
+    },
+)
+
+
+def _make_find_tools_dispatch(
+    catalog: list[tuple[Tool, str]],
+) -> Callable[[str, dict], dict]:
+    """Build the dispatcher for `suite_find_tools` over a snapshot of the catalog.
+
+    `catalog` is a list of (tool, source_package) for every real (non-meta) tool
+    in the aggregated surface.
+    """
+
+    def dispatch(name: str, args: dict) -> dict:
+        query = str(args.get("query") or "").strip().lower()
+        package = str(args.get("package") or "").strip().lower()
+        results: list[dict[str, Any]] = []
+        for tool, source in catalog:
+            if package and source != package:
+                continue
+            if query and query not in tool.name.lower() and query not in (
+                (tool.description or "").lower()
+            ):
+                continue
+            results.append(
+                {
+                    "name": tool.name,
+                    "package": source,
+                    "description": tool.description,
+                    "inputSchema": tool.inputSchema,
+                }
+            )
+        return {"count": len(results), "tools": results}
+
+    return dispatch
+
+
+# ---------------------------------------------------------------------------
 # Aggregation
 # ---------------------------------------------------------------------------
 
@@ -236,6 +312,20 @@ def _aggregate() -> tuple[list[Tool], dict[str, Callable[[str, dict], dict]]]:
             )
         else:
             logger.info("goldensuite-mcp: registered %d tools from %s", added, source_name)
+
+    # Register the discovery meta-tool over a snapshot of the real tools (it does
+    # not list itself). Its name can't collide -- no sub-package ships it -- but
+    # guard anyway so a future clash is visible rather than silently shadowing.
+    if _FIND_TOOLS_NAME not in seen:
+        catalog = [(t, seen[t.name]) for t in all_tools]
+        all_tools.append(_FIND_TOOLS_TOOL)
+        name_to_dispatch[_FIND_TOOLS_NAME] = _make_find_tools_dispatch(catalog)
+        seen[_FIND_TOOLS_NAME] = "goldensuite"
+    else:
+        logger.warning(
+            "goldensuite-mcp: %r already registered by %s; discovery meta-tool not added",
+            _FIND_TOOLS_NAME, seen[_FIND_TOOLS_NAME],
+        )
 
     return all_tools, name_to_dispatch
 

--- a/packages/python/goldensuite-mcp/tests/test_find_tools.py
+++ b/packages/python/goldensuite-mcp/tests/test_find_tools.py
@@ -1,0 +1,82 @@
+"""Tests for the `suite_find_tools` discovery meta-tool.
+
+`list_tools` shows only the curated headline set, which would leave the ~80
+non-headline tools undiscoverable. `suite_find_tools` returns the full catalog
+(optionally filtered) so a client can find a hidden tool and call it by exact
+name. These tests pin: it's in the default listing, it enumerates the full
+surface, keyword/package filters work, hidden tools show up in it, and it does
+not list itself.
+"""
+from __future__ import annotations
+
+
+def test_find_tools_is_in_default_listing(monkeypatch):
+    monkeypatch.delenv("GOLDENSUITE_MCP_TOOLS", raising=False)
+    from goldensuite_mcp.server import _aggregate, _apply_tool_filter
+
+    tools, _ = _aggregate()
+    listed = {t.name for t in _apply_tool_filter(tools)}
+    assert "suite_find_tools" in listed
+
+
+def test_find_tools_dispatch_returns_full_catalog(monkeypatch):
+    from goldensuite_mcp.server import _aggregate
+
+    tools, dispatch = _aggregate()
+    real_tool_names = {t.name for t in tools} - {"suite_find_tools"}
+    out = dispatch["suite_find_tools"]("suite_find_tools", {})
+    returned = {r["name"] for r in out["tools"]}
+    assert out["count"] == len(real_tool_names)
+    # It enumerates every real tool but NOT itself.
+    assert returned == real_tool_names
+    assert "suite_find_tools" not in returned
+
+
+def test_find_tools_entries_carry_schema(monkeypatch):
+    from goldensuite_mcp.server import _aggregate
+
+    tools, dispatch = _aggregate()
+    out = dispatch["suite_find_tools"]("suite_find_tools", {})
+    entry = out["tools"][0]
+    assert set(entry) == {"name", "package", "description", "inputSchema"}
+    assert isinstance(entry["inputSchema"], dict)
+
+
+def test_find_tools_keyword_filter(monkeypatch):
+    from goldensuite_mcp.server import _aggregate
+
+    tools, dispatch = _aggregate()
+    full = {t.name for t in tools}
+    if "identity_resolve" not in full:  # gated behind optional extras
+        return
+    out = dispatch["suite_find_tools"]("suite_find_tools", {"query": "identity"})
+    names = {r["name"] for r in out["tools"]}
+    assert names, "expected identity_* matches"
+    assert all("identity" in n or "identity" in (r["description"] or "").lower()
+               for n, r in ((r["name"], r) for r in out["tools"]))
+    assert "identity_resolve" in names
+
+
+def test_find_tools_package_filter(monkeypatch):
+    from goldensuite_mcp.server import _aggregate
+
+    tools, dispatch = _aggregate()
+    out = dispatch["suite_find_tools"]("suite_find_tools", {"package": "goldencheck"})
+    assert out["tools"], "expected goldencheck tools"
+    assert all(r["package"] == "goldencheck" for r in out["tools"])
+    assert "scan" in {r["name"] for r in out["tools"]}
+
+
+def test_find_tools_surfaces_hidden_tools(monkeypatch):
+    """A tool hidden from the curated listing must still be discoverable here."""
+    monkeypatch.delenv("GOLDENSUITE_MCP_TOOLS", raising=False)
+    from goldensuite_mcp.server import _aggregate, _apply_tool_filter
+
+    tools, dispatch = _aggregate()
+    listed = {t.name for t in _apply_tool_filter(tools)}
+    out = dispatch["suite_find_tools"]("suite_find_tools", {})
+    discoverable = {r["name"] for r in out["tools"]}
+    full = {t.name for t in tools}
+    if "identity_merge" in full:
+        assert "identity_merge" not in listed  # hidden from list_tools
+        assert "identity_merge" in discoverable  # but found via search


### PR DESCRIPTION
**Stacked on #1639** (base = `feat/goldensuite-mcp-curated-tools`).

## What

#1639 curates `list_tools` down to ~25, which hides ~80 tools. This adds one curated tool, **`suite_find_tools`**, so a client can still *discover* the long tail without flipping to `full`.

```
suite_find_tools({ query?: string, package?: enum })
  -> { count, tools: [{ name, package, description, inputSchema }, ...] }
```

Model flow: sees ~25 headline tools + `suite_find_tools` → needs something niche → searches → gets name + schema → calls it by exact name (dispatch is complete). Progressive disclosure, not `action`-style god-tools that would throw away per-tool schemas.

## How

- Built in `_aggregate` over a snapshot of the real tools, so it's part of the single source of truth. Does **not** list itself. Name-collision guarded.
- Added to `CURATED_TOOLS` so it's visible by default.
- `inputSchema`: optional `query` (case-insensitive substring over name+description) + optional `package` enum.

Live smoke: default 26 listed / 106 full; `find all` returns 105 (excludes itself); `query:identity` → the 9 identity tools; `package:goldenpipe` → its 4 tools; entries carry `inputSchema`.

## Tests

6 new (in default listing, full-catalog enumeration minus-self, entries carry schema, keyword filter, package filter, hidden-tool-still-discoverable). All 23 suite-mcp tests green; ruff clean. Folded into the unreleased 0.4.0 (README + CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s