### PR TITLE
feat(goldenmatch): arrow-descent D5a -- scoring leaf extractions via seam column reads

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -32,12 +32,26 @@ array-ization is leaf-local (`to_list`/`to_numpy` before rapidfuzz).
 - **D4 — ClusterFrames + golden-from-frames dual-backend** (pipeline.py ~2650,
   ~2925): ClusterFrames.metadata/assignments as Frames; the stats/member-id
   reads (`pl.col("size")>1 & ~oversized`) via seam ops. Real port work.
-- **D5 — classic fuzzy scoring on the seam** (largest; REQUIRED before dep
-  removal because configs the fused kernel declines still need block/score on
-  arrow): build_blocks' per-block frames + score_blocks_parallel orchestration
-  go Frame; leaf extraction (`to_list`/`to_numpy` for rapidfuzz) works on
-  ArrowColumn. Probabilistic + semantic-blocking + bucket paths follow the
-  same shape. Wall-gated per stage (>10% → owned kernel rule stands).
+- **D5 — classic fuzzy scoring on the seam (SUB-BATCHED, recon 2026-07-12;
+  order D5a → D5c → D5b → D5d)**. Findings: BlockResult.df is an
+  eagerly-collected group re-wrapped `.lazy()` (blocker.py:470-473), NOT a
+  live filter; grouping already seam-routed (group_partitions :378);
+  score_buckets' kernel is ALREADY arrow at the FFI (:762-766) -- only its
+  polars scaffolding ports; _find_exact_match_ids + cross-source filter
+  already seam.
+  - D5a (wall-neutral, zero new ops): leaf-extraction migration --
+    block_df["x"].to_list()/.to_numpy()/.unique().to_list() sites in
+    find_fuzzy_matches (:1096), _score_one_block (:1350-1353), probabilistic
+    (:1263-1339), bucket fallback (score_buckets:822-825) → seam column reads.
+  - D5c (narrow): _get_transformed_values fallback (:429) →
+    derive_transformed_column (seam twin exists); probabilistic .to_dicts()
+    (:1263) needs the ONE missing seam op.
+  - D5b (WALL-GATED 100K/1M): BlockResult.df becomes a seam Frame
+    (materialized, score_buckets slice model); drop .lazy()/.collect()
+    round-trips; candidate probe → Frame.height.
+  - D5d (heaviest, THE hot path, strictest gate): score_buckets' polars
+    scaffolding (with_columns/hash/partition_by/sort/slice, :953/:997/:1035)
+    → seam; compute core already arrow.
 - **D6 — the deletion**: default already arrow; delete the `polars` opt-out
   value + PolarsFrame + `_polars_dtype` + polars constructor branches;
   `_polars_lazy` proxy SURVIVES only in the extra-gated integration modules

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -819,9 +819,12 @@ def score_buckets(
 
         # Python per-pair fallback: materialize the columns as lists.
         # field_specs: list of (xform_col, weight, score_fn, scorer_name).
-        row_ids = sorted_df["__row_id__"].to_list()
+        from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+        _sf = _to_frame_d5(sorted_df)
+        row_ids = _sf.column("__row_id__").to_list()
         field_arrays = [
-            sorted_df[col].to_list() for col, _w, _fn, _name in field_specs
+            _sf.column(col).to_list() for col, _w, _fn, _name in field_specs
         ]
         score_fns = [fn for _col, _w, fn, _name in field_specs]
         n_fields = len(field_specs)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -921,7 +921,7 @@ def run_dedupe(
     )
 
 
-def _dict_frame_to_arrow(obj):
+def _dict_frame_to_arrow(obj: Any) -> Any:
     """D3 (arrow descent): the INTERNAL pipeline dicts emit pa.Table for their
     frame values on BOTH lanes. polars frames convert zero-copy; pa passes
     through; None stays None. _api._to_result_table is a passthrough now."""

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1263,7 +1263,9 @@ def score_probabilistic(
     for row in block_df.select(["__row_id__"] + cols).to_dicts():
         row_lookup[row["__row_id__"]] = row
 
-    row_ids = block_df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+    row_ids = _to_frame_d5(block_df).column("__row_id__").to_list()
 
     # Compute weight range for normalization
     max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
@@ -1336,7 +1338,10 @@ def _field_values_from_list(raw: list | None, f, n: int) -> list[str | None]:
 def _field_values_for_block(block_df: pl.DataFrame, f, n: int) -> list[str | None]:
     """Transformed per-field values for a block, matching comparison_vector.
     Missing column -> all-null (slow path: level 0)."""
-    raw = block_df[f.field].to_list() if f.field in block_df.columns else None
+    from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+    _bf = _to_frame_d5(block_df)
+    raw = _bf.column(f.field).to_list() if f.field in _bf.columns else None
     return _field_values_from_list(raw, f, n)
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -416,11 +416,13 @@ def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> lis
     callers that bypass the pipeline (DataFrame entry points, tests calling
     find_fuzzy_matches directly).
     """
+    from goldenmatch.core.frame import to_frame
     from goldenmatch.core.matchkey import _try_native_chain, _xform_sig
 
+    frame = to_frame(block_df)
     sig = _xform_sig(field)
-    if sig in block_df.columns:
-        return block_df[sig].to_list()
+    if sig in frame.columns:
+        return frame.column(sig).to_list()
 
     col = field.field
     assert col is not None, "field.field must be set; upstream validation enforces"
@@ -429,7 +431,7 @@ def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> lis
         result_df = block_df.select(native_expr.alias("__tmp__"))
         return result_df["__tmp__"].to_list()
 
-    values = block_df[col].to_list()
+    values = frame.column(col).to_list()
     return [apply_transforms(v, field.transforms) if v is not None else None for v in values]
 
 
@@ -1093,7 +1095,9 @@ def find_fuzzy_matches(
     if n < 2:
         return _emit_empty()
 
-    row_ids = block_df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+    row_ids = _to_frame_d5(block_df).column("__row_id__").to_list()
 
     # Separate exact (cheap), record_embedding, and fuzzy (expensive) fields.
     # initialism_match / alias_match are equality-style (1.0/0.0) scorers with
@@ -1350,7 +1354,11 @@ def _score_one_block(
     block_df = block.df.collect()
 
     if across_files_only and source_lookup:
-        sources_in_block = block_df["__source__"].unique().to_list()
+        from goldenmatch.core.frame import to_frame as _to_frame_d5
+
+        sources_in_block = (
+            _to_frame_d5(block_df).column("__source__").unique().to_list()
+        )
         if len(sources_in_block) < 2:
             return _empty_pair_stream_df() if _emit_dataframe else []
 


### PR DESCRIPTION
3.x arrow-descent batch 4 (D4a #1712 merged; D5 sub-batch map committed here: order D5a/c/b/d, recon-verified).

- Wall-neutral, zero new ops: per-block value extractions in find_fuzzy_matches, _get_transformed_values (fast path + raw fallback), _score_one_block, probabilistic, and score_buckets' Python fallback read through the seam -- identical extraction on polars, ArrowFrame-tolerant for D5b.
- The native-expr branch of _get_transformed_values stays for D5c (derive_transformed_column twin exists); D5b (BlockResult Frame representation) and D5d (bucket scaffolding) carry the 100K/1M wall gates.

Gates: scorer / probabilistic / score_buckets_multipass / pipeline / differential -- 183 passed. ruff clean.