### PR TITLE
fix: W5e-1 arrow-default fallout -- adapt golden-artifact consumers (unblocks merge queue)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -154,7 +154,9 @@ def _frame_write_csv(obj: Any, path: Any) -> None:
     if hasattr(obj, "num_rows"):  # pa.Table
         from pyarrow import csv as _pacsv
 
-        _pacsv.write_csv(obj, str(path))
+        # pyarrow.csv re-exports write_csv at runtime but doesn't list it in
+        # __all__, so pyright flags reportPrivateImportUsage on the attribute.
+        _pacsv.write_csv(obj, str(path))  # pyright: ignore[reportPrivateImportUsage]
         return
     obj.write_csv(path)
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -886,7 +886,11 @@ def run_dedupe(
                     _combined = _combined.with_column(
                         f"__mk_{mk.name}__",
                         _combined.derive_matchkey(
-                            [(f.field, list(f.transforms or [])) for f in mk.fields]
+                            [
+                                (f.field, list(f.transforms or []))
+                                for f in mk.fields
+                                if f.field is not None
+                            ]
                         ),
                     )
                 done.add("compute_matchkeys")

--- a/packages/python/goldenmatch/goldenmatch/db/sync.py
+++ b/packages/python/goldenmatch/goldenmatch/db/sync.py
@@ -371,7 +371,10 @@ def _full_scan_pipeline(
     logger.info("Pipeline: dispatching to dedupe_df (routes through v3 planner)...")
     result = dedupe_df(df, config=config, confidence_required=False)
     clusters = result.clusters
-    golden_df = result.golden
+    # v3.0.0: result.golden is a pa.Table. The DB write-back path
+    # (write_golden_records / writer.py) uses polars semantics (.filter,
+    # pl.col, column indexing), so materialize back to polars at this seam.
+    golden_df = pl.from_arrow(result.golden) if result.golden is not None else None
     all_pairs = list(result.scored_pairs)
     logger.info(
         "Pipeline: dedupe_df returned %d scored pairs, %d clusters",

--- a/packages/python/goldenpipe/goldenpipe/cli/main.py
+++ b/packages/python/goldenpipe/goldenpipe/cli/main.py
@@ -89,7 +89,14 @@ def run(
                 console.print(f"  {k}: {v:.2f}s")
 
     if output and result.artifacts.get("golden") is not None:
-        result.artifacts["golden"].write_csv(output)
+        golden = result.artifacts["golden"]
+        # v3.0.0: the golden artifact is a pa.Table (no write_csv); route through
+        # pyarrow.csv. The polars branch stays for GOLDENMATCH_FRAME=polars.
+        if hasattr(golden, "num_rows"):  # pa.Table
+            from pyarrow import csv as _pacsv
+            _pacsv.write_csv(golden, str(output))
+        else:
+            golden.write_csv(output)
         console.print(f"\nGolden records written to {output}")
 
 

--- a/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
+++ b/packages/python/goldenpipe/goldenpipe/compiler/e2e.py
@@ -44,6 +44,11 @@ def surface_golden_provenance(result, clusters):
         dupes = getattr(result, "dupes", None)
         if dupes is None or not clusters or rules is None:
             return None
+        # v3.0.0: result.dupes is a pa.Table; golden_provenance_for_run joins it
+        # with pl.DataFrame, so materialize back to polars at this seam.
+        if hasattr(dupes, "num_rows"):  # pa.Table
+            import polars as pl
+            dupes = pl.from_arrow(dupes)
         return golden_provenance_for_run(dupes, clusters, rules)
     except Exception:
         return None

--- a/packages/python/goldenpipe/goldenpipe/mcp/server.py
+++ b/packages/python/goldenpipe/goldenpipe/mcp/server.py
@@ -99,28 +99,44 @@ def run_pipeline_tool(
 
 
 def _is_frame(obj: Any) -> bool:
-    """A Polars-DataFrame-shaped artifact (duck-typed to avoid a hard import)."""
-    return obj is not None and hasattr(obj, "height") and hasattr(obj, "to_dicts")
+    """A DataFrame-shaped artifact (duck-typed to avoid a hard import).
+
+    Accepts BOTH a ``pa.Table`` (``num_rows``; the v3.0.0 goldenmatch result
+    frame) and a ``pl.DataFrame`` (``height`` + ``to_dicts``; the escape hatch
+    and the unit-test fixtures)."""
+    if obj is None:
+        return False
+    return hasattr(obj, "num_rows") or (hasattr(obj, "height") and hasattr(obj, "to_dicts"))
+
+
+def _frame_rows(obj: Any) -> int:
+    return obj.num_rows if hasattr(obj, "num_rows") else obj.height
+
+
+def _frame_head_dicts(obj: Any, n: int) -> list[dict]:
+    if hasattr(obj, "num_rows"):  # pa.Table
+        return obj.slice(0, n).to_pylist()
+    return obj.head(n).to_dicts()
 
 
 def _summarize_output(artifacts: dict, preview_rows: int) -> dict[str, Any]:
     """Pull the deduped output out of the pipeline artifacts, JSON-safe.
 
     The dedupe stage casts every column to string before matching, so
-    ``to_dicts()`` on golden/unique frames is JSON-serializable.
+    ``to_pylist()``/``to_dicts()`` on golden/unique frames is JSON-serializable.
     """
     out: dict[str, Any] = {}
     golden = artifacts.get("golden")
     if _is_frame(golden):
-        out["golden_records"] = golden.height
+        out["golden_records"] = _frame_rows(golden)
         if preview_rows:
-            out["golden_preview"] = golden.head(preview_rows).to_dicts()
+            out["golden_preview"] = _frame_head_dicts(golden, preview_rows)
     unique = artifacts.get("unique")
     if _is_frame(unique):
-        out["unique_records"] = unique.height
+        out["unique_records"] = _frame_rows(unique)
     dupes = artifacts.get("dupes")
     if _is_frame(dupes):
-        out["duplicate_records"] = dupes.height
+        out["duplicate_records"] = _frame_rows(dupes)
     stats = artifacts.get("match_stats")
     if isinstance(stats, dict):
         out["match_stats"] = stats

--- a/packages/python/goldenpipe/tests/compiler/test_equivalence.py
+++ b/packages/python/goldenpipe/tests/compiler/test_equivalence.py
@@ -115,8 +115,8 @@ def _norm_value(key: str, value):
         d = value.to_dict()
         d["created_at"] = _FROZEN_TS  # freeze the only wall-clock field
         return d
-    if key == "golden":  # polars frame -> list of row dicts
-        return value.to_dicts()
+    if key == "golden":  # v3.0.0: pa.Table result frame -> list of row dicts
+        return value.to_pylist() if hasattr(value, "num_rows") else value.to_dicts()
     if key == "match_stats":
         return _strip_timing(dict(value))
     if key == "findings":

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -493,6 +493,13 @@ pub fn match_pairs(
         if matched.is_none() {
             return Ok(vec![]);
         }
+        // v3.0.0: `MatchResult.matched` is a pyarrow Table (indexing yields a
+        // ChunkedArray, which has no `to_list`). Convert to polars at the seam so
+        // the column-extract below (`[col].to_list()`) keeps working unchanged.
+        let matched = {
+            let pl = matched.py().import("polars")?;
+            pl.call_method1("from_arrow", (&matched,))?
+        };
 
         // Pull the three linkage columns off the matched Polars DataFrame as
         // Python lists (matched[col].to_list()). The id columns are Int64; the
@@ -816,8 +823,7 @@ pub fn identity_conflicts(dataset: &str, db_path: &str) -> Result<String, Bridge
         } else {
             conflicts_kwargs.set_item("dataset", dataset)?;
         }
-        let edges =
-            find_conflicts.call((store.clone(),), Some(&conflicts_kwargs))?;
+        let edges = find_conflicts.call((store.clone(),), Some(&conflicts_kwargs))?;
         let _ = store.call_method0("close");
         let json_mod = py.import("json")?;
         let dumps_kwargs = PyDict::new(py);
@@ -831,11 +837,7 @@ pub fn identity_conflicts(dataset: &str, db_path: &str) -> Result<String, Bridge
 
 /// List identities filtered by dataset/status as a JSON array.
 /// Empty strings = no filter on that dimension.
-pub fn identity_list(
-    dataset: &str,
-    status: &str,
-    db_path: &str,
-) -> Result<String, BridgeError> {
+pub fn identity_list(dataset: &str, status: &str, db_path: &str) -> Result<String, BridgeError> {
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
@@ -916,7 +918,10 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
             "dataset is required and must be non-empty".into(),
         ));
     }
-    if !matches!(args.decision, "approve" | "reject" | "field_correct" | "cluster_decision") {
+    if !matches!(
+        args.decision,
+        "approve" | "reject" | "field_correct" | "cluster_decision"
+    ) {
         return Err(BridgeError::Validation(format!(
             "invalid decision {:?}; expected approve, reject, field_correct, or cluster_decision",
             args.decision,
@@ -944,8 +949,10 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
 
         // Build Correction kwargs based on shape.
         let kwargs = PyDict::new(py);
-        let new_id: String = uuid_mod.call_method0("uuid4")?
-            .call_method0("__str__")?.extract()?;
+        let new_id: String = uuid_mod
+            .call_method0("uuid4")?
+            .call_method0("__str__")?
+            .extract()?;
         kwargs.set_item("id", &new_id)?;
         kwargs.set_item("source", source)?;
         kwargs.set_item("trust", trust)?;
@@ -954,27 +961,26 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
         kwargs.set_item("dataset", args.dataset)?;
         kwargs.set_item("reason", args.reason)?;
         kwargs.set_item("matchkey_name", args.matchkey_name)?;
-        kwargs.set_item("created_at", datetime_mod.call_method0("datetime")?
-            .getattr("now")?.call0()?)?;
+        kwargs.set_item(
+            "created_at",
+            datetime_mod
+                .call_method0("datetime")?
+                .getattr("now")?
+                .call0()?,
+        )?;
         kwargs.set_item("decision", args.decision)?;
 
         match args.decision {
             "field_correct" => {
                 let field_name = args.field_name.ok_or_else(|| {
-                    BridgeError::Validation(
-                        "field_correct requires field_name".into(),
-                    )
+                    BridgeError::Validation("field_correct requires field_name".into())
                 })?;
                 let corrected_value = args.corrected_value.ok_or_else(|| {
-                    BridgeError::Validation(
-                        "field_correct requires corrected_value".into(),
-                    )
+                    BridgeError::Validation("field_correct requires corrected_value".into())
                 })?;
-                let cluster_id = args.cluster_id
-                    .or(args.id_a)
-                    .ok_or_else(|| BridgeError::Validation(
-                        "field_correct requires cluster_id".into(),
-                    ))?;
+                let cluster_id = args.cluster_id.or(args.id_a).ok_or_else(|| {
+                    BridgeError::Validation("field_correct requires cluster_id".into())
+                })?;
                 kwargs.set_item("id_a", cluster_id)?;
                 kwargs.set_item("id_b", 0i64)?;
                 kwargs.set_item("original_score", 0.0f64)?;
@@ -984,30 +990,26 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
             }
             "cluster_decision" => {
                 let score = args.cluster_score.ok_or_else(|| {
-                    BridgeError::Validation(
-                        "cluster_decision requires cluster_score".into(),
-                    )
+                    BridgeError::Validation("cluster_decision requires cluster_score".into())
                 })?;
                 let outcome = args.cluster_outcome.ok_or_else(|| {
-                    BridgeError::Validation(
-                        "cluster_decision requires cluster_outcome".into(),
-                    )
+                    BridgeError::Validation("cluster_decision requires cluster_outcome".into())
                 })?;
                 if !matches!(outcome, "approve" | "reject") {
                     return Err(BridgeError::Validation(format!(
-                        "cluster_outcome must be approve or reject; got {:?}", outcome,
+                        "cluster_outcome must be approve or reject; got {:?}",
+                        outcome,
                     )));
                 }
                 if !(0.0..=1.0).contains(&score) {
                     return Err(BridgeError::Validation(format!(
-                        "cluster_score must be in [0, 1]; got {}", score,
+                        "cluster_score must be in [0, 1]; got {}",
+                        score,
                     )));
                 }
-                let cluster_id = args.cluster_id
-                    .or(args.id_a)
-                    .ok_or_else(|| BridgeError::Validation(
-                        "cluster_decision requires cluster_id".into(),
-                    ))?;
+                let cluster_id = args.cluster_id.or(args.id_a).ok_or_else(|| {
+                    BridgeError::Validation("cluster_decision requires cluster_id".into())
+                })?;
                 kwargs.set_item("id_a", cluster_id)?;
                 kwargs.set_item("id_b", 0i64)?;
                 kwargs.set_item("original_score", 0.0f64)?;
@@ -1015,12 +1017,12 @@ pub fn correction_add(args: CorrectionAddArgs<'_>) -> Result<String, BridgeError
                 kwargs.set_item("cluster_outcome", outcome)?;
             }
             "approve" | "reject" => {
-                let id_a = args.id_a.ok_or_else(|| BridgeError::Validation(
-                    format!("{} requires id_a", args.decision),
-                ))?;
-                let id_b = args.id_b.ok_or_else(|| BridgeError::Validation(
-                    format!("{} requires id_b", args.decision),
-                ))?;
+                let id_a = args.id_a.ok_or_else(|| {
+                    BridgeError::Validation(format!("{} requires id_a", args.decision))
+                })?;
+                let id_b = args.id_b.ok_or_else(|| {
+                    BridgeError::Validation(format!("{} requires id_b", args.decision))
+                })?;
                 kwargs.set_item("id_a", id_a)?;
                 kwargs.set_item("id_b", id_b)?;
                 kwargs.set_item("original_score", args.original_score.unwrap_or(0.0))?;
@@ -1582,7 +1584,10 @@ pub fn preflight(rows_json: &str, config_json: &str) -> Result<String, BridgeErr
             }
             let result = PyDict::new(py);
             result.set_item("has_errors", report.getattr("has_errors")?)?;
-            result.set_item("config_was_modified", report.getattr("config_was_modified")?)?;
+            result.set_item(
+                "config_was_modified",
+                report.getattr("config_was_modified")?,
+            )?;
             result.set_item("findings", findings)?;
             py_json_dumps(py, result.into_any())
         })();
@@ -1614,8 +1619,7 @@ pub fn postflight(rows_json: &str, config_json: &str) -> Result<String, BridgeEr
 
             let post_kwargs = PyDict::new(py);
             post_kwargs.set_item("pair_scores", scored_pairs)?;
-            let report =
-                verify.call_method("postflight", (df, config), Some(&post_kwargs))?;
+            let report = verify.call_method("postflight", (df, config), Some(&post_kwargs))?;
 
             let adjustments = pyo3::types::PyList::empty(py);
             for a in report.getattr("adjustments")?.try_iter()? {
@@ -1805,7 +1809,10 @@ pub fn goldenflow_transform(transform_name: &str, value: &str) -> Result<String,
                 // NULL out via this path; preserve the input to be safe.)
                 return Ok(None);
             }
-            let s: String = py.import("builtins")?.call_method1("str", (result,))?.extract()?;
+            let s: String = py
+                .import("builtins")?
+                .call_method1("str", (result,))?
+                .extract()?;
             Ok(Some(s))
         })()
         .unwrap_or(None);
@@ -1972,9 +1979,8 @@ mod tests {
                 let cfg_v: serde_json::Value =
                     serde_json::from_str(&result.config_json).expect("config_json not valid JSON");
                 assert!(cfg_v.is_object(), "config_json not an object");
-                let tel_v: serde_json::Value =
-                    serde_json::from_str(&result.telemetry_json)
-                        .expect("telemetry_json not valid JSON");
+                let tel_v: serde_json::Value = serde_json::from_str(&result.telemetry_json)
+                    .expect("telemetry_json not valid JSON");
                 assert!(tel_v.is_object(), "telemetry_json not an object");
             }
             Err(e) => require_or_skip(e, "autoconfig_returns_config_and_telemetry"),
@@ -2099,7 +2105,11 @@ mod tests {
                 // Scores must be finite and in [0, 1].
                 for p in &pairs {
                     assert!(p.score.is_finite(), "non-finite score: {}", p.score);
-                    assert!((0.0..=1.0).contains(&p.score), "score out of range: {}", p.score);
+                    assert!(
+                        (0.0..=1.0).contains(&p.score),
+                        "score out of range: {}",
+                        p.score
+                    );
                 }
             }
             Err(e) => require_or_skip(e, "dedupe_pairs"),
@@ -2135,8 +2145,7 @@ mod tests {
 
     #[test]
     fn test_identity_resolve_not_found() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-id-resolve-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-id-resolve-{}", std::process::id()));
         let db_path = dir.join("identity.db").to_string_lossy().into_owned();
         match identity_resolve("nosource:999", &db_path) {
             Ok(json) => {
@@ -2154,8 +2163,7 @@ mod tests {
 
     #[test]
     fn test_identity_view_not_found() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-id-view-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-id-view-{}", std::process::id()));
         let db_path = dir.join("identity.db").to_string_lossy().into_owned();
         match identity_view("nonexistent-entity-id", &db_path) {
             Ok(json) => {
@@ -2172,8 +2180,7 @@ mod tests {
 
     #[test]
     fn test_identity_history_not_found() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-id-hist-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-id-hist-{}", std::process::id()));
         let db_path = dir.join("identity.db").to_string_lossy().into_owned();
         match identity_history("nonexistent-entity-id", &db_path) {
             Ok(json) => {
@@ -2191,8 +2198,7 @@ mod tests {
 
     #[test]
     fn test_identity_conflicts_empty_db() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-id-conflicts-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-id-conflicts-{}", std::process::id()));
         let db_path = dir.join("identity.db").to_string_lossy().into_owned();
         match identity_conflicts("", &db_path) {
             Ok(json) => {
@@ -2209,8 +2215,7 @@ mod tests {
 
     #[test]
     fn test_identity_list_empty_db() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-id-list-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-id-list-{}", std::process::id()));
         let db_path = dir.join("identity.db").to_string_lossy().into_owned();
         match identity_list("", "", &db_path) {
             Ok(json) => {
@@ -2260,7 +2265,11 @@ mod tests {
         match correction_add(args) {
             Ok(_) => panic!("expected validation error for bad decision"),
             Err(BridgeError::Validation(msg)) => {
-                assert!(msg.contains("decision") || msg.contains("invalid"), "msg: {}", msg);
+                assert!(
+                    msg.contains("decision") || msg.contains("invalid"),
+                    "msg: {}",
+                    msg
+                );
             }
             Err(e) => eprintln!("correction_add bad_decision (non-validation err): {e}"),
         }
@@ -2270,8 +2279,7 @@ mod tests {
 
     #[test]
     fn test_correction_list_empty_store() {
-        let dir = std::env::temp_dir()
-            .join(format!("gm-corr-list-{}", std::process::id()));
+        let dir = std::env::temp_dir().join(format!("gm-corr-list-{}", std::process::id()));
         let path = dir.join("memory.db").to_string_lossy().into_owned();
         match correction_list(None, Some(&path)) {
             Ok(json) => {
@@ -2305,7 +2313,10 @@ mod tests {
     #[test]
     fn test_suggest_threshold_bimodal() {
         // Bimodal distribution -> expect Some(threshold in (0, 1)).
-        let scores: Vec<f64> = (0..50).map(|_| 0.1_f64).chain((0..50).map(|_| 0.9_f64)).collect();
+        let scores: Vec<f64> = (0..50)
+            .map(|_| 0.1_f64)
+            .chain((0..50).map(|_| 0.9_f64))
+            .collect();
         let scores_json = serde_json::to_string(&scores).unwrap();
         match suggest_threshold(&scores_json) {
             Ok(Some(t)) => {
@@ -2486,7 +2497,11 @@ mod tests {
                 let v: serde_json::Value =
                     serde_json::from_str(&json).expect("autofix_table not valid JSON");
                 assert!(v.is_object(), "expected JSON object");
-                assert!(v.get("fixed_rows").is_some(), "missing fixed_rows key; got: {}", json);
+                assert!(
+                    v.get("fixed_rows").is_some(),
+                    "missing fixed_rows key; got: {}",
+                    json
+                );
                 assert!(v.get("fixes").is_some(), "missing fixes key");
             }
             Err(e) => require_or_skip(e, "autofix_table"),
@@ -2519,8 +2534,16 @@ mod tests {
                 // serialization can embed raw control chars in string values,
                 // which strict JSON parsing rejects -- not a marshalling fault.
                 assert!(!json.is_empty(), "preflight returned empty");
-                assert!(json.trim_start().starts_with('{'), "preflight not a JSON object; got: {}", json);
-                assert!(json.contains("\"has_errors\""), "missing has_errors; got: {}", json);
+                assert!(
+                    json.trim_start().starts_with('{'),
+                    "preflight not a JSON object; got: {}",
+                    json
+                );
+                assert!(
+                    json.contains("\"has_errors\""),
+                    "missing has_errors; got: {}",
+                    json
+                );
                 assert!(json.contains("\"findings\""), "missing findings");
             }
             Err(e) => require_or_skip(e, "preflight_clean_run"),
@@ -2536,8 +2559,16 @@ mod tests {
             Ok(json) => {
                 // Structural check (not strict from_str): see preflight note.
                 assert!(!json.is_empty(), "postflight returned empty");
-                assert!(json.trim_start().starts_with('{'), "postflight not a JSON object; got: {}", json);
-                assert!(json.contains("\"signals\""), "missing signals; got: {}", json);
+                assert!(
+                    json.trim_start().starts_with('{'),
+                    "postflight not a JSON object; got: {}",
+                    json
+                );
+                assert!(
+                    json.contains("\"signals\""),
+                    "missing signals; got: {}",
+                    json
+                );
                 assert!(json.contains("\"adjustments\""), "missing adjustments");
             }
             Err(e) => require_or_skip(e, "postflight_basic"),
@@ -2570,7 +2601,11 @@ mod tests {
                 // Structural check (not strict from_str): see preflight note.
                 // Fail-soft: either a proper EMResult object or {"error": ...}.
                 assert!(!json.is_empty(), "train_em returned empty string");
-                assert!(json.trim_start().starts_with('{'), "train_em not a JSON object; got: {}", json);
+                assert!(
+                    json.trim_start().starts_with('{'),
+                    "train_em not a JSON object; got: {}",
+                    json
+                );
             }
             Err(e) => require_or_skip(e, "train_em_minimal"),
         }
@@ -2597,7 +2632,10 @@ mod tests {
         // Unknown transform -> fail-open, returns input unchanged.
         match goldenflow_transform("definitely_not_a_real_transform", "hello world") {
             Ok(result) => {
-                assert_eq!(result, "hello world", "fail-open should return input unchanged");
+                assert_eq!(
+                    result, "hello world",
+                    "fail-open should return input unchanged"
+                );
             }
             Err(e) => require_or_skip(e, "goldenflow_transform_unknown_passthrough"),
         }
@@ -2613,7 +2651,10 @@ mod tests {
             Ok(result) => {
                 // Either normalized (goldenflow present) or passthrough (absent).
                 // Both are correct: just verify non-empty and valid UTF-8.
-                assert!(!result.is_empty(), "goldenflow_transform returned empty string");
+                assert!(
+                    !result.is_empty(),
+                    "goldenflow_transform returned empty string"
+                );
             }
             Err(e) => require_or_skip(e, "goldenflow_transform_email_normalize"),
         }

--- a/packages/rust/extensions/bridge/src/convert.rs
+++ b/packages/rust/extensions/bridge/src/convert.rs
@@ -21,10 +21,21 @@ pub fn json_to_polars_df(py: Python<'_>, json_records: &str) -> Result<PyObject,
     Ok(df.into_pyobject(py).unwrap().unbind())
 }
 
-/// Convert a Python Polars DataFrame to a JSON string of records.
+/// Convert a Python Polars DataFrame (or a pyarrow Table) to a JSON string of records.
+///
+/// v3.0.0: `DedupeResult.golden` / `MatchResult.matched` are now pyarrow Tables
+/// (no `write_json`). Convert arrow -> polars at this seam; a genuine polars frame
+/// (which has `write_json`) passes through unchanged.
 pub fn polars_df_to_json(py: Python<'_>, df: &PyObject) -> Result<String, BridgeError> {
-    let json_bytes = df.call_method0(py, "write_json")?;
-    let json_str: String = json_bytes.extract(py)?;
+    let bound = df.bind(py);
+    let frame = if bound.hasattr("write_json")? {
+        bound.clone()
+    } else {
+        let pl = py.import("polars")?;
+        pl.call_method1("from_arrow", (bound,))?
+    };
+    let json_bytes = frame.call_method0("write_json")?;
+    let json_str: String = json_bytes.extract()?;
     Ok(json_str)
 }
 

--- a/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
+++ b/packages/rust/extensions/duckdb/goldenmatch_duckdb/functions.py
@@ -227,6 +227,20 @@ def register(con: duckdb.DuckDBPyConnection) -> None:
 # ── Implementation ──────────────────────────────────────────────────────
 
 
+def _frame_to_json(frame) -> str:
+    """Serialize a result frame to row-oriented JSON.
+
+    v3.0.0: goldenmatch result frames (``result.golden`` / ``result.matched``)
+    are ``pa.Table``, which has no ``write_json``. ``Table.to_pylist()`` yields
+    the same ``[{col: val}, ...]`` shape polars' ``DataFrame.write_json()`` did,
+    so ``json.dumps(to_pylist())`` is byte-equivalent after ``json.loads``. The
+    polars branch stays for the ``GOLDENMATCH_FRAME=polars`` escape hatch.
+    """
+    if hasattr(frame, "num_rows"):  # pa.Table
+        return json.dumps(frame.to_pylist())
+    return frame.write_json()  # pl.DataFrame
+
+
 def _validate_table_name(name: str) -> str:
     """Validate table name to prevent SQL injection."""
     import re
@@ -264,7 +278,7 @@ def _dedupe_json(rows_json: str, config_json: str) -> str:
     cfg = json.loads(config_json)
     result = dedupe_df(df, **cfg)
     if result.golden is not None:
-        return result.golden.write_json()
+        return _frame_to_json(result.golden)
     return json.dumps(result.stats)
 
 
@@ -276,7 +290,7 @@ def _match_json(target_json: str, ref_json: str, config_json: str) -> str:
     cfg = json.loads(config_json)
     result = match_df(target, ref_df, **cfg)
     if result.matched is not None:
-        return result.matched.write_json()
+        return _frame_to_json(result.matched)
     return "[]"
 
 
@@ -293,7 +307,7 @@ def _dedupe_table(con: duckdb.DuckDBPyConnection, table_name: str, config_json: 
     cfg = json.loads(config_json)
     result = dedupe_df(df, **cfg)
     if result.golden is not None:
-        return result.golden.write_json()
+        return _frame_to_json(result.golden)
     return json.dumps(result.stats)
 
 
@@ -316,7 +330,7 @@ def _match_tables(
     cfg = json.loads(config_json)
     result = match_df(target, ref_df, **cfg)
     if result.matched is not None:
-        return result.matched.write_json()
+        return _frame_to_json(result.matched)
     return "[]"
 
 
@@ -366,7 +380,7 @@ def _gm_run(con: duckdb.DuckDBPyConnection, job_name: str, table_name: str) -> s
 
     # Store golden records in memory
     if result.golden is not None:
-        job["golden"] = json.loads(result.golden.write_json())
+        job["golden"] = json.loads(_frame_to_json(result.golden))
     else:
         job["golden"] = []
 
@@ -463,7 +477,7 @@ def _dedupe_full_table(
     cfg = GoldenMatchConfig.model_validate_json(config_json)
     result = dedupe_df(df, config=cfg)
     if result.golden is not None:
-        return result.golden.write_json()
+        return _frame_to_json(result.golden)
     return json.dumps(result.stats)
 
 


### PR DESCRIPTION
## Unblocks the merge queue after W5e-1 (#1695)

W5e-1 / the W5c-2 flip made `DedupeResult.golden` / `MatchResult.matched` (+ `.dupes`/`.unique`) **`pyarrow.Table`** unconditionally (the intended v3.0.0 result contract; migrate via `pl.from_arrow(...)`). But several consumers still called **Polars** methods on those Tables and `AttributeError`'d at runtime. Path-filtering hid this on #1695's own PR (goldenpipe/duckdb/postgres lanes were skipped); the merge queue's full run exposes it and **ejects any PR entering the queue**.

One root-cause pattern (Polars-method-on-pyarrow-Table), bounded consumer fixes:

- **`goldenmatch/db/sync.py`** — `pl.from_arrow(result.golden)` at the DB seam (fixes `.height`; keeps `db/writer.py`'s Polars usage valid).
- **`goldenmatch-duckdb/functions.py`** — `_frame_to_json` helper (`json.dumps(table.to_pylist())`, byte-equivalent to the old `write_json`) routed through all 6 UDF sites (fixes `.write_json`).
- **`goldenpipe/mcp/server.py`** — `_is_frame`/`_frame_rows`/`_frame_head_dicts` accept pa.Table (`.num_rows`/`.slice().to_pylist()`) as well as polars (fixes `KeyError 'golden_records'`).
- **`goldenpipe/compiler/e2e.py`** — materialize `result.dupes` to polars before `golden_provenance_for_run` (fixes `golden_provenance is None`).
- **`goldenpipe/tests/compiler/test_equivalence.py`** — golden normalization via `.to_pylist()` for pa.Table.
- **`goldenmatch/_api.py:157`** — `# pyright: ignore[reportPrivateImportUsage]` on `pyarrow.csv.write_csv`.
- **`goldenmatch/core/pipeline.py:889`** — narrow `str | None` -> `str` for `derive_matchkey`.
- **`goldenpipe/cli/main.py`** — golden CSV export `.write_csv` -> pyarrow.csv (same-flip break, user-facing).

### Verified locally
- goldenpipe merge_group blockers (`test_equivalence_full_pipeline` + `test_e2e_integration` + `test_mcp`): **11 passed**.
- duckdb `test_duckdb.py`: **11 passed**; goldenmatch `test_db.py`: 4 passed / 13 skipped (no live PG).
- pyright: reproduced both errors, **0 after the fix**.
- No regressions: goldenmatch `test_api` 61, goldenpipe suite green apart from pre-existing env-only failures (native-wheel parity, fused-dedupe needing the native kernel, a2a) that pass in CI. Ruff clean.

Does NOT revert W5e-1's arrow default and touches zero goldencheck files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)