### PR TITLE
chore(golden-suite): 0.2.1 -- goldencheck floor >=3.0.0

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.1] - 2026-07-12
+
+### Changed
+- **goldencheck floor raised to `goldencheck[polars]>=3.0.0`** -- goldencheck 3.0.0
+  flips the default scan path to Arrow-native and Polars-free (`pip install
+  goldencheck` scans CSV/Parquet/Excel end to end with no Polars; pyarrow is a base
+  dep). `[polars]` is retained because the suite bundles goldenmatch, whose quality
+  bridge calls `scan_dataframe(pl.DataFrame)`, and goldenmatch pulls Polars anyway.
+  Cut after goldencheck 3.0.0 landed on PyPI (member-on-PyPI-first lockstep).
+
 ## [0.2.0] - 2026-07-12
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.0"
+version = "0.2.1"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -38,7 +38,7 @@ dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch>=3.0",                 # entity resolution: dedupe, match, golden records (>=3.0: Arrow-native results -- pa.Table -- + arrow default backend)
-    "goldencheck[polars]>=2.0.0",       # data validation (>=2.0.0 = Polars-optional flip; [polars] since CSV + full scan need it)
+    "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting


### PR DESCRIPTION
Lockstep follow-on to goldencheck 3.0.0 (now live on PyPI). Bumps the golden-suite goldencheck floor to `goldencheck[polars]>=3.0.0` + version 0.2.1 + CHANGELOG. Member-on-PyPI-first satisfied. After merge: tag `golden-suite-v0.2.1` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)