### PR TITLE
feat(goldenmatch): W5a -- domain-extraction seam coverage + ensure_row_ids

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -532,14 +532,20 @@ def _extract_software_features_df(
         if result.confidence < confidence_threshold:
             low_confidence_ids.append(rid)
 
-    enhanced = df.with_columns([
-        pl.Series("__sw_name__", names_norm, dtype=pl.Utf8),
-        pl.Series("__sw_version__", versions, dtype=pl.Utf8),
-        pl.Series("__sw_edition__", editions, dtype=pl.Utf8),
-        pl.Series("__sw_platform__", platforms, dtype=pl.Utf8),
-        pl.Series("__sw_part_num__", part_numbers, dtype=pl.Utf8),
-        pl.Series("__extract_confidence__", confidences, dtype=pl.Float64),
-    ])
+    # W5a: seam attach (backend-agnostic column constructors).
+    from goldenmatch.core.frame import column_from_values, to_frame
+
+    frame = to_frame(df)
+    for _n, _v, _d in (
+        ("__sw_name__", names_norm, "utf8"),
+        ("__sw_version__", versions, "utf8"),
+        ("__sw_edition__", editions, "utf8"),
+        ("__sw_platform__", platforms, "utf8"),
+        ("__sw_part_num__", part_numbers, "utf8"),
+        ("__extract_confidence__", confidences, "float64"),
+    ):
+        frame = frame.with_column(_n, column_from_values(_v, _d, backend="polars"))
+    enhanced = frame.native
 
     n_names = sum(1 for n in names_norm if n)
     n_versions = sum(1 for v in versions if v)
@@ -590,14 +596,19 @@ def _extract_product_features_df(
     brands_norm = [b.upper().strip() if b else None for b in brands]
 
     # Add derived columns
-    enhanced = df.with_columns([
-        pl.Series("__brand__", brands_norm, dtype=pl.Utf8),
-        pl.Series("__model__", models, dtype=pl.Utf8),
-        pl.Series("__model_norm__", models_norm, dtype=pl.Utf8),
-        pl.Series("__color__", colors, dtype=pl.Utf8),
-        pl.Series("__specs__", specs_strs, dtype=pl.Utf8),
-        pl.Series("__extract_confidence__", confidences, dtype=pl.Float64),
-    ])
+    from goldenmatch.core.frame import column_from_values, to_frame
+
+    frame = to_frame(df)
+    for _n, _v, _d in (
+        ("__brand__", brands_norm, "utf8"),
+        ("__model__", models, "utf8"),
+        ("__model_norm__", models_norm, "utf8"),
+        ("__color__", colors, "utf8"),
+        ("__specs__", specs_strs, "utf8"),
+        ("__extract_confidence__", confidences, "float64"),
+    ):
+        frame = frame.with_column(_n, column_from_values(_v, _d, backend="polars"))
+    enhanced = frame.native
 
     n_with_model = sum(1 for m in models if m)
     n_with_brand = sum(1 for b in brands if b)
@@ -625,8 +636,14 @@ def _extract_biblio_features_df(
         features = extract_biblio_features(text)
         title_keys.append(features.get("title_key"))
 
-    enhanced = df.with_columns([
-        pl.Series("__title_key__", title_keys, dtype=pl.Utf8),
-    ])
+    from goldenmatch.core.frame import column_from_values, to_frame
+
+    enhanced = (
+        to_frame(df)
+        .with_column(
+            "__title_key__", column_from_values(title_keys, "utf8", backend="polars")
+        )
+        .native
+    )
 
     return enhanced, []

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -213,6 +213,9 @@ class Frame(Protocol):
     def with_gt_column(self, src: str, threshold: Any, name: str) -> Frame: ...
     def with_coalesce(self, cols: Sequence[str], name: str) -> Frame: ...
     def group_max(self, keys: Sequence[str], value: str) -> Frame: ...
+    # W5a: pipeline._add_row_ids' exact chain, eager (the #844 reuse-existing
+    # branch pinned; offset applied only when > 0; final Int64 cast always).
+    def ensure_row_ids(self, name: str = "__row_id__", offset: int = 0) -> Frame: ...
 
 
 class PolarsColumn:
@@ -717,6 +720,16 @@ class PolarsFrame:
     def group_max(self, keys: Sequence[str], value: str) -> PolarsFrame:
         # distributed/scoring.py dedup: group_by(keys).agg(max(value)).
         return PolarsFrame(self._df.group_by(list(keys)).agg(pl.col(value).max()))
+
+    def ensure_row_ids(self, name: str = "__row_id__", offset: int = 0) -> PolarsFrame:
+        # pipeline.py:715-733 VERBATIM (eager): reuse-existing (#844), offset
+        # only when > 0, Int64 cast always.
+        df = self._df
+        if name not in df.columns:
+            df = df.with_row_index(name)
+        if offset > 0:
+            df = df.with_columns((pl.col(name) + offset).alias(name))
+        return PolarsFrame(df.with_columns(pl.col(name).cast(pl.Int64)))
 
 
 class ArrowColumn:
@@ -1392,6 +1405,22 @@ class ArrowFrame:
         data[value] = pa.array([maxes[k] for k in order], type=self._tbl.column(value).type)
         return ArrowFrame(pa.table(data))
 
+    def ensure_row_ids(self, name: str = "__row_id__", offset: int = 0) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        tbl = self._tbl
+        if name not in tbl.column_names:
+            tbl = tbl.append_column(
+                name, pa.array(range(tbl.num_rows), type=pa.uint32())
+            )
+        arr = tbl.column(name)
+        if offset > 0:
+            arr = pc.add(arr, offset)
+        arr = pc.cast(arr, pa.int64())
+        idx = tbl.column_names.index(name)
+        return ArrowFrame(tbl.set_column(idx, name, arr))
+
 
 def to_frame(obj: Any) -> Frame:
     """Idempotent coercion: raw ``pl.DataFrame``/``pa.Table``, a
@@ -1502,6 +1531,20 @@ def frame_from_column_data(data: dict[str, list], backend: str | None = None) ->
     import pyarrow as pa
 
     return ArrowFrame(pa.table({k: pa.array(v) for k, v in data.items()}))
+
+
+def column_from_values(
+    values: Sequence[Any], dtype: str, backend: str | None = None
+) -> Column:
+    """Build a Column from a Python value list with an explicit vocabulary
+    dtype -- the domain-extraction attach shape (``pl.Series(name, vals,
+    dtype)``; the name comes from ``with_column``)."""
+    b = backend if backend is not None else resolve_frame_backend()
+    if b == "polars":
+        return PolarsColumn(pl.Series("", list(values), dtype=_polars_dtype(dtype)))
+    import pyarrow as pa
+
+    return ArrowColumn(pa.array(list(values), type=_arrow_dtype(dtype)))
 
 
 def frame_from_records(rows: Sequence[dict], backend: str | None = None) -> Frame:

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -330,3 +330,32 @@ def test_frame_to_arrow_roundtrip(backend):
     t = f.to_arrow()
     assert isinstance(t, pa.Table)
     assert t.column("id").to_pylist() == [1, 2]
+
+
+# -- W5a ops ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_column_from_values(backend):
+    from goldenmatch.core.frame import column_from_values
+
+    f = _mk({"id": [1, 2]}, backend)
+    col = column_from_values(["x", None], "utf8", backend=backend)
+    out = f.with_column("__d__", col)
+    assert out.column("__d__").to_list() == ["x", None]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ensure_row_ids_synthesizes_and_casts(backend):
+    f = _mk({"v": ["a", "b"]}, backend)
+    out = f.ensure_row_ids()
+    assert out.column("__row_id__").to_list() == [0, 1]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_ensure_row_ids_reuses_existing_and_offsets(backend):
+    # the #844 collision guard: an existing __row_id__ is respected; offset
+    # applies to it (reference/incremental disjoint id spaces).
+    f = _mk({"__row_id__": [5, 9], "v": ["a", "b"]}, backend)
+    assert f.ensure_row_ids().column("__row_id__").to_list() == [5, 9]
+    assert f.ensure_row_ids(offset=100).column("__row_id__").to_list() == [105, 109]


### PR DESCRIPTION
W5 batch 1 (plan: docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md, merged with W4f #1678). Still 2.x: no default flip.

- Closes the W5 recon's one real coverage gap: domain.py extraction was zero-seam. The loops were already per-row Python; only the column attach was polars. New module constructor column_from_values(values, dtype, backend); all three _extract_*_df blocks ported (polars-pinned, byte-identical).
- New Frame op ensure_row_ids(name, offset): pipeline._add_row_ids' exact chain EAGER, with the #844 reuse-existing-__row_id__ collision guard pinned by fixture. This is the W5b arrow-lane twin for the row-id stage.

Gates: test_domain / test_domain_packs / test_domain_registry unedited (52 passed); frame w4 ops (65). ruff clean.