### PR TITLE
fix(autoconfig): pre-flight pair-count guard in cross_blocking_overlap (zero-config 500K BUDGET_TIME)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -27,6 +27,14 @@ BUDGET_COLUMN_PRIORS = 5.0
 BUDGET_SPARSE_MATCH = 2.0
 BUDGET_FULL_POP_HITS = 15.0
 BUDGET_CROSS_BLOCKING = 20.0
+# Skip cross-blocking-overlap when a key would co-block more than this many pairs
+# (sum over group sizes of k*(k-1)/2). Such a key is far too coarse to be a useful
+# discriminator -- its overlap signal is uninformative -- and materializing its
+# O(sum group^2) pairs blows the wall budget. At 500K a geo key (state/zip) co-blocks
+# billions of pairs; the old in-loop time check burned the full BUDGET_CROSS_BLOCKING
+# (~20s) per key and returned None anyway (the controller BUDGET_TIME regression). The
+# pre-flight pair-count is a cheap O(distinct-values) groupby -- no materialization.
+_MAX_CROSS_BLOCKING_PAIRS = 2_000_000
 BUDGET_CORRUPTION = 3.0
 
 # Identity-column heuristics. Column-name regex -> identity_score floor.
@@ -290,7 +298,25 @@ def compute_cross_blocking_overlap(
         # identical values to the old list-agg -- pinned by unedited tests).
         from goldenmatch.core.frame import to_frame
 
-        indexed = to_frame(df).with_row_index("__row__")
+        framed = to_frame(df)
+
+        # Pre-flight: skip keys too coarse to compare. Counting co-blocked pairs
+        # from group sizes (sum k*(k-1)/2) is a cheap O(distinct-values) groupby;
+        # materializing them is O(sum group^2). A key over the cap is a poor
+        # discriminator anyway, so returning None (no signal) is the right answer
+        # -- computed instantly instead of after a ~20s budget burn.
+        for _k in (key_a, key_b):
+            _sizes = framed.group_len([_k]).column("len").to_list()
+            _n_pairs = sum(s * (s - 1) // 2 for s in _sizes if s > 1)
+            if _n_pairs > _MAX_CROSS_BLOCKING_PAIRS:
+                logger.info(
+                    "compute_cross_blocking_overlap: key %r co-blocks %d pairs "
+                    "(> %d cap) -- too coarse to compare; returning None",
+                    _k, _n_pairs, _MAX_CROSS_BLOCKING_PAIRS,
+                )
+                return None
+
+        indexed = framed.with_row_index("__row__")
 
         if (time.time() - start) > BUDGET_CROSS_BLOCKING:
             return None

--- a/packages/python/goldenmatch/tests/test_indicators.py
+++ b/packages/python/goldenmatch/tests/test_indicators.py
@@ -189,6 +189,33 @@ def test_cross_blocking_overlap_budget_returns_none(monkeypatch):
     assert result is None
 
 
+def test_cross_blocking_overlap_coarse_key_skips_via_preflight(monkeypatch):
+    """A key too coarse to be a useful discriminator (it co-blocks more than the
+    pair cap) returns None from the CHEAP pre-flight -- never materializing the
+    O(sum group^2) pairs. This is the fix for the 500K controller BUDGET_TIME:
+    coarse geo keys (state/zip) co-block billions of pairs; the old in-loop time
+    check burned the full BUDGET_CROSS_BLOCKING (~20s) and returned None anyway."""
+    import time
+
+    from goldenmatch.core import indicators
+    monkeypatch.setattr(indicators, "_MAX_CROSS_BLOCKING_PAIRS", 100)
+    n = 4000  # one giant group under 'coarse' -> 4000*3999/2 ~= 8M pairs >> cap
+    df = pl.DataFrame({"coarse": ["x"] * n, "fine": [str(i) for i in range(n)]})
+    t0 = time.time()
+    result = indicators.compute_cross_blocking_overlap(df, "coarse", "fine")
+    elapsed = time.time() - t0
+    assert result is None  # coarse key -> skip (not a computed float)
+    assert elapsed < 2.0  # pre-flight groupby, NOT an 8M-pair materialization
+
+
+def test_cross_blocking_overlap_fine_keys_unaffected_by_cap():
+    """Below the cap the guard is inert: correct overlap still computed."""
+    from goldenmatch.core.indicators import compute_cross_blocking_overlap
+    # 'a' and 'b' induce the SAME grouping -> co-blocked pair sets identical -> 1.0
+    df = pl.DataFrame({"a": ["p", "p", "q", "q"], "b": ["1", "1", "2", "2"]})
+    assert compute_cross_blocking_overlap(df, "a", "b") == 1.0
+
+
 def test_compute_corruption_score_budget_returns_zero(monkeypatch):
     """Budget exhaustion -> return 0.0 sentinel."""
     from goldenmatch.core import indicators


### PR DESCRIPTION
## The residual zero-config 500K regression, root-caused + fixed

#1654 fixed the zero-config **death-spiral** (`BUDGET_ITERATIONS`), but 500K still went RED with a *different* stop: `ControllerNotConfidentError … sub-profile: scoring, stop_reason: **BUDGET_TIME**`. This is the second, distinct defect.

### Root cause (instrumented, runs #23/#24)
The controller's `_call_policy_propose` took **40.5s / 26.5s per iteration** at 500K. It's `rule_cross_blocking_disagreement` → **`compute_cross_blocking_overlap`**, which materializes every co-blocked pair via a nested Python loop — **O(Σ group²)**. Measured on the person fixture: `cross_blocking_overlap(email,*)` = **41.0s / 26.4s**, because `email` has one pathological group of **8375 rows** (a shared/role inbox) → ~35M pairs from that group alone. `full_pop_matchkey_hits` = 0.1s (cheap, ruled out).

The `BUDGET_CROSS_BLOCKING=20s` guard checks time **inside** the O(n²) loop, so it burned the full ~20s **per key** and returned `None` anyway — pure waste. With the controller's 60s budget at 500K, ~1.5 such iterations fit → never converges → RED.

### Why it hid 2 months + why #1654 missed it
Config/scale-sensitive: it only bites at scale with a giant-group key, and a local repro produces a *different* config (finer keys) so it never triggers. #1654 was validated at **100K locally** — too small, wrong config.

### Fix
A cheap **O(distinct-values) pre-flight**: count co-blocked pairs from group sizes (Σ k(k-1)/2) and return `None` immediately when a key exceeds `_MAX_CROSS_BLOCKING_PAIRS` (2M). Such a key is too coarse to be a useful discriminator, so `None` (no signal) is correct — and it's the **same result the 20s timeout already produced, just instant**. Behavior-preserving for the controller's decisions; removes the wasted ~40s/iteration. Good keys ≈ tens of thousands of pairs (well under the cap); the pathological `email` ≈ 35M (skipped).

### Tests
2 new unit tests (coarse key → pre-flight None + fast; fine keys → unchanged overlap); 20 indicators + 27 controller/rules/budget tests green; ruff clean.

**500K wall confirmation pending** (bench-zero-config dispatch on this branch, run #25) — will post the median wall before merge (target ~4-min May baseline vs the RED regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RvH3nXr1xZeVdx6twynC2s