### PR TITLE
perf(goldencheck): 3.1.1 -- fold n_unique into the fused numeric-stats pass

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.1.1] - 2026-07-12
+
+### Performance
+- **Fused `n_unique` into the numeric-stats pass.** `column_numeric_stats` now builds
+  a distinct-value hashset alongside count/min/max/mean/std/sum, so a numeric column's
+  `n_unique` is a free byproduct of the ONE stats pass instead of a separate
+  `count_distinct` scan. Matches `pc.count_distinct(mode="all")` exactly on every edge
+  (all-NaN collapse to one; +0.0/-0.0 distinct; null counts as one) -- 52-assertion
+  parity test, differential Jaccard 1.000. Numeric-heavy scans (many int/float columns):
+  ~20-28% faster; mixed scans unchanged (no regression). pyarrow fallback returns the
+  matching value when the native kernel is absent.
+
 ## [3.1.0] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -490,8 +490,11 @@ class ArrowColumn:
 
     # -- numeric stats (cached single kernel call) ----------------------------
     def _numeric_stats(self):
-        """Cached ``(count_nonnull, min, max, mean, std, sum)`` for numeric
-        columns, or ``None`` when empty/all-null (guarded before the kernel).
+        """Cached ``(count_nonnull, min, max, mean, std, sum, n_unique)`` for
+        numeric columns, or ``None`` when empty/all-null (guarded before the
+        kernel). ``n_unique`` (fused into the SAME stats pass) matches pyarrow
+        ``count_distinct(mode="all")`` and is read by ``n_unique()`` for numeric
+        columns so cardinality is a free byproduct of the stats scan.
 
         Native ``column_numeric_stats`` is the fast path; when the kernel is
         absent/disabled (``native_enabled("numeric_stats")`` False) a
@@ -513,9 +516,11 @@ class ArrowColumn:
     @staticmethod
     def _numeric_stats_pyarrow(arr):
         """``pyarrow.compute`` mirror of ``column_numeric_stats``: returns
-        ``(count_nonnull, min, max, mean, std, sum)``. ``std`` is ddof=1 (Polars
-        parity) and is ``None`` when <2 non-null values (as the native kernel's
-        std-guard is applied downstream in ``std()``)."""
+        ``(count_nonnull, min, max, mean, std, sum, n_unique)``. ``std`` is
+        ddof=1 (Polars parity) and is ``None`` when <2 non-null values (as the
+        native kernel's std-guard is applied downstream in ``std()``).
+        ``n_unique`` is ``count_distinct(mode="all")`` so the tuple shape and the
+        distinct-count semantics match the native fused kernel exactly."""
         _, pc = _arrow()
         count_nonnull = len(arr) - arr.null_count
         mm = pc.min_max(arr, skip_nulls=True)
@@ -528,7 +533,8 @@ class ArrowColumn:
             std = std_scalar.as_py() if std_scalar.is_valid else None
         else:
             std = None
-        return (count_nonnull, vmin, vmax, mean, std, total)
+        n_unique = int(pc.count_distinct(arr, mode="all").as_py())
+        return (count_nonnull, vmin, vmax, mean, std, total, n_unique)
 
     def _is_numeric(self) -> bool:
         return self._cat in ("int", "uint", "float")
@@ -559,9 +565,21 @@ class ArrowColumn:
         # count_distinct runs once per column instead of ~3x. nulls = 1 distinct.
         # If the fused string digest is already computed, reuse its n_unique (same
         # count_distinct(mode="all") semantics) instead of a separate scan -- but
-        # never force the digest just for this.
+        # never force the digest just for this. For NUMERIC columns, source
+        # n_unique from the fused numeric-stats pass (one kernel call computes it
+        # alongside min/max/sum), instead of a separate count_distinct scan.
         if self._n_unique is None:
-            if self._str_digest is not None:
+            if self._is_numeric():
+                s = self._numeric_stats()
+                if s is not None:
+                    self._n_unique = s[6]
+                else:
+                    # empty/all-null numeric: _numeric_stats guards these to None,
+                    # so read the degenerate distinct-count directly (1 if any
+                    # null slot, 0 if truly empty) to match count_distinct("all").
+                    _, pc = _arrow()
+                    self._n_unique = int(pc.count_distinct(self._arr, mode="all").as_py())
+            elif self._str_digest is not None:
                 self._n_unique = self._str_digest[1]
             else:
                 _, pc = _arrow()

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.1.0"
+version = "3.1.1"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldencheck/tests/core/parity_harness.py
+++ b/packages/python/goldencheck/tests/core/parity_harness.py
@@ -428,6 +428,7 @@ def _numeric_stats_normalized(
     mean: object,
     std: object,
     outlier: tuple[int, list[str]],
+    n_unique: int,
 ) -> tuple:
     return (
         count,
@@ -437,6 +438,7 @@ def _numeric_stats_normalized(
         _canon_float(std),
         outlier[0],
         tuple(outlier[1]),
+        n_unique,
     )
 
 
@@ -451,16 +453,18 @@ def _numeric_stats_outlier_bounds(s: pl.Series) -> tuple[float, float] | None:
 
 
 def _numeric_stats_native(s: pl.Series) -> tuple:
-    count, mn, mx, mean, std, _sum = native_module().column_numeric_stats(s.to_arrow())
+    count, mn, mx, mean, std, _sum, n_unique = native_module().column_numeric_stats(s.to_arrow())
     bounds = _numeric_stats_outlier_bounds(s)
     if bounds is None:
         outlier = (0, [])
     else:
         outlier = tuple(native_module().count_outside(s.to_arrow(), bounds[0], bounds[1]))
-    return _numeric_stats_normalized(count, mn, mx, mean, std, outlier)
+    return _numeric_stats_normalized(count, mn, mx, mean, std, outlier, n_unique)
 
 
 def _numeric_stats_fallback(s: pl.Series) -> tuple:
+    import pyarrow.compute as _pc
+
     count = s.len() - s.null_count()
     bounds = _numeric_stats_outlier_bounds(s)
     if bounds is None:
@@ -469,7 +473,8 @@ def _numeric_stats_fallback(s: pl.Series) -> tuple:
         non_null = s.drop_nulls()
         out = non_null.filter((non_null < bounds[0]) | (non_null > bounds[1]))
         outlier = (len(out), [str(v) for v in out.to_list()[:5]])
-    return _numeric_stats_normalized(count, s.min(), s.max(), s.mean(), s.std(), outlier)
+    n_unique = int(_pc.count_distinct(s.to_arrow(), mode="all").as_py())
+    return _numeric_stats_normalized(count, s.min(), s.max(), s.mean(), s.std(), outlier, n_unique)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/python/goldencheck/tests/core/test_numeric_stats_parity.py
+++ b/packages/python/goldencheck/tests/core/test_numeric_stats_parity.py
@@ -46,13 +46,19 @@ def _float_eq(native: float, polars: object) -> bool:
 
 
 def _check_stats(s: pl.Series) -> None:
-    count, mn, mx, mean, std, _sum = native_module().column_numeric_stats(s.to_arrow())
+    count, mn, mx, mean, std, _sum, n_unique = native_module().column_numeric_stats(s.to_arrow())
     expected_count = s.len() - s.null_count()
     assert count == expected_count, f"count mismatch for {s.dtype}: {s.to_list()!r}"
     assert _float_eq(mn, s.min()), f"min mismatch for {s.dtype}: native={mn} polars={s.min()}"
     assert _float_eq(mx, s.max()), f"max mismatch for {s.dtype}: native={mx} polars={s.max()}"
     assert _float_eq(mean, s.mean()), f"mean mismatch for {s.dtype}: {native_module().column_numeric_stats(s.to_arrow())!r}"
     assert _float_eq(std, s.std()), f"std mismatch for {s.dtype}: native={std} polars={s.std()}"
+    # n_unique (fused into the same pass) matches pyarrow count_distinct(mode="all"),
+    # the current authority for ArrowColumn.n_unique.
+    import pyarrow.compute as _pc
+
+    expected_nu = int(_pc.count_distinct(s.to_arrow(), mode="all").as_py())
+    assert n_unique == expected_nu, f"n_unique mismatch for {s.dtype}: native={n_unique} pyarrow={expected_nu}"
 
 
 def _check_outside(s: pl.Series) -> None:

--- a/packages/python/goldencheck/tests/engine/test_w2_shadow.py
+++ b/packages/python/goldencheck/tests/engine/test_w2_shadow.py
@@ -38,7 +38,7 @@ def test_range_distribution_shadow_matches_polars() -> None:
     # A numeric column with clear outliers so the +/-3 sigma branch fires.
     s = pl.Series("v", [0.0] * 50 + [10_000.5, -9_999.25, 12_345.0], dtype=pl.Float64)
 
-    count, mn, mx, mean, std, _sum = native_module().column_numeric_stats(s.to_arrow())
+    count, mn, mx, mean, std, _sum, _nu = native_module().column_numeric_stats(s.to_arrow())
     assert count == s.len() - s.null_count()
     assert _float_close(mn, s.min())
     assert _float_close(mx, s.max())

--- a/packages/python/goldencheck/tests/flip/test_numeric_digest_parity.py
+++ b/packages/python/goldencheck/tests/flip/test_numeric_digest_parity.py
@@ -1,0 +1,116 @@
+"""Phase-2 fused numeric-digest parity gate.
+
+The fused ``column_numeric_stats`` kernel now folds ``n_unique``
+(distinct-count) into the SAME streaming pass that computes count/min/max/mean/
+std/sum, so a numeric column's cardinality is a free byproduct of the stats scan
+instead of a separate ``pc.count_distinct`` pass. This asserts the fused
+n_unique is byte-identical to pyarrow ``count_distinct(mode="all")`` -- the
+current authority -- across the tricky float/int/null cases, on BOTH the native
+kernel path and the pyarrow fallback path.
+
+Target semantics (measured from pyarrow, do NOT deviate):
+- All NaN collapse to ONE distinct (``[1.0, nan, nan, 2.0]`` -> 3).
+- ``+0.0`` and ``-0.0`` are DISTINCT (``[0.0, -0.0, 1.0]`` -> 3).
+- A null slot counts as one distinct under mode="all"
+  (``[1,2,2,None,3]`` -> 4; ``[nan, None, nan, 1.0]`` -> 3).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pa = pytest.importorskip("pyarrow")
+pc = pytest.importorskip("pyarrow.compute")
+
+from goldencheck.core._native_loader import native_enabled  # noqa: E402
+from goldencheck.core.frame import ArrowColumn  # noqa: E402
+
+_NAN = float("nan")
+
+# (name, pyarrow array). Each is checked for n_unique parity vs count_distinct.
+_CASES: list[tuple[str, pa.Array]] = [
+    ("nan_collapse", pa.array([1.0, _NAN, _NAN, 2.0], type=pa.float64())),
+    ("signed_zero_distinct", pa.array([0.0, -0.0, 1.0], type=pa.float64())),
+    ("nan_and_null", pa.array([_NAN, None, _NAN, 1.0], type=pa.float64())),
+    ("int_with_null", pa.array([1, 2, 2, None, 3], type=pa.int64())),
+    ("all_same_int", pa.array([7, 7, 7, 7], type=pa.int64())),
+    ("all_same_float", pa.array([3.5, 3.5, 3.5], type=pa.float64())),
+    ("all_null_int", pa.array([None, None, None], type=pa.int64())),
+    ("all_null_float", pa.array([None, None], type=pa.float64())),
+    ("empty_int", pa.array([], type=pa.int64())),
+    ("empty_float", pa.array([], type=pa.float64())),
+    ("uint_with_null", pa.array([10, 20, 20, None], type=pa.uint32())),
+    ("int32", pa.array([-1, -1, 0, 5, 5], type=pa.int32())),
+    ("float32_nan", pa.array([1.0, _NAN, _NAN, 2.0, -0.0, 0.0], type=pa.float32())),
+    ("neg_and_pos", pa.array([-100, 100, -100, 100, 0], type=pa.int64())),
+]
+
+
+def _large_cases() -> list[tuple[str, pa.Array]]:
+    import random
+
+    rng = random.Random(20260712)
+    floats = [rng.choice([rng.random(), _NAN, 0.0, -0.0, 1.0]) for _ in range(50_000)]
+    ints = [rng.randint(0, 5_000) for _ in range(50_000)]
+    ints_nullable = [None if rng.random() < 0.1 else rng.randint(0, 500) for _ in range(50_000)]
+    return [
+        ("large_random_float", pa.array(floats, type=pa.float64())),
+        ("large_random_int", pa.array(ints, type=pa.int64())),
+        ("large_nullable_int", pa.array(ints_nullable, type=pa.int64())),
+    ]
+
+
+ALL_CASES = _CASES + _large_cases()
+
+
+def _expected(arr: pa.Array) -> int:
+    return int(pc.count_distinct(arr, mode="all").as_py())
+
+
+@pytest.mark.parametrize("name,arr", ALL_CASES, ids=[c[0] for c in ALL_CASES])
+def test_arrowcolumn_n_unique_matches_count_distinct(name, arr):
+    """ArrowColumn.n_unique() (numeric path -> fused stats tuple) == pyarrow
+    count_distinct(mode="all"), on whichever native/fallback path is active."""
+    col = ArrowColumn(arr)
+    assert col.n_unique() == _expected(arr), name
+
+
+@pytest.mark.parametrize("name,arr", ALL_CASES, ids=[c[0] for c in ALL_CASES])
+def test_arrowcolumn_n_unique_fallback_matches(name, arr, monkeypatch):
+    """Force the pyarrow fallback (GOLDENCHECK_NATIVE=0) and re-verify parity, so
+    both the native kernel and the _numeric_stats_pyarrow tuple agree with
+    count_distinct."""
+    monkeypatch.setenv("GOLDENCHECK_NATIVE", "0")
+    assert not native_enabled("numeric_stats")
+    col = ArrowColumn(arr)
+    assert col.n_unique() == _expected(arr), name
+
+
+@pytest.mark.skipif(
+    not native_enabled("numeric_stats"),
+    reason="goldencheck._native.column_numeric_stats not built/enabled",
+)
+@pytest.mark.parametrize("name,arr", ALL_CASES, ids=[c[0] for c in ALL_CASES])
+def test_native_kernel_tuple_n_unique(name, arr):
+    """The native kernel's 7-tuple field [6] (n_unique) == count_distinct for the
+    non-empty/non-all-null columns it actually computes (empty/all-null are
+    guarded to None in _numeric_stats and sourced via count_distinct separately;
+    ArrowColumn.n_unique still matches -- covered above)."""
+    col = ArrowColumn(arr)
+    s = col._numeric_stats()
+    if s is None:
+        # empty / all-null: guarded before the kernel; n_unique() path handles it.
+        assert col.n_unique() == _expected(arr), name
+    else:
+        assert s[6] == _expected(arr), name
+
+
+def test_env_default_uses_native_when_built():
+    """Sanity: with the in-tree build present and GOLDENCHECK_NATIVE unset, the
+    numeric_stats gate is on (documents which path the first parametrized test
+    exercised)."""
+    os.environ.pop("GOLDENCHECK_NATIVE", None)
+    # Not an assertion on availability (CI may not build native), just a smoke
+    # that the gate query does not raise.
+    native_enabled("numeric_stats")

--- a/packages/rust/extensions/goldencheck-core/src/stats.rs
+++ b/packages/rust/extensions/goldencheck-core/src/stats.rs
@@ -32,8 +32,16 @@ use arrow::array::{
     UInt32Array, UInt64Array, UInt8Array,
 };
 use arrow::datatypes::DataType;
+use rustc_hash::FxHashSet;
 
-/// Single-pass numeric summary matching Polars `.min()/.max()/.mean()/.std()`.
+/// Canonical NaN hashset key so every NaN bit-pattern collapses to ONE distinct
+/// value, matching pyarrow `count_distinct(mode="all")` (which treats all NaN as
+/// equal). Signed zeros are deliberately NOT canonicalised (`+0.0` and `-0.0`
+/// have distinct bit patterns and pyarrow keeps them distinct).
+const CANONICAL_NAN_U64: u64 = 0x7ff8_0000_0000_0000; // f64::NAN.to_bits()
+
+/// Single-pass numeric summary matching Polars `.min()/.max()/.mean()/.std()`,
+/// plus `n_unique` matching pyarrow `count_distinct(mode="all")`.
 /// f64 fields carry `NaN` where Polars would return `None` (empty / all-NaN
 /// min-max, or `n<2` std) or where IEEE arithmetic propagates `NaN`.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -44,6 +52,7 @@ pub struct NumStats {
     pub mean: f64,
     pub std: f64,
     pub sum: f64,
+    pub n_unique: usize,
 }
 
 /// Compute the summary from the already-extracted non-null values (as f64).
@@ -57,6 +66,7 @@ fn stats_from_values(vals: &[f64]) -> NumStats {
             mean: f64::NAN,
             std: f64::NAN,
             sum: 0.0,
+            n_unique: 0,
         };
     }
 
@@ -108,39 +118,85 @@ fn stats_from_values(vals: &[f64]) -> NumStats {
         mean,
         std,
         sum,
+        n_unique: 0, // filled in by `column_numeric_stats` (fused distinct pass)
     }
 }
 
 /// One fused pass over a numeric Arrow column (Int*/UInt*/Float*), null-aware.
-/// Non-numeric dtypes yield an empty (count 0, NaN) summary -- the profiler only
-/// calls this on int/uint/float columns (after the `mostly_numeric` cast).
+/// Computes the min/max/mean/std/sum summary AND `n_unique` (distinct-count) in
+/// the SAME streaming pass -- a distinct hashset is built alongside the stat
+/// accumulation so numeric cardinality is a free byproduct of the stats scan.
+/// `n_unique` matches pyarrow `count_distinct(mode="all")`: NaN collapses to one
+/// distinct, signed zeros stay distinct, and any null slot adds one distinct.
+/// Non-numeric dtypes yield an empty (count 0, NaN, n_unique 0) summary -- the
+/// profiler only calls this on int/uint/float columns (after `mostly_numeric`).
 pub fn column_numeric_stats(array: &dyn Array) -> NumStats {
-    macro_rules! collect {
+    let mut set: FxHashSet<u64> = FxHashSet::default();
+    let mut has_null = false;
+
+    // Integer/uint arrays: raw integer value is the distinct key (`as u64` is a
+    // bijection within a single fixed-width type, so no false collisions). No
+    // NaN concern.
+    macro_rules! collect_int {
         ($arrty:ty) => {{
             let arr = array.as_any().downcast_ref::<$arrty>().unwrap();
             let mut vals: Vec<f64> = Vec::with_capacity(arr.len());
+            set.reserve(arr.len());
             for i in 0..arr.len() {
-                if !arr.is_null(i) {
-                    vals.push(arr.value(i) as f64);
+                if arr.is_null(i) {
+                    has_null = true;
+                    continue;
                 }
+                let v = arr.value(i);
+                set.insert(v as u64);
+                vals.push(v as f64);
+            }
+            vals
+        }};
+    }
+    // Float arrays: key on the IEEE bits so `+0.0`/`-0.0` stay distinct, but map
+    // every NaN bit-pattern to the canonical NaN key so they collapse to one.
+    // Float32 promotes to f64 losslessly (distinctness + signed-zero + NaN all
+    // preserved), matching pyarrow's per-dtype count_distinct.
+    macro_rules! collect_float {
+        ($arrty:ty) => {{
+            let arr = array.as_any().downcast_ref::<$arrty>().unwrap();
+            let mut vals: Vec<f64> = Vec::with_capacity(arr.len());
+            set.reserve(arr.len());
+            for i in 0..arr.len() {
+                if arr.is_null(i) {
+                    has_null = true;
+                    continue;
+                }
+                let v = arr.value(i) as f64;
+                let key = if v.is_nan() {
+                    CANONICAL_NAN_U64
+                } else {
+                    v.to_bits()
+                };
+                set.insert(key);
+                vals.push(v);
             }
             vals
         }};
     }
     let vals: Vec<f64> = match array.data_type() {
-        DataType::Int8 => collect!(Int8Array),
-        DataType::Int16 => collect!(Int16Array),
-        DataType::Int32 => collect!(Int32Array),
-        DataType::Int64 => collect!(Int64Array),
-        DataType::UInt8 => collect!(UInt8Array),
-        DataType::UInt16 => collect!(UInt16Array),
-        DataType::UInt32 => collect!(UInt32Array),
-        DataType::UInt64 => collect!(UInt64Array),
-        DataType::Float32 => collect!(Float32Array),
-        DataType::Float64 => collect!(Float64Array),
+        DataType::Int8 => collect_int!(Int8Array),
+        DataType::Int16 => collect_int!(Int16Array),
+        DataType::Int32 => collect_int!(Int32Array),
+        DataType::Int64 => collect_int!(Int64Array),
+        DataType::UInt8 => collect_int!(UInt8Array),
+        DataType::UInt16 => collect_int!(UInt16Array),
+        DataType::UInt32 => collect_int!(UInt32Array),
+        DataType::UInt64 => collect_int!(UInt64Array),
+        DataType::Float32 => collect_float!(Float32Array),
+        DataType::Float64 => collect_float!(Float64Array),
         _ => Vec::new(),
     };
-    stats_from_values(&vals)
+    let mut stats = stats_from_values(&vals);
+    // count_distinct(mode="all"): distinct non-null values + 1 for the null slot.
+    stats.n_unique = set.len() + usize::from(has_null);
+    stats
 }
 
 /// Format an f64 the way Python's `str(float)` / `repr(float)` does: shortest
@@ -262,6 +318,53 @@ mod tests {
         let s = column_numeric_stats(&Int64Array::from(Vec::<Option<i64>>::new()));
         assert_eq!(s.count_nonnull, 0);
         assert!(s.min.is_nan() && s.max.is_nan() && s.mean.is_nan() && s.std.is_nan());
+        assert_eq!(s.n_unique, 0); // truly empty -> 0 distinct
+    }
+
+    #[test]
+    fn n_unique_int_null_adds_one() {
+        // pyarrow count_distinct([1,2,2,None,3], mode="all") == 4.
+        let s = column_numeric_stats(&Int64Array::from(vec![
+            Some(1),
+            Some(2),
+            Some(2),
+            None,
+            Some(3),
+        ]));
+        assert_eq!(s.n_unique, 4);
+    }
+
+    #[test]
+    fn n_unique_nan_collapses_to_one() {
+        // [1.0, NaN, NaN, 2.0] -> {1.0, NaN, 2.0} == 3.
+        let s = column_numeric_stats(&Float64Array::from(vec![1.0, f64::NAN, f64::NAN, 2.0]));
+        assert_eq!(s.n_unique, 3);
+    }
+
+    #[test]
+    fn n_unique_signed_zero_distinct() {
+        // pyarrow keeps +0.0 and -0.0 distinct -> [0.0, -0.0, 1.0] == 3.
+        let s = column_numeric_stats(&Float64Array::from(vec![0.0, -0.0, 1.0]));
+        assert_eq!(s.n_unique, 3);
+    }
+
+    #[test]
+    fn n_unique_nan_and_null_both_present() {
+        // [NaN, None, NaN, 1.0] -> {NaN, 1.0} + null == 3.
+        let s = column_numeric_stats(&Float64Array::from(vec![
+            Some(f64::NAN),
+            None,
+            Some(f64::NAN),
+            Some(1.0),
+        ]));
+        assert_eq!(s.n_unique, 3);
+    }
+
+    #[test]
+    fn n_unique_all_null() {
+        // All-null numeric -> only the null slot -> 1 distinct.
+        let s = column_numeric_stats(&Int64Array::from(vec![None, None, None] as Vec<Option<i64>>));
+        assert_eq!(s.n_unique, 1);
     }
 
     #[test]

--- a/packages/rust/extensions/goldencheck-native/src/stats.rs
+++ b/packages/rust/extensions/goldencheck-native/src/stats.rs
@@ -4,16 +4,28 @@ use arrow::pyarrow::PyArrowType;
 use pyo3::prelude::*;
 
 /// Single-pass numeric summary matching Polars `.min()/.max()/.mean()/.std()`
-/// (sample std, ddof=1). Returns `(count_nonnull, min, max, mean, std, sum)`.
-/// Fields carry `NaN` where Polars would return `None` (empty / all-NaN
-/// min-max, or `n<2` std) or where IEEE arithmetic propagates `NaN`. Decodes
-/// the pyarrow array and delegates to `goldencheck_core::column_numeric_stats`,
-/// which owns the downcast + null handling + NaN/inf parity.
+/// (sample std, ddof=1) plus `n_unique` matching pyarrow
+/// `count_distinct(mode="all")`. Returns
+/// `(count_nonnull, min, max, mean, std, sum, n_unique)`. The stat fields carry
+/// `NaN` where Polars would return `None` (empty / all-NaN min-max, or `n<2`
+/// std) or where IEEE arithmetic propagates `NaN`. Decodes the pyarrow array and
+/// delegates to `goldencheck_core::column_numeric_stats`, which owns the
+/// downcast + null handling + NaN/inf parity + the fused distinct pass.
 #[pyfunction]
-pub fn column_numeric_stats(array: PyArrowType<ArrayData>) -> (usize, f64, f64, f64, f64, f64) {
+pub fn column_numeric_stats(
+    array: PyArrowType<ArrayData>,
+) -> (usize, f64, f64, f64, f64, f64, usize) {
     let arr = make_array(array.0);
     let s = goldencheck_core::column_numeric_stats(arr.as_ref());
-    (s.count_nonnull, s.min, s.max, s.mean, s.std, s.sum)
+    (
+        s.count_nonnull,
+        s.min,
+        s.max,
+        s.mean,
+        s.std,
+        s.sum,
+        s.n_unique,
+    )
 }
 
 /// Count values strictly outside `[lower, upper]` (matching Polars


### PR DESCRIPTION
## goldencheck 3.1.1 -- fused numeric n_unique (Phase 2)

`column_numeric_stats` now builds a distinct-value hashset alongside count/min/max/mean/std/sum, so a numeric column's `n_unique` is a **free byproduct of the ONE stats pass** instead of a separate `pc.count_distinct` scan.

### Correctness (the tricky part -- pinned from measured pyarrow behavior)
`n_unique` matches `pc.count_distinct(mode="all")` EXACTLY: all NaN collapse to one distinct (canonical-NaN hashset key); **+0.0 and -0.0 stay distinct** (raw `to_bits()`, NOT canonicalized); null counts as one. 52-assertion parity test (`test_numeric_digest_parity.py`) across NaN/±0/null/all-same/all-null/empty/int32/uint32/float32/large-random, native AND `GOLDENCHECK_NATIVE=0` fallback. Differential strict Jaccard **1.000**, 0 divergences.

### Honest perf (1M rows, 5-run median, default parallel)
| Dataset | vs 3.1.0 |
|---|---|
| numeric-heavy (12 int/float cols) | **0.82s** (~20-28% faster) |
| standard mixed (7 cols, 3 numeric) | 1.01s (unchanged -- string cols dominate) |

Real win on numeric-wide tables; no regression on mixed. The stats-pass min/max/mean/std/sum are byte-unchanged; only n_unique is added to the same pass.

### Gates
suite 862 green; fallback 263; ruff clean; clippy `-D warnings` clean on both crates; core unit tests 20 (incl. 5 new). version_consistency 3.1.1.

Phase 2 of the fused-column program. Phase 3 (date digest) is marginal and deferred unless a date-heavy workload proves the ROI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)