### PR TITLE
feat(goldenmatch): A9 complete -- golden oracle seam-native, fast routes polars-present-only

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -780,6 +780,19 @@ def _polars_native_eligible(
     return True
 
 
+def _polars_importable() -> bool:
+    """True when polars is actually installed (D6 fallback gate: the fast
+    columnar + vectorized survivorship routes are polars-present WALL
+    optimizations; without polars the seam-native oracle/default routes
+    carry the load -- the spec's correct-but-slower Arrow+Python lane)."""
+    try:
+        import polars  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
 def build_golden_records_batch(
     multi_df: Any,  # pl.DataFrame | ray.data.Dataset (Phase 4)
     rules: GoldenRulesConfig,
@@ -884,7 +897,11 @@ def build_golden_records_batch(
             else pl.from_arrow(multi_df)
         )
 
-    if _polars_native_eligible(rules, quality_scores):
+    if _polars_native_eligible(rules, quality_scores) and _polars_importable():
+        # Polars-present WALL optimization (approximates most_complete
+        # confidence -- the historical contract when polars is installed).
+        # Without polars, fall through to the seam-native routes below
+        # (the spec's correct-but-slower Arrow+Python fallback lane).
         user_cols = [
             c for c in _mf.columns
             if not _is_internal(c) and c != "__cluster_id__"
@@ -906,6 +923,7 @@ def build_golden_records_batch(
             provenance is False
             and quality_scores is None
             and survivorship_native_eligible(rules, provenance)
+            and _polars_importable()
         ):
             from goldenmatch.core.survivorship.native import (
                 _golden_df_to_rows,
@@ -916,17 +934,24 @@ def build_golden_records_batch(
 
         from goldenmatch.core.survivorship.conditions import build_resolution_order
         from goldenmatch.core.survivorship.resolve import resolve_cluster
-        _s_pl = _mdf_pl()
+        # A9: seam-native oracle -- seam sort (stable; the D5d-accepted
+        # delta) + run_lengths adjacent-run slices == the old
+        # partition_by(maintain_order=True) on key-sorted input.
         s_sorted = (
-            _s_pl.sort(["__cluster_id__", "__row_id__"])
-            if "__row_id__" in _s_pl.columns
-            else _s_pl.sort("__cluster_id__")
+            _mf.sort(["__cluster_id__", "__row_id__"])
+            if "__row_id__" in _mf.columns
+            else _mf.sort(["__cluster_id__"])
         )
         s_user_cols = [c for c in s_sorted.columns if not _is_internal(c) and c != "__cluster_id__"]
         order = build_resolution_order(rules.field_rules, rules.field_groups, s_user_cols)
         s_results = []
-        for cdf in s_sorted.partition_by("__cluster_id__", maintain_order=True):
-            cid = cdf["__cluster_id__"][0]
+        _s_sizes = s_sorted.run_lengths("__cluster_id__")
+        _s_cids = s_sorted.column("__cluster_id__").to_list()
+        _s_off = 0
+        for _s_sz in _s_sizes:
+            cdf = s_sorted.slice(_s_off, _s_sz)
+            cid = _s_cids[_s_off]
+            _s_off += _s_sz
             per_scores = (cluster_pair_scores or {}).get(int(cid))
             rec, prov = resolve_cluster(cdf, rules, order, quality_scores=quality_scores,
                                         pair_scores=per_scores, provenance=provenance,

--- a/packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py
@@ -21,6 +21,8 @@ def resolve_cluster(cluster_df, rules, resolution_order, *,
                     quality_scores=None, pair_scores=None, provenance=False,
                     cluster_id=None):
     # Local import avoids any import cycle (golden imports resolve lazily).
+    # A9: seam reads -- cluster_df may be a pl.DataFrame or seam Frame slice.
+    from goldenmatch.core.frame import to_frame as _tf_a9
     from goldenmatch.core.golden import (
         ClusterProvenance,
         FieldProvenance,
@@ -29,11 +31,12 @@ def resolve_cluster(cluster_df, rules, resolution_order, *,
         merge_field,
     )
 
-    user_cols = [c for c in cluster_df.columns if not _is_internal(c) and c != "__cluster_id__"]
-    n = cluster_df.height
-    col_arrays = {c: cluster_df[c].to_list() for c in user_cols}
-    source_array = cluster_df["__source__"].to_list() if "__source__" in cluster_df.columns else None
-    row_id_array = cluster_df["__row_id__"].to_list() if "__row_id__" in cluster_df.columns else None
+    _cf = _tf_a9(cluster_df)
+    user_cols = [c for c in _cf.columns if not _is_internal(c) and c != "__cluster_id__"]
+    n = _cf.height
+    col_arrays = {c: _cf.column(c).to_list() for c in user_cols}
+    source_array = _cf.column("__source__").to_list() if "__source__" in _cf.columns else None
+    row_id_array = _cf.column("__row_id__").to_list() if "__row_id__" in _cf.columns else None
 
     # Remap pair_scores (row-id keyed) to positional indices, like build_golden_records_batch.
     positional_pair_scores = None
@@ -56,9 +59,9 @@ def resolve_cluster(cluster_df, rules, resolution_order, *,
     date_arrays: dict = {}
 
     def _dates_for(date_col):
-        if date_col and date_col in cluster_df.columns:
+        if date_col and date_col in _cf.columns:
             if date_col not in date_arrays:
-                date_arrays[date_col] = cluster_df[date_col].to_list()
+                date_arrays[date_col] = _cf.column(date_col).to_list()
             return date_arrays[date_col]
         return None
 


### PR DESCRIPTION
Completes A9 (endgame plan): the golden demux's polars compute is now OPTIONAL, not required.

- **The survivorship ORACLE is seam-native**: `resolve_cluster` reads via the seam, and the oracle route in `build_golden_records_batch` runs seam sort + `run_lengths` adjacent-run slices (== the old `partition_by(maintain_order=True)` on key-sorted input, the D5d-probed equivalence), handing seam Frame slices to the oracle. Zero polars anywhere in the oracle path.
- **The two fast routes become polars-present WALL optimizations** (`_polars_importable()` gate): the polars-native columnar builder (approximates most_complete confidence -- the historical contract when polars is installed) and the vectorized survivorship kernel route. Byte-identical behavior when polars is present; WITHOUT polars, the seam-native oracle/default routes carry the load -- the spec's correct-but-slower Arrow+Python fallback lane.
- With this, every golden path is: fused kernel (arrow+Rust) -> polars-present optimizations -> seam-native oracle. Nothing REQUIRES polars.

Batteries: golden / fused / frames-parity / survivorship (181 + 352) green; differential harness green on both lanes. (One pre-existing env-skew failure in `tests/survivorship/test_groups.py::test_infermap_smoke_real` -- goldencheck-types resolved from the main checkout's old branch; unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW