### PR TITLE
feat(goldenmatch)!: W5c-2 -- THE FLIP: result frames become pa.Table (v3.0.0)

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
@@ -86,10 +86,18 @@ assertions migrate to Arrow, results become `pa.Table`. W0-W4 merged/queued
     expectations per-backend per the W3a sample contract). Wall + RSS both
     lanes on the 100K gate + 1M dispatch bench (fused-with_columns loss
     measured; >10% → multi-column derive op).
-- **W5c (v3.0.0 branch)** — result flip: 5 fields → pa.Table, _repr_html_ /
-  to_csv re-render, migration guide (pl.from_arrow one-liner), input
-  polymorphism already in place. Fused/golden_fused backend-conditional
-  audit. Ingest loop → pa.concat_tables.
+- **W5c (v3.0.0)** — W5c-1 (SHIPPED #1690): type-agnostic result accessors,
+  flip becomes a field-type change. W5c-2 (THE FLIP): 4 construction sites
+  wrap frames with a to-arrow helper; consumers migrate: cli/demo.py (3
+  sites), mcp/server.py (5), the 13 test files/16 sites (W5d fold-in);
+  migration guide (pl.from_arrow one-liner). FUSED AUDIT (2026-07-12,
+  PASS): fused_match.py:162 is seam-routed comment-only;
+  golden_fused.py:466's polars-only decline `resolve_frame_backend() !=
+  "arrow" and _polars_native_eligible(...)` simply never fires when arrow
+  is the only backend -- BY DESIGN per its W2e-3 comment; W5e deletes the
+  decline + the _polars_native_eligible import. Ingest loop →
+  pa.concat_tables (already concat_frames on the arrow lane; the polars
+  branch dies at W5e).
 - **W5d (RESCOPED 2026-07-12: collapses into W5c-2)** — the ~334-file count
   measured ANY pl usage in tests; the REAL result-assertion surface is 13
   files / 16 call sites (grep: .golden/.dupes/.unique/.matched/.unmatched

--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
@@ -90,9 +90,14 @@ assertions migrate to Arrow, results become `pa.Table`. W0-W4 merged/queued
   to_csv re-render, migration guide (pl.from_arrow one-liner), input
   polymorphism already in place. Fused/golden_fused backend-conditional
   audit. Ingest loop → pa.concat_tables.
-- **W5d** — test migration (~334 files; mechanical to_dicts/pl.DataFrame →
-  arrow equivalents in waves by directory, shard-aware per
-  [[feedback_pytest_split_shard_shift_clobber]]).
+- **W5d (RESCOPED 2026-07-12: collapses into W5c-2)** — the ~334-file count
+  measured ANY pl usage in tests; the REAL result-assertion surface is 13
+  files / 16 call sites (grep: .golden/.dupes/.unique/.matched/.unmatched
+  followed by a polars method). Everything else constructs polars INPUTS —
+  which stay valid forever: inputs are polymorphic (Arrow C stream), and
+  polars remains a DEV/TEST dependency after leaving the runtime deps (the
+  spec's "dependency list" is install_requires). The 16 sites migrate IN the
+  flip PR. The differential/parity suites collapse per W5e as planned.
 - **W5e** — the deletion: polars out of deps ([polars] nowhere), PolarsFrame
   + _polars_dtype + polars constructor branches + env var + _polars_lazy
   proxy deleted; parity suites collapse to single-backend; fallback-contract

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.0.0] - 2026-07-12
+
+### Changed
+- **BREAKING: result frames are now `pyarrow.Table`.** `DedupeResult.golden` /
+  `.dupes` / `.unique` and `MatchResult.matched` / `.unmatched` return
+  `pa.Table` instead of `pl.DataFrame` (Polars-eviction W5, spec
+  `docs/superpowers/specs/2026-07-09-goldenmatch-polars-eviction-design.md`).
+  Migration is a one-liner: `pl.from_arrow(result.golden)`. Inputs are
+  unchanged (polars/pandas/arrow all accepted). `to_csv` and the notebook
+  `_repr_html_` render from Arrow natively.
+- The arrow ingest lane runs the expression stages (row-ids, standardize,
+  exact matchkeys) eagerly on the Frame seam; validation rules and auto-fix
+  are seam-routed with probed arrow twins (RE2 regex owned contract).
+
 ### Added
 - Experimental GOLDENMATCH_FRAME=arrow lane: file ingest via pyarrow with a polars-parity reader corpus and a frame-backend differential harness (Polars-eviction W1).
 - **Fused auto-routing at the golden + match seams (controller-driven).** The pipeline now auto-routes covered slow-path runs to the fused Arrow-native kernels, byte-identically, with no config change and per-surface kill-switches. **Golden routing is the broad, LIVE win:** at the golden seam the pipeline tries `golden_fused.run_golden_fused_arrow` by default on every covered slow-path config and reaches golden output at roughly 2x lower peak RSS; it declines to the classic builder (unchanged output) when the config is uncovered, the native kernel is absent, full `ClusterProvenance` lineage is requested, or the run is fast-path-eligible. Surfaced on `DedupeResult.golden_fused_used`; kill-switch `GOLDENMATCH_GOLDEN_FUSED=0`. **Match routing is a documented DORMANT capacity-survival scaffold, not a live default.** A controller post-step (`maybe_route_fused_match`) can short-circuit the match stage to the fused match kernel under an estimated-peak-RSS pressure gate, but the gate is deliberately narrow (`auto_split=False`, no identity/adaptive/memory/llm_boost/confidence_majority/full-provenance, not across-files-only, a covered weighted matchkey, and real memory pressure). Because zero-config auto-config commits `auto_split=True` and explicit configs bypass the controller, it effectively never fires by default. When it does fire it is a capacity mode that sheds `scored_pairs`, cluster-confidence, and lineage to survive; marked `DedupeResult.match_fused_capacity_mode` and controller-telemetry `rule_name` `+fused_match_post_step`. Kill-switch `GOLDENMATCH_MATCH_FUSED=0`; the wake-up path (a postflight-threshold fast-follow, or an explicit opt-in) is a follow-up. New env knobs (`core/fused_routing.py`, `ExecutionPlan.use_fused_match`): `GOLDENMATCH_GOLDEN_FUSED`, `GOLDENMATCH_MATCH_FUSED`, `GOLDENMATCH_FUSED_PRESSURE_FRACTION` (default 0.65), and the est-RSS calibration coefficients `GOLDENMATCH_FUSED_RSS_SCALE` / `_BYTES_PER_PAIR` / `_BYTES_PER_CELL` / `_BLOCK_CONCURRENCY`. No new native symbols (reuses the `golden_fused` / `match_fused` kernels), no new MCP tools / CLI commands / A2A skills.

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -5,7 +5,7 @@ Quick start:
 
     # Deduplicate a CSV
     result = gm.dedupe("customers.csv", exact=["email"], fuzzy={"name": 0.85})
-    result.golden.write_csv("deduped.csv")
+    result.to_csv("deduped.csv")  # result frames are pa.Table (v3.0.0)
 
     # Match across files
     result = gm.match("targets.csv", "reference.csv", fuzzy={"name": 0.85})
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "2.8.0"
+__version__ = "3.0.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -7,7 +7,7 @@ Usage:
     import goldenmatch as gm
 
     result = gm.dedupe("data.csv", exact=["email"], fuzzy={"name": 0.85})
-    result.golden.write_csv("output.csv")
+    result.to_csv("output.csv")  # result frames are pa.Table (v3.0.0)
 """
 from __future__ import annotations
 
@@ -125,6 +125,17 @@ def _detect_llm_provider() -> str | None:
 # so the flip is a field-type change rather than a method rewrite.
 
 
+def _to_result_table(obj: Any) -> Any:
+    """v3.0.0: result frames are pa.Table. The pipeline's internal frames
+    convert here (polars .to_arrow() zero-copy); pa.Table passes through.
+    Migration guide: wrap with pl.from_arrow(...) for the old type."""
+    if obj is None:
+        return None
+    if hasattr(obj, "num_rows"):  # already a pa.Table
+        return obj
+    return obj.to_arrow()
+
+
 def _frame_height(obj: Any) -> int:
     return obj.num_rows if hasattr(obj, "num_rows") else obj.height
 
@@ -164,10 +175,10 @@ class DedupeResult:
             per-cluster pair_scores when oversized clusters split).
         config: The GoldenMatchConfig used for this run.
     """
-    golden: pl.DataFrame | None = None
+    golden: Any | None = None  # pa.Table (v3.0.0)
     clusters: dict[int, dict] = field(default_factory=dict)
-    dupes: pl.DataFrame | None = None
-    unique: pl.DataFrame | None = None
+    dupes: Any | None = None  # pa.Table (v3.0.0)
+    unique: Any | None = None  # pa.Table (v3.0.0)
     stats: dict = field(default_factory=dict)
     scored_pairs: list[tuple[int, int, float]] = field(default_factory=list)
     config: Any = None
@@ -304,8 +315,8 @@ class MatchResult:
         unmatched: DataFrame of unmatched target records.
         stats: Summary statistics.
     """
-    matched: pl.DataFrame | None = None
-    unmatched: pl.DataFrame | None = None
+    matched: Any | None = None  # pa.Table (v3.0.0)
+    unmatched: Any | None = None  # pa.Table (v3.0.0)
     stats: dict = field(default_factory=dict)
     postflight_report: PostflightReport | None = None
     # See DedupeResult.memory_stats note — same intentional duplication.
@@ -421,10 +432,10 @@ def dedupe(
 
     _mem = result.get("memory_stats")
     return DedupeResult(
-        golden=result.get("golden"),
+        golden=_to_result_table(result.get("golden")),
         clusters=result.get("clusters", {}),
-        dupes=result.get("dupes"),
-        unique=result.get("unique"),
+        dupes=_to_result_table(result.get("dupes")),
+        unique=_to_result_table(result.get("unique")),
         stats=_extract_stats(result),
         scored_pairs=result.get("scored_pairs", []),
         config=cfg,
@@ -681,10 +692,10 @@ def dedupe_df(
     warn_if_slow_path(_native, logger)
 
     dedupe_result = DedupeResult(
-        golden=result.get("golden"),
+        golden=_to_result_table(result.get("golden")),
         clusters=result.get("clusters", {}),
-        dupes=result.get("dupes"),
-        unique=result.get("unique"),
+        dupes=_to_result_table(result.get("dupes")),
+        unique=_to_result_table(result.get("unique")),
         stats=_extract_stats(result),
         scored_pairs=result.get("scored_pairs", []),
         config=config,
@@ -888,8 +899,8 @@ def match_df(
     warn_if_slow_path(_native, logger)
 
     return MatchResult(
-        matched=result.get("matched"),
-        unmatched=result.get("unmatched"),
+        matched=_to_result_table(result.get("matched")),
+        unmatched=_to_result_table(result.get("unmatched")),
         stats=_extract_stats(result),
         postflight_report=pf,
         memory_stats=_mem,
@@ -1080,8 +1091,8 @@ def match(
 
     _mem = result.get("memory_stats")
     return MatchResult(
-        matched=result.get("matched"),
-        unmatched=result.get("unmatched"),
+        matched=_to_result_table(result.get("matched")),
+        unmatched=_to_result_table(result.get("unmatched")),
         stats=_extract_stats(result),
         postflight_report=_attach_memory_to_postflight(
             result.get("postflight_report"), _mem

--- a/packages/python/goldenmatch/goldenmatch/cli/demo.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/demo.py
@@ -171,13 +171,13 @@ def demo_cmd(
         console.print(cluster_table)
 
     # Golden records
-    if result.golden is not None and result.golden.height > 0:
+    if result.golden is not None and result.golden.num_rows > 0:
         console.print()
         golden_table = Table(title="Golden Records (merged)", border_style="#2ecc71", header_style="bold #2ecc71")
-        cols = [c for c in result.golden.columns if not c.startswith("__")]
+        cols = [c for c in result.golden.column_names if not c.startswith("__")]
         for col in cols[:5]:
             golden_table.add_column(col)
-        for row in result.golden.to_dicts():
+        for row in result.golden.to_pylist():
             golden_table.add_row(*[str(row.get(c, ""))[:25] for c in cols[:5]])
         console.print(golden_table)
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1127,14 +1127,16 @@ def _tool_get_golden_record(cluster_id: int) -> dict:
     if _result.golden is None:
         return {"error": "No golden records available"}
 
-    golden_rows = _result.golden.filter(
-        _result.golden["__cluster_id__"] == cluster_id
-    ) if "__cluster_id__" in _result.golden.columns else None
+    import pyarrow.compute as pc
 
-    if golden_rows is None or golden_rows.height == 0:
+    golden_rows = _result.golden.filter(
+        pc.equal(_result.golden.column("__cluster_id__"), cluster_id)
+    ) if "__cluster_id__" in _result.golden.column_names else None
+
+    if golden_rows is None or golden_rows.num_rows == 0:
         return {"error": f"No golden record for cluster {cluster_id}"}
 
-    row = golden_rows.to_dicts()[0]
+    row = golden_rows.to_pylist()[0]
     clean = {k: v for k, v in row.items() if not k.startswith("__")}
     return {"cluster_id": cluster_id, "golden_record": clean}
 
@@ -1368,19 +1370,21 @@ def _tool_export_results(output_path: str, fmt: str) -> dict:
         return path
     if fmt == "json":
         if _result.golden is not None:
-            golden_dicts = _result.golden.to_dicts()
+            golden_dicts = _result.golden.to_pylist()
             clean = [{k: v for k, v in r.items() if not k.startswith("__")} for r in golden_dicts]
             path.write_text(json.dumps(clean, default=str, indent=2))
         else:
             path.write_text("[]")
     else:
         if _result.golden is not None:
-            cols = [c for c in _result.golden.columns if not c.startswith("__")]
-            _result.golden.select(cols).write_csv(str(path))
+            from pyarrow import csv as _pacsv
+
+            cols = [c for c in _result.golden.column_names if not c.startswith("__")]
+            _pacsv.write_csv(_result.golden.select(cols), str(path))
         else:
             path.write_text("")
 
-    return {"exported": str(path), "format": fmt, "records": _result.golden.height if _result.golden is not None else 0}
+    return {"exported": str(path), "format": fmt, "records": _result.golden.num_rows if _result.golden is not None else 0}
 
 
 def _tool_list_domains() -> dict:

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "2.8.0"
+version = "3.0.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "2.8.0",
+      "version": "3.0.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
+++ b/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
@@ -45,9 +45,9 @@ def pairs_from_match_result(
     """Direct extraction from MatchResult.matched. No closure needed --
     each row is one (target_id, ref_id) pair. Pairs NOT canonicalized
     (target/ref are semantically distinct, e.g. DBLP vs ACM)."""
-    if result.matched is None or result.matched.num_rows == 0:
+    m = result.matched
+    if m is None:
         return set()
-    return {
-        (row[target_id_col], row[ref_id_col])
-        for row in result.matched.iter_rows(named=True)
-    }
+    # v3.0.0: matched is pa.Table; the unit test feeds a raw pl.DataFrame.
+    rows = m.to_pylist() if hasattr(m, "num_rows") else m.to_dicts()
+    return {(row[target_id_col], row[ref_id_col]) for row in rows}

--- a/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
+++ b/packages/python/goldenmatch/tests/_helpers/benchmark_pairs.py
@@ -45,7 +45,7 @@ def pairs_from_match_result(
     """Direct extraction from MatchResult.matched. No closure needed --
     each row is one (target_id, ref_id) pair. Pairs NOT canonicalized
     (target/ref are semantically distinct, e.g. DBLP vs ACM)."""
-    if result.matched is None or result.matched.height == 0:
+    if result.matched is None or result.matched.num_rows == 0:
         return set()
     return {
         (row[target_id_col], row[ref_id_col])

--- a/packages/python/goldenmatch/tests/documents/test_e2e.py
+++ b/packages/python/goldenmatch/tests/documents/test_e2e.py
@@ -59,8 +59,8 @@ def test_extracted_frame_feeds_dedupe_df_and_finds_the_dupe(tmp_path):
     assert len(dupe_clusters) == 1
     assert dupe_clusters[0]["size"] == 2
     # Grace (no duplicate) surfaces in the unique table, not in a multi-member cluster.
-    assert result.unique is not None and result.unique.height == 1
-    assert result.unique["full_name"].to_list() == ["Grace Hopper"]
+    assert result.unique is not None and result.unique.num_rows == 1
+    assert result.unique["full_name"].to_pylist() == ["Grace Hopper"]
 
 
 INV = get_template("invoice")

--- a/packages/python/goldenmatch/tests/test_autoconfig_probabilistic_entry.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_probabilistic_entry.py
@@ -34,7 +34,7 @@ def test_config_runs_through_dedupe():
     result = goldenmatch.dedupe_df(df, config=cfg)
     # John/Jon+Smith+same email, Jane, Bob/Bobby+Jones+same email -> 3 clusters.
     assert len(result.clusters) == 3
-    assert result.unique.height == 1
+    assert result.unique.num_rows == 1
 
 
 def test_accepts_lazyframe():

--- a/packages/python/goldenmatch/tests/test_columnar_pipeline_parity.py
+++ b/packages/python/goldenmatch/tests/test_columnar_pipeline_parity.py
@@ -215,7 +215,7 @@ def test_pipeline_columnar_gate_parity(monkeypatch):
         res = gm.dedupe_df(df, config=_cfg())
         monkeypatch.setattr(scorer_mod, "score_blocks_columnar", real)
         part = frozenset(frozenset(c["members"]) for c in res.clusters.values())
-        return part, len(res.clusters), res.dupes.height, res.unique.height, called["columnar"]
+        return part, len(res.clusters), res.dupes.num_rows, res.unique.num_rows, called["columnar"]
 
     off = _result(False)
     on = _result(True)

--- a/packages/python/goldenmatch/tests/test_confidence_majority_678.py
+++ b/packages/python/goldenmatch/tests/test_confidence_majority_678.py
@@ -168,5 +168,5 @@ def test_pipeline_threads_pair_scores_into_confidence_majority() -> None:
     # "Bravo", NOT the count-majority winner "Alpha". This is byte-for-byte
     # the value that flips if the pipeline stops passing cluster_pair_scores.
     assert result.golden is not None
-    assert result.golden.height == 1
-    assert result.golden["name"][0] == "Bravo"
+    assert result.golden.num_rows == 1
+    assert result.golden.column("name")[0].as_py() == "Bravo"

--- a/packages/python/goldenmatch/tests/test_ensemble_scorer.py
+++ b/packages/python/goldenmatch/tests/test_ensemble_scorer.py
@@ -138,4 +138,4 @@ class TestFSEnsembleEndToEnd:
 
         # Must not raise (was: ValueError: Unknown scorer: 'ensemble' at EM train)
         result = dedupe_df(df, config=cfg)
-        assert result.dupes is not None and result.dupes.height > 0
+        assert result.dupes is not None and result.dupes.num_rows > 0

--- a/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
+++ b/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
@@ -253,4 +253,4 @@ def test_v2_config_runs_end_to_end(monkeypatch):
     fields = [f.field for f in cfg.get_matchkeys()[0].fields]
     assert "dob" in fields  # lever #1 active under v2
     result = dedupe_df(df, config=cfg)
-    assert result.dupes is not None and result.dupes.height > 0
+    assert result.dupes is not None and result.dupes.num_rows > 0

--- a/packages/python/goldenmatch/tests/test_fused_telemetry.py
+++ b/packages/python/goldenmatch/tests/test_fused_telemetry.py
@@ -123,7 +123,10 @@ def _multi_partition(clusters: dict) -> set[frozenset[int]]:
     return {frozenset(c["members"]) for c in clusters.values() if c["size"] > 1}
 
 
-def _golden_content(g: pl.DataFrame) -> pl.DataFrame:
+def _golden_content(g) -> pl.DataFrame:
+    # v3.0.0: result frames are pa.Table; compare in polars (dev dep).
+    if not isinstance(g, pl.DataFrame):
+        g = pl.from_arrow(g)
     cols = [c for c in g.columns if c not in ("__cluster_id__", "__golden_confidence__")]
     return g.select(sorted(cols)).sort(sorted(cols))
 
@@ -224,8 +227,8 @@ def test_end_to_end_golden_routing_parity(monkeypatch):
 
     assert fused.golden is not None and classic.golden is not None
     assert_frame_equal(
-        fused.golden.sort("__cluster_id__"),
-        classic.golden.sort("__cluster_id__"),
+        pl.from_arrow(fused.golden).sort("__cluster_id__"),
+        pl.from_arrow(classic.golden).sort("__cluster_id__"),
         check_column_order=False,
         check_row_order=False,
     )
@@ -262,11 +265,11 @@ def test_end_to_end_match_capacity_parity_lock(monkeypatch):
     assert _multi_partition(fused.clusters) == _multi_partition(classic.clusters)
 
     # dupes / unique row populations byte-identical.
-    assert set(fused.dupes["__row_id__"].to_list()) == set(
-        classic.dupes["__row_id__"].to_list()
+    assert set(fused.dupes["__row_id__"].to_pylist()) == set(
+        classic.dupes["__row_id__"].to_pylist()
     )
-    assert set(fused.unique["__row_id__"].to_list()) == set(
-        classic.unique["__row_id__"].to_list()
+    assert set(fused.unique.column("__row_id__").to_pylist()) == set(
+        classic.unique.column("__row_id__").to_pylist()
     )
 
     # Golden content byte-identical (modulo cluster id + confidence).

--- a/packages/python/goldenmatch/tests/test_golden_partition_perf.py
+++ b/packages/python/goldenmatch/tests/test_golden_partition_perf.py
@@ -77,15 +77,15 @@ class TestGoldenPartitionOutput:
         # build_golden_record skips oversized; with max_block_size=100 and
         # cluster sizes of 3, nothing is oversized.
         assert result.golden is not None
-        assert result.golden.height == multi_member_count
-        assert result.golden.height == 15
+        assert result.golden.num_rows == multi_member_count
+        assert result.golden.num_rows == 15
 
     def test_no_duplicate_cluster_ids_in_golden(self):
         """The partitioned path must not emit two goldens for one cluster."""
         df = _cluster_df_with_dupes(n_clusters=25, members_per_cluster=4)
         result = dedupe_df(df, config=self._config())
         assert result.golden is not None
-        cids = result.golden["__cluster_id__"].to_list()
+        cids = result.golden["__cluster_id__"].to_pylist()
         assert len(cids) == len(set(cids)), (
             f"Found duplicate cluster ids in golden output: {sorted(cids)}"
         )
@@ -113,7 +113,7 @@ class TestGoldenPartitionOutput:
             cluster_zip_sets[cid] = member_zips
 
         # Every golden row's zip must be in its cluster's member-zip set.
-        for row in result.golden.iter_rows(named=True):
+        for row in result.golden.to_pylist():
             cid = row["__cluster_id__"]
             zip_val = str(row["zip"])
             assert zip_val in cluster_zip_sets[cid], (
@@ -161,7 +161,7 @@ class TestGoldenPartitionOutput:
             cid for cid, info in result.clusters.items()
             if info.get("oversized")
         }
-        golden_cids = set(result.golden["__cluster_id__"].to_list())
+        golden_cids = set(result.golden["__cluster_id__"].to_pylist())
         assert oversized_cids.isdisjoint(golden_cids), (
             f"Oversized clusters {oversized_cids} leaked into golden {golden_cids}"
         )

--- a/packages/python/goldenmatch/tests/test_probabilistic_bench_dump.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic_bench_dump.py
@@ -151,7 +151,7 @@ def test_bench_dump_noop_when_env_unset(tmp_path):
     written = list(tmp_path.glob("*.parquet"))
     assert written == [], f"hook wrote files with env unset: {written}"
     # Scoring still ran: the unset path must not accidentally no-op matching.
-    assert result.dupes is not None and result.dupes.height > 0, (
+    assert result.dupes is not None and result.dupes.num_rows > 0, (
         "dedupe produced no duplicate pairs with env unset -- scoring silently no-oped"
     )
 

--- a/packages/python/goldenmatch/tests/test_quality_weighting.py
+++ b/packages/python/goldenmatch/tests/test_quality_weighting.py
@@ -103,12 +103,14 @@ def test_dedupe_df_pipeline_runs_with_quality_weighting() -> None:
 
     result = dedupe_df(df, exact=["name"], confidence_required=False)
     assert result.golden is not None
-    golden = result.golden.filter(pl.col("name") == "dupperson")
+    import pyarrow.compute as pc
+
+    golden = result.golden.filter(pc.equal(result.golden.column("name"), "dupperson"))
     # Only assert the merge happened + a canonical value was chosen; default
     # most_complete prefers the longer 'California' regardless, so this is a
     # wiring/no-crash guard (the flip itself is locked by the test above).
-    assert golden.height == 1
-    assert golden["state"][0] in ("California", "Californa")
+    assert golden.num_rows == 1
+    assert golden.column("state")[0].as_py() in ("California", "Californa")
 
 
 def test_quality_scan_scoped_to_cluster_members(monkeypatch):

--- a/packages/python/goldenmatch/tests/test_throughput_integration.py
+++ b/packages/python/goldenmatch/tests/test_throughput_integration.py
@@ -127,7 +127,7 @@ def test_non_throughput_still_builds_golden():
 
     res = dedupe_df(df)
     assert res.throughput_posture is None
-    assert res.golden is not None and res.golden.height >= 1, (
+    assert res.golden is not None and res.golden.num_rows >= 1, (
         "normal run must still produce golden records"
     )
 

--- a/packages/python/goldenmatch/tests/test_unified_exclude_columns.py
+++ b/packages/python/goldenmatch/tests/test_unified_exclude_columns.py
@@ -281,10 +281,10 @@ def test_e2e_hand_written_config_exclude_columns_propagates_to_transform():
     # The golden output is downstream of GoldenFlow -- assert hashes
     # survived. The actual columns present depend on the pipeline's
     # output shape, but record_hash must be byte-identical where present.
-    if result.dupes is not None and "record_hash" in result.dupes.columns:
-        assert set(result.dupes["record_hash"].to_list()) <= set(original_hashes)
-    if result.unique is not None and "record_hash" in result.unique.columns:
-        assert set(result.unique["record_hash"].to_list()) <= set(original_hashes)
+    if result.dupes is not None and "record_hash" in result.dupes.column_names:
+        assert set(result.dupes["record_hash"].to_pylist()) <= set(original_hashes)
+    if result.unique is not None and "record_hash" in result.unique.column_names:
+        assert set(result.unique["record_hash"].to_pylist()) <= set(original_hashes)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
W5's breaking batch, per the approved spec (W5 row = v3.0.0). PyPI release stays human-gated; this makes main v3-bound.

BREAKING: DedupeResult.golden/dupes/unique + MatchResult.matched/unmatched are pyarrow.Table (was pl.DataFrame). Migration: pl.from_arrow(result.golden). Inputs unchanged (polymorphic).

- W5c-1 (#1690) made every result surface type-agnostic, so this lands as a field-type change: 4 construction sites wrap with _to_result_table (polars .to_arrow() zero-copy).
- In-package consumers migrated: cli/demo (3), mcp/server (4: pc.equal filter, to_pylist, pyarrow.csv export). dbt/tui consume the INTERNAL dict result (still polars until W5e) -- unaffected, verified.
- W5d folded in: the real result-assertion surface was 14 test files (the 334 count was input construction, which stays valid; polars remains a dev/test dep) -- all migrated.
- Fused decline audit PASS (in plan); version 3.0.0 (pyproject + __init__).

Gates: differential harness green POST-FLIP; 290+ tests across api/quality/confidence/exclude/fused-telemetry/columnar-parity/ensemble/partition-perf/docs-e2e/pipeline/engine/golden/cluster/tui/preview/mcp. ruff clean.