### PR TITLE
perf(goldencheck): 3.0.2 -- ~2x faster Arrow scan (vectorized string ops + column caching)

### DIFF
--- a/packages/python/goldencheck/.gitignore
+++ b/packages/python/goldencheck/.gitignore
@@ -44,3 +44,6 @@ packages/goldencheck-js/package-lock.json
 # Flip differential: regenerable corpus + captured findings (scripts/flip_corpus.py)
 tests/flip/corpus/
 tests/flip/authoritative_findings.json
+packages/python/goldencheck/scripts/_perf_scan.parquet
+
+scripts/_perf_scan.parquet

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.0.2] - 2026-07-12
+
+### Performance
+- **Iterative hotspot pass on the Arrow scan path -- ~2x faster** (1M x 7 columns:
+  scan_file 3.74s -> 1.91s, native; findings unchanged, differential Jaccard 1.000).
+  - `str_match_count` / `str_replace_all` / `str_to_date` now prefer **vectorized**
+    `pyarrow.compute` (`match_substring_regex` / `replace_substring_regex` / `strptime`)
+    over the list-based native kernel, which forced `to_pylist()` materialization of
+    the whole column (the single largest scan cost at 1M rows). The native kernel
+    remains the fallback for patterns pyarrow's RE2 cannot compile (e.g. `\uXXXX`).
+  - `value_counts_desc` uses `pc.value_counts` (C++) instead of a Python `Counter`
+    over a materialized list.
+  - `ArrowFrame` caches wrapped columns and `ArrowColumn` memoizes
+    `n_unique`/`drop_nulls`/`numeric_stats`, so those run once per column instead of
+    once per profiler (all seam profilers share one frame).
+  - Net effect: the compiled kernel (`[native]`) now measurably accelerates a scan
+    (1.91s vs 3.04s pyarrow-only) where before the string/cast overhead masked it.
+
 ## [3.0.1] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.0.1"
+__version__ = "3.0.2"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -444,7 +444,7 @@ class ArrowColumn:
     ``max()`` on a date column returns a ``datetime.date`` (freshness needs it).
     """
 
-    __slots__ = ("_arr", "_cat", "_num_stats")
+    __slots__ = ("_arr", "_cat", "_num_stats", "_n_unique", "_dropna")
 
     def __init__(self, arr: Any) -> None:
         pa, _ = _arrow()
@@ -453,6 +453,8 @@ class ArrowColumn:
         self._arr = arr
         self._cat = _arrow_neutral_dtype(arr.type)
         self._num_stats: Any = None   # None=unset, False=empty/all-null, tuple=cached
+        self._n_unique: int | None = None      # memoized across profilers (see ArrowFrame cache)
+        self._dropna: ArrowColumn | None = None
 
     # -- numeric stats (cached single kernel call) ----------------------------
     def _numeric_stats(self):
@@ -515,12 +517,20 @@ class ArrowColumn:
         return self._arr.null_count
 
     def n_unique(self) -> int:
-        _, pc = _arrow()
-        return int(pc.count_distinct(self._arr, mode="all").as_py())   # nulls = 1 distinct (Polars parity)
+        # Memoized: cardinality + uniqueness + the scan-loop ColumnProfile each ask
+        # for this on the SAME cached column (ArrowFrame reuses instances), so
+        # count_distinct runs once per column instead of ~3x. nulls = 1 distinct.
+        if self._n_unique is None:
+            _, pc = _arrow()
+            self._n_unique = int(pc.count_distinct(self._arr, mode="all").as_py())
+        return self._n_unique
 
     def drop_nulls(self) -> ArrowColumn:
-        _, pc = _arrow()
-        return ArrowColumn(pc.drop_null(self._arr))
+        # Memoized: several profilers drop_nulls the same column; do it once.
+        if self._dropna is None:
+            _, pc = _arrow()
+            self._dropna = ArrowColumn(pc.drop_null(self._arr))
+        return self._dropna
 
     def unique(self) -> ArrowColumn:
         _, pc = _arrow()
@@ -589,11 +599,21 @@ class ArrowColumn:
         return int(r or 0)
 
     def str_match_count(self, pattern: str) -> int:
-        if native_enabled("regex"):
-            return _regex_kernel().str_contains_count(self._arr.to_pylist(), pattern)
+        # Prefer the VECTORIZED pyarrow path (pc.match_substring_regex + pc.sum, C++,
+        # no Python-list materialization). The native kernel is list-based, so routing
+        # through it forces `self._arr.to_pylist()` on the whole column -- at 1M rows
+        # that to_pylist was the single largest scan cost. pyarrow's RE2 agrees with
+        # the kernel/Polars on the format/pattern-consistency patterns (verified by
+        # the finding-set differential). Fall back to the kernel only when RE2 cannot
+        # compile the pattern (e.g. \uXXXX escapes the encoding checks use).
         _, pc = _arrow()
-        mask = pc.match_substring_regex(self._arr, pattern)   # null preserved on null input
-        return int(pc.sum(mask, skip_nulls=True).as_py() or 0)
+        try:
+            mask = pc.match_substring_regex(self._arr, pattern)   # null preserved on null input
+            return int(pc.sum(mask, skip_nulls=True).as_py() or 0)
+        except Exception:  # noqa: BLE001 - RE2 compile error -> kernel fallback
+            if native_enabled("regex"):
+                return _regex_kernel().str_contains_count(self._arr.to_pylist(), pattern)
+            raise
 
     def str_filter(self, pattern: str, *, matching: bool) -> ArrowColumn:
         pa, pc = _arrow()
@@ -693,15 +713,17 @@ class ArrowColumn:
         return ArrowColumn(self._arr.slice(offset, length))
 
     def str_replace_all(self, pattern: str, value: str) -> ArrowColumn:
+        # Prefer VECTORIZED pyarrow (no to_pylist round-trip); RE2 preserves nulls,
+        # matching Polars' str.replace_all. Kernel fallback only on RE2 compile error.
         pa, pc = _arrow()
-        if native_enabled("regex"):
-            out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
-            return ArrowColumn(pa.array(out, type=pa.string()))
-        # pyarrow fallback: replace_substring_regex preserves nulls, matching
-        # Polars' str.replace_all. Cast to string() so the result column dtype
-        # matches the native path (input may be large_string).
-        out = pc.replace_substring_regex(self._arr, pattern, value)
-        return ArrowColumn(pc.cast(out, pa.string()))
+        try:
+            out = pc.replace_substring_regex(self._arr, pattern, value)
+            return ArrowColumn(pc.cast(out, pa.string()))
+        except Exception:  # noqa: BLE001 - RE2 compile error -> kernel fallback
+            if native_enabled("regex"):
+                out = _regex_kernel().str_replace_all(self._arr.to_pylist(), pattern, value)
+                return ArrowColumn(pa.array(out, type=pa.string()))
+            raise
 
     def str_len_chars(self) -> ArrowColumn:
         # pc.utf8_length -> per-value character count (nulls preserved), matching
@@ -711,7 +733,15 @@ class ArrowColumn:
         return ArrowColumn(pc.utf8_length(self._arr))
 
     def value_counts_desc(self) -> list[tuple[Any, int]]:
-        return sorted(Counter(self._arr.to_pylist()).items(), key=_VC_KEY)
+        # pc.value_counts counts in C++ (no Python Counter over a materialized 1M
+        # list); only the DISTINCT values are pulled to Python. pyarrow includes
+        # null as a value (like Polars value_counts), so _VC_KEY's nulls-last rule
+        # still applies. Same (value, count) pairs -> identical _VC_KEY ordering.
+        _, pc = _arrow()
+        vc = pc.value_counts(self._arr)
+        values = vc.field("values").to_pylist()
+        counts = vc.field("counts").to_pylist()
+        return sorted(zip(values, counts), key=_VC_KEY)
 
     def eq(self, value: Any) -> ArrowColumn:
         _, pc = _arrow()
@@ -768,10 +798,11 @@ class ArrowColumn:
 class ArrowFrame:
     """``pyarrow.Table``-backed frame implementing the ``Frame`` Protocol."""
 
-    __slots__ = ("_tbl",)
+    __slots__ = ("_tbl", "_col_cache")
 
     def __init__(self, tbl: Any) -> None:
         self._tbl = tbl
+        self._col_cache: dict[str, ArrowColumn] = {}
 
     @property
     def columns(self) -> list[str]:
@@ -786,7 +817,16 @@ class ArrowFrame:
         return self._tbl
 
     def column(self, name: str) -> ArrowColumn:
-        return ArrowColumn(self._tbl.column(name))
+        # Cache the wrapped column: every seam profiler on the scan loop calls
+        # frame.column(name) for the same column, and they all share this one
+        # ArrowFrame (to_frame is idempotent). Reusing the instance means
+        # combine_chunks + the memoized n_unique/drop_nulls/numeric_stats run
+        # ONCE per column instead of once per profiler.
+        col = self._col_cache.get(name)
+        if col is None:
+            col = ArrowColumn(self._tbl.column(name))
+            self._col_cache[name] = col
+        return col
 
 
 def to_frame(native: Any) -> Frame:

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -785,14 +785,20 @@ class ArrowColumn:
         pa, pc = _arrow()
         if strict:
             raise NotImplementedError("goldencheck str_to_date supports strict=False only")
-        if native_enabled("str_to_date"):
-            iso = _date_kernel().str_to_date(self._arr.to_pylist(), fmt)
-            vals = [date.fromisoformat(s) if s is not None else None for s in iso]
-            return ArrowColumn(pa.array(vals, type=pa.date32()))
-        # pyarrow fallback: strptime with error_is_null (== Polars strict=False:
-        # unparseable -> null) then narrow the timestamp to date32.
-        ts = pc.strptime(self._arr, format=fmt, unit="s", error_is_null=True)
-        return ArrowColumn(pc.cast(ts, pa.date32()))
+        # Prefer VECTORIZED pyarrow strptime (error_is_null == Polars strict=False).
+        # The native path forced to_pylist AND a second Python fromisoformat loop --
+        # two O(N) passes. Both parse an EXPLICIT format, so strptime matches the
+        # kernel's directive parsing; fall back to the kernel only if strptime cannot
+        # handle the format string.
+        try:
+            ts = pc.strptime(self._arr, format=fmt, unit="s", error_is_null=True)
+            return ArrowColumn(pc.cast(ts, pa.date32()))
+        except Exception:  # noqa: BLE001 - unsupported format directive -> kernel fallback
+            if native_enabled("str_to_date"):
+                iso = _date_kernel().str_to_date(self._arr.to_pylist(), fmt)
+                vals = [date.fromisoformat(s) if s is not None else None for s in iso]
+                return ArrowColumn(pa.array(vals, type=pa.date32()))
+            raise
 
 
 class ArrowFrame:

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.0.1"
+version = "3.0.2"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/scripts/perf_scan.py
+++ b/packages/python/goldencheck/scripts/perf_scan.py
@@ -5,9 +5,18 @@ reference + a cProfile top-N. Run each perf iteration to track the hotspot.
   python scripts/perf_scan.py --profile  # + cProfile top-15 by tottime
 """
 from __future__ import annotations
-import argparse, cProfile, io, pstats, statistics, time
+
+import argparse
+import cProfile
+import io
+import pstats
+import statistics
+import time
 from pathlib import Path
-import numpy as np, pyarrow as pa, pyarrow.parquet as pq
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 N = 1_000_000
 TMP = Path(__file__).parent / "_perf_scan.parquet"

--- a/packages/python/goldencheck/scripts/perf_scan.py
+++ b/packages/python/goldencheck/scripts/perf_scan.py
@@ -1,0 +1,65 @@
+"""Reusable scan perf harness: wall (5-run median, native + fallback) + a Polars
+reference + a cProfile top-N. Run each perf iteration to track the hotspot.
+
+  python scripts/perf_scan.py            # wall only
+  python scripts/perf_scan.py --profile  # + cProfile top-15 by tottime
+"""
+from __future__ import annotations
+import argparse, cProfile, io, pstats, statistics, time
+from pathlib import Path
+import numpy as np, pyarrow as pa, pyarrow.parquet as pq
+
+N = 1_000_000
+TMP = Path(__file__).parent / "_perf_scan.parquet"
+
+
+def _make() -> Path:
+    r = np.random.default_rng(7)
+    tbl = pa.table({
+        "id": np.arange(N, dtype=np.int64),
+        "score": r.normal(100, 15, N),
+        "amount": np.floor(10 ** r.uniform(0, 6, N)).astype(np.int64) + 1,
+        "region": np.array(["north", "south", "east", "west"])[r.integers(0, 4, N)],
+        "email": np.array([f"u{i % 50000}@x.com" for i in range(N)]),
+        "code": np.array([str(v) for v in r.integers(0, 1_000_000, N)]),  # numeric-looking str
+        "flag": r.integers(0, 2, N).astype(bool),
+    })
+    pq.write_table(tbl, TMP)
+    return TMP
+
+
+def _median(fn, runs=5):
+    ts = []
+    for _ in range(runs):
+        t = time.perf_counter(); n = fn(); ts.append(time.perf_counter() - t)
+    return statistics.median(ts), min(ts), n
+
+
+def main():
+    ap = argparse.ArgumentParser(); ap.add_argument("--profile", action="store_true"); a = ap.parse_args()
+    p = _make()
+    from goldencheck.engine.scanner import scan_file
+    print(f"scan_file wall, {N:,} rows x 7 cols (5-run median):")
+    med, mn, n = _median(lambda: len(scan_file(p)[0]))
+    print(f"  scan_file            median {med:6.3f}s (min {mn:.3f})  {n} findings")
+
+    # Polars reference: same column profilers over a PolarsFrame
+    import polars as pl
+    from goldencheck.core.frame import PolarsFrame
+    from scripts.flip_differential import _run_seam
+    cols = pl.read_parquet(p).columns
+    med2, mn2, _ = _median(lambda: len(_run_seam(PolarsFrame(pl.read_parquet(p)), cols)))
+    print(f"  [ref] polars seam    median {med2:6.3f}s (min {mn2:.3f})")
+
+    if a.profile:
+        pr = cProfile.Profile(); pr.enable(); scan_file(p); pr.disable()
+        s = io.StringIO(); pstats.Stats(pr, stream=s).sort_stats("tottime").print_stats(15)
+        print("\n--- cProfile top (tottime) ---")
+        for line in s.getvalue().splitlines():
+            if "goldencheck" in line or "pyarrow" in line or "{method" in line or "tottime" in line or "seconds" in line:
+                print(line[:120])
+    TMP.unlink(missing_ok=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## goldencheck 3.0.2 -- scan perf

Iterative hotspot pass on the 3.0.x Arrow scan path (measure -> kill top hotspot -> repeat). Every step verified: finding-set differential **Jaccard 1.000**, suite green both native and no-native.

### Trajectory (1M x 7, native, 5-run median scan_file)
| step | change | wall |
|---|---|---|
| 3.0.1 | (vectorized cast) | 3.74s |
| 1 | `str_match_count` vectorized (pyarrow RE2, no `to_pylist`) | 2.99s |
| 2 | `str_replace_all` + `value_counts_desc` vectorized | 2.35s |
| 3 | cache seam columns + memoize `n_unique`/`drop_nulls`/`numeric_stats` | 2.21s |
| 4 | `str_to_date` vectorized (`pc.strptime`) | **1.91s** |

**~2x faster.** The list-based native string/date kernels forced `to_pylist()` materialization of the whole column -- the single largest cost -- so the seam now prefers vectorized `pyarrow.compute` and falls back to the kernel only when RE2 can't compile a pattern (`\uXXXX`). Column caching means `combine_chunks` + the memoized reductions run once per column instead of once per profiler (all seam profilers share one frame).

Side effect: the compiled kernel now **measurably accelerates** a scan (1.91s native vs 3.04s pyarrow-only) -- before, the string/cast overhead masked it.

### Correctness
- differential strict Jaccard **1.000**, 0 divergences (pyarrow RE2 == kernel/Polars on the format/pattern/temporal patterns).
- ArrowColumn parity 28/28; suite 867 native / 149 relations+profilers no-native. version_consistency 3.0.2.

Adds `scripts/perf_scan.py` (reusable bench+profile). Remaining gap vs Polars is the diffuse single-threaded pyarrow dispatch -- addressed separately by a column-parallelism pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)