### PR TITLE
feat(goldencheck): W5 drift -- reuse chi2_gof + pearson_r kernels (shadow)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-goldencheck-w5-drift-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w5-drift-design.md
@@ -37,3 +37,9 @@ So W5 = **shadow-wire `chi2_gof` + `pearson_r` into `drift/detector.py`** (mirro
 
 ## Non-goals
 - No new kernels. No kstest/distribution-fit reproduction (declined, same as W4). No entropy/bounds kernel (pure arithmetic, no scipy, low value). No re-wiring drift's fd/keys/regex checks (already native via their own kernels). No changing user-visible output (shadow). No polars-free wiring (Flip).
+
+## Review corrections (folded — 2026-07-11)
+- **[nit] `_check_distribution_drift` does NOT call `dist.fit()`** — the fit happens at baseline-profile time (baseline's `_fit_distribution`); drift reconstructs `fit_params` from the SAVED `sp.params` and only calls `kstest`. The decline is unchanged (kstest's Kolmogorov p-value is the non-reproducible surface), but the described surface was slightly off.
+- **[nit] detector.py imports NEITHER `native_enabled`/`native_module` NOR `pyarrow`** (unlike baseline/statistical.py) — W5 must ADD both imports.
+- **[nit] shadow test must gate on / assert `native_enabled("chi2_gof")` + `native_enabled("pearson_r")`** so a bad W4 rebase that drops the `_COMPONENT_SYMBOLS` entries surfaces as a SKIP (visible), not a silent false-green (the kernels no-op if the symbol is missing).
+- **[confirmed] the two existing handlers are `except Exception` (detector.py:348, :701)** — the shadow blocks MUST have their OWN `try/except BaseException` (pyo3 PanicException is a BaseException and would escape the surrounding `except Exception`).

--- a/docs/superpowers/specs/2026-07-11-goldencheck-w5-drift-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w5-drift-design.md
@@ -1,0 +1,39 @@
+# GoldenCheck W5 — drift detection (reuse wave) — design
+
+Date: 2026-07-11
+Status: wave design (Arrow fused-scan program; /goal "all Ws implemented"). Pending spec review.
+Program: `...-arrow-fused-scan-engine-program-design.md` + `...-W-path-scoping.md`. **W5 — drift.**
+Base: fresh `origin/main` (W0-land + CSV + W1 + W2 + W3 merged; W4 #1685 enqueuing — the reused kernels `chi2_gof`/`pearson_r`/`chi2_contingency_stat` land with W4 before this PRs; rebase onto them).
+
+## Goal
+
+Bring `drift/detector.py`'s statistics onto the Rust-source-of-truth kernels. **W5 is a REUSE wave — it adds NO new kernels.** Recon (source-verified) shows drift's scipy surface is a subset of what W1–W4 already built:
+- `_compute_benford_pvalue` (detector.py:346) does `_stats.chisquare(f_obs=observed, f_exp=expected)` — **identical** to baseline `_compute_benford`; reuses W4 **`chi2_gof`**.
+- `_compute_correlation` pearson branch (detector.py:699) does `_stats.pearsonr(a_vals, b_vals)` (uses only `corr`) — reuses W4 **`pearson_r`**.
+- `_compute_correlation` cramers_v branch (detector.py:706) calls `_cramers_v` from `baseline/correlation.py` — **already shadow-wired in W4** (`chi2_contingency_stat`); nothing to do here.
+- Benford leading-digit COUNTS (`_leading_digit_counts`, detector.py:340) already use the native `benford` kernel (W0-land). Nothing to do.
+
+**DECLINED (documented, stays Python — same boundary as W4):** `_check_distribution_drift` (detector.py:109-146) fits candidate distributions via scipy `dist.fit()` (lognorm numerical MLE) + `_stats.kstest` (Kolmogorov p-value). Not byte-reproducible; identical decline to W4's `_fit_distribution`.
+
+So W5 = **shadow-wire `chi2_gof` + `pearson_r` into `drift/detector.py`** (mirroring exactly how W4 wired them into `baseline/`), + a shadow test, + record the distribution/kstest decline. The 13 drift check-TYPES are unchanged; their non-stat parts already route through existing kernels (fd/keys/regex/benford) or are pure arithmetic (entropy/bounds) — out of scope (no scipy, no new Rust).
+
+## Wiring (shadow — mirrors W4)
+- `_compute_benford_pvalue`: after `_chi2, pvalue = _stats.chisquare(...)`, when `native_enabled("chi2_gof")`, ALSO compute `native_module().chi2_gof(observed, expected)` in shadow (try/except **BaseException** — pyo3 PanicException is a BaseException, the W4 lesson); discard. Finding unchanged.
+- `_compute_correlation` pearson: after `corr, _ = _stats.pearsonr(a_vals, b_vals)`, when `native_enabled("pearson_r")`, ALSO compute `pearson_r(pa.array(a_vals, float64), pa.array(b_vals, float64))` in shadow; discard. (Cast to float64 first — pearson_r panics on int arrays, the W4 lesson.) Value unchanged.
+- No wiring for cramers_v (baseline `_cramers_v` already carries the W4 shadow).
+
+## Parity / contract
+- No NEW parity contract — `chi2_gof` + `pearson_r` are already registered + parity-locked in the W4 harness. W5 adds only a shadow test asserting the kernels match scipy on drift's inputs (the same epsilon as W4).
+- Authoritative drift Findings UNCHANGED (shadow); `import goldencheck` zero polars (drift lazy-imports scipy); existing drift tests UNEDITED.
+
+## Testing
+- Python: existing `drift`/`detector` tests UNEDITED green (shadow). A shadow test `tests/engine/test_w5_drift_shadow.py`: for a benford-eligible drift fixture + a correlated-numeric drift fixture, assert `chi2_gof`/`pearson_r` (on the inputs drift feeds scipy) match scipy within epsilon. `skipif` on `native_enabled(...)`.
+- `import goldencheck` zero polars; ruff clean. NO Rust changes → no cargo/clippy/wasm needed (but confirm the reused symbols are present).
+
+## Risks
+- **Thin wave — the value is correctness-of-reuse, not new kernels.** The risk is mis-wiring: passing the wrong array/list shape to a kernel, or letting a pyo3 panic escape. Mitigated by mirroring W4's exact wiring (float64 cast + `except BaseException`) and the shadow test.
+- **drift lazy-imports scipy (`_SCIPY_AVAILABLE`)** — the shadow calls must sit on the path where scipy already succeeded (inside the existing try), so a scipy-absent env is unaffected.
+- **rebase onto W4** — the reused kernels only exist once W4 merges; branch/rebase accordingly.
+
+## Non-goals
+- No new kernels. No kstest/distribution-fit reproduction (declined, same as W4). No entropy/bounds kernel (pure arithmetic, no scipy, low value). No re-wiring drift's fd/keys/regex checks (already native via their own kernels). No changing user-visible output (shadow). No polars-free wiring (Flip).

--- a/docs/superpowers/specs/2026-07-11-goldencheck-w6-semantic-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w6-semantic-design.md
@@ -1,0 +1,43 @@
+# GoldenCheck W6 — semantic classification (decline + regex reuse) — design
+
+Date: 2026-07-11
+Status: wave design (Arrow fused-scan program; /goal "all Ws implemented"). Pending spec review.
+Program: `...-arrow-fused-scan-engine-program-design.md` + `...-W-path-scoping.md`. **W6 — semantic (the final content wave before the Flip).**
+Base: fresh `origin/main` (W0-land…W3 merged; W4 #1685 enqueuing). **Independent of W4/W5** — W6 reuses only the `regex` kernel (`str_contains_count`), on main since S2.2. Branch off current main; no W4 rebase needed.
+
+## Goal
+
+Resolve the semantic layer's place in the Rust-source-of-truth program. Recon (source-verified) splits it cleanly:
+
+- **`baseline/semantic.py` `_infer_with_embeddings` — DECLINED (documented, stays Python/ML).** Semantic-type inference via `sentence_transformers` embeddings + cosine similarity is an ML model: non-deterministic across versions/hardware, not a fused-kernel candidate. This is exactly the program design's "W6 semantic stays ML fallback." The keyword fallback (`_infer_with_keywords`/`_match_column_keywords`) is pure-Python dict/substring matching — no scipy, no heavy compute, no Rust value.
+- **`semantic/classifier.py` `_check_format_match` (classifier.py:197-209) — REUSE the `regex` kernel.** It does `non_null.str.contains(r"...", literal=False).sum()` for email/phone/date shape detection — EXACTLY what the existing `str_contains_count(values, pattern)` kernel computes (both Polars `str.contains` and the kernel use the Rust `regex` crate → byte-identical match count). Shadow-wire it.
+- The other `_check_value_signals` (classifier.py:156-195: `min_unique_pct`, `max_unique`, `mixed_case`, `avg_length_min`, `numeric`, `short_strings`) are pure-Python/Polars primitives over already-covered quantities (n_unique, str-len, dtype) — no scipy, low value, out of scope.
+
+So W6 = **shadow-wire `_check_format_match` to `str_contains_count`** + **formally record the embeddings decline** (the program's semantic-ML boundary). It closes the content waves: after W6, every scipy/Polars statistic on the scan path is either Rust-authoritative-in-shadow or an explicitly-registered decline (embeddings, scipy `.fit()`/kstest, the neutral dtype-string). That decline inventory is the input to the Flip gate.
+
+## Wiring (shadow — mirrors W1–W5)
+- `_check_format_match(non_null, format_type)`: after computing `matches = non_null.str.contains(pattern, literal=False).sum()`, when `native_enabled("regex")`, ALSO compute `native_module().str_contains_count(non_null.to_list(), pattern)` (or the Arrow-in form the kernel exposes — CHECK the `str_contains_count` signature: S2.2 built it as `&[Option<String>]`/list-based; pass `non_null.to_list()`) in shadow (try/except **BaseException**); discard. The authoritative `matches`/return stays Polars. Map the three patterns (`@.*\.`, `\d{3}.*\d{3}.*\d{4}`, `\d{4}-\d{2}-\d{2}`) through unchanged.
+- If the kernel's list vs Polars `str.contains` count could differ on nulls: `non_null` is already null-dropped, so both count over the same non-null values — confirm in the shadow test.
+
+## The decline inventory (record for the Flip gate)
+W6 writes/updates a short decline registry (in the spec + a code comment) enumerating what STAYS Python and why — the Flip's §8b gate consumes this:
+1. **Embeddings semantic inference** (`_infer_with_embeddings`) — ML model, non-deterministic. Fallback: keyword matching (deterministic, pure-Python).
+2. **scipy distribution `.fit()` + `kstest`** (`baseline/statistical.py` `_fit_distribution`, `drift/detector.py` `_check_distribution_drift`) — numerical MLE + Kolmogorov p-value, not byte-reproducible (W4/W5 decline).
+3. **`inferred_type` = `str(pl.dtype)`** — the neutral dtype-string divergence (W1), a registered Flip-gate bucket.
+4. **`df.sample(seed=42)`** sampling PRNG + scipy KS/chi2/pearsonr p-value last-digits — the owned-contract epsilon classes (program design §OWNED CONTRACT).
+
+## Parity / contract
+- No NEW kernel, no NEW parity contract — `str_contains_count` (regex) is already parity-locked (S2.2). W6 adds only a shadow test asserting the kernel's count matches Polars `str.contains(...).sum()` on the three format patterns.
+- Authoritative semantic classification UNCHANGED (shadow); embeddings path untouched; `import goldencheck` zero polars (semantic lazy-imports its deps); existing semantic/classifier tests UNEDITED.
+
+## Testing
+- Python: existing `semantic`/`classifier` tests UNEDITED green. A shadow test `tests/engine/test_w6_semantic_shadow.py`: for email/phone/date-shaped string columns, assert `str_contains_count(non_null.to_list(), pattern) == int(non_null.str.contains(pattern, literal=False).sum())` for the three patterns. `skipif` on `native_enabled("regex")`.
+- `import goldencheck` zero polars; ruff clean. NO Rust changes (regex kernel already built) → no cargo/clippy/wasm.
+
+## Risks
+- **regex-count parity on the three patterns** — Polars `str.contains(literal=False)` and the Rust `regex` crate should be byte-identical (same engine), but VERIFY the `.*` / anchoring behavior matches on the shadow corpus (esp. the phone `\d{3}.*\d{3}.*\d{4}` with `.*` greediness — match COUNT is a presence test, so greediness doesn't change presence). Register nothing unless a real divergence appears.
+- **thin wave** — like W5, the value is closing the decline inventory + one reuse-wiring, not new kernels. That's the correct end state: the semantic ML layer SHOULD stay Python.
+- **`str_contains_count` input form** — confirm whether it takes a Python list or an Arrow array; pass the matching shape.
+
+## Non-goals
+- No embedding/ML reproduction in Rust (declined — the whole point). No kerneling the pure-Python value-signal primitives. No changing user-visible output (shadow). No polars-free wiring (Flip). No new kernels.

--- a/packages/python/goldencheck/goldencheck/drift/detector.py
+++ b/packages/python/goldencheck/goldencheck/drift/detector.py
@@ -20,6 +20,7 @@ from goldencheck.baseline.models import BaselineProfile
 from goldencheck.baseline.patterns import _induce_column_grammars
 from goldencheck.baseline.semantic import infer_semantic_types
 from goldencheck.baseline.statistical import _leading_digit_counts
+from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.models.finding import Finding, Severity
 
 __all__ = ["run_drift_checks"]
@@ -344,6 +345,14 @@ def _compute_benford_pvalue(values: np.ndarray) -> float | None:
     expected = [math.log10(1 + 1 / d) * total for d in range(1, 10)]
     try:
         _chi2, pvalue = _stats.chisquare(f_obs=observed, f_exp=expected)
+        # Shadow (W5 reuse): compute the W4 native chi2_gof kernel alongside the
+        # authoritative scipy value and discard it. `except BaseException` because
+        # a pyo3 PanicException is a BaseException and would escape `except Exception`.
+        if native_enabled("chi2_gof"):
+            try:
+                native_module().chi2_gof(observed, expected)
+            except BaseException:  # noqa: BLE001 - shadow must never raise out
+                pass
         return float(pvalue)
     except Exception as exc:
         logger.debug("Benford chi-square test failed: %s", exc)
@@ -697,6 +706,20 @@ def _compute_correlation(
             if np.std(a_vals) == 0.0 or np.std(b_vals) == 0.0:
                 return None
             corr, _ = _stats.pearsonr(a_vals, b_vals)
+            # Shadow (W5 reuse): compute the W4 native pearson_r kernel alongside
+            # the authoritative scipy value and discard it. a_vals/b_vals are
+            # already Float64 (drift pre-casts). `except BaseException` because a
+            # pyo3 PanicException would escape `except Exception`.
+            if native_enabled("pearson_r"):
+                try:
+                    import pyarrow as pa
+
+                    native_module().pearson_r(
+                        pa.array(a_vals, type=pa.float64()),
+                        pa.array(b_vals, type=pa.float64()),
+                    )
+                except BaseException:  # noqa: BLE001 - shadow must never raise out
+                    pass
             return float(corr) if np.isfinite(corr) else None
         except Exception as exc:
             logger.debug("Pearson correlation failed for (%s, %s): %s", col_a, col_b, exc)

--- a/packages/python/goldencheck/tests/engine/test_w5_drift_shadow.py
+++ b/packages/python/goldencheck/tests/engine/test_w5_drift_shadow.py
@@ -1,0 +1,68 @@
+"""Shadow-compute proof for the two W5 drift reuse kernels.
+
+`drift/detector.py` now shadow-computes the W4 native kernels
+(`chi2_gof` / `pearson_r`) alongside the authoritative scipy path in
+`_compute_benford_pvalue` and `_compute_correlation`, discarding the result.
+This test proves the kernel values MATCH the scipy values drift feeds them --
+on the exact input shapes drift builds (a benford observed/expected pair and a
+correlated Float64 numeric pair) -- i.e. they are ready to become authoritative
+at a future Flip.
+
+It asserts nothing about drift's emitted `Finding`s; the existing drift tests
+stay green unedited. Each half skips cleanly when the relevant native kernel
+isn't built/enabled (e.g. before the W4 rebase lands the symbols) -- the skip is
+VISIBLE, so a bad rebase that drops the kernel surfaces as a skip, not a silent
+false-green.
+"""
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pyarrow as pa
+import pytest
+import scipy.stats as _stats
+from goldencheck.core._native_loader import native_enabled, native_module
+
+_EPS = 1e-9
+
+chi2_only = pytest.mark.skipif(
+    not native_enabled("chi2_gof"),
+    reason="goldencheck native chi2_gof kernel not built/enabled",
+)
+pearson_only = pytest.mark.skipif(
+    not native_enabled("pearson_r"),
+    reason="goldencheck native pearson_r kernel not built/enabled",
+)
+
+
+@chi2_only
+def test_chi2_gof_shadow_matches_scipy_on_benford_inputs() -> None:
+    # The shapes drift's _compute_benford_pvalue feeds scipy: 9 observed
+    # leading-digit counts vs Benford expected counts scaled to the same total.
+    observed = [301, 176, 125, 97, 79, 67, 58, 51, 46]
+    total = sum(observed)
+    expected = [math.log10(1 + 1 / d) * total for d in range(1, 10)]
+
+    _chi2, scipy_p = _stats.chisquare(f_obs=observed, f_exp=expected)
+    kernel = native_module().chi2_gof(observed, expected)
+    # chi2_gof returns the p-value (matching scipy's second return element).
+    kernel_p = kernel[1] if isinstance(kernel, (tuple, list)) else kernel
+    assert abs(float(kernel_p) - float(scipy_p)) < _EPS
+
+
+@pearson_only
+def test_pearson_r_shadow_matches_scipy_on_correlated_pair() -> None:
+    # The shape drift's _compute_correlation pearson branch feeds scipy: two
+    # already-Float64 numpy arrays. Build a correlated pair (>= 30 rows).
+    rng = np.random.default_rng(42)
+    a_vals = np.arange(50, dtype=np.float64)
+    b_vals = 2.0 * a_vals + rng.normal(0.0, 3.0, size=50)
+
+    scipy_corr, _ = _stats.pearsonr(a_vals, b_vals)
+    kernel = native_module().pearson_r(
+        pa.array(a_vals, type=pa.float64()),
+        pa.array(b_vals, type=pa.float64()),
+    )
+    kernel_corr = kernel[0] if isinstance(kernel, (tuple, list)) else kernel
+    assert abs(float(kernel_corr) - float(scipy_corr)) < _EPS


### PR DESCRIPTION
## W5 -- drift detection (reuse wave)

Sixth wave of the goldencheck 3.0.0 Arrow-native fused-scan program (after W0-land #1661, CSV #1670, W1 #1676, W2 #1681, W3 #1683, W4 #1685). A **reuse wave -- adds NO new kernels**. Additive, no version bump, shadow.

### Why no new kernels
Source-verified recon shows `drift/detector.py`'s scipy surface is a subset of what W1-W4 already built:
- `_compute_benford_pvalue` does `_stats.chisquare(observed, expected)` -- byte-identical to baseline `_compute_benford`; reuses W4 `chi2_gof`.
- `_compute_correlation` pearson does `_stats.pearsonr(a, b)` (uses only `corr`); reuses W4 `pearson_r`. Drift is the safer caller -- it already pre-casts to Float64.
- cramers_v delegates to `baseline/correlation.py` `_cramers_v` (already W4-wired). Benford COUNTS already use the W0-land `benford` kernel.
- DECLINED (same as W4): `_check_distribution_drift`'s `kstest` (Kolmogorov p-value) -- not byte-reproducible.

### Wiring (shadow, mirrors W1-W4)
Shadow-computes `chi2_gof` + `pearson_r` alongside the authoritative scipy compute and discards. Each shadow block has its OWN `try/except BaseException` -- the surrounding handlers are `except Exception`, and a pyo3 PanicException is a BaseException that would escape them (the W4 lesson). detector.py gained the `native_enabled`/`native_module` imports (it had neither).

### Verification
- Shadow tests RUN + PASS on the merged-W4 base (chi2_gof/pearson_r match scipy within 1e-9 on drift's inputs); drift regression 41 passed UNEDITED; `import goldencheck` zero polars. No Rust changes.

Rebased onto fresh origin/main (W4 merged; the reused kernels are present).

Spec: `docs/superpowers/specs/2026-07-11-goldencheck-w5-drift-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h