### PR TITLE
chore(deps): goldencheck[polars]>=2.0.0 coordination + golden-suite 0.1.10

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.1.10] - 2026-07-11
+
+### Changed
+- Bumped the goldencheck floor to **`goldencheck[polars]>=2.0.0`** (was `>=1.4.1`), per the
+  lockstep policy. goldencheck 2.0.0 completes its Polars eviction: Polars is no longer a base
+  dependency (it moved to the `goldencheck[polars]` extra). The `[polars]` marker keeps CSV
+  reading and the full `scan_file`/`scan_dataframe` scan working in a suite install (Parquet/
+  Excel + `scan_columns` run Polars-free). goldenmatch (a suite member) already pulls Polars,
+  so the suite is unaffected at runtime; this is the explicit declaration.
+
 ## [0.1.9] - 2026-07-08
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.9"
+version = "0.1.10"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -38,7 +38,7 @@ dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
-    "goldencheck>=1.4.1",               # data validation (rules discovered from your data; >=1.4.1 = rapidfuzz cell_quality)
+    "goldencheck[polars]>=2.0.0",       # data validation (>=2.0.0 = Polars-optional flip; [polars] since CSV + full scan need it)
     "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -167,7 +167,7 @@ agent = [
     "aiohttp>=3.14.0",
 ]
 quality = [
-    "goldencheck>=0.5.0",
+    "goldencheck[polars]>=2.0.0",  # cell_quality uses goldencheck's Polars path; [polars] since 2.0.0 made Polars optional
 ]
 transform = [
     "goldenflow>=1.0.0",


### PR DESCRIPTION
## Summary

Coordinated dependency follow-up after goldencheck 2.0.0 (Polars now optional, published to PyPI). Declares `goldencheck[polars]>=2.0.0` for the two consumers that use goldencheck's Polars-requiring `cell_quality`, and bumps golden-suite for the lockstep.

- **goldenmatch** `[quality]` extra: `goldencheck>=0.5.0` -> `goldencheck[polars]>=2.0.0`. The quality extra calls `goldencheck.cell_quality(pl.DataFrame)`, which needs Polars; the `[polars]` marker makes that explicit (goldenmatch's base already pulls Polars, so runtime was fine -- this is the honest declaration).
- **golden-suite** floor: `goldencheck>=1.4.1` -> `goldencheck[polars]>=2.0.0`; version `0.1.9` -> `0.1.10`. Mirrors the goldenflow>=2.0.0 lockstep bump from 0.1.9. Keeps CSV + full-scan working in a suite install (Parquet/Excel + scan_columns run Polars-free).

Note: the adjacent `goldenflow>=2.0.0` line uses no `[extra]` (it relies on transitive Polars via goldenmatch); `[polars]` here is the more explicit form for the same situation.

## Test plan
- [x] `check_version_consistency.py` green (22 packages, golden-suite 0.1.10 in lockstep)
- [ ] CI green

Follow-up (separate, after this merges): cut `golden-suite-v0.1.10` to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h