### PR TITLE
chore(golden-suite): 0.2.3 -- bump goldenflow floor to >=2.1.0

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.3] - 2026-07-13
+
+### Changed
+- goldenflow floor to `goldenflow>=2.1.0` (2.1.0: owned auto-detect profile
+  kernel -- zero-config type inference is now a cross-surface goldenflow-core
+  kernel; base `goldenflow-native` floor `>=0.27.0`).
+
 ## [0.2.2] - 2026-07-13
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.2"
+version = "0.2.3"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -39,7 +39,7 @@ dependencies = [
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
     "goldenmatch[polars]>=3.1",         # entity resolution: dedupe, match, golden records (>=3.1: Arrow-native engine, polars OPTIONAL upstream -- the suite keeps [polars] so the wall-optimization paths + the classic lane stay on for suite installs)
     "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
-    "goldenflow>=2.0.0",                 # transform / standardize / normalize (>=2.0.0 = Polars eviction FLIPPED: Polars-free by default, moved to goldenflow[polars]; native is a base dep)
+    "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts


### PR DESCRIPTION
Lockstep suite bump: goldenflow 2.1.0 (owned auto-detect profile kernel; native floor >=0.27.0) is live on PyPI, so bump the golden-suite floor to `goldenflow>=2.1.0` and cut 0.2.3. Deps-only meta-package, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)