### PR TITLE
feat(goldenmatch): arrow-native endgame A1-A8 + A9-slice-1 -- bridge ledger 21 -> 6

### DIFF
--- a/docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md
+++ b/docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md
@@ -1,0 +1,208 @@
+# GoldenMatch Arrow-native endgame — the full map
+
+Mission (Ben, 2026-07-13): make GoldenMatch **Arrow-native, Rust, fused
+compute** — all of it, not just the spine. This map is the authoritative
+inventory of where every compute path stands and the batch plan to the
+end-state. Supersedes the widening roadmap's transitional notes in
+`2026-07-12-goldenmatch-arrow-descent-3x.md` (that plan's D1-D5/D2s/deep-D2/
+W-1..W-7 history stands; this plan owns what remains).
+
+## End-state definition (three invariants, testable)
+
+1. **Zero polars at runtime.** `import goldenmatch` + any pipeline run with
+   any config loads no polars unless an EXTRA-GATED integration is enabled
+   (goldencheck/goldenflow keep polars as THEIR declared dep only if their
+   own arrow surfaces cannot cover the call). Proof: an import-hook CI test
+   (the goldencheck 2.0.0 precedent) that fails the suite if `polars` lands
+   in `sys.modules` on the arrow lane.
+2. **All engine compute arrow-native.** Every stage computes on
+   `pa.Table`/arrow buffers via the Frame seam or `pa.compute`; per-batch
+   parity gates (the differential harness + per-feature pins).
+3. **Hot paths in owned Rust kernels, fused where FFI-crossing repeats.**
+   "Hot" is MEASURED (the audit lesson: wall-clock on real shapes, never
+   static counts). Fusion only where a profile shows per-call FFI/materialize
+   overhead — the match_fused/golden_fused precedent (wall wash, ~2x RSS win;
+   scale/composability is the justification, not raw speed).
+
+## Layer inventory (2026-07-13, post W-1..W-7)
+
+### Layer 1 — DONE: Arrow-native + Rust fused (the hot spine)
+- `run_match_fused_arrow` / `run_match_fused_multipass_arrow`: block + score
+  + dedup + cluster in ONE FFI call (native `fused.rs`).
+- `run_golden_fused_arrow`: survivorship kernel, pa in -> pa out (deep-D2),
+  indices returned, gather via `take()`.
+- Bucket scoring: `score_block_pairs_arrow` (zero-copy buffers into Rust
+  rapidfuzz), seam scaffolding (D5), per-lane bucket assignment.
+- Native crate surface already present (packages/rust/extensions/native/src):
+  autoconfig, block, bloom, cluster, documents, featurize, fused, golden,
+  hash, pairs, perceptual, score, sketch, suggest.
+
+### Layer 2 — DONE: Arrow-native Python (seam / pa.compute, no Rust)
+Ingest (pyarrow csv/parquet readers), eager standardize/matchkeys,
+`precompute_matchkey_transforms_frame`, static blocking + exact match
+(Acero), splits/report/outputs (native parquet), validation (W-3),
+lineage reads (W-2), probabilistic data reads (W-6), clustering data prep.
+
+### Layer 3 — THE REMAINING WORK: bridged polars compute
+Every entry below runs ON the Frame lane today via a zero-copy `pa->pl`
+bridge; the compute substrate is still polars. Ordered by plan batch.
+
+## Batch plan (A-series: arrow-native ports; K-series: Rust/fused kernels)
+
+Each batch: own PR, parity pin(s) vs the bridged implementation
+(byte-identical or documented-equivalence), differential-harness green,
+bridge deleted in the same PR. Perf gates only where a stage is hot at 1M+.
+
+### A1 — quality via goldencheck's OWN arrow surface  [replaces a FINAL bridge]
+goldencheck 3.0.0 shipped the Arrow Flip: default scan is polars-free
+(`goldencheck/core/frame.py` + `kernels.py`, fused string digest). Port
+`run_quality_check`'s integration adapter to hand goldencheck a `pa.Table`
+and consume its arrow results; polars loads ONLY if goldencheck's own
+gated paths need it. Also flip `compute_quality_scores` (the golden
+quality-weighting bridge) onto goldencheck's arrow cell-quality if exposed;
+if not, file the goldencheck issue and keep that single bridge with a
+pointer. RECON AT START: goldencheck's public arrow entry signature.
+
+### A2 — transform via goldenflow's OWN arrow/fused surface  [replaces a FINAL bridge]
+goldenflow has owned Rust kernels + fused columnar apply (str+num+nullable,
+default-on) and a WASM build. Port `run_transform`'s adapter to the
+arrow/fused apply path. Same recon caveat as A1.
+
+### A3 — analyzer + postflight + auto-suggest arrow entries
+W3d already seamed the block analyzer's REDUCTIONS; the residue is
+`analyze_blocking`'s entry frame ops + sampling (Frame.sample exists,
+statistical contract) and `postflight`'s score-histogram reads (pure
+Python over pair lists + seam column reads — small). Deletes two bridges.
+
+### A4 — memory corrections arrow-native
+`_build_hash_to_rids` is a polars expr chain ending in per-row sha256.
+REUSE `fingerprint-core` (the cross-surface record-id hash crate — :h1:
+canonical fingerprint) instead of re-porting the ad-hoc sha256: one
+kernel, already cross-surface-pinned. Fallback: seam cast_str reads +
+Python hash (correct, slower). Deletes the memory bridge.
+
+### A5 — identity arrow-native (LARGEST single port)
+`identity/resolve.py` (~1000+ lines): row payload extraction
+(select_dicts — trivial), record-id fingerprinting (fingerprint-core,
+same as A4), and the incremental mini-frame machinery (schema-aligned
+concat for match_record). Split: A5a resolve_clusters payload path
+(the dedupe-pipeline surface — select_dicts + fingerprints); A5b the
+incremental match_record mini-frames (concat_frames seam op exists;
+schema alignment via select_cast). SP-C already feeds ClusterFrames
+directly. Deletes the identity bridge.
+
+### A6 — semantic blocking + domain extraction arrow-native
+- Semantic sources (initialism / alias / embedding candidates): key
+  derivation is string ops (seam derive twins cover); embedding retrieval
+  goes through goldenembed (model-bound, representation-light). The
+  `__raw__` capture is already seam (W-7).
+- Domain extraction (`extract_features`): regex/derive columns — seam
+  derive_transformed_column-shaped; port the feature exprs to arrow_derive.
+- Both are offline-testable except the embedding model (mock the model,
+  pin the frame handoffs — the W-7 pin pattern).
+
+### A7 — throughput sketch tier arrow-native
+The `_tp` block: text extraction (seam cast_str reads), simhash/minhash
+sketching — native `sketch.rs` + `simhash` kernels ALREADY EXIST; the
+blockers are the polars-local glue reads. Port reads to seam; sketches go
+straight to the existing kernels. Deletes the throughput bridge.
+
+### A8 — rerank + LLM tail
+Model-bound stages; frames only supply row text. Port the text extraction
+to seam reads (select_dicts / column reads). Smallest batch; deletes the
+last two call-site bridges.
+
+### A9 — golden slow-path demux retirement
+After A1-A8 the remaining `_as_polars_df` sites are the golden DECLINE
+replays (fast-columnar `build_golden_records_df` + batch builder) and the
+from-frames recompute. End-state options, decided by measurement:
+(a) widen `golden_fused_ready` coverage until declines are rare, keep a
+seam-Python slow builder for the residue (port build_golden_records_batch's
+per-cluster merge to seam reads — it is already to_list-shaped); or
+(b) port the fast columnar path to pa.compute. Either way the polars demux
+dies here. The order-sensitivity lesson (Acero vs polars join row order)
+pins the parity fixtures.
+
+### K1 — precompute/derive kernel (MEASURE FIRST)
+At 10M the matchkey precompute was 90s polars-batched; the arrow lane loops
+per-signature. Profile at 1M/10M on the frame lane; if the python-fallback
+transform chains (soundex/metaphone) dominate, add a native chain kernel
+(hash.rs/featurize.rs adjacency). If the native-expr chains dominate, the
+arrow_derive vectorized path may already win — do nothing (the
+goldenflow-kernel lesson: measure-first byte-identical wins were 3-8x, NOT
+where predicted).
+
+### K2 — fused prep (SPECULATIVE — only if K1 profiling shows FFI churn)
+quality-scan + transform + standardize + matchkey precompute in one pass
+over the table (the goldencheck fused-scan shape). Only if a 10M profile
+shows the stage seams costing real wall; otherwise skip — fusion for
+composability is already delivered by match_fused.
+
+### D6 — the deletion (the finish line)
+Preconditions: A1-A9 merged; frame-lane bench config exists (see below);
+import-hook zero-polars test green on the full arrow-lane suite.
+Contents: delete the polars opt-out value, PolarsFrame + PolarsColumn,
+`_polars_dtype`, polars constructor branches, the `.lazy()` classic prep
+block (the Frame branch becomes THE pipeline), `_as_polars_df`;
+`_polars_lazy` proxy survives only inside goldencheck/goldenflow adapters
+if A1/A2 recon finds gated residue. polars -> dev-dep group. Parity suites
+collapse single-backend. Docs sweep. Ships as a 3.x minor.
+
+## EXECUTION STATUS (2026-07-13, same-day)
+
+**IMPLEMENTED (A1-A8, stacked behind W-1 #1731):** bridge ledger 21 -> 8.
+- A1 quality: scan arrow-native via goldencheck's own surface; bridge
+  narrowed to apply_fixes-when-findings; version-SKEW fallback (installed
+  goldencheck predating its Arrow Flip bridges+retries; floor bump at D6).
+- A2 transform: adapter dual-rep, exclusions on the seam; bridge narrowed
+  to goldenflow's auto-detect engine call. FILED: goldenflow arrow
+  auto-detect + goldencheck apply_fixes arrow port (sibling batches).
+- A3 analyzer/postflight: candidate transforms via derive_transformed_
+  column (compound keys pipe-join with concat_str null propagation);
+  _sample_block_sizes via derive_block_key + group_len.
+- A4 memory: **MAP CORRECTION** -- fingerprint-core replacement was WRONG
+  (record_hash is PERSISTED; format change breaks re-anchoring). Format-
+  preserving seam port instead; both hash contracts byte-stable.
+- A5 identity: dedupe path seam-native; **A5b RESIDUAL** = fingerprint
+  canonicalization (canonicalize_records_df/batch_fingerprints entry
+  bridges -- the :h1: dtype contract ports against the fingerprint parity
+  corpus) + the incremental match_record mini-frames + the Ray branch.
+- A6 semantic/domain: extractors seam-native (backend-detected attach);
+  _apply_domain_extraction dual-rep; semantic receives LANE-NATIVE handles.
+- A7 throughput: tier-local polars import GONE; seam cast_str/fill_null +
+  semantic_dtype fallback pick; sketches on the existing kernels.
+- A8 rerank/llm/boost: text extraction via select_dicts; 4 bridges retired.
+
+**REMAINING (each needs its own dedicated effort):**
+- A9 golden demux: build_golden_records_batch has THREE internal routes
+  (polars-native columnar, survivorship native kernel, slow sorted
+  oracle) -- port against the golden fixture corpus; frames-path decline
+  recompute stays (join-order hazard). The remaining 8 ledger bridges are
+  all A9-adjacent (demux replays, quality_scores/cell_quality, adaptive
+  refiner, NE-on-exact) + the identity/W-4 pin rename.
+- K1/K2: remote 1M/10M profiles first (frame-lane bench config
+  prerequisite -- zero-config bench now ENGAGES the lane post W-5).
+- D6: requires the full W+A stack merged, the import-hook zero-polars
+  test, floor bumps (goldencheck>=3.0), and a 3.x minor release.
+
+## Cross-cutting gates
+
+- **Frame-lane bench config** (FIRST, before A1): a bench-zero-config
+  variant that is frame-lane-eligible (quality/transform run via bridges
+  today = realistic) at 100K/1M, so every A-batch has a wall+RSS gate.
+  The zero-config bench takes auto_config and now ENGAGES the lane (W-5
+  removed the preflight decline) — verify, else add a fixed-config bench.
+- **Bridge-count tripwire**: a unit test asserting the exact set of
+  remaining `_as_polars_df` call sites; every A-batch shrinks the list —
+  no silent new bridges.
+- **Parity discipline**: breadth sweeps with symmetric-decline asserts
+  (the deep-D2 date32 lesson: one happy-path pin != coverage).
+- **Measure-first for every K-batch**: 5-run median wall on real shapes at
+  1M+ before designing; byte-identical output or no ship.
+
+## Sizing (rough, PR-count)
+
+A1 2 / A2 2 / A3 1-2 / A4 1 / A5 3-4 / A6 2-3 / A7 1-2 / A8 1 / A9 2-3 /
+K1 1-2 (post-profile) / D6 2 (deletion + docs/release). ~20-25 PRs.
+Order: bench config -> A1/A2 (default-config compute goes arrow) ->
+A4/A3/A8 (small) -> A7 -> A6 -> A5 (largest) -> A9 -> K1(-K2) -> D6.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -67,33 +67,34 @@ def _sample_block_sizes_per_key(
 
     Returns ``[]`` when df is empty.
     """
-    if df.height == 0:
+    # A3: seam-driven both lanes (derive_block_key is the twin of
+    # _build_block_key_expr; group_len is the sizes reduction).
+    from goldenmatch.core.frame import to_frame
+
+    f = to_frame(df)
+    if f.height == 0:
         return []
 
-    from goldenmatch.core.blocker import _build_block_key_expr
-
-    n = min(df.height, sample_cap)
-    sample = df.head(n) if df.height > n else df
+    n = min(f.height, sample_cap)
+    sample = f.head(n) if f.height > n else f
 
     keys = list(blocking.keys or [])
     keys.extend(blocking.passes or [])
 
     out: list[tuple[Any, list[int], Exception | None]] = []
     for key in keys:
-        if not all(f in df.columns for f in key.fields):
+        if not all(fld in f.columns for fld in key.fields):
             continue
         try:
-            expr = _build_block_key_expr(key)
-            sizes_series = (
-                sample.with_columns(expr)
-                .group_by("__block_key__")
-                .len()
-                .get_column("len")
+            keyed = sample.with_column(
+                "__block_key__",
+                sample.derive_block_key(key.fields, key.transforms or []),
             )
+            sizes = keyed.group_len(["__block_key__"]).column("len").to_list()
         except Exception as exc:
             out.append((key, [], exc))
             continue
-        out.append((key, [int(s) for s in sizes_series.to_list()], None))
+        out.append((key, [int(v) for v in sizes], None))
     return out
 
 
@@ -1036,7 +1037,9 @@ def _signal_blocking_recall(
     a uniform 1000-row sample when df.height >= 10_000. Reserved for the
     iterative autoconfig loop so postflight has a meaningful recall estimate.
     """
-    if df.height < 10_000:
+    from goldenmatch.core.frame import to_frame as _tf_a3
+
+    if _tf_a3(df).height < 10_000:
         return "deferred"
     _ = (config, pair_scores, current_threshold)  # silence unused
     return "deferred"
@@ -1147,7 +1150,9 @@ def _signal_block_size_percentiles(
     Preflight Check 4). Returns zeros on failure or when blocking is absent.
     """
     zero = {"p50": 0, "p95": 0, "p99": 0, "max": 0}
-    if config.blocking is None or df.height == 0:
+    from goldenmatch.core.frame import to_frame as _tf_a3
+
+    if config.blocking is None or _tf_a3(df).height == 0:
         return zero
 
     all_sizes = _sample_block_sizes(df, config.blocking, sample_cap=10_000)

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from itertools import combinations
 
 from goldenmatch._polars_lazy import pl
-from goldenmatch.utils.transforms import apply_transforms
 
 logger = logging.getLogger(__name__)
 
@@ -130,37 +129,40 @@ def generate_candidates(matchkey_columns: list[str]) -> list[dict]:
 # ── Scoring ──────────────────────────────────────────────────────────────────
 
 
-def _apply_candidate_transforms(df: pl.DataFrame, candidate: dict) -> pl.DataFrame:
-    """Apply a candidate's transforms and add __block_key__ column."""
+def _apply_candidate_transforms(df, candidate: dict):
+    """Apply a candidate's transforms and add __block_key__ column.
+
+    A3 (arrow-native endgame): seam-driven both lanes. Per-field derivation
+    is ``derive_transformed_column`` (cast-then-chain -- the D5c-probed twin
+    of the old ``cast(Utf8).map_elements(apply_transforms)`` expr). Compound
+    keys join "||" in Python with the old ``concat_str`` NULL PROPAGATION
+    (any null field -> null key); the analyzer runs on samples, so the list
+    round-trip is size-bounded. Returns a seam Frame.
+    """
+    from goldenmatch.core.frame import PolarsFrame, column_from_values, to_frame
+
+    f = to_frame(df)
     key_fields = candidate["key_fields"]
     transforms = candidate["transforms"]
 
     if len(key_fields) == 1:
         col = key_fields[0]
-        tfms = transforms  # flat list of transforms
-        if tfms:
-            expr = pl.col(col).cast(pl.Utf8).map_elements(
-                lambda val, t=tfms: apply_transforms(val, t),
-                return_dtype=pl.Utf8,
-            )
-        else:
-            expr = pl.col(col).cast(pl.Utf8)
-        return df.with_columns(expr.alias("__block_key__"))
-    else:
-        # Compound: transforms is a list of lists
-        field_exprs = []
-        for i, col in enumerate(key_fields):
-            tfms = transforms[i] if i < len(transforms) else []
-            if tfms:
-                expr = pl.col(col).cast(pl.Utf8).map_elements(
-                    lambda val, t=tfms: apply_transforms(val, t),
-                    return_dtype=pl.Utf8,
-                )
-            else:
-                expr = pl.col(col).cast(pl.Utf8)
-            field_exprs.append(expr)
-        concat_expr = pl.concat_str(field_exprs, separator="||")
-        return df.with_columns(concat_expr.alias("__block_key__"))
+        return f.with_column(
+            "__block_key__",
+            f.derive_transformed_column(col, list(transforms or [])),
+        )
+    parts = []
+    for i, col in enumerate(key_fields):
+        tfms = transforms[i] if i < len(transforms) else []
+        parts.append(f.derive_transformed_column(col, list(tfms)).to_list())
+    joined = [
+        "||".join(vals) if all(v is not None for v in vals) else None
+        for vals in zip(*parts)
+    ]
+    backend = "polars" if isinstance(f, PolarsFrame) else "arrow"
+    return f.with_column(
+        "__block_key__", column_from_values(joined, "utf8", backend=backend)
+    )
 
 
 def score_candidate(
@@ -173,9 +175,12 @@ def score_candidate(
     Returns a dict with group_count, max_group_size, mean_group_size,
     std_group_size, total_comparisons, and score.
     """
+    from goldenmatch.core.frame import to_frame as _tf_a3
+
     # Check columns exist
+    _cols_a3 = _tf_a3(df).columns
     for col in candidate["key_fields"]:
-        if col not in df.columns:
+        if col not in _cols_a3:
             return {
                 "group_count": 0,
                 "max_group_size": 0,
@@ -190,9 +195,15 @@ def score_candidate(
     # arrow backend until W5 lifts the ingest shim; the REDUCTIONS below run
     # through the seam (W3d).
 
-    from goldenmatch.core.frame import to_frame
 
-    df_valid = to_frame(df_with_key.filter(pl.col("__block_key__").is_not_null()))
+    _keys = df_with_key.column("__block_key__").to_list()
+    from goldenmatch.core.frame import PolarsFrame as _PF
+    from goldenmatch.core.frame import column_from_values as _cfv
+
+    _backend = "polars" if isinstance(df_with_key, _PF) else "arrow"
+    df_valid = df_with_key.filter_mask(
+        _cfv([k is not None for k in _keys], "bool", backend=_backend)
+    )
 
     if df_valid.height == 0:
         return {
@@ -374,7 +385,9 @@ def analyze_blocking(
     # At scale, per-candidate scoring runs a Python-UDF `map_elements` over the
     # full df. With ~260 candidates that's a multi-GB, multi-minute hang at 5M
     # rows. Block-size distribution is shape-only; sample is sufficient.
-    n_full = df.height
+    from goldenmatch.core.frame import to_frame as _tf_a3
+
+    n_full = _tf_a3(df).height
     if n_full > _SCORE_SAMPLE_THRESHOLD:
         from goldenmatch.core.frame import to_frame
 

--- a/packages/python/goldenmatch/goldenmatch/core/boost.py
+++ b/packages/python/goldenmatch/goldenmatch/core/boost.py
@@ -54,9 +54,12 @@ def extract_feature_matrix(
     If include_embeddings is True and sentence-transformers is available,
     adds cosine similarity features per column (6 features per column instead of 5).
     """
-    row_ids = df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    row_ids = _fa8.column("__row_id__").to_list()
     id_to_idx = {rid: i for i, rid in enumerate(row_ids)}
-    rows = df.to_dicts()
+    rows = _fa8.select_dicts(list(_fa8.columns))
 
     # Try to compute embeddings for each column
     embeddings_per_col: dict[str, np.ndarray | None] = {}
@@ -246,8 +249,11 @@ def finetune_and_rescore(
             "Install with: pip install goldenmatch[embeddings]"
         )
 
-    rows = df.to_dicts()
-    row_ids = df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    rows = _fa8.select_dicts(list(_fa8.columns))
+    row_ids = _fa8.column("__row_id__").to_list()
     id_to_idx = {rid: i for i, rid in enumerate(row_ids)}
     matchable = [c for c in columns if not c.startswith("__")]
 
@@ -343,8 +349,11 @@ def load_finetuned_and_rescore(
     logger.info("Loading fine-tuned model from %s", model_path)
     model = SentenceTransformer(str(model_path))
 
-    rows = df.to_dicts()
-    row_ids = df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    rows = _fa8.select_dicts(list(_fa8.columns))
+    row_ids = _fa8.column("__row_id__").to_list()
     id_to_idx = {rid: i for i, rid in enumerate(row_ids)}
     matchable = [c for c in columns if not c.startswith("__")]
 
@@ -441,8 +450,11 @@ def boost_accuracy(
     all_features = extract_feature_matrix(candidate_pairs, df, matchable_columns, include_embeddings=True)
 
     # Build row lookup
-    rows = df.to_dicts()
-    row_ids = df["__row_id__"].to_list()
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    rows = _fa8.select_dicts(list(_fa8.columns))
+    row_ids = _fa8.column("__row_id__").to_list()
     id_to_idx = {rid: i for i, rid in enumerate(row_ids)}
 
     # Adaptive labeling loop

--- a/packages/python/goldenmatch/goldenmatch/core/domain.py
+++ b/packages/python/goldenmatch/goldenmatch/core/domain.py
@@ -20,6 +20,12 @@ from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 logger = logging.getLogger(__name__)
 
 
+def _tf_dom(df):
+    from goldenmatch.core.frame import to_frame
+
+    return to_frame(df)
+
+
 # Columns that extract_features may add to a DataFrame, by domain:
 #   bibliographic → __title_key__
 #   electronics   → __brand__, __model__, __model_norm__, __color__, __specs__, __extract_confidence__
@@ -478,11 +484,14 @@ def _detect_product_subdomain(df: pl.DataFrame, domain: DomainProfile) -> str:
     if not text_col or text_col not in df.columns:
         return "electronics"
 
-    sample = df.head(min(200, df.height))
+    from goldenmatch.core.frame import to_frame as _tf_a6
+
+    _f = _tf_a6(df)
+    sample = _f.head(min(200, _f.height))
     sw_signals = 0
     hw_signals = 0
 
-    for row in sample.select([text_col]).to_dicts():
+    for row in sample.select_dicts([text_col]):
         text = str(row.get(text_col, "") or "").lower()
         # Software signals
         if any(w in text for w in ("software", "license", "edition", "upgrade", "upg",
@@ -517,7 +526,7 @@ def _extract_software_features_df(
     confidences = []
     low_confidence_ids = []
 
-    for row in df.select(["__row_id__", text_col]).to_dicts():
+    for row in _tf_dom(df).select_dicts(["__row_id__", text_col]):
         text = str(row.get(text_col, "") or "")
         rid = row["__row_id__"]
 
@@ -533,9 +542,10 @@ def _extract_software_features_df(
             low_confidence_ids.append(rid)
 
     # W5a: seam attach (backend-agnostic column constructors).
-    from goldenmatch.core.frame import column_from_values, to_frame
+    from goldenmatch.core.frame import PolarsFrame, column_from_values, to_frame
 
     frame = to_frame(df)
+    _bk = "polars" if isinstance(frame, PolarsFrame) else "arrow"
     for _n, _v, _d in (
         ("__sw_name__", names_norm, "utf8"),
         ("__sw_version__", versions, "utf8"),
@@ -544,14 +554,14 @@ def _extract_software_features_df(
         ("__sw_part_num__", part_numbers, "utf8"),
         ("__extract_confidence__", confidences, "float64"),
     ):
-        frame = frame.with_column(_n, column_from_values(_v, _d, backend="polars"))
+        frame = frame.with_column(_n, column_from_values(_v, _d, backend=_bk))
     enhanced = frame.native
 
     n_names = sum(1 for n in names_norm if n)
     n_versions = sum(1 for v in versions if v)
     logger.info(
         "Software extraction: %d/%d names, %d/%d versions, %d low-confidence",
-        n_names, df.height, n_versions, df.height, len(low_confidence_ids),
+        n_names, frame.height, n_versions, frame.height, len(low_confidence_ids),
     )
 
     return enhanced, low_confidence_ids
@@ -572,7 +582,7 @@ def _extract_product_features_df(
     confidences = []
     low_confidence_ids = []
 
-    for row in df.select(["__row_id__", text_col]).to_dicts():
+    for row in _tf_dom(df).select_dicts(["__row_id__", text_col]):
         text = str(row.get(text_col, "") or "")
         rid = row["__row_id__"]
 
@@ -596,9 +606,10 @@ def _extract_product_features_df(
     brands_norm = [b.upper().strip() if b else None for b in brands]
 
     # Add derived columns
-    from goldenmatch.core.frame import column_from_values, to_frame
+    from goldenmatch.core.frame import PolarsFrame, column_from_values, to_frame
 
     frame = to_frame(df)
+    _bk = "polars" if isinstance(frame, PolarsFrame) else "arrow"
     for _n, _v, _d in (
         ("__brand__", brands_norm, "utf8"),
         ("__model__", models, "utf8"),
@@ -607,14 +618,14 @@ def _extract_product_features_df(
         ("__specs__", specs_strs, "utf8"),
         ("__extract_confidence__", confidences, "float64"),
     ):
-        frame = frame.with_column(_n, column_from_values(_v, _d, backend="polars"))
+        frame = frame.with_column(_n, column_from_values(_v, _d, backend=_bk))
     enhanced = frame.native
 
     n_with_model = sum(1 for m in models if m)
     n_with_brand = sum(1 for b in brands if b)
     logger.info(
         "Product extraction: %d/%d models, %d/%d brands, %d low-confidence",
-        n_with_model, df.height, n_with_brand, df.height, len(low_confidence_ids),
+        n_with_model, frame.height, n_with_brand, frame.height, len(low_confidence_ids),
     )
 
     return enhanced, low_confidence_ids
@@ -631,17 +642,19 @@ def _extract_biblio_features_df(
         return df, []
 
     title_keys = []
-    for row in df.select([text_col]).to_dicts():
+    for row in _tf_dom(df).select_dicts([text_col]):
         text = str(row.get(text_col, "") or "")
         features = extract_biblio_features(text)
         title_keys.append(features.get("title_key"))
 
-    from goldenmatch.core.frame import column_from_values, to_frame
+    from goldenmatch.core.frame import PolarsFrame, column_from_values, to_frame
 
+    _fr = to_frame(df)
+    _bk = "polars" if isinstance(_fr, PolarsFrame) else "arrow"
     enhanced = (
-        to_frame(df)
+        _fr
         .with_column(
-            "__title_key__", column_from_values(title_keys, "utf8", backend="polars")
+            "__title_key__", column_from_values(title_keys, "utf8", backend=_bk)
         )
         .native
     )

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -864,21 +864,34 @@ def build_golden_records_batch(
                 multi_df, rules, user_columns=user_columns,
             )
 
-    if "__cluster_id__" not in multi_df.columns:
+    # A9: dual-rep entry. The default slow route below is seam-native; the
+    # specialized routes (polars-native columnar, survivorship native/oracle)
+    # bridge internally -- their compute ports are the remainder of A9.
+    from goldenmatch.core.frame import to_frame as _tf_a9
+
+    _mf = _tf_a9(multi_df)
+    if "__cluster_id__" not in _mf.columns:
         raise ValueError("multi_df must contain __cluster_id__ column")
-    if provenance and "__row_id__" not in multi_df.columns:
+    if provenance and "__row_id__" not in _mf.columns:
         raise ValueError("provenance=True requires a __row_id__ column")
-    if multi_df.height == 0:
+    if _mf.height == 0:
         return []
+
+    def _mdf_pl():
+        return (
+            multi_df
+            if isinstance(multi_df, pl.DataFrame)
+            else pl.from_arrow(multi_df)
+        )
 
     if _polars_native_eligible(rules, quality_scores):
         user_cols = [
-            c for c in multi_df.columns
+            c for c in _mf.columns
             if not _is_internal(c) and c != "__cluster_id__"
         ]
         if user_cols:
             return _build_golden_records_polars_native(
-                multi_df, rules, user_cols, provenance=provenance,
+                _mdf_pl(), rules, user_cols, provenance=provenance,
             )
 
     if _survivorship_active(rules):
@@ -898,15 +911,16 @@ def build_golden_records_batch(
                 _golden_df_to_rows,
                 build_survivorship_native,
             )
-            golden_df = build_survivorship_native(multi_df, rules)
+            golden_df = build_survivorship_native(_mdf_pl(), rules)
             return _golden_df_to_rows(golden_df)
 
         from goldenmatch.core.survivorship.conditions import build_resolution_order
         from goldenmatch.core.survivorship.resolve import resolve_cluster
+        _s_pl = _mdf_pl()
         s_sorted = (
-            multi_df.sort(["__cluster_id__", "__row_id__"])
-            if "__row_id__" in multi_df.columns
-            else multi_df.sort("__cluster_id__")
+            _s_pl.sort(["__cluster_id__", "__row_id__"])
+            if "__row_id__" in _s_pl.columns
+            else _s_pl.sort("__cluster_id__")
         )
         s_user_cols = [c for c in s_sorted.columns if not _is_internal(c) and c != "__cluster_id__"]
         order = build_resolution_order(rules.field_rules, rules.field_groups, s_user_cols)
@@ -923,22 +937,27 @@ def build_golden_records_batch(
             s_results.append(rec)
         return s_results
 
-    sorted_df = multi_df.sort("__cluster_id__")
-    sizes = (
-        sorted_df.lazy()
-        .group_by("__cluster_id__", maintain_order=True)
-        .agg(pl.len().alias("__size__"))
-        .collect()
-    )
-    cluster_ids = sizes["__cluster_id__"].to_list()
-    size_list = sizes["__size__"].to_list()
+    # A9: seam-native (the D5d shape). Seam sort is stable maintain_order
+    # (a deterministic refinement of the old plain sort -- the D5d-accepted
+    # delta); run_lengths on the key-sorted frame == the old maintain_order
+    # agg; per-run cluster ids come from the run offsets.
+    sorted_frame = _mf.sort(["__cluster_id__"])
+    size_list = sorted_frame.run_lengths("__cluster_id__")
+    _cid_all = sorted_frame.column("__cluster_id__").to_list()
+    cluster_ids = []
+    _off = 0
+    for _sz in size_list:
+        cluster_ids.append(_cid_all[_off])
+        _off += _sz
 
-    user_cols = [c for c in sorted_df.columns if not _is_internal(c) and c != "__cluster_id__"]
-    col_arrays: dict[str, list] = {col: sorted_df[col].to_list() for col in user_cols}
-    has_source = "__source__" in sorted_df.columns
-    source_array = sorted_df["__source__"].to_list() if has_source else None
-    has_row_id = "__row_id__" in sorted_df.columns
-    row_id_array = sorted_df["__row_id__"].to_list() if has_row_id else None
+    user_cols = [c for c in sorted_frame.columns if not _is_internal(c) and c != "__cluster_id__"]
+    col_arrays: dict[str, list] = {
+        col: sorted_frame.column(col).to_list() for col in user_cols
+    }
+    has_source = "__source__" in sorted_frame.columns
+    source_array = sorted_frame.column("__source__").to_list() if has_source else None
+    has_row_id = "__row_id__" in sorted_frame.columns
+    row_id_array = sorted_frame.column("__row_id__").to_list() if has_row_id else None
 
     # Lazy-load date columns when actually needed by a rule. Most workloads
     # use the default ``most_complete`` strategy and never reach this branch.
@@ -991,9 +1010,9 @@ def build_golden_records_batch(
                 sources = source_array[offset:offset + size]
             elif field_rule.strategy == "most_recent" and field_rule.date_column:
                 date_col = field_rule.date_column
-                if date_col in sorted_df.columns:
+                if date_col in sorted_frame.columns:
                     if date_col not in date_arrays:
-                        date_arrays[date_col] = sorted_df[date_col].to_list()
+                        date_arrays[date_col] = sorted_frame.column(date_col).to_list()
                     dates = date_arrays[date_col][offset:offset + size]
             if quality_scores is not None and row_id_array is not None:
                 weights = [

--- a/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_cluster.py
@@ -74,11 +74,14 @@ def llm_cluster_pairs(
 
     # Prepare row lookup
     row_lookup = {}
-    for row in df.to_dicts():
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    for row in _fa8.select_dicts(list(_fa8.columns)):
         row_lookup[row["__row_id__"]] = row
 
     # Determine display columns
-    display_cols = [c for c in df.columns if not c.startswith("__")][:6]
+    display_cols = [c for c in _fa8.columns if not c.startswith("__")][:6]
 
     # Process each component
     provider = config.provider

--- a/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/llm_scorer.py
@@ -185,9 +185,12 @@ def llm_score_pairs(
         model = "gpt-4o-mini" if provider == "openai" else "claude-haiku-4-5-20251001"
 
     # Build row lookup
-    cols = display_columns or [c for c in df.columns if not c.startswith("__")]
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    cols = display_columns or [c for c in _fa8.columns if not c.startswith("__")]
     row_lookup: dict[int, dict] = {}
-    for row in df.select(["__row_id__"] + cols).to_dicts():
+    for row in _fa8.select_dicts(["__row_id__"] + cols):
         row_lookup[row["__row_id__"]] = row
 
     # Classify pairs into tiers

--- a/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
+++ b/packages/python/goldenmatch/goldenmatch/core/memory/corrections.py
@@ -6,7 +6,6 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from goldenmatch._polars_lazy import pl
 from goldenmatch.core.memory.store import Correction, _canon_pair
 
 if TYPE_CHECKING:
@@ -51,16 +50,19 @@ class CorrectionStats:
         return True
 
 
-def build_row_lookup(df: pl.DataFrame, fields: list[str]) -> dict[int, tuple]:
+def build_row_lookup(df, fields: list[str]) -> dict[int, tuple]:
     """Build row ID to field values lookup once for all pairs."""
-    available = [f for f in fields if f in df.columns]
-    if "__row_id__" not in df.columns:
+    from goldenmatch.core.frame import to_frame
+
+    _f = to_frame(df)
+    available = [f for f in fields if f in _f.columns]
+    if "__row_id__" not in _f.columns:
         log.warning("DataFrame missing __row_id__ column, corrections cannot be applied")
         return {}
     if not available:
         log.warning("No matchkey fields found in DataFrame: %s", fields)
         return {}
-    rows = df.select(["__row_id__"] + available).to_dicts()
+    rows = _f.select_dicts(["__row_id__"] + available)
     return {r["__row_id__"]: tuple(r[f] for f in available) for r in rows}
 
 
@@ -70,48 +72,59 @@ def compute_field_hash(row_a_vals: tuple, row_b_vals: tuple) -> str:
     return hashlib.sha256(combined.encode()).hexdigest()[:16]
 
 
-def compute_record_hash(df: pl.DataFrame, row_id: int) -> str:
+def compute_record_hash(df, row_id: int) -> str:
     """Hash content fields (sorted by name) for entity identity check.
 
     Excludes ``__row_id__`` so two runs over the same content produce the
-    same hash even if row order changes.
+    same hash even if row order changes. A4: dual-rep via the seam; the
+    ``str(v)``-over-raw-values format is the PERSISTED contract -- do not
+    change it (stored corrections re-anchor against it).
     """
-    filtered = df.filter(pl.col("__row_id__") == row_id)
-    if filtered.is_empty():
+    from goldenmatch.core.frame import to_frame
+
+    _f = to_frame(df)
+    filtered = _f.filter_in("__row_id__", [row_id])
+    if filtered.height == 0:
         log.warning("Row ID %d not found in DataFrame, returning empty hash", row_id)
         return ""
-    content_cols = sorted(c for c in df.columns if c != "__row_id__")
-    row = filtered.select(content_cols).row(0)
-    return hashlib.sha256("|".join(str(v) for v in row).encode()).hexdigest()[:16]
+    content_cols = sorted(c for c in _f.columns if c != "__row_id__")
+    row = filtered.select_dicts(content_cols)[0]
+    return hashlib.sha256(
+        "|".join(str(row[c]) for c in content_cols).encode()
+    ).hexdigest()[:16]
 
 
-def _build_hash_to_rids(df: pl.DataFrame) -> dict[str, list[int]]:
-    """Vectorized record_hash to [row_ids] map."""
-    sorted_cols = sorted(c for c in df.columns if c != "__row_id__")
-    hashed = df.select(
-        pl.col("__row_id__"),
-        pl.concat_str(
-            [pl.col(c).cast(pl.Utf8) for c in sorted_cols],
-            separator="|",
-        )
-        .map_elements(
-            lambda s: hashlib.sha256(s.encode()).hexdigest()[:16],
-            return_dtype=pl.Utf8,
-        )
-        .alias("__rec_hash__"),
-    )
+def _build_hash_to_rids(df) -> dict[str, list[int]]:
+    """record_hash to [row_ids] map (A4: dual-rep via the seam).
+
+    Format contract (PERSISTED in memory stores -- byte-stable): per-column
+    polars-Utf8-cast strings (the seam's ``cast_str`` pins those semantics
+    on both lanes, incl. the float formatter), "|"-joined, sha256[:16].
+    Rows with ANY null value hash to ``None`` (the old ``concat_str``
+    null-propagation + ``map_elements`` null skip) and land under the
+    ``None`` key exactly as before -- their rids still count as present.
+    """
+    from goldenmatch.core.frame import to_frame
+
+    _f = to_frame(df)
+    sorted_cols = sorted(c for c in _f.columns if c != "__row_id__")
+    rids = _f.column("__row_id__").to_list()
+    col_vals = [_f.column(c).cast_str().to_list() for c in sorted_cols]
     out: dict[str, list[int]] = {}
-    for rid, h in zip(
-        hashed["__row_id__"].to_list(), hashed["__rec_hash__"].to_list()
-    ):
-        out.setdefault(h, []).append(int(rid))
+    for i, rid in enumerate(rids):
+        parts = [cv[i] for cv in col_vals]
+        if any(p is None for p in parts):
+            h = None
+        else:
+            h = hashlib.sha256("|".join(parts).encode()).hexdigest()[:16]
+        out.setdefault(h, []).append(int(rid))  # type: ignore[arg-type]
     return out
 
 
 def apply_corrections(
     scored_pairs: list[tuple[int, int, float]],
     store: MemoryStore,
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table (A4: dual-rep via the seam)
     matchkey_fields: list[str],
     dataset: str | None = None,
     reanchor: bool = True,
@@ -129,7 +142,9 @@ def apply_corrections(
     if not all_corrections:
         return scored_pairs, stats
 
-    if "__row_id__" not in df.columns:
+    from goldenmatch.core.frame import to_frame as _tf_a4
+
+    if "__row_id__" not in _tf_a4(df).columns:
         log.warning("DataFrame missing __row_id__ column, corrections cannot be applied")
         return scored_pairs, stats
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2660,16 +2660,15 @@ def _run_dedupe_pipeline(
     _tp_plan = getattr(config, "_throughput_plan", None)
     if _tp_plan is not None and getattr(_tp_plan, "verify_mode", "full") == "sketch_distance":
         import numpy as _np_tp
-        import polars as _pl_tp
 
         from goldenmatch.core import throughput_verify as _tv
 
         # all_ids is built in Step 4 below but we need it now for the remap.
         # Derive it early; Step 4 will re-derive from the same collected_df.
-        # W-7 (TRANSITIONAL): the sketch tier is a polars-local block
-        # (imports _pl_tp); bridge the Frame lane's table once here.
-        _tp_src = _as_polars_df(collected_df)
-        _tp_all_ids = _tp_src["__row_id__"].to_list()
+        # A7: the sketch tier reads via the seam (the minhash/simhash
+        # kernels are representation-free over text lists) -- no bridge.
+        _tp_src = _tf_d2s(collected_df)
+        _tp_all_ids = _tp_src.column("__row_id__").to_list()
 
         _tp_blocking = config.blocking
         _tp_strategy = getattr(_tp_blocking, "strategy", "lsh") if _tp_blocking else "lsh"
@@ -2695,7 +2694,7 @@ def _run_dedupe_pipeline(
             else:
                 _tp_col = _tp_sc.column or _tp_src.columns[0]
                 _tp_texts = (
-                    _tp_src[_tp_col].cast(_pl_tp.Utf8).fill_null("").to_list()
+                    _tp_src.column(_tp_col).cast_str().fill_null("").to_list()
                 )
                 try:
                     from goldenmatch.core.embedder import get_embedder as _get_embedder
@@ -2756,8 +2755,10 @@ def _run_dedupe_pipeline(
             else:
                 # Fallback: pick first string-ish column
                 _tp_str_cols = [
-                    c for c, dt in _tp_src.schema.items()
-                    if dt in (_pl_tp.Utf8, _pl_tp.String) and not c.startswith("__")
+                    c
+                    for c in _tp_src.columns
+                    if not c.startswith("__")
+                    and _tp_src.column(c).semantic_dtype() == "text"
                 ]
                 _tp_col = _tp_str_cols[0] if _tp_str_cols else _tp_src.columns[0]
                 _tp_mode = "char"
@@ -2766,7 +2767,7 @@ def _run_dedupe_pipeline(
                 _tp_lsh_seed = 0
 
             _tp_texts = (
-                collected_df[_tp_col].cast(_pl_tp.Utf8).fill_null("").to_list()
+                _tp_src.column(_tp_col).cast_str().fill_null("").to_list()
             )
             from goldenmatch.core.lsh_blocker import MinHashLSHBlocker as _MinHashLSHBlocker
             _tp_n_bands = _tp_plan.sketch_bands or 20

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -644,9 +644,8 @@ def _apply_postflight(
     no ``_preflight_report`` — i.e. the caller did not go through
     ``auto_configure_df``.
     """
-    # W-5 widening (TRANSITIONAL): postflight reads score histograms off a
-    # polars frame; bridge at entry (D6 prerequisite).
-    df = _as_polars_df(df)
+    # A3: postflight's inputs are the pair-score list + config (no frame
+    # reads survive in its body) -- no bridge.
     from goldenmatch.core.autoconfig_verify import (
         PreflightReport as _PfR,
     )
@@ -685,11 +684,7 @@ def _run_auto_suggest(df: pl.DataFrame, config: GoldenMatchConfig) -> None:
     if not config.blocking or not config.blocking.auto_suggest:
         return
 
-    # W-5 widening (TRANSITIONAL): the block analyzer takes polars; bridge
-    # the Frame lane's pa.Table at entry. W3d seamed its reductions -- the
-    # deep entry port rides the analyzer's own batch (D6 prerequisite).
-    df = _as_polars_df(df)
-
+    # A3: the analyzer is seam-driven dual-rep -- no bridge.
     matchkey_columns = _extract_matchkey_columns(config)
     if not matchkey_columns:
         return

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -353,10 +353,10 @@ def _resolve_identities(
     if not config.identity or not config.identity.enabled:
         return None
 
-    # W-4 widening (TRANSITIONAL): identity internals are polars-heavy
-    # (schema-aligned concat, incremental mini-frames) -- bridge the Frame
-    # lane's pa.Table at entry. The deep identity port is a D6 prerequisite.
-    df = _as_polars_df(df)
+    # A5: the batch dedupe path (resolve_clusters payload reads) is
+    # dual-rep; the incremental match_record mini-frame machinery stays
+    # polars (reached only via the identity APIs, which receive polars).
+    # The Ray-distributed branch bridges below (its own tier).
 
     # Phase 6: distributed dispatch when clusters is a Ray Dataset.
     try:
@@ -384,7 +384,7 @@ def _resolve_identities(
             )
             mk_name = matchkeys[0].name if matchkeys else None
             summary = resolve_identities_distributed(
-                clusters, df, scored_pairs, mk_name,
+                clusters, _as_polars_df(df), scored_pairs, mk_name,
                 dsn=config.identity.connection,
                 run_name=run_name,
                 dataset=config.identity.dataset,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -554,9 +554,8 @@ def _apply_memory_post(
     """Apply stored corrections to scored pairs. Returns (pairs, stats|None)."""
     if memory_store is None or config.memory is None:
         return all_pairs, None
-    # W-4 widening (TRANSITIONAL): apply_corrections' record-hash builder is
-    # a polars expr chain -- bridge at entry; deep port is a D6 prerequisite.
-    df = _as_polars_df(df)
+    # A4: apply_corrections is dual-rep (seam reads; hash format contract
+    # preserved byte-stable) -- no bridge.
     try:
         from goldenmatch.core.memory.corrections import apply_corrections
         # f.field is Optional[str] at schema level but is non-None for every

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -456,9 +456,15 @@ def _apply_domain_extraction(
         return combined_lf
 
     from goldenmatch.core.domain import detect_domain, extract_features
+    from goldenmatch.core.frame import to_frame as _tf_dom_p
 
-    combined_df_tmp = combined_lf.collect()
-    user_cols = [c for c in combined_df_tmp.columns if not c.startswith("__")]
+    # A6: dual-rep -- accepts a LazyFrame (classic), eager native, or seam
+    # Frame; the extractors are seam-driven and preserve the caller's lane.
+    _was_lazy = isinstance(combined_lf, pl.LazyFrame)
+    combined_df_tmp = combined_lf.collect() if _was_lazy else _tf_dom_p(combined_lf).native
+    user_cols = [
+        c for c in _tf_dom_p(combined_df_tmp).columns if not c.startswith("__")
+    ]
 
     if domain_cfg.mode == "auto" or domain_cfg.mode is None:
         domain_profile = detect_domain(user_cols)
@@ -509,7 +515,7 @@ def _apply_domain_extraction(
             len(extractions), len(low_conf_ids),
         )
 
-    return combined_df_tmp.lazy()
+    return combined_df_tmp.lazy() if _was_lazy else combined_df_tmp
 
 
 def _apply_memory_pre(memory_store: Any, config: GoldenMatchConfig, matchkeys: list) -> None:
@@ -1108,8 +1114,8 @@ def _semantic_name_column(
 
 def _semantic_blocking_pairs(
     config: GoldenMatchConfig,
-    combined_lf: pl.LazyFrame,
-    collected_df: pl.DataFrame,
+    combined_lf: Any,  # pl.LazyFrame | seam Frame (build_blocks is dual-rep)
+    collected_df: Any,  # pl.DataFrame | pa.Table
     matchkeys: list,
     matched_pairs: set[tuple[int, int]],
     across_files_only: bool,
@@ -1152,8 +1158,10 @@ def _semantic_blocking_pairs(
         MatchkeyField,
     )
     from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.frame import to_frame as _tf_sem
 
-    name_col = _semantic_name_column(config, matchkeys, list(collected_df.columns))
+    _sem_cols = list(_tf_sem(collected_df).columns)
+    name_col = _semantic_name_column(config, matchkeys, _sem_cols)
     if name_col is None:
         logger.warning("semantic_blocking: no usable name column found; skipping")
         return []
@@ -1189,7 +1197,7 @@ def _semantic_blocking_pairs(
     # (e.g. no standardization configured, or an upstream path that didn't
     # capture it) -- the fall back is the prior behavior, never worse.
     key_name_col = f"{_SEMANTIC_RAW_COL_PREFIX}{name_col}"
-    if key_name_col not in collected_df.columns:
+    if key_name_col not in _sem_cols:
         key_name_col = name_col
 
     out: list[tuple[int, int, float]] = []
@@ -1817,15 +1825,9 @@ def _run_dedupe_pipeline(
                     )
 
         if config.domain and config.domain.enabled:
-            # W-7 (TRANSITIONAL): domain extraction is a polars-lazy stage;
-            # round-trip through the bridge in classic order (post-standardize,
-            # pre-matchkeys is satisfied: matchkeys derive below on _frame).
+            # A6: domain extraction is seam-driven dual-rep -- lane preserved.
             with stage("domain_extraction"):
-                _frame = _tf_lane(
-                    _apply_domain_extraction(
-                        _as_polars_df(_frame.native).lazy(), config
-                    ).collect().to_arrow()
-                )
+                _frame = _tf_lane(_apply_domain_extraction(_frame.native, config))
 
         with stage("precompute_matchkey_transforms"):
             collected_frame = precompute_matchkey_transforms_frame(_frame, matchkeys)
@@ -2562,15 +2564,10 @@ def _run_dedupe_pipeline(
                 "semantic_blocking is incompatible with COLUMNAR_PIPELINE"
             )
         with stage("semantic_blocking"):
-            # W-7 (TRANSITIONAL): semantic sources read polars; bridge both
-            # handles on the Frame lane (combined_lf is the Frame there).
-            _sem_lf = (
-                combined_lf
-                if isinstance(combined_lf, pl.LazyFrame)
-                else _as_polars_df(collected_df).lazy()
-            )
+            # A6: the semantic sources are dual-rep (build_blocks + seam
+            # column reads) -- both handles pass through on the caller's lane.
             _semantic_pairs = _semantic_blocking_pairs(
-                config, _sem_lf, _as_polars_df(collected_df), matchkeys,
+                config, combined_lf, collected_df, matchkeys,
                 matched_pairs, across_files_only,
                 source_lookup if across_files_only else None,
             )

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -440,9 +440,9 @@ def _cast_user_cols_to_str(df: pl.DataFrame) -> pl.DataFrame:
 
 
 def _apply_domain_extraction(
-    combined_lf: pl.LazyFrame,
+    combined_lf: Any,  # pl.LazyFrame (classic) | native frame (Frame lane)
     config: GoldenMatchConfig,
-) -> pl.LazyFrame:
+) -> Any:
     """Run domain feature extraction if configured.
 
     Materializes derived columns (``__title_key__``, ``__brand__``,
@@ -1772,8 +1772,17 @@ def _run_dedupe_pipeline(
 
         if config.validation and config.validation.rules:
             with stage("validation"):
+                _v_rules = [
+                    ValidationRule(
+                        column=rc.column,
+                        rule_type=rc.rule_type,
+                        params=rc.params,
+                        action=rc.action,
+                    )
+                    for rc in config.validation.rules
+                ]
                 _valid_native, quarantine_df, _val_report = validate_dataframe(
-                    _frame.native, config.validation.rules
+                    _frame.native, _v_rules
                 )
                 logger.info(
                     "Validation: %d quarantined rows",

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1754,12 +1754,12 @@ def _run_dedupe_pipeline(
         if config.transform is None or config.transform.mode != "disabled":
             from goldenmatch.core.transform import run_transform
             with stage("pipeline_prep_transform"):
-                _pl_tmp, tf_fixes = run_transform(
-                    _as_polars_df(_frame.native), config.transform
-                )
+                # A2: the adapter is dual-rep (lane preserved; goldenflow's
+                # auto-detect engine bridges internally at one call).
+                _t_out, tf_fixes = run_transform(_frame.native, config.transform)
                 if tf_fixes:
                     logger.info("GoldenFlow: %d transforms applied", len(tf_fixes))
-                _frame = _tf_lane(_pl_tmp.to_arrow())
+                _frame = _tf_lane(_t_out)
 
         if config.validation and config.validation.auto_fix:
             with stage("auto_fix"):

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2584,7 +2584,7 @@ def _run_dedupe_pipeline(
     # ── Step 3.3: CROSS-ENCODER RERANKING (optional) ──
     for mk in matchkeys:
         if mk.type == "weighted" and mk.rerank:
-            all_pairs = rerank_top_pairs(all_pairs, _as_polars_df(collected_df), mk)
+            all_pairs = rerank_top_pairs(all_pairs, collected_df, mk)
             break  # rerank once with the first rerank-enabled matchkey
 
     # ── Step 3.4: LLM SCORER (optional) ──
@@ -2598,7 +2598,7 @@ def _run_dedupe_pipeline(
             # purpose (cluster-mode cost stays None for this task).
             from goldenmatch.core.llm_cluster import llm_cluster_pairs
             all_pairs = _unwrap_llm_pairs(
-                llm_cluster_pairs(all_pairs, _as_polars_df(collected_df), config=config.llm_scorer)
+                llm_cluster_pairs(all_pairs, collected_df, config=config.llm_scorer)
             )
         else:
             from goldenmatch.core.llm_scorer import llm_score_pairs
@@ -2608,7 +2608,7 @@ def _run_dedupe_pipeline(
             _scored, llm_budget_summary = cast(
                 "tuple[list[tuple[int, int, float]], dict | None]",
                 llm_score_pairs(
-                    all_pairs, _as_polars_df(collected_df),
+                    all_pairs, collected_df,
                     config=config.llm_scorer, return_budget=True,
                 ),
             )
@@ -2624,7 +2624,7 @@ def _run_dedupe_pipeline(
                 c for c in _collected_frame.columns if not c.startswith("__")
             ]
             all_pairs = boost_accuracy(
-                all_pairs, _as_polars_df(collected_df), matchable_cols,
+                all_pairs, collected_df, matchable_cols,
                 provider=llm_provider,
                 api_key=None,  # auto-detect from env/settings
                 model_name=None,  # auto-detect

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1443,12 +1443,12 @@ def _golden_from_multi_df(
     if fused_golden_df is not None:
         return fused_golden_df, True
 
-    if not _is_pl:
-        multi_df = _as_polars_df(multi_df)
-        if not provenance_on and _polars_native_eligible(
-            golden_rules, quality_scores=quality_scores
-        ):
-            return build_golden_records_df(multi_df, golden_rules), False
+    if not _is_pl and not provenance_on and _polars_native_eligible(
+        golden_rules, quality_scores=quality_scores
+    ):
+        # Fast columnar stays polars (the W2e-3 Acero-port rejection);
+        # bridge for IT only. The batch builder below is dual-rep (A9).
+        return build_golden_records_df(_as_polars_df(multi_df), golden_rules), False
 
     golden_records = build_golden_records_batch(
         multi_df,
@@ -3306,10 +3306,9 @@ def _run_dedupe_pipeline(
                             golden_records = []
                             golden_fused_used = True
                         else:
-                            # Deep-D2 decline path: bridge, then replay the
-                            # polars demux (fast columnar when eligible) so
-                            # the Frame lane stays byte-identical to classic.
-                            multi_df = _as_polars_df(multi_df)
+                            # A9: the batch builder is dual-rep -- only the
+                            # fast columnar replay still bridges (W2e-3
+                            # Acero-port rejection).
                             if (
                                 not _provenance_on
                                 and _polars_native_eligible(
@@ -3318,7 +3317,7 @@ def _run_dedupe_pipeline(
                             ):
                                 with stage("golden_build_records_df_fast"):
                                     golden_df = build_golden_records_df(
-                                        multi_df, golden_rules
+                                        _as_polars_df(multi_df), golden_rules
                                     )
                                 golden_records = []
                             else:

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1743,12 +1743,13 @@ def _run_dedupe_pipeline(
         if config.quality is None or config.quality.mode != "disabled":
             from goldenmatch.core.quality import run_quality_check
             with stage("pipeline_prep_quality_scan"):
-                _pl_tmp, gc_fixes = run_quality_check(
-                    _as_polars_df(_frame.native), config.quality
-                )
+                # A1: goldencheck's scan is arrow-native (its 3.x Arrow
+                # Flip) -- hand the table straight through; the fix engine
+                # bridges internally ONLY when the scan found something.
+                _q_out, gc_fixes = run_quality_check(_frame.native, config.quality)
                 if gc_fixes:
                     logger.info("GoldenCheck: %d fixes applied", len(gc_fixes))
-                _frame = _tf_lane(_pl_tmp.to_arrow())
+                _frame = _tf_lane(_q_out)
 
         if config.transform is None or config.transform.mode != "disabled":
             from goldenmatch.core.transform import run_transform

--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -10,13 +10,17 @@ from goldenmatch._polars_lazy import pl
 logger = logging.getLogger(__name__)
 
 
-def _scan_findings(df: pl.DataFrame, domain: str | None):
+def _scan_findings(df, domain: str | None):
     """Run the goldencheck scan and confidence-downgrade pass.
+
+    A1 (arrow-native endgame): ``df`` may be a ``pa.Table`` -- goldencheck
+    3.x's ``scan_dataframe`` accepts it NATIVELY (its own Arrow Flip), so
+    the Frame lane's scan runs polars-free end to end. The temp-CSV
+    fallback (older goldencheck) bridges to polars for write_csv only.
 
     Prefers the in-memory `scan_dataframe` entry point (added 2026-05-28
     to skip the write_csv/read_csv round-trip that was 121s of the 10M
-    pipeline_prep_quality_scan wall). Falls back to the temp-CSV path
-    when an older goldencheck is installed.
+    pipeline_prep_quality_scan wall).
     """
     from goldencheck.engine.confidence import apply_confidence_downgrade
 
@@ -26,10 +30,20 @@ def _scan_findings(df: pl.DataFrame, domain: str | None):
         scan_dataframe = None  # type: ignore[assignment]
 
     if scan_dataframe is not None:
-        findings, _ = scan_dataframe(df, domain=domain)
+        try:
+            findings, _ = scan_dataframe(df, domain=domain)
+        except Exception:
+            if isinstance(df, pl.DataFrame):
+                raise
+            # Installed goldencheck predates its Arrow Flip (scan_dataframe
+            # is polars-only there): bridge and retry. Floor bumps to
+            # goldencheck>=3.0 remove this at D6.
+            findings, _ = scan_dataframe(pl.from_arrow(df), domain=domain)
         return apply_confidence_downgrade(findings, llm_boost=False)
 
     from goldencheck.engine.scanner import scan_file
+    if not isinstance(df, pl.DataFrame):  # legacy goldencheck: polars csv path
+        df = pl.from_arrow(df)  # type: ignore[assignment]
     with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
         df.write_csv(tmp.name)
         tmp_path = Path(tmp.name)
@@ -202,9 +216,9 @@ def row_quality_floor(
 
 
 def run_quality_check(
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table (A1: scan arrow-native; lane preserved)
     config=None,
-) -> tuple[pl.DataFrame, list[dict]]:
+) -> tuple:
     """Run GoldenCheck scan + fix if available.
 
     Returns (fixed_df, list_of_fixes) matching autofix format.
@@ -236,10 +250,10 @@ def run_quality_check(
 
 
 def _scan_only(
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table (scan is arrow-native; passthrough return)
     mode: str,
     domain: str | None,
-) -> tuple[pl.DataFrame, list[dict]]:
+) -> tuple:
     """Run GoldenCheck scan without fixes. Reports findings."""
     from goldencheck.models.finding import Severity
 
@@ -285,18 +299,31 @@ def _scan_only(
 
 
 def _scan_and_fix(
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table
     mode: str,
     fix_mode: str,
     domain: str | None,
-) -> tuple[pl.DataFrame, list[dict]]:
-    """Run GoldenCheck scan + apply fixes."""
+) -> tuple:
+    """Run GoldenCheck scan + apply fixes.
+
+    A1: the SCAN runs arrow-native on a pa.Table; ``apply_fixes`` is the
+    single remaining polars surface in goldencheck's fix engine, so the
+    bridge narrows to exactly that call -- and only when the scan found
+    anything (a clean frame stays polars-free). goldencheck-side arrow
+    port of apply_fixes is filed in the endgame plan.
+    """
     from goldencheck.engine.fixer import apply_fixes
 
     findings = _scan_findings(df, domain=domain)
 
-    # Apply fixes
-    fixed_df, report = apply_fixes(df, findings, mode=fix_mode)
+    if not findings and not isinstance(df, pl.DataFrame):
+        return df, []
+
+    # Apply fixes (polars surface; bridge the table here only)
+    _df_pl = df if isinstance(df, pl.DataFrame) else pl.from_arrow(df)
+    fixed_df, report = apply_fixes(_df_pl, findings, mode=fix_mode)
+    if not isinstance(df, pl.DataFrame):
+        fixed_df = fixed_df.to_arrow()  # stay on the caller's lane
 
     # Convert to autofix-compatible format
     fixes = []

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1586,7 +1586,7 @@ def score_blocks_parallel(
 
 def rerank_top_pairs(
     pairs: list[tuple[int, int, float]],
-    df,  # pl.DataFrame | pa.Table (A8: seam reads)
+    df: Any,  # pl.DataFrame | pa.Table (A8: seam reads)
     mk: MatchkeyConfig,
 ) -> list[tuple[int, int, float]]:
     """Re-score borderline pairs with a pre-trained cross-encoder.

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1586,7 +1586,7 @@ def score_blocks_parallel(
 
 def rerank_top_pairs(
     pairs: list[tuple[int, int, float]],
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table (A8: seam reads)
     mk: MatchkeyConfig,
 ) -> list[tuple[int, int, float]]:
     """Re-score borderline pairs with a pre-trained cross-encoder.
@@ -1626,9 +1626,12 @@ def rerank_top_pairs(
         return pairs
 
     # Build row lookup for serialization
-    matchable_cols = [c for c in df.columns if not c.startswith("__")]
+    from goldenmatch.core.frame import to_frame as _tf_a8
+
+    _fa8 = _tf_a8(df)
+    matchable_cols = [c for c in _fa8.columns if not c.startswith("__")]
     row_lookup: dict[int, dict] = {}
-    for row in df.select(["__row_id__"] + matchable_cols).to_dicts():
+    for row in _fa8.select_dicts(["__row_id__"] + matchable_cols):
         row_lookup[row["__row_id__"]] = row
 
     # Serialize borderline pairs

--- a/packages/python/goldenmatch/goldenmatch/core/transform.py
+++ b/packages/python/goldenmatch/goldenmatch/core/transform.py
@@ -25,11 +25,11 @@ def _do_transform(df: pl.DataFrame):
 
 
 def run_transform(
-    df: pl.DataFrame,
+    df,  # pl.DataFrame | pa.Table (A2: lane preserved; bridge at _do_transform)
     config=None,
     *,
     strict: bool = False,
-) -> tuple[pl.DataFrame, list[dict]]:
+) -> tuple:
     """Run GoldenFlow transform if available.
 
     Returns (transformed_df, list_of_fixes) matching autofix format.
@@ -68,41 +68,63 @@ def run_transform(
     # unchanged after, so a record_hash column with exclude_columns=
     # ['record_hash'] passes through verbatim even when GoldenFlow has a
     # lowercase/strip rule for it. Column order is preserved.
+    # A2 (arrow-native endgame): the adapter is dual-rep. Exclusion strip /
+    # re-attach runs on the CALLER'S lane via the seam; the single remaining
+    # polars surface is goldenflow's zero-config auto-detect engine
+    # (transform_df), bridged around _do_transform only. goldenflow's
+    # polars-free columnar `transform` needs an explicit covered config +
+    # arrow auto-detect -- filed in the endgame plan.
+    from goldenmatch.core.frame import to_frame as _tf_a2
+
+    _in_frame = _tf_a2(df)
+    _is_pl_in = isinstance(df, pl.DataFrame)
+
     excluded_set: set[str] = set()
     try:
         from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
         runtime_excl = _RUNTIME_EXCLUDE_COLUMNS.get()
         if runtime_excl:
-            excluded_set = {c for c in runtime_excl if c in df.columns}
+            excluded_set = {c for c in runtime_excl if c in _in_frame.columns}
     except Exception:
         # ContextVar lookup is best-effort; pipeline never blocks on it.
         excluded_set = set()
 
-    original_columns = df.columns
-    preserved_df: pl.DataFrame | None = None
+    original_columns = list(_in_frame.columns)
+    preserved_frame = None
     if excluded_set:
-        preserved_df = df.select(list(excluded_set))
-        df = df.drop(list(excluded_set))
-        if preserved_df.width > 0:
+        preserved_frame = _in_frame.select(list(excluded_set))
+        _in_frame = _in_frame.drop(list(excluded_set))
+        if len(preserved_frame.columns) > 0:
             logger.debug(
                 "GoldenFlow: %d column(s) skipped via exclude_columns: %s",
                 len(excluded_set), sorted(excluded_set),
             )
 
+    def _restore(frame):
+        if preserved_frame is None or not preserved_frame.columns:
+            return frame
+        out = frame
+        for c in preserved_frame.columns:
+            out = out.with_column(c, preserved_frame.column(c))
+        return out.select(original_columns)
+
     try:
-        result = _do_transform(df)
+        _bridge_df = (
+            _in_frame.native if _is_pl_in else pl.from_arrow(_in_frame.native)
+        )
+        result = _do_transform(_bridge_df)
     except Exception:
         logger.warning("GoldenFlow: transform failed, skipping", exc_info=True)
         if strict:
             raise
-        # Restore preserved columns to the input df before returning.
-        if preserved_df is not None and preserved_df.width > 0:
-            df = df.hstack(preserved_df).select(original_columns)
-        return df, []
+        # Restore preserved columns to the input frame before returning.
+        return _restore(_in_frame).native, []
 
-    # Re-attach preserved columns and restore the original column order.
-    if preserved_df is not None and preserved_df.width > 0:
-        result.df = result.df.hstack(preserved_df).select(original_columns)
+    # Re-attach preserved columns and restore order on the caller's lane.
+    _res_frame = _tf_a2(
+        result.df if _is_pl_in else result.df.to_arrow()
+    )
+    _res_frame = _restore(_res_frame)
 
     # Convert manifest to autofix-compatible format
     fixes = []
@@ -127,7 +149,7 @@ def run_transform(
     elif mode == "announced":
         logger.info("GoldenFlow: no transforms needed")
 
-    return result.df, fixes
+    return _res_frame.native, fixes
 
 
 def build_transform(column: str, op: str):

--- a/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py
@@ -82,8 +82,13 @@ def _is_unbatchable_dtype(dtype: pl.DataType) -> bool:
     return False
 
 
-def canonicalize_records_df(df: pl.DataFrame):
+def canonicalize_records_df(df):
     """Return ``(batch_df_or_None, fallback_mask)``.
+
+    A5 NOTE: accepts a pa.Table via an entry bridge -- the dtype-driven
+    canonicalization below implements the cross-surface :h1: fingerprint
+    contract; its arrow port is a dedicated batch (A5b in the endgame
+    plan) with the fingerprint parity corpus as the gate.
 
     ``batch_df`` is a canonicalized frame (clean Int64/finite-Float64/Bool/Utf8
     /typed-Null) restricted to the fully-batchable rows, in ORIGINAL row order,
@@ -94,6 +99,8 @@ def canonicalize_records_df(df: pl.DataFrame):
     un-batchable dtype is present -- that column is in every row's hash, so no
     row can be batched.
     """
+    if not isinstance(df, pl.DataFrame):  # A5b entry bridge (see docstring)
+        df = pl.from_arrow(df)
     height = df.height
     # Drop __-prefixed columns (both kernels + per-row payload exclude them).
     keep_cols = [c for c in df.columns if not c.startswith("__")]
@@ -160,7 +167,7 @@ def canonicalize_records_df(df: pl.DataFrame):
     return batch_df, mask_list
 
 
-def batch_fingerprints(df: pl.DataFrame) -> list[str | None]:
+def batch_fingerprints(df) -> list[str | None]:
     """One fingerprint per row of ``df``, in row order. ``None`` for a row the
     canonical spec can't fingerprint (caller falls back to the legacy id).
 
@@ -172,6 +179,8 @@ def batch_fingerprints(df: pl.DataFrame) -> list[str | None]:
         record_fingerprints_batch_arrow,
     )
 
+    if not isinstance(df, pl.DataFrame):  # A5b entry bridge (see canonicalize)
+        df = pl.from_arrow(df)
     out: list[str | None] = [None] * df.height
     batch_df, mask = canonicalize_records_df(df)
     if batch_df is not None and batch_df.height:

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -164,23 +164,26 @@ def derive_record_id(
 
 
 def _golden_record_from_members(
-    df: pl.DataFrame, row_ids: list[int]
+    df, row_ids: list[int]
 ) -> dict[str, Any]:
-    """Roll up cluster members into a single representative row (most-complete)."""
+    """Roll up cluster members into a single representative row (most-complete).
+
+    A5: seam-driven both lanes (column reads + Python folds).
+    """
     from goldenmatch.core.frame import to_frame
 
-    members = to_frame(df).filter_in("__row_id__", row_ids).native
-    if members.is_empty():
+    members = to_frame(df).filter_in("__row_id__", row_ids)
+    if members.height == 0:
         return {}
     out: dict[str, Any] = {}
     for col in members.columns:
         if col.startswith("__"):
             continue
-        non_null = members[col].drop_nulls()
-        if non_null.is_empty():
+        non_null = [v for v in members.column(col).to_list() if v is not None]
+        if not non_null:
             continue
         # Pick the longest non-null string representation (most-complete)
-        values = [(str(v), v) for v in non_null.to_list()]
+        values = [(str(v), v) for v in non_null]
         values.sort(key=lambda x: len(x[0]), reverse=True)
         out[col] = values[0][1]
     return out
@@ -248,7 +251,7 @@ def _frames_iter(
 
 def resolve_clusters(
     clusters: dict[int, dict] | None = None,
-    df: pl.DataFrame | None = None,
+    df: Any = None,  # pl.DataFrame | pa.Table (A5: dual-rep dedupe path)
     scored_pairs: list[tuple[int, int, float]] | None = None,
     matchkey_name: str | None = None,
     store: IdentityStore | None = None,
@@ -293,7 +296,9 @@ def resolve_clusters(
         scored_pairs = []
 
     summary = ResolveSummary()
-    if df.is_empty():
+    from goldenmatch.core.frame import to_frame as _tf_a5e
+
+    if _tf_a5e(df).height == 0:
         return summary
 
     # Iteration source: ascending-cluster_id ``(cluster_id, info)`` pairs.
@@ -314,7 +319,10 @@ def resolve_clusters(
     # canonical spec can't fingerprint fall back to the legacy json.dumps id
     # ("{source}:hash:{12}"). Run `goldenmatch identity migrate-ids` to rewrite
     # any pre-v2 ":hash:" ids in the store to their ":h1:" equivalents.
-    rows = df.to_dicts()
+    from goldenmatch.core.frame import to_frame as _tf_a5
+
+    _fa5 = _tf_a5(df)
+    rows = _fa5.select_dicts(list(_fa5.columns))
     rowid_to_recid: dict[int, str] = {}
     rowid_to_payload: dict[int, dict[str, Any]] = {}
     rowid_to_source: dict[int, str] = {}
@@ -927,9 +935,9 @@ def match_record_to_entity(
         return {}
     from goldenmatch.core.frame import to_frame
 
-    matched_rows = to_frame(df).filter_in("__row_id__", list(matches.keys())).native
+    _mframe = to_frame(df).filter_in("__row_id__", list(matches.keys()))
     rowid_to_candidates: dict[int, list[str]] = {}
-    for row in matched_rows.to_dicts():
+    for row in _mframe.select_dicts(list(_mframe.columns)):
         rid = row.get("__row_id__")
         if rid is None:
             continue

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 8,  # A1-A4, A6 (domain+semantic), A7, A8 retired
+    "core/pipeline.py": 6,  # A1-A8 + A9-slice-1 retired; rebase onto deep-D2b removed the 2 frames-path sites
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 13,  # A1/A2/A4/A7 + A8 (rerank, llm x2, boost) retired
+    "core/pipeline.py": 11,  # A1/A2/A4/A7/A8 + A3 (auto-suggest, postflight) retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 17,  # A1 quality, A2 transform, A4 memory, A7 throughput retired
+    "core/pipeline.py": 13,  # A1/A2/A4/A7 + A8 (rerank, llm x2, boost) retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -1,0 +1,34 @@
+"""Bridge-count tripwire (endgame map, cross-cutting gate).
+
+`_as_polars_df` is the polars re-entry bridge. The endgame's A-series
+retires them batch by batch; this ledger pins the EXACT count so no new
+bridge lands silently and every A-batch must shrink the number here.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+PKG = Path(__file__).parent.parent / "goldenmatch"
+
+# A-series ledger: update DOWNWARD only (see
+# docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
+EXPECTED_BRIDGE_CALLS = {
+    "core/pipeline.py": 20,  # A1 retired the quality prep bridge
+}
+
+
+def _count_calls(text: str) -> int:
+    return len(re.findall(r"_as_polars_df\(", text)) - text.count("def _as_polars_df(")
+
+
+def test_bridge_call_site_ledger():
+    found: dict[str, int] = {}
+    for py in PKG.rglob("*.py"):
+        n = _count_calls(py.read_text(encoding="utf-8"))
+        if n > 0:
+            found[py.relative_to(PKG).as_posix()] = n
+    assert found == EXPECTED_BRIDGE_CALLS, (
+        "Bridge ledger drift. If you ADDED a bridge: don't -- port via the "
+        f"seam instead. If you RETIRED one: update the ledger. Found: {found}"
+    )

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 19,  # A1 quality + A2 transform prep bridges retired
+    "core/pipeline.py": 18,  # A1 quality, A2 transform, A4 memory retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 20,  # A1 retired the quality prep bridge
+    "core/pipeline.py": 19,  # A1 quality + A2 transform prep bridges retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 18,  # A1 quality, A2 transform, A4 memory retired
+    "core/pipeline.py": 17,  # A1 quality, A2 transform, A4 memory, A7 throughput retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_bridge_ledger.py
+++ b/packages/python/goldenmatch/tests/test_bridge_ledger.py
@@ -14,7 +14,7 @@ PKG = Path(__file__).parent.parent / "goldenmatch"
 # A-series ledger: update DOWNWARD only (see
 # docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md).
 EXPECTED_BRIDGE_CALLS = {
-    "core/pipeline.py": 11,  # A1/A2/A4/A7/A8 + A3 (auto-suggest, postflight) retired
+    "core/pipeline.py": 8,  # A1-A4, A6 (domain+semantic), A7, A8 retired
 }
 
 

--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -740,10 +740,11 @@ def test_frame_lane_adaptive_golden_parity(tmp_path, monkeypatch):
     assert _norm_result(frame_lane) == _norm_result(classic)
 
 
-def test_frame_lane_semantic_bridge_called_with_polars(tmp_path, monkeypatch):
-    """W-7: semantic blocking engages the Frame lane; the sources get a
-    POLARS frame via the bridge on both lanes (no model download -- the
-    internals are stubbed; this pins the handoff types + raw capture)."""
+def test_frame_lane_semantic_gets_lane_native_handles(tmp_path, monkeypatch):
+    """A6: semantic blocking engages the Frame lane; the sources receive the
+    LANE-NATIVE handles (seam Frame + pa.Table -- no bridge; build_blocks and
+    the column reads are dual-rep). No model download -- internals stubbed;
+    pins the handoff types + the __raw__ capture."""
     import goldenmatch.core.pipeline as P
     import polars as _pl
     from goldenmatch.config.schemas import (
@@ -775,8 +776,10 @@ def test_frame_lane_semantic_bridge_called_with_polars(tmp_path, monkeypatch):
     def fake_semantic(config, combined_lf, collected_df, *a, **k):
         seen["lf_type"] = type(combined_lf).__name__
         seen["df_type"] = type(collected_df).__name__
+        from goldenmatch.core.frame import to_frame as _tf_t
+
         seen["has_raw"] = any(
-            c.startswith("__raw__") for c in collected_df.columns
+            c.startswith("__raw__") for c in _tf_t(collected_df).columns
         )
         return []
 
@@ -788,7 +791,7 @@ def test_frame_lane_semantic_bridge_called_with_polars(tmp_path, monkeypatch):
     )
     P.run_dedupe([(str(csv), "people")], cfg)
     assert hits and hits[0] is True, f"lane not engaged: {hits}"
-    assert seen["lf_type"] == "LazyFrame"
-    assert seen["df_type"] == "DataFrame"
+    assert seen["lf_type"] == "ArrowFrame"
+    assert seen["df_type"] == "Table"
     assert isinstance(_pl.DataFrame(), _pl.DataFrame)
     assert seen["has_raw"] is True


### PR DESCRIPTION
The endgame A-series (map + execution status in docs/superpowers/plans/2026-07-13-goldenmatch-arrow-native-endgame.md, committed here): the Frame lane's feature compute moves from bridged polars to arrow-native, batch by batch, with a bridge-count tripwire (tests/test_bridge_ledger.py) pinning the exact remaining call sites.

- **A1 quality**: scan runs on goldencheck's own arrow surface (pa.Table native, its 3.x Arrow Flip); bridge narrowed to apply_fixes-when-findings; version-skew fallback for an installed goldencheck predating the flip.
- **A2 transform**: adapter dual-rep, exclusions on the seam; bridge narrowed to goldenflow's auto-detect engine call.
- **A3 analyzer/postflight**: candidate transforms via the derive twins (compound keys keep concat_str null propagation); _sample_block_sizes via derive_block_key + group_len.
- **A4 memory**: MAP CORRECTION -- fingerprint-core swap was wrong (record_hash is PERSISTED; format change breaks re-anchoring). Format-preserving seam port; both hash contracts byte-stable (seam cast_str pins polars float formatting).
- **A5 identity**: dedupe path seam-native; fingerprint :h1: canonicalization scoped to A5b entry bridges (ports against the fingerprint parity corpus); Ray branch keeps its scoped bridge.
- **A6 semantic/domain**: extractors seam-native (backend-detected attach); domain dual-rep; semantic receives LANE-NATIVE handles.
- **A7 throughput**: tier-local polars import GONE; sketches on the existing Rust kernels.
- **A8 rerank/llm/boost**: text extraction via select_dicts; four bridges retired.
- **A9 slice 1**: golden batch builder dual-rep -- default slow route fully seam-native (sort + run_lengths); specialized routes scoped for the A9 remainder; decline replays hand the NATIVE to the batch builder.

Ledger: 21 -> 6 (the rebase onto deep-D2b retired the two frames-path sites the audit predicted). Wall: the full stack benched 362.88s median vs 361.51s post-flip baseline (run 29221674038) -- wall-neutral. 222-test battery + differential harness green post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW