### PR TITLE
feat(goldensuite-mcp): composite workflow tools (dedupe_file, match_sources, assess_file, clean_and_dedupe)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldensuite-mcp-composite-workflow-tools.md
+++ b/docs/superpowers/plans/2026-07-11-goldensuite-mcp-composite-workflow-tools.md
@@ -84,7 +84,7 @@ Expected: either PASS (golden populated by default — good) or FAIL with `golde
 
 - [ ] **Step 3: If golden is None, find how to enable it**
 
-If FAIL: inspect `dedupe_df` in `goldenmatch/_api.py` and `run_pipeline`/`output_golden` in `goldenmatch/core/pipeline.py`. Determine the call that populates golden (likely `dedupe_df(df, output_golden=True)` or a config flag). Record the exact call in a comment at the top of the test file — Task 1.2 uses it. If golden is populated by default, no change needed; note that.
+If FAIL: golden is expected to be populated by default (`DedupeResult.golden` is set from the pipeline's return dict unconditionally; `output_golden` gates only the *disk write*, not computation — see `goldenmatch/core/pipeline.py`). Note: `dedupe_df` has **no** `output_golden` kwarg — that flag lives on `run_dedupe_df`, so do not try to pass it to `dedupe_df`. If golden genuinely comes back `None`, investigate how `run_dedupe_df` gates golden and thread it through `session.deduplicate`. Record the exact working call in a comment at the top of the test file — Task 1.2 uses it. Most likely outcome: golden is populated by default and no change is needed.
 
 - [ ] **Step 4: Commit the pinned probe**
 
@@ -368,7 +368,10 @@ def _upload(dispatch, args):
 def orchestrate_dedupe_file(dispatch, args):
     steps = []
     ok, res, label = _upload(dispatch, args)
-    steps.append({"step": label, "ok": ok, **({"path": res.get("path"), "rows": res.get("rows")} if ok else {"error": res.get("error")})})
+    # NOTE: upload_dataset returns {path, bytes, filename} -- no row count. Don't
+    # record "rows" here (it would always be None); row/record counts come from
+    # the dedupe step's results.total_records.
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
     if not ok:
         return _finish("dedupe_file", steps)
     path = res["path"]
@@ -494,11 +497,11 @@ Add the composite names to `CURATED_TOOLS`:
 
 **Files:** `composites.py`, `tests/test_composites.py`
 
-- [ ] **Step 1: Failing unit test** with a fake table exposing `upload_dataset`, `analyze_data`, `scan`; assert steps `["upload","analyze","scan"]`, `ok True`, `summary` mentions rows + a quality signal. Add a **degraded** test: table missing `scan` → analyze step `ok True`, scan step `ok False`, composite `ok True` (degraded), profile still present.
+- [ ] **Step 1: Failing unit test** with a fake table exposing `upload_dataset`, `analyze_data`, `scan`; assert steps `["upload","analyze","scan"]`, `ok True`, `summary` mentions rows + a quality signal. Add a **degraded** test: table missing `scan` → analyze step `ok True`, scan step `ok False`, composite `ok True` (degraded), profile still present, **and assert `out["summary"]` is NOT a failure message** (does not start with "assess_file failed at step").
 
 - [ ] **Step 2: Run to verify it fails.**
 
-- [ ] **Step 3: Implement `orchestrate_assess_file`** — upload → `analyze_data(file_path=path)` → `scan(path)` (check the goldencheck `scan` arg name — likely `path`; confirm from `goldencheck.mcp.server` TOOLS). No `output_path`, no `config`/`outputs` export. Degraded rule: a failed `scan` does **not** flip the composite to `ok:false` (override `_finish` for this workflow, or pass a `degraded_steps={"scan"}` set so `_finish` ignores it when computing `ok`). Add its spec entry (inputSchema = `_FILE_INPUT_PROPS` only). Extend `_summarize` for `assess_file`.
+- [ ] **Step 3: Implement `orchestrate_assess_file`** — upload → `analyze_data(file_path=path)` → `scan(path)` (check the goldencheck `scan` arg name — likely `path`; confirm from `goldencheck.mcp.server` TOOLS). No `output_path`, no `config`/`outputs` export. Degraded rule: a failed `scan` does **not** flip the composite to `ok:false` — thread a `degraded_steps={"scan"}` set through `_finish` so it is excluded from the `ok = all(...)` computation. **Coordinate `_summarize`:** its current first branch emits "failed at step X" whenever any step is `not ok`; it must use the SAME degraded-aware `ok` (ignore degraded steps) so a degraded-but-successful `assess_file` gets a real summary, not a failure message. Add its spec entry (inputSchema = `_FILE_INPUT_PROPS` only).
 
 - [ ] **Step 4: Run to verify pass.**
 

--- a/docs/superpowers/plans/2026-07-11-goldensuite-mcp-composite-workflow-tools.md
+++ b/docs/superpowers/plans/2026-07-11-goldensuite-mcp-composite-workflow-tools.md
@@ -1,0 +1,564 @@
+# goldensuite-mcp Composite Workflow Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add four one-call "composite" workflow tools (`dedupe_file`, `match_sources`, `assess_file`, `clean_and_dedupe`) to the `goldensuite-mcp` aggregator, each orchestrating the underlying MCP dispatchers so an agent does a common multi-step path in a single call.
+
+**Architecture:** Two phases. **Phase 1** (goldenmatch): add an optional `output_path` to `agent_deduplicate` / `agent_match_sources` so the stateless ER tools can write their golden/linked records to a CSV (today they return summaries only, and the base `export_results` tool is dead in the aggregator because it reads a module-global `_result` that is never populated there). **Phase 2** (goldensuite-mcp): a new `composites.py` module whose composite tools call the aggregated `name_to_dispatch` table, thread each step's output to the next, and return a merged `{summary, steps[], config, outputs}` shape; registered in `_aggregate` and added to `CURATED_TOOLS`.
+
+**Tech Stack:** Python 3.11+, `mcp` (`mcp.types.Tool`), pytest, polars (already a goldenmatch dep). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md`
+
+**Prerequisites:** #1639 (curated listing) + #1640 (`suite_find_tools`) merged to `main`. Phase 2 rebases onto a `main` that also has Phase 1.
+
+---
+
+## Test environment (Windows worktree)
+
+All pytest commands run through the main repo venv with the worktree packages on `PYTHONPATH` (worktree-skew playbook). Set once per shell:
+
+```bash
+cd /d/show_case/gm-composites
+PP=$(for d in packages/python/*/; do echo -n "D:/show_case/gm-composites/${d%/};"; done)
+RUN="GOLDENMATCH_NATIVE=0 POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 PYTHONPATH=$PP ../../show_case/goldenmatch/.venv/Scripts/python.exe -m pytest"
+```
+
+Then e.g. `eval "$RUN packages/python/goldensuite-mcp/tests/test_composites.py -q"`.
+
+Commit with `git -c commit.gpgsign=false commit` and the standard Co-Authored-By / Claude-Session trailer.
+
+---
+
+## File Structure
+
+**Phase 1 — goldenmatch (its own PR/branch `feat/goldenmatch-agent-output-path` off `main`):**
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py` — `agent_deduplicate` + `agent_match_sources` handlers (write golden/linked CSV when `output_path` given) and their two `Tool` definitions (add `output_path` to `inputSchema`).
+- Test: `packages/python/goldenmatch/tests/test_agent_output_path.py` (new).
+
+**Phase 2 — goldensuite-mcp (`feat/goldensuite-mcp-composites`, rebased onto Phase-1 main):**
+- Create: `packages/python/goldensuite-mcp/goldensuite_mcp/composites.py` — composite specs, `run_step`, `build_composites`.
+- Modify: `packages/python/goldensuite-mcp/goldensuite_mcp/server.py` — call `build_composites` in `_aggregate`; add composite names to `CURATED_TOOLS`.
+- Test: `packages/python/goldensuite-mcp/tests/test_composites.py` (new).
+- Modify: `packages/python/goldensuite-mcp/README.md`, `CHANGELOG.md`, `pyproject.toml`, `goldensuite_mcp/__init__.py` (version bump, lockstep).
+
+---
+
+# Phase 1 — goldenmatch golden-out
+
+### Task 1.1: Spike — pin how golden records come out of the stateless dedupe path
+
+**Files:**
+- Test: `packages/python/goldenmatch/tests/test_agent_output_path.py`
+
+- [ ] **Step 1: Write a probe test that asserts the golden frame is reachable**
+
+```python
+# packages/python/goldenmatch/tests/test_agent_output_path.py
+from pathlib import Path
+import polars as pl
+from goldenmatch.core.agent import AgentSession
+
+def _fixture_csv(tmp_path: Path) -> str:
+    df = pl.DataFrame({
+        "name": ["John Smith", "Jon Smith", "Mary Jones", "Karen White"],
+        "email": ["j@x.com", "j@x.com", "m@y.com", "k@z.com"],
+    })
+    p = tmp_path / "in.csv"
+    df.write_csv(p)
+    return str(p)
+
+def test_dedupe_result_exposes_golden(tmp_path):
+    raw = AgentSession().deduplicate(_fixture_csv(tmp_path))
+    result = raw["results"]
+    # The golden frame must be reachable and writable. If this fails with
+    # golden is None, the pipeline ran with output_golden=False -> see step 3.
+    assert getattr(result, "golden", None) is not None
+    assert result.golden.height >= 1
+```
+
+- [ ] **Step 2: Run it to see whether golden is populated by default**
+
+Run: `eval "$RUN packages/python/goldenmatch/tests/test_agent_output_path.py::test_dedupe_result_exposes_golden -q"`
+Expected: either PASS (golden populated by default — good) or FAIL with `golden is None`.
+
+- [ ] **Step 3: If golden is None, find how to enable it**
+
+If FAIL: inspect `dedupe_df` in `goldenmatch/_api.py` and `run_pipeline`/`output_golden` in `goldenmatch/core/pipeline.py`. Determine the call that populates golden (likely `dedupe_df(df, output_golden=True)` or a config flag). Record the exact call in a comment at the top of the test file — Task 1.2 uses it. If golden is populated by default, no change needed; note that.
+
+- [ ] **Step 4: Commit the pinned probe**
+
+```bash
+git add packages/python/goldenmatch/tests/test_agent_output_path.py
+git -c commit.gpgsign=false commit -m "test(goldenmatch): pin stateless golden-frame extraction for agent output_path"
+```
+
+### Task 1.2: `agent_deduplicate` writes golden CSV when `output_path` is given
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py` — `agent_deduplicate` handler (~line 644-665) + its `Tool` definition (~line 150).
+- Test: `packages/python/goldenmatch/tests/test_agent_output_path.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_agent_deduplicate_writes_golden(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+    from goldenmatch.core.agent import AgentSession
+    out = tmp_path / "golden.csv"
+    res = _dispatch(
+        "agent_deduplicate",
+        {"file_path": _fixture_csv(tmp_path), "output_path": str(out)},
+        AgentSession,
+    )
+    assert res["golden_path"] == str(out)
+    assert res["golden_records"] >= 1
+    assert out.exists()
+    got = pl.read_csv(out)
+    assert got.height == res["golden_records"]
+    # internal columns are stripped
+    assert not any(c.startswith("__") for c in got.columns)
+
+def test_agent_deduplicate_no_output_path_unchanged(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+    from goldenmatch.core.agent import AgentSession
+    res = _dispatch("agent_deduplicate", {"file_path": _fixture_csv(tmp_path)}, AgentSession)
+    assert "golden_path" not in res
+    assert "results" in res  # existing summary contract intact
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `eval "$RUN packages/python/goldenmatch/tests/test_agent_output_path.py -q"`
+Expected: `test_agent_deduplicate_writes_golden` FAILS (`KeyError: 'golden_path'`); the `_unchanged` test PASSES.
+
+- [ ] **Step 3: Implement — write golden in the handler**
+
+In `agent_tools.py`, the `agent_deduplicate` branch: after `raw = session.deduplicate(...)`, before building the summary return, add (using the extraction pinned in Task 1.1; `raw["results"].golden` shown here):
+
+```python
+        golden_extra: dict = {}
+        output_path = args.get("output_path")
+        if output_path:
+            safe = _ingest.safe_path(output_path)  # allowed-root guard; see _ingest
+            gres = raw.get("results")
+            golden = getattr(gres, "golden", None)
+            if golden is None:
+                golden_extra = {"golden_path": None, "golden_error": "no golden frame produced"}
+            else:
+                cols = [c for c in golden.columns if not c.startswith("__")]
+                golden.select(cols).write_csv(str(safe))
+                golden_extra = {"golden_path": str(safe), "golden_records": golden.height}
+```
+
+Then merge `golden_extra` into the returned dict (`return {..., **golden_extra}`). Confirm `_ingest.safe_path` (or the existing `_safe_path_or_error`) is the right guard — reuse whatever the file-writing tools already use; do not invent a new one.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `eval "$RUN packages/python/goldenmatch/tests/test_agent_output_path.py -q"`
+Expected: all PASS.
+
+- [ ] **Step 5: Add `output_path` to the `agent_deduplicate` Tool inputSchema**
+
+In the `agent_deduplicate` `Tool(...)` definition (~line 150), add to `inputSchema.properties`:
+
+```python
+                "output_path": {
+                    "type": "string",
+                    "description": "Optional. If given, write the golden (deduplicated) records to this CSV path and return golden_path + golden_records. Omit to get the summary only.",
+                },
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py packages/python/goldenmatch/tests/test_agent_output_path.py
+git -c commit.gpgsign=false commit -m "feat(goldenmatch): agent_deduplicate optional output_path writes golden CSV"
+```
+
+### Task 1.3: `agent_match_sources` writes linked-pairs CSV when `output_path` is given
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py` — `agent_match_sources` handler (~line 667-686) + its `Tool` (~line 169).
+- Test: `packages/python/goldenmatch/tests/test_agent_output_path.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def _two_fixtures(tmp_path):
+    a = tmp_path / "a.csv"; b = tmp_path / "b.csv"
+    pl.DataFrame({"name": ["John Smith", "Mary Jones"], "id": [1, 2]}).write_csv(a)
+    pl.DataFrame({"name": ["Jon Smith", "Karen White"], "id": [9, 8]}).write_csv(b)
+    return str(a), str(b)
+
+def test_agent_match_sources_writes_matches(tmp_path):
+    from goldenmatch.mcp.agent_tools import _dispatch
+    from goldenmatch.core.agent import AgentSession
+    a, b = _two_fixtures(tmp_path)
+    out = tmp_path / "matches.csv"
+    res = _dispatch("agent_match_sources",
+                    {"file_a": a, "file_b": b, "output_path": str(out)}, AgentSession)
+    assert res["matches_path"] == str(out)
+    assert out.exists()
+```
+
+Inspect what `session.match_sources(...)["results"]` exposes for the linked frame (Task 1.1-style probe if needed — it may be `.golden`, `.matches`, or `.linked`). Use the actual attribute; assert `matched_pairs` count if available.
+
+- [ ] **Step 2: Run to verify it fails** — `KeyError: 'matches_path'`.
+
+- [ ] **Step 3: Implement** the same `output_path` pattern in the `agent_match_sources` branch, writing the linked/matched frame (attribute confirmed above), returning `{"matches_path": ..., "matched_pairs": N}`.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Add `output_path` to the `agent_match_sources` Tool inputSchema** (same property text, "matched pairs" wording).
+
+- [ ] **Step 6: Commit.**
+
+### Task 1.4: Phase 1 PR
+
+- [ ] Push `feat/goldenmatch-agent-output-path`, open PR to `main`, arm auto-merge (`gh pr merge <n> --auto --squash`). Phase 2 waits for this to land.
+
+---
+
+# Phase 2 — composites (goldensuite-mcp)
+
+> Rebase `feat/goldensuite-mcp-composites` onto a `main` containing Phase 1 + #1639/#1640 before starting Task 2.2's dedupe end-to-end. `assess_file` (Task 2.4) needs no Phase 1.
+
+### Task 2.1: `composites.py` scaffold + `run_step` helper
+
+**Files:**
+- Create: `packages/python/goldensuite-mcp/goldensuite_mcp/composites.py`
+- Test: `packages/python/goldensuite-mcp/tests/test_composites.py`
+
+- [ ] **Step 1: Write the failing test for `run_step`**
+
+```python
+# tests/test_composites.py
+from goldensuite_mcp.composites import run_step
+
+def _table(**tools):
+    # tools: name -> callable(name, args) -> dict
+    return dict(tools)
+
+def test_run_step_success():
+    t = _table(foo=lambda n, a: {"value": a["x"] + 1})
+    ok, res = run_step(t, "foo", {"x": 1})
+    assert ok is True and res == {"value": 2}
+
+def test_run_step_error_dict_is_failure():
+    t = _table(foo=lambda n, a: {"error": "boom"})
+    ok, res = run_step(t, "foo", {})
+    assert ok is False and "boom" in res["error"]
+
+def test_run_step_raise_is_failure():
+    def boom(n, a): raise ValueError("kaboom")
+    ok, res = run_step(_table(foo=boom), "foo", {})
+    assert ok is False and "kaboom" in res["error"]
+
+def test_run_step_missing_tool_is_failure():
+    ok, res = run_step({}, "nope", {})
+    assert ok is False and "nope" in res["error"]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `ModuleNotFoundError: goldensuite_mcp.composites`.
+
+- [ ] **Step 3: Implement `run_step`**
+
+```python
+# goldensuite_mcp/composites.py
+from __future__ import annotations
+from collections.abc import Callable
+
+Dispatch = dict[str, Callable[[str, dict], dict]]
+
+def run_step(dispatch: Dispatch, tool_name: str, args: dict) -> tuple[bool, dict]:
+    """Run one composite step. Returns (ok, result). A missing tool, a raised
+    exception, or a returned {"error": ...} are all failures."""
+    handler = dispatch.get(tool_name)
+    if handler is None:
+        return False, {"error": f"tool {tool_name!r} not available in this suite build"}
+    try:
+        result = handler(tool_name, args or {})
+    except Exception as exc:  # noqa: BLE001
+        return False, {"error": f"{type(exc).__name__}: {exc}"}
+    if isinstance(result, dict) and "error" in result:
+        return False, result
+    return True, result
+```
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): composites run_step helper`).
+
+### Task 2.2: `dedupe_file` composite (reference implementation)
+
+**Files:**
+- Modify: `goldensuite_mcp/composites.py`
+- Test: `tests/test_composites.py`
+
+- [ ] **Step 1: Write failing unit test with a fake dispatch table**
+
+```python
+def _fake_dedupe_table(rec):
+    # rec: list to record calls
+    def upload(n, a): rec.append(("upload", a)); return {"path": "/up/in.csv", "bytes": 10, "filename": "in.csv"}
+    def autoconf(n, a): rec.append(("autoconf", a)); return {"config": {"matchkeys": ["exact(email)"]}}
+    def dedup(n, a):
+        rec.append(("dedup", a))
+        return {"confidence_distribution": {"auto_merged": 2, "review": 1, "auto_rejected": 0},
+                "golden_path": a["output_path"], "golden_records": 3, "results": {"total_records": 4}}
+    return {"upload_dataset": upload, "auto_configure": autoconf, "agent_deduplicate": dedup}
+
+def test_dedupe_file_shape_and_threading():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    tools, dispatch = build_composites(_fake_dedupe_table(rec))
+    out = dispatch["dedupe_file"]("dedupe_file", {"file_content": "...", "filename": "in.csv"})
+    assert out["workflow"] == "dedupe_file"
+    assert out["ok"] is True
+    steps = [s["step"] for s in out["steps"]]
+    assert steps == ["upload", "auto_configure", "deduplicate"]
+    # threading: uploaded path reached later steps
+    assert dict(rec)["autoconf"]["file_path"] == "/up/in.csv"
+    assert dict(rec)["dedup"]["file_path"] == "/up/in.csv"
+    # golden path generated + surfaced in outputs
+    assert out["outputs"]["golden_path"].endswith(".golden.csv")
+    assert isinstance(out["summary"], str) and out["summary"]
+
+def test_dedupe_file_short_circuits_on_step_failure():
+    from goldensuite_mcp.composites import build_composites
+    tbl = _fake_dedupe_table([])
+    tbl["auto_configure"] = lambda n, a: {"error": "autoconf boom"}
+    _, dispatch = build_composites(tbl)
+    out = dispatch["dedupe_file"]("dedupe_file", {"file_content": "...", "filename": "in.csv"})
+    assert out["ok"] is False
+    assert [s["step"] for s in out["steps"]] == ["upload", "auto_configure"]
+    assert "boom" in out["summary"].lower() or "auto_configure" in out["summary"]
+```
+
+- [ ] **Step 2: Run to verify it fails** — `ImportError: build_composites`.
+
+- [ ] **Step 3: Implement `build_composites` + the `dedupe_file` orchestrator**
+
+Add to `composites.py`: an `_gen_output_path(src_path, suffix)` helper that derives a sibling path under the same dir (e.g. `<stem>.golden.csv`) — this keeps the output under the uploads/allowed-root dir that `upload_dataset` already returned. Implement `orchestrate_dedupe_file(dispatch, args)` following the spec chain (upload → auto_configure → agent_deduplicate with generated `output_path`), building `steps` via `run_step`, short-circuiting on `ok is False`, and returning the merged dict. Register it in `build_composites` with its `Tool` (inputSchema mirrors `upload_dataset`: `file_content`, `filename`, `file_path`, `encoding`, plus `exclude_columns`). Full code:
+
+```python
+import os
+from mcp.types import Tool
+
+_FILE_INPUT_PROPS = {
+    "file_content": {"type": "string", "description": "Inline file bytes (base64 or text)."},
+    "filename": {"type": "string", "description": "Original filename for an inline upload."},
+    "file_path": {"type": "string", "description": "Server path to an already-uploaded file."},
+    "encoding": {"type": "string", "description": "Inline content encoding: 'base64' (default) or 'text'."},
+}
+
+def _gen_output_path(src_path: str, suffix: str) -> str:
+    stem, _ = os.path.splitext(src_path)
+    return f"{stem}.{suffix}.csv"
+
+def _upload(dispatch, args):
+    """Resolve the input to a server path: pass inline bytes or an existing path."""
+    up = {k: args[k] for k in ("file_content", "filename", "file_path", "encoding") if k in args}
+    if args.get("file_path") and "file_content" not in args:
+        return True, {"path": args["file_path"], "filename": os.path.basename(args["file_path"])}, "upload"
+    ok, res = run_step(dispatch, "upload_dataset", up)
+    return ok, res, "upload"
+
+def orchestrate_dedupe_file(dispatch, args):
+    steps = []
+    ok, res, label = _upload(dispatch, args)
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path"), "rows": res.get("rows")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+    path = res["path"]
+
+    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
+    ok, res = run_step(dispatch, "auto_configure", {"file_path": path, **excl})
+    steps.append({"step": "auto_configure", "ok": ok, **({"config": res.get("config") or res} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+    config = res.get("config") or res
+
+    golden_path = _gen_output_path(path, "golden")
+    ok, res = run_step(dispatch, "agent_deduplicate",
+                       {"file_path": path, "config": config, "output_path": golden_path, **excl})
+    cd = res.get("confidence_distribution", {}) if ok else {}
+    steps.append({"step": "deduplicate", "ok": ok,
+                  **({"auto_merge": cd.get("auto_merged"), "review": cd.get("review"),
+                      "reject": cd.get("auto_rejected"), "golden_path": res.get("golden_path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+
+    outputs = {"golden_path": res.get("golden_path"),
+               "golden_records": res.get("golden_records"),
+               "total_records": (res.get("results") or {}).get("total_records")}
+    return _finish("dedupe_file", steps, config=config, outputs=outputs)
+
+def _finish(workflow, steps, config=None, outputs=None):
+    ok = all(s["ok"] for s in steps)
+    out = {"workflow": workflow, "ok": ok, "summary": _summarize(workflow, steps, outputs), "steps": steps}
+    if config is not None:
+        out["config"] = config
+    if outputs is not None:
+        out["outputs"] = outputs
+    return out
+
+def _summarize(workflow, steps, outputs):
+    if not all(s["ok"] for s in steps):
+        bad = next(s for s in steps if not s["ok"])
+        return f"{workflow} failed at step '{bad['step']}': {bad.get('error')}"
+    if workflow == "dedupe_file" and outputs:
+        d = next((s for s in steps if s["step"] == "deduplicate"), {})
+        return (f"{outputs.get('total_records')} records -> {outputs.get('golden_records')} golden; "
+                f"{d.get('auto_merge')} merged, {d.get('review')} to review. Written to {outputs.get('golden_path')}.")
+    return f"{workflow} ok"
+
+_COMPOSITE_SPECS = [
+    {"name": "dedupe_file",
+     "description": "One call: dedupe a single CSV. Uploads the file, auto-configures matching, runs entity resolution with confidence gating, and writes golden (deduplicated) records to a CSV. Returns a summary + the golden file path.",
+     "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS,
+        "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}}, "required": []},
+     "orchestrate": orchestrate_dedupe_file},
+]
+
+def build_composites(dispatch):
+    tools, table = [], {}
+    for spec in _COMPOSITE_SPECS:
+        tools.append(Tool(name=spec["name"], description=spec["description"], inputSchema=spec["inputSchema"]))
+        fn = spec["orchestrate"]
+        table[spec["name"]] = (lambda f: (lambda name, args: f(dispatch, args or {})))(fn)
+    return tools, table
+```
+
+- [ ] **Step 4: Run to verify pass** — `eval "$RUN packages/python/goldensuite-mcp/tests/test_composites.py -q"`.
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): dedupe_file composite`).
+
+### Task 2.3: Register composites in `_aggregate` + curate
+
+**Files:**
+- Modify: `goldensuite_mcp/server.py` (`_aggregate`, `CURATED_TOOLS`)
+- Test: `tests/test_composites.py`
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+def test_dedupe_file_registered_and_curated():
+    from goldensuite_mcp.server import _aggregate, _apply_tool_filter
+    import os
+    os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
+    tools, dispatch = _aggregate()
+    names = {t.name for t in tools}
+    assert "dedupe_file" in names
+    assert "dedupe_file" in dispatch
+    listed = {t.name for t in _apply_tool_filter(tools)}
+    assert "dedupe_file" in listed  # curated by default
+    # discoverable via suite_find_tools
+    out = dispatch["suite_find_tools"]("suite_find_tools", {})
+    assert "dedupe_file" in {r["name"] for r in out["tools"]}
+```
+
+- [ ] **Step 2: Run to verify it fails** — `dedupe_file` not in names.
+
+- [ ] **Step 3: Wire `build_composites` into `_aggregate`**
+
+In `server.py::_aggregate`, after the sub-package loop and **before** the `suite_find_tools` block (so composites are in the catalog snapshot), add:
+
+```python
+    from goldensuite_mcp.composites import build_composites
+    composite_tools, composite_dispatch = build_composites(name_to_dispatch)
+    for tool in composite_tools:
+        if tool.name in seen:
+            logger.warning("composite %r shadowed by earlier %s", tool.name, seen[tool.name])
+            continue
+        seen[tool.name] = "goldensuite"
+        all_tools.append(tool)
+        name_to_dispatch[tool.name] = composite_dispatch[tool.name]
+```
+
+Note: `build_composites` closes over `name_to_dispatch`. Because Python closures capture by reference and the composite dispatchers are only *called* later (at request time), the table they see already contains every sub-package tool. Confirm the `suite_find_tools` snapshot line runs after this block.
+
+Add the composite names to `CURATED_TOOLS`:
+
+```python
+    # composite workflow tools -- one-call happy paths
+    "dedupe_file", "match_sources", "assess_file", "clean_and_dedupe",
+```
+
+- [ ] **Step 4: Run to verify pass.** Also run the whole suite-mcp test dir to confirm no regression: `eval "$RUN packages/python/goldensuite-mcp/tests/ -q"`.
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): register composites in _aggregate + curate`).
+
+### Task 2.4: `assess_file` composite (read-only, no Phase 1 dependency)
+
+**Files:** `composites.py`, `tests/test_composites.py`
+
+- [ ] **Step 1: Failing unit test** with a fake table exposing `upload_dataset`, `analyze_data`, `scan`; assert steps `["upload","analyze","scan"]`, `ok True`, `summary` mentions rows + a quality signal. Add a **degraded** test: table missing `scan` → analyze step `ok True`, scan step `ok False`, composite `ok True` (degraded), profile still present.
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Implement `orchestrate_assess_file`** — upload → `analyze_data(file_path=path)` → `scan(path)` (check the goldencheck `scan` arg name — likely `path`; confirm from `goldencheck.mcp.server` TOOLS). No `output_path`, no `config`/`outputs` export. Degraded rule: a failed `scan` does **not** flip the composite to `ok:false` (override `_finish` for this workflow, or pass a `degraded_steps={"scan"}` set so `_finish` ignores it when computing `ok`). Add its spec entry (inputSchema = `_FILE_INPUT_PROPS` only). Extend `_summarize` for `assess_file`.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): assess_file composite`).
+
+### Task 2.5: `match_sources` composite
+
+**Files:** `composites.py`, `tests/test_composites.py`
+
+- [ ] **Step 1: Failing unit test** — fake table with `upload_dataset` (called twice) + `agent_match_sources`; two file inputs (`file_a_content`/`file_a_name` + `file_b_content`/`file_b_name`, or `file_a`/`file_b`). Assert both uploads happened, `agent_match_sources` got both paths + a generated `output_path`, and `outputs.matches_path` is surfaced.
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Implement `orchestrate_match_sources`** — resolve two inputs via `_upload` (generalize `_upload` to take a field prefix, or add `_upload_named`), then `agent_match_sources(file_a=pa, file_b=pb, output_path=<gen matches>)`, thread and surface `matches_path`/`matched_pairs`. Spec entry inputSchema mirrors `agent_match_sources`. Extend `_summarize`.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): match_sources composite`).
+
+### Task 2.6: `clean_and_dedupe` composite
+
+**Files:** `composites.py`, `tests/test_composites.py`
+
+- [ ] **Step 1: Failing unit test** — fake table with `upload_dataset`, `run_transforms`, `agent_deduplicate`. Assert steps `["upload","clean","deduplicate"]`; `run_transforms` got a generated `output_path` (cleaned CSV) and its returned `output_path` is threaded as `agent_deduplicate`'s `file_path`; final `outputs.golden_path` surfaced. Add a soft-dep test: `run_transforms` returns `{"error": "goldenflow is not installed…"}` → composite `ok:false`, short-circuits at `clean`.
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Implement `orchestrate_clean_and_dedupe`** — upload → `run_transforms(file_path=path, output_path=<gen cleaned>)` → capture `res["output_path"]` as `cleaned` → `agent_deduplicate(file_path=cleaned, output_path=<gen golden>)`. Spec entry inputSchema = `_FILE_INPUT_PROPS` + `exclude_columns`. Extend `_summarize`.
+
+- [ ] **Step 4: Run to verify pass.**
+
+- [ ] **Step 5: Commit** (`feat(goldensuite-mcp): clean_and_dedupe composite`).
+
+### Task 2.7: End-to-end parity + docs + version
+
+**Files:** `tests/test_composites.py`, `README.md`, `CHANGELOG.md`, `pyproject.toml`, `goldensuite_mcp/__init__.py`
+
+- [ ] **Step 1: Write one real end-to-end test per composite through the aggregator**
+
+For `assess_file` (no Phase 1 needed) and — once Phase 1 is on main — `dedupe_file`: build the real aggregator (`_aggregate()`), call the composite dispatch on a tiny fixture CSV written to a temp path passed as `file_path`, assert `ok True` and (for dedupe) that `outputs.golden_path` exists on disk. **Parity:** call the same tools by hand through the aggregated dispatch in sequence and assert the composite's `outputs` (summary counts + golden file row count) match.
+
+- [ ] **Step 2: Run to verify** — `eval "$RUN packages/python/goldensuite-mcp/tests/ -q"`. If Phase 1 isn't merged yet, mark the dedupe-family end-to-end tests with `pytest.mark.skipif` on absence of the `output_path` capability (probe `agent_deduplicate` schema) so the suite stays green until Phase 1 lands.
+
+- [ ] **Step 3: Lint** — `eval "${RUN%pytest} -m ruff check packages/python/goldensuite-mcp/"` (or run ruff directly). Fix any findings.
+
+- [ ] **Step 4: Docs** — add a "Composite workflows" section to `README.md` (the four tools, one-call examples, note the merged return shape + that they orchestrate the granular tools). Add a `0.5.0` entry to `CHANGELOG.md`.
+
+- [ ] **Step 5: Version bump (lockstep)** — `pyproject.toml` and `goldensuite_mcp/__init__.py` `__version__` both to `0.5.0` (the version_consistency gate checks both — do not skip `__init__`).
+
+- [ ] **Step 6: Commit** (`feat(goldensuite-mcp): composite end-to-end tests + docs + 0.5.0`).
+
+### Task 2.8: Phase 2 PR
+
+- [ ] Push `feat/goldensuite-mcp-composites`, open PR to `main`, arm auto-merge. Confirm `version_consistency` + `docs_consistency` gates are green (both files bumped).
+
+---
+
+## Notes for the implementer
+
+- **Curated + discoverable for free:** because composites are added to `all_tools`/`name_to_dispatch` in `_aggregate` before the `suite_find_tools` snapshot and their names are in `CURATED_TOOLS`, they list by default and appear in discovery with no extra wiring — Task 2.3's test guards this.
+- **`safe_path` / allowed-root:** every generated `output_path` derives from the path `upload_dataset` returned, which is already under the allowed-root uploads dir — so the Phase 1 write guard passes. Never build an output path from raw caller input.
+- **Don't call Python APIs from composites.** Only the dispatch table. That is the parity guarantee (spec, "Why the dispatcher seam").
+- **Confirm leaf field names** (`confidence_distribution` keys, `scan`'s arg name, `run_transforms`' returned `output_path` key, the match result's linked-frame attribute) against the real tools as you implement each task — the spec fixes the shape, not every leaf.

--- a/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
@@ -3,7 +3,9 @@
 **Date:** 2026-07-10
 **Status:** Approved (brainstorm) → spec
 **Package:** `packages/python/goldensuite-mcp`
-**Depends on:** curated tool listing (PR #1639) + `suite_find_tools` (PR #1640)
+**Depends on:** curated tool listing (PR #1639) + `suite_find_tools` (PR #1640) +
+**Phase 1 goldenmatch golden-out** (`output_path` on `agent_deduplicate` /
+`agent_match_sources`; separate goldenmatch PR — see Build order)
 
 ## Problem
 
@@ -38,12 +40,13 @@ and a human gets "CSV in → result out" without chaining.
 - Not available on the standalone `goldenmatch-mcp`. Per decision **PD2**
   (consolidate on the unified endpoint), `dedupe_file`/`match_sources` live only
   in `goldensuite-mcp` even though they are goldenmatch-only. Accepted tradeoff.
-- No new persistence. Composites rely on the tools' existing server-side session
-  state (see "Why the dispatcher seam").
+- No new persistence / no server-global state. Composites thread step outputs
+  inline (the batch-ER tools are stateless; see "Why the dispatcher seam").
 
 ## Why the dispatcher seam (not the Python APIs)
 
-Two facts about the current tools make calling the dispatchers the correct seam:
+Calling the dispatchers (not the Python APIs) keeps composites thin and parity-
+guaranteed with the granular tools. Two facts make it work:
 
 1. **Inline-or-path inputs.** Every goldenmatch input tool accepts inline file
    bytes (`file_content` + `filename`) *or* a server `file_path` via the shared
@@ -52,14 +55,46 @@ Two facts about the current tools make calling the dispatchers the correct seam:
    in the `_ingest` resolver — they take a bare `file_path` and read it directly;
    threading the server path still works because the path is readable, the
    composite just doesn't rely on the resolver for those steps.
-2. **Shared server-side session state.** `agent_deduplicate` / `agent_match_sources`
-   populate the server session; `export_results(output_path)` exports the *last
-   run*. Calling the dispatchers in order threads this state implicitly — exactly
-   what a human calling the tools in sequence gets.
+2. **Stateless, self-contained returns.** The batch-ER tools (`agent_deduplicate`,
+   `agent_match_sources`) create a fresh `AgentSession` per call and return their
+   result inline — they do **not** share server state across calls. Composites
+   thread by passing each step's returned path/config to the next call.
 
-Calling the underlying Python APIs directly would re-implement this orchestration
-and could drift from what the MCP tools actually do. The dispatcher seam keeps
-composites thin and parity-guaranteed.
+### The `_result`-global gotcha (why Phase 1 exists)
+
+The base non-agent tools (`export_results`, `list_clusters`, `get_cluster`,
+`get_golden_record`, `find_duplicates`) read a **module-global `_result` that is
+only populated when the standalone GoldenMatch server boots with a dataset**
+(`_initialize(file_paths)` in `goldenmatch/mcp/server.py`). The `goldensuite-mcp`
+aggregator imports the tools without ever booting that way, so `_result` is
+`None` and those base tools are effectively **dead in the aggregated endpoint** —
+they cannot be composite steps.
+
+As a result `agent_deduplicate` returns only a **summary** today
+(`_serialize_result` reduces the `DedupeResult` to counts + match rate) even
+though the golden records exist on `result.golden` (the pipeline just runs with
+`output_golden=False` by default). Delivering a golden file therefore needs a
+**Phase 1** goldenmatch change; the composites are **Phase 2**.
+
+## Phase 1 — stateless golden-out (goldenmatch prerequisite)
+
+Add an optional `output_path` (CSV) to the `agent_deduplicate` and
+`agent_match_sources` MCP tools, mirroring the existing `run_transforms`
+`output_path` pattern:
+
+- When `output_path` is provided, the handler runs the stateless pipeline with
+  golden/linked output enabled, writes the result frame to `output_path`
+  (stripping `__`-prefixed internal columns, as `export_results` does), and adds
+  `{"golden_path": output_path, "golden_records": N}` (dedupe) /
+  `{"matches_path": output_path, "matched_pairs": N}` (match) to the return.
+- When absent, behavior is unchanged (summary only) — fully backward compatible.
+- `output_path` is validated through the same `safe_path`/allowed-root guard the
+  other file-writing tools use.
+
+This is a small, additive change to `goldenmatch/mcp/agent_tools.py` (+ the two
+tools' input schemas), lands as its own goldenmatch PR, and is independently
+useful (any agent chaining these tools can now get a file). Phase 2 composites
+call these tools with a generated `output_path`.
 
 ## Architecture
 
@@ -110,20 +145,25 @@ Single-source dedupe. Chain:
 
 1. `upload_dataset(file_content, filename)` → `path`
 2. `auto_configure(file_path=path)` → `config` (surfaced for transparency/reuse)
-3. `agent_deduplicate(file_path=path, config=config)` → clusters + confidence gating
-4. `export_results(output_path=<gen>)` → `golden_path`
+3. `agent_deduplicate(file_path=path, config=config, output_path=<gen>)` →
+   confidence gating + `golden_path` (Phase 1 `output_path` writes the golden CSV)
 
-`output_path` is generated under the uploads dir (e.g. `<stem>.golden.csv`) and
-returned. `exclude_columns` passes through to steps 2–3.
+The dedupe step both returns the summary/gating **and** writes the golden file
+(Phase 1), so there is no separate `export_results` step (that base tool reads the
+dead `_result` global — see the gotcha above). `output_path` is generated under
+the uploads dir (e.g. `<stem>.golden.csv`) and returned. `exclude_columns` passes
+through to steps 2–3.
 
 ### `match_sources`
 
 Cross-source linkage. Chain:
 
 1. `upload_dataset` × 2 → `path_a`, `path_b`
-2. `agent_match_sources(file_a=path_a, file_b=path_b, config?)` → matched pairs
-3. `export_results(output_path=<gen>)` → `matches_path`
+2. `agent_match_sources(file_a=path_a, file_b=path_b, config?, output_path=<gen>)`
+   → matched-pairs summary + `matches_path` (Phase 1 `output_path` writes the
+   linked-pairs CSV)
 
+No separate `export_results` step (same dead-`_result` reason as `dedupe_file`).
 Input mirrors `agent_match_sources`: `file_a_content`/`file_a_name` +
 `file_b_content`/`file_b_name`, or `file_a`/`file_b` paths.
 
@@ -146,8 +186,8 @@ Standardize then dedupe. Chain:
 
 1. `upload_dataset` → `path`
 2. `run_transforms(file_path=path, output_path=<gen cleaned>)` → `cleaned_path`
-3. `agent_deduplicate(file_path=cleaned_path)` → clusters
-4. `export_results(output_path=<gen>)` → `golden_path`
+3. `agent_deduplicate(file_path=cleaned_path, output_path=<gen golden>)` →
+   summary + `golden_path` (Phase 1 `output_path`)
 
 Uses goldenmatch's **`run_transforms`** tool, *not* goldenflow's raw `transform`.
 `run_transforms` is a goldenmatch tool (inline-or-path via `_ingest`) that runs
@@ -177,13 +217,17 @@ placement decision.
   "steps": [
     { "step": "upload",        "ok": true, "path": "/uploads/derm.csv", "rows": 288 },
     { "step": "auto_configure","ok": true, "matchkeys": ["exact(npi)", "weighted(full_name,phone)"] },
-    { "step": "deduplicate",   "ok": true, "n_clusters": 172, "auto_merge": 98, "review": 14, "reject": 4 },
-    { "step": "export",        "ok": true, "golden_path": "/uploads/derm.golden.csv" }
+    { "step": "deduplicate",   "ok": true, "auto_merge": 98, "review": 14, "reject": 4, "golden_path": "/uploads/derm.golden.csv" }
   ],
   "config": { /* config used, where relevant */ },
-  "outputs": { "golden_path": "/uploads/derm.golden.csv", "clusters_preview": [ /* first N */ ] }
+  "outputs": { "golden_path": "/uploads/derm.golden.csv", "golden_records": 172, "total_records": 288 }
 }
 ```
+
+`outputs` carries the workflow's headline results (the written file path + counts
+the dedupe tool returns). Full cluster membership is **not** returned inline — the
+golden file is the artifact; `get_cluster`/`list_clusters` can't back an inline
+preview in the aggregator (dead `_result` global).
 
 - `summary`: one human-readable line.
 - `steps`: ordered, one entry per attempted step, each with `step`, `ok`, and that
@@ -217,7 +261,8 @@ synthetic frames):
 2. **Threading** — the path from `upload_dataset` reaches later steps; generated
    `output_path` is returned in `outputs`.
 3. **Parity** — a composite's result matches calling the same tools by hand in
-   sequence through the aggregator (same clusters / same export path).
+   sequence through the aggregator (same summary counts / same written golden
+   file contents).
 4. **Failure injection** — a fake dispatch table whose step-K returns `{"error"}`
    (or raises) → composite short-circuits, `ok:false`, `steps` ends at K.
 5. **Degraded assess_file** — `scan` missing → step `ok:false`, composite
@@ -230,11 +275,21 @@ test per composite runs through the real aggregated dispatch on a fixture file.
 
 ## Build order
 
-`dedupe_file` first as the reference implementation (module scaffold + step
-helper + return contract + its tests). The other three reuse the identical spec
-shape and helper. Lands as `feat/goldensuite-mcp-composites` off `main` once
-#1639/#1640 merge (rebase onto the merged main so the `_aggregate` registration
-point and `CURATED_TOOLS` are present).
+**Phase 1 — goldenmatch golden-out (separate goldenmatch PR).** Add the optional
+`output_path` to `agent_deduplicate` + `agent_match_sources` (writes golden /
+linked CSV, backward compatible). Ships and merges on its own; independently
+useful.
+
+**Phase 2 — composites (`feat/goldensuite-mcp-composites`).** `dedupe_file` first
+as the reference implementation (module scaffold + step helper + return contract +
+tests), then `assess_file`, `match_sources`, `clean_and_dedupe` reuse the identical
+shape/helper. Rebase onto a `main` that has Phase 1 + #1639/#1640 merged so the
+`output_path` capability, the `_aggregate` registration point, and `CURATED_TOOLS`
+are all present.
+
+Note: Phase 2's end-to-end tests for the dedupe-family composites depend on Phase 1
+being present (the golden file). Until Phase 1 merges, those composites are
+summary-only; `assess_file` is buildable/verifiable without Phase 1.
 
 ## Risks / open items (pinned at implementation)
 

--- a/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
@@ -249,3 +249,8 @@ point and `CURATED_TOOLS` are present).
 - **`output_path` location.** Generated under the existing uploads/allowed-root
   dir so it passes `safe_path`; never a caller-controlled absolute path unless it
   already resolves under the allowed root.
+- **`clean_and_dedupe` soft dependency.** `run_transforms` returns
+  `{"error": "goldenflow is not installed…"}` when `goldenmatch[transform]` is
+  absent. This is a clean `{"error"}` return, so the composite short-circuits with
+  `ok:false` and a clear message per the error-handling contract — no hang. The
+  plan should note this soft dependency.

--- a/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
@@ -45,10 +45,13 @@ and a human gets "CSV in → result out" without chaining.
 
 Two facts about the current tools make calling the dispatchers the correct seam:
 
-1. **Inline-or-path inputs.** Every goldenmatch input tool already accepts inline
-   file bytes (`file_content` + `filename`) *or* a server `file_path` via the
-   shared `_ingest` resolver (PR #1613). So a composite can upload once and thread
-   the returned path to later steps.
+1. **Inline-or-path inputs.** Every goldenmatch input tool accepts inline file
+   bytes (`file_content` + `filename`) *or* a server `file_path` via the shared
+   `_ingest` resolver (PR #1613). So a composite can upload once and thread the
+   returned path to later steps. Cross-package steps (goldencheck `scan`) are *not*
+   in the `_ingest` resolver — they take a bare `file_path` and read it directly;
+   threading the server path still works because the path is readable, the
+   composite just doesn't rely on the resolver for those steps.
 2. **Shared server-side session state.** `agent_deduplicate` / `agent_match_sources`
    populate the server session; `export_results(output_path)` exports the *last
    run*. Calling the dispatchers in order threads this state implicitly — exactly
@@ -139,17 +142,30 @@ returns the profile (`ok:true` overall, degraded).
 
 ### `clean_and_dedupe`
 
-Standardize then dedupe (cross-package). Chain:
+Standardize then dedupe. Chain:
 
 1. `upload_dataset` → `path`
-2. `transform(path, recipe)` → cleaned file/path (goldenflow)
-3. `agent_deduplicate(file_path=cleaned)` → clusters
+2. `run_transforms(file_path=path, output_path=<gen cleaned>)` → `cleaned_path`
+3. `agent_deduplicate(file_path=cleaned_path)` → clusters
 4. `export_results(output_path=<gen>)` → `golden_path`
 
-`transform` gets a **default recipe** (trim / lowercase / standardize
-names+address), overridable via a `transforms` arg. The exact default recipe is
-pinned during implementation against goldenflow's transform names, with a fixture
-test.
+Uses goldenmatch's **`run_transforms`** tool, *not* goldenflow's raw `transform`.
+`run_transforms` is a goldenmatch tool (inline-or-path via `_ingest`) that runs
+goldenflow's normalization under the hood, **writes the cleaned CSV to a caller-
+supplied `output_path`, and returns it** — so there is a concrete cleaned path to
+thread into step 3. (Goldenflow's own `transform` MCP tool takes a YAML config
+*path* and returns a manifest with no output file, so it is the wrong seam here.)
+
+`run_transforms` applies goldenmatch's built-in normalization set
+(`TransformConfig(mode="silent")`: phone → E.164, dates → ISO, categorical
+spelling, Unicode). No caller-supplied recipe in the first cut — the default set
+is the goldenmatch-blessed normalization and avoids changing match semantics
+unexpectedly. A configurable recipe can be a later addition if needed.
+
+Note: because `run_transforms` wraps goldenflow internally, `clean_and_dedupe` is
+effectively a **goldenmatch-only** chain (only `assess_file`'s `scan` step is
+genuinely cross-package), though it still lives in `goldensuite-mcp` per the
+placement decision.
 
 ## Return contract (all four)
 
@@ -226,9 +242,10 @@ point and `CURATED_TOOLS` are present).
   returns for cluster counts, what `auto_configure` exposes as `matchkeys`) are
   read from the real tool returns during implementation; the spec fixes the shape,
   not every leaf field.
-- **`clean_and_dedupe` default recipe.** Pinned against goldenflow's actual
-  transform names with a fixture test; conservative default (trim/lowercase/
-  standardize) to avoid changing match semantics unexpectedly.
+- **`clean_and_dedupe` normalization.** Fixed to `run_transforms`' built-in set
+  (`TransformConfig(mode="silent")`); no caller recipe in the first cut. A fixture
+  test asserts the cleaned file is written to the generated `output_path` and
+  threaded into dedupe.
 - **`output_path` location.** Generated under the existing uploads/allowed-root
   dir so it passes `safe_path`; never a caller-controlled absolute path unless it
   already resolves under the allowed root.

--- a/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
+++ b/docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md
@@ -1,0 +1,234 @@
+# goldensuite-mcp composite workflow tools — design
+
+**Date:** 2026-07-10
+**Status:** Approved (brainstorm) → spec
+**Package:** `packages/python/goldensuite-mcp`
+**Depends on:** curated tool listing (PR #1639) + `suite_find_tools` (PR #1640)
+
+## Problem
+
+The unified `goldensuite-mcp` endpoint exposes ~105 tools. PR #1639 curates the
+default `list_tools` down to ~25 headline verbs and PR #1640 adds
+`suite_find_tools` for discovery. Those solve *tool count*. They do not solve
+*round-trips*: the common happy paths (dedupe a file, match two sources, assess a
+file, clean-then-dedupe) each take an agent 3–4 sequential tool calls, and a
+non-agent caller has to know the exact sequence.
+
+Composite workflow tools encode those happy paths as **one MCP call each** that
+orchestrates the underlying tools, so an agent does the common thing in one hop
+and a human gets "CSV in → result out" without chaining.
+
+## Goals
+
+- Four composite tools on `goldensuite-mcp`: `dedupe_file`, `match_sources`,
+  `assess_file`, `clean_and_dedupe`.
+- One call runs the multi-step path; returns a **merged** result (human `summary`
+  + structured per-step state + outputs) so both agents and humans are served.
+- Thin orchestration: composites call the **already-aggregated dispatchers**
+  (`name_to_dispatch`), i.e. the exact code path a user chaining the tools would
+  hit — guaranteeing behavior parity with the granular tools.
+- Composites are discoverable (`suite_find_tools`) and listed by default
+  (`CURATED_TOOLS`).
+
+## Non-goals
+
+- Not replacing the granular tools. Composites are additive; the granular tools
+  stay for recovery and non-standard flows.
+- Not `action`-style god-tools. Each composite has a real, specific input schema.
+- Not available on the standalone `goldenmatch-mcp`. Per decision **PD2**
+  (consolidate on the unified endpoint), `dedupe_file`/`match_sources` live only
+  in `goldensuite-mcp` even though they are goldenmatch-only. Accepted tradeoff.
+- No new persistence. Composites rely on the tools' existing server-side session
+  state (see "Why the dispatcher seam").
+
+## Why the dispatcher seam (not the Python APIs)
+
+Two facts about the current tools make calling the dispatchers the correct seam:
+
+1. **Inline-or-path inputs.** Every goldenmatch input tool already accepts inline
+   file bytes (`file_content` + `filename`) *or* a server `file_path` via the
+   shared `_ingest` resolver (PR #1613). So a composite can upload once and thread
+   the returned path to later steps.
+2. **Shared server-side session state.** `agent_deduplicate` / `agent_match_sources`
+   populate the server session; `export_results(output_path)` exports the *last
+   run*. Calling the dispatchers in order threads this state implicitly — exactly
+   what a human calling the tools in sequence gets.
+
+Calling the underlying Python APIs directly would re-implement this orchestration
+and could drift from what the MCP tools actually do. The dispatcher seam keeps
+composites thin and parity-guaranteed.
+
+## Architecture
+
+### Module
+
+New `goldensuite_mcp/composites.py`, isolated from `server.py`:
+
+- A **composite spec** per workflow: `name`, `description`, `inputSchema`, and an
+  `orchestrate(dispatch, args) -> dict` function. `dispatch` is the aggregated
+  `name_to_dispatch` table (a `dict[str, Callable[[str, dict], dict]]`).
+- `build_composites(name_to_dispatch) -> tuple[list[Tool], dict[str, Callable]]`
+  returns the composite `Tool` objects plus a dispatch entry per composite (each
+  entry closes over `name_to_dispatch`).
+
+`server.py` calls `build_composites` inside `_aggregate`, **after** the
+sub-package adapters (so the dispatch table is complete) and **before** the
+`suite_find_tools` catalog snapshot (so composites appear in discovery). Composite
+names are added to `CURATED_TOOLS`.
+
+Boundary check: `composites.py` depends only on a dispatch-table interface
+(`str, dict -> dict`), so each `orchestrate` fn is unit-testable with a fake
+dispatch table and no sub-packages imported.
+
+### Step helper
+
+A small internal helper runs one step and normalizes success/failure:
+
+```
+run_step(dispatch, tool_name, args) -> (ok: bool, result: dict)
+```
+
+- Calls `dispatch[tool_name](tool_name, args)`.
+- Treats a raised exception **or** a returned `{"error": ...}` as failure.
+- Missing tool in the table (optional dep not installed) → failure with a clear
+  message.
+
+Each `orchestrate` fn builds a `steps` list, short-circuiting on the first failure.
+
+## The four composites
+
+All accept the same file input as the underlying tools: inline `file_content` +
+`filename`, or an existing server `file_path`. Upload happens **once** per input;
+the returned path is threaded to subsequent steps.
+
+### `dedupe_file`
+
+Single-source dedupe. Chain:
+
+1. `upload_dataset(file_content, filename)` → `path`
+2. `auto_configure(file_path=path)` → `config` (surfaced for transparency/reuse)
+3. `agent_deduplicate(file_path=path, config=config)` → clusters + confidence gating
+4. `export_results(output_path=<gen>)` → `golden_path`
+
+`output_path` is generated under the uploads dir (e.g. `<stem>.golden.csv`) and
+returned. `exclude_columns` passes through to steps 2–3.
+
+### `match_sources`
+
+Cross-source linkage. Chain:
+
+1. `upload_dataset` × 2 → `path_a`, `path_b`
+2. `agent_match_sources(file_a=path_a, file_b=path_b, config?)` → matched pairs
+3. `export_results(output_path=<gen>)` → `matches_path`
+
+Input mirrors `agent_match_sources`: `file_a_content`/`file_a_name` +
+`file_b_content`/`file_b_name`, or `file_a`/`file_b` paths.
+
+### `assess_file`
+
+Read-only readiness report. Chain:
+
+1. `upload_dataset` → `path`
+2. `analyze_data(file_path=path)` → profile (goldenmatch)
+3. `scan(path)` → data-quality findings (goldencheck)
+
+No export, no mutation. `summary` combines "N rows, K columns, dedupe-ready?" with
+the quality headline. If `scan` is unavailable (goldencheck `[mcp]` extra not
+installed), step 3 records `ok:false` with a clear note and the composite still
+returns the profile (`ok:true` overall, degraded).
+
+### `clean_and_dedupe`
+
+Standardize then dedupe (cross-package). Chain:
+
+1. `upload_dataset` → `path`
+2. `transform(path, recipe)` → cleaned file/path (goldenflow)
+3. `agent_deduplicate(file_path=cleaned)` → clusters
+4. `export_results(output_path=<gen>)` → `golden_path`
+
+`transform` gets a **default recipe** (trim / lowercase / standardize
+names+address), overridable via a `transforms` arg. The exact default recipe is
+pinned during implementation against goldenflow's transform names, with a fixture
+test.
+
+## Return contract (all four)
+
+```jsonc
+{
+  "workflow": "dedupe_file",
+  "ok": true,
+  "summary": "288 records -> 172 entities; 116 merged, 14 to review. Facility mode on.",
+  "steps": [
+    { "step": "upload",        "ok": true, "path": "/uploads/derm.csv", "rows": 288 },
+    { "step": "auto_configure","ok": true, "matchkeys": ["exact(npi)", "weighted(full_name,phone)"] },
+    { "step": "deduplicate",   "ok": true, "n_clusters": 172, "auto_merge": 98, "review": 14, "reject": 4 },
+    { "step": "export",        "ok": true, "golden_path": "/uploads/derm.golden.csv" }
+  ],
+  "config": { /* config used, where relevant */ },
+  "outputs": { "golden_path": "/uploads/derm.golden.csv", "clusters_preview": [ /* first N */ ] }
+}
+```
+
+- `summary`: one human-readable line.
+- `steps`: ordered, one entry per attempted step, each with `step`, `ok`, and that
+  step's key outputs. Ends at the first failure.
+- `config` / `outputs`: workflow-relevant structured results (absent for
+  `assess_file`, which has no config/export).
+
+### Error handling
+
+- A step failure (raised exception or `{"error"}`) short-circuits: `ok:false`, the
+  failed step recorded with its error, subsequent steps omitted, `summary` states
+  where it died. No partial-success ambiguity.
+- `assess_file` is the one degraded-mode exception: a missing optional sub-tool
+  (e.g. goldencheck not installed) records that step `ok:false` but the composite
+  still returns the steps that succeeded (`ok:true`, degraded) — it is a read-only
+  report, not a transaction.
+
+## Curation & discovery
+
+- All four names added to `CURATED_TOOLS` → listed by default.
+- Registered before the `suite_find_tools` snapshot → returned by discovery with
+  full `inputSchema`.
+
+## Testing
+
+Fixtures-first with tiny CSVs (reuse existing suite-mcp test fixtures / small
+synthetic frames):
+
+1. **Shape** — each composite returns the merged contract (keys present, `steps`
+   ordered, `ok` correct).
+2. **Threading** — the path from `upload_dataset` reaches later steps; generated
+   `output_path` is returned in `outputs`.
+3. **Parity** — a composite's result matches calling the same tools by hand in
+   sequence through the aggregator (same clusters / same export path).
+4. **Failure injection** — a fake dispatch table whose step-K returns `{"error"}`
+   (or raises) → composite short-circuits, `ok:false`, `steps` ends at K.
+5. **Degraded assess_file** — `scan` missing → step `ok:false`, composite
+   `ok:true` with the profile still present.
+6. **Discovery + curation** — each composite is in the default listing and in
+   `suite_find_tools` output.
+
+Unit tests use a fake dispatch table (no sub-packages imported); one end-to-end
+test per composite runs through the real aggregated dispatch on a fixture file.
+
+## Build order
+
+`dedupe_file` first as the reference implementation (module scaffold + step
+helper + return contract + its tests). The other three reuse the identical spec
+shape and helper. Lands as `feat/goldensuite-mcp-composites` off `main` once
+#1639/#1640 merge (rebase onto the merged main so the `_aggregate` registration
+point and `CURATED_TOOLS` are present).
+
+## Risks / open items (pinned at implementation)
+
+- **Exact step outputs.** `steps[*]` field names (e.g. what `agent_deduplicate`
+  returns for cluster counts, what `auto_configure` exposes as `matchkeys`) are
+  read from the real tool returns during implementation; the spec fixes the shape,
+  not every leaf field.
+- **`clean_and_dedupe` default recipe.** Pinned against goldenflow's actual
+  transform names with a fixture test; conservative default (trim/lowercase/
+  standardize) to avoid changing match semantics unexpectedly.
+- **`output_path` location.** Generated under the existing uploads/allowed-root
+  dir so it passes `safe_path`; never a caller-controlled absolute path unless it
+  already resolves under the allowed root.

--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.5.0 (2026-07-11)
+
+### Added
+
+- **Composite workflow tools** — four curated one-call tools that orchestrate the
+  granular sub-package tools into a single dispatch: `dedupe_file`
+  (`upload_dataset` -> `auto_configure` -> `agent_deduplicate`), `match_sources`
+  (upload A + upload B -> `agent_match_sources`), `assess_file` (`upload_dataset`
+  -> `analyze_data` -> `scan`, read-only), and `clean_and_dedupe`
+  (`upload_dataset` -> `run_transforms` -> `agent_deduplicate`). Each returns a
+  uniform `{workflow, ok, summary, steps, config?, outputs?}` envelope, short-
+  circuits on the first hard step failure, and dispatches against the same
+  aggregated table so the granular tools stay individually listed and callable.
+  `assess_file`'s `scan` step is degraded-optional — a build without goldencheck
+  still returns `ok: true` with the profile intact. Live registration lives in
+  `composites.py` (`build_composites`), wired into `_aggregate` before the
+  `suite_find_tools` snapshot. (README: "Composite workflows".)
+
 ## 0.4.0 (2026-07-10)
 
 ### Added

--- a/packages/python/goldensuite-mcp/README.md
+++ b/packages/python/goldensuite-mcp/README.md
@@ -84,6 +84,62 @@ just aren't listed. (`suite_find_tools` does not list itself.) This keeps the
 default surface small while leaving the full ~105-tool catalog one search away,
 instead of collapsing everything into a few overloaded `action`-style god-tools.
 
+## Composite workflows (one-call happy paths)
+
+The aggregator also registers four **composite** tools that orchestrate the
+granular sub-package tools into a single call, so an agent doesn't have to
+chain upload -> configure -> match/dedupe by hand. Each is curated (listed by
+default) and dispatches against the same aggregated tool table — the granular
+tools it calls stay individually listed and callable.
+
+| Composite | Chain | Writes |
+| --- | --- | --- |
+| **`dedupe_file`** | `upload_dataset` -> `auto_configure` -> `agent_deduplicate` | golden CSV |
+| **`match_sources`** | upload A + upload B -> `agent_match_sources` | matches CSV |
+| **`assess_file`** | `upload_dataset` -> `analyze_data` -> `scan` | nothing (read-only) |
+| **`clean_and_dedupe`** | `upload_dataset` -> `run_transforms` -> `agent_deduplicate` | golden CSV |
+
+Each accepts a file either inline (`file_content` + `filename`) or as an
+already-uploaded server path (`file_path`); `match_sources` takes the pair
+(`file_a*` / `file_b*`).
+
+```jsonc
+// dedupe one CSV end-to-end
+dedupe_file({ "file_path": "/data/contacts.csv" })
+
+// link two sources
+match_sources({ "file_a": "/data/crm.csv", "file_b": "/data/signups.csv" })
+
+// read-only quality + profile check
+assess_file({ "file_path": "/data/contacts.csv" })
+
+// normalize then dedupe
+clean_and_dedupe({ "file_path": "/data/contacts.csv" })
+```
+
+**Merged return shape** — every composite returns one uniform envelope:
+
+```jsonc
+{
+  "workflow": "dedupe_file",
+  "ok": true,                 // false if a non-degraded step failed
+  "summary": "5 records -> 3 golden; 1 merged, 0 to review. Written to /data/contacts.golden.csv.",
+  "steps": [                  // one entry per orchestrated step, in order
+    { "step": "upload", "ok": true, "path": "/data/contacts.csv" },
+    { "step": "auto_configure", "ok": true, "config": { } },
+    { "step": "deduplicate", "ok": true, "auto_merge": 1, "review": 0, "golden_path": "/data/contacts.golden.csv" }
+  ],
+  "config": { },             // when a configure step ran (transparency)
+  "outputs": { "golden_path": "/data/contacts.golden.csv", "golden_records": 3, "total_records": 5 }
+}
+```
+
+A composite **short-circuits** on the first hard step failure (`ok: false`,
+`summary` names the failing step). `assess_file` treats its `scan` step as
+**degraded-optional**: if goldencheck isn't in the build, `scan` reports
+unavailable but the composite still returns `ok: true` with the profile intact.
+Writes are guarded by `GOLDENMATCH_ALLOWED_ROOT` like the underlying tools.
+
 ## Claude Desktop / Claude Code config
 
 ```json

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/__init__.py
@@ -12,5 +12,5 @@ are logged at startup so deployers know which tool was shadowed.
 """
 from goldensuite_mcp.server import create_server
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 __all__ = ["create_server", "__version__"]

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -40,13 +40,28 @@ def _gen_output_path(src_path: str, suffix: str) -> str:
     return f"{stem}.{suffix}.csv"
 
 
-def _upload(dispatch, args):
-    """Resolve the input to a server path: pass inline bytes or an existing path."""
-    up = {k: args[k] for k in ("file_content", "filename", "file_path", "encoding") if k in args}
-    if args.get("file_path") and "file_content" not in args:
-        return True, {"path": args["file_path"], "filename": os.path.basename(args["file_path"])}, "upload"
+def _upload_named(dispatch, args, content_key, name_key, path_key, label):
+    """Resolve one named input to a server path. Maps the caller's per-file keys
+    (e.g. file_a_content/file_a_name/file_a) onto upload_dataset's standard
+    file_content/filename/file_path keys. An existing path skips the upload."""
+    if args.get(path_key) and content_key not in args:
+        return True, {"path": args[path_key], "filename": os.path.basename(args[path_key])}, label
+    up = {}
+    if content_key in args:
+        up["file_content"] = args[content_key]
+    if name_key in args:
+        up["filename"] = args[name_key]
+    if path_key in args:
+        up["file_path"] = args[path_key]
+    if "encoding" in args:
+        up["encoding"] = args["encoding"]
     ok, res = run_step(dispatch, "upload_dataset", up)
-    return ok, res, "upload"
+    return ok, res, label
+
+
+def _upload(dispatch, args):
+    """Resolve the single-file input to a server path (default key names)."""
+    return _upload_named(dispatch, args, "file_content", "filename", "file_path", "upload")
 
 
 def orchestrate_dedupe_file(dispatch, args):
@@ -79,6 +94,39 @@ def orchestrate_dedupe_file(dispatch, args):
                "golden_records": res.get("golden_records"),
                "total_records": (res.get("results") or {}).get("total_records")}
     return _finish("dedupe_file", steps, config=config, outputs=outputs)
+
+
+def orchestrate_match_sources(dispatch, args):
+    """Link two sources: upload both -> agent_match_sources -> surface matches."""
+    steps = []
+    ok, res, label = _upload_named(dispatch, args, "file_a_content", "file_a_name", "file_a", "upload_a")
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("match_sources", steps)
+    path_a = res["path"]
+
+    ok, res, label = _upload_named(dispatch, args, "file_b_content", "file_b_name", "file_b", "upload_b")
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("match_sources", steps)
+    path_b = res["path"]
+
+    matches_path = _gen_output_path(path_a, "matches")
+    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
+    ok, res = run_step(dispatch, "agent_match_sources",
+                       {"file_a": path_a, "file_b": path_b, "output_path": matches_path, **excl})
+    results = (res.get("results") or {}) if ok else {}
+    m_path = (res.get("matches_path") or res.get("output_path")) if ok else None
+    m_pairs = res.get("matched_pairs") if ok else None
+    if ok and m_pairs is None:
+        m_pairs = results.get("total_matched_records") or results.get("scored_pairs")
+    steps.append({"step": "match", "ok": ok,
+                  **({"matches_path": m_path, "matched_pairs": m_pairs} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("match_sources", steps)
+
+    outputs = {"matches_path": m_path, "matched_pairs": m_pairs, "match_rate": results.get("match_rate")}
+    return _finish("match_sources", steps, outputs=outputs)
 
 
 def orchestrate_assess_file(dispatch, args):
@@ -133,6 +181,11 @@ def _summarize(workflow, steps, outputs, degraded_steps=frozenset()):
             return (f"{rows} rows profiled; health {sc.get('health_grade')} "
                     f"(score {sc.get('health_score')}, {sc.get('total_findings')} findings).")
         return f"{rows} rows profiled; quality scan unavailable (goldencheck not in this build)."
+    if workflow == "match_sources" and outputs:
+        pairs = outputs.get("matched_pairs")
+        dest = outputs.get("matches_path")
+        tail = f" Written to {dest}." if dest else ""
+        return f"Matched two sources: {pairs} matched pairs.{tail}"
     return f"{workflow} ok"
 
 
@@ -146,6 +199,19 @@ _COMPOSITE_SPECS = [
      "description": "One call: assess a single file's quality. Uploads the file, profiles it (record count, detected domain, recommended matching strategy), then runs a data-quality scan (health grade + findings). Read-only -- writes nothing. The quality scan is skipped gracefully if goldencheck isn't installed.",
      "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS}, "required": []},
      "orchestrate": orchestrate_assess_file},
+    {"name": "match_sources",
+     "description": "One call: link two sources. Uploads both files, then runs cross-source matching with intelligent strategy selection and returns the matched pairs (and a matches file path when the engine writes one).",
+     "inputSchema": {"type": "object", "properties": {
+        "file_a": {"type": "string", "description": "Server path to source A (already uploaded)."},
+        "file_a_content": {"type": "string", "description": "Inline bytes for source A (base64 or text)."},
+        "file_a_name": {"type": "string", "description": "Original filename for inline source A."},
+        "file_b": {"type": "string", "description": "Server path to source B (already uploaded)."},
+        "file_b_content": {"type": "string", "description": "Inline bytes for source B (base64 or text)."},
+        "file_b_name": {"type": "string", "description": "Original filename for inline source B."},
+        "encoding": {"type": "string", "description": "Inline content encoding: 'base64' (default) or 'text'."},
+        "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}},
+        "required": []},
+     "orchestrate": orchestrate_match_sources},
 ]
 
 

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
+
+import os
 from collections.abc import Callable
+
+from mcp.types import Tool
 
 Dispatch = dict[str, Callable[[str, dict], dict]]
 
@@ -17,3 +21,100 @@ def run_step(dispatch: Dispatch, tool_name: str, args: dict) -> tuple[bool, dict
     if isinstance(result, dict) and "error" in result:
         return False, result
     return True, result
+
+
+# ---------------------------------------------------------------------------
+# Composite orchestrations
+# ---------------------------------------------------------------------------
+
+_FILE_INPUT_PROPS = {
+    "file_content": {"type": "string", "description": "Inline file bytes (base64 or text)."},
+    "filename": {"type": "string", "description": "Original filename for an inline upload."},
+    "file_path": {"type": "string", "description": "Server path to an already-uploaded file."},
+    "encoding": {"type": "string", "description": "Inline content encoding: 'base64' (default) or 'text'."},
+}
+
+
+def _gen_output_path(src_path: str, suffix: str) -> str:
+    stem, _ = os.path.splitext(src_path)
+    return f"{stem}.{suffix}.csv"
+
+
+def _upload(dispatch, args):
+    """Resolve the input to a server path: pass inline bytes or an existing path."""
+    up = {k: args[k] for k in ("file_content", "filename", "file_path", "encoding") if k in args}
+    if args.get("file_path") and "file_content" not in args:
+        return True, {"path": args["file_path"], "filename": os.path.basename(args["file_path"])}, "upload"
+    ok, res = run_step(dispatch, "upload_dataset", up)
+    return ok, res, "upload"
+
+
+def orchestrate_dedupe_file(dispatch, args):
+    steps = []
+    ok, res, label = _upload(dispatch, args)
+    # NOTE: upload_dataset returns {path, bytes, filename} -- no row count; don't record "rows".
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+    path = res["path"]
+
+    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
+    ok, res = run_step(dispatch, "auto_configure", {"file_path": path, **excl})
+    steps.append({"step": "auto_configure", "ok": ok, **({"config": res.get("config") or res} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+    config = res.get("config") or res
+
+    golden_path = _gen_output_path(path, "golden")
+    ok, res = run_step(dispatch, "agent_deduplicate",
+                       {"file_path": path, "config": config, "output_path": golden_path, **excl})
+    cd = res.get("confidence_distribution", {}) if ok else {}
+    steps.append({"step": "deduplicate", "ok": ok,
+                  **({"auto_merge": cd.get("auto_merged"), "review": cd.get("review"),
+                      "reject": cd.get("auto_rejected"), "golden_path": res.get("golden_path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("dedupe_file", steps)
+
+    outputs = {"golden_path": res.get("golden_path"),
+               "golden_records": res.get("golden_records"),
+               "total_records": (res.get("results") or {}).get("total_records")}
+    return _finish("dedupe_file", steps, config=config, outputs=outputs)
+
+
+def _finish(workflow, steps, config=None, outputs=None, degraded_steps=frozenset()):
+    ok = all(s["ok"] for s in steps if s["step"] not in degraded_steps)
+    out = {"workflow": workflow, "ok": ok, "summary": _summarize(workflow, steps, outputs, degraded_steps), "steps": steps}
+    if config is not None:
+        out["config"] = config
+    if outputs is not None:
+        out["outputs"] = outputs
+    return out
+
+
+def _summarize(workflow, steps, outputs, degraded_steps=frozenset()):
+    if not all(s["ok"] for s in steps if s["step"] not in degraded_steps):
+        bad = next(s for s in steps if not s["ok"] and s["step"] not in degraded_steps)
+        return f"{workflow} failed at step '{bad['step']}': {bad.get('error')}"
+    if workflow == "dedupe_file" and outputs:
+        d = next((s for s in steps if s["step"] == "deduplicate"), {})
+        return (f"{outputs.get('total_records')} records -> {outputs.get('golden_records')} golden; "
+                f"{d.get('auto_merge')} merged, {d.get('review')} to review. Written to {outputs.get('golden_path')}.")
+    return f"{workflow} ok"
+
+
+_COMPOSITE_SPECS = [
+    {"name": "dedupe_file",
+     "description": "One call: dedupe a single CSV. Uploads the file, auto-configures matching, runs entity resolution with confidence gating, and writes golden (deduplicated) records to a CSV. Returns a summary + the golden file path.",
+     "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS,
+        "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}}, "required": []},
+     "orchestrate": orchestrate_dedupe_file},
+]
+
+
+def build_composites(dispatch):
+    tools, table = [], {}
+    for spec in _COMPOSITE_SPECS:
+        tools.append(Tool(name=spec["name"], description=spec["description"], inputSchema=spec["inputSchema"]))
+        fn = spec["orchestrate"]
+        table[spec["name"]] = (lambda f: (lambda name, args: f(dispatch, args or {})))(fn)
+    return tools, table

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+from collections.abc import Callable
+
+Dispatch = dict[str, Callable[[str, dict], dict]]
+
+
+def run_step(dispatch: Dispatch, tool_name: str, args: dict) -> tuple[bool, dict]:
+    """Run one composite step. Returns (ok, result). A missing tool, a raised
+    exception, or a returned {"error": ...} are all failures."""
+    handler = dispatch.get(tool_name)
+    if handler is None:
+        return False, {"error": f"tool {tool_name!r} not available in this suite build"}
+    try:
+        result = handler(tool_name, args or {})
+    except Exception as exc:  # noqa: BLE001
+        return False, {"error": f"{type(exc).__name__}: {exc}"}
+    if isinstance(result, dict) and "error" in result:
+        return False, result
+    return True, result

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -56,6 +56,10 @@ def _upload_named(dispatch, args, content_key, name_key, path_key, label):
     if "encoding" in args:
         up["encoding"] = args["encoding"]
     ok, res = run_step(dispatch, "upload_dataset", up)
+    if ok and not res.get("path"):
+        # Guard the happy-path assumption: a malformed upload return (no path)
+        # degrades to a clean composite failure instead of a KeyError downstream.
+        return False, {"error": f"upload_dataset returned no path: {res}"}, label
     return ok, res, label
 
 

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -81,6 +81,32 @@ def orchestrate_dedupe_file(dispatch, args):
     return _finish("dedupe_file", steps, config=config, outputs=outputs)
 
 
+def orchestrate_assess_file(dispatch, args):
+    """Read-only health check: upload -> analyze_data -> scan. The goldencheck
+    `scan` step is optional -- if goldencheck isn't in the build, the composite
+    still succeeds (degraded) and reports the profile without a quality grade."""
+    steps = []
+    degraded = {"scan"}
+    ok, res, label = _upload(dispatch, args)
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("assess_file", steps, degraded_steps=degraded)
+    path = res["path"]
+
+    ok, res = run_step(dispatch, "analyze_data", {"file_path": path})
+    rows = (res.get("total_records") or res.get("rows") or res.get("row_count")) if ok else None
+    steps.append({"step": "analyze", "ok": ok,
+                  **({"rows": rows, "profile": res} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("assess_file", steps, degraded_steps=degraded)
+
+    ok, res = run_step(dispatch, "scan", {"file_path": path})
+    steps.append({"step": "scan", "ok": ok,
+                  **({"health_grade": res.get("health_grade"), "health_score": res.get("health_score"),
+                      "total_findings": res.get("total_findings")} if ok else {"error": res.get("error")})})
+    return _finish("assess_file", steps, degraded_steps=degraded)
+
+
 def _finish(workflow, steps, config=None, outputs=None, degraded_steps=frozenset()):
     ok = all(s["ok"] for s in steps if s["step"] not in degraded_steps)
     out = {"workflow": workflow, "ok": ok, "summary": _summarize(workflow, steps, outputs, degraded_steps), "steps": steps}
@@ -99,6 +125,14 @@ def _summarize(workflow, steps, outputs, degraded_steps=frozenset()):
         d = next((s for s in steps if s["step"] == "deduplicate"), {})
         return (f"{outputs.get('total_records')} records -> {outputs.get('golden_records')} golden; "
                 f"{d.get('auto_merge')} merged, {d.get('review')} to review. Written to {outputs.get('golden_path')}.")
+    if workflow == "assess_file":
+        a = next((s for s in steps if s["step"] == "analyze"), {})
+        sc = next((s for s in steps if s["step"] == "scan"), {})
+        rows = a.get("rows")
+        if sc.get("ok"):
+            return (f"{rows} rows profiled; health {sc.get('health_grade')} "
+                    f"(score {sc.get('health_score')}, {sc.get('total_findings')} findings).")
+        return f"{rows} rows profiled; quality scan unavailable (goldencheck not in this build)."
     return f"{workflow} ok"
 
 
@@ -108,6 +142,10 @@ _COMPOSITE_SPECS = [
      "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS,
         "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}}, "required": []},
      "orchestrate": orchestrate_dedupe_file},
+    {"name": "assess_file",
+     "description": "One call: assess a single file's quality. Uploads the file, profiles it (record count, detected domain, recommended matching strategy), then runs a data-quality scan (health grade + findings). Read-only -- writes nothing. The quality scan is skipped gracefully if goldencheck isn't installed.",
+     "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS}, "required": []},
+     "orchestrate": orchestrate_assess_file},
 ]
 
 

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -96,6 +96,44 @@ def orchestrate_dedupe_file(dispatch, args):
     return _finish("dedupe_file", steps, config=config, outputs=outputs)
 
 
+def orchestrate_clean_and_dedupe(dispatch, args):
+    """Normalize then dedupe: upload -> run_transforms -> agent_deduplicate.
+    The cleaned file that run_transforms writes is threaded into the dedupe."""
+    steps = []
+    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
+
+    ok, res, label = _upload(dispatch, args)
+    steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("clean_and_dedupe", steps)
+    path = res["path"]
+
+    cleaned_path = _gen_output_path(path, "cleaned")
+    ok, res = run_step(dispatch, "run_transforms", {"file_path": path, "output_path": cleaned_path})
+    steps.append({"step": "clean", "ok": ok,
+                  **({"cleaned_path": res.get("output_path"), "transforms_applied": res.get("transforms_applied")}
+                     if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("clean_and_dedupe", steps)
+    cleaned = res.get("output_path") or cleaned_path
+
+    golden_path = _gen_output_path(cleaned, "golden")
+    ok, res = run_step(dispatch, "agent_deduplicate",
+                       {"file_path": cleaned, "output_path": golden_path, **excl})
+    cd = res.get("confidence_distribution", {}) if ok else {}
+    steps.append({"step": "deduplicate", "ok": ok,
+                  **({"auto_merge": cd.get("auto_merged"), "review": cd.get("review"),
+                      "reject": cd.get("auto_rejected"), "golden_path": res.get("golden_path")}
+                     if ok else {"error": res.get("error")})})
+    if not ok:
+        return _finish("clean_and_dedupe", steps)
+
+    outputs = {"cleaned_path": cleaned, "golden_path": res.get("golden_path"),
+               "golden_records": res.get("golden_records"),
+               "total_records": (res.get("results") or {}).get("total_records")}
+    return _finish("clean_and_dedupe", steps, outputs=outputs)
+
+
 def orchestrate_match_sources(dispatch, args):
     """Link two sources: upload both -> agent_match_sources -> surface matches."""
     steps = []
@@ -186,6 +224,13 @@ def _summarize(workflow, steps, outputs, degraded_steps=frozenset()):
         dest = outputs.get("matches_path")
         tail = f" Written to {dest}." if dest else ""
         return f"Matched two sources: {pairs} matched pairs.{tail}"
+    if workflow == "clean_and_dedupe" and outputs:
+        c = next((s for s in steps if s["step"] == "clean"), {})
+        d = next((s for s in steps if s["step"] == "deduplicate"), {})
+        return (f"{outputs.get('total_records')} records cleaned "
+                f"({c.get('transforms_applied')} transforms) -> "
+                f"{outputs.get('golden_records')} golden; {d.get('auto_merge')} merged, "
+                f"{d.get('review')} to review. Written to {outputs.get('golden_path')}.")
     return f"{workflow} ok"
 
 
@@ -212,6 +257,11 @@ _COMPOSITE_SPECS = [
         "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}},
         "required": []},
      "orchestrate": orchestrate_match_sources},
+    {"name": "clean_and_dedupe",
+     "description": "One call: clean then dedupe a single CSV. Uploads the file, runs GoldenFlow transforms (phone/date/unicode/categorical normalization), then runs entity resolution on the cleaned data and writes golden records. Returns a summary + the golden file path. Requires the transform extra for the clean step.",
+     "inputSchema": {"type": "object", "properties": {**_FILE_INPUT_PROPS,
+        "exclude_columns": {"type": "array", "items": {"type": "string"}, "description": "Columns to exclude from matching."}}, "required": []},
+     "orchestrate": orchestrate_clean_and_dedupe},
 ]
 
 

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -78,11 +78,16 @@ def orchestrate_dedupe_file(dispatch, args):
     steps.append({"step": "auto_configure", "ok": ok, **({"config": res.get("config") or res} if ok else {"error": res.get("error")})})
     if not ok:
         return _finish("dedupe_file", steps)
+    # Surface auto_configure's result for transparency, but do NOT hand it to
+    # agent_deduplicate: the MCP tool's `config` param expects a real Config
+    # object (or None), not auto_configure's serialized display dict -- passing
+    # the dict dies with `'dict' object has no attribute 'get_matchkeys'`. Omit
+    # config so agent_deduplicate auto-configures internally (config=None path).
     config = res.get("config") or res
 
     golden_path = _gen_output_path(path, "golden")
     ok, res = run_step(dispatch, "agent_deduplicate",
-                       {"file_path": path, "config": config, "output_path": golden_path, **excl})
+                       {"file_path": path, "output_path": golden_path, **excl})
     cd = res.get("confidence_distribution", {}) if ok else {}
     steps.append({"step": "deduplicate", "ok": ok,
                   **({"auto_merge": cd.get("auto_merged"), "review": cd.get("review"),

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -60,6 +60,8 @@ CURATED_TOOLS: frozenset[str] = frozenset({
     "analyze_frame", "detect_regressions",
     # discovery meta-tool -- how a client reaches the ~80 non-headline tools
     "suite_find_tools",
+    # composite workflow tools -- one-call happy paths
+    "dedupe_file", "match_sources", "assess_file", "clean_and_dedupe",
 })
 
 
@@ -312,6 +314,19 @@ def _aggregate() -> tuple[list[Tool], dict[str, Callable[[str, dict], dict]]]:
             )
         else:
             logger.info("goldensuite-mcp: registered %d tools from %s", added, source_name)
+
+    # Register composite workflow tools BEFORE the discovery snapshot so they
+    # appear both in the catalog and in suite_find_tools. They dispatch against
+    # the aggregated real-tool table (name_to_dispatch) built above.
+    from goldensuite_mcp.composites import build_composites
+    composite_tools, composite_dispatch = build_composites(name_to_dispatch)
+    for tool in composite_tools:
+        if tool.name in seen:
+            logger.warning("composite %r shadowed by earlier %s", tool.name, seen[tool.name])
+            continue
+        seen[tool.name] = "goldensuite"
+        all_tools.append(tool)
+        name_to_dispatch[tool.name] = composite_dispatch[tool.name]
 
     # Register the discovery meta-tool over a snapshot of the real tools (it does
     # not list itself). Its name can't collide -- no sub-package ships it -- but

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldensuite-mcp"
-version = "0.4.0"
+version = "0.5.0"
 description = "One MCP server exposing every Golden Suite tool — goldenmatch, goldencheck, goldenflow, goldenpipe, infermap"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -28,3 +28,46 @@ def test_run_step_raise_is_failure():
 def test_run_step_missing_tool_is_failure():
     ok, res = run_step({}, "nope", {})
     assert ok is False and "nope" in res["error"]
+
+
+def _fake_dedupe_table(rec):
+    def upload(n, a):
+        rec.append(("upload", a))
+        return {"path": "/up/in.csv", "bytes": 10, "filename": "in.csv"}
+
+    def autoconf(n, a):
+        rec.append(("autoconf", a))
+        return {"config": {"matchkeys": ["exact(email)"]}}
+
+    def dedup(n, a):
+        rec.append(("dedup", a))
+        return {"confidence_distribution": {"auto_merged": 2, "review": 1, "auto_rejected": 0},
+                "golden_path": a["output_path"], "golden_records": 3, "results": {"total_records": 4}}
+
+    return {"upload_dataset": upload, "auto_configure": autoconf, "agent_deduplicate": dedup}
+
+
+def test_dedupe_file_shape_and_threading():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    tools, dispatch = build_composites(_fake_dedupe_table(rec))
+    out = dispatch["dedupe_file"]("dedupe_file", {"file_content": "...", "filename": "in.csv"})
+    assert out["workflow"] == "dedupe_file"
+    assert out["ok"] is True
+    steps = [s["step"] for s in out["steps"]]
+    assert steps == ["upload", "auto_configure", "deduplicate"]
+    assert dict(rec)["autoconf"]["file_path"] == "/up/in.csv"
+    assert dict(rec)["dedup"]["file_path"] == "/up/in.csv"
+    assert out["outputs"]["golden_path"].endswith(".golden.csv")
+    assert isinstance(out["summary"], str) and out["summary"]
+
+
+def test_dedupe_file_short_circuits_on_step_failure():
+    from goldensuite_mcp.composites import build_composites
+    tbl = _fake_dedupe_table([])
+    tbl["auto_configure"] = lambda n, a: {"error": "autoconf boom"}
+    _, dispatch = build_composites(tbl)
+    out = dispatch["dedupe_file"]("dedupe_file", {"file_content": "...", "filename": "in.csv"})
+    assert out["ok"] is False
+    assert [s["step"] for s in out["steps"]] == ["upload", "auto_configure"]
+    assert "boom" in out["summary"].lower() or "auto_configure" in out["summary"]

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -137,3 +137,56 @@ def test_assess_file_degraded_without_scan():
     assert out["ok"] is True
     assert "profile" in steps["analyze"]  # profile still present
     assert not out["summary"].startswith("assess_file failed at step")
+
+
+# --- Task 2.5: match_sources ----------------------------------------------
+
+def _fake_match_table(rec):
+    def upload(n, a):
+        rec.append(("upload", a))
+        return {"path": f"/up/{a.get('filename', 'x')}", "bytes": 10, "filename": a.get("filename")}
+
+    def match(n, a):
+        rec.append(("match", a))
+        return {"matches_path": a["output_path"], "matched_pairs": 7,
+                "results": {"match_rate": 0.42, "total_matched_records": 14}}
+
+    return {"upload_dataset": upload, "agent_match_sources": match}
+
+
+def test_match_sources_shape_and_threading():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    _, dispatch = build_composites(_fake_match_table(rec))
+    out = dispatch["match_sources"]("match_sources",
+        {"file_a_content": "a", "file_a_name": "a.csv", "file_b_content": "b", "file_b_name": "b.csv"})
+    assert out["ok"] is True
+    assert [s["step"] for s in out["steps"]] == ["upload_a", "upload_b", "match"]
+    # both files uploaded
+    assert sum(1 for k, _ in rec if k == "upload") == 2
+    m = dict(rec)["match"]
+    assert m["file_a"] == "/up/a.csv"
+    assert m["file_b"] == "/up/b.csv"
+    assert m["output_path"].endswith(".matches.csv")
+    assert out["outputs"]["matches_path"].endswith(".matches.csv")
+    assert out["outputs"]["matched_pairs"] == 7
+    assert isinstance(out["summary"], str) and out["summary"]
+
+
+def test_match_sources_short_circuits_on_second_upload():
+    from goldensuite_mcp.composites import build_composites
+    tbl = _fake_match_table([])
+    calls = {"n": 0}
+
+    def upload(n, a):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            return {"error": "upload b boom"}
+        return {"path": f"/up/{a.get('filename', 'x')}", "filename": a.get("filename")}
+
+    tbl["upload_dataset"] = upload
+    _, dispatch = build_composites(tbl)
+    out = dispatch["match_sources"]("match_sources",
+        {"file_a_content": "a", "file_a_name": "a.csv", "file_b_content": "b", "file_b_name": "b.csv"})
+    assert out["ok"] is False
+    assert [s["step"] for s in out["steps"]] == ["upload_a", "upload_b"]

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -71,3 +71,17 @@ def test_dedupe_file_short_circuits_on_step_failure():
     assert out["ok"] is False
     assert [s["step"] for s in out["steps"]] == ["upload", "auto_configure"]
     assert "boom" in out["summary"].lower() or "auto_configure" in out["summary"]
+
+
+def test_dedupe_file_registered_and_curated():
+    from goldensuite_mcp.server import _aggregate, _apply_tool_filter
+    import os
+    os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
+    tools, dispatch = _aggregate()
+    names = {t.name for t in tools}
+    assert "dedupe_file" in names
+    assert "dedupe_file" in dispatch
+    listed = {t.name for t in _apply_tool_filter(tools)}
+    assert "dedupe_file" in listed
+    out = dispatch["suite_find_tools"]("suite_find_tools", {})
+    assert "dedupe_file" in {r["name"] for r in out["tools"]}

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -85,3 +85,55 @@ def test_dedupe_file_registered_and_curated():
     assert "dedupe_file" in listed
     out = dispatch["suite_find_tools"]("suite_find_tools", {})
     assert "dedupe_file" in {r["name"] for r in out["tools"]}
+
+
+# --- Task 2.4: assess_file (read-only, degraded-aware) --------------------
+
+def _fake_assess_table(rec, with_scan=True):
+    def upload(n, a):
+        rec.append(("upload", a))
+        return {"path": "/up/in.csv", "bytes": 10, "filename": "in.csv"}
+
+    def analyze(n, a):
+        rec.append(("analyze", a))
+        return {"total_records": 100, "domain": "healthcare", "recommended_strategy": "exact(email)"}
+
+    def scan(n, a):
+        rec.append(("scan", a))
+        return {"rows": 100, "columns": 4, "health_grade": "B", "health_score": 82,
+                "total_findings": 3, "errors": 1, "warnings": 2}
+
+    t = {"upload_dataset": upload, "analyze_data": analyze}
+    if with_scan:
+        t["scan"] = scan
+    return t
+
+
+def test_assess_file_happy():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    _, dispatch = build_composites(_fake_assess_table(rec))
+    out = dispatch["assess_file"]("assess_file", {"file_content": "...", "filename": "in.csv"})
+    assert out["ok"] is True
+    assert [s["step"] for s in out["steps"]] == ["upload", "analyze", "scan"]
+    assert dict(rec)["analyze"]["file_path"] == "/up/in.csv"
+    assert dict(rec)["scan"]["file_path"] == "/up/in.csv"
+    # read-only: no config, no outputs
+    assert "config" not in out and "outputs" not in out
+    # summary mentions rows + a quality signal
+    assert "100" in out["summary"]
+    assert "B" in out["summary"] or "finding" in out["summary"].lower()
+
+
+def test_assess_file_degraded_without_scan():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    _, dispatch = build_composites(_fake_assess_table(rec, with_scan=False))
+    out = dispatch["assess_file"]("assess_file", {"file_content": "...", "filename": "in.csv"})
+    steps = {s["step"]: s for s in out["steps"]}
+    assert steps["analyze"]["ok"] is True
+    assert steps["scan"]["ok"] is False
+    # degraded but successful: a missing optional scan does not fail the composite
+    assert out["ok"] is True
+    assert "profile" in steps["analyze"]  # profile still present
+    assert not out["summary"].startswith("assess_file failed at step")

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -41,6 +41,9 @@ def _fake_dedupe_table(rec):
 
     def dedup(n, a):
         rec.append(("dedup", a))
+        # Contract: dedupe_file must NOT hand auto_configure's display dict to
+        # agent_deduplicate -- its `config` param wants a Config object/None.
+        assert "config" not in a, "dedupe_file must not pass config to agent_deduplicate"
         return {"confidence_distribution": {"auto_merged": 2, "review": 1, "auto_rejected": 0},
                 "golden_path": a["output_path"], "golden_records": 3, "results": {"total_records": 4}}
 

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -190,3 +190,65 @@ def test_match_sources_short_circuits_on_second_upload():
         {"file_a_content": "a", "file_a_name": "a.csv", "file_b_content": "b", "file_b_name": "b.csv"})
     assert out["ok"] is False
     assert [s["step"] for s in out["steps"]] == ["upload_a", "upload_b"]
+
+
+# --- Task 2.6: clean_and_dedupe -------------------------------------------
+
+def _fake_clean_table(rec, transforms_ok=True):
+    def upload(n, a):
+        rec.append(("upload", a))
+        return {"path": "/up/in.csv", "bytes": 10, "filename": "in.csv"}
+
+    def transforms(n, a):
+        rec.append(("clean", a))
+        if not transforms_ok:
+            return {"error": "goldenflow is not installed. Install with: pip install goldenmatch[transform]"}
+        return {"file": a["file_path"], "output_path": a["output_path"],
+                "transforms_applied": 5, "total_records": 10}
+
+    def dedup(n, a):
+        rec.append(("dedup", a))
+        return {"confidence_distribution": {"auto_merged": 1, "review": 0, "auto_rejected": 0},
+                "golden_path": a["output_path"], "golden_records": 9, "results": {"total_records": 10}}
+
+    return {"upload_dataset": upload, "run_transforms": transforms, "agent_deduplicate": dedup}
+
+
+def test_clean_and_dedupe_happy():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    _, dispatch = build_composites(_fake_clean_table(rec))
+    out = dispatch["clean_and_dedupe"]("clean_and_dedupe", {"file_content": "...", "filename": "in.csv"})
+    assert out["ok"] is True
+    assert [s["step"] for s in out["steps"]] == ["upload", "clean", "deduplicate"]
+    clean_call = dict(rec)["clean"]
+    assert clean_call["file_path"] == "/up/in.csv"
+    assert clean_call["output_path"].endswith(".cleaned.csv")
+    dedup_call = dict(rec)["dedup"]
+    # the cleaned path returned by run_transforms is threaded as the dedupe input
+    assert dedup_call["file_path"].endswith(".cleaned.csv")
+    assert out["outputs"]["golden_path"].endswith(".golden.csv")
+    assert isinstance(out["summary"], str) and out["summary"]
+
+
+def test_clean_and_dedupe_soft_dep_short_circuit():
+    from goldensuite_mcp.composites import build_composites
+    rec = []
+    _, dispatch = build_composites(_fake_clean_table(rec, transforms_ok=False))
+    out = dispatch["clean_and_dedupe"]("clean_and_dedupe", {"file_content": "...", "filename": "in.csv"})
+    assert out["ok"] is False
+    assert [s["step"] for s in out["steps"]] == ["upload", "clean"]
+    # deduplicate never ran
+    assert not any(k == "dedup" for k, _ in rec)
+
+
+def test_all_four_composites_exist_no_dangling_curated():
+    from goldensuite_mcp.server import _aggregate, CURATED_TOOLS
+    import os
+    os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
+    tools, _ = _aggregate()
+    names = {t.name for t in tools}
+    for c in ("dedupe_file", "assess_file", "match_sources", "clean_and_dedupe"):
+        assert c in names, f"{c} not registered"
+    # every composite curated name now resolves to a real tool
+    assert {"dedupe_file", "assess_file", "match_sources", "clean_and_dedupe"} <= (CURATED_TOOLS & names)

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -1,0 +1,30 @@
+from goldensuite_mcp.composites import run_step
+
+
+def _table(**tools):
+    return dict(tools)
+
+
+def test_run_step_success():
+    t = _table(foo=lambda n, a: {"value": a["x"] + 1})
+    ok, res = run_step(t, "foo", {"x": 1})
+    assert ok is True and res == {"value": 2}
+
+
+def test_run_step_error_dict_is_failure():
+    t = _table(foo=lambda n, a: {"error": "boom"})
+    ok, res = run_step(t, "foo", {})
+    assert ok is False and "boom" in res["error"]
+
+
+def test_run_step_raise_is_failure():
+    def boom(n, a):
+        raise ValueError("kaboom")
+
+    ok, res = run_step(_table(foo=boom), "foo", {})
+    assert ok is False and "kaboom" in res["error"]
+
+
+def test_run_step_missing_tool_is_failure():
+    ok, res = run_step({}, "nope", {})
+    assert ok is False and "nope" in res["error"]

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -1,3 +1,7 @@
+import csv as _csv
+import os
+
+import pytest
 from goldensuite_mcp.composites import run_step
 
 
@@ -78,7 +82,6 @@ def test_dedupe_file_short_circuits_on_step_failure():
 
 def test_dedupe_file_registered_and_curated():
     from goldensuite_mcp.server import _aggregate, _apply_tool_filter
-    import os
     os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
     tools, dispatch = _aggregate()
     names = {t.name for t in tools}
@@ -246,8 +249,7 @@ def test_clean_and_dedupe_soft_dep_short_circuit():
 
 
 def test_all_four_composites_exist_no_dangling_curated():
-    from goldensuite_mcp.server import _aggregate, CURATED_TOOLS
-    import os
+    from goldensuite_mcp.server import CURATED_TOOLS, _aggregate
     os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
     tools, _ = _aggregate()
     names = {t.name for t in tools}
@@ -255,3 +257,96 @@ def test_all_four_composites_exist_no_dangling_curated():
         assert c in names, f"{c} not registered"
     # every composite curated name now resolves to a real tool
     assert {"dedupe_file", "assess_file", "match_sources", "clean_and_dedupe"} <= (CURATED_TOOLS & names)
+
+
+# --- Task 2.7: end-to-end through the REAL aggregator ---------------------
+#
+# These run against _aggregate() (no fakes), on tiny CSVs written to a temp
+# dir. assess_file needs no file-writing capability and runs anywhere the
+# goldenmatch/goldencheck sub-packages import. dedupe_file needs Phase 1's
+# agent_deduplicate `output_path`; it is skipped where that capability is
+# absent (this worktree) and runs in CI once Phase 1 merges.
+
+
+def _write_people_csv(path):
+    rows = [
+        {"id": "1", "name": "Alice Smith", "email": "alice@example.com"},
+        {"id": "2", "name": "Alice Smith", "email": "alice@example.com"},
+        {"id": "3", "name": "Bob Jones", "email": "bob@example.com"},
+        {"id": "4", "name": "Bob Jones", "email": "bob@example.com"},
+        {"id": "5", "name": "Carol White", "email": "carol@example.com"},
+    ]
+    with open(path, "w", newline="", encoding="utf-8") as fh:
+        w = _csv.DictWriter(fh, fieldnames=["id", "name", "email"])
+        w.writeheader()
+        w.writerows(rows)
+
+
+def _real_aggregate():
+    from goldensuite_mcp.server import _aggregate
+    os.environ.pop("GOLDENSUITE_MCP_TOOLS", None)
+    return _aggregate()
+
+
+def _has_output_path(tools, tool_name):
+    t = next((t for t in tools if t.name == tool_name), None)
+    return t is not None and "output_path" in (t.inputSchema.get("properties") or {})
+
+
+def test_assess_file_end_to_end(tmp_path):
+    """assess_file through the real aggregator on a real CSV (no writes)."""
+    tools, dispatch = _real_aggregate()
+    if "analyze_data" not in dispatch:
+        pytest.skip("goldenmatch analyze_data not available in this build")
+    csv_path = tmp_path / "people.csv"
+    _write_people_csv(csv_path)
+
+    os.environ["GOLDENMATCH_ALLOWED_ROOT"] = str(tmp_path)
+    try:
+        out = dispatch["assess_file"]("assess_file", {"file_path": str(csv_path)})
+    finally:
+        os.environ.pop("GOLDENMATCH_ALLOWED_ROOT", None)
+
+    assert out["workflow"] == "assess_file"
+    assert out["ok"] is True
+    labels = [s["step"] for s in out["steps"]]
+    assert labels[:2] == ["upload", "analyze"]
+    analyze = next(s for s in out["steps"] if s["step"] == "analyze")
+    assert analyze["ok"] is True and "profile" in analyze
+    # read-only: nothing written
+    assert "outputs" not in out
+
+
+@pytest.mark.skipif(
+    not _has_output_path(_real_aggregate()[0], "agent_deduplicate"),
+    reason="agent_deduplicate lacks output_path (pre-Phase-1 goldenmatch build)",
+)
+def test_dedupe_file_end_to_end_and_parity(tmp_path):
+    """dedupe_file end-to-end: golden CSV lands on disk, and its row count
+    matches a by-hand upload+auto_configure+agent_deduplicate run."""
+    tools, dispatch = _real_aggregate()
+    csv_path = tmp_path / "people.csv"
+    _write_people_csv(csv_path)
+    os.environ["GOLDENMATCH_ALLOWED_ROOT"] = str(tmp_path)
+    try:
+        out = dispatch["dedupe_file"]("dedupe_file", {"file_path": str(csv_path)})
+        assert out["ok"] is True, out
+        golden = (out.get("outputs") or {}).get("golden_path")
+        assert golden and os.path.exists(golden), f"golden not written: {golden}"
+        with open(golden, encoding="utf-8") as fh:
+            composite_rows = sum(1 for _ in fh)
+
+        # By-hand parity path through the same aggregated dispatch. A file_path
+        # input needs no upload (upload_dataset is for inline file_content), so
+        # this mirrors what the composite does: auto_configure then dedupe.
+        dispatch["auto_configure"]("auto_configure", {"file_path": str(csv_path)})
+        manual_golden = str(tmp_path / "manual.golden.csv")
+        dispatch["agent_deduplicate"](
+            "agent_deduplicate", {"file_path": str(csv_path), "output_path": manual_golden})
+        with open(manual_golden, encoding="utf-8") as fh:
+            manual_rows = sum(1 for _ in fh)
+    finally:
+        os.environ.pop("GOLDENMATCH_ALLOWED_ROOT", None)
+
+    assert composite_rows == manual_rows, (
+        f"composite golden {composite_rows} rows != manual {manual_rows}")


### PR DESCRIPTION
## What

Four one-call **composite** tools on the unified `goldensuite-mcp` endpoint, each orchestrating the aggregated MCP dispatchers so an agent does a common multi-step path in a single call:

| Tool | Chain |
|---|---|
| `dedupe_file` | upload → auto_configure → agent_deduplicate → golden CSV |
| `match_sources` | upload ×2 → agent_match_sources → matches CSV |
| `assess_file` | upload → analyze_data + scan (read-only readiness report) |
| `clean_and_dedupe` | upload → run_transforms → agent_deduplicate → golden CSV |

Merged return shape `{workflow, ok, summary, steps[], config?, outputs?}`: a human `summary` line + structured per-step state. A step failure short-circuits (`ok:false`); `assess_file` is degraded-aware (a missing goldencheck `scan` keeps `ok:true` with the profile). All four are curated (listed by default) and discoverable via `suite_find_tools`.

## Design

- **Dispatcher seam:** composites call the aggregated `name_to_dispatch` table (the exact path a user chaining the tools hits) — thin, parity-guaranteed. New `composites.py`; registered in `_aggregate` before the `suite_find_tools` snapshot.
- **Depends on the golden-out change (#1659, separate goldenmatch PR):** the file is written by Phase 1's `output_path` on `agent_deduplicate`/`agent_match_sources`. Until #1659 is on main, the dedupe/match end-to-end file-writing test `skipif`s; `assess_file` needs no Phase 1.

## Tests

38 pass / 1 skip (the Phase-1-guarded dedupe e2e). Unit tests (fake dispatch tables) cover threading, short-circuit, degraded assess_file, soft-dep. Real-aggregator e2e for `assess_file`; dedupe e2e + row-count parity verified live against Phase-1 goldenmatch (golden CSV written). ruff clean. Bumped 0.4.0 → 0.5.0 (lockstep).

Brainstorm→spec→plan→TDD→two-stage review throughout. Spec `docs/superpowers/specs/2026-07-10-goldensuite-mcp-composite-workflow-tools-design.md`; plan `docs/superpowers/plans/2026-07-11-goldensuite-mcp-composite-workflow-tools.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s