### PR TITLE
fix(goldenanalysis): correct native null_ratio on all-null columns

### DIFF
--- a/packages/python/goldenanalysis/tests/core/test_native_parity.py
+++ b/packages/python/goldenanalysis/tests/core/test_native_parity.py
@@ -232,36 +232,74 @@ def _frames() -> dict:
     }
 
 
+def _native_supported_frames() -> dict:
+    """Frames whose columns are all a native-supported dtype (no Arrow ``Null``).
+
+    The value-interning kernels (``duplicate_row_ratio`` / ``distinct_count``)
+    reject the Arrow ``Null`` dtype by design -- interning has no values to key on
+    -- so the RAW kernel raises ``TypeError`` and the public dispatcher catches it
+    and falls back to pure. The raw-native parity tests below therefore exclude
+    Null-dtype frames (empty / all-null): feeding those kernels a dtype they are
+    built to reject is out of contract. End-to-end behaviour on those frames --
+    including that ``null_ratio_per_column`` DOES handle Null dtype natively
+    (all-null => 1.0 via ``logical_null_count``) while the other two fall back to
+    pure -- is covered by ``test_frame_kernels_dispatcher_matches_pure``.
+    """
+    import polars as pl
+
+    return {
+        name: df
+        for name, df in _frames().items()
+        if not any(df[c].dtype == pl.Null for c in df.columns)
+    }
+
+
 @native_only
-@pytest.mark.parametrize("name", sorted(_frames()))
+@pytest.mark.parametrize("name", sorted(_native_supported_frames()))
 def test_duplicate_row_ratio_parity(name: str) -> None:
     from goldenanalysis.core import aggregate
 
-    df = _frames()[name]
+    df = _native_supported_frames()[name]
     native = native_module().duplicate_row_ratio([df[c].to_arrow() for c in df.columns])
     assert native == aggregate._duplicate_row_ratio_pure(df)
 
 
 @native_only
-@pytest.mark.parametrize("name", sorted(_frames()))
+@pytest.mark.parametrize("name", sorted(_native_supported_frames()))
 def test_null_ratio_per_column_parity(name: str) -> None:
     from goldenanalysis.core import aggregate
 
-    df = _frames()[name]
+    df = _native_supported_frames()[name]
     ratios = native_module().null_ratio_per_column([df[c].to_arrow() for c in df.columns])
     native = dict(zip(df.columns, ratios))
     assert native == aggregate._null_ratio_per_column_pure(df)
 
 
 @native_only
-@pytest.mark.parametrize("name", sorted(_frames()))
+@pytest.mark.parametrize("name", sorted(_native_supported_frames()))
 def test_distinct_count_parity(name: str) -> None:
     from goldenanalysis.core import aggregate
 
-    df = _frames()[name]
+    df = _native_supported_frames()[name]
     for col in df.columns:
         native = native_module().distinct_count(df[col].to_arrow())
         assert native == aggregate._distinct_count_pure(df[col])
+
+
+@native_only
+@pytest.mark.parametrize("name", sorted(_frames()))
+def test_frame_kernels_dispatcher_matches_pure(name: str) -> None:
+    """End-to-end: the public dispatchers match the pure path on EVERY frame,
+    including the Null-dtype ``empty`` / ``all_null`` frames where the kernel
+    raises and the dispatcher falls back to pure. This is the production contract
+    the raw-native tests above cannot assert on Null dtype."""
+    from goldenanalysis.core import aggregate
+
+    df = _frames()[name]
+    assert aggregate.null_ratio_per_column(df) == aggregate._null_ratio_per_column_pure(df)
+    assert aggregate.duplicate_row_ratio(df) == aggregate._duplicate_row_ratio_pure(df)
+    for col in df.columns:
+        assert aggregate.distinct_count(df[col]) == aggregate._distinct_count_pure(df[col])
 
 
 def test_native_dtype_fallback_returns_pure(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/rust/extensions/analysis-native/src/lib.rs
+++ b/packages/rust/extensions/analysis-native/src/lib.rs
@@ -255,6 +255,12 @@ fn cluster_size_histogram(values: PyArrowType<ArrayData>) -> PyResult<Vec<i64>> 
 
 /// Per-column null ratio (`null_count / len`, 0.0 for empty columns) for each
 /// Arrow column. Reads Arrow null buffers directly -- no interning needed.
+///
+/// Uses `logical_null_count`, NOT `null_count`: an all-null column has the Arrow
+/// `Null` dtype (a `NullArray`), which carries no physical validity buffer, so
+/// `null_count()` reports 0 and the ratio would wrongly come out 0.0 instead of
+/// 1.0. `logical_null_count()` counts a `NullArray` as all-null and is identical
+/// to `null_count()` for every supported dtype (a validity-buffer-backed array).
 #[pyfunction]
 fn null_ratio_per_column(cols: Vec<PyArrowType<ArrayData>>) -> PyResult<Vec<f64>> {
     Ok(cols
@@ -265,7 +271,7 @@ fn null_ratio_per_column(cols: Vec<PyArrowType<ArrayData>>) -> PyResult<Vec<f64>
             if n == 0 {
                 0.0
             } else {
-                arr.null_count() as f64 / n as f64
+                arr.logical_null_count() as f64 / n as f64
             }
         })
         .collect())


### PR DESCRIPTION
## What and why

Fixes the pre-existing `goldenanalysis_native` red on `main` (an **advisory** lane, so it was invisible until the full-matrix run of the CI-hardening work surfaced it) — and in the process found a **real native correctness bug**.

### The bug

`null_ratio_per_column` (in `analysis-native`) used `arr.null_count()` — the **physical** validity-bitmap null count. An all-null column has the Arrow `Null` dtype (a `NullArray`), which carries **no physical validity buffer**, so `null_count()` returns `0` and the ratio came out `0.0` instead of `1.0`.

In production, with native enabled, **an entirely-null column was silently reported as 0% null.** Unlike the value-interning kernels (`duplicate_row_ratio` / `distinct_count`, which *raise* `TypeError` on Null dtype so the dispatcher falls back to pure), `null_ratio` didn't raise — it returned the wrong value directly, so no fallback ever kicked in.

Caught by a new dispatcher-level parity test: `aggregate.null_ratio_per_column(all_null_df)` returned `{'a': 0.0}` vs pure's `{'a': 1.0}`.

### The fix

- **Kernel:** `arr.null_count()` → `arr.logical_null_count()`, which counts a `NullArray` as all-null and is **identical to `null_count()` for every supported (validity-buffer-backed) dtype** — so no supported-dtype result changes.
- **Tests:** the parity tests were red because they fed Null-dtype frames (`empty` / `all_null`) **directly** to the raw `duplicate_row_ratio` / `distinct_count` kernels, which reject Null dtype by design (interning has no values to key on). Restrict the raw-native parity tests to native-supported dtypes, and add `test_frame_kernels_dispatcher_matches_pure` — which asserts the **public dispatchers** match pure on **every** frame, covering both `null_ratio`'s native Null-dtype path (`all_null` ⇒ `1.0`) and the interning kernels' `raise → pure` fallback. That new test is what catches the `null_ratio` bug end-to-end.

## Testing

Built `analysis-native` locally (`scripts/build_analysis_native.py`) and ran the suite:

- `goldenanalysis/tests/core` → **75 passed, 1 skipped** (was **10 failing** on the Null-dtype frames).
- Direct kernel check: `null_ratio_per_column` now returns `1.0` for all-null and `0.0` for empty (both correct vs pure).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — bugfix realigning native with the pure reference; no API change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a — behavior now matches the documented pure reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x)_