### PR TITLE
feat(goldenmatch): D5d score_buckets scaffolding onto the Frame seam

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -49,9 +49,20 @@ array-ization is leaf-local (`to_list`/`to_numpy` before rapidfuzz).
   - D5b (WALL-GATED 100K/1M): BlockResult.df becomes a seam Frame
     (materialized, score_buckets slice model); drop .lazy()/.collect()
     round-trips; candidate probe → Frame.height.
-  - D5d (heaviest, THE hot path, strictest gate): score_buckets' polars
-    scaffolding (with_columns/hash/partition_by/sort/slice, :953/:997/:1035)
-    → seam; compute core already arrow.
+  - D5d (heaviest, THE hot path, strictest gate) PORT SPEC (read 2026-07-12):
+    _score_single_pass (score_buckets.py ~:985-1070) stage-by-stage --
+    (1) keyed = slim_df.with_columns(key_expr) → frame.with_column("__block_key__",
+    frame.derive_block_key(...)) (W2a twin of _build_block_key_expr);
+    (2) PRESERVE the #422 small-block fast path (height < n_buckets skips
+    hash+partition) verbatim; (3) bucket hash stays PER-LANE native (W4e
+    precedent: shard-internal, not output-visible; sorted-slice blocks are
+    hash-independent); (4) partition_by(as_dict) → group_partitions;
+    (5) per-bucket sort(__block_key__)+slice → frame.sort/slice (already
+    ops); (6) MUST PRESERVE: the del keyed/del bucketed RSS points, every
+    stage() wrapper, and the print instrumentation (RSS bench attribution).
+    GATES: 100K A/B + 1M dispatch + RSS comparison (rss workstream
+    constraint: hold wall+accuracy, don't regress peak RSS); the 5M
+    distributed stack re-run if the bucket lane is touched by ray_backend.
 - **D6 — the deletion**: default already arrow; delete the `polars` opt-out
   value + PolarsFrame + `_polars_dtype` + polars constructor branches;
   `_polars_lazy` proxy SURVIVES only in the extra-gated integration modules

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -715,16 +715,15 @@ def score_buckets(
         assert fast_path_specs is not None  # gated by dispatcher
         threshold, total_weight, field_specs, ne_specs = fast_path_specs
         _te = time.perf_counter() if _bucket_debug else 0.0
-        sorted_df = bucket_df.sort("__block_key__")
-        sizes = (
-            sorted_df.lazy()
-            .group_by("__block_key__", maintain_order=True)
-            .agg(pl.len().alias("__size__"))
-            .collect()
-        )
-        if sizes.height == 0:
+        # D5d: seam sort + run_lengths (== the old maintain_order agg on
+        # key-sorted input; arrow twin is vectorized run_end_encode).
+        from goldenmatch.core.frame import to_frame as _tf
+
+        sorted_frame = _tf(bucket_df).sort(["__block_key__"])
+        sorted_df = sorted_frame.native
+        size_list = sorted_frame.run_lengths("__block_key__")
+        if not size_list:
             return [], 0
-        size_list = sizes["__size__"].to_list()
         weights = [w for _col, w, _fn, _name in field_specs]
 
         # Native Arrow kernel: hand the block-sorted __row_id__ + field columns
@@ -927,18 +926,16 @@ def score_buckets(
         # Sort once, slice per block (zero-copy view over the sorted parent).
         # Avoids partition_by's millions-of-tiny-eager-frames allocation that
         # fragments glibc's malloc arena on Linux (1.4 GB / 30s RSS climb).
-        sorted_df = bucket_df.sort("__block_key__")
-        sizes = (
-            sorted_df.lazy()
-            .group_by("__block_key__", maintain_order=True)
-            .agg(pl.len().alias("__size__"))
-            .collect()
-        )
-        if sizes.height == 0:
+        from goldenmatch.core.frame import to_frame as _tf
+
+        sorted_frame = _tf(bucket_df).sort(["__block_key__"])
+        sorted_df = sorted_frame.native
+        # Pre-materialized run sizes (seam run_lengths == the old
+        # maintain_order agg on key-sorted input; the inner loop stays
+        # Polars-scalar-indexing-free, the hottest line at 1.67M blocks).
+        size_list = sorted_frame.run_lengths("__block_key__")
+        if not size_list:
             return [], 0
-        # Pre-materialize as Python lists so the inner loop avoids per-iter
-        # Polars scalar indexing (the hottest line per block at 1.67M blocks).
-        size_list = sizes["__size__"].to_list()
         local_pairs: list[tuple[int, int, float]] = []
         local_blocks = 0
         offset = 0
@@ -993,11 +990,17 @@ def score_buckets(
         RSS). Accumulates into a LOCAL pass_pairs -- it must NOT mutate
         matched_pairs (that happens once, after all passes, in the caller).
         """
-        key_expr = _build_block_key_expr(key)
-
         with stage("bucket_assign"):
             _ta = time.perf_counter()
-            keyed = slim_df.with_columns(key_expr)
+            # D5d: seam block-key derivation (derive_block_key is the W2a
+            # twin of _build_block_key_expr, both backends).
+            from goldenmatch.core.frame import to_frame as _tf
+
+            _slim_frame = _tf(slim_df)
+            keyed = _slim_frame.with_column(
+                "__block_key__",
+                _slim_frame.derive_block_key(key.fields, key.transforms or []),
+            ).native
             print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: keyed (with_columns key_expr) in {time.perf_counter()-_ta:.2f}s", flush=True)
 
         # #422 fix 1: small-block fast path. When prepared_df.height < n_buckets,
@@ -1032,15 +1035,17 @@ def score_buckets(
 
             with stage("bucket_partition"):
                 _tp = time.perf_counter()
-                # First-level partition: N eager DataFrames keyed by bucket id.
-                # Polars >= 1.0 returns tuple-keyed dict when as_dict=True with a
-                # single partition column; unwrap below.
-                buckets_dict = bucketed.partition_by(
-                    "__bucket__", as_dict=True,
-                )
+                # First-level partition via the seam (group_partitions ==
+                # partition_by with unwrapped keys; N eager frames).
+                from goldenmatch.core.frame import to_frame as _tf
+
+                buckets_dict = {
+                    k: part.native
+                    for k, part in _tf(bucketed).group_partitions("__bucket__")
+                }
                 # Free the pre-partition `keyed` and `bucketed` parents.
-                # partition_by built N independent eager frames; the original
-                # contiguous parents are dead weight from this point forward.
+                # group_partitions built N independent eager frames; the
+                # original contiguous parents are dead weight now.
                 del keyed
                 del bucketed
                 print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: partition_by(bucket) in {time.perf_counter()-_tp:.2f}s -> {len(buckets_dict)} buckets", flush=True)

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -40,7 +40,6 @@ from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig
 from goldenmatch.core._native_loader import native_enabled, native_module
 from goldenmatch.core.bench import record_metrics, stage
-from goldenmatch.core.blocker import _build_block_key_expr
 
 logger = logging.getLogger(__name__)
 

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -222,6 +222,11 @@ class Frame(Protocol):
     # documented owned contract for user patterns (Rust-regex on polars;
     # exotic constructs may differ, same stance as the W2a derive chains).
     # with_null_where nulls COL where mask is True, dtype-preserving.
+    # D5d: adjacent-run sizes of KEY on input SORTED BY KEY (the bucket
+    # workers' block-size derivation). PRECONDITION: rows sorted by `key` --
+    # polars groups by VALUE (split runs merge), arrow run_end_encode is
+    # adjacency-based; they agree ONLY on sorted input (probed 2026-07-12).
+    def run_lengths(self, key: str) -> list[int]: ...
     # D5c: row-dict projection (probabilistic's select(cols).to_dicts()).
     def select_dicts(self, cols: Sequence[str]) -> list[dict]: ...
     def evaluate_validation_rule(
@@ -749,6 +754,17 @@ class PolarsFrame:
         if offset > 0:
             df = df.with_columns((pl.col(name) + offset).alias(name))
         return PolarsFrame(df.with_columns(pl.col(name).cast(pl.Int64)))
+
+    def run_lengths(self, key: str) -> list[int]:
+        # score_buckets' block sizes: group_by(maintain_order).agg(len) on
+        # key-sorted input (see the protocol precondition).
+        return (
+            self._df.lazy()
+            .group_by(key, maintain_order=True)
+            .agg(pl.len().alias("__size__"))
+            .collect()["__size__"]
+            .to_list()
+        )
 
     def select_dicts(self, cols: Sequence[str]) -> list[dict]:
         # probabilistic.py row_lookup build: select(cols).to_dicts().
@@ -1627,6 +1643,15 @@ class ArrowFrame:
         arr = pc.cast(arr, pa.int64())
         idx = tbl.column_names.index(name)
         return ArrowFrame(tbl.set_column(idx, name, arr))
+
+    def run_lengths(self, key: str) -> list[int]:
+        import pyarrow.compute as pc
+
+        arr = self._tbl.column(key).combine_chunks()
+        if len(arr) == 0:
+            return []
+        ends = pc.run_end_encode(arr).run_ends.to_pylist()
+        return [ends[0]] + [ends[i] - ends[i - 1] for i in range(1, len(ends))]
 
     def select_dicts(self, cols: Sequence[str]) -> list[dict]:
         return self._tbl.select(list(cols)).to_pylist()

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -419,3 +419,41 @@ def test_derive_transformed_column_matches_python_oracle(backend, chain):
     f = _mk({"name": vals}, backend)
     legacy = [apply_transforms(v, chain) if v is not None else None for v in vals]
     assert f.derive_transformed_column("name", chain).to_list() == legacy
+
+
+# -- D5d pins ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_run_lengths_on_sorted_input(backend):
+    # score_buckets' block sizes: adjacent-run sizes of a KEY-SORTED column.
+    # PRECONDITION is sorted input -- polars groups by VALUE (split runs
+    # merge) while arrow run_end_encode is adjacency-based; they agree only
+    # when the key is sorted (probed 2026-07-12), which is the sole call
+    # shape (workers sort by __block_key__ first).
+    f = _mk({"k": [None, None, "a", "a", "a", "b", "c", "c"], "v": list(range(8))}, backend)
+    assert f.run_lengths("k") == [2, 3, 1, 2]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_run_lengths_empty_and_single(backend):
+    assert _mk({"k": []}, backend).run_lengths("k") == []
+    assert _mk({"k": ["x"]}, backend).run_lengths("k") == [1]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_run_lengths_matches_worker_sort_then_sizes(backend):
+    # End-to-end worker shape: seam sort then run_lengths == the legacy
+    # group_by(maintain_order=True).agg(len) on the sorted frame.
+    df = pl.DataFrame({"__block_key__": ["b", "a", None, "b", "a", "c"], "v": [1, 2, 3, 4, 5, 6]})
+    f = _mk({"__block_key__": df["__block_key__"].to_list(), "v": df["v"].to_list()}, backend)
+    sf = f.sort(["__block_key__"])
+    legacy = (
+        df.sort("__block_key__")
+        .lazy()
+        .group_by("__block_key__", maintain_order=True)
+        .agg(pl.len().alias("__size__"))
+        .collect()["__size__"]
+        .to_list()
+    )
+    assert sf.run_lengths("__block_key__") == legacy


### PR DESCRIPTION
Part of the 3.x arrow descent (plan: docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md). Ports the bucket backend's frame scaffolding to seam ops so the arrow lane can descend into score_buckets later without touching the scoring bodies.

## What

- **New seam op `run_lengths(key)`**: adjacent-run sizes on KEY-SORTED input. polars = the exact `group_by(maintain_order=True).agg(len)` chain the workers used; arrow = vectorized `pc.run_end_encode`. The two agree ONLY on sorted input (polars groups by value so split runs merge; arrow is adjacency-based -- probed before pinning). Precondition documented in the protocol and pinned in fixtures (`test_frame_w4_ops.py`, D5d section).
- **`_score_single_pass`**: block-key derivation via `frame.derive_block_key` (the W2a twin of `_build_block_key_expr`); partition via `group_partitions`. The bucket hash stays per-lane native polars for now (`slim_df` is still `pl.DataFrame` at this layer). The #422 small-block fast path, the `del keyed`/`del bucketed` RSS points, every `stage()` wrapper, and the print instrumentation are preserved verbatim.
- **Both bucket workers** (`_score_one_bucket`, `_score_one_bucket_fast`): sort + block sizes via the seam. Seam sort is stable (`maintain_order=True`), a deterministic refinement of the old plain sort.

## Gates

- Local (both lanes, pure + native): scorer, score_buckets_multipass, bucket_febrl3_parity, native_parity, pipeline, frame_seam(+arrow), frame_w4_ops, frame_backend_differential -- all green.
- Differential harness: arrow reproduces polars on every dataset (clean_person / dirty_variant / fused_covered).
- Wall A/B dispatched (bench-zero-config, 5-run median, branch vs main): runs 29206711987 (d5d) / 29206712639 (baseline). Will post results here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW
