### PR TITLE
feat(goldenmatch): W4a -- tail/distributed seam ops, fixtures-first (+ W4 plan)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w4.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w4.md
@@ -1,0 +1,170 @@
+# GoldenMatch Polars eviction — W4 plan (tails)
+
+Spec row (2026-07-09 design, §3): distributed (Ray `map_batches(batch_format="pyarrow")`),
+chunked, db/identity, web, TUI engine, MCP/A2A handlers, in-repo downstream consumers →
+"Polars unreferenced" in those areas. W0-W3 merged (#1616, #1622, #1632-#1655,
+#1657/#1660/#1663/#1664/#1665). Post-W3 inventory: 1,556 `pl.` uses / 404 files; W4 tail
+share ≈ 420 uses.
+
+## Recon findings (2026-07-11)
+
+### Tails (identity / db / web / tui / chunked / mcp / a2a / connectors)
+
+1. **Dominant unmapped shape: positive `is_in(id_list)` filter** —
+   `identity/resolve.py:170,918,996`, `db/sync.py:994`, `tui/engine.py:312,338,339`.
+   Seam has `filter_not_in` only. NEW op `filter_in(col, values)`.
+2. **IO is the dominant tail shape and stays OUT of the seam by design** — read_csv/
+   scan_csv/scan_parquet/read_json/scan_ndjson across web, mcp (5×), a2a (5×),
+   connectors, chunked, sync. These route through `core/ingest.py::load_file` /
+   `core/io_arrow.py` (+ a write-side twin where needed), not Frame ops.
+3. **LazyFrame plumbing is concentrated and stubborn**: `db/sync.py` (staging-parquet +
+   weakref.finalize GC hazard #388, explicit isinstance-LazyFrame collect branch at 355),
+   `chunked.py` (scan+slice streaming), `connectors/*` read contracts return LazyFrame.
+   Eager-only seam cannot represent these. Strategy: keep the lazy PLUMBING but make the
+   payloads backend-polymorphic at the boundaries (arrow lane goes eager via io_arrow;
+   polars lane unchanged) — no seam LazyFrame.
+4. **Schema-vocabulary blockers**: `identity/resolve.py` graph-bootstrap frames use
+   `pl.Datetime` (753-806) — `_SCHEMA_DTYPES` has no datetime. Extend the vocabulary
+   (`"datetime_us"`), pinned by fixtures. `_stitch_new_record` builds a single row
+   aligned to the parent frame's LIVE dtypes (dtype fidelity is load-bearing for the
+   payload hash, resolve.py:1007-1023) — needs a `row_aligned_to(frame, dict)`-shaped op
+   or stays native behind an explicit backend branch.
+5. **`identity/fingerprint_batch.py` is a native-dtype-lattice canonicalizer** (Binary/
+   Duration/Decimal/Datetime tz+unit/List/Struct dispatch, temporal formatting, overflow
+   guards). `semantic_dtype()`'s 5-tag set is far too coarse. Port = hand-written
+   Arrow-native twin (`fingerprint_batch_arrow`) selected by backend, cross-pinned by the
+   existing fingerprint golden vectors — NOT a seam port.
+6. **Backend leakage to convert**: `web/routers/match.py:168` catches
+   `pl.exceptions.ColumnNotFoundError`; `a2a/skills.py:481` isinstance-dispatches on
+   `pl.DataFrame`. Convert to backend-neutral (seam exception mapping / Frame isinstance).
+7. **Inference-based `pl.DataFrame(rows)` constructions** (db connectors, sync golden_df,
+   a2a, tui) violate `frame_from_rows`' explicit-schema contract. Strategy: connector/IO
+   boundaries construct via a new `frame_from_records(rows, backend)` op with
+   inference parity pinned by fixtures (arrow: pa.Table.from_pylist), OR stay native
+   where they feed straight into polars-only paths until W5.
+8. Clean fits already: `web/preview.py` (int64 schema → frame_from_rows),
+   `tui/boost_tab.py` (`filter_eq`), `web/runs.py` (n_unique/filter_eq),
+   `identity/stitching.py` (`filter_nonblank_key` + near-`group_partitions`),
+   `chunked.py` block-key derivation (== `derive_block_key`), concat accumulation
+   (`concat_frames`), `db/hybrid_blocking.py` (empty-frame sentinels).
+
+### Distributed (clustering.py 114 / identity_partition.py 27 / scoring.py 21 / pipeline.py 18 / record_store.py 11 / golden.py 11)
+
+1. **Every Ray `map_batches`/`iter_batches` is ALREADY `batch_format="pyarrow"`** (30+
+   sites verified; zero polars batch format). UDF pattern everywhere:
+   `pl.from_arrow(batch)` → polars exprs → `.to_arrow()`. Port = flip UDF INTERNALS at
+   the bookends; Ray plumbing untouched. No spec-feared batch-format migration needed.
+2. **Memory-tuned WCC = `randomized_contraction_wcc`** (clustering.py:1281; distributed
+   kernels 1115-1240). Polars is NOT the load-bearing memory holder — per-batch
+   transient frames + Arrow transport + `_rc_checkpoint` (1147: ds.write_parquet +
+   read_parquet, deliberate lineage truncation per 1348-1352) cap memory. Kernel port is
+   memory-safe IF the checkpoint boundary + per-batch materialization are preserved.
+   The 5M chain bench still gates (expected != measured).
+3. **No module-level pl.* execution remains in distributed/** (function-local imports;
+   dtype constants inside bodies). No lazy-import hazard.
+4. **Recurring shapes → ops**: `pl.concat` symmetrize/merge/explode (clustering 885-946,
+   scoring 362 `vertical_relaxed`, identity_partition 171) → module-level `concat_frames`
+   EXISTS (agent missed it; scoring needs a `relaxed=True` variant); window ops
+   `pl.len().over()` / `min().over()` (clustering 430, 1235) → NEW `with_group_len_over` /
+   `with_group_min_over`; `pl.min_horizontal`/`max_horizontal` pair canonicalization
+   (scoring 560) → NEW `with_pair_canonical` (or two horizontal ops);
+   `replace_strict` row_id→cluster remap (pipeline.py:411-413 uses `default=-1` then
+   filters the sentinel) → REVIEWER-RESOLVED: `map_column` is strict-raise on both
+   backends (frame.py:449/938) and does NOT cover it; extend `map_column` with an
+   optional `default=` (None keeps the raise contract), fixtures pin both modes.
+5. **record_store bucketing** (199-279): join → `join_inner`; `partition_by` →
+   `group_partitions`; polars `.hash(seed=BUCKET_HASH_SEED) % n_buckets` — per-backend
+   hash acceptable for shard layout (not output-visible within a run), BUT
+   REVIEWER-FOUND HAZARD: bucket dirs PERSIST and are reused
+   (`GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST=1` pipeline.py:3209-3217; caller-managed
+   path stores, record_store.py:79-81) and `materialize_bucketed_blocks` does NOT clear
+   an existing bucket_dir (mkdir exist_ok=True, record_store.py:226) while the dir key
+   signature is CONFIG-ONLY (pipeline.py:846-864) — a backend flip (or data change) over
+   a persisted store leaves stale bucket parquets that iter_buckets returns → stale rows
+   scored. Latent pre-existing bug that per-backend hashing newly triggers. W4e MUST
+   clear the bucket_dir on materialize (or fold backend+data into the signature).
+   `write_parquet(compression=snappy)`/`read_parquet` shard IO → io_arrow twins.
+6. **Keep as subsystems, not seam ports**: scoring's `apply_standardization(df.lazy())` /
+   `compute_matchkeys(df.lazy())` collect chains (the W5 expression-stage boundary — same
+   engines the core pipeline uses pre-collect); the RC hash/rep-selection kernel
+   (`(A*u+B)%p` + sort_by.first) stays a compute kernel (native/pyarrow direct).
+   REVIEWER: those engines are ALSO called from tui/engine.py:200,213 +
+   core/chunked.py:101,106,295 (+ core/incremental.py:66-68, W5/core scope) — W4d must
+   stamp the same `# W5:` boundary comments there; boundary comments satisfy the exit
+   criterion, silence does not.
+7. **Boundary-only files**: golden.py / identity.py / dataset.py are pl.from_arrow
+   conversion adapters; sample.py / indicators.py are `from_dicts` constructors →
+   `frame_from_records`.
+
+## Batching (each its own PR, no stacking on unmerged predecessors)
+
+- **W4a — seam ops, fixtures-first (ALL new ops for W4b-e live here)**:
+  `filter_in(col, values)`; `group_collect_ids(key, id_col)` (stitching list-agg) IF
+  reused else group_partitions; schema vocabulary `datetime_us` (bare pl.Datetime == us
+  no-tz, matching resolve.py; arrow twin `pa.timestamp("us")`, mirroring the
+  utf8→large_string mapping at frame.py:1160); `frame_from_records` (inference-parity
+  fixtures: int/float/str/bool/None promotion, empty rows, nested→reject);
+  `with_row_index_int64(name, offset)` (chunked offset arithmetic + web/preview
+  int_range; existing with_row_index is uint32 `__row__`); `map_column(default=)`
+  extension (strict-raise default preserved); `concat_frames(relaxed=True)`
+  (vertical_relaxed); `with_group_len_over(key, name)` + `with_group_min_over(key,
+  value, name)` (clustering windows); `with_pair_canonical(a, b)`
+  (min_horizontal/max_horizontal); `unique_by(subset, keep)` (keep="last" ordering
+  semantics pinned — clustering ~1237, pipeline.py:1970). Pre-decision (reviewer):
+  resolve.py's `_stitch_new_record` row-aligned-to-live-dtypes construction stays a
+  NATIVE branch (needs the full dtype lattice, out of _SCHEMA_DTYPES scope) — no op.
+  W4e select+cast+alias shapes: reuse `select` + `with_column`/cast_str or
+  frame_from_columns; if a byte-fit gap appears mid-batch, add `select_cast` then,
+  fixtures-first. Polars impls byte-equal to the raw snippets; arrow twins parity-pinned.
+- **W4b — identity**: resolve.py (filter_in + graph-bootstrap frames onto extended
+  vocabulary + stitch row-aligned construction), stitching.py, fingerprint_batch arrow
+  twin (golden-vector cross-pin). Gates: identity suites + fingerprint goldens unedited.
+- **W4c — db + connectors**: connector contract stays DataFrame-shaped for polars lane;
+  read/write boundaries via load_file/io_arrow where arrow-lane reachable; sync.py lazy
+  plumbing kept, payload boundaries polymorphic; Null→Utf8 promotion recipe becomes a
+  shared helper with an arrow twin. Gates: db suites, sync tests unedited.
+- **W4d — chunked + web + tui + mcp/a2a handlers**: chunked derive/concat onto seam,
+  scan-slice streaming stays native behind explicit backend branch (arrow lane: io_arrow
+  chunked reader); web/tui filter/is_in/read sites; mcp/a2a read_csv sites → load_file;
+  backend-leakage conversions (pl.exceptions, isinstance); `# W5:` boundary comments on
+  tui/engine + chunked std/matchkey lazy-engine call sites. Gates: test_chunked.py,
+  test_streaming.py, test_tui.py, web router suites, mcp/a2a suites.
+- **W4e — distributed**: UDF-internal ports at the pl.from_arrow/.to_arrow bookends
+  (identity_partition first — pure relational, best seam fit; then pipeline/golden
+  adapters; then clustering label/WCC kernels; record_store bucketing incl the
+  MANDATORY bucket_dir clear-on-materialize fix; scoring explode/canonicalize — its
+  lazy std/matchkey chains stay native with a W5 boundary comment). RC checkpoint
+  boundary + per-batch materialization PRESERVED (memory profile). GATES:
+  bench-distributed-stack.yml 5M chain baseline BEFORE the batch, re-run after (wall +
+  peak RSS within noise); unit suites: test_distributed_clustering(.py/_e2e),
+  test_distributed_randomized_contraction_wcc, test_two_phase_wcc,
+  test_distributed_scoring(+_tuning), test_distributed_pipeline(+_branch),
+  test_distributed_golden, test_distributed_dataset/indicators/sample/block_shuffle,
+  test_phase5_distributed_pipeline, test_ray_backend, test_prepared_record_store(+
+  _controller/_pipeline), test_bucketed_store, test_partitioned_block_scoring_pipeline,
+  test_score_buckets_*, test_sail_* parity stack, tests/identity/
+  test_distributed_identity*. Ray tests in CI via .venv/bin/python NOT uv run.
+- **W4f — downstream consumers**: SQL-extensions bridge JSON→Arrow, goldenmatch-duckdb
+  `.arrow()`, goldenmatch-kg, dbt adapter surfaces (spec risk row). Survey at batch
+  start; port or explicitly defer with notes.
+
+## Exit gates (whole wave)
+
+- Full goldenmatch shards + heavy + fallback + goldenmatch_frame_diff lanes green.
+- bench-distributed-stack 5M chain: wall + peak RSS within noise of the pre-W4e baseline
+  (run baseline BEFORE W4e lands, same runner class).
+- Spec W4 exit ("Polars unreferenced" in tail areas) interpreted honestly: tail modules
+  either (a) routed through the seam/io_arrow, or (b) carry an explicit
+  `# W5:` native-polars boundary comment where the polars-default lane legitimately
+  keeps them (LazyFrame plumbing, fingerprint polars twin) — zero SILENT usages.
+- No default flip; GOLDENMATCH_FRAME stays polars. 2.x minor.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| WCC memory profile destabilized (spec risk) | Baseline 5M chain bench pre-W4e; gate on wall+RSS |
+| frame_from_records inference parity drift (polars vs pa.from_pylist) | Fixtures-first corpus: None columns, mixed int/float, bool, empty, nested reject |
+| Datetime vocabulary extension leaks tz/unit ambiguity | Pin exactly one spelling (`datetime_us`, no tz) matching resolve.py's actual frames |
+| sync.py weakref/staging GC hazard (#388) re-broken by refactor | Do NOT restructure the lazy plumbing; only touch payload boundaries; #388 test unedited |
+| Ray batch_format flip changes shard boundaries/nondeterminism | (fill from recon) diff canonicalized outputs, not shard layout |

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -94,6 +94,10 @@ class Column(Protocol):
     def semantic_dtype(self) -> str: ...
 
 
+# W4a: map_column's "no default" marker -- None is a legitimate default value.
+_MAP_RAISE: Any = object()
+
+
 @runtime_checkable
 class Frame(Protocol):
     # W2b relational-op contracts (pinned by tests/test_frame_relational_ops.py):
@@ -150,7 +154,9 @@ class Frame(Protocol):
     def filter_nonblank_key(self, col: str) -> Frame: ...
     def filter_target_split(self, a: str, b: str, values: Sequence[Any]) -> Frame: ...
     def with_fill_null(self, cols: Sequence[str], value: Any) -> Frame: ...
-    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> Frame: ...
+    def map_column(
+        self, src: str, dst: str, mapping: dict, dtype: str = "int64", default: Any = _MAP_RAISE
+    ) -> Frame: ...
     def apply_weak_quality(self, weak_threshold: float) -> Frame: ...
     def select_eligible_clusters(self) -> Frame: ...
     # W2d ops: with_column attaches a derived Column; group_partitions is
@@ -184,6 +190,18 @@ class Frame(Protocol):
         self, fields_with_chains: Sequence[tuple[str, Sequence[str]]], sep: str = "||"
     ) -> Column: ...
     def derive_ne_joined(self, fields: Sequence[str]) -> Column: ...
+    # W4a tail/distributed ops (fixtures: tests/test_frame_w4_ops.py). Probed
+    # semantics: filter_in DROPS null rows on both backends (polars null mask,
+    # pc.is_in False); with_pair_canonical min/max_horizontal SKIP nulls;
+    # unique_by result ORDER is engine-defined (SET contract; keep refers to
+    # input order); with_group_len_over counts null keys as a group.
+    def filter_in(self, col: str, values: Sequence[Any]) -> Frame: ...
+    def with_row_index_int64(self, name: str, offset: int = 0) -> Frame: ...
+    def with_int64_offset(self, col: str, offset: int) -> Frame: ...
+    def with_group_len_over(self, key: str, name: str) -> Frame: ...
+    def with_group_min_over(self, key: str, value: str, name: str) -> Frame: ...
+    def with_pair_canonical(self, a: str, b: str) -> Frame: ...
+    def unique_by(self, subset: Sequence[str], keep: str = "first") -> Frame: ...
 
 
 class PolarsColumn:
@@ -446,10 +464,18 @@ class PolarsFrame:
         # cluster.py ~589-592: coalesce native-bridge null edges.
         return PolarsFrame(self._df.with_columns([pl.col(c).fill_null(value) for c in cols]))
 
-    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> PolarsFrame:
+    def map_column(
+        self, src: str, dst: str, mapping: dict, dtype: str = "int64", default: Any = _MAP_RAISE
+    ) -> PolarsFrame:
         # cluster.py ~1151-1152: tag pairs with their cluster id.
-        # replace_strict RAISES on unmapped source values (contract).
-        return PolarsFrame(self._df.with_columns(pl.col(src).replace_strict(mapping).alias(dst)))
+        # replace_strict RAISES on unmapped source values (contract). W4a:
+        # optional default= (distributed/pipeline.py:411 remap-with-sentinel);
+        # PROBED: polars maps null -> default too (not passthrough).
+        if default is _MAP_RAISE:
+            expr = pl.col(src).replace_strict(mapping)
+        else:
+            expr = pl.col(src).replace_strict(mapping, default=default)
+        return PolarsFrame(self._df.with_columns(expr.alias(dst)))
 
     def apply_weak_quality(self, weak_threshold: float) -> PolarsFrame:
         # cluster.py Step-3 (~718-729) VERBATIM: quality recompute (split rows
@@ -607,6 +633,44 @@ class PolarsFrame:
         # precompute_matchkey_transforms' derived-NE join (matchkey.py:381-386).
         expr = pl.concat_str([pl.col(c).cast(pl.Utf8).fill_null("") for c in fields], separator=" ")
         return PolarsColumn(self._df.select(expr.alias("__ne__"))["__ne__"])
+
+    # -- W4a tail/distributed ops --------------------------------------------
+
+    def filter_in(self, col: str, values: Sequence[Any]) -> PolarsFrame:
+        # resolve.py:170/918/996, sync.py:994, tui/engine.py:312/338/339.
+        return PolarsFrame(self._df.filter(pl.col(col).is_in(list(values))))
+
+    def with_row_index_int64(self, name: str, offset: int = 0) -> PolarsFrame:
+        # web/preview.py:189's pl.int_range(0, height, dtype=Int64) + offset.
+        return PolarsFrame(
+            self._df.with_columns(
+                pl.int_range(offset, offset + self._df.height, dtype=pl.Int64).alias(name)
+            )
+        )
+
+    def with_int64_offset(self, col: str, offset: int) -> PolarsFrame:
+        # chunked.py:91-93: (col + offset).cast(Int64) in place.
+        return PolarsFrame(self._df.with_columns((pl.col(col) + offset).cast(pl.Int64).alias(col)))
+
+    def with_group_len_over(self, key: str, name: str) -> PolarsFrame:
+        # clustering.py ~430: per-row group size window.
+        return PolarsFrame(self._df.with_columns(pl.len().over(key).alias(name)))
+
+    def with_group_min_over(self, key: str, value: str, name: str) -> PolarsFrame:
+        # clustering.py ~1234: per-row group min window.
+        return PolarsFrame(self._df.with_columns(pl.col(value).min().over(key).alias(name)))
+
+    def with_pair_canonical(self, a: str, b: str) -> PolarsFrame:
+        # distributed/scoring.py ~560: canonical (min, max) endpoint order.
+        return PolarsFrame(
+            self._df.with_columns(
+                [pl.min_horizontal(a, b).alias(a), pl.max_horizontal(a, b).alias(b)]
+            )
+        )
+
+    def unique_by(self, subset: Sequence[str], keep: str = "first") -> PolarsFrame:
+        # clustering ~1237 / pipeline.py:1970. Result order engine-defined.
+        return PolarsFrame(self._df.unique(subset=list(subset), keep=keep))  # type: ignore[arg-type]
 
 
 class ArrowColumn:
@@ -935,14 +999,23 @@ class ArrowFrame:
             tbl = tbl.set_column(idx, c, pc.fill_null(tbl.column(c), value))
         return ArrowFrame(tbl)
 
-    def map_column(self, src: str, dst: str, mapping: dict, dtype: str = "int64") -> ArrowFrame:
+    def map_column(
+        self, src: str, dst: str, mapping: dict, dtype: str = "int64", default: Any = _MAP_RAISE
+    ) -> ArrowFrame:
         import pyarrow as pa
 
         vals = self._tbl.column(src).to_pylist()
-        try:
-            mapped = [None if v is None else mapping[v] for v in vals]
-        except KeyError as e:  # replace_strict twin: unmapped RAISES
-            raise ValueError(f"map_column: value {e.args[0]!r} in {src!r} not in mapping") from e
+        if default is _MAP_RAISE:
+            try:
+                mapped = [None if v is None else mapping[v] for v in vals]
+            except KeyError as e:  # replace_strict twin: unmapped RAISES
+                raise ValueError(
+                    f"map_column: value {e.args[0]!r} in {src!r} not in mapping"
+                ) from e
+        else:
+            # PROBED polars parity: replace_strict(mapping, default) maps
+            # unmapped values AND nulls to the default.
+            mapped = [mapping.get(v, default) for v in vals]
         return ArrowFrame(self._tbl.append_column(dst, pa.array(mapped, type=_arrow_dtype(dtype))))
 
     def apply_weak_quality(self, weak_threshold: float) -> ArrowFrame:
@@ -1104,6 +1177,90 @@ class ArrowFrame:
 
         return ArrowColumn(arrow_derive.ne_joined_column([self._tbl.column(f) for f in fields]))
 
+    # -- W4a tail/distributed ops --------------------------------------------
+
+    def filter_in(self, col: str, values: Sequence[Any]) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        # Nones are stripped from the value set: polars drops null rows even
+        # when None is listed (probed), while pc.is_in would MATCH them.
+        vals = [v for v in values if v is not None]
+        if not vals:
+            return ArrowFrame(self._tbl.slice(0, 0))
+        # pc.is_in: null -> False == polars null-mask DROP (probed).
+        mask = pc.is_in(self._tbl.column(col), value_set=pa.array(vals))
+        return ArrowFrame(self._tbl.filter(mask))
+
+    def with_row_index_int64(self, name: str, offset: int = 0) -> ArrowFrame:
+        import pyarrow as pa
+
+        n = self._tbl.num_rows
+        return ArrowFrame(
+            self._tbl.append_column(name, pa.array(range(offset, offset + n), type=pa.int64()))
+        )
+
+    def with_int64_offset(self, col: str, offset: int) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        idx = self._tbl.column_names.index(col)
+        arr = pc.cast(pc.add(self._tbl.column(col), offset), pa.int64())
+        return ArrowFrame(self._tbl.set_column(idx, col, arr))
+
+    def with_group_len_over(self, key: str, name: str) -> ArrowFrame:
+        from collections import Counter
+
+        import pyarrow as pa
+
+        keys = self._tbl.column(key).to_pylist()
+        counts = Counter(keys)  # None keys count as a group (polars over parity)
+        return ArrowFrame(
+            self._tbl.append_column(name, pa.array([counts[k] for k in keys], type=pa.uint32()))
+        )
+
+    def with_group_min_over(self, key: str, value: str, name: str) -> ArrowFrame:
+        keys = self._tbl.column(key).to_pylist()
+        vals = self._tbl.column(value).to_pylist()
+        mins: dict = {}
+        for k, v in zip(keys, vals):
+            if v is None:
+                continue
+            if k not in mins or v < mins[k]:
+                mins[k] = v
+        out = [mins.get(k) for k in keys]
+        return ArrowFrame(
+            self._tbl.append_column(name, _pa_array_typed(out, self._tbl.column(value).type))
+        )
+
+    def with_pair_canonical(self, a: str, b: str) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        ca, cb = self._tbl.column(a), self._tbl.column(b)
+        # An all-null column is null()-typed and breaks element_wise (the W1
+        # count_distinct lesson) -- cast it to the partner's type first.
+        if pa.types.is_null(ca.type) and not pa.types.is_null(cb.type):
+            ca = ca.cast(cb.type)
+        elif pa.types.is_null(cb.type) and not pa.types.is_null(ca.type):
+            cb = cb.cast(ca.type)
+        # element_wise min/max skip nulls by default (polars horizontal parity).
+        mn, mx = pc.min_element_wise(ca, cb), pc.max_element_wise(ca, cb)
+        tbl = self._tbl.set_column(self._tbl.column_names.index(a), a, mn)
+        return ArrowFrame(tbl.set_column(tbl.column_names.index(b), b, mx))
+
+    def unique_by(self, subset: Sequence[str], keep: str = "first") -> ArrowFrame:
+        if keep not in ("first", "last"):
+            raise ValueError(f"unique_by keep must be first/last, got {keep!r}")
+        cols = [self._tbl.column(c).to_pylist() for c in subset]
+        kept: dict = {}
+        for i, key in enumerate(zip(*cols)):
+            if keep == "first":
+                kept.setdefault(key, i)
+            else:
+                kept[key] = i
+        return ArrowFrame(self._tbl.take(sorted(kept.values())))
+
 
 def to_frame(obj: Any) -> Frame:
     """Idempotent coercion: raw ``pl.DataFrame``/``pa.Table``, a
@@ -1137,7 +1294,7 @@ def to_frame(obj: Any) -> Frame:
 # The pinned dtype vocabulary for frame_from_columns/empty_frame schemas.
 # Deliberately tiny: exactly what the engine's frame-construction call sites
 # use (cluster.py assignment/metadata buffers, scorer pair streams).
-_SCHEMA_DTYPES = ("int64", "uint32", "float64", "utf8", "bool")
+_SCHEMA_DTYPES = ("int64", "uint32", "float64", "utf8", "bool", "datetime_us")
 
 
 def _polars_dtype(name: str) -> Any:
@@ -1147,6 +1304,8 @@ def _polars_dtype(name: str) -> Any:
         "float64": pl.Float64,
         "utf8": pl.Utf8,
         "bool": pl.Boolean,
+        # W4a: identity graph frames (resolve.py) use bare pl.Datetime == us, no tz.
+        "datetime_us": pl.Datetime,
     }[name]
 
 
@@ -1159,6 +1318,7 @@ def _arrow_dtype(name: str) -> Any:
         "float64": pa.float64(),
         "utf8": pa.large_string(),  # Polars exports Utf8 as LargeUtf8
         "bool": pa.bool_(),
+        "datetime_us": pa.timestamp("us"),
     }[name]
 
 
@@ -1168,19 +1328,52 @@ def _check_schema(schema: dict[str, str]) -> None:
         raise ValueError(f"unsupported schema dtype(s) {bad}; supported: {_SCHEMA_DTYPES}")
 
 
-def concat_frames(frames: Sequence[Frame]) -> Frame:
+def _pa_array_typed(values: list, typ: Any) -> Any:
+    """pa.array with the source column type when castable, inference fallback."""
+    import pyarrow as pa
+
+    try:
+        return pa.array(values, type=typ)
+    except (pa.ArrowInvalid, pa.ArrowTypeError):  # pragma: no cover -- defensive
+        return pa.array(values)
+
+
+def concat_frames(frames: Sequence[Frame], relaxed: bool = False) -> Frame:
     """Vertical concat, schema-checked by the underlying engine. All frames
     must share a backend (mixing indicates a caller bug, not a coercion
-    opportunity)."""
+    opportunity). W4a: ``relaxed=True`` == polars vertical_relaxed == arrow
+    promote_options="permissive" (PROBED: int64+float64 -> float64 on both)."""
     if not frames:
         raise ValueError("concat_frames requires at least one frame")
     if all(isinstance(f, PolarsFrame) for f in frames):
-        return PolarsFrame(pl.concat([f.native for f in frames], how="vertical"))
+        how = "vertical_relaxed" if relaxed else "vertical"
+        return PolarsFrame(pl.concat([f.native for f in frames], how=how))  # type: ignore[arg-type]
     if all(isinstance(f, ArrowFrame) for f in frames):
         import pyarrow as pa
 
+        if relaxed:
+            return ArrowFrame(
+                pa.concat_tables([f.native for f in frames], promote_options="permissive")
+            )
         return ArrowFrame(pa.concat_tables([f.native for f in frames]))
     raise TypeError("concat_frames requires all frames on the same backend")
+
+
+def frame_from_records(rows: Sequence[dict], backend: str | None = None) -> Frame:
+    """Build a Frame from a list of dict rows with ENGINE INFERENCE -- the
+    db-connector / a2a / tui boundary shape (``pl.DataFrame(rows)``). Unlike
+    ``frame_from_rows`` there is no explicit schema; per-backend dtype
+    inference is the documented contract (values parity, not dtype parity).
+    Empty rows -> zero-column empty frame on both backends."""
+    b = backend if backend is not None else resolve_frame_backend()
+    rows = list(rows)
+    if b == "polars":
+        return PolarsFrame(pl.DataFrame(rows))
+    import pyarrow as pa
+
+    if not rows:
+        return ArrowFrame(pa.table({}))
+    return ArrowFrame(pa.Table.from_pylist(rows))
 
 
 def frame_from_columns(

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -1,0 +1,231 @@
+# tests/test_frame_w4_ops.py
+"""W4a seam ops -- fixtures-first semantics pins for the tail/distributed ports.
+
+Every op is pinned on BOTH backends (PolarsFrame byte-equal to the raw
+polars snippet it replaces; ArrowFrame value-parity). Edge cases below were
+EMPIRICALLY PROBED against polars 2026-07-11:
+- replace_strict(mapping, default=d): null input maps to d (not passthrough)
+- min_horizontal/max_horizontal SKIP nulls ((None,2) -> 2 for BOTH)
+- is_in: null rows DROP even when None is in the values list; pc.is_in
+  returns False for null -> same drop
+- unique(subset, keep) result ORDER is engine-defined -> SET contract,
+  kept-row identity pinned
+- vertical_relaxed int->float promotion == pa concat promote_options=permissive
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.core.frame import (
+    ArrowFrame,
+    PolarsFrame,
+    concat_frames,
+    empty_frame,
+    frame_from_records,
+)
+
+
+def _mk(data: dict, backend: str):
+    df = pl.DataFrame(data)
+    if backend == "polars":
+        return PolarsFrame(df)
+    return ArrowFrame(df.to_arrow())
+
+
+BACKENDS = ["polars", "arrow"]
+
+
+# -- filter_in ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_filter_in_keeps_only_members(backend):
+    f = _mk({"id": [1, 2, 3, 4], "v": ["a", "b", "c", "d"]}, backend)
+    out = f.filter_in("id", [3, 1])
+    assert sorted(zip(out.column("id").to_list(), out.column("v").to_list())) == [
+        (1, "a"),
+        (3, "c"),
+    ]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_filter_in_drops_nulls_even_when_none_listed(backend):
+    # probe P6/P10: polars null.is_in -> null -> drop; pc.is_in null -> False.
+    f = _mk({"id": [1, None, 3]}, backend)
+    assert f.filter_in("id", [1, None]).column("id").to_list() == [1]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_filter_in_empty_values(backend):
+    f = _mk({"id": [1, 2]}, backend)
+    assert f.filter_in("id", []).height == 0
+
+
+# -- with_row_index_int64 / with_int64_offset --------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_row_index_int64(backend):
+    f = _mk({"v": ["a", "b", "c"]}, backend)
+    out = f.with_row_index_int64("__row_id__")
+    assert out.column("__row_id__").to_list() == [0, 1, 2]
+    out2 = f.with_row_index_int64("__row_id__", offset=100)
+    assert out2.column("__row_id__").to_list() == [100, 101, 102]
+
+
+def test_with_row_index_int64_dtype_is_int64():
+    # web/preview.py:189 uses pl.int_range(..., dtype=pl.Int64) -- pin Int64,
+    # NOT the uint32 of the W3a with_row_index op.
+    f = PolarsFrame(pl.DataFrame({"v": [1]}))
+    assert f.with_row_index_int64("__row_id__").native["__row_id__"].dtype == pl.Int64
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_int64_offset(backend):
+    # chunked.py:91-93 shape: (col + offset).cast(Int64), in place.
+    f = _mk({"__row_id__": [0, 1, 2], "v": ["a", "b", "c"]}, backend)
+    out = f.with_int64_offset("__row_id__", 1000)
+    assert out.column("__row_id__").to_list() == [1000, 1001, 1002]
+    assert out.columns == ["__row_id__", "v"]  # replaced in place, position kept
+
+
+# -- map_column default= extension --------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_map_column_default_maps_unmapped_and_null(backend):
+    # probe P1: replace_strict(mapping, default=-1) maps BOTH unmapped values
+    # AND nulls to the default. pipeline.py:411-413 filters the sentinel after.
+    f = _mk({"x": [1, 2, None, 9]}, backend)
+    out = f.map_column("x", "y", {1: 10, 2: 20}, default=-1)
+    assert out.column("y").to_list() == [10, 20, -1, -1]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_map_column_without_default_still_raises(backend):
+    f = _mk({"x": [1, 7]}, backend)
+    with pytest.raises(Exception):
+        f.map_column("x", "y", {1: 10})
+
+
+# -- window ops ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_group_len_over(backend):
+    # clustering.py ~430: pl.len().over("label") per-row group size.
+    f = _mk({"label": ["a", "b", "a", "a"]}, backend)
+    assert f.with_group_len_over("label", "n").column("n").to_list() == [3, 1, 3, 3]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_group_len_over_null_key_is_a_group(backend):
+    f = _mk({"label": ["a", None, None]}, backend)
+    assert f.with_group_len_over("label", "n").column("n").to_list() == [1, 2, 2]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_group_min_over(backend):
+    # clustering.py ~1234: pl.col(v).min().over(k).
+    f = _mk({"cur": ["a", "a", "b"], "lbl": [5, 2, 9]}, backend)
+    assert f.with_group_min_over("cur", "lbl", "mn").column("mn").to_list() == [2, 2, 9]
+
+
+# -- pair canonicalization -----------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_pair_canonical(backend):
+    # scoring.py ~560: min_horizontal/max_horizontal(id_a, id_b) in place.
+    f = _mk({"id_a": [5, 1, 3], "id_b": [2, 4, 3]}, backend)
+    out = f.with_pair_canonical("id_a", "id_b")
+    assert out.column("id_a").to_list() == [2, 1, 3]
+    assert out.column("id_b").to_list() == [5, 4, 3]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_pair_canonical_null_skips(backend):
+    # probe P2/P11: horizontal min AND max both skip nulls -> (None, 2) -> 2/2.
+    f = _mk({"id_a": [None], "id_b": [2]}, backend)
+    out = f.with_pair_canonical("id_a", "id_b")
+    assert out.column("id_a").to_list() == [2]
+    assert out.column("id_b").to_list() == [2]
+
+
+# -- unique_by ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_unique_by_keep_first_set_contract(backend):
+    # probe P3: result ORDER is engine-defined; the SET of kept rows is the pin.
+    f = _mk({"k": [1, 2, 1, 3, 2], "v": ["a", "b", "c", "d", "e"]}, backend)
+    out = f.unique_by(["k"])  # ONE call: row order differs between calls
+    kept = sorted(zip(out.column("k").to_list(), out.column("v").to_list()))
+    assert kept == [(1, "a"), (2, "b"), (3, "d")]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_unique_by_keep_last(backend):
+    # pipeline.py:1970 shape: unique(subset=["__row_id__"], keep="last").
+    f = _mk({"k": [1, 2, 1, 3, 2], "v": ["a", "b", "c", "d", "e"]}, backend)
+    out = f.unique_by(["k"], keep="last")
+    kept = sorted(zip(out.column("k").to_list(), out.column("v").to_list()))
+    assert kept == [(1, "c"), (2, "e"), (3, "d")]
+
+
+# -- concat_frames relaxed -------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_concat_frames_relaxed_promotes_int_to_float(backend):
+    # probe P4/P12: vertical_relaxed int64+float64 -> float64; pa permissive same.
+    a = _mk({"x": [1, 2]}, backend)
+    b = _mk({"x": [1.5]}, backend)
+    out = concat_frames([a, b], relaxed=True)
+    assert out.column("x").to_list() == [1.0, 2.0, 1.5]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_concat_frames_strict_unchanged(backend):
+    a = _mk({"x": [1]}, backend)
+    b = _mk({"x": [2]}, backend)
+    assert concat_frames([a, b]).column("x").to_list() == [1, 2]
+
+
+# -- frame_from_records -----------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_frame_from_records_inference_parity(backend):
+    # db connectors / a2a / tui shape: pl.DataFrame(list_of_dicts) inference.
+    rows = [{"a": 1, "b": "x"}, {"a": None, "b": "y"}]
+    f = frame_from_records(rows, backend=backend)
+    assert f.columns == ["a", "b"]
+    assert f.column("a").to_list() == [1, None]
+    assert f.column("b").to_list() == ["x", "y"]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_frame_from_records_empty(backend):
+    f = frame_from_records([], backend=backend)
+    assert f.height == 0
+    assert f.columns == []
+
+
+# -- datetime_us schema vocabulary -------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_empty_frame_datetime_us(backend):
+    # identity/resolve.py graph-bootstrap frames use bare pl.Datetime (== us,
+    # no tz); arrow twin is pa.timestamp("us").
+    f = empty_frame({"id": "utf8", "created_at": "datetime_us"}, backend=backend)
+    assert f.height == 0
+    assert f.columns == ["id", "created_at"]
+    if backend == "polars":
+        assert f.native.schema["created_at"] == pl.Datetime(time_unit="us")
+    else:
+        import pyarrow as pa
+
+        assert f.native.schema.field("created_at").type == pa.timestamp("us")


### PR DESCRIPTION
W4 batch 1 of 6 (plan: docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w4.md, committed here with both recon reports + reviewer findings).

New Frame ops, fixtures-first (tests/test_frame_w4_ops.py, 39 tests, both backends), zero call sites in this batch:
- filter_in (probed: null rows DROP even when None is listed; the arrow twin strips Nones from the value set since pc.is_in would MATCH them)
- with_row_index_int64 (+offset) and with_int64_offset (chunked/web row-id shapes; existing with_row_index is uint32)
- with_group_len_over / with_group_min_over (clustering window shapes; null keys form a group)
- with_pair_canonical (probed: min/max_horizontal BOTH skip nulls; arrow casts null()-typed all-null columns to the partner type first -- the W1 count_distinct lesson)
- unique_by (SET contract; keep=first/last pins kept-row identity, result order engine-defined)
- map_column default= extension (probed: polars replace_strict(default) maps null -> default too)
- concat_frames relaxed= (vertical_relaxed == pa promote_options=permissive, probed)
- frame_from_records (engine-inference dict-rows constructor; values parity, per-backend dtype inference documented)
- schema vocabulary datetime_us (bare pl.Datetime == us no-tz / pa.timestamp(us))

Gates: 117 passed across w4-ops + relational + seam-arrow + backend-env + lazy-import suites. ruff check + format clean.