### PR TITLE
fix(goldenmatch): cast pl.from_arrow result before .lazy() -- pyright red on main

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -810,7 +810,8 @@ def run_dedupe(
         from goldenmatch.core.frame import ArrowFrame as _ArrowFrame
 
         if isinstance(lf, _ArrowFrame):
-            lf = pl.from_arrow(lf.native).lazy()
+            # from_arrow is typed DataFrame | Series; a Table is always a DataFrame
+            lf = cast("pl.DataFrame", pl.from_arrow(lf.native)).lazy()
         if column_map:
             lf = apply_column_map(lf, column_map)
         required = _get_required_columns(config)


### PR DESCRIPTION
Required pyright lane is red on main: the W2d ingest shim in pipeline.py calls .lazy() on pl.from_arrow's DataFrame | Series union. Every PR is blocked on it (first seen on #1654). A pa.Table always yields a DataFrame; cast narrows it.

One-line type fix, no runtime change.