### PR TITLE
feat(goldenmatch): D2s-c per-lane bucket assignment + fused-entry seam reads

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1026,9 +1026,15 @@ def score_buckets(
             # bench can attribute it instead of pooling it into the unwrapped
             # gap between bucket_assign and bucket_partition.
             with stage("bucket_hash_modulo"):
-                bucketed = keyed.with_columns(
-                    (pl.col("__block_key__").hash(seed=BUCKET_HASH_SEED) % n_buckets)
-                    .alias("__bucket__")
+                # D2s-c: per-lane bucket assignment via the seam (polars impl
+                # is this stage's old hash(seed) % n expr verbatim; buckets
+                # are shard-internal, never output-visible).
+                bucketed = (
+                    _tf(keyed)
+                    .with_bucket_column(
+                        "__block_key__", "__bucket__", n_buckets, BUCKET_HASH_SEED
+                    )
+                    .native
                 )
             print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: bucketed (hash %% N) in {time.perf_counter()-_tb:.2f}s", flush=True)
 

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -227,6 +227,16 @@ class Frame(Protocol):
     # polars groups by VALUE (split runs merge), arrow run_end_encode is
     # adjacency-based; they agree ONLY on sorted input (probed 2026-07-12).
     def run_lengths(self, key: str) -> list[int]: ...
+    # D2s-c: bucket assignment for score_buckets' first-level partition.
+    # PER-LANE contract (W4e precedent): buckets are shard-internal and never
+    # output-visible (workers sort by __block_key__ inside each bucket), so
+    # the two backends need NOT agree on assignments -- only on the shape:
+    # values in [0, n_buckets), deterministic within a lane, equal keys ->
+    # equal bucket. polars = the pipeline's hash(seed) % n expr VERBATIM;
+    # arrow = dictionary-encode codes % n (vectorized, no hash kernel in pc).
+    def with_bucket_column(
+        self, key: str, dst: str, n_buckets: int, seed: int
+    ) -> Frame: ...
     # D5c: row-dict projection (probabilistic's select(cols).to_dicts()).
     def select_dicts(self, cols: Sequence[str]) -> list[dict]: ...
     def evaluate_validation_rule(
@@ -764,6 +774,16 @@ class PolarsFrame:
             .agg(pl.len().alias("__size__"))
             .collect()["__size__"]
             .to_list()
+        )
+
+    def with_bucket_column(
+        self, key: str, dst: str, n_buckets: int, seed: int
+    ) -> PolarsFrame:
+        # score_buckets' bucket_hash_modulo stage VERBATIM.
+        return PolarsFrame(
+            self._df.with_columns(
+                (pl.col(key).hash(seed=seed) % n_buckets).alias(dst)
+            )
         )
 
     def select_dicts(self, cols: Sequence[str]) -> list[dict]:
@@ -1652,6 +1672,27 @@ class ArrowFrame:
             return []
         ends = pc.run_end_encode(arr).run_ends.to_pylist()
         return [ends[0]] + [ends[i] - ends[i - 1] for i in range(1, len(ends))]
+
+    def with_bucket_column(
+        self, key: str, dst: str, n_buckets: int, seed: int
+    ) -> ArrowFrame:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        # Per-lane assignment (see the protocol note): dictionary codes are
+        # dense first-appearance ints, so % n_buckets spreads distinct keys
+        # round-robin. seed is unused on this lane (no pc hash kernel); null
+        # keys get code null -> fill 0 (they land in one bucket, same as the
+        # polars lane where hash(null) is a single value).
+        arr = self._tbl.column(key).combine_chunks()
+        codes = pc.fill_null(arr.dictionary_encode().indices, 0)
+        codes64 = pc.cast(codes, pa.int64())
+        # pc has no mod kernel: x - (x // n) * n (codes are non-negative;
+        # integer pc.divide truncates like //).
+        bucket = pc.subtract(
+            codes64, pc.multiply(pc.divide(codes64, n_buckets), n_buckets)
+        )
+        return ArrowFrame(self._tbl.append_column(dst, bucket))
 
     def select_dicts(self, cols: Sequence[str]) -> list[dict]:
         return self._tbl.select(list(cols)).to_pylist()

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1436,13 +1436,18 @@ def _run_fused_match_short_circuit(
     if _preflight is not None and not getattr(config, "_strict_autoconfig", False):
         return None
 
+    # D2s-c: seam reads (dual-rep once the spine hands Frames at D2s-d).
+    from goldenmatch.core.frame import to_frame as _tf_entry
     from goldenmatch.core.fused_match import (
         run_match_fused_arrow,
         run_match_fused_multipass_arrow,
     )
 
-    n_rows = collected_df.height
-    columns = {c: collected_df[c].to_arrow() for c in _fused_needed_src_cols(config)}
+    _cf_entry = _tf_entry(collected_df)
+    n_rows = _cf_entry.height
+    columns = {
+        c: _cf_entry.column(c).to_arrow() for c in _fused_needed_src_cols(config)
+    }
     fused_tbl = run_match_fused_arrow(
         columns, config, n_rows=n_rows
     ) or run_match_fused_multipass_arrow(columns, config, n_rows=n_rows)

--- a/packages/python/goldenmatch/tests/test_frame_w4_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_w4_ops.py
@@ -457,3 +457,31 @@ def test_run_lengths_matches_worker_sort_then_sizes(backend):
         .to_list()
     )
     assert sf.run_lengths("__block_key__") == legacy
+
+
+# -- D2s-c pins ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+def test_with_bucket_column_shape_contract(backend):
+    # PER-LANE contract: values in [0, n), deterministic within a lane,
+    # equal keys -> equal bucket. Cross-lane assignments need NOT agree
+    # (buckets are shard-internal, never output-visible).
+    f = _mk({"k": ["a", "b", "a", None, "c", None]}, backend)
+    out = f.with_bucket_column("k", "__bucket__", 4, 12345)
+    vals = out.column("__bucket__").to_list()
+    assert all(v is not None and 0 <= v < 4 for v in vals)
+    assert vals[0] == vals[2]  # equal keys same bucket
+    assert vals[3] == vals[5]  # null keys share one bucket
+    again = f.with_bucket_column("k", "__bucket__", 4, 12345).column("__bucket__").to_list()
+    assert vals == again  # deterministic
+
+
+def test_with_bucket_column_polars_matches_legacy_expr():
+    df = pl.DataFrame({"k": ["a", "b", "c", "a", None]})
+    seed = 0xC2B5C0BBE7ED5E5D
+    legacy = df.with_columns((pl.col("k").hash(seed=seed) % 8).alias("__bucket__"))
+    from goldenmatch.core.frame import PolarsFrame
+
+    out = PolarsFrame(df).with_bucket_column("k", "__bucket__", 8, seed)
+    assert out.native["__bucket__"].to_list() == legacy["__bucket__"].to_list()


### PR DESCRIPTION
Third D2s spine-descent batch (plan: docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md).

## What

- **New seam op `with_bucket_column(key, dst, n_buckets, seed)`**: score_buckets' first-level partition assignment. PER-LANE contract (W4e precedent) -- buckets are shard-internal and never output-visible (workers sort by `__block_key__` inside each bucket), so the two backends need not agree on assignments, only on the shape: values in `[0, n)`, deterministic within a lane, equal keys -> equal bucket. polars = the `bucket_hash_modulo` `hash(seed) % n` expr VERBATIM (pinned against the legacy expr in a fixture); arrow = dictionary-encode codes mod n (vectorized; `pc` has no mod kernel, so `x - (x // n) * n`; null keys share one bucket, mirroring `hash(null)`).
- **`score_buckets` bucket_hash_modulo stage** routes through the op (stage wrapper + instrumentation untouched).
- **`_run_fused_match_short_circuit` entry reads** (height + per-column `to_arrow` for the kernel FFI) via the seam -- dual-rep once D2s-d hands Frames past the collect.

## Gates

- Behavior-preserving on every existing path (polars impls verbatim; no caller hands Frames yet).
- Local: frame_w4_ops (84 incl the new shape-contract + legacy-expr pins), score_buckets_multipass, bucket_febrl3_parity, pipeline, differential harness all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW