### PR TITLE
perf(goldencheck): 3.0.1 -- vectorize ArrowColumn string->numeric cast

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.0.1] - 2026-07-12
+
+### Performance
+- **Vectorized `ArrowColumn.cast` (string -> numeric).** The 3.0.0 implementation
+  parsed string columns element-by-element in a Python loop (`float(v)`/`int(v)`
+  with try/except), which made `type_inference`'s numeric probe the dominant cost
+  of a scan and scaled linearly with row count -- ~2M `float()`+`append` calls on
+  a 1M-row string column, and catastrophic on larger data. Replaced with a single
+  vectorized `pyarrow.compute` pass: regex-mask non-numeric literals to null, then
+  one `pc.cast`. Roughly halves column-profiling wall on string-heavy data and
+  removes the O(N) Python loop entirely. Findings are unchanged (the finding-set
+  differential stays at Jaccard 1.000; owned contract: a value is numeric if it
+  matches a standard decimal/float literal, so non-standard tokens like `inf`/`nan`
+  or underscored digits are treated as non-numeric).
+
 ## [3.0.0] - 2026-07-11
 
 ### Changed (BREAKING)

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -97,6 +97,13 @@ def dtype_category(pl_dtype: Any) -> str:
 
 _CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings only; resolved via getattr in cast()
 
+# Standard numeric-literal shapes for the vectorized ArrowColumn string->numeric
+# cast (RE2, anchored full-match). Match what float()/int() accept for the common
+# case; the owned contract treats non-standard tokens (inf/nan/underscored) as
+# non-numeric -> null, which is the sensible answer for "is this column numeric".
+_INT_LITERAL_RE = r"^[+-]?\d+$"
+_FLOAT_LITERAL_RE = r"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$"
+
 
 class NativeRequiredError(RuntimeError):
     """A covered hard op needs the native regex kernel. Install it with
@@ -543,6 +550,21 @@ class ArrowColumn:
     def get(self, index: int) -> Any:
         return self._arr[index].as_py()
 
+    def _cast_str_numeric(self, target: Any, pattern: str) -> ArrowColumn:
+        """Vectorized string -> numeric cast with null-on-unparseable (polars
+        strict=False). Regex-mask the values that are NOT a standard numeric
+        literal to null, then a single vectorized pc.cast -- no per-element
+        Python loop (that loop made type_inference's cast the dominant scan cost:
+        2M float()/append calls on a 1M-row column). Leading/trailing whitespace
+        is trimmed first to match Python float()/int() acceptance.
+        """
+        pa, pc = _arrow()
+        a = self._arr
+        stripped = pc.utf8_trim_whitespace(a)
+        looks_numeric = pc.match_substring_regex(stripped, pattern)
+        cleaned = pc.if_else(looks_numeric, stripped, pa.scalar(None, type=a.type))
+        return ArrowColumn(pc.cast(cleaned, target))
+
     def cast(self, kind: str, *, strict: bool = False) -> ArrowColumn:
         pa, pc = _arrow()
         import pyarrow.types as pat
@@ -551,29 +573,11 @@ class ArrowColumn:
         is_str = pat.is_string(a.type) or pat.is_large_string(a.type)
         if kind == "float":
             if is_str:
-                out = []
-                for v in a.to_pylist():
-                    if v is None:
-                        out.append(None)
-                        continue
-                    try:
-                        out.append(float(v))
-                    except (ValueError, TypeError):
-                        out.append(None)   # unparseable -> null (pl strict=False)
-                return ArrowColumn(pa.array(out, type=pa.float64()))
+                return self._cast_str_numeric(pa.float64(), _FLOAT_LITERAL_RE)
             return ArrowColumn(pc.cast(a, pa.float64(), safe=False))
         if kind == "int":
             if is_str:
-                out = []
-                for v in a.to_pylist():
-                    if v is None:
-                        out.append(None)
-                        continue
-                    try:
-                        out.append(int(v))
-                    except (ValueError, TypeError):
-                        out.append(None)
-                return ArrowColumn(pa.array(out, type=pa.int64()))
+                return self._cast_str_numeric(pa.int64(), _INT_LITERAL_RE)
             return ArrowColumn(pc.cast(a, pa.int64(), safe=False))
         if kind == "str":
             return ArrowColumn(pc.cast(a, pa.string()))

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.0.0"
+version = "3.0.1"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## goldencheck 3.0.1 -- perf fix

Measuring 3.0.0 scan perf (5-run median, 1M x 6) surfaced a regression: the Arrow column path was ~17x slower than the 2.x Polars path, and cProfile pinned it on ONE method -- `ArrowColumn.cast` (string->numeric, used by `type_inference`) parsed strings **element-by-element in a Python loop** (`float(v)`/`int(v)` + try/except), ~2M `float()`+`append` calls on a 1M-row string column. O(N) Python, catastrophic at scale.

### Fix
Vectorized `ArrowColumn.cast`: `pc.utf8_trim_whitespace` -> `pc.match_substring_regex` (numeric-literal mask) -> `pc.if_else` null-out non-numeric -> a single `pc.cast`. No Python loop.

### Measured (1M x 6, 5-run median, column-profiling)
| | before (3.0.0) | after (3.0.1) |
|---|---|---|
| ArrowFrame native | 2.71s | **1.39s** |
| ArrowFrame pyarrow-fallback | 2.65s | ~1.4s |
| (PolarsFrame ~2.x reference) | 0.16s | 0.16s |

Roughly halves column-profiling wall and removes the O(N) Python loop (the loop, not the residual gap, was the scaling hazard). The remaining gap vs Polars is architectural -- pyarrow.compute is single-threaded per op vs Polars' multithreaded fused engine -- and is a separate follow-on, not a bug.

### Correctness (unchanged)
- Finding-set differential: strict Jaccard **1.000**, 0 divergences.
- ArrowColumn parity: **28/28** (cast still matches `PolarsColumn` on the corpus).
- Suite: **867** native / **799** `GOLDENCHECK_NATIVE=0`. ruff clean. version_consistency lockstep (3.0.1).
- Owned contract note: numeric = a standard decimal/float literal, so `inf`/`nan`/underscored tokens are treated as non-numeric (the sensible answer for "is this column numeric").

After merge: tag `goldencheck-v3.0.1` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)