### PR TITLE
feat(goldenmatch): W4e-1 -- distributed relational sites + bucket-store stale-file fix

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -202,6 +202,7 @@ class Frame(Protocol):
     def with_group_min_over(self, key: str, value: str, name: str) -> Frame: ...
     def with_pair_canonical(self, a: str, b: str) -> Frame: ...
     def unique_by(self, subset: Sequence[str], keep: str = "first") -> Frame: ...
+    def with_mod_column(self, src: str, n: int, name: str) -> Frame: ...
 
 
 class PolarsColumn:
@@ -671,6 +672,10 @@ class PolarsFrame:
     def unique_by(self, subset: Sequence[str], keep: str = "first") -> PolarsFrame:
         # clustering ~1237 / pipeline.py:1970. Result order engine-defined.
         return PolarsFrame(self._df.unique(subset=list(subset), keep=keep))  # type: ignore[arg-type]
+
+    def with_mod_column(self, src: str, n: int, name: str) -> PolarsFrame:
+        # distributed/identity_partition.py:100-102 partition tag.
+        return PolarsFrame(self._df.with_columns((pl.col(src) % n).alias(name)))
 
 
 class ArrowColumn:
@@ -1260,6 +1265,16 @@ class ArrowFrame:
             else:
                 kept[key] = i
         return ArrowFrame(self._tbl.take(sorted(kept.values())))
+
+    def with_mod_column(self, src: str, n: int, name: str) -> ArrowFrame:
+        import pyarrow as pa
+
+        # No pc.mod kernel; Python % == polars % (PROBED: -11 % 3 == 1 on both).
+        vals = self._tbl.column(src).to_pylist()
+        out = [None if v is None else v % n for v in vals]
+        return ArrowFrame(
+            self._tbl.append_column(name, pa.array(out, type=self._tbl.column(src).type))
+        )
 
 
 def to_frame(obj: Any) -> Frame:

--- a/packages/python/goldenmatch/goldenmatch/distributed/identity_partition.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/identity_partition.py
@@ -62,43 +62,43 @@ def partition_cluster_frames(
           is deterministic; Polars' ``__hash__`` is based on bytewise
           contents on the i64 column).
     """
-    import polars as _pl
+    from goldenmatch.core.frame import empty_frame, to_frame
 
     if num_partitions < 1:
         raise ValueError(
             f"num_partitions must be >= 1; got {num_partitions}"
         )
 
+    # W4e: seam schemas + ops; ClusterFrames stays polars-typed until W5.
     empty_assignments_schema = {
-        "cluster_id": _pl.Int64(),
-        "member_id":  _pl.Int64(),
+        "cluster_id": "int64",
+        "member_id": "int64",
     }
     empty_metadata_schema = {
-        "cluster_id":       _pl.Int64(),
-        "size":             _pl.Int64(),
-        "confidence":       _pl.Float64(),
-        "quality":          _pl.Utf8(),
-        "oversized":        _pl.Boolean(),
-        "bottleneck_pair_a": _pl.Int64(),
-        "bottleneck_pair_b": _pl.Int64(),
+        "cluster_id": "int64",
+        "size": "int64",
+        "confidence": "float64",
+        "quality": "utf8",
+        "oversized": "bool",
+        "bottleneck_pair_a": "int64",
+        "bottleneck_pair_b": "int64",
     }
 
     if frames.metadata.is_empty():
         return [
             ClusterFrames(
-                assignments=_pl.DataFrame(schema=empty_assignments_schema),
-                metadata=_pl.DataFrame(schema=empty_metadata_schema),
+                assignments=empty_frame(empty_assignments_schema, backend="polars").native,
+                metadata=empty_frame(empty_metadata_schema, backend="polars").native,
             )
             for _ in range(num_partitions)
         ]
 
     # Tag every cluster with its partition index via ``cluster_id %
-    # num_partitions``. Polars supports modulo on integer columns
-    # natively. For i64 cluster_ids, this gives a uniform partition
+    # num_partitions``. For i64 cluster_ids this gives a uniform partition
     # distribution as long as cluster_ids aren't pathologically
     # correlated with N (uuidv7 + offset minted ids satisfy this).
-    metadata_tagged = frames.metadata.with_columns(
-        (_pl.col("cluster_id") % num_partitions).alias("__partition__"),
+    metadata_tagged = to_frame(frames.metadata).with_mod_column(
+        "cluster_id", num_partitions, "__partition__"
     )
 
     # Build partition_id -> cluster_id table once, then join the
@@ -107,21 +107,17 @@ def partition_cluster_frames(
     # the hash keeps the partition assignment consistent if the modulo
     # logic ever moves (single source of truth: metadata_tagged).
     partition_index = metadata_tagged.select(["cluster_id", "__partition__"])
-    assignments_tagged = frames.assignments.join(
-        partition_index, on="cluster_id", how="inner",
+    assignments_tagged = to_frame(frames.assignments).join_inner(
+        partition_index, on="cluster_id"
     )
 
     out: list[ClusterFrames] = []
     for i in range(num_partitions):
         part_assignments = (
-            assignments_tagged
-            .filter(_pl.col("__partition__") == i)
-            .drop("__partition__")
+            assignments_tagged.filter_eq("__partition__", i).drop(["__partition__"]).native
         )
         part_metadata = (
-            metadata_tagged
-            .filter(_pl.col("__partition__") == i)
-            .drop("__partition__")
+            metadata_tagged.filter_eq("__partition__", i).drop(["__partition__"]).native
         )
         out.append(ClusterFrames(
             assignments=part_assignments,
@@ -145,29 +141,29 @@ def merge_partitioned_frames(parts: list[ClusterFrames]) -> ClusterFrames:
         A single ``ClusterFrames`` whose ``assignments`` and ``metadata``
         are the row-concatenation of each partition's frames.
     """
-    import polars as _pl
+    from goldenmatch.core.frame import concat_frames, empty_frame, to_frame
 
     if not parts:
         # Caller should provide at least one partition; mirror the
         # ``partition_cluster_frames`` empty-input shape so the
         # round-trip is total.
         empty_assignments_schema = {
-            "cluster_id": _pl.Int64(),
-            "member_id":  _pl.Int64(),
-        }
+        "cluster_id": "int64",
+        "member_id": "int64",
+    }
         empty_metadata_schema = {
-            "cluster_id":       _pl.Int64(),
-            "size":             _pl.Int64(),
-            "confidence":       _pl.Float64(),
-            "quality":          _pl.Utf8(),
-            "oversized":        _pl.Boolean(),
-            "bottleneck_pair_a": _pl.Int64(),
-            "bottleneck_pair_b": _pl.Int64(),
-        }
+        "cluster_id": "int64",
+        "size": "int64",
+        "confidence": "float64",
+        "quality": "utf8",
+        "oversized": "bool",
+        "bottleneck_pair_a": "int64",
+        "bottleneck_pair_b": "int64",
+    }
         return ClusterFrames(
-            assignments=_pl.DataFrame(schema=empty_assignments_schema),
-            metadata=_pl.DataFrame(schema=empty_metadata_schema),
+            assignments=empty_frame(empty_assignments_schema, backend="polars").native,
+            metadata=empty_frame(empty_metadata_schema, backend="polars").native,
         )
-    assignments = _pl.concat([p.assignments for p in parts])
-    metadata = _pl.concat([p.metadata for p in parts])
+    assignments = concat_frames([to_frame(p.assignments) for p in parts]).native
+    metadata = concat_frames([to_frame(p.metadata) for p in parts]).native
     return ClusterFrames(assignments=assignments, metadata=metadata)

--- a/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/indicators.py
@@ -21,13 +21,20 @@ if TYPE_CHECKING:
 _INDICATOR_SAMPLE_CAP = 5000
 
 
+def _ffr_native(rows):
+    # W4e: seam constructor (engine inference); polars-typed contract until W5.
+    from goldenmatch.core.frame import frame_from_records
+
+    return frame_from_records(list(rows), backend="polars").native
+
+
 def _collect_indicator_sample(ds: Dataset, cap: int = _INDICATOR_SAMPLE_CAP) -> pl.DataFrame:
     total = ds.count()
     if total == 0:
         return pl.DataFrame()
     fraction = min(1.0, cap / total)
     rows = ds.random_sample(fraction=fraction).take(cap)
-    return pl.from_dicts(list(rows))
+    return _ffr_native(list(rows))
 
 
 def compute_column_priors_distributed(ds: Dataset) -> dict[str, ColumnPrior]:

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -405,13 +405,15 @@ def _join_clusters_to_rows(ds: Dataset, clusters: dict) -> Dataset:
             )
         lookup_raw = _ray.get(map_ref)
         lookup: dict[int, int] = dict(lookup_raw) if not isinstance(lookup_raw, dict) else lookup_raw
-        keys = list(lookup.keys())
-        vals = list(lookup.values())
-        out = df.with_columns(
-            pl.col("__row_id__").replace_strict(
-                keys, vals, default=-1,
-            ).alias("__cluster_id__")
-        ).filter(pl.col("__cluster_id__") != -1)
+        # W4e: seam ops (map_column default= == replace_strict(keys, vals,
+        # default); filter_not_in([-1]) == != -1, nulls unreachable post-default).
+        from goldenmatch.core.frame import to_frame
+
+        out = (
+            to_frame(df)
+            .map_column("__row_id__", "__cluster_id__", lookup, default=-1)
+            .filter_not_in("__cluster_id__", [-1])
+        )
         return out.to_arrow()
 
     return ds.map_batches(_annotate, batch_format="pyarrow")

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -223,16 +223,30 @@ def materialize_bucketed_blocks(
     """
     sig_hash = _sanitize_signature(signature)
     bucket_dir = store.path.parent / f"buckets_{sig_hash}"
+    # W4e FIX (latent stale-file bug): the signature is CONFIG-ONLY, so a
+    # persisted store re-materialized with different data (or, post-W5, a
+    # different backend hash) would leave stale bucket=K parquets that
+    # iter_buckets happily returns. Materialize is an authoritative rebuild:
+    # clear the dir first.
+    if bucket_dir.exists():
+        import shutil
+
+        shutil.rmtree(bucket_dir)
     bucket_dir.mkdir(parents=True, exist_ok=True)
 
     # Normalize to a Polars DataFrame.
     if isinstance(block_assignments, dict):
         if not block_assignments:
             return bucket_dir
-        rid_to_block = pl.DataFrame({
-            "__row_id__": list(block_assignments.keys()),
-            "__block_key__": list(block_assignments.values()),
-        })
+        from goldenmatch.core.frame import frame_from_column_data
+
+        rid_to_block = frame_from_column_data(
+            {
+                "__row_id__": list(block_assignments.keys()),
+                "__block_key__": list(block_assignments.values()),
+            },
+            backend="polars",
+        ).native
     else:
         rid_to_block = block_assignments
         if rid_to_block.height == 0:
@@ -246,24 +260,25 @@ def materialize_bucketed_blocks(
 
     # Inner join attaches __block_key__. Rows in `df` without an
     # assignment drop out (matches v1: unassigned rows weren't scored).
-    keyed = df.join(rid_to_block, on="__row_id__", how="inner")
+    from goldenmatch.core.frame import to_frame
 
-    # Bucket assignment via Polars xxHash with fixed seed.
-    with_bucket = keyed.with_columns(
+    keyed = to_frame(df).join_inner(to_frame(rid_to_block), on="__row_id__")
+
+    # Bucket assignment via Polars xxHash with fixed seed. W5: bucket layout
+    # is per-backend shard-internal (never output-visible; the clear-on-
+    # materialize above makes cross-run reuse of a differently-hashed layout
+    # impossible) -- the arrow lane gets its own stable hash at the flip.
+    with_bucket = keyed.native.with_columns(
         (pl.col("__block_key__").hash(seed=BUCKET_HASH_SEED) % n_buckets)
         .alias("__bucket__"),
     )
 
-    for bucket_id, bucket_df in with_bucket.partition_by(
-        "__bucket__", as_dict=True,
-    ).items():
-        # bucket_id may arrive as a tuple (Polars >= 1.0 with as_dict=True
-        # uses tuple keys for partition cols). Unwrap.
-        if isinstance(bucket_id, tuple):
-            bucket_id = bucket_id[0]
+    # W4e: group_partitions == partition_by(as_dict) with unwrapped keys.
+    for bucket_id, bucket_frame in to_frame(with_bucket).group_partitions("__bucket__"):
         bucket_path = bucket_dir / f"bucket={int(bucket_id)}" / "data.parquet"
         bucket_path.parent.mkdir(parents=True, exist_ok=True)
-        bucket_df.drop("__bucket__").write_parquet(
+        # W5: parquet shard IO goes through io_arrow twins at the flip.
+        bucket_frame.drop(["__bucket__"]).native.write_parquet(
             bucket_path, compression="snappy",
         )
 

--- a/packages/python/goldenmatch/goldenmatch/distributed/sample.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/sample.py
@@ -9,6 +9,13 @@ if TYPE_CHECKING:
     from ray.data import Dataset
 
 
+def _ffr_native(rows):
+    # W4e: seam constructor (engine inference); polars-typed contract until W5.
+    from goldenmatch.core.frame import frame_from_records
+
+    return frame_from_records(list(rows), backend="polars").native
+
+
 def take_sample_distributed(ds: Dataset, sample_cap: int = 20_000) -> pl.DataFrame:
     """Pull a bounded sample from a Ray Dataset as a Polars DataFrame.
 
@@ -28,4 +35,4 @@ def take_sample_distributed(ds: Dataset, sample_cap: int = 20_000) -> pl.DataFra
         # Pull a small headroom so random_sample's approximate fraction
         # doesn't undershoot the cap on tiny inputs.
         rows = ds.random_sample(fraction=min(1.0, fraction * 1.5)).take(sample_cap)
-    return pl.from_dicts(list(rows))
+    return _ffr_native(list(rows))

--- a/packages/python/goldenmatch/tests/test_bucketed_store.py
+++ b/packages/python/goldenmatch/tests/test_bucketed_store.py
@@ -172,3 +172,37 @@ def test_hash_distribution_skew_bounded(tmp_path: Path):
             sizes.append(load_bucket(path).height)
     assert min(sizes) > 0
     assert max(sizes) / min(sizes) <= 3.0
+
+
+def test_materialize_clears_stale_bucket_files(tmp_path):
+    """W4e regression: re-materializing over an existing bucket_dir must not
+    leave bucket files from the previous materialize (the signature is
+    config-only, so data changes reuse the same dir)."""
+    import polars as pl
+    from goldenmatch.distributed.record_store import (
+        PreparedRecordStore,
+        iter_buckets,
+        materialize_bucketed_blocks,
+    )
+
+    store = PreparedRecordStore(path=tmp_path / "prep.duckdb")
+    df1 = pl.DataFrame({"__row_id__": [1, 2, 3], "name": ["a", "b", "c"]})
+    assign1 = {1: "k1", 2: "k2", 3: "k3"}
+    d1 = materialize_bucketed_blocks(
+        store, df1, block_assignments=assign1, n_buckets=8, signature="sig"
+    )
+    first = {b for b, _ in iter_buckets(d1)}
+    assert first
+
+    # Second materialize, SAME signature, one row: only its bucket survives.
+    df2 = pl.DataFrame({"__row_id__": [1], "name": ["a"]})
+    d2 = materialize_bucketed_blocks(
+        store, df2, block_assignments={1: "k1"}, n_buckets=8, signature="sig"
+    )
+    assert d2 == d1
+    second = {b for b, _ in iter_buckets(d2)}
+    assert len(second) == 1
+    total_rows = sum(
+        pl.read_parquet(p).height for _, p in iter_buckets(d2)
+    )
+    assert total_rows == 1

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -252,3 +252,14 @@ def test_frame_from_column_data_empty_columns(backend):
     f = frame_from_column_data({"a": [], "b": []}, backend=backend)
     assert f.height == 0
     assert f.columns == ["a", "b"]
+
+
+# -- with_mod_column (W4e) --------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_mod_column(backend):
+    # identity_partition.py partition tag: cluster_id % num_partitions.
+    f = _mk({"cluster_id": [10, 11, 12, None]}, backend)
+    out = f.with_mod_column("cluster_id", 3, "__partition__")
+    assert out.column("__partition__").to_list() == [1, 2, 0, None]


### PR DESCRIPTION
W4 batch 6 (off fresh main; W4e-2 clustering/scoring kernels follow separately with the 5M bench gate).

- New seam op with_mod_column (partition tag; arrow twin via Python % -- probed == polars % incl negatives; no pc.mod kernel exists).
- identity_partition.py fully seam-routed (empty_frame schemas / with_mod_column / join_inner / filter_eq / drop / concat_frames).
- distributed/pipeline.py _annotate: replace_strict(keys, vals, default=-1) + != -1 -> map_column(default=-1) + filter_not_in([-1]) (value-identical).
- sample.py / indicators.py from_dicts -> frame_from_records (probed missing-key inference parity).
- record_store.py: join_inner + group_partitions + frame_from_column_data; polars .hash(seed) stays native with the per-backend W5 note. **FIX (plan-reviewer-found latent bug)**: materialize_bucketed_blocks now clears an existing bucket_dir -- the cache signature is config-only, so re-materializing with different data left stale bucket parquets that iter_buckets returned and workers scored. Regression test added.
- RC-WCC checkpoint boundary untouched (W4e-2 scope).

Gates: partition_cluster_frames, bucketed_store (+ new stale-file regression), prepared_record_store, frame w4 ops, relational ops -- 128 passed locally; Ray suites in CI. ruff clean.