### PR TITLE
fix(goldenanalysis): make _mean_pure Python-version-independent (naive sum)

### DIFF
--- a/packages/python/goldenanalysis/goldenanalysis/core/aggregate.py
+++ b/packages/python/goldenanalysis/goldenanalysis/core/aggregate.py
@@ -170,7 +170,18 @@ def mean(values: Sequence[float]) -> float:
 
 def _mean_pure(values: Sequence[float]) -> float:
     vals = [float(v) for v in values if v is not None]
-    return sum(vals) / len(vals) if vals else 0.0
+    if not vals:
+        return 0.0
+    # Explicit naive left-to-right accumulation -- NOT builtin ``sum()``. As of
+    # CPython 3.12 ``sum()`` uses Neumaier compensated summation for floats, so
+    # its result drifts from the native kernel's naive ``iter().sum::<f64>()`` by
+    # a few ULPs on large inputs (and would silently vary by Python version). A
+    # plain fold is naive on every version, keeping ``_mean_pure`` byte-identical
+    # to the Rust reference. The summation-order fixture pins this ordering.
+    total = 0.0
+    for v in vals:
+        total += v
+    return total / len(vals)
 
 
 def _mean_native(values: Sequence[float]) -> float:

--- a/packages/python/goldenanalysis/tests/core/test_aggregate_wave2.py
+++ b/packages/python/goldenanalysis/tests/core/test_aggregate_wave2.py
@@ -18,9 +18,19 @@ def test_mean_filters_none():
     assert agg.mean([1.0, None, 3.0]) == 2.0
 
 
-def test_mean_matches_python_sum_over_same_order():
+def test_mean_matches_naive_left_to_right_sum():
+    # The native kernel sums naively left-to-right (`iter().sum::<f64>()`), and
+    # `_mean_pure` mirrors it with an explicit fold. Assert against a naive
+    # reference, NOT builtin `sum()`: CPython 3.12 made `sum()` use Neumaier
+    # COMPENSATED summation for floats, so on this order-sensitive fixture it
+    # recovers the 100 ones (=> 100.0) while the naive kernel cancels them to 0.0.
+    # Comparing to `sum()` would therefore fail on 3.12+ and pass on <=3.11 --
+    # a version-dependent assertion. The explicit fold is naive on every version.
     v = [1e16] + [1.0] * 100 + [-1e16]
-    assert agg.mean(v) == sum(v) / len(v)
+    naive = 0.0
+    for x in v:
+        naive += x
+    assert agg.mean(v) == naive / len(v)
 
 
 def test_min_max_basic():


### PR DESCRIPTION
## What and why

Second (and final) fix for the `goldenanalysis_native` lane, which stayed red after #1643 — an **advisory** lane, so it merged anyway, but it's still red on `main`. This clears the remaining failure.

### The bug

`test_mean_parity_random` failed on Python 3.12+ with a ~3-ULP mismatch between the native `mean` kernel and `_mean_pure`.

**Root cause:** CPython **3.12 changed builtin `sum()` to use Neumaier *compensated* summation** for floats. `_mean_pure` did `sum(vals) / len(vals)`, so on 3.12+ it returns the compensated result, while the native kernel uses naive `iter().sum::<f64>()`. They diverge by a few ULPs on large inputs. The tests passed on 3.11 (naive `sum()`) but fail under the CI lane's 3.12+ interpreter — the "native byte-identical to `_mean_pure`" invariant silently depended on the Python version.

### The fix

`_mean_pure` now does an explicit **naive left-to-right fold** instead of builtin `sum()`, so it is naive on every Python version and byte-matches the Rust reference. One function, no API change.

## Testing

Built `analysis-native` for **Python 3.12** and ran the parity suite:

- **Unfixed:** `5 failed, 52 passed, 1 skipped` — reproduces the CI failure exactly.
- **Fixed:** `57 passed, 1 skipped`.

Cross-checked the exact CI values on **both 3.12 and 3.13**: the naive `_mean_pure` equals the native result (`451.3919227215358` / `447.5930259888186`), whereas the old `sum()` produced the compensated `451.3919227215361` / `447.5930259888189` that failed CI.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (existing parity suite now green on 3.12/3.13)
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — realigns pure with the native reference; the naive result is the documented byte-identical target)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (the rationale is documented inline where it matters most — at `_mean_pure`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDkMRQ2u3pmPdnKosm1x3x)_