### PR TITLE
feat(goldencheck-core): W0-land -- Arrow-in-core kernel foundation (3.0.0 fused-scan program)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldencheck-w0-land-arrow-core.md
+++ b/docs/superpowers/plans/2026-07-11-goldencheck-w0-land-arrow-core.md
@@ -1,0 +1,98 @@
+# W0-land: Arrow-in-core kernel foundation — Implementation Plan
+
+> Use superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Land the Arrow-in-core kernel foundation (from the stale `feat/goldencheck-arrow-native-core` branch) onto main-with-2.0.0: convert the 5 existing `goldencheck-core` kernels (benford, keys/composite/FD/approx-FD, fuzzy) from slice-in to **Arrow-in** (`&dyn Array`), thin the `-native` shims, and land the reusable **parity-oracle harness**. Reconcile to `arrow = 59` (main's native version) and integrate alongside the regex/date/dc kernels 2.0.0 added.
+
+**Architecture:** The proven code exists on `feat/goldencheck-arrow-native-core` (built against arrow 55). This wave PORTS that code onto fresh main, fixing (a) arrow 55->59 API deltas, (b) coexistence with the regex/date/dc kernels on main. Rust kernel = source of truth; parity harness asserts native == Python fallback with an empty accepted-divergence registry.
+
+**Program:** `docs/superpowers/specs/2026-07-11-goldencheck-arrow-fused-scan-engine-program-design.md` (this is W0-land, the foundation wave).
+
+---
+
+## Audit result (already done — the strategy)
+
+- **NOT a rebase** — the branch's `_native_loader` reference-mode flip is ALREADY on main (2.0.0), and its pyproject/ci/version changes conflict. Only the KERNEL work + parity harness are new value.
+- **Port these from the branch** (reference: `git show feat/goldencheck-arrow-native-core:<path>`): `goldencheck-core/src/{arrow_support.rs, benford.rs, keys.rs, fuzzy.rs, lib.rs}`, `goldencheck-core/Cargo.toml` (arrow dep), `goldencheck-native/src/{keys.rs, fuzzy.rs, profile.rs}` (thinned shims), `tests/core/{parity_harness.py, test_parity_harness.py, test_loader_reference_mode.py}`, and call-site adaptations in `goldencheck/profilers/fuzzy_values.py` + `goldencheck/cell_quality.py`.
+- **Reconcile:** arrow **59** not 55 (match `goldencheck-native`); leave main's `regex.rs`/`date.rs`/`dc.rs` UNTOUCHED (they stay list/string-based this wave); do NOT touch `_native_loader.py` (already reference-mode), pyproject version (stays 2.0.0), ci.yml.
+
+## Conventions (worktree `gc-w0`, branch `feat/goldencheck-w0-land-arrow-core`, off fresh main)
+
+Rust toolchain: `export PATH="/d/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin:$PATH" CARGO_HOME=/d/.cargo RUSTUP_HOME=/d/.rustup`.
+Python: `export PYTHONPATH="D:/show_case/gc-w0/packages/python/goldencheck" POLARS_SKIP_CPU_CHECK=1 GOLDENCHECK_NATIVE=auto; PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe`.
+Native build: `$PY scripts/build_goldencheck_native.py` then Windows `.dll`->`.pyd` copy (see prior waves). Ruff 100-char.
+
+**INVARIANTS:** native output byte/set-identical to before (the kernels were already exact — any diff is a mechanism bug); the S2.2/S2.3 regex/date native paths still work (regex+str_to_date symbols present + enabled); `import goldencheck` loads zero polars; existing tests + `tests/core/test_native_parity.py` pass. Commit per task; do NOT push (PR at end).
+
+---
+
+## Task 1: Arrow dep + `arrow_support.rs` + Benford Arrow-in-core (prove the pattern)
+
+**Files:** `goldencheck-core/Cargo.toml`, `goldencheck-core/src/{arrow_support.rs (new), benford.rs, lib.rs}`, `goldencheck-native/src/profile.rs` (benford shim).
+
+- [ ] **Step 1:** Add to `goldencheck-core/Cargo.toml` `[dependencies]`: `arrow = { version = "59", default-features = false }` (match native's version; native adds `features=["pyarrow"]` — core does NOT need pyarrow, just the array types). READ the branch's Cargo.toml (`git show feat/goldencheck-arrow-native-core:packages/rust/extensions/goldencheck-core/Cargo.toml`) for the feature set it used (it used arrow 55) and adapt to 59.
+- [ ] **Step 2:** Create `goldencheck-core/src/arrow_support.rs` — port from the branch (`git show feat/goldencheck-arrow-native-core:packages/rust/extensions/goldencheck-core/src/arrow_support.rs`). Fix arrow 55->59 API (array downcast helpers, null-bitmap iteration). This is the shared Arrow-decode helper module.
+- [ ] **Step 3:** Convert `benford.rs`: signature `benford_leading_digits(array: &dyn Array) -> Result<[u64;9], ArrowError>` (port from branch), downcast Float64/Int64/Decimal + honor null bitmap. Add `mod arrow_support;` + re-export in `lib.rs`.
+- [ ] **Step 4:** Thin `goldencheck-native/src/profile.rs` (the benford shim): decode `PyArrowType<ArrayData>` -> `ArrayRef`, hand `array.as_ref()` to core (port from branch's version).
+- [ ] **Step 5:** Build + test:
+```bash
+cd packages/rust/extensions/goldencheck-core && cargo test --release 2>&1 | grep -E "^error|test result:"
+cargo build -p goldencheck-native --release 2>&1 | grep -E "^error" || echo "native builds"
+```
+Fix arrow-59 API errors until clean. Then `rustfmt` the touched files.
+- [ ] **Step 6:** Build the ext + verify benford + the S2.2/S2.3 regex/date symbols still present:
+```bash
+cd /d/show_case/gc-w0 && $PY scripts/build_goldencheck_native.py   # + .dll->.pyd
+$PY -c "import goldencheck._native as n; print('benford', hasattr(n,'benford_leading_digits'), 'regex', hasattr(n,'str_contains_count'), 'date', hasattr(n,'str_to_date'))"
+$PY -m pytest packages/python/goldencheck/tests/core/test_native_parity.py -k benford -v
+```
+- [ ] **Step 7:** Commit.
+```bash
+git add packages/rust/extensions/goldencheck-core packages/rust/extensions/goldencheck-native/src/profile.rs
+git commit -m "feat(goldencheck-core): W0-land Benford Arrow-in-core (arrow 59) + arrow_support module"
+```
+
+## Task 2: keys + fuzzy Arrow-in-core + thin their shims
+
+**Files:** `goldencheck-core/src/{keys.rs, fuzzy.rs, lib.rs}`, `goldencheck-native/src/{keys.rs, fuzzy.rs}`.
+
+- [ ] Port keys.rs (composite_key/FD/approx-FD kernels) + fuzzy.rs to Arrow-in from the branch (`git show feat/goldencheck-arrow-native-core:...`), reconciled to arrow 59. Thin the native keys.rs/fuzzy.rs shims (the branch removed the native `intern_column`; that logic moved to core). Build both crates clean (grep `^error`), rustfmt.
+- [ ] Verify all 5 component symbols present + the parity for keys/fuzzy:
+```bash
+$PY scripts/build_goldencheck_native.py   # + .pyd
+$PY -m pytest packages/python/goldencheck/tests/core/test_native_parity.py -v
+```
+- [ ] Commit: `feat(goldencheck-core): W0-land key/FD + fuzzy kernels Arrow-in-core (arrow 59)`.
+
+## Task 3: parity-oracle harness + call-site adaptations
+
+**Files:** `tests/core/{parity_harness.py (new), test_parity_harness.py (new), test_loader_reference_mode.py (new)}`, `goldencheck/profilers/fuzzy_values.py`, `goldencheck/cell_quality.py`.
+
+- [ ] Port the parity-oracle harness + its tests from the branch (empty accepted-divergence registry). It runs each component twice (native + fallback) on random+adversarial fixtures, compares, looks up the registry. Adapt any import paths to current main.
+- [ ] Port the call-site adaptations in `fuzzy_values.py` + `cell_quality.py` (they now pass Arrow to the kernel via `.to_arrow()` — reconcile with how main's versions call the kernel). Confirm the two GoldenMatch bridges (`cell_quality`, `functional_dependencies`) keep their pyarrow-facing signatures.
+- [ ] Run the harness both lanes + the bridges:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core/ -v            # harness + parity, native present
+GOLDENCHECK_NATIVE=0 $PY -m pytest packages/python/goldencheck/tests/core/ -v   # fallback lane
+$PY -m pytest packages/python/goldencheck/tests -k "cell_quality or functional_dependencies or fuzzy" -v
+```
+Expected: harness green with EMPTY registry (kernels are exact); both lanes green.
+- [ ] Ruff clean; commit: `test(goldencheck): W0-land parity-oracle harness + Arrow call-sites`.
+
+## Task 4: final verification + PR
+
+- [ ] Full targeted verification:
+```bash
+$PY -m pytest packages/python/goldencheck/tests/core packages/python/goldencheck/tests/test_import_no_polars.py -v
+$PY -m pytest packages/python/goldencheck/tests -k "native_parity or relations or profilers" -q
+cd packages/rust/extensions/goldencheck-core && cargo test --release 2>&1 | grep -E "^error|test result:"
+$PY -m ruff check packages/python/goldencheck/goldencheck packages/python/goldencheck/tests
+```
+Confirm: 5 kernels Arrow-in-core; regex/date/dc untouched + still working; parity harness green empty-registry; both native + fallback lanes green; `import goldencheck` zero polars; version stays 2.0.0 (internal refactor, minor — actually no version change this wave).
+- [ ] PR to main (additive/internal — the Arrow-in-core refactor changes no Python output; native stays byte/set-exact). Arm auto-merge.
+
+## Done criteria
+- 5 `goldencheck-core` kernels take `&dyn Array` (Arrow-in-core), arrow=59 lockstep with native; `-native` shims are thin pyarrow marshalling.
+- Parity-oracle harness reusable, green, empty accepted-divergence registry.
+- regex/date/dc kernels untouched; all native symbols present + enabled; zero polars on import; existing suite green.
+- Foundation ready for W1 (fused aggregate checks) to build on.

--- a/packages/python/goldencheck/tests/core/parity_harness.py
+++ b/packages/python/goldencheck/tests/core/parity_harness.py
@@ -1,0 +1,329 @@
+"""Reusable parity-oracle harness. The Rust kernel is the source of truth; the
+pure-Python/Polars fallback is asserted 'conforms or is documented-lossy'. Every
+divergence must appear in ACCEPTED_DIVERGENCES (with a rationale + product-decision
+ref) or the harness fails. Wave 0: the registry is EMPTY (all 5 kernels are
+byte/set-exact), which validates the harness mechanics on known-exact code.
+
+New waves add kernels by appending a Component to REGISTERED_COMPONENTS -- each
+reuses the generators/fallbacks the hard-coded test_native_parity.py already
+defines, so parity checking of a new surface is a few lines, not a new test file.
+"""
+from __future__ import annotations
+
+import os
+import random
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import polars as pl
+import pyarrow as pa
+from goldencheck import cell_quality as _cell_quality
+from goldencheck import functional_dependencies as _fd_bridge
+from goldencheck.core._native_loader import native_module
+from goldencheck.profilers import fuzzy_values as fv
+from goldencheck.relations import approx_fd as afd
+from goldencheck.relations import composite_key as ck
+from goldencheck.relations import functional_dependency as fd
+
+# Reuse the fixture generators + Python-fallback helpers the hard-coded parity
+# test already defines instead of duplicating them.
+from tests.core import test_native_parity as tp
+
+
+@dataclass(frozen=True)
+class Divergence:
+    component: str
+    rationale: str
+    decision_ref: str
+
+
+# Empty in Wave 0. A future wave adds an entry when a kernel is deemed "more
+# correct" than the Polars fallback AND the product decision is signed off.
+ACCEPTED_DIVERGENCES: tuple[Divergence, ...] = ()
+
+
+@dataclass
+class Component:
+    name: str                                  # loader component key
+    run_native: Callable[[Any], Any]           # fixture -> native result (normalized)
+    run_fallback: Callable[[Any], Any]         # fixture -> Python fallback result (normalized)
+    fixtures: Callable[[int], list[Any]]       # seed -> list of input fixtures
+
+
+def _accepted(name: str) -> bool:
+    return any(d.component == name for d in ACCEPTED_DIVERGENCES)
+
+
+def compare(component: Component, seed: int) -> list[str]:
+    """Return unexpected-divergence descriptions (empty list = parity)."""
+    problems: list[str] = []
+    for fx in component.fixtures(seed):
+        nat = component.run_native(fx)
+        fb = component.run_fallback(fx)
+        if nat != fb and not _accepted(component.name):
+            problems.append(
+                f"{component.name}: native={nat!r} fallback={fb!r} on fixture={fx!r}"
+            )
+    return problems
+
+
+@contextmanager
+def _native_env(value: str) -> Iterator[None]:
+    """Temporarily force GOLDENCHECK_NATIVE (the loader re-reads it every call)."""
+    prev = os.environ.get("GOLDENCHECK_NATIVE")
+    os.environ["GOLDENCHECK_NATIVE"] = value
+    try:
+        yield
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENCHECK_NATIVE", None)
+        else:
+            os.environ["GOLDENCHECK_NATIVE"] = prev
+
+
+# ---------------------------------------------------------------------------
+# benford
+# ---------------------------------------------------------------------------
+def _benford_fixtures(seed: int) -> list[np.ndarray]:
+    rng = random.Random(seed)
+    random_arr = np.array(
+        [rng.uniform(1e-4, 1e7) for _ in range(8000)]
+        + [rng.lognormvariate(0, 4) for _ in range(2000)],
+        dtype=np.float64,
+    )
+    # Include the adversarial float edge-cases once (seed-invariant), so every
+    # seed exercises the powers-of-ten / null-magnitude boundary too.
+    adversarial = np.array(
+        [10.0**k for k in range(-12, 13)]
+        + [9.999999999, 1.0000001, 99.9, 100.0, 999999.0]
+        + [0.0, -1.0, -1e6, float("nan"), float("inf"), float("-inf")]
+        + [1e-300, 1e300, 5e-1, 4.4],
+        dtype=np.float64,
+    )
+    return [random_arr, adversarial]
+
+
+def _benford_native(vals: np.ndarray) -> list[int]:
+    return list(native_module().benford_leading_digits(pa.array(vals)))
+
+
+def _benford_fallback(vals: np.ndarray) -> list[int]:
+    return tp._python_histogram(vals)
+
+
+# ---------------------------------------------------------------------------
+# composite_keys
+# ---------------------------------------------------------------------------
+def _keys_fixtures(seed: int) -> list[pl.DataFrame]:
+    df = tp._random_keyless_df(seed).drop("d")
+    candidates = ck._select_candidates(df, df.height)
+    if len(candidates) < 2:
+        return []  # both paths would be trivially empty; nothing to compare
+    return [df]
+
+
+def _keys_native(df: pl.DataFrame) -> set[tuple]:
+    candidates = ck._select_candidates(df, df.height)
+    single_unique = [False] * len(candidates)
+    arrays = [df[c].to_arrow() for c in candidates]
+    nat = native_module().composite_key_search(arrays, ck.MAX_KEY_SIZE, single_unique)
+    return {tuple(k) for k in nat}
+
+
+def _keys_fallback(df: pl.DataFrame) -> set[tuple]:
+    candidates = ck._select_candidates(df, df.height)
+    py = ck._python_search(df, candidates, df.height, ck.MAX_KEY_SIZE)
+    return {tuple(k) for k in py}
+
+
+# ---------------------------------------------------------------------------
+# functional_dependencies (kernel)
+# ---------------------------------------------------------------------------
+def _fd_fixtures(seed: int) -> list[pl.DataFrame]:
+    rng = random.Random(seed)
+    n = 400
+    zips = [rng.randint(0, 30) for _ in range(n)]
+    z2c: dict[int, int] = {}
+    city = [z2c.setdefault(z, rng.randint(0, 20)) for z in zips]  # zip -> city strict
+    df = pl.DataFrame({
+        "zip": zips,
+        "city": city,
+        "flag": [rng.randint(0, 1) for _ in range(n)],
+        "amt": [rng.randint(0, 9) for _ in range(n)],
+    })
+    if len(fd._select_candidates(df, df.height)) < 2:
+        return []
+    return [df]
+
+
+def _fd_native(df: pl.DataFrame) -> set[tuple[int, int]]:
+    cols = fd._select_candidates(df, df.height)
+    arrays = [df[c].to_arrow() for c in cols]
+    return set(native_module().discover_functional_dependencies(arrays))
+
+
+def _fd_fallback(df: pl.DataFrame) -> set[tuple[int, int]]:
+    cols = fd._select_candidates(df, df.height)
+    return set(fd._discover_python(df, cols, df.height))
+
+
+# ---------------------------------------------------------------------------
+# approximate_fd (discovery + violation rows)
+# ---------------------------------------------------------------------------
+def _afd_fixtures(seed: int) -> list[pl.DataFrame]:
+    rng = random.Random(seed)
+    n = 400
+    zips = [rng.randint(0, 15) for _ in range(n)]
+    z2c: dict[int, int] = {}
+    city = [z2c.setdefault(z, rng.randint(0, 12)) for z in zips]
+    for _ in range(rng.randint(1, 6)):
+        city[rng.randrange(n)] = rng.randint(13, 20)  # inject violations
+    df = pl.DataFrame(
+        {"zip": zips, "city": city, "noise": [rng.randint(0, 5) for _ in range(n)]}
+    )
+    return [df]
+
+
+def _afd_native(df: pl.DataFrame) -> tuple:
+    cols = afd._select_candidates(df)
+    arrays = [df[c].to_arrow() for c in cols]
+    triples = {
+        (i, j, v)
+        for i, j, v in native_module().discover_approximate_fds(arrays, afd._MIN_CONFIDENCE)
+    }
+    # Also fold in the per-pair violation rows so a divergence in either the
+    # discovered pairs OR the flagged rows trips the oracle.
+    rows = frozenset(
+        (i, j, tuple(native_module().fd_violation_rows(arrays[i], arrays[j])))
+        for i, j, _v in triples
+    )
+    return (frozenset(triples), rows)
+
+
+def _afd_fallback(df: pl.DataFrame) -> tuple:
+    cols = afd._select_candidates(df)
+    cols_ids = [afd._intern(df[c].to_list()) for c in cols]
+    triples = set(afd._discover_python(cols_ids, df.height, afd._MIN_CONFIDENCE))
+    rows = frozenset(
+        (i, j, tuple(afd._violation_rows(cols_ids[i], cols_ids[j]))) for i, j, _v in triples
+    )
+    return (frozenset(triples), rows)
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_values
+# ---------------------------------------------------------------------------
+def _fuzzy_fixtures(seed: int) -> list[list[str]]:
+    rng = random.Random(seed)
+    bases = ["California", "Texas", "New York", "Florida", "Washington", "Arizona"]
+    values: list[str] = []
+    for b in bases:
+        values.append(b)
+        for _ in range(rng.randint(0, 3)):
+            s = list(b.lower())
+            if len(s) > 3 and rng.random() < 0.7:
+                del s[rng.randrange(len(s))]
+            values.append("".join(s).upper() if rng.random() < 0.3 else "".join(s))
+    return [list(dict.fromkeys(values))]  # distinct, order-preserving
+
+
+def _fuzzy_native(values: list[str]) -> set[frozenset]:
+    # The native pyfunction signature was preserved as ``Vec<String>`` (not
+    # Arrow-in) -- pass the plain list directly, matching the real call site
+    # in goldencheck/profilers/fuzzy_values.py.
+    nat = native_module().near_duplicate_value_clusters(values, fv._MIN_SIMILARITY)
+    return {frozenset(c) for c in nat}
+
+
+def _fuzzy_fallback(values: list[str]) -> set[frozenset]:
+    py = fv._python_clusters(values, fv._MIN_SIMILARITY)
+    return {frozenset(c) for c in py}
+
+
+# ---------------------------------------------------------------------------
+# cell_quality (public bridge) -- native-on vs native-off of the SAME public
+# API. Real comparison (env-toggle), and transitively covers the fuzzy kernel.
+# ---------------------------------------------------------------------------
+def _cell_quality_fixtures(seed: int) -> list[pl.DataFrame]:
+    # A near-dup categorical column where each canonical spelling STRICTLY
+    # dominates its variants. Deterministic + tie-free on purpose: cell_quality
+    # picks the canonical via ``max(members, key=freq)``, whose tie-break is
+    # sensitive to polars ``.unique()`` member order (not stable across
+    # processes). With a strict frequency winner per cluster, the penalized-set
+    # (= every non-canonical variant) is order-invariant, so this stays a
+    # meaningful native-vs-fallback parity check (cluster MEMBERSHIP divergence
+    # would still be caught) instead of tie-break noise. Seed-invariant: the
+    # bridge is transitively covered by the fuzzy_values kernel.
+    del seed
+    comp: dict[str, int] = {
+        "California": 40, "Californa": 3, "CALIFORNIA": 2,  # canonical: California
+        "Texas": 30, "texas": 3,                            # canonical: Texas
+        "New York": 25, "New Yrok": 2,                      # canonical: New York
+        "Florida": 10, "Washington": 5,                     # clean singletons
+    }
+    col: list[str] = []
+    for value, count in comp.items():
+        col.extend([value] * count)
+    df = pl.DataFrame({"state": col, "id": list(range(len(col)))})
+    return [df]
+
+
+def _cell_quality_native(df: pl.DataFrame) -> dict:
+    with _native_env("1"):
+        return _cell_quality(df)
+
+
+def _cell_quality_fallback(df: pl.DataFrame) -> dict:
+    with _native_env("0"):
+        return _cell_quality(df)
+
+
+# ---------------------------------------------------------------------------
+# functional_dependencies (public bridge) -- native-on vs native-off of the
+# public FD API. Light smoke fixture; transitively covered by the FD kernels.
+# ---------------------------------------------------------------------------
+def _fd_bridge_fixtures(seed: int) -> list[pl.DataFrame]:
+    rng = random.Random(seed)
+    n = 300
+    zips = [rng.randint(0, 20) for _ in range(n)]
+    z2c: dict[int, int] = {}
+    city = [z2c.setdefault(z, rng.randint(0, 15)) for z in zips]  # strict zip -> city
+    area = [z2c[z] for z in zips]
+    for _ in range(rng.randint(2, 8)):
+        area[rng.randrange(n)] = rng.randint(16, 25)  # a few violations => approx FD
+    df = pl.DataFrame({"zip": zips, "city": city, "area": area})
+    return [df]
+
+
+def _fd_bridge_records(df: pl.DataFrame) -> list[tuple[str, tuple[str, ...], float]]:
+    recs = _fd_bridge(df)
+    return [(r.determinant, tuple(r.dependents), r.confidence) for r in recs]
+
+
+def _fd_bridge_native(df: pl.DataFrame) -> list:
+    with _native_env("1"):
+        return _fd_bridge_records(df)
+
+
+def _fd_bridge_fallback(df: pl.DataFrame) -> list:
+    with _native_env("0"):
+        return _fd_bridge_records(df)
+
+
+REGISTERED_COMPONENTS: list[Component] = [
+    Component("benford", _benford_native, _benford_fallback, _benford_fixtures),
+    Component("composite_keys", _keys_native, _keys_fallback, _keys_fixtures),
+    Component("functional_dependencies", _fd_native, _fd_fallback, _fd_fixtures),
+    Component("approximate_fd", _afd_native, _afd_fallback, _afd_fixtures),
+    Component("fuzzy_values", _fuzzy_native, _fuzzy_fallback, _fuzzy_fixtures),
+    Component("cell_quality", _cell_quality_native, _cell_quality_fallback, _cell_quality_fixtures),
+    Component(
+        "functional_dependencies_bridge",
+        _fd_bridge_native,
+        _fd_bridge_fallback,
+        _fd_bridge_fixtures,
+    ),
+]

--- a/packages/python/goldencheck/tests/core/test_loader_reference_mode.py
+++ b/packages/python/goldencheck/tests/core/test_loader_reference_mode.py
@@ -1,0 +1,28 @@
+import pytest
+from goldencheck.core import _native_loader as L
+
+
+@pytest.mark.skipif(not L.native_available(), reason="native ext not built")
+def test_auto_uses_native_wherever_symbol_exists(monkeypatch):
+    """Under the reference-mode flip, `auto` no longer consults an allow-list.
+
+    ``_GATED_ON`` is retained on main as byte-exact sign-off documentation (see
+    ``_native_loader.py``), but ``native_enabled`` must return True for a
+    component whose native symbol(s) exist even when it is absent from
+    ``_GATED_ON`` -- proving `auto` no longer gates on that allow-list."""
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "auto")
+    assert "regex" not in L._GATED_ON
+    assert L.native_enabled("regex") is True
+
+
+@pytest.mark.skipif(not L.native_available(), reason="native ext not built")
+def test_approximate_fd_requires_both_symbols(monkeypatch):
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "auto")
+    # approximate_fd needs BOTH discover_approximate_fds AND fd_violation_rows.
+    assert L.native_enabled("approximate_fd") is True
+
+
+def test_native_disabled_env_forces_python(monkeypatch):
+    """mode==0 still forces the Python path (unchanged)."""
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "0")
+    assert L.native_enabled("benford") is False

--- a/packages/python/goldencheck/tests/core/test_parity_harness.py
+++ b/packages/python/goldencheck/tests/core/test_parity_harness.py
@@ -1,0 +1,28 @@
+"""Drives the reusable parity-oracle harness over every registered component.
+
+Wave 0: all 5 kernels are byte/set-exact, so every component x seed case must
+pass with an EMPTY accepted-divergence registry. This validates the harness
+mechanics on known-exact code before a future wave adds a genuinely-divergent
+kernel."""
+from __future__ import annotations
+
+import pytest
+from goldencheck.core._native_loader import native_available
+
+from tests.core import parity_harness as ph
+
+native_only = pytest.mark.skipif(not native_available(), reason="native ext not built")
+
+
+@native_only
+@pytest.mark.parametrize("comp", ph.REGISTERED_COMPONENTS, ids=lambda c: c.name)
+@pytest.mark.parametrize("seed", range(6))
+def test_component_parity(comp: ph.Component, seed: int) -> None:
+    problems = ph.compare(comp, seed)
+    assert problems == [], "\n".join(problems)
+
+
+def test_accepted_divergences_empty_in_wave0() -> None:
+    # Wave 0 guarantee: nothing diverges yet. This is the tripwire a later wave
+    # must consciously edit when it accepts its first divergence.
+    assert ph.ACCEPTED_DIVERGENCES == ()

--- a/packages/rust/extensions/goldencheck-core/Cargo.toml
+++ b/packages/rust/extensions/goldencheck-core/Cargo.toml
@@ -1,8 +1,10 @@
 # goldencheck-core -- pyo3-free kernel library for GoldenCheck's CPU-bound
-# deep-profiling work. The `score-core` analogue: pure compute over slices, no
-# Python, no Arrow. The pyo3 + Arrow C Data Interface shims live in the sibling
-# `goldencheck-native` crate, which path-depends on this one. Keeping the kernel
-# logic pyo3-free means it can later back a DuckDB/DataFusion SQL surface (as
+# deep-profiling work. The `score-core` analogue: pure compute, no Python
+# (pyo3-free). Benford + the shared `arrow_support` interning helper take Arrow
+# arrays (`&dyn Array`) directly -- the Arrow boundary lives in this pyo3-free
+# core, not in the sibling `goldencheck-native` crate, which path-depends on
+# this one and now only marshals pyarrow<->Arrow. Keeping the kernel logic
+# pyo3-free means it can later back a DuckDB/DataFusion SQL surface (as
 # `score-core`/`graph-core` do for goldenmatch) without dragging in CPython.
 [package]
 name = "goldencheck-core"
@@ -25,6 +27,12 @@ rustc-hash = "2"
 regex = "1"
 # Same engine Polars uses for str.to_date, so date parsing is byte-identical.
 chrono = { version = "0.4", default-features = false, features = ["std"] }
+# Arrow arrays cross the core<->native boundary as concrete types; pin the SAME
+# version + crate form as goldencheck-native (arrow 59) -- a mismatch is a linker/type error.
+# default-features = false keeps csv/ipc/json/compute out; we only read array
+# buffers. We deliberately do NOT enable `pyarrow` here (native's shims stay
+# the only place that needs it) -- this crate stays pyo3-free.
+arrow = { version = "59", default-features = false }
 
 [dev-dependencies]
 # Property/parity checks for the Benford leading-digit extraction, plus the

--- a/packages/rust/extensions/goldencheck-core/src/arrow_support.rs
+++ b/packages/rust/extensions/goldencheck-core/src/arrow_support.rs
@@ -3,10 +3,14 @@
 //! (for Benford). Moved down from the `goldencheck-native` pyo3 shim so the
 //! Arrow boundary lives in the pyo3-free core. No pyo3, no Python.
 use arrow::array::{
-    Array, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
-    LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+    Array, BooleanArray, DictionaryArray, Float32Array, Float64Array, Int16Array, Int32Array,
+    Int64Array, Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array,
+    UInt8Array,
 };
-use arrow::datatypes::DataType;
+use arrow::datatypes::{
+    ArrowNativeType, DataType, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
+    UInt64Type, UInt8Type,
+};
 use arrow::error::ArrowError;
 use rustc_hash::FxHashMap;
 
@@ -114,6 +118,47 @@ pub fn intern_column(array: &dyn Array) -> Result<Vec<u64>, ArrowError> {
             }
             Ok(ids)
         }
+        // Dictionary-encoded (e.g. a Polars Categorical/Enum column). The
+        // dictionary *is* the interning: intern the (small) values array ONCE,
+        // then map each row's key through it -- O(dict) hashing + O(rows) index
+        // lookups, instead of O(rows) hashing on the raw path. A null row keeps
+        // id 0.
+        DataType::Dictionary(key_type, _) => {
+            macro_rules! intern_dict {
+                ($kt:ty) => {{
+                    let dict = array
+                        .as_any()
+                        .downcast_ref::<DictionaryArray<$kt>>()
+                        .unwrap();
+                    // Dense id per dictionary entry (recurses on the small values
+                    // array; null entries -> 0, values -> 1,2,... first-seen).
+                    let value_ids = intern_column(dict.values().as_ref())?;
+                    let keys = dict.keys();
+                    let mut ids = Vec::with_capacity(keys.len());
+                    for i in 0..keys.len() {
+                        if keys.is_null(i) {
+                            ids.push(0);
+                        } else {
+                            ids.push(value_ids[keys.value(i).as_usize()]);
+                        }
+                    }
+                    Ok(ids)
+                }};
+            }
+            match key_type.as_ref() {
+                DataType::Int8 => intern_dict!(Int8Type),
+                DataType::Int16 => intern_dict!(Int16Type),
+                DataType::Int32 => intern_dict!(Int32Type),
+                DataType::Int64 => intern_dict!(Int64Type),
+                DataType::UInt8 => intern_dict!(UInt8Type),
+                DataType::UInt16 => intern_dict!(UInt16Type),
+                DataType::UInt32 => intern_dict!(UInt32Type),
+                DataType::UInt64 => intern_dict!(UInt64Type),
+                other => Err(ArrowError::InvalidArgumentError(format!(
+                    "key/FD kernels: unsupported dictionary key type {other:?}"
+                ))),
+            }
+        }
         other => Err(ArrowError::InvalidArgumentError(format!(
             "key/FD kernels do not support Arrow dtype {other:?}; \
              cast to string/int/float/bool first"
@@ -161,5 +206,38 @@ mod tests {
     fn arc_dyn_array_accepted() {
         let a: Arc<dyn Array> = Arc::new(StringArray::from(vec!["a", "b"]));
         assert_eq!(intern_column(a.as_ref()).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn dictionary_encoded_interns_like_plain_string() {
+        use arrow::array::{DictionaryArray, Int32Array};
+        use arrow::datatypes::Int32Type;
+
+        let plain = StringArray::from(vec![Some("x"), Some("y"), Some("x"), None]);
+        let plain_ids = intern_column(&plain).unwrap();
+
+        // Same logical values, dictionary-encoded: dict = [x, y], keys = [0,1,0,null].
+        let dict: DictionaryArray<Int32Type> = vec![Some("x"), Some("y"), Some("x"), None]
+            .into_iter()
+            .collect();
+        let dict_ids = intern_column(&dict).unwrap();
+        assert_eq!(dict_ids, plain_ids);
+
+        // Sanity: raw keys/values shape is as expected.
+        let keys: Int32Array = dict.keys().clone();
+        assert_eq!(keys.len(), 4);
+    }
+
+    #[test]
+    fn dictionary_unsupported_key_type_errors() {
+        // Values array itself unsupported (Date32) surfaces through the recursive
+        // intern_column call on `dict.values()`.
+        use arrow::array::{Date32Array, DictionaryArray, Int32Array};
+        use arrow::datatypes::Int32Type;
+        let values: Date32Array = vec![1, 2].into();
+        let keys = Int32Array::from(vec![0, 1, 0]);
+        let dict =
+            DictionaryArray::<Int32Type>::try_new(keys, std::sync::Arc::new(values)).unwrap();
+        assert!(intern_column(&dict).is_err());
     }
 }

--- a/packages/rust/extensions/goldencheck-core/src/arrow_support.rs
+++ b/packages/rust/extensions/goldencheck-core/src/arrow_support.rs
@@ -1,0 +1,165 @@
+//! Arrow-native decoding helpers shared by the kernels: column interning to
+//! dense `u64` value-ids (for the key/FD kernels) and typed numeric extraction
+//! (for Benford). Moved down from the `goldencheck-native` pyo3 shim so the
+//! Arrow boundary lives in the pyo3-free core. No pyo3, no Python.
+use arrow::array::{
+    Array, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array, Int64Array, Int8Array,
+    LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::datatypes::DataType;
+use arrow::error::ArrowError;
+use rustc_hash::FxHashMap;
+
+/// Intern one Arrow column to dense `u64` value-ids. Null slots all share a
+/// single reserved id (0) distinct from every real value's id; non-null values
+/// get dense ids 1,2,3,... in first-seen order. Floats are keyed by bit pattern
+/// (exact value identity); booleans map true->1, false->2, null->0. Returns an
+/// `ArrowError` for dtypes the key/FD kernels don't support.
+///
+/// Takes a borrowed `&dyn Array` and downcasts to the concrete typed array,
+/// keeping the caller's data untouched (byte-identical semantics to the
+/// previous owned-`ArrayData` native shim, so interned ids stay stable).
+pub fn intern_column(array: &dyn Array) -> Result<Vec<u64>, ArrowError> {
+    macro_rules! intern_primitive {
+        ($arrty:ty, $keyty:ty, $keyexpr:expr) => {{
+            let arr = array.as_any().downcast_ref::<$arrty>().unwrap();
+            let mut map: FxHashMap<$keyty, u64> = FxHashMap::default();
+            let mut ids = Vec::with_capacity(arr.len());
+            let mut next: u64 = 1; // 0 is reserved for null
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    ids.push(0);
+                    continue;
+                }
+                let key: $keyty = $keyexpr(arr, i);
+                let id = *map.entry(key).or_insert_with(|| {
+                    let v = next;
+                    next += 1;
+                    v
+                });
+                ids.push(id);
+            }
+            Ok(ids)
+        }};
+    }
+
+    match array.data_type() {
+        DataType::Utf8 => {
+            let arr = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
+            let mut ids = Vec::with_capacity(arr.len());
+            let mut next: u64 = 1;
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    ids.push(0);
+                    continue;
+                }
+                let id = *map.entry(arr.value(i)).or_insert_with(|| {
+                    let v = next;
+                    next += 1;
+                    v
+                });
+                ids.push(id);
+            }
+            Ok(ids)
+        }
+        DataType::LargeUtf8 => {
+            let arr = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
+            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
+            let mut ids = Vec::with_capacity(arr.len());
+            let mut next: u64 = 1;
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    ids.push(0);
+                    continue;
+                }
+                let id = *map.entry(arr.value(i)).or_insert_with(|| {
+                    let v = next;
+                    next += 1;
+                    v
+                });
+                ids.push(id);
+            }
+            Ok(ids)
+        }
+        DataType::Int8 => intern_primitive!(Int8Array, i8, |a: &Int8Array, i| a.value(i)),
+        DataType::Int16 => intern_primitive!(Int16Array, i16, |a: &Int16Array, i| a.value(i)),
+        DataType::Int32 => intern_primitive!(Int32Array, i32, |a: &Int32Array, i| a.value(i)),
+        DataType::Int64 => intern_primitive!(Int64Array, i64, |a: &Int64Array, i| a.value(i)),
+        DataType::UInt8 => intern_primitive!(UInt8Array, u8, |a: &UInt8Array, i| a.value(i)),
+        DataType::UInt16 => intern_primitive!(UInt16Array, u16, |a: &UInt16Array, i| a.value(i)),
+        DataType::UInt32 => intern_primitive!(UInt32Array, u32, |a: &UInt32Array, i| a.value(i)),
+        DataType::UInt64 => intern_primitive!(UInt64Array, u64, |a: &UInt64Array, i| a.value(i)),
+        // Floats keyed by bit pattern (exact value identity; matches Polars
+        // equality semantics for finite values, which is all a key column has).
+        DataType::Float32 => {
+            intern_primitive!(Float32Array, u32, |a: &Float32Array, i| a
+                .value(i)
+                .to_bits())
+        }
+        DataType::Float64 => {
+            intern_primitive!(Float64Array, u64, |a: &Float64Array, i| a
+                .value(i)
+                .to_bits())
+        }
+        DataType::Boolean => {
+            let arr = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+            let mut ids = Vec::with_capacity(arr.len());
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    ids.push(0);
+                } else {
+                    ids.push(if arr.value(i) { 1 } else { 2 });
+                }
+            }
+            Ok(ids)
+        }
+        other => Err(ArrowError::InvalidArgumentError(format!(
+            "key/FD kernels do not support Arrow dtype {other:?}; \
+             cast to string/int/float/bool first"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{Float64Array, Int64Array, StringArray};
+    use std::sync::Arc;
+
+    #[test]
+    fn interns_strings_dense_from_one_nulls_zero() {
+        let a = StringArray::from(vec![Some("x"), Some("y"), Some("x"), None]);
+        let ids = intern_column(&a).unwrap();
+        assert_eq!(ids[0], ids[2]); // same value -> same id
+        assert_ne!(ids[0], ids[1]); // different value -> different id
+        assert_eq!(ids[3], 0); // null -> reserved 0
+        assert!(ids[0] >= 1 && ids[1] >= 1);
+    }
+
+    #[test]
+    fn interns_ints_and_floats_by_value() {
+        let a = Int64Array::from(vec![Some(5), Some(5), Some(6), None]);
+        let ids = intern_column(&a).unwrap();
+        assert_eq!(ids[0], ids[1]);
+        assert_ne!(ids[0], ids[2]);
+        assert_eq!(ids[3], 0);
+        let f = Float64Array::from(vec![Some(1.5), Some(1.5), Some(2.5)]);
+        let fids = intern_column(&f).unwrap();
+        assert_eq!(fids[0], fids[1]);
+        assert_ne!(fids[0], fids[2]);
+    }
+
+    #[test]
+    fn unsupported_dtype_errors() {
+        use arrow::array::Date32Array;
+        let a = Date32Array::from(vec![1, 2, 3]);
+        assert!(intern_column(&a).is_err());
+    }
+
+    #[test]
+    fn arc_dyn_array_accepted() {
+        let a: Arc<dyn Array> = Arc::new(StringArray::from(vec!["a", "b"]));
+        assert_eq!(intern_column(a.as_ref()).unwrap().len(), 2);
+    }
+}

--- a/packages/rust/extensions/goldencheck-core/src/benford.rs
+++ b/packages/rust/extensions/goldencheck-core/src/benford.rs
@@ -28,7 +28,18 @@
 //! `log10().floor()` step already agrees with `math.log10` (shared libm), so
 //! this makes the histogram byte-identical; the goldencheck parity test asserts
 //! it on random + adversarial (powers-of-ten, sub-normal-magnitude) data.
+//!
+//! `benford_leading_digits` is the Arrow-in entry point (native's pyo3 shim
+//! decodes pyarrow -> `ArrayRef` and calls it directly). `benford_leading_digits_slice`
+//! stays `pub` (not `pub(crate)`) because it's also the entry point for the
+//! non-Arrow surfaces that call this crate directly with plain `&[f64]`:
+//! `goldencheck-wasm` (JSON in/out over wasm-bindgen), the `goldenmatch_pg`
+//! Postgres extension, and this crate's own `tests/golden.rs` cross-surface
+//! fixture.
 
+use arrow::array::{Array, Float64Array};
+use arrow::datatypes::DataType;
+use arrow::error::ArrowError;
 use std::sync::OnceLock;
 
 // f64 exponent range is roughly 1e-323 .. 1e308; index = exp + OFFSET.
@@ -66,12 +77,40 @@ fn pow10(exp: i32) -> f64 {
     }
 }
 
+/// Leading-digit (1..=9) histogram for a Float64 Arrow column. Null slots are
+/// dropped (their backing f64 is undefined), matching the Python reference which
+/// only sees non-null values. Non-Float64 input is an error (the caller casts in
+/// Polars before `.to_arrow()`).
+pub fn benford_leading_digits(array: &dyn Array) -> Result<[u64; 9], ArrowError> {
+    if array.data_type() != &DataType::Float64 {
+        return Err(ArrowError::InvalidArgumentError(format!(
+            "benford_leading_digits expects a Float64 array, got {:?}",
+            array.data_type()
+        )));
+    }
+    let arr = array.as_any().downcast_ref::<Float64Array>().unwrap();
+    if arr.null_count() == 0 {
+        // True zero-copy: the Arrow values buffer *is* `&[f64]` (deref of the
+        // shared `ScalarBuffer`) -- hand it straight to the slice kernel, no
+        // owned Vec. On a 1M-row column this avoids an 8 MB memcpy per call.
+        Ok(benford_leading_digits_slice(arr.values()))
+    } else {
+        // Null slots have an undefined backing f64, so we can't pass the raw
+        // buffer; compact the valid values (only the non-null subset) instead.
+        let vals: Vec<f64> = (0..arr.len())
+            .filter(|&i| !arr.is_null(i))
+            .map(|i| arr.value(i))
+            .collect();
+        Ok(benford_leading_digits_slice(&vals))
+    }
+}
+
 /// Leading-digit (1..=9) counts for the Benford conformance check.
 ///
 /// `out[i]` is the number of finite, strictly-positive values whose leading
 /// significant digit is `i + 1`. Non-positive and non-finite values are
 /// skipped, exactly as the Python reference does.
-pub fn benford_leading_digits(values: &[f64]) -> [u64; 9] {
+pub fn benford_leading_digits_slice(values: &[f64]) -> [u64; 9] {
     let mut counts = [0u64; 9];
     for &v in values {
         if v <= 0.0 || !v.is_finite() {
@@ -96,7 +135,7 @@ mod tests {
     fn basic_digits() {
         // 1.x, 9.x, 19 -> 1, 200 -> 2, 0 and -5 skipped, NaN/inf skipped.
         let v = [1.5, 9.9, 19.0, 200.0, 0.0, -5.0, f64::NAN, f64::INFINITY];
-        let c = benford_leading_digits(&v);
+        let c = benford_leading_digits_slice(&v);
         assert_eq!(c[0], 2); // digit 1: 1.5, 19.0
         assert_eq!(c[1], 1); // digit 2: 200.0
         assert_eq!(c[8], 1); // digit 9: 9.9
@@ -105,6 +144,22 @@ mod tests {
 
     #[test]
     fn empty_is_all_zero() {
-        assert_eq!(benford_leading_digits(&[]), [0u64; 9]);
+        assert_eq!(benford_leading_digits_slice(&[]), [0u64; 9]);
+    }
+
+    #[test]
+    fn arrow_matches_slice_and_drops_nulls() {
+        use arrow::array::Float64Array;
+        let arr = Float64Array::from(vec![Some(1.5), None, Some(200.0), None, Some(9.9)]);
+        let via_arrow = benford_leading_digits(&arr).unwrap();
+        let via_slice = benford_leading_digits_slice(&[1.5, 200.0, 9.9]);
+        assert_eq!(via_arrow, via_slice);
+    }
+
+    #[test]
+    fn arrow_rejects_non_float64() {
+        use arrow::array::Int64Array;
+        let arr = Int64Array::from(vec![1, 2, 3]);
+        assert!(benford_leading_digits(&arr).is_err());
     }
 }

--- a/packages/rust/extensions/goldencheck-core/src/fuzzy.rs
+++ b/packages/rust/extensions/goldencheck-core/src/fuzzy.rs
@@ -25,7 +25,18 @@
 //!
 //! Pairwise edit distance is the part that is painfully slow in Python and fast
 //! here -- this kernel genuinely beats a pure-Python fallback.
+//!
+//! `near_duplicate_clusters` is the Arrow-in entry point (native's pyo3 shim
+//! decodes pyarrow -> `ArrayRef` and calls it directly). `near_duplicate_clusters_slice`
+//! stays `pub` (not `pub(crate)`) because it's also the entry point for the
+//! non-Arrow surfaces that call this crate directly with plain `&[String]`:
+//! `goldencheck-wasm` (JSON in/out over wasm-bindgen), the `goldenmatch_pg`
+//! Postgres extension, and this crate's own `tests/golden.rs` cross-surface
+//! fixture.
 
+use arrow::array::{Array, LargeStringArray, StringArray};
+use arrow::datatypes::DataType;
+use arrow::error::ArrowError;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 const MAX_BLOCK: usize = 300;
@@ -122,7 +133,7 @@ impl UnionFind {
 
 /// Cluster the distinct `values` into groups of edit-distance-close strings.
 /// Returns clusters (each a sorted list of indices into `values`) of size >= 2.
-pub fn near_duplicate_clusters(values: &[String], min_similarity: f64) -> Vec<Vec<usize>> {
+pub fn near_duplicate_clusters_slice(values: &[String], min_similarity: f64) -> Vec<Vec<usize>> {
     let n = values.len();
     if n < 2 {
         return Vec::new();
@@ -189,6 +200,36 @@ pub fn near_duplicate_clusters(values: &[String], min_similarity: f64) -> Vec<Ve
     clusters
 }
 
+/// Cluster the distinct string `values` of a column into edit-distance-close
+/// groups. Input must be a null-free Utf8/LargeUtf8 array; indices map 1:1.
+pub fn near_duplicate_clusters(
+    array: &dyn Array,
+    min_similarity: f64,
+) -> Result<Vec<Vec<usize>>, ArrowError> {
+    if array.null_count() > 0 {
+        return Err(ArrowError::InvalidArgumentError(
+            "near_duplicate_clusters expects a null-free array (pass distinct non-null values)"
+                .into(),
+        ));
+    }
+    let values: Vec<String> = match array.data_type() {
+        DataType::Utf8 => {
+            let a = array.as_any().downcast_ref::<StringArray>().unwrap();
+            (0..a.len()).map(|i| a.value(i).to_string()).collect()
+        }
+        DataType::LargeUtf8 => {
+            let a = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
+            (0..a.len()).map(|i| a.value(i).to_string()).collect()
+        }
+        other => {
+            return Err(ArrowError::InvalidArgumentError(format!(
+                "near_duplicate_clusters expects Utf8/LargeUtf8, got {other:?}"
+            )))
+        }
+    };
+    Ok(near_duplicate_clusters_slice(&values, min_similarity))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -200,7 +241,7 @@ mod tests {
     #[test]
     fn clusters_typos_and_case() {
         let values = v(&["California", "Californa", "CALIFORNIA", "Texas", "New York"]);
-        let clusters = near_duplicate_clusters(&values, 0.8);
+        let clusters = near_duplicate_clusters_slice(&values, 0.8);
         // The three California variants cluster; Texas / New York stand alone.
         assert_eq!(clusters.len(), 1);
         assert_eq!(clusters[0], vec![0, 1, 2]);
@@ -209,19 +250,34 @@ mod tests {
     #[test]
     fn short_string_typo_via_prefix_block() {
         let values = v(&["Jon", "John", "Jane"]);
-        let clusters = near_duplicate_clusters(&values, 0.7);
+        let clusters = near_duplicate_clusters_slice(&values, 0.7);
         assert_eq!(clusters, vec![vec![0, 1]]); // jon/john; jane separate
     }
 
     #[test]
     fn nothing_when_all_distinct() {
         let values = v(&["apple", "banana", "cherry"]);
-        assert!(near_duplicate_clusters(&values, 0.8).is_empty());
+        assert!(near_duplicate_clusters_slice(&values, 0.8).is_empty());
     }
 
     #[test]
     fn empty_and_singleton() {
-        assert!(near_duplicate_clusters(&[], 0.8).is_empty());
-        assert!(near_duplicate_clusters(&v(&["x"]), 0.8).is_empty());
+        assert!(near_duplicate_clusters_slice(&[], 0.8).is_empty());
+        assert!(near_duplicate_clusters_slice(&v(&["x"]), 0.8).is_empty());
+    }
+
+    #[test]
+    fn arrow_clusters_match_string_slice() {
+        use arrow::array::StringArray;
+        let arr = StringArray::from(vec!["California", "Californa", "CALIFORNIA", "Texas"]);
+        let via_arrow = near_duplicate_clusters(&arr, 0.8).unwrap();
+        assert_eq!(via_arrow, vec![vec![0, 1, 2]]);
+    }
+
+    #[test]
+    fn arrow_rejects_nulls() {
+        use arrow::array::StringArray;
+        let arr = StringArray::from(vec![Some("a"), None, Some("b")]);
+        assert!(near_duplicate_clusters(&arr, 0.8).is_err());
     }
 }

--- a/packages/rust/extensions/goldencheck-core/src/keys.rs
+++ b/packages/rust/extensions/goldencheck-core/src/keys.rs
@@ -9,14 +9,102 @@
 //!     lowest-cardinality columns; the native primitive lets the caller raise
 //!     that.
 //!
-//! Columns are passed pre-hashed (`&[u64]` per column, one entry per row) by the
-//! `goldencheck-native` shim, which interns each Arrow cell (including a stable
-//! sentinel for nulls) to a `u64`. Working on hashed columns keeps this kernel
-//! dtype-agnostic and pyo3-free. Counts are exact: row-tuples are compared in
-//! full (not just by a combined hash), so there is no collision-driven
-//! miscount.
+//! Columns are interned to dense `u64` ids (via `arrow_support::intern_column`,
+//! including a stable sentinel for nulls) before the combinatorial kernels run.
+//! Working on hashed columns keeps the kernels dtype-agnostic. Counts are
+//! exact: row-tuples are compared in full (not just by a combined hash), so
+//! there is no collision-driven miscount.
+//!
+//! Each public kernel has two entry points: the no-suffix name takes Arrow
+//! arrays (`&[ArrayRef]` / `&dyn Array`) and interns them internally -- this is
+//! the entry point `goldencheck-native`'s pyo3 shim calls. The `_slice`-suffixed
+//! twin takes already-interned `&[u64]` columns directly; it stays `pub`
+//! because it's also the entry point for the non-Arrow surfaces that call this
+//! crate directly with pre-interned ids: `goldencheck-wasm` (JSON in/out over
+//! wasm-bindgen), the `goldenmatch_pg` Postgres extension, and this crate's own
+//! `tests/golden.rs` cross-surface fixture.
 
+use arrow::array::{Array, ArrayRef};
+use arrow::error::ArrowError;
 use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::arrow_support::intern_column;
+
+fn intern_all(columns: &[ArrayRef]) -> Result<Vec<Vec<u64>>, ArrowError> {
+    columns.iter().map(|a| intern_column(a.as_ref())).collect()
+}
+
+/// Whether `lhs -> rhs` holds over two Arrow columns. Interns each column then
+/// delegates to [`functional_dependency_holds_slice`].
+pub fn functional_dependency_holds(lhs: &dyn Array, rhs: &dyn Array) -> Result<bool, ArrowError> {
+    let l = intern_column(lhs)?;
+    let r = intern_column(rhs)?;
+    if l.len() != r.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "functional_dependency_holds: lhs and rhs differ in length".into(),
+        ));
+    }
+    Ok(functional_dependency_holds_slice(&l, &r))
+}
+
+/// Discover all strict single-column FDs among Arrow `columns`.
+pub fn discover_functional_dependencies(
+    columns: &[ArrayRef],
+) -> Result<Vec<(usize, usize)>, ArrowError> {
+    if columns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids = intern_all(columns)?;
+    let refs: Vec<&[u64]> = ids.iter().map(|c| c.as_slice()).collect();
+    Ok(discover_functional_dependencies_slice(&refs))
+}
+
+/// Discover *approximate* FDs among Arrow `columns`.
+pub fn discover_approximate_fds(
+    columns: &[ArrayRef],
+    min_confidence: f64,
+) -> Result<Vec<(usize, usize, usize)>, ArrowError> {
+    if columns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids = intern_all(columns)?;
+    let refs: Vec<&[u64]> = ids.iter().map(|c| c.as_slice()).collect();
+    Ok(discover_approximate_fds_slice(&refs, min_confidence))
+}
+
+/// Row indices where `dep` deviates from its per-`det`-group mode, over two
+/// Arrow columns.
+pub fn fd_violation_rows(det: &dyn Array, dep: &dyn Array) -> Result<Vec<usize>, ArrowError> {
+    let d = intern_column(det)?;
+    let p = intern_column(dep)?;
+    if d.len() != p.len() {
+        return Err(ArrowError::InvalidArgumentError(
+            "fd_violation_rows: det and dep differ in length".into(),
+        ));
+    }
+    Ok(fd_violation_rows_slice(&d, &p))
+}
+
+/// Search for minimal composite keys over Arrow `columns`. `n_rows` is derived
+/// from the first interned column (identical to the old native shim).
+pub fn composite_key_search(
+    columns: &[ArrayRef],
+    max_size: usize,
+    single_unique: &[bool],
+) -> Result<Vec<Vec<usize>>, ArrowError> {
+    if columns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let ids = intern_all(columns)?;
+    let n_rows = ids[0].len();
+    let refs: Vec<&[u64]> = ids.iter().map(|c| c.as_slice()).collect();
+    Ok(composite_key_search_slice(
+        &refs,
+        n_rows,
+        max_size,
+        single_unique,
+    ))
+}
 
 /// Per-column domain size = max interned id + 1 (ids are dense 0..k from the
 /// caller's interner). Used to mixed-radix pack a row-tuple into one integer.
@@ -94,7 +182,7 @@ fn tuple_distinct_count_with(columns: &[&[u64]], subset: &[usize], doms: &[u128]
 /// `n_unique`, which materializes full distinct counts even for a pair that
 /// breaks on row 2. Most candidate pairs are NOT dependencies, so the bail-out
 /// dominates the batch discovery below.
-pub fn functional_dependency_holds(lhs: &[u64], rhs: &[u64]) -> bool {
+pub fn functional_dependency_holds_slice(lhs: &[u64], rhs: &[u64]) -> bool {
     debug_assert_eq!(lhs.len(), rhs.len());
     let mut map: FxHashMap<u64, u64> = FxHashMap::default();
     map.reserve(lhs.len());
@@ -118,7 +206,7 @@ pub fn functional_dependency_holds(lhs: &[u64], rhs: &[u64]) -> bool {
 /// early-exit above this is where the native path beats the vectorized
 /// baseline. Trivial pairs are skipped: a constant `dep` (domain 1) is implied
 /// by everything, and a unique `det` (all-distinct) implies everything.
-pub fn discover_functional_dependencies(columns: &[&[u64]]) -> Vec<(usize, usize)> {
+pub fn discover_functional_dependencies_slice(columns: &[&[u64]]) -> Vec<(usize, usize)> {
     let n_cols = columns.len();
     let n_rows = columns.first().map(|c| c.len()).unwrap_or(0);
     if n_cols < 2 || n_rows == 0 {
@@ -143,7 +231,7 @@ pub fn discover_functional_dependencies(columns: &[&[u64]]) -> Vec<(usize, usize
             if det == dep || distinct[dep] <= 1 {
                 continue; // constant dep is implied by everything -- trivial
             }
-            if functional_dependency_holds(columns[det], columns[dep]) {
+            if functional_dependency_holds_slice(columns[det], columns[dep]) {
                 out.push((det, dep));
             }
         }
@@ -193,7 +281,7 @@ fn fd_violation_count(det: &[u64], dep: &[u64]) -> usize {
 /// Row indices where `dep` deviates from its per-`det`-group mode -- the rows
 /// that break an otherwise-strong dependency (likely data-entry errors). Sorted
 /// ascending. Both slices must be the same length.
-pub fn fd_violation_rows(det: &[u64], dep: &[u64]) -> Vec<usize> {
+pub fn fd_violation_rows_slice(det: &[u64], dep: &[u64]) -> Vec<usize> {
     let modes = fd_group_modes(det, dep);
     det.iter()
         .zip(dep.iter())
@@ -212,7 +300,7 @@ pub fn fd_violation_rows(det: &[u64], dep: &[u64]) -> Vec<usize> {
 ///
 /// Skips constant dependents and determinants whose average group size is below
 /// `MIN_AVG_GROUP` (the near-unique-determinant false-positive guard).
-pub fn discover_approximate_fds(
+pub fn discover_approximate_fds_slice(
     columns: &[&[u64]],
     min_confidence: f64,
 ) -> Vec<(usize, usize, usize)> {
@@ -258,7 +346,7 @@ pub fn discover_approximate_fds(
 /// caller detects these cheaply and reports them as simple candidate keys); we
 /// skip subsets touching them so composite results are genuinely *new*
 /// information. Returns subsets as sorted column-index vectors.
-pub fn composite_key_search(
+pub fn composite_key_search_slice(
     columns: &[&[u64]],
     n_rows: usize,
     max_size: usize,
@@ -331,8 +419,8 @@ mod tests {
         // city -> country holds; country -> city breaks.
         let city = [1u64, 2, 3, 1];
         let country = [9u64, 9, 8, 9];
-        assert!(functional_dependency_holds(&city, &country));
-        assert!(!functional_dependency_holds(&country, &city));
+        assert!(functional_dependency_holds_slice(&city, &country));
+        assert!(!functional_dependency_holds_slice(&country, &city));
     }
 
     #[test]
@@ -341,9 +429,9 @@ mod tests {
         // so zip->city holds at 8/9 ~= 0.889. det avg group = 3 (meets guard).
         let det = [1u64, 1, 1, 2, 2, 2, 3, 3, 3];
         let dep = [10u64, 10, 10, 20, 20, 99, 30, 30, 30];
-        assert_eq!(fd_violation_rows(&det, &dep), vec![5]);
+        assert_eq!(fd_violation_rows_slice(&det, &dep), vec![5]);
         let cols: Vec<&[u64]> = vec![&det, &dep];
-        let fds = discover_approximate_fds(&cols, 0.8);
+        let fds = discover_approximate_fds_slice(&cols, 0.8);
         // det(0) -> dep(1) with 1 violation; not the reverse (dep near-unique det).
         assert!(fds.contains(&(0, 1, 1)));
     }
@@ -354,7 +442,7 @@ mod tests {
         let det = [1u64, 2, 3, 4, 5, 6];
         let dep = [9u64, 9, 8, 8, 7, 7];
         let cols: Vec<&[u64]> = vec![&det, &dep];
-        assert!(discover_approximate_fds(&cols, 0.8)
+        assert!(discover_approximate_fds_slice(&cols, 0.8)
             .iter()
             .all(|&(d, _, _)| d != 0));
     }
@@ -369,7 +457,7 @@ mod tests {
         let constant = [7u64, 7, 7, 7];
         let uniq = [1u64, 2, 3, 4];
         let cols: Vec<&[u64]> = vec![&zip, &city, &constant, &uniq];
-        let fds = discover_functional_dependencies(&cols);
+        let fds = discover_functional_dependencies_slice(&cols);
         // zip->city present; city->zip absent; nothing -> constant (col2) since
         // constant is skipped as a dep; uniq (col3) skipped as det.
         assert!(fds.contains(&(0, 1)));
@@ -384,7 +472,7 @@ mod tests {
         let a = [1u64, 1, 2, 2];
         let b = [10u64, 20, 10, 20];
         let cols: Vec<&[u64]> = vec![&a, &b];
-        let keys = composite_key_search(&cols, 4, 3, &[false, false]);
+        let keys = composite_key_search_slice(&cols, 4, 3, &[false, false]);
         assert_eq!(keys, vec![vec![0, 1]]);
     }
 
@@ -393,7 +481,50 @@ mod tests {
         let a = [1u64, 2, 3, 4]; // unique alone
         let b = [10u64, 10, 20, 20];
         let cols: Vec<&[u64]> = vec![&a, &b];
-        let keys = composite_key_search(&cols, 4, 3, &[true, false]);
+        let keys = composite_key_search_slice(&cols, 4, 3, &[true, false]);
         assert!(keys.is_empty());
+    }
+
+    #[test]
+    fn arrow_fd_holds_matches_slice() {
+        use arrow::array::StringArray;
+        let city = StringArray::from(vec!["a", "b", "c", "a"]);
+        let country = StringArray::from(vec!["x", "x", "y", "x"]);
+        assert!(functional_dependency_holds(&city, &country).unwrap());
+        assert!(!functional_dependency_holds(&country, &city).unwrap());
+    }
+
+    #[test]
+    fn arrow_discover_fd_matches_slice() {
+        use arrow::array::{ArrayRef, Int64Array};
+        use std::sync::Arc;
+        let zip: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 2, 3]));
+        let city: ArrayRef = Arc::new(Int64Array::from(vec![10, 10, 10, 30]));
+        let cols = vec![zip, city];
+        let fds = discover_functional_dependencies(&cols).unwrap();
+        assert!(fds.contains(&(0, 1)));
+        assert!(!fds.contains(&(1, 0)));
+    }
+
+    #[test]
+    fn arrow_composite_key_matches_slice() {
+        use arrow::array::{ArrayRef, Int64Array};
+        use std::sync::Arc;
+        let a: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 2, 2]));
+        let b: ArrayRef = Arc::new(Int64Array::from(vec![10, 20, 10, 20]));
+        let keys = composite_key_search(&[a, b], 3, &[false, false]).unwrap();
+        assert_eq!(keys, vec![vec![0, 1]]);
+    }
+
+    #[test]
+    fn arrow_approximate_fds_and_violation_rows_match_slice() {
+        use arrow::array::{ArrayRef, Int64Array};
+        use std::sync::Arc;
+        let det: ArrayRef = Arc::new(Int64Array::from(vec![1, 1, 1, 2, 2, 2, 3, 3, 3]));
+        let dep: ArrayRef = Arc::new(Int64Array::from(vec![10, 10, 10, 20, 20, 99, 30, 30, 30]));
+        let fds = discover_approximate_fds(&[det.clone(), dep.clone()], 0.8).unwrap();
+        assert!(fds.contains(&(0, 1, 1)));
+        let rows = fd_violation_rows(det.as_ref(), dep.as_ref()).unwrap();
+        assert_eq!(rows, vec![5]);
     }
 }

--- a/packages/rust/extensions/goldencheck-core/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-core/src/lib.rs
@@ -6,16 +6,19 @@
 //! `GOLDENCHECK_NATIVE` opts in (see `goldencheck/core/_native_loader.py`); the
 //! pure-Python implementation stays the default and the fallback.
 //!
-//! The kernels here take plain slices (`&[f64]`, `&[u64]`) so they carry no
-//! Python or Arrow types -- the `goldencheck-native` crate owns the
-//! `#[pyfunction]` shims and the zero-copy Arrow reads, and delegates the
-//! actual work here. This mirrors `score-core` / `graph-core` on the
-//! goldenmatch side.
+//! Most kernels take plain slices (`&[f64]`, `&[u64]`) so they carry no Python
+//! or Arrow types. Benford is the exception (and the model for future
+//! conversions): it takes Arrow arrays (`&dyn Array`) directly via the shared
+//! `arrow_support` module, so the Arrow boundary lives in this pyo3-free core
+//! -- the `goldencheck-native` crate now only marshals pyarrow<->Arrow for it,
+//! it doesn't own the zero-copy read. This mirrors `score-core` / `graph-core`
+//! on the goldenmatch side.
 //!
 //! Most kernels compare interned ids by equality only. The denial-constraint
 //! kernel (`dc`) is the exception: its columns arrive order-preservingly
 //! rank-encoded, so it does ordered `<`/`<=`/`>`/`>=` comparisons over those ids.
 
+mod arrow_support;
 mod benford;
 mod date;
 mod dc;
@@ -23,7 +26,8 @@ mod fuzzy;
 mod keys;
 mod regex;
 
-pub use benford::benford_leading_digits;
+pub use arrow_support::intern_column;
+pub use benford::{benford_leading_digits, benford_leading_digits_slice};
 pub use date::str_to_date;
 pub use dc::{dc_pair_evidence, dc_row_evidence, Pred};
 pub use fuzzy::near_duplicate_clusters;

--- a/packages/rust/extensions/goldencheck-core/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-core/src/lib.rs
@@ -6,13 +6,16 @@
 //! `GOLDENCHECK_NATIVE` opts in (see `goldencheck/core/_native_loader.py`); the
 //! pure-Python implementation stays the default and the fallback.
 //!
-//! Most kernels take plain slices (`&[f64]`, `&[u64]`) so they carry no Python
-//! or Arrow types. Benford is the exception (and the model for future
-//! conversions): it takes Arrow arrays (`&dyn Array`) directly via the shared
-//! `arrow_support` module, so the Arrow boundary lives in this pyo3-free core
-//! -- the `goldencheck-native` crate now only marshals pyarrow<->Arrow for it,
-//! it doesn't own the zero-copy read. This mirrors `score-core` / `graph-core`
-//! on the goldenmatch side.
+//! Benford, the key/FD kernels, and the fuzzy near-duplicate kernel take Arrow
+//! arrays (`&dyn Array` / `&[ArrayRef]`) directly via the shared `arrow_support`
+//! module, so the Arrow boundary lives in this pyo3-free core -- the
+//! `goldencheck-native` crate only marshals pyarrow<->Arrow for them, it
+//! doesn't own the zero-copy read. This mirrors `score-core` / `graph-core` on
+//! the goldenmatch side. Each of these also keeps a `_slice`-suffixed twin
+//! (over already-interned `&[u64]` / plain `&[String]`) as the entry point for
+//! non-Arrow surfaces that call this crate directly: `goldencheck-wasm`
+//! (JSON in/out over wasm-bindgen), the `goldenmatch_pg` Postgres extension,
+//! and this crate's own `tests/golden.rs` cross-surface fixture.
 //!
 //! Most kernels compare interned ids by equality only. The denial-constraint
 //! kernel (`dc`) is the exception: its columns arrive order-preservingly
@@ -30,9 +33,11 @@ pub use arrow_support::intern_column;
 pub use benford::{benford_leading_digits, benford_leading_digits_slice};
 pub use date::str_to_date;
 pub use dc::{dc_pair_evidence, dc_row_evidence, Pred};
-pub use fuzzy::near_duplicate_clusters;
+pub use fuzzy::{near_duplicate_clusters, near_duplicate_clusters_slice};
 pub use keys::{
-    composite_key_search, discover_approximate_fds, discover_functional_dependencies,
-    fd_violation_rows, functional_dependency_holds, tuple_distinct_count,
+    composite_key_search, composite_key_search_slice, discover_approximate_fds,
+    discover_approximate_fds_slice, discover_functional_dependencies,
+    discover_functional_dependencies_slice, fd_violation_rows, fd_violation_rows_slice,
+    functional_dependency_holds, functional_dependency_holds_slice, tuple_distinct_count,
 };
 pub use regex::{str_contains_count, str_filter_mask, str_replace_all};

--- a/packages/rust/extensions/goldencheck-core/tests/golden.rs
+++ b/packages/rust/extensions/goldencheck-core/tests/golden.rs
@@ -144,7 +144,7 @@ fn reproduces_golden_vectors() {
         .map(|x| x.as_u64().unwrap())
         .collect();
     assert_eq!(
-        gc::benford_leading_digits(&bvals).to_vec(),
+        gc::benford_leading_digits_slice(&bvals).to_vec(),
         benford_want,
         "benford_leading_digits"
     );

--- a/packages/rust/extensions/goldencheck-core/tests/golden.rs
+++ b/packages/rust/extensions/goldencheck-core/tests/golden.rs
@@ -61,11 +61,12 @@ fn reproduces_golden_vectors() {
     let cols = columns(&fd["columns"]);
     let refs: Vec<&[u64]> = cols.iter().map(|c| c.as_slice()).collect();
     assert_eq!(
-        gc::discover_functional_dependencies(&refs),
+        gc::discover_functional_dependencies_slice(&refs),
         as_pairs(&fd["discover_expected"]),
         "discover_functional_dependencies"
     );
-    let approx = gc::discover_approximate_fds(&refs, fd["approx_min_confidence"].as_f64().unwrap());
+    let approx =
+        gc::discover_approximate_fds_slice(&refs, fd["approx_min_confidence"].as_f64().unwrap());
     let approx_want: Vec<(usize, usize, usize)> = fd["approx_expected"]
         .as_array()
         .unwrap()
@@ -84,7 +85,7 @@ fn reproduces_golden_vectors() {
     let det = fd["holds_det"].as_u64().unwrap() as usize;
     let dep = fd["holds_dep"].as_u64().unwrap() as usize;
     assert_eq!(
-        gc::functional_dependency_holds(&cols[det], &cols[dep]),
+        gc::functional_dependency_holds_slice(&cols[det], &cols[dep]),
         fd["holds_expected"].as_bool().unwrap(),
         "functional_dependency_holds"
     );
@@ -95,7 +96,7 @@ fn reproduces_golden_vectors() {
         .map(|x| x.as_u64().unwrap() as usize)
         .collect();
     assert_eq!(
-        gc::fd_violation_rows(&cols[det], &cols[dep]),
+        gc::fd_violation_rows_slice(&cols[det], &cols[dep]),
         viol_want,
         "fd_violation_rows"
     );
@@ -110,7 +111,7 @@ fn reproduces_golden_vectors() {
         .iter()
         .map(|b| b.as_bool().unwrap())
         .collect();
-    let keys = gc::composite_key_search(
+    let keys = gc::composite_key_search_slice(
         &ck_refs,
         ck_cols[0].len(),
         ck["max_size"].as_u64().unwrap() as usize,
@@ -170,7 +171,7 @@ fn reproduces_golden_vectors() {
         })
         .collect();
     assert_eq!(
-        gc::near_duplicate_clusters(&nd_vals, nd["min_similarity"].as_f64().unwrap()),
+        gc::near_duplicate_clusters_slice(&nd_vals, nd["min_similarity"].as_f64().unwrap()),
         nd_want,
         "near_duplicate_clusters"
     );

--- a/packages/rust/extensions/goldencheck-native/Cargo.lock
+++ b/packages/rust/extensions/goldencheck-native/Cargo.lock
@@ -364,6 +364,7 @@ dependencies = [
 name = "goldencheck-core"
 version = "0.1.0"
 dependencies = [
+ "arrow",
  "chrono",
  "regex",
  "rustc-hash",

--- a/packages/rust/extensions/goldencheck-native/src/fuzzy.rs
+++ b/packages/rust/extensions/goldencheck-native/src/fuzzy.rs
@@ -1,20 +1,20 @@
 //! Shim for the fuzzy near-duplicate value-clustering kernel.
+//!
+//! Python callers (`cell_quality.py`, `core/kernels.py`,
+//! `profilers/fuzzy_values.py`) all pass a plain `list[str]` here today (a
+//! column's distinct values are a small set, so the Arrow C Data Interface
+//! buys nothing on this path) -- so the pyfunction signature stays `Vec<String>`
+//! and delegates to the core's `_slice` entry point, which is also what
+//! `goldencheck-wasm` and the `goldenmatch_pg` Postgres extension call.
 use pyo3::prelude::*;
 
-/// Cluster the distinct `values` of a column into groups of edit-distance-close
-/// strings (inconsistent encodings of the same thing). Returns clusters as
-/// lists of indices into `values`; clusters have size >= 2.
-///
-/// Takes a plain `list[str]` (a column's distinct values are a small set, so the
-/// Arrow C Data Interface buys nothing here) and delegates to
-/// `goldencheck_core::near_duplicate_clusters`.
 #[pyfunction]
 #[pyo3(signature = (values, min_similarity))]
 pub fn near_duplicate_value_clusters(
     values: Vec<String>,
     min_similarity: f64,
 ) -> PyResult<Vec<Vec<usize>>> {
-    Ok(goldencheck_core::near_duplicate_clusters(
+    Ok(goldencheck_core::near_duplicate_clusters_slice(
         &values,
         min_similarity,
     ))

--- a/packages/rust/extensions/goldencheck-native/src/keys.rs
+++ b/packages/rust/extensions/goldencheck-native/src/keys.rs
@@ -1,180 +1,20 @@
-//! Arrow-reading shims for the combinatorial key / functional-dependency
-//! kernels in `goldencheck-core`.
+//! pyarrow<->Arrow marshalling shims for the combinatorial key /
+//! functional-dependency kernels in `goldencheck-core`.
 //!
-//! Each column is interned to dense `u64` value-ids (nulls get their own id) so
-//! the core kernels stay dtype-agnostic and exact (equality is on the real
-//! value, never a lossy hash). Supports the dtypes the deep-profiler hands us:
-//! Utf8/LargeUtf8, the signed/unsigned ints, Float64/Float32, and Boolean.
-use arrow::array::{
-    Array, ArrayData, BooleanArray, DictionaryArray, Float32Array, Float64Array, Int16Array,
-    Int32Array, Int64Array, Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array,
-    UInt64Array, UInt8Array,
-};
-use arrow::datatypes::{
-    ArrowNativeType, DataType, Int16Type, Int32Type, Int64Type, Int8Type, UInt16Type, UInt32Type,
-    UInt64Type, UInt8Type,
-};
+//! Interning (Arrow value -> dense `u64` id, nulls to a reserved id, including
+//! Dictionary-encoded/Categorical columns) now lives in
+//! `goldencheck_core::arrow_support::intern_column`; these `#[pyfunction]`s
+//! only decode pyarrow arrays into `ArrayRef` and call the core Arrow API.
+use arrow::array::{make_array, ArrayData, ArrayRef};
 use arrow::pyarrow::PyArrowType;
 use pyo3::prelude::*;
-use rustc_hash::FxHashMap;
 
-/// Intern one Arrow column to dense `u64` value-ids. Null slots all share a
-/// single reserved id distinct from every real value's id.
-fn intern_column(data: ArrayData) -> PyResult<Vec<u64>> {
-    // Intern a primitive column by reading its Arrow **values buffer as a
-    // slice** (`arr.values()`, zero-copy) rather than per-element `value(i)`,
-    // and split a no-null fast path (skips the per-row validity branch) from the
-    // masked path. `keymap` turns a raw native value into the map key (identity
-    // for ints, bit-pattern for floats).
-    macro_rules! intern_primitive {
-        ($arr:expr, $keyty:ty, $keymap:expr) => {{
-            let arr = $arr;
-            let values = arr.values(); // &[native], the shared Arrow buffer
-            let keymap = $keymap;
-            let mut map: FxHashMap<$keyty, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1; // 0 is reserved for null
-            match arr.nulls() {
-                None => {
-                    for &raw in values.iter() {
-                        let id = *map.entry(keymap(raw)).or_insert_with(|| {
-                            let v = next;
-                            next += 1;
-                            v
-                        });
-                        ids.push(id);
-                    }
-                }
-                Some(nulls) => {
-                    for (i, &raw) in values.iter().enumerate() {
-                        if nulls.is_null(i) {
-                            ids.push(0);
-                            continue;
-                        }
-                        let id = *map.entry(keymap(raw)).or_insert_with(|| {
-                            let v = next;
-                            next += 1;
-                            v
-                        });
-                        ids.push(id);
-                    }
-                }
-            }
-            Ok(ids)
-        }};
-    }
+fn to_arrays(v: Vec<PyArrowType<ArrayData>>) -> Vec<ArrayRef> {
+    v.into_iter().map(|a| make_array(a.0)).collect()
+}
 
-    match data.data_type() {
-        DataType::Utf8 => {
-            let arr = StringArray::from(data);
-            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
-                }
-                let id = *map.entry(arr.value(i)).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
-            }
-            Ok(ids)
-        }
-        DataType::LargeUtf8 => {
-            let arr = LargeStringArray::from(data);
-            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
-                }
-                let id = *map.entry(arr.value(i)).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
-            }
-            Ok(ids)
-        }
-        DataType::Int8 => intern_primitive!(Int8Array::from(data), i8, |v: i8| v),
-        DataType::Int16 => intern_primitive!(Int16Array::from(data), i16, |v: i16| v),
-        DataType::Int32 => intern_primitive!(Int32Array::from(data), i32, |v: i32| v),
-        DataType::Int64 => intern_primitive!(Int64Array::from(data), i64, |v: i64| v),
-        DataType::UInt8 => intern_primitive!(UInt8Array::from(data), u8, |v: u8| v),
-        DataType::UInt16 => intern_primitive!(UInt16Array::from(data), u16, |v: u16| v),
-        DataType::UInt32 => intern_primitive!(UInt32Array::from(data), u32, |v: u32| v),
-        DataType::UInt64 => intern_primitive!(UInt64Array::from(data), u64, |v: u64| v),
-        // Floats keyed by bit pattern (exact value identity; matches Polars
-        // equality semantics for finite values, which is all a key column has).
-        DataType::Float32 => {
-            intern_primitive!(Float32Array::from(data), u32, |v: f32| v.to_bits())
-        }
-        DataType::Float64 => {
-            intern_primitive!(Float64Array::from(data), u64, |v: f64| v.to_bits())
-        }
-        DataType::Boolean => {
-            let arr = BooleanArray::from(data);
-            let mut ids = Vec::with_capacity(arr.len());
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                } else {
-                    ids.push(if arr.value(i) { 1 } else { 2 });
-                }
-            }
-            Ok(ids)
-        }
-        // Dictionary-encoded (e.g. a Polars Categorical/Enum column). The
-        // dictionary *is* the interning: intern the (small) values array ONCE,
-        // then map each row's key through it — O(dict) hashing + O(rows) index
-        // lookups, instead of O(rows) hashing on the raw path. A null row keeps
-        // id 0. This is the zero-extra-work path when a categorical column flows
-        // straight through as an Arrow dictionary.
-        DataType::Dictionary(key_type, _) => {
-            macro_rules! intern_dict {
-                ($kt:ty) => {{
-                    let dict = DictionaryArray::<$kt>::from(data);
-                    // Dense id per dictionary entry (recurses on the small values
-                    // array; null entries -> 0, values -> 1,2,… first-seen).
-                    let value_ids = intern_column(dict.values().to_data())?;
-                    let keys = dict.keys();
-                    let mut ids = Vec::with_capacity(keys.len());
-                    for i in 0..keys.len() {
-                        if keys.is_null(i) {
-                            ids.push(0);
-                        } else {
-                            ids.push(value_ids[keys.value(i).as_usize()]);
-                        }
-                    }
-                    Ok(ids)
-                }};
-            }
-            match key_type.as_ref() {
-                DataType::Int8 => intern_dict!(Int8Type),
-                DataType::Int16 => intern_dict!(Int16Type),
-                DataType::Int32 => intern_dict!(Int32Type),
-                DataType::Int64 => intern_dict!(Int64Type),
-                DataType::UInt8 => intern_dict!(UInt8Type),
-                DataType::UInt16 => intern_dict!(UInt16Type),
-                DataType::UInt32 => intern_dict!(UInt32Type),
-                DataType::UInt64 => intern_dict!(UInt64Type),
-                other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
-                    "key/FD kernels: unsupported dictionary key type {other:?}"
-                ))),
-            }
-        }
-        other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
-            "key/FD kernels do not support Arrow dtype {other:?}; \
-             cast to a supported type (string/int/float/bool) first"
-        ))),
-    }
+fn map_err(e: arrow::error::ArrowError) -> PyErr {
+    pyo3::exceptions::PyTypeError::new_err(e.to_string())
 }
 
 /// Search for minimal composite keys over `field_arrays`.
@@ -191,21 +31,8 @@ pub fn composite_key_search(
     max_size: usize,
     single_unique: Vec<bool>,
 ) -> PyResult<Vec<Vec<usize>>> {
-    if field_arrays.is_empty() {
-        return Ok(Vec::new());
-    }
-    let columns: Vec<Vec<u64>> = field_arrays
-        .into_iter()
-        .map(|a| intern_column(a.0))
-        .collect::<PyResult<_>>()?;
-    let n_rows = columns[0].len();
-    let refs: Vec<&[u64]> = columns.iter().map(|c| c.as_slice()).collect();
-    Ok(goldencheck_core::composite_key_search(
-        &refs,
-        n_rows,
-        max_size,
-        &single_unique,
-    ))
+    goldencheck_core::composite_key_search(&to_arrays(field_arrays), max_size, &single_unique)
+        .map_err(map_err)
 }
 
 /// Whether `lhs -> rhs` holds (every distinct lhs value maps to one rhs value).
@@ -215,32 +42,21 @@ pub fn functional_dependency_holds(
     lhs: PyArrowType<ArrayData>,
     rhs: PyArrowType<ArrayData>,
 ) -> PyResult<bool> {
-    let l = intern_column(lhs.0)?;
-    let r = intern_column(rhs.0)?;
-    if l.len() != r.len() {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "functional_dependency_holds: lhs and rhs differ in length",
-        ));
-    }
-    Ok(goldencheck_core::functional_dependency_holds(&l, &r))
+    goldencheck_core::functional_dependency_holds(
+        make_array(lhs.0).as_ref(),
+        make_array(rhs.0).as_ref(),
+    )
+    .map_err(map_err)
 }
 
 /// Discover all strict single-column FDs `(det_idx, dep_idx)` among
-/// `field_arrays`. Interns each column once and reuses it across every pair
-/// (delegates to `goldencheck_core::discover_functional_dependencies`).
+/// `field_arrays` (delegates to
+/// `goldencheck_core::discover_functional_dependencies`).
 #[pyfunction]
 pub fn discover_functional_dependencies(
     field_arrays: Vec<PyArrowType<ArrayData>>,
 ) -> PyResult<Vec<(usize, usize)>> {
-    if field_arrays.is_empty() {
-        return Ok(Vec::new());
-    }
-    let columns: Vec<Vec<u64>> = field_arrays
-        .into_iter()
-        .map(|a| intern_column(a.0))
-        .collect::<PyResult<_>>()?;
-    let refs: Vec<&[u64]> = columns.iter().map(|c| c.as_slice()).collect();
-    Ok(goldencheck_core::discover_functional_dependencies(&refs))
+    goldencheck_core::discover_functional_dependencies(&to_arrays(field_arrays)).map_err(map_err)
 }
 
 /// Discover *approximate* FDs `(det_idx, dep_idx, n_violations)` holding for a
@@ -252,18 +68,8 @@ pub fn discover_approximate_fds(
     field_arrays: Vec<PyArrowType<ArrayData>>,
     min_confidence: f64,
 ) -> PyResult<Vec<(usize, usize, usize)>> {
-    if field_arrays.is_empty() {
-        return Ok(Vec::new());
-    }
-    let columns: Vec<Vec<u64>> = field_arrays
-        .into_iter()
-        .map(|a| intern_column(a.0))
-        .collect::<PyResult<_>>()?;
-    let refs: Vec<&[u64]> = columns.iter().map(|c| c.as_slice()).collect();
-    Ok(goldencheck_core::discover_approximate_fds(
-        &refs,
-        min_confidence,
-    ))
+    goldencheck_core::discover_approximate_fds(&to_arrays(field_arrays), min_confidence)
+        .map_err(map_err)
 }
 
 /// Row indices where `dep` deviates from its per-`det`-group mode (the rows that
@@ -274,12 +80,6 @@ pub fn fd_violation_rows(
     det: PyArrowType<ArrayData>,
     dep: PyArrowType<ArrayData>,
 ) -> PyResult<Vec<usize>> {
-    let d = intern_column(det.0)?;
-    let p = intern_column(dep.0)?;
-    if d.len() != p.len() {
-        return Err(pyo3::exceptions::PyValueError::new_err(
-            "fd_violation_rows: det and dep differ in length",
-        ));
-    }
-    Ok(goldencheck_core::fd_violation_rows(&d, &p))
+    goldencheck_core::fd_violation_rows(make_array(det.0).as_ref(), make_array(dep.0).as_ref())
+        .map_err(map_err)
 }

--- a/packages/rust/extensions/goldencheck-native/src/profile.rs
+++ b/packages/rust/extensions/goldencheck-native/src/profile.rs
@@ -1,42 +1,20 @@
 //! Arrow-reading shims for the column-profiling kernels.
-use arrow::array::{Array, ArrayData, Float64Array};
+use arrow::array::{make_array, ArrayData};
 use arrow::pyarrow::PyArrowType;
 use pyo3::prelude::*;
 
-/// Benford leading-digit histogram for a Float64 Arrow column.
-///
-/// Reads the array zero-copy via the Arrow C Data Interface, drops null slots
-/// (their backing value is undefined), and delegates to
-/// `goldencheck_core::benford_leading_digits`. Returns the 9 per-digit counts
-/// (digits 1..=9) as a Python list -- the same `Counter` the pure-Python
-/// `goldencheck.baseline.statistical._compute_benford` builds, so the caller's
-/// chi-squared step is unchanged.
+/// Benford leading-digit histogram for a Float64 Arrow column. Decodes the
+/// pyarrow array and delegates to `goldencheck_core::benford_leading_digits`
+/// (which owns the Float64 downcast + null handling). Returns the 9 per-digit
+/// counts (digits 1..=9) as a Python list -- the same `Counter` the
+/// pure-Python `goldencheck.baseline.statistical._compute_benford` builds, so
+/// the caller's chi-squared step is unchanged.
 ///
 /// The caller must pass a Float64 array (cast in Polars before `.to_arrow()`);
 /// non-Float64 input raises `TypeError`.
 #[pyfunction]
 pub fn benford_leading_digits(values: PyArrowType<ArrayData>) -> PyResult<[u64; 9]> {
-    let data = values.0;
-    if !matches!(data.data_type(), arrow::datatypes::DataType::Float64) {
-        return Err(pyo3::exceptions::PyTypeError::new_err(format!(
-            "benford_leading_digits expects a Float64 array, got {:?}",
-            data.data_type()
-        )));
-    }
-    let arr = Float64Array::from(data);
-    // Honour the null mask: a null slot's backing f64 is undefined.
-    if arr.null_count() == 0 {
-        // True zero-copy: the Arrow values buffer *is* `&[f64]` (deref of the
-        // shared `ScalarBuffer`) — hand it straight to the kernel, no owned Vec.
-        // On a 1M-row column this avoids an 8 MB memcpy per call.
-        Ok(goldencheck_core::benford_leading_digits(arr.values()))
-    } else {
-        // Null slots have an undefined backing f64, so we can't pass the raw
-        // buffer; compact the valid values (only the non-null subset) instead.
-        let vals: Vec<f64> = (0..arr.len())
-            .filter(|&i| !arr.is_null(i))
-            .map(|i| arr.value(i))
-            .collect();
-        Ok(goldencheck_core::benford_leading_digits(&vals))
-    }
+    let array = make_array(values.0);
+    goldencheck_core::benford_leading_digits(array.as_ref())
+        .map_err(|e| pyo3::exceptions::PyTypeError::new_err(e.to_string()))
 }

--- a/packages/rust/extensions/goldencheck-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-wasm/src/lib.rs
@@ -56,7 +56,7 @@ fn refs(interned: &[Vec<u64>]) -> Vec<&[u64]> {
 pub fn gc_discover_functional_dependencies(columns_json: &str) -> Result<String, JsError> {
     let columns = parse_columns(columns_json)?;
     let interned = intern_all(&columns);
-    let out = gc::discover_functional_dependencies(&refs(&interned));
+    let out = gc::discover_functional_dependencies_slice(&refs(&interned));
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -69,7 +69,7 @@ pub fn gc_discover_approximate_fds(
 ) -> Result<String, JsError> {
     let columns = parse_columns(columns_json)?;
     let interned = intern_all(&columns);
-    let out = gc::discover_approximate_fds(&refs(&interned), min_confidence);
+    let out = gc::discover_approximate_fds_slice(&refs(&interned), min_confidence);
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -88,7 +88,7 @@ pub fn gc_functional_dependency_holds(lhs_json: &str, rhs_json: &str) -> Result<
     }
     let l = intern(&lhs);
     let r = intern(&rhs);
-    let out = gc::functional_dependency_holds(&l, &r);
+    let out = gc::functional_dependency_holds_slice(&l, &r);
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -105,7 +105,7 @@ pub fn gc_fd_violation_rows(det_json: &str, dep_json: &str) -> Result<String, Js
     }
     let d = intern(&det);
     let p = intern(&dep);
-    let out = gc::fd_violation_rows(&d, &p);
+    let out = gc::fd_violation_rows_slice(&d, &p);
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -127,7 +127,7 @@ pub fn gc_composite_key_search(
     }
     let interned = intern_all(&columns);
     let n_rows = interned[0].len();
-    let out = gc::composite_key_search(&refs(&interned), n_rows, max_size, &single_unique);
+    let out = gc::composite_key_search_slice(&refs(&interned), n_rows, max_size, &single_unique);
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }
 
@@ -155,6 +155,6 @@ pub fn gc_near_duplicate_clusters(
 ) -> Result<String, JsError> {
     let values: Vec<String> =
         serde_json::from_str(values_json).map_err(|e| JsError::new(&format!("bad values: {e}")))?;
-    let out = gc::near_duplicate_clusters(&values, min_similarity);
+    let out = gc::near_duplicate_clusters_slice(&values, min_similarity);
     serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/packages/rust/extensions/goldencheck-wasm/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-wasm/src/lib.rs
@@ -140,7 +140,7 @@ pub fn gc_benford_leading_digits(values_json: &str) -> Result<String, JsError> {
     let values: Vec<Option<f64>> =
         serde_json::from_str(values_json).map_err(|e| JsError::new(&format!("bad values: {e}")))?;
     let finite: Vec<f64> = values.into_iter().flatten().collect();
-    let out = gc::benford_leading_digits(&finite);
+    let out = gc::benford_leading_digits_slice(&finite);
     serde_json::to_string(&out.to_vec()).map_err(|e| JsError::new(&e.to_string()))
 }
 

--- a/packages/rust/extensions/postgres/src/goldencheck_kernels.rs
+++ b/packages/rust/extensions/postgres/src/goldencheck_kernels.rs
@@ -84,7 +84,7 @@ pub fn goldencheck_near_duplicates(
     min_similarity: f64,
 ) -> TableIterator<'static, (name!(cluster, i64), name!(member, i64))> {
     let strings: Vec<String> = values.into_iter().map(|v| v.unwrap_or_default()).collect();
-    let clusters = goldencheck_core::near_duplicate_clusters(&strings, min_similarity);
+    let clusters = goldencheck_core::near_duplicate_clusters_slice(&strings, min_similarity);
     let rows: Vec<(i64, i64)> = clusters
         .into_iter()
         .enumerate()
@@ -109,7 +109,7 @@ pub fn goldencheck_discover_fds(
         None => return TableIterator::new(Vec::new()),
     };
     let refs: Vec<&[u64]> = cols.iter().map(Vec::as_slice).collect();
-    let pairs = goldencheck_core::discover_functional_dependencies(&refs);
+    let pairs = goldencheck_core::discover_functional_dependencies_slice(&refs);
     TableIterator::new(
         pairs
             .into_iter()
@@ -134,7 +134,7 @@ pub fn goldencheck_discover_approx_fds(
         None => return TableIterator::new(Vec::new()),
     };
     let refs: Vec<&[u64]> = cols.iter().map(Vec::as_slice).collect();
-    let triples = goldencheck_core::discover_approximate_fds(&refs, min_confidence);
+    let triples = goldencheck_core::discover_approximate_fds_slice(&refs, min_confidence);
     TableIterator::new(
         triples
             .into_iter()
@@ -184,7 +184,7 @@ pub fn goldencheck_composite_keys(
     }
     let cand: Vec<&[u64]> = cand_orig.iter().map(|&i| cols[i].as_slice()).collect();
     let single_unique = vec![false; cand.len()];
-    let keys = goldencheck_core::composite_key_search(
+    let keys = goldencheck_core::composite_key_search_slice(
         &cand,
         n_rows,
         max_size.max(0) as usize,

--- a/packages/rust/extensions/postgres/src/goldencheck_kernels.rs
+++ b/packages/rust/extensions/postgres/src/goldencheck_kernels.rs
@@ -67,7 +67,7 @@ fn interned_columns(flat: &[Option<String>], n_cols: usize) -> Option<Vec<Vec<u6
 /// surfaces produce.
 #[pg_extern]
 pub fn goldencheck_benford(values: Vec<f64>) -> Vec<i64> {
-    goldencheck_core::benford_leading_digits(&values)
+    goldencheck_core::benford_leading_digits_slice(&values)
         .iter()
         .map(|&c| c as i64)
         .collect()


### PR DESCRIPTION
## Summary

**W0-land** of the goldencheck Arrow-native fused-scan program (the path to 3.0.0 / complete Polars eviction). Lands the Arrow-in-core kernel foundation: the 5 `goldencheck-core` kernels now take Arrow arrays (`&dyn Array`) instead of typed slices, plus a reusable parity-oracle harness. Internal refactor — native output is byte/set-identical, no Python API change.

This ports the proven (but stale, v1.4.0) `feat/goldencheck-arrow-native-core` work onto main-with-2.0.0, reconciled to `arrow 59` and integrated alongside the regex/date/dc kernels 2.0.0 added.

## What changed

- **arrow-rs in `goldencheck-core`** (`arrow = 59`, matching `goldencheck-native` — version lockstep is the top risk; both on the umbrella `arrow` crate). New `arrow_support.rs` (shared Arrow decode + null-bitmap + `intern_column`).
- **5 kernels Arrow-in-core**: benford, composite-key, functional-dependency, approximate-FD, fuzzy — signatures move from `&[f64]`/`&[u64]` to `&dyn Array` with internal downcast + null-awareness (a correctness upgrade — the null bitmap was previously lost). `-native` shims thin to pure pyarrow↔ArrayRef marshalling.
- **Slice entry points kept** for the non-Arrow consumers that drifted onto main since the branch was cut (goldencheck-wasm, goldenmatch_pg, core's golden.rs, and the fuzzy pyfunction's `list[str]` Python callers) — so nothing breaks.
- **Dictionary/Categorical interning** (main's PR #1470, added after the branch) ported into `arrow_support::intern_column` with a new parity test — avoids regressing categorical key/FD discovery.
- **Reusable parity-oracle harness** (`tests/core/parity_harness.py`) with an **empty** accepted-divergence registry: runs each component native + fallback, compares, fails on any unregistered divergence. Green empty-registry run validates the harness against known-exact code before later waves rely on it.

## Not in scope
No new check kernels (Waves 1-6); regex/date/dc kernels untouched (stay list/string-based, a later conversion); no numpy/scipy work; no version bump (internal, minor); pure-Python fallbacks retained.

## Test plan
- [x] `cargo test` (goldencheck-core): 38 pass; native + wasm build clean; clippy zero warnings
- [x] All 8 native symbols present (5 kernels + regex + str_to_date); parity 41/41 (incl. new dictionary test)
- [x] Parity-oracle harness green, empty registry, BOTH lanes (123 native / 121 fallback)
- [x] 202 relations/profilers tests pass; `import goldencheck` loads zero polars; ruff clean
- [ ] Full suite + native lane green in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h