### PR TITLE
fix(goldenmatch): _KeyModeBlock shim gains materialize()/n_rows() (D5b follow-up)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/ray_backend.py
@@ -45,6 +45,20 @@ class _KeyModeBlock:
     df: pl.LazyFrame
     pre_scored_pairs: list | None = None
 
+    def materialize(self):
+        # D5b: mirror BlockResult's representation-agnostic read.
+        from goldenmatch.core.frame import Frame, to_frame
+
+        d = self.df
+        if isinstance(d, Frame):
+            return d
+        if isinstance(d, pl.LazyFrame):
+            d = d.collect()
+        return to_frame(d)
+
+    def n_rows(self) -> int:
+        return self.materialize().height
+
 
 def _ensure_ray():
     """Import and initialize Ray lazily."""
@@ -163,7 +177,7 @@ def score_blocks_ray(
             # block_key arrives as tuple under Polars >= 1.0 partition_by.
             if isinstance(block_key, tuple):
                 block_key = block_key[0]
-            shim = _KeyModeBlock(block_key=str(block_key), df=block_df.lazy())
+            shim = _KeyModeBlock(block_key=str(block_key), df=block_df)
             all_pairs.extend(
                 _score_one_block(
                     shim, mk_config, exclude,


### PR DESCRIPTION
The distributed_broad (non-required) lane caught the duck-typed BlockResult stand-in used by the key-mode Ray task -- it lacked D5b's representation-agnostic reads, breaking _score_one_block on Ray workers. The queue had locked #1718's branch, so this ships as the immediate follow-up. The shim now mirrors materialize()/n_rows() and hands the eager frame directly (drops its own .lazy() re-wrap).