### PR TITLE
feat(goldenmatch): arrow-descent D5c -- thin scoring derivations onto the seam

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -222,6 +222,8 @@ class Frame(Protocol):
     # documented owned contract for user patterns (Rust-regex on polars;
     # exotic constructs may differ, same stance as the W2a derive chains).
     # with_null_where nulls COL where mask is True, dtype-preserving.
+    # D5c: row-dict projection (probabilistic's select(cols).to_dicts()).
+    def select_dicts(self, cols: Sequence[str]) -> list[dict]: ...
     def evaluate_validation_rule(
         self, column: str, rule_type: str, params: dict
     ) -> Column: ...
@@ -747,6 +749,10 @@ class PolarsFrame:
         if offset > 0:
             df = df.with_columns((pl.col(name) + offset).alias(name))
         return PolarsFrame(df.with_columns(pl.col(name).cast(pl.Int64)))
+
+    def select_dicts(self, cols: Sequence[str]) -> list[dict]:
+        # probabilistic.py row_lookup build: select(cols).to_dicts().
+        return self._df.select(list(cols)).to_dicts()
 
     def evaluate_validation_rule(
         self, column: str, rule_type: str, params: dict
@@ -1621,6 +1627,9 @@ class ArrowFrame:
         arr = pc.cast(arr, pa.int64())
         idx = tbl.column_names.index(name)
         return ArrowFrame(tbl.set_column(idx, name, arr))
+
+    def select_dicts(self, cols: Sequence[str]) -> list[dict]:
+        return self._tbl.select(list(cols)).to_pylist()
 
     def evaluate_validation_rule(
         self, column: str, rule_type: str, params: dict

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1260,7 +1260,9 @@ def score_probabilistic(
     # Build row lookup
     cols = [f.field for f in mk.fields if f.field != "__record__"]
     row_lookup: dict[int, dict] = {}
-    for row in block_df.select(["__row_id__"] + cols).to_dicts():
+    from goldenmatch.core.frame import to_frame as _tf_d5c
+
+    for row in _tf_d5c(block_df).select_dicts(["__row_id__"] + cols):
         row_lookup[row["__row_id__"]] = row
 
     from goldenmatch.core.frame import to_frame as _to_frame_d5

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -417,7 +417,7 @@ def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> lis
     find_fuzzy_matches directly).
     """
     from goldenmatch.core.frame import to_frame
-    from goldenmatch.core.matchkey import _try_native_chain, _xform_sig
+    from goldenmatch.core.matchkey import _xform_sig
 
     frame = to_frame(block_df)
     sig = _xform_sig(field)
@@ -426,10 +426,11 @@ def _get_transformed_values(block_df: pl.DataFrame, field: MatchkeyField) -> lis
 
     col = field.field
     assert col is not None, "field.field must be set; upstream validation enforces"
-    native_expr = _try_native_chain(col, field.transforms)
-    if native_expr is not None:
-        result_df = block_df.select(native_expr.alias("__tmp__"))
-        return result_df["__tmp__"].to_list()
+    # D5c: derive_transformed_column IS the seam twin of the old
+    # _try_native_chain select (native chain when portable, RAW-value python
+    # fallback otherwise -- same branches, both backends).
+    if field.transforms:
+        return frame.derive_transformed_column(col, list(field.transforms)).to_list()
 
     values = frame.column(col).to_list()
     return [apply_transforms(v, field.transforms) if v is not None else None for v in values]

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -392,3 +392,30 @@ def test_auto_fix_drops_empty_rows_and_null_cols_both_backends():
     pf, _ = PolarsFrame(df).auto_fix()
     af, _ = ArrowFrame(df.to_arrow()).auto_fix()
     assert pf.native.height == af.native.num_rows == 1
+
+
+# -- D5c pins ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_select_dicts(backend):
+    # probabilistic row_lookup shape: select(cols).to_dicts() / to_pylist().
+    f = _mk({"__row_id__": [1, 2], "name": ["a", None], "x": [9, 8]}, backend)
+    assert f.select_dicts(["__row_id__", "name"]) == [
+        {"__row_id__": 1, "name": "a"},
+        {"__row_id__": 2, "name": None},
+    ]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("chain", [["lowercase"], ["soundex"], ["lowercase", "soundex"]])
+def test_derive_transformed_column_matches_python_oracle(backend, chain):
+    # D5c pins the _get_transformed_values fallback collapse: derive ==
+    # [apply_transforms(v, chain) if v is not None else None] on both
+    # backends, native AND non-native chains.
+    from goldenmatch.utils.transforms import apply_transforms
+
+    vals = ["  José Müller ", "SMITH-jones", None, "o'brien", ""]
+    f = _mk({"name": vals}, backend)
+    legacy = [apply_transforms(v, chain) if v is not None else None for v in vals]
+    assert f.derive_transformed_column("name", chain).to_list() == legacy


### PR DESCRIPTION
3.x arrow-descent batch 5 (D5a #1714 merged).

- _get_transformed_values' native-expr fallback collapses into derive_transformed_column (probed byte-identical to the legacy triple-branch on native AND non-native chains, both backends; pin fixtures added).
- probabilistic's row_lookup build via the new select_dicts op (the one read the seam lacked).
- Remaining D5: D5b (BlockResult-as-Frame) and D5d (bucket scaffolding), both wall-gated per the plan.

Gates: frame w4 ops (+3) / scorer / probabilistic / pipeline / differential -- 252 passed. ruff clean.