### PR TITLE
feat(goldenmatch): Polars eviction W2c -- columnar spine onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2.md
+++ b/docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2.md
@@ -240,10 +240,14 @@ order sort explicitly, which the fixtures document).
 - **W2c (columnar spine port)**: `find_fuzzy_matches_columnar` /
   `score_blocks_columnar` (scorer), `build_cluster_frames` + `_columnar_presplit`
   (cluster), `build_golden_records_from_frames` (golden) route through W2b ops;
-  `_columnar_pipeline_enabled` becomes the seam insertion point; the 4
-  scorer/golden joins move to `join_inner`/`join_left`. Exit gate: dispatch
-  `bench-zero-config.yml` at 1M on both backends BEFORE merge (the exact-match
-  self-join is the named perf suspect); >10% -> kernel per spec 4.3.
+  the 4 scorer/golden joins move to `join_inner`/`join_left`.
+  [W2c-execution amendments: `_columnar_pipeline_enabled` is NOT touched (the
+  flag stays 0 per the do-not-flip verdict; W2c only ports call sites), and
+  the 1M `bench-zero-config.yml` exit gate runs the DEFAULT backend only --
+  an arrow e2e 1M is meaningless before W2d moves the ingest boundary; the
+  both-backends 1M is W2d's exit gate. Detailed batch plan:
+  2026-07-10-goldenmatch-polars-eviction-w2c.md.]
+  >10% on a ported op -> kernel per spec 4.3.
 - **W2d (blocker + ingest Frame return)**: `_build_static_blocks` group_by loop,
   sentinel filter, sorted-neighborhood sort/slice onto seam ops; `load_file`
   returns a Frame (callers `load_files`/`apply_column_map`/`validate_columns`

--- a/docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2c.md
+++ b/docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2c.md
@@ -1,0 +1,133 @@
+# GoldenMatch Polars eviction — W2c plan (columnar spine port)
+
+Parent plan: `docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2.md`
+(batch table). Predecessors merged: W0 #1616, W1 #1622, W2a #1632, W2b #1633.
+Spec: `docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md`.
+
+## Goal
+
+Port the columnar pair-stream spine onto the Frame seam so the SAME code runs
+on either backend: `_find_exact_match_ids` + the columnar scorer emit/filter
+paths (scorer.py), `build_cluster_frames` + `_columnar_presplit` + the
+native-arrow bridge (cluster.py), `_multi_df_from_frames` +
+`build_golden_records_from_frames` routing (golden.py), and the pipeline's
+frame threading between them.
+
+## Non-goals / invariants (recon-verified 2026-07-10)
+
+- **Default behavior changes: NONE.** `GOLDENMATCH_FRAME` stays `polars`
+  (every seam op delegates byte-identically); `GOLDENMATCH_COLUMNAR_PIPELINE`
+  stays `0` (the do-NOT-flip verdict stands: ~1-2% slower / +13-16% RSS).
+  W2c is dual-backend routing only.
+- **End-to-end arrow through the engine is W2d**, not W2c: `load_file` still
+  converts to Polars at the ingest boundary, so in arrow mode the engine
+  internals continue to receive Polars frames until W2d. W2c's arrow backend
+  is exercised at the UNIT level (fixtures + arrow twins constructing
+  ArrowFrames directly), and that is stated honestly in the PR.
+- The golden fast/slow builders (`build_golden_records_df`,
+  `build_golden_records_batch`) and everything below them stay raw
+  Polars/list — W2e's expression-tail territory.
+- No new Rust kernels unless the exit bench shows >10% on a ported op.
+
+## New seam ops (fixtures-first, same W2b discipline)
+
+Mechanical ops (Polars impl = the exact engine call, Arrow impl = pc twin):
+
+| Op | Polars semantics | Call site |
+| --- | --- | --- |
+| `Frame.select(cols)` | keep-subset projection (inverse of `drop`) | pipeline:2778 is the ONLY standalone site (reviewer fix: scorer:379 is the lazy collect that stays raw Polars until W2d; golden:1296 lives inside `select_eligible_clusters`) |
+| `Frame.filter_eq(col, value)` | `.filter(pl.col(c) == v)` | cluster:651 |
+| `Frame.filter_not_in(col, values)` | `.filter(~col.is_in(values))` | cluster:706-707 |
+| `Frame.filter_ne_cols(a, b)` | `.filter(col(a) != col(b))` — null -> mask null -> row DROPS. Pin = parity with the COLUMNAR Polars engine. NOTE (reviewer): the list path's `dict.get(a) != dict.get(b)` would KEEP a one-sided-unknown pair — a pre-existing list-vs-columnar divergence, unreachable in-pipeline because `source_lookup` is total. Do NOT "fix" the drop into a keep; the arrow twin's oracle is the columnar Polars path, not the list path | scorer:1381/1850 |
+| `Frame.filter_nonblank_key(col)` | drop null + `cast(Utf8, strict=False).strip()==""` — the DQbench-T3 blank-exclusion. The `strict=False` cast is part of the contract (reviewer fix): non-string mk columns stringify first, and un-castable values become null -> `!=` null -> row DROPS. Fixture corpus includes a non-Utf8 column + an uncastable case. OPPOSITE of `filter_valid_key` re `""` -> its own named op | scorer:385-388 |
+| `Frame.filter_target_split(a, b, values)` | `col(a).is_in(v) != col(b).is_in(v)` (XOR) as ONE semantic op — raw is_in+xor masks stay off the protocol | scorer:1988 |
+| `Frame.with_fill_null(col, value)` | `.with_columns(col.fill_null(v))` | cluster:589-592 |
+| `Frame.map_column(src, dst, mapping)` | `.with_columns(col(src).replace_strict(mapping).alias(dst))` — replace_strict RAISES on unmapped values and takes dtype from the mapping; the arrow twin must raise too, not null-fill (reviewer fix; fixture pins the raise) | cluster:1151-1152 |
+| `frame_from_rows(rows, schema)` | `pl.DataFrame(rows, schema, orient="row")`. Accepts BOTH tuple rows (scorer:1735) and dict rows (cluster:711-712 passes list-of-dicts — reviewer fix). Explicit string schema required; where the raw site infers (cluster:709-710 names-only schema), the port asserts the explicit dtypes match | scorer:1735, cluster:708-714 |
+| `concat_columns([cols])` | `pl.concat([s1, s2])` (Column concat; `.unique()` composes) | cluster:1938-1940 |
+
+Semantic ops (whole intent as one op — the when/then block must NOT leak an
+expression surface through the seam, per spec 4.1):
+
+| Op | Replaces |
+| --- | --- |
+| `apply_weak_quality(metadata, weak_threshold)` | cluster.py:718-729's two `with_columns(when/then/otherwise)` passes (quality recompute + 0.7 confidence damp, strict `>` on threshold). Polars impl = that exact expression; Arrow impl = pc.if_else chain. Two reviewer-named traps: (a) the split branch's `.then()` carries the existing quality COLUMN through, not a literal; (b) Polars `when()` treats a NULL condition as false (falls through) while `pc.if_else` emits null — unreachable in-engine (both presplit paths coalesce min/avg to 0.0 first) but the null-condition fixture row pins the fall-through behavior explicitly. |
+| `select_eligible_clusters(metadata)` | golden.py:1293-1297's `(size > 1) & ~oversized` -> `select("cluster_id")` (parenthesization is load-bearing — the raw `&`-precedence trap noted in-code). |
+
+Shared schema constants: backend-neutral string-schema dicts
+`PAIR_STREAM_SCHEMA_SPEC = {"id_a": "int64", "id_b": "int64", "score": "float64"}`
+and the 9-col `CLUSTER_METADATA_SCHEMA_SPEC` live in `frame.py`;
+`scorer._pair_stream_schema()` derives its Polars dict from the spec (single
+source of truth; the PEP-562 lazy export is unchanged).
+
+## Call-site port (per file)
+
+1. **scorer.py** — `_find_exact_match_ids`: eager select -> `to_frame` ->
+   `filter_nonblank_key` -> `self_join_on` -> `column(...).to_numpy()` (the
+   lazy `.select().collect()` stays caller-side Polars until W2d).
+   `_emit_empty`/`pairs_list_to_df` -> `empty_frame`/`frame_from_rows`.
+   Both cross-source filters (the byte-identical twins at 1364-1384 and
+   1801-1854 — port BOTH or neither, they are mirror-flagged) ->
+   `frame_from_columns` + `rename` + `join_left` + `filter_ne_cols` + `drop`.
+   `score_blocks_columnar` empties/concat -> `empty_frame`/`concat_frames`;
+   `_filter_target_ids_df` -> `filter_target_split`.
+2. **cluster.py** — `build_cluster_frames`: buffer-fill constructions ->
+   `frame_from_columns`; oversized/auto-split filters -> `filter_mask`/
+   `filter_eq`/`filter_not_in` + `concat_frames`+`frame_from_rows`; the Step-3
+   quality block -> `apply_weak_quality`; native branch fill-nulls ->
+   `with_fill_null`. `_columnar_presplit` -> `map_column` + covered to_list
+   ops. Arrow bridge: all_ids via `concat_columns(...).unique()`, kernel
+   outputs -> `frame_from_columns` (accepts pa.Array already).
+   `ClusterFrames` fields: keep `pl.DataFrame` typing for now — internals
+   wrap via `to_frame()` and return `.native`, so the dataclass contract
+   (and every downstream consumer) is untouched on the default backend.
+3. **golden.py** — `_multi_df_from_frames` -> `select_eligible_clusters` +
+   `join_inner(on)` + `rename` + `join_inner(left_on/right_on)`;
+   `build_golden_records_from_frames` height/columns checks -> seam.
+4. **pipeline.py** — `_golden_source` projection -> `select`; the
+   `_columnar_pairs_df` and `ClusterFrames` threading keeps native frames
+   (wrap-at-use), so stage signatures don't change in W2c.
+
+## Tests
+
+- The five spine parity files stay green UNEDITED:
+  `test_pair_stream_columnar_parity.py`, `test_cluster_columnar_parity.py`,
+  `test_cluster_frames_out_parity.py`, `test_golden_from_frames_parity.py`,
+  `test_columnar_pipeline_parity.py` (they pin byte-parity vs the list/dict
+  predecessors — the port must be invisible to them).
+- New `tests/test_frame_relational_ops.py` sections for every new op
+  (delegation parity vs the raw snippet + cross-backend canonical equality),
+  fixtures BEFORE Arrow impls.
+- New arrow twins: unit tests constructing ArrowFrames for
+  `apply_weak_quality`, `_find_exact_match_ids`'s seam pieces, the
+  cross-source filter, and `map_column` — proving the arrow lane at the op
+  level (e2e arrives with W2d).
+- Full goldenmatch shards + heavy + fallback + differential lane green.
+
+## Exit gate (before merge)
+
+- Dispatch `bench-zero-config.yml` at 1M on the branch (via
+  `gh workflow run --ref <branch>`; reviewer-verified dispatchable) vs latest
+  main baseline, DEFAULT backend: wall within noise. The exact-match
+  self-join is the named suspect from spec section 6 — with
+  `GOLDENMATCH_FRAME=polars` the op delegates to the identical Polars join,
+  so the expected delta is zero; the bench PROVES the wrapper overhead is nil
+  rather than assuming it.
+- **Stated deviation from the parent plan** (reviewer-required): the parent's
+  W2c row says 1M "on both backends"; W2c runs the default backend only. An
+  arrow-backend 1M e2e is meaningless before W2d (ingest still converts to
+  Polars at the boundary, and the workflow has no `GOLDENMATCH_FRAME` input).
+  The both-backends 1M moves to W2d's exit gate; the parent plan's W2c/W2d
+  rows are annotated accordingly in this PR. The parent's
+  "`_columnar_pipeline_enabled` becomes the seam insertion point" wording is
+  likewise corrected there (the flag stays 0; W2c only ports call sites).
+- `throughput-gate` green (cost-based; candidates unchanged).
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Wrapper overhead on hot per-block loops (cross-source filter runs per block) | Wrappers are `__slots__` objects delegating one call; 1M bench is the proof; >10% -> inline the Polars call behind `resolve_frame_backend()` branch instead of wrapping |
+| The mirror-flagged twin filters drift | Port both in one commit; the parity tests cover both entries |
+| `apply_weak_quality` arrow impl diverges on null edges | Fixture rows with null min/avg_edge pinned first |
+| `frame_from_rows` dtype inference vs explicit schema | Schema REQUIRED (no inference), string vocabulary |

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -546,7 +546,6 @@ def build_cluster_frames(
     import numpy as _np
     import polars as _pl
 
-    from goldenmatch.core.scorer import PAIR_STREAM_SCHEMA
 
     pairs_list = list(pairs)
     if all_ids is None:                       # mirror build_clusters (:411-417)
@@ -556,14 +555,19 @@ def build_cluster_frames(
             seen.add(b)
         all_ids = list(seen)
 
-    pairs_df = _pl.DataFrame(
+    # W2c: constructed via the seam (spec schema == PAIR_STREAM_SCHEMA).
+    from goldenmatch.core.frame import PAIR_STREAM_SCHEMA_SPEC as _PAIR_SPEC
+    from goldenmatch.core.frame import frame_from_columns as _ffc
+
+    pairs_df = _ffc(
         {
             "id_a": [p[0] for p in pairs_list],
             "id_b": [p[1] for p in pairs_list],
             "score": [p[2] for p in pairs_list],
         },
-        schema=PAIR_STREAM_SCHEMA,
-    )
+        _PAIR_SPEC,
+        backend="polars",
+    ).native
     # BULK pre-split frames. Two paths, IDENTICAL output schema/shape (the SP-A
     # parity test runs both native=1 and native=0):
     #   - Native: the Arrow kernel ALREADY returns canonical (assignments,
@@ -586,10 +590,9 @@ def build_cluster_frames(
             pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size,
         )
         assignments = frames0.assignments
-        metadata = frames0.metadata.with_columns(
-            _pl.col("min_edge").fill_null(0.0),
-            _pl.col("avg_edge").fill_null(0.0),
-        )
+        from goldenmatch.core.frame import to_frame as _tf
+
+        metadata = _tf(frames0.metadata).with_fill_null(["min_edge", "avg_edge"], 0.0).native
     else:
         sorted_clusters, metadata_by_cid, _weak = _columnar_presplit(
             pairs_list, pairs_df, all_ids, max_cluster_size,
@@ -645,10 +648,16 @@ def build_cluster_frames(
         # label subs contiguously from max(live_cids)+1. split rows carry
         # quality="split" so the Step-3 vectorized weak/quality block's
         # when(quality=="split") short-circuit preserves them.
-        oversized = sorted(metadata.filter(_pl.col("oversized"))["cluster_id"].to_list())
+        from goldenmatch.core.frame import to_frame as _tf2
+
+        _mf = _tf2(metadata)
+        oversized = sorted(
+            _mf.filter_mask(_mf.column("oversized")).column("cluster_id").to_list()
+        )
         if oversized:
+            _af = _tf2(assignments)
             members_by_cid = {
-                int(cid): assignments.filter(_pl.col("cluster_id") == cid)["member_id"].to_list()
+                int(cid): _af.filter_eq("cluster_id", cid).column("member_id").to_list()
                 for cid in oversized
             }
             live_cids = set(range(1, metadata.height + 1))
@@ -703,30 +712,31 @@ def build_cluster_frames(
                     "avg_edge": (sum(_sv) / len(_sv)) if _sv else 0.0,
                 })
             if drop_cids:
-                assignments = assignments.filter(~_pl.col("cluster_id").is_in(drop_cids))
-                metadata = metadata.filter(~_pl.col("cluster_id").is_in(drop_cids))
+                assignments = _tf2(assignments).filter_not_in("cluster_id", list(drop_cids)).native
+                metadata = _tf2(metadata).filter_not_in("cluster_id", list(drop_cids)).native
             if split_assign_rows:
-                assignments = _pl.concat([assignments, _pl.DataFrame(
-                    split_assign_rows, schema=["cluster_id", "member_id"], orient="row")])
-                metadata = _pl.concat(
-                    [metadata, _pl.DataFrame(split_meta_rows, schema=metadata.schema)],
-                    how="vertical",
+                # W2c: explicit spec schemas (the raw site inferred int64 from
+                # names-only / reflected metadata.schema -- identical dtypes).
+                from goldenmatch.core.frame import (
+                    CLUSTER_METADATA_SCHEMA_SPEC as _META_SPEC,
                 )
+                from goldenmatch.core.frame import concat_frames as _cf
+                from goldenmatch.core.frame import frame_from_rows as _ffr
+
+                assignments = _cf([
+                    _tf2(assignments),
+                    _ffr(split_assign_rows, {"cluster_id": "int64", "member_id": "int64"}, backend="polars"),
+                ]).native
+                metadata = _cf([
+                    _tf2(metadata),
+                    _ffr(split_meta_rows, _META_SPEC, backend="polars"),
+                ]).native
 
     # Step 3: vectorized weak/quality (excludes "split" rows -- none in Task 1).
     # Reproduces the dict path's _finalize_clusters weak/quality logic.
-    metadata = metadata.with_columns(
-        _pl.when(_pl.col("quality") == "split").then(_pl.col("quality"))
-        .when(
-            (_pl.col("size") > 1)
-            & ((_pl.col("avg_edge") - _pl.col("min_edge")) > weak_cluster_threshold)
-        )
-        .then(_pl.lit("weak")).otherwise(_pl.lit("strong")).alias("quality"),
-    ).with_columns(
-        _pl.when(_pl.col("quality") == "weak")
-        .then(_pl.col("confidence") * 0.7).otherwise(_pl.col("confidence"))
-        .alias("confidence"),
-    )
+    from goldenmatch.core.frame import to_frame as _tf3
+
+    metadata = _tf3(metadata).apply_weak_quality(weak_cluster_threshold).native
 
     _emit_cluster_profile_frames(metadata, assignments, pairs_list)
     return ClusterFrames(assignments=assignments, metadata=metadata)
@@ -1043,7 +1053,6 @@ def _columnar_presplit(
       frames-out parity gate (tests/test_cluster_frames_out_parity.py) doesn't
       regress.
     """
-    import polars as _pl
 
     # --- Step 1: Union-Find member sets (PRE-split). -----------------------
     native = native_module() if native_enabled("clustering") else None
@@ -1148,9 +1157,9 @@ def _columnar_presplit(
         transient: dict[int, dict[tuple[int, int], float]] = {}
         with stage("cluster_pair_scores_fill"):
             if not pairs_df.is_empty():
-                tagged = pairs_df.with_columns(
-                    _pl.col("id_a").replace_strict(member_to_cid).alias("__cid__"),
-                )
+                from goldenmatch.core.frame import to_frame as _tf4
+
+                tagged = _tf4(pairs_df).map_column("id_a", "__cid__", member_to_cid).native
                 for id_a, id_b, score, cid in zip(
                     tagged["id_a"].to_list(),
                     tagged["id_b"].to_list(),
@@ -1935,10 +1944,12 @@ def build_clusters_arrow_native(
         if pairs_df.is_empty():
             all_ids = []
         else:
-            ids_series = _pl.concat(
-                [pairs_df["id_a"], pairs_df["id_b"]],
-            ).unique()
-            all_ids = [int(i) for i in ids_series.to_list()]
+            from goldenmatch.core.frame import concat_columns as _cc
+            from goldenmatch.core.frame import to_frame as _tf5
+
+            _pf = _tf5(pairs_df)
+            ids_col = _cc([_pf.column("id_a"), _pf.column("id_b")]).unique()
+            all_ids = [int(i) for i in ids_col.to_list()]
 
     a_arrow = pairs_df["id_a"].to_arrow() if not pairs_df.is_empty() \
         else _pl.Series("id_a", [], dtype=_pl.Int64).to_arrow()

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -100,6 +100,23 @@ class Frame(Protocol):
     def sort(self, keys: Sequence[str]) -> Frame: ...
     def slice(self, offset: int, length: int) -> Frame: ...
     def take_rows(self, indices: Sequence[int]) -> Frame: ...
+    # W2c ops (columnar spine port; contracts pinned in
+    # tests/test_frame_relational_ops.py -- notably: filter_ne_cols null ->
+    # DROP (columnar-engine parity, NOT the list path's dict.get semantics);
+    # filter_nonblank_key includes the strict=False Utf8 cast and DROPS "";
+    # map_column RAISES on unmapped (replace_strict twin); apply_weak_quality
+    # reproduces cluster.py Step-3's when/then including the null-condition
+    # fall-through-to-strong.
+    def select(self, cols: Sequence[str]) -> Frame: ...
+    def filter_eq(self, col: str, value: Any) -> Frame: ...
+    def filter_not_in(self, col: str, values: Sequence[Any]) -> Frame: ...
+    def filter_ne_cols(self, a: str, b: str) -> Frame: ...
+    def filter_nonblank_key(self, col: str) -> Frame: ...
+    def filter_target_split(self, a: str, b: str, values: Sequence[Any]) -> Frame: ...
+    def with_fill_null(self, cols: Sequence[str], value: Any) -> Frame: ...
+    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> Frame: ...
+    def apply_weak_quality(self, weak_threshold: float) -> Frame: ...
+    def select_eligible_clusters(self) -> Frame: ...
 
 
 class PolarsColumn:
@@ -277,6 +294,82 @@ class PolarsFrame:
     def take_rows(self, indices: Sequence[int]) -> PolarsFrame:
         # blocker ANN/canopy positional selection (blocker.py ~574/~881).
         return PolarsFrame(self._df[list(indices)])
+
+    # -- W2c ops (each delegates to the exact engine call, cited per op) ----
+
+    def select(self, cols: Sequence[str]) -> PolarsFrame:
+        return PolarsFrame(self._df.select(list(cols)))
+
+    def filter_eq(self, col: str, value: Any) -> PolarsFrame:
+        # cluster.py ~651: per-oversized-cluster member extraction.
+        return PolarsFrame(self._df.filter(pl.col(col) == value))
+
+    def filter_not_in(self, col: str, values: Sequence[Any]) -> PolarsFrame:
+        # cluster.py ~706-707: drop split ORIGINAL cluster rows.
+        return PolarsFrame(self._df.filter(~pl.col(col).is_in(list(values))))
+
+    def filter_ne_cols(self, a: str, b: str) -> PolarsFrame:
+        # scorer.py ~1381/~1850 cross-source filter. NULL comparison -> null
+        # mask -> row DROPS (columnar-engine parity; the list path's
+        # dict.get() would KEEP a one-sided unknown -- unreachable in-pipeline
+        # because source_lookup is total; do not "fix" this to keep).
+        return PolarsFrame(self._df.filter(pl.col(a) != pl.col(b)))
+
+    def filter_nonblank_key(self, col: str) -> PolarsFrame:
+        # scorer.py ~385-388 blank-exclusion (DQbench T3): drop null AND
+        # blank/whitespace-only. strict=False cast is part of the contract
+        # (non-string keys stringify; uncastable -> null -> drops). OPPOSITE
+        # of filter_valid_key re "".
+        return PolarsFrame(
+            self._df.filter(
+                pl.col(col).is_not_null()
+                & (pl.col(col).cast(pl.Utf8, strict=False).str.strip_chars() != "")
+            )
+        )
+
+    def filter_target_split(self, a: str, b: str, values: Sequence[Any]) -> PolarsFrame:
+        # scorer.py ~1986-1990 VERBATIM: keep pairs where EXACTLY ONE endpoint
+        # is a target (Int64 series, matching _filter_target_ids_df).
+        s = pl.Series("__t__", list(values), dtype=pl.Int64)
+        return PolarsFrame(self._df.filter(pl.col(a).is_in(s) != pl.col(b).is_in(s)))
+
+    def with_fill_null(self, cols: Sequence[str], value: Any) -> PolarsFrame:
+        # cluster.py ~589-592: coalesce native-bridge null edges.
+        return PolarsFrame(self._df.with_columns([pl.col(c).fill_null(value) for c in cols]))
+
+    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> PolarsFrame:
+        # cluster.py ~1151-1152: tag pairs with their cluster id.
+        # replace_strict RAISES on unmapped source values (contract).
+        return PolarsFrame(self._df.with_columns(pl.col(src).replace_strict(mapping).alias(dst)))
+
+    def apply_weak_quality(self, weak_threshold: float) -> PolarsFrame:
+        # cluster.py Step-3 (~718-729) VERBATIM: quality recompute (split rows
+        # pass through untouched; weak = size>1 and edge-gap > threshold,
+        # strict >) then 0.7 confidence damp on weak. Null conditions fall
+        # through to "strong" (Polars when() treats null as false).
+        df = self._df.with_columns(
+            pl.when(pl.col("quality") == "split")
+            .then(pl.col("quality"))
+            .when(
+                (pl.col("size") > 1) & ((pl.col("avg_edge") - pl.col("min_edge")) > weak_threshold)
+            )
+            .then(pl.lit("weak"))
+            .otherwise(pl.lit("strong"))
+            .alias("quality"),
+        ).with_columns(
+            pl.when(pl.col("quality") == "weak")
+            .then(pl.col("confidence") * 0.7)
+            .otherwise(pl.col("confidence"))
+            .alias("confidence"),
+        )
+        return PolarsFrame(df)
+
+    def select_eligible_clusters(self) -> PolarsFrame:
+        # golden.py ~1293-1297 VERBATIM: multi-member, not oversized. The
+        # parentheses are load-bearing (& binds tighter than >).
+        return PolarsFrame(
+            self._df.filter((pl.col("size") > 1) & ~pl.col("oversized")).select("cluster_id")
+        )
 
 
 class ArrowColumn:
@@ -471,6 +564,130 @@ class ArrowFrame:
     def take_rows(self, indices: Sequence[int]) -> ArrowFrame:
         return ArrowFrame(self._tbl.take(list(indices)))
 
+    # -- W2c ops (pc twins; Polars-parity semantics pinned by fixtures) -----
+
+    def _filter_nullable_mask(self, mask: Any) -> ArrowFrame:
+        return ArrowFrame(self._tbl.filter(mask, null_selection_behavior="drop"))
+
+    def select(self, cols: Sequence[str]) -> ArrowFrame:
+        return ArrowFrame(self._tbl.select(list(cols)))
+
+    def filter_eq(self, col: str, value: Any) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        # null == value -> null -> drop (matches Polars ==).
+        return self._filter_nullable_mask(pc.equal(self._tbl.column(col), value))
+
+    def filter_not_in(self, col: str, values: Sequence[Any]) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        c = self._tbl.column(col)
+        # Polars ~is_in yields null for null input -> row drops; Arrow is_in
+        # returns FALSE for nulls, so AND with validity to reproduce the drop.
+        keep = pc.and_kleene(
+            pc.invert(pc.is_in(c, value_set=pa.array(list(values)))), pc.is_valid(c)
+        )
+        return self._filter_nullable_mask(keep)
+
+    def filter_ne_cols(self, a: str, b: str) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        # not_equal null-propagates -> drop, same as Polars != (see the
+        # PolarsFrame op note re the list path's differing dict semantics).
+        return self._filter_nullable_mask(pc.not_equal(self._tbl.column(a), self._tbl.column(b)))
+
+    def filter_nonblank_key(self, col: str) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        from goldenmatch.core import arrow_derive
+
+        c = self._tbl.column(col)
+        cast = arrow_derive.cast_utf8(c)  # the strict=False Utf8 cast twin
+        nonblank = pc.not_equal(pc.utf8_trim_whitespace(cast), "")
+        keep = pc.and_kleene(pc.is_valid(c), nonblank)  # null cast -> null -> drop
+        return self._filter_nullable_mask(keep)
+
+    def filter_target_split(self, a: str, b: str, values: Sequence[Any]) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        vs = pa.array(list(values))
+
+        def _mask(col_name: str) -> Any:
+            c = self._tbl.column(col_name)
+            # Preserve null -> null (Polars is_in) so the XOR null-propagates
+            # and the row drops; Arrow is_in alone would emit false.
+            return pc.if_else(
+                pc.is_valid(c), pc.is_in(c, value_set=vs), pa.scalar(None, pa.bool_())
+            )
+
+        return self._filter_nullable_mask(pc.not_equal(_mask(a), _mask(b)))
+
+    def with_fill_null(self, cols: Sequence[str], value: Any) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        tbl = self._tbl
+        for c in cols:
+            idx = tbl.column_names.index(c)
+            tbl = tbl.set_column(idx, c, pc.fill_null(tbl.column(c), value))
+        return ArrowFrame(tbl)
+
+    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> ArrowFrame:
+        import pyarrow as pa
+
+        vals = self._tbl.column(src).to_pylist()
+        try:
+            mapped = [None if v is None else mapping[v] for v in vals]
+        except KeyError as e:  # replace_strict twin: unmapped RAISES
+            raise ValueError(f"map_column: value {e.args[0]!r} in {src!r} not in mapping") from e
+        return ArrowFrame(self._tbl.append_column(dst, pa.array(mapped, type=_arrow_dtype(dtype))))
+
+    def apply_weak_quality(self, weak_threshold: float) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        tbl = self._tbl
+        q = tbl.column("quality")
+        size = tbl.column("size")
+        gap = pc.subtract(tbl.column("avg_edge"), tbl.column("min_edge"))
+        conf = tbl.column("confidence")
+
+        def _cond(c: Any) -> Any:
+            # Polars when() treats a NULL condition as FALSE (falls through);
+            # pc.if_else would propagate null -- fill to false to match.
+            return pc.fill_null(c, False)
+
+        import pyarrow as pa
+
+        qt = (
+            q.type
+            if not isinstance(q, pa.ChunkedArray)
+            else q.chunk(0).type
+            if q.num_chunks
+            else pa.large_string()
+        )
+        weak_lit = pa.scalar("weak", type=qt)
+        strong_lit = pa.scalar("strong", type=qt)
+        is_split = _cond(pc.equal(q, "split"))
+        is_weak = _cond(pc.and_kleene(pc.greater(size, 1), pc.greater(gap, weak_threshold)))
+        new_q = pc.if_else(is_split, q, pc.if_else(is_weak, weak_lit, strong_lit))
+        new_conf = pc.if_else(_cond(pc.equal(new_q, "weak")), pc.multiply(conf, 0.7), conf)
+        qi = tbl.column_names.index("quality")
+        tbl = tbl.set_column(qi, "quality", new_q)
+        ci = tbl.column_names.index("confidence")
+        return ArrowFrame(tbl.set_column(ci, "confidence", new_conf))
+
+    def select_eligible_clusters(self) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        keep = pc.and_kleene(
+            pc.greater(self._tbl.column("size"), 1),
+            pc.invert(self._tbl.column("oversized")),
+        )
+        return ArrowFrame(
+            self._tbl.filter(keep, null_selection_behavior="drop").select(["cluster_id"])
+        )
+
 
 def to_frame(obj: Any) -> Frame:
     """Idempotent coercion: raw ``pl.DataFrame``/``pa.Table``, a
@@ -577,3 +794,59 @@ def frame_from_columns(
 def empty_frame(schema: dict[str, str], backend: str | None = None) -> Frame:
     """A zero-row Frame with the given schema (same dtype vocabulary)."""
     return frame_from_columns({k: [] for k in schema}, schema, backend=backend)
+
+
+# -- W2c: shared spine schemas + row/column constructors ----------------------
+
+# Backend-neutral schema specs (string dtype vocabulary). Single source of
+# truth: scorer's Polars PAIR_STREAM_SCHEMA derives from the pair-stream spec.
+PAIR_STREAM_SCHEMA_SPEC: dict[str, str] = {"id_a": "int64", "id_b": "int64", "score": "float64"}
+CLUSTER_METADATA_SCHEMA_SPEC: dict[str, str] = {
+    "cluster_id": "int64",
+    "size": "int64",
+    "confidence": "float64",
+    "quality": "utf8",
+    "oversized": "bool",
+    "bottleneck_pair_a": "int64",
+    "bottleneck_pair_b": "int64",
+    "min_edge": "float64",
+    "avg_edge": "float64",
+}
+
+
+def frame_from_rows(
+    rows: Sequence[Any], schema: dict[str, str], backend: str | None = None
+) -> Frame:
+    """Build a Frame from ROW-oriented data -- tuple rows (scorer's pair
+    lists) or dict rows (cluster's split-metadata rows) -- with an EXPLICIT
+    string schema (no inference; where a raw call site infers, the port
+    asserts the explicit dtypes instead)."""
+    _check_schema(schema)
+    names = list(schema)
+    if rows and isinstance(rows[0], dict):
+        data = {n: [r[n] for r in rows] for n in names}
+    else:
+        data = {n: [r[i] for r in rows] for i, n in enumerate(names)}
+    return frame_from_columns(data, schema, backend=backend)
+
+
+def concat_columns(cols: Sequence[Column]) -> Column:
+    """Vertical concat of Columns (cluster.py's all-ids build); backends must
+    match. `.unique()` composes on the result."""
+    if not cols:
+        raise ValueError("concat_columns requires at least one column")
+    if all(isinstance(c, PolarsColumn) for c in cols):
+        return PolarsColumn(pl.concat([c._s for c in cols]))  # noqa: SLF001
+    if all(isinstance(c, ArrowColumn) for c in cols):
+        import pyarrow as pa
+
+        chunks: list[Any] = []
+        for c in cols:
+            arr = c.to_arrow()
+            chunks.extend(arr.chunks if isinstance(arr, pa.ChunkedArray) else [arr])
+        return ArrowColumn(
+            pa.concat_arrays(
+                [ch.combine_chunks() if isinstance(ch, pa.ChunkedArray) else ch for ch in chunks]
+            )
+        )
+    raise TypeError("concat_columns requires all columns on the same backend")

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1290,24 +1290,25 @@ def _multi_df_from_frames(
     # parentheses: Polars ``&`` binds tighter than ``>``, so the
     # unparenthesized ``pl.col("size") > 1 & ~pl.col("oversized")``
     # is a different (wrong) predicate.
-    multi_cluster_ids = (
-        frames.metadata
-        .filter((pl.col("size") > 1) & ~pl.col("oversized"))
-        .select("cluster_id")
-    )
+    # W2c: routed through the Frame seam (select_eligible_clusters carries
+    # the load-bearing parenthesization; joins are the W2b named variants).
+    from goldenmatch.core.frame import to_frame
+
+    multi_cluster_ids = to_frame(frames.metadata).select_eligible_clusters()
 
     # Vectorized join: attach __cluster_id__ to each source row whose
     # __row_id__ appears in the assignments frame. ``inner`` join
     # drops rows that aren't members of any eligible cluster.
-    assignments_multi = frames.assignments.join(
-        multi_cluster_ids, on="cluster_id", how="inner",
-    ).rename({"cluster_id": "__cluster_id__"})
+    assignments_multi = (
+        to_frame(frames.assignments)
+        .join_inner(multi_cluster_ids, on="cluster_id")
+        .rename({"cluster_id": "__cluster_id__"})
+    )
 
-    return source_df.join(
-        assignments_multi,
-        left_on="__row_id__",
-        right_on="member_id",
-        how="inner",
+    return (
+        to_frame(source_df)
+        .join_inner(assignments_multi, left_on="__row_id__", right_on="member_id")
+        .native
     )
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2775,10 +2775,12 @@ def _run_dedupe_pipeline(
                 _internal_prefixes = (
                     "__xform_", "__mk_", "__block_key__", "__bucket__",
                 )
-                _golden_source = collected_df.select([
+                from goldenmatch.core.frame import to_frame as _tf_golden
+
+                _golden_source = _tf_golden(collected_df).select([
                     c for c in collected_df.columns
                     if not any(c.startswith(p) for p in _internal_prefixes)
-                ])
+                ]).native
             # Source per-cluster pair scores from the view so the slow builder's
             # confidence_majority survivorship weights by edge confidence instead
             # of degrading to count-majority (the frames-out cluster dict carries

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -375,28 +375,29 @@ def _find_exact_match_ids(
     The legacy ``find_exact_matches`` delegates here for any caller that
     still needs the list[tuple] shape (8 call sites at the time of this
     refactor: chunked, incremental, tui/engine, tests, benchmark scripts)."""
+    # W2c: post-collect work routes through the Frame seam (byte-identical
+    # PolarsFrame delegation on the default backend; dual-backend once W2d
+    # threads Frames past the ingest boundary). The lazy projection stays
+    # raw Polars until W2d.
+    from goldenmatch.core.frame import to_frame
+
     mk_col = f"__mk_{mk.name}__"
     df = lf.select("__row_id__", mk_col).collect()
-    # Exclude null AND empty/blank matchkey values. Two records both missing a
-    # field (e.g. a blanked phone -> "") must NOT be an exact match: otherwise
-    # every blank-valued record joins on "" and Union-Find transitively explodes
-    # the clusters (the DQbench T3 precision collapse, 2026-06-06). Blank != a
-    # shared identity claim.
-    df = df.filter(
-        pl.col(mk_col).is_not_null()
-        & (pl.col(mk_col).cast(pl.Utf8, strict=False).str.strip_chars() != "")
-    )
-    if df.height < 2:
+    # Exclude null AND empty/blank matchkey values (filter_nonblank_key). Two
+    # records both missing a field (e.g. a blanked phone -> "") must NOT be an
+    # exact match: otherwise every blank-valued record joins on "" and
+    # Union-Find transitively explodes the clusters (the DQbench T3 precision
+    # collapse, 2026-06-06). Blank != a shared identity claim.
+    frame = to_frame(df).filter_nonblank_key(mk_col)
+    if frame.height < 2:
         return np.empty(0, dtype=np.int64), np.empty(0, dtype=np.int64)
-    joined = df.join(df, on=mk_col, suffix="_right").filter(
-        pl.col("__row_id__") < pl.col("__row_id___right")
-    )
+    joined = frame.self_join_on(mk_col, "__row_id__")
     if joined.height == 0:
         return np.empty(0, dtype=np.int64), np.empty(0, dtype=np.int64)
     # to_numpy() on Int64 columns is zero-copy from Arrow. No Python ints
-    # are created; the buffer is the same one Polars allocated for the join.
-    ids_a = joined["__row_id__"].to_numpy()
-    ids_b = joined["__row_id___right"].to_numpy()
+    # are created; the buffer is the same one the engine allocated for the join.
+    ids_a = joined.column("__row_id__").to_numpy()
+    ids_b = joined.column("__row_id___right").to_numpy()
     return ids_a, ids_b
 
 
@@ -1068,7 +1069,7 @@ def find_fuzzy_matches(
     # ``list[tuple]`` path (permanent opt-in, default). These two helpers
     # keep the branch bodies readable and the conversion in one place.
     def _emit_empty() -> list[tuple[int, int, float]] | pl.DataFrame:
-        return pl.DataFrame(schema=_pair_stream_schema()) if _emit_dataframe else []
+        return _empty_pair_stream_df() if _emit_dataframe else []
 
     def _emit_results(
         results: list[tuple[int, int, float]],
@@ -1342,17 +1343,16 @@ def _score_one_block(
     comprehension. Default False keeps the legacy list contract as the
     permanent opt-in alongside the default ``list[tuple]`` path.
 
-    NOTE (Wave 3 convergence): the ``_emit_dataframe=True`` path duplicates the
-    across-files Polars-filter logic in ``_score_one_block_columnar`` below. They
-    are byte-identical today; if you change one, mirror the other until Wave 3
-    retires ``_score_one_block_columnar``.
+    NOTE (W2c): the across-files filter is shared with
+    ``_score_one_block_columnar`` via ``_cross_source_filter_df`` -- the old
+    "mirror any change" rule is retired.
     """
     block_df = block.df.collect()
 
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()
         if len(sources_in_block) < 2:
-            return pl.DataFrame(schema=_pair_stream_schema()) if _emit_dataframe else []
+            return _empty_pair_stream_df() if _emit_dataframe else []
 
     pairs = find_fuzzy_matches(
         block_df, mk,
@@ -1365,22 +1365,9 @@ def _score_one_block(
         # find_fuzzy_matches emits a frame in every branch under the flag.
         assert isinstance(pairs, pl.DataFrame)
         if across_files_only and source_lookup and not pairs.is_empty():
-            # Vectorized cross-source filter: join row_id -> source on
-            # both endpoints, keep pairs whose sources differ. Avoids the
-            # per-pair Python dict lookup the list path does.
-            src_map = pl.DataFrame({
-                "__row_id__": list(source_lookup.keys()),
-                "__src__": list(source_lookup.values()),
-            })
-            pairs = (
-                pairs
-                .join(src_map.rename({"__row_id__": "id_a", "__src__": "src_a"}),
-                      on="id_a", how="left")
-                .join(src_map.rename({"__row_id__": "id_b", "__src__": "src_b"}),
-                      on="id_b", how="left")
-                .filter(pl.col("src_a") != pl.col("src_b"))
-                .drop(["src_a", "src_b"])
-            )
+            # Vectorized cross-source filter (W2c: shared seam-routed helper
+            # with _score_one_block_columnar -- the old mirror rule is retired).
+            pairs = _cross_source_filter_df(pairs, source_lookup)
         return pairs
 
     # Legacy list path (permanent opt-in alongside the default ``list[tuple]`` path).
@@ -1703,10 +1690,14 @@ def _pair_stream_schema() -> dict[str, pl.DataType]:
     """
     global _PAIR_STREAM_SCHEMA_CACHE
     if _PAIR_STREAM_SCHEMA_CACHE is None:
+        # Derived from the backend-neutral spec (W2c): frame.py's
+        # PAIR_STREAM_SCHEMA_SPEC is the single source of truth; this maps it
+        # to Polars dtypes for the Polars-typed consumers.
+        from goldenmatch.core.frame import PAIR_STREAM_SCHEMA_SPEC
+
+        _pl_dtype = {"int64": pl.Int64, "float64": pl.Float64, "utf8": pl.Utf8, "bool": pl.Boolean, "uint32": pl.UInt32}
         _PAIR_STREAM_SCHEMA_CACHE = {
-            "id_a": pl.Int64(),
-            "id_b": pl.Int64(),
-            "score": pl.Float64(),
+            k: _pl_dtype[v]() for k, v in PAIR_STREAM_SCHEMA_SPEC.items()
         }
     return _PAIR_STREAM_SCHEMA_CACHE
 
@@ -1723,6 +1714,20 @@ def __getattr__(name: str) -> dict[str, pl.DataType]:
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
+def _empty_pair_stream_df() -> pl.DataFrame:
+    """Zero-row canonical pair-stream frame, via the seam (W2c)."""
+    from goldenmatch.core.frame import PAIR_STREAM_SCHEMA_SPEC, empty_frame
+
+    return empty_frame(PAIR_STREAM_SCHEMA_SPEC, backend="polars").native
+
+
+def _concat_pair_frames(frames: list[pl.DataFrame]) -> pl.DataFrame:
+    """Vertical concat of pair-stream frames, via the seam (W2c)."""
+    from goldenmatch.core.frame import concat_frames, to_frame
+
+    return concat_frames([to_frame(f) for f in frames]).native
+
+
 def pairs_list_to_df(pairs: list[tuple[int, int, float]]) -> pl.DataFrame:
     """Adapter: legacy ``(id_a, id_b, score)`` list -> typed DataFrame.
 
@@ -1730,9 +1735,11 @@ def pairs_list_to_df(pairs: list[tuple[int, int, float]]) -> pl.DataFrame:
     downstream Polars expressions (joins, group_by, with_columns) work
     without an ``if df.is_empty()`` guard at every call site.
     """
-    if not pairs:
-        return pl.DataFrame(schema=_pair_stream_schema())
-    return pl.DataFrame(pairs, schema=_pair_stream_schema(), orient="row")
+    # W2c: routed through the seam's row constructor (explicit spec schema;
+    # backend pinned to polars until W2d threads Frames between stages).
+    from goldenmatch.core.frame import PAIR_STREAM_SCHEMA_SPEC, frame_from_rows
+
+    return frame_from_rows(pairs, PAIR_STREAM_SCHEMA_SPEC, backend="polars").native
 
 
 def pairs_df_to_list(df: pl.DataFrame) -> list[tuple[int, int, float]]:
@@ -1814,16 +1821,16 @@ def _score_one_block_columnar(
     pays before its caller would re-convert. Across-files filtering is
     applied as a Polars expression on the result frame, vectorized.
 
-    NOTE (Wave 3 convergence): the across-files Polars-filter logic here is
-    byte-identical to ``_score_one_block(..., _emit_dataframe=True)``. Mirror any
-    change to both until Wave 3 retires this twin.
+    NOTE (W2c): the across-files filter is shared with
+    ``_score_one_block(..., _emit_dataframe=True)`` via
+    ``_cross_source_filter_df`` -- the old mirror rule is retired.
     """
     block_df = block.df.collect()
 
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()
         if len(sources_in_block) < 2:
-            return pl.DataFrame(schema=_pair_stream_schema())
+            return _empty_pair_stream_df()
 
     pairs_df = find_fuzzy_matches_columnar(
         block_df, mk,
@@ -1832,24 +1839,9 @@ def _score_one_block_columnar(
     )
 
     if across_files_only and source_lookup and not pairs_df.is_empty():
-        # Vectorized: keep pairs where id_a and id_b have DIFFERENT
-        # source labels. Build a small Polars frame of (row_id ->
-        # source) and join twice; cheap at block scale (block_df is
-        # already collected) and avoids the per-pair Python lookup
-        # the list path does.
-        src_map = pl.DataFrame({
-            "__row_id__": list(source_lookup.keys()),
-            "__src__": list(source_lookup.values()),
-        })
-        pairs_df = (
-            pairs_df
-            .join(src_map.rename({"__row_id__": "id_a", "__src__": "src_a"}),
-                  on="id_a", how="left")
-            .join(src_map.rename({"__row_id__": "id_b", "__src__": "src_b"}),
-                  on="id_b", how="left")
-            .filter(pl.col("src_a") != pl.col("src_b"))
-            .drop(["src_a", "src_b"])
-        )
+        # Vectorized cross-source filter (W2c: shared seam-routed helper with
+        # _score_one_block's _emit_dataframe branch -- mirror rule retired).
+        pairs_df = _cross_source_filter_df(pairs_df, source_lookup)
 
     return pairs_df
 
@@ -1899,7 +1891,7 @@ def score_blocks_columnar(
     if max_workers is None:
         max_workers = _DEFAULT_MAX_WORKERS
     if not blocks:
-        return pl.DataFrame(schema=_pair_stream_schema())
+        return _empty_pair_stream_df()
 
     # Small block count: skip thread overhead (mirrors
     # score_blocks_parallel's <=2 branch).
@@ -1926,8 +1918,8 @@ def score_blocks_columnar(
                         matched_pairs.add((min(a, b), max(a, b)))
                 frames.append(df_pairs)
         if not frames:
-            return pl.DataFrame(schema=_pair_stream_schema())
-        return pl.concat(frames)
+            return _empty_pair_stream_df()
+        return _concat_pair_frames(frames)
 
     # Parallel path: ThreadPoolExecutor, mirroring score_blocks_parallel.
     # rapidfuzz.cdist + the native scorer release the GIL on the hot
@@ -1971,8 +1963,8 @@ def score_blocks_columnar(
                 )
 
     if not frames:
-        return pl.DataFrame(schema=_pair_stream_schema())
-    return pl.concat(frames)
+        return _empty_pair_stream_df()
+    return _concat_pair_frames(frames)
 
 
 def _filter_target_ids_df(
@@ -1981,10 +1973,38 @@ def _filter_target_ids_df(
     """Vectorized equivalent of the list-path's per-pair
     ``(a in target_ids) != (b in target_ids)`` filter. Match mode
     keeps only pairs where exactly one of (id_a, id_b) is in
-    ``target_ids``."""
+    ``target_ids``. W2c: routed through the seam's filter_target_split."""
     if pairs_df.is_empty():
         return pairs_df
-    target_series = pl.Series("__t__", list(target_ids), dtype=pl.Int64)
-    return pairs_df.filter(
-        pl.col("id_a").is_in(target_series) != pl.col("id_b").is_in(target_series),
+    from goldenmatch.core.frame import to_frame
+
+    return to_frame(pairs_df).filter_target_split("id_a", "id_b", list(target_ids)).native
+
+
+def _cross_source_filter_df(pairs_df: pl.DataFrame, source_lookup: dict[int, str]) -> pl.DataFrame:
+    """The across-files cross-source filter, ONE implementation for both
+    ``_score_one_block(_emit_dataframe=True)`` and
+    ``_score_one_block_columnar`` (they were byte-identical mirror-flagged
+    twins before W2c; sharing the body retires the mirror rule). Join
+    row_id -> source onto both endpoints, keep pairs whose sources differ,
+    drop the helper columns. Null-source rows DROP (columnar-engine
+    semantics; unreachable in-pipeline because source_lookup is total)."""
+    from goldenmatch.core.frame import ArrowFrame, frame_from_columns, to_frame
+
+    pairs_frame = to_frame(pairs_df)
+    src_map = frame_from_columns(
+        {
+            "__row_id__": list(source_lookup.keys()),
+            "__src__": list(source_lookup.values()),
+        },
+        {"__row_id__": "int64", "__src__": "utf8"},
+        backend="arrow" if isinstance(pairs_frame, ArrowFrame) else "polars",
+    )
+    return (
+        pairs_frame
+        .join_left(src_map.rename({"__row_id__": "id_a", "__src__": "src_a"}), on="id_a")
+        .join_left(src_map.rename({"__row_id__": "id_b", "__src__": "src_b"}), on="id_b")
+        .filter_ne_cols("src_a", "src_b")
+        .drop(["src_a", "src_b"])
+        .native
     )

--- a/packages/python/goldenmatch/tests/test_frame_relational_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_relational_ops.py
@@ -344,3 +344,196 @@ def test_frame_from_columns_numpy_buffers() -> None:
     for backend in ("polars", "arrow"):
         f = frame_from_columns(data, schema, backend=backend)
         assert f.column("a").to_list() == [1, 2, 3]
+
+
+# ---- W2c ops: columnar-spine port fixtures -----------------------------------
+
+
+def _meta_tbl() -> pa.Table:
+    # cluster-metadata shaped corpus: split-preserved, weak-by-gap, strong,
+    # size-1, and a null-edge row (pins the when()-null fall-through).
+    return pa.table(
+        {
+            "cluster_id": pa.array([1, 2, 3, 4, 5], type=pa.int64()),
+            "size": pa.array([3, 2, 2, 1, 2], type=pa.int64()),
+            "confidence": pa.array([0.9, 0.8, 0.7, 1.0, 0.6], type=pa.float64()),
+            "quality": pa.array(["split", "strong", "strong", "strong", "strong"]),
+            "oversized": pa.array([True, False, False, False, False], type=pa.bool_()),
+            "bottleneck_pair_a": pa.array([0, 0, 0, 0, 0], type=pa.int64()),
+            "bottleneck_pair_b": pa.array([0, 0, 0, 0, 0], type=pa.int64()),
+            "min_edge": pa.array([0.0, 0.5, 0.85, 0.0, None], type=pa.float64()),
+            "avg_edge": pa.array([0.0, 0.9, 0.9, 0.0, None], type=pa.float64()),
+        }
+    )
+
+
+def test_select_and_delegation() -> None:
+    tbl = pa.table({"a": pa.array([1]), "b": pa.array([2]), "c": pa.array([3])})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        got = frame.select(["c", "a"])
+        assert got.columns == ["c", "a"]
+    assert pf.select(["c", "a"]).native.equals(pf.native.select(["c", "a"]))
+
+
+def test_filter_eq_and_not_in() -> None:
+    tbl = pa.table({"cid": pa.array([1, 2, 1, None, 3], type=pa.int64()),
+                    "i": pa.array([0, 1, 2, 3, 4], type=pa.int64())})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        assert frame.filter_eq("cid", 1).column("i").to_list() == [0, 2]
+        # null cid drops on BOTH ops (polars null-mask semantics).
+        assert frame.filter_not_in("cid", [1]).column("i").to_list() == [1, 4]
+
+
+def test_filter_ne_cols_null_drops() -> None:
+    tbl = pa.table({"a": pa.array(["x", "x", None, "y"], type=pa.string()),
+                    "b": pa.array(["x", "z", "x", None], type=pa.string()),
+                    "i": pa.array([0, 1, 2, 3], type=pa.int64())})
+    pf, af = _pair(tbl)
+    # Columnar-engine parity: null comparison -> row DROPS (rows 2 and 3).
+    for frame in (pf, af):
+        assert frame.filter_ne_cols("a", "b").column("i").to_list() == [1]
+
+
+def test_filter_nonblank_key_semantics() -> None:
+    tbl = pa.table({"mk": pa.array(["ok", "", "  ", None, "x||y"], type=pa.string()),
+                    "i": pa.array([0, 1, 2, 3, 4], type=pa.int64())})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        # DROPS "" and whitespace-only (opposite of filter_valid_key).
+        assert frame.filter_nonblank_key("mk").column("i").to_list() == [0, 4]
+
+
+def test_filter_nonblank_key_nonstring_casts() -> None:
+    # strict=False cast contract: int keys stringify, so they survive.
+    tbl = pa.table({"mk": pa.array([7030, None, 12], type=pa.int64()),
+                    "i": pa.array([0, 1, 2], type=pa.int64())})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        assert frame.filter_nonblank_key("mk").column("i").to_list() == [0, 2]
+
+
+def test_filter_target_split_xor() -> None:
+    tbl = pa.table({"id_a": pa.array([1, 1, 3, 4], type=pa.int64()),
+                    "id_b": pa.array([5, 2, 1, 6], type=pa.int64()),
+                    "i": pa.array([0, 1, 2, 3], type=pa.int64())})
+    pf, af = _pair(tbl)
+    targets = [1, 2]
+    # row0: a in, b out -> KEEP; row1: BOTH in -> drop;
+    # row2: a out, b in -> KEEP; row3: BOTH out -> drop.
+    for frame in (pf, af):
+        assert frame.filter_target_split("id_a", "id_b", targets).column("i").to_list() == [0, 2]
+
+
+def test_with_fill_null() -> None:
+    tbl = pa.table({"min_edge": pa.array([0.5, None], type=pa.float64()),
+                    "avg_edge": pa.array([None, 0.9], type=pa.float64())})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        got = frame.with_fill_null(["min_edge", "avg_edge"], 0.0)
+        assert got.column("min_edge").to_list() == [0.5, 0.0]
+        assert got.column("avg_edge").to_list() == [0.0, 0.9]
+
+
+def test_map_column_maps_and_raises_on_unmapped() -> None:
+    tbl = pa.table({"id_a": pa.array([10, 20], type=pa.int64())})
+    pf, af = _pair(tbl)
+    mapping = {10: 1, 20: 2}
+    for frame in (pf, af):
+        got = frame.map_column("id_a", "__cid__", mapping)
+        assert got.column("__cid__").to_list() == [1, 2]
+    for frame in (pf, af):
+        with pytest.raises(Exception):  # replace_strict raises; arrow twin raises ValueError
+            frame.map_column("id_a", "__cid__", {10: 1})
+
+
+def test_apply_weak_quality_parity() -> None:
+    pf, af = _pair("m", _meta_tbl()) if False else (
+        PolarsFrame(pl.from_arrow(_meta_tbl())), ArrowFrame(_meta_tbl()))
+    threshold = 0.3
+    want_q = ["split", "weak", "strong", "strong", "strong"]  # null gap falls through
+    want_conf = [0.9, 0.8 * 0.7, 0.7, 1.0, 0.6]
+    for frame in (pf, af):
+        got = frame.apply_weak_quality(threshold)
+        assert got.column("quality").to_list() == want_q
+        assert got.column("confidence").to_list() == pytest.approx(want_conf)
+    # delegation parity: byte-equal to the raw Step-3 expression.
+    raw = pf.native.with_columns(
+        pl.when(pl.col("quality") == "split").then(pl.col("quality"))
+        .when((pl.col("size") > 1) & ((pl.col("avg_edge") - pl.col("min_edge")) > threshold))
+        .then(pl.lit("weak")).otherwise(pl.lit("strong")).alias("quality"),
+    ).with_columns(
+        pl.when(pl.col("quality") == "weak")
+        .then(pl.col("confidence") * 0.7).otherwise(pl.col("confidence"))
+        .alias("confidence"),
+    )
+    assert pf.apply_weak_quality(threshold).native.equals(raw)
+
+
+def test_select_eligible_clusters() -> None:
+    pf, af = PolarsFrame(pl.from_arrow(_meta_tbl())), ArrowFrame(_meta_tbl())
+    # size>1 AND not oversized: clusters 2, 3, 5 (1 is oversized, 4 is size-1).
+    for frame in (pf, af):
+        got = frame.select_eligible_clusters()
+        assert got.columns == ["cluster_id"]
+        assert sorted(got.column("cluster_id").to_list()) == [2, 3, 5]
+
+
+def test_frame_from_rows_tuples_and_dicts() -> None:
+    from goldenmatch.core.frame import frame_from_rows
+
+    schema = {"cluster_id": "int64", "member_id": "int64"}
+    for backend in ("polars", "arrow"):
+        f = frame_from_rows([(1, 10), (1, 11)], schema, backend=backend)
+        assert f.column("member_id").to_list() == [10, 11]
+        g = frame_from_rows(
+            [{"cluster_id": 2, "member_id": 20}], schema, backend=backend
+        )
+        assert g.column("cluster_id").to_list() == [2]
+        e = frame_from_rows([], schema, backend=backend)
+        assert e.height == 0 and set(e.columns) == set(schema)
+
+
+def test_concat_columns_unique() -> None:
+    from goldenmatch.core.frame import concat_columns
+
+    tbl = pa.table({"id_a": pa.array([1, 2], type=pa.int64()),
+                    "id_b": pa.array([2, 3], type=pa.int64())})
+    pf, af = _pair(tbl)
+    for frame in (pf, af):
+        merged = concat_columns([frame.column("id_a"), frame.column("id_b")])
+        assert sorted(merged.unique().to_list()) == [1, 2, 3]
+
+
+def test_schema_specs_exported() -> None:
+    from goldenmatch.core.frame import CLUSTER_METADATA_SCHEMA_SPEC, PAIR_STREAM_SCHEMA_SPEC
+
+    assert PAIR_STREAM_SCHEMA_SPEC == {"id_a": "int64", "id_b": "int64", "score": "float64"}
+    assert list(CLUSTER_METADATA_SCHEMA_SPEC) == [
+        "cluster_id", "size", "confidence", "quality", "oversized",
+        "bottleneck_pair_a", "bottleneck_pair_b", "min_edge", "avg_edge",
+    ]
+
+
+def test_cross_source_filter_dual_backend() -> None:
+    # W2c arrow twin of scorer._cross_source_filter_df (the shared helper
+    # that replaced the mirror-flagged twins): identical pair survival on
+    # both backends. E2e arrow arrives with W2d; this pins the helper.
+    from goldenmatch.core.scorer import _cross_source_filter_df
+
+    lookup = {1: "a", 2: "b", 3: "a", 4: "a"}
+    pairs = pa.table(
+        {
+            "id_a": pa.array([1, 1, 3], type=pa.int64()),
+            "id_b": pa.array([2, 3, 4], type=pa.int64()),
+            "score": pa.array([0.9, 0.8, 0.7], type=pa.float64()),
+        }
+    )
+    got_pl = _cross_source_filter_df(pl.from_arrow(pairs), lookup)
+    got_pa = _cross_source_filter_df(pairs, lookup)
+    # only (1,2) crosses sources; (1,3) and (3,4) are same-source.
+    assert got_pl["id_a"].to_list() == [1] and got_pl["id_b"].to_list() == [2]
+    assert got_pa.column("id_a").to_pylist() == [1]
+    assert got_pa.column("id_b").to_pylist() == [2]
+    assert set(got_pl.columns) == set(got_pa.column_names) == {"id_a", "id_b", "score"}


### PR DESCRIPTION
## Wave 2 batch C of the [Polars-eviction program](docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md)

Plan: `docs/superpowers/plans/2026-07-10-goldenmatch-polars-eviction-w2c.md` (reviewer-hardened). Predecessors: W0 #1616, W1 #1622, W2a #1632, W2b #1633.

Ports the columnar pair-stream spine onto the Frame seam. **Default behavior unchanged by construction**: `GOLDENMATCH_FRAME` stays `polars` (byte-identical delegation), `GOLDENMATCH_COLUMNAR_PIPELINE` stays `0` (the do-not-flip verdict stands). E2e arrow through the engine arrives with W2d; W2c's arrow backend is proven at the op level.

### What's in it
- **10 new seam ops**, fixtures-first: the semantic trio `apply_weak_quality` (cluster Step-3's when/then verbatim, incl. the null-condition fall-through-to-strong that pc.if_else would get wrong), `select_eligible_clusters`, `filter_target_split`; plus `select`/`filter_eq`/`filter_not_in`/`filter_ne_cols`/`filter_nonblank_key` (the `strict=False` cast is part of the contract)/`with_fill_null`/`map_column` (`replace_strict` raise-on-unmapped twin); `frame_from_rows` (tuple AND dict rows), `concat_columns`, backend-neutral `PAIR_STREAM`/`CLUSTER_METADATA` schema specs (scorer's Polars schema now derives from the spec -- single source of truth).
- **scorer**: `_find_exact_match_ids` post-collect via the seam (zero-copy `to_numpy` preserved); the two mirror-flagged cross-source filter twins now SHARE `_cross_source_filter_df` -- **the 'mirror any change' rule is retired** and the helper is dual-backend; `_filter_target_ids_df` via `filter_target_split`; constructors/empties/concats seam-routed.
- **cluster**: `build_cluster_frames` (constructions, auto-split filters/concats, Step-3 -> `apply_weak_quality`), `_columnar_presplit` -> `map_column`, arrow-bridge all-ids -> `concat_columns`. `ClusterFrames` keeps `pl.DataFrame` typing (wrap-at-use) so every consumer is untouched.
- **golden**: `_multi_df_from_frames` via `select_eligible_clusters` + the W2b named joins. **pipeline**: `_golden_source` slim projection via `select`.
- Documented divergence pinned, not papered: the columnar cross-source filter DROPS one-sided-unknown-source pairs where the list path would keep them (unreachable -- `source_lookup` is total); the arrow twin's oracle is the columnar engine.

### Verification
- The **five spine parity suites pass UNEDITED** (pair-stream, cluster-columnar, cluster-frames-out, golden-from-frames, columnar-pipeline) -- the port is invisible to them.
- 498 targeted tests green locally + the full differential harness (3 datasets, arrow==polars).
- ruff + `check_map_elements` clean.
- Exit gate: 1M `bench-zero-config` dispatch on this branch vs main (default backend -- stated deviation from the parent plan's both-backends wording; arrow e2e 1M is W2d's gate). Results will be posted here before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW