### PR TITLE
feat(goldenmatch): D2s-b Frame-level precompute_matchkey_transforms

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/matchkey.py
+++ b/packages/python/goldenmatch/goldenmatch/core/matchkey.py
@@ -415,3 +415,66 @@ def precompute_matchkey_transforms(
     # reasons other than chunk consolidation. Lane closed; remove the
     # experiment plumbing to keep this hot path free of dead code.
     return df
+
+
+def precompute_matchkey_transforms_frame(frame, matchkeys: list[MatchkeyConfig]):
+    """Frame-level twin of ``precompute_matchkey_transforms`` (D2s-b, spine
+    descent). Accepts a seam ``Frame`` (or a native frame) and returns a Frame
+    of the same backend with the identical ``__xform_<sig>__`` / derived-NE
+    columns appended.
+
+    - Polars lane: delegates to ``precompute_matchkey_transforms`` VERBATIM --
+      the batched one-pass ``with_columns`` there is wall-load-bearing (one
+      fused pass vs 6 full-frame passes was 90s at 10M; see its docstring).
+    - Arrow lane: per-signature ``derive_transformed_column`` appends (cheap:
+      ``pa.Table`` column append is zero-copy on existing columns) + the
+      ``derive_ne_joined`` twin for synthesized NE columns. Cast-then-chain
+      equals the legacy raw-value python fallback for every viable input: the
+      python fallback calls ``str`` methods directly, so it only ever runs
+      over string columns (non-string would raise today), where the pre-cast
+      is a no-op.
+
+    Signature dedup, the record_embedding skip, absent-field skip, and the
+    "already present" reuse mirror the legacy function exactly.
+    """
+    from goldenmatch.core.frame import PolarsFrame, to_frame
+
+    f = to_frame(frame)
+    if isinstance(f, PolarsFrame):
+        return PolarsFrame(precompute_matchkey_transforms(f.native, matchkeys))
+
+    # Synthesized NE columns first (matchkey.py legacy order): a derived NE
+    # field must exist before its xform signature materializes below.
+    seen_derived: set[str] = set()
+    for mk in matchkeys:
+        for ne in (getattr(mk, "negative_evidence", None) or []):
+            src = getattr(ne, "derive_from", None)
+            if not src or ne.field in f.columns or ne.field in seen_derived:
+                continue
+            if not all(c in f.columns for c in src):
+                continue
+            seen_derived.add(ne.field)
+            f = f.with_column(ne.field, f.derive_ne_joined(list(src)))
+
+    seen: set[str] = set()
+
+    def _materialize(f, field_obj):
+        if getattr(field_obj, "scorer", None) == "record_embedding":
+            return f
+        if field_obj.field not in f.columns:
+            return f
+        sig = _xform_sig(field_obj)
+        if sig in seen or sig in f.columns:
+            return f
+        seen.add(sig)
+        return f.with_column(
+            sig,
+            f.derive_transformed_column(field_obj.field, list(field_obj.transforms or [])),
+        )
+
+    for mk in matchkeys:
+        for field in mk.fields:
+            f = _materialize(f, field)
+        for ne in (getattr(mk, "negative_evidence", None) or []):
+            f = _materialize(f, ne)
+    return f

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -59,3 +59,95 @@ def test_build_static_blocks_dual_rep(rep):
     blocks = build_blocks(_entries()[rep], cfg)
     keyed = {b.block_key: sorted(b.materialize().column("__row_id__").to_list()) for b in blocks}
     assert keyed == {"ann": [0, 1]}
+
+
+# -- D2s-b: Frame-level precompute_matchkey_transforms ------------------------------
+
+
+def _mk_cfgs():
+    from goldenmatch.config.schemas import NegativeEvidenceField
+
+    return [
+        MatchkeyConfig(
+            name="a",
+            type="weighted", threshold=0.8,
+            fields=[
+                MatchkeyField(field="first", transforms=["lowercase", "strip"], scorer="jaro_winkler", weight=1.0),
+                MatchkeyField(field="last", transforms=["soundex"], scorer="jaro_winkler", weight=1.0),
+                MatchkeyField(field="plain", scorer="exact", weight=1.0),
+            ],
+            negative_evidence=[
+                NegativeEvidenceField(
+                    field="full_name",
+                    derive_from=["first", "last"],
+                    scorer="jaro_winkler",
+                    threshold=0.9,
+                    penalty=0.5,
+                )
+            ],
+        ),
+        # Same (field, transforms) as mk "a" -> signature reuse, no dup column.
+        MatchkeyConfig(
+            name="b",
+            type="weighted", threshold=0.8,
+            fields=[MatchkeyField(field="first", transforms=["lowercase", "strip"], scorer="jaro_winkler", weight=1.0)],
+        ),
+    ]
+
+
+def test_precompute_frame_arrow_matches_legacy_polars():
+    from goldenmatch.core.matchkey import (
+        precompute_matchkey_transforms,
+        precompute_matchkey_transforms_frame,
+    )
+
+    df = pl.DataFrame(
+        {
+            "__row_id__": pl.Series([0, 1, 2], dtype=pl.Int64),
+            "first": ["  Ann ", None, "BOB"],
+            "last": ["Smith", "Jones", None],
+            "plain": ["x", None, "z"],
+        }
+    )
+    mks = _mk_cfgs()
+    legacy = precompute_matchkey_transforms(df, mks)
+    arrow = precompute_matchkey_transforms_frame(ArrowFrame(df.to_arrow()), mks)
+    # Column ORDER is not part of the contract (consumers read __xform_*__
+    # by name; legacy batches python-fallback columns after all native ones).
+    assert set(arrow.columns) == set(legacy.columns)
+    for c in legacy.columns:
+        assert arrow.column(c).to_list() == legacy[c].to_list(), c
+
+
+def test_precompute_frame_polars_delegates_verbatim():
+    from goldenmatch.core.matchkey import (
+        precompute_matchkey_transforms,
+        precompute_matchkey_transforms_frame,
+    )
+
+    df = pl.DataFrame({"__row_id__": [0, 1], "first": ["A", "b"]})
+    mks = [
+        MatchkeyConfig(
+            name="a", type="weighted", threshold=0.8, fields=[MatchkeyField(field="first", transforms=["lowercase"], scorer="jaro_winkler", weight=1.0)]
+        )
+    ]
+    out = precompute_matchkey_transforms_frame(PolarsFrame(df), mks)
+    assert out.native.equals(precompute_matchkey_transforms(df, mks))
+
+
+def test_precompute_frame_skips_record_embedding_and_missing_fields():
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms_frame
+
+    df = pl.DataFrame({"__row_id__": [0], "first": ["a"]})
+    mks = [
+        MatchkeyConfig(
+            name="a",
+            type="weighted", threshold=0.8,
+            fields=[
+                MatchkeyField(field="first", scorer="record_embedding", columns=["first"], weight=1.0),
+                MatchkeyField(field="absent", scorer="exact", weight=1.0),
+            ],
+        )
+    ]
+    out = precompute_matchkey_transforms_frame(ArrowFrame(df.to_arrow()), mks)
+    assert list(out.columns) == ["__row_id__", "first"]


### PR DESCRIPTION
Second D2s spine-descent batch (plan: docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md). Adds `precompute_matchkey_transforms_frame` -- the Frame-level twin of the collect-boundary's last polars-only op -- so D2s-d can move the `pl.from_arrow` shim below the collect.

## What

- **Polars lane** delegates to the legacy `precompute_matchkey_transforms` VERBATIM: its batched one-pass `with_columns` is wall-load-bearing (one fused pass vs per-signature passes was 90s at 10M; see its docstring).
- **Arrow lane** loops `derive_transformed_column` per deduped signature (`pa.Table` column append is cheap) + `derive_ne_joined` for synthesized NE columns. Cast-then-chain equals the legacy raw-value python fallback for every viable input: `apply_transform` calls str methods directly, so python-fallback chains only ever run over string columns, where the pre-cast is a no-op.
- Signature dedup, the `record_embedding` skip, absent-field skip, and already-present reuse mirror the legacy function exactly. Column ORDER is not part of the contract (consumers read `__xform_*__` by name; legacy batches python-fallback columns after all native ones).
- **Pins** (`tests/test_spine_dual_rep.py`): arrow twin vs legacy polars output value-identical across native chains (lowercase/strip), python fallback (soundex), identity transforms, and NE `derive_from`; polars delegation frame-equal; record_embedding/absent-field skips.

## Gates

- No call-site change -- the pipeline wires this in at D2s-d (wall+RSS gated). Behavior-preserving on every existing path.
- Local: spine_dual_rep (12), matchkey, scorer, pipeline all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW
