### PR TITLE
chore(goldenmatch): 3.1.1 -- ship the frame-lane perf pass

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-07-13
+
+### Performance
+- Frame-lane hotspot pass (profiler-driven, byte-identical outputs): cluster
+  dict assembly goes columnar (was 35% of a 1M wall), transform-chain
+  fallbacks resolve their callable once per column, and soundex/metaphone
+  dispatch straight to the Rust jellyfish functions. 1M-row wall
+  7.6s -> 5.5s. (These were mentioned in the 3.1.0 notes but merged just
+  after the 3.1.0 tag; this patch actually ships them.)
+
 ## [3.1.0] - 2026-07-13
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.1.0"
+version = "3.1.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Patch release: the profiler-driven frame-lane perf pass (#1740, 1M wall 7.6s -> 5.5s byte-identical) merged just AFTER the v3.1.0 tag, so the 3.1.0 wheel does not contain it despite the release notes mentioning it. 3.1.1 actually ships it and the CHANGELOG says so explicitly. Version lockstep (pyproject / __init__ / server.json x2) + consistency gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QG75kK6gDnti5SbESeDFiW