### PR TITLE
docs(goldencheck): 2.0.0 polars-optional sweep (native.mdx + llms.txt)

### DIFF
--- a/docs-site/goldencheck/native.mdx
+++ b/docs-site/goldencheck/native.mdx
@@ -4,10 +4,12 @@ description: "GoldenCheck's optional Rust/Arrow runtime and the deep-profiling c
 keywords: ["goldencheck", "native", "rust", "arrow", "deep profiling", "functional dependency", "composite key", "fuzzy", "referential integrity", "freshness", "denial constraint"]
 ---
 
-GoldenCheck is pure-Python and Polars-native, so the everyday sampled scan is
-already fast. For the CPU-heavy **deep-profiling** checks there's an optional
-compiled runtime, and the package falls back to pure Python when it isn't
-installed — behaviour is identical either way, native only changes wall-clock.
+GoldenCheck is pure-Python; the full scan is Polars-backed (via the `[polars]`
+extra since 2.0.0), so the everyday sampled scan is fast, while the structural
+`scan_columns` checks and Parquet/Excel reading run Polars-free. For the
+CPU-heavy **deep-profiling** checks there's an optional compiled runtime, and
+the package falls back to pure Python when it isn't installed — behaviour is
+identical either way, native only changes wall-clock.
 
 ```bash
 pip install goldencheck[native]

--- a/packages/python/goldencheck/llms.txt
+++ b/packages/python/goldencheck/llms.txt
@@ -7,11 +7,13 @@
 - Remote MCP: https://goldencheck-mcp-production.up.railway.app/mcp/ (19 tools, Smithery: https://smithery.ai/servers/benzsevern/goldencheck)
 - A2A Server: `goldencheck agent-serve --port 8100` (9 skills)
 - CLI: `goldencheck scan`, `goldencheck validate`, + 14 more commands
-- Python API: `from goldencheck import scan_file, validate_file, health_score, create_baseline`
+- Python API: `from goldencheck import scan_file, scan_columns, scan_file_columns, read_columns, validate_file, health_score, create_baseline` (scan_columns / read_columns / scan_file_columns are the Polars-free structural path)
 - REST API: `goldencheck serve` on port 8000
 
 ## Install
-- `pip install goldencheck` — core scanning
+- `pip install goldencheck` — Polars-free base: structural scan (`scan_columns`) + Parquet/Excel reading (`read_columns`/`scan_file_columns`)
+- `pip install goldencheck[polars]` — CSV reading + the full `scan_file`/`scan_dataframe` scan (Polars; since 2.0.0 Polars is optional)
+- `pip install goldencheck[parquet]` — Polars-free Parquet reading (pyarrow)
 - `pip install goldencheck[llm]` — LLM boost (~$0.01/scan)
 - `pip install goldencheck[baseline]` — deep profiling & drift detection
 - `pip install goldencheck[mcp]` — MCP server for Claude Desktop


### PR DESCRIPTION
## Summary

Rollout docs sweep for goldencheck 2.0.0 (Polars now optional). P4b already updated `overview.mdx`/`README.md` + CHANGELOG; this catches the two surfaces it missed.

- **`docs-site/goldencheck/native.mdx`**: line 7 said "GoldenCheck is pure-Python and Polars-native" (stale for 2.0.0). Reframed: the full scan is Polars-backed via `[polars]`, while `scan_columns` + Parquet/Excel reading run Polars-free.
- **`packages/python/goldencheck/llms.txt`** (agent-discovery surface): Install section said `pip install goldencheck -- core scanning` (implied CSV/full-scan works out of the box). Split into the polars-optional reality + added `[polars]`/`[parquet]` extras; added the polars-free API (`scan_columns`/`read_columns`/`scan_file_columns`) to the Python API line.

## Sweep result
- Removal-grep for "polars is a base dep / CSV works OOTB" across all goldencheck + suite surfaces: the two above were the only stale hits. README install (P4b), overview.mdx (P4b), suite READMEs/llms.txt: already clean. Root llms.txt is a one-line summary deferring to the per-package file.
- `check_docs_consistency`: all relevant gates PASS (install-claims resolve, version-consistency, readme-callouts). The one FAIL is the pre-existing repo-wide "orphan detection" (every package's pages, unrelated to this rollout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h