### PR TITLE
feat(goldenmatch): deep-D2b -- frames-path golden bridge removal (the last one)

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -148,9 +148,15 @@ cannot move while downstream still takes pl.LazyFrame):**
   arrow. **PARTIAL 2026-07-13: run_golden_fused_arrow is dual-rep (pa in ->
   pa out, no round-trip; provenance bridges at entry); bridge removed on the
   FUSED-HELPER and DICT golden paths (decline replays the polars demux for
-  byte-parity). RESIDUAL: the FRAMES-path golden still bridges
-  (_golden_source -> _multi_df_from_frames polars join) -- deep-D2b ports
-  _multi_df_from_frames + the from-frames demux; required before D6.**
+  byte-parity). DEEP-D2b (2026-07-13): the FRAMES-path
+  bridge is gone too -- _multi_df_from_frames normalizes ClusterFrames to the
+  source lane (zero-copy to_arrow) and joins single-backend; the fused try
+  gets the lane-native frame. On kernel DECLINE,
+  build_golden_records_from_frames RECOMPUTES multi_df via the polars join
+  from a bridged source (Acero vs polars join ROW ORDER differs and the
+  batch builder's first-occurrence tie-breaks are order-sensitive --
+  recompute is byte-identical by construction). The GOLDEN BRIDGE is now
+  decline-fallback-only on all three paths.**
 - D6 after the spine holds a full-suite arrow lane with zero polars imports
   (assert via an import-hook test, the goldencheck 2.0.0 precedent).
 

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1292,21 +1292,30 @@ def _multi_df_from_frames(
     # is a different (wrong) predicate.
     # W2c: routed through the Frame seam (select_eligible_clusters carries
     # the load-bearing parenthesization; joins are the W2b named variants).
-    from goldenmatch.core.frame import to_frame
+    from goldenmatch.core.frame import ArrowFrame, to_frame
 
-    multi_cluster_ids = to_frame(frames.metadata).select_eligible_clusters()
+    src_frame = to_frame(source_df)
+    meta = to_frame(frames.metadata)
+    assign = to_frame(frames.assignments)
+    # Deep-D2b: joins are single-backend; normalize the (small) cluster
+    # frames to the SOURCE lane (zero-copy to_arrow on polars natives).
+    if isinstance(src_frame, ArrowFrame) and not isinstance(meta, ArrowFrame):
+        meta = ArrowFrame(frames.metadata.to_arrow())
+        assign = ArrowFrame(frames.assignments.to_arrow())
+
+    multi_cluster_ids = meta.select_eligible_clusters()
 
     # Vectorized join: attach __cluster_id__ to each source row whose
     # __row_id__ appears in the assignments frame. ``inner`` join
     # drops rows that aren't members of any eligible cluster.
     assignments_multi = (
-        to_frame(frames.assignments)
+        assign
         .join_inner(multi_cluster_ids, on="cluster_id")
         .rename({"cluster_id": "__cluster_id__"})
     )
 
     return (
-        to_frame(source_df)
+        src_frame
         .join_inner(assignments_multi, left_on="__row_id__", right_on="member_id")
         .native
     )
@@ -1368,16 +1377,32 @@ def build_golden_records_from_frames(
           ``source_df`` -> ``(None, [])`` (those clusters are silently
           dropped, consistent with the existing pipeline).
     """
-    if source_df.height == 0 or frames.assignments.is_empty():
+    from goldenmatch.core.frame import to_frame as _tf_frames
+
+    _src = _tf_frames(source_df)
+    if _src.height == 0 or frames.assignments.is_empty():
         return None, []
 
-    if "__row_id__" not in source_df.columns:
+    if "__row_id__" not in _src.columns:
         raise ValueError(
             "build_golden_records_from_frames: source_df must contain a "
             "__row_id__ column. Use "
             "source_df.with_row_index(name='__row_id__') if your input "
             "frame doesn't have one.",
         )
+
+    # Deep-D2b: on a non-polars source this builder is the KERNEL-DECLINE
+    # path (the pipeline tried the fused kernel first) -- recompute multi_df
+    # on the POLARS lane from a bridged source rather than bridging the
+    # Acero join output: join ROW ORDER differs between engines, and the
+    # batch builder's tie-breaks (first-occurrence) are order-sensitive.
+    # Recomputing via the polars join is byte-identical to the classic lane
+    # by construction.
+    if not isinstance(source_df, pl.DataFrame):
+        from goldenmatch.core.frame import Frame
+
+        _native = source_df.native if isinstance(source_df, Frame) else source_df
+        source_df = pl.from_arrow(_native)  # type: ignore[assignment]
 
     multi_df = _multi_df_from_frames(source_df, frames)
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2992,17 +2992,19 @@ def _run_dedupe_pipeline(
             # survivorship never reads, BEFORE the join, so golden records carry
             # the same columns as the dict path (byte-identical golden). Keep
             # __row_id__ (the from-frames join needs it). Same env opt-out.
-            _golden_source = _as_polars_df(collected_df)
+            # Deep-D2b: lane-native; the fused try consumes it directly and
+            # build_golden_records_from_frames bridges internally on decline.
+            _golden_source = collected_df
             if os.environ.get("GOLDENMATCH_GOLDEN_SLIM_MULTIDF", "1") != "0":
                 _internal_prefixes = (
                     "__xform_", "__mk_", "__block_key__", "__bucket__",
                 )
                 from goldenmatch.core.frame import to_frame as _tf_golden
 
-                _golden_source = _as_polars_df(_tf_golden(collected_df).select([
+                _golden_source = _tf_golden(collected_df).select([
                     c for c in _collected_frame.columns
                     if not any(c.startswith(p) for p in _internal_prefixes)
-                ]).native)
+                ]).native
             # Source per-cluster pair scores from the view so the slow builder's
             # confidence_majority survivorship weights by edge confidence instead
             # of degrading to count-majority (the frames-out cluster dict carries

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -353,3 +353,40 @@ def test_frame_lane_declines_when_quality_enabled(tmp_path, monkeypatch):
     # consulted and the classic lane ran; results still come back arrow.
     assert hits == []
     assert res["golden"] is None or hasattr(res["golden"], "num_rows")
+
+
+def test_frames_path_fused_golden_gets_arrow_table(tmp_path, monkeypatch):
+    """Deep-D2b: on the Frame lane the frames-path golden hands the fused
+    kernel the lane-native pa.Table (no polars round-trip) and reproduces
+    the classic lane exactly."""
+    import goldenmatch.core.golden_fused as GF
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import GoldenFieldRule, GoldenRulesConfig
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+    csv = _lane_csv(tmp_path)
+    cfg = _lane_cfg(mk_type="weighted")
+    # field_rules -> _polars_native_eligible False -> the frames path tries
+    # the fused kernel with the lane-native frame
+    cfg.golden_rules = GoldenRulesConfig(
+        default_strategy="most_complete",
+        field_rules={"city": GoldenFieldRule(strategy="majority_vote")},
+    )
+
+    calls = []
+    orig = GF.run_golden_fused_arrow
+
+    def spy(columns, *a, **k):
+        r = orig(columns, *a, **k)
+        calls.append((type(columns).__name__, r is not None))
+        return r
+
+    monkeypatch.setattr(GF, "run_golden_fused_arrow", spy)
+    frame_lane = P.run_dedupe([(str(csv), "people")], cfg)
+    if not calls or not calls[0][1]:
+        pytest.skip("native golden_fused kernel unavailable")
+    assert calls[0][0] == "Table", calls
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", "0")
+    classic = P.run_dedupe([(str(csv), "people")], cfg)
+    assert _norm_result(frame_lane) == _norm_result(classic)


### PR DESCRIPTION
Completes deep-D2 (follow-on to #1727): the golden bridge is now decline-fallback-only on all three golden paths (fused-helper, dict, frames).

## What

- **`_multi_df_from_frames`**: normalizes the (small) ClusterFrames to the SOURCE lane (zero-copy `to_arrow` on polars natives) so the W2c seam joins run single-backend; the frames-path fused try receives the lane-native `pa.Table` directly.
- **`build_golden_records_from_frames`**: seam entry reads; on a non-polars source (= the kernel-decline path -- the pipeline tried fused first) it RECOMPUTES `multi_df` via the polars join from a bridged source rather than bridging the Acero join output. Join ROW ORDER differs between engines and the batch builder's first-occurrence tie-breaks are order-sensitive; recomputing is byte-identical to the classic lane by construction.
- **pipeline frames block**: both `_as_polars_df` bridges dropped (`_golden_source` is lane-native).

## Gates

- New e2e pin: the frames-path fused golden receives `pa.Table` on the Frame lane (`('Table', accepted)`) vs `DataFrame` on classic, outputs identical (ran against the real native kernel).
- Battery: spine_dual_rep (23), pipeline, golden_from_frames parity + oversized, golden_fused, pipeline_fused_golden (151 total) green with native; differential harness green on both lanes; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW