### PR TITLE
fix(mcp): golden-reading tools handle polars OR pa.Table golden

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -1123,15 +1123,37 @@ def _tool_get_cluster(cluster_id: int) -> dict:
     return {"cluster_id": cluster_id, "size": info["size"], "members": members}
 
 
+def _golden_as_table(golden):
+    """Normalize a golden frame to a ``pyarrow.Table``.
+
+    Session runs (``dedupe_df`` -> ``DedupeResult.golden``) already produce a
+    ``pa.Table``, but the standalone ``MatchEngine.run_full`` path still yields a
+    polars ``DataFrame`` (``EngineResult.golden: pl.DataFrame``). The
+    golden-reading MCP tools are written against the ``pa.Table`` API
+    (``to_pylist``/``column_names``/``select``/``num_rows``/``filter``), so a
+    polars golden would ``AttributeError``. Convert here so both paths work. The
+    lasting fix is making ``EngineResult.golden`` a ``pa.Table`` in the
+    polars-eviction program; this keeps the MCP surface working meanwhile.
+    """
+    if golden is None:
+        return None
+    import pyarrow as pa
+    if isinstance(golden, pa.Table):
+        return golden
+    to_arrow = getattr(golden, "to_arrow", None)  # polars.DataFrame -> pa.Table
+    return to_arrow() if callable(to_arrow) else golden
+
+
 def _tool_get_golden_record(cluster_id: int) -> dict:
-    if _result.golden is None:
+    golden = _golden_as_table(_result.golden)
+    if golden is None:
         return {"error": "No golden records available"}
 
     import pyarrow.compute as pc
 
-    golden_rows = _result.golden.filter(
-        pc.equal(_result.golden.column("__cluster_id__"), cluster_id)
-    ) if "__cluster_id__" in _result.golden.column_names else None
+    golden_rows = golden.filter(
+        pc.equal(golden.column("__cluster_id__"), cluster_id)
+    ) if "__cluster_id__" in golden.column_names else None
 
     if golden_rows is None or golden_rows.num_rows == 0:
         return {"error": f"No golden record for cluster {cluster_id}"}
@@ -1368,23 +1390,24 @@ def _tool_export_results(output_path: str, fmt: str) -> dict:
     path = _safe_path_or_error(output_path)
     if isinstance(path, dict):
         return path
+    golden = _golden_as_table(_result.golden)
     if fmt == "json":
-        if _result.golden is not None:
-            golden_dicts = _result.golden.to_pylist()
+        if golden is not None:
+            golden_dicts = golden.to_pylist()
             clean = [{k: v for k, v in r.items() if not k.startswith("__")} for r in golden_dicts]
             path.write_text(json.dumps(clean, default=str, indent=2))
         else:
             path.write_text("[]")
     else:
-        if _result.golden is not None:
+        if golden is not None:
             from pyarrow import csv as _pacsv
 
-            cols = [c for c in _result.golden.column_names if not c.startswith("__")]
-            _pacsv.write_csv(_result.golden.select(cols), str(path))
+            cols = [c for c in golden.column_names if not c.startswith("__")]
+            _pacsv.write_csv(golden.select(cols), str(path))
         else:
             path.write_text("")
 
-    return {"exported": str(path), "format": fmt, "records": _result.golden.num_rows if _result.golden is not None else 0}
+    return {"exported": str(path), "format": fmt, "records": golden.num_rows if golden is not None else 0}
 
 
 def _tool_list_domains() -> dict:

--- a/packages/python/goldenmatch/tests/test_mcp_golden_types.py
+++ b/packages/python/goldenmatch/tests/test_mcp_golden_types.py
@@ -1,0 +1,57 @@
+"""The golden-reading MCP tools must handle BOTH golden frame types.
+
+Standalone `MatchEngine.run_full` yields `EngineResult.golden: pl.DataFrame`,
+while session/`dedupe_df` runs yield `DedupeResult.golden: pa.Table` (post the
+W5 Arrow flip). `_tool_export_results` / `_tool_get_golden_record` are written
+against the pa.Table API, so a polars golden used to `AttributeError`
+(`'DataFrame' object has no attribute 'to_pylist'`). `_golden_as_table`
+normalizes; these tests lock both types.
+"""
+import polars as pl
+import pyarrow as pa
+
+
+def test_golden_as_table_normalizes_polars_and_passes_arrow():
+    from goldenmatch.mcp.server import _golden_as_table
+
+    assert _golden_as_table(None) is None
+    tbl = pa.table({"a": [1, 2]})
+    assert _golden_as_table(tbl) is tbl  # pa.Table passthrough (identity)
+    df = pl.DataFrame({"a": [1, 2]})
+    out = _golden_as_table(df)
+    assert isinstance(out, pa.Table) and out.num_rows == 2
+
+
+def _run(monkeypatch, golden):
+    from goldenmatch.mcp import server as gm
+    fake = type("R", (), {"golden": golden})()
+    monkeypatch.setattr(gm, "_result", fake)
+    return gm
+
+
+def test_export_and_golden_record_handle_polars_golden(tmp_path, monkeypatch):
+    """The exact pre-existing bug: standalone polars golden -> the tools crashed."""
+    golden = pl.DataFrame({"__cluster_id__": [0, 1], "name": ["A", "B"]})
+    gm = _run(monkeypatch, golden)
+
+    out_json = tmp_path / "g.json"
+    r = gm._tool_export_results(str(out_json), "json")
+    assert "error" not in r and out_json.exists() and r["records"] == 2
+    # internal __ columns stripped in the written JSON
+    assert "__cluster_id__" not in out_json.read_text()
+
+    out_csv = tmp_path / "g.csv"
+    r2 = gm._tool_export_results(str(out_csv), "csv")
+    assert "error" not in r2 and out_csv.exists()
+
+    r3 = gm._tool_get_golden_record(0)
+    assert "error" not in r3 and r3["golden_record"]["name"] == "A"
+
+
+def test_export_handles_arrow_golden_unchanged(tmp_path, monkeypatch):
+    """The session pa.Table path keeps working (regression guard)."""
+    golden = pa.table({"__cluster_id__": [0], "name": ["A"]})
+    gm = _run(monkeypatch, golden)
+    out = tmp_path / "g.csv"
+    r = gm._tool_export_results(str(out), "csv")
+    assert "error" not in r and out.exists() and r["records"] == 1


### PR DESCRIPTION
## Bug
`_tool_export_results` (JSON `.to_pylist()` / CSV `_pacsv.write_csv(.select())`) and `_tool_get_golden_record` are written against the `pa.Table` API, but the **standalone** `MatchEngine.run_full` path yields `EngineResult.golden` as a **polars DataFrame** (only the session `dedupe_df`/`DedupeResult.golden` path is `pa.Table` post the W5 flip). So on the standalone server, `export_results` crashed with `AttributeError: 'DataFrame' object has no attribute 'to_pylist'` (was failing in `test_mcp_and_watch`, which CI ignores — so it slipped).

## Fix
`_golden_as_table()` normalizes the golden frame to `pa.Table` at point of use (polars `.to_arrow()`; `pa.Table` passthrough). Both golden-reading tools use it. Localized and safe; the lasting fix is making `EngineResult.golden` a `pa.Table` in the polars-eviction program.

## Tests
New `tests/test_mcp_golden_types.py` (normalize helper + export/golden_record on polars golden + pa.Table regression guard). `test_mcp_and_watch.py` now **14/14 green** (was 10/1-fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)