### PR TITLE
docs(goldenmatch): v3.0.0 sweep -- Arrow-native results + arrow default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ pip install golden-suite    # the WHOLE suite (Check + Flow + Match + Analysis +
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
+> **v3.0.0** — **v3.0.0 — Arrow-native results.** Result frames are now `pyarrow.Table`
+(migrate with `pl.from_arrow(result.golden)`); inputs are unchanged. The
+Arrow frame backend is the default — measured ~36% faster end-to-end on the
+100K zero-config benchmark — with `GOLDENMATCH_FRAME=polars` as the opt-out.
+>
 > **v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
 >
 > **v2.3.0 — Auto-enabled semantic blocking, now default-on** — text-heavy data automatically routes to SimHash-over-embeddings blocking when an embedder is reachable (a byte-identical no-op otherwise). Plus pluggable pgvector / DuckDB-HNSW vector-index backends and opt-in Fellegi-Sunter routing for no-strong-identifier datasets (`GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC=1`).
->
-> **v2.2.0 — Semantic blocking** — an opt-in recall lever for abbreviations and aliases. `dedupe_df(semantic_blocking=...)` unions extra candidate sources (initialism/abbreviation blocking, a business-alias canonical-form table, and an embedding ANN pass) into the pipeline. Off by default; on the abbreviation-heavy benchmark it adds **+5.3pp recall at zero precision cost**.
 <!-- README-callouts:end -->
 
 ---

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -48,6 +48,7 @@
                   "goldenmatch/installation",
                   "goldenmatch/cli",
                   "goldenmatch/tui",
+                  "goldenmatch/migrating-to-v3",
                   "goldenmatch/migrating-to-v2",
                   "goldenmatch/v1-to-v2",
                   "goldenmatch/v1-vs-v2"

--- a/docs-site/goldenmatch/api-quick-reference.mdx
+++ b/docs-site/goldenmatch/api-quick-reference.mdx
@@ -43,9 +43,9 @@ result = goldenmatch.dedupe_df(
 ## `DedupeResult` fields
 
 ```python
-result.golden          # pl.DataFrame | None - canonical records with __cluster_id__
-result.dupes           # pl.DataFrame | None - duplicate records with __row_id__
-result.unique          # pl.DataFrame | None - non-duplicate records
+result.golden          # pa.Table | None - canonical records with __cluster_id__ (v3: pl.from_arrow(...) for a Polars frame)
+result.dupes           # pa.Table | None - duplicate records with __row_id__
+result.unique          # pa.Table | None - non-duplicate records
 result.clusters        # dict[int, dict] - {cluster_id: {"members": [row_ids], "pair_scores": {(a,b): score}}}
 result.scored_pairs    # list[tuple[int, int, float]] - all matched pairs
 result.stats           # dict - total_records, total_clusters, matched_records, match_rate

--- a/docs-site/goldenmatch/migrating-to-v3.mdx
+++ b/docs-site/goldenmatch/migrating-to-v3.mdx
@@ -1,0 +1,68 @@
+---
+title: "Migrating to v3"
+description: "GoldenMatch 3.0.0: Arrow-native results and the Arrow frame backend by default"
+---
+
+GoldenMatch 3.0.0 completes the public half of the Polars-eviction program:
+results are Arrow-native, and the Arrow frame backend is the default engine
+lane. Inputs are unchanged.
+
+## The one breaking change: result frames are `pyarrow.Table`
+
+`DedupeResult.golden`, `.dupes`, `.unique` and `MatchResult.matched`,
+`.unmatched` now return `pyarrow.Table` (they were `polars.DataFrame`).
+
+If you consumed those frames with Polars, migration is one line:
+
+```python
+import polars as pl
+
+result = gm.dedupe_df(df)
+golden = pl.from_arrow(result.golden)   # zero-copy back to a Polars frame
+```
+
+Common direct translations if you'd rather stay on Arrow:
+
+| v2 (`pl.DataFrame`)         | v3 (`pa.Table`)                     |
+| --------------------------- | ----------------------------------- |
+| `frame.height`              | `table.num_rows`                    |
+| `frame.columns`             | `table.column_names`                |
+| `frame.to_dicts()`          | `table.to_pylist()`                 |
+| `frame["col"].to_list()`    | `table["col"].to_pylist()`          |
+| `frame.write_csv(path)`     | `result.to_csv(path)` (works on both) |
+
+Everything else on the result objects is unchanged: `result.clusters`,
+`result.stats`, `result.scored_pairs`, `to_csv`, the notebook display, and
+`__repr__` all behave as before.
+
+## Inputs are NOT affected
+
+`dedupe_df` / `match_df` accept Polars, pandas, and Arrow inputs exactly as in
+v2 (Arrow C stream polymorphism). Your ingestion code does not change.
+
+## The Arrow backend is now the default
+
+`GOLDENMATCH_FRAME` defaults to `arrow` — the measured-faster lane (~36%
+faster end-to-end on the 100K zero-config A/B benchmark). Behavior is
+output-equivalent to the Polars lane, enforced by a differential harness with
+frozen fixtures.
+
+If you need the old lane while validating the upgrade:
+
+```bash
+export GOLDENMATCH_FRAME=polars   # opt-out escape hatch
+```
+
+The `polars` backend (and the `polars` runtime dependency) will be removed in
+a 3.x minor once the remaining engine internals complete their Arrow descent —
+pin `GOLDENMATCH_FRAME=polars` only as a transition aid, not a long-term
+configuration.
+
+## Notes for specific surfaces
+
+- **MCP / A2A**: tool responses were already JSON — no change.
+- **dbt (`dbt-goldensuite`)**: unaffected in 3.0.0 (it consumes the internal
+  pipeline result, still Polars-backed until the engine descent completes).
+- **One behavioral nuance**: sampling-based auto-config decisions are
+  deterministic per backend but may legitimately differ between the `arrow`
+  and `polars` lanes (documented statistical contract of `Frame.sample`).

--- a/docs-site/goldenmatch/python-api.mdx
+++ b/docs-site/goldenmatch/python-api.mdx
@@ -83,7 +83,7 @@ Match a target file against a reference file.
 
 ```python
 result = gm.match("new.csv", "master.csv", fuzzy={"name": 0.85})
-result.matched.write_csv("matches.csv")
+result.to_csv("matches.csv")  # v3: result frames are pa.Table; to_csv works on both
 ```
 
 ### match_df

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -507,7 +507,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 |----------|---------|--------|--------|
 | `GOLDENMATCH_NATIVE` | `auto` | `auto` / `1` / `0` | Native kernel gate. `1` requires native (raises if missing); `0` forces Python. |
 | `GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE` | off | `1` | Polars-native address-normalize fast path. |
-| `GOLDENMATCH_FRAME` | `polars` | `polars`/`arrow` | Frame backend. `arrow` is EXPERIMENTAL, part of the Polars-eviction program: file ingest via pyarrow, and the fused match entry (`run_match_fused_arrow`) derives its block-key/score columns polars-free. Output-equivalence enforced by a differential harness + frozen fixtures. |
+| `GOLDENMATCH_FRAME` | `arrow` | `arrow`/`polars` | Frame backend. `arrow` is the DEFAULT since v3.0.0 (measured ~36% faster end-to-end on the 100K zero-config A/B): file ingest via pyarrow, the ingest-front and expression stages run eagerly on the Frame seam, and result frames are `pyarrow.Table`. `polars` is the opt-out escape hatch until it is removed in a 3.x minor. Output-equivalence enforced by a differential harness + frozen fixtures. |
 | `GOLDENMATCH_AUTOCONFIG_MEMORY` | `1` | `0`/`1` | Cross-run auto-config memory. `0` for reproducible/CI runs. |
 | `GOLDENMATCH_PLANNING_EFFORT` | `normal` | `fast`/`normal`/`thinking`/`einstein` | Auto-config iteration budget. |
 | `GOLDENMATCH_DISTRIBUTED_PIPELINE` | unset | `1`/`2` | Distributed execution phase. `2` = real streaming (needs `__row_id__`, writes to `output_path`). |

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [3.0.0] - 2026-07-12
 
+<!-- README-callout
+**v3.0.0 — Arrow-native results.** Result frames are now `pyarrow.Table`
+(migrate with `pl.from_arrow(result.golden)`); inputs are unchanged. The
+Arrow frame backend is the default — measured ~36% faster end-to-end on the
+100K zero-config benchmark — with `GOLDENMATCH_FRAME=polars` as the opt-out.
+-->
+
 ### Changed
 - **BREAKING: result frames are now `pyarrow.Table`.** `DedupeResult.golden` /
   `.dupes` / `.unique` and `MatchResult.matched` / `.unmatched` return

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -57,11 +57,14 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
+> **v3.0.0** — **v3.0.0 — Arrow-native results.** Result frames are now `pyarrow.Table`
+(migrate with `pl.from_arrow(result.golden)`); inputs are unchanged. The
+Arrow frame backend is the default — measured ~36% faster end-to-end on the
+100K zero-config benchmark — with `GOLDENMATCH_FRAME=polars` as the opt-out.
+>
 > **v2.4.0 — The healing loop, now default-on across every surface** — every `dedupe_df` run surfaces ranked, self-verified config-suggestions on `result.suggestions` when there's headroom (free on a healthy run, no second pipeline pass). `dedupe_df(suggest=True)` returns verified suggestions; `heal=True` applies them and re-runs, returning the healed `result.config` + `result.heal_trail`. Available across Python, CLI (`--suggest` / `--heal`), MCP, A2A, REST, web, the TUI, and the edge-safe TypeScript port via WebAssembly. Needs `goldenmatch[native]`; degrades gracefully without it. Kill-switch `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`.
 >
 > **v2.3.0 — Auto-enabled semantic blocking, now default-on** — text-heavy data automatically routes to SimHash-over-embeddings blocking when an embedder is reachable (a byte-identical no-op otherwise). Plus pluggable pgvector / DuckDB-HNSW vector-index backends and opt-in Fellegi-Sunter routing for no-strong-identifier datasets (`GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC=1`).
->
-> **v2.2.0 — Semantic blocking** — an opt-in recall lever for abbreviations and aliases. `dedupe_df(semantic_blocking=...)` unions extra candidate sources (initialism/abbreviation blocking, a business-alias canonical-form table, and an embedding ANN pass) into the pipeline. Off by default; on the abbreviation-heavy benchmark it adds **+5.3pp recall at zero precision cost**.
 <!-- README-callouts:end -->
 
 ---


### PR DESCRIPTION
rollout-docs-sweep for the shipped v3.0.0 surface (#1693 results->pa.Table, #1695 arrow default).

- tuning.mdx GOLDENMATCH_FRAME row (default=arrow, measured ~36% faster, polars opt-out until a 3.x minor)
- api-quick-reference + python-api result-type docs with the pl.from_arrow migration note
- NEW migrating-to-v3.mdx + nav entry (docs.json validated)
- CHANGELOG 3.0.0 README-callout + regenerated README blocks (--check green)

version_consistency OK locally; the docs_consistency orphan check false-positives on Windows path separators (flags every existing page) -- green on Linux CI.