### PR TITLE
feat(goldencheck): W1 fused aggregate kernel + neutral dtype vocabulary (Arrow fused-scan program)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldencheck-w1-fused-aggregate.md
+++ b/docs/superpowers/plans/2026-07-11-goldencheck-w1-fused-aggregate.md
@@ -1,0 +1,62 @@
+# GoldenCheck W1 — fused aggregate — Implementation Plan
+
+> Use superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Build the fused Arrow-native `column_aggregate` kernel (`{len, null_count, n_unique_nonnull, dtype}` in one pass) + the neutral dtype vocabulary/`dtype_category` shim. Shadow-wire the full-scan column loop; convert the dtype gates. `scan_columns` untouched. No user-visible change.
+
+**Spec:** `docs/superpowers/specs/2026-07-11-goldencheck-w1-fused-aggregate-design.md`.
+**Base:** fresh `origin/main` (W0-land arrow-in-core + parity harness + CSV kernel). Worktree `gc-w1`, branch `feat/goldencheck-w1-fused-aggregate`.
+
+## Conventions
+Rust: `export PATH="/d/.rustup/toolchains/1.94.0-x86_64-pc-windows-msvc/bin:$PATH" CARGO_HOME=/d/.cargo RUSTUP_HOME=/d/.rustup`. Python: `export PYTHONPATH="D:/show_case/gc-w1/packages/python/goldencheck" POLARS_SKIP_CPU_CHECK=1 GOLDENCHECK_NATIVE=auto; PY=/d/show_case/goldenmatch/.venv/Scripts/python.exe`. Native build per prior waves (.dll->.pyd). Ruff 100-char.
+
+**Contract (from spec):** `ColumnAgg{len, null_count, n_unique_nonnull, dtype: DtypeCat}` — ONE pass (bitmap null_count + one non-null hash set + O(1) dtype). uniqueness = n_unique_nonnull; cardinality = n_unique_nonnull + (1 if null_count>0); nullability = len+null_count. `dtype_category(arrow)` = the 8 neutral cats == `_neutral_dtype(pl.dtype)`. Kernel replaces COUNTS+dtype-gate only (not value passes).
+
+**INVARIANTS:** native `column_aggregate` == Polars reductions (parity, empty registry); `dtype_category==_neutral_dtype` (8 cats); `scan_columns` UNCHANGED; full-scan `ColumnProfile` authoritative values UNCHANGED (Polars) — fused runs SHADOW; `inferred_type` string unchanged (neutral divergence deferred to Flip); existing tests UNEDITED; `import goldencheck` zero polars; regex/date/csv_infer/benford symbols intact. Commit per task; don't push.
+
+---
+
+## Task 1: `column_aggregate` + `dtype_category` Rust kernel + parity
+
+**Files:** `goldencheck-core/src/aggregate.rs` (new), `lib.rs`; `goldencheck-native/src/aggregate.rs` (new) + `lib.rs`; `_native_loader.py` (`column_aggregate` component); Test `tests/core/test_column_aggregate_parity.py` (new).
+
+- [ ] **Step 1:** `goldencheck-core/src/aggregate.rs`: `pub enum DtypeCat { Str, Int, Uint, Float, Date, Datetime, Bool, Other }` + `pub fn dtype_category(array: &dyn Array) -> DtypeCat` (Arrow type -> cat: Utf8/LargeUtf8->Str; Int*->Int; UInt*->Uint; Float*->Float; Date32/Date64->Date; Timestamp->Datetime; Boolean->Bool; else Other). `pub struct ColumnAgg { pub len: usize, pub null_count: usize, pub n_unique_nonnull: usize, pub dtype: DtypeCat }` + `pub fn column_aggregate(array: &dyn Array) -> ColumnAgg` — ONE pass: `len = array.len()`, `null_count = array.null_count()` (bitmap), `n_unique_nonnull` = hash the non-null values (downcast per type; for float, hash the bit pattern -- but MATCH Polars n_unique on NaN: test what Polars does + match, register a divergence if unmatchable), `dtype = dtype_category(array)`. `#[cfg(test)]` tests. `mod aggregate;` + `pub use` in lib.rs.
+- [ ] **Step 2:** `goldencheck-native/src/aggregate.rs`: `#[pyfunction] pub fn column_aggregate(array: PyArrowType<ArrayData>) -> (usize, usize, usize, String)` returning `(len, null_count, n_unique_nonnull, dtype_str)` where dtype_str is the neutral string ("str"/"int"/.../"other"). Register in native lib.rs. Add `"column_aggregate": ("column_aggregate",)` to `_COMPONENT_SYMBOLS`.
+- [ ] **Step 3:** Build both crates (grep `^error`), rustfmt/clippy, wasm check. Build ext (.dll->.pyd). Verify `column_aggregate` + benford/regex/date/csv_infer symbols present.
+- [ ] **Step 4:** PARITY test `tests/core/test_column_aggregate_parity.py`: for random + adversarial columns (ints, floats incl NaN, strings, bools, dates, all-null, single, with/without nulls, heterogeneous-via-arrow), build a `pl.Series`, call native `column_aggregate(series.to_arrow())`, assert `len == len(s)`, `null_count == s.null_count()`, `n_unique_nonnull == s.drop_nulls().n_unique()`, `dtype_str == _neutral_dtype(s.dtype)`. Register `column_aggregate` in the parity harness (empty divergence — if NaN forces a divergence, register it explicitly). Both lanes.
+- [ ] **Step 5:** Commit: `feat(goldencheck-core): W1 column_aggregate + dtype_category fused kernel (parity w/ Polars)`.
+
+## Task 2: Python `dtype_category` mirror + convert the dtype gates (output-identical)
+
+**Files:** `goldencheck/core/frame.py` (or a small `dtype.py`) — a `dtype_category()` helper; `engine/scanner.py` + `profilers/type_inference.py` — route their dtype gates through it.
+
+- [ ] **Step 1:** Add a Python `dtype_category(pl_dtype_or_arrow) -> str` returning the 8 neutral cats. It must equal `_neutral_dtype` for pl dtypes (reuse/wrap `_neutral_dtype`) and match the Rust kernel. (This consolidates the shim; `_neutral_dtype` already exists — `dtype_category` is the single public entry.)
+- [ ] **Step 2:** Convert the full-scan column-loop dtype gates in `scanner.py` (`is_string = col.dtype in (pl.Utf8, pl.String)` etc.) + `type_inference.py`'s dtype branch to call `dtype_category(...)` and compare to `"str"`/`"int"`/etc. This must be OUTPUT-IDENTICAL (type_inference already branches on `_neutral_dtype` values; the column-loop tuple checks map 1:1). Do the type_inference + column-loop sites ONLY (leave the other ~13 dtype sites with a tracking comment).
+- [ ] **Step 3:** Run existing profiler/scanner tests -> UNEDITED green (output-identical):
+```bash
+$PY -m pytest packages/python/goldencheck/tests -k "type_inference or scanner or profilers" -q
+```
+Ruff clean. Commit: `refactor(goldencheck): W1 dtype_category shim + convert type_inference/column-loop gates (output-identical)`.
+
+## Task 3: shadow-wire the full-scan column loop + shadow test
+
+**Files:** `engine/scanner.py` (the `_scan_dataframe_impl` column loop); Test `tests/engine/test_column_aggregate_shadow.py` (new).
+
+- [ ] **Step 1:** In the `_scan_dataframe_impl` column loop, when `native_enabled("column_aggregate")`, ALSO compute the fused kernel in SHADOW: `agg = native_module().column_aggregate(col.to_arrow())`. The AUTHORITATIVE `ColumnProfile` values STAY the Polars-computed ones (`null_count`, `n_unique`, `str(col.dtype)`). The shadow agg is computed + (optionally) logged/asserted in tests — do NOT change the emitted ColumnProfile. (Keep it cheap + guarded; if native absent, skip the shadow compute entirely.)
+- [ ] **Step 2:** Shadow test `tests/engine/test_column_aggregate_shadow.py`: for a fixture `pl.DataFrame`, assert that for each column `column_aggregate(col.to_arrow())` MATCHES the Polars `ColumnProfile` values the loop computes (`null_count`, `n_unique_nonnull == non_null.n_unique()`, `dtype_category == _neutral_dtype`). This proves the fused values are ready to become authoritative at the Flip.
+- [ ] **Step 3:** Run + verify the full scan's OUTPUT is unchanged (ColumnProfile authoritative values identical):
+```bash
+$PY -m pytest packages/python/goldencheck/tests/engine/test_column_aggregate_shadow.py -v
+$PY -m pytest packages/python/goldencheck/tests -k "scan_dataframe or scan_file or scanner" -q
+```
+Existing scan tests UNEDITED green. Ruff clean. Commit: `feat(goldencheck): W1 shadow-compute column_aggregate in the full-scan loop (authoritative unchanged)`.
+
+## Task 4: final verification + PR
+
+- [ ] Full targeted verification: parity (both lanes); scan_columns UNCHANGED (its tests unedited); full-scan ColumnProfile unchanged; dtype-gate sites output-identical; cargo test; wasm check; ruff; import gate; all native symbols intact. Confirm NO user-visible change (shadow). PR to main (additive, no version bump), arm auto-merge.
+
+## Done criteria
+- `column_aggregate` + `dtype_category` fused kernel (Rust source of truth), parity-green vs Polars (empty registry, NaN handled/registered).
+- Neutral dtype vocabulary + `dtype_category` shim landed; type_inference + column-loop gates converted (output-identical).
+- Full-scan loop shadow-computes the fused agg; authoritative ColumnProfile UNCHANGED; shadow test proves the match.
+- scan_columns untouched; existing suite green; zero polars; no version bump. Foundation + pattern ready for W2.

--- a/docs/superpowers/specs/2026-07-11-goldencheck-w1-fused-aggregate-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w1-fused-aggregate-design.md
@@ -7,9 +7,14 @@ Base: fresh `origin/main` (has W0-land arrow-in-core + parity harness; CSV wave 
 
 ## Goal
 
-Build a **fused Arrow-native Rust kernel** that computes, in ONE pass over a column, the aggregate stats the four cheapest checks need — **nullability, uniqueness, cardinality, type_inference** — plus the `ColumnProfile` fields. Rust = source of truth; the current Polars/`PyColumn` path is the parity oracle + fallback. Define the **owned neutral dtype vocabulary** + a single `dtype_category()` shim that replaces the ~15 duplicated `pl.Utf8`/numeric-tuple dtype checks. **Shadow discipline:** the fused path is computed + CI-compared but the 2.x output stays authoritative until the Flip.
+Build a **fused Arrow-native Rust kernel** `column_aggregate(&dyn Array)` that computes, in ONE pass over a column, the aggregate stats the cheap column checks need (`null_count`, `n_unique_nonnull`, `dtype`) — feeding **nullability, uniqueness, cardinality** and the `ColumnProfile`. Rust = source of truth; the current Polars/`PyColumn` path is the parity oracle. Define the **owned neutral dtype vocabulary** + a single `dtype_category()` shim that replaces the duplicated `pl.Utf8`/numeric-tuple dtype checks (used by the four checks' dtype gates, incl. `type_inference`'s gate).
 
-These four checks are ALREADY polars-free via `scan_columns`/`PyColumn` (S2.1). W1 is NOT about eviction — it is about (a) FUSING them into one kernel pass (perf/peak-RSS + the pattern for W2-W5), (b) making them Rust-authoritative, (c) landing the dtype vocabulary, (d) wiring the fused kernel into BOTH scan paths (`scan_columns` + the full-scan column loop, which still uses raw `pl.Series` ops).
+**Corrected scope (from spec review):**
+- The three MECHANICAL profilers in `scan_columns` are Nullability/Uniqueness/Cardinality (`_MECHANICAL_PROFILERS`, scanner.py). **`type_inference` is NOT in `scan_columns`** — it's full-scan-only and can't run on a `PyColumn` (it needs `.cast("float")`, which `PyColumn` doesn't implement). W1 touches type_inference only via its **dtype gate** (`dtype_category`), not a scan_columns swap.
+- **`scan_columns` (list-backed `PyColumn` over `dict[str,list]`) is UNCHANGED in W1.** Routing an Arrow-in kernel there would need a per-column `list -> Arrow` build that may be net-negative on small columns AND re-introduce an Arrow-type-inference step that must match `PyColumn.dtype`'s first-non-null heuristic — not worth it now. Leave `scan_columns` on PyColumn (already polars-free).
+- **The fused kernel targets the FULL-SCAN column loop** (`_scan_dataframe_impl`, raw `pl.Series`), in SHADOW: convert each `pl.Series -> Arrow (to_arrow()) -> column_aggregate`, CI-compare to the Polars-computed `ColumnProfile` stats, but the authoritative values stay Polars until the Flip (when the full-scan input becomes Arrow and the `to_arrow()` cost disappears).
+
+So W1 = (a) the fused kernel + the pattern for W2-W5, (b) the neutral dtype vocabulary + `dtype_category` shim (collapsing the dtype-check debt), (c) Rust-authoritative-in-shadow for the full-scan aggregates. **Perf is measure-first**, not asserted — real fusion (one bitmap+hashset pass) is a genuine win over Arrow, but over Python lists it may not beat `set()`/`sum()`; W1's value is the pattern + vocabulary + Rust-authority, and any perf claim is measured before it's made (the repo's measure-wall-clock lesson).
 
 ## The neutral dtype vocabulary (the cross-cutting decision, fixed here)
 
@@ -23,31 +28,35 @@ Adopt the vocabulary the Frame seam's `_neutral_dtype` already uses: **`str`, `i
 `column_aggregate(array: &dyn Array) -> ColumnAgg` in `goldencheck-core` (new `fused.rs` or `aggregate.rs`):
 ```rust
 pub struct ColumnAgg {
-    pub len: usize,          // total rows
-    pub null_count: usize,   // from the Arrow null bitmap (correctness upgrade — bitmap-direct)
-    pub n_unique: usize,     // distinct non-null values (hash set; null counted per the seam: cardinality counts null-as-1, uniqueness post-drop-nulls)
-    pub dtype: DtypeCat,     // the neutral category
+    pub len: usize,               // total rows
+    pub null_count: usize,        // from the Arrow null bitmap (correctness upgrade — bitmap-direct)
+    pub n_unique_nonnull: usize,  // distinct EXCLUDING null (one hash set, non-null only)
+    pub dtype: DtypeCat,          // the neutral category
     // room to grow (min/max land in W2 for range)
 }
 ```
-- **ONE pass**: stream the null bitmap for `null_count`; build a hash set for `n_unique` in the same pass; `dtype` from the array type (O(1)). (n_unique's null-counting must match the seam exactly: `cardinality` uses full-column `n_unique` counting null as 1 distinct; `uniqueness` uses post-`drop_nulls` n_unique. Decide whether the kernel returns both `n_unique_all` and `n_unique_nonnull`, or the caller adjusts by +1 when a null exists — match `PyColumn.n_unique` / `_neutral_dtype` behaviour exactly, verified by parity.)
+- **ONE pass**: stream the null bitmap for `null_count`; build ONE hash set over the non-null values for `n_unique_nonnull`; `dtype` from the array type (O(1)). NO second hash set.
+- **Caller derivations (verified against the profilers):** uniqueness uses `n_unique_nonnull` directly (matches `non_null.n_unique()`); cardinality uses `n_unique_nonnull + (1 if null_count > 0 else 0)` (matches `PyColumn.n_unique() == len(set(self._v))`, which counts null as 1 distinct); nullability uses `len` + `null_count`; the full-scan `ColumnProfile.unique_count` also uses `n_unique_nonnull` (`non_null.n_unique()`). So one `n_unique_nonnull` + `null_count` covers all four — the "+1 in the caller" is the resolution of the flagged null-counting risk.
+- **The kernel replaces the COUNTS + dtype gate ONLY** — not the value passes: cardinality's `sample_values` (`drop_nulls().unique().sort()`) and type_inference's numeric-cast still touch raw values (unchanged). W1 does not eliminate those.
 - Native shim + `_COMPONENT_SYMBOLS["column_aggregate"]`. Arrow-in (reuse W0-land's `arrow_support`).
 
-## Wiring (shadow)
-- **`scan_columns` (polars-free, PyColumn-backed):** the nullability/uniqueness/cardinality/type_inference profilers currently each call `col.null_count()` / `col.n_unique()` / `col.dtype` on `PyColumn`. Route these through `column_aggregate` (one kernel call per column feeding all four) when `native_enabled("column_aggregate")`; PyColumn stays the fallback. This is where the fused kernel becomes REAL + authoritative (scan_columns is already polars-free, so no shadow needed here — it's a direct swap, parity-gated).
-- **Full scan (`_scan_dataframe_impl` column loop, raw `pl.Series`):** compute `column_aggregate` in SHADOW — convert each `pl.Series -> Arrow (to_arrow()) -> column_aggregate`, compare to the Polars-computed `null_count`/`n_unique`/`dtype` via the parity harness, but the **authoritative `ColumnProfile` values stay the Polars ones** until the Flip. (At the Flip, the full scan takes Arrow directly and the fused values become authoritative.)
-- The redundant double-compute (the column loop computes null_count/n_unique for `ColumnProfile` AND the profilers recompute) is noted; fully collapsing it is a Flip-time cleanup, not W1.
+## Wiring
+- **`scan_columns` (list-backed PyColumn): UNCHANGED in W1** (see Goal — no Arrow-in swap over Python lists this wave).
+- **Full scan (`_scan_dataframe_impl` column loop, raw `pl.Series`): compute `column_aggregate` in SHADOW.** Convert each `pl.Series -> Arrow (to_arrow()) -> column_aggregate`; CI-compare (via the parity harness) to the Polars-computed `null_count`/`n_unique_nonnull`/`dtype`; the **authoritative `ColumnProfile` values stay the Polars ones** until the Flip (when the full-scan input becomes Arrow and `to_arrow()` disappears). No user-visible change.
+- **dtype gates -> neutral, NOW, authoritative (output-identical).** `type_inference` (and the column-loop `is_string`/`is_numeric` gates) already branch on the NEUTRAL dtype semantics (`type_inference.py` reads `col.dtype -> _neutral_dtype`, branching on `"str"`/`"int"`/`"float"`; the column loop's `pl.Utf8`/numeric-tuple checks map 1:1 to `str`/`int`/`uint`/`float`). Routing these gates through `dtype_category` is output-identical PROVIDED `dtype_category(arrow) == _neutral_dtype(pl.dtype)` (parity-locked). This is authoritative now (not shadow) because it changes no output.
+- **`ColumnProfile.inferred_type` string -> the ONE deferred divergence.** It is `str(pl.dtype)` (`"Int64"`) today; the neutral form (`"int"`) is a DIFFERENT value from anything the profilers' dtype gates emit. W1 does NOT change `inferred_type` (stays `str(pl.dtype)`, user-visible); the neutral-vs-Polars-string difference is registered for the Flip's dtype-string bucket.
+- The redundant double-compute (loop computes counts for `ColumnProfile` AND profilers recompute) is noted; collapsing it is Flip-time cleanup, not W1.
 
 ## Parity / contract
-- `column_aggregate` (native) == the `PyColumn`/Polars reductions: `null_count` exact, `n_unique` exact (matching the seam's null-counting), `dtype` == `_neutral_dtype`. Registered in the W0-land parity harness, **empty divergence registry** (these are integer/enum-exact).
-- No user-visible change (shadow); the neutral-vs-Polars `inferred_type` string is the only divergence, deferred to the Flip.
-- `import goldencheck` loads zero polars; existing suite green (the swap in `scan_columns` is parity-locked; the full-scan authoritative output unchanged).
+- `column_aggregate` (native, on `pl.Series.to_arrow()`) == the Polars reductions: `null_count` exact, `n_unique_nonnull` == `non_null.n_unique()` exact, `dtype` == `_neutral_dtype(pl.dtype)`. Registered in the W0-land parity harness, **empty divergence registry** (integer/enum-exact).
+- `dtype_category(arrow) == _neutral_dtype(pl.dtype)` — the parity that makes the gate-routing output-identical. Assert across all 8 categories.
+- No user-visible change: `scan_columns` unchanged; the full-scan `ColumnProfile` authoritative values stay Polars; `inferred_type` string unchanged (its neutral-form divergence is deferred to the Flip).
+- `import goldencheck` loads zero polars; existing suite green.
 
 ## Testing
-- Rust: `column_aggregate` + `dtype_category` over Arrow arrays (null/empty/single/all-null; each of the 8 dtype categories; n_unique with + without nulls).
-- Parity harness: native `column_aggregate` == `PyColumn` reductions on random + adversarial columns (register `column_aggregate`, empty divergence).
-- Python: `scan_columns` findings for nullability/uniqueness/cardinality/type_inference are IDENTICAL with the fused kernel routed in (parity-locked — existing `scan_columns` tests pass UNEDITED). The full-scan `ColumnProfile` values unchanged (authoritative Polars path untouched); a shadow test asserts the fused values MATCH the Polars ones on a fixture.
-- `dtype_category` shim: the converted call sites (type_inference + the column-loop dtype gates) behave identically (existing tests unedited).
+- Rust: `column_aggregate` + `dtype_category` over Arrow arrays — null/empty/single/all-null; each of the 8 dtype categories; `n_unique_nonnull` with + without nulls; **NaN-float and heterogeneous inputs** (float NaN counts distinct differently across engines; include so the divergence, if any, is caught).
+- Parity harness: native `column_aggregate` == Polars reductions on random + adversarial columns (register `column_aggregate`, empty divergence).
+- Python: existing `scan_columns` tests pass UNEDITED (scan_columns untouched). The full-scan `ColumnProfile` values unchanged (authoritative Polars path); a SHADOW test asserts `column_aggregate` (on `pl.Series.to_arrow()`) MATCHES the Polars `null_count`/`n_unique`/`dtype` on a corpus. The `dtype_category`-converted gate sites (`type_inference` + the column-loop `is_string`/`is_numeric`) behave identically -> existing profiler/scanner tests pass UNEDITED.
 
 ## Risks
 - **n_unique null-counting mismatch** — the seam's cardinality-counts-null-as-1 vs uniqueness-post-dropnull is subtle; the kernel must expose whatever the callers need + parity-lock it. Top risk (a silent off-by-one in a count).

--- a/docs/superpowers/specs/2026-07-11-goldencheck-w1-fused-aggregate-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w1-fused-aggregate-design.md
@@ -1,0 +1,59 @@
+# GoldenCheck W1 — fused aggregate column checks — design
+
+Date: 2026-07-11
+Status: wave design (Arrow fused-scan program). Pending spec review + user approval.
+Program: `2026-07-11-goldencheck-arrow-fused-scan-engine-program-design.md` + `...-W-path-scoping.md`. This is **W1** — the first wave that builds the fused-kernel scan pattern, on the lowest-risk checks. It also lands the **neutral dtype vocabulary + `dtype_category` shim** the whole W-path depends on.
+Base: fresh `origin/main` (has W0-land arrow-in-core + parity harness; CSV wave enqueuing).
+
+## Goal
+
+Build a **fused Arrow-native Rust kernel** that computes, in ONE pass over a column, the aggregate stats the four cheapest checks need — **nullability, uniqueness, cardinality, type_inference** — plus the `ColumnProfile` fields. Rust = source of truth; the current Polars/`PyColumn` path is the parity oracle + fallback. Define the **owned neutral dtype vocabulary** + a single `dtype_category()` shim that replaces the ~15 duplicated `pl.Utf8`/numeric-tuple dtype checks. **Shadow discipline:** the fused path is computed + CI-compared but the 2.x output stays authoritative until the Flip.
+
+These four checks are ALREADY polars-free via `scan_columns`/`PyColumn` (S2.1). W1 is NOT about eviction — it is about (a) FUSING them into one kernel pass (perf/peak-RSS + the pattern for W2-W5), (b) making them Rust-authoritative, (c) landing the dtype vocabulary, (d) wiring the fused kernel into BOTH scan paths (`scan_columns` + the full-scan column loop, which still uses raw `pl.Series` ops).
+
+## The neutral dtype vocabulary (the cross-cutting decision, fixed here)
+
+Adopt the vocabulary the Frame seam's `_neutral_dtype` already uses: **`str`, `int`, `uint`, `float`, `date`, `datetime`, `bool`, `other`** (8 categories). This becomes the owned `inferred_type` value + the input to every dtype gate. It is COARSER than Polars' `str(dtype)` (`"Int64"` -> `"int"`, losing bit-width — nothing in the data-quality reporting depends on bit-width; documented).
+
+- **`dtype_category(&dyn Array) -> DtypeCat`** in `goldencheck-core` (Arrow type -> the 8 categories), + a Python `dtype_category()` mirror. The ~15 duplicated `col.dtype in (pl.Utf8, pl.String)` / numeric-tuple checks across `scanner.py`, `_post_classification_checks`, `profilers/*`, `relations/*`, `semantic/classifier.py` collapse into this one shim (mechanical; do it incrementally, not all at once — W1 lands the shim + converts the type_inference + column-loop sites; later waves convert their own).
+- **`inferred_type` stays `str(pl.dtype)` (user-visible) until the Flip** — the fused kernel produces the neutral vocabulary, and the neutral-vs-Polars-string difference is a **registered divergence** (the Flip gate's dtype-string bucket). W1 does NOT change what users see; it just makes the neutral form available + authoritative-in-shadow.
+
+## The fused kernel
+
+`column_aggregate(array: &dyn Array) -> ColumnAgg` in `goldencheck-core` (new `fused.rs` or `aggregate.rs`):
+```rust
+pub struct ColumnAgg {
+    pub len: usize,          // total rows
+    pub null_count: usize,   // from the Arrow null bitmap (correctness upgrade — bitmap-direct)
+    pub n_unique: usize,     // distinct non-null values (hash set; null counted per the seam: cardinality counts null-as-1, uniqueness post-drop-nulls)
+    pub dtype: DtypeCat,     // the neutral category
+    // room to grow (min/max land in W2 for range)
+}
+```
+- **ONE pass**: stream the null bitmap for `null_count`; build a hash set for `n_unique` in the same pass; `dtype` from the array type (O(1)). (n_unique's null-counting must match the seam exactly: `cardinality` uses full-column `n_unique` counting null as 1 distinct; `uniqueness` uses post-`drop_nulls` n_unique. Decide whether the kernel returns both `n_unique_all` and `n_unique_nonnull`, or the caller adjusts by +1 when a null exists — match `PyColumn.n_unique` / `_neutral_dtype` behaviour exactly, verified by parity.)
+- Native shim + `_COMPONENT_SYMBOLS["column_aggregate"]`. Arrow-in (reuse W0-land's `arrow_support`).
+
+## Wiring (shadow)
+- **`scan_columns` (polars-free, PyColumn-backed):** the nullability/uniqueness/cardinality/type_inference profilers currently each call `col.null_count()` / `col.n_unique()` / `col.dtype` on `PyColumn`. Route these through `column_aggregate` (one kernel call per column feeding all four) when `native_enabled("column_aggregate")`; PyColumn stays the fallback. This is where the fused kernel becomes REAL + authoritative (scan_columns is already polars-free, so no shadow needed here — it's a direct swap, parity-gated).
+- **Full scan (`_scan_dataframe_impl` column loop, raw `pl.Series`):** compute `column_aggregate` in SHADOW — convert each `pl.Series -> Arrow (to_arrow()) -> column_aggregate`, compare to the Polars-computed `null_count`/`n_unique`/`dtype` via the parity harness, but the **authoritative `ColumnProfile` values stay the Polars ones** until the Flip. (At the Flip, the full scan takes Arrow directly and the fused values become authoritative.)
+- The redundant double-compute (the column loop computes null_count/n_unique for `ColumnProfile` AND the profilers recompute) is noted; fully collapsing it is a Flip-time cleanup, not W1.
+
+## Parity / contract
+- `column_aggregate` (native) == the `PyColumn`/Polars reductions: `null_count` exact, `n_unique` exact (matching the seam's null-counting), `dtype` == `_neutral_dtype`. Registered in the W0-land parity harness, **empty divergence registry** (these are integer/enum-exact).
+- No user-visible change (shadow); the neutral-vs-Polars `inferred_type` string is the only divergence, deferred to the Flip.
+- `import goldencheck` loads zero polars; existing suite green (the swap in `scan_columns` is parity-locked; the full-scan authoritative output unchanged).
+
+## Testing
+- Rust: `column_aggregate` + `dtype_category` over Arrow arrays (null/empty/single/all-null; each of the 8 dtype categories; n_unique with + without nulls).
+- Parity harness: native `column_aggregate` == `PyColumn` reductions on random + adversarial columns (register `column_aggregate`, empty divergence).
+- Python: `scan_columns` findings for nullability/uniqueness/cardinality/type_inference are IDENTICAL with the fused kernel routed in (parity-locked — existing `scan_columns` tests pass UNEDITED). The full-scan `ColumnProfile` values unchanged (authoritative Polars path untouched); a shadow test asserts the fused values MATCH the Polars ones on a fixture.
+- `dtype_category` shim: the converted call sites (type_inference + the column-loop dtype gates) behave identically (existing tests unedited).
+
+## Risks
+- **n_unique null-counting mismatch** — the seam's cardinality-counts-null-as-1 vs uniqueness-post-dropnull is subtle; the kernel must expose whatever the callers need + parity-lock it. Top risk (a silent off-by-one in a count).
+- **Shadow conversion cost** — `pl.Series.to_arrow()` per column in the full scan adds work; it's shadow (CI/divergence-corpus), acceptable, and disappears at the Flip when input is Arrow.
+- **dtype_category incremental conversion** — converting only SOME of the ~15 dtype sites in W1 risks inconsistency; convert a coherent set (type_inference + the ColumnProfile loop) + leave the rest with a tracking note; do NOT half-convert a single profiler.
+- **arrow-rs lockstep** (W0-land's standing risk) — the new kernel uses the same `arrow=59`.
+
+## Non-goals
+- min/max/histogram (W2 range). No other checks. No changing user-visible `inferred_type` (Flip). No collapsing the full double-compute (Flip). No removing PyColumn (it's the fallback). No new dtype categories beyond the 8.

--- a/packages/python/goldencheck/goldencheck/baseline/constraints.py
+++ b/packages/python/goldencheck/goldencheck/baseline/constraints.py
@@ -156,6 +156,7 @@ def _mine_temporal_orders(
     for i, col_a in enumerate(present):
         for col_b in present[i + 1 :]:
             try:
+                # TODO(W-path): route via dtype_category
                 a = df[col_a] if df[col_a].dtype in (pl.Date, pl.Datetime) else df[col_a].cast(pl.Date)
                 b = df[col_b] if df[col_b].dtype in (pl.Date, pl.Datetime) else df[col_b].cast(pl.Date)
             except Exception as exc:

--- a/packages/python/goldencheck/goldencheck/baseline/correlation.py
+++ b/packages/python/goldencheck/goldencheck/baseline/correlation.py
@@ -176,6 +176,7 @@ def analyze_correlations(df: pl.DataFrame) -> list[CorrelationEntry]:
     - Each pair must have at least _MIN_ROWS non-null rows.
     """
     # Partition columns by type
+    # TODO(W-path): route via dtype_category
     numeric_cols: list[str] = [
         c for c in df.columns if df[c].dtype in (pl.Float32, pl.Float64, pl.Int8, pl.Int16,
                                                   pl.Int32, pl.Int64, pl.UInt8, pl.UInt16,

--- a/packages/python/goldencheck/goldencheck/baseline/statistical.py
+++ b/packages/python/goldencheck/goldencheck/baseline/statistical.py
@@ -87,6 +87,7 @@ def profile_statistical(
         if len(non_null) < _MIN_ROWS:
             continue
 
+        # TODO(W-path): route via dtype_category
         is_numeric = series.dtype in (
             pl.Int8, pl.Int16, pl.Int32, pl.Int64,
             pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,

--- a/packages/python/goldencheck/goldencheck/cell_quality.py
+++ b/packages/python/goldencheck/goldencheck/cell_quality.py
@@ -89,6 +89,7 @@ def _fuzzy_penalties(df: pl.DataFrame, col: str, scores: dict[tuple[int, str], f
 
 def _future_penalties(df: pl.DataFrame, col: str, scores: dict[tuple[int, str], float]) -> None:
     s = df[col]
+    # TODO(W-path): route via dtype_category
     is_date = s.dtype == pl.Date
     now: _dt.date | _dt.datetime = _dt.date.today() if is_date else _dt.datetime.now()
     try:

--- a/packages/python/goldencheck/goldencheck/core/_native_loader.py
+++ b/packages/python/goldencheck/goldencheck/core/_native_loader.py
@@ -112,6 +112,7 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     "regex": ("str_contains_count", "str_filter_mask", "str_replace_all"),
     "str_to_date": ("str_to_date",),
     "csv_infer": ("csv_infer_columns",),
+    "column_aggregate": ("column_aggregate",),
 }
 
 

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -84,6 +84,16 @@ def _neutral_dtype(dt: Any) -> str:
     return "other"
 
 
+def dtype_category(pl_dtype: Any) -> str:
+    """Public single entry point for the neutral dtype vocabulary
+    (str/int/uint/float/date/datetime/bool/other). Mirrors the Rust
+    kernel's ``dtype_category`` string-for-string. Callers that need the
+    neutral category for a dtype gate should route through this rather
+    than reimplementing tuple/equality checks against ``pl.*`` dtypes.
+    """
+    return _neutral_dtype(pl_dtype)
+
+
 _CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings only; resolved via getattr in cast()
 
 
@@ -144,7 +154,7 @@ class PolarsColumn:
 
     @property
     def dtype(self) -> str:
-        return _neutral_dtype(self._s.dtype)
+        return dtype_category(self._s.dtype)
 
     def dtype_repr(self) -> str:
         return str(self._s.dtype)

--- a/packages/python/goldencheck/goldencheck/drift/detector.py
+++ b/packages/python/goldencheck/goldencheck/drift/detector.py
@@ -88,6 +88,7 @@ def _check_statistical(df: pl.DataFrame, baseline: BaselineProfile) -> list[Find
         if len(series) < 30:
             continue
 
+        # TODO(W-path): route via dtype_category
         is_numeric = df[col].dtype in (
             pl.Int8, pl.Int16, pl.Int32, pl.Int64,
             pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
@@ -484,6 +485,7 @@ def _check_temporal_order_drift(df: pl.DataFrame, baseline: BaselineProfile) -> 
             continue
 
         try:
+            # TODO(W-path): route via dtype_category
             a = df[col_before] if df[col_before].dtype in (pl.Date, pl.Datetime) else df[col_before].cast(pl.Date)
             b = df[col_after] if df[col_after].dtype in (pl.Date, pl.Datetime) else df[col_after].cast(pl.Date)
         except Exception as exc:
@@ -640,6 +642,7 @@ def _check_correlations(df: pl.DataFrame, baseline: BaselineProfile) -> list[Fin
 
     # new_correlation: INFO for newly emerged strong correlations not in baseline
     # Check numeric-numeric pairs
+    # TODO(W-path): route via dtype_category
     numeric_cols = [
         c for c in df.columns
         if df[c].dtype in (pl.Int8, pl.Int16, pl.Int32, pl.Int64,

--- a/packages/python/goldencheck/goldencheck/engine/fixer.py
+++ b/packages/python/goldencheck/goldencheck/engine/fixer.py
@@ -58,6 +58,8 @@ def _has_match(s: pl.Series, pattern: str) -> bool:
     return bool(s.str.contains(pattern).fill_null(False).any())
 
 
+# TODO(W-path): route the repeated `s.dtype not in (pl.Utf8, pl.String)` guards
+# in this file (_trim_whitespace..._coerce_numeric) via dtype_category
 def _trim_whitespace(s: pl.Series) -> pl.Series:
     if s.dtype not in (pl.Utf8, pl.String):
         return s

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -10,7 +10,7 @@ from goldencheck._polars_lazy import pl
 
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile
-from goldencheck.core._native_loader import native_enabled
+from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import PyFrame, dtype_category
 from goldencheck.engine.confidence import apply_corroboration_boost
 from goldencheck.engine.reader import read_columns, read_file
@@ -389,6 +389,18 @@ def _scan_dataframe_impl(
         # surrounding I/O). Strict 2x reduction; zero behavioral change.
         n_unique = non_null.n_unique() if non_null_len > 0 else 0
         null_count = col.null_count()
+        # Shadow-compute the fused native column_aggregate kernel on the real
+        # scan path so it runs against production shapes ahead of the Flip
+        # (see tests/engine/test_column_aggregate_shadow.py for the parity
+        # assertion). NOT authoritative -- the ColumnProfile below is built
+        # from the Polars values above exactly as before this shadow wire.
+        if native_enabled("column_aggregate"):
+            try:
+                native_module().column_aggregate(col.to_arrow())
+            except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
+                logger.debug(
+                    "column_aggregate shadow compute failed on column %s: %s", col_name, e
+                )
         cp = ColumnProfile(
             name=col_name,
             inferred_type=str(col.dtype),

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -11,7 +11,7 @@ from goldencheck._polars_lazy import pl
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile
 from goldencheck.core._native_loader import native_enabled
-from goldencheck.core.frame import PyFrame
+from goldencheck.core.frame import PyFrame, dtype_category
 from goldencheck.engine.confidence import apply_corroboration_boost
 from goldencheck.engine.reader import read_columns, read_file
 from goldencheck.engine.sampler import maybe_sample
@@ -98,7 +98,7 @@ def _post_classification_checks(
         if col_name not in sample.columns:
             continue
         col = sample[col_name]
-        if col.dtype not in (pl.Utf8, pl.String):
+        if dtype_category(col.dtype) != "str":
             continue
 
         # Detect digit characters in person name columns
@@ -142,7 +142,7 @@ def _post_classification_checks(
         if col_name not in sample.columns:
             continue
         col = sample[col_name]
-        if col.dtype not in (pl.Utf8, pl.String):
+        if dtype_category(col.dtype) != "str":
             continue
         non_null = col.drop_nulls()
         total = len(non_null)
@@ -190,12 +190,9 @@ def _post_classification_checks(
         col = sample[col_name]
 
         # Accept string or numeric columns (numeric IDs are common)
-        is_string = col.dtype in (pl.Utf8, pl.String)
-        is_numeric = col.dtype in (
-            pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-            pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-            pl.Float32, pl.Float64,
-        )
+        _cat = dtype_category(col.dtype)
+        is_string = _cat == "str"
+        is_numeric = _cat in ("int", "uint", "float")
         if not (is_string or is_numeric):
             continue
 

--- a/packages/python/goldencheck/goldencheck/llm/rule_generator.py
+++ b/packages/python/goldencheck/goldencheck/llm/rule_generator.py
@@ -211,6 +211,7 @@ def _apply_single_rule(df: pl.DataFrame, rule: GeneratedRule) -> list[Finding]:
     findings: list[Finding] = []
 
     if rule.rule_type == "regex" and params.pattern:
+        # TODO(W-path): route via dtype_category
         if col.dtype in (pl.Utf8, pl.String):
             non_null = col.drop_nulls()
             if len(non_null) > 0:
@@ -230,6 +231,7 @@ def _apply_single_rule(df: pl.DataFrame, rule: GeneratedRule) -> list[Finding]:
                     ))
 
     elif rule.rule_type == "length":
+        # TODO(W-path): route via dtype_category
         if col.dtype in (pl.Utf8, pl.String):
             non_null = col.drop_nulls()
             if len(non_null) > 0:

--- a/packages/python/goldencheck/goldencheck/relations/age_validation.py
+++ b/packages/python/goldencheck/goldencheck/relations/age_validation.py
@@ -37,6 +37,7 @@ def _is_dob_column(name: str) -> bool:
 
 def _try_parse_dates(series: pl.Series) -> pl.Series:
     """Attempt to cast a series to Date."""
+    # TODO(W-path): route the dtype gates in this file via dtype_category
     if series.dtype in (pl.Date, pl.Datetime):
         return series.cast(pl.Date)
     if series.dtype in (pl.Utf8, pl.String):

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -169,6 +169,7 @@ def _check_value_signals(non_null: pl.Series, col: pl.Series, signals: dict) -> 
         elif key == "min_match_pct":
             pass  # Used with format_match, handled there
         elif key == "mixed_case":
+            # TODO(W-path): route the dtype gates in this function via dtype_category
             if non_null.dtype not in (pl.Utf8, pl.String):
                 return False
             sample = non_null.head(100).to_list()

--- a/packages/python/goldencheck/tests/core/parity_harness.py
+++ b/packages/python/goldencheck/tests/core/parity_harness.py
@@ -316,6 +316,38 @@ def _fd_bridge_fallback(df: pl.DataFrame) -> list:
 
 
 # ---------------------------------------------------------------------------
+# column_aggregate (fused len/null_count/n_unique_nonnull/dtype scan)
+# ---------------------------------------------------------------------------
+def _column_aggregate_fixtures(seed: int) -> list[pl.Series]:
+    rng = random.Random(seed)
+    n = rng.randint(0, 200)
+    int_vals = [rng.choice([None, rng.randint(-50, 50)]) for _ in range(n)]
+    float_pool = [None, 0.0, -0.0, float("nan")] + [rng.uniform(-50, 50) for _ in range(20)]
+    float_vals = [rng.choice(float_pool) for _ in range(n)]
+    str_pool = [None, "a", "b", "c", "aa", "bb", ""]
+    str_vals = [rng.choice(str_pool) for _ in range(n)]
+    return [
+        pl.Series("i", int_vals, dtype=pl.Int64),
+        pl.Series("f", float_vals, dtype=pl.Float64),
+        pl.Series("s", str_vals, dtype=pl.Utf8),
+    ]
+
+
+def _column_aggregate_native(s: pl.Series) -> tuple:
+    from goldencheck.core.frame import _neutral_dtype
+
+    ln, nc, nu, dt = native_module().column_aggregate(s.to_arrow())
+    return (ln, nc, nu, dt, _neutral_dtype(s.dtype))
+
+
+def _column_aggregate_fallback(s: pl.Series) -> tuple:
+    from goldencheck.core.frame import _neutral_dtype
+
+    dt = _neutral_dtype(s.dtype)
+    return (len(s), s.null_count(), s.drop_nulls().n_unique(), dt, dt)
+
+
+# ---------------------------------------------------------------------------
 # csv_infer (owned CSV type-inference)
 # ---------------------------------------------------------------------------
 def _csv_infer_fixtures(seed: int) -> list[tuple[list[str], list[list[str]]]]:
@@ -347,4 +379,10 @@ REGISTERED_COMPONENTS: list[Component] = [
         _fd_bridge_fixtures,
     ),
     Component("csv_infer", _csv_infer_native, _csv_infer_fallback, _csv_infer_fixtures),
+    Component(
+        "column_aggregate",
+        _column_aggregate_native,
+        _column_aggregate_fallback,
+        _column_aggregate_fixtures,
+    ),
 ]

--- a/packages/python/goldencheck/tests/core/test_column_aggregate_parity.py
+++ b/packages/python/goldencheck/tests/core/test_column_aggregate_parity.py
@@ -1,0 +1,179 @@
+"""Parity: the native `column_aggregate` fused kernel must produce the SAME
+`(len, null_count, n_unique_nonnull, dtype)` tuple Polars would give via
+`len(s)`, `s.null_count()`, `s.drop_nulls().n_unique()`, and
+`goldencheck.core.frame._neutral_dtype(s.dtype)`.
+
+Covers every neutral dtype category (str, int, uint, float, date, datetime,
+bool, other-via-a-List) plus the float NaN / signed-zero uniqueness
+subtleties documented in `goldencheck-core/src/aggregate.rs`: Polars
+`n_unique()` treats all NaN payloads as one distinct value, and treats
+`-0.0`/`0.0` as equal -- both verified empirically against Polars 1.40.1.
+
+Skips cleanly when the native extension isn't built (pure-Python-only env)."""
+from __future__ import annotations
+
+import random
+from datetime import date, datetime
+
+import polars as pl
+import pytest
+from goldencheck.core._native_loader import native_available, native_module
+from goldencheck.core.frame import _neutral_dtype
+
+native_only = pytest.mark.skipif(
+    not native_available(), reason="goldencheck native extension not built"
+)
+
+
+def _check(s: pl.Series) -> None:
+    ln, nc, nu, dt = native_module().column_aggregate(s.to_arrow())
+    assert ln == len(s), f"len mismatch for {s.dtype}"
+    assert nc == s.null_count(), f"null_count mismatch for {s.dtype}"
+    assert nu == s.drop_nulls().n_unique(), f"n_unique mismatch for {s.dtype}: {s.to_list()!r}"
+    assert dt == _neutral_dtype(s.dtype), f"dtype mismatch: native={dt} expected={_neutral_dtype(s.dtype)}"
+
+
+# ---------------------------------------------------------------------------
+# One case per neutral dtype category, each with nulls + a repeat + a
+# singleton so len/null_count/n_unique are all exercised together.
+# ---------------------------------------------------------------------------
+@native_only
+def test_str_dtype() -> None:
+    _check(pl.Series("s", ["a", "b", "a", None, "a"], dtype=pl.Utf8))
+
+
+@native_only
+def test_int_dtype() -> None:
+    _check(pl.Series("i", [1, 2, 1, None, -3], dtype=pl.Int64))
+
+
+@native_only
+def test_uint_dtype() -> None:
+    _check(pl.Series("u", [1, 2, 1, None, 3], dtype=pl.UInt32))
+
+
+@native_only
+def test_float_dtype() -> None:
+    _check(pl.Series("f", [1.5, 2.5, 1.5, None, -3.5], dtype=pl.Float64))
+
+
+@native_only
+def test_date_dtype() -> None:
+    _check(
+        pl.Series(
+            "d",
+            [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 1), None],
+            dtype=pl.Date,
+        )
+    )
+
+
+@native_only
+def test_datetime_dtype() -> None:
+    _check(
+        pl.Series(
+            "dt",
+            [datetime(2020, 1, 1, 1), datetime(2020, 1, 1, 2), datetime(2020, 1, 1, 1), None],
+            dtype=pl.Datetime,
+        )
+    )
+
+
+@native_only
+def test_bool_dtype() -> None:
+    _check(pl.Series("b", [True, False, True, None], dtype=pl.Boolean))
+
+
+@native_only
+def test_other_dtype_list() -> None:
+    # A List column has no neutral-dtype str/int/... mapping -> "other". The
+    # kernel must not panic on it; n_unique_nonnull is best-effort (0) so we
+    # only assert len/null_count/dtype here (n_unique is documented not
+    # meaningful for "other").
+    s = pl.Series("l", [[1, 2], [3], None, [1, 2]], dtype=pl.List(pl.Int64))
+    ln, nc, _nu, dt = native_module().column_aggregate(s.to_arrow())
+    assert ln == len(s)
+    assert nc == s.null_count()
+    assert dt == "other" == _neutral_dtype(s.dtype)
+
+
+# ---------------------------------------------------------------------------
+# NaN / signed-zero float parity -- the empirically-verified Polars semantics
+# the Rust kernel's canonicalisation matches (see aggregate.rs doc comment).
+# ---------------------------------------------------------------------------
+@native_only
+def test_float_nan_collapses_to_one_distinct_value() -> None:
+    s = pl.Series("f", [1.0, 2.0, float("nan"), float("nan")], dtype=pl.Float64)
+    assert s.n_unique() == 3  # Polars: {1.0, 2.0, NaN}
+    _check(s)
+
+
+@native_only
+def test_float_signed_zero_collapses_to_one_distinct_value() -> None:
+    s = pl.Series("f", [0.0, -0.0], dtype=pl.Float64)
+    assert s.n_unique() == 1  # Polars: 0.0 == -0.0
+    _check(s)
+
+
+@native_only
+def test_float_mixed_nan_and_signed_zero() -> None:
+    s = pl.Series(
+        "f", [1.0, 2.0, float("nan"), float("nan"), 0.0, -0.0], dtype=pl.Float64
+    )
+    _check(s)
+
+
+@native_only
+def test_float32_nan_and_signed_zero() -> None:
+    s = pl.Series("f", [1.0, float("nan"), float("nan"), 0.0, -0.0], dtype=pl.Float32)
+    _check(s)
+
+
+# ---------------------------------------------------------------------------
+# Structural edge cases: all-null, single value, empty.
+# ---------------------------------------------------------------------------
+@native_only
+def test_all_null() -> None:
+    _check(pl.Series("i", [None, None, None], dtype=pl.Int64))
+
+
+@native_only
+def test_single_value() -> None:
+    _check(pl.Series("s", ["only"], dtype=pl.Utf8))
+
+
+@native_only
+def test_empty() -> None:
+    _check(pl.Series("i", [], dtype=pl.Int64))
+
+
+# ---------------------------------------------------------------------------
+# Random fuzz over each dtype category.
+# ---------------------------------------------------------------------------
+@native_only
+@pytest.mark.parametrize("seed", range(10))
+def test_random_int(seed: int) -> None:
+    rng = random.Random(seed)
+    n = rng.randint(0, 200)
+    vals = [rng.choice([None, rng.randint(-50, 50)]) for _ in range(n)]
+    _check(pl.Series("i", vals, dtype=pl.Int64))
+
+
+@native_only
+@pytest.mark.parametrize("seed", range(10))
+def test_random_float(seed: int) -> None:
+    rng = random.Random(seed)
+    n = rng.randint(0, 200)
+    pool = [None, 0.0, -0.0, float("nan")] + [rng.uniform(-50, 50) for _ in range(20)]
+    vals = [rng.choice(pool) for _ in range(n)]
+    _check(pl.Series("f", vals, dtype=pl.Float64))
+
+
+@native_only
+@pytest.mark.parametrize("seed", range(10))
+def test_random_str(seed: int) -> None:
+    rng = random.Random(seed)
+    n = rng.randint(0, 200)
+    pool = [None, "a", "b", "c", "aa", "bb", ""]
+    vals = [rng.choice(pool) for _ in range(n)]
+    _check(pl.Series("s", vals, dtype=pl.Utf8))

--- a/packages/python/goldencheck/tests/engine/test_column_aggregate_shadow.py
+++ b/packages/python/goldencheck/tests/engine/test_column_aggregate_shadow.py
@@ -1,0 +1,73 @@
+"""Shadow-compute proof: the native `column_aggregate` fused kernel produces
+the SAME `(len, null_count, n_unique_nonnull, dtype)` values as the Polars
+computation the full-scan column loop (`_scan_dataframe_impl` in
+`engine/scanner.py`) actually uses to build the authoritative `ColumnProfile`.
+
+This does NOT assert anything about the scan's output -- that's covered by
+the existing `test_scanner.py` / `test_scan_dataframe` suites, which stay
+green unedited. This test proves the fused values are ready to become
+authoritative at a future Flip, by checking them against a DataFrame with
+the same variety of column shapes the full scan sees in production."""
+from __future__ import annotations
+
+from datetime import date
+
+import polars as pl
+import pytest
+from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import _neutral_dtype
+
+native_only = pytest.mark.skipif(
+    not native_enabled("column_aggregate"),
+    reason="goldencheck native column_aggregate kernel not built/enabled",
+)
+
+
+@pytest.fixture
+def shadow_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "int_col": pl.Series([1, 2, 1, None, -3, 2], dtype=pl.Int64),
+            "float_col": pl.Series([1.5, float("nan"), 1.5, None, -3.5, 0.0], dtype=pl.Float64),
+            "str_col": pl.Series(["a", "b", "a", None, "c", "b"], dtype=pl.Utf8),
+            "bool_col": pl.Series([True, False, True, None, False, True], dtype=pl.Boolean),
+            "date_col": pl.Series(
+                [date(2020, 1, 1), date(2020, 1, 2), date(2020, 1, 1), None,
+                 date(2020, 1, 3), date(2020, 1, 2)],
+                dtype=pl.Date,
+            ),
+            "all_null_col": pl.Series([None, None, None, None, None, None], dtype=pl.Int64),
+            "with_nulls_col": pl.Series(["x", None, "x", None, "y", None], dtype=pl.Utf8),
+        }
+    )
+
+
+@native_only
+def test_shadow_matches_polars_for_every_column(shadow_df: pl.DataFrame) -> None:
+    for col_name in shadow_df.columns:
+        col = shadow_df[col_name]
+        expected = (
+            len(col),
+            col.null_count(),
+            col.drop_nulls().n_unique(),
+            _neutral_dtype(col.dtype),
+        )
+        actual = native_module().column_aggregate(col.to_arrow())
+        assert actual == expected, f"mismatch for column {col_name!r}: {actual} != {expected}"
+
+
+@native_only
+def test_shadow_runs_on_real_scan_path(shadow_df: pl.DataFrame) -> None:
+    """The scanner's full-scan column loop shadow-computes column_aggregate on
+    every column without raising and without altering the authoritative
+    ColumnProfile output -- exercised end-to-end via scan_dataframe."""
+    from goldencheck.engine.scanner import scan_dataframe
+
+    findings, profile = scan_dataframe(shadow_df, file_path="<shadow>")
+    assert {cp.name for cp in profile.columns} == set(shadow_df.columns)
+    for cp in profile.columns:
+        col = shadow_df[cp.name]
+        non_null = col.drop_nulls()
+        assert cp.null_count == col.null_count()
+        assert cp.unique_count == (non_null.n_unique() if len(non_null) > 0 else 0)
+        assert cp.inferred_type == str(col.dtype)

--- a/packages/rust/extensions/goldencheck-core/src/aggregate.rs
+++ b/packages/rust/extensions/goldencheck-core/src/aggregate.rs
@@ -1,0 +1,470 @@
+//! Fused single-pass column aggregate: `{len, null_count, n_unique_nonnull,
+//! dtype}` computed together over one Arrow column. Feeds the
+//! nullability/uniqueness/cardinality checks in `goldencheck.baseline` --
+//! today those each re-scan the column separately (Polars `.len()`,
+//! `.null_count()`, `.n_unique()`, `.dtype`); this kernel gives the same four
+//! numbers in one pass over the Arrow buffer.
+//!
+//! `dtype_category` maps an Arrow `DataType` to the neutral vocabulary the
+//! Python side already uses (`goldencheck.core.frame._neutral_dtype`):
+//! `str | int | uint | float | date | datetime | bool | other`.
+//!
+//! Parity subtlety (Polars `Series.n_unique()`), verified empirically against
+//! Polars 1.40.1:
+//!   - `[1.0, 2.0, NaN, NaN].n_unique() == 3` -- Polars treats ALL NaN payloads
+//!     as one distinct value, unlike raw bit-pattern equality (which would
+//!     split on differing NaN payloads/signs).
+//!   - `[0.0, -0.0].n_unique() == 1` -- Polars treats positive and negative
+//!     zero as the same value, unlike `f64::to_bits` (which differ).
+//!
+//! We therefore canonicalise before hashing: any NaN collapses to a single
+//! canonical bit pattern, and `-0.0` normalises to `0.0`. This makes the
+//! native uniqueness count agree with Polars on both cases; see
+//! `tests/core/test_column_aggregate_parity.py` for the cross-check.
+use arrow::array::{
+    Array, BooleanArray, Date32Array, Date64Array, Float32Array, Float64Array, Int16Array,
+    Int32Array, Int64Array, Int8Array, LargeStringArray, StringArray, TimestampMicrosecondArray,
+    TimestampMillisecondArray, TimestampNanosecondArray, TimestampSecondArray, UInt16Array,
+    UInt32Array, UInt64Array, UInt8Array,
+};
+use arrow::datatypes::DataType;
+use rustc_hash::FxHashSet;
+
+/// Neutral dtype vocabulary, matching `goldencheck.core.frame._neutral_dtype`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DtypeCat {
+    Str,
+    Int,
+    Uint,
+    Float,
+    Date,
+    Datetime,
+    Bool,
+    Other,
+}
+
+impl DtypeCat {
+    /// The Python-side string the neutral vocabulary uses.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Str => "str",
+            Self::Int => "int",
+            Self::Uint => "uint",
+            Self::Float => "float",
+            Self::Date => "date",
+            Self::Datetime => "datetime",
+            Self::Bool => "bool",
+            Self::Other => "other",
+        }
+    }
+}
+
+/// Classify an Arrow column into the neutral dtype vocabulary.
+pub fn dtype_category(array: &dyn Array) -> DtypeCat {
+    use DataType::*;
+    match array.data_type() {
+        Utf8 | LargeUtf8 | Utf8View => DtypeCat::Str,
+        Int8 | Int16 | Int32 | Int64 => DtypeCat::Int,
+        UInt8 | UInt16 | UInt32 | UInt64 => DtypeCat::Uint,
+        Float16 | Float32 | Float64 => DtypeCat::Float,
+        Date32 | Date64 => DtypeCat::Date,
+        Timestamp(_, _) => DtypeCat::Datetime,
+        Boolean => DtypeCat::Bool,
+        _ => DtypeCat::Other,
+    }
+}
+
+/// Result of a fused single-pass column scan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ColumnAgg {
+    pub len: usize,
+    pub null_count: usize,
+    pub n_unique_nonnull: usize,
+    pub dtype: DtypeCat,
+}
+
+/// Canonical bit pattern all NaN payloads collapse to before hashing, so
+/// Polars' "all NaN are one distinct value" semantics are preserved.
+const CANON_NAN_BITS: u64 = f64::NAN.to_bits();
+
+/// Bit-pattern key for an f64 that matches Polars uniqueness semantics:
+/// NaN (any payload/sign) canonicalises to one bit pattern, and `-0.0`
+/// normalises to `0.0`.
+#[inline]
+fn f64_unique_key(v: f64) -> u64 {
+    if v.is_nan() {
+        CANON_NAN_BITS
+    } else if v == 0.0 {
+        0.0f64.to_bits() // normalises -0.0 -> +0.0's bit pattern
+    } else {
+        v.to_bits()
+    }
+}
+
+#[inline]
+fn f32_unique_key(v: f32) -> u64 {
+    f64_unique_key(v as f64)
+}
+
+/// One fused pass over an Arrow column: length, null count, distinct
+/// non-null value count, and the neutral dtype category.
+pub fn column_aggregate(array: &dyn Array) -> ColumnAgg {
+    let len = array.len();
+    let null_count = array.null_count();
+    let dtype = dtype_category(array);
+
+    let n_unique_nonnull: usize = match array.data_type() {
+        DataType::Utf8 => {
+            let arr = array.as_any().downcast_ref::<StringArray>().unwrap();
+            let mut seen: FxHashSet<&str> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::LargeUtf8 => {
+            let arr = array.as_any().downcast_ref::<LargeStringArray>().unwrap();
+            let mut seen: FxHashSet<&str> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::Boolean => {
+            let arr = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+            let mut seen: FxHashSet<bool> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::Int8 => {
+            let arr = array.as_any().downcast_ref::<Int8Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as i64);
+            }
+            seen.len()
+        }
+        DataType::Int16 => {
+            let arr = array.as_any().downcast_ref::<Int16Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as i64);
+            }
+            seen.len()
+        }
+        DataType::Int32 => {
+            let arr = array.as_any().downcast_ref::<Int32Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as i64);
+            }
+            seen.len()
+        }
+        DataType::Int64 => {
+            let arr = array.as_any().downcast_ref::<Int64Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::UInt8 => {
+            let arr = array.as_any().downcast_ref::<UInt8Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as u64);
+            }
+            seen.len()
+        }
+        DataType::UInt16 => {
+            let arr = array.as_any().downcast_ref::<UInt16Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as u64);
+            }
+            seen.len()
+        }
+        DataType::UInt32 => {
+            let arr = array.as_any().downcast_ref::<UInt32Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as u64);
+            }
+            seen.len()
+        }
+        DataType::UInt64 => {
+            let arr = array.as_any().downcast_ref::<UInt64Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::Float32 => {
+            let arr = array.as_any().downcast_ref::<Float32Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(f32_unique_key(arr.value(i)));
+            }
+            seen.len()
+        }
+        DataType::Float64 => {
+            let arr = array.as_any().downcast_ref::<Float64Array>().unwrap();
+            let mut seen: FxHashSet<u64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(f64_unique_key(arr.value(i)));
+            }
+            seen.len()
+        }
+        DataType::Date32 => {
+            let arr = array.as_any().downcast_ref::<Date32Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i) as i64);
+            }
+            seen.len()
+        }
+        DataType::Date64 => {
+            let arr = array.as_any().downcast_ref::<Date64Array>().unwrap();
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            for i in 0..len {
+                if arr.is_null(i) {
+                    continue;
+                }
+                seen.insert(arr.value(i));
+            }
+            seen.len()
+        }
+        DataType::Timestamp(unit, _) => {
+            use arrow::datatypes::TimeUnit::*;
+            let mut seen: FxHashSet<i64> = FxHashSet::default();
+            match unit {
+                Second => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<TimestampSecondArray>()
+                        .unwrap();
+                    for i in 0..len {
+                        if !arr.is_null(i) {
+                            seen.insert(arr.value(i));
+                        }
+                    }
+                }
+                Millisecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<TimestampMillisecondArray>()
+                        .unwrap();
+                    for i in 0..len {
+                        if !arr.is_null(i) {
+                            seen.insert(arr.value(i));
+                        }
+                    }
+                }
+                Microsecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<TimestampMicrosecondArray>()
+                        .unwrap();
+                    for i in 0..len {
+                        if !arr.is_null(i) {
+                            seen.insert(arr.value(i));
+                        }
+                    }
+                }
+                Nanosecond => {
+                    let arr = array
+                        .as_any()
+                        .downcast_ref::<TimestampNanosecondArray>()
+                        .unwrap();
+                    for i in 0..len {
+                        if !arr.is_null(i) {
+                            seen.insert(arr.value(i));
+                        }
+                    }
+                }
+            }
+            seen.len()
+        }
+        // Unsupported dtype for uniqueness counting (the profilers only run
+        // this kernel on str/numeric/bool/date columns). Best-effort: report
+        // 0 rather than panicking; callers should not rely on this number for
+        // `Other` columns.
+        _ => 0,
+    };
+
+    ColumnAgg {
+        len,
+        null_count,
+        n_unique_nonnull,
+        dtype,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{
+        BooleanArray, Date32Array, Float64Array, Int32Array, StringArray,
+        TimestampMicrosecondArray, UInt32Array,
+    };
+
+    #[test]
+    fn str_basic() {
+        let a = StringArray::from(vec![Some("x"), Some("y"), Some("x"), None]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.len, 4);
+        assert_eq!(r.null_count, 1);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Str);
+    }
+
+    #[test]
+    fn int_basic() {
+        let a = Int32Array::from(vec![Some(1), Some(2), Some(1), None]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.null_count, 1);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Int);
+    }
+
+    #[test]
+    fn uint_basic() {
+        let a = UInt32Array::from(vec![Some(1u32), Some(2), Some(2)]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Uint);
+    }
+
+    #[test]
+    fn float_with_nan_collapses_to_one() {
+        // Matches Polars: [1.0, 2.0, NaN, NaN].n_unique() == 3 (NaN is one value).
+        let a = Float64Array::from(vec![1.0, 2.0, f64::NAN, f64::NAN]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.n_unique_nonnull, 3);
+        assert_eq!(r.dtype, DtypeCat::Float);
+    }
+
+    #[test]
+    fn float_signed_zero_collapses_to_one() {
+        // Matches Polars: [0.0, -0.0].n_unique() == 1.
+        let a = Float64Array::from(vec![0.0, -0.0]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.n_unique_nonnull, 1);
+    }
+
+    #[test]
+    fn float_mixed_nan_and_zero() {
+        let a = Float64Array::from(vec![1.0, 2.0, f64::NAN, f64::NAN, 0.0, -0.0]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.n_unique_nonnull, 4); // {1.0, 2.0, NaN, 0.0}
+    }
+
+    #[test]
+    fn bool_basic() {
+        let a = BooleanArray::from(vec![Some(true), Some(false), Some(true), None]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.null_count, 1);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Bool);
+    }
+
+    #[test]
+    fn date_basic() {
+        let a = Date32Array::from(vec![Some(1), Some(2), Some(1), None]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.null_count, 1);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Date);
+    }
+
+    #[test]
+    fn datetime_basic() {
+        let a: TimestampMicrosecondArray = vec![Some(1i64), Some(2), Some(1), None].into();
+        let r = column_aggregate(&a);
+        assert_eq!(r.null_count, 1);
+        assert_eq!(r.n_unique_nonnull, 2);
+        assert_eq!(r.dtype, DtypeCat::Datetime);
+    }
+
+    #[test]
+    fn all_null() {
+        let a = Int32Array::from(vec![None, None, None]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.len, 3);
+        assert_eq!(r.null_count, 3);
+        assert_eq!(r.n_unique_nonnull, 0);
+    }
+
+    #[test]
+    fn empty() {
+        let a = Int32Array::from(Vec::<Option<i32>>::new());
+        let r = column_aggregate(&a);
+        assert_eq!(r.len, 0);
+        assert_eq!(r.null_count, 0);
+        assert_eq!(r.n_unique_nonnull, 0);
+    }
+
+    #[test]
+    fn single_value() {
+        let a = StringArray::from(vec![Some("only")]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.len, 1);
+        assert_eq!(r.null_count, 0);
+        assert_eq!(r.n_unique_nonnull, 1);
+    }
+
+    #[test]
+    fn other_dtype_reports_zero_unique_not_panic() {
+        use arrow::array::BinaryArray;
+        let a = BinaryArray::from(vec![Some(b"a".as_ref()), Some(b"b".as_ref())]);
+        let r = column_aggregate(&a);
+        assert_eq!(r.dtype, DtypeCat::Other);
+        assert_eq!(r.n_unique_nonnull, 0);
+        assert_eq!(r.len, 2);
+    }
+}

--- a/packages/rust/extensions/goldencheck-core/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-core/src/lib.rs
@@ -21,6 +21,7 @@
 //! kernel (`dc`) is the exception: its columns arrive order-preservingly
 //! rank-encoded, so it does ordered `<`/`<=`/`>`/`>=` comparisons over those ids.
 
+mod aggregate;
 mod arrow_support;
 mod benford;
 mod csv_infer;
@@ -30,6 +31,7 @@ mod fuzzy;
 mod keys;
 mod regex;
 
+pub use aggregate::{column_aggregate, dtype_category, ColumnAgg, DtypeCat};
 pub use arrow_support::intern_column;
 pub use benford::{benford_leading_digits, benford_leading_digits_slice};
 pub use csv_infer::{infer_and_type, read_csv_bytes, read_csv_owned_bytes, TypedColumn};

--- a/packages/rust/extensions/goldencheck-native/src/aggregate.rs
+++ b/packages/rust/extensions/goldencheck-native/src/aggregate.rs
@@ -1,0 +1,22 @@
+//! Arrow-reading shim for the fused column-aggregate kernel.
+use arrow::array::{make_array, ArrayData};
+use arrow::pyarrow::PyArrowType;
+use pyo3::prelude::*;
+
+/// One fused pass over an Arrow column: `(len, null_count, n_unique_nonnull,
+/// dtype)`. `dtype` is the neutral vocabulary string
+/// (`goldencheck.core.frame._neutral_dtype`): `str | int | uint | float |
+/// date | datetime | bool | other`. Decodes the pyarrow array and delegates
+/// to `goldencheck_core::column_aggregate`, which owns the downcast + null
+/// handling + Polars-parity NaN/signed-zero uniqueness canonicalisation.
+#[pyfunction]
+pub fn column_aggregate(array: PyArrowType<ArrayData>) -> PyResult<(usize, usize, usize, String)> {
+    let arr = make_array(array.0);
+    let agg = goldencheck_core::column_aggregate(arr.as_ref());
+    Ok((
+        agg.len,
+        agg.null_count,
+        agg.n_unique_nonnull,
+        agg.dtype.as_str().to_string(),
+    ))
+}

--- a/packages/rust/extensions/goldencheck-native/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-native/src/lib.rs
@@ -12,6 +12,7 @@
 //! plain slices and delegate to `goldencheck-core`.
 use pyo3::prelude::*;
 
+mod aggregate;
 mod csv_infer;
 mod date;
 mod dc;
@@ -24,6 +25,7 @@ mod regex;
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     m.add_function(wrap_pyfunction!(profile::benford_leading_digits, m)?)?;
+    m.add_function(wrap_pyfunction!(aggregate::column_aggregate, m)?)?;
     m.add_function(wrap_pyfunction!(keys::composite_key_search, m)?)?;
     m.add_function(wrap_pyfunction!(keys::functional_dependency_holds, m)?)?;
     m.add_function(wrap_pyfunction!(keys::discover_functional_dependencies, m)?)?;


### PR DESCRIPTION
## Summary

**W1** of the goldencheck Arrow-native fused-scan program (path to 3.0.0). Builds the first fused Arrow-native kernel + lands the neutral dtype vocabulary the whole W-path depends on. Additive, **no user-visible change** (shadow discipline).

## What changed

- **`column_aggregate(&dyn Array) -> {len, null_count, n_unique_nonnull, dtype}`** (`goldencheck-core`, arrow-native) — one fused pass (null bitmap + one non-null hash set + O(1) dtype) feeding nullability/uniqueness/cardinality + `ColumnProfile`. Rust = source of truth. **NaN/signed-zero pinned to Polars**: empirically confirmed Polars `n_unique` treats all NaN as 1 distinct + `-0.0`==`0.0`, and canonicalized the Rust float hashing to match exactly (no divergence). Parity-green vs Polars across all 8 dtype categories + null/empty/single/NaN.
- **Neutral dtype vocabulary + `dtype_category` shim** — `str/int/uint/float/date/datetime/bool/other` (the seam's `_neutral_dtype` set), one public entry replacing the duplicated `pl.Utf8`/numeric-tuple checks. Converted the type_inference + column-loop gates (output-identical); 13 other sites TODO-marked for their own waves.
- **Shadow-wired** into the full-scan column loop: `column_aggregate` runs on `col.to_arrow()` on the real scan path (guarded, result discarded), so the kernel is exercised, but the authoritative `ColumnProfile` stays the Polars values until the Flip. A shadow test proves fused == Polars per column.

## Scope notes
`scan_columns` (list-backed PyColumn) is UNCHANGED (an Arrow-in swap over Python lists isn't worth it now). `type_inference` is full-scan-only (can't run on PyColumn — needs `.cast("float")`), so W1 touches only its dtype gate. `inferred_type` string stays `str(pl.dtype)` (its neutral-form divergence is deferred to the Flip's dtype bucket).

## Test plan
- [x] `column_aggregate` == Polars reductions (null_count / n_unique_nonnull / dtype) across all 8 categories + NaN/signed-zero; parity harness registered, empty divergence
- [x] `dtype_category` gate conversion output-identical (type_inference/scanner tests UNEDITED)
- [x] Shadow test: fused == Polars per column; full-scan `ColumnProfile` output byte-unchanged
- [x] `scan_columns` untouched; `import goldencheck` zero polars; cargo (66) + wasm + clippy clean
- [ ] Full suite + native lane green in CI

Additive, no version bump. Foundation + fused-kernel pattern for W2-W5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h