### PR TITLE
feat(goldencheck)!: 3.0.0 Flip -- Arrow-native default scan, Polars evicted from the default path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2228,14 +2228,15 @@ jobs:
         # are self-contained, only the builtin tmp_path fixture).
         run: uv run --no-sync python -m pytest packages/python/goldenflow/tests/nopolars --noconftest -v
 
-  # P4b Task 3: promoted to ci-required. Builds the goldencheck native regex kernel,
-  # UNINSTALLS polars, then proves the polars-free read/scan surface for real
-  # (read_columns/scan_file_columns over Parquet via pyarrow + Excel via openpyxl,
-  # scan_columns structural checks) AND that the uncovered tail (CSV, scan_file()'s
-  # full scan) declines with the helpful `goldencheck[polars]` ImportError rather than
-  # crashing or silently degrading. A red here means either regressed (a module grew a
-  # top-level `import polars`, a covered reader broke, or a decline path stopped
-  # raising the helpful error) -- gate on it like any other required lane.
+  # ci-required. Builds the goldencheck native regex kernel, UNINSTALLS polars, then
+  # proves the polars-free scan surface for real. 3.0.0 CONTRACT FLIP: the default scan
+  # is now Arrow-native, so this lane asserts the FULL scan SUCCEEDS polars-absent --
+  # CSV + Parquet + Excel via scan_file()/scan_dataframe(pa.Table), plus the covered
+  # scan_columns structural checks. The only path that still declines with the helpful
+  # `goldencheck[polars]` ImportError is the scan_dataframe(pl.DataFrame) overload. A red
+  # here means a regression (a scan-path module grew a top-level `import polars`, an
+  # Arrow reader broke, or the pl.DataFrame overload stopped raising the helpful error)
+  # -- gate on it like any other required lane.
   goldencheck_nopolars:
     needs: changes
     if: needs.changes.outputs.goldencheck_nopolars == 'true' || needs.changes.outputs.force_all == 'true'

--- a/docs-site/goldencheck/native.mdx
+++ b/docs-site/goldencheck/native.mdx
@@ -4,9 +4,9 @@ description: "GoldenCheck's optional Rust/Arrow runtime and the deep-profiling c
 keywords: ["goldencheck", "native", "rust", "arrow", "deep profiling", "functional dependency", "composite key", "fuzzy", "referential integrity", "freshness", "denial constraint"]
 ---
 
-GoldenCheck is pure-Python; the full scan is Polars-backed (via the `[polars]`
-extra since 2.0.0), so the everyday sampled scan is fast, while the structural
-`scan_columns` checks and Parquet/Excel reading run Polars-free. For the
+GoldenCheck is pure-Python; as of 3.0.0 the everyday scan is **Arrow-native** and
+Polars-free — `scan_file`, `scan_dataframe`, and the CLI run on a `pyarrow.Table`
+(a base dependency), so CSV/Parquet/Excel scanning needs no Polars. For the
 CPU-heavy **deep-profiling** checks there's an optional compiled runtime, and
 the package falls back to pure Python when it isn't installed — behaviour is
 identical either way, native only changes wall-clock.
@@ -19,17 +19,16 @@ pip install goldencheck[native]
 your code changes. Control it with `GOLDENCHECK_NATIVE=auto|0|1` (`auto` is the
 default: use native where available, fall back otherwise).
 
-goldencheck-native also backs the **Polars-free structural checks** — the format,
-encoding, pattern, and temporal profilers that run inside `scan_columns` (and the
-Parquet/Excel `read_columns`/`scan_file_columns` paths). That means a Polars-absent
-install (`pip install goldencheck[native]`, without `[polars]`) can still run those
-checks at native speed; only CSV reading and the full `scan_file`/`scan_dataframe`
-scan need `goldencheck[polars]`.
+goldencheck-native also accelerates the **format, encoding, pattern, and temporal
+profilers** that run on the Arrow-native scan path. Since the whole scan is
+Polars-free in 3.0.0, `pip install goldencheck[native]` runs those checks at native
+speed on any CSV/Parquet/Excel source with no Polars installed.
 
-Extras at a glance: `[polars]` adds Polars for CSV reading and the full scan;
-`[parquet]` adds pyarrow alone for Polars-free Parquet reading; `[native]` adds the
-Rust kernels below (works with or without Polars installed); `[baseline]` adds
-scipy/numpy for deep profiling and drift detection.
+Extras at a glance: `[native]` adds the Rust kernels below (Polars not required);
+`[baseline]` adds scipy/numpy **and Polars** for the deep statistical profiling,
+drift, and correlation subsystems; `[polars]` adds Polars only for the
+`scan_dataframe(pl.DataFrame)` convenience overload. `pyarrow` is a base dependency
+(the scan frame), so Parquet/Excel reading works out of the box with no extra.
 
 ## How the kernels earn their place
 

--- a/docs-site/goldencheck/overview.mdx
+++ b/docs-site/goldencheck/overview.mdx
@@ -39,16 +39,23 @@ pip install goldencheck[db]                  # database scanning
 pip install goldencheck[mcp]                 # MCP server
 ```
 
-## Polars is optional (2.0.0)
+## Polars-free by default (3.0.0)
 
-As of 2.0.0, `pip install goldencheck` does not pull in Polars. `import goldencheck`,
-`scan_columns(...)`, and Parquet/Excel reading via `read_columns`/`scan_file_columns` all
-work without it.
+As of 3.0.0 the default scan path is **Arrow-native** and needs no Polars. `pip install
+goldencheck` scans CSV, Parquet, and Excel end-to-end — `scan_file`, `scan_dataframe`, and
+the CLI all run on a `pyarrow.Table` (a base dependency now). The 2.0.0 rule that CSV and the
+full scan needed `goldencheck[polars]` no longer applies.
 
-Install `goldencheck[polars]` for CSV reading and the full `scan_file`/`scan_dataframe` scan
-— Polars' CSV dtype inference isn't reproducible without it, and the full scan is Polars-native.
-Calling a Polars-only path without the extra raises a clear `ImportError` telling you which
-extra to add.
+Polars is only used by two opt-in extras:
+
+- `goldencheck[baseline]` — pulls Polars (plus scipy/numpy) for the statistical, drift, and
+  correlation subsystems, which still run on Polars.
+- `goldencheck[polars]` — only for the `scan_dataframe(pl.DataFrame)` convenience overload.
+  `scan_dataframe` accepts a `pyarrow.Table` natively; a `polars.DataFrame` is converted via
+  `.to_arrow()` when Polars is present.
+
+`inferred_type` reports a neutral dtype vocabulary (`str`, `int`, `uint`, `float`, `date`,
+`datetime`, `bool`, `other`) rather than raw Polars dtype names.
 
 ## Quickstart
 

--- a/docs/superpowers/plans/2026-07-11-goldencheck-flip-cutover.md
+++ b/docs/superpowers/plans/2026-07-11-goldencheck-flip-cutover.md
@@ -1,0 +1,54 @@
+# GoldenCheck Flip cutover — implementation plan
+
+> Executes the owned-contract cutover from `2026-07-11-goldencheck-flip-3.0.0-design.md`, decision folded: **gate on `[baseline]` extra** — base install = polars-free default scanning; baseline/drift/correlation stay polars+scipy behind an extra.
+
+**Goal:** `scan_file`/`scan_dataframe` run polars-free on the default path via the Arrow seam (kernel-authoritative), owned deterministic sample + neutral dtype vocabulary become the emitted contract, `[polars]` leaves the base/default surface, version → 3.0.0. PyPI publish stays human-gated.
+
+**Foundation (landed, Stage 0 / PR #1692):** `ArrowColumn`/`ArrowFrame` seam + §8b differential (strict Jaccard 1.000). Baseline suite = 838 engine/profilers/relations/core green.
+
+**Gate at every stage:** the 838-test suite green (fixing tests to the owned contract where the contract legitimately changed), the §8b differential still 1.000 strict, `import goldencheck` polars-free.
+
+---
+
+## Stage A — scan engine Arrow-native (the core; owned contract on)
+
+**Files:** `engine/scanner.py` (`_scan_dataframe_impl`, `_post_classification_checks`, the `scan_file`/`scan_dataframe` entry points), `engine/reader.py`, `engine/sampler.py`, `semantic/classifier.py`, the 5 non-seam-clean relation profilers.
+
+- **A1 — read into Arrow.** `read_file`/`read_columns` return a `pyarrow.Table` (owned `csv_infer` for CSV, `pyarrow.parquet` for parquet, `openpyxl`→Arrow for excel — all already polars-free). `scan_file(path)` builds an `ArrowFrame`. `scan_dataframe` accepts a `pyarrow.Table` natively; keep a `pl.DataFrame` convenience overload that converts via `.to_arrow()` ONLY when polars imports.
+- **A2 — loop through the seam.** `_scan_dataframe_impl` iterates `frame.column(name)` (ArrowFrame) instead of `df[col]`; `inferred_type = frame.column(name).dtype_repr()` (neutral vocab). Cache the per-column `column_aggregate` for len/null/n_unique. Remove the Population B shadow blocks (the kernel is now the authoritative `col.method()`).
+- **A3 — owned deterministic sample.** `engine/sampler.py`: replace `df.sample(n, seed=42)` with an owned stride/reservoir sample over the Arrow table (seeded, stable across runs + workers). Register the owned-sample divergence class in the parity harness.
+- **A4 — relation profilers.** Port `age_validation` + `approx_duplicate` to their W3 kernels (`age_mismatch`/`duplicate_signatures`) authoritatively over the ArrowFrame (they already shadow them). Reroute `composite_key`/`functional_dependency`/`approx_fd` off `frame.native` onto `frame.column(...)`/seam `to_list`.
+- **A5 — `_post_classification_checks` + `classify_columns` + `semantic/classifier`.** Route through the seam; add the small missing seam ops semantic needs (`str_len_chars`-mean via Arrow, `head(n).to_list`). These are on the default path so must be polars-free.
+- **Gate A:** 838 suite green (owned-contract test fixes: inferred_type neutral strings, owned-sample-dependent findings), differential 1.000 strict, `python -c "import goldencheck"` imports zero polars, and a default `scan_file` on a parquet/csv works with polars UNINSTALLED (smoke).
+
+## Stage B — dependency surface
+
+**Files:** `pyproject.toml`, module import audit.
+- Move `polars` from the standalone `polars` extra to a dep of the `[baseline]` extra (scipy+polars). Base deps: no polars.
+- Audit every `from goldencheck._polars_lazy import pl` on the default scan path — none may be reached without polars. Off-path modules (llm/agent/cli/reporters/tui/differ/db_scanner) keep the lazy shim but must not be imported by the default path.
+- **Gate B:** default `scan_file` + `scan_columns` + CLI `check` run in a polars-UNINSTALLED interpreter; `[baseline]`-gated features raise a clean "install goldencheck[baseline]" when polars/scipy absent.
+
+## Stage C — version + nopolars tests
+
+**Files:** `pyproject.toml` `version`, `goldencheck/__init__.py __version__`, `server.json` (×2), `tests/nopolars/test_polars_absent.py`.
+- Bump 3.0.0 in lockstep (the `version_consistency` required gate).
+- Rewrite `tests/nopolars/test_polars_absent.py`: the assertions that the polars-absent path *declines* invert — `scan_file(csv)`/`scan_file(parquet)` must now SUCCEED via the owned/Arrow path. This lane is in `ci-required`.
+- **Gate C:** `version_consistency` green; nopolars lane green with the inverted assertions.
+
+## Stage D — docs sweep (rollout-docs-sweep skill)
+
+- Every surface that says polars is required / that CSV or full-scan needs `goldencheck[polars]`; the `[baseline]` extra; CHANGELOG 3.0.0; tuning/config docs; `engine/CLAUDE.md` seed=42 contract note (goes stale — owned sample now).
+- Removal/rename grep: `seed=42`, `pl.read_csv`-requires, `goldencheck[polars]` messaging.
+- **Gate D:** doc CI gates (callout-sync/version-consistency/nav) green.
+
+## Stage E — land
+
+- PR to main; merge on green (merge queue). **Do NOT tag/publish 3.0.0 to PyPI — human-gated** (2.0.0 precedent).
+
+---
+
+## Risk register
+- **Test fan-out:** A2/A3 change the emitted contract (dtype strings, sampled rows) → many existing tests assert the old contract. Each fix must be a genuine contract update, not a masking change; the differential is the guard that findings are otherwise identical.
+- **Excel→Arrow** path: openpyxl returns Python cells; confirm the owned typing matches the prior `pl.read_excel` dtype inference or register the delta.
+- **age_validation/approx_duplicate kernel ports:** their W3 kernels were shadow-validated on fixtures; porting them to authoritative must keep the relation-profiler tests green (they encode the Polars behavior) — the W3 parity already proved byte/set-identity, so expect green.
+- **Non-goals:** no baseline/drift/correlation port (gated on `[baseline]`), no new numerics, no DataFusion, no PyPI publish.

--- a/docs/superpowers/specs/2026-07-11-goldencheck-flip-3.0.0-design.md
+++ b/docs/superpowers/specs/2026-07-11-goldencheck-flip-3.0.0-design.md
@@ -1,0 +1,71 @@
+# GoldenCheck Flip (3.0.0) — owned-contract cutover — design
+
+Date: 2026-07-11
+Status: wave design — the Flip wave of the Arrow-native fused-scan program. HUMAN-GATED (§8b sign-off).
+Program: `2026-07-11-goldencheck-arrow-fused-scan-engine-program-design.md` (§8b Flip gate) + `...-W-path-scoping.md`.
+Base: fresh `origin/main` (W0-land…W6 all merged; 17 kernels + parity harness live). Worktree `D:\show_case\gc-flip`, branch `feat/goldencheck-flip-3.0.0`.
+
+## What the Flip actually is (recon-corrected)
+
+The Flip is the irreversible 3.0.0 cutover to the **owned contract**: the Rust/Arrow fused kernels become authoritative, the owned deterministic sample + owned dtype vocabulary become the emitted values, and Polars stops being required. Per §3 the finding set is NOT unconditionally bit-identical to the 2.x Polars path, so the cutover is gated on a **measured** differential (§8b), not an assertion of zero delta.
+
+**The lever is the Frame seam, not a 30-module rewrite.** The column profilers already route through `core/frame.py` (`to_frame(frame)` → `col.mean()/std()/min()/max()/filter_outside()/count_gt()/diff()/is_sorted()`). Those methods exist on `PolarsColumn` (Polars-backed) but NOT on `PyColumn` (polars-free: only drop_nulls/unique/cast). That gap is exactly why W2–W5 kernels run as *shadow* — the authoritative value still comes from `PolarsColumn`. Give the seam an **Arrow-backed column** whose distributional/relational methods resolve to the W1–W5 kernels, and every profiler runs unchanged, polars-free, kernel-authoritative. The shadow blocks then become dead code.
+
+### Two kernel populations (recon §1 — the critical distinction)
+- **Population A / C — already native-authoritative-when-present** (W0-land relational kernels: composite_keys, functional_dependencies, approximate_fd, fuzzy_values, benford counts, csv_infer; and core/frame regex/str_to_date which already `raise NativeRequiredError`). For these the Flip is "remove the Polars fallback branch," NOT "flip authority." They must be held **constant** in the differential — any delta there is a kernel bug.
+- **Population B — genuinely shadow** (W2–W5, 13 sites: column_aggregate, numeric_stats/count_outside, date_freshness, sequence_analysis, chi2_gof, pearson_r, chi2_contingency, duplicate_signatures, age_mismatch, regex-format-count). These are the true "flip authority" sites and the ONLY expected source of a contract delta (beyond owned sample + owned dtype).
+
+## Staged execution (measurement FIRST, cutover gated on it)
+
+### Stage 0 — Arrow-backed Column via kernels (the lever; also enables the measurement)
+Implement on the polars-free Arrow column (extend `PyColumn`, or a new `ArrowColumn` backed by a `pyarrow.ChunkedArray`/`Array`) every method the distributional/sequence/freshness profilers call, delegating to the native kernels:
+- `mean/std/min/max/sum/count` → `column_numeric_stats`
+- `filter_outside(lo,hi)` / outlier sample → `count_outside`
+- `diff/is_sorted/gap analysis` → `sequence_analysis`
+- `count_gt(now)/max` for dates → `date_freshness`
+- `dtype` → neutral vocab (already present)
+Kernel results are the SAME ones validated byte/epsilon-exact in the W2–W5 parity harness, so Stage 0 is wiring, not new numerics. Gate on `native_enabled(...)`; if a kernel symbol is absent the Arrow column raises `NativeRequiredError` (matches the existing regex/date policy — the native wheel is mandatory in the polars-free world).
+
+### Stage 1 — the §8b differential measurement harness (THE GATE)
+New harness `tests/flip/differential.py` (+ a runnable `scripts/flip_differential.py`):
+- **Corpus**: generated synthetic datasets (a `scripts/flip_corpus.py` generator) exercising every check family — numeric distributions (outliers), sequences/gaps, dates/freshness, duplicates, age-vs-dob, correlations/contingency, Benford, plus mixed dtypes and at least one dataset > `sample_size` (100k) so the sample path fires. Plus the 2 existing CSV fixtures.
+- **Two runs per dataset**: (P) authoritative 2.x path = `scan_file`/`scan_dataframe` on a `pl.DataFrame` (PolarsColumn); (F) fused path = the same scan on an Arrow-backed Frame (Stage-0 column) with owned sample + owned dtype. Both return `list[Finding]`.
+- **Finding key**: `(check, column, severity)` PLUS `affected_rows` and a normalized `message`/`sample_values` — because Population B divergences surface in counts/samples, a bare `(check,column,severity)` key would false-pass (recon §8).
+- **Metrics (§8b)**: (1) finding-set Jaccard + count delta per (check, severity); (2) **stat-threshold-flip** bucket (finding appears/disappears because statrs p-value crossed a cutoff scipy didn't); (3) **owned-sample-flip** bucket (finding differs only because the sampled rows differ); (4) `inferred_type` string diffs; (5) max stat-float delta per stat family; (6) `DatasetProfile.health_score` grade delta (secondary end-to-end invariant).
+- **Acceptance (§8b)**: non-stat, non-sample findings MUST be identical (**Jaccard 1.0**) — any delta there is a kernel bug that BLOCKS the flip. Stat-threshold + owned-sample buckets are QUANTIFIED and must sit within an expected band (e.g. stat flips only in p∈[0.04,0.06]); dtype-string diffs are expected (owned vocabulary). Emit a report artifact (`docs/superpowers/specs/flip-differential-report.md`).
+
+**Stage 1 output is presented for human sign-off before any Stage ≥2 work.** If acceptance fails, stop and fix the kernel bug (do not flip).
+
+### Stage 2 — owned deterministic sample
+Replace `engine/sampler.py` `df.sample(n, seed=42)` (Polars PRNG) with an owned deterministic reservoir/stride sample over the Arrow table (seeded, stable across runs + `--workers`). Register as an accepted divergence. This is the only sampling seam on the scan path (recon §2).
+
+### Stage 3 — flip authority + delete shadows + owned dtype
+- Route `_scan_dataframe_impl`'s column loop through the Frame seam (it currently calls `df[col].n_unique()`/`col.to_arrow()` directly) so the Arrow column drives it.
+- `scanner.py:406` `inferred_type=str(col.dtype)` → `dtype_category(col.dtype)` (neutral vocab; the seam already returns it).
+- Remove the now-dead Population B shadow blocks (13 sites) — the kernel is now the authoritative `col.method()`.
+- Migrate the scipy-backed baseline/drift/correlation paths to the kernels they already shadow (chi2_gof/pearson_r/chi2_contingency) as the authoritative call; keep scipy only where declined (dist.fit/kstest — those stay, gated on the `[baseline]` extra, NOT `[polars]`).
+
+### Stage 4 — Arrow-native scan_file + remove `[polars]`
+- `scan_file` reads into an Arrow table (owned csv_infer / pyarrow parquet / openpyxl excel — all already polars-free) and wraps in the Arrow Frame. No `pl.read_csv`.
+- `scan_dataframe`: accept a `pyarrow.Table` natively; keep a `pl.DataFrame` convenience overload (converts via `.to_arrow()`) ONLY when polars is importable — so polars becomes a pure convenience, not a requirement.
+- Remove the `polars = ["polars>=1.0"]` extra from pyproject. Audit the ~30 `from goldencheck._polars_lazy import pl` modules: on the scan_file finding path they must not need polars; off-path modules (llm/agent/cli/reporters/tui/differ/db_scanner) may keep the lazy shim but must degrade cleanly.
+
+### Stage 5 — version, tests, docs
+- Bump 3.0.0 in lockstep: pyproject.toml, `__init__.py __version__`, both `server.json` version fields (the `version_consistency` required gate enforces this).
+- Rewrite `tests/nopolars/test_polars_absent.py`: the assertions that polars-absent *declines* (esp. csv full-scan RAISES, line 149) invert — the full scan must now SUCCEED via the owned/Arrow path. This lane is in `ci-required`.
+- Rollout docs sweep (skill): every surface that says polars is required / that CSV/full-scan needs `goldencheck[polars]`; CHANGELOG 3.0.0; tuning/config docs; the `engine/CLAUDE.md` seed=42 contract note (goes stale).
+- **PyPI publish of 3.0.0 stays HUMAN-GATED** — landing 3.0.0 code on main is not the release; the maintainer cuts the tag (goldencheck 2.0.0 precedent).
+
+## Contract / parity
+- Non-stat findings: strict identity (Jaccard 1.0), enforced by the Stage-1 harness as a CI gate going forward.
+- Registered accepted divergences (populate `ACCEPTED_DIVERGENCES`, currently empty): owned-sample class, statrs-threshold-flip class, owned dtype vocabulary.
+- Population A/C held constant — differential proves zero delta there or the flip is blocked.
+
+## Risks
+- **Scope**: Stages 3–4 are the large, irreversible part. Each stage is independently verifiable; Stage 1 (measurement) gates the rest. Do NOT proceed past Stage 1 without the differential coming back within acceptance + human sign-off.
+- **Off-path polars modules**: complete dependency removal may surface a module that genuinely needs polars on the scan path; if so, that becomes a scoped sub-task, not a silent `[polars]` retention.
+- **Arrow column perf**: the kernels already carry the CPU work; the seam wrapper must not re-materialize per call. Measure wall on the >100k dataset.
+- **nopolars test inversion** is a required gate — rewrite, don't just re-enable.
+
+## Non-goals
+- No new numerics (kernels already validated). No DataFusion. No PyPI publish (human-gated). No reproduction of the declined scipy dist.fit()/kstest (they stay, gated on `[baseline]`). No touching Population A/C authority.

--- a/packages/python/goldencheck/.gitignore
+++ b/packages/python/goldencheck/.gitignore
@@ -40,3 +40,7 @@ packages/goldencheck-js/dist/
 packages/goldencheck-js/node_modules/
 package-lock.json
 packages/goldencheck-js/package-lock.json
+
+# Flip differential: regenerable corpus + captured findings (scripts/flip_corpus.py)
+tests/flip/corpus/
+tests/flip/authoritative_findings.json

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,46 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.0.0] - 2026-07-11
+
+### Changed (BREAKING)
+- **The default scan path is now Arrow-native and Polars-free.** `scan_file`,
+  `scan_dataframe`, and the CLI `check`/`scan` run WITHOUT Polars -- including
+  CSV. `scan_file` reads through an Arrow-native reader (`read_file_arrow`) and
+  the scan frame is a `pyarrow.Table`, so a plain `pip install goldencheck` can
+  scan CSV/Parquet/Excel end-to-end with no Polars installed. The 2.0.0 rule
+  that "CSV reading and the full scan still require `goldencheck[polars]`" is no
+  longer true.
+- **`pyarrow` is now a base dependency** (the scan frame is a `pyarrow.Table`).
+- **Polars is no longer needed for the default scan.** It moved to two opt-in
+  extras: `goldencheck[baseline]` now pulls `polars>=1.0` for the scipy-backed
+  statistical / drift / correlation subsystems (which still run on Polars), and
+  `goldencheck[polars]` remains only for the `scan_dataframe(pl.DataFrame)`
+  convenience overload. `scan_dataframe` accepts a `pyarrow.Table` natively; a
+  `polars.DataFrame` is converted via `.to_arrow()` only when Polars is present.
+- **`inferred_type` now emits a neutral dtype vocabulary** (`str`, `int`,
+  `uint`, `float`, `date`, `datetime`, `bool`, `other`) instead of raw Polars
+  dtype strings (`Int64`, `Utf8`, ...). Scan output, profiles, and the MCP/agent
+  `type` fields report the neutral names.
+- **Sampling is an owned deterministic sample.** The large-file sampler replaced
+  the Polars PRNG (`df.sample(seed=42)`) with an owned deterministic stride
+  sample over the Arrow table -- stable across runs and `--workers`, registered
+  as an accepted divergence from the old Polars-native sample.
+
+### Notes
+- The compiled native kernel (`goldencheck[native]`) still accelerates the
+  numeric / sequence / date / regex checks; the profilers self-skip those when
+  it is absent (graceful degradation, unchanged pattern).
+- The `nopolars` CI lane now asserts the **full** scan (CSV + `scan_file` +
+  the CLI) succeeds with Polars uninstalled -- previously it asserted only the
+  covered-columns subset ran Polars-free.
+
+### Migration
+- Most users need no change: `pip install goldencheck` now scans everything
+  without Polars. Only add `goldencheck[polars]` if you call
+  `scan_dataframe(pl.DataFrame)` with a Polars frame, and `goldencheck[baseline]`
+  if you use the statistical baseline / drift / correlation features.
+
 ## [2.0.0] - 2026-07-11
 
 ### Changed (BREAKING)

--- a/packages/python/goldencheck/README.md
+++ b/packages/python/goldencheck/README.md
@@ -39,18 +39,18 @@ Built by [Ben Severn](https://bensevern.dev).
 pip install goldencheck
 ```
 
-The base install is Polars-free: `scan_columns`, `read_columns`, and `scan_file_columns`
-work out of the box for Parquet and Excel sources. For CSV reading and the full
-`scan_file`/`scan_dataframe` scan, add the `[polars]` extra:
+The base install is Polars-free and scans everything: `scan_file`, `scan_dataframe`,
+and the CLI run Arrow-native (the scan frame is a `pyarrow.Table`), so CSV, Parquet,
+and Excel all work out of the box with no Polars installed.
 
-```bash
-pip install goldencheck[polars]
-```
-
-> **2.0.0 breaking change:** Polars moved from a hard dependency to the `[polars]` extra.
-> If your code reads CSVs or calls `scan_file`/`scan_dataframe`, add `goldencheck[polars]`
-> when upgrading — calling those paths without it raises a clear `ImportError` naming the
-> extra to install.
+> **3.0.0 breaking change:** The default scan path is Arrow-native and Polars-free —
+> including CSV, which needed `goldencheck[polars]` in 2.0.0 and no longer does.
+> `pyarrow` is now a base dependency. Polars moved to two opt-in extras: add
+> `goldencheck[baseline]` for the scipy-backed statistical / drift / correlation
+> features (they still run on Polars), and `goldencheck[polars]` only if you call
+> `scan_dataframe(pl.DataFrame)` with a Polars frame (it accepts a `pyarrow.Table`
+> natively). `inferred_type` now reports a neutral dtype vocabulary (`str`, `int`,
+> `float`, `date`, ...) instead of raw Polars dtype names.
 
 With LLM boost support:
 
@@ -88,8 +88,8 @@ import { readFile, scanData } from "goldencheck/node";
 
 ## Quick Start
 
-CSV scanning below needs `pip install goldencheck[polars]` (see [Install](#install)).
-Parquet/Excel scanning works with the base install.
+CSV, Parquet, and Excel scanning all work with the base install — the scan path
+is Arrow-native and needs no Polars.
 
 ```bash
 # Scan a file — discovers issues, launches interactive TUI
@@ -555,7 +555,8 @@ Tested on a custom benchmark with 341 planted data quality issues across 9 categ
 
 | Dependency | Purpose |
 |-----------|---------|
-| [Polars](https://pola.rs/) | CSV reading + the full scan (optional, `[polars]`) |
+| [pyarrow](https://arrow.apache.org/docs/python/) | Arrow-native scan frame (base dep) — CSV/Parquet/Excel scanning, no Polars |
+| [Polars](https://pola.rs/) | Optional: `[baseline]` stat/drift features + the `scan_dataframe(pl.DataFrame)` overload (`[polars]`) |
 | [Typer](https://typer.tiangolo.com/) | CLI framework |
 | [Textual](https://textual.textualize.io/) | Interactive TUI |
 | [Rich](https://rich.readthedocs.io/) | CLI output formatting |

--- a/packages/python/goldencheck/docs/architecture.md
+++ b/packages/python/goldencheck/docs/architecture.md
@@ -17,7 +17,7 @@ goldencheck/
 │   └── writer.py            # Serialize config back to YAML
 │
 ├── engine/
-│   ├── reader.py            # Read CSV/Parquet/Excel into a Polars DataFrame
+│   ├── reader.py            # Arrow-native read of CSV/Parquet/Excel into a pyarrow.Table (no Polars)
 │   ├── sampler.py           # maybe_sample() — reservoir sample for large files
 │   ├── scanner.py           # Orchestrate profilers, return findings + profile
 │   └── validator.py         # Apply pinned rules from config, return violations

--- a/packages/python/goldencheck/docs/installation.md
+++ b/packages/python/goldencheck/docs/installation.md
@@ -19,13 +19,17 @@ This installs GoldenCheck with all core dependencies:
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| polars | >=1.0 | Data operations |
+| pyarrow | >=14 | Arrow-native scan frame — CSV/Parquet/Excel scanning (no Polars) |
 | typer | >=0.12 | CLI framework |
 | rich | >=13.0 | Console output |
 | pyyaml | >=6.0 | Config file parsing |
 | pydantic | >=2.0 | Config validation |
 | openpyxl | >=3.1 | Excel file support |
 | textual | >=1.0 | Interactive TUI |
+
+> As of 3.0.0 the default scan is Arrow-native and Polars-free. Polars is no longer a
+> core dependency — it ships only in the `[baseline]` (statistical / drift features) and
+> `[polars]` (the `scan_dataframe(pl.DataFrame)` overload) extras.
 
 ## With LLM Boost
 

--- a/packages/python/goldencheck/docs/superpowers/specs/flip-differential-report.md
+++ b/packages/python/goldencheck/docs/superpowers/specs/flip-differential-report.md
@@ -1,0 +1,221 @@
+# Flip §8b Differential — Stage 0 (seam-clean column profilers)
+
+Authoritative = seam profilers over a `PolarsFrame` (2.x-Polars).  
+Fused = the SAME profilers over an `ArrowFrame` (owned Arrow-native seam).
+
+Profilers exercised: TypeInference, Nullability, Uniqueness, RangeDistribution, Cardinality, SequenceDetection, Freshness.
+## Overall verdict
+
+- STRICT (non-stat/non-dtype) Jaccard = 1.000 (PASS iff 1.000)  ->  PASS
+- dtype-vocab diffs (expected, raw-polars vs neutral): **27**
+- max stat-float delta across all datasets: **0.000e+00**
+- strict-set divergences: **0** (must be 0)
+
+
+## age_dob
+
+- full finding-set Jaccard (with sample_values): **1.000** (3/3)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (3/3)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| nullability | 1 | 2 | 2 | +0 |
+| range_distribution | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| age | `Int64` | `int` |
+| date_of_birth | `Date` | `date` |
+
+## benford
+
+- full finding-set Jaccard (with sample_values): **1.000** (7/7)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (7/7)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| nullability | 1 | 2 | 2 | +0 |
+| range_distribution | 1 | 2 | 2 | +0 |
+| range_distribution | 2 | 1 | 1 | +0 |
+| type_inference | 2 | 1 | 1 | +0 |
+| uniqueness | 2 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| amount | `Int64` | `int` |
+| flat_id | `Int64` | `int` |
+
+## correlation
+
+- full finding-set Jaccard (with sample_values): **1.000** (16/16)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (16/16)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| cardinality | 1 | 2 | 2 | +0 |
+| nullability | 1 | 5 | 5 | +0 |
+| range_distribution | 1 | 3 | 3 | +0 |
+| range_distribution | 2 | 3 | 3 | +0 |
+| uniqueness | 1 | 3 | 3 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| var_a | `Float64` | `float` |
+| var_b | `Float64` | `float` |
+| var_c | `Float64` | `float` |
+| cat1 | `String` | `str` |
+| cat2 | `String` | `str` |
+
+## duplicates
+
+- full finding-set Jaccard (with sample_values): **1.000** (5/5)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (5/5)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| cardinality | 1 | 2 | 2 | +0 |
+| nullability | 1 | 3 | 3 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| first_name | `String` | `str` |
+| city | `String` | `str` |
+| email | `String` | `str` |
+
+## freshness
+
+- full finding-set Jaccard (with sample_values): **1.000** (2/2)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (2/2)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| nullability | 1 | 1 | 1 | +0 |
+| stale_data | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| event_date | `Date` | `date` |
+
+## large_sampled
+
+- full finding-set Jaccard (with sample_values): **1.000** (12/12)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (12/12)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| cardinality | 1 | 1 | 1 | +0 |
+| nullability | 1 | 4 | 4 | +0 |
+| range_distribution | 1 | 3 | 3 | +0 |
+| range_distribution | 2 | 2 | 2 | +0 |
+| type_inference | 2 | 1 | 1 | +0 |
+| uniqueness | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| measure | `Float64` | `float` |
+| region | `String` | `str` |
+| amount | `Int64` | `int` |
+| rec_id | `Int64` | `int` |
+
+## mixed_dtypes
+
+- full finding-set Jaccard (with sample_values): **1.000** (15/15)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (15/15)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| cardinality | 1 | 2 | 2 | +0 |
+| nullability | 1 | 6 | 6 | +0 |
+| range_distribution | 1 | 4 | 4 | +0 |
+| range_distribution | 2 | 1 | 1 | +0 |
+| type_inference | 2 | 1 | 1 | +0 |
+| uniqueness | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| i8 | `Int8` | `int` |
+| u32 | `UInt32` | `uint` |
+| f32 | `Float32` | `float` |
+| flag | `Boolean` | `bool` |
+| label | `String` | `str` |
+| maybe_num | `String` | `str` |
+
+## numeric_outliers
+
+- full finding-set Jaccard (with sample_values): **1.000** (9/9)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (9/9)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| nullability | 1 | 3 | 3 | +0 |
+| range_distribution | 1 | 3 | 3 | +0 |
+| range_distribution | 2 | 2 | 2 | +0 |
+| uniqueness | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| score | `Float64` | `float` |
+| noise | `Float64` | `float` |
+| count | `Int64` | `int` |
+
+## sequence_gaps
+
+- full finding-set Jaccard (with sample_values): **1.000** (5/5)
+- STRICT (non-sample/non-dtype) Jaccard: **1.000** (5/5)
+- max stat-float delta: **0.000e+00**
+
+### finding count per (check, severity)
+
+| check | severity | authoritative | fused | delta |
+|---|---|---|---|---|
+| nullability | 1 | 1 | 1 | +0 |
+| range_distribution | 1 | 1 | 1 | +0 |
+| sequence_detection | 2 | 1 | 1 | +0 |
+| type_inference | 2 | 1 | 1 | +0 |
+| uniqueness | 1 | 1 | 1 | +0 |
+
+### dtype vocabulary (expected raw-polars vs neutral divergence)
+
+| column | authoritative repr | fused repr |
+|---|---|---|
+| row_id | `Int64` | `int` |

--- a/packages/python/goldencheck/docs/wiki/Architecture.md
+++ b/packages/python/goldencheck/docs/wiki/Architecture.md
@@ -13,7 +13,7 @@ goldencheck/
 │   └── writer.py            # Serialize config back to YAML
 │
 ├── engine/
-│   ├── reader.py            # Read CSV/Parquet/Excel into a Polars DataFrame
+│   ├── reader.py            # Arrow-native read of CSV/Parquet/Excel into a pyarrow.Table (no Polars)
 │   ├── sampler.py           # maybe_sample() — reservoir sample for large files
 │   ├── scanner.py           # Orchestrate profilers, return findings + profile
 │   └── validator.py         # Apply pinned rules from config, return violations

--- a/packages/python/goldencheck/docs/wiki/Installation.md
+++ b/packages/python/goldencheck/docs/wiki/Installation.md
@@ -15,13 +15,17 @@ This installs GoldenCheck with all core dependencies:
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| polars | >=1.0 | Data operations |
+| pyarrow | >=14 | Arrow-native scan frame — CSV/Parquet/Excel scanning (no Polars) |
 | typer | >=0.12 | CLI framework |
 | rich | >=13.0 | Console output |
 | pyyaml | >=6.0 | Config file parsing |
 | pydantic | >=2.0 | Config validation |
 | openpyxl | >=3.1 | Excel file support |
 | textual | >=1.0 | Interactive TUI |
+
+> As of 3.0.0 the default scan is Arrow-native and Polars-free. Polars is no longer a
+> core dependency — it ships only in the `[baseline]` (statistical / drift features) and
+> `[polars]` (the `scan_dataframe(pl.DataFrame)` overload) extras.
 
 ## With LLM Boost
 

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "2.0.0"
+__version__ = "3.0.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -450,15 +450,44 @@ class ArrowColumn:
     # -- numeric stats (cached single kernel call) ----------------------------
     def _numeric_stats(self):
         """Cached ``(count_nonnull, min, max, mean, std, sum)`` for numeric
-        columns, or ``None`` when empty/all-null (guarded before the kernel)."""
+        columns, or ``None`` when empty/all-null (guarded before the kernel).
+
+        Native ``column_numeric_stats`` is the fast path; when the kernel is
+        absent/disabled (``native_enabled("numeric_stats")`` False) a
+        ``pyarrow.compute`` fallback computes the identical tuple within the
+        already-accepted stat epsilon (``std`` uses ddof=1 to match
+        Polars/kernel). Restores the accelerator-not-requirement contract."""
         if self._num_stats is not None:
             return None if self._num_stats is False else self._num_stats
         arr = self._arr
         if len(arr) == 0 or arr.null_count == len(arr):
             self._num_stats = False
             return None
-        self._num_stats = native_module().column_numeric_stats(arr)
+        if native_enabled("numeric_stats"):
+            self._num_stats = native_module().column_numeric_stats(arr)
+        else:
+            self._num_stats = self._numeric_stats_pyarrow(arr)
         return self._num_stats
+
+    @staticmethod
+    def _numeric_stats_pyarrow(arr):
+        """``pyarrow.compute`` mirror of ``column_numeric_stats``: returns
+        ``(count_nonnull, min, max, mean, std, sum)``. ``std`` is ddof=1 (Polars
+        parity) and is ``None`` when <2 non-null values (as the native kernel's
+        std-guard is applied downstream in ``std()``)."""
+        _, pc = _arrow()
+        count_nonnull = len(arr) - arr.null_count
+        mm = pc.min_max(arr, skip_nulls=True)
+        vmin = mm["min"].as_py()
+        vmax = mm["max"].as_py()
+        mean = pc.mean(arr, skip_nulls=True).as_py()
+        total = pc.sum(arr, skip_nulls=True).as_py()
+        if count_nonnull >= 2:
+            std_scalar = pc.stddev(arr, ddof=1, skip_nulls=True)
+            std = std_scalar.as_py() if std_scalar.is_valid else None
+        else:
+            std = None
+        return (count_nonnull, vmin, vmax, mean, std, total)
 
     def _is_numeric(self) -> bool:
         return self._cat in ("int", "uint", "float")
@@ -556,14 +585,25 @@ class ArrowColumn:
         return int(r or 0)
 
     def str_match_count(self, pattern: str) -> int:
-        return _regex_kernel().str_contains_count(self._arr.to_pylist(), pattern)
+        if native_enabled("regex"):
+            return _regex_kernel().str_contains_count(self._arr.to_pylist(), pattern)
+        _, pc = _arrow()
+        mask = pc.match_substring_regex(self._arr, pattern)   # null preserved on null input
+        return int(pc.sum(mask, skip_nulls=True).as_py() or 0)
 
     def str_filter(self, pattern: str, *, matching: bool) -> ArrowColumn:
-        pa, _ = _arrow()
-        vals = self._arr.to_pylist()
-        mask = _regex_kernel().str_filter_mask(vals, pattern)   # list[bool | None]
-        kept = [v for v, m in zip(vals, mask) if m is not None and m == matching]
-        return ArrowColumn(pa.array(kept, type=pa.string()))
+        pa, pc = _arrow()
+        if native_enabled("regex"):
+            vals = self._arr.to_pylist()
+            mask = _regex_kernel().str_filter_mask(vals, pattern)   # list[bool | None]
+            kept = [v for v, m in zip(vals, mask) if m is not None and m == matching]
+            return ArrowColumn(pa.array(kept, type=pa.string()))
+        # pyarrow fallback: match_substring_regex -> bool mask (null on null input);
+        # ~mask is null-preserving so nulls drop from BOTH matching/non-matching
+        # (Polars' filter drops null-mask rows), matching PyColumn's `m is not None`.
+        mask = pc.match_substring_regex(self._arr, pattern)
+        sel = mask if matching else pc.invert(mask)
+        return ArrowColumn(pc.filter(self._arr, sel, null_selection_behavior="drop"))
 
     def min(self) -> Any:
         if self._is_numeric():
@@ -649,9 +689,15 @@ class ArrowColumn:
         return ArrowColumn(self._arr.slice(offset, length))
 
     def str_replace_all(self, pattern: str, value: str) -> ArrowColumn:
-        pa, _ = _arrow()
-        out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
-        return ArrowColumn(pa.array(out, type=pa.string()))
+        pa, pc = _arrow()
+        if native_enabled("regex"):
+            out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
+            return ArrowColumn(pa.array(out, type=pa.string()))
+        # pyarrow fallback: replace_substring_regex preserves nulls, matching
+        # Polars' str.replace_all. Cast to string() so the result column dtype
+        # matches the native path (input may be large_string).
+        out = pc.replace_substring_regex(self._arr, pattern, value)
+        return ArrowColumn(pc.cast(out, pa.string()))
 
     def str_len_chars(self) -> ArrowColumn:
         # pc.utf8_length -> per-value character count (nulls preserved), matching
@@ -702,12 +748,17 @@ class ArrowColumn:
         return int(round(s[5])) if self._cat in ("int", "uint") else s[5]
 
     def str_to_date(self, fmt: str, *, strict: bool) -> ArrowColumn:
-        pa, _ = _arrow()
+        pa, pc = _arrow()
         if strict:
             raise NotImplementedError("goldencheck str_to_date supports strict=False only")
-        iso = _date_kernel().str_to_date(self._arr.to_pylist(), fmt)
-        vals = [date.fromisoformat(s) if s is not None else None for s in iso]
-        return ArrowColumn(pa.array(vals, type=pa.date32()))
+        if native_enabled("str_to_date"):
+            iso = _date_kernel().str_to_date(self._arr.to_pylist(), fmt)
+            vals = [date.fromisoformat(s) if s is not None else None for s in iso]
+            return ArrowColumn(pa.array(vals, type=pa.date32()))
+        # pyarrow fallback: strptime with error_is_null (== Polars strict=False:
+        # unparseable -> null) then narrow the timestamp to date32.
+        ts = pc.strptime(self._arr, format=fmt, unit="s", error_is_null=True)
+        return ArrowColumn(pc.cast(ts, pa.date32()))
 
 
 class ArrowFrame:

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -387,11 +387,345 @@ class PyFrame:
         return PyColumn(self._cols[name])
 
 
+def _arrow():
+    """Lazy pyarrow accessor — mirrors ``_polars_lazy`` so ``import
+    goldencheck.core.frame`` works without pyarrow for the pure-Polars path.
+    Returns ``(pyarrow, pyarrow.compute)``."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    return pa, pc
+
+
+def _arrow_neutral_dtype(arr_type: Any) -> str:
+    """Arrow type -> neutral dtype vocabulary (str/int/uint/float/date/datetime/
+    bool/other). MUST agree with ``dtype_category(pl_dtype)`` for the same data so
+    ``ArrowColumn.dtype == PolarsColumn.dtype``."""
+    import pyarrow.types as pat
+
+    if pat.is_string(arr_type) or pat.is_large_string(arr_type):
+        return "str"
+    if pat.is_unsigned_integer(arr_type):   # must precede is_integer (true for both)
+        return "uint"
+    if pat.is_integer(arr_type):
+        return "int"
+    if pat.is_floating(arr_type):
+        return "float"
+    if pat.is_date(arr_type):
+        return "date"
+    if pat.is_timestamp(arr_type):
+        return "datetime"
+    if pat.is_boolean(arr_type):
+        return "bool"
+    return "other"
+
+
+class ArrowColumn:
+    """``pyarrow.Array``-backed column implementing the full ``Column`` Protocol.
+
+    Parity oracle is ``PolarsColumn``: for the same data every method returns a
+    byte/epsilon-identical result, EXCEPT ``dtype_repr`` (see its docstring). The
+    numeric reductions route through the native ``column_numeric_stats`` kernel
+    (one cached call); temporal/string/bool reductions use ``pyarrow.compute`` so
+    ``max()`` on a date column returns a ``datetime.date`` (freshness needs it).
+    """
+
+    __slots__ = ("_arr", "_cat", "_num_stats")
+
+    def __init__(self, arr: Any) -> None:
+        pa, _ = _arrow()
+        if isinstance(arr, pa.ChunkedArray):
+            arr = arr.combine_chunks()
+        self._arr = arr
+        self._cat = _arrow_neutral_dtype(arr.type)
+        self._num_stats: Any = None   # None=unset, False=empty/all-null, tuple=cached
+
+    # -- numeric stats (cached single kernel call) ----------------------------
+    def _numeric_stats(self):
+        """Cached ``(count_nonnull, min, max, mean, std, sum)`` for numeric
+        columns, or ``None`` when empty/all-null (guarded before the kernel)."""
+        if self._num_stats is not None:
+            return None if self._num_stats is False else self._num_stats
+        arr = self._arr
+        if len(arr) == 0 or arr.null_count == len(arr):
+            self._num_stats = False
+            return None
+        self._num_stats = native_module().column_numeric_stats(arr)
+        return self._num_stats
+
+    def _is_numeric(self) -> bool:
+        return self._cat in ("int", "uint", "float")
+
+    def _scalar(self, value: Any) -> Any:
+        """Wrap a comparison value as an Arrow scalar of THIS column's type so
+        date/datetime comparisons work; numeric values pass straight through."""
+        if self._cat in ("date", "datetime"):
+            pa, _ = _arrow()
+            return pa.scalar(value, type=self._arr.type)
+        return value
+
+    # -- Column Protocol ------------------------------------------------------
+    def __len__(self) -> int:
+        return len(self._arr)
+
+    def null_count(self) -> int:
+        return self._arr.null_count
+
+    def n_unique(self) -> int:
+        _, pc = _arrow()
+        return int(pc.count_distinct(self._arr, mode="all").as_py())   # nulls = 1 distinct (Polars parity)
+
+    def drop_nulls(self) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.drop_null(self._arr))
+
+    def unique(self) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.unique(self._arr))
+
+    def sort(self) -> ArrowColumn:
+        _, pc = _arrow()
+        idx = pc.sort_indices(self._arr, null_placement="at_start")   # ascending, nulls-first (Polars)
+        return ArrowColumn(self._arr.take(idx))
+
+    def to_list(self) -> list:
+        return self._arr.to_pylist()
+
+    @property
+    def dtype(self) -> str:
+        return self._cat
+
+    def dtype_repr(self) -> str:
+        # OWNED-contract dtype vocabulary: returns the NEUTRAL category, unlike
+        # PolarsColumn.dtype_repr which returns raw ``str(pl.dtype)``. This
+        # divergence is EXPECTED and measured by the Flip differential, not a bug.
+        return self._cat
+
+    def to_arrow(self) -> Any:
+        return self._arr
+
+    def get(self, index: int) -> Any:
+        return self._arr[index].as_py()
+
+    def cast(self, kind: str, *, strict: bool = False) -> ArrowColumn:
+        pa, pc = _arrow()
+        import pyarrow.types as pat
+
+        a = self._arr
+        is_str = pat.is_string(a.type) or pat.is_large_string(a.type)
+        if kind == "float":
+            if is_str:
+                out = []
+                for v in a.to_pylist():
+                    if v is None:
+                        out.append(None)
+                        continue
+                    try:
+                        out.append(float(v))
+                    except (ValueError, TypeError):
+                        out.append(None)   # unparseable -> null (pl strict=False)
+                return ArrowColumn(pa.array(out, type=pa.float64()))
+            return ArrowColumn(pc.cast(a, pa.float64(), safe=False))
+        if kind == "int":
+            if is_str:
+                out = []
+                for v in a.to_pylist():
+                    if v is None:
+                        out.append(None)
+                        continue
+                    try:
+                        out.append(int(v))
+                    except (ValueError, TypeError):
+                        out.append(None)
+                return ArrowColumn(pa.array(out, type=pa.int64()))
+            return ArrowColumn(pc.cast(a, pa.int64(), safe=False))
+        if kind == "str":
+            return ArrowColumn(pc.cast(a, pa.string()))
+        raise KeyError(kind)
+
+    def member_count(self, values: list) -> int:
+        pa, pc = _arrow()
+        r = pc.sum(pc.is_in(self._arr, value_set=pa.array(values))).as_py()
+        return int(r or 0)
+
+    def str_match_count(self, pattern: str) -> int:
+        return _regex_kernel().str_contains_count(self._arr.to_pylist(), pattern)
+
+    def str_filter(self, pattern: str, *, matching: bool) -> ArrowColumn:
+        pa, _ = _arrow()
+        vals = self._arr.to_pylist()
+        mask = _regex_kernel().str_filter_mask(vals, pattern)   # list[bool | None]
+        kept = [v for v, m in zip(vals, mask) if m is not None and m == matching]
+        return ArrowColumn(pa.array(kept, type=pa.string()))
+
+    def min(self) -> Any:
+        if self._is_numeric():
+            s = self._numeric_stats()
+            if s is None:
+                return None
+            return int(round(s[1])) if self._cat in ("int", "uint") else s[1]
+        _, pc = _arrow()
+        return pc.min(self._arr).as_py()
+
+    def max(self) -> Any:
+        if self._is_numeric():
+            s = self._numeric_stats()
+            if s is None:
+                return None
+            return int(round(s[2])) if self._cat in ("int", "uint") else s[2]
+        _, pc = _arrow()
+        return pc.max(self._arr).as_py()
+
+    def mean(self) -> Any:
+        if not self._is_numeric():
+            return None
+        s = self._numeric_stats()
+        return None if s is None else s[3]
+
+    def std(self) -> Any:
+        if not self._is_numeric():
+            return None
+        s = self._numeric_stats()
+        if s is None or s[0] < 2:   # ddof=1 needs >=2 non-null (Polars -> None)
+            return None
+        return s[4]
+
+    def diff(self) -> ArrowColumn:
+        pa, pc = _arrow()
+        import pyarrow.types as pat
+
+        a = self._arr
+        # pl.Series.diff() dtype rule: SIGNED ints keep their type and WRAP
+        # (Int8 diff stays Int8, wrapping_sub); UNSIGNED ints upcast to the next
+        # wider SIGNED type (UInt8->Int16, UInt32->Int64) so diffs can go negative.
+        if pat.is_unsigned_integer(a.type):
+            widen = {1: pa.int16(), 2: pa.int32(), 4: pa.int64(), 8: pa.int64()}
+            a = pc.cast(a, widen[a.type.bit_width // 8], safe=False)
+        n = len(a)
+        null_head = pa.array([None], type=a.type)
+        if n == 0:
+            return ArrowColumn(a.slice(0, 0))
+        if n == 1:
+            return ArrowColumn(null_head)
+        # pc.subtract WRAPS on overflow (non-checked variant) -> matches Int64
+        # diff's wrapping_sub; narrower ints were widened above so never overflow.
+        d = pc.subtract(a.slice(1), a.slice(0, n - 1))
+        return ArrowColumn(pa.concat_arrays([null_head, d]))
+
+    def is_sorted(self) -> bool:
+        _, pc = _arrow()
+        a = self._arr
+        if len(a) <= 1:
+            return True
+        idx = pc.sort_indices(a, null_placement="at_start")   # ascending nulls-first (Polars)
+        return a.equals(a.take(idx))
+
+    def count_gt(self, value: Any) -> int:
+        _, pc = _arrow()
+        r = pc.sum(pc.greater(self._arr, self._scalar(value))).as_py()
+        return int(r or 0)
+
+    def count_eq(self, value: Any) -> int:
+        _, pc = _arrow()
+        r = pc.sum(pc.equal(self._arr, self._scalar(value))).as_py()
+        return int(r or 0)
+
+    def filter_outside(self, lower: Any, upper: Any) -> ArrowColumn:
+        _, pc = _arrow()
+        a = self._arr
+        mask = pc.or_(pc.less(a, lower), pc.greater(a, upper))
+        return ArrowColumn(pc.filter(a, mask))
+
+    def slice(self, offset: int, length: int | None = None) -> ArrowColumn:
+        if length is None:
+            return ArrowColumn(self._arr.slice(offset))
+        return ArrowColumn(self._arr.slice(offset, length))
+
+    def str_replace_all(self, pattern: str, value: str) -> ArrowColumn:
+        pa, _ = _arrow()
+        out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
+        return ArrowColumn(pa.array(out, type=pa.string()))
+
+    def value_counts_desc(self) -> list[tuple[Any, int]]:
+        return sorted(Counter(self._arr.to_pylist()).items(), key=_VC_KEY)
+
+    def eq(self, value: Any) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.equal(self._arr, self._scalar(value)))
+
+    def filter_by(self, mask: Column) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.filter(self._arr, mask._arr, null_selection_behavior="drop"))
+
+    def is_null(self) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.is_null(self._arr))
+
+    def gt_mask(self, other: Column) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.greater(self._arr, other._arr))
+
+    def eq_mask(self, other: Column) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.equal(self._arr, other._arr))
+
+    def fill_null(self, value: Any) -> ArrowColumn:
+        _, pc = _arrow()
+        return ArrowColumn(pc.fill_null(self._arr, value))
+
+    def sum(self) -> Any:
+        if not self._is_numeric():
+            return None
+        s = self._numeric_stats()
+        if s is None:
+            return 0   # Polars empty/all-null numeric sum -> 0
+        return int(round(s[5])) if self._cat in ("int", "uint") else s[5]
+
+    def str_to_date(self, fmt: str, *, strict: bool) -> ArrowColumn:
+        pa, _ = _arrow()
+        if strict:
+            raise NotImplementedError("goldencheck str_to_date supports strict=False only")
+        iso = _date_kernel().str_to_date(self._arr.to_pylist(), fmt)
+        vals = [date.fromisoformat(s) if s is not None else None for s in iso]
+        return ArrowColumn(pa.array(vals, type=pa.date32()))
+
+
+class ArrowFrame:
+    """``pyarrow.Table``-backed frame implementing the ``Frame`` Protocol."""
+
+    __slots__ = ("_tbl",)
+
+    def __init__(self, tbl: Any) -> None:
+        self._tbl = tbl
+
+    @property
+    def columns(self) -> list[str]:
+        return self._tbl.column_names
+
+    @property
+    def height(self) -> int:
+        return self._tbl.num_rows
+
+    @property
+    def native(self) -> Any:
+        return self._tbl
+
+    def column(self, name: str) -> ArrowColumn:
+        return ArrowColumn(self._tbl.column(name))
+
+
 def to_frame(native: Any) -> Frame:
-    if isinstance(native, (PolarsFrame, PyFrame)):
+    if isinstance(native, (PolarsFrame, PyFrame, ArrowFrame)):
         return native
     if isinstance(native, pl.DataFrame):
         return PolarsFrame(native)
+    try:
+        import pyarrow as pa
+    except ImportError:
+        pa = None
+    if pa is not None and isinstance(native, pa.Table):
+        return ArrowFrame(native)
     raise TypeError(
-        f"to_frame() expects a polars.DataFrame, PolarsFrame, or PyFrame; got {type(native)!r}"
+        f"to_frame() expects a polars.DataFrame, pyarrow.Table, PolarsFrame, PyFrame, "
+        f"or ArrowFrame; got {type(native)!r}"
     )

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -44,6 +44,7 @@ class Column(Protocol):
     def filter_outside(self, lower: Any, upper: Any) -> Column: ...
     def slice(self, offset: int, length: int | None = None) -> Column: ...
     def str_replace_all(self, pattern: str, value: str) -> Column: ...
+    def str_len_chars(self) -> Column: ...
     def value_counts_desc(self) -> list[tuple[Any, int]]: ...
     def eq(self, value: Any) -> Column: ...
     def filter_by(self, mask: Column) -> Column: ...
@@ -212,6 +213,9 @@ class PolarsColumn:
     def str_replace_all(self, pattern: str, value: str) -> PolarsColumn:
         return PolarsColumn(self._s.str.replace_all(pattern, value))
 
+    def str_len_chars(self) -> PolarsColumn:
+        return PolarsColumn(self._s.str.len_chars())
+
     def value_counts_desc(self) -> list[tuple[Any, int]]:
         vc = self._s.value_counts()
         pairs = zip(vc[self._s.name].to_list(), vc["count"].to_list())   # (value, count)
@@ -327,6 +331,9 @@ class PyColumn:
 
     def str_replace_all(self, pattern: str, value: str) -> PyColumn:
         return PyColumn(_regex_kernel().str_replace_all(self._v, pattern, value))
+
+    def str_len_chars(self) -> PyColumn:
+        return PyColumn([None if v is None else len(v) for v in self._v])
 
     def value_counts_desc(self) -> list[tuple[Any, int]]:
         return sorted(Counter(self._v).items(), key=_VC_KEY)
@@ -646,6 +653,13 @@ class ArrowColumn:
         out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
         return ArrowColumn(pa.array(out, type=pa.string()))
 
+    def str_len_chars(self) -> ArrowColumn:
+        # pc.utf8_length -> per-value character count (nulls preserved), matching
+        # pl.Series.str.len_chars(). The result is an integer column so
+        # ``.mean()`` routes through the numeric-stats kernel like Polars' mean.
+        _, pc = _arrow()
+        return ArrowColumn(pc.utf8_length(self._arr))
+
     def value_counts_desc(self) -> list[tuple[Any, int]]:
         return sorted(Counter(self._arr.to_pylist()).items(), key=_VC_KEY)
 
@@ -674,6 +688,12 @@ class ArrowColumn:
         return ArrowColumn(pc.fill_null(self._arr, value))
 
     def sum(self) -> Any:
+        if self._cat == "bool":
+            # Polars Series.sum() on Boolean returns the count of True (nulls
+            # skipped) as an int; pc.sum over a bool array does the same.
+            _, pc = _arrow()
+            r = pc.sum(self._arr).as_py()
+            return int(r or 0)
         if not self._is_numeric():
             return None
         s = self._numeric_stats()

--- a/packages/python/goldencheck/goldencheck/engine/CLAUDE.md
+++ b/packages/python/goldencheck/goldencheck/engine/CLAUDE.md
@@ -3,8 +3,8 @@
 ## Scanner Pipeline Order
 
 ```
-read_file(path)                         # reader.py — CSV/Parquet/Excel → pl.DataFrame
-maybe_sample(df, max_rows=100_000)      # sampler.py — deterministic seed=42
+read_file_arrow(path)                   # reader.py — CSV/Parquet/Excel → pyarrow.Table (Arrow-native, no Polars)
+maybe_sample(frame, max_rows=100_000)   # sampler.py — owned deterministic stride sample (3.0.0)
 run COLUMN_PROFILERS per column         # 10 profilers, shared context dict
 run RELATION_PROFILERS on full sample   # temporal, null_correlation, numeric_cross, age_validation
 classify_columns(sample)                # semantic/classifier.py
@@ -47,18 +47,23 @@ The CLI's `_do_scan` does this; the `review` command does it too. Don't skip it.
 
 Supported formats: `.csv`, `.parquet`, `.xlsx`, `.xls`
 
-CSV fallback chain:
-1. `pl.read_csv(path, infer_schema_length=10000)` — UTF-8
-2. `pl.read_csv(path, infer_schema_length=10000, encoding="latin-1")` — Latin-1 fallback
-3. Raises `ValueError` with hint about `--separator`/`--quote-char`
+Two readers live here:
+- **`read_file_arrow(path)`** — the default, Arrow-native reader the scan path uses
+  (`scan_file` → `read_file_arrow`). Returns a `pyarrow.Table`, no Polars involved.
+- **`read_file(path)`** — the legacy Polars reader (`pl.DataFrame`), still used by the
+  `scan_dataframe(pl.DataFrame)` overload / `[polars]` callers. Its CSV fallback chain
+  (`pl.read_csv` UTF-8 → latin-1 → `ValueError` with a `--separator`/`--quote-char` hint)
+  is unchanged, but it is NOT on the default scan path anymore.
 
 Excel raises a user-friendly `ValueError` on password-protected files.
 
 ## sampler.py
 
 ```python
-maybe_sample(df, max_rows=100_000)  # returns df unchanged if ≤ max_rows
-# uses df.sample(n=max_rows, seed=42) — deterministic, Polars native
+maybe_sample(frame, max_rows=100_000)  # returns frame unchanged if ≤ max_rows
+# 3.0.0: OWNED deterministic stride/reservoir sample over the Arrow table —
+# stable across runs AND --workers, Polars-free. Replaced the old Polars PRNG
+# (df.sample(n=max_rows, seed=42)); the swap is a registered accepted divergence.
 ```
 
 Default `sample_size` is `100_000`. Overridable via `scan_file(path, sample_size=N)`.

--- a/packages/python/goldencheck/goldencheck/engine/reader.py
+++ b/packages/python/goldencheck/goldencheck/engine/reader.py
@@ -66,6 +66,60 @@ def read_file(path: Path) -> pl.DataFrame:
         raise ValueError(f"Unsupported file format: {ext}")
 
 
+def _cols_to_table(cols: dict[str, list]):
+    """Build a ``pyarrow.Table`` from a ``dict[str, list]`` of native Python
+    scalars (owned-CSV / Excel readers). pyarrow infers each column's Arrow type
+    from its values -- the same value-level typing the owned readers pin against
+    the prior Polars behaviour. An empty dict yields an empty table."""
+    import pyarrow as pa
+
+    if not cols:
+        return pa.table({})
+    return pa.table({name: pa.array(vals) for name, vals in cols.items()})
+
+
+def read_file_arrow(path: Path):
+    """Polars-free file read into a ``pyarrow.Table`` for the default scan path.
+
+    - **Parquet** -> ``pyarrow.parquet.read_table`` (native Arrow, zero copy).
+    - **Excel** -> ``openpyxl`` -> owned per-column coercion -> Arrow (the same
+      ``_read_excel_columns`` typing used by ``read_columns``).
+    - **CSV** -> the OWNED inference contract (``_read_csv_columns_owned`` ->
+      native ``csv_infer`` kernel or the Python reference in
+      ``engine/csv_infer.py``). This is a *documented, different* dtype-inference
+      contract from ``pl.read_csv`` (leading-zero -> str, inf/nan -> str), NOT a
+      byte-identical stand-in. It is the owned contract the Flip emits.
+
+    The legacy Polars ``read_file`` stays for callers that still need a
+    ``pl.DataFrame``; the scanner's ``scan_file`` uses this Arrow path.
+    """
+    path = Path(path).resolve()
+    ext = path.suffix.lower()
+    if ext not in SUPPORTED_EXTENSIONS:
+        raise ValueError(
+            f"Unsupported file format: {ext}. Supported: {', '.join(sorted(SUPPORTED_EXTENSIONS))}"
+        )
+    if not path.exists():
+        raise FileNotFoundError(f"File not found: {path.name}")
+    logger.info("Reading %s (%s) [arrow]", path.name, ext)
+    if path.stat().st_size == 0:
+        raise ValueError("File has no data rows. Nothing to profile.")
+
+    if ext == ".parquet":
+        try:
+            import pyarrow.parquet as pq
+        except ImportError as e:
+            raise ImportError(
+                "Reading Parquet needs pyarrow: pip install goldencheck[parquet]"
+            ) from e
+        return pq.read_table(str(path))
+    if ext in (".xlsx", ".xls"):
+        return _cols_to_table(_read_excel_columns(path))
+    if ext == ".csv":
+        return _cols_to_table(_read_csv_columns_owned(path))
+    raise ValueError(f"Unsupported file format: {ext}")
+
+
 def _read_csv_columns(path: Path) -> dict[str, list]:
     """Read a CSV file into a dict[str, list] using Polars.
 

--- a/packages/python/goldencheck/goldencheck/engine/sampler.py
+++ b/packages/python/goldencheck/goldencheck/engine/sampler.py
@@ -1,10 +1,66 @@
-"""Smart sampling for large datasets."""
+"""Smart sampling for large datasets.
+
+Owned deterministic sample (Flip, Stage A3). The default scan path samples an
+Arrow table (``ArrowFrame`` / ``pyarrow.Table``) with an evenly-strided,
+seed-free index set: ``idx[i] = (i * n) // max_rows`` for ``i in range(max_rows)``.
+
+This replaces the prior Polars PRNG sample (``df.sample(n, seed=42)``). The stride
+selection is:
+
+- **deterministic** -- the same rows every run, no RNG state;
+- **worker-count independent** -- the index set is a pure function of ``(n,
+  max_rows)``, so a distributed / multi-``--workers`` run sees the identical
+  sample as a single-box run;
+- **order-preserving** -- indices are strictly increasing, so downstream
+  order-sensitive checks (sequence/freshness) see rows in original order.
+
+Off-default callers that still hand a ``pl.DataFrame`` (agent preview, baseline
+builder, CLI) keep the legacy Polars-backed behaviour -- those surfaces are
+gated on the ``[baseline]`` extra in a later Flip stage.
+"""
 from __future__ import annotations
 
-from goldencheck._polars_lazy import pl
+from typing import Any
 
 
-def maybe_sample(df: pl.DataFrame, max_rows: int = 100_000) -> pl.DataFrame:
-    if len(df) <= max_rows:
-        return df
-    return df.sample(n=max_rows, seed=42)
+def _owned_stride_indices(n: int, max_rows: int) -> list[int]:
+    """Evenly-strided, strictly-increasing row indices selecting ``max_rows``
+    of ``n`` rows. Pure function of ``(n, max_rows)`` -- no RNG, stable across
+    runs and worker counts."""
+    return [(i * n) // max_rows for i in range(max_rows)]
+
+
+def maybe_sample(data: Any, max_rows: int = 100_000) -> Any:
+    """Down-sample ``data`` to at most ``max_rows`` rows.
+
+    Accepts an ``ArrowFrame`` / ``pyarrow.Table`` (default scan path -> owned
+    deterministic stride sample, returns an ``ArrowFrame``) or a legacy
+    ``pl.DataFrame`` (off-default callers -> unchanged Polars-backed behaviour).
+    Returns the input unchanged when it already has ``<= max_rows`` rows.
+    """
+    # Default scan path first: Arrow-native owned deterministic sample. Checked
+    # BEFORE any Polars import so the default scan stays polars-free.
+    import pyarrow as pa
+
+    from goldencheck.core.frame import ArrowFrame
+
+    if isinstance(data, (ArrowFrame, pa.Table)):
+        tbl = data.native if isinstance(data, ArrowFrame) else data
+        n = tbl.num_rows
+        if n <= max_rows:
+            return data if isinstance(data, ArrowFrame) else ArrowFrame(tbl)
+        idx = pa.array(_owned_stride_indices(n, max_rows), type=pa.int64())
+        return ArrowFrame(tbl.take(idx))
+
+    # Legacy Polars path (off-default callers: agent/baseline/cli). Kept until
+    # those surfaces move behind the [baseline] extra.
+    try:
+        import polars as pl
+    except ImportError:
+        pl = None
+    if pl is not None and isinstance(data, pl.DataFrame):
+        if len(data) <= max_rows:
+            return data
+        return data.sample(n=max_rows, seed=42)
+
+    raise TypeError(f"maybe_sample expects an ArrowFrame, pyarrow.Table, or polars.DataFrame; got {type(data)!r}")

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -6,14 +6,12 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from goldencheck._polars_lazy import pl
-
 if TYPE_CHECKING:
     from goldencheck.baseline.models import BaselineProfile
-from goldencheck.core._native_loader import native_enabled, native_module
-from goldencheck.core.frame import PyFrame, dtype_category
+from goldencheck.core._native_loader import native_enabled
+from goldencheck.core.frame import PyFrame
 from goldencheck.engine.confidence import apply_corroboration_boost
-from goldencheck.engine.reader import read_columns, read_file
+from goldencheck.engine.reader import read_columns
 from goldencheck.engine.sampler import maybe_sample
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.models.profile import ColumnProfile, DatasetProfile
@@ -85,20 +83,28 @@ RELATION_PROFILERS = [
 ]
 
 def _post_classification_checks(
-    sample: pl.DataFrame,
+    sample,
     findings: list[Finding],
     column_types: dict,
 ) -> list[Finding]:
-    """Add findings that require semantic type knowledge."""
+    """Add findings that require semantic type knowledge.
+
+    Routes through the Frame/Column seam so ``sample`` may be an Arrow-native
+    ``ArrowFrame`` (default scan path) or a ``PolarsFrame``.
+    """
+    from goldencheck.core.frame import to_frame
+
+    frame = to_frame(sample)
+    cols = frame.columns
     new_findings = list(findings)
 
     for col_name, classification in column_types.items():
         if classification.type_name != "person_name":
             continue
-        if col_name not in sample.columns:
+        if col_name not in cols:
             continue
-        col = sample[col_name]
-        if dtype_category(col.dtype) != "str":
+        col = frame.column(col_name)
+        if col.dtype != "str":
             continue
 
         # Detect digit characters in person name columns
@@ -106,13 +112,12 @@ def _post_classification_checks(
         if len(non_null) == 0:
             continue
 
-        digit_mask = non_null.str.contains(r"\d")
-        digit_count = int(digit_mask.sum())
+        digit_count = non_null.str_match_count(r"\d")
         if digit_count > 0:
             digit_pct = digit_count / len(non_null)
             # Only flag if it's a minority (< 10%) — widespread digits means it's not really a name column
             if 0 < digit_pct < 0.10:
-                sample_vals = non_null.filter(digit_mask).head(5).to_list()
+                sample_vals = non_null.str_filter(r"\d", matching=True).slice(0, 5).to_list()
                 new_findings.append(Finding(
                     severity=Severity.WARNING,
                     column=col_name,
@@ -129,7 +134,6 @@ def _post_classification_checks(
 
     # --- Code-like format inconsistency (e.g. 5-digit vs 9-digit zip) ---
     # Only add if no pattern_consistency finding already exists at WARNING+ for this column
-    from goldencheck.profilers.pattern_consistency import _generalize_series
     existing_pc_cols = {
         f.column for f in new_findings
         if f.check == "pattern_consistency" and f.severity in (Severity.WARNING, Severity.ERROR)
@@ -139,32 +143,31 @@ def _post_classification_checks(
             continue
         if col_name in existing_pc_cols:
             continue
-        if col_name not in sample.columns:
+        if col_name not in cols:
             continue
-        col = sample[col_name]
-        if dtype_category(col.dtype) != "str":
+        col = frame.column(col_name)
+        if col.dtype != "str":
             continue
         non_null = col.drop_nulls()
         total = len(non_null)
         if total == 0:
             continue
-        # Check for mixed-length patterns (e.g. DDDDD vs DDDDD-DDDD).
-        # Vectorised via Polars regex — see _generalize_series docstring;
-        # the previous map_elements(_generalize) was a top-3 self-time
-        # hot spot in the scale-audit cProfile.
-        patterns = _generalize_series(non_null)
-        pattern_counts = patterns.value_counts().sort("count", descending=True)
+        # Generalise each value to its digit/letter skeleton (letters -> L, then
+        # digits -> D; order matches PatternConsistencyProfiler / _generalize_series),
+        # then tally the skeletons via the seam.
+        patterns = non_null.str_replace_all(r"\p{L}", "L").str_replace_all(r"\d", "D")
+        pattern_counts = patterns.value_counts_desc()
         if len(pattern_counts) < 2:
             continue
-        dominant_pattern = pattern_counts[col_name][0]
+        dominant_pattern = pattern_counts[0][0]
         # Only check code-like patterns (mostly digits)
         digit_ratio = sum(1 for c in dominant_pattern if c == "D") / max(len(dominant_pattern), 1)
         if digit_ratio < 0.5:
             continue
         # Look for any secondary pattern with different length
         for i in range(1, len(pattern_counts)):
-            minority_pattern = pattern_counts[col_name][i]
-            minority_count = int(pattern_counts["count"][i])
+            minority_pattern, minority_count = pattern_counts[i]
+            minority_count = int(minority_count)
             if abs(len(dominant_pattern) - len(minority_pattern)) > 1:
                 new_findings.append(Finding(
                     severity=Severity.WARNING,
@@ -176,7 +179,7 @@ def _post_classification_checks(
                         f"'{dominant_pattern}'"
                     ),
                     affected_rows=minority_count,
-                    sample_values=non_null.filter(patterns == minority_pattern).head(5).to_list(),
+                    sample_values=non_null.filter_by(patterns.eq(minority_pattern)).slice(0, 5).to_list(),
                     suggestion="Standardize values to a single format/pattern",
                     confidence=0.8,
                     metadata={"dominant_pattern": dominant_pattern, "minority_pattern": minority_pattern},
@@ -186,11 +189,11 @@ def _post_classification_checks(
     # --- String length format check for identifier-like columns ---
     _ID_NAME_KEYWORDS = ("id", "number", "code", "auth", "key")
     _ID_NAME_EXCLUDE = ("phone", "npi")
-    for col_name in sample.columns:
-        col = sample[col_name]
+    for col_name in cols:
+        col = frame.column(col_name)
 
         # Accept string or numeric columns (numeric IDs are common)
-        _cat = dtype_category(col.dtype)
+        _cat = col.dtype
         is_string = _cat == "str"
         is_numeric = _cat in ("int", "uint", "float")
         if not (is_string or is_numeric):
@@ -209,22 +212,23 @@ def _post_classification_checks(
             continue
 
         # Cast to string for length analysis
-        str_vals = non_null.cast(pl.String) if is_numeric else non_null
-        lengths = str_vals.str.len_chars().alias("_len")
-        length_counts = lengths.value_counts().sort("count", descending=True)
+        str_vals = non_null.cast("str") if is_numeric else non_null
+        lengths = str_vals.str_len_chars()
+        length_counts = lengths.value_counts_desc()
 
         if len(length_counts) == 0:
             continue
 
-        dominant_length = int(length_counts["_len"][0])
-        dominant_count = int(length_counts["count"][0])
+        dominant_length = int(length_counts[0][0])
+        dominant_count = int(length_counts[0][1])
         dominant_pct = dominant_count / total
 
         outlier_count = total - dominant_count
 
         if dominant_pct > 0.90 and outlier_count > 0:
-            sample_mask = lengths != dominant_length
-            sample_vals = str_vals.filter(sample_mask).head(5).to_list()
+            _lens = lengths.to_list()
+            _svals = str_vals.to_list()
+            sample_vals = [_svals[i] for i in range(len(_lens)) if _lens[i] != dominant_length][:5]
             new_findings.append(Finding(
                 severity=Severity.WARNING,
                 column=col_name,
@@ -287,7 +291,7 @@ def scan_file_columns(path: Path) -> list[Finding]:
 
 
 def scan_dataframe(
-    df: pl.DataFrame,
+    df,
     file_path: str | Path = "<dataframe>",
     sample_size: int = 100_000,
     return_sample: bool = False,
@@ -296,22 +300,22 @@ def scan_dataframe(
     schema: object | None = None,
     deep: bool = False,
     denial: bool = False,
-) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
-    """Scan an already-loaded Polars DataFrame.
+) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, object]:
+    """Scan an already-loaded table.
 
-    Same semantics as :func:`scan_file` but accepts a DataFrame directly.
-    The CSV round-trip in `goldenmatch.core.quality.run_quality_check` was
-    surfacing as 121s of `pipeline_prep_quality_scan` wall on the 10M
-    quality-invariant-scale bench: writing the full df to a temp CSV
-    just so this function could read it back. With this entry point the
-    caller hands the in-memory frame straight to the scanner.
+    Accepts a ``pyarrow.Table`` natively (wrapped in an Arrow-native
+    ``ArrowFrame``); a ``polars.DataFrame`` is a convenience overload, converted
+    via ``.to_arrow()`` when Polars is importable. Same semantics as
+    :func:`scan_file` but the caller hands the in-memory table straight to the
+    scanner (skips a CSV round-trip -- the 10M QIS bench spent 121s of
+    `pipeline_prep_quality_scan` wall writing df to a temp CSV just to read it
+    back).
 
-    `file_path` is purely cosmetic (populates `DatasetProfile.file_path`
-    for downstream reports / drift checks); pass it when you have a real
-    path, otherwise the default `"<dataframe>"` sentinel is fine.
+    `file_path` is purely cosmetic (populates `DatasetProfile.file_path`).
     """
+    frame = _coerce_to_arrow_frame(df)
     return _scan_dataframe_impl(
-        df,
+        frame,
         file_path=str(file_path),
         sample_size=sample_size,
         return_sample=return_sample,
@@ -332,10 +336,13 @@ def scan_file(
     schema: object | None = None,  # goldencheck_types.InferredSchema; loose typing avoids hard import dep
     deep: bool = False,
     denial: bool = False,
-) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
-    df = read_file(path)
+) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, object]:
+    from goldencheck.core.frame import ArrowFrame
+    from goldencheck.engine.reader import read_file_arrow
+
+    frame = ArrowFrame(read_file_arrow(path))
     return _scan_dataframe_impl(
-        df,
+        frame,
         file_path=str(path),
         sample_size=sample_size,
         return_sample=return_sample,
@@ -347,8 +354,58 @@ def scan_file(
     )
 
 
+def _coerce_to_arrow_frame(data):
+    """Wrap ``data`` in an Arrow-native ``ArrowFrame``. Accepts a ``pyarrow.Table``
+    or (convenience) a ``polars.DataFrame`` (converted via ``.to_arrow()`` only
+    when Polars imports) or an already-wrapped ``ArrowFrame``."""
+    from goldencheck.core.frame import ArrowFrame
+
+    import pyarrow as pa
+
+    if isinstance(data, ArrowFrame):
+        return data
+    if isinstance(data, pa.Table):
+        return ArrowFrame(data)
+    try:
+        import polars as _pl
+    except ImportError:
+        raise TypeError(
+            f"scan_dataframe expects a pyarrow.Table or polars.DataFrame; got {type(data)!r}"
+        )
+    if isinstance(data, _pl.DataFrame):
+        return ArrowFrame(data.to_arrow())
+    raise TypeError(
+        f"scan_dataframe expects a pyarrow.Table or polars.DataFrame; got {type(data)!r}"
+    )
+
+
+def _to_polars(frame):
+    """Materialise a seam Frame back to a ``polars.DataFrame`` for the off-default
+    branches (baseline drift, learned rules, denial) that still run on Polars."""
+    import polars as _pl
+
+    native = frame.native
+    if isinstance(native, _pl.DataFrame):
+        return native
+    return _pl.from_arrow(native)
+
+
+def _sample_for_return(frame):
+    """The ``return_sample=True`` payload: a ``polars.DataFrame`` when Polars is
+    importable (downstream LLM sample-block builder consumes Polars), else the
+    Arrow-native ``pyarrow.Table``."""
+    native = frame.native
+    try:
+        import polars as _pl
+    except ImportError:
+        return native
+    if isinstance(native, _pl.DataFrame):
+        return native
+    return _pl.from_arrow(native)
+
+
 def _scan_dataframe_impl(
-    df: pl.DataFrame,
+    frame,
     *,
     file_path: str,
     sample_size: int,
@@ -358,52 +415,39 @@ def _scan_dataframe_impl(
     schema: object | None,
     deep: bool = False,
     denial: bool = False,
-) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, pl.DataFrame]:
-    row_count = len(df)
+) -> tuple[list[Finding], DatasetProfile] | tuple[list[Finding], DatasetProfile, object]:
+    from goldencheck.core.frame import to_frame
+
+    frame = to_frame(frame)   # idempotent; normalises to a seam Frame
+    columns = frame.columns
+    row_count = frame.height
     # Deep mode profiles the FULL population (no 100K sample cap) -- removes
     # sampling error on cardinality / uniqueness / rare-value / composite-key
-    # checks. Heavier, but the Polars profilers are vectorized and the native
-    # kernels (when goldencheck[native] is installed) carry the CPU-bound work.
-    sample = df if deep else maybe_sample(df, max_rows=sample_size)
+    # checks. Heavier, but the seam profilers are vectorized and the native
+    # kernels carry the CPU-bound work.
+    sample = frame if deep else maybe_sample(frame, max_rows=sample_size)
     logger.info(
         "Scanning %d rows, %d columns%s",
-        row_count, len(df.columns), " (deep: full population)" if deep else "",
+        row_count, len(columns), " (deep: full population)" if deep else "",
     )
 
     all_findings: list[Finding] = []
     column_profiles: list[ColumnProfile] = []
     profiler_context: dict = {}
 
-    for col_name in df.columns:
-        col = df[col_name]
+    for col_name in columns:
+        col = frame.column(col_name)
         non_null = col.drop_nulls()
         non_null_len = len(non_null)
-        # Cache n_unique + null_count once per column. The prior code called
-        # non_null.n_unique() TWICE in the same ColumnProfile kwarg list (for
-        # unique_count and unique_pct) and col.null_count() twice (null_count
-        # and null_pct). At the QIS 10M bench (6 columns) that was 12 full-
-        # frame Polars hash-aggregations + 12 null counts in the column-
-        # profile loop alone -- the dominant cost of pipeline_prep_quality_scan
-        # at 120.8s (v17 measured no change after PR #562's CSV round-trip
-        # removal, confirming the bottleneck was inside this loop, not the
-        # surrounding I/O). Strict 2x reduction; zero behavioral change.
+        # Cache n_unique + null_count once per column (both feed two ColumnProfile
+        # kwargs each). The kernel-backed ArrowColumn carries the CPU work.
         n_unique = non_null.n_unique() if non_null_len > 0 else 0
         null_count = col.null_count()
-        # Shadow-compute the fused native column_aggregate kernel on the real
-        # scan path so it runs against production shapes ahead of the Flip
-        # (see tests/engine/test_column_aggregate_shadow.py for the parity
-        # assertion). NOT authoritative -- the ColumnProfile below is built
-        # from the Polars values above exactly as before this shadow wire.
-        if native_enabled("column_aggregate"):
-            try:
-                native_module().column_aggregate(col.to_arrow())
-            except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                logger.debug(
-                    "column_aggregate shadow compute failed on column %s: %s", col_name, e
-                )
         cp = ColumnProfile(
             name=col_name,
-            inferred_type=str(col.dtype),
+            # OWNED dtype contract: neutral vocabulary (str/int/uint/float/date/
+            # datetime/bool/other) via the Arrow seam, not raw `str(pl.dtype)`.
+            inferred_type=col.dtype_repr(),
             null_count=null_count,
             null_pct=null_count / row_count if row_count > 0 else 0,
             unique_count=n_unique,
@@ -430,9 +474,9 @@ def _scan_dataframe_impl(
     # population; otherwise the same sample every other profiler ran on.
     if denial:
         from goldencheck.denial.mine import DenialConstraintProfiler
-        target = df if deep else sample
+        target = frame if deep else sample
         try:
-            all_findings.extend(DenialConstraintProfiler().profile(target))
+            all_findings.extend(DenialConstraintProfiler().profile(_to_polars(target)))
         except Exception as e:
             logger.warning("DenialConstraintProfiler failed: %s", e)
 
@@ -465,7 +509,7 @@ def _scan_dataframe_impl(
         if unmapped_cols:
             cols_in_sample = [c for c in unmapped_cols if c in sample.columns]
             if cols_in_sample:
-                heuristic = classify_columns(sample.select(cols_in_sample), type_defs=type_defs)
+                heuristic = classify_columns(sample, type_defs=type_defs, only=cols_in_sample)
             else:
                 heuristic = {}
         else:
@@ -500,7 +544,7 @@ def _scan_dataframe_impl(
             from goldencheck.llm.rule_generator import apply_rules, load_rules
             rules = load_rules(rules_path)
             if rules:
-                rule_findings = apply_rules(sample, rules)
+                rule_findings = apply_rules(_to_polars(sample), rules)
                 all_findings.extend(rule_findings)
                 logger.info("Applied %d learned rules, got %d findings", len(rules), len(rule_findings))
         except Exception as e:
@@ -535,7 +579,7 @@ def _scan_dataframe_impl(
                 "Baseline source %r doesn't match scan file %r",
                 baseline.source_filename, scan_basename,
             )
-        drift_findings = run_drift_checks(sample, baseline)
+        drift_findings = run_drift_checks(_to_polars(sample), baseline)
         all_findings.extend(drift_findings)
 
     # Suppress PatternConsistencyProfiler findings for baseline-covered columns
@@ -547,9 +591,9 @@ def _scan_dataframe_impl(
         ]
 
     all_findings.sort(key=lambda f: f.severity, reverse=True)
-    profile = DatasetProfile(file_path=file_path, row_count=row_count, column_count=len(df.columns), columns=column_profiles)
+    profile = DatasetProfile(file_path=file_path, row_count=row_count, column_count=len(columns), columns=column_profiles)
     if return_sample:
-        return all_findings, profile, sample
+        return all_findings, profile, _sample_for_return(sample)
     return all_findings, profile
 
 

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -358,9 +358,9 @@ def _coerce_to_arrow_frame(data):
     """Wrap ``data`` in an Arrow-native ``ArrowFrame``. Accepts a ``pyarrow.Table``
     or (convenience) a ``polars.DataFrame`` (converted via ``.to_arrow()`` only
     when Polars imports) or an already-wrapped ``ArrowFrame``."""
-    from goldencheck.core.frame import ArrowFrame
-
     import pyarrow as pa
+
+    from goldencheck.core.frame import ArrowFrame
 
     if isinstance(data, ArrowFrame):
         return data

--- a/packages/python/goldencheck/goldencheck/profilers/freshness.py
+++ b/packages/python/goldencheck/goldencheck/profilers/freshness.py
@@ -19,43 +19,11 @@ from __future__ import annotations
 import datetime as _dt
 import logging
 
-from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
 
 logger = logging.getLogger(__name__)
-
-_EPOCH_DATE = _dt.date(1970, 1, 1)
-_EPOCH_DT = _dt.datetime(1970, 1, 1)
-
-
-def _now_epoch_for_array(arr_type, now: _dt.date | _dt.datetime) -> int | None:
-    """Offset-free epoch of ``now`` in the Arrow array's native temporal unit
-    (spec B2). Pure subtraction from the naive 1970-01-01 epoch -- NEVER
-    ``.timestamp()`` (that would apply the machine's local UTC offset). Returns
-    ``None`` for a non-temporal array so the shadow simply skips."""
-    import pyarrow as pa
-
-    if pa.types.is_date32(arr_type):
-        d = now.date() if isinstance(now, _dt.datetime) else now
-        return (d - _EPOCH_DATE).days
-    if pa.types.is_date64(arr_type):
-        d = now.date() if isinstance(now, _dt.datetime) else now
-        return (d - _EPOCH_DATE).days * 86_400_000
-    if pa.types.is_timestamp(arr_type):
-        dt = now if isinstance(now, _dt.datetime) else _dt.datetime(now.year, now.month, now.day)
-        delta = dt - _EPOCH_DT
-        unit = arr_type.unit
-        if unit == "s":
-            return delta // _dt.timedelta(seconds=1)
-        if unit == "ms":
-            return delta // _dt.timedelta(milliseconds=1)
-        if unit == "us":
-            return delta // _dt.timedelta(microseconds=1)
-        if unit == "ns":
-            return (delta // _dt.timedelta(microseconds=1)) * 1000
-    return None
 
 # Newest value older than this (days) on an update/event column => likely stale.
 _STALE_DAYS = 365
@@ -89,23 +57,11 @@ class FreshnessProfiler(BaseProfiler):
         # comparison against a naive `now` raises -> skip gracefully.
         now: _dt.date | _dt.datetime = _dt.date.today() if is_date else _dt.datetime.now()
         try:
+            # Flip: count_gt/max are kernel-authoritative via the Arrow seam
+            # (ArrowColumn -> date_freshness). The former Population-B shadow
+            # recompute (date_freshness, result discarded) is now dead and removed.
             future_count = non_null.count_gt(now)
             newest = non_null.max()
-            # Shadow-compute the fused native date_freshness kernel on the real
-            # scan path so it runs against production shapes ahead of the Flip
-            # (see tests/engine/test_w2_shadow.py for the parity assertion). This
-            # sits INSIDE the try AFTER the successful count_gt/max so a tz-aware
-            # column that makes Polars bail never reaches the kernel (spec S). The
-            # inner try guarantees a shadow failure never trips the outer except
-            # (which would drop legitimate findings) -- NOT authoritative.
-            if native_enabled("date_freshness"):
-                try:
-                    arr = non_null.to_arrow()
-                    now_epoch = _now_epoch_for_array(arr.type, now)
-                    if now_epoch is not None:
-                        native_module().date_freshness(arr, now_epoch)
-                except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                    logger.debug("date_freshness shadow failed on %s: %s", column, e)
         except Exception:  # noqa: BLE001 - tz-aware vs naive, exotic dtype, etc.
             return []
 

--- a/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
+++ b/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -43,30 +42,16 @@ class RangeDistributionProfiler(BaseProfiler):
             message=f"Range: min={col_min}, max={col_max}, mean={mean:.2f}",
         ))
 
-        # Shadow-compute the fused native numeric_stats kernel on the real scan
-        # path so it runs against production shapes ahead of the Flip (see
-        # tests/engine/test_w2_shadow.py for the parity assertion). NOT
-        # authoritative -- the Polars-computed mean/std/min/max above stay the
-        # emitted values. Fully guarded + swallow-on-error: shadow only.
-        native_stats = native_enabled("numeric_stats")
-        if native_stats:
-            try:
-                native_module().column_numeric_stats(non_null.to_arrow())
-            except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                logger.debug("column_numeric_stats shadow failed on %s: %s", column, e)
-
+        # Flip: mean/std/min/max above are kernel-authoritative via the Arrow
+        # seam (ArrowColumn.mean/std/min/max -> column_numeric_stats), and the
+        # outlier count comes from filter_outside. The former Population-B shadow
+        # recompute (column_numeric_stats / count_outside, result discarded) is
+        # now dead and has been removed.
         if std is not None and std > 0:
             lower = mean - 3 * std
             upper = mean + 3 * std
             outliers = non_null.filter_outside(lower, upper)
             outlier_count = len(outliers)
-            # Shadow the outlier count/sample kernel with the POLARS-computed
-            # lower/upper (spec B1) so boundary values agree with filter_outside.
-            if native_stats:
-                try:
-                    native_module().count_outside(non_null.to_arrow(), lower, upper)
-                except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                    logger.debug("count_outside shadow failed on %s: %s", column, e)
             if outlier_count > 0:
                 sample = outliers.to_list()[:5]
                 # Determine how many stddevs outliers are

--- a/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/sequence_detection.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import logging
 
-from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 from goldencheck.profilers.base import BaseProfiler
@@ -53,16 +52,9 @@ class SequenceDetectionProfiler(BaseProfiler):
             # Not sequential — skip
             return findings
 
-        # Shadow-compute the fused native sequence_analysis kernel on the real
-        # scan path so it runs against production shapes ahead of the Flip (see
-        # tests/engine/test_w2_shadow.py for the parity assertion). NOT
-        # authoritative -- the Polars gap scan below stays the emitted values.
-        # Fully guarded + swallow-on-error: shadow only.
-        if native_enabled("sequence_analysis"):
-            try:
-                native_module().sequence_analysis(non_null.to_arrow())
-            except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                logger.debug("sequence_analysis shadow failed on %s: %s", column, e)
+        # Flip: diff/count_eq/count_gt/is_sorted/min/max above are
+        # kernel-authoritative via the Arrow seam. The former Population-B shadow
+        # recompute (sequence_analysis, result discarded) is now dead and removed.
 
         # Column is sequential — find gaps
         col_min = int(non_null.min())

--- a/packages/python/goldencheck/goldencheck/relations/age_validation.py
+++ b/packages/python/goldencheck/goldencheck/relations/age_validation.py
@@ -1,24 +1,26 @@
 """Age vs DOB cross-validation profiler.
 
-**Polars-accelerator-only (declined from the seam eviction, R4).** This profiler's core is a Polars
-expression tree -- ``df.select(actual=pl.col(age_col).cast(...), expected=((pl.lit(reference_date)
-.cast(pl.Date) - pl.col(dob_col).str.to_date(...)).dt.total_days() / 365.25))`` -- with no
-byte-identical ``Frame``/``Column``-seam equivalent (the seam models per-column reductions +
-element-wise ops, not ``pl.col``/``pl.lit``/``.dt`` expression trees or date arithmetic). It is NOT
-routed through the seam; it stays import-safe (lazy ``pl``) but requires Polars at runtime. See
-``docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r4-decline.md``.
+**Flip (Stage A4): kernel-authoritative.** The mismatch scan runs through the
+fused native ``age_mismatch`` kernel (byte/index-parity-validated in W3,
+tests/engine/test_w3_shadow.py) over Arrow arrays pulled from the Frame/Column
+seam, so it drives a ``PolarsFrame`` (tests) or an Arrow-native ``ArrowFrame``
+(default scan) unchanged. Date parsing + reference-date discovery use
+``pyarrow.compute`` on the seam's Arrow arrays -- no Polars expression trees. A
+polars-free ``pyarrow`` fallback reproduces the kernel when it is unavailable.
 """
 from __future__ import annotations
 
 import datetime
 import logging
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
 from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 logger = logging.getLogger(__name__)
+
+_EPOCH = datetime.date(1970, 1, 1)
+_NUMERIC = ("int", "uint", "float")
 
 # Words that contain "age" but are NOT age columns
 _AGE_EXCLUSIONS = ("stage", "page", "usage", "mileage", "dosage", "voltage")
@@ -39,133 +41,118 @@ def _is_dob_column(name: str) -> bool:
     return any(kw in lower for kw in ("birth", "dob", "born"))
 
 
-def _try_parse_dates(series: pl.Series) -> pl.Series:
-    """Attempt to cast a series to Date."""
-    # TODO(W-path): route the dtype gates in this file via dtype_category
-    if series.dtype in (pl.Date, pl.Datetime):
-        return series.cast(pl.Date)
-    if series.dtype in (pl.Utf8, pl.String):
-        return series.str.to_date(format="%Y-%m-%d", strict=False)
-    return series
+def _parse_date32(col):
+    """Parse a seam ``Column`` to a ``pyarrow`` ``date32`` array, or ``None`` when
+    the column isn't date-like. Mirrors the prior ``_try_parse_dates``:
+    date/datetime -> Date; string -> ``to_date("%Y-%m-%d", strict=False)``; other
+    -> not a date."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    cat = col.dtype
+    if cat == "date":
+        arr = col.to_arrow()
+        return arr if arr.type == pa.date32() else pc.cast(arr, pa.date32())
+    if cat == "datetime":
+        return pc.cast(col.to_arrow(), pa.date32())
+    if cat == "str":
+        return col.str_to_date("%Y-%m-%d", strict=False).to_arrow()
+    return None
+
+
+def _age_mismatch(actual, dob_date32, ref_epoch_days):
+    """``(count, sample_indices[:5])`` of rows where ``|actual - expected| > 2``
+    years. Native kernel when available; polars-free ``pyarrow`` fallback else."""
+    if native_enabled("age_mismatch"):
+        return native_module().age_mismatch(actual, dob_date32, ref_epoch_days)
+
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    dob_days = pc.cast(dob_date32, pa.float64())  # days since epoch (float for div)
+    expected = pc.divide(pc.subtract(float(ref_epoch_days), dob_days), 365.25)
+    diff = pc.abs(pc.subtract(actual, expected))
+    mism = pc.and_(pc.greater(diff, 2.0), pc.and_(pc.is_valid(actual), pc.is_valid(dob_date32)))
+    mism = pc.fill_null(mism, False).to_pylist()
+    indices = [i for i, v in enumerate(mism) if v]
+    return len(indices), indices[:5]
 
 
 class AgeValidationProfiler:
     """Cross-validates age columns against date-of-birth columns."""
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        findings: list[Finding] = []
+        import pyarrow as pa
+        import pyarrow.compute as pc
 
-        age_cols = [c for c in df.columns if _is_age_column(c)]
-        dob_cols = [c for c in df.columns if _is_dob_column(c)]
-
+        cols = frame.columns
+        age_cols = [c for c in cols if _is_age_column(c)]
+        dob_cols = [c for c in cols if _is_dob_column(c)]
         if not age_cols or not dob_cols:
-            return findings
+            return []
 
-        # Find reference date: max date from non-DOB date columns, <= today
+        # Reference date: max parseable date from non-DOB date columns, <= today.
         today = datetime.date.today()
+        today_scalar = pa.scalar(today, type=pa.date32())
         reference_date = today
-
-        date_cols_for_ref = [
-            c for c in df.columns
-            if c not in dob_cols
-        ]
-        for col_name in date_cols_for_ref:
+        for col_name in cols:
+            if col_name in dob_cols:
+                continue
             try:
-                parsed = _try_parse_dates(df[col_name])
-                if parsed.dtype != pl.Date:
-                    continue
-                valid = parsed.drop_nulls().filter(parsed.drop_nulls() <= today)
-                if len(valid) > 0:
-                    max_date = valid.max()
-                    if max_date and max_date <= today:
-                        reference_date = max_date
-                        break
+                d32 = _parse_date32(frame.column(col_name))
             except Exception:
                 continue
+            if d32 is None:
+                continue
+            nn = pc.drop_null(d32)
+            if len(nn) == 0:
+                continue
+            keep = pc.filter(nn, pc.less_equal(nn, today_scalar))
+            if len(keep) == 0:
+                continue
+            mx = pc.max(keep).as_py()
+            if mx is not None and mx <= today:
+                reference_date = mx
+                break
+
+        ref_epoch_days = (reference_date - _EPOCH).days
+        findings: list[Finding] = []
 
         for age_col in age_cols:
-            # Age column must be numeric
-            col_series = df[age_col]
-            if col_series.dtype not in (
-                pl.Int8, pl.Int16, pl.Int32, pl.Int64,
-                pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
-                pl.Float32, pl.Float64,
-            ):
+            age_seam = frame.column(age_col)
+            if age_seam.dtype not in _NUMERIC:
                 continue
+            actual_arrow = age_seam.cast("float").to_arrow()
 
             for dob_col in dob_cols:
                 try:
-                    dob_series = _try_parse_dates(df[dob_col])
-                    if dob_series.dtype != pl.Date:
-                        continue
+                    dob_d32 = _parse_date32(frame.column(dob_col))
                 except Exception:
                     continue
-
-                # Calculate expected age using DataFrame select for proper evaluation
-                # Check ORIGINAL column dtype, not parsed dtype (dob_series is already Date)
-                original_dtype = df[dob_col].dtype
+                if dob_d32 is None:
+                    continue
                 try:
-                    if original_dtype in (pl.Utf8, pl.String):
-                        dob_expr = pl.col(dob_col).str.to_date(format="%Y-%m-%d", strict=False)
-                    else:
-                        dob_expr = pl.col(dob_col).cast(pl.Date, strict=False)
-
-                    result = df.select(
-                        actual=pl.col(age_col).cast(pl.Float64),
-                        expected=(
-                            (pl.lit(reference_date).cast(pl.Date) - dob_expr)
-                            .dt.total_days()
-                            / 365.25
-                        ),
-                    )
-
-                    actual = result["actual"]
-                    expected = result["expected"]
-                    diff = (actual - expected).abs()
-
-                    non_null_mask = actual.is_not_null() & expected.is_not_null()
-                    mismatch_mask = (diff > 2.0) & non_null_mask
-
-                    mismatch_count = int(mismatch_mask.sum())
-
-                    # Shadow-compute the fused native age_mismatch kernel alongside the
-                    # authoritative Polars compute above (see tests/engine/test_w3_shadow.py
-                    # for the parity assertion). NOT authoritative -- the finding below is
-                    # built from the Polars values exactly as before this shadow wire. Its
-                    # OWN try/except so a shadow failure can never reach the outer
-                    # ``except: continue`` and suppress a Finding.
-                    if native_enabled("age_mismatch"):
-                        try:
-                            ref_epoch_days = (
-                                reference_date - datetime.date(1970, 1, 1)
-                            ).days
-                            dob_date32 = df.select(dob_expr.alias("d"))["d"].to_arrow()
-                            actual_arrow = result["actual"].to_arrow()
-                            native_module().age_mismatch(
-                                actual_arrow, dob_date32, ref_epoch_days
-                            )
-                        except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                            logger.debug("age_mismatch shadow compute failed: %s", e)
-
-                    if mismatch_count > 0:
-                        sample_ages = col_series.filter(mismatch_mask).head(5).to_list()
-                        findings.append(Finding(
-                            severity=Severity.ERROR,
-                            column=age_col,
-                            check="cross_column",
-                            message=(
-                                f"{mismatch_count} row(s) where {age_col} doesn't match "
-                                f"calculated age from {dob_col} — values mismatch by more "
-                                f"than 2 years"
-                            ),
-                            affected_rows=mismatch_count,
-                            sample_values=[str(v) for v in sample_ages],
-                            suggestion=f"Verify {age_col} values against {dob_col}",
-                            confidence=0.9,
-                        ))
-                except Exception:
+                    count, indices = _age_mismatch(actual_arrow, dob_d32, ref_epoch_days)
+                except Exception as e:  # noqa: BLE001 - any kernel/arrow failure -> skip pair
+                    logger.debug("age_mismatch failed for %s/%s: %s", age_col, dob_col, e)
                     continue
+
+                if count > 0:
+                    sample_ages = [str(age_seam.get(i)) for i in indices[:5]]
+                    findings.append(Finding(
+                        severity=Severity.ERROR,
+                        column=age_col,
+                        check="cross_column",
+                        message=(
+                            f"{count} row(s) where {age_col} doesn't match "
+                            f"calculated age from {dob_col} — values mismatch by more "
+                            f"than 2 years"
+                        ),
+                        affected_rows=count,
+                        sample_values=sample_ages,
+                        suggestion=f"Verify {age_col} values against {dob_col}",
+                        confidence=0.9,
+                    ))
 
         return findings

--- a/packages/python/goldencheck/goldencheck/relations/age_validation.py
+++ b/packages/python/goldencheck/goldencheck/relations/age_validation.py
@@ -69,7 +69,9 @@ def _age_mismatch(actual, dob_date32, ref_epoch_days):
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    dob_days = pc.cast(dob_date32, pa.float64())  # days since epoch (float for div)
+    # date32 -> float64 isn't a supported direct cast; go via int32 (which IS the
+    # days-since-epoch representation) then widen to float for the division.
+    dob_days = pc.cast(pc.cast(dob_date32, pa.int32()), pa.float64())  # days since epoch
     expected = pc.divide(pc.subtract(float(ref_epoch_days), dob_days), 365.25)
     diff = pc.abs(pc.subtract(actual, expected))
     mism = pc.and_(pc.greater(diff, 2.0), pc.and_(pc.is_valid(actual), pc.is_valid(dob_date32)))

--- a/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_duplicate.py
@@ -10,24 +10,18 @@ that are duplicated or near-duplicated. This profiler covers both:
   punctuation): ``"Acme, Inc."`` vs ``"acme inc"`` vs ``"ACME  Inc"``. These are
   the most common real-world dupes that exact matching misses.
 
-Intentionally pure-Polars: the work is a normalize + group-by, which Polars
-already does vectorized + multithreaded. Per the native-kernel lesson
-(packages/python/goldencheck/CLAUDE.md), we don't reach for Rust where Polars is
-already the fast path -- the gate is "beat Polars", and here it wouldn't.
-
-True edit-distance fuzzy matching (typos that survive normalization, e.g.
-``Jon``/``John``) needs blocking + pairwise scoring and is a heavier follow-up;
-this profiler is the deterministic normalize-and-group tier.
-
-**Polars-accelerator-only (declined from the seam eviction, R4).** The core is a ``pl.concat_str`` +
-``str.*`` expression chain inside ``df.select`` followed by ``group_by(...).len()`` + two real
-``.join()``s -- relational-engine ops the ``Frame``/``Column`` seam does not expose. It is NOT routed
-through the seam; it stays import-safe (lazy ``pl``) but requires Polars at runtime. See
-``docs/superpowers/specs/2026-07-09-goldencheck-relation-ports-r4-decline.md``.
+**Flip (Stage A4): kernel-authoritative.** The four counts (exact rows/groups,
+near rows/groups) come from the fused native ``duplicate_signatures`` kernel over
+the Arrow columns -- byte/set-parity-validated in W3 (tests/engine/test_w3_shadow.py).
+When the native kernel is unavailable, a polars-free pure-Python fallback
+reproduces the identical normalize-and-group signatures. Nothing on this path
+requires Polars.
 """
 from __future__ import annotations
 
 import logging
+import re
+from collections import Counter
 
 from goldencheck._polars_lazy import pl
 from goldencheck.core._native_loader import native_enabled, native_module
@@ -37,19 +31,21 @@ from goldencheck.models.finding import Finding, Severity
 logger = logging.getLogger(__name__)
 
 _SEP = "\x1f"  # unit separator -- won't appear in normal data
-_MAX_SAMPLE = 5
+_NORM_RE = re.compile(r"[^0-9a-z]+")
 
 
+# --- Polars parity-reference helpers -----------------------------------------
+# The profiler is now kernel-authoritative (Arrow + duplicate_signatures). These
+# two Polars helpers are retained ONLY as the byte-for-byte ground-truth oracle
+# for the W3 parity test (tests/engine/test_w3_shadow.py). They are lazy (no
+# Polars import at module load) and are NOT on the scan path.
 def _normalized_signature(df: pl.DataFrame) -> pl.Series:
     """One signature string per row: string columns normalized (lowercased,
-    punctuation/whitespace collapsed), other columns cast as-is. Two rows share
-    a signature iff they are equal after that normalization."""
+    punctuation/whitespace collapsed), other columns cast as-is."""
     exprs = []
     for name, dtype in zip(df.columns, df.dtypes):
         col = pl.col(name).cast(pl.Utf8).fill_null("")
         if dtype == pl.Utf8:
-            # lowercase -> collapse any run of non-alphanumerics to a single
-            # space -> trim. "Acme, Inc." and "acme  inc" both -> "acme inc".
             col = col.str.to_lowercase().str.replace_all(r"[^0-9a-z]+", " ").str.strip_chars()
         exprs.append(col.alias(name))
     return df.select(pl.concat_str(exprs, separator=_SEP)).to_series()
@@ -61,84 +57,122 @@ def _exact_signature(df: pl.DataFrame) -> pl.Series:
     return df.select(pl.concat_str(exprs, separator=_SEP)).to_series()
 
 
+def _cast_str(value) -> str:
+    """``pl.col(x).cast(pl.Utf8).fill_null("")`` equivalent for a Python scalar:
+    null -> "", bool -> lowercase, everything else -> ``str(v)``."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def _py_duplicate_signatures(col_lists, is_string) -> tuple[int, int, int, int]:
+    """Polars-free mirror of ``goldencheck_core::duplicate_signatures``: build a
+    per-row exact + normalized signature, then count rows/groups. Matches the
+    kernel's four counts on identical input."""
+    n = len(col_lists[0]) if col_lists else 0
+    exact_sigs: list[str] = []
+    norm_sigs: list[str] = []
+    for r in range(n):
+        exact_parts: list[str] = []
+        norm_parts: list[str] = []
+        for ci, vals in enumerate(col_lists):
+            s = _cast_str(vals[r])
+            exact_parts.append(s)
+            if is_string[ci]:
+                norm_parts.append(_NORM_RE.sub(" ", s.lower()).strip())
+            else:
+                norm_parts.append(s)
+        exact_sigs.append(_SEP.join(exact_parts))
+        norm_sigs.append(_SEP.join(norm_parts))
+
+    ec = Counter(exact_sigs)
+    nc = Counter(norm_sigs)
+    exact_rows = sum(1 for s in exact_sigs if ec[s] >= 2)
+    exact_groups = sum(1 for c in ec.values() if c >= 2)
+    near_rows = 0
+    near_group_sigs: set[str] = set()
+    for i in range(n):
+        if nc[norm_sigs[i]] >= 2 and ec[exact_sigs[i]] < 2:
+            near_rows += 1
+            near_group_sigs.add(norm_sigs[i])
+    return exact_rows, exact_groups, near_rows, len(near_group_sigs)
+
+
 class ApproxDuplicateProfiler:
     """Dataset-level relation profiler: exact + near-duplicate rows."""
 
-    def profile(self, frame: pl.DataFrame) -> list[Finding]:
+    def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        n_rows = df.height
-        if n_rows < 2 or df.width == 0:
+        cols = frame.columns
+        n_rows = frame.height
+        if n_rows < 2 or len(cols) == 0:
             return []
 
-        work = pl.DataFrame({
-            "__norm__": _normalized_signature(df),
-            "__exact__": _exact_signature(df),
-        })
-        norm_counts = work.group_by("__norm__").len().rename({"len": "__nc__"})
-        exact_counts = work.group_by("__exact__").len().rename({"len": "__ec__"})
-        work = work.join(norm_counts, on="__norm__").join(exact_counts, on="__exact__")
+        seam_cols = [frame.column(c) for c in cols]
+        # is_string selects the columns normalized for the near-dup signature. It
+        # mirrors the prior ``dt == pl.Utf8`` mask: a Polars Categorical maps to
+        # neutral "other" (NOT "str"), so it is excluded exactly as before.
+        is_string = [c.dtype == "str" for c in seam_cols]
 
-        # Shadow-compute the fused native duplicate_signatures kernel alongside the
-        # authoritative Polars group_by/join above (see tests/engine/test_w3_shadow.py
-        # for the parity assertion). NOT authoritative -- the findings below are built
-        # from the Polars values exactly as before this shadow wire. Wrapped so a shadow
-        # failure can never change or suppress an emitted Finding.
+        edr = edg = ndr = ndg = 0
         if native_enabled("duplicate_signatures"):
             try:
-                is_string = [dt == pl.Utf8 for dt in df.dtypes]
-                native_module().duplicate_signatures(
-                    [df[c].to_arrow() for c in df.columns], is_string
+                arrays = [c.to_arrow() for c in seam_cols]
+                edr, edg, ndr, ndg = native_module().duplicate_signatures(arrays, is_string)
+            except Exception as e:  # noqa: BLE001 - native failure -> pure-Python path
+                logger.debug("duplicate_signatures kernel failed, using Python fallback: %s", e)
+                edr, edg, ndr, ndg = _py_duplicate_signatures(
+                    [c.to_list() for c in seam_cols], is_string
                 )
-            except Exception as e:  # noqa: BLE001 - shadow-only, never affects output
-                logger.debug("duplicate_signatures shadow compute failed: %s", e)
+        else:
+            edr, edg, ndr, ndg = _py_duplicate_signatures(
+                [c.to_list() for c in seam_cols], is_string
+            )
 
         findings: list[Finding] = []
 
         # Exact duplicate rows (any row whose exact signature repeats).
-        exact_dups = work.filter(pl.col("__ec__") >= 2)
-        if exact_dups.height > 0:
-            n_groups = exact_dups["__exact__"].n_unique()
+        if edr > 0:
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column="__dataset__",
                 check="duplicate_rows",
                 message=(
-                    f"{exact_dups.height} rows are exact duplicates "
-                    f"({n_groups} distinct duplicated record{'s' if n_groups != 1 else ''})."
+                    f"{edr} rows are exact duplicates "
+                    f"({edg} distinct duplicated record{'s' if edg != 1 else ''})."
                 ),
-                affected_rows=exact_dups.height,
+                affected_rows=edr,
                 sample_values=[],
                 suggestion=(
                     "De-duplicate before downstream processing, or confirm the "
                     "repetition is intentional (e.g. a denormalized fact table)."
                 ),
                 confidence=0.7,
-                metadata={"technique": "duplicate_rows", "duplicate_groups": n_groups},
+                metadata={"technique": "duplicate_rows", "duplicate_groups": edg},
             ))
 
         # Near-duplicates: share a normalized signature with another row but have
         # NO exact twin -- i.e. they differ only by case / whitespace / punctuation.
-        near_dups = work.filter((pl.col("__nc__") >= 2) & (pl.col("__ec__") < 2))
-        if near_dups.height > 0:
-            n_groups = near_dups["__norm__"].n_unique()
+        if ndr > 0:
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column="__dataset__",
                 check="near_duplicate_rows",
                 message=(
-                    f"{near_dups.height} rows are near-duplicates — identical after "
+                    f"{ndr} rows are near-duplicates — identical after "
                     f"lowercasing, collapsing whitespace, and removing punctuation "
-                    f"({n_groups} group{'s' if n_groups != 1 else ''})."
+                    f"({ndg} group{'s' if ndg != 1 else ''})."
                 ),
-                affected_rows=near_dups.height,
+                affected_rows=ndr,
                 sample_values=[],
                 suggestion=(
                     "Standardize casing/whitespace/punctuation (or run an entity-"
                     "resolution pass) so these records reconcile to one."
                 ),
                 confidence=0.6,
-                metadata={"technique": "near_duplicate_rows", "near_duplicate_groups": n_groups},
+                metadata={"technique": "near_duplicate_rows", "near_duplicate_groups": ndg},
             ))
 
         return findings

--- a/packages/python/goldencheck/goldencheck/relations/approx_fd.py
+++ b/packages/python/goldencheck/goldencheck/relations/approx_fd.py
@@ -21,7 +21,7 @@ grouping columns qualify.
 from __future__ import annotations
 
 from goldencheck.core._native_loader import native_enabled, native_module
-from goldencheck.core.frame import _neutral_dtype, to_frame
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _MIN_ROWS = 100
@@ -33,11 +33,12 @@ _MAX_FINDINGS = 8
 _SUPPORTED = frozenset({"str", "int", "uint", "bool"})
 
 
-def _select_candidates(df) -> list[str]:
+def _select_candidates(frame) -> list[str]:
+    frame = to_frame(frame)
     scored: list[tuple[int, str]] = []
-    for col in df.columns:
-        series = df[col]
-        if _neutral_dtype(series.dtype) not in _SUPPORTED:
+    for col in frame.columns:
+        series = frame.column(col)
+        if series.dtype not in _SUPPORTED:
             continue
         nu = series.n_unique()
         if nu <= 1:
@@ -107,11 +108,10 @@ class ApproximateFDProfiler:
 
     def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        n_rows = df.height
+        n_rows = frame.height
         if n_rows < _MIN_ROWS or len(frame.columns) < 2:
             return []
-        cols = _select_candidates(df)
+        cols = _select_candidates(frame)
         if len(cols) < 2:
             return []
 
@@ -125,9 +125,9 @@ class ApproximateFDProfiler:
                 for i, j, _v in triples[:_MAX_FINDINGS]:
                     violations_of[(i, j)] = native_module().fd_violation_rows(arrays[i], arrays[j])
             except Exception:  # noqa: BLE001 - any native failure -> Python path
-                triples, violations_of = self._python(df, cols, n_rows)
+                triples, violations_of = self._python(frame, cols, n_rows)
         else:
-            triples, violations_of = self._python(df, cols, n_rows)
+            triples, violations_of = self._python(frame, cols, n_rows)
 
         if not triples:
             return []
@@ -170,9 +170,9 @@ class ApproximateFDProfiler:
         return findings
 
     def _python(
-        self, df, cols: list[str], n_rows: int
+        self, frame, cols: list[str], n_rows: int
     ) -> tuple[list[tuple[int, int, int]], dict[tuple[int, int], list[int]]]:
-        cols_ids = [_intern(df[c].to_list()) for c in cols]
+        cols_ids = [_intern(frame.column(c).to_list()) for c in cols]
         triples = _discover_python(cols_ids, n_rows, _MIN_CONFIDENCE)
         triples.sort(key=lambda t: t[2])
         violations_of = {

--- a/packages/python/goldencheck/goldencheck/relations/composite_key.py
+++ b/packages/python/goldencheck/goldencheck/relations/composite_key.py
@@ -20,7 +20,7 @@ information, not a violation.
 from __future__ import annotations
 
 from goldencheck.core._native_loader import native_enabled, native_module
-from goldencheck.core.frame import _neutral_dtype, to_frame
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 # A key wider than this is rarely a meaningful natural key and the search space
@@ -35,12 +35,13 @@ MAX_REPORTED_KEYS = 3
 _SUPPORTED = frozenset({"str", "int", "uint", "float", "bool"})
 
 
-def _select_candidates(df, n_rows: int) -> list[str]:
+def _select_candidates(frame, n_rows: int) -> list[str]:
     """Non-constant, supported-dtype columns, most-discriminative first, capped."""
+    frame = to_frame(frame)
     scored: list[tuple[int, str]] = []
-    for col in df.columns:
-        series = df[col]
-        if _neutral_dtype(series.dtype) not in _SUPPORTED:
+    for col in frame.columns:
+        series = frame.column(col)
+        if series.dtype not in _SUPPORTED:
             continue
         nu = series.n_unique()
         if nu <= 1:  # constant column can never help form a key
@@ -51,16 +52,16 @@ def _select_candidates(df, n_rows: int) -> list[str]:
     return [col for _nu, col in scored[:MAX_CANDIDATE_COLS]]
 
 
-def _has_single_column_key(df, n_rows: int) -> bool:
-    for col in df.columns:
-        series = df[col]
+def _has_single_column_key(frame, n_rows: int) -> bool:
+    for col in frame.columns:
+        series = frame.column(col)
         if series.null_count() == 0 and series.n_unique() == n_rows:
             return True
     return False
 
 
 def _python_search(
-    df, candidates: list[str], n_rows: int, max_size: int
+    frame, candidates: list[str], n_rows: int, max_size: int
 ) -> list[list[int]]:
     """Polars-free mirror of goldencheck_core::composite_key_search.
 
@@ -69,9 +70,10 @@ def _python_search(
     and supersets of a found key are pruned. The distinct-tuple test runs in
     pure Python (``len(set(zip(...)))``) rather than Polars ``n_unique`` — the
     Rust kernel is the fast reference; this is the correctness fallback when the
-    native wheel isn't installed. Columns are pulled out of the Polars frame once
-    with ``to_list``; the Polars *engine* no longer runs the distinct counts."""
-    col_values = [df[c].to_list() for c in candidates]
+    native wheel isn't installed. Columns are pulled out of the frame once
+    with ``to_list``; the engine no longer runs the distinct counts."""
+    frame = to_frame(frame)
+    col_values = [frame.column(c).to_list() for c in candidates]
     idxs = list(range(len(candidates)))
     found: list[list[int]] = []
     cap = min(max_size, len(idxs))
@@ -101,15 +103,14 @@ class CompositeKeyProfiler:
 
     def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        n_rows = df.height
+        n_rows = frame.height
         if n_rows < 2 or len(frame.columns) < 2:
             return []
         # Only interesting when there's no single-column key.
-        if _has_single_column_key(df, n_rows):
+        if _has_single_column_key(frame, n_rows):
             return []
 
-        candidates = _select_candidates(df, n_rows)
+        candidates = _select_candidates(frame, n_rows)
         if len(candidates) < 2:
             return []
 
@@ -125,9 +126,9 @@ class CompositeKeyProfiler:
                     arrays, MAX_KEY_SIZE, single_unique
                 )
             except Exception:  # noqa: BLE001 - any native failure -> Python path
-                keys_idx = _python_search(df, candidates, n_rows, MAX_KEY_SIZE)
+                keys_idx = _python_search(frame, candidates, n_rows, MAX_KEY_SIZE)
         else:
-            keys_idx = _python_search(df, candidates, n_rows, MAX_KEY_SIZE)
+            keys_idx = _python_search(frame, candidates, n_rows, MAX_KEY_SIZE)
 
         if not keys_idx:
             return []

--- a/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
+++ b/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
@@ -23,7 +23,7 @@ reports a bounded number of findings.
 from __future__ import annotations
 
 from goldencheck.core._native_loader import native_enabled, native_module
-from goldencheck.core.frame import _neutral_dtype, to_frame
+from goldencheck.core.frame import to_frame
 from goldencheck.models.finding import Finding, Severity
 
 _MIN_ROWS = 50          # enough support that a strict FD isn't a small-sample fluke
@@ -33,13 +33,14 @@ _MAX_FINDINGS = 10
 _SUPPORTED = frozenset({"str", "int", "uint", "bool"})
 
 
-def _select_candidates(df, n_rows: int) -> list[str]:
+def _select_candidates(frame, n_rows: int) -> list[str]:
     """Supported-dtype, non-constant columns; lowest-cardinality first (the
     interesting determinants), capped."""
+    frame = to_frame(frame)
     scored: list[tuple[int, str]] = []
-    for col in df.columns:
-        series = df[col]
-        if _neutral_dtype(series.dtype) not in _SUPPORTED:
+    for col in frame.columns:
+        series = frame.column(col)
+        if series.dtype not in _SUPPORTED:
             continue
         nu = series.n_unique()
         if nu <= 1:
@@ -49,7 +50,7 @@ def _select_candidates(df, n_rows: int) -> list[str]:
     return [c for _nu, c in scored[:_MAX_CANDIDATES]]
 
 
-def _discover_python(df, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
+def _discover_python(frame, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
     """Polars-free mirror of the kernel: det->dep holds iff
     n_distinct(det, dep) == n_distinct(det). Skips trivial pairs identically.
 
@@ -58,8 +59,9 @@ def _discover_python(df, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
     the fast reference; this is the correctness fallback when the native wheel
     isn't installed (roughly ~4x slower than the old Polars path, acceptable for
     a safety net). Values are pulled out of the Polars frame once with
-    ``to_list``; the Polars *engine* no longer runs the distinct counts."""
-    lists = {c: df[c].to_list() for c in cols}
+    ``to_list``; the engine no longer runs the distinct counts."""
+    frame = to_frame(frame)
+    lists = {c: frame.column(c).to_list() for c in cols}
     distinct = {c: len(set(lists[c])) for c in cols}
     out: list[tuple[int, int]] = []
     for i, det in enumerate(cols):
@@ -78,12 +80,11 @@ class FunctionalDependencyProfiler:
 
     def profile(self, frame) -> list[Finding]:
         frame = to_frame(frame)
-        df = frame.native
-        n_rows = df.height
+        n_rows = frame.height
         if n_rows < _MIN_ROWS or len(frame.columns) < 2:
             return []
 
-        cols = _select_candidates(df, n_rows)
+        cols = _select_candidates(frame, n_rows)
         if len(cols) < 2:
             return []
 
@@ -93,9 +94,9 @@ class FunctionalDependencyProfiler:
                 arrays = [frame.column(c).to_arrow() for c in cols]
                 pairs = native_module().discover_functional_dependencies(arrays)
             except Exception:  # noqa: BLE001 - any native failure -> pure-Python path
-                pairs = _discover_python(df, cols, n_rows)
+                pairs = _discover_python(frame, cols, n_rows)
         else:
-            pairs = _discover_python(df, cols, n_rows)
+            pairs = _discover_python(frame, cols, n_rows)
 
         if not pairs:
             return []

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -9,7 +9,7 @@ from typing import Any
 import yaml
 
 from goldencheck._polars_lazy import pl
-from goldencheck.core._native_loader import native_enabled, native_module
+from goldencheck.core.frame import to_frame
 
 logger = logging.getLogger(__name__)
 
@@ -97,16 +97,25 @@ def load_type_defs(
 
 
 def classify_columns(
-    df: pl.DataFrame,
+    df,
     custom_types_path: Path | None = None,
     type_defs: dict[str, TypeDef] | None = None,
+    only: list[str] | None = None,
 ) -> dict[str, ColumnClassification]:
-    """Classify each column's semantic type with provenance."""
+    """Classify each column's semantic type with provenance.
+
+    Routes through the backend-neutral Frame/Column seam, so ``df`` may be a
+    ``pl.DataFrame`` (wrapped as ``PolarsFrame``) or an Arrow-native
+    ``ArrowFrame`` -- the default scan path passes the latter. ``only`` restricts
+    classification to a subset of columns (used by the schema-aware scan branch).
+    """
     if type_defs is None:
         type_defs = load_type_defs(custom_types_path)
+    frame = to_frame(df)
     results = {}
 
-    for col_name in df.columns:
+    names = frame.columns if only is None else [c for c in frame.columns if c in only]
+    for col_name in names:
         # 1. Name heuristic matching
         classification = _match_by_name(col_name, type_defs)
         if classification:
@@ -114,7 +123,7 @@ def classify_columns(
             continue
 
         # 2. Value-based inference
-        classification = _match_by_value(df, col_name, type_defs)
+        classification = _match_by_value(frame, col_name, type_defs)
         if classification:
             results[col_name] = ColumnClassification(type_name=classification, source="value")
             continue
@@ -140,8 +149,8 @@ def _match_by_name(col_name: str, type_defs: dict[str, TypeDef]) -> str | None:
                 return type_name
     return None
 
-def _match_by_value(df: pl.DataFrame, col_name: str, type_defs: dict[str, TypeDef]) -> str | None:
-    col = df[col_name]
+def _match_by_value(frame, col_name: str, type_defs: dict[str, TypeDef]) -> str | None:
+    col = frame.column(col_name)
     non_null = col.drop_nulls()
     if len(non_null) == 0:
         return None
@@ -154,8 +163,10 @@ def _match_by_value(df: pl.DataFrame, col_name: str, type_defs: dict[str, TypeDe
             return type_name
     return None
 
-def _check_value_signals(non_null: pl.Series, col: pl.Series, signals: dict) -> bool:
-    """Check if ALL value signals are satisfied."""
+def _check_value_signals(non_null, col, signals: dict) -> bool:
+    """Check if ALL value signals are satisfied. ``non_null``/``col`` are seam
+    ``Column``s (Polars- or Arrow-backed); dtype gates use the neutral vocabulary
+    (``str``/``int``/``float``/...)."""
     for key, value in signals.items():
         if key == "min_unique_pct":
             if non_null.n_unique() / len(non_null) < value:
@@ -170,52 +181,42 @@ def _check_value_signals(non_null: pl.Series, col: pl.Series, signals: dict) -> 
         elif key == "min_match_pct":
             pass  # Used with format_match, handled there
         elif key == "mixed_case":
-            # TODO(W-path): route the dtype gates in this function via dtype_category
-            if non_null.dtype not in (pl.Utf8, pl.String):
+            if non_null.dtype != "str":
                 return False
-            sample = non_null.head(100).to_list()
+            sample = non_null.slice(0, 100).to_list()
             has_upper = any(any(c.isupper() for c in str(s)) for s in sample)
             has_lower = any(any(c.islower() for c in str(s)) for s in sample)
             if not (has_upper and has_lower):
                 return False
         elif key == "avg_length_min":
-            if non_null.dtype not in (pl.Utf8, pl.String):
+            if non_null.dtype != "str":
                 return False
-            avg_len = non_null.str.len_chars().mean()
+            avg_len = non_null.str_len_chars().mean()
             if avg_len is None or avg_len < value:
                 return False
         elif key == "numeric":
-            if col.dtype not in (pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.Float32, pl.Float64):
+            # Matches the prior gate exactly: signed-int / float only (UInt was
+            # NOT accepted by the original ``pl.Int*/pl.Float*`` tuple).
+            if col.dtype not in ("int", "float"):
                 return False
         elif key == "short_strings":
-            if non_null.dtype not in (pl.Utf8, pl.String):
+            if non_null.dtype != "str":
                 return False
-            avg_len = non_null.str.len_chars().mean()
+            avg_len = non_null.str_len_chars().mean()
             if avg_len is None or avg_len >= 5:
                 return False
     return True
 
-def _count_matches(non_null: pl.Series, pattern: str) -> int:
-    """Count values in ``non_null`` matching ``pattern`` (Polars-authoritative).
-
-    W6 shadow-wire: when the ``regex`` kernel is enabled, ALSO compute the count
-    via the Rust ``str_contains_count`` kernel (both Polars ``str.contains`` and
-    the kernel use the Rust ``regex`` crate, so the counts are byte-identical).
-    The kernel result is discarded -- the authoritative count stays Polars until
-    the Flip. Mirrors the profiler call form (``PyColumn.str_match_count``):
-    ``str_contains_count(<list of non-null values>, pattern) -> int``.
-    """
-    matches = int(non_null.str.contains(pattern, literal=False).sum())
-    if native_enabled("regex"):
-        try:  # noqa: SIM105 - shadow compute, discard result, never fail the caller
-            native_module().str_contains_count(non_null.to_list(), pattern)
-        except BaseException:  # noqa: BLE001 - shadow must never affect the return
-            pass
-    return matches
+def _count_matches(non_null, pattern: str) -> int:
+    """Count values in ``non_null`` matching ``pattern`` via the seam
+    ``str_match_count`` (Arrow -> native regex kernel; Polars -> ``str.contains``;
+    both use the Rust ``regex`` crate, so counts are byte-identical -- proven in
+    tests/engine/test_w6_semantic_shadow.py)."""
+    return non_null.str_match_count(pattern)
 
 
-def _check_format_match(non_null: pl.Series, format_type: str) -> bool:
-    if non_null.dtype not in (pl.Utf8, pl.String):
+def _check_format_match(non_null, format_type: str) -> bool:
+    if non_null.dtype != "str":
         return False
     if format_type == "email":
         return _count_matches(non_null, r"@.*\.") / len(non_null) >= 0.70

--- a/packages/python/goldencheck/goldencheck/semantic/classifier.py
+++ b/packages/python/goldencheck/goldencheck/semantic/classifier.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import yaml
 
-from goldencheck._polars_lazy import pl
 from goldencheck.core.frame import to_frame
 
 logger = logging.getLogger(__name__)

--- a/packages/python/goldencheck/llms.txt
+++ b/packages/python/goldencheck/llms.txt
@@ -7,15 +7,14 @@
 - Remote MCP: https://goldencheck-mcp-production.up.railway.app/mcp/ (19 tools, Smithery: https://smithery.ai/servers/benzsevern/goldencheck)
 - A2A Server: `goldencheck agent-serve --port 8100` (9 skills)
 - CLI: `goldencheck scan`, `goldencheck validate`, + 14 more commands
-- Python API: `from goldencheck import scan_file, scan_columns, scan_file_columns, read_columns, validate_file, health_score, create_baseline` (scan_columns / read_columns / scan_file_columns are the Polars-free structural path)
+- Python API: `from goldencheck import scan_file, scan_dataframe, validate_file, health_score, create_baseline` (the default scan path is Arrow-native and Polars-free; `scan_dataframe` accepts a `pyarrow.Table` natively)
 - REST API: `goldencheck serve` on port 8000
 
 ## Install
-- `pip install goldencheck` — Polars-free base: structural scan (`scan_columns`) + Parquet/Excel reading (`read_columns`/`scan_file_columns`)
-- `pip install goldencheck[polars]` — CSV reading + the full `scan_file`/`scan_dataframe` scan (Polars; since 2.0.0 Polars is optional)
-- `pip install goldencheck[parquet]` — Polars-free Parquet reading (pyarrow)
+- `pip install goldencheck` — Arrow-native, Polars-free: full scan (`scan_file`/`scan_dataframe`) of CSV/Parquet/Excel (pyarrow is a base dep since 3.0.0)
+- `pip install goldencheck[baseline]` — deep statistical profiling & drift detection (pulls scipy/numpy + Polars)
+- `pip install goldencheck[polars]` — only for the `scan_dataframe(pl.DataFrame)` convenience overload
 - `pip install goldencheck[llm]` — LLM boost (~$0.01/scan)
-- `pip install goldencheck[baseline]` — deep profiling & drift detection
 - `pip install goldencheck[mcp]` — MCP server for Claude Desktop
 
 ## Quick Examples

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "2.0.0"
+version = "3.0.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -25,7 +25,15 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
-    # polars moved to the [polars] extra in 2.0.0 (see optional-dependencies)
+    # Polars is NOT a base dep. In 2.0.0 it moved to the [polars] extra; in 3.0.0
+    # the default scan path is Arrow-native (the fused Rust/Arrow seam), so polars
+    # is only needed for the opt-in [baseline] stat/drift features and the
+    # scan_dataframe(pl.DataFrame) convenience overload ([polars] extra).
+    # pyarrow is a BASE dep in 3.0.0 -- the scan frame is a pyarrow.Table and every
+    # scan routes through the Arrow seam. The compiled goldencheck-native kernel
+    # ([native] extra) accelerates the numeric/sequence/date/regex checks and the
+    # profilers self-skip those when it is absent (same pattern as 2.x).
+    "pyarrow>=14",
     "typer>=0.12",
     "rich>=13.0",
     "pyyaml>=6.0",
@@ -70,8 +78,12 @@ agent = [
     "aiohttp>=3.14.0",
 ]
 baseline = [
+    # The baseline statistics + drift + correlation subsystems are opt-in and still
+    # run on Polars (group_by/pivot/join) + scipy. 3.0.0 gates them here rather than
+    # porting them off Polars -- installing [baseline] pulls the polars they need.
     "scipy>=1.11",
     "numpy>=1.26",
+    "polars>=1.0",
 ]
 native = [
     # Optional Rust/PyO3 acceleration for the CPU-bound deep-profiling kernels

--- a/packages/python/goldencheck/scripts/flip_corpus.py
+++ b/packages/python/goldencheck/scripts/flip_corpus.py
@@ -1,0 +1,152 @@
+"""Flip §8b differential corpus generator (polars-free: numpy + pyarrow).
+
+Generates a deterministic synthetic corpus that exercises every goldencheck
+check family, so the Flip differential (2.x-Polars authoritative vs owned-fused)
+measures real finding-set deltas. One dataset exceeds the 100k sample cap so the
+owned-sample path fires.
+
+Usage:  python scripts/flip_corpus.py [out_dir]   (default: <pkg>/tests/flip/corpus)
+Writes one .parquet per dataset. Seeded; byte-stable across runs.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+SEED = 42
+EPOCH_DAY = np.datetime64("1970-01-01")
+
+
+def _rng(tag: str) -> np.random.Generator:
+    # Distinct but deterministic stream per dataset (no wall-clock).
+    return np.random.default_rng(SEED + (abs(hash(tag)) % 100_000))
+
+
+def ds_numeric_outliers(n: int = 5_000) -> pa.Table:
+    r = _rng("numeric_outliers")
+    x = r.normal(100.0, 15.0, n)
+    # inject a handful of >3sigma outliers deterministically
+    x[:: n // 20] = 1_000.0
+    y = r.normal(0.0, 1.0, n)
+    ints = r.integers(0, 500, n)
+    return pa.table({"score": x, "noise": y, "count": ints})
+
+
+def ds_sequence_gaps(n: int = 3_000) -> pa.Table:
+    r = _rng("sequence_gaps")
+    ids = np.arange(1, n + 1, dtype=np.int64)
+    # punch gaps
+    keep = np.ones(n, dtype=bool)
+    keep[r.choice(n, size=n // 50, replace=False)] = False
+    seq = ids[keep]
+    return pa.table({"row_id": seq})
+
+
+def ds_freshness(n: int = 4_000) -> pa.Table:
+    r = _rng("freshness")
+    base = np.datetime64("2024-01-01")
+    days = r.integers(-800, 40, n)  # a few future dates
+    dates = base + days.astype("timedelta64[D]")
+    return pa.table({"event_date": pa.array(dates)})
+
+
+def ds_duplicates(n: int = 6_000) -> pa.Table:
+    r = _rng("duplicates")
+    names = np.array(["Alice", "Bob", "Carol", "Dan", "Eve"])
+    first = names[r.integers(0, len(names), n)]
+    cities = np.array(["NYC", "LA", "SF", "Chicago"])
+    city = cities[r.integers(0, len(cities), n)]
+    # force exact dup rows: copy first 500 rows onto the last 500
+    first = first.copy()
+    city = city.copy()
+    first[-500:] = first[:500]
+    city[-500:] = city[:500]
+    emails = np.array([f"user{i % 1000}@example.com" for i in range(n)])
+    return pa.table({"first_name": first, "city": city, "email": emails})
+
+
+def ds_age_dob(n: int = 4_000) -> pa.Table:
+    r = _rng("age_dob")
+    ages = r.integers(18, 90, n).astype(np.int64)
+    # dob consistent with age for most, mismatched for a slice
+    ref = np.datetime64("2024-06-01")
+    dob = ref - (ages.astype("timedelta64[D]") * 365 + r.integers(0, 364, n).astype("timedelta64[D]"))
+    ages_reported = ages.copy()
+    ages_reported[:: n // 25] += 20  # deterministic mismatches
+    return pa.table({"age": ages_reported, "date_of_birth": pa.array(dob.astype("datetime64[D]"))})
+
+
+def ds_correlation(n: int = 5_000) -> pa.Table:
+    r = _rng("correlation")
+    a = r.normal(0, 1, n)
+    b = 0.8 * a + r.normal(0, 0.5, n)  # correlated
+    c = r.normal(0, 1, n)  # independent
+    cat1 = np.array(["x", "y", "z"])[r.integers(0, 3, n)]
+    cat2 = np.array(["p", "q"])[r.integers(0, 2, n)]
+    return pa.table({"var_a": a, "var_b": b, "var_c": c, "cat1": cat1, "cat2": cat2})
+
+
+def ds_benford(n: int = 5_000) -> pa.Table:
+    r = _rng("benford")
+    # Benford-ish: 10**uniform  -> leading-digit distribution follows Benford
+    benford_like = np.floor(10 ** r.uniform(0, 6, n)).astype(np.int64) + 1
+    # anti-benford: uniform leading digits
+    anti = r.integers(100000, 999999, n).astype(np.int64)
+    return pa.table({"amount": benford_like, "flat_id": anti})
+
+
+def ds_mixed_dtypes(n: int = 2_000) -> pa.Table:
+    r = _rng("mixed_dtypes")
+    return pa.table(
+        {
+            "i8": pa.array(r.integers(-100, 100, n), type=pa.int8()),
+            "u32": pa.array(r.integers(0, 1_000_000, n), type=pa.uint32()),
+            "f32": pa.array(r.normal(0, 1, n).astype(np.float32), type=pa.float32()),
+            "flag": pa.array(r.integers(0, 2, n).astype(bool)),
+            "label": np.array(["a", "b", "c"])[r.integers(0, 3, n)],
+            "maybe_num": np.array([str(v) for v in r.integers(0, 1000, n)]),  # numeric-looking strings
+        }
+    )
+
+
+def ds_large_sampled(n: int = 250_000) -> pa.Table:
+    """> sample_size (100k) so the owned-sample path fires in the differential."""
+    r = _rng("large_sampled")
+    x = r.normal(50.0, 10.0, n)
+    x[:: n // 200] = 5_000.0  # outliers spread through the population
+    grp = np.array(["north", "south", "east", "west"])[r.integers(0, 4, n)]
+    amt = np.floor(10 ** r.uniform(0, 6, n)).astype(np.int64) + 1
+    ids = np.arange(1, n + 1, dtype=np.int64)
+    return pa.table({"measure": x, "region": grp, "amount": amt, "rec_id": ids})
+
+
+DATASETS = {
+    "numeric_outliers": ds_numeric_outliers,
+    "sequence_gaps": ds_sequence_gaps,
+    "freshness": ds_freshness,
+    "duplicates": ds_duplicates,
+    "age_dob": ds_age_dob,
+    "correlation": ds_correlation,
+    "benford": ds_benford,
+    "mixed_dtypes": ds_mixed_dtypes,
+    "large_sampled": ds_large_sampled,
+}
+
+
+def main() -> None:
+    out = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(__file__).parent.parent / "tests" / "flip" / "corpus"
+    out.mkdir(parents=True, exist_ok=True)
+    for name, fn in DATASETS.items():
+        tbl = fn()
+        path = out / f"{name}.parquet"
+        pq.write_table(tbl, path)
+        print(f"wrote {path}  ({tbl.num_rows} rows x {tbl.num_columns} cols)")
+    print(f"\ncorpus -> {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldencheck/scripts/flip_corpus.py
+++ b/packages/python/goldencheck/scripts/flip_corpus.py
@@ -10,6 +10,7 @@ Writes one .parquet per dataset. Seeded; byte-stable across runs.
 """
 from __future__ import annotations
 
+import hashlib
 import sys
 from pathlib import Path
 
@@ -22,8 +23,12 @@ EPOCH_DAY = np.datetime64("1970-01-01")
 
 
 def _rng(tag: str) -> np.random.Generator:
-    # Distinct but deterministic stream per dataset (no wall-clock).
-    return np.random.default_rng(SEED + (abs(hash(tag)) % 100_000))
+    # Distinct but deterministic stream per dataset. Uses a STABLE hash (md5) --
+    # Python's builtin hash() salts str hashes per process (PYTHONHASHSEED), so
+    # hash(tag) would make the "deterministic" corpus differ every run and the
+    # parity test flaky (bit us: CI regenerated a different f32 column than local).
+    offset = int(hashlib.md5(tag.encode()).hexdigest(), 16) % 100_000
+    return np.random.default_rng(SEED + offset)
 
 
 def ds_numeric_outliers(n: int = 5_000) -> pa.Table:

--- a/packages/python/goldencheck/scripts/flip_differential.py
+++ b/packages/python/goldencheck/scripts/flip_differential.py
@@ -1,0 +1,355 @@
+"""Flip §8b differential measurement — authoritative 2.x-Polars vs owned-fused.
+
+Stage 1 of the Flip. Runs each corpus dataset through BOTH scan paths and
+reports the finding-set delta per §8b:
+  (1) finding-set Jaccard + count delta per (check, severity)
+  (2) stat-threshold-flip bucket   (statrs p-value crossed a cutoff scipy didn't)
+  (3) owned-sample-flip bucket      (finding differs only because sampled rows differ)
+  (4) inferred_type string diffs
+  (5) max stat-float delta per stat family
+  (6) DatasetProfile.health_score grade delta (secondary invariant)
+
+Acceptance (§8b): non-stat, non-sample findings MUST be identical (Jaccard 1.0).
+Any delta there is a KERNEL BUG that blocks the Flip.
+
+Run via the main venv with the worktree on PYTHONPATH:
+  .venv/Scripts/python.exe scripts/flip_differential.py [--fused] [--corpus DIR]
+
+Without --fused it captures ONLY the authoritative side (P) and validates the
+corpus triggers findings across families (a smoke gate before the fused side
+exists). With --fused it runs both and emits the report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+
+from goldencheck.core.frame import dtype_category
+
+_FLOAT_RE = re.compile(r"-?\d+\.\d+(?:[eE][+-]?\d+)?|-?\d+(?:[eE][+-]?\d+)?")
+
+# check families that are statistical (statrs/scipy) -- their threshold flips
+# are an accepted divergence class, held apart from the strict-identity set.
+STAT_CHECKS = {
+    "correlation",
+    "cross_column",
+    "benford",
+    "distribution",
+    "statistical_baseline",
+    "drift",
+}
+
+
+def _finding_key(f) -> tuple:
+    """Differential key: identity fields PLUS the count where numeric divergence surfaces."""
+    return (f.check, f.column, int(f.severity), f.affected_rows)
+
+
+def _finding_full(f) -> dict:
+    d = asdict(f)
+    d["severity"] = int(f.severity)
+    # normalize sample order (kernel vs polars may emit a different in-group order)
+    d["sample_values"] = sorted(str(v) for v in (f.sample_values or []))
+    return d
+
+
+def run_authoritative(path: Path) -> tuple[list, dict]:
+    """The current 2.x-Polars authoritative scan (PolarsColumn)."""
+    from goldencheck.engine.scanner import scan_file
+
+    findings, profile = scan_file(path, baseline=None)
+    prof = {
+        "columns": {c.name: c.inferred_type for c in profile.columns},
+    }
+    return findings, prof
+
+
+# The seam-clean COLUMN profilers -- their bodies route through the Frame/Column
+# seam (to_frame -> frame.column(name) -> col.<method>()), so an ArrowFrame drives
+# them polars-free with no profiler change. These are the ones the Flip fuses.
+def _seam_profilers():
+    from goldencheck.profilers.cardinality import CardinalityProfiler
+    from goldencheck.profilers.freshness import FreshnessProfiler
+    from goldencheck.profilers.nullability import NullabilityProfiler
+    from goldencheck.profilers.range_distribution import RangeDistributionProfiler
+    from goldencheck.profilers.sequence_detection import SequenceDetectionProfiler
+    from goldencheck.profilers.type_inference import TypeInferenceProfiler
+    from goldencheck.profilers.uniqueness import UniquenessProfiler
+
+    # Order mirrors COLUMN_PROFILERS in engine/scanner.py (subset that is seam-clean).
+    return [
+        TypeInferenceProfiler(),
+        NullabilityProfiler(),
+        UniquenessProfiler(),
+        RangeDistributionProfiler(),
+        CardinalityProfiler(),
+        SequenceDetectionProfiler(),
+        FreshnessProfiler(),
+    ]
+
+
+def _run_seam(frame, columns: list[str]) -> list:
+    """Run the seam-clean column profilers over one frame (PolarsFrame or
+    ArrowFrame), matching the scanner's per-column loop + shared context dict."""
+    profilers = _seam_profilers()
+    findings: list = []
+    context: dict = {}
+    for name in columns:
+        for prof in profilers:
+            try:
+                findings.extend(prof.profile(frame, name, context=context))
+            except Exception as e:  # noqa: BLE001 - surface as a captured error, not a crash
+                findings.append(_ErrorFinding(prof.__class__.__name__, name, repr(e)))
+    return findings
+
+
+class _ErrorFinding:
+    """Sentinel so a profiler crash on one side shows up as a strict-set diff
+    rather than silently vanishing."""
+
+    def __init__(self, profiler: str, column: str, err: str) -> None:
+        self.check = f"__error__:{profiler}"
+        self.column = column
+        self.severity = 3
+        self.affected_rows = -1
+        self.message = err
+        self.sample_values: list = []
+
+
+def run_authoritative_seam(path: Path):
+    """Authoritative side of the fused diff: seam profilers over a PolarsFrame."""
+    import polars as pl
+
+    from goldencheck.core.frame import PolarsFrame
+
+    df = pl.read_parquet(path)
+    frame = PolarsFrame(df)
+    return _run_seam(frame, df.columns), {c: dtype_category(df[c].dtype) for c in df.columns}, \
+        {c: str(df[c].dtype) for c in df.columns}
+
+
+def run_fused_seam(path: Path):
+    """Fused side of the diff: the SAME seam profilers over an ArrowFrame."""
+    import pyarrow.parquet as pq
+
+    from goldencheck.core.frame import ArrowFrame
+
+    tbl = pq.read_table(path)
+    frame = ArrowFrame(tbl)
+    cols = tbl.column_names
+    return _run_seam(frame, cols), {c: frame.column(c).dtype for c in cols}, \
+        {c: frame.column(c).dtype_repr() for c in cols}
+
+
+def _summarize(name: str, findings: list) -> dict:
+    by_check: dict[str, int] = {}
+    for f in findings:
+        by_check[f.check] = by_check.get(f.check, 0) + 1
+    return {"dataset": name, "n_findings": len(findings), "by_check": by_check}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--fused", action="store_true", help="run the owned-fused side + diff (Stage-0 column required)")
+    ap.add_argument("--corpus", default=str(Path(__file__).parent.parent / "tests" / "flip" / "corpus"))
+    ap.add_argument("--out", default=str(Path(__file__).parent.parent / "tests" / "flip" / "authoritative_findings.json"))
+    args = ap.parse_args()
+
+    corpus = sorted(Path(args.corpus).glob("*.parquet"))
+    if not corpus:
+        raise SystemExit(f"no corpus at {args.corpus} -- run scripts/flip_corpus.py first")
+
+    print(f"corpus: {len(corpus)} datasets\n")
+    all_p: dict[str, dict] = {}
+    families_seen: set[str] = set()
+    for path in corpus:
+        name = path.stem
+        findings, prof = run_authoritative(path)
+        summ = _summarize(name, findings)
+        families_seen.update(summ["by_check"])
+        all_p[name] = {
+            "summary": summ,
+            "inferred_types": prof["columns"],
+            "findings": [_finding_full(f) for f in findings],
+        }
+        checks = ", ".join(f"{k}:{v}" for k, v in sorted(summ["by_check"].items()))
+        print(f"  {name:18s} {summ['n_findings']:4d} findings  [{checks}]")
+
+    Path(args.out).write_text(json.dumps(all_p, indent=2, default=str))
+    print(f"\nauthoritative findings -> {args.out}")
+    print(f"check families triggered ({len(families_seen)}): {', '.join(sorted(families_seen))}")
+
+    if not args.fused:
+        print("\n(--fused not set: authoritative-only smoke capture. Fused side + diff pending Stage 0.)")
+        return
+
+    # --- Fused side + §8b differential (Stage 0) -----------------------------
+    report_path = Path(__file__).parent.parent / "docs" / "superpowers" / "specs" / "flip-differential-report.md"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    lines: list[str] = [
+        "# Flip §8b Differential — Stage 0 (seam-clean column profilers)",
+        "",
+        "Authoritative = seam profilers over a `PolarsFrame` (2.x-Polars).  ",
+        "Fused = the SAME profilers over an `ArrowFrame` (owned Arrow-native seam).",
+        "",
+        "Profilers exercised: TypeInference, Nullability, Uniqueness, RangeDistribution, "
+        "Cardinality, SequenceDetection, Freshness.",
+        "",
+    ]
+
+    overall_strict_inter = 0
+    overall_strict_union = 0
+    overall_dtype_diffs = 0
+    overall_max_stat_delta = 0.0
+    overall_strict_diffs: list[str] = []
+
+    for path in corpus:
+        name = path.stem
+        p_find, p_neutral, p_repr = run_authoritative_seam(path)
+        f_find, f_neutral, f_repr = run_fused_seam(path)
+
+        # (1) full finding-set Jaccard (identity + sorted sample_values)
+        p_full = {_full_key(f) for f in p_find}
+        f_full = {_full_key(f) for f in f_find}
+        full_inter = len(p_full & f_full)
+        full_union = len(p_full | f_full) or 1
+        full_jaccard = full_inter / full_union
+
+        # count delta per (check, severity)
+        p_cs = _count_by_check_sev(p_find)
+        f_cs = _count_by_check_sev(f_find)
+        cs_rows = []
+        for key in sorted(set(p_cs) | set(f_cs)):
+            pc_, fc_ = p_cs.get(key, 0), f_cs.get(key, 0)
+            cs_rows.append((key[0], key[1], pc_, fc_, fc_ - pc_))
+
+        # (2) dtype-vocab diff: raw-polars repr vs neutral (expected to differ)
+        dtype_rows = []
+        for col in p_repr:
+            if p_repr[col] != f_repr.get(col):
+                dtype_rows.append((col, p_repr[col], f_repr.get(col)))
+        overall_dtype_diffs += len(dtype_rows)
+
+        # (3) max stat-float delta per numeric check (parse message numbers)
+        max_stat_delta, stat_detail = _max_stat_float_delta(p_find, f_find)
+        overall_max_stat_delta = max(overall_max_stat_delta, max_stat_delta)
+
+        # (4) STRICT set: non-sample, non-dtype findings that differ (must be empty)
+        p_strict = {_strict_key(f) for f in p_find}
+        f_strict = {_strict_key(f) for f in f_find}
+        strict_inter = len(p_strict & f_strict)
+        strict_union = len(p_strict | f_strict) or 1
+        strict_jaccard = strict_inter / strict_union
+        overall_strict_inter += strict_inter
+        overall_strict_union += len(p_strict | f_strict)
+        for k in sorted(p_strict ^ f_strict):
+            side = "P-only" if k in p_strict else "F-only"
+            overall_strict_diffs.append(f"{name}: {side} {k}")
+
+        print(
+            f"  {name:18s} full-J={full_jaccard:.3f}  strict-J={strict_jaccard:.3f}  "
+            f"dtype-vocab-diffs={len(dtype_rows)}  max-stat-delta={max_stat_delta:.2e}"
+        )
+
+        lines += [
+            f"## {name}",
+            "",
+            f"- full finding-set Jaccard (with sample_values): **{full_jaccard:.3f}** "
+            f"({full_inter}/{full_union})",
+            f"- STRICT (non-sample/non-dtype) Jaccard: **{strict_jaccard:.3f}** "
+            f"({strict_inter}/{strict_union})",
+            f"- max stat-float delta: **{max_stat_delta:.3e}**"
+            + (f" ({stat_detail})" if stat_detail else ""),
+            "",
+            "### finding count per (check, severity)",
+            "",
+            "| check | severity | authoritative | fused | delta |",
+            "|---|---|---|---|---|",
+        ]
+        for check, sev, pc_, fc_, delta in cs_rows:
+            lines.append(f"| {check} | {sev} | {pc_} | {fc_} | {delta:+d} |")
+        lines += ["", "### dtype vocabulary (expected raw-polars vs neutral divergence)", ""]
+        if dtype_rows:
+            lines += ["| column | authoritative repr | fused repr |", "|---|---|---|"]
+            lines += [f"| {c} | `{a}` | `{b}` |" for c, a, b in dtype_rows]
+        else:
+            lines.append("_(no dtype_repr divergence)_")
+        if p_strict ^ f_strict:
+            lines += ["", "### STRICT-SET DIVERGENCE (kernel bug — blocks the Flip)", ""]
+            for k in sorted(p_strict ^ f_strict):
+                side = "P-only" if k in p_strict else "F-only"
+                lines.append(f"- `{side}` {k}")
+        lines.append("")
+
+    overall_strict_j = overall_strict_inter / (overall_strict_union or 1)
+    verdict = (
+        f"STRICT (non-stat/non-dtype) Jaccard = {overall_strict_j:.3f} "
+        f"(PASS iff 1.000)  ->  {'PASS' if overall_strict_j == 1.0 else 'FAIL'}"
+    )
+    summary = [
+        "## Overall verdict",
+        "",
+        f"- {verdict}",
+        f"- dtype-vocab diffs (expected, raw-polars vs neutral): **{overall_dtype_diffs}**",
+        f"- max stat-float delta across all datasets: **{overall_max_stat_delta:.3e}**",
+        f"- strict-set divergences: **{len(overall_strict_diffs)}** (must be 0)",
+        "",
+    ]
+    if overall_strict_diffs:
+        summary += ["### strict divergences", ""] + [f"- {d}" for d in overall_strict_diffs] + [""]
+    lines = lines[:6] + summary + lines[6:]
+
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+    print("\n" + verdict)
+    print(f"dtype-vocab diffs: {overall_dtype_diffs} | max stat-float delta: {overall_max_stat_delta:.3e}")
+    print(f"strict-set divergences: {len(overall_strict_diffs)}")
+    print(f"report -> {report_path}")
+
+
+def _full_key(f) -> tuple:
+    return (f.check, f.column, int(f.severity), f.affected_rows,
+            tuple(sorted(str(v) for v in (getattr(f, "sample_values", None) or []))))
+
+
+def _strict_key(f) -> tuple:
+    """Identity WITHOUT sample_values — the strict-identity set (§8b metric 4)."""
+    return (f.check, f.column, int(f.severity), f.affected_rows)
+
+
+def _count_by_check_sev(findings: list) -> dict:
+    out: dict = {}
+    for f in findings:
+        key = (f.check, int(f.severity))
+        out[key] = out.get(key, 0) + 1
+    return out
+
+
+def _max_stat_float_delta(p_find: list, f_find: list) -> tuple[float, str]:
+    """Max abs delta between the floats parsed from messages of findings matched
+    by (check, column, severity). Catches stat drift the strict key would miss."""
+    def by_key(fs):
+        d: dict = {}
+        for f in fs:
+            d.setdefault((f.check, f.column, int(f.severity)), []).append(f)
+        return d
+
+    p_by, f_by = by_key(p_find), by_key(f_find)
+    max_delta = 0.0
+    detail = ""
+    for key in set(p_by) & set(f_by):
+        for pf, ff in zip(p_by[key], f_by[key]):
+            pv = [float(x) for x in _FLOAT_RE.findall(pf.message)]
+            fv = [float(x) for x in _FLOAT_RE.findall(ff.message)]
+            for a, b in zip(pv, fv):
+                delta = abs(a - b)
+                if delta > max_delta:
+                    max_delta = delta
+                    detail = f"{key[0]}/{key[1]}"
+    return max_delta, detail
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldencheck/scripts/flip_differential.py
+++ b/packages/python/goldencheck/scripts/flip_differential.py
@@ -122,7 +122,6 @@ class _ErrorFinding:
 def run_authoritative_seam(path: Path):
     """Authoritative side of the fused diff: seam profilers over a PolarsFrame."""
     import polars as pl
-
     from goldencheck.core.frame import PolarsFrame
 
     df = pl.read_parquet(path)
@@ -134,7 +133,6 @@ def run_authoritative_seam(path: Path):
 def run_fused_seam(path: Path):
     """Fused side of the diff: the SAME seam profilers over an ArrowFrame."""
     import pyarrow.parquet as pq
-
     from goldencheck.core.frame import ArrowFrame
 
     tbl = pq.read_table(path)

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldencheck/tests/engine/test_column_aggregate_shadow.py
+++ b/packages/python/goldencheck/tests/engine/test_column_aggregate_shadow.py
@@ -70,4 +70,6 @@ def test_shadow_runs_on_real_scan_path(shadow_df: pl.DataFrame) -> None:
         non_null = col.drop_nulls()
         assert cp.null_count == col.null_count()
         assert cp.unique_count == (non_null.n_unique() if len(non_null) > 0 else 0)
-        assert cp.inferred_type == str(col.dtype)
+        # Flip owned dtype contract: inferred_type is the NEUTRAL vocabulary
+        # (str/int/uint/float/date/datetime/bool/other), not raw ``str(pl.dtype)``.
+        assert cp.inferred_type == _neutral_dtype(col.dtype)

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -1,0 +1,153 @@
+"""Stage-0 Flip parity gate: ArrowColumn == PolarsColumn on the corpus.
+
+For every column of every corpus parquet, load it BOTH as a ``pl.DataFrame`` and
+a ``pyarrow.Table`` and assert ``ArrowColumn`` returns the SAME result as
+``PolarsColumn`` for every applicable method. ``PolarsColumn`` is the parity
+oracle. This MUST be green before the fused differential (Task 3) is meaningful.
+
+The only intentional divergence is ``dtype_repr`` (owned-contract neutral
+vocabulary vs raw ``str(pl.dtype)``) -- it is deliberately NOT asserted here and
+is measured by the differential instead.
+"""
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+from pathlib import Path
+
+import polars as pl
+import pyarrow.parquet as pq
+import pytest
+
+from goldencheck.core.frame import ArrowColumn, PolarsColumn
+
+CORPUS = Path(__file__).parent / "corpus"
+NUMERIC = {"int", "uint", "float"}
+
+
+def _ensure_corpus() -> list[Path]:
+    files = sorted(CORPUS.glob("*.parquet"))
+    if not files:
+        script = Path(__file__).parent.parent / "scripts" / "flip_corpus.py"
+        subprocess.run([sys.executable, str(script)], check=True)
+        files = sorted(CORPUS.glob("*.parquet"))
+    return files
+
+
+CORPUS_FILES = _ensure_corpus()
+
+
+def _sorted_str(values) -> list[str]:
+    return sorted("<NULL>" if v is None else str(v) for v in values)
+
+
+def _both_none_or_close(pv, av, *, rel=1e-9) -> None:
+    if pv is None or av is None:
+        assert pv is None and av is None, f"None mismatch: pl={pv!r} arrow={av!r}"
+        return
+    assert math.isclose(float(pv), float(av), rel_tol=rel, abs_tol=1e-12), (
+        f"float mismatch: pl={pv!r} arrow={av!r}"
+    )
+
+
+def _params():
+    out = []
+    for path in CORPUS_FILES:
+        df = pl.read_parquet(path)
+        for name in df.columns:
+            out.append((path.stem, name))
+    return out
+
+
+@pytest.mark.parametrize("dataset,column", _params())
+def test_arrow_matches_polars(dataset: str, column: str) -> None:
+    path = CORPUS / f"{dataset}.parquet"
+    df = pl.read_parquet(path)
+    tbl = pq.read_table(path)
+
+    pol = PolarsColumn(df[column])
+    arr = ArrowColumn(tbl.column(column))
+
+    # --- universal (every dtype) ---------------------------------------------
+    assert len(pol) == len(arr)
+    assert pol.null_count() == arr.null_count()
+    assert pol.n_unique() == arr.n_unique()
+    assert pol.dtype == arr.dtype, f"neutral dtype: pl={pol.dtype} arrow={arr.dtype}"
+    assert _sorted_str(pol.drop_nulls().to_list()) == _sorted_str(arr.drop_nulls().to_list())
+    assert pol.is_sorted() == arr.is_sorted(), "is_sorted diverged"
+    # min/max work for all dtypes (kernel for numeric, pyarrow for temporal/str/bool)
+    pmin, amin = pol.min(), arr.min()
+    if isinstance(pmin, (int, float)) and not isinstance(pmin, bool):
+        _both_none_or_close(pmin, amin)
+    else:
+        assert pmin == amin, f"min mismatch: pl={pmin!r} arrow={amin!r}"
+    pmax, amax = pol.max(), arr.max()
+    if isinstance(pmax, (int, float)) and not isinstance(pmax, bool):
+        _both_none_or_close(pmax, amax)
+    else:
+        assert pmax == amax, f"max mismatch: pl={pmax!r} arrow={amax!r}"
+
+    # --- numeric-only --------------------------------------------------------
+    if pol.dtype in NUMERIC:
+        _both_none_or_close(pol.mean(), arr.mean())
+        # std is a variance reduction: Polars and the Rust kernel use different
+        # summation, so they agree to ~7 sig-figs (looser than the mean epsilon),
+        # widened further on float32/uint32 source.
+        _both_none_or_close(pol.std(), arr.std(), rel=1e-6)
+        # sum: exact for int/uint, close for float
+        if pol.dtype in ("int", "uint"):
+            assert pol.sum() == arr.sum(), f"sum: pl={pol.sum()} arrow={arr.sum()}"
+        else:
+            # float sum accumulates: Polars sums in the source precision, the
+            # kernel in f64, so float32 columns diverge at ~1e-6 rel (stat epsilon).
+            _both_none_or_close(pol.sum(), arr.sum(), rel=1e-6)
+
+        # filter_outside using the population's own 3-sigma band
+        m, s = pol.mean(), pol.std()
+        if s is not None and s > 0:
+            lo, hi = m - 3 * s, m + 3 * s
+            p_out = _sorted_str(pol.filter_outside(lo, hi).to_list())
+            a_out = _sorted_str(arr.filter_outside(lo, hi).to_list())
+            assert len(p_out) == len(a_out), f"filter_outside count: {len(p_out)} vs {len(a_out)}"
+            # element-wise float-close on sorted values
+            for pv, av in zip(sorted(pol.filter_outside(lo, hi).to_list()),
+                              sorted(arr.filter_outside(lo, hi).to_list())):
+                _both_none_or_close(pv, av)
+
+        # count_gt(median)
+        med = df[column].median()
+        if med is not None:
+            assert pol.count_gt(med) == arr.count_gt(med), "count_gt diverged"
+
+        # diff().to_list()
+        p_diff = pol.diff().to_list()
+        a_diff = arr.diff().to_list()
+        assert len(p_diff) == len(a_diff)
+        for pv, av in zip(p_diff, a_diff):
+            _both_none_or_close(pv, av)
+
+        # cast('float') round-trips numeric
+        for pv, av in zip(pol.cast("float").to_list(), arr.cast("float").to_list()):
+            _both_none_or_close(pv, av)
+
+    # --- string cast('float', strict=False): unparseable -> null -------------
+    if pol.dtype == "str":
+        p_cast = pol.cast("float", strict=False).to_list()
+        a_cast = arr.cast("float", strict=False).to_list()
+        assert len(p_cast) == len(a_cast)
+        for pv, av in zip(p_cast, a_cast):
+            _both_none_or_close(pv, av)
+
+
+def test_dtype_repr_is_owned_divergence() -> None:
+    """dtype_repr is the ONE intentional divergence: ArrowColumn returns the
+    neutral category, PolarsColumn returns raw str(pl.dtype)."""
+    df = pl.read_parquet(CORPUS / "mixed_dtypes.parquet")
+    tbl = pq.read_table(CORPUS / "mixed_dtypes.parquet")
+    col = "i8"
+    pol = PolarsColumn(df[col])
+    arr = ArrowColumn(tbl.column(col))
+    assert pol.dtype_repr() == "Int8"          # raw polars vocabulary
+    assert arr.dtype_repr() == "int"           # owned neutral vocabulary
+    assert pol.dtype == arr.dtype == "int"     # ...but neutral dtype agrees

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -19,7 +19,6 @@ from pathlib import Path
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
-
 from goldencheck.core.frame import ArrowColumn, PolarsColumn
 
 CORPUS = Path(__file__).parent / "corpus"

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -16,10 +16,15 @@ import subprocess
 import sys
 from pathlib import Path
 
-import polars as pl
-import pyarrow.parquet as pq
 import pytest
-from goldencheck.core.frame import ArrowColumn, PolarsColumn
+
+# The parity oracle is PolarsColumn, and the corpus generator (scripts/flip_corpus.py,
+# run via subprocess) needs numpy + pyarrow. Skip cleanly rather than error in a
+# minimal-deps CI job where any of these is absent (e.g. numpy is not a base dep).
+pl = pytest.importorskip("polars")
+pytest.importorskip("numpy")  # corpus generator dependency
+pq = pytest.importorskip("pyarrow.parquet")
+from goldencheck.core.frame import ArrowColumn, PolarsColumn  # noqa: E402
 
 CORPUS = Path(__file__).parent / "corpus"
 NUMERIC = {"int", "uint", "float"}

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -139,6 +139,11 @@ def test_arrow_matches_polars(dataset: str, column: str) -> None:
         for pv, av in zip(p_cast, a_cast):
             _both_none_or_close(pv, av)
 
+        # str_len_chars(): per-value character count (nulls preserved) + its mean
+        # (the seam op the semantic classifier's avg_length signals rely on).
+        assert pol.str_len_chars().to_list() == arr.str_len_chars().to_list(), "str_len_chars diverged"
+        _both_none_or_close(pol.str_len_chars().mean(), arr.str_len_chars().mean())
+
 
 def test_dtype_repr_is_owned_divergence() -> None:
     """dtype_repr is the ONE intentional divergence: ArrowColumn returns the

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -23,6 +23,7 @@ import pytest
 # minimal-deps CI job where any of these is absent (e.g. numpy is not a base dep).
 pl = pytest.importorskip("polars")
 pytest.importorskip("numpy")  # corpus generator dependency
+pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
 from goldencheck.core.frame import ArrowColumn, PolarsColumn  # noqa: E402
 
@@ -33,8 +34,10 @@ NUMERIC = {"int", "uint", "float"}
 def _ensure_corpus() -> list[Path]:
     files = sorted(CORPUS.glob("*.parquet"))
     if not files:
-        script = Path(__file__).parent.parent / "scripts" / "flip_corpus.py"
-        subprocess.run([sys.executable, str(script)], check=True)
+        # scripts/ lives at the PACKAGE root: tests/flip/<this> -> parents[2].
+        # Pass the corpus dir explicitly so the generator writes where we read.
+        script = Path(__file__).parents[2] / "scripts" / "flip_corpus.py"
+        subprocess.run([sys.executable, str(script), str(CORPUS)], check=True)
         files = sorted(CORPUS.glob("*.parquet"))
     return files
 
@@ -94,18 +97,21 @@ def test_arrow_matches_polars(dataset: str, column: str) -> None:
 
     # --- numeric-only --------------------------------------------------------
     if pol.dtype in NUMERIC:
-        _both_none_or_close(pol.mean(), arr.mean())
-        # std is a variance reduction: Polars and the Rust kernel use different
-        # summation, so they agree to ~7 sig-figs (looser than the mean epsilon),
-        # widened further on float32/uint32 source.
-        _both_none_or_close(pol.std(), arr.std(), rel=1e-6)
+        # float32 accumulates in lower precision: Polars reduces in the source
+        # precision while pyarrow/the kernel promote to f64, so f32 columns diverge
+        # at ~1e-6 rel (a genuine stat epsilon that does NOT move findings -- the
+        # finding-set differential is 1.000 including f32). Widen the tolerance for
+        # f32 sources; f64 stays tight (a real bug would diverge far more).
+        is_f32 = pa.types.is_float32(tbl.column(column).type)
+        num_rel = 1e-5 if is_f32 else 1e-9
+        _both_none_or_close(pol.mean(), arr.mean(), rel=num_rel)
+        # std is a variance reduction (looser than mean), widened further on f32.
+        _both_none_or_close(pol.std(), arr.std(), rel=max(1e-6, num_rel))
         # sum: exact for int/uint, close for float
         if pol.dtype in ("int", "uint"):
             assert pol.sum() == arr.sum(), f"sum: pl={pol.sum()} arrow={arr.sum()}"
         else:
-            # float sum accumulates: Polars sums in the source precision, the
-            # kernel in f64, so float32 columns diverge at ~1e-6 rel (stat epsilon).
-            _both_none_or_close(pol.sum(), arr.sum(), rel=1e-6)
+            _both_none_or_close(pol.sum(), arr.sum(), rel=max(1e-6, num_rel))
 
         # filter_outside using the population's own 3-sigma band
         m, s = pol.mean(), pol.std()

--- a/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
+++ b/packages/python/goldencheck/tests/nopolars/test_polars_absent.py
@@ -1,17 +1,20 @@
-"""GoldenCheck Stage-2 S2.0: goldencheck works with **polars genuinely uninstalled**.
+"""GoldenCheck 3.0.0: the DEFAULT scan path runs with **polars genuinely uninstalled**.
 
-This module imports polars NOWHERE. It is the living proof for the Polars-eviction end
-state (P4, where `polars` moves to the `[polars]` extra). Every other polars-free test in
-the suite still touches polars somewhere, so none of them can run in a polars-absent
-interpreter; this one can.
+This module imports polars NOWHERE. It is the living proof for the 3.0.0 Flip end state:
+`scan_file`/`scan_dataframe` are Arrow-native (the fused Rust/Arrow seam), so the full
+default scan -- not just the covered-columns subset -- succeeds without polars. polars is
+only needed for the opt-in [baseline] stat/drift features and the scan_dataframe(pl.DataFrame)
+convenience overload.
 
 It is `skipif`'d OUT of the normal suite (where polars IS present), so it is inert there
 and only executes in the dedicated `goldencheck_nopolars` CI lane (and any local run where
 polars is absent).
 
-NOTE (S2.0): goldencheck has no non-Polars `Column`/`Frame` backend yet (that arrives with
-S2.1), so this lane asserts import-survival + a clean decline on the uncovered tail ONLY --
-NOT a covered scan. The covered-scan assertions land when S2.1 ships the backend.
+CONTRACT FLIP (3.0.0): pre-3.0 this lane asserted the full scan DECLINED (raised the
+`goldencheck[polars]` ImportError) polars-absent. It now asserts the full scan SUCCEEDS via
+the owned Arrow contract, emitting the neutral dtype vocabulary. The numeric/sequence/date/
+regex checks self-skip when the native kernel is also absent (same graceful-degradation
+pattern as the hard/temporal checks).
 """
 
 from __future__ import annotations
@@ -130,22 +133,47 @@ def test_read_columns_parquet_excel_polars_free(tmp_path) -> None:
     assert "polars" not in sys.modules
 
 
-def test_csv_reads_owned_and_full_scan_declines_without_polars(tmp_path) -> None:
-    # CSV now reads Polars-free via goldencheck's OWN inference contract (the native
-    # csv_infer kernel, or the Python reference fallback) -- so read_columns(csv) works
-    # WITHOUT Polars (deliberately differs from pl.read_csv; see engine/csv_infer.py).
-    # But scan_file()'s FULL scan (classification/sampling/denial) reads via
-    # read_file() -> pl.read_csv(), which still needs Polars and must decline with the
-    # helpful `goldencheck[polars]` ImportError rather than crash or silently degrade.
-    import pytest
+def test_csv_full_scan_succeeds_without_polars(tmp_path) -> None:
+    # 3.0.0 CONTRACT FLIP: scan_file() now runs the FULL default scan Arrow-native,
+    # so a CSV full scan SUCCEEDS polars-free (was: raised goldencheck[polars]).
     from goldencheck import read_columns
     from goldencheck.engine.scanner import scan_file
 
     csv = tmp_path / "c.csv"
-    csv.write_text("a\n1\n", encoding="utf-8")
-    # CSV reads via the owned path (int column), no ImportError, no Polars:
-    assert read_columns(csv) == {"a": [1]}
-    # scan_file() -> read_file() -> pl.read_csv() on the lazy proxy -> helpful ImportError:
-    with pytest.raises(ImportError, match=r"goldencheck\[polars\]"):
-        scan_file(csv)
+    csv.write_text("a,b\n1,x\n2,y\n3,x\n", encoding="utf-8")
+    # CSV reads via the owned inference path (int + str columns), no Polars:
+    assert read_columns(csv) == {"a": [1, 2, 3], "b": ["x", "y", "x"]}
+    # Full scan succeeds and emits the neutral dtype vocabulary:
+    findings, profile = scan_file(csv)
+    assert isinstance(findings, list)
+    types = {c.name: c.inferred_type for c in profile.columns}
+    assert types["a"] == "int"  # neutral vocab, not raw "Int64"
+    assert types["b"] == "str"
+    assert "polars" not in sys.modules
+
+
+def test_parquet_full_scan_succeeds_without_polars(tmp_path) -> None:
+    # Parquet full scan is Arrow-native end to end -- succeeds polars-free.
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    from goldencheck.engine.scanner import scan_file
+
+    pqp = tmp_path / "f.parquet"
+    pq.write_table(pa.table({"pk": list(range(50)), "grade": ["A", "B"] * 25}), pqp)
+    findings, profile = scan_file(pqp)
+    assert isinstance(findings, list)
+    checks = {f.check for f in findings}
+    assert "uniqueness" in checks  # pk unique
+    assert {c.name: c.inferred_type for c in profile.columns}["pk"] == "int"
+    assert "polars" not in sys.modules
+
+
+def test_scan_dataframe_accepts_arrow_table_without_polars() -> None:
+    # 3.0.0 scan_dataframe accepts a pyarrow.Table natively (no pl.DataFrame needed).
+    import pyarrow as pa
+    from goldencheck.engine.scanner import scan_dataframe
+
+    tbl = pa.table({"id": list(range(30)), "val": [1.0, 2.0, 3.0] * 10})
+    findings, _profile = scan_dataframe(tbl)
+    assert isinstance(findings, list)
     assert "polars" not in sys.modules

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -167,7 +167,7 @@ agent = [
     "aiohttp>=3.14.0",
 ]
 quality = [
-    "goldencheck[polars]>=2.0.0",  # cell_quality uses goldencheck's Polars path; [polars] since 2.0.0 made Polars optional
+    "goldencheck[polars]>=3.0.0",  # cell_quality / functional_dependencies / scan_dataframe take a pl.DataFrame -> goldencheck's [polars] path; NOT [baseline] (no scipy stat/drift features used)
 ]
 transform = [
     "goldenflow>=1.0.0",


### PR DESCRIPTION
## goldencheck 3.0.0 -- the Flip (owned-contract cutover)

The default scan path is now **Arrow-native and Polars-free**. The Rust/Arrow fused kernels (built shadow-only through waves W0-W6) become authoritative; the owned deterministic sample + neutral dtype vocabulary are the emitted contract; Polars leaves the default surface.

Per the program design's **§8b Flip gate**, this cutover is gated on a *measured* finding-set differential, not an assertion of zero delta. That measurement is in this PR and is green.

### §8b differential (the gate) -- PASS
9-dataset synthetic corpus (one > the 100k sample cap), default-scan profilers run over `PolarsFrame` (authoritative 2.x) vs `ArrowFrame` (owned fused):

| metric | result |
|---|---|
| strict Jaccard (non-stat/non-dtype findings) | **1.000** every dataset |
| full Jaccard (incl. sample_values) | **1.000** every dataset |
| max stat-float delta | **0.000e+00** |
| strict-set divergences (kernel bugs) | **0** |
| dtype-vocab diffs (expected owned vocabulary) | 27 |

Report: `packages/python/goldencheck/docs/superpowers/specs/flip-differential-report.md`. Harness: `scripts/flip_differential.py --fused` + `scripts/flip_corpus.py`. Arrow-column parity: `tests/flip/test_arrow_column_parity.py` (28 tests, ArrowColumn == PolarsColumn).

### What changes (BREAKING, 3.0.0)
- **`scan_file`/`scan_dataframe`/CLI `check` run without Polars.** The scan frame is a `pyarrow.Table`; the column loop routes through the Arrow seam (`core/frame.py` `ArrowColumn`/`ArrowFrame`), kernel-authoritative. Population B shadow blocks removed.
- **`pyarrow` is now a base dependency; Polars is not.** Polars moved to the `[baseline]` extra (its opt-in scipy stat/drift/correlation subsystems still use Polars group_by/pivot) and the `[polars]` extra (the `scan_dataframe(pl.DataFrame)` convenience overload). Scope decision: baseline/drift/correlation are gated on `[baseline]` rather than ported.
- **`inferred_type` emits the neutral dtype vocabulary** (`str`/`int`/`uint`/`float`/`date`/`datetime`/`bool`/`other`) instead of raw Polars dtype strings.
- **Owned deterministic sample** replaces the `df.sample(seed=42)` Polars PRNG (stable across runs + workers).
- **nopolars CI lane inverted**: the full scan now *succeeds* Polars-absent (was: declined). Verified with Polars genuinely import-blocked -- 9/9 green including CSV/parquet full scan + `scan_dataframe(pyarrow.Table)`.
- `age_validation` + `approx_duplicate` compute via their W3 kernels; 3 relation profilers rerouted off `frame.native`.

### Verification
- Core suite (engine/profilers/relations/core/semantic) + flip tests: **895 passed**, ruff clean.
- `import goldencheck` and `scan_file` (parquet + CSV) confirmed Polars-free in a fresh interpreter.
- Docs swept (README, CHANGELOG 3.0.0, docs-site, `engine/CLAUDE.md` seed=42 note, golden-suite floor under `[Unreleased]`, `goldenmatch[quality]` pin -> `goldencheck[polars]>=3.0.0`).

### Not in scope / follow-on
- No baseline/drift/correlation Polars port (gated on `[baseline]`). No DataFusion. Surfaces (WASM+SQL) remain a separate program phase.
- **golden-suite is NOT cut here** -- its floor is staged under `[Unreleased]`; the lockstep suite release follows once goldencheck 3.0.0 is on PyPI.

Supersedes #1692 (Stage 0 folded in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)