### PR TITLE
feat(goldenmatch): D6 gate -- the covered engine runs with polars ABSENT

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -377,7 +377,9 @@ def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
         # because they're real values (an explicit empty-cell in the
         # source); dropping them aggressively lost 3 records on the
         # cross-file dedupe regression suite (PR #390 fix).
-        if isinstance(lf, pl.LazyFrame):
+        from goldenmatch.core.frame import is_polars_lazyframe
+
+        if is_polars_lazyframe(lf):
             df_with_key = (
                 lf
                 .with_columns(block_key_expr)
@@ -1176,14 +1178,16 @@ def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
     # normalizes ONCE here (lossless -- polars stays a dependency until D6).
     # Only the static/adaptive primary builder is dual-rep; it receives the
     # ORIGINAL entry object so the arrow lane skips the polars round-trip.
+    from goldenmatch.core.frame import is_polars_dataframe, is_polars_lazyframe
+
     _lf_entry = lf
-    if not isinstance(lf, pl.LazyFrame):
+    if not is_polars_lazyframe(lf):
         from goldenmatch.core.frame import Frame
 
         native = lf.native if isinstance(lf, Frame) else lf
         lf = (
             native.lazy()
-            if isinstance(native, pl.DataFrame)
+            if is_polars_dataframe(native)
             else cast(pl.DataFrame, pl.from_arrow(native)).lazy()
         )
 

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -1980,7 +1980,7 @@ def build_clusters_arrow_native(
             ids_col = _cc([_pf.column("id_a"), _pf.column("id_b")]).unique()
             all_ids = [int(i) for i in ids_col.to_list()]
 
-    def _one_arr(col):
+    def _one_arr(col: Any):
         # kernel FFI takes pa.Array; the arrow lane's columns are chunked.
         a = col.to_arrow()
         if isinstance(a, _pa.ChunkedArray):

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -525,6 +525,7 @@ def build_cluster_frames(
     weak_cluster_threshold: float,
     auto_split: bool,
     split_edge_budget: int | None = None,
+    backend: str = "polars",
 ) -> ClusterFrames:
     """SP-A frames-out entry point (the default cluster-stage path).
 
@@ -544,7 +545,6 @@ def build_cluster_frames(
     ``pair_scores`` stripped, everything else byte-identical.
     """
     import numpy as _np
-    import polars as _pl
 
 
     pairs_list = list(pairs)
@@ -566,7 +566,7 @@ def build_cluster_frames(
             "score": [p[2] for p in pairs_list],
         },
         _PAIR_SPEC,
-        backend="polars",
+        backend=backend,
     ).native
     # BULK pre-split frames. Two paths, IDENTICAL output schema/shape (the SP-A
     # parity test runs both native=1 and native=0):
@@ -626,18 +626,41 @@ def build_cluster_frames(
             m_bot_b[i] = bot[1]
             m_min[i] = md["min_edge"]   # coalesced 0.0, never None
             m_avg[i] = md["avg_edge"]
-        assignments = _pl.DataFrame({"cluster_id": a_cid, "member_id": a_mid})
-        metadata = _pl.DataFrame({
-            "cluster_id": m_cid,
-            "size": m_size,
-            "confidence": m_conf,
-            "quality": _pl.Series("quality", ["strong"] * n_clusters, dtype=_pl.Utf8),
-            "oversized": m_over,
-            "bottleneck_pair_a": m_bot_a,
-            "bottleneck_pair_b": m_bot_b,
-            "min_edge": m_min,
-            "avg_edge": m_avg,
-        })
+        # D6: lane-native construction (numpy -> arrow is zero-copy).
+        if backend == "polars":
+            import polars as _pl
+
+            assignments = _pl.DataFrame({"cluster_id": a_cid, "member_id": a_mid})
+            metadata = _pl.DataFrame({
+                "cluster_id": m_cid,
+                "size": m_size,
+                "confidence": m_conf,
+                "quality": _pl.Series("quality", ["strong"] * n_clusters, dtype=_pl.Utf8),
+                "oversized": m_over,
+                "bottleneck_pair_a": m_bot_a,
+                "bottleneck_pair_b": m_bot_b,
+                "min_edge": m_min,
+                "avg_edge": m_avg,
+            })
+        else:
+            import pyarrow as _pa
+
+            assignments = _pa.table(
+                {"cluster_id": _pa.array(a_cid), "member_id": _pa.array(a_mid)}
+            )
+            metadata = _pa.table({
+                "cluster_id": _pa.array(m_cid),
+                "size": _pa.array(m_size),
+                "confidence": _pa.array(m_conf),
+                "quality": _pa.array(
+                    ["strong"] * n_clusters, type=_pa.large_string()
+                ),
+                "oversized": _pa.array(m_over),
+                "bottleneck_pair_a": _pa.array(m_bot_a),
+                "bottleneck_pair_b": _pa.array(m_bot_b),
+                "min_edge": _pa.array(m_min),
+                "avg_edge": _pa.array(m_avg),
+            })
 
     if auto_split:
         # Frames-native auto-split: the per-cluster dict (the SP1 bench loss) is
@@ -1156,15 +1179,17 @@ def _columnar_presplit(
     else:
         transient: dict[int, dict[tuple[int, int], float]] = {}
         with stage("cluster_pair_scores_fill"):
-            if not pairs_df.is_empty():
+            from goldenmatch.core.frame import to_frame as _tf_d6
+
+            if _tf_d6(pairs_df).height > 0:
                 from goldenmatch.core.frame import to_frame as _tf4
 
-                tagged = _tf4(pairs_df).map_column("id_a", "__cid__", member_to_cid).native
+                tagged = _tf4(pairs_df).map_column("id_a", "__cid__", member_to_cid)
                 for id_a, id_b, score, cid in zip(
-                    tagged["id_a"].to_list(),
-                    tagged["id_b"].to_list(),
-                    tagged["score"].to_list(),
-                    tagged["__cid__"].to_list(),
+                    tagged.column("id_a").to_list(),
+                    tagged.column("id_b").to_list(),
+                    tagged.column("score").to_list(),
+                    tagged.column("__cid__").to_list(),
                     strict=True,
                 ):
                     transient.setdefault(int(cid), {})[(id_a, id_b)] = score
@@ -1806,20 +1831,24 @@ def cluster_frames_to_dict(frames: ClusterFrames) -> dict[int, dict]:
     """
     assignments = frames.assignments
     metadata = frames.metadata
-    if assignments.is_empty():
+    from goldenmatch.core.frame import to_frame as _tf_cd
+
+    assignments = _tf_cd(assignments)
+    metadata = _tf_cd(metadata)
+    if assignments.height == 0:
         return {}
 
     # Build member lists by cluster_id from the assignments frame.
     by_cid: dict[int, list[int]] = {}
     for cid, mid in zip(
-        assignments["cluster_id"].to_list(),
-        assignments["member_id"].to_list(),
+        assignments.column("cluster_id").to_list(),
+        assignments.column("member_id").to_list(),
         strict=True,
     ):
         by_cid.setdefault(int(cid), []).append(int(mid))
 
     out: dict[int, dict] = {}
-    for row in metadata.iter_rows(named=True):
+    for row in metadata.select_dicts(list(metadata.columns)):
         cid = int(row["cluster_id"])
         bot = (row["bottleneck_pair_a"], row["bottleneck_pair_b"])
         out[cid] = {
@@ -1936,33 +1965,50 @@ def build_clusters_arrow_native(
             pairs_df, all_ids=all_ids, max_cluster_size=max_cluster_size,
         )
 
-    import polars as _pl
+    import pyarrow as _pa
 
+    from goldenmatch.core.frame import to_frame as _tf5
+
+    _pf = _tf5(pairs_df)
     if all_ids is None:
-        # Vectorized derive: concat id_a/id_b and uniq. Polars handles
-        # this without materializing a Python list.
-        if pairs_df.is_empty():
+        # Vectorized derive: concat id_a/id_b and uniq (seam; both lanes).
+        if _pf.height == 0:
             all_ids = []
         else:
             from goldenmatch.core.frame import concat_columns as _cc
-            from goldenmatch.core.frame import to_frame as _tf5
 
-            _pf = _tf5(pairs_df)
             ids_col = _cc([_pf.column("id_a"), _pf.column("id_b")]).unique()
             all_ids = [int(i) for i in ids_col.to_list()]
 
-    a_arrow = pairs_df["id_a"].to_arrow() if not pairs_df.is_empty() \
-        else _pl.Series("id_a", [], dtype=_pl.Int64).to_arrow()
-    b_arrow = pairs_df["id_b"].to_arrow() if not pairs_df.is_empty() \
-        else _pl.Series("id_b", [], dtype=_pl.Int64).to_arrow()
-    s_arrow = pairs_df["score"].to_arrow() if not pairs_df.is_empty() \
-        else _pl.Series("score", [], dtype=_pl.Float64).to_arrow()
-    all_ids_arrow = _pl.Series("__ids__", all_ids, dtype=_pl.Int64).to_arrow()
+    def _one_arr(col):
+        # kernel FFI takes pa.Array; the arrow lane's columns are chunked.
+        a = col.to_arrow()
+        if isinstance(a, _pa.ChunkedArray):
+            a = (
+                a.combine_chunks()
+                if a.num_chunks != 1
+                else a.chunk(0)
+            )
+            if isinstance(a, _pa.ChunkedArray):
+                a = a.chunk(0) if a.num_chunks else _pa.array([], type=a.type)
+        return a
+
+    if _pf.height > 0:
+        a_arrow = _one_arr(_pf.column("id_a"))
+        b_arrow = _one_arr(_pf.column("id_b"))
+        s_arrow = _one_arr(_pf.column("score"))
+    else:
+        a_arrow = _pa.array([], type=_pa.int64())
+        b_arrow = _pa.array([], type=_pa.int64())
+        s_arrow = _pa.array([], type=_pa.float64())
+    all_ids_arrow = _pa.array(all_ids, type=_pa.int64())
 
     (
         a_cid, a_mid,
         m_cid, m_size, m_conf, m_over, m_bot_a, m_bot_b, m_min, m_avg,
     ) = arrow_fn(a_arrow, b_arrow, s_arrow, all_ids_arrow, max_cluster_size)
+
+    import polars as _pl
 
     assignments = _pl.DataFrame({
         "cluster_id": _pl.from_arrow(a_cid),

--- a/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py
@@ -119,6 +119,28 @@ class ClusterPairScores:
         the accessors (built on demand, O(cluster size)). The global dict-of-dicts
         is NEVER resident.
         """
+        # D6: arrow-lane / polars-free path -- the assignments frame may be a
+        # pa.Table; delegate to the BYTE-IDENTICAL Python reference
+        # (from_pairs semantics: input order, LAST-WINS, both-endpoints-in-
+        # same-cid) via a seam-read member->cid map. The polars join below is
+        # the polars-present WALL optimization (10x at 100M pairs).
+        from goldenmatch.core.frame import is_polars_dataframe as _is_pl_df
+
+        if not _is_pl_df(assignments):
+            from goldenmatch.core.frame import to_frame as _tf
+
+            _af = _tf(assignments)
+            member_to_cid = dict(
+                zip(
+                    _af.column("member_id").to_list(),
+                    _af.column("cluster_id").to_list(),
+                )
+            )
+            fake_clusters = {}
+            for mid, cid in member_to_cid.items():
+                fake_clusters.setdefault(int(cid), {"members": []})["members"].append(mid)
+            return cls.from_pairs(all_pairs, fake_clusters)
+
         # all_pairs is the raw list[(a,b,s)] AS-GIVEN. NEVER canonicalize.
         a_col, b_col, s_col = [], [], []
         for a, b, s in all_pairs:

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -1865,6 +1865,30 @@ class ArrowFrame:
         return ArrowFrame(tbl), fixes
 
 
+def is_polars_lazyframe(obj: Any) -> bool:
+    """Import-free type guard (D6 zero-polars gate): a pl.LazyFrame can only
+    exist if polars is already imported, so an unloaded polars means False
+    without triggering the lazy proxy."""
+    import sys
+
+    if "polars" not in sys.modules:
+        return False
+    import polars as _pl
+
+    return isinstance(obj, _pl.LazyFrame)
+
+
+def is_polars_dataframe(obj: Any) -> bool:
+    """Import-free type guard (see is_polars_lazyframe)."""
+    import sys
+
+    if "polars" not in sys.modules:
+        return False
+    import polars as _pl
+
+    return isinstance(obj, _pl.DataFrame)
+
+
 def to_frame(obj: Any) -> Frame:
     """Idempotent coercion: raw ``pl.DataFrame``/``pa.Table``, a
     ``dict[str, pa.Array]`` (the fused-FFI column shape), or a ``Frame``.

--- a/packages/python/goldenmatch/goldenmatch/core/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/core/golden.py
@@ -1341,11 +1341,16 @@ def _multi_df_from_frames(
     src_frame = to_frame(source_df)
     meta = to_frame(frames.metadata)
     assign = to_frame(frames.assignments)
-    # Deep-D2b: joins are single-backend; normalize the (small) cluster
-    # frames to the SOURCE lane (zero-copy to_arrow on polars natives).
+    # Deep-D2b/D6: joins are single-backend; normalize the (small) cluster
+    # frames to the SOURCE lane in EITHER direction (zero-copy each way).
     if isinstance(src_frame, ArrowFrame) and not isinstance(meta, ArrowFrame):
         meta = ArrowFrame(frames.metadata.to_arrow())
         assign = ArrowFrame(frames.assignments.to_arrow())
+    elif not isinstance(src_frame, ArrowFrame) and isinstance(meta, ArrowFrame):
+        import polars as _pl_norm
+
+        meta = to_frame(_pl_norm.from_arrow(frames.metadata))
+        assign = to_frame(_pl_norm.from_arrow(frames.assignments))
 
     multi_cluster_ids = meta.select_eligible_clusters()
 
@@ -1424,7 +1429,7 @@ def build_golden_records_from_frames(
     from goldenmatch.core.frame import to_frame as _tf_frames
 
     _src = _tf_frames(source_df)
-    if _src.height == 0 or frames.assignments.is_empty():
+    if _src.height == 0 or _tf_frames(frames.assignments).height == 0:
         return None, []
 
     if "__row_id__" not in _src.columns:
@@ -1442,15 +1447,21 @@ def build_golden_records_from_frames(
     # batch builder's tie-breaks (first-occurrence) are order-sensitive.
     # Recomputing via the polars join is byte-identical to the classic lane
     # by construction.
-    if not isinstance(source_df, pl.DataFrame):
+    from goldenmatch.core.frame import is_polars_dataframe as _is_pl_df_g
+
+    if not _is_pl_df_g(source_df) and _polars_importable():
         from goldenmatch.core.frame import Frame
 
         _native = source_df.native if isinstance(source_df, Frame) else source_df
         source_df = pl.from_arrow(_native)  # type: ignore[assignment]
+    # Zero-polars env: proceed on the arrow join directly -- there is no
+    # polars parity target to match; the arrow join order is deterministic
+    # and the builders' winners remain valid (correct-but-different
+    # tie-breaks, the spec's fallback-lane contract).
 
     multi_df = _multi_df_from_frames(source_df, frames)
 
-    if multi_df.height == 0:
+    if _tf_frames(multi_df).height == 0:
         return None, []
 
     # Preserve the dict pipeline's fast/slow decision (pipeline.py
@@ -1459,6 +1470,7 @@ def build_golden_records_from_frames(
     fast_eligible = (
         not provenance
         and _polars_native_eligible(rules, quality_scores=quality_scores)
+        and _polars_importable()  # WALL optimization; seam batch otherwise
     )
     if fast_eligible:
         golden_df = build_golden_records_df(multi_df, rules)

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1389,11 +1389,29 @@ def _golden_records_to_df(golden_records: list[dict]) -> pl.DataFrame | None:
     all_keys: set[str] = set()
     for row in golden_rows:
         all_keys.update(row.keys())
-    schema_overrides = {
-        k: pl.Utf8 for k in all_keys
-        if k not in ("__cluster_id__", "__golden_confidence__")
-    }
-    return pl.DataFrame(golden_rows, schema_overrides=schema_overrides)
+    from goldenmatch.core.golden import _polars_importable as _pl_ok
+
+    if _pl_ok():
+        schema_overrides = {
+            k: pl.Utf8 for k in all_keys
+            if k not in ("__cluster_id__", "__golden_confidence__")
+        }
+        return pl.DataFrame(golden_rows, schema_overrides=schema_overrides)
+    # Zero-polars lane: pa.Table with python str() for the user columns
+    # (no polars formatter to match in this env; internals keep native types).
+    import pyarrow as _pa
+
+    cols: dict[str, Any] = {}
+    for k in sorted(all_keys):
+        vals = [row.get(k) for row in golden_rows]
+        if k in ("__cluster_id__", "__golden_confidence__"):
+            cols[k] = _pa.array(vals)
+        else:
+            cols[k] = _pa.array(
+                [None if v is None else str(v) for v in vals],
+                type=_pa.large_string(),
+            )
+    return _pa.table(cols)
 
 
 def _golden_from_multi_df(
@@ -1728,7 +1746,9 @@ def _run_dedupe_pipeline(
     # silently get the stale entry. Column names defend against a different
     # schema; height defends against same-schema-different-rows (e.g. an empty
     # input vs a populated one) — the `test_dedupe_df_empty` flake.
-    if not isinstance(combined_lf, pl.LazyFrame):
+    from goldenmatch.core.frame import is_polars_lazyframe as _is_pl_lf
+
+    if not _is_pl_lf(combined_lf):
         # D2s-d2b Frame lane (arrow spine), WIDENED W-1: runs the prep stages
         # in CLASSIC ORDER (quality -> transform -> standardize -> matchkeys
         # -> precompute; the E.164 stage-order lesson). quality/transform are
@@ -2888,11 +2908,14 @@ def _run_dedupe_pipeline(
                 split_edge_budget=split_edge_budget,
             )
         else:
+            from goldenmatch.core.frame import ArrowFrame as _AF_d6
+
             cluster_frames = build_cluster_frames(
                 all_pairs, all_ids,
                 max_cluster_size=max_cluster_size,
                 weak_cluster_threshold=weak_threshold,
                 auto_split=auto_split,
+                backend="arrow" if isinstance(_collected_frame, _AF_d6) else "polars",
                 split_edge_budget=split_edge_budget,
             )
             # Do NOT rebuild the dict eagerly. stats + dupes (always-run hot path)
@@ -3079,6 +3102,13 @@ def _run_dedupe_pipeline(
         # relevant universe; scoped so cell_quality is not paid over the whole
         # frame on every default dedupe.
         _member_ids = _golden_member_row_ids()
+        from goldenmatch.core.golden import _polars_importable as _pl_ok
+        if _member_ids and not _pl_ok():
+            # Zero-polars env: goldencheck's cell_quality is polars-backed;
+            # quality weighting fails OPEN (None = no weighting), the same
+            # contract as goldencheck-absent. Re-opens when goldencheck
+            # ships an arrow cell_quality.
+            _member_ids = []
         if _member_ids:
             from goldenmatch.core.quality import compute_quality_scores
             with stage("golden_quality_scores"):

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -385,7 +385,9 @@ def _find_exact_match_ids(
     # D2s-a (spine descent): dual-rep entry. Legacy pl.LazyFrame callers keep
     # the lazy projection+collect verbatim; a seam Frame (or eager native)
     # projects via the seam so the arrow lane never round-trips polars.
-    if isinstance(lf, pl.LazyFrame):
+    from goldenmatch.core.frame import is_polars_lazyframe
+
+    if is_polars_lazyframe(lf):
         df = lf.select("__row_id__", mk_col).collect()
     else:
         df = to_frame(lf).select(["__row_id__", mk_col]).native

--- a/packages/python/goldenmatch/tests/_zero_polars_probe.py
+++ b/packages/python/goldenmatch/tests/_zero_polars_probe.py
@@ -1,0 +1,72 @@
+"""Subprocess probe for the D6 zero-polars gate (run via test_zero_polars_gate).
+
+Runs an eligible exact dedupe on the Frame lane and exits nonzero if polars
+landed in sys.modules.
+"""
+import os
+import pathlib
+import sys
+import tempfile
+
+
+# Simulate the D6 end-state: polars is NOT INSTALLED. Any import attempt
+# raises ImportError, so polars-present optimizations must fail open/soft
+# and the seam-native routes must carry the run.
+class _PolarsBlocker:
+    def find_module(self, name, path=None):  # noqa: D102 (py<3.12 protocol)
+        if name == "polars" or name.startswith("polars."):
+            return self
+        return None
+
+    def find_spec(self, name, path=None, target=None):  # noqa: D102
+        if name == "polars" or name.startswith("polars."):
+            raise ImportError("polars blocked (D6 zero-polars gate)")
+        return None
+
+    def load_module(self, name):  # noqa: D102
+        raise ImportError("polars blocked (D6 zero-polars gate)")
+
+
+sys.meta_path.insert(0, _PolarsBlocker())
+
+os.environ["GOLDENMATCH_FRAME"] = "arrow"
+os.environ["GOLDENMATCH_NATIVE"] = "0"
+os.environ["POLARS_SKIP_CPU_CHECK"] = "1"
+
+d = pathlib.Path(tempfile.mkdtemp())
+csv = d / "people.csv"
+csv.write_text(
+    "first,last,city\n"
+    "ann,smith,nyc\n"
+    "ann,smith,nyc\n"
+    "bob,jones,la\n"
+    "bobby,jones,la\n"
+    "cara,lee,sf\n",
+    encoding="utf-8",
+)
+
+import goldenmatch.core.pipeline as P  # noqa: E402
+from goldenmatch.config.schemas import (  # noqa: E402
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    QualityConfig,
+    TransformConfig,
+)
+
+cfg = GoldenMatchConfig(
+    matchkeys=[
+        MatchkeyConfig(
+            name="k",
+            type="exact",
+            fields=[MatchkeyField(field="first"), MatchkeyField(field="last")],
+        )
+    ],
+    quality=QualityConfig(mode="disabled"),
+    transform=TransformConfig(mode="disabled"),
+)
+res = P.run_dedupe([(str(csv), "people")], cfg)
+assert res["golden"] is not None and res["golden"].num_rows >= 1
+
+assert "polars" not in sys.modules
+print("ZERO-POLARS OK")

--- a/packages/python/goldenmatch/tests/test_zero_polars_gate.py
+++ b/packages/python/goldenmatch/tests/test_zero_polars_gate.py
@@ -1,0 +1,27 @@
+"""D6 gate: the arrow lane's covered engine runs with polars NEVER imported.
+
+Subprocess-based (the W0 lazy-import gate precedent): run an eligible
+dedupe on the Frame lane (tests/_zero_polars_probe.py) and assert
+``polars`` is absent from ``sys.modules``. This is the endgame's
+invariant #1 arbiter -- every ``isinstance(x, pl.X)`` on a hot path
+triggers the lazy proxy and fails this test until it is guarded.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+_PROBE = Path(__file__).parent / "_zero_polars_probe.py"
+
+
+def test_arrow_lane_exact_dedupe_imports_zero_polars():
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(Path(__file__).parent.parent)
+    proc = subprocess.run(
+        [sys.executable, str(_PROBE)],
+        capture_output=True, text=True, env=env, timeout=300,
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2000:]}"
+    assert "ZERO-POLARS OK" in proc.stdout


### PR DESCRIPTION
The endgame's invariant #1, PROVEN: `tests/test_zero_polars_gate.py` runs an eligible dedupe (exact matching + blocking + clustering + golden survivorship + results) on the Frame lane in a subprocess whose `meta_path` BLOCKS polars imports -- simulating the D6 end-state (polars not installed) -- and the run succeeds end to end.

Tracer-driven ports/gates (one import-trigger at a time):

- **Import-free type guards** (`is_polars_lazyframe`/`is_polars_dataframe`): a pl object can only exist if polars is already loaded, so an unloaded polars answers False without touching the lazy proxy. The Frame-lane isinstance sites in pipeline/scorer/blocker route through them.
- **`build_cluster_frames` is lane-aware** (`backend` param; numpy -> `pa.table` zero-copy on the arrow lane); presplit pair-tagging, `cluster_frames_to_dict`, and the profile emitter read via the seam; the native kernel wrapper coerces chunked columns to the FFI's `pa.Array`.
- **`ClusterPairScores.from_frames`**: the arrow/polars-free path delegates to the BYTE-IDENTICAL `from_pairs` reference via a seam member->cid map; the polars join remains the polars-present optimization (10x at 100M pairs).
- **`build_golden_records_from_frames`**: the join-order parity recompute bridges only when polars is importable; the zero-polars lane proceeds on the deterministic arrow join (no parity target exists in that env -- the spec's correct-but-slower fallback contract).
- **`_golden_records_to_df`**: pa.Table construction in the zero-polars lane.
- **Quality weighting fails OPEN** without polars (the goldencheck-absent contract) until goldencheck ships an arrow cell_quality.

Polars-present behavior byte-unchanged everywhere: 414 tests + the differential harness green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW