### PR TITLE
chore(golden-suite): 0.2.2 -- goldenmatch[polars]>=3.1 floor

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.2] - 2026-07-13
+
+### Changed
+- goldenmatch floor to `goldenmatch[polars]>=3.1` (3.1.0: Arrow-native engine,
+  polars optional upstream; the suite pins the `[polars]` extra so the
+  wall-optimization paths and the classic `GOLDENMATCH_FRAME=polars` lane stay
+  available for suite installs).
+
 ## [0.2.1] - 2026-07-12
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.1"
+version = "0.2.2"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch>=3.0",                 # entity resolution: dedupe, match, golden records (>=3.0: Arrow-native results -- pa.Table -- + arrow default backend)
+    "goldenmatch[polars]>=3.1",         # entity resolution: dedupe, match, golden records (>=3.1: Arrow-native engine, polars OPTIONAL upstream -- the suite keeps [polars] so the wall-optimization paths + the classic lane stay on for suite installs)
     "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
Lockstep floor bump for the goldenmatch 3.1.0 release (verified on PyPI: no core polars dep; the [polars] extra carries the wall optimizations). The suite pins `goldenmatch[polars]>=3.1` so suite installs keep the polars-present optimization paths and the classic lane on. 0.2.2 in version/changelog lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW