### PR TITLE
feat(goldenmatch): W4d -- chunked/web/tui/mcp/a2a onto the seam + W5 boundary comments

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -149,6 +149,7 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
         _analysis = session.analyze(params["file_path"])
         decision = select_strategy(
             profile_for_agent(
+                # W5: CSV ingest routes through core/ingest.load_file (io_arrow) at the flip.
                 pl.read_csv(params["file_path"], encoding="utf8-lossy", ignore_errors=True)
             ),
             allow_pprl=allow_pprl,
@@ -478,6 +479,7 @@ def _serialise_result(obj: Any) -> dict:
             try:
                 import polars as pl
 
+                # W5: native-type dispatch; becomes Frame isinstance at the flip.
                 if isinstance(v, pl.DataFrame):
                     out[k] = {"rows": v.height, "columns": v.columns}
                     continue

--- a/packages/python/goldenmatch/goldenmatch/core/chunked.py
+++ b/packages/python/goldenmatch/goldenmatch/core/chunked.py
@@ -86,16 +86,23 @@ class ChunkedMatcher:
             self._chunk_count += 1
             chunk_start = time.perf_counter()
 
-            # Add row IDs with offset
-            chunk_df = chunk_df.with_row_index("__row_id__").with_columns(
-                (pl.col("__row_id__") + self._row_offset).cast(pl.Int64).alias("__row_id__")
+            # Add row IDs with offset (W4d: seam ops, byte-identical chain)
+            from goldenmatch.core.frame import to_frame
+
+            chunk_df = (
+                to_frame(chunk_df)
+                .with_row_index("__row_id__")
+                .with_int64_offset("__row_id__", self._row_offset)
+                .with_literal_column("__source__", "source")
+                .native
             )
-            chunk_df = chunk_df.with_columns(pl.lit("source").alias("__source__"))
 
             # Auto-fix
             chunk_df, _ = auto_fix_dataframe(chunk_df)
 
             # Standardize
+            # W5: apply_standardization/compute_matchkeys are the LazyFrame
+            # expression engines; they rewire with the core pipeline flip.
             if self.config.standardization:
                 lf = chunk_df.lazy()
                 lf = apply_standardization(lf, self.config.standardization)
@@ -291,7 +298,9 @@ class ChunkedMatcher:
         keep_cols = self._slim_columns(matchkeys)
         chunk_slim = chunk_df.select([c for c in keep_cols if c in chunk_df.columns])
 
-        joint = pl.concat([chunk_slim, self._index_df], how="vertical")
+        from goldenmatch.core.frame import concat_frames, to_frame
+
+        joint = concat_frames([to_frame(chunk_slim), to_frame(self._index_df)]).native
         joint_df = compute_matchkeys(joint.lazy(), matchkeys).collect()
 
         chunk_lo = self._row_offset
@@ -396,10 +405,14 @@ class ChunkedMatcher:
                 # then stack. compute_matchkeys was already applied on the
                 # joint frame upstream; re-stacking slim frames is cheap.
                 cols = [c for c in index_subset.columns if c in chunk_subset.columns]
-                combined = pl.concat(
-                    [chunk_subset.select(cols), index_subset.select(cols)],
-                    how="vertical",
-                )
+                from goldenmatch.core.frame import concat_frames, to_frame
+
+                combined = concat_frames(
+                    [
+                        to_frame(chunk_subset.select(cols)),
+                        to_frame(index_subset.select(cols)),
+                    ]
+                ).native
                 synthetic_blocks.append(
                     BlockResult(block_key=bk, df=combined.lazy(), strategy="static"),
                 )
@@ -427,7 +440,11 @@ class ChunkedMatcher:
         if self._index_df is None:
             self._index_df = slim_df
         else:
-            self._index_df = pl.concat([self._index_df, slim_df], how="vertical")
+            from goldenmatch.core.frame import concat_frames, to_frame
+
+            self._index_df = concat_frames(
+                [to_frame(self._index_df), to_frame(slim_df)]
+            ).native
 
         # If blocking is static, also partition the slim slice by each
         # blocking key and append into the bucketed index. The bucketed
@@ -454,4 +471,8 @@ class ChunkedMatcher:
                     if existing is None:
                         bucket[bk] = part_df
                     else:
-                        bucket[bk] = pl.concat([existing, part_df], how="vertical")
+                        from goldenmatch.core.frame import concat_frames, to_frame
+
+                        bucket[bk] = concat_frames(
+                            [to_frame(existing), to_frame(part_df)]
+                        ).native

--- a/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py
@@ -802,6 +802,7 @@ def _dispatch(
             return {"error": "Missing required parameter: file_path"}
 
         try:
+            # W5: CSV ingest routes through core/ingest.load_file (io_arrow) at the flip.
             df = pl.read_csv(file_path, encoding="utf8-lossy", ignore_errors=True)
         except FileNotFoundError:
             return {"error": f"File not found: {file_path}"}

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 from goldenmatch._polars_lazy import pl
+from goldenmatch.core.frame import frame_from_records as _frame_from_records
+from goldenmatch.core.frame import to_frame as _to_frame
 
 
 @dataclass
@@ -197,6 +199,7 @@ class MatchEngine:
 
         # ── Standardization ──
         if config.standardization and config.standardization.rules:
+            # W5: LazyFrame expression engines; rewire with the core pipeline flip.
             combined_lf = apply_standardization(combined_lf, config.standardization.rules)
 
         # ── Domain feature extraction ──
@@ -309,7 +312,7 @@ class MatchEngine:
         for cluster_id, cluster_info in clusters.items():
             if cluster_info["size"] > 1 and not cluster_info["oversized"]:
                 member_ids = cluster_info["members"]
-                cluster_df = collected_df.filter(pl.col("__row_id__").is_in(member_ids))
+                cluster_df = _to_frame(collected_df).filter_in("__row_id__", member_ids).native
                 golden = build_golden_record(cluster_df, golden_rules)
                 golden["__cluster_id__"] = cluster_id
                 golden_records.append(golden)
@@ -326,7 +329,7 @@ class MatchEngine:
                     if isinstance(val_info, dict) and "value" in val_info:
                         row[col] = val_info["value"]
                 golden_rows.append(row)
-            golden_df = pl.DataFrame(golden_rows)
+            golden_df = _frame_from_records(golden_rows, backend="polars").native
 
         # ── Classify dupes / unique ──
         multi_cluster_ids = [cid for cid, c in clusters.items() if c["size"] > 1]
@@ -335,8 +338,8 @@ class MatchEngine:
             dupe_row_ids.update(clusters[cid]["members"])
         unique_row_ids = set(all_ids) - dupe_row_ids
 
-        dupes_df = collected_df.filter(pl.col("__row_id__").is_in(list(dupe_row_ids)))
-        unique_df = collected_df.filter(pl.col("__row_id__").is_in(list(unique_row_ids)))
+        dupes_df = _to_frame(collected_df).filter_in("__row_id__", list(dupe_row_ids)).native
+        unique_df = _to_frame(collected_df).filter_in("__row_id__", list(unique_row_ids)).native
 
         # ── Stats ──
         stats = self._compute_stats(clusters, collected_df.height)

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py
@@ -11,6 +11,7 @@ from textual.message import Message
 from textual.widgets import Button, DataTable, Static
 
 from goldenmatch._polars_lazy import pl
+from goldenmatch.core.frame import to_frame as _to_frame
 from goldenmatch.tui.engine import EngineResult
 
 logger = logging.getLogger(__name__)
@@ -229,8 +230,8 @@ class BoostTab(Static):
         )
 
         # Build row lookup
-        row_a = self._data.filter(pl.col("__row_id__") == a)
-        row_b = self._data.filter(pl.col("__row_id__") == b)
+        row_a = _to_frame(self._data).filter_eq("__row_id__", a).native
+        row_b = _to_frame(self._data).filter_eq("__row_id__", b).native
 
         # Populate tables
         for table_id, row_df, label in [

--- a/packages/python/goldenmatch/goldenmatch/web/preview.py
+++ b/packages/python/goldenmatch/goldenmatch/web/preview.py
@@ -12,6 +12,7 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
     RulesPayload,
 )
+from goldenmatch.core.frame import to_frame as _to_frame
 from goldenmatch.core.lineage import build_lineage
 from goldenmatch.core.pipeline import run_dedupe_df
 from goldenmatch.web.registry import PreviewRegistry
@@ -186,7 +187,7 @@ def run_preview(
 
     # Re-attach __row_id__ so build_lineage can resolve pair indices. The pipeline
     # adds __row_id__ on its working copy; reconstruct the same column here.
-    enriched = df.with_columns(pl.int_range(0, df.height, dtype=pl.Int64).alias("__row_id__"))
+    enriched = _to_frame(df).with_row_index_int64("__row_id__").native
     lineage_records = build_lineage(
         scored_pairs=scored_pairs,
         df=enriched,

--- a/packages/python/goldenmatch/goldenmatch/web/routers/match.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/match.py
@@ -165,6 +165,7 @@ async def match_run(payload: MatchRequest, request: Request) -> dict:
         )
     except HTTPException:
         raise
+    # W5: backend-specific exception surface; goes backend-neutral at the flip.
     except (pl.exceptions.ColumnNotFoundError, ValueError) as exc:
         # KeyError is intentionally NOT caught here — it usually signals a
         # bug inside goldenmatch (renamed dict key, missing internal field)

--- a/packages/python/goldenmatch/goldenmatch/web/runs.py
+++ b/packages/python/goldenmatch/goldenmatch/web/runs.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from goldenmatch._polars_lazy import pl
+from goldenmatch.core.frame import to_frame as _to_frame
 
 
 @dataclass(frozen=True)
@@ -50,7 +51,7 @@ def load_run_manifest(ref: RunRef) -> RunManifest:
         run_name=ref.run_name,
         generated_at=lineage.get("generated_at", ""),
         total_pairs=int(lineage.get("total_pairs", 0)),
-        cluster_count=int(df.select(pl.col("cluster_id").n_unique()).item()),
+        cluster_count=int(_to_frame(df).column("cluster_id").n_unique()),
         row_count=int(df.height),
     )
 
@@ -95,7 +96,7 @@ def cluster_summaries(ref: RunRef) -> list[dict]:
 def cluster_detail(ref: RunRef, cluster_id: int) -> dict:
     df = load_clusters_df(ref)
     lineage = load_lineage(ref)
-    members = df.filter(pl.col("cluster_id") == cluster_id)
+    members = _to_frame(df).filter_eq("cluster_id", cluster_id).native
     if members.height == 0:
         raise KeyError(cluster_id)
     row_ids = [int(r) for r in members["row_id"]]


### PR DESCRIPTION
W4 batch 4 (off fresh main, W4c #1671 merged).

- chunked.py: row-id offset chain -> with_row_index + with_int64_offset + with_literal_column (byte-identical); four vertical concats -> concat_frames; scan-slice streaming + the std/matchkey lazy engines stay native with # W5: boundary comments.
- tui/engine.py: three __row_id__ membership filters -> filter_in; golden rows -> frame_from_records. tui/boost_tab.py: filter_eq x2. web/runs.py: n_unique + filter_eq. web/preview.py: int_range row index -> with_row_index_int64.
- # W5: boundary comments on mcp/a2a read_csv handlers, web/routers/match.py pl.exceptions catch, a2a isinstance-DataFrame dispatch, tui lazy-engine call sites (plan reviewer scope: boundary comments satisfy the W4 exit criterion, silence does not).

Gates: test_chunked, test_tui, test_streaming, test_a2a, test_mcp_ingest, test_mcp_new_tools, test_preview, test_api_rest_controller -- all green, unedited. ruff clean.