### PR TITLE
feat(goldenmatch): optional output_path on agent_deduplicate/agent_match_sources

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -592,9 +592,14 @@ def _write_frame_csv(
             "error": f"output_path rejected: {validated['error']}",
         }
 
-    cols = [c for c in frame.columns if not c.startswith("__")]
-    frame.select(cols).write_csv(str(validated))
-    return {path_key: str(validated), records_key: frame.height}
+    # Results are Arrow-native post-3.0.0 (the W5 pa.Table flip); write via
+    # pyarrow's CSV writer, mirroring server.py's export_results path. Do NOT
+    # reintroduce polars here (the eviction program removed it from this seam).
+    from pyarrow import csv as _pacsv
+
+    cols = [c for c in frame.column_names if not c.startswith("__")]
+    _pacsv.write_csv(frame.select(cols), str(validated))
+    return {path_key: str(validated), records_key: frame.num_rows}
 
 
 def handle_agent_tool(name: str, arguments: dict) -> list[TextContent]:

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -155,6 +155,7 @@ AGENT_TOOLS = [
                 "file_path": {"type": "string"},
                 "config": {"type": "object"},
                 "exclude_columns": _EXCLUDE_COLUMNS_SCHEMA,
+                "output_path": {"type": "string", "description": "Optional. If given, write the golden (deduplicated) records to this CSV path and return golden_path + golden_records. Omit to get the summary only."},
                 "file_content": {
                     "type": "string",
                     "description": "Alternative to file_path: file bytes (base64 default, or raw with encoding='text')",
@@ -553,6 +554,39 @@ def _serialize_result(result: Any) -> dict:
     return {"value": str(result)}
 
 
+def _write_frame_csv(
+    output_path: str,
+    frame: Any,
+    label: str,
+    *,
+    count_key: str | None = None,
+) -> dict:
+    """Validate *output_path* and write *frame* to CSV, stripping `__` columns.
+
+    Reuses the same ``safe_path`` guard the other file-writing MCP tools use
+    (via ``server._safe_path_or_error``). Returns a dict to merge into the
+    tool response: ``{"<label>_path": str, "<count_key>": height}`` on success,
+    or ``{"<label>_path": None, "<label>_error": ...}`` when no frame exists /
+    the path is rejected.
+    """
+    from goldenmatch.mcp.server import _safe_path_or_error
+
+    path_key = f"{label}_path"
+    error_key = f"{label}_error"
+    records_key = count_key or f"{label}_records"
+
+    if frame is None:
+        return {path_key: None, error_key: f"no {label} frame produced"}
+
+    validated = _safe_path_or_error(output_path)
+    if isinstance(validated, dict):  # {"error": ...} from the guard
+        return {path_key: None, error_key: validated["error"]}
+
+    cols = [c for c in frame.columns if not c.startswith("__")]
+    frame.select(cols).write_csv(str(validated))
+    return {path_key: str(validated), records_key: frame.height}
+
+
 def handle_agent_tool(name: str, arguments: dict) -> list[TextContent]:
     """Route an agent-level MCP tool call to the appropriate handler.
 
@@ -655,7 +689,7 @@ def _dispatch(
             if _excl_token is not None:
                 from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
                 _RUNTIME_EXCLUDE_COLUMNS.reset(_excl_token)
-        return {
+        out = {
             "reasoning": raw.get("reasoning", {}),
             "confidence_distribution": raw.get("confidence_distribution", {}),
             "storage": raw.get("storage", "memory"),
@@ -663,6 +697,11 @@ def _dispatch(
                 or {"available": False, "source": None},
             "results": _serialize_result(raw.get("results")),
         }
+        output_path = args.get("output_path")
+        if output_path:
+            golden = getattr(raw.get("results"), "golden", None)
+            out.update(_write_frame_csv(output_path, golden, "golden"))
+        return out
 
     if name == "agent_match_sources":
         session = session_cls()

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -176,6 +176,7 @@ AGENT_TOOLS = [
                 "file_b": {"type": "string"},
                 "config": {"type": "object"},
                 "exclude_columns": _EXCLUDE_COLUMNS_SCHEMA,
+                "output_path": {"type": "string", "description": "Optional. If given, write the linked/matched pairs to this CSV path and return matches_path + matched_pairs. Omit to get the summary only."},
                 "file_a_content": {"type": "string", "description": "Alternative to file_a: base64/text bytes"},
                 "file_a_name": {"type": "string"},
                 "file_b_content": {"type": "string", "description": "Alternative to file_b: base64/text bytes"},
@@ -717,12 +718,21 @@ def _dispatch(
             if _excl_token is not None:
                 from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
                 _RUNTIME_EXCLUDE_COLUMNS.reset(_excl_token)
-        return {
+        out = {
             "reasoning": raw.get("reasoning", {}),
             "telemetry": session.last_telemetry
                 or {"available": False, "source": None},
             "results": _serialize_result(raw.get("results")),
         }
+        output_path = args.get("output_path")
+        if output_path:
+            matched = getattr(raw.get("results"), "matched", None)
+            out.update(
+                _write_frame_csv(
+                    output_path, matched, "matches", count_key="matched_pairs"
+                )
+            )
+        return out
 
     if name == "agent_explain_pair":
         from goldenmatch._api import explain_pair_df

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -581,7 +581,16 @@ def _write_frame_csv(
 
     validated = _safe_path_or_error(output_path)
     if isinstance(validated, dict):  # {"error": ...} from the guard
-        return {path_key: None, error_key: validated["error"]}
+        # Path REJECTION (outside GOLDENMATCH_ALLOWED_ROOT / NUL byte) — set a
+        # top-level `error` too, the convention handle_agent_tool uses for
+        # failure, so an agent that asked to write a file cannot mistake the
+        # buried namespaced error for success. (The benign no-frame case above
+        # stays informational-only: nothing was asked-for-but-refused.)
+        return {
+            path_key: None,
+            error_key: validated["error"],
+            "error": f"output_path rejected: {validated['error']}",
+        }
 
     cols = [c for c in frame.columns if not c.startswith("__")]
     frame.select(cols).write_csv(str(validated))

--- a/packages/python/goldenmatch/tests/test_agent_output_path.py
+++ b/packages/python/goldenmatch/tests/test_agent_output_path.py
@@ -81,3 +81,64 @@ def test_agent_match_sources_no_output_path_unchanged(tmp_path):
     res = _dispatch("agent_match_sources", {"file_a": a, "file_b": b}, AgentSession)
     assert "matches_path" not in res
     assert "results" in res
+
+
+def test_agent_deduplicate_output_path_rejected_surfaces_top_level_error(
+    tmp_path, monkeypatch
+):
+    """A path outside GOLDENMATCH_ALLOWED_ROOT must fail loudly (top-level error).
+
+    The `safe_path` guard reads GOLDENMATCH_ALLOWED_ROOT; point it at a
+    sandbox dir and aim output_path at a SIBLING outside it. The guard
+    rejects, and the fix must surface a top-level `error` (not just the
+    buried golden_error) so an agent can't mistake it for a successful write.
+    """
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    root = tmp_path / "sandbox"
+    root.mkdir()
+    monkeypatch.setenv("GOLDENMATCH_ALLOWED_ROOT", str(root))
+
+    # Fixture lives INSIDE the root (so ingest/read isn't what's rejected);
+    # the OUTPUT target is a sibling OUTSIDE the root.
+    fixture = _fixture_csv(root)
+    outside = tmp_path / "escape.csv"
+
+    res = _dispatch(
+        "agent_deduplicate",
+        {"file_path": fixture, "output_path": str(outside)},
+        AgentSession,
+    )
+
+    assert res["golden_path"] is None
+    assert "error" in res  # top-level, unmissable
+    assert "golden_error" in res
+    assert not outside.exists()  # nothing written outside the root
+
+
+def test_agent_deduplicate_no_golden_frame_is_benign(tmp_path, monkeypatch):
+    """A None golden frame is a benign 'nothing to write' — namespaced error
+    only, NO top-level `error` (that's reserved for path rejection)."""
+    from goldenmatch.mcp import agent_tools
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    # Force golden to None on whatever result the pipeline produced, without
+    # depending on data that happens to yield an empty golden frame.
+    real_write = agent_tools._write_frame_csv
+
+    def _none_frame_write(output_path, frame, label, **kw):
+        return real_write(output_path, None, label, **kw)
+
+    monkeypatch.setattr(agent_tools, "_write_frame_csv", _none_frame_write)
+
+    out = tmp_path / "golden.csv"
+    res = _dispatch(
+        "agent_deduplicate",
+        {"file_path": _fixture_csv(tmp_path), "output_path": str(out)},
+        AgentSession,
+    )
+
+    assert res["golden_path"] is None
+    assert res.get("golden_error") == "no golden frame produced"
+    assert "error" not in res  # benign: no top-level failure signal
+    assert not out.exists()

--- a/packages/python/goldenmatch/tests/test_agent_output_path.py
+++ b/packages/python/goldenmatch/tests/test_agent_output_path.py
@@ -1,12 +1,11 @@
 # Task 1.1 spike result — golden extraction, verified working:
 #   raw = AgentSession().deduplicate(file_path)
-#   golden_df = raw["results"].golden          # polars.DataFrame | None, populated by default
+#   golden_tbl = raw["results"].golden         # pyarrow.Table | None (3.0.0 Arrow flip), populated by default
 # The match side exposes the linked frame as `raw["results"].matched` (MatchResult.matched).
-# Both frames may carry `__`-prefixed internal columns which are stripped before write_csv.
+# Both tables may carry `__`-prefixed internal columns which are stripped before the pyarrow CSV write.
 from pathlib import Path
 
 import polars as pl
-
 from goldenmatch.core.agent import AgentSession
 
 
@@ -32,7 +31,7 @@ def test_dedupe_result_exposes_golden(tmp_path):
     raw = AgentSession().deduplicate(_fixture_csv(tmp_path))
     result = raw["results"]
     assert getattr(result, "golden", None) is not None
-    assert result.golden.height >= 1
+    assert result.golden.num_rows >= 1
 
 
 def test_agent_deduplicate_writes_golden(tmp_path):

--- a/packages/python/goldenmatch/tests/test_agent_output_path.py
+++ b/packages/python/goldenmatch/tests/test_agent_output_path.py
@@ -1,0 +1,83 @@
+# Task 1.1 spike result — golden extraction, verified working:
+#   raw = AgentSession().deduplicate(file_path)
+#   golden_df = raw["results"].golden          # polars.DataFrame | None, populated by default
+# The match side exposes the linked frame as `raw["results"].matched` (MatchResult.matched).
+# Both frames may carry `__`-prefixed internal columns which are stripped before write_csv.
+from pathlib import Path
+
+import polars as pl
+
+from goldenmatch.core.agent import AgentSession
+
+
+def _fixture_csv(tmp_path: Path) -> str:
+    df = pl.DataFrame({
+        "name": ["John Smith", "Jon Smith", "Mary Jones", "Karen White"],
+        "email": ["j@x.com", "j@x.com", "m@y.com", "k@z.com"],
+    })
+    p = tmp_path / "in.csv"
+    df.write_csv(p)
+    return str(p)
+
+
+def _two_fixtures(tmp_path):
+    a = tmp_path / "a.csv"
+    b = tmp_path / "b.csv"
+    pl.DataFrame({"name": ["John Smith", "Mary Jones"], "id": [1, 2]}).write_csv(a)
+    pl.DataFrame({"name": ["Jon Smith", "Karen White"], "id": [9, 8]}).write_csv(b)
+    return str(a), str(b)
+
+
+def test_dedupe_result_exposes_golden(tmp_path):
+    raw = AgentSession().deduplicate(_fixture_csv(tmp_path))
+    result = raw["results"]
+    assert getattr(result, "golden", None) is not None
+    assert result.golden.height >= 1
+
+
+def test_agent_deduplicate_writes_golden(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    out = tmp_path / "golden.csv"
+    res = _dispatch(
+        "agent_deduplicate",
+        {"file_path": _fixture_csv(tmp_path), "output_path": str(out)},
+        AgentSession,
+    )
+    assert res["golden_path"] == str(out)
+    assert res["golden_records"] >= 1
+    assert out.exists()
+    got = pl.read_csv(out)
+    assert got.height == res["golden_records"]
+    assert not any(c.startswith("__") for c in got.columns)
+
+
+def test_agent_deduplicate_no_output_path_unchanged(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    res = _dispatch("agent_deduplicate", {"file_path": _fixture_csv(tmp_path)}, AgentSession)
+    assert "golden_path" not in res
+    assert "results" in res
+
+
+def test_agent_match_sources_writes_matches(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    a, b = _two_fixtures(tmp_path)
+    out = tmp_path / "matches.csv"
+    res = _dispatch(
+        "agent_match_sources",
+        {"file_a": a, "file_b": b, "output_path": str(out)},
+        AgentSession,
+    )
+    assert res["matches_path"] == str(out)
+    assert out.exists()
+
+
+def test_agent_match_sources_no_output_path_unchanged(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+
+    a, b = _two_fixtures(tmp_path)
+    res = _dispatch("agent_match_sources", {"file_a": a, "file_b": b}, AgentSession)
+    assert "matches_path" not in res
+    assert "results" in res


### PR DESCRIPTION
## What

Adds an optional `output_path` to the `agent_deduplicate` and `agent_match_sources` MCP tools. When given, the tool writes its golden (deduplicated) / linked-matched records to that CSV path and returns `golden_path`+`golden_records` / `matches_path`+`matched_pairs`. Omit it and behavior is **unchanged** (summary only) — fully backward compatible.

## Why

The batch-ER agent tools are stateless and returned a summary only; the golden records existed on `result.golden`/`result.matched` but were discarded by `_serialize_result`. The base `export_results` tool can't help in an aggregated/stateless context (it reads a module-global `_result` only populated at standalone-server boot). This makes the agent tools self-sufficient for producing a file — independently useful, and the prerequisite for the goldensuite-mcp composite workflow tools.

## How

- New `_write_frame_csv` helper: validates `output_path` through the **same** `_safe_path_or_error`/`safe_path` guard `export_results` uses (lazy import — `server` imports `agent_tools` at module top), strips `__`-prefixed internal columns, writes the frame. On guard **rejection** (path outside `GOLDENMATCH_ALLOWED_ROOT`) it surfaces a **top-level `error`** so an agent can't miss it; a benign no-frame case returns a namespaced `*_error` only.
- `output_path` added to both tools' `inputSchema`.

## Tests

7 tests (`tests/test_agent_output_path.py`): writes golden/matches CSV + row count + `__`-column stripping; backward-compat (absent output_path unchanged) for both tools; guard-rejection surfaces top-level error + nothing written outside root; benign None-frame. Guard-rejection test verified RED without the fix. TDD; spec + code-quality reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s