### PR TITLE
feat(goldenmatch)!: arrow-descent D3 -- internal result dicts emit pa.Table

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -18,9 +18,12 @@ array-ization is leaf-local (`to_list`/`to_numpy` before rapidfuzz).
   oversized id sets, and the collected-frame splits run on ArrowFrame seam ops
   (`filter_in`/`filter_not_in`/`with_gt_column`). `_to_result_table` already
   passes pa.Table through — no consumer breaks. ~10 pl uses out of the lane.
-- **D2 — fused golden slot arrow**: `_try_fused_golden`/`run_golden_fused_arrow`
-  returns arrow; `golden_df` slot retyped `Frame`-polymorphic. Slow-path
-  `_golden_records_to_df` untouched (fused lane never hits it).
+- **D2 — fused golden slot arrow (RE-ORDERED after D3/D4, recon 2026-07-12)**:
+  run_golden_fused_arrow's kernel returns INDICES and the Python side GATHERS
+  on the multi_df frame (_gather_with_nulls over pl.Series) -- an arrow output
+  is only an end-conversion until multi_df itself arrives as arrow, which
+  requires collected_df unification (D3) / ClusterFrames (D4). Deep D2 =
+  gather on ArrowColumn once the input is arrow.
 - **D3 — terminal splits + result dict via the seam** (pipeline.py ~3098-3230):
   dupes/unique splits via `filter_in` on `to_frame(collected_df)`; BOTH lanes
   emit pa.Table in the INTERNAL dict. Must migrate the internal-dict consumers

--- a/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
+++ b/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
@@ -104,10 +104,11 @@ def run_goldenmatch_dedupe(
             and getattr(c, "field_name", None)
             and getattr(c, "corrected_value", None) is not None
         ]
-        if field_level and "__cluster_id__" in output_df.columns:
-            # W5: results become pa.Table at v3.0.0 -- this patch loop and the
-            # duckdb registration flip with the results type.
-            import polars as pl
+        if field_level and "__cluster_id__" in output_df.column_names:
+            # D3 (arrow descent): the internal dict emits pa.Table; the patch
+            # loop and the duckdb registration run on Arrow (duckdb's
+            # replacement scan reads pa.Table natively).
+            import pyarrow as pa
 
             # Build a Python-side patch map then materialize.
             patches: dict[tuple[int, str], str] = {}
@@ -119,12 +120,12 @@ def run_goldenmatch_dedupe(
 
             # Apply patches column-by-column. For each touched column we
             # build an array of overrides aligned to output_df rows.
-            cluster_ids = output_df["__cluster_id__"].to_list()
+            cluster_ids = output_df["__cluster_id__"].to_pylist()
             for fname in {f for _, f in patches.keys()}:
-                if fname not in output_df.columns:
+                if fname not in output_df.column_names:
                     stale += sum(1 for k in patches if k[1] == fname)
                     continue
-                col_vals = output_df[fname].to_list()
+                col_vals = output_df[fname].to_pylist()
                 changed = False
                 for i, cid in enumerate(cluster_ids):
                     new = patches.get((int(cid), fname))
@@ -133,8 +134,9 @@ def run_goldenmatch_dedupe(
                         applied += 1
                         changed = True
                 if changed:
-                    output_df = output_df.with_columns(
-                        pl.Series(name=fname, values=col_vals)
+                    idx = output_df.column_names.index(fname)
+                    output_df = output_df.set_column(
+                        idx, fname, pa.array(col_vals, type=output_df.schema.field(fname).type)
                     )
 
     if output_df is not None:
@@ -147,7 +149,7 @@ def run_goldenmatch_dedupe(
     conn.close()
     return {
         "input_rows": df.height,
-        "output_rows": output_df.height if output_df is not None else 0,
+        "output_rows": output_df.num_rows if output_df is not None else 0,
         "clusters": stats.get("total_clusters", 0),
         "applied_corrections": applied,
         "stale_corrections": stale,

--- a/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
+++ b/packages/dbt/goldensuite/dbt_goldensuite/materialize.py
@@ -80,6 +80,10 @@ def run_goldenmatch_dedupe(
     output_df = result.get("golden")
     if output_df is None:
         output_df = result.get("output")
+    # D3: the pipeline dict emits pa.Table; tests (and any legacy caller)
+    # may still hand a polars frame -- normalize to Arrow here.
+    if output_df is not None and not hasattr(output_df, "num_rows"):
+        output_df = output_df.to_arrow()
 
     # v1.18.x Phase 3: optional field-level correction overrides from
     # MemoryStore. Iterate field-level corrections for this dataset and

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -1306,9 +1306,9 @@ def _extract_stats(result: dict) -> dict:
     # duplicates were found.
     total_records = 0
     if dupes is not None:
-        total_records += dupes.height
+        total_records += _frame_height(dupes)
     if unique is not None:
-        total_records += unique.height
+        total_records += _frame_height(unique)
 
     # Defensive: if a pipeline path ever produces a golden-only result with
     # dupes/unique elided, total_records would silently be 0 and match_rate
@@ -1323,7 +1323,7 @@ def _extract_stats(result: dict) -> dict:
             "tables — total_records will be 0. This shape is not produced by "
             "the standard pipeline; if you hit this, the pipeline output "
             "contract has changed and _extract_stats needs updating.",
-            golden.height,
+            _frame_height(golden),
         )
 
     total_clusters = sum(1 for c in clusters.values() if c.get("size", 0) > 1)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -921,6 +921,15 @@ def run_dedupe(
     )
 
 
+def _dict_frame_to_arrow(obj):
+    """D3 (arrow descent): the INTERNAL pipeline dicts emit pa.Table for their
+    frame values on BOTH lanes. polars frames convert zero-copy; pa passes
+    through; None stays None. _api._to_result_table is a passthrough now."""
+    if obj is None or hasattr(obj, "num_rows"):
+        return obj
+    return obj.to_arrow()
+
+
 def _prep_cache_signature(config: GoldenMatchConfig) -> str:
     """Stable string signature of the prep-step config slots.
 
@@ -1557,11 +1566,11 @@ def _run_fused_match_short_circuit(
 
     return {
         "clusters": clusters,
-        "golden": golden_df,
-        "unique": unique_df,
-        "dupes": dupes_df,
+        "golden": _dict_frame_to_arrow(golden_df),
+        "unique": _dict_frame_to_arrow(unique_df),
+        "dupes": _dict_frame_to_arrow(dupes_df),
         "report": report,
-        "quarantine": quarantine_df,
+        "quarantine": _dict_frame_to_arrow(quarantine_df),
         "postflight_report": None,
         "memory_stats": None,
         "identity_summary": None,
@@ -3104,8 +3113,11 @@ def _run_dedupe_pipeline(
             dupe_row_ids.update(clusters[cid]["members"])
     unique_row_ids = set(all_ids) - dupe_row_ids
 
-    dupes_df = collected_df.filter(pl.col("__row_id__").is_in(list(dupe_row_ids)))
-    unique_df = collected_df.filter(pl.col("__row_id__").is_in(list(unique_row_ids)))
+    from goldenmatch.core.frame import to_frame as _to_frame_d3
+
+    _cf = _to_frame_d3(collected_df)
+    dupes_df = _cf.filter_in("__row_id__", list(dupe_row_ids)).native
+    unique_df = _cf.filter_in("__row_id__", list(unique_row_ids)).native
 
     # ── Step 6: REPORT ──
     report = None
@@ -3221,11 +3233,11 @@ def _run_dedupe_pipeline(
 
     results = {
         "clusters": _clusters_dict(),
-        "golden": golden_df,
-        "unique": unique_df,
-        "dupes": dupes_df,
+        "golden": _dict_frame_to_arrow(golden_df),
+        "unique": _dict_frame_to_arrow(unique_df),
+        "dupes": _dict_frame_to_arrow(dupes_df),
         "report": report,
-        "quarantine": quarantine_df,
+        "quarantine": _dict_frame_to_arrow(quarantine_df),
         "postflight_report": postflight_report,
         "memory_stats": memory_stats,
         "identity_summary": identity_summary,
@@ -3687,8 +3699,8 @@ def _run_match_pipeline(
             memory_store.close()
 
     return {
-        "matched": matched_df,
-        "unmatched": unmatched_df,
+        "matched": _dict_frame_to_arrow(matched_df),
+        "unmatched": _dict_frame_to_arrow(unmatched_df),
         "report": report,
         "quarantine": quarantine_df_match,
         "postflight_report": postflight_report,

--- a/packages/python/goldenmatch/goldenmatch/web/routers/match.py
+++ b/packages/python/goldenmatch/goldenmatch/web/routers/match.py
@@ -99,21 +99,22 @@ def _execute_match(
 
     result = run_match_df(target_df, ref_df, config, auto_config=False)
 
-    matched: pl.DataFrame | None = result.get("matched")
-    unmatched: pl.DataFrame | None = result.get("unmatched")
+    # D3: the internal dict emits pa.Table.
+    matched = result.get("matched")
+    unmatched = result.get("unmatched")
 
     matched_rows = (
-        matched.head(ROW_CAP).to_dicts() if matched is not None else []
+        matched.slice(0, ROW_CAP).to_pylist() if matched is not None else []
     )
     unmatched_rows = (
-        unmatched.head(ROW_CAP).to_dicts() if unmatched is not None else []
+        unmatched.slice(0, ROW_CAP).to_pylist() if unmatched is not None else []
     )
 
-    matched_total = matched.height if matched is not None else 0
-    unmatched_total = unmatched.height if unmatched is not None else 0
+    matched_total = matched.num_rows if matched is not None else 0
+    unmatched_total = unmatched.num_rows if unmatched is not None else 0
     target_total = target_df.height
     matched_targets = (
-        len(set(matched["__target_row_id__"].to_list())) if matched is not None else 0
+        len(set(matched["__target_row_id__"].to_pylist())) if matched is not None else 0
     )
 
     return {

--- a/packages/python/goldenmatch/tests/test_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_pipeline.py
@@ -222,7 +222,7 @@ class TestRunMatch:
         )
         # Each target should have at most one match in best mode
         if results["matched"] is not None and len(results["matched"]) > 0:
-            target_ids = results["matched"]["__target_row_id__"].to_list()
+            target_ids = results["matched"]["__target_row_id__"].to_pylist()
             assert len(target_ids) == len(set(target_ids))
 
 

--- a/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_frames_out_parity.py
@@ -172,7 +172,8 @@ def _golden_as_setrows(results):
     if golden is None:
         return None
     rows = []
-    for row in golden.iter_rows(named=True):
+    _iter = golden.to_pylist() if hasattr(golden, 'num_rows') else golden.iter_rows(named=True)
+    for row in _iter:
         norm = {}
         for k, v in row.items():
             norm[k] = frozenset(v) if isinstance(v, list) else v

--- a/packages/python/goldenmatch/tests/test_pipeline_fused_golden.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_fused_golden.py
@@ -110,8 +110,8 @@ def test_fused_golden_byte_identical_to_classic(monkeypatch):
 
     assert fused["golden"] is not None
     assert classic["golden"] is not None
-    a = fused["golden"].sort("__cluster_id__")
-    b = classic["golden"].sort("__cluster_id__")
+    a = pl.from_arrow(fused["golden"]).sort("__cluster_id__")
+    b = pl.from_arrow(classic["golden"]).sort("__cluster_id__")
     assert_frame_equal(a, b, check_column_order=False, check_row_order=False)
 
 
@@ -122,7 +122,7 @@ def test_kill_switch_uses_classic(monkeypatch):
     monkeypatch.setenv("GOLDENMATCH_GOLDEN_FUSED", "0")
     res = run_dedupe_df(df, cfg)
     assert res["golden_fused_used"] is False
-    assert res["golden"] is not None and res["golden"].height > 0
+    assert res["golden"] is not None and res["golden"].num_rows > 0
 
 
 def test_full_provenance_declines_fused(monkeypatch):
@@ -134,7 +134,7 @@ def test_full_provenance_declines_fused(monkeypatch):
     monkeypatch.delenv("GOLDENMATCH_GOLDEN_FUSED", raising=False)
     res = run_dedupe_df(df, cfg)
     assert res["golden_fused_used"] is False
-    assert res["golden"] is not None and res["golden"].height > 0
+    assert res["golden"] is not None and res["golden"].num_rows > 0
 
 
 def _write_nonstring_csv(path) -> None:
@@ -171,9 +171,10 @@ def test_file_path_nonstring_golden_byte_identical(tmp_path, monkeypatch):
     assert classic["golden_fused_used"] is False
 
     assert fused["golden"] is not None and classic["golden"] is not None
-    # The classic slow path emits `age` as Utf8; the fix makes fused match.
-    assert classic["golden"].schema["age"] == pl.Utf8
-    assert fused["golden"].schema["age"] == pl.Utf8
-    a = fused["golden"].sort("__cluster_id__")
-    b = classic["golden"].sort("__cluster_id__")
+    a = pl.from_arrow(fused["golden"]).sort("__cluster_id__")
+    b = pl.from_arrow(classic["golden"]).sort("__cluster_id__")
+    # The classic slow path emits `age` as Utf8; the fix makes fused match
+    # (asserted on the polars view of the arrow tables).
+    assert b["age"].dtype == pl.Utf8
+    assert a["age"].dtype == pl.Utf8
     assert_frame_equal(a, b, check_column_order=False, check_row_order=False)

--- a/packages/python/goldenmatch/tests/test_pipeline_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_fused_match.py
@@ -109,9 +109,12 @@ def _multi_partition(clusters: dict) -> set[frozenset[int]]:
     }
 
 
-def _golden_content(g: pl.DataFrame) -> pl.DataFrame:
+def _golden_content(g) -> pl.DataFrame:
     """Golden user-value rows, modulo cluster id + confidence (the fused path
-    numbers clusters differently and sheds confidence in capacity mode)."""
+    numbers clusters differently and sheds confidence in capacity mode).
+    D3: the dict emits pa.Table; compare in polars (dev dep)."""
+    if not isinstance(g, pl.DataFrame):
+        g = pl.from_arrow(g)
     cols = [c for c in g.columns if c not in ("__cluster_id__", "__golden_confidence__")]
     return g.select(sorted(cols)).sort(sorted(cols))
 
@@ -169,11 +172,11 @@ def test_fused_match_short_circuit_byte_identical(monkeypatch):
     assert _multi_partition(fused["clusters"]) == _multi_partition(classic["clusters"])
 
     # dupes / unique row populations byte-identical.
-    assert set(fused["dupes"]["__row_id__"].to_list()) == set(
-        classic["dupes"]["__row_id__"].to_list()
+    assert set(fused["dupes"]["__row_id__"].to_pylist()) == set(
+        classic["dupes"]["__row_id__"].to_pylist()
     )
-    assert set(fused["unique"]["__row_id__"].to_list()) == set(
-        classic["unique"]["__row_id__"].to_list()
+    assert set(fused["unique"]["__row_id__"].to_pylist()) == set(
+        classic["unique"]["__row_id__"].to_pylist()
     )
 
     # Golden content byte-identical (modulo cluster id + confidence).
@@ -237,12 +240,12 @@ def test_oversized_cluster_excluded_from_golden_like_classic(monkeypatch):
     assert fused["match_fused_capacity_mode"] is True
 
     # No golden records for any cluster (all multi-member clusters are oversized).
-    assert classic["golden"] is None or classic["golden"].height == 0
-    assert fused["golden"] is None or fused["golden"].height == 0
+    assert classic["golden"] is None or classic["golden"].num_rows == 0
+    assert fused["golden"] is None or fused["golden"].num_rows == 0
 
     # Oversized members still land in dupes on BOTH paths.
-    assert set(fused["dupes"]["__row_id__"].to_list()) == set(
-        classic["dupes"]["__row_id__"].to_list()
+    assert set(fused["dupes"]["__row_id__"].to_pylist()) == set(
+        classic["dupes"]["__row_id__"].to_pylist()
     )
     assert _multi_partition(fused["clusters"]) == _multi_partition(classic["clusters"])
 

--- a/packages/python/goldenmatch/tests/test_standardize.py
+++ b/packages/python/goldenmatch/tests/test_standardize.py
@@ -382,7 +382,7 @@ class TestStandardizationInPipeline:
         # Verify standardized data
         golden = results["golden"]
         if golden is not None and len(golden) > 0:
-            row = golden.to_dicts()[0]
+            row = golden.to_pylist()[0]
             # Phone should be digits only
             if "phone" in row and row["phone"]:
                 assert row["phone"].isdigit()
@@ -420,5 +420,5 @@ def test_arrow_lane_standardize_runs_after_default_prep(tmp_path, monkeypatch):
     res = run_dedupe([(str(path), "src")], cfg)
     golden = res["golden"]
     assert golden is not None
-    for v in golden["phone"].to_list():
+    for v in golden["phone"].to_pylist():
         assert v.isdigit(), f"stage order inverted: phone={v!r}"

--- a/scripts/diff_frame_backends.py
+++ b/scripts/diff_frame_backends.py
@@ -379,12 +379,19 @@ def canonicalize_result(result: dict, row_keys: list[str]) -> dict:
     golden: dict[str, dict[str, str | None]] = {}
     golden_df = result.get("golden")
     if golden_df is not None:
-        user_cols = [
-            c
-            for c in golden_df.columns
-            if not c.startswith("__") and c != "row_key"
-        ]
-        for row in golden_df.iter_rows(named=True):
+        # D3: the internal dict emits pa.Table.
+        _cols = (
+            list(golden_df.column_names)
+            if hasattr(golden_df, "column_names")
+            else list(golden_df.columns)
+        )
+        user_cols = [c for c in _cols if not c.startswith("__") and c != "row_key"]
+        _rows = (
+            golden_df.to_pylist()
+            if hasattr(golden_df, "num_rows")
+            else golden_df.iter_rows(named=True)
+        )
+        for row in _rows:
             cid = row["__cluster_id__"]
             keys = cid_to_sorted_keys.get(cid)
             if keys is None:


### PR DESCRIPTION
3.x arrow-descent batch 2 (D1 #1701 merged; plan correction committed here: D2-deep re-ordered after D3/D4 since the golden kernel gathers indices on the input frame).

- _dict_frame_to_arrow at all three dict sites (classic dedupe, fused short-circuit, match): golden/dupes/unique/quarantine/matched/unmatched emit pa.Table on BOTH lanes; _api._to_result_table becomes a passthrough.
- Consumers migrated in the same batch: _api._extract_stats, web match router, dbt materialize (pa patch loop; duckdb reads pa.Table natively), the differential + frames-out parity harnesses, and the dict-frame test reads. tui/web-run/preview consume dicts only -- verified unaffected.
- BREAKING only for internal-dict consumers; the public API flipped in 3.0.0.

Gates: 195 passed across api/pipeline/fused-byte-identity/differential/standardize/quality/frames-out/engine/golden. ruff clean.