### PR TITLE
feat(goldenmatch)!: W5e-1 -- arrow becomes the default frame backend

### DIFF
--- a/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
+++ b/docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w5.md
@@ -106,6 +106,11 @@ assertions migrate to Arrow, results become `pa.Table`. W0-W4 merged/queued
   polars remains a DEV/TEST dependency after leaving the runtime deps (the
   spec's "dependency list" is install_requires). The 16 sites migrate IN the
   flip PR. The differential/parity suites collapse per W5e as planned.
+- **W5e WALL GATE PASSED (2026-07-12, measured)**: 100K zero-config A/B on
+  identical runner + bench config, 5-run medians -- polars lane 119.12s
+  (run 29176760816) vs ARROW LANE 76.44s (run 29176760301): the arrow lane
+  is 36% FASTER. No fused multi-column derive op needed; the default flip
+  is justified by measurement.
 - **W5e** — the deletion: polars out of deps ([polars] nowhere), PolarsFrame
   + _polars_dtype + polars constructor branches + env var + _polars_lazy
   proxy deleted; parity suites collapse to single-backend; fallback-contract

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -28,16 +28,16 @@ _VALID_FRAME_BACKENDS = ("polars", "arrow")
 def resolve_frame_backend() -> str:
     """Resolve the ``GOLDENMATCH_FRAME`` env var to a Frame backend name.
 
-    Reads ``GOLDENMATCH_FRAME`` (default ``"polars"``), stripped and
-    lowercased. Valid values are ``"polars"`` (default, byte-identical
-    behavior) and ``"arrow"`` (routes file ingest through pyarrow -- see
-    ``core/ingest.py::load_file``).
+    Reads ``GOLDENMATCH_FRAME`` (default ``"arrow"`` since v3.0.0 -- the
+    measured-faster lane: 100K zero-config A/B medians 76.4s arrow vs
+    119.1s polars, runs 29176760301/29176760816). ``"polars"`` remains the
+    opt-out escape hatch until the W5e deletion train removes it.
 
     Raises:
         ValueError: if the env var is set to anything else, naming the bad
             value and the valid options.
     """
-    raw = os.environ.get("GOLDENMATCH_FRAME", "polars").strip().lower()
+    raw = os.environ.get("GOLDENMATCH_FRAME", "arrow").strip().lower()
     if raw not in _VALID_FRAME_BACKENDS:
         raise ValueError(
             f"Invalid GOLDENMATCH_FRAME={raw!r}; valid options are "

--- a/packages/python/goldenmatch/goldenmatch/core/io_arrow.py
+++ b/packages/python/goldenmatch/goldenmatch/core/io_arrow.py
@@ -43,6 +43,7 @@ Known reader deltas vs ``load_file`` (documented, not silently tolerated):
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,9 @@ from goldenmatch.core.ingest import _TEXT_SUFFIXES, _is_probably_utf8
 # default null_values list is much wider, so it must be narrowed explicitly
 # rather than left at the default.
 _NULL_VALUES = [""]
+
+
+logger = logging.getLogger(__name__)
 
 
 def read_table_arrow(
@@ -128,10 +132,15 @@ def _read_csv_arrow(path: Path, *, separator: str, encoding: str | None):
         # there is no observable difference from a direct strict read.
         return _read_csv_direct(path, parse_options)
 
-    # Non-UTF-8 file: mirror ingest.py's cp1252 fallback (no warning log
-    # here -- load_file already logs it; this reader is a parallel path,
-    # not the caller-facing one, so it stays quiet to avoid double-logging
-    # once wired into the pipeline).
+    # Non-UTF-8 file: mirror ingest.py's cp1252 fallback INCLUDING the
+    # warning (W5e: on the arrow-default route THIS is the caller-facing
+    # reader -- ingest.py's polars-route warning never fires, so the
+    # "stays quiet to avoid double-logging" assumption inverted).
+    logger.warning(
+        "%s is not valid UTF-8; decoding as Windows-1252 (cp1252). "
+        "Pass encoding=/--encoding to override if that is wrong.",
+        path,
+    )
     text = path.read_bytes().decode("cp1252", errors="replace")
     return _read_csv_from_text(text, parse_options)
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -854,8 +854,20 @@ def run_dedupe(
         # decline the eager path when either is configured; the polars stages
         # then run as before). _run_dedupe_pipeline skips whatever is listed
         # in _eager_stages_done -- re-running standardize is NOT idempotent.
+        # The prep block sits BETWEEN ingest and the standardize stage and
+        # can MUTATE data (goldencheck quality + goldenflow transform are
+        # DEFAULT-ON: they run unless mode == "disabled"; transform E.164s
+        # phones, which is how the ordering bug surfaced). The eager path is
+        # only sound when the pipeline's own prep gates all evaluate False --
+        # mirrored VERBATIM from _run_dedupe_pipeline's stage conditions.
+        _prep_will_run = (
+            (config.quality is None or config.quality.mode != "disabled")
+            or (config.transform is None or config.transform.mode != "disabled")
+            or bool(config.validation and config.validation.auto_fix)
+        )
         _eager_ok = (
-            config.semantic_blocking is None
+            not _prep_will_run
+            and config.semantic_blocking is None
             and not (config.domain and config.domain.enabled)
         )
         if _eager_ok:

--- a/packages/python/goldenmatch/tests/test_frame_backend_env.py
+++ b/packages/python/goldenmatch/tests/test_frame_backend_env.py
@@ -23,8 +23,15 @@ from goldenmatch.core.ingest import load_file
 # --------------------------------------------------------------------------
 
 
-def test_resolve_frame_backend_default_is_polars(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_frame_backend_default_is_arrow(monkeypatch: pytest.MonkeyPatch) -> None:
+    # v3.0.0: arrow is the default (measured 36% faster at 100K); polars is
+    # the opt-out until the W5e deletion train removes it.
     monkeypatch.delenv("GOLDENMATCH_FRAME", raising=False)
+    assert resolve_frame_backend() == "arrow"
+
+
+def test_resolve_frame_backend_polars_opt_out(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "polars")
     assert resolve_frame_backend() == "polars"
 
 

--- a/packages/python/goldenmatch/tests/test_golden_fused.py
+++ b/packages/python/goldenmatch/tests/test_golden_fused.py
@@ -91,7 +91,10 @@ def _cluster_frame():
     )
 
 
-def test_run_declines_fast_path_eligible_simple_config():
+def test_run_declines_fast_path_eligible_simple_config(monkeypatch):
+    # These pin the POLARS-lane decline (the arrow lane keeps the kernel by
+    # W2e-3 design; audited in the W5 plan) -- pin the backend explicitly.
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "polars")
     df = _cluster_frame()
     # simple most_complete default, no field_rules/groups/overrides, no quality_scores
     rules = GoldenRulesConfig(default_strategy="most_complete")
@@ -614,7 +617,10 @@ def _assert_value_conf_parity_q(df, rules, cols, quality_scores):
     return got_map, ref_map
 
 
-def test_quality_scores_forces_off_fast_path():
+def test_quality_scores_forces_off_fast_path(monkeypatch):
+    # These pin the POLARS-lane decline (the arrow lane keeps the kernel by
+    # W2e-3 design; audited in the W5 plan) -- pin the backend explicitly.
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "polars")
     # A bare most_complete default declines (fast-path eligible); adding a non-None
     # quality_scores makes it exact-path-eligible, so the fused path RUNS (does not
     # decline) even without a field_rule -- confirms the _polars_native_eligible

--- a/packages/python/goldenmatch/tests/test_standardize.py
+++ b/packages/python/goldenmatch/tests/test_standardize.py
@@ -386,3 +386,39 @@ class TestStandardizationInPipeline:
             # Phone should be digits only
             if "phone" in row and row["phone"]:
                 assert row["phone"].isdigit()
+
+
+def test_arrow_lane_standardize_runs_after_default_prep(tmp_path, monkeypatch):
+    """W5e regression: the arrow lane's eager standardize must DECLINE when
+    the default-on prep block (goldencheck quality / goldenflow transform)
+    will run -- transform E.164s phones, so eager-standardize-before-prep
+    inverted the stage order and golden phones came out '+1...'."""
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+    path = tmp_path / "messy.csv"
+    pl.DataFrame({
+        "email": ["A@B.COM", "a@b.com"],
+        "phone": ["(267) 555-1234", "267-555-1234"],
+    }).write_csv(path)
+    from goldenmatch.config.schemas import (
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+        StandardizationConfig,
+    )
+    from goldenmatch.core.pipeline import run_dedupe
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="k",
+            fields=[MatchkeyField(column="email", transforms=["lowercase"])],
+            comparison="exact",
+        )],
+        standardization=StandardizationConfig(
+            rules={"email": ["email"], "phone": ["phone"]}
+        ),
+    )
+    res = run_dedupe([(str(path), "src")], cfg)
+    golden = res["golden"]
+    assert golden is not None
+    for v in golden["phone"].to_list():
+        assert v.isdigit(), f"stage order inverted: phone={v!r}"


### PR DESCRIPTION
W5's default flip, measurement-justified: 100K zero-config A/B (5-run medians, identical runner) -- arrow 76.4s vs polars 119.1s (36% faster). Runs 29176760301 / 29176760816; recorded in the W5 plan (committed here).

- GOLDENMATCH_FRAME defaults to arrow; polars stays the opt-out escape hatch until the W5e deletion train removes the backend.
- Default-pin test updated + explicit opt-out pin added.

Gates: backend_env / differential / zero_label_stability / autoconfig / pipeline / api / ingest -- 240+ locally. ruff clean.