### PR TITLE
fix(autoconfig): zero-config death-spiral on typo-heavy person data

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py
@@ -38,6 +38,12 @@ def mass_borderline(scores: list[float], threshold: float, band: float = 0.1) ->
     return sum(1 for s in scores if lo <= s <= hi) / len(scores)
 
 
+# Minimum in-cluster triple count for a transitivity estimate to count as
+# evidence. Below this, the rate is returned as vacuously 1.0 (not
+# evaluable) -- systemic non-transitivity at real scale always has support.
+_MIN_TRIPLE_SUPPORT = 30
+
+
 def transitivity_rate(
     members_by_cluster: dict[int, list[int]],
     pair_scores: dict[tuple[int, int], float],
@@ -50,7 +56,14 @@ def transitivity_rate(
     (a,c) score >= threshold.
 
     Pair lookup canonicalizes (a,b) as (min,max) per project convention.
-    Returns 1.0 when no clusters have >= 3 members (vacuously transitive).
+    Returns 1.0 when no clusters have >= 3 members (vacuously transitive),
+    AND when fewer than ``_MIN_TRIPLE_SUPPORT`` triples exist -- a rate
+    estimated from a handful of triples is sampling noise, not a signal.
+    Without the support floor, small controller samples on typo-heavy person
+    data hard-RED the cluster verdict on 2-of-13-triangle noise, the
+    controller reacts by lowering thresholds, borderline pairs multiply,
+    transitivity gets WORSE, and zero-config death-spirals to
+    BUDGET_ITERATIONS (the 2026-07-10 bench regression's terminal layer).
     Samples up to ``max_samples`` triples for cost control.
     """
     import random
@@ -68,7 +81,9 @@ def transitivity_rate(
             for _ in range(min(max_samples, 100)):
                 a, b, c = sorted(rng.sample(members, 3))
                 triples.append((a, b, c))
-    if not triples:
+    if len(triples) < _MIN_TRIPLE_SUPPORT:
+        # Too few triples for the rate to mean anything (includes the
+        # no-triples vacuous case). See docstring.
         return 1.0
     if len(triples) > max_samples:
         triples = rng.sample(triples, max_samples)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -148,6 +148,55 @@ def _near_dup_locked(config: GoldenMatchConfig) -> bool:
     return b is not None and b.strategy in ("lsh", "simhash")
 
 
+def _blocking_recovery_target(
+    mk: MatchkeyConfig, profile: ComplexityProfile
+) -> tuple[str, list[str]] | None:
+    """Pick the blocking-recovery key for the text-field rules.
+
+    ``first_token`` (the DBLP-ACM lesson) is right for TEXT corpora: titles
+    sharing a first word co-block. For NAME columns it is recall-blind --
+    equality on the first token still splits typo variants
+    ("michael"/"micheal"), the exact population fuzzy matching exists for; it
+    RED-looped zero-config on person data for two months (the 2026-07-10
+    bench regression: iterations bounced between identifier blocking with
+    ZERO candidates and token-name blocking with mass_above_threshold=1.0 --
+    two RED shapes with no lever proposing the canonical middle).
+
+    Names get the repo-canonical phonetic block: ``soundex`` on the SURNAME
+    when one is present (the same key the differential harness's known-good
+    deterministic config and the compound builder's pass-3 recall net use --
+    surnames spread across soundex codes; given names are too concentrated),
+    else soundex on the first name-class field.
+
+    Name detection uses ``_classify_by_name`` (column-NAME classification,
+    consistent with the rest of autoconfig) -- NOT
+    ``profile.data.column_types``, whose coarse map labels person-name
+    columns plain ``text``.
+    """
+    from goldenmatch.core.autoconfig import _classify_by_name
+
+    text_fallback: str | None = None
+    name_fields: list[str] = []
+    for f in mk.fields or []:
+        if f.field is None:
+            continue
+        if _classify_by_name(f.field) == "name":
+            name_fields.append(f.field)
+        elif text_fallback is None:
+            col_type = profile.data.column_types.get(f.field, "unknown")
+            if col_type in ("text", "name"):
+                text_fallback = f.field
+    if name_fields:
+        surname = next(
+            (n for n in name_fields if "last" in n.lower() or "surname" in n.lower()),
+            None,
+        )
+        return (surname or name_fields[0], ["lowercase", "soundex"])
+    if text_fallback is not None:
+        return (text_fallback, ["lowercase", "first_token"])
+    return None
+
+
 def rule_blocking_singleton_trap(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -185,23 +234,15 @@ def rule_blocking_singleton_trap(
     mk = _first_weighted_mk(current)
     if mk is None:
         return None
-    target_field: str | None = None
-    for f in mk.fields or []:
-        if f.field is None:
-            continue
-        col_type = profile.data.column_types.get(f.field, "unknown")
-        if col_type in ("text", "name"):
-            target_field = f.field
-            break
-    if target_field is None:
+    target = _blocking_recovery_target(mk, profile)
+    if target is None:
         return None
-
-    # Build a new blocking key on raw text with first_token + lowercase.
+    target_field, transforms = target
     new_blocking = current.blocking.model_copy(update={
         "strategy": "static",
         "keys": [BlockingKeyConfig(
             fields=[target_field],
-            transforms=["lowercase", "first_token"],
+            transforms=transforms,
         )],
     })
     new_cfg = current.model_copy(update={"blocking": new_blocking})
@@ -211,11 +252,11 @@ def rule_blocking_singleton_trap(
             f"candidates_compared=0 with n_blocks={bp.n_blocks}; "
             f"singletons={bp.singleton_block_count}/{bp.n_blocks} "
             f"({bp.singleton_block_count / bp.n_blocks:.0%}); "
-            f"switching blocking to first_token({target_field!r})"
+            f"switching blocking to {transforms[-1]}({target_field!r})"
         ),
         config_diff={
             "blocking.keys[0].fields": [target_field],
-            "blocking.keys[0].transforms": ["lowercase", "first_token"],
+            "blocking.keys[0].transforms": transforms,
         },
     )
     return new_cfg, decision
@@ -455,29 +496,23 @@ def rule_blocking_key_swap(
     mk = _first_weighted_mk(current)
     if mk is None:
         return None
-    target_field: str | None = None
-    for f in mk.fields or []:
-        if f.field is None:
-            continue
-        col_type = profile.data.column_types.get(f.field, "unknown")
-        if col_type in ("text", "name"):
-            target_field = f.field
-            break
-    if target_field is None:
+    target = _blocking_recovery_target(mk, profile)
+    if target is None:
         return None
+    target_field, transforms = target
 
     # Avoid proposing a config we already have (anti-oscillation belt-and-suspenders)
     existing_first_key = (current.blocking.keys or [None])[0]
     if (existing_first_key is not None
             and existing_first_key.fields == [target_field]
-            and "first_token" in (existing_first_key.transforms or [])):
+            and transforms[-1] in (existing_first_key.transforms or [])):
         return None
 
     new_blocking = current.blocking.model_copy(update={
         "strategy": "static",
         "keys": [BlockingKeyConfig(
             fields=[target_field],
-            transforms=["lowercase", "first_token"],
+            transforms=transforms,
         )],
     })
 
@@ -504,7 +539,7 @@ def rule_blocking_key_swap(
         f"after {len(history.decisions)} prior decision(s), "
         f"candidates_compared={sp.candidates_compared} "
         f"but mass_above_threshold={sp.mass_above_threshold}; "
-        f"swapping blocking to first_token({target_field!r})"
+        f"swapping blocking to {transforms[-1]}({target_field!r})"
     ]
     if dropped_names:
         rationale_parts.append(
@@ -516,7 +551,7 @@ def rule_blocking_key_swap(
         rationale="".join(rationale_parts),
         config_diff={
             "blocking.keys[0].fields": [target_field],
-            "blocking.keys[0].transforms": ["lowercase", "first_token"],
+            "blocking.keys[0].transforms": transforms,
             **({"matchkeys.dropped": dropped_names} if dropped_names else {}),
         },
     )

--- a/packages/python/goldenmatch/tests/test_autoconfig_rules.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_rules.py
@@ -437,3 +437,62 @@ def test_rule_sparse_match_expand_no_fire_when_not_sparse():
     ctx = _ctx_with_sparsity(_V110SV(is_sparse=False, estimated_n_true_pairs=100))
     outcome = rule_sparse_match_expand(profile, cfg, _empty_history(), ctx=ctx)
     assert outcome is None
+
+
+# ---- 2026-07-10 zero-config regression fixes ---------------------------------
+
+
+def test_blocking_recovery_prefers_soundex_surname():
+    """Name-class columns get the canonical phonetic block on the SURNAME --
+    first_token equality-splits typo'd names (the two-month zero-config
+    RED-loop). Text corpora keep first_token (the DBLP-ACM lesson)."""
+    from types import SimpleNamespace
+
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.autoconfig_rules import _blocking_recovery_target
+
+    mk = MatchkeyConfig(
+        name="mk", type="weighted", threshold=0.8,
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.5),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", weight=0.5),
+        ],
+    )
+    profile = SimpleNamespace(data=SimpleNamespace(column_types={
+        "first_name": "text", "last_name": "text",  # the coarse map lies; name
+    }))                                              # detection is by column NAME
+    target = _blocking_recovery_target(mk, profile)
+    assert target == ("last_name", ["lowercase", "soundex"])
+
+    mk_text = MatchkeyConfig(
+        name="mk", type="weighted", threshold=0.8,
+        fields=[MatchkeyField(field="title", scorer="token_sort", weight=1.0)],
+    )
+    profile_text = SimpleNamespace(data=SimpleNamespace(column_types={"title": "text"}))
+    target_text = _blocking_recovery_target(mk_text, profile_text)
+    assert target_text == ("title", ["lowercase", "first_token"])
+
+
+def test_transitivity_rate_small_sample_not_evidence():
+    """A transitivity estimate from a handful of triples is sampling noise --
+    below the support floor it returns vacuously 1.0 instead of hard-REDding
+    the cluster verdict (the zero-config death-spiral's terminal layer)."""
+    from goldenmatch.core._profile_helpers import _MIN_TRIPLE_SUPPORT, transitivity_rate
+
+    # Two 3-member clusters = 2 triples, both non-transitive: below the
+    # floor -> 1.0 (not evaluable).
+    members = {1: [1, 2, 3], 2: [4, 5, 6]}
+    scores = {(1, 2): 0.9, (2, 3): 0.9, (4, 5): 0.9, (5, 6): 0.9}  # a-c edges missing
+    assert transitivity_rate(members, scores, 0.8) == 1.0
+
+    # A cluster large enough to clear the floor with the same broken shape
+    # must still be flagged (rate < 1).
+    big = list(range(100, 100 + 12))  # C(12,3) = 220 triples >= floor
+    members_big = {1: big}
+    scores_chain = {
+        (min(a, b), max(a, b)): 0.9
+        for a, b in zip(big, big[1:])  # chain only: most triples fail
+    }
+    rate = transitivity_rate(members_big, scores_chain, 0.8)
+    assert rate < 0.85
+    assert _MIN_TRIPLE_SUPPORT <= 220


### PR DESCRIPTION
## The since-mid-May zero-config regression, root-caused and fixed

**Symptom:** `bench-zero-config.yml` went from ~4 min at 500K (last green: 2026-05-16) to 90+ min; 1M ran 80+ min (expected 2-3). Locally, 100K zero-config raised `ControllerNotConfidentError` (RED, `BUDGET_ITERATIONS`) ~3-in-4 runs. Invisible for two months because the workflow is dispatch-only. Found via the Polars-eviction W2c bench gate; full investigation dossier in the work tracker (`project_zeroconfig_perf_regression_main`).

**Root cause — two coordinated defects forming a death-spiral:**
1. **Recall-blind blocking recovery** (`autoconfig_rules.py`): the recovery rules committed `['lowercase','first_token']` on NAME columns — right for text corpora (its DBLP-ACM origin), but equality on the first token still splits typo'd names (`michael`/`micheal`). The controller bounced between identifier blocking (zero candidates → RED) and token-name blocking (indiscriminate → RED); no lever ever proposed the canonical middle. Fix: `_blocking_recovery_target` routes name-class columns (detected by `_classify_by_name` — the profile's coarse `column_types` labels person names plain `text`) to `['lowercase','soundex']` on the **surname** (the known-good key: surnames spread across soundex codes); text keeps `first_token`.
2. **Transitivity noise hard-REDs the cluster verdict** (`_profile_helpers.py`): the rate was estimated from a HANDFUL of in-cluster triples (observed 0.15 over ~13 triples at max-cluster-size 3) and `< 0.85` → RED. The controller lowered thresholds in response, borderline pairs multiplied, transitivity got WORSE → `BUDGET_ITERATIONS`. Fix: `_MIN_TRIPLE_SUPPORT=30` floor — below it the rate is vacuously 1.0 (not evaluable); systemic non-transitivity at real scale always has support (pinned by test: a 220-triple broken chain still flags).

**Evidence chain:** per-iteration config/verdict dumps on main (5 iterations: no phonetic pass anywhere, thresholds walking 0.8→0.7 futilely, scoring GREEN + cluster RED once blocking was fixed, transitivity 0.67→0.15→0.0 as thresholds dropped). May-15 SHA green repeatedly under identical local conditions.

**Verification:** repro (100K synthetic person fixture, zero-config `dedupe_df`): before 3/3 RED → after **3/3 GREEN at 33.3/33.9/33.5s** (May baseline: 57s). 48 controller-adjacent tests + 23 rules tests green (2 new: surname-soundex routing, transitivity support floor). **500K wall proof via `bench-zero-config` dispatch will be posted here before merge** (target: ~4-min May baseline).

Follow-ups tracked (not this PR): trial-time mega-block fail-fast cap; bench-fixture `cluster_id` leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW