### PR TITLE
feat(goldenmatch): arrow-descent D1 -- fused-helper tail stays pa.Table

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -1,0 +1,51 @@
+# GoldenMatch 3.x — engine-internals arrow descent (polars out of runtime deps)
+
+Follow-on to the shipped 3.0.0 (results = pa.Table, arrow default). Recon
+2026-07-12 mapped `_run_dedupe_pipeline`'s engine segment (terminal collect →
+result dict): **the arrow lane (fused short-circuit) is ALREADY Arrow at the
+compute core** (`run_match_fused_arrow` → pa.Table; `run_golden_fused_arrow`)
+and re-materializes to polars at exactly three seams. The classic lane's
+scorer/cluster stages are genuine polars logic the fused kernel bypasses.
+
+Counts: prep segment 32 `pl.` uses; engine segment 24; fused helper ~15
+(the D1 targets). `score_blocks_parallel` holds per-block `pl.LazyFrame`s;
+array-ization is leaf-local (`to_list`/`to_numpy` before rapidfuzz).
+
+## Batches (each its own PR; no stacking on unmerged predecessors)
+
+- **D1 — fused-helper tail stays pa.Table** (pipeline.py ~1452-1543): drop the
+  `pl.from_arrow(fused_tbl)` round-trip; sizes (`group_len`), dupe/golden/
+  oversized id sets, and the collected-frame splits run on ArrowFrame seam ops
+  (`filter_in`/`filter_not_in`/`with_gt_column`). `_to_result_table` already
+  passes pa.Table through — no consumer breaks. ~10 pl uses out of the lane.
+- **D2 — fused golden slot arrow**: `_try_fused_golden`/`run_golden_fused_arrow`
+  returns arrow; `golden_df` slot retyped `Frame`-polymorphic. Slow-path
+  `_golden_records_to_df` untouched (fused lane never hits it).
+- **D3 — terminal splits + result dict via the seam** (pipeline.py ~3098-3230):
+  dupes/unique splits via `filter_in` on `to_frame(collected_df)`; BOTH lanes
+  emit pa.Table in the INTERNAL dict. Must migrate the internal-dict consumers
+  in the SAME batch: dbt materialize (the W5-stamped patch loop flips here),
+  tui/engine.py EngineResult reads, web/routers run+match.
+- **D4 — ClusterFrames + golden-from-frames dual-backend** (pipeline.py ~2650,
+  ~2925): ClusterFrames.metadata/assignments as Frames; the stats/member-id
+  reads (`pl.col("size")>1 & ~oversized`) via seam ops. Real port work.
+- **D5 — classic fuzzy scoring on the seam** (largest; REQUIRED before dep
+  removal because configs the fused kernel declines still need block/score on
+  arrow): build_blocks' per-block frames + score_blocks_parallel orchestration
+  go Frame; leaf extraction (`to_list`/`to_numpy` for rapidfuzz) works on
+  ArrowColumn. Probabilistic + semantic-blocking + bucket paths follow the
+  same shape. Wall-gated per stage (>10% → owned kernel rule stands).
+- **D6 — the deletion**: default already arrow; delete the `polars` opt-out
+  value + PolarsFrame + `_polars_dtype` + polars constructor branches;
+  `_polars_lazy` proxy SURVIVES only in the extra-gated integration modules
+  (quality/transform — verified they import via the proxy, so polars loads
+  only when the gated stages run); polars moves runtime→dev-dep group; parity
+  suites collapse to single-backend; docs sweep; 3.x minor release.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Internal-dict consumers missed at D3 | Recon enumerated them (dbt/tui/web/_api); grep for result["golden"]-style reads in the D3 PR |
+| Classic-lane scorer port regresses wall | Per-stage wall gates; the fused lane covers the hot configs so D5's exposure is the declined-config tail |
+| Deleting the polars opt-out strands a user mid-migration | D6 ships in a LATER 3.x minor than D1-D5; deprecation note already in tuning.mdx |

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1449,38 +1449,38 @@ def _run_fused_match_short_circuit(
     max_cluster_size = 100
     if config.golden_rules is not None:
         max_cluster_size = config.golden_rules.max_cluster_size
-    fused_df = pl.from_arrow(fused_tbl)
-    assert isinstance(fused_df, pl.DataFrame)  # from_arrow returns a DataFrame for a Table
-    sizes = fused_df.group_by("__cluster_id__").agg(pl.len().alias("__size__"))
+    # D1 (arrow descent): the kernel's pa.Table is NOT round-tripped through
+    # polars. Cluster sizes + id sets derive from Python folds over the arrow
+    # columns (small: one entry per cluster); the collected-frame splits run
+    # on seam ops (byte-identical polars delegation until D3 unifies).
+    from goldenmatch.core.frame import ArrowFrame, to_frame
+
+    fused_frame = ArrowFrame(fused_tbl)
+    _rid_list = fused_frame.column("__row_id__").to_list()
+    _cid_list = fused_frame.column("__cluster_id__").to_list()
+    _size_by_cid: dict[int, int] = {}
+    for _cid in _cid_list:
+        _size_by_cid[_cid] = _size_by_cid.get(_cid, 0) + 1
     # dupes: members of every multi-member cluster (oversized INCLUDED, mirroring
     # the classic size>1 dupe rule). golden: non-oversized multi-member only.
-    dupe_ids = sizes.filter(pl.col("__size__") > 1)["__cluster_id__"].to_list()
-    golden_ids = sizes.filter(
-        (pl.col("__size__") > 1) & (pl.col("__size__") <= max_cluster_size)
-    )["__cluster_id__"].to_list()
-    oversized_ids = set(
-        sizes.filter(pl.col("__size__") > max_cluster_size)["__cluster_id__"].to_list()
-    )
+    dupe_ids = {c for c, n in _size_by_cid.items() if n > 1}
+    golden_ids = {c for c, n in _size_by_cid.items() if 1 < n <= max_cluster_size}
+    oversized_ids = {c for c, n in _size_by_cid.items() if n > max_cluster_size}
 
-    dupe_row_ids = fused_df.filter(pl.col("__cluster_id__").is_in(dupe_ids))[
-        "__row_id__"
-    ].to_list()
-    golden_row_ids = fused_df.filter(pl.col("__cluster_id__").is_in(golden_ids))[
-        "__row_id__"
-    ].to_list()
+    dupe_row_ids = [r for r, c in zip(_rid_list, _cid_list) if c in dupe_ids]
+    golden_row_ids = [r for r, c in zip(_rid_list, _cid_list) if c in golden_ids]
     dupe_set = set(dupe_row_ids)
-    all_ids = collected_df["__row_id__"].to_list()
+    collected_frame = to_frame(collected_df)
+    all_ids = collected_frame.column("__row_id__").to_list()
     unique_row_ids = [r for r in all_ids if r not in dupe_set]
-    dupes_df = collected_df.filter(pl.col("__row_id__").is_in(dupe_row_ids))
-    unique_df = collected_df.filter(pl.col("__row_id__").is_in(unique_row_ids))
+    dupes_df = collected_frame.filter_in("__row_id__", dupe_row_ids).native
+    unique_df = collected_frame.filter_in("__row_id__", unique_row_ids).native
 
     # Clusters dict (capacity mode: pair_scores/confidence/bottleneck shed). Same
     # STRUCTURE as build_clusters so DedupeResult.clusters consumers don't break;
     # confidence sentinel mirrors cluster.py (1.0 singleton / 0.0 multi).
     grouped: dict[int, list[int]] = {}
-    for rid, cid in zip(
-        fused_df["__row_id__"].to_list(), fused_df["__cluster_id__"].to_list()
-    ):
+    for rid, cid in zip(_rid_list, _cid_list):
         grouped.setdefault(cid, []).append(rid)
     clusters: dict[int, dict] = {}
     for cid, members in grouped.items():
@@ -1515,13 +1515,13 @@ def _run_fused_match_short_circuit(
 
             quality_scores = (
                 compute_quality_scores(
-                    collected_df.filter(pl.col("__row_id__").is_in(golden_row_ids))
+                    collected_frame.filter_in("__row_id__", golden_row_ids).native
                 )
                 or None
             )
         # Build multi_df: member rows + slim internal columns + __cluster_id__
         # (mirrors the dict-path golden branch for byte-identity).
-        multi_df = collected_df.filter(pl.col("__row_id__").is_in(golden_row_ids))
+        multi_df = collected_frame.filter_in("__row_id__", golden_row_ids).native
         if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
             _internal_prefixes = ("__xform_", "__mk_", "__block_key__", "__bucket__")
             multi_df = multi_df.select(
@@ -1531,7 +1531,16 @@ def _run_fused_match_short_circuit(
                     if not any(c.startswith(p) for p in _internal_prefixes)
                 ]
             )
-        multi_df = multi_df.join(fused_df, on="__row_id__", how="inner")
+        # __cluster_id__ attach: map_column over the kernel's rid->cid map is
+        # byte-equivalent to the old inner join against the fused frame
+        # (unique rid keys; downstream golden groups by cluster, order-free)
+        # and keeps the arrow table un-round-tripped.
+        _rid_to_cid = dict(zip(_rid_list, _cid_list))
+        multi_df = (
+            to_frame(multi_df)
+            .map_column("__row_id__", "__cluster_id__", _rid_to_cid)
+            .native
+        )
         golden_df, golden_fused_used = _golden_from_multi_df(
             multi_df, golden_rules, quality_scores, config.output.lineage_provenance
         )


### PR DESCRIPTION
3.x arrow-descent batch 1 (plan: docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md, committed here with the engine recon).

- The fused short-circuit no longer round-trips the kernel's pa.Table through polars: sizes + id sets via Python folds over the arrow columns; collected-frame splits + quality/multi_df filters via seam ops.
- multi_df __cluster_id__ attach via map_column over the kernel's rid->cid map -- byte-equivalent to the old inner join (unique keys, order-free downstream).
- ~10 pl uses removed from the arrow lane. D2 (fused golden slot) next.

Gates: fused_telemetry byte-identity parity locks vs classic, api_fused_routing, fused_match, pipeline, controller_fused, frame_backend_differential -- all green. ruff clean.