### PR TITLE
feat(goldenmatch): deep-D2 -- run_golden_fused_arrow dual-rep, golden bridge off the fused/dict paths

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -144,8 +144,13 @@ cannot move while downstream still takes pl.LazyFrame):**
     A/B + RSS hold; the decline list must be asserted by a fixture per
     flag (Frame lane refuses, classic lane output identical).
 - Deep-D2 proper (golden_fused dual-rep: seam sort/filter/gather;
-  `gather_with_nulls` becomes a seam op; arrow twin = `take` with null
-  indices) once multi_df is arrow.
+  arrow gather twin = `take` with null indices, PROBED) once multi_df is
+  arrow. **PARTIAL 2026-07-13: run_golden_fused_arrow is dual-rep (pa in ->
+  pa out, no round-trip; provenance bridges at entry); bridge removed on the
+  FUSED-HELPER and DICT golden paths (decline replays the polars demux for
+  byte-parity). RESIDUAL: the FRAMES-path golden still bridges
+  (_golden_source -> _multi_df_from_frames polars join) -- deep-D2b ports
+  _multi_df_from_frames + the from-frames demux; required before D6.**
 - D6 after the spine holds a full-suite arrow lane with zero polars imports
   (assert via an import-hook test, the goldencheck 2.0.0 precedent).
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden_fused.py
@@ -341,7 +341,23 @@ def _gather_with_nulls(series: pl.Series, idx: list[int]) -> pl.Series:
     ).to_series()
 
 
-def _build_date_arrays(sdf: pl.DataFrame, date_col: str | None) -> tuple[Any, Any] | None:
+def _ARROW_MOST_RECENT_ORDER_SAFE(t: Any) -> bool:
+    """Arrow twin of _MOST_RECENT_ORDER_SAFE_DTYPES: types whose int64 physical
+    cast is order-preserving vs the reference's Python-object compare. uint64
+    excluded (wraps on cast, same as the polars gate)."""
+    import pyarrow as pa
+
+    return (
+        pa.types.is_date(t)
+        or pa.types.is_timestamp(t)
+        or pa.types.is_time(t)
+        or pa.types.is_duration(t)
+        or pa.types.is_signed_integer(t)
+        or (pa.types.is_unsigned_integer(t) and t.bit_width < 64)
+    )
+
+
+def _build_date_arrays(sdf: Any, date_col: str | None) -> tuple[Any, Any] | None:
     """Build the ``(date_i64, null_mask_i64)`` Arrow arrays for a ``most_recent``
     date column, or ``None`` to decline. Shared by the scalar and group
     ``most_recent`` paths. Declines when the column is absent (the reference's
@@ -352,10 +368,24 @@ def _build_date_arrays(sdf: pl.DataFrame, date_col: str | None) -> tuple[Any, An
 
     if not date_col or date_col not in sdf.columns:
         return None
-    date_series = sdf.get_column(date_col)
-    if not isinstance(date_series.dtype, _MOST_RECENT_ORDER_SAFE_DTYPES):
-        return None
-    phys_list = date_series.to_physical().cast(pl.Int64).to_list()
+    # Deep-D2: ``sdf`` is the seam Frame; dual-rep dtype gate + physical i64.
+    from goldenmatch.core.frame import PolarsFrame
+
+    if isinstance(sdf, PolarsFrame):
+        date_series = sdf.native.get_column(date_col)
+        if not isinstance(date_series.dtype, _MOST_RECENT_ORDER_SAFE_DTYPES):
+            return None
+        phys_list = date_series.to_physical().cast(pl.Int64).to_list()
+    else:
+        import pyarrow as pa
+        import pyarrow.compute as pc
+
+        t = sdf.native.schema.field(date_col).type
+        if not _ARROW_MOST_RECENT_ORDER_SAFE(t):
+            return None
+        phys_list = pc.cast(
+            sdf.native.column(date_col).combine_chunks(), pa.int64()
+        ).to_pylist()
     date_vals = [0 if x is None else int(x) for x in phys_list]
     mask_vals = [1 if x is None else 0 for x in phys_list]
     return pa.array(date_vals, type=pa.int64()), pa.array(mask_vals, type=pa.int64())
@@ -480,28 +510,60 @@ def run_golden_fused_arrow(
     if fn is None:
         return None
 
+    # Deep-D2: dual-rep entry -- a pa.Table / seam Frame flows through the
+    # seam with NO polars round-trip (return type matches the input lane).
+    # Provenance assembly stays polars-only for now: bridge that case up front.
+    from goldenmatch.core.frame import Frame, PolarsFrame, to_frame
+
     df = columns
-    if "__cluster_id__" not in df.columns:
+    if provenance and not isinstance(df, pl.DataFrame):
+        _native = df.native if isinstance(df, Frame) else df
+        df = pl.from_arrow(_native)  # type: ignore[assignment]
+    fr = to_frame(df)
+    if "__cluster_id__" not in fr.columns:
         return None
+    _is_pl = isinstance(fr, PolarsFrame)
 
     # Spec 4.3: within-cluster members must be __row_id__-ascending for the
     # kernel's first-occurrence tie-breaks to match the reference.
-    sort_cols = ["__cluster_id__", "__row_id__"] if "__row_id__" in df.columns else ["__cluster_id__"]
-    sdf = df.sort(sort_cols)
+    sort_cols = ["__cluster_id__", "__row_id__"] if "__row_id__" in fr.columns else ["__cluster_id__"]
+    if _is_pl:
+        _sdf_native = fr.native.sort(sort_cols)
+        # Drop singletons (size <= 1), mirroring _multi_df_from_frames'
+        # size > 1 filter. The window filter preserves the sort order.
+        _sdf_native = _sdf_native.filter(pl.len().over("__cluster_id__") > 1)
+        sdf = to_frame(_sdf_native)
+    else:
+        sdf = fr.sort(sort_cols)
+        # Sorted input -> run_lengths gives per-cluster sizes in order; the
+        # repeated size>1 mask is the window filter's arrow twin.
+        _sizes = sdf.run_lengths("__cluster_id__")
+        if any(sz <= 1 for sz in _sizes):
+            import pyarrow as pa
 
-    # Drop singletons (size <= 1), mirroring _multi_df_from_frames' size > 1
-    # filter. A plain cluster frame carries no oversized flag, so ~oversized is
-    # trivially satisfied here. The window filter preserves the sort order.
-    sdf = sdf.filter(pl.len().over("__cluster_id__") > 1)
+            _mask: list[bool] = []
+            for sz in _sizes:
+                _mask.extend([sz > 1] * sz)
+            sdf = to_frame(sdf.native.filter(pa.array(_mask)))
 
     user_cols = [c for c in sdf.columns if not _is_internal(c) and c != "__cluster_id__"]
 
     if sdf.height == 0 or not user_cols:
         # Nothing to build -- an empty golden frame with the expected columns.
-        empty = {c: pl.Series(c, [], dtype=sdf[c].dtype) for c in user_cols}
-        empty["__cluster_id__"] = pl.Series("__cluster_id__", [], dtype=pl.Int64)
-        empty["__golden_confidence__"] = pl.Series("__golden_confidence__", [], dtype=pl.Float64)
-        empty_df = pl.DataFrame(empty)
+        if _is_pl:
+            empty = {c: pl.Series(c, [], dtype=sdf.native[c].dtype) for c in user_cols}
+            empty["__cluster_id__"] = pl.Series("__cluster_id__", [], dtype=pl.Int64)
+            empty["__golden_confidence__"] = pl.Series("__golden_confidence__", [], dtype=pl.Float64)
+            empty_df: Any = pl.DataFrame(empty)
+        else:
+            import pyarrow as pa
+
+            _tbl = sdf.native
+            _arrays = [pa.array([], type=_tbl.schema.field(c).type) for c in user_cols]
+            _names = list(user_cols)
+            _arrays += [pa.array([], type=pa.int64()), pa.array([], type=pa.float64())]
+            _names += ["__cluster_id__", "__golden_confidence__"]
+            empty_df = pa.Table.from_arrays(_arrays, names=_names)
         return (empty_df, []) if provenance else empty_df
 
     # ── Stage 5: identify group-owned columns (resolved as a unit, NOT via the
@@ -607,12 +669,19 @@ def run_golden_fused_arrow(
 
     import pyarrow as pa
 
+    def _col_i64_arrow(name: str) -> Any:
+        if _is_pl:
+            return sdf.native.get_column(name).cast(pl.Int64).to_arrow()
+        import pyarrow.compute as pc
+
+        return pc.cast(sdf.native.column(name).combine_chunks(), pa.int64())
+
     n = sdf.height
     if "__row_id__" in sdf.columns:
-        row_ids_arr = sdf.get_column("__row_id__").cast(pl.Int64).to_arrow()
+        row_ids_arr = _col_i64_arrow("__row_id__")
     else:
         row_ids_arr = pa.array(range(n), type=pa.int64())
-    cluster_ids_arr = sdf.get_column("__cluster_id__").cast(pl.Int64).to_arrow()
+    cluster_ids_arr = _col_i64_arrow("__cluster_id__")
 
     # Build the comparable keys per column from the RAW Python values:
     #   text = Python `str(v)` (byte-identical to the reference's `str(v)`;
@@ -628,7 +697,7 @@ def run_golden_fused_arrow(
     # code space as the referenced column's factorized winner value.
     col_maps: dict[str, dict] = {}
     for c in user_cols:
-        values = sdf.get_column(c).to_list()
+        values = sdf.column(c).to_list()
         text = [None if v is None else str(v) for v in values]
         codes, vmap = _factorize_with_map(values)
         col_maps[c] = vmap
@@ -652,7 +721,7 @@ def run_golden_fused_arrow(
     if need_source:
         if "__source__" not in sdf.columns:
             return None
-        src_values = sdf.get_column("__source__").to_list()
+        src_values = sdf.column("__source__").to_list()
         src_codes, src_map = _factorize_with_map(src_values)
         source_code_arr = pa.array(src_codes, type=pa.int64())
         for ci, rlist in enumerate(candidate_rules):
@@ -699,7 +768,7 @@ def run_golden_fused_arrow(
     qweights: list[Any] = [empty_f64 for _ in user_cols]
     if quality_scores is not None:
         if "__row_id__" in sdf.columns:
-            row_ids_list = sdf.get_column("__row_id__").to_list()
+            row_ids_list = sdf.column("__row_id__").to_list()
         else:
             row_ids_list = list(range(n))
         for ci, c in enumerate(user_cols):
@@ -721,8 +790,8 @@ def run_golden_fused_arrow(
         and "__row_id__" in sdf.columns
         and any(r.strategy == "confidence_majority" for rlist in candidate_rules for r in rlist)
     ):
-        cid_list = sdf.get_column("__cluster_id__").to_list()
-        rid_list = sdf.get_column("__row_id__").to_list()
+        cid_list = sdf.column("__cluster_id__").to_list()
+        rid_list = sdf.column("__row_id__").to_list()
         pos = 0
         n_local = len(cid_list)
         while pos < n_local:
@@ -876,15 +945,6 @@ def run_golden_fused_arrow(
         side,
     )
 
-    out: dict[str, pl.Series] = {}
-    for ci, c in enumerate(user_cols):
-        out[c] = _gather_with_nulls(sdf.get_column(c), list(winner_idx[ci]))
-
-    result = pl.DataFrame(out)
-    result = result.with_columns(
-        pl.Series("__cluster_id__", list(cluster_ids_out), dtype=pl.Int64)
-    )
-
     # __golden_confidence__ = mean of per-UNIT confidences. A resolution unit is a
     # scalar column OR a whole group (resolve.py:100/149) -- so the denominator is
     # `n_scalar_cols + n_groups`, NOT n_output_cols: each group contributes exactly
@@ -904,7 +964,33 @@ def run_golden_fused_arrow(
         / denom
         for k in range(n_clusters)
     ]
-    result = result.with_columns(pl.Series("__golden_confidence__", gconf, dtype=pl.Float64))
+
+    if _is_pl:
+        out: dict[str, pl.Series] = {}
+        for ci, c in enumerate(user_cols):
+            out[c] = _gather_with_nulls(sdf.native.get_column(c), list(winner_idx[ci]))
+        result: Any = pl.DataFrame(out)
+        result = result.with_columns(
+            pl.Series("__cluster_id__", list(cluster_ids_out), dtype=pl.Int64)
+        )
+        result = result.with_columns(
+            pl.Series("__golden_confidence__", gconf, dtype=pl.Float64)
+        )
+    else:
+        # Arrow gather twin (probed): take() with null indices yields nulls --
+        # the -1 sentinel maps to None, preserving the source dtype exactly.
+        _tbl = sdf.native
+        _arrays = []
+        for ci, c in enumerate(user_cols):
+            _idx = pa.array(
+                [int(i) if i >= 0 else None for i in winner_idx[ci]], type=pa.int64()
+            )
+            _arrays.append(_tbl.column(c).combine_chunks().take(_idx))
+        _arrays.append(pa.array([int(x) for x in cluster_ids_out], type=pa.int64()))
+        _arrays.append(pa.array(gconf, type=pa.float64()))
+        result = pa.Table.from_arrays(
+            _arrays, names=[*user_cols, "__cluster_id__", "__golden_confidence__"]
+        )
 
     if not provenance:
         return result
@@ -912,7 +998,7 @@ def run_golden_fused_arrow(
     # ── Stage 8: per-field provenance (assembled from data the kernel already
     # returns -- no kernel change). See _build_provenance_records for the mapping.
     records = _build_provenance_records(
-        sdf=sdf,
+        sdf=sdf.native,
         n=n,
         user_cols=user_cols,
         out=out,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1318,9 +1318,19 @@ def _try_fused_golden(
     # (__cluster_id__ Int64 / __golden_confidence__ Float64 already agree). We
     # deliberately do NOT keep native dtypes -- that would change the slow
     # path's own behavior, out of scope for a transparent routing flag.
-    return result.with_columns(
-        [pl.col(c).cast(pl.Utf8) for c in result.columns if not c.startswith("__")]
-    )
+    if isinstance(result, pl.DataFrame):
+        return result.with_columns(
+            [pl.col(c).cast(pl.Utf8) for c in result.columns if not c.startswith("__")]
+        )
+    # Deep-D2 arrow lane: same cast via the seam (Column.cast_str pins the
+    # polars Utf8-cast semantics, incl. the float formatter).
+    from goldenmatch.core.frame import to_frame as _tf_cast
+
+    _rf = _tf_cast(result)
+    for c in _rf.columns:
+        if not c.startswith("__"):
+            _rf = _rf.with_column(c, _rf.column(c).cast_str())
+    return _rf.native
 
 
 def _golden_records_to_df(golden_records: list[dict]) -> pl.DataFrame | None:
@@ -1377,8 +1387,16 @@ def _golden_from_multi_df(
     ``confidence_majority`` is the only strategy that consumes them and is excluded
     upstream by ``config_needs_artifacts``, so ``None`` is byte-identical here.
     """
-    fast_eligible = not provenance_on and _polars_native_eligible(
-        golden_rules, quality_scores=quality_scores
+    # Deep-D2: multi_df may be a pa.Table (Frame lane). The polars fast
+    # columnar path only applies to polars input; the fused kernel takes the
+    # native directly (no round-trip). On kernel decline/absence, BRIDGE and
+    # replay the exact polars demux so output stays byte-identical to the
+    # classic lane.
+    _is_pl = isinstance(multi_df, pl.DataFrame)
+    fast_eligible = (
+        _is_pl
+        and not provenance_on
+        and _polars_native_eligible(golden_rules, quality_scores=quality_scores)
     )
     if fast_eligible:
         return build_golden_records_df(multi_df, golden_rules), False
@@ -1393,6 +1411,13 @@ def _golden_from_multi_df(
     )
     if fused_golden_df is not None:
         return fused_golden_df, True
+
+    if not _is_pl:
+        multi_df = _as_polars_df(multi_df)
+        if not provenance_on and _polars_native_eligible(
+            golden_rules, quality_scores=quality_scores
+        ):
+            return build_golden_records_df(multi_df, golden_rules), False
 
     golden_records = build_golden_records_batch(
         multi_df,
@@ -1586,7 +1611,7 @@ def _run_fused_match_short_circuit(
         # (unique rid keys; downstream golden groups by cluster, order-free)
         # and keeps the arrow table un-round-tripped.
         _rid_to_cid = dict(zip(_rid_list, _cid_list))
-        multi_df = _as_polars_df(
+        multi_df = (
             to_frame(multi_df)
             .map_column("__row_id__", "__cluster_id__", _rid_to_cid)
             .native
@@ -3045,10 +3070,8 @@ def _run_dedupe_pipeline(
                     member_ids_all = list(row_to_cluster.keys())
 
                 with stage("golden_multi_df_filter"):
-                    multi_df = _as_polars_df(
-                        _collected_frame.filter_in(
-                            "__row_id__", member_ids_all
-                        ).native
+                    _multi_frame = _collected_frame.filter_in(
+                        "__row_id__", member_ids_all
                     )
 
                 # Slim projection (PR #595). v32 attribution localized the
@@ -3068,22 +3091,18 @@ def _run_dedupe_pipeline(
                         _internal_prefixes = (
                             "__xform_", "__mk_", "__block_key__", "__bucket__",
                         )
-                        multi_df = multi_df.select([
-                            c for c in multi_df.columns
+                        _multi_frame = _multi_frame.select([
+                            c for c in _multi_frame.columns
                             if not any(c.startswith(p) for p in _internal_prefixes)
                         ])
 
                 with stage("golden_attach_cluster_id"):
-                    # Attach __cluster_id__ via replace_strict. The old keys/new
-                    # vals lists are tiny (1 entry per member); the join itself
-                    # is linear in `multi_df.height`.
-                    multi_df = multi_df.with_columns(
-                        pl.col("__row_id__").replace_strict(
-                            list(row_to_cluster.keys()),
-                            list(row_to_cluster.values()),
-                            return_dtype=pl.Int64,
-                        ).alias("__cluster_id__")
-                    )
+                    # Attach __cluster_id__ via the seam map_column -- its
+                    # polars impl IS the replace_strict expr this stage used
+                    # (byte-identical); the arrow lane stays un-round-tripped.
+                    multi_df = _multi_frame.map_column(
+                        "__row_id__", "__cluster_id__", row_to_cluster
+                    ).native
                 # Batch builder: sorts by __cluster_id__ once and pre-extracts
                 # each user column to a Python list ONCE. At 5M / 1.67M
                 # multi-member clusters the previous partition_by(as_dict=True)
@@ -3106,7 +3125,8 @@ def _run_dedupe_pipeline(
                 # (per-field source_row_id, custom merge_field rules) stay intact.
                 _provenance_on = config.output.lineage_provenance
                 _fast_eligible = (
-                    not _provenance_on
+                    isinstance(multi_df, pl.DataFrame)
+                    and not _provenance_on
                     and _polars_native_eligible(golden_rules, quality_scores=quality_scores)
                 )
                 if _fast_eligible:
@@ -3153,12 +3173,28 @@ def _run_dedupe_pipeline(
                             golden_records = []
                             golden_fused_used = True
                         else:
-                            golden_records = build_golden_records_batch(
-                                multi_df, golden_rules,
-                                quality_scores=quality_scores,
-                                provenance=_provenance_on,
-                                cluster_pair_scores=cluster_pair_scores,
-                            )
+                            # Deep-D2 decline path: bridge, then replay the
+                            # polars demux (fast columnar when eligible) so
+                            # the Frame lane stays byte-identical to classic.
+                            multi_df = _as_polars_df(multi_df)
+                            if (
+                                not _provenance_on
+                                and _polars_native_eligible(
+                                    golden_rules, quality_scores=quality_scores
+                                )
+                            ):
+                                with stage("golden_build_records_df_fast"):
+                                    golden_df = build_golden_records_df(
+                                        multi_df, golden_rules
+                                    )
+                                golden_records = []
+                            else:
+                                golden_records = build_golden_records_batch(
+                                    multi_df, golden_rules,
+                                    quality_scores=quality_scores,
+                                    provenance=_provenance_on,
+                                    cluster_pair_scores=cluster_pair_scores,
+                                )
 
     # Build golden DataFrame (slow path: walks the list[dict] returned by
     # build_golden_records_batch. The fast path above already populated

--- a/packages/python/goldenmatch/tests/test_golden_fused.py
+++ b/packages/python/goldenmatch/tests/test_golden_fused.py
@@ -2150,3 +2150,65 @@ def test_fused_takes_simple_configs_on_arrow_backend(monkeypatch):
         grow = got_rows[cid]
         for col in ("name", "zip"):
             assert grow[col] == wrow[col], (cid, col)
+
+
+# -- deep-D2: arrow-input dual-rep ----------------------------------------------------
+
+
+def _deep_d2_frame():
+    return pl.DataFrame(
+        {
+            "__row_id__": [0, 1, 2, 10, 11, 20],
+            "__cluster_id__": [1, 1, 1, 2, 2, 3],
+            "name": ["Bob", "Robert", None, "Sue", "Suzanne", "Solo"],
+            "email": [None, "b@x.com", "b@x.com", "s@y.com", None, "z@z.com"],
+            "age": [30, None, 31, 44, 44, 9],
+        }
+    )
+
+
+def _deep_d2_rules():
+    return GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_rules={"email": GoldenFieldRule(strategy="majority_vote")},
+    )
+
+
+def test_run_arrow_input_matches_polars_input(monkeypatch):
+    """Deep-D2: a pa.Table input runs the kernel with NO polars round-trip and
+    reproduces the polars-input output value-for-value (return type follows
+    the input lane: pa.Table in -> pa.Table out)."""
+    import pyarrow as pa
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+    df = _deep_d2_frame()
+    rules = _deep_d2_rules()
+    got_pl = run_golden_fused_arrow(df, rules)
+    got_pa = run_golden_fused_arrow(df.to_arrow(), rules)
+    if got_pl is None:
+        pytest.skip("native golden_fused kernel unavailable")
+    assert isinstance(got_pa, pa.Table)
+    assert list(got_pa.column_names) == list(got_pl.columns)
+    for c in got_pl.columns:
+        assert got_pa.column(c).to_pylist() == got_pl[c].to_list(), c
+
+
+def test_run_arrow_input_singleton_filter_and_empty(monkeypatch):
+    import pyarrow as pa
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+    rules = _deep_d2_rules()
+    # all singletons -> empty output with expected columns, arrow-typed
+    df = pl.DataFrame(
+        {
+            "__row_id__": [0, 1],
+            "__cluster_id__": [1, 2],
+            "name": ["A", "B"],
+        }
+    )
+    got = run_golden_fused_arrow(df.to_arrow(), rules)
+    if got is None:
+        pytest.skip("native golden_fused kernel unavailable")
+    assert isinstance(got, pa.Table)
+    assert got.num_rows == 0
+    assert list(got.column_names) == ["name", "__cluster_id__", "__golden_confidence__"]


### PR DESCRIPTION
Deep-D2 of the 3.x arrow descent: the fused golden kernel now consumes a pa.Table directly (pa in -> pa out, zero polars round-trip). The D2s-d2b golden bridge remains ONLY on the frames-path golden (residual noted in the plan: deep-D2b ports `_multi_df_from_frames` + the from-frames demux; required before D6).

## What

- **`golden_fused.run_golden_fused_arrow` dual-rep**: seam-Frame entry (provenance bridges to polars up front -- provenance assembly stays polars-only); polars branches VERBATIM (sort+window filter, `_gather_with_nulls`, pl output). Arrow branches: seam sort + `run_lengths` singleton mask, kernel-feed reads via seam columns + `pc.cast(int64)`, `_build_date_arrays` arrow dtype gate (`_ARROW_MOST_RECENT_ORDER_SAFE`; uint64 excluded like the polars gate), output via `take()` with null indices (PROBED == `_gather_with_nulls`, dtype-preserving) + `pa.Table.from_arrays`. The `__golden_confidence__` computation hoisted above the result build (pure Python, lane-free).
- **`_try_fused_golden`**: final Utf8 cast dual-rep via seam `cast_str` (pins polars string semantics on arrow, incl the float formatter).
- **`_golden_from_multi_df` + the dict-path demux**: fast columnar only on polars input; fused tries the native directly; on kernel decline the path BRIDGES then replays the exact polars demux (fast columnar when eligible, else batch) so Frame-lane output stays byte-identical to the classic lane in every fallback combination.
- **Dict-path `multi_df` now built lane-native**: `filter_in` / seam select / `map_column` attach (the seam's polars impl IS the old `replace_strict` expr).

## Gates

- New pins: arrow-input == polars-input value-for-value (mixed dtypes, nulls, field_rules; singleton filter; empty-frame construction) -- ran with the native kernel present, no skips.
- All golden_fused / fused-pipeline suites (130) green with native; e2e Frame-lane parity pins (exact/weighted/bucket) green; differential harness green on both lanes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW