### PR TITLE
docs(goldencheck): CHANGELOG entry for scan_columns + native regex/date components

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -30,6 +30,21 @@ All notable changes to GoldenCheck will be documented in this file.
   `goldencheck_*` UDFs (goldenmatch-duckdb) and the Postgres `goldencheck_*`
   functions (goldenmatch_pg 0.13.0), completing GoldenCheck's cross-surface
   parity (roadmap P5).
+- **`scan_columns(columns)`** -- a reduced, **Polars-free** structural scan of
+  in-memory column data (`dict[str, list]` in, `list[Finding]` out). Always runs
+  the mechanical structural checks (nullability, uniqueness, cardinality); also
+  runs the format, encoding, pattern-consistency, and temporal-order checks when
+  `goldencheck[native]` is installed. Byte-identical to the corresponding
+  `scan_dataframe` checks; complements `scan_dataframe` for callers that want the
+  covered structural checks without constructing a Polars DataFrame. Internally
+  this is the covered-subset backend of the Polars-eviction program (a backend-
+  neutral Frame/Column seam with a pure-Python backend); new `goldencheck-native`
+  kernel components `regex` (string-pattern checks) and `str_to_date` (chrono
+  date parsing, the same engine Polars uses) back the format/encoding/pattern and
+  temporal profilers on the non-Polars path, byte-identically. `NativeRequiredError`
+  is raised if a native-only covered check is requested without the kernel built.
+  (Polars remains a base dependency today; making it optional is a later stage of
+  the program.)
 
 ## [1.4.1] - 2026-07-02
 


### PR DESCRIPTION
## Summary

End-of-rollout docs sweep for the Stage-2 goldencheck Polars-eviction (S2.0 #1618, S2.1 #1630, S2.2 #1635, S2.3 #1644). Adds a CHANGELOG `[Unreleased]` entry for the one user-facing addition: the new public `scan_columns()` export + the `goldencheck-native` `regex`/`str_to_date` kernel components.

## Sweep result

- **Removal/rename grep across all doc surfaces: clean.** The renamed private symbol (`_COVERED_COLUMN_PROFILERS` → `_MECHANICAL_PROFILERS`/`_HARD_PROFILERS`) appears in no README/mdx/CHANGELOG — nothing stale.
- **`scan_columns` was a new public export with no CHANGELOG entry** — added, matching the `scan_dataframe` precedent (1.3.0).
- **`native.mdx` deliberately NOT touched.** It documents native kernels as measured *speedups* ("beat Polars"). The new regex/str_to_date kernels are byte-identical but exist for polars-free capability, not speed, and that user story only goes live with **P4** (the deps-flip). Documenting them there now would be misleading; it belongs in the P4 rollout.

The entry is honest that Polars remains a base dependency today (the eviction's weight payoff lands with P4, not this stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h