### PR TITLE
perf(goldencheck): 3.1.3 -- parallelize the relation-profiler loop (deterministic)

### DIFF
--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.1.3] - 2026-07-12
+
+### Performance
+- **Parallel relation-profiler loop.** 3.0.3 parallelized the column loop; the relation
+  profilers (temporal / duplicate / functional-dependency / composite-key / age / ...)
+  still ran sequentially. Each is independent and only READS the (cache-populated) frame,
+  so they now fan across the same thread pool and merge in `RELATION_PROFILERS` order --
+  byte-identical to sequential (verified: `scan_file` 1-thread vs 8-thread findings
+  identical incl. order; differential Jaccard 1.000). Relation/date-heavy scans (many
+  temporal pairs): a 6-date-column scan went 0.856s -> 0.612s (~1.4x). No regression on
+  column-bound scans. Same `GOLDENCHECK_SCAN_THREADS` gate.
+
 ## [3.1.2] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.1.2"
+__version__ = "3.1.3"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/goldencheck/engine/scanner.py
+++ b/packages/python/goldencheck/goldencheck/engine/scanner.py
@@ -452,6 +452,18 @@ def _profile_column(frame, sample, col_name: str, row_count: int):
     return cp, findings
 
 
+def _run_relation(profiler, sample) -> list[Finding]:
+    """Run ONE relation profiler over the whole (sampled) frame. Each relation
+    profiler is independent and only READS the frame (its column caches are already
+    populated by the column loop; it builds any derived data locally), so relations
+    are safe to run concurrently -- results are merged in RELATION_PROFILERS order."""
+    try:
+        return list(profiler.profile(sample))
+    except Exception as e:  # noqa: BLE001 - one relation profiler failing must not sink the scan
+        logger.warning("Relation profiler %s failed: %s", type(profiler).__name__, e)
+        return []
+
+
 def _scan_dataframe_impl(
     frame,
     *,
@@ -507,12 +519,17 @@ def _scan_dataframe_impl(
         column_profiles.append(cp)
         all_findings.extend(findings)
 
-    for profiler in RELATION_PROFILERS:
-        try:
-            findings = profiler.profile(sample)
-            all_findings.extend(findings)
-        except Exception as e:
-            logger.warning("Relation profiler %s failed: %s", type(profiler).__name__, e)
+    # Relation profilers are independent of each other and only READ the (now
+    # cache-populated) frame, so fan them across the same thread pool and merge in
+    # RELATION_PROFILERS order (deterministic, byte-identical to sequential).
+    if n_threads > 1 and len(RELATION_PROFILERS) > 1:
+        with ThreadPoolExecutor(max_workers=min(n_threads, len(RELATION_PROFILERS))) as pool:
+            rel_results = list(pool.map(lambda pr: _run_relation(pr, sample), RELATION_PROFILERS))
+        for fs in rel_results:
+            all_findings.extend(fs)
+    else:
+        for profiler in RELATION_PROFILERS:
+            all_findings.extend(_run_relation(profiler, sample))
 
     # Denial-constraint discovery is opt-in (NOT part of RELATION_PROFILERS) --
     # it is a heavier cross-column miner. Under --deep it sees the full

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.1.2"
+version = "3.1.3"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenCheck",
   "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## goldencheck 3.1.3 -- parallel relation loop

3.0.3 parallelized the COLUMN loop; the RELATION profilers (temporal / duplicate / functional-dependency / composite-key / age / null-correlation / numeric-cross / approx-fd) still ran sequentially. Each is independent and only READS the (cache-populated) frame -- it builds any derived data locally -- so they now fan across the same thread pool and merge in `RELATION_PROFILERS` order.

**Deterministic:** `scan_file` 1-thread vs 8-thread findings byte-identical incl. order; differential strict Jaccard **1.000**.

### Measured (1M, 5-run median)
| dataset | before | after |
|---|---|---|
| date-heavy 6col (15 temporal pairs) | 0.856s | **0.612s (~1.4x)** |
| column-bound 7col | ~unchanged (no regression) |

Helps relation/date-heavy scans; neutral elsewhere. Same `GOLDENCHECK_SCAN_THREADS` gate.

### Correctness
suite 838 green (native + `GOLDENCHECK_SCAN_THREADS=4`); ruff clean; version_consistency 3.1.3.

Note (measure-first): the wide-scan residual is NOT a GIL-bound fd/composite Python hotpath -- those discover via native Rust kernels. It's single-threaded kernel calls (duplicate_signatures / fd discovery / full-population n_unique) = the intra-op parallelism gap, deliberately NOT chased (the #688 rayon futex-park risk + oversubscription with these thread pools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)