### PR TITLE
feat(goldencheck): W6 semantic -- reuse regex kernel in format-match; embeddings declined (shadow)

### DIFF
--- a/docs/superpowers/specs/2026-07-11-goldencheck-w6-semantic-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-w6-semantic-design.md
@@ -1,0 +1,43 @@
+# GoldenCheck W6 — semantic classification (decline + regex reuse) — design
+
+Date: 2026-07-11
+Status: wave design (Arrow fused-scan program; /goal "all Ws implemented"). Pending spec review.
+Program: `...-arrow-fused-scan-engine-program-design.md` + `...-W-path-scoping.md`. **W6 — semantic (the final content wave before the Flip).**
+Base: fresh `origin/main` (W0-land…W3 merged; W4 #1685 enqueuing). **Independent of W4/W5** — W6 reuses only the `regex` kernel (`str_contains_count`), on main since S2.2. Branch off current main; no W4 rebase needed.
+
+## Goal
+
+Resolve the semantic layer's place in the Rust-source-of-truth program. Recon (source-verified) splits it cleanly:
+
+- **`baseline/semantic.py` `_infer_with_embeddings` — DECLINED (documented, stays Python/ML).** Semantic-type inference via `sentence_transformers` embeddings + cosine similarity is an ML model: non-deterministic across versions/hardware, not a fused-kernel candidate. This is exactly the program design's "W6 semantic stays ML fallback." The keyword fallback (`_infer_with_keywords`/`_match_column_keywords`) is pure-Python dict/substring matching — no scipy, no heavy compute, no Rust value.
+- **`semantic/classifier.py` `_check_format_match` (classifier.py:197-209) — REUSE the `regex` kernel.** It does `non_null.str.contains(r"...", literal=False).sum()` for email/phone/date shape detection — EXACTLY what the existing `str_contains_count(values, pattern)` kernel computes (both Polars `str.contains` and the kernel use the Rust `regex` crate → byte-identical match count). Shadow-wire it.
+- The other `_check_value_signals` (classifier.py:156-195: `min_unique_pct`, `max_unique`, `mixed_case`, `avg_length_min`, `numeric`, `short_strings`) are pure-Python/Polars primitives over already-covered quantities (n_unique, str-len, dtype) — no scipy, low value, out of scope.
+
+So W6 = **shadow-wire `_check_format_match` to `str_contains_count`** + **formally record the embeddings decline** (the program's semantic-ML boundary). It closes the content waves: after W6, every scipy/Polars statistic on the scan path is either Rust-authoritative-in-shadow or an explicitly-registered decline (embeddings, scipy `.fit()`/kstest, the neutral dtype-string). That decline inventory is the input to the Flip gate.
+
+## Wiring (shadow — mirrors W1–W5)
+- `_check_format_match(non_null, format_type)`: after computing `matches = non_null.str.contains(pattern, literal=False).sum()`, when `native_enabled("regex")`, ALSO compute `native_module().str_contains_count(non_null.to_list(), pattern)` (or the Arrow-in form the kernel exposes — CHECK the `str_contains_count` signature: S2.2 built it as `&[Option<String>]`/list-based; pass `non_null.to_list()`) in shadow (try/except **BaseException**); discard. The authoritative `matches`/return stays Polars. Map the three patterns (`@.*\.`, `\d{3}.*\d{3}.*\d{4}`, `\d{4}-\d{2}-\d{2}`) through unchanged.
+- If the kernel's list vs Polars `str.contains` count could differ on nulls: `non_null` is already null-dropped, so both count over the same non-null values — confirm in the shadow test.
+
+## The decline inventory (record for the Flip gate)
+W6 writes/updates a short decline registry (in the spec + a code comment) enumerating what STAYS Python and why — the Flip's §8b gate consumes this:
+1. **Embeddings semantic inference** (`_infer_with_embeddings`) — ML model, non-deterministic. Fallback: keyword matching (deterministic, pure-Python).
+2. **scipy distribution `.fit()` + `kstest`** (`baseline/statistical.py` `_fit_distribution`, `drift/detector.py` `_check_distribution_drift`) — numerical MLE + Kolmogorov p-value, not byte-reproducible (W4/W5 decline).
+3. **`inferred_type` = `str(pl.dtype)`** — the neutral dtype-string divergence (W1), a registered Flip-gate bucket.
+4. **`df.sample(seed=42)`** sampling PRNG + scipy KS/chi2/pearsonr p-value last-digits — the owned-contract epsilon classes (program design §OWNED CONTRACT).
+
+## Parity / contract
+- No NEW kernel, no NEW parity contract — `str_contains_count` (regex) is already parity-locked (S2.2). W6 adds only a shadow test asserting the kernel's count matches Polars `str.contains(...).sum()` on the three format patterns.
+- Authoritative semantic classification UNCHANGED (shadow); embeddings path untouched; `import goldencheck` zero polars (semantic lazy-imports its deps); existing semantic/classifier tests UNEDITED.
+
+## Testing
+- Python: existing `semantic`/`classifier` tests UNEDITED green. A shadow test `tests/engine/test_w6_semantic_shadow.py`: for email/phone/date-shaped string columns, assert `str_contains_count(non_null.to_list(), pattern) == int(non_null.str.contains(pattern, literal=False).sum())` for the three patterns. `skipif` on `native_enabled("regex")`.
+- `import goldencheck` zero polars; ruff clean. NO Rust changes (regex kernel already built) → no cargo/clippy/wasm.
+
+## Risks
+- **regex-count parity on the three patterns** — Polars `str.contains(literal=False)` and the Rust `regex` crate should be byte-identical (same engine), but VERIFY the `.*` / anchoring behavior matches on the shadow corpus (esp. the phone `\d{3}.*\d{3}.*\d{4}` with `.*` greediness — match COUNT is a presence test, so greediness doesn't change presence). Register nothing unless a real divergence appears.
+- **thin wave** — like W5, the value is closing the decline inventory + one reuse-wiring, not new kernels. That's the correct end state: the semantic ML layer SHOULD stay Python.
+- **`str_contains_count` input form** — confirm whether it takes a Python list or an Arrow array; pass the matching shape.
+
+## Non-goals
+- No embedding/ML reproduction in Rust (declined — the whole point). No kerneling the pure-Python value-signal primitives. No changing user-visible output (shadow). No polars-free wiring (Flip). No new kernels.

--- a/packages/python/goldencheck/goldencheck/baseline/semantic.py
+++ b/packages/python/goldencheck/goldencheck/baseline/semantic.py
@@ -139,6 +139,13 @@ def _infer_with_embeddings(df: pl.DataFrame) -> dict[str, list[str]]:  # noqa: P
     """Classify columns using sentence-transformer cosine similarity.
 
     Raises ``ImportError`` if *sentence_transformers* is not installed.
+
+    W6 DECLINE (Rust-source-of-truth program, decline inventory #1): this
+    embeddings path STAYS Python/ML. Semantic-type inference via
+    ``sentence_transformers`` + cosine similarity is a non-deterministic ML model
+    (varies across versions/hardware) -- not a fused-kernel candidate. The
+    deterministic keyword fallback (``_infer_with_keywords``) is pure-Python
+    dict/substring matching with no heavy compute, so it needs no Rust either.
     """
     import numpy as np  # type: ignore[import]
     from sentence_transformers import SentenceTransformer  # type: ignore[import]

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -9,6 +9,7 @@ from typing import Any
 import yaml
 
 from goldencheck._polars_lazy import pl
+from goldencheck.core._native_loader import native_enabled, native_module
 
 logger = logging.getLogger(__name__)
 
@@ -194,16 +195,32 @@ def _check_value_signals(non_null: pl.Series, col: pl.Series, signals: dict) -> 
                 return False
     return True
 
+def _count_matches(non_null: pl.Series, pattern: str) -> int:
+    """Count values in ``non_null`` matching ``pattern`` (Polars-authoritative).
+
+    W6 shadow-wire: when the ``regex`` kernel is enabled, ALSO compute the count
+    via the Rust ``str_contains_count`` kernel (both Polars ``str.contains`` and
+    the kernel use the Rust ``regex`` crate, so the counts are byte-identical).
+    The kernel result is discarded -- the authoritative count stays Polars until
+    the Flip. Mirrors the profiler call form (``PyColumn.str_match_count``):
+    ``str_contains_count(<list of non-null values>, pattern) -> int``.
+    """
+    matches = int(non_null.str.contains(pattern, literal=False).sum())
+    if native_enabled("regex"):
+        try:  # noqa: SIM105 - shadow compute, discard result, never fail the caller
+            native_module().str_contains_count(non_null.to_list(), pattern)
+        except BaseException:  # noqa: BLE001 - shadow must never affect the return
+            pass
+    return matches
+
+
 def _check_format_match(non_null: pl.Series, format_type: str) -> bool:
     if non_null.dtype not in (pl.Utf8, pl.String):
         return False
     if format_type == "email":
-        matches = non_null.str.contains(r"@.*\.", literal=False).sum()
-        return matches / len(non_null) >= 0.70
+        return _count_matches(non_null, r"@.*\.") / len(non_null) >= 0.70
     elif format_type == "phone":
-        matches = non_null.str.contains(r"\d{3}.*\d{3}.*\d{4}", literal=False).sum()
-        return matches / len(non_null) >= 0.70
+        return _count_matches(non_null, r"\d{3}.*\d{3}.*\d{4}") / len(non_null) >= 0.70
     elif format_type == "date":
-        matches = non_null.str.contains(r"\d{4}-\d{2}-\d{2}", literal=False).sum()
-        return matches / len(non_null) >= 0.50
+        return _count_matches(non_null, r"\d{4}-\d{2}-\d{2}") / len(non_null) >= 0.50
     return False

--- a/packages/python/goldencheck/tests/engine/test_w6_semantic_shadow.py
+++ b/packages/python/goldencheck/tests/engine/test_w6_semantic_shadow.py
@@ -1,0 +1,96 @@
+"""Shadow-compute proof for the W6 semantic format-match reuse.
+
+`semantic/classifier.py` `_check_format_match` now shadow-computes the `regex`
+kernel (`str_contains_count`) alongside the authoritative Polars
+`str.contains(...).sum()` for the three format patterns (email/phone/date),
+discarding the kernel result. This test proves the kernel count MATCHES the
+Polars count the classifier actually uses -- i.e. the reuse is byte-identical
+and ready to become authoritative at a future Flip.
+
+No NEW kernel and no NEW parity contract: `str_contains_count` (the `regex`
+component) is already parity-locked since S2.2. The regex kernel IS built on
+this branch, so this test should RUN and PASS -- if it skips, the kernel isn't
+built. The authoritative semantic classification is UNCHANGED (shadow); the
+existing semantic/classifier tests stay green unedited."""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldencheck.core._native_loader import native_enabled, native_module
+
+regex_only = pytest.mark.skipif(
+    not native_enabled("regex"),
+    reason="goldencheck native regex kernel not built/enabled",
+)
+
+# The three format patterns, verbatim from `_check_format_match`.
+EMAIL_PATTERN = r"@.*\."
+PHONE_PATTERN = r"\d{3}.*\d{3}.*\d{4}"
+DATE_PATTERN = r"\d{4}-\d{2}-\d{2}"
+
+_EMAIL_COL = pl.Series(
+    "email",
+    [
+        "alice@example.com",
+        "bob@work.org",
+        "carol@sub.domain.co.uk",
+        "not-an-email",  # no @.
+        "dave@localhost",  # @ but no dot
+        None,
+    ],
+)
+_PHONE_COL = pl.Series(
+    "phone",
+    [
+        "555-123-4567",
+        "(212) 867 5309",
+        "800.555.0199",
+        "12345",  # too short
+        "abc-def-ghij",  # no digits
+        None,
+    ],
+)
+_DATE_COL = pl.Series(
+    "date",
+    [
+        "2026-07-11",
+        "1999-01-01",
+        "2000-12-31T23:59:59",
+        "07/11/2026",  # wrong shape
+        "not a date",
+        None,
+    ],
+)
+
+
+@regex_only
+@pytest.mark.parametrize(
+    ("col", "pattern"),
+    [
+        (_EMAIL_COL, EMAIL_PATTERN),
+        (_PHONE_COL, PHONE_PATTERN),
+        (_DATE_COL, DATE_PATTERN),
+    ],
+)
+def test_str_contains_count_matches_polars(col: pl.Series, pattern: str) -> None:
+    """The regex kernel count == Polars `str.contains(...).sum()` per pattern.
+
+    `_check_format_match` drops nulls before counting, so both the Polars path
+    and the kernel count over the same non-null values."""
+    non_null = col.drop_nulls()
+    polars_count = int(non_null.str.contains(pattern, literal=False).sum())
+    kernel_count = native_module().str_contains_count(non_null.to_list(), pattern)
+    assert kernel_count == polars_count
+
+
+@regex_only
+def test_all_three_patterns_against_all_cols() -> None:
+    """Cross every column against every pattern -- kernel == Polars for all 9."""
+    cols = [_EMAIL_COL, _PHONE_COL, _DATE_COL]
+    patterns = [EMAIL_PATTERN, PHONE_PATTERN, DATE_PATTERN]
+    for col in cols:
+        non_null = col.drop_nulls()
+        for pattern in patterns:
+            polars_count = int(non_null.str.contains(pattern, literal=False).sum())
+            kernel_count = native_module().str_contains_count(non_null.to_list(), pattern)
+            assert kernel_count == polars_count, (col.name, pattern)


### PR DESCRIPTION
## W6 -- semantic classification (final content wave)

Seventh wave of the goldencheck 3.0.0 Arrow-native fused-scan program (after W0-land #1661, CSV #1670, W1 #1676, W2 #1681, W3 #1683, W4 #1685, W5 #1687). Closes the content waves before the Flip. Additive, no version bump, shadow.

### Scope: one reuse-wiring + a documented decline
- **Embeddings semantic inference (`baseline/semantic.py` `_infer_with_embeddings`) -- DECLINED, stays Python/ML.** `sentence_transformers` embeddings are non-deterministic across versions/hardware -- not a fused-kernel candidate. This is the program design's "semantic stays ML fallback." Recorded as decline-inventory #1 (a docstring note; no logic change).
- **`semantic/classifier.py` `_check_format_match` -- REUSE the `regex` kernel.** It did `non_null.str.contains(pattern).sum()` for email/phone/date; that's exactly `str_contains_count(values, pattern)` (both use the Rust `regex` crate). Shadow-wired via a small DRY `_count_matches` helper; the three patterns unchanged.
- The other value-signal primitives (`min_unique_pct`, `mixed_case`, `avg_length`, ...) are pure-Python/Polars over already-covered quantities -- no scipy, out of scope.

### Decline inventory (input to the Flip gate)
This wave formalizes what STAYS Python and why: (1) embeddings semantic inference; (2) scipy `.fit()` + kstest (W4/W5); (3) `inferred_type = str(pl.dtype)` neutral-string divergence (W1); (4) `df.sample(seed=42)` PRNG + scipy p-value last-digits (owned-contract epsilon). After W6, every scipy/Polars statistic on the scan path is either Rust-authoritative-in-shadow or an explicitly-registered decline.

### Wiring (shadow, mirrors W1-W5)
Shadow-computes `str_contains_count` alongside the authoritative Polars `str.contains().sum()` and discards; guarded by `native_enabled("regex")` + its own `try/except BaseException`.

### Verification
- Shadow test RUNS + PASSES (kernel count == Polars `str.contains().sum()` on all three patterns); semantic/classifier regression 49 passed UNEDITED; `import goldencheck` zero polars. No Rust changes (regex kernel already on main since S2.2).

Spec: `docs/superpowers/specs/2026-07-11-goldencheck-w6-semantic-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KWa2qYerDVRSMQBWDtuY2h