### PR TITLE
chore(golden-suite): 0.2.0 -- goldenmatch floor >=3.0

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.0] - 2026-07-12
+
+### Changed
+- **goldenmatch floor raised to `>=3.0`** -- goldenmatch 3.0.0 returns
+  Arrow-native results (`pyarrow.Table`; migrate with
+  `pl.from_arrow(result.golden)`) and defaults to the Arrow frame backend
+  (~36% faster on the 100K zero-config benchmark;
+  `GOLDENMATCH_FRAME=polars` is the opt-out). See goldenmatch's
+  migrating-to-v3 guide.
+
 ## [0.1.10] - 2026-07-11
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.1.10"
+__version__ = "0.2.0"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.1.10"
+version = "0.2.0"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch>=2.8",                 # entity resolution: dedupe, match, golden records (>=2.8 mandates the B1 silent-corruption + healer fixes)
+    "goldenmatch>=3.0",                 # entity resolution: dedupe, match, golden records (>=3.0: Arrow-native results -- pa.Table -- + arrow default backend)
     "goldencheck[polars]>=2.0.0",       # data validation (>=2.0.0 = Polars-optional flip; [polars] since CSV + full scan need it)
     "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
Lockstep follow-up to the goldenmatch 3.0.0 release (live on PyPI). Floor raised to >=3.0 with the Arrow-native-results note; golden-suite 0.1.10 -> 0.2.0 across pyproject/__init__/CHANGELOG (version gate green locally). golden-suite release tag follows this merge.