### PR TITLE
perf(goldencheck): 3.1.2 -- eliminate whole-column materialization in sample paths (date-heavy 3.55x)

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.1.2] - 2026-07-12
+
+### Performance
+- **Eliminated whole-column materialization in sample paths.** Several profilers
+  built findings' `sample_values` (or drift category sets) by materializing the
+  ENTIRE filtered column and then taking the first few -- e.g. `filter(...).to_list()[:5]`
+  on a column with hundreds of thousands of matching rows. Now they `.slice(0, N)`
+  BEFORE `to_list` (11 sites across temporal / numeric_cross / format_detection /
+  encoding_detection / pattern_consistency / range_distribution), and drift builds
+  category sets from `.unique()` (distinct-only) instead of every row. Semantically
+  identical (differential Jaccard 1.000; suite green native + fallback). Date-heavy
+  and dirty/high-finding scans benefit most: a 6-column date scan went 1.393s -> 0.392s
+  (~3.55x). Added `PyColumn.slice` for the polars-free covered-columns backend.
+
 ## [3.1.1] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.1.1"
+__version__ = "3.1.2"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/core/frame.py
+++ b/packages/python/goldencheck/goldencheck/core/frame.py
@@ -337,6 +337,10 @@ class PyColumn:
     def to_list(self) -> list:
         return list(self._v)
 
+    def slice(self, offset: int, length: int | None = None) -> PyColumn:
+        end = None if length is None else offset + length
+        return PyColumn(self._v[offset:end])
+
     @property
     def dtype(self) -> str:
         non_null = [v for v in self._v if v is not None]

--- a/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/drift_detection.py
@@ -71,9 +71,14 @@ class DriftDetectionProfiler(BaseProfiler):
                     confidence=0.6,
                 ))
         else:
-            # Categorical drift: look for new categories in second half
-            cats_first = set(first_half.cast("str", strict=True).to_list())
-            cats_second = set(second_half.cast("str", strict=True).to_list())
+            # Categorical drift: look for new categories in second half.
+            # Materialize only the DISTINCT values (`.unique()`) per half, not every
+            # row -- `set(X.to_list()) == set(X.unique().to_list())`, but for a
+            # low-cardinality column (dates, categoricals) this turns a whole-column
+            # to_list (~500k elements) into a distinct-only one. This was the dominant
+            # cost of scanning date/categorical-heavy tables.
+            cats_first = set(first_half.cast("str", strict=True).unique().to_list())
+            cats_second = set(second_half.cast("str", strict=True).unique().to_list())
             new_cats = cats_second - cats_first
 
             if new_cats:

--- a/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/encoding_detection.py
@@ -42,7 +42,7 @@ class EncodingDetectionProfiler(BaseProfiler):
         # 1. Zero-width Unicode characters (confidence: 0.8 — almost always wrong)
         zw_count = non_null.str_match_count(ZERO_WIDTH_PATTERN)
         if zw_count > 0:
-            sample = non_null.str_filter(ZERO_WIDTH_PATTERN, matching=True).to_list()[:5]
+            sample = non_null.str_filter(ZERO_WIDTH_PATTERN, matching=True).slice(0, 5).to_list()
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column=column,
@@ -60,7 +60,7 @@ class EncodingDetectionProfiler(BaseProfiler):
         # 2. Smart/curly quotes (confidence: 0.6 — could be intentional)
         sq_count = non_null.str_match_count(SMART_QUOTES_PATTERN)
         if sq_count > 0:
-            sample = non_null.str_filter(SMART_QUOTES_PATTERN, matching=True).to_list()[:5]
+            sample = non_null.str_filter(SMART_QUOTES_PATTERN, matching=True).slice(0, 5).to_list()
             findings.append(Finding(
                 severity=Severity.INFO,
                 column=column,
@@ -80,7 +80,7 @@ class EncodingDetectionProfiler(BaseProfiler):
         if na_count > 0:
             # Only flag if zero-width chars were NOT already found for the same rows
             # (avoid duplicate noise), but still report non-ASCII separately
-            sample = non_null.str_filter(NON_ASCII_PATTERN, matching=True).to_list()[:5]
+            sample = non_null.str_filter(NON_ASCII_PATTERN, matching=True).slice(0, 5).to_list()
             findings.append(Finding(
                 severity=Severity.INFO,
                 column=column,
@@ -98,7 +98,7 @@ class EncodingDetectionProfiler(BaseProfiler):
         # 4. Control characters (confidence: 0.8 — rarely valid in data)
         ctrl_count = non_null.str_match_count(CONTROL_CHAR_PATTERN)
         if ctrl_count > 0:
-            sample = non_null.str_filter(CONTROL_CHAR_PATTERN, matching=True).to_list()[:5]
+            sample = non_null.str_filter(CONTROL_CHAR_PATTERN, matching=True).slice(0, 5).to_list()
             findings.append(Finding(
                 severity=Severity.WARNING,
                 column=column,

--- a/packages/python/goldencheck/goldencheck/profilers/format_detection.py
+++ b/packages/python/goldencheck/goldencheck/profilers/format_detection.py
@@ -47,7 +47,7 @@ class FormatDetectionProfiler(BaseProfiler):
                 ))
                 non_match_count = total - match_count
                 if non_match_count > 0:
-                    sample = non_null.str_filter(pattern, matching=False).to_list()[:5]
+                    sample = non_null.str_filter(pattern, matching=False).slice(0, 5).to_list()
                     # Non-matching findings inherit same confidence as detection
                     findings.append(Finding(
                         severity=Severity.WARNING,

--- a/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
+++ b/packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py
@@ -112,7 +112,7 @@ class PatternConsistencyProfiler(BaseProfiler):
                 severity = Severity.INFO
                 confidence = 0.5
             # Find sample values that match this minority pattern
-            sample_vals = non_null.filter_by(patterns.eq(minority_pattern)).to_list()[:5]
+            sample_vals = non_null.filter_by(patterns.eq(minority_pattern)).slice(0, 5).to_list()
 
             # Detect structural pattern shift (e.g., letter-first vs digit-first = mixed standards)
             dom_starts_alpha = dominant_pattern and dominant_pattern[0] == "L"

--- a/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
+++ b/packages/python/goldencheck/goldencheck/profilers/range_distribution.py
@@ -53,7 +53,7 @@ class RangeDistributionProfiler(BaseProfiler):
             outliers = non_null.filter_outside(lower, upper)
             outlier_count = len(outliers)
             if outlier_count > 0:
-                sample = outliers.to_list()[:5]
+                sample = outliers.slice(0, 5).to_list()
                 # Determine how many stddevs outliers are
                 # Use max deviation to determine confidence
                 max_dev = max(

--- a/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
+++ b/packages/python/goldencheck/goldencheck/relations/numeric_cross.py
@@ -89,8 +89,8 @@ class NumericCrossColumnProfiler:
 
         if violation_count > 0:
             sample_vals = []
-            val_filtered = val_series.filter_by(violation_mask).to_list()[:3]
-            max_filtered = max_series.filter_by(violation_mask).to_list()[:3]
+            val_filtered = val_series.filter_by(violation_mask).slice(0, 3).to_list()
+            max_filtered = max_series.filter_by(violation_mask).slice(0, 3).to_list()
             sample_vals = [f"{v} exceeds {m}" for v, m in zip(val_filtered, max_filtered)]
 
             return Finding(

--- a/packages/python/goldencheck/goldencheck/relations/temporal.py
+++ b/packages/python/goldencheck/goldencheck/relations/temporal.py
@@ -140,8 +140,11 @@ class TemporalOrderProfiler:
         violation_count = violation_mask.sum()
 
         if violation_count > 0:
-            sample_starts = start_series.filter_by(violation_mask).cast("str").to_list()[:3]
-            sample_ends = end_series.filter_by(violation_mask).cast("str").to_list()[:3]
+            # slice to 3 BEFORE cast+to_list: filtering can leave hundreds of
+            # thousands of violation rows, and materializing all of them as strings
+            # just to take the first 3 was the dominant cost of date-heavy scans.
+            sample_starts = start_series.filter_by(violation_mask).slice(0, 3).cast("str").to_list()
+            sample_ends = end_series.filter_by(violation_mask).slice(0, 3).cast("str").to_list()
             samples = [f"{s} > {e}" for s, e in zip(sample_starts, sample_ends)]
 
             return Finding(

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.1.1"
+version = "3.1.2"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## goldencheck 3.1.2 -- sample-path materialization fix (Phase 3, measure-driven)

Phase 3 measure-first: a date-heavy scan's cost was NOT a digest-able reduction but **whole-column materialization** in profilers that only need a few sample rows. So this ships the real fix instead of the (marginal) date digest.

- **drift_detection**: category sets built from `cast('str').to_list()` on the whole column -> `.unique()` (distinct-only). `set(X.to_list()) == set(X.unique().to_list())`, but distinct-only for a low-cardinality column turns a ~500k-row to_list into a ~2k one.
- **temporal / numeric_cross / format_detection / encoding_detection / pattern_consistency / range_distribution** (11 sites): `filter(...).to_list()[:N]` materialized the ENTIRE filtered set (up to ~250k-500k rows) to take N samples -> `.slice(0, N)` BEFORE `to_list`.
- Added `PyColumn.slice` (the polars-free covered-columns seam backend lacked it; caught by seam-parity tests).

### Measured
| Dataset (1M) | before | after |
|---|---|---|
| date-heavy 6col | 1.393s | **0.392s (~3.55x)** |

Generalizes to any scan on data with many findings (outliers, format mismatches, encoding issues, ordering violations) -- all previously paid to materialize the full violating set.

### Correctness
Semantically identical: differential strict Jaccard **1.000**, 0 divergences; suite **922** native / **149** fallback; ruff clean; version_consistency 3.1.2.

The scalar date digest (Phase 3 as originally scoped) was confirmed marginal by profiling and deliberately NOT built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)