### PR TITLE
feat(goldenmatch): W5b-3a -- validation rules onto the seam (+ W5b-3 rescope)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
@@ -67,10 +67,19 @@ assertions migrate to Arrow, results become `pa.Table`. W0-W4 merged/queued
     Frame; shim right before build_blocks/block_scorer (blocker already
     seam-internal, blocker.py:381/737; scorer takes a clean DF handoff).
     Domain extraction (gated) declines the eager path when enabled.
-  - W5b-3: prep-block integrations rewire to the subsystems' OWN arrow
-    surfaces (goldencheck's covered PyFrame backend; goldenflow's evicted
-    core; autofix/validate get seam twins) — REQUIRED before W5e since
-    polars dies; each integration its own PR with subsystem parity gates.
+  - W5b-3 (RESCOPED 2026-07-12): goldenmatch's polars removal does NOT
+    require goldencheck/goldenflow to be polars-free. At W5e the
+    quality/transform integrations become EXTRA-GATED: config.quality
+    requires goldencheck (which carries polars as ITS dep until its own
+    3.0 arrow program lands — project_goldencheck_arrow_fused_scan);
+    the integration functions import polars lazily inside the gated path
+    (transitively available when the extra is installed), so goldenmatch
+    core never imports it. goldencheck's scan_dataframe takes pl.DataFrame
+    (scanner.py:289; PyFrame.from_columns exists internally — a pa entry
+    point rides goldencheck 3.0, not this program). W5b-3 therefore =
+    seam ports for the goldenmatch-INTERNAL prep stages only: autofix
+    (core/autofix.py ~15 pl uses) + validate (core/validate.py ~9);
+    autoconfig already Frame-accepting since W3e.
   - Prep cache stores pl.DataFrame (pipeline.py:899) — becomes
     backend-typed at W5b-3.
   - Differential harness proves END-TO-END parity each step (controller

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -216,6 +216,16 @@ class Frame(Protocol):
     # W5a: pipeline._add_row_ids' exact chain, eager (the #844 reuse-existing
     # branch pinned; offset applied only when > 0; final Int64 cast always).
     def ensure_row_ids(self, name: str = "__row_id__", offset: int = 0) -> Frame: ...
+    # W5b-3 validation ops. evaluate_validation_rule returns a bool Column
+    # (True=passed) for one rule; polars impl == validate._evaluate_rule
+    # VERBATIM. Arrow regex twin uses RE2 (pc.match_substring_regex) -- the
+    # documented owned contract for user patterns (Rust-regex on polars;
+    # exotic constructs may differ, same stance as the W2a derive chains).
+    # with_null_where nulls COL where mask is True, dtype-preserving.
+    def evaluate_validation_rule(
+        self, column: str, rule_type: str, params: dict
+    ) -> Column: ...
+    def with_null_where(self, col: str, mask: Column) -> Frame: ...
 
 
 class PolarsColumn:
@@ -730,6 +740,53 @@ class PolarsFrame:
         if offset > 0:
             df = df.with_columns((pl.col(name) + offset).alias(name))
         return PolarsFrame(df.with_columns(pl.col(name).cast(pl.Int64)))
+
+    def evaluate_validation_rule(
+        self, column: str, rule_type: str, params: dict
+    ) -> PolarsColumn:
+        # validate.py:_evaluate_rule VERBATIM per branch.
+        series = self._df[column]
+        if rule_type == "not_null":
+            out = series.is_not_null()
+        elif rule_type == "regex":
+            pattern = params["pattern"]
+            out = (
+                series.is_not_null()
+                & series.fill_null("").str.contains(pattern)
+                & series.is_not_null()
+            )
+        elif rule_type == "min_length":
+            length = params["length"]
+            out = (
+                series.is_not_null()
+                & (series.fill_null("").str.len_chars() >= length)
+                & series.is_not_null()
+            )
+        elif rule_type == "max_length":
+            length = params["length"]
+            out = (
+                series.is_not_null()
+                & (series.fill_null("").str.len_chars() <= length)
+                & series.is_not_null()
+            )
+        elif rule_type == "in_set":
+            out = series.is_not_null() & series.is_in(params["values"])
+        elif rule_type == "format":
+            checker = params["__checker__"]  # resolved by the caller
+            out = series.map_elements(checker, return_dtype=pl.Boolean)
+        else:
+            raise ValueError(f"Unknown rule_type: {rule_type!r}")
+        return PolarsColumn(out)
+
+    def with_null_where(self, col: str, mask: Column) -> PolarsFrame:
+        # validate.py "null" action: when(passed).then(col).otherwise(None);
+        # mask here is FAILED (True = null it out). Dtype-preserving.
+        m = mask._s if isinstance(mask, PolarsColumn) else pl.Series(mask.to_list())  # noqa: SLF001
+        return PolarsFrame(
+            self._df.with_columns(
+                pl.when(m).then(None).otherwise(pl.col(col)).alias(col)
+            )
+        )
 
 
 class ArrowColumn:
@@ -1420,6 +1477,45 @@ class ArrowFrame:
         arr = pc.cast(arr, pa.int64())
         idx = tbl.column_names.index(name)
         return ArrowFrame(tbl.set_column(idx, name, arr))
+
+    def evaluate_validation_rule(
+        self, column: str, rule_type: str, params: dict
+    ) -> ArrowColumn:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        arr = self._tbl.column(column).combine_chunks()
+        valid = pc.is_valid(arr)
+        if rule_type == "not_null":
+            out = valid
+        elif rule_type == "regex":
+            # RE2 owned contract (see protocol note).
+            filled = pc.fill_null(pc.cast(arr, pa.large_string()), "")
+            out = pc.and_(valid, pc.match_substring_regex(filled, params["pattern"]))
+        elif rule_type == "min_length":
+            filled = pc.fill_null(pc.cast(arr, pa.large_string()), "")
+            out = pc.and_(valid, pc.greater_equal(pc.utf8_length(filled), params["length"]))
+        elif rule_type == "max_length":
+            filled = pc.fill_null(pc.cast(arr, pa.large_string()), "")
+            out = pc.and_(valid, pc.less_equal(pc.utf8_length(filled), params["length"]))
+        elif rule_type == "in_set":
+            vals = [v for v in params["values"] if v is not None]
+            out = pc.and_(valid, pc.is_in(arr, value_set=pa.array(vals)))
+        elif rule_type == "format":
+            checker = params["__checker__"]
+            out = pa.array([checker(v) for v in arr.to_pylist()], type=pa.bool_())
+        else:
+            raise ValueError(f"Unknown rule_type: {rule_type!r}")
+        return ArrowColumn(out)
+
+    def with_null_where(self, col: str, mask: Column) -> ArrowFrame:
+        import pyarrow.compute as pc
+
+        m = mask.to_arrow() if hasattr(mask, "to_arrow") else mask
+        idx = self._tbl.column_names.index(col)
+        src = self._tbl.column(col).combine_chunks()
+        nulled = pc.if_else(pc.fill_null(m, False), None, src)
+        return ArrowFrame(self._tbl.set_column(idx, col, nulled))
 
 
 def to_frame(obj: Any) -> Frame:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -845,10 +845,42 @@ def run_dedupe(
     from goldenmatch.core.frame import ArrowFrame as _AF
     from goldenmatch.core.frame import concat_frames as _concat_frames
 
+    _eager_done: frozenset[str] = frozenset()
     if frames and all(isinstance(f, _AF) for f in frames):
         _combined = _concat_frames(frames)
-        # W5b-1 shim (single, post-ingest): the expression stages below are
-        # still polars-lazy; removal point is W5b-2+.
+        # W5b-2: run standardize + exact matchkeys EAGERLY on the arrow frame
+        # when nothing polars-bound sits between them (domain extraction and
+        # semantic blocking both inject columns between the two stages --
+        # decline the eager path when either is configured; the polars stages
+        # then run as before). _run_dedupe_pipeline skips whatever is listed
+        # in _eager_stages_done -- re-running standardize is NOT idempotent.
+        _eager_ok = (
+            config.semantic_blocking is None
+            and not (config.domain and config.domain.enabled)
+        )
+        if _eager_ok:
+            done: set[str] = set()
+            if config.standardization and config.standardization.rules:
+                for _col, _std_names in config.standardization.rules.items():
+                    if _col not in _combined.columns:
+                        continue
+                    _combined = _combined.with_column(
+                        _col, _combined.derive_standardized_column(_col, _std_names)
+                    )
+                done.add("standardize")
+            _exact_mks = [mk for mk in matchkeys if mk.type == "exact"]
+            if _exact_mks:
+                for mk in _exact_mks:
+                    _combined = _combined.with_column(
+                        f"__mk_{mk.name}__",
+                        _combined.derive_matchkey(
+                            [(f.field, list(f.transforms or [])) for f in mk.fields]
+                        ),
+                    )
+                done.add("compute_matchkeys")
+            _eager_done = frozenset(done)
+        # W5b-1 shim (single, post-eager-stages): everything below is still
+        # polars-lazy; removal point is W5b-3 (prep-block integrations).
         combined_df = cast("pl.DataFrame", pl.from_arrow(_combined.native))
     else:
         combined_df = pl.concat([f.collect() for f in frames])
@@ -869,6 +901,7 @@ def run_dedupe(
         # and serve the stale prepared frame -- silently dropping the second
         # input's extra rows. Height disambiguates same-schema/different-rows.
         _prep_cache_seed=(id(combined_lf), combined_df.height),
+        _eager_stages_done=_eager_done,
     )
 
 
@@ -1530,6 +1563,7 @@ def _run_dedupe_pipeline(
     llm_max_labels: int = 500,
     auto_config: bool = False,
     auto_config_llm_provider: str | None = None,
+    _eager_stages_done: frozenset[str] = frozenset(),
     _prep_cache_seed: tuple[int, int] | int | None = None,
     _prep_store: PreparedRecordStore | None = None,
 ) -> dict:
@@ -1752,7 +1786,11 @@ def _run_dedupe_pipeline(
                 pl.col(_sem_name_col).alias(_raw_col)
             )
 
-    if config.standardization and config.standardization.rules:
+    if (
+        config.standardization
+        and config.standardization.rules
+        and "standardize" not in _eager_stages_done
+    ):
         with stage("standardize"):
             combined_lf = apply_standardization(combined_lf, config.standardization.rules)
         combined_lf = _force_collect_if_staged(combined_lf, "standardize")
@@ -1767,9 +1805,16 @@ def _run_dedupe_pipeline(
         _apply_memory_pre(memory_store, config, matchkeys)
 
     # ── Step 2: TRANSFORM ──
-    with stage("compute_matchkeys"):
-        combined_lf = compute_matchkeys(combined_lf, matchkeys)
-    combined_lf = _force_collect_if_staged(combined_lf, "compute_matchkeys")
+    if "compute_matchkeys" not in _eager_stages_done:
+        with stage("compute_matchkeys"):
+            combined_lf = compute_matchkeys(combined_lf, matchkeys)
+        combined_lf = _force_collect_if_staged(combined_lf, "compute_matchkeys")
+    else:
+        # Eager arrow path already derived the __mk_*__ columns; keep the
+        # telemetry surface identical (compute_matchkeys emits this).
+        from goldenmatch.core.matchkey import _emit_matchkey_profile
+
+        _emit_matchkey_profile(combined_lf, matchkeys)
 
     # ── Step 2.5: AUTO-SUGGEST blocking keys ──
     # Hoist matchkey transforms onto the materialized df once — eliminates

--- a/packages/python/goldenmatch/goldenmatch/core/validate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/validate.py
@@ -61,41 +61,6 @@ _FORMAT_CHECKERS = {
 }
 
 
-def _evaluate_rule(series: pl.Series, rule: ValidationRule) -> pl.Series:
-    """Evaluate a rule against a series, returning a boolean Series (True=passed)."""
-    _n = len(series)
-
-    if rule.rule_type == "not_null":
-        return series.is_not_null()
-
-    if rule.rule_type == "regex":
-        pattern = rule.params["pattern"]
-        # Null values fail regex
-        return series.is_not_null() & series.fill_null("").str.contains(pattern) & series.is_not_null()
-
-    if rule.rule_type == "min_length":
-        length = rule.params["length"]
-        return series.is_not_null() & (series.fill_null("").str.len_chars() >= length) & series.is_not_null()
-
-    if rule.rule_type == "max_length":
-        length = rule.params["length"]
-        return series.is_not_null() & (series.fill_null("").str.len_chars() <= length) & series.is_not_null()
-
-    if rule.rule_type == "in_set":
-        values = rule.params["values"]
-        return series.is_not_null() & series.is_in(values)
-
-    if rule.rule_type == "format":
-        fmt_type = rule.params["type"]
-        checker = _FORMAT_CHECKERS.get(fmt_type)
-        if checker is None:
-            raise ValueError(f"Unknown format type: {fmt_type!r}. Available: {sorted(_FORMAT_CHECKERS)}")
-        # Use map_elements for format checking
-        return series.map_elements(checker, return_dtype=pl.Boolean)
-
-    raise ValueError(f"Unknown rule_type: {rule.rule_type!r}")
-
-
 def validate_dataframe(
     df: pl.DataFrame,
     rules: list[ValidationRule],
@@ -109,22 +74,38 @@ def validate_dataframe(
         - quarantine_df: rows that failed quarantine rules (with __quarantine_reason__)
         - validation_report: list of dicts with rule evaluation stats
     """
-    validation_report: list[dict] = []
-    quarantine_mask = pl.Series("__q__", [False] * df.height)
-    quarantine_reasons: list[list[str]] = [[] for _ in range(df.height)]
+    # W5b-3: seam-driven. PolarsFrame.evaluate_validation_rule carries the
+    # legacy _evaluate_rule branches VERBATIM (the delegation oracle moved
+    # into the seam); mask bookkeeping runs in Python lists on both backends.
+    from goldenmatch.core.frame import column_from_values, to_frame
 
-    working_df = df.clone()
+    validation_report: list[dict] = []
+    height = df.height
+    quarantine_flags: list[bool] = [False] * height
+    quarantine_reasons: list[list[str]] = [[] for _ in range(height)]
+
+    frame = to_frame(df.clone())
+    backend = "polars"  # df arrives polars until the W5c/W5e flip
 
     for rule in rules:
-        if rule.column not in working_df.columns:
+        if rule.column not in frame.columns:
             raise ValueError(f"Column {rule.column!r} not found in DataFrame")
 
-        series = working_df[rule.column]
-        passed = _evaluate_rule(series, rule)
-        failed = ~passed
+        params = dict(rule.params or {})
+        if rule.rule_type == "format":
+            fmt_type = params["type"]
+            checker = _FORMAT_CHECKERS.get(fmt_type)
+            if checker is None:
+                raise ValueError(
+                    f"Unknown format type: {fmt_type!r}. "
+                    f"Available: {sorted(_FORMAT_CHECKERS)}"
+                )
+            params["__checker__"] = checker
+        passed = frame.evaluate_validation_rule(rule.column, rule.rule_type, params)
+        passed_list = [bool(v) for v in passed.to_list()]
 
-        total_checked = len(series)
-        passed_count = int(passed.sum())
+        total_checked = height
+        passed_count = sum(passed_list)
         failed_count = total_checked - passed_count
         fail_rate = failed_count / total_checked if total_checked > 0 else 0.0
 
@@ -139,44 +120,43 @@ def validate_dataframe(
 
         if rule.action == "flag":
             flag_col = f"__vf_{rule.column}_{rule.rule_type}__"
-            working_df = working_df.with_columns(passed.alias(flag_col))
+            frame = frame.with_column(flag_col, passed)
 
         elif rule.action == "null":
-            # Set failing values to null
-            working_df = working_df.with_columns(
-                pl.when(passed)
-                .then(pl.col(rule.column))
-                .otherwise(None)
-                .alias(rule.column)
+            failed_col = column_from_values(
+                [not p for p in passed_list], "bool", backend=backend
             )
+            frame = frame.with_null_where(rule.column, failed_col)
 
         elif rule.action == "quarantine":
-            # Mark rows for quarantine
-            quarantine_mask = quarantine_mask | failed
-            failed_list = failed.to_list()
-            for i, is_failed in enumerate(failed_list):
-                if is_failed:
+            for i, is_passed in enumerate(passed_list):
+                if not is_passed:
+                    quarantine_flags[i] = True
                     quarantine_reasons[i].append(
                         f"{rule.column}:{rule.rule_type}"
                     )
 
     # Split into valid and quarantine DataFrames
-    quarantine_df = working_df.filter(quarantine_mask)
-    valid_df = working_df.filter(~quarantine_mask)
+    q_mask = column_from_values(quarantine_flags, "bool", backend=backend)
+    keep_mask = column_from_values(
+        [not q for q in quarantine_flags], "bool", backend=backend
+    )
+    quarantine_frame = frame.filter_mask(q_mask)
+    valid_df = frame.filter_mask(keep_mask).native
 
     # Add quarantine reason column
-    if quarantine_df.height > 0:
-        # Build reason strings for quarantined rows
-        reason_series_data = []
-        quarantine_indices = quarantine_mask.to_list()
-        for i, is_q in enumerate(quarantine_indices):
-            if is_q:
-                reason_series_data.append("; ".join(quarantine_reasons[i]))
-        quarantine_df = quarantine_df.with_columns(
-            pl.Series("__quarantine_reason__", reason_series_data)
-        )
+    if quarantine_frame.height > 0:
+        reason_series_data = [
+            "; ".join(quarantine_reasons[i])
+            for i, is_q in enumerate(quarantine_flags)
+            if is_q
+        ]
+        quarantine_df = quarantine_frame.with_column(
+            "__quarantine_reason__",
+            column_from_values(reason_series_data, "utf8", backend=backend),
+        ).native
     else:
-        quarantine_df = quarantine_df.with_columns(
+        quarantine_df = quarantine_frame.native.with_columns(
             pl.Series("__quarantine_reason__", [], dtype=pl.Utf8)
         )
 


### PR DESCRIPTION
W5 batch 4 (W5b-2 #1684 merged). Still 2.x.

- New ops: evaluate_validation_rule (polars impl = legacy _evaluate_rule branches VERBATIM, oracle moved into the seam, orphan deleted; arrow twin = pc twins with the RE2 owned contract for user regex patterns, documented on the protocol) and with_null_where (dtype-preserving null-out; pc.if_else twin).
- validate_dataframe drives the seam end-to-end (rule eval, flag columns, null action, quarantine split); mask bookkeeping in Python lists on both backends.
- Plan rescope committed: goldencheck/goldenflow integrations become EXTRA-GATED at W5e (their polars is their own dep; goldenmatch never imports it) — W5b-3's code scope is the goldenmatch-internal stages only. autofix is W5b-3b (own pass: the whitespace-collapse regex needs the RE2-vs-Rust probe treatment).

Gates: test_validate unedited (15) + frame w4 ops (65). ruff clean.