### PR TITLE
fix(publish-containers): goldensuite-mcp image uses PyPI goldenflow-native wheel (--no-sources)

### DIFF
--- a/packages/python/goldensuite-mcp/Dockerfile.mcp
+++ b/packages/python/goldensuite-mcp/Dockerfile.mcp
@@ -16,9 +16,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY . /app
 
 # Install the goldensuite-mcp package and all sub-packages it depends on.
-# Use uv for workspace-aware install; fall back to pip if uv isn't present.
+# `--no-sources` ignores the root `[tool.uv.sources]` workspace path overrides so
+# native transitive deps (e.g. `goldenflow-native`, a BASE dep of goldenflow since
+# the Polars eviction) resolve from their published PyPI abi3 wheels instead of
+# building from the Rust source in-tree -- the image has no cargo, so a source
+# build fails with "Do you have cargo in your PATH?". The pure-Python packages
+# below still install from their local paths (explicit path args, not sources).
 RUN pip install --no-cache-dir uv \
-    && uv pip install --system --no-cache \
+    && uv pip install --system --no-cache --no-sources \
         ./packages/python/goldencheck-types \
         ./packages/python/goldenmatch \
         ./packages/python/goldencheck \


### PR DESCRIPTION
## Issue

Part of #1656 (main-health). `publish-containers` is red on main: the `goldensuite-mcp` image build fails at:
```
× Failed to build goldenflow-native → maturin.build_wheel failed
  → Cargo metadata failed. Do you have cargo in your PATH?
```

## Root cause

`goldenflow-native>=0.26.0` became a **base** dependency of goldenflow (Polars eviction — it's the default Polars-free kernel). The `goldensuite-mcp` image does `COPY . /app` then `uv pip install` **from the repo root**, so uv honored the root `[tool.uv.sources]` override (`goldenflow-native = { path = "packages/rust/extensions/native-flow" }`) and tried to build the Rust kernel from source — but the image has no cargo. goldensuite-mcp is the only image that installs goldenflow, so it's the only one that broke.

## Fix

Add `--no-sources` to the `uv pip install`, so native transitive deps resolve from their **published abi3 wheels** (goldenflow-native 0.26.0 ships both `manylinux_2_28_x86_64` and `_aarch64`, covering the image's amd64+arm64 legs). The pure-Python packages still install from their explicit local path args.

## Validation

`uv pip install --dry-run` from the repo root:
- **before:** `goldenflow-native @ file:///.../native-flow` (source build → needs cargo)
- **after (`--no-sources`):** `goldenflow-native==0.26.0` (PyPI wheel, no build)

The prior build reached the goldenflow-native step cleanly (base image + diptest + QEMU all work; the other 6 images build fine), so this is the targeted fix. `publish-containers` runs on the merge-to-main push and will confirm green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s