### PR TITLE
feat(goldenmatch): D2s-d1 mechanical collected_df/prepared_df reads onto the seam

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -115,6 +115,34 @@ cannot move while downstream still takes pl.LazyFrame):**
   `collected_df[c].to_arrow()` -> seam column reads).
 - D2s-d: move the :900 shim below collect for the eager-eligible arrow path
   (collected_df becomes Frame-typed); wall+RSS gate at 100K/1M.
+  **CONSUMER AUDIT (Explore, 2026-07-12) -- sub-batch spec:**
+  - D2s-d1 (mechanical, behavior-preserving both lanes): rewrite the B-class
+    collected_df reads via to_frame -- .height 1916/2601/3159 (+len at
+    3200/3203, quarantine 1784), .columns 2404/2473/2539/2913,
+    [col].to_list 2449/2615, select+to_dicts 1929 (select_dicts twin),
+    filter(is_in) 2861/2983 (filter_in), cast/fill_null/to_list 2475/2546
+    (Column.cast_str+fill_null), schema.items 2536 (rewrite over columns +
+    semantic_dtype). score_buckets prepared_df/slim_df: .height 486/528/
+    1012/1018, .columns 335/418/577-594/1097, .select 595; workers:
+    filter(pl.Series(mask)) 756 -> filter_mask, [col].to_list 831,
+    null_count 844; native-kernel extraction 760-764 is a no-op on arrow
+    (ArrowColumn.to_arrow already returns the pa array).
+  - D2s-d2 (the flip): eager-arrow path keeps _combined as ArrowFrame;
+    collected via precompute_matchkey_transforms_frame (producer twin
+    DONE); exact lane already dual-rep (D2s-a: _find_exact_match_ids
+    accepts Frame -- kill the combined_lf=collected_df.lazy() alias for
+    this path); score_buckets Frame entry (post-d1); GOLDEN BRIDGE:
+    multi_df -> pl.from_arrow at the golden-builder boundary ONLY (the
+    shim moves DOWN, not out; deep-D2 removes it). DECLINE the Frame lane
+    (fall back to today's :900 shim) when any C-class flag is set:
+    auto_suggest, memory store, pre/postflight, adaptive golden rules,
+    quality_weighting, rerank, llm scorer/boost, probabilistic EM,
+    NE-on-exact, identity, lineage. _semantic_blocking_pairs already
+    excluded by _eager_ok. _run_fused_match_short_circuit is seam-clean;
+    result frames already sink via _dict_frame_to_arrow.
+  - GATES: differential harness (bucket + fused datasets) + 100K/1M wall
+    A/B + RSS hold; the decline list must be asserted by a fixture per
+    flag (Frame lane refuses, classic lane output identical).
 - Deep-D2 proper (golden_fused dual-rep: seam sort/filter/gather;
   `gather_with_nulls` becomes a seam op; arrow twin = `take` with null
   indices) once multi_df is arrow.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -332,7 +332,9 @@ def _resolve_ne_specs(
         if fn is None:
             continue
         xform_col = _xform_sig(ne)
-        if xform_col not in prepared_df.columns:
+        from goldenmatch.core.frame import to_frame as _tf_cols
+
+        if xform_col not in _tf_cols(prepared_df).columns:
             continue
         out.append((xform_col, fn, float(ne.threshold), float(ne.penalty)))
     return out
@@ -415,7 +417,9 @@ def _resolve_fast_path(
             _decline(f"_resolve_score_pair_callable({scorer!r}) is None")
             return None
         xform_col = _xform_sig(f)
-        if xform_col not in prepared_df.columns:
+        from goldenmatch.core.frame import to_frame as _tf_cols
+
+        if xform_col not in _tf_cols(prepared_df).columns:
             return None
         field_specs.append((xform_col, float(weight), fn, scorer))
         total_weight += float(weight)
@@ -483,7 +487,12 @@ def score_buckets(
     Returns:
         All fuzzy pairs as (id_a, id_b, score) tuples.
     """
-    if prepared_df.height == 0:
+    # D2s-d1: dual-rep entry (Frame at D2s-d2); scalar reads via the seam.
+    from goldenmatch.core.frame import to_frame as _tf_entry
+
+    _prep_frame = _tf_entry(prepared_df)
+    prepared_df = _prep_frame.native
+    if _prep_frame.height == 0:
         return []
     # Resolve the block-key list HONORING multi-pass blocking: a `multi_pass`
     # config carries its keys in `.passes` with `.keys` empty (the schema
@@ -525,7 +534,7 @@ def score_buckets(
     # Three 5M Linux runs hung mid-score_buckets with no substage closing;
     # these prints expose the actual hang line.
     _t0 = time.perf_counter()
-    print(f"[score_buckets] entry: prepared_df.height={prepared_df.height} n_buckets={n_buckets}", flush=True)
+    print(f"[score_buckets] entry: prepared_df.height={_prep_frame.height} n_buckets={n_buckets}", flush=True)
 
     # Verbose per-bucket timing breakdown (issue #688 diagnosis aid). OFF by
     # default; set GOLDENMATCH_BUCKET_DEBUG=1 to split every native bucket call
@@ -574,15 +583,15 @@ def score_buckets(
     if os.environ.get("GOLDENMATCH_BUCKET_SLIM_PROJECTION", "1") != "0":
         with stage("bucket_slim_projection"):
             keep: list[str] = ["__row_id__"]
-            if "__source__" in prepared_df.columns:
+            if "__source__" in _prep_frame.columns:
                 keep.append("__source__")
-            keep.extend(c for c in prepared_df.columns if c.startswith("__xform_"))
+            keep.extend(c for c in _prep_frame.columns if c.startswith("__xform_"))
             # Probabilistic scoring (score_probabilistic_vectorized) reads the
             # RAW field columns and applies transforms itself, so keep them
             # (the weighted fast path uses __xform_* and doesn't need these).
             if is_probabilistic:
                 for f in mk.fields:
-                    if f.field in prepared_df.columns and f.field not in keep:
+                    if f.field in _prep_frame.columns and f.field not in keep:
                         keep.append(f.field)
             # Source fields the block-key expression reads. Multi-key blocking
             # (rare today) accumulates fields across every key in the config.
@@ -590,15 +599,17 @@ def score_buckets(
             for key in pass_keys:
                 block_key_sources.update(key.fields)
             for col in block_key_sources:
-                if col in prepared_df.columns and col not in keep:
+                if col in _prep_frame.columns and col not in keep:
                     keep.append(col)
-            slim_df = prepared_df.select(keep)
+            slim_frame = _prep_frame.select(keep)
+            slim_df = slim_frame.native
             print(
                 f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: slim projection "
-                f"{len(prepared_df.columns)} -> {len(keep)} cols",
+                f"{len(_prep_frame.columns)} -> {len(keep)} cols",
                 flush=True,
             )
     else:
+        slim_frame = _prep_frame
         slim_df = prepared_df
 
     # Freeze the exclude set ONCE across ALL passes (parity with polars-direct,
@@ -753,15 +764,32 @@ def score_buckets(
                 import numpy as np
 
                 row_mask = np.repeat(np.array(keep, dtype=bool), size_list)
-                native_sorted_df = sorted_df.filter(pl.Series(row_mask))
+                if isinstance(sorted_df, pl.DataFrame):
+                    native_sorted_df = sorted_df.filter(pl.Series(row_mask))
+                else:  # pa.Table lane: Table.filter takes a boolean array
+                    import pyarrow as _pa
+
+                    native_sorted_df = sorted_df.filter(_pa.array(row_mask))
                 kept_size_list = [s for s, k in zip(size_list, keep) if k]
                 if not kept_size_list:
                     return [], 0
-            row_ids_arrow = native_sorted_df["__row_id__"].cast(pl.Int64).to_arrow()
-            field_arrays_arrow = [
-                native_sorted_df[col].to_arrow()
-                for col, _w, _fn, _name in field_specs
-            ]
+            if isinstance(native_sorted_df, pl.DataFrame):
+                row_ids_arrow = native_sorted_df["__row_id__"].cast(pl.Int64).to_arrow()
+                field_arrays_arrow = [
+                    native_sorted_df[col].to_arrow()
+                    for col, _w, _fn, _name in field_specs
+                ]
+            else:  # pa.Table lane: already arrow -- combine chunks for the FFI
+                import pyarrow as _pa
+                import pyarrow.compute as _pc
+
+                row_ids_arrow = _pc.cast(
+                    native_sorted_df.column("__row_id__").combine_chunks(), _pa.int64()
+                )
+                field_arrays_arrow = [
+                    native_sorted_df.column(col).combine_chunks()
+                    for col, _w, _fn, _name in field_specs
+                ]
             size_list = kept_size_list
             _tk0 = time.perf_counter() if _bucket_debug else 0.0
             # Track 1 Fix B: prefer the prebuilt exclude handle (closed-over
@@ -828,7 +856,7 @@ def score_buckets(
         n_fields = len(field_specs)
         # NE per-pair specs (post-2026-05-29 widening). Pre-materialize the
         # NE xform columns; empty when NE missing / all-broken (no overhead).
-        ne_arrays = [sorted_df[col].to_list() for col, _fn, _t, _p in ne_specs]
+        ne_arrays = [_sf.column(col).to_list() for col, _fn, _t, _p in ne_specs]
         ne_fns = [fn for _col, fn, _t, _p in ne_specs]
         ne_thresholds = [t for _col, _fn, t, _p in ne_specs]
         ne_penalties = [p for _col, _fn, _t, p in ne_specs]
@@ -841,7 +869,7 @@ def score_buckets(
         # gain, so a column with nulls falls back to the per-pair loop wholesale.
         vec_scorer_names: list[str] | None = None
         if n_ne == 0 and all(name in _VEC_SUPPORTED for _c, _w, _fn, name in field_specs):
-            if all(sorted_df[col].null_count() == 0 for col, _w, _fn, _name in field_specs):
+            if all(_sf.column(col).null_count() == 0 for col, _w, _fn, _name in field_specs):
                 vec_scorer_names = [name for _c, _w, _fn, name in field_specs]
         local_pairs: list[tuple[int, int, float]] = []
         local_blocks = 0
@@ -1009,13 +1037,14 @@ def score_buckets(
         # straight to treating `keyed` as the single bucket and scoring.
         # On the streaming-block sync caller, this hits on every per-block
         # invocation (block size ~8, n_buckets default 32-128).
-        if prepared_df.height < n_buckets:
+        if _prep_frame.height < n_buckets:
             bucketed = keyed
-            # Wrap in a single-bucket dict to share the scoring path below.
-            buckets_dict: dict[Any, pl.DataFrame] = {0: bucketed}
+            # Wrap in a single-bucket dict to share the scoring path below
+            # (native frames: pl.DataFrame or pa.Table by lane).
+            buckets_dict: dict[Any, Any] = {0: bucketed}
             print(
                 f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: "
-                f"small-block fast path (height={prepared_df.height} < n_buckets={n_buckets}); "
+                f"small-block fast path (height={_prep_frame.height} < n_buckets={n_buckets}); "
                 f"skipping hash+partition_by. See #422.",
                 flush=True,
             )
@@ -1094,7 +1123,7 @@ def score_buckets(
     all_pairs: list[tuple[int, int, float]] = []
     total_blocks_scored = 0
     total_non_empty = 0
-    slim_cols = set(slim_df.columns)
+    slim_cols = set(slim_frame.columns)
     for key in pass_keys:
         if not set(key.fields) <= slim_cols:
             logger.warning(

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1562,7 +1562,7 @@ def _run_fused_match_short_circuit(
     report = None
     if output_report:
         report = generate_dedupe_report(
-            total_records=collected_df.height,
+            total_records=collected_frame.height,
             total_clusters=len(clusters),
             cluster_sizes=[c["size"] for c in clusters.values()],
             oversized_clusters=len(oversized_ids),
@@ -1912,8 +1912,15 @@ def _run_dedupe_pipeline(
     )
     _columnar_pairs_df: pl.DataFrame | None = None
 
+    # D2s-d1: collected_df is dual-rep from here down (Frame at D2s-d2);
+    # always-on reads go through the seam. Decline-listed blocks (throughput
+    # tier, quality_weighting, llm boost/scorer, semantic) keep raw polars --
+    # they force the classic polars lane at D2s-d2.
+    from goldenmatch.core.frame import to_frame as _tf_d2s
+
+    _collected_frame = _tf_d2s(collected_df)
     # Top-line metric: every downstream pair-count ratio depends on N.
-    record_metric("record_count", collected_df.height)
+    record_metric("record_count", _collected_frame.height)
     record_metrics({
         "matchkey_count": len(matchkeys),
         "exact_matchkey_count": sum(1 for mk in matchkeys if mk.type == "exact"),
@@ -1926,7 +1933,7 @@ def _run_dedupe_pipeline(
     # Build source lookup for across_files_only filtering
     source_lookup = {}
     if across_files_only:
-        for row in collected_df.select("__row_id__", "__source__").to_dicts():
+        for row in _collected_frame.select_dicts(["__row_id__", "__source__"]):
             source_lookup[row["__row_id__"]] = row["__source__"]
 
     # Phase 1: Exact matchkeys (fast)
@@ -2612,7 +2619,7 @@ def _run_dedupe_pipeline(
             )
 
     # ── Step 4: CLUSTER ──
-    all_ids = collected_df["__row_id__"].to_list()
+    all_ids = _collected_frame.column("__row_id__").to_list()
     max_cluster_size = 100
     weak_threshold = 0.3
     auto_split = True
@@ -2910,7 +2917,7 @@ def _run_dedupe_pipeline(
                 from goldenmatch.core.frame import to_frame as _tf_golden
 
                 _golden_source = _tf_golden(collected_df).select([
-                    c for c in collected_df.columns
+                    c for c in _collected_frame.columns
                     if not any(c.startswith(p) for p in _internal_prefixes)
                 ]).native
             # Source per-cluster pair scores from the view so the slow builder's
@@ -2980,9 +2987,9 @@ def _run_dedupe_pipeline(
                     member_ids_all = list(row_to_cluster.keys())
 
                 with stage("golden_multi_df_filter"):
-                    multi_df = collected_df.filter(
-                        pl.col("__row_id__").is_in(member_ids_all)
-                    )
+                    multi_df = _collected_frame.filter_in(
+                        "__row_id__", member_ids_all
+                    ).native
 
                 # Slim projection (PR #595). v32 attribution localized the
                 # +9 GB peak jump entirely to golden_attach_cluster_id's
@@ -3156,7 +3163,7 @@ def _run_dedupe_pipeline(
             )
             total_clusters = len(clusters)
         report = generate_dedupe_report(
-            total_records=len(collected_df),
+            total_records=_collected_frame.height,
             total_clusters=total_clusters,
             cluster_sizes=cluster_sizes,
             oversized_clusters=oversized_count,


### PR DESCRIPTION
First D2s-d sub-batch. The plan commit on this branch carries the full consumer audit + the d1/d2 spec (golden bridge, per-flag decline list).

## What

Every ALWAYS-ON B-class read of `collected_df` (pipeline) and `prepared_df`/`slim_df` (score_buckets) routes through `to_frame` -- behavior-preserving polars delegation today, dual-rep when D2s-d2 hands Frames past the collect.

- **pipeline**: `record_count` metric, across-files `source_lookup` (`select_dicts`), Step-4 `all_ids`, golden slim column list, dict-path `multi_df` filter (`filter_in`), both report `total_records`, fused-helper report via the existing `collected_frame`.
- **score_buckets**: `_prep_frame` at entry (height/columns/select), `slim_frame` alongside `slim_df`, #422 fast-path height reads, `_resolve_ne_specs`/`_resolve_fast_path` column probes, worker mask-filter + native-kernel extraction dual-rep (pa.Table lane: `Table.filter(bool array)` + `pc.cast(int64)` -- already-arrow columns skip the polars round-trip), NE arrays + vec-lane `null_count` via the fallback frame.
- **Decline-listed blocks keep raw polars** (throughput tier, quality_weighting, llm boost/scorer, semantic): they force the classic lane at D2s-d2.

## Gates

- Behavior-preserving on every existing path (polars lane delegates verbatim; no caller hands Frames yet).
- Local: pipeline / scorer / multipass / spine_dual_rep / differential harness + native-lane febrl3+native_parity all green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW