### PR TITLE
feat(goldenmatch): D2s-a spine descent -- exact-match + static blocking accept a seam Frame

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -70,6 +70,57 @@ array-ization is leaf-local (`to_list`/`to_numpy` before rapidfuzz).
   only when the gated stages run); polars moves runtime→dev-dep group; parity
   suites collapse to single-backend; docs sweep; 3.x minor release.
 
+## Recon 2026-07-12 (post-D5d): the spine blocks deep-D2 and D6
+
+D1/D3/D4/D5a-d are MERGED (#1701/#1708/#1712/#1714/#1717/#1718+#1719/#1720).
+Deep-D2's precondition is NOT met: `combined_lf` is a polars LazyFrame on BOTH
+lanes (pipeline.py ~1864 `combined_lf.collect()` -> `collected_df:
+pl.DataFrame` -> `multi_df` polars everywhere). The GOLDENMATCH_FRAME=arrow
+lane flips seam ops, but the pipeline SPINE (ingest scan_csv/scan_parquet ->
+prep exprs -> precompute_matchkey_transforms -> collect) still materializes
+polars. Consequently:
+
+- Deep-D2 (gather on ArrowColumn) would be dead code today -- no caller can
+  hand golden_fused an arrow multi_df, and no gate can exercise it e2e.
+- D6 (polars out of runtime deps) is blocked on the same spine: as long as
+  the collect boundary yields pl.DataFrame, polars is load-bearing on every
+  run regardless of lane.
+
+**Spine map (Explore recon 2026-07-12).** Ingest front (load_file rename/
+validate/__source__/ensure_row_ids) + eager standardize/exact-matchkeys
+ALREADY run on ArrowFrame when `_eager_ok` (pipeline.py:811-897); the
+arrow->polars shim is `pl.from_arrow(_combined.native)` at pipeline.py:900
+(W5b-1). Between the shim and the collect at :1864: prep-cache, gated
+quality/transform (default-ON, decline the eager lane), auto_fix
+(validation.auto_fix), quarantine split (validation.rules), semantic raw
+capture, standardize, domain, compute_matchkeys, then
+`precompute_matchkey_transforms` (matchkey.py:291 -- ALWAYS runs, polars-only;
+per-column seam twins exist via derive_transformed_column but the batched
+one-pass with_columns orchestration does not). Post-re-wrap (:1868) lazy
+consumers: _find_exact_match_ids, find_exact_matches, build_blocks x2,
+_semantic_blocking_pairs; everything else drives off eager collected_df.
+
+**Next batch series (D2s -- spine descent, CONSUMERS-FIRST; the boundary
+cannot move while downstream still takes pl.LazyFrame):**
+- D2s-a: exact-match consumers dual-rep -- _find_exact_match_ids /
+  find_exact_matches accept Frame (seam group ops exist); build_blocks entry
+  Frame-typed (blocker grouping already seam-routed).
+- D2s-b: Frame-level precompute_matchkey_transforms -- arrow path loops
+  derive_transformed_column (column-append is cheap on arrow); polars path
+  keeps the existing batched one-pass with_columns VERBATIM (the 90s-at-10M
+  lesson in its docstring). NE derived columns need a fill_null("")
+  space-join twin (check derive_block_key sep-null semantics first).
+- D2s-c: bucket hash + remaining engine-segment `pl.` residue per-lane
+  (score_buckets keyed hash, _run_fused_match_short_circuit entry columns
+  `collected_df[c].to_arrow()` -> seam column reads).
+- D2s-d: move the :900 shim below collect for the eager-eligible arrow path
+  (collected_df becomes Frame-typed); wall+RSS gate at 100K/1M.
+- Deep-D2 proper (golden_fused dual-rep: seam sort/filter/gather;
+  `gather_with_nulls` becomes a seam op; arrow twin = `take` with null
+  indices) once multi_df is arrow.
+- D6 after the spine holds a full-suite arrow lane with zero polars imports
+  (assert via an import-hook test, the goldencheck 2.0.0 precedent).
+
 ## Risks
 
 | Risk | Mitigation |

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -332,7 +332,7 @@ def _build_block_key_expr(key_config: BlockingKeyConfig) -> pl.Expr:
         return pl.concat_str(field_exprs, separator="||").alias("__block_key__")
 
 
-def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
     """Build static blocks — original blocking logic.
 
     Groups records by each blocking key, skipping blocks with < 2 records
@@ -377,18 +377,35 @@ def _build_static_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Block
         # because they're real values (an explicit empty-cell in the
         # source); dropping them aggressively lost 3 records on the
         # cross-file dedupe regression suite (PR #390 fix).
-        df_with_key = (
-            lf
-            .with_columns(block_key_expr)
-            .filter(
-                pl.col("__block_key__").is_not_null()
-                & ~pl.col("__block_key__")
-                    .str.strip_chars()
-                    .str.to_lowercase()
-                    .is_in(["nan", "null", "none"])
+        if isinstance(lf, pl.LazyFrame):
+            df_with_key = (
+                lf
+                .with_columns(block_key_expr)
+                .filter(
+                    pl.col("__block_key__").is_not_null()
+                    & ~pl.col("__block_key__")
+                        .str.strip_chars()
+                        .str.to_lowercase()
+                        .is_in(["nan", "null", "none"])
+                )
+                .collect()
             )
-            .collect()
-        )
+        else:
+            # D2s-a: seam Frame (or eager native) entry -- derive_block_key is
+            # the twin of _build_block_key_expr; filter_valid_key is the
+            # sentinel guard verbatim. The lazy branch above stays raw Polars:
+            # its fused with_columns+filter+collect is RSS-load-bearing (#375)
+            # and legacy callers hand genuinely-lazy frames.
+            from goldenmatch.core.frame import to_frame as _tf
+
+            _f = _tf(lf)
+            _f = _f.with_column(
+                "__block_key__",
+                _f.derive_block_key(
+                    key_config.fields, key_config.transforms or []
+                ),
+            )
+            df_with_key = _f.filter_valid_key("__block_key__").native
 
         # Group by block key (W2c/W2d seam: group_partitions is the
         # hash-grouped twin of group_by iteration -- deterministic
@@ -1137,7 +1154,7 @@ def select_best_blocking_key(
     return best_key
 
 
-def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
     """Build blocks from a LazyFrame based on blocking configuration.
 
     Routes by config.strategy:
@@ -1154,6 +1171,22 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
     Returns:
         List of BlockResult, one per valid block.
     """
+    # D2s-a: every non-static strategy + key auto-select + profile emission
+    # still takes a polars LazyFrame, so a seam Frame (or eager native)
+    # normalizes ONCE here (lossless -- polars stays a dependency until D6).
+    # Only the static/adaptive primary builder is dual-rep; it receives the
+    # ORIGINAL entry object so the arrow lane skips the polars round-trip.
+    _lf_entry = lf
+    if not isinstance(lf, pl.LazyFrame):
+        from goldenmatch.core.frame import Frame
+
+        native = lf.native if isinstance(lf, Frame) else lf
+        lf = (
+            native.lazy()
+            if isinstance(native, pl.DataFrame)
+            else pl.from_arrow(native).lazy()
+        )
+
     # Auto-select: pick best key based on histogram analysis
     if config.auto_select and config.keys and len(config.keys) > 1:
         best_key = select_best_blocking_key(lf, config.keys, config.max_block_size)
@@ -1211,12 +1244,12 @@ def build_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
         return blocks
 
     if config.strategy == "static":
-        blocks = _build_static_blocks(lf, config)
+        blocks = _build_static_blocks(_lf_entry, config)
         _emit_blocking_profile(blocks, config, lf)
         return blocks
 
     # strategy == "adaptive"
-    primary_blocks = _build_static_blocks(lf, config)
+    primary_blocks = _build_static_blocks(_lf_entry, config)
     sub_block_keys = config.sub_block_keys or []
 
     results: list[BlockResult] = []

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
@@ -1184,7 +1184,7 @@ def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
         lf = (
             native.lazy()
             if isinstance(native, pl.DataFrame)
-            else pl.from_arrow(native).lazy()
+            else cast(pl.DataFrame, pl.from_arrow(native)).lazy()
         )
 
     # Auto-select: pick best key based on histogram analysis

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -348,7 +348,7 @@ def _apply_negative_evidence_to_exact_pairs(  # pyright: ignore[reportUnusedFunc
 
 
 def find_exact_matches(
-    lf: pl.LazyFrame, mk: MatchkeyConfig
+    lf: Any, mk: MatchkeyConfig
 ) -> list[tuple[int, int, float]]:
     """Find exact matches by grouping on the matchkey column.
 
@@ -363,7 +363,7 @@ def find_exact_matches(
 
 
 def _find_exact_match_ids(
-    lf: pl.LazyFrame, mk: MatchkeyConfig,
+    lf: Any, mk: MatchkeyConfig,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Same Polars self-join as ``find_exact_matches`` but returns the two
     row-id columns as zero-copy int64 numpy arrays -- skipping the
@@ -382,7 +382,13 @@ def _find_exact_match_ids(
     from goldenmatch.core.frame import to_frame
 
     mk_col = f"__mk_{mk.name}__"
-    df = lf.select("__row_id__", mk_col).collect()
+    # D2s-a (spine descent): dual-rep entry. Legacy pl.LazyFrame callers keep
+    # the lazy projection+collect verbatim; a seam Frame (or eager native)
+    # projects via the seam so the arrow lane never round-trips polars.
+    if isinstance(lf, pl.LazyFrame):
+        df = lf.select("__row_id__", mk_col).collect()
+    else:
+        df = to_frame(lf).select(["__row_id__", mk_col]).native
     # Exclude null AND empty/blank matchkey values (filter_nonblank_key). Two
     # records both missing a field (e.g. a blanked phone -> "") must NOT be an
     # exact match: otherwise every blank-valued record joins on "" and

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -1,0 +1,57 @@
+"""D2s-a pins: exact-match + static-blocking entries accept a seam Frame.
+
+The spine descent (plan 2026-07-12, D2s series) moves the arrow->polars
+boundary below the collect; these fixtures pin that the two hot lazy-consumer
+entries produce identical output for a pl.LazyFrame, a PolarsFrame, and an
+ArrowFrame carrying the same rows.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.frame import ArrowFrame, PolarsFrame
+from goldenmatch.core.scorer import _find_exact_match_ids, find_exact_matches
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig, MatchkeyField
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "__row_id__": pl.Series([0, 1, 2, 3, 4, 5], dtype=pl.Int64),
+            "name": ["ann", "ann", "bob", None, "nan", "cat"],
+            "__mk_k__": ["a1", "a1", "b2", None, "", "c3"],
+        }
+    )
+
+
+def _entries():
+    df = _df()
+    return {
+        "lazy": df.lazy(),
+        "polars_frame": PolarsFrame(df),
+        "arrow_frame": ArrowFrame(df.to_arrow()),
+    }
+
+
+@pytest.mark.parametrize("rep", ["lazy", "polars_frame", "arrow_frame"])
+def test_find_exact_match_ids_dual_rep(rep):
+    mk = MatchkeyConfig(name="k", type="exact", fields=[MatchkeyField(field="name")])
+    ids_a, ids_b = _find_exact_match_ids(_entries()[rep], mk)
+    assert sorted(zip(ids_a.tolist(), ids_b.tolist())) == [(0, 1)]
+
+
+@pytest.mark.parametrize("rep", ["lazy", "polars_frame", "arrow_frame"])
+def test_find_exact_matches_dual_rep(rep):
+    mk = MatchkeyConfig(name="k", type="exact", fields=[MatchkeyField(field="name")])
+    assert find_exact_matches(_entries()[rep], mk) == [(0, 1, 1.0)]
+
+
+@pytest.mark.parametrize("rep", ["lazy", "polars_frame", "arrow_frame"])
+def test_build_static_blocks_dual_rep(rep):
+    # "nan" is a sentinel-filtered key; null drops; ann pair survives.
+    cfg = BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])])
+    blocks = build_blocks(_entries()[rep], cfg)
+    keyed = {b.block_key: sorted(b.materialize().column("__row_id__").to_list()) for b in blocks}
+    assert keyed == {"ann": [0, 1]}

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -9,11 +9,15 @@ from __future__ import annotations
 
 import polars as pl
 import pytest
-
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
 from goldenmatch.core.blocker import build_blocks
 from goldenmatch.core.frame import ArrowFrame, PolarsFrame
 from goldenmatch.core.scorer import _find_exact_match_ids, find_exact_matches
-from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig, MatchkeyConfig, MatchkeyField
 
 
 def _df() -> pl.DataFrame:


### PR DESCRIPTION
First consumers-first batch of the D2s spine-descent series (the plan update in this PR records the post-D5d recon: the pipeline spine `combined_lf -> collect()` is polars on BOTH lanes, which blocks deep-D2 and D6; the boundary cannot move until the post-collect consumers accept Frames).

## What

- **Plan recon** (`docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md`): spine map (ingest front + eager standardize/matchkeys already ArrowFrame when `_eager_ok`; the arrow->polars shim is `pl.from_arrow` at pipeline.py:900) + the D2s-a..d batch breakdown replacing the old deep-D2 slot.
- **`_find_exact_match_ids` / `find_exact_matches` dual-rep**: legacy `pl.LazyFrame` callers keep the lazy projection+collect verbatim; a seam Frame (or eager native) projects via the seam. Downstream was already seam-routed (W2c).
- **`build_blocks` dual-rep entry**: normalizes ONCE to a polars LazyFrame for non-static strategies + auto-select + profile emission (lossless; polars stays a dep until D6); the static/adaptive primary builder receives the original entry object -- `derive_block_key` + `filter_valid_key` twins replace the lazy `with_columns+filter+collect`, which stays raw polars on the LazyFrame branch (RSS-load-bearing, #375).
- **New pins**: `tests/test_spine_dual_rep.py` -- identical exact-ids and static blocks across lazy / PolarsFrame / ArrowFrame entries (incl. null + `"nan"` sentinel filtering).

## Gates

- No caller hands Frames yet (that is D2s-d, wall-gated) -- this batch is behavior-preserving on every existing path: the LazyFrame branches are verbatim.
- Local: blocker / scorer / pipeline / score_buckets_multipass / bucket_febrl3_parity / frame_backend_differential all green; differential harness reproduces polars on every dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW
