### PR TITLE
fix(goldensuite-mcp): run HTTP transport stateful so session-keyed tools work remotely

### DIFF
--- a/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/cli.py
@@ -33,7 +33,18 @@ def _serve_http(host: str, port: int) -> None:
     from goldensuite_mcp.server import create_server
 
     server = create_server()
-    session_manager = StreamableHTTPSessionManager(app=server, stateless=True)
+    # Stateful sessions (NOT stateless): the 8 stateful goldenmatch tools
+    # (list_clusters/get_cluster/get_golden_record/explain_match/evaluate/
+    # export_results/match_record/find_duplicates) carry run state across calls
+    # via a session-keyed store (see goldenmatch.mcp._session_ctx / _session_store,
+    # PR #1713). That store is keyed on the per-connection ServerSession, so it
+    # only persists when the HTTP layer keeps one ServerSession alive across a
+    # client's requests -- i.e. stateful mode, which issues an Mcp-Session-Id the
+    # client echoes. Under stateless=True every POST built a fresh ServerSession,
+    # so `dedupe_file` then `list_clusters` in the same client session missed the
+    # store and returned "No run loaded". Bounded by the store's LRU(64)+TTL(1h);
+    # single Railway replica so no cross-instance session affinity concern.
+    session_manager = StreamableHTTPSessionManager(app=server, stateless=False)
 
     @contextlib.asynccontextmanager
     async def lifespan(app: Starlette) -> AsyncIterator[None]:

--- a/packages/python/goldensuite-mcp/tests/test_http_stateful.py
+++ b/packages/python/goldensuite-mcp/tests/test_http_stateful.py
@@ -1,0 +1,35 @@
+"""The HTTP transport must run STATEFUL, not stateless.
+
+The 8 stateful goldenmatch tools (list_clusters/get_cluster/get_golden_record/
+explain_match/evaluate/export_results/match_record/find_duplicates) carry run
+state across calls via a session-keyed store (PR #1713) keyed on the
+per-connection ServerSession. That only persists when the HTTP layer keeps one
+ServerSession alive across a client's requests -- i.e. stateful mode. Under
+stateless=True a live smoke test showed `dedupe_file` then `list_clusters` in the
+same client session returned "No run loaded". This locks the fix in.
+"""
+from unittest import mock
+
+from goldensuite_mcp import cli
+
+
+def test_serve_http_builds_stateful_session_manager():
+    captured = {}
+
+    class _FakeMgr:
+        def __init__(self, app, stateless):
+            captured["stateless"] = stateless
+
+        def run(self):  # pragma: no cover - lifespan not entered in this test
+            raise AssertionError("lifespan should not run")
+
+        def handle_request(self, *a, **k):  # pragma: no cover
+            pass
+
+    with mock.patch(
+        "mcp.server.streamable_http_manager.StreamableHTTPSessionManager", _FakeMgr
+    ), mock.patch("uvicorn.run") as run:
+        cli._serve_http("127.0.0.1", 8300)
+
+    assert captured["stateless"] is False, "HTTP transport must be stateful (see PR #1713)"
+    run.assert_called_once()


### PR DESCRIPTION
The live goldensuite-mcp HTTP server ran `StreamableHTTPSessionManager(stateless=True)`. In stateless mode every POST builds a fresh `ServerSession`, so the session-keyed run state from #1713 (keyed on the per-connection ServerSession) never carried between calls.

**Caught by a live smoke test after deploying #1713:** `dedupe_file` (composite) succeeded end-to-end (5 records -> 2 golden, wrote CSV), but `list_clusters` in the *same client session* returned `"No run loaded"` -- the 8 stateful tools were still effectively dead on the remote (now a clean error instead of the pre-#1713 crash).

Flip to `stateless=False` so one `ServerSession` + its `Mcp-Session-Id` persists across a client's calls. Bounded by the store's LRU(64)+TTL(1h); single Railway replica so no cross-instance session-affinity concern. Composites (self-contained single-call) are unaffected.

Adds `test_http_stateful.py` locking the stateful choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)