### PR TITLE
perf(goldencheck): 3.1.0 -- fused single-pass string-column digest

### DIFF
--- a/docs/superpowers/specs/2026-07-12-goldencheck-fused-column-kernel-design.md
+++ b/docs/superpowers/specs/2026-07-12-goldencheck-fused-column-kernel-design.md
@@ -1,0 +1,48 @@
+# GoldenCheck fused per-column kernel — design
+
+Date: 2026-07-12
+Status: wave design of the Arrow fused-scan program — realizing the "FUSED" the program was named for. Grounds: measured pass inventory (~8 passes/column) + the per-profiler reduction recon (2026-07-12).
+Base: perf work merged/queued (3.0.1 vectorized cast, 3.0.2 vectorized string ops + column caching, 3.0.3 parallel scan). Branch `perf/goldencheck-fused-column-kernel`.
+
+## Problem
+
+After the 3.0.x perf passes the scan makes each vectorized op fast and runs columns in parallel, but it still does **N separate passes per column** over the same bytes (measured: ~8/column; e.g. a string column does 2 casts + up to 7 regex match-counts + n_unique + drop_nulls, each a distinct scan). Polars' 0.33s (vs our 1.36s) comes from its query optimizer fusing those into far fewer materializations. The program design's original headline — "one column's ~13 checks in 1-2 shared passes" — was never built; the W-waves shipped individual kernels and the Flip wired them through the seam method-by-method.
+
+## Architecture — fused digest, memoized on `ArrowColumn` (profilers UNCHANGED)
+
+Do NOT rewire the profilers. Instead: the **first** seam reduction on a column triggers ONE fused Rust kernel pass that computes everything that column's dtype needs; the result is cached on the `ArrowColumn`, and every subsequent seam method reads from the cache. This extends the existing `_num_stats`/`_n_unique`/`_dropna` memoization to a full digest. The `Column` seam is unchanged, so the profilers, the differential harness, and the Jaccard-1.0 gate are all unchanged — the kernel computes the SAME quantities, in one pass.
+
+Per-dtype fused kernels in `goldencheck-core` (arrow-in, matching the existing kernels), PyO3-shimmed in `goldencheck-native`, gated by `native_enabled(...)` with the current pyarrow.compute path as the fallback (accelerator-not-requirement).
+
+### The digest structs (from the recon reduction table)
+- **Universal core** (every dtype): `count`, `null_count`, `n_unique` (+ capped `distinct_values`) — satisfies nullability + uniqueness + cardinality in one pass.
+- **Numeric** (`column_numeric_stats` already fuses the 6 stats): fold `n_unique` into that SAME streaming pass (build the distinct hashset while accumulating min/max/sum/sumsq). Non-fusable tail stays separate: outlier sample (2-pass, needs mean/std), sequence gaps (needs materialized distinct-set).
+- **String** (the BIG win — ~10 passes today): ONE pass computing `null_count`, `n_unique` (hashset), `float_castable_count`, `int_castable_count`, and `match_count[pattern]` for the 7 fixed patterns (email/phone/url + 4 encoding patterns). `str::to_lowercase`-free; regex crate (matches pyarrow RE2 on these fixed patterns — differential-gated). Skeleton value-counts (pattern_consistency) stays a 2nd derived pass; fuzzy clustering stays external.
+- **Date/datetime**: `count`, `null_count`, `n_unique`, `max`, `count_gt(now)` — one pass (`now` passed in at the column's granularity).
+- **Bool / other**: universal core only.
+
+### Materialized-value tails (unchanged, kept separate)
+Outlier samples, format/encoding sample rows, pattern skeleton groups, cardinality distinct samples, sequence gaps, drift per-half sets, fuzzy clusters — these need rows, not scalars. They remain their own (fast, vectorized) passes; the fused kernel does NOT try to produce them. It only fuses the SCALAR reductions that dominate the pass count.
+
+### Two cross-profiler dependencies to preserve
+1. `type_inference` writes `context[column]["mostly_numeric"]` (gates range_distribution on string cols). The fused string digest emits `float_castable_count`, so the promotion decision reads the digest — no re-scan.
+2. `drift_detection` needs per-HALF aggregates (split at `total//2`) — a whole-column pass can't produce these. Drift stays on its own slice-then-reduce path (it also has a `total < 1000` gate, so it rarely fires on the small end).
+
+## Phasing (measure + differential-1.000 gate each)
+- **Phase 1 — STRING digest** (biggest ROI, self-contained): the fused string kernel + wire `ArrowColumn` to compute+cache it and have `str_match_count`/`cast('float'/'int')`/`n_unique`/`null_count` read from it for string columns. Collapses ~10 string passes -> 1. Ship + measure.
+- **Phase 2 — NUMERIC digest**: fold `n_unique` (and optionally `is_sorted`/diff-counts) into `column_numeric_stats`'s pass. Smaller (numeric already fuses 6). Ship + measure only if Phase 1 ROI justifies.
+- **Phase 3 — date/bool/other**: universal-core digest. Marginal; do only if measured.
+
+## Correctness / contract
+- The fused kernel MUST produce byte/epsilon-identical scalars to the current per-method path. Gate: the finding-set differential (strict Jaccard 1.000) + the ArrowColumn parity tests, run with the fused path ON and OFF. Any divergence = revert/fix, not ship.
+- RE2-vs-regex-crate on the 7 fixed patterns: the differential is the arbiter; the encoding `\uXXXX` patterns already route to the kernel today, so parity there is expected.
+- Native-absent: pyarrow.compute fallback path unchanged (accelerator-not-requirement).
+- Determinism preserved (pure per-column function; composes with the 3.0.3 thread pool).
+
+## Risks
+- **ROI**: caching already deduped n_unique/stats; the win is concentrated in string columns' cast+regex passes. Phase 1 measures whether it's worth Phases 2-3. Be honest if it plateaus.
+- **Kernel scope creep**: keep the kernel to SCALAR reductions; never try to fuse the materialized-value tails.
+- **New kernel symbol wheel skew**: a depended-on new symbol must ship in the published wheel (the #688 lesson) — but in-tree build covers dev; the fallback keeps it correct if absent.
+
+## Non-goals
+No profiler rewrite. No fusing materialized-value passes. No new numerics. No change to the owned contract / finding set.

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.1.0] - 2026-07-12
+
+### Performance
+- **Fused single-pass string-column digest.** A new native kernel
+  (`string_column_digest`) computes a string column's `null_count`, `n_unique`, and
+  the match count for all 7 fixed scan patterns (email/phone/url + 4 encoding
+  patterns) in ONE pass over the data, instead of ~10 separate passes (each
+  `str_match_count` was its own scan; the 4 encoding patterns went through a
+  `to_pylist` + regex-kernel round-trip). `ArrowColumn` computes+caches the digest on
+  the first known-pattern `str_match_count` for a string column; subsequent
+  known-pattern counts and `n_unique`/`null_count` read the cache. Findings are
+  unchanged (differential Jaccard 1.000; all 7 patterns compile in the regex crate).
+  1M x 7 scan_file: 1.36s -> **0.98s** (with the 3.0.3 parallel scan); string-heavy
+  data benefits most. Cumulative 3.0.1 -> 3.1.0: 3.74s -> 0.98s (~3.8x). The pyarrow
+  fallback is unchanged when the native kernel is absent.
+
 ## [3.0.3] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.0.3"
+__version__ = "3.1.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/_native_loader.py
+++ b/packages/python/goldencheck/goldencheck/core/_native_loader.py
@@ -114,6 +114,7 @@ _COMPONENT_SYMBOLS: dict[str, tuple[str, ...]] = {
     "csv_infer": ("csv_infer_columns",),
     "column_aggregate": ("column_aggregate",),
     "numeric_stats": ("column_numeric_stats", "count_outside"),
+    "string_digest": ("string_column_digest",),
     "sequence_analysis": ("sequence_analysis",),
     "date_freshness": ("date_freshness",),
     "duplicate_signatures": ("duplicate_signatures",),

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -104,6 +104,34 @@ _CAST_KIND = {"float": "Float64", "int": "Int64", "str": "String"}   # strings o
 _INT_LITERAL_RE = r"^[+-]?\d+$"
 _FLOAT_LITERAL_RE = r"^[+-]?(\d+\.?\d*|\.\d+)([eE][+-]?\d+)?$"
 
+# The 7 fixed patterns every string column is scanned for by format_detection
+# (email/phone/url) and encoding_detection (non-ascii/zero-width/smart-quotes/
+# control). These MUST be byte-identical to the constants in those profilers so
+# `pattern in _SCAN_STRING_PATTERNS` matches at the seam. When native is enabled,
+# the FIRST `str_match_count` of any of these on a string column computes the
+# fused digest (null_count + n_unique + all 7 match counts) in ONE Rust pass and
+# caches it on the ArrowColumn; every subsequent known-pattern match count (and,
+# opportunistically, n_unique/null_count) reads the cache. Order is load-bearing:
+# the digest returns match_counts aligned to this tuple.
+#
+# The zero-width and smart-quote patterns are the raw-string ``\uXXXX`` escape
+# forms (literal backslashes) that ``encoding_detection`` passes -- pyarrow RE2
+# can't compile them, so they already route to the regex crate, and the digest
+# uses the same engine. They're built from code points (not typed as literal
+# ``\uXXXX`` or as the raw Unicode characters) so a source formatter can't
+# silently un-escape them and break the byte-exact ``pattern in ...`` seam match.
+_ZERO_WIDTH_PATTERN = "[" + "".join(f"\\u{c:04X}" for c in (0x200B, 0x200C, 0x200D, 0xFEFF)) + "]"
+_SMART_QUOTES_PATTERN = "[" + "".join(f"\\u{c:04X}" for c in (0x2018, 0x2019, 0x201C, 0x201D)) + "]"
+_SCAN_STRING_PATTERNS: tuple[str, ...] = (
+    r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",  # email (format_detection)
+    r"^\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$",             # phone (format_detection)
+    r"^https?://",                                         # url (format_detection)
+    r"[^\x00-\x7F]",                                       # non-ascii (encoding_detection)
+    _ZERO_WIDTH_PATTERN,                                   # zero-width (encoding_detection)
+    _SMART_QUOTES_PATTERN,                                 # smart quotes (encoding_detection)
+    r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]",                   # control chars (encoding_detection)
+)
+
 
 class NativeRequiredError(RuntimeError):
     """A covered hard op needs the native regex kernel. Install it with
@@ -444,7 +472,7 @@ class ArrowColumn:
     ``max()`` on a date column returns a ``datetime.date`` (freshness needs it).
     """
 
-    __slots__ = ("_arr", "_cat", "_num_stats", "_n_unique", "_dropna")
+    __slots__ = ("_arr", "_cat", "_num_stats", "_n_unique", "_dropna", "_str_digest")
 
     def __init__(self, arr: Any) -> None:
         pa, _ = _arrow()
@@ -455,6 +483,10 @@ class ArrowColumn:
         self._num_stats: Any = None   # None=unset, False=empty/all-null, tuple=cached
         self._n_unique: int | None = None      # memoized across profilers (see ArrowFrame cache)
         self._dropna: ArrowColumn | None = None
+        # Fused string digest (null_count, n_unique, match_counts) for the 7 fixed
+        # scan patterns. None=unset; computed once by the first known-pattern
+        # str_match_count and read by later known-pattern counts + n_unique/null_count.
+        self._str_digest: tuple[int, int, list[int]] | None = None
 
     # -- numeric stats (cached single kernel call) ----------------------------
     def _numeric_stats(self):
@@ -514,15 +546,26 @@ class ArrowColumn:
         return len(self._arr)
 
     def null_count(self) -> int:
+        # Opportunistically read the fused string digest if it's already been
+        # computed (do NOT force it just for null_count). pyarrow's null_count is
+        # already cheap, so this only shortcuts when the digest happens to exist.
+        if self._str_digest is not None:
+            return self._str_digest[0]
         return self._arr.null_count
 
     def n_unique(self) -> int:
         # Memoized: cardinality + uniqueness + the scan-loop ColumnProfile each ask
         # for this on the SAME cached column (ArrowFrame reuses instances), so
         # count_distinct runs once per column instead of ~3x. nulls = 1 distinct.
+        # If the fused string digest is already computed, reuse its n_unique (same
+        # count_distinct(mode="all") semantics) instead of a separate scan -- but
+        # never force the digest just for this.
         if self._n_unique is None:
-            _, pc = _arrow()
-            self._n_unique = int(pc.count_distinct(self._arr, mode="all").as_py())
+            if self._str_digest is not None:
+                self._n_unique = self._str_digest[1]
+            else:
+                _, pc = _arrow()
+                self._n_unique = int(pc.count_distinct(self._arr, mode="all").as_py())
         return self._n_unique
 
     def drop_nulls(self) -> ArrowColumn:
@@ -598,7 +641,33 @@ class ArrowColumn:
         r = pc.sum(pc.is_in(self._arr, value_set=pa.array(values))).as_py()
         return int(r or 0)
 
+    def _is_string(self) -> bool:
+        return self._cat == "str"
+
+    def _compute_str_digest(self) -> tuple[int, int, list[int]]:
+        """Run the fused string kernel ONCE (null_count, n_unique, and the match
+        count for all 7 fixed scan patterns in a single pass) and cache it. Only
+        called when the column is a string type and native ``string_digest`` is
+        enabled. Reused by every subsequent known-pattern ``str_match_count`` and
+        opportunistically by ``n_unique``/``null_count``."""
+        if self._str_digest is None:
+            null_count, n_unique, match_counts = native_module().string_column_digest(
+                self._arr, list(_SCAN_STRING_PATTERNS)
+            )
+            self._str_digest = (null_count, n_unique, list(match_counts))
+        return self._str_digest
+
     def str_match_count(self, pattern: str) -> int:
+        # Fused digest fast path: the first known-pattern match count on a string
+        # column computes null_count + n_unique + all 7 fixed-pattern match counts
+        # in ONE Rust pass (collapsing the ~10 separate scans a string column
+        # otherwise makes); every later known-pattern count reads the cache. The
+        # kernel is byte-identical to the per-pattern path (finding-set differential
+        # Jaccard 1.000). Unknown patterns / non-string cols / native-off fall
+        # through to the vectorized pyarrow path unchanged.
+        if self._is_string() and native_enabled("string_digest") and pattern in _SCAN_STRING_PATTERNS:
+            _, _, match_counts = self._compute_str_digest()
+            return match_counts[_SCAN_STRING_PATTERNS.index(pattern)]
         # Prefer the VECTORIZED pyarrow path (pc.match_substring_regex + pc.sum, C++,
         # no Python-list materialization). The native kernel is list-based, so routing
         # through it forces `self._arr.to_pylist()` on the whole column -- at 1M rows

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.0.3"
+version = "3.1.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.0.3",
+  "version": "3.1.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.0.3",
+      "version": "3.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldencheck/tests/flip/test_string_digest_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_string_digest_parity.py
@@ -1,0 +1,117 @@
+"""Phase-1 fused string-digest parity gate.
+
+The fused ``string_column_digest`` kernel folds ~10 per-column string passes
+(``null_count`` + ``n_unique`` + the 7 fixed ``str_match_count`` scans) into ONE
+Rust pass. This asserts it is byte-identical to the per-method path:
+
+- ``match_counts[i]`` == the regex-crate ``str_contains_count(patterns[i])`` (the
+  ground truth the ``str_match_count`` fallback uses) for each of the 7 patterns.
+- ``n_unique`` == pyarrow ``count_distinct(mode="all")`` (nulls = one distinct).
+- ``null_count`` == ``arr.null_count``.
+
+Also checks the ``ArrowColumn`` wiring: the digest fast path returns the same
+counts as the pyarrow/kernel fallback, computes the digest exactly once, and
+opportunistically feeds ``n_unique``/``null_count``.
+"""
+from __future__ import annotations
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+pc = pytest.importorskip("pyarrow.compute")
+
+from goldencheck.core._native_loader import native_enabled, native_module  # noqa: E402
+from goldencheck.core.frame import _SCAN_STRING_PATTERNS, ArrowColumn  # noqa: E402
+
+# Skip cleanly when the native kernel isn't built (the fused path is an optional
+# accelerator; the fallback is covered by the existing pyarrow parity suite).
+pytestmark = pytest.mark.skipif(
+    not native_enabled("string_digest"),
+    reason="goldencheck._native.string_column_digest not built/enabled",
+)
+
+# Tricky code points built via chr() so the source stays plain-ASCII.
+_ZW = chr(0x200B)      # zero-width space
+_FEFF = chr(0xFEFF)    # zero-width no-break space (BOM)
+_RSQUO = chr(0x2019)   # right single quote (smart quote)
+_LDQUO = chr(0x201C)   # left double quote (smart quote)
+_EACUTE = chr(0x00E9)  # é (non-ascii)
+_BELL = chr(0x0007)    # bell (control char)
+
+
+def _corpus() -> list[str | None]:
+    return [
+        "alice@example.com",
+        "bob.smith@sub.domain.co",
+        "not-an-email",
+        "(212) 555-0198",
+        "212.555.0198",
+        "5550198",  # too short -> not a phone
+        "https://example.com/path",
+        "http://x.io",
+        "ftp://nope",  # not http(s)
+        "plain text",
+        "caf" + _EACUTE,             # non-ascii
+        "zero" + _ZW + "width",      # zero-width + non-ascii
+        "bom" + _FEFF,               # BOM + non-ascii
+        "smart" + _RSQUO + "quote",  # smart quote + non-ascii
+        "quote" + _LDQUO + "d",      # smart quote + non-ascii
+        "ctrl" + _BELL + "char",     # control char
+        None,
+        None,
+        "alice@example.com",  # duplicate of row 0
+    ]
+
+
+@pytest.mark.parametrize("large", [False, True])
+def test_digest_matches_per_method_path(large: bool) -> None:
+    vals = _corpus()
+    typ = pa.large_string() if large else pa.string()
+    arr = pa.array(vals, type=typ)
+
+    null_count, n_unique, match_counts = native_module().string_column_digest(
+        arr, list(_SCAN_STRING_PATTERNS)
+    )
+
+    # 1) match_counts == the regex-crate kernel per pattern (ground truth).
+    pylist = arr.to_pylist()
+    for i, pat in enumerate(_SCAN_STRING_PATTERNS):
+        expected = native_module().str_contains_count(pylist, pat)
+        assert match_counts[i] == expected, (
+            f"pattern {i} {pat!r}: digest={match_counts[i]} kernel={expected}"
+        )
+
+    # 2) n_unique == pyarrow count_distinct(mode="all").
+    assert n_unique == int(pc.count_distinct(arr, mode="all").as_py())
+
+    # 3) null_count == arr.null_count.
+    assert null_count == arr.null_count
+
+
+def test_arrowcolumn_fast_path_equals_fallback_and_caches() -> None:
+    arr = pa.array(_corpus(), type=pa.string())
+
+    col = ArrowColumn(arr)
+    fast = [col.str_match_count(p) for p in _SCAN_STRING_PATTERNS]
+
+    # The digest is computed exactly once and cached.
+    assert col._str_digest is not None
+
+    # Reference: the regex-crate kernel (what the pyarrow path falls back to for
+    # the \uXXXX encoding patterns RE2 cannot compile).
+    pylist = arr.to_pylist()
+    ref = [native_module().str_contains_count(pylist, p) for p in _SCAN_STRING_PATTERNS]
+    assert fast == ref
+
+    # n_unique / null_count read the cached digest (same values as a fresh scan).
+    assert col.n_unique() == int(pc.count_distinct(arr, mode="all").as_py())
+    assert col.null_count() == arr.null_count
+
+
+def test_unknown_pattern_does_not_force_digest() -> None:
+    arr = pa.array(["aXb", "cd", None, "X"], type=pa.string())
+    col = ArrowColumn(arr)
+    # A pattern NOT in the fixed set stays on the vectorized pyarrow path and must
+    # not populate the digest cache.
+    assert col.str_match_count("X") == 2
+    assert col._str_digest is None

--- a/packages/rust/extensions/goldencheck-core/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-core/src/lib.rs
@@ -37,6 +37,7 @@ mod keys;
 mod regex;
 mod sequence;
 mod stats;
+mod string_digest;
 
 pub use age::{age_mismatch, AgeStats};
 pub use aggregate::{column_aggregate, dtype_category, ColumnAgg, DtypeCat};
@@ -59,3 +60,4 @@ pub use keys::{
 pub use regex::{str_contains_count, str_filter_mask, str_replace_all};
 pub use sequence::{sequence_analysis, SeqStats};
 pub use stats::{column_numeric_stats, count_outside, NumStats};
+pub use string_digest::{string_column_digest, StringDigest};

--- a/packages/rust/extensions/goldencheck-core/src/string_digest.rs
+++ b/packages/rust/extensions/goldencheck-core/src/string_digest.rs
@@ -1,0 +1,204 @@
+//! Fused single-pass string-column digest for the scan's format/encoding
+//! profilers. Today a string column makes ~10 separate passes over the same
+//! bytes: `n_unique` (`count_distinct`), `null_count`, and up to 7
+//! `str_match_count(pattern)` regex scans (3 format patterns + 4 encoding
+//! patterns), each a distinct materialization. This kernel folds all of them
+//! into ONE pass over the `StringArray` / `LargeStringArray`.
+//!
+//! # Parity contract
+//!
+//! - `null_count` == `arr.null_count` (pyarrow).
+//! - `n_unique` == pyarrow `count_distinct(mode="all")`: distinct **non-null**
+//!   values plus one if any null is present (nulls collapse to a single
+//!   distinct). Built with a `HashSet<&str>` borrowing straight from the
+//!   array's value buffer -- no per-element `String` allocation.
+//! - `match_counts[i]` == `str_match_count(patterns[i])` (mirrors
+//!   `pc.match_substring_regex(...).sum()` on the non-null column). Each pattern
+//!   is compiled once with the `regex` crate -- the same engine Polars uses and
+//!   the one the encoding patterns' `\uXXXX` escapes already route to today
+//!   (pyarrow RE2 cannot compile them). Match is an unanchored `is_match`
+//!   search, agreeing with pyarrow's unanchored `match_substring_regex`; the
+//!   `^`/`$` anchors live inside the email/phone/url patterns themselves.
+//!
+//! The digest fuses only SCALAR reductions. Materialized-value tails (pattern
+//! skeletons, sample rows, fuzzy clusters) stay on their own passes.
+use arrow::array::{Array, LargeStringArray, StringArray};
+use arrow::datatypes::DataType;
+use regex::Regex;
+use rustc_hash::FxHashSet;
+
+/// One-pass string-column summary. `match_counts` is aligned to the `patterns`
+/// slice passed to [`string_column_digest`] (same length, same order).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StringDigest {
+    pub null_count: usize,
+    pub n_unique: usize,
+    pub match_counts: Vec<usize>,
+}
+
+/// Fold `null_count`, `n_unique`, and per-pattern match counts into a single
+/// pass over a Utf8 / LargeUtf8 Arrow column. Non-string dtypes yield a
+/// zero/empty digest (the caller only invokes this on string columns).
+///
+/// Patterns are compiled once up front; a pattern that fails to compile in the
+/// `regex` crate propagates as `regex::Error` so the caller can fall back to
+/// the per-pattern path for it rather than silently miscounting.
+pub fn string_column_digest(
+    array: &dyn Array,
+    patterns: &[String],
+) -> Result<StringDigest, regex::Error> {
+    let regexes: Vec<Regex> = patterns
+        .iter()
+        .map(|p| Regex::new(p))
+        .collect::<Result<_, _>>()?;
+
+    let mut null_count = 0usize;
+    let mut any_null = false;
+    let mut seen: FxHashSet<&str> = FxHashSet::default();
+    let mut match_counts = vec![0usize; regexes.len()];
+
+    macro_rules! scan {
+        ($arrty:ty) => {{
+            let arr = array.as_any().downcast_ref::<$arrty>().unwrap();
+            seen.reserve(arr.len());
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    null_count += 1;
+                    any_null = true;
+                    continue;
+                }
+                let v: &str = arr.value(i);
+                seen.insert(v);
+                for (j, re) in regexes.iter().enumerate() {
+                    if re.is_match(v) {
+                        match_counts[j] += 1;
+                    }
+                }
+            }
+        }};
+    }
+
+    match array.data_type() {
+        DataType::Utf8 => scan!(StringArray),
+        DataType::LargeUtf8 => scan!(LargeStringArray),
+        // Non-string dtype: caller never reaches here on the fused path, but
+        // return an empty digest rather than panic.
+        _ => {}
+    }
+
+    // count_distinct(mode="all"): non-null distinct + 1 for the null "value".
+    let n_unique = seen.len() + usize::from(any_null);
+    Ok(StringDigest {
+        null_count,
+        n_unique,
+        match_counts,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use arrow::array::{LargeStringArray, StringArray};
+
+    // The 7 fixed scan patterns (exact strings passed at the seam).
+    const EMAIL: &str = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$";
+    const PHONE: &str = r"^\(?\d{3}\)?[\s.-]?\d{3}[\s.-]?\d{4}$";
+    const URL: &str = r"^https?://";
+    const NONASCII: &str = r"[^\x00-\x7F]";
+    const ZEROWID: &str = r"[​‌‍﻿]";
+    const SMARTQ: &str = r"[‘’“”]";
+    const CONTROL: &str = r"[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]";
+
+    fn all_patterns() -> Vec<String> {
+        [EMAIL, PHONE, URL, NONASCII, ZEROWID, SMARTQ, CONTROL]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn all_seven_patterns_compile() {
+        for p in all_patterns() {
+            Regex::new(&p).unwrap_or_else(|e| panic!("pattern {p:?} failed: {e}"));
+        }
+    }
+
+    #[test]
+    fn null_and_unique_semantics() {
+        let a = StringArray::from(vec![Some("x"), Some("y"), Some("x"), None, None]);
+        let d = string_column_digest(&a, &[]).unwrap();
+        assert_eq!(d.null_count, 2);
+        // distinct non-null {x, y} = 2, plus 1 for the null value = 3.
+        assert_eq!(d.n_unique, 3);
+    }
+
+    #[test]
+    fn no_nulls_no_phantom_distinct() {
+        let a = StringArray::from(vec!["a", "b", "c", "a"]);
+        let d = string_column_digest(&a, &[]).unwrap();
+        assert_eq!(d.null_count, 0);
+        assert_eq!(d.n_unique, 3); // {a,b,c}, no null bump
+    }
+
+    #[test]
+    fn email_phone_url_counts() {
+        let a = StringArray::from(vec![
+            Some("a@b.com"),
+            Some("x@y.org"),
+            Some("(123) 456-7890"),
+            Some("https://example.com"),
+            Some("plain text"),
+            None,
+        ]);
+        let pats: Vec<String> = [EMAIL, PHONE, URL].iter().map(|s| s.to_string()).collect();
+        let d = string_column_digest(&a, &pats).unwrap();
+        assert_eq!(d.match_counts, vec![2, 1, 1]);
+        assert_eq!(d.null_count, 1);
+    }
+
+    #[test]
+    fn encoding_patterns_count() {
+        let a = StringArray::from(vec![
+            Some("café"),            // non-ascii é
+            Some("zero\u{200B}wid"), // zero-width space
+            Some("smart\u{2019}q"),  // right single quote
+            Some("ctrl\u{0007}"),    // bell control char
+            Some("clean"),
+        ]);
+        let pats: Vec<String> = [NONASCII, ZEROWID, SMARTQ, CONTROL]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let d = string_column_digest(&a, &pats).unwrap();
+        // non-ascii: café, zero-width, smart-quote all contain non-ascii = 3
+        assert_eq!(d.match_counts[0], 3);
+        assert_eq!(d.match_counts[1], 1); // zero-width
+        assert_eq!(d.match_counts[2], 1); // smart quote
+        assert_eq!(d.match_counts[3], 1); // control
+    }
+
+    #[test]
+    fn large_utf8_supported() {
+        let a = LargeStringArray::from(vec![Some("a@b.com"), None, Some("a@b.com")]);
+        let pats: Vec<String> = [EMAIL].iter().map(|s| s.to_string()).collect();
+        let d = string_column_digest(&a, &pats).unwrap();
+        assert_eq!(d.match_counts, vec![2]);
+        assert_eq!(d.null_count, 1);
+        assert_eq!(d.n_unique, 2); // {a@b.com} + null
+    }
+
+    #[test]
+    fn empty_column() {
+        let a = StringArray::from(Vec::<Option<&str>>::new());
+        let d = string_column_digest(&a, &all_patterns()).unwrap();
+        assert_eq!(d.null_count, 0);
+        assert_eq!(d.n_unique, 0);
+        assert_eq!(d.match_counts, vec![0; 7]);
+    }
+
+    #[test]
+    fn bad_pattern_errors() {
+        let a = StringArray::from(vec!["x"]);
+        assert!(string_column_digest(&a, &["[unclosed".to_string()]).is_err());
+    }
+}

--- a/packages/rust/extensions/goldencheck-native/src/lib.rs
+++ b/packages/rust/extensions/goldencheck-native/src/lib.rs
@@ -27,6 +27,7 @@ mod profile;
 mod regex;
 mod sequence;
 mod stats;
+mod string_digest;
 
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -35,6 +36,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(aggregate::column_aggregate, m)?)?;
     m.add_function(wrap_pyfunction!(stats::column_numeric_stats, m)?)?;
     m.add_function(wrap_pyfunction!(stats::count_outside, m)?)?;
+    m.add_function(wrap_pyfunction!(string_digest::string_column_digest, m)?)?;
     m.add_function(wrap_pyfunction!(sequence::sequence_analysis, m)?)?;
     m.add_function(wrap_pyfunction!(freshness::date_freshness, m)?)?;
     m.add_function(wrap_pyfunction!(keys::composite_key_search, m)?)?;

--- a/packages/rust/extensions/goldencheck-native/src/string_digest.rs
+++ b/packages/rust/extensions/goldencheck-native/src/string_digest.rs
@@ -1,0 +1,24 @@
+//! Arrow-reading shim for the fused string-column digest kernel. Decodes the
+//! pyarrow array (zero-copy via the C Data Interface) and delegates to
+//! `goldencheck_core::string_column_digest`, which owns the downcast, the
+//! single-pass null/n_unique accumulation, and the per-pattern regex counting.
+use arrow::array::{make_array, ArrayData};
+use arrow::pyarrow::PyArrowType;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+
+/// Fused single-pass string digest: `(null_count, n_unique, match_counts)` for
+/// the given `patterns` (aligned to the input order). `n_unique` matches pyarrow
+/// `count_distinct(mode="all")` (nulls count as one distinct); `match_counts[i]`
+/// matches `str_match_count(patterns[i])`. A pattern that the `regex` crate
+/// cannot compile raises `ValueError` so the caller falls back per-pattern.
+#[pyfunction]
+pub fn string_column_digest(
+    array: PyArrowType<ArrayData>,
+    patterns: Vec<String>,
+) -> PyResult<(usize, usize, Vec<usize>)> {
+    let arr = make_array(array.0);
+    let d = goldencheck_core::string_column_digest(arr.as_ref(), &patterns)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+    Ok((d.null_count, d.n_unique, d.match_counts))
+}


### PR DESCRIPTION
## goldencheck 3.1.0 -- fused string-column digest

Realizes the unbuilt core of the "fused scan engine": a string column did ~10 separate passes (each `str_match_count` its own scan; the 4 encoding patterns via a `to_pylist`+regex-kernel round-trip). New native kernel `string_column_digest` does **one pass** computing null_count + n_unique + all 7 fixed-pattern match counts.

Architecture: fuse via a **memoized digest on `ArrowColumn`**, NOT by rewiring profilers. First known-pattern `str_match_count` on a string column computes the digest once and caches it; subsequent known-pattern counts + `n_unique`/`null_count` read the cache. The `Column` seam, the profilers, and the differential-1.000 gate are unchanged.

### Kernel
- `goldencheck-core/src/string_digest.rs`: one pass over `StringArray`/`LargeStringArray`, `FxHashSet<&str>` borrowed from the value buffer (no per-element alloc), pre-compiled regexes. `n_unique` matches pyarrow `count_distinct(mode="all")`. 8 core unit tests.
- `goldencheck-native` PyO3 shim + `_COMPONENT_SYMBOLS` registration. All 7 patterns compile in the regex crate (none fall back).

### Measured (1M x 7, 5-run median)
| | scan_file |
|---|---|
| 3.0.3 (parallel) | 1.36s |
| **3.1.0 (parallel + digest)** | **0.98s** |
| (Polars reference) | 0.33s |

~1.4x on top of 3.0.3; **cumulative 3.0.1 -> 3.1.0: 3.74s -> 0.98s (~3.8x)**, Polars gap ~11x -> ~3x. String-heavy data benefits most.

### Correctness
- differential strict Jaccard **1.000**, 0 divergences; new `test_string_digest_parity.py` (digest match_counts == current `str_match_count`; n_unique == `count_distinct(mode='all')`).
- suite 810 green; `GOLDENCHECK_NATIVE=0` fallback intact (263 passed, digest test skips cleanly); ruff clean; clippy `-D warnings` clean on both crates; version_consistency 3.1.0.
- accelerator-not-requirement preserved (pyarrow fallback when native absent).

Design: `docs/superpowers/specs/2026-07-12-goldencheck-fused-column-kernel-design.md`. Phase 1 (string) of the fused-column program; numeric/date digests are follow-on phases gated on measured ROI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)