### PR TITLE
feat(goldenmatch): Polars eviction W3a -- controller/profiling seam reductions

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w3.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w3.md
@@ -1,0 +1,168 @@
+# GoldenMatch Polars eviction — W3 plan (controller/autoconfig dual-backend)
+
+Spec: `docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md`
+W3 row: "Controller/autoconfig front: profiling, indicators, complexity
+signals — mostly column reductions (goldencheck-shaped)" -> Controller
+dual-backend. Predecessors: W0-W2 all merged (#1616/#1622/#1632/#1633/#1642/
+#1650/#1651/#1655). Recon 2026-07-11 (line refs verified against this tree).
+
+## Invariants (unchanged from W2)
+
+- NO default flip: `GOLDENMATCH_FRAME` stays `polars`; every surface keeps
+  receiving `pl.DataFrame` today (ingest converts at the boundary until W5).
+  W3 is dual-backend PREP: seam ops + parity fixtures + call sites routed so
+  an ArrowFrame COULD flow.
+- PolarsColumn/PolarsFrame impls delegate to the exact Polars call each site
+  uses (byte-identical); Arrow impls parity-pinned by fixtures FIRST.
+- `complexity_profile.py` needs NO port (pure dataclasses — recon-verified).
+- Every batch is its own PR off the predecessor's merged main (the W2
+  fold-and-checkout-ours drill when parallelizing).
+- pytest-split shard-shift discipline: new test files added with the
+  rootdir-relative deselect lesson in mind; watch for clobber reds.
+- MERGE ORDER GUARD: #1654 (zero-config fix) touches autoconfig_rules +
+  _profile_helpers — fold origin/main into this branch when it merges,
+  BEFORE any call-site batch ships.
+
+## Batches
+
+### W3a — seam ops, fixtures-first, pure-additive (mirrors W2b)
+
+Column protocol + both backends (goldencheck-proven shapes marked GC):
+- `drop_nulls() -> Column` (GC), `cast_str(strict: bool = True) -> Column`
+  (GC `cast` — W3 needs only the Utf8 flavor; arrow twin = arrow_derive
+  cast_utf8 for strict=False parity, pc.cast for strict),
+  `fill_null(value) -> Column` (GC), `sum()`, `mean()`, `min()`, `std()`
+  (GC; std ddof=1 pinned — polars default), `value_counts_desc() ->
+  list[tuple[value, int]]` (GC — count-desc order pinned; ties by value for
+  cross-backend determinism), `str_len_chars() -> Column` (net-new; polars
+  `.str.len_chars()` vs `pc.utf8_length` — CODEPOINT semantics pinned by
+  fixture with multibyte corpus).
+- Frame protocol + both backends:
+  - `sample(n, seed, shuffle=True) -> Frame` — THE controller op.
+    CONTRACT: polars `df.sample(n=…, seed=…, shuffle=…)` rows are the
+    REFERENCE; the arrow impl CANNOT reproduce polars' RNG, so the contract
+    is statistical, not byte: same n, deterministic for a given seed on the
+    same backend, no duplicates. Cross-backend fixtures assert SHAPE +
+    determinism-per-backend, NOT row identity. Downstream parity across
+    backends is therefore config-level (the controller's verdicts on ITS
+    backend's sample), documented loudly — this is the one W3 op where
+    byte-parity is impossible by construction.
+  - `with_row_index(name="__row__") -> Frame`.
+  - `joint_n_unique(cols) -> int` (autoconfig:3203 composite cardinality).
+  - `group_nunique(key, value) -> Frame[key, n_unique]` (_source_disjoint).
+  - `head(n) -> Frame` (indicators/profilers `df.head`; alias of
+    slice(0, n) — thin, but named for call-site fidelity).
+  - `coverage_ratio(pass_field_lists: Sequence[Sequence[str]]) -> float`
+    (_union_coverage:1436-1451 as ONE semantic op: fraction of rows covered
+    by at least one pass's all-non-null fields; polars impl = the exact
+    pl.repeat/mask loop; arrow = pc.is_valid + and/or folds).
+- `semantic_dtype() -> str` Column op (reviewer SHOULD-FIX, the strongest
+  finding): a pinned cross-backend mapping to {text, numeric, date, bool,
+  unknown}. Four sites branch on Polars dtype strings/objects
+  (autoconfig:88, controller:1875, profiler:104/114,
+  indicators._compute_identity_score:95) and Arrow stringifies float64 as
+  "double" — contains neither "int" nor "float" — so float columns would
+  silently classify "unknown" and skew controller verdicts. Raw
+  `str(dtype)` stays polars-side only where byte-fidelity matters
+  (ColumnProfile.dtype pins the polars spelling; the native classify JSON
+  gets the normalized tag — decided at W3c port time with a fixture).
+- W3c's previously-unnamed ops, added HERE per fixtures-first (reviewer):
+  Frame `distinct_row_count()` (profiler:173 df.unique().height), Column
+  `blank_count()` (strip=="" count, profiler:131), and the all-empty-row
+  fold (profiler:176-191) declared PYTHON-SIDE over to_list (cold path,
+  explicit decision, not an op).
+- `sample` default is `shuffle=False` (reviewer NIT: 3 of 5 call sites use
+  polars' default; the controller passes shuffle=True explicitly).
+- `group_nunique` contract pins the either-col-null row DROP
+  (_source_disjoint's frame-level drop_nulls on the 2-col selection) —
+  an arrow impl that groups nulls would flip the disjoint verdict.
+- Fixtures in test_frame_relational_ops.py (existing file — no shard-shift)
+  covering: null/empty columns, multibyte str_len, value_counts tie order
+  (+ null-exclusion pinned), std ddof, sample determinism-per-backend +
+  n>height behavior (pinned to polars' actual), joint vs single-col
+  n_unique null semantics, semantic_dtype across
+  utf8/large_utf8/int/float/double/date/bool/null, coverage_ratio's
+  edge cases (missing column -> pass contributes nothing; empty
+  pass_field_lists -> 0.0; empty fields-list INSIDE a pass -> pinned
+  (all-True mask covers everything -> 1.0, unreachable today, asserted);
+  float-NaN counts as non-null on BOTH backends; height==0 -> 0.0).
+
+### W3b — indicators port (lowest risk)
+
+`indicators.py`: compute_column_priors (head + n_unique + cast/fill_null/
+to_list), estimate_sparse_match_signal + estimate_full_pop_hits (group_len +
+Python pair math — the `.select((n*(n-1)/2).sum())` expression moves to
+Python over group_len output: SAME values, pinned by test_indicators.py
+unedited), corruption score, compute_cross_blocking_overlap
+(with_row_index + the list-agg stays Python over group_partitions if the
+expression shape resists a clean op — recon flags this as the one candidate
+to leave partially Polars with a W5 note). Budget semantics unchanged
+(test_indicators_budget.py unedited).
+
+### W3c — profiling port
+
+`autoconfig._emit_data_profile`, `autoconfig_controller.
+_compute_data_profile_from_df` (twins — port BOTH, consider extracting the
+shared body like W2c's _cross_source_filter_df), `autoconfig.
+profile_columns`, `profiler.py` (profile_column/profile_dataframe), and the
+W2e-2-deferred `matchkey._emit_matchkey_profile` — its Chao1
+value_counts["count"]-probing replaced by value_counts_desc + Python f1/f2
+(cleaner AND backend-neutral). Gates: test_profiler.py, test_matchkey.py,
+test_profile_emitter.py unedited.
+
+### W3d — autoconfig blocking measurement + block_analyzer
+
+build_blocking's null_rate/_max_block_size/_nonnull_ratio (group_len + max +
+drop_nulls), joint cardinality -> joint_n_unique, _union_coverage ->
+coverage_ratio, _check_source_overlap/_source_disjoint -> unique/filter_eq/
+group_nunique, block_analyzer.score_candidate — NOT a derive_block_key reuse
+(reviewer): its compound candidates carry PER-FIELD transforms and its
+empty-transform path is bare cast+concat_str, not blocker's expr. Port via
+per-field derive_transformed_column composition + the concat op, with the
+polars impl delegating to block_analyzer's own _apply_candidate_transforms
+for byte-fidelity; group_len + mean/std/max for stats. estimate_recall
+(sample + cast_str + fill_null). Gates: test_autoconfig.py,
+test_block_analyzer.py unedited.
+
+### W3e — controller plumbing + entry boundary (NO default flip)
+
+_take_sample/_sample_one/_stratified_sample/_pick_stratification_key onto
+Frame.sample/concat_frames/head; reference merge stays pl.concat
+vertical_relaxed (NEW op only if a call site needs it on arrow — it can't
+until W5; leave with a W5 note). auto_configure_df's isinstance gate
+(3546-3644) additionally accepts a Frame — unwrap `.native` AT THE TOP,
+before the throughput early-check (3593-3606) and the exclusions gate
+(both isinstance-DataFrame-guarded; a wrapped Frame would silently skip
+them — reviewer). PolarsFrame -> today's path; ArrowFrame ->
+pl.from_arrow shim with the W5 removal note (the W2d explicit-boundary
+pattern). The `reference` param stays Polars-only (deliberate: match-mode
+arrow can't flow until W5). _stratified_sample's partition uses the
+existing group_partitions (first-appearance order == partition_by
+maintain_order — already pinned by its W2d fixture). Gates:
+test_autoconfig_controller*.py, the serial heavy test_controller_adaptive_
+e2e.py, goldenmatch_frame_diff lane green.
+
+## Exit gates (whole wave)
+
+- Full goldenmatch shards + heavy + fallback green; differential harness
+  green. W5 IMPLICATION, stated now (reviewer): the harness stays green in
+  W3 only because ingest converts to polars in BOTH lanes, so both sample
+  identically. Once arrow flows past ingest (W5), per-backend sampling
+  means controller OUTPUT may legitimately differ across lanes — the
+  harness's controller expectations must become per-backend then; that is
+  the documented `sample` contract, not a bug.
+- throughput-gate green (cost metrics unchanged — the port is delegation).
+- No wall gate: the W2c precedent (both-refs-identical under the same
+  workload) + zero-config fix's bench provide the baseline; a W3-specific
+  wall run is meaningless while the tiny-block perf item is open (tracked
+  separately). State this in each PR.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| `sample` cross-backend non-parity misread as a bug later | The op docstring + fixtures pin the statistical contract explicitly; controller verdicts are per-backend by design |
+| Twins drift (_emit_data_profile vs _compute_data_profile_from_df) | Extract shared body in W3c (the W2c retire-the-mirror pattern) |
+| value_counts_desc tie order differs polars-vs-arrow | Secondary sort by value pinned in the op (both backends), fixture with ties |
+| Indicator budget checks time out differently after seam wrapping | Budgets are wall-clock guards, not outputs; test_indicators_budget.py pins the sentinel behavior unedited |
+| #1654 conflict (autoconfig_rules/_profile_helpers) | Fold main on its merge before W3b+ ship |

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -46,6 +46,25 @@ def resolve_frame_backend() -> str:
     return raw
 
 
+def _semantic_dtype_name(dtype_str: str) -> str:
+    """Cross-backend dtype tag: {text, numeric, date, bool, unknown}.
+
+    Polars spells Float64/Int64/String/Date/Boolean; Arrow spells
+    double/int64/large_string/date32[day]/bool. Raw substring checks like
+    `"float" in str(dtype)` misclassify Arrow's "double" as unknown -- this
+    table is the one normalization point (W3a, reviewer finding)."""
+    d = dtype_str.lower()
+    if any(t in d for t in ("utf", "str", "string")):
+        return "text"
+    if any(t in d for t in ("int", "float", "double", "decimal", "uint")):
+        return "numeric"
+    if any(t in d for t in ("date", "time")):
+        return "date"
+    if "bool" in d:
+        return "bool"
+    return "unknown"
+
+
 @runtime_checkable
 class Column(Protocol):
     def __len__(self) -> int: ...
@@ -56,6 +75,23 @@ class Column(Protocol):
     def unique(self) -> Column: ...
     def max(self) -> Any: ...
     def to_numpy(self) -> Any: ...
+    # W3a reduction ops (contracts in tests/test_frame_relational_ops.py):
+    # value_counts_desc INCLUDES nulls as a countable value (polars parity)
+    # and pins count-desc + stringified-value tiebreak ordering; std is
+    # ddof=1; semantic_dtype normalizes cross-backend dtype naming (Arrow
+    # says "double" where Polars says Float64 -- raw str(dtype) checks
+    # misclassify floats as unknown on arrow).
+    def drop_nulls(self) -> Column: ...
+    def cast_str(self, strict: bool = True) -> Column: ...
+    def fill_null(self, value: Any) -> Column: ...
+    def sum(self) -> Any: ...
+    def mean(self) -> Any: ...
+    def min(self) -> Any: ...
+    def std(self) -> Any: ...
+    def value_counts_desc(self) -> list[tuple[Any, int]]: ...
+    def str_len_chars(self) -> Column: ...
+    def blank_count(self) -> int: ...
+    def semantic_dtype(self) -> str: ...
 
 
 @runtime_checkable
@@ -124,6 +160,18 @@ class Frame(Protocol):
     def with_column(self, name: str, col: Column) -> Frame: ...
     def with_literal_column(self, name: str, value: Any) -> Frame: ...
     def group_partitions(self, key: str) -> list[tuple[Any, Frame]]: ...
+    # W3a controller/profiling ops. `sample`: statistical contract, NOT
+    # byte -- polars' RNG is not reproducible on arrow; same n,
+    # deterministic per (seed, backend), no duplicates, n>height raises.
+    # Once arrow flows past ingest (W5) the differential harness's
+    # controller expectations become per-backend BY DESIGN.
+    def sample(self, n: int, seed: int | None = None, shuffle: bool = False) -> Frame: ...
+    def with_row_index(self, name: str = "__row__") -> Frame: ...
+    def head(self, n: int) -> Frame: ...
+    def joint_n_unique(self, cols: Sequence[str]) -> int: ...
+    def group_nunique(self, key: str, value: str) -> Frame: ...
+    def coverage_ratio(self, pass_field_lists: Sequence[Sequence[str]]) -> float: ...
+    def distinct_row_count(self) -> int: ...
     # W2e-1: one field's standardizer chain (apply_standardization's
     # per-column derivation as a seam op; `address`/plugins fall back to the
     # pure-Python STANDARDIZERS oracle on the arrow backend).
@@ -171,6 +219,48 @@ class PolarsColumn:
 
     def to_numpy(self) -> Any:
         return self._s.to_numpy()
+
+    # -- W3a reductions (exact-delegation; contracts in the fixtures) ------
+
+    def drop_nulls(self) -> PolarsColumn:
+        return PolarsColumn(self._s.drop_nulls())
+
+    def cast_str(self, strict: bool = True) -> PolarsColumn:
+        return PolarsColumn(self._s.cast(pl.Utf8, strict=strict))
+
+    def fill_null(self, value: Any) -> PolarsColumn:
+        return PolarsColumn(self._s.fill_null(value))
+
+    def sum(self) -> Any:
+        return self._s.sum()
+
+    def mean(self) -> Any:
+        return self._s.mean()
+
+    def min(self) -> Any:
+        return self._s.min()
+
+    def std(self) -> Any:
+        return self._s.std()  # ddof=1, polars default (fixture-pinned)
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        # Includes nulls as a value (polars parity); ordering imposed HERE
+        # (polars value_counts has no order guarantee): count desc, then
+        # stringified value (None first) for cross-backend determinism.
+        vc = self._s.value_counts()
+        pairs = list(zip(vc[self._s.name].to_list(), vc["count"].to_list()))
+        pairs.sort(key=lambda t: (-t[1], t[0] is not None, str(t[0])))
+        return pairs
+
+    def str_len_chars(self) -> PolarsColumn:
+        return PolarsColumn(self._s.str.len_chars())
+
+    def blank_count(self) -> int:
+        # profiler.py:131 shape: non-null values whose strip() == "".
+        return int((self._s.drop_nulls().str.strip_chars() == "").sum())
+
+    def semantic_dtype(self) -> str:
+        return _semantic_dtype_name(str(self._s.dtype))
 
 
 class PolarsFrame:
@@ -407,6 +497,59 @@ class PolarsFrame:
         parts = self._df.partition_by(key, maintain_order=True, include_key=True)
         return [(p[key][0], PolarsFrame(p)) for p in parts]
 
+    # -- W3a controller/profiling ops ---------------------------------------
+
+    def sample(self, n: int, seed: int | None = None, shuffle: bool = False) -> PolarsFrame:
+        # Statistical contract (see Frame protocol note): polars rows are the
+        # per-backend reference; n>height raises (polars ShapeError).
+        return PolarsFrame(self._df.sample(n=n, seed=seed, shuffle=shuffle))
+
+    def with_row_index(self, name: str = "__row__") -> PolarsFrame:
+        return PolarsFrame(self._df.with_row_index(name))
+
+    def head(self, n: int) -> PolarsFrame:
+        return PolarsFrame(self._df.head(n))
+
+    def joint_n_unique(self, cols: Sequence[str]) -> int:
+        # autoconfig:3203 composite cardinality (null combos count).
+        return int(self._df.select(list(cols)).n_unique())
+
+    def group_nunique(self, key: str, value: str) -> PolarsFrame:
+        # _source_disjoint shape: rows where EITHER col is null are DROPPED
+        # (frame-level drop_nulls on the 2-col selection) before grouping.
+        g = (
+            self._df.select([key, value])
+            .drop_nulls()
+            .group_by(key)
+            .agg(pl.col(value).n_unique().alias("n_unique"))
+        )
+        return PolarsFrame(g)
+
+    def coverage_ratio(self, pass_field_lists: Sequence[Sequence[str]]) -> float:
+        # _union_coverage:1436-1451 VERBATIM: fraction of rows covered by at
+        # least one pass whose fields are ALL non-null. Missing column ->
+        # that pass covers nothing; empty pass list -> 0.0; an empty
+        # fields-list INSIDE a pass covers everything (all-True fold,
+        # unreachable today, pinned by fixture); height==0 -> 0.0.
+        if self._df.height == 0:
+            return 0.0
+        covered = pl.repeat(False, self._df.height, eager=True)
+        for fields in pass_field_lists:
+            present = pl.repeat(True, self._df.height, eager=True)
+            ok = True
+            for f in fields:
+                if f not in self._df.columns:
+                    ok = False
+                    break
+                present = present & self._df[f].is_not_null()
+            if not ok:
+                continue
+            covered = covered | present
+        return float(covered.sum() / self._df.height)
+
+    def distinct_row_count(self) -> int:
+        return int(self._df.unique().height)
+
     def derive_standardized_column(self, field: str, std_names: Sequence[str]) -> PolarsColumn:
         # Byte-identical to apply_standardization's three per-column branches
         # (standardize.py:443-501): native builders as one fused expr chain,
@@ -516,6 +659,71 @@ class ArrowColumn:
         if hasattr(arr, "combine_chunks"):
             arr = arr.combine_chunks()
         return arr.to_numpy(zero_copy_only=False)
+
+    # -- W3a reductions (pc twins; contracts in the fixtures) --------------
+
+    def drop_nulls(self) -> ArrowColumn:
+        import pyarrow.compute as pc
+
+        return ArrowColumn(pc.drop_null(self._col))
+
+    def cast_str(self, strict: bool = True) -> ArrowColumn:
+        from goldenmatch.core import arrow_derive
+
+        # strict is a polars-ism (uncastable -> null when False); the
+        # arrow_derive cast handles every dtype in the corpus and never
+        # raises for them, so both flavors route through it (fixture-pinned
+        # against BOTH strict values on the polars side).
+        return ArrowColumn(arrow_derive.cast_utf8(self._col))
+
+    def fill_null(self, value: Any) -> ArrowColumn:
+        import pyarrow.compute as pc
+
+        return ArrowColumn(pc.fill_null(self._col, value))
+
+    def sum(self) -> Any:
+        import pyarrow.compute as pc
+
+        v = pc.sum(self._col).as_py()
+        return v
+
+    def mean(self) -> Any:
+        import pyarrow.compute as pc
+
+        return pc.mean(self._col).as_py()
+
+    def min(self) -> Any:
+        import pyarrow.compute as pc
+
+        return pc.min(self._col).as_py()
+
+    def std(self) -> Any:
+        import pyarrow.compute as pc
+
+        return pc.stddev(self._col, ddof=1).as_py()  # polars ddof=1 parity
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        import pyarrow.compute as pc
+
+        vc = pc.value_counts(self._col)  # includes nulls, like polars
+        pairs = [(d["values"], d["counts"]) for d in vc.to_pylist()]
+        pairs.sort(key=lambda t: (-t[1], t[0] is not None, str(t[0])))
+        return pairs
+
+    def str_len_chars(self) -> ArrowColumn:
+        import pyarrow.compute as pc
+
+        return ArrowColumn(pc.utf8_length(self._col))  # codepoints, like polars
+
+    def blank_count(self) -> int:
+        import pyarrow.compute as pc
+
+        nonnull = pc.drop_null(self._col)
+        return pc.sum(pc.equal(pc.utf8_trim_whitespace(nonnull), "")).as_py() or 0
+
+    def semantic_dtype(self) -> str:
+        t = self._col.type if not hasattr(self._col, "chunks") else self._col.type
+        return _semantic_dtype_name(str(t))
 
 
 class ArrowFrame:
@@ -810,6 +1018,71 @@ class ArrowFrame:
                 order.append(v)
             groups[v].append(i)
         return [(v, ArrowFrame(self._tbl.take(groups[v]))) for v in order]
+
+    # -- W3a controller/profiling ops ---------------------------------------
+
+    def sample(self, n: int, seed: int | None = None, shuffle: bool = False) -> ArrowFrame:
+        import random
+
+        if n > self._tbl.num_rows:
+            raise ValueError(
+                f"cannot take a larger sample ({n}) than the population "
+                f"({self._tbl.num_rows}) -- polars ShapeError parity"
+            )
+        rng = random.Random(seed)
+        idx = rng.sample(range(self._tbl.num_rows), n)
+        if not shuffle:
+            idx.sort()  # polars shuffle=False keeps frame order
+        return ArrowFrame(self._tbl.take(idx))
+
+    def with_row_index(self, name: str = "__row__") -> ArrowFrame:
+        import pyarrow as pa
+
+        idx = pa.array(range(self._tbl.num_rows), type=pa.uint32())
+        return ArrowFrame(self._tbl.add_column(0, name, idx))
+
+    def head(self, n: int) -> ArrowFrame:
+        return ArrowFrame(self._tbl.slice(0, n))
+
+    def joint_n_unique(self, cols: Sequence[str]) -> int:
+        rows = zip(*(self._tbl.column(c).to_pylist() for c in cols))
+        return len(set(rows))
+
+    def group_nunique(self, key: str, value: str) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        sub = self._tbl.select([key, value])
+        keep = pc.and_kleene(pc.is_valid(sub.column(key)), pc.is_valid(sub.column(value)))
+        sub = sub.filter(keep)  # either-col-null rows DROP (contract)
+        grouped = sub.group_by(key).aggregate([(value, "count_distinct")])
+        names = ["n_unique" if c == f"{value}_count_distinct" else c for c in grouped.column_names]
+        return ArrowFrame(grouped.rename_columns(names))
+
+    def coverage_ratio(self, pass_field_lists: Sequence[Sequence[str]]) -> float:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        n = self._tbl.num_rows
+        if n == 0:
+            return 0.0
+        covered = pa.array([False] * n, type=pa.bool_())
+        for fields in pass_field_lists:
+            present = pa.array([True] * n, type=pa.bool_())
+            ok = True
+            for f in fields:
+                if f not in self._tbl.column_names:
+                    ok = False
+                    break
+                present = pc.and_(present, pc.is_valid(self._tbl.column(f)))
+            if not ok:
+                continue
+            covered = pc.or_(covered, present)
+        return float((pc.sum(covered).as_py() or 0) / n)
+
+    def distinct_row_count(self) -> int:
+        cols = self._tbl.column_names
+        rows = zip(*(self._tbl.column(c).to_pylist() for c in cols))
+        return len(set(rows))
 
     def derive_standardized_column(self, field: str, std_names: Sequence[str]) -> ArrowColumn:
         from goldenmatch.core import arrow_derive

--- a/packages/python/goldenmatch/tests/test_frame_relational_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_relational_ops.py
@@ -573,3 +573,161 @@ def test_group_partitions_unsorted_and_nulls() -> None:
         assert got == {"x": [0, 2, 5], "y": [1, 4], None: [3]}
         # first-appearance order
         assert [k for k, _ in parts] == ["x", "y", None]
+
+
+# ---- W3a ops: controller/profiling reductions ---------------------------------
+
+
+def _w3_pair(cols: dict) -> tuple[PolarsFrame, ArrowFrame]:
+    tbl = pa.table(cols)
+    return PolarsFrame(pl.from_arrow(tbl)), ArrowFrame(tbl)
+
+
+def test_w3_column_reductions_parity() -> None:
+    pf, af = _w3_pair({"n": pa.array([1.0, 2.0, 3.0, None], type=pa.float64())})
+    for frame in (pf, af):
+        c = frame.column("n")
+        assert c.drop_nulls().to_list() == [1.0, 2.0, 3.0]
+        assert c.sum() == 6.0
+        assert c.mean() == 2.0
+        assert c.min() == 1.0
+        assert c.std() == 1.0  # ddof=1 pinned
+        assert c.fill_null(0.0).to_list() == [1.0, 2.0, 3.0, 0.0]
+
+
+def test_w3_value_counts_desc_includes_nulls_pinned_order() -> None:
+    pf, af = _w3_pair({"c": pa.array(["a", "b", "a", None, "a", "b"], type=pa.string())})
+    want = [("a", 3), ("b", 2), (None, 1)]  # count desc; null in the tail tie
+    for frame in (pf, af):
+        assert frame.column("c").value_counts_desc() == want
+
+
+def test_w3_value_counts_tie_order() -> None:
+    pf, af = _w3_pair({"c": pa.array(["x", "y", "x", "y"], type=pa.string())})
+    for frame in (pf, af):
+        assert frame.column("c").value_counts_desc() == [("x", 2), ("y", 2)]
+
+
+def test_w3_str_len_chars_codepoints() -> None:
+    pf, af = _w3_pair({"c": pa.array(["héllo", "", None, "aé£€"], type=pa.string())})
+    for frame in (pf, af):
+        assert frame.column("c").str_len_chars().to_list() == [5, 0, None, 4]
+
+
+def test_w3_blank_count() -> None:
+    pf, af = _w3_pair({"c": pa.array(["x", "", "  ", None, "\t"], type=pa.string())})
+    for frame in (pf, af):
+        assert frame.column("c").blank_count() == 3
+
+
+def test_w3_cast_str_both_strict_flavors() -> None:
+    pf, af = _w3_pair({"n": pa.array([7030, None], type=pa.int64())})
+    for strict in (True, False):
+        want = pf.column("n").cast_str(strict=strict).to_list()
+        got = af.column("n").cast_str(strict=strict).to_list()
+        assert got == want == ["7030", None]
+
+
+def test_w3_semantic_dtype() -> None:
+    import datetime as dt
+
+    pf, af = _w3_pair(
+        {
+            "t": pa.array(["x"], type=pa.string()),
+            "f": pa.array([1.5], type=pa.float64()),  # arrow says "double"
+            "i": pa.array([1], type=pa.int64()),
+            "d": pa.array([dt.date(2020, 1, 1)], type=pa.date32()),
+            "b": pa.array([True], type=pa.bool_()),
+        }
+    )
+    for frame in (pf, af):
+        assert frame.column("t").semantic_dtype() == "text"
+        assert frame.column("f").semantic_dtype() == "numeric"  # THE double fix
+        assert frame.column("i").semantic_dtype() == "numeric"
+        assert frame.column("d").semantic_dtype() == "date"
+        assert frame.column("b").semantic_dtype() == "bool"
+
+
+def test_w3_sample_contract() -> None:
+    tbl = pa.table({"i": pa.array(list(range(100)), type=pa.int64())})
+    pf, af = PolarsFrame(pl.from_arrow(tbl)), ArrowFrame(tbl)
+    for frame in (pf, af):
+        s1 = frame.sample(10, seed=42)
+        s2 = frame.sample(10, seed=42)
+        assert s1.height == s2.height == 10
+        # deterministic per (seed, backend)
+        assert s1.column("i").to_list() == s2.column("i").to_list()
+        # no duplicates
+        assert len(set(s1.column("i").to_list())) == 10
+        # n > height raises (polars ShapeError parity)
+        with pytest.raises(Exception):
+            frame.sample(1000, seed=1)
+
+
+def test_w3_with_row_index_and_head() -> None:
+    pf, af = _w3_pair({"c": pa.array(["a", "b", "c"], type=pa.string())})
+    for frame in (pf, af):
+        idx = frame.with_row_index("__row__")
+        assert idx.columns[0] == "__row__"
+        assert idx.column("__row__").to_list() == [0, 1, 2]
+        assert frame.head(2).column("c").to_list() == ["a", "b"]
+
+
+def test_w3_joint_n_unique_null_combos() -> None:
+    pf, af = _w3_pair(
+        {
+            "a": pa.array([1, 1, None, 1], type=pa.int64()),
+            "b": pa.array([2, 3, 2, 2], type=pa.int64()),
+        }
+    )
+    for frame in (pf, af):
+        assert frame.joint_n_unique(["a", "b"]) == 3  # (1,2) dup; null combo counts
+
+
+def test_w3_group_nunique_drops_either_null() -> None:
+    pf, af = _w3_pair(
+        {
+            "k": pa.array(["x", "x", "y", None, "y"], type=pa.string()),
+            "v": pa.array(["s1", "s2", "s1", "s1", None], type=pa.string()),
+        }
+    )
+    for frame in (pf, af):
+        got = frame.group_nunique("k", "v")
+        d = dict(zip(got.column("k").to_list(), got.column("n_unique").to_list()))
+        # null-k row and null-v row both dropped BEFORE grouping.
+        assert d == {"x": 2, "y": 1}
+
+
+def test_w3_coverage_ratio_edges() -> None:
+    pf, af = _w3_pair(
+        {
+            "a": pa.array(["x", None, "z", None], type=pa.string()),
+            "b": pa.array([1.0, 2.0, None, float("nan")], type=pa.float64()),
+        }
+    )
+    for frame in (pf, af):
+        # pass [a]: rows 0,2; pass [b]: rows 0,1,3 (NaN is non-null!) -> union all 4
+        assert frame.coverage_ratio([["a"], ["b"]]) == 1.0
+        # single pass [a,b]: both non-null -> row 0 and row 3? a[3]=None -> just row 0
+        assert frame.coverage_ratio([["a", "b"]]) == 0.25
+        # missing column: pass contributes nothing
+        assert frame.coverage_ratio([["nope"]]) == 0.0
+        # empty pass list
+        assert frame.coverage_ratio([]) == 0.0
+        # empty fields INSIDE a pass covers everything (pinned; unreachable today)
+        assert frame.coverage_ratio([[]]) == 1.0
+    # height == 0
+    e = pa.table({"a": pa.array([], type=pa.string())})
+    assert ArrowFrame(e).coverage_ratio([["a"]]) == 0.0
+    assert PolarsFrame(pl.from_arrow(e)).coverage_ratio([["a"]]) == 0.0
+
+
+def test_w3_distinct_row_count() -> None:
+    pf, af = _w3_pair(
+        {
+            "a": pa.array([1, 1, 2, None], type=pa.int64()),
+            "b": pa.array(["x", "x", "y", "z"], type=pa.string()),
+        }
+    )
+    for frame in (pf, af):
+        assert frame.distinct_row_count() == 3


### PR DESCRIPTION
## Wave 3 batch A of the [Polars-eviction program](docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md)

Plan: `docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w3.md` (reviewer-hardened). Predecessors: all of W0-W2 (#1616...#1655).

Pure-additive ops batch (the W2b pattern) for the controller/autoconfig front — 11 Column reductions + 7 Frame ops, both backends, fixtures-first, zero call-site changes. Highlights:
- **`semantic_dtype`** (reviewer's strongest catch): Arrow stringifies float64 as `double`, which the existing `"float" in str(dtype)` checks misclassify as unknown — silently skewing controller `column_types` on the arrow backend. One pinned normalization table.
- **`sample`** carries a STATISTICAL contract, not byte-parity (polars' RNG is not reproducible on arrow): deterministic per (seed, backend), no duplicates, n>height raises. The W5 differential-harness implication (per-backend controller expectations once arrow flows past ingest) is documented in the plan so it can't be rediscovered as a bug.
- **`value_counts_desc`** includes nulls (polars parity) and IMPOSES count-desc + value-tiebreak ordering (polars itself guarantees none) — the goldencheck-proven shape `_emit_matchkey_profile`'s Chao1 will consume in W3c.
- **`coverage_ratio`** = `_union_coverage` as one semantic op with all edge cases pinned (missing column, empty pass list, empty fields-inside-pass, float-NaN non-null, zero-height).

### Verification
13 new fixtures in the existing `test_frame_relational_ops.py` (no pytest-split shard shift); 362-test seam battery green; ruff clean.

W3b (indicators) follows on this batch's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW