### PR TITLE
feat(goldenmatch): W5b-1 -- arrow ingest front goes eager; shim moves below row-ids

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
@@ -51,14 +51,32 @@ assertions migrate to Arrow, results become `pa.Table`. W0-W4 merged/queued
 - **W5a (2.x)** — close the coverage gap: domain-extraction derive ops or
   arrow twin (fixtures-first, per-domain corpora); `ensure_row_ids` op with
   the #844 reuse branch pinned. Gates: domain suites unedited.
-- **W5b (2.x)** — arrow flows past ingest UNDER THE ENV GATE: eager
-  Frame-based expression-stage path (standardize/matchkey/domain/row-ids) for
-  GOLDENMATCH_FRAME=arrow; polars lazy path UNCHANGED as default. Remove the
-  W2d shim for the arrow lane. Differential harness now proves END-TO-END
-  parity (its controller expectations go per-backend per the W3a sample
-  contract). Wall + RSS both lanes on the 100K gate + 1M dispatch bench
-  (the fused-with_columns loss is measured here; >10% → fuse eagerly via
-  multi-column derive op).
+- **W5b (2.x, SUB-BATCHED; recon 2026-07-11 mapped _run_dedupe_pipeline)** —
+  arrow flows past ingest UNDER THE ENV GATE, boundary moving down in steps:
+  - W5b-1 (SHIPPED #1682): ingest front eager (column_map/validate/__source__/
+    ensure_row_ids); ONE post-ingest shim at pipeline.py:852.
+  - RECON FINDING: the polars-bound PREP BLOCK (quality=goldencheck
+    quality.py:24, transform=goldenflow transform.py:27, autofix, validation
+    validate.py, auto-config) sits BETWEEN ingest and standardize
+    (pipeline.py:1620-1712) — the boundary cannot cross it wholesale. All
+    prep stages are CONFIG-CONDITIONAL (skip when unset).
+  - W5b-2: arrow-eager standardize+matchkeys for the NO-PREP config shape
+    (the default/zero-config path): when the arrow lane is active and
+    quality/transform/autofix/validation/autoconfig are unset, run
+    derive_standardized_column + derive_matchkey/precompute eagerly on the
+    Frame; shim right before build_blocks/block_scorer (blocker already
+    seam-internal, blocker.py:381/737; scorer takes a clean DF handoff).
+    Domain extraction (gated) declines the eager path when enabled.
+  - W5b-3: prep-block integrations rewire to the subsystems' OWN arrow
+    surfaces (goldencheck's covered PyFrame backend; goldenflow's evicted
+    core; autofix/validate get seam twins) — REQUIRED before W5e since
+    polars dies; each integration its own PR with subsystem parity gates.
+  - Prep cache stores pl.DataFrame (pipeline.py:899) — becomes
+    backend-typed at W5b-3.
+  - Differential harness proves END-TO-END parity each step (controller
+    expectations per-backend per the W3a sample contract). Wall + RSS both
+    lanes on the 100K gate + 1M dispatch bench (fused-with_columns loss
+    measured; >10% → multi-column derive op).
 - **W5c (v3.0.0 branch)** — result flip: 5 fields → pa.Table, _repr_html_ /
   to_csv re-render, migration guide (pl.from_arrow one-liner), input
   polymorphism already in place. Fused/golden_fused backend-conditional

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -800,18 +800,38 @@ def run_dedupe(
         else:
             file_path, source_name = file_spec[0], file_spec[1]
             column_map = None
-        # W2d: opt into the Frame return; shim ArrowFrame -> polars-lazy
-        # IMMEDIATELY (before column_map/validate, which keep receiving
-        # LazyFrames untouched). The conversion is now an EXPLICIT pipeline
-        # boundary instead of being buried in load_file -- its removal point
-        # is W2e, when the expression stages (_add_row_ids, standardize,
-        # matchkeys) port to the seam and arrow can flow past ingest.
+        # W5b-1: the shim boundary moved BELOW row-ids. The arrow lane's
+        # ingest front (column_map / validate / __source__ / row-ids) runs
+        # EAGERLY on the seam; conversion to polars-lazy happens once, after
+        # the concat. Removal point: W5b-2+, as standardize/matchkeys/domain
+        # go eager and the boundary keeps moving down.
         lf = load_file(file_path, return_frame=True)
         from goldenmatch.core.frame import ArrowFrame as _ArrowFrame
 
         if isinstance(lf, _ArrowFrame):
-            # from_arrow is typed DataFrame | Series; a Table is always a DataFrame
-            lf = cast("pl.DataFrame", pl.from_arrow(lf.native)).lazy()
+            frame = lf
+            if column_map:
+                # apply_column_map parity: same missing-source check + message.
+                _missing = [src for src in column_map if src not in frame.columns]
+                if _missing:
+                    raise ValueError(
+                        f"Column map references columns not in file: {_missing}. "
+                        f"Available: {sorted(set(frame.columns))}"
+                    )
+                frame = frame.rename(column_map)
+            required = _get_required_columns(config)
+            # validate_columns parity: same message shape.
+            _missing = [c for c in required if c not in frame.columns]
+            if _missing:
+                raise ValueError(
+                    f"Missing required columns: {_missing}. "
+                    f"Available columns: {list(frame.columns)}"
+                )
+            frame = frame.with_literal_column("__source__", source_name)
+            frame = frame.ensure_row_ids(offset=offset)
+            offset += frame.height
+            frames.append(frame)
+            continue
         if column_map:
             lf = apply_column_map(lf, column_map)
         required = _get_required_columns(config)
@@ -822,7 +842,16 @@ def run_dedupe(
         offset += len(collected)
         frames.append(collected.lazy())
 
-    combined_df = pl.concat([f.collect() for f in frames])
+    from goldenmatch.core.frame import ArrowFrame as _AF
+    from goldenmatch.core.frame import concat_frames as _concat_frames
+
+    if frames and all(isinstance(f, _AF) for f in frames):
+        _combined = _concat_frames(frames)
+        # W5b-1 shim (single, post-ingest): the expression stages below are
+        # still polars-lazy; removal point is W5b-2+.
+        combined_df = cast("pl.DataFrame", pl.from_arrow(_combined.native))
+    else:
+        combined_df = pl.concat([f.collect() for f in frames])
     combined_lf = combined_df.lazy()
 
     return _run_dedupe_pipeline(


### PR DESCRIPTION
W5 batch 2 (W5a #1679 merged). Still 2.x, env-gated.

- run_dedupe's arrow lane runs the ingest front (column_map / validate / __source__ / ensure_row_ids with the #844 reuse guard) EAGERLY on the seam; ONE post-ingest shim after concat_frames converts to polars-lazy for the expression stages (removal point W5b-2+: standardize/matchkeys/domain go eager next, the boundary keeps moving down).
- Error-message parity with apply_column_map/validate_columns pinned inline.
- Polars lane byte-unchanged.

Gates: frame_backend_env / io_arrow_ingest_parity / ingest / frame_backend_differential (end-to-end proof of the moved boundary) -- 49 passed; test_pipeline 12. ruff clean.