### PR TITLE
ci: goldenmatch[polars] stopgap across dedupe/autoconfig lanes (rust, rust_pgrx, duckdb, dbt)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2749,7 +2749,7 @@ jobs:
           cache: pip
       # dbt-adapters 1.24.0 raises KeyError: 'javascript' against dbt-core 1.11.x
       # during macro parsing — pin <1.24 until upstream ships a clean release.
-      - run: pip install 'dbt-core>=1.11,<1.12' 'dbt-adapters<1.24' 'dbt-duckdb>=1.10,<1.11' pytest -e 'packages/dbt/goldensuite[quality]'
+      - run: pip install 'dbt-core>=1.11,<1.12' 'dbt-adapters<1.24' 'dbt-duckdb>=1.10,<1.11' pytest polars -e 'packages/dbt/goldensuite[quality]'
       - name: dbt parse (macro compile smoke)
         run: cd packages/dbt/goldensuite && dbt parse --no-version-check --profiles-dir .
       - name: pytest (macro render + correction CRUD)
@@ -2822,7 +2822,7 @@ jobs:
         # (and goldenflow, for the goldenflow_* transform functions) at
         # runtime. The package install here is what `init()` in the
         # bridge will find when Postgres starts.
-        run: pip install --break-system-packages goldenmatch>=1.1.0 goldenflow pyarrow
+        run: pip install --break-system-packages 'goldenmatch[polars]>=1.1.0' goldenflow pyarrow
 
       - name: Install cargo-pgrx
         # 0.12.9 pin matches the pgrx version in
@@ -2867,7 +2867,7 @@ jobs:
         run: |
           PYTHON_SITE=$(python -c "import site; print(site.getsitepackages()[0])")
           sudo rm -f /usr/lib/python3/dist-packages/typing_extensions.py
-          sudo pip install --break-system-packages goldenmatch>=1.1.0 goldenflow 2>/dev/null || true
+          sudo pip install --break-system-packages 'goldenmatch[polars]>=1.1.0' goldenflow 2>/dev/null || true
           echo "${PYTHON_SITE}" | sudo tee /usr/lib/python3/dist-packages/goldenmatch.pth
 
       - name: psql smoke (scalar scorer, dedupe, autoconfig)
@@ -3150,7 +3150,7 @@ jobs:
           # source change here would surface — but the duckdb lane filter only
           # fires on extensions/duckdb/** changes, so for cross-package
           # regressions, rely on the regular `python` lane to catch them.
-          pip install -e "../../../python/goldenmatch[web]"
+          pip install -e "../../../python/goldenmatch[web,polars]"
           # goldencheck supplies the deep-profiling kernels the goldencheck_* UDFs
           # delegate to (goldencheck.core.kernels). Editable, pure-Python path —
           # the native goldencheck-core wheel isn't built here, so the UDF tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1616,7 +1616,7 @@ jobs:
           python-version: "3.12"
       - name: Install goldenmatch + pin the pyo3 interpreter
         run: |
-          python -m pip install goldenmatch pyarrow
+          python -m pip install 'goldenmatch[polars]' pyarrow
           echo "PYO3_PYTHON=$(which python)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -1758,7 +1758,7 @@ jobs:
           python-version: "3.12"
       - name: Install goldenmatch + pin the pyo3 interpreter
         run: |
-          python -m pip install goldenmatch pyarrow
+          python -m pip install 'goldenmatch[polars]' pyarrow
           echo "PYO3_PYTHON=$(which python)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" >> "$GITHUB_ENV"
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
## Problem

The `rust` + `rust_pgrx` (coverage) lanes install goldenmatch from PyPI to back the pyo3 bridge tests (`GOLDENMATCH_BRIDGE_REQUIRE_PY=1` makes a Python failure a hard fail). After goldenmatch's polars-eviction (3.0.0 moved polars to an optional `[polars]` extra), `pip install goldenmatch` no longer pulls polars, so the bridge dedupe/autoconfig tests fail with `ModuleNotFoundError: No module named 'polars'`. The install line predates the eviction and was never updated.

**Latent because** the rust lanes are path-filtered (`packages/rust/**`) and haven't run on recent main PRs. The first PR to touch `packages/rust` (the goldenflow owned auto-detect kernel, #1746) forced the `rust` lane to run and exposed it — main's rust lane has been silently broken since the eviction.

## Fix

Install the `[polars]` extra in both bridge lanes, restoring the pre-eviction test setup (the bridge legitimately exercises goldenmatch's optional polars backend). One-line, self-validating (editing ci.yml force-runs the full matrix incl. rust).

## Follow-up (not this PR)

The deeper fix — making goldenmatch's bridge dedupe/autoconfig path run polars-free so the lane can drop the extra — belongs to the goldenmatch polars-eviction project and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
