### PR TITLE
feat(goldenmatch): arrow-descent D5b -- BlockResult goes representation-agnostic

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py
@@ -166,7 +166,7 @@ def _materialize_blocks_to_arrow(
     values_chunks: list[list[str]] = []
 
     for block in blocks:
-        block_df = block.df.collect()
+        block_df = block.materialize().native
         if block_df.height < 2:
             continue
         if across_files_only and source_lookup:

--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -197,7 +197,7 @@ def score_blocks_ray(
             if hasattr(block, 'df') and hasattr(block.df, 'collect'):
                 collected_block = type(block)(
                     block_key=block.block_key,
-                    df=block.df.collect().lazy(),
+                    df=block.materialize().native,
                     strategy=block.strategy,
                     depth=getattr(block, 'depth', 0),
                     parent_key=getattr(block, 'parent_key', None),

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -54,7 +54,7 @@ def _emit_blocking_profile(
     sizes: list[int] = []
     for b in blocks:
         try:
-            size = b.df.select(pl.len()).collect().item()
+            size = b.n_rows()
         except Exception:
             size = 0
         sizes.append(size)
@@ -200,7 +200,7 @@ def measure_blocking_profile(
             sizes = []
             for b in build_blocks(lf, blocking_cfg):
                 try:
-                    sizes.append(b.df.select(pl.len()).collect().item())
+                    sizes.append(b.n_rows())
                 except Exception:
                     sizes.append(0)
             chao1_f1: int | None = None
@@ -240,14 +240,35 @@ def measure_blocking_profile(
 
 @dataclass
 class BlockResult:
-    """Result of blocking: a block key and its associated LazyFrame."""
+    """Result of blocking: a block key and its member rows.
+
+    D5b (arrow descent): ``df`` accepts a legacy ``pl.LazyFrame`` (usually an
+    eagerly-collected group re-wrapped lazy), an eager ``pl.DataFrame``, or a
+    seam ``Frame``. Consumers use ``materialize()`` / ``n_rows()`` -- the
+    representation-agnostic reads -- instead of ``.collect()`` round-trips.
+    """
 
     block_key: str
-    df: pl.LazyFrame
+    df: Any
     strategy: str = "static"
     depth: int = 0
     parent_key: str | None = None
     pre_scored_pairs: list[tuple[int, int, float]] | None = None
+
+    def materialize(self):
+        """The block's rows as a seam Frame (collects a legacy LazyFrame once)."""
+        from goldenmatch.core.frame import Frame, to_frame
+
+        d = self.df
+        if isinstance(d, Frame):
+            return d
+        if isinstance(d, pl.LazyFrame):
+            d = d.collect()
+        return to_frame(d)
+
+    def n_rows(self) -> int:
+        """Row count without a full materialization round-trip at call sites."""
+        return self.materialize().height
 
 
 def collect_blocking_fields(config: BlockingConfig) -> list[str]:
@@ -429,7 +450,7 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
                     useful_subs: list[BlockResult] = []
                     for b in sub_blocks:
                         try:
-                            sub_size = b.df.collect().height if isinstance(b.df, pl.LazyFrame) else len(b.df)
+                            sub_size = b.n_rows()
                         except Exception:
                             sub_size = size + 1  # treat unknown as not-useful
                         if sub_size < size and sub_size >= 2:
@@ -469,7 +490,7 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
 
             results.append(BlockResult(
                 block_key=key_str,
-                df=group_df.lazy(),
+                df=group_df,  # D5b: eager (was group_df.lazy() -- a re-wrap)
             ))
 
     if hot_blocks_split or hot_blocks_skipped:
@@ -985,7 +1006,7 @@ def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Bloc
 
     scored_pairs = []
     for block in sample_blocks:
-        block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
+        block_df = block.materialize().native
         pairs = find_fuzzy_matches(block_df, score_mk)
         scored_pairs.extend(pairs)
 
@@ -1200,7 +1221,7 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
 
     results: list[BlockResult] = []
     for block in primary_blocks:
-        block_df = block.df.collect()
+        block_df = block.materialize().native
         size = len(block_df)
 
         if size > config.max_block_size and sub_block_keys:

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -320,7 +320,7 @@ def apply_learned_blocks(
     seen: set[frozenset[int]] = set()
     deduped: list = []
     for block in all_blocks:
-        block_df = block.df.collect()
+        block_df = block.materialize().native
         members = frozenset(block_df["__row_id__"].to_list())
         if members not in seen:
             seen.add(members)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2067,7 +2067,7 @@ def _run_dedupe_pipeline(
                     # has no ambiguity.
                     assignment_parts = []
                     for blk in blocks:
-                        lf = blk.df if isinstance(blk.df, pl.LazyFrame) else blk.df.lazy()
+                        lf = blk.materialize().native.lazy()
                         assignment_parts.append(
                             lf.select("__row_id__").with_columns(
                                 pl.lit(blk.block_key).alias("__block_key__"),
@@ -2110,12 +2110,7 @@ def _run_dedupe_pipeline(
                 if len(blocks) <= _BLOCK_SAMPLE_SKIP_THRESHOLD:
                     for blk in blocks:
                         try:
-                            df_blk = blk.df
-                            if isinstance(df_blk, pl.LazyFrame):
-                                size = int(df_blk.select(pl.len()).collect().item())
-                            else:
-                                size = int(df_blk.height)
-                            block_size_samples.append(size)
+                            block_size_samples.append(blk.n_rows())
                         except Exception:  # pragma: no cover -- defensive
                             continue
                 else:
@@ -2280,9 +2275,7 @@ def _run_dedupe_pipeline(
                     # filtering, so `pairs` is the emitted set directly.
                     for block in blocks:
                         block_df = (
-                            block.df.collect()
-                            if isinstance(block.df, pl.LazyFrame)
-                            else block.df
+                            block.materialize().native
                         )
                         _accumulate_block_candidate_pairs(
                             block_df, _bench_candidate_pairs
@@ -2301,7 +2294,7 @@ def _run_dedupe_pipeline(
                 # is exact (the batched path doesn't expose per-block candidates).
                 block_scorer = probabilistic_block_scorer(mk, em_result)
                 for block in blocks:
-                    block_df = block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
+                    block_df = block.materialize().native
                     _accumulate_block_candidate_pairs(
                         block_df, _bench_candidate_pairs
                     )

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -469,7 +469,7 @@ def _sample_blocked_pairs(
 
     for bi in order:
         block = blocks[bi]
-        block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+        block_df = block.materialize().native
         row_ids = sorted(block_df["__row_id__"].to_list())  # canonical order before the seeded sample
         if len(row_ids) < 2:
             continue
@@ -1696,7 +1696,6 @@ def score_probabilistic_blocks_batched(
     """
     from concurrent.futures import ThreadPoolExecutor
 
-    import polars as pl
 
     if exclude_pairs is None:
         exclude_pairs = set()
@@ -1711,7 +1710,7 @@ def score_probabilistic_blocks_batched(
     base_excl = set(exclude_pairs)
 
     def _bdf(block):
-        return block.df.collect() if isinstance(block.df, pl.LazyFrame) else block.df
+        return block.materialize().native
 
     # Split the work into independent scoring units + a per-unit scorer. Native/
     # scalar path: one unit per block. Vectorized path: row-capped batches of

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1352,7 +1352,7 @@ def _score_one_block(
     ``_score_one_block_columnar`` via ``_cross_source_filter_df`` -- the old
     "mirror any change" rule is retired.
     """
-    block_df = block.df.collect()
+    block_df = block.materialize().native
 
     if across_files_only and source_lookup:
         from goldenmatch.core.frame import to_frame as _to_frame_d5
@@ -1467,7 +1467,7 @@ def score_blocks_parallel(
         all_pairs = []
         total_candidates = 0
         for block in blocks:
-            block_df = block.df.collect()
+            block_df = block.materialize().native
             n = block_df.height
             total_candidates += n * (n - 1) // 2
             pairs = _score_one_block(
@@ -1518,7 +1518,7 @@ def score_blocks_parallel(
         total_candidates = 0
         for block in blocks:
             try:
-                n = int(block.df.select(pl.len()).collect().item())
+                n = block.n_rows()
             except Exception:
                 n = 0
             total_candidates += n * (n - 1) // 2
@@ -1834,7 +1834,7 @@ def _score_one_block_columnar(
     ``_score_one_block(..., _emit_dataframe=True)`` via
     ``_cross_source_filter_df`` -- the old mirror rule is retired.
     """
-    block_df = block.df.collect()
+    block_df = block.materialize().native
 
     if across_files_only and source_lookup:
         sources_in_block = block_df["__source__"].unique().to_list()

--- a/packages/python/goldenmatch/tests/analyze_fuzzy.py
+++ b/packages/python/goldenmatch/tests/analyze_fuzzy.py
@@ -124,12 +124,12 @@ def run_fuzzy_analysis(threshold: float, sample_size: int | None = None):
         if mk.type == "weighted":
             blocks = build_blocks(df.lazy(), cfg.blocking)
             print(f"  Blocks created: {len(blocks):,}")
-            block_sizes = [b.df.collect().height for b in blocks[:100]]
+            block_sizes = [b.materialize().native.height for b in blocks[:100]]
             if block_sizes:
                 print(f"  Avg block size (sample): {sum(block_sizes)/len(block_sizes):.1f}")
 
             for i, block in enumerate(blocks):
-                block_df = block.df.collect()
+                block_df = block.materialize().native
                 pairs = find_fuzzy_matches(block_df, mk)
                 for a, b, s in pairs:
                     fuzzy_pairs.append((a, b, s))

--- a/packages/python/goldenmatch/tests/benchmarks/run_amazon_google_bench.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_amazon_google_bench.py
@@ -114,7 +114,7 @@ t0 = time.perf_counter()
 blocks = build_blocks(collected.lazy(), blocking)
 all_pairs = []
 for block in blocks:
-    bdf = block.df.collect()
+    bdf = block.materialize().native
     all_pairs.extend(find_fuzzy_matches(bdf, mk_emb, pre_scored_pairs=block.pre_scored_pairs))
 all_pairs = cross_filter(all_pairs)
 t_base = time.perf_counter() - t0

--- a/packages/python/goldenmatch/tests/benchmarks/run_ann_finetune_sim.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_ann_finetune_sim.py
@@ -56,7 +56,7 @@ def run_pipeline_get_pairs(df_a, df_b, matchkeys, blocking, standardization=None
         if mk.type == "weighted" and blocking:
             blocks = build_blocks(combined.lazy(), blocking)
             for block in blocks:
-                bdf = block.df.collect()
+                bdf = block.materialize().native
                 pairs = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
                 all_pairs.extend(pairs)
 

--- a/packages/python/goldenmatch/tests/benchmarks/run_boost_accuracy.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_boost_accuracy.py
@@ -95,7 +95,7 @@ def run_abt_buy():
     blocks = build_blocks(cdf.lazy(), blk)
     candidate_pairs = []
     for b in blocks:
-        bdf = b.df.collect()
+        bdf = b.materialize().native
         candidate_pairs.extend(find_fuzzy_matches(bdf, mk, pre_scored_pairs=b.pre_scored_pairs))
 
     # Filter to cross-source only

--- a/packages/python/goldenmatch/tests/benchmarks/run_cross_encoder_sim.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_cross_encoder_sim.py
@@ -61,7 +61,7 @@ def run_pipeline_get_pairs(df_a, df_b, matchkeys, blocking, standardization=None
         if mk.type == "weighted" and blocking:
             blocks = build_blocks(combined.lazy(), blocking)
             for block in blocks:
-                bdf = block.df.collect()
+                bdf = block.materialize().native
                 p = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
                 all_pairs.extend(p)
     return all_pairs, combined

--- a/packages/python/goldenmatch/tests/benchmarks/run_domain_bench.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_domain_bench.py
@@ -152,7 +152,7 @@ t0 = time.perf_counter()
 blocks = build_blocks(collected.lazy(), blocking_ann)
 emb_pairs = []
 for block in blocks:
-    bdf = block.df.collect()
+    bdf = block.materialize().native
     emb_pairs.extend(find_fuzzy_matches(bdf, mk_emb, pre_scored_pairs=block.pre_scored_pairs))
 emb_pairs = cross_source_filter(emb_pairs)
 t_emb = time.perf_counter() - t0

--- a/packages/python/goldenmatch/tests/benchmarks/run_leipzig.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_leipzig.py
@@ -107,7 +107,7 @@ def run_matching(
         elif mk.type == "weighted" and blocking:
             blocks = build_blocks(combined.lazy(), blocking)
             for block in blocks:
-                bdf = block.df.collect()
+                bdf = block.materialize().native
                 pairs = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
                 all_pairs.extend(pairs)
 

--- a/packages/python/goldenmatch/tests/benchmarks/run_llm_boost_sim.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_llm_boost_sim.py
@@ -74,7 +74,7 @@ def run_pipeline_get_pairs(df_a, df_b, matchkeys, blocking, standardization=None
         elif mk.type == "weighted" and blocking:
             blocks = build_blocks(combined.lazy(), blocking)
             for block in blocks:
-                bdf = block.df.collect()
+                bdf = block.materialize().native
                 pairs = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
                 all_pairs.extend(pairs)
 

--- a/packages/python/goldenmatch/tests/benchmarks/run_llm_budget_bench.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_llm_budget_bench.py
@@ -137,7 +137,7 @@ t0 = time.perf_counter()
 blocks = build_blocks(collected.lazy(), blocking)
 all_pairs = []
 for block in blocks:
-    bdf = block.df.collect()
+    bdf = block.materialize().native
     pairs = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
     all_pairs.extend(pairs)
 

--- a/packages/python/goldenmatch/tests/benchmarks/run_optimal_boost.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_optimal_boost.py
@@ -60,7 +60,7 @@ def get_pairs(combined, matchkeys, blocking):
         if mk.type == "weighted" and blocking:
             blocks = build_blocks(df.lazy(), blocking)
             for block in blocks:
-                bdf = block.df.collect()
+                bdf = block.materialize().native
                 p = find_fuzzy_matches(bdf, mk, pre_scored_pairs=block.pre_scored_pairs)
                 all_pairs.extend(p)
     return all_pairs, df

--- a/packages/python/goldenmatch/tests/benchmarks/run_product_sweep.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_product_sweep.py
@@ -46,7 +46,7 @@ def run_and_evaluate(name, df_a, df_b, gt, matchkeys, blocking=None, std=None):
         elif mk.type == "weighted" and blocking:
             blocks = build_blocks(combined.lazy(), blocking)
             for b in blocks:
-                bdf = b.df.collect()
+                bdf = b.materialize().native
                 all_pairs.extend(find_fuzzy_matches(bdf, mk, pre_scored_pairs=b.pre_scored_pairs))
 
     found = set()

--- a/packages/python/goldenmatch/tests/benchmarks/run_scale_curve.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_scale_curve.py
@@ -148,7 +148,7 @@ def run_benchmark(n: int) -> dict:
 
     t0 = time.perf_counter()
     for block in blocks:
-        bdf = block.df.collect()
+        bdf = block.materialize().native
         pairs = find_fuzzy_matches(bdf, mk_fuzzy, exclude_pairs=matched_pairs,
                                     pre_scored_pairs=block.pre_scored_pairs)
         all_pairs.extend(pairs)

--- a/packages/python/goldenmatch/tests/benchmarks/run_v030_benchmarks.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_v030_benchmarks.py
@@ -211,7 +211,7 @@ def bench_probabilistic_dblp_acm(df, gt):
     blocks = build_blocks(collected.lazy(), blocking)
     all_pairs = []
     for block in blocks:
-        block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+        block_df = block.materialize().native if hasattr(block.df, 'collect') else block.df
         pairs = score_probabilistic(block_df, mk, em_result)
         all_pairs.extend(pairs)
 
@@ -259,7 +259,7 @@ def bench_static_blocking_dblp_acm(df, gt):
     collected = lf.collect()
     blocks = build_blocks(collected.lazy(), blocking)
     n_blocks = len(blocks)
-    total_block_records = sum(b.df.collect().height for b in blocks)
+    total_block_records = sum(b.materialize().native.height for b in blocks)
 
     matched_pairs: set[tuple[int, int]] = set()
     pairs = score_blocks_parallel(blocks, mk, matched_pairs)
@@ -324,7 +324,7 @@ def bench_learned_blocking_dblp_acm(df, gt):
     # Phase 3: Apply learned blocks to full dataset
     learned_blocks = apply_learned_blocks(collected.lazy(), rules, max_block_size=500)
     n_blocks = len(learned_blocks)
-    total_block_records = sum(b.df.collect().height for b in learned_blocks)
+    total_block_records = sum(b.materialize().native.height for b in learned_blocks)
 
     matched_pairs2: set[tuple[int, int]] = set()
     pairs = score_blocks_parallel(learned_blocks, mk, matched_pairs2)

--- a/packages/python/goldenmatch/tests/benchmarks/run_v030_quick.py
+++ b/packages/python/goldenmatch/tests/benchmarks/run_v030_quick.py
@@ -140,7 +140,7 @@ print(f"    Scoring {len(blocks_fs)} blocks (vectorized, full blocks)...", flush
 fs_scorer = probabilistic_block_scorer(mk_fs, em)
 pairs_fs = []
 for i, block in enumerate(blocks_fs):
-    block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
+    block_df = block.materialize().native if hasattr(block.df, 'collect') else block.df
     pairs_fs.extend(fs_scorer(block_df))
     if (i + 1) % 20 == 0:
         print(f"    Block {i+1}/{len(blocks_fs)}, {len(pairs_fs)} pairs so far...", flush=True)
@@ -161,7 +161,7 @@ print("  Running static blocking...", flush=True)
 t0 = time.perf_counter()
 static_blocks = build_blocks(collected.lazy(), blocking)
 n_static = len(static_blocks)
-total_static = sum(b.df.collect().height for b in static_blocks)
+total_static = sum(b.materialize().native.height for b in static_blocks)
 matched2 = set()
 pairs_static = score_blocks_parallel(static_blocks, mk_w, matched2)
 t_static = time.perf_counter() - t0
@@ -195,7 +195,7 @@ for r in rules[:3]:
 
 learned_blocks = apply_learned_blocks(collected.lazy(), rules, max_block_size=1000)
 n_learned = len(learned_blocks)
-total_learned = sum(b.df.collect().height for b in learned_blocks)
+total_learned = sum(b.materialize().native.height for b in learned_blocks)
 matched3 = set()
 pairs_learned_raw = score_blocks_parallel(learned_blocks, mk_w, matched3)
 # Deduplicate pairs (same pair can appear in multiple learned blocks)

--- a/packages/python/goldenmatch/tests/test_ann_subblock.py
+++ b/packages/python/goldenmatch/tests/test_ann_subblock.py
@@ -68,7 +68,7 @@ class TestANNSubBlock:
         for block in result:
             assert block.strategy == "ann"
         # Total records in sub-blocks should be <= original
-        total = sum(len(b.df.collect()) for b in result)
+        total = sum(len(b.materialize().native) for b in result)
         assert total <= n
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_blocking_union_1207.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_blocking_union_1207.py
@@ -221,7 +221,7 @@ def _membership_recall(df: pl.DataFrame, cfg, truth: set[tuple[int, int]]) -> fl
     blocks = build_blocks(df_rid.lazy(), cfg)
     row_to_blocks: dict[int, set[int]] = defaultdict(set)
     for bi, b in enumerate(blocks):
-        bdf = b.df.collect() if hasattr(b.df, "collect") else b.df
+        bdf = b.materialize().native if hasattr(b.df, "collect") else b.df
         for rid in bdf["__row_id__"].to_list():
             row_to_blocks[int(rid)].add(bi)
     covered = sum(1 for a, c in truth if row_to_blocks[a] & row_to_blocks[c])

--- a/packages/python/goldenmatch/tests/test_blocker.py
+++ b/packages/python/goldenmatch/tests/test_blocker.py
@@ -53,7 +53,7 @@ class TestBuildBlocks:
 
         # Each block should have 2 records
         for r in results:
-            block_df = r.df.collect()
+            block_df = r.materialize().native
             assert len(block_df) == 2
 
     def test_skips_blocks_with_fewer_than_2_records(self):
@@ -317,7 +317,7 @@ class TestSortedNeighborhood:
         assert len(results) == 3
         for r in results:
             assert r.strategy == "sorted_neighborhood"
-            collected = r.df.collect()
+            collected = r.materialize().native
             assert len(collected) == 3
 
     def test_small_dataset_single_block(self):
@@ -340,7 +340,7 @@ class TestSortedNeighborhood:
 
         assert len(results) == 1
         assert results[0].strategy == "sorted_neighborhood"
-        assert len(results[0].df.collect()) == 3
+        assert len(results[0].materialize().native) == 3
 
     def test_sorted_neighborhood_metadata(self):
         """Sorted neighborhood blocks have correct strategy metadata."""

--- a/packages/python/goldenmatch/tests/test_blocking_multipass.py
+++ b/packages/python/goldenmatch/tests/test_blocking_multipass.py
@@ -21,7 +21,7 @@ from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
 def _members(blocks):
     out = []
     for b in blocks:
-        bdf = b.df.collect() if hasattr(b.df, "collect") else b.df
+        bdf = b.materialize().native if hasattr(b.df, "collect") else b.df
         out.append(frozenset(bdf["__row_id__"].to_list()))
     return out
 

--- a/packages/python/goldenmatch/tests/test_canopy.py
+++ b/packages/python/goldenmatch/tests/test_canopy.py
@@ -164,5 +164,5 @@ class TestCanopyBlockerIntegration:
 
         blocks = build_blocks(df, config)
         for block in blocks:
-            block_df = block.df.collect()
+            block_df = block.materialize().native
             assert len(block_df) >= 2, "Canopy blocks should have at least 2 members"

--- a/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
+++ b/packages/python/goldenmatch/tests/test_datafusion_spine_parity.py
@@ -163,7 +163,7 @@ def _inmemory_comparand(blocks, config):
     threshold = mk.threshold
     best: dict[tuple[int, int], float] = {}  # canonical (a<b) -> MAX score
     for b in blocks:
-        bdf = b.df.collect() if isinstance(b.df, pl.LazyFrame) else b.df
+        bdf = b.materialize().native if isinstance(b.df, pl.LazyFrame) else b.df
         ids = bdf["__row_id__"].cast(pl.Int64).to_list()
         vals = bdf[field].to_list()
         for i in range(len(ids)):

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -267,7 +267,7 @@ def test_match_fused_fs_matches_pipeline_fs_block_scorer():
     scorer = probabilistic_block_scorer(config.get_matchkeys()[0], em)
     pairs = []
     for br in build_blocks(df.lazy(), config.blocking):
-        g = br.df.collect() if hasattr(br.df, "collect") else br.df
+        g = br.materialize().native if hasattr(br.df, "collect") else br.df
         pairs += scorer(g)
     parent = list(range(df.height))
 

--- a/packages/python/goldenmatch/tests/test_hot_block_split.py
+++ b/packages/python/goldenmatch/tests/test_hot_block_split.py
@@ -49,7 +49,7 @@ class TestHotBlockSplit:
         )
         # No sub-block should exceed max_block_size.
         for r in results:
-            size = r.df.collect().height
+            size = r.materialize().native.height
             assert size <= 3, f"Block {r.block_key} has {size} rows > max=3"
 
     def test_oversized_block_with_no_splittable_column_is_skipped(self):
@@ -92,7 +92,7 @@ class TestHotBlockSplit:
         # One single 8-row block, intact.
         assert len(results) == 1
         assert results[0].block_key == "19382"
-        assert results[0].df.collect().height == 8
+        assert results[0].materialize().native.height == 8
 
     def test_bench_records_split_count(self):
         """`hot_blocks_split_count` should land on the active recorder."""

--- a/packages/python/goldenmatch/tests/test_learned_blocking.py
+++ b/packages/python/goldenmatch/tests/test_learned_blocking.py
@@ -101,7 +101,7 @@ class TestApplyLearnedBlocks:
         blocks = apply_learned_blocks(df.lazy(), rules)
         # Should be deduplicated
         block_keys = [b.block_key for b in blocks]
-        assert len(block_keys) == len(set(b.df.collect()["__row_id__"].to_list()[0] for b in blocks)) or True
+        assert len(block_keys) == len(set(b.materialize().native["__row_id__"].to_list()[0] for b in blocks)) or True
         # Just verify no crash and blocks exist
         assert len(blocks) > 0
 

--- a/packages/python/goldenmatch/tests/test_lsh_blocker.py
+++ b/packages/python/goldenmatch/tests/test_lsh_blocker.py
@@ -97,7 +97,7 @@ def test_build_blocks_dispatch_lsh():
     assert blocks, "expected at least one LSH block"
     found_pair = False
     for b in blocks:
-        members = b.df.collect()["__row_id__"].to_list()
+        members = b.materialize().native["__row_id__"].to_list()
         assert len(members) >= 2  # non-singleton blocks only
         assert b.strategy == "minhash_lsh"
         if 0 in members and 1 in members:

--- a/packages/python/goldenmatch/tests/test_perceptual_feature.py
+++ b/packages/python/goldenmatch/tests/test_perceptual_feature.py
@@ -172,7 +172,7 @@ def test_perceptual_feature_blocks_and_scores_image_variants():
     cfg = BlockingConfig(strategy="perceptual", perceptual=PerceptualKeyConfig(column="ph"))
     blocks = build_blocks(df.lazy(), cfg)
 
-    member_sets = [set(b.df.collect()["__row_id__"].to_list()) for b in blocks]
+    member_sets = [set(b.materialize().native["__row_id__"].to_list()) for b in blocks]
     # the variant pair co-occurs in at least one block (candidate generation)
     assert any({0, 1} <= s for s in member_sets)
     # and the scorer ranks the variant above the distinct image (the evidence)
@@ -211,7 +211,7 @@ def test_perceptual_blocking_recall_gate():
         ]
     df = pl.DataFrame({"__row_id__": ids, "ph": hashes})
     cfg = BlockingConfig(strategy="perceptual", perceptual=PerceptualKeyConfig(column="ph"))
-    member_sets = [set(b.df.collect()["__row_id__"].to_list()) for b in build_blocks(df.lazy(), cfg)]
+    member_sets = [set(b.materialize().native["__row_id__"].to_list()) for b in build_blocks(df.lazy(), cfg)]
     for i in range(len(bases)):  # recall: each variant pair co-occurs in a block
         assert any({2 * i, 2 * i + 1} <= s for s in member_sets), f"variant {i} not blocked"
 

--- a/packages/python/goldenmatch/tests/test_simhash_blocker.py
+++ b/packages/python/goldenmatch/tests/test_simhash_blocker.py
@@ -144,7 +144,7 @@ def test_blocks_emits_simhash_lsh_blockresults():
     assert blocks, "expected at least one SimHash block"
     found_pair = False
     for blk in blocks:
-        members = blk.df.collect()["__row_id__"].to_list()
+        members = blk.materialize().native["__row_id__"].to_list()
         assert len(members) >= 2  # non-singleton blocks only
         assert blk.strategy == "simhash_lsh"
         if 0 in members and 1 in members:
@@ -181,7 +181,7 @@ def test_build_blocks_dispatch_simhash(monkeypatch):
     assert blocks
     found_pair = False
     for blk in blocks:
-        members = blk.df.collect()["__row_id__"].to_list()
+        members = blk.materialize().native["__row_id__"].to_list()
         assert blk.strategy == "simhash_lsh"
         if 0 in members and 1 in members:
             found_pair = True


### PR DESCRIPTION
3.x arrow-descent batch 6 (D5c #1717 merged). WALL GATE PASSED before this PR opened: 100K zero-config A/B, 5-run medians, same config -- D5b branch 103.63s (run 29200533065) vs main 106.24s (run 29200533502), ~2.5% faster (dropping the .lazy() re-wrap round-trips).

- BlockResult.df widens (legacy LazyFrame | eager DataFrame | seam Frame) with materialize() -> Frame and n_rows() as the representation-agnostic reads.
- Static producer stores the eager group frame (the old .lazy() was a pure re-wrap); every consumer round-trip across scorer/blocker/pipeline/probabilistic + the block-size histogram migrates; 33-site sweep over tests + bench scripts.
- Adaptive/semantic producers keep lazy frames (union-tolerated); their port rides D5d.

Gates: blocker/scorer/hot-block-split/multipass/canopy/fused_match/lsh/simhash/pipeline/differential -- 177 passed. ruff clean.