### PR TITLE
feat(goldenmatch): D2s-d2a Frame-lane eligibility predicate

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3909,3 +3909,51 @@ def _score_partition_with_config(  # pyright: ignore[reportUnusedFunction]
             all_pairs.extend(pairs)
 
     return all_pairs
+
+
+def _frame_lane_eligible(
+    config: GoldenMatchConfig,
+    matchkeys: list[Any],
+    *,
+    writes_outputs: bool,
+) -> bool:
+    """D2s-d2 gate: may the engine keep ``collected_df`` as a seam Frame?
+
+    True only when NO consumer on the run needs the polars-bound classic
+    surface (the C-class list from the D2s-d audit). Any flagged feature
+    forces the classic ``pl.from_arrow`` lane -- correctness first; each
+    flag re-opens as its consumer ports. This predicate must stay in
+    lockstep with the decline list in the 3.x plan (D2s-d spec).
+
+    ``writes_outputs`` covers the file-output tail (write_output + lineage),
+    which reads ``collected_df`` through polars-bound builders.
+    """
+    if getattr(config, "_throughput_plan", None) is not None:
+        return False
+    if getattr(config, "_preflight_report", None) is not None:
+        return False
+    if config.memory and config.memory.enabled:
+        return False
+    if config.identity and config.identity.enabled:
+        return False
+    if config.blocking and getattr(config.blocking, "auto_suggest", False):
+        return False
+    if config.llm_boost:
+        return False
+    if config.llm_scorer and config.llm_scorer.enabled:
+        return False
+    gr = config.golden_rules
+    if gr is not None and (
+        getattr(gr, "adaptive", False) or getattr(gr, "quality_weighting", False)
+    ):
+        return False
+    for mk in matchkeys:
+        if mk.type == "probabilistic":
+            return False
+        if mk.type == "weighted" and getattr(mk, "rerank", None):
+            return False
+        if mk.type == "exact" and (getattr(mk, "negative_evidence", None) or []):
+            return False
+    if writes_outputs:
+        return False
+    return True

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -151,3 +151,77 @@ def test_precompute_frame_skips_record_embedding_and_missing_fields():
     ]
     out = precompute_matchkey_transforms_frame(ArrowFrame(df.to_arrow()), mks)
     assert list(out.columns) == ["__row_id__", "first"]
+
+
+# -- D2s-d2a: the Frame-lane eligibility predicate ----------------------------------
+
+
+def _base_cfg(**overrides):
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="k",
+                type="exact",
+                fields=[MatchkeyField(field="name")],
+            )
+        ],
+        **overrides,
+    )
+    return cfg
+
+
+def _eligible(cfg, writes_outputs=False):
+    from goldenmatch.core.pipeline import _frame_lane_eligible
+
+    return _frame_lane_eligible(cfg, cfg.get_matchkeys(), writes_outputs=writes_outputs)
+
+
+def test_frame_lane_eligible_baseline():
+    assert _eligible(_base_cfg()) is True
+
+
+def test_frame_lane_declines_writes_outputs():
+    assert _eligible(_base_cfg(), writes_outputs=True) is False
+
+
+def test_frame_lane_declines_throughput_plan():
+    cfg = _base_cfg()
+    object.__setattr__(cfg, "_throughput_plan", object())
+    assert _eligible(cfg) is False
+
+
+def test_frame_lane_declines_preflight():
+    cfg = _base_cfg()
+    object.__setattr__(cfg, "_preflight_report", {"x": 1})
+    assert _eligible(cfg) is False
+
+
+def test_frame_lane_declines_probabilistic_mk():
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    cfg = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="p",
+                type="probabilistic",
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", weight=1.0)],
+                threshold=0.8,
+            )
+        ],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+    assert _eligible(cfg) is False
+
+
+def test_frame_lane_declines_ne_on_exact():
+    from goldenmatch.config.schemas import NegativeEvidenceField
+
+    cfg = _base_cfg()
+    cfg.matchkeys[0].negative_evidence = [
+        NegativeEvidenceField(
+            field="name", scorer="jaro_winkler", threshold=0.9, penalty=0.5
+        )
+    ]
+    assert _eligible(cfg) is False


### PR DESCRIPTION
Thin first slice of the D2s-d2 flip (spec: the plan's D2s-d section, landed with #1724).

## What

`_frame_lane_eligible(config, matchkeys, writes_outputs=)` encodes the consumer audit's C-class decline list as a pure, fixture-pinned function BEFORE the flip wires it in. Any flagged feature -- throughput plan, pre/postflight, memory store, identity, blocking auto-suggest, llm boost/scorer, adaptive or quality-weighted golden, probabilistic EM, weighted rerank, NE-on-exact, file outputs (incl lineage) -- forces the classic `pl.from_arrow` lane. Correctness first; each flag re-opens as its consumer ports. The predicate must stay in lockstep with the plan's decline list.

Pins: baseline eligible; one fixture per representative flag class (writes_outputs, `_throughput_plan`, `_preflight_report`, probabilistic mk, NE-on-exact).

## Gates

- Dead code until D2s-d2b wires it at the shim -- zero behavior change.
- Local: spine_dual_rep (18), pipeline green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW