### PR TITLE
feat(goldenmatch): W-1 Frame-lane widening -- quality/transform prep bridges

### DIFF
--- a/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
+++ b/docs/superpowers/plans/2026-07-12-goldenmatch-arrow-descent-3x.md
@@ -160,6 +160,42 @@ cannot move while downstream still takes pl.LazyFrame):**
 - D6 after the spine holds a full-suite arrow lane with zero polars imports
   (assert via an import-hook test, the goldencheck 2.0.0 precedent).
 
+## Frame-lane WIDENING roadmap (2026-07-13, post-deep-D2)
+
+Ben's observation: ~11 of 13 feature classes DECLINE the Frame lane, and the
+default config (quality/transform default-ON) never engages it. The decline
+lane falls back to polars -- which cannot survive D6 (no polars to fall back
+to). Every flag must resolve to PORT (consumer goes dual-rep) or EXTRA-GATE
+(polars becomes that feature's own declared dep, the quality/transform
+pattern) before D6. Criterion: default-config impact x port cost.
+
+| Flag | Decision | Batch |
+| --- | --- | --- |
+| quality prep (default-ON) | EXTRA-GATE (locked design) -- BRIDGE at run_quality_check entry (pa->pl->pa, zero-copy) | W-1 (this) |
+| transform prep (default-ON) | EXTRA-GATE (locked design) -- same bridge | W-1 (this) |
+| writes_outputs (write_output+lineage) | PORT (core, common) | W-2 |
+| validation rules/auto_fix | PORT (validate_dataframe/auto_fix seam twins exist: evaluate_validation_rule, auto_fix) | W-3 |
+| identity | PORT (core feature; reads row attrs off collected) | W-4 |
+| memory corrections | PORT (apply_corrections column reads) | W-4 |
+| auto-suggest / block analyzer | PORT (W3d reductions already seam) | W-5 |
+| postflight/preflight (auto_config) | PORT with the controller lane | W-5 |
+| probabilistic EM | PORT (probabilistic.py already part-seam via D5a/c) | W-6 |
+| NE-on-exact | PORT (small; _apply_negative_evidence_to_exact_pairs column reads) | W-6 |
+| throughput sketch tier | EXTRA-GATE candidate (rare, polars-heavy local block) or late port | W-7 |
+| rerank (cross-encoder) | LATE PORT (rare; reads text cols) | W-7 |
+| llm boost/scorer | LATE PORT (rare; reads row text) | W-7 |
+| semantic blocking | PORT (excluded by eager gate today; embedding reads) | W-7 |
+| domain extraction | PORT (eager gate exclusion) | W-7 |
+| adaptive golden rules | LATE PORT (refiner reads prepared_df) | W-7 |
+
+W-1 (quality/transform bridges) restructures the engine Frame branch to run
+the stages in CLASSIC PREP ORDER (quality -> transform -> standardize ->
+matchkeys -> precompute; the E.164 stage-order lesson) -- the eager
+standardize/matchkey shortcut only applies when prep is a no-op, exactly as
+today. Prep CACHE is skipped on the Frame lane (correctness first). GATE:
+the differential harness datasets run DEFAULT configs (quality ON), so
+post-W-1 they exercise the Frame lane cross-rep e2e for the first time.
+
 ## Risks
 
 | Risk | Mitigation |

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -865,11 +865,17 @@ def run_dedupe(
             or (config.transform is None or config.transform.mode != "disabled")
             or bool(config.validation and config.validation.auto_fix)
         )
-        _eager_ok = (
-            not _prep_will_run
-            and config.semantic_blocking is None
+        # W-1 widening: prep (quality/transform) no longer forces the classic
+        # lane -- the engine Frame branch bridges those integrations in prep
+        # order. auto_fix still declines (inside _frame_lane_eligible). The
+        # EAGER standardize/matchkeys shortcut below still requires prep-off
+        # (prep mutates data BEFORE standardize -- the E.164 lesson).
+        _lane_ok = (
+            config.semantic_blocking is None
             and not (config.domain and config.domain.enabled)
         )
+        _eager_ok = not _prep_will_run and _lane_ok
+        _eager_done: frozenset[str] = frozenset()
         if _eager_ok:
             done: set[str] = set()
             if config.standardization and config.standardization.rules:
@@ -895,29 +901,29 @@ def run_dedupe(
                     )
                 done.add("compute_matchkeys")
             _eager_done = frozenset(done)
-            # D2s-d2b Frame lane: when no C-class consumer is flagged, skip
-            # the polars shim entirely -- the engine receives the ArrowFrame
-            # and keeps the spine arrow through collect (predicate =
-            # _frame_lane_eligible; GOLDEN BRIDGE re-enters polars only at
-            # the golden builders until deep-D2). GOLDENMATCH_FRAME_LANE=0
-            # kill-switch restores the classic shim.
-            _writes_outputs = bool(
-                output_golden or output_clusters or output_dupes or output_unique
+        # D2s-d2b Frame lane (W-1: also engages when prep runs -- the engine
+        # bridges quality/transform): when no C-class consumer is flagged,
+        # skip the polars shim entirely -- the engine receives the ArrowFrame
+        # and keeps the spine arrow through collect. GOLDENMATCH_FRAME_LANE=0
+        # kill-switch restores the classic shim.
+        _writes_outputs = bool(
+            output_golden or output_clusters or output_dupes or output_unique
+        )
+        if (
+            _lane_ok
+            and os.environ.get("GOLDENMATCH_FRAME_LANE", "1") != "0"
+            and os.environ.get("GOLDENMATCH_COLUMNAR_PIPELINE", "0") != "1"
+            and _frame_lane_eligible(
+                config, matchkeys, writes_outputs=_writes_outputs
             )
-            if (
-                os.environ.get("GOLDENMATCH_FRAME_LANE", "1") != "0"
-                and os.environ.get("GOLDENMATCH_COLUMNAR_PIPELINE", "0") != "1"
-                and _frame_lane_eligible(
-                    config, matchkeys, writes_outputs=_writes_outputs
-                )
-            ):
-                return _run_dedupe_pipeline(
-                    _combined, config, matchkeys,
-                    output_golden, output_clusters,
-                    output_dupes, output_unique, output_report,
-                    across_files_only, llm_retrain, llm_provider, llm_max_labels,
-                    _eager_stages_done=_eager_done,
-                )
+        ):
+            return _run_dedupe_pipeline(
+                _combined, config, matchkeys,
+                output_golden, output_clusters,
+                output_dupes, output_unique, output_report,
+                across_files_only, llm_retrain, llm_provider, llm_max_labels,
+                _eager_stages_done=_eager_done,
+            )
         # W5b-1 shim (single, post-eager-stages): everything below is still
         # polars-lazy; removal point is W5b-3 (prep-block integrations).
         combined_df = cast("pl.DataFrame", pl.from_arrow(_combined.native))
@@ -1698,18 +1704,70 @@ def _run_dedupe_pipeline(
     # schema; height defends against same-schema-different-rows (e.g. an empty
     # input vs a populated one) — the `test_dedupe_df_empty` flake.
     if not isinstance(combined_lf, pl.LazyFrame):
-        # D2s-d2b Frame lane (arrow spine): entered only from run_dedupe's
-        # eligibility gate -- every prep stage below is a no-op by
-        # construction (_eager_ok + _frame_lane_eligible), so the prep block
-        # reduces to the matchkey precompute. combined_lf IS a seam Frame
-        # from here down; downstream consumers are dual-rep (D2s-a/d1).
+        # D2s-d2b Frame lane (arrow spine), WIDENED W-1: runs the prep stages
+        # in CLASSIC ORDER (quality -> transform -> standardize -> matchkeys
+        # -> precompute; the E.164 stage-order lesson). quality/transform are
+        # EXTRA-GATED integrations that keep polars as THEIR dep, so they run
+        # through a zero-copy pa->pl->pa BRIDGE at their entry (the golden-
+        # bridge pattern). Everything else on the decline list is still
+        # refused by run_dedupe's gate. Prep CACHE is skipped on this lane
+        # (correctness first). combined_lf IS a seam Frame from here down.
         from goldenmatch.core.frame import to_frame as _tf_lane
         from goldenmatch.core.matchkey import precompute_matchkey_transforms_frame
 
+        _frame = _tf_lane(combined_lf)
+
+        if config.quality is None or config.quality.mode != "disabled":
+            from goldenmatch.core.quality import run_quality_check
+            with stage("pipeline_prep_quality_scan"):
+                _pl_tmp, gc_fixes = run_quality_check(
+                    _as_polars_df(_frame.native), config.quality
+                )
+                if gc_fixes:
+                    logger.info("GoldenCheck: %d fixes applied", len(gc_fixes))
+                _frame = _tf_lane(_pl_tmp.to_arrow())
+
+        if config.transform is None or config.transform.mode != "disabled":
+            from goldenmatch.core.transform import run_transform
+            with stage("pipeline_prep_transform"):
+                _pl_tmp, tf_fixes = run_transform(
+                    _as_polars_df(_frame.native), config.transform
+                )
+                if tf_fixes:
+                    logger.info("GoldenFlow: %d transforms applied", len(tf_fixes))
+                _frame = _tf_lane(_pl_tmp.to_arrow())
+
+        if (
+            "standardize" not in _eager_stages_done
+            and config.standardization
+            and config.standardization.rules
+        ):
+            with stage("standardize"):
+                for _col, _std_names in config.standardization.rules.items():
+                    if _col not in _frame.columns:
+                        continue
+                    _frame = _frame.with_column(
+                        _col, _frame.derive_standardized_column(_col, _std_names)
+                    )
+
+        if "compute_matchkeys" not in _eager_stages_done:
+            with stage("compute_matchkeys"):
+                for _mk in matchkeys:
+                    if _mk.type != "exact":
+                        continue
+                    _frame = _frame.with_column(
+                        f"__mk_{_mk.name}__",
+                        _frame.derive_matchkey(
+                            [
+                                (f.field, list(f.transforms or []))
+                                for f in _mk.fields
+                                if f.field is not None
+                            ]
+                        ),
+                    )
+
         with stage("precompute_matchkey_transforms"):
-            collected_frame = precompute_matchkey_transforms_frame(
-                _tf_lane(combined_lf), matchkeys
-            )
+            collected_frame = precompute_matchkey_transforms_frame(_frame, matchkeys)
         collected_df = collected_frame.native
         combined_lf = collected_frame
         quarantine_df = None

--- a/packages/python/goldenmatch/tests/test_pipeline.py
+++ b/packages/python/goldenmatch/tests/test_pipeline.py
@@ -144,6 +144,10 @@ class TestRunDedupe:
         """
         import goldenmatch.core.pipeline as pipeline_mod
 
+        # W-1 widening: the Frame lane skips the prep cache entirely; this
+        # test pins the CLASSIC lane's cache-seed mechanics.
+        monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", "0")
+
         captured = {}
         real = pipeline_mod._run_dedupe_pipeline
 

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -326,8 +326,10 @@ def test_frame_lane_engages_and_matches_classic(tmp_path, monkeypatch, backend, 
     assert _norm_result(frame_lane) == _norm_result(classic)
 
 
-def test_frame_lane_declines_when_quality_enabled(tmp_path, monkeypatch):
-    """Default-on goldencheck quality keeps the classic lane (eager gate)."""
+def test_frame_lane_engages_when_quality_enabled(tmp_path, monkeypatch):
+    """W-1 widening: default-on goldencheck quality no longer keeps the
+    classic lane -- the predicate is consulted and the lane engages (the
+    integration runs through the prep bridge)."""
     import goldenmatch.core.pipeline as P
 
     monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
@@ -349,9 +351,7 @@ def test_frame_lane_declines_when_quality_enabled(tmp_path, monkeypatch):
         P, "_frame_lane_eligible", lambda *a, **k: (hits.append(orig(*a, **k)) or hits[-1])
     )
     res = P.run_dedupe([(str(csv), "people")], cfg)
-    # _eager_ok is False (quality default-on), so the predicate is never
-    # consulted and the classic lane ran; results still come back arrow.
-    assert hits == []
+    assert hits and hits[0] is True
     assert res["golden"] is None or hasattr(res["golden"], "num_rows")
 
 
@@ -386,7 +386,50 @@ def test_frames_path_fused_golden_gets_arrow_table(tmp_path, monkeypatch):
     if not calls or not calls[0][1]:
         pytest.skip("native golden_fused kernel unavailable")
     assert calls[0][0] == "Table", calls
-
     monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", "0")
     classic = P.run_dedupe([(str(csv), "people")], cfg)
     assert _norm_result(frame_lane) == _norm_result(classic)
+
+
+def test_frame_lane_engages_on_default_config_with_prep_bridges(tmp_path, monkeypatch):
+    """W-1 widening: a FULLY DEFAULT config (quality/transform default-ON)
+    engages the Frame lane; the integrations run through the pa->pl->pa
+    bridge in classic prep order and output matches the classic lane
+    (including goldenflow's E.164 phone transform surviving the bridge)."""
+    import goldenmatch.core.pipeline as P
+    from goldenmatch.config.schemas import GoldenMatchConfig
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME", "arrow")
+    csv = tmp_path / "people.csv"
+    csv.write_text(
+        "first,last,phone\n"
+        "ann,smith,(267) 555-1234\n"
+        "ann,smith,267-555-1234\n"
+        "bob,jones,555 0001\n"
+        "bob,jones,5550001\n"
+        "cara,lee,\n"
+        "dan,kim,9998887777\n",
+        encoding="utf-8",
+    )
+    cfg = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="exact_name",
+                type="exact",
+                fields=[MatchkeyField(field="first"), MatchkeyField(field="last")],
+            )
+        ]
+    )
+    hits = []
+    orig = P._frame_lane_eligible
+    monkeypatch.setattr(
+        P, "_frame_lane_eligible", lambda *a, **k: (hits.append(orig(*a, **k)) or hits[-1])
+    )
+    frame_lane = P.run_dedupe([(str(csv), "people")], cfg)
+    assert hits and hits[0] is True, f"Frame lane did not engage on default config: {hits}"
+    monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", "0")
+    classic = P.run_dedupe([(str(csv), "people")], cfg)
+    assert _norm_result(frame_lane) == _norm_result(classic)
+    # the transform bridge actually ran: phones are E.164 in golden
+    golden_rows = frame_lane["golden"].to_pylist()
+    assert any(str(r.get("phone", "")).startswith("+") for r in golden_rows)


### PR DESCRIPTION
First batch of the Frame-lane WIDENING roadmap (committed in the plan with this PR): ~11 of 13 feature classes declined the Frame lane, and the DEFAULT config (quality/transform default-ON) never engaged it. The roadmap classifies every decline flag as PORT or EXTRA-GATE (criterion: default-config impact x port cost) -- required before D6, since the decline lane's polars fallback cannot survive polars leaving runtime deps.

## What

- **Engine Frame branch** now runs the prep stages in CLASSIC ORDER (quality -> transform -> standardize -> matchkeys -> precompute; the E.164 stage-order lesson). quality/transform are EXTRA-GATED integrations that keep polars as THEIR dep (locked design), so they run through a zero-copy `pa->pl->pa` bridge at their entry -- the golden-bridge pattern. Prep cache is skipped on this lane (correctness first).
- **run_dedupe gate**: prep no longer forces the classic shim (`_lane_ok` split from `_eager_ok`); the EAGER standardize/matchkeys shortcut still requires prep-off, unchanged. Dispatch hoisted out of the eager-only block.
- **Stale pins updated**: quality-on now ENGAGES the lane (was: declines); the prep-cache-seed test pins the classic lane explicitly.
- **New pin**: a FULLY DEFAULT config engages the Frame lane, goldenflow's E.164 phone transform survives the bridge (`+12675551234` in golden), output == classic lane.

## Gates

- The differential harness's default-config datasets now exercise the widened lane cross-rep for the first time -- green on every dataset.
- spine_dual_rep / pipeline / scorer / blocker / matchkey (138) + native-lane febrl3 / multipass / fused_golden green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW