### PR TITLE
docs(goldencheck): 3.0.1-3.1.3 perf arc + GOLDENCHECK_SCAN_THREADS + fix stale pure-Polars claim

### DIFF
--- a/docs-site/goldencheck/native.mdx
+++ b/docs-site/goldencheck/native.mdx
@@ -21,8 +21,17 @@ default: use native where available, fall back otherwise).
 
 goldencheck-native also accelerates the **format, encoding, pattern, and temporal
 profilers** that run on the Arrow-native scan path. Since the whole scan is
-Polars-free in 3.0.0, `pip install goldencheck[native]` runs those checks at native
-speed on any CSV/Parquet/Excel source with no Polars installed.
+Polars-free (as of 3.0.0), `pip install goldencheck[native]` runs those checks at
+native speed on any CSV/Parquet/Excel source with no Polars installed.
+
+As of the current 3.1.x line the `[native]` kernel is a **real, measurable
+accelerator** of the everyday scan, not just the deep-profiling checks. On the
+1M-row x 7-column mixed shape a native scan runs roughly **1.9s vs 3.0s** for the
+pure-pyarrow fallback. Before 3.0.x, string/cast overhead in the scan masked the
+kernel's benefit; now that the hot paths are fused (see below), installing
+`[native]` is a genuine speedup. It stays an accelerator, not a requirement: a
+base `pip install goldencheck` still scans polars-free through `pyarrow.compute`,
+just slower on the numeric- and regex-heavy checks.
 
 Extras at a glance: `[native]` adds the Rust kernels below (Polars not required);
 `[baseline]` adds scipy/numpy **and Polars** for the deep statistical profiling,
@@ -34,10 +43,15 @@ drift, and correlation subsystems; `[polars]` adds Polars only for the
 
 Every kernel had to clear two gates before being switched on by default: it must
 be **byte-identical / integer-exact** to the pure-Python reference, **and**
-measurably **faster than the Polars baseline** on a real workload. (One early
-kernel was actually *slower* than Polars and was rewritten before shipping — the
-rule is "beat Polars", not "it's Rust".) Checks where Polars already wins —
-duplicate-row detection, referential integrity, freshness — stay pure-Polars.
+measurably faster than the reference implementation on a real workload. When the
+kernels were first added, that reference was the old Polars scan path, so the
+original bar was "beat Polars" (one early kernel was actually *slower* than
+Polars and was rewritten before shipping — the rule was "beat Polars", not "it's
+Rust"). After the 3.0.0 Flip there is no Polars in the default scan at all: the
+whole scan is Arrow-native, so duplicate-row detection, referential integrity,
+and freshness now run on the Arrow seam (`pyarrow.compute` plus these kernels),
+Polars-free like everything else. The per-kernel speedups below are still the
+measured wins over that original baseline.
 
 | Check | Speedup | What it finds |
 |---|---|---|
@@ -47,6 +61,34 @@ duplicate-row detection, referential integrity, freshness — stay pure-Polars.
 | Approximate-FD violations | 15.5× | the few rows that break a near-perfect dependency (likely data-entry errors) |
 | Fuzzy value clustering | 76× | inconsistent categorical encodings (`California` / `Californa` / `CALIFORNIA`) |
 | Denial-constraint evidence | ~1.5–1.8× vs a Polars cross-join (~60–96× vs pure Python) | violating rows for if-then / cross-tuple invariants (`dc.rs`) |
+
+## How the default scan got ~3.8x faster (3.0.1 - 3.1.3)
+
+The Arrow-native scan that shipped in 3.0.0 was then tuned hard across the 3.0.x
+and 3.1.x releases. On a 1M-row x 7-column mixed table the default scan went from
+**3.74s to about 1.0s (~3.8x)**, and every release stayed byte-identical (same
+findings, same order). Numeric-wide and date/relation-heavy tables see additional
+wins. The levers:
+
+- **Vectorized pyarrow ops** over per-element Python loops on the hot paths.
+- **Fused single-pass kernels.** A string-column digest computes null-count,
+  distinct-count, and every format/encoding pattern match in ONE pass over the
+  column instead of a separate scan per check; `n_unique` is folded into the
+  numeric-stats pass so it's a free byproduct.
+- **A parallel scan.** Column profilers AND relation profilers fan out across a
+  thread pool. It's deterministic: results merge in profiler order, so findings
+  are byte-identical to the sequential path.
+- **No whole-column materialization in sample paths** — profilers slice to the few
+  sample values they need before converting to Python, instead of realizing the
+  entire filtered column.
+
+### `GOLDENCHECK_SCAN_THREADS`
+
+The scan thread pool is controlled by `GOLDENCHECK_SCAN_THREADS`. The default is
+parallel: `min(cpu, 8, ncols)` threads, engaged when there are at least 2 columns
+and at least 50k rows. Set `GOLDENCHECK_SCAN_THREADS=1` to force the sequential
+path (useful for debugging or reproducible profiling). Findings are deterministic
+either way.
 
 ## New deep-profiling checks
 

--- a/docs-site/goldencheck/overview.mdx
+++ b/docs-site/goldencheck/overview.mdx
@@ -126,3 +126,11 @@ drift = [f for f in findings if f.source == "baseline_drift"]
 ## Benchmark
 
 GoldenCheck scores 88.40 on DQBench (versus Pandera 32.51, Great Expectations 21.68, Soda 22.36), at roughly 482K rows/sec.
+
+The Arrow-native scan that shipped in 3.0.0 got roughly **3.8x faster** across the
+3.0.x and 3.1.x releases (a 1M-row x 7-column mixed scan went 3.74s to about 1.0s),
+each release byte-identical to the last. The wins come from vectorized pyarrow ops,
+fused single-pass kernels, and a deterministic parallel scan. The scan thread pool
+is tunable with `GOLDENCHECK_SCAN_THREADS` (default parallel; set it to `1` to force
+sequential). Installing `goldencheck[native]` accelerates the scan further. See
+[Native acceleration](/goldencheck/native) for the details.

--- a/packages/python/goldencheck/README.md
+++ b/packages/python/goldencheck/README.md
@@ -52,6 +52,24 @@ and Excel all work out of the box with no Polars installed.
 > natively). `inferred_type` now reports a neutral dtype vocabulary (`str`, `int`,
 > `float`, `date`, ...) instead of raw Polars dtype names.
 
+### Performance
+
+The default scan is fast out of the box: it's Arrow-native, uses fused single-pass
+kernels (one pass over each column for null-count, distinct-count, and every
+format/encoding pattern), and runs a deterministic parallel scan across columns and
+relation profilers. Across the 3.0.x and 3.1.x releases the default scan got roughly
+**3.8x faster** (a 1M-row x 7-column mixed scan went from 3.74s to about 1.0s), each
+release byte-identical to the last.
+
+- **`GOLDENCHECK_SCAN_THREADS`** tunes the scan thread pool. Default is parallel
+  (`min(cpu, 8, ncols)` threads, when there are at least 2 columns and 50k rows);
+  set `GOLDENCHECK_SCAN_THREADS=1` to force sequential (e.g. for reproducible
+  profiling). Findings are identical either way.
+- **`pip install goldencheck[native]`** adds the compiled Rust kernels, which now
+  measurably accelerate the scan (roughly 1.9s vs 3.0s on the 1M x 7 shape). It's an
+  accelerator, not a requirement — the base install still scans polars-free through
+  `pyarrow.compute`.
+
 With LLM boost support:
 
 ```bash

--- a/packages/python/goldencheck/llms.txt
+++ b/packages/python/goldencheck/llms.txt
@@ -11,7 +11,8 @@
 - REST API: `goldencheck serve` on port 8000
 
 ## Install
-- `pip install goldencheck` — Arrow-native, Polars-free: full scan (`scan_file`/`scan_dataframe`) of CSV/Parquet/Excel (pyarrow is a base dep since 3.0.0)
+- `pip install goldencheck` — Arrow-native, Polars-free: full scan (`scan_file`/`scan_dataframe`) of CSV/Parquet/Excel (pyarrow is a base dep since 3.0.0); fast by default (fused single-pass kernels + parallel scan)
+- `pip install goldencheck[native]` — compiled Rust kernels; now measurably accelerate the scan (~1.9s vs ~3.0s on 1M x 7), still optional (base install scans polars-free via pyarrow.compute)
 - `pip install goldencheck[baseline]` — deep statistical profiling & drift detection (pulls scipy/numpy + Polars)
 - `pip install goldencheck[polars]` — only for the `scan_dataframe(pl.DataFrame)` convenience overload
 - `pip install goldencheck[llm]` — LLM boost (~$0.01/scan)
@@ -126,6 +127,9 @@ ignore:
 
 ## Performance
 - 1M rows in 2.07s (482K rows/sec)
+- Default Arrow scan got ~3.8x faster across 3.0.x/3.1.x (1M x 7: 3.74s -> ~1.0s), each release byte-identical
+- `GOLDENCHECK_SCAN_THREADS` tunes the scan thread pool (default parallel = min(cpu, 8, ncols) at >=2 cols and >=50k rows; set `1` for sequential/reproducible profiling)
+- `goldencheck[native]` accelerates the scan (~1.9s vs ~3.0s on 1M x 7); accelerator, not a requirement
 - LLM boost: ~$0.01 per scan
 - 3 domain packs: healthcare, finance, ecommerce
 


### PR DESCRIPTION
Deep docs sweep for the goldencheck perf arc. The 3.0.0 Flip was already documented; this covers the 3.0.1-3.1.3 performance work + the new thread knob + a stale claim the Flip predates.

### Changes
- **`docs-site/goldencheck/native.mdx`** — fixed a STALE claim (below); added "How the default scan got ~3.8x faster (3.0.1-3.1.3)" (vectorized pyarrow, fused single-pass kernels, deterministic parallel scan, no whole-column materialization) + a `GOLDENCHECK_SCAN_THREADS` subsection; intro now notes `[native]` measurably accelerates the everyday scan (~1.9s vs ~3.0s on 1M x 7), not just deep-profiling.
- **`docs-site/goldencheck/overview.mdx`** — perf-arc paragraph in `## Benchmark` (DQBench/throughput numbers untouched).
- **`packages/python/goldencheck/README.md`** — new Performance subsection (fast-by-default fused kernels + parallel scan, `GOLDENCHECK_SCAN_THREADS`, `[native]` = accelerator-not-requirement).
- **`packages/python/goldencheck/llms.txt`** — refreshed install + Performance lines.

### Stale claim fixed
`native.mdx` said *"Checks where Polars already wins ... stay pure-Polars"* -- FALSE after the 3.0.0 Flip: there's no Polars path in the default scan; duplicate-row / referential / freshness run on the Arrow seam (pyarrow.compute + kernels), Polars-free. Rewrote to keep the historical "beat Polars" gate framing but drop the false present-tense claim.

### Gates
`version_consistency` PASS, `readme_callouts --check` PASS, `docs.json` nav resolves, install-claims-resolve PASS. The one `check_docs_consistency` failure is the documented Windows-only `.mdx orphan detection` false positive (flags all ~55 pages via backslash slugs; passes on Linux CI) -- no `.mdx` added/removed, `docs.json` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)