### PR TITLE
perf(goldencheck): 3.0.3 -- parallel column scan (deterministic)

### DIFF
--- a/packages/python/goldencheck/.gitignore
+++ b/packages/python/goldencheck/.gitignore
@@ -42,7 +42,7 @@ package-lock.json
 packages/goldencheck-js/package-lock.json
 
 # Flip differential: regenerable corpus + captured findings (scripts/flip_corpus.py)
-tests/flip/corpus/
+tests/flip/corpus*/
 tests/flip/authoritative_findings.json
 packages/python/goldencheck/scripts/_perf_scan.parquet
 

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.0.3] - 2026-07-12
+
+### Performance
+- **Parallel column scan.** The column-profiling loop now fans out across a thread
+  pool (pyarrow.compute and the native kernels release the GIL). Column profiling is
+  independent per column and `profiler_context` is per-column, so results are merged
+  in COLUMN order and are byte-identical to the sequential path (verified: `scan_file`
+  1-thread vs 8-thread findings identical incl. order; differential Jaccard 1.000).
+  1M x 7: scan_file 1.97s -> 1.36s. Gated by `GOLDENCHECK_SCAN_THREADS` (default:
+  parallel when >=2 columns and >=50k rows, capped at min(cpu, 8, ncols); `1` forces
+  sequential). Cumulative with 3.0.1/3.0.2: 3.74s -> 1.36s (~2.75x).
+
 ## [3.0.2] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.0.2"
+__version__ = "3.0.3"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -404,6 +406,52 @@ def _sample_for_return(frame):
     return _pl.from_arrow(native)
 
 
+def _scan_threads(ncols: int, row_count: int) -> int:
+    """How many threads to fan the column loop across. `GOLDENCHECK_SCAN_THREADS`
+    overrides (1 = sequential, for debug/determinism checks). Otherwise parallelize
+    only when there's enough work to beat the thread-pool overhead: multiple columns
+    and a non-trivial row count. Capped at min(cpu, 8, ncols)."""
+    env = os.environ.get("GOLDENCHECK_SCAN_THREADS")
+    if env is not None:
+        try:
+            return max(1, min(int(env), ncols))
+        except ValueError:
+            return 1
+    if ncols < 2 or row_count < 50_000:
+        return 1
+    return max(1, min(os.cpu_count() or 1, 8, ncols))
+
+
+def _profile_column(frame, sample, col_name: str, row_count: int):
+    """Profile ONE column: its ColumnProfile (from the full ``frame``) + the
+    COLUMN_PROFILERS over ``sample``. Pure w.r.t. its inputs and a LOCAL context
+    dict, so it is safe to run concurrently across columns (see the caller)."""
+    ctx: dict = {}   # per-column: context is keyed by column, no cross-column reads
+    col = frame.column(col_name)
+    non_null = col.drop_nulls()
+    non_null_len = len(non_null)
+    n_unique = non_null.n_unique() if non_null_len > 0 else 0
+    null_count = col.null_count()
+    cp = ColumnProfile(
+        name=col_name,
+        # OWNED dtype contract: neutral vocabulary (str/int/uint/float/date/
+        # datetime/bool/other) via the Arrow seam, not raw `str(pl.dtype)`.
+        inferred_type=col.dtype_repr(),
+        null_count=null_count,
+        null_pct=null_count / row_count if row_count > 0 else 0,
+        unique_count=n_unique,
+        unique_pct=n_unique / non_null_len if non_null_len > 0 else 0,
+        row_count=row_count,
+    )
+    findings: list[Finding] = []
+    for profiler in COLUMN_PROFILERS:
+        try:
+            findings.extend(profiler.profile(sample, col_name, context=ctx))
+        except Exception as e:  # noqa: BLE001 - one profiler failing must not sink the scan
+            logger.warning("Profiler %s failed on column %s: %s", type(profiler).__name__, col_name, e)
+    return cp, findings
+
+
 def _scan_dataframe_impl(
     frame,
     *,
@@ -433,34 +481,31 @@ def _scan_dataframe_impl(
 
     all_findings: list[Finding] = []
     column_profiles: list[ColumnProfile] = []
-    profiler_context: dict = {}
 
-    for col_name in columns:
-        col = frame.column(col_name)
-        non_null = col.drop_nulls()
-        non_null_len = len(non_null)
-        # Cache n_unique + null_count once per column (both feed two ColumnProfile
-        # kwargs each). The kernel-backed ArrowColumn carries the CPU work.
-        n_unique = non_null.n_unique() if non_null_len > 0 else 0
-        null_count = col.null_count()
-        cp = ColumnProfile(
-            name=col_name,
-            # OWNED dtype contract: neutral vocabulary (str/int/uint/float/date/
-            # datetime/bool/other) via the Arrow seam, not raw `str(pl.dtype)`.
-            inferred_type=col.dtype_repr(),
-            null_count=null_count,
-            null_pct=null_count / row_count if row_count > 0 else 0,
-            unique_count=n_unique,
-            unique_pct=n_unique / non_null_len if non_null_len > 0 else 0,
-            row_count=row_count,
-        )
+    # Column profiling is embarrassingly parallel across columns: each column's
+    # ColumnProfile + COLUMN_PROFILERS depend only on that column (profiler_context
+    # is keyed by column -- type_inference writes context[col], range_distribution
+    # reads context[col] -- so a per-column context has no cross-column dependency),
+    # and pyarrow.compute / the native kernels release the GIL. We run columns on a
+    # thread pool and merge results in COLUMN ORDER (not completion order) so the
+    # finding set is identical to the sequential path (the differential enforces it).
+    n_threads = _scan_threads(len(columns), row_count)
+    if n_threads > 1:
+        # Pre-populate the frame column caches single-threaded so the parallel
+        # tasks only READ them -- concurrent dict writes (ArrowFrame._col_cache)
+        # aren't safe. combine_chunks runs here, once per column. No-op for frames
+        # whose column() doesn't cache.
+        for col_name in columns:
+            frame.column(col_name)
+            if sample is not frame:
+                sample.column(col_name)
+        with ThreadPoolExecutor(max_workers=n_threads) as pool:
+            results = list(pool.map(lambda c: _profile_column(frame, sample, c, row_count), columns))
+    else:
+        results = [_profile_column(frame, sample, c, row_count) for c in columns]
+    for cp, findings in results:
         column_profiles.append(cp)
-        for profiler in COLUMN_PROFILERS:
-            try:
-                findings = profiler.profile(sample, col_name, context=profiler_context)
-                all_findings.extend(findings)
-            except Exception as e:
-                logger.warning("Profiler %s failed on column %s: %s", type(profiler).__name__, col_name, e)
+        all_findings.extend(findings)
 
     for profiler in RELATION_PROFILERS:
         try:

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.0.2"
+version = "3.0.3"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_arrow_column_parity.py
@@ -12,6 +12,7 @@ is measured by the differential instead.
 from __future__ import annotations
 
 import math
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -27,7 +28,12 @@ pa = pytest.importorskip("pyarrow")
 pq = pytest.importorskip("pyarrow.parquet")
 from goldencheck.core.frame import ArrowColumn, PolarsColumn  # noqa: E402
 
-CORPUS = Path(__file__).parent / "corpus"
+# Per-xdist-worker corpus dir: the corpus is (re)generated at collection time, and
+# under `pytest -n auto` multiple workers would otherwise write the SAME parquet files
+# concurrently -> a reader sees a half-written file ("Invalid thrift: protocol error").
+# A worker-local dir gives each worker its own (deterministic, identical) corpus.
+_WORKER = os.environ.get("PYTEST_XDIST_WORKER", "")
+CORPUS = Path(__file__).parent / (f"corpus_{_WORKER}" if _WORKER else "corpus")
 NUMERIC = {"int", "uint", "float"}
 
 


### PR DESCRIPTION
## goldencheck 3.0.3 -- parallel column scan

Fans the column-profiling loop across a thread pool (pyarrow.compute + native kernels release the GIL). Safe because column profiling is independent per column and `profiler_context` is per-column (type_inference writes context[col], range_distribution reads context[col]).

Three hazards closed:
- **Determinism** -- results merged in COLUMN order (not completion order) -> finding set byte-identical to sequential. Verified: `scan_file` 1-thread vs 8-thread findings identical incl. order.
- **Per-column context** -- each task gets a local context dict, no cross-thread sharing.
- **Cache races** -- ArrowFrame column caches pre-populated single-threaded; parallel tasks only read.

Gated by `GOLDENCHECK_SCAN_THREADS` (default: parallel when >=2 cols and >=50k rows, capped at min(cpu,8,ncols); `1`=sequential).

**1M x 7: scan_file 1.97s -> 1.36s.** Cumulative 3.0.1->3.0.3: 3.74s -> 1.36s (~2.75x).

Correctness: differential Jaccard 1.000; suite 867 green both sequential AND `GOLDENCHECK_SCAN_THREADS=4`; ruff clean; version_consistency 3.0.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)