### PR TITLE
feat(goldenmatch): autoconfig arrow-port PR-1 -- cast_all_str + count_duplicate_rows seam ops

### DIFF
--- a/docs/superpowers/plans/2026-07-13-goldenmatch-autoconfig-arrow-port-plan.md
+++ b/docs/superpowers/plans/2026-07-13-goldenmatch-autoconfig-arrow-port-plan.md
@@ -1,0 +1,202 @@
+# GoldenMatch autoconfig Arrow-port Implementation Plan
+
+> **For agentic workers:** Use superpowers:subagent-driven-development. Each PR is
+> its own branch off the predecessor's merged main. Steps use checkbox (`- [ ]`).
+
+**Goal:** Make zero-config `dedupe_df` run Polars-free by Arrow-porting the
+autoconfig stack + the `run_dedupe_df` controller front-door.
+
+**Architecture:** Extend the existing `frame.py` dual-backend seam (add the few
+missing ops), reroute each polars-bound autoconfig call site through `to_frame(df)`
+leaving module test files unedited (byte-parity proof), then flip the boundary
+last. Sampled paths assert config-equivalence, not row-identity.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-goldenmatch-autoconfig-arrow-port-design.md`
+
+**Reference skills:** @superpowers:test-driven-development, @superpowers:verification-before-completion
+
+---
+
+## Box + CI conventions (every PR)
+
+- goldenmatch Python tests: `.venv/Scripts/python.exe -m pytest <path>` with
+  `POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8`; `GOLDENMATCH_NATIVE=0` where
+  the native kernel would hang the box. Heavy/native/distributed lanes = CI's job.
+- Toggle backends with `GOLDENMATCH_FRAME=arrow` / `=polars` to exercise both.
+- Each PR: fold `origin/main` before shipping; `ruff check packages/python/goldenmatch`
+  (whole package, isort); watch pytest-split shard-shift (new test files → 
+  rootdir-relative deselects, verify "N deselected").
+- Commit trailer:
+  ```
+  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+  Claude-Session: https://claude.ai/code/session_01RvH3nXr1xZeVdx6772
+  ```
+- **CI note (learned this session):** any ci.yml edit force_all's the full matrix
+  in the merge queue; the goldenmatch-consuming lanes now install `goldenmatch[polars]`
+  (#1747 stopgap), so zero-config-needs-polars is masked — do NOT rely on those
+  lanes to catch a polars regression until PR-6's tripwire lands.
+
+---
+
+## PR-1 — seam-op foundation (fixtures-first, pure-additive)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/frame.py` (Protocol + both backends)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/arrow_derive.py` (arrow impls if needed)
+- Test: `packages/python/goldenmatch/tests/test_frame_relational_ops.py`
+
+New seam ops (each: `Frame`/`Column` Protocol method + `PolarsFrame` + `ArrowFrame`):
+1. **`cast_all_str()`** — cast every non-`__`-prefixed column to Utf8. Polars:
+   `df.cast({c: pl.Utf8 for c in df.columns if not c.startswith("__")})`. Arrow:
+   cast those columns to LargeUtf8 (match `run_dedupe_df:439` semantics exactly —
+   `__`-prefixed columns untouched).
+2. **`count_duplicate_rows()`** — `height - distinct_row_count()`. (Confirm
+   `distinct_row_count` semantics on both backends match `df.unique().height`.)
+3. **all-empty-row count** — decide: a seam op, OR a Python helper over
+   `to_frame(df).select_dicts()`/`to_list()` (cold path; W3 plan's stated approach).
+   Prefer the Python-side helper if the fold is cheap; document the choice.
+4. **grouped block-size** (only if PR-5 needs it beyond `group_len`/`run_lengths`) —
+   defer to PR-5 if unclear; do NOT speculatively add.
+
+- [ ] **Step 1: Write failing parity fixtures** in `test_frame_relational_ops.py`
+  for `cast_all_str` and `count_duplicate_rows`: build a frame with mixed dtypes +
+  `__`-prefixed cols + duplicate rows + nulls; assert `PolarsFrame` and `ArrowFrame`
+  produce identical results (cast: same string spelling per cell; dup-count: same
+  integer). Pin the semantic deltas (null handling, `__`-col exclusion).
+- [ ] **Step 2: Run — expect FAIL** (ops undefined).
+  `POLARS_SKIP_CPU_CHECK=1 ... pytest tests/test_frame_relational_ops.py -k "cast_all_str or duplicate" -v`
+- [ ] **Step 3: Implement** the ops on the Protocol + both backends (+ arrow_derive
+  helper if the arrow impl is non-trivial). Cite the call site in each docstring.
+- [ ] **Step 4: Run — expect PASS.** Also run the full `test_frame_relational_ops.py`
+  (unchanged existing ops must stay green).
+- [ ] **Step 5: whole-package ruff + commit.**
+  `git commit -m "feat(goldenmatch): cast_all_str + count_duplicate_rows seam ops (autoconfig arrow-port PR-1)"`
+
+**Review:** spec-compliance (are ONLY these ops added, both backends, fixtures pin
+semantics?) + code-quality (DRY vs sibling ops, no call-site changes leaked).
+Arm auto-merge; land before PR-2.
+
+---
+
+## PR-2 — `profiler.profile_dataframe` port
+
+**Files:** Modify `core/profiler.py`; leave `tests/test_profiler.py` UNEDITED.
+
+- [ ] Route `profile_dataframe`'s `df.unique().height` → `count_duplicate_rows`/
+  `distinct_row_count`; the all-empty-row fold → the PR-1 helper; `df.filter(...)`
+  and `df[col].dtype in (pl.Utf8, pl.String)` → seam (`filter_valid_key`/`semantic_dtype`
+  or the dtype-spelling check). Accept `to_frame(df)` at the top.
+- [ ] **Gate:** `test_profiler.py` UNEDITED passes (byte-parity on the polars path)
+  AND a new arrow-path assertion (`GOLDENMATCH_FRAME=arrow`) matches.
+- [ ] ruff + commit + review + land.
+
+**Risk: low.**
+
+---
+
+## PR-3 — dtype contract + `autoconfig.py` body residue
+
+**Files:** Modify `core/autoconfig.py`; add an arrow→polars dtype-spelling map
+(new small module or a table in autoconfig/frame); tests for the map.
+
+- [ ] **Dtype map:** at the `profile_columns` → `autoconfig_classify_columns`
+  boundary, map arrow dtype spelling to the polars spelling the kernel expects
+  (`"double"`→`"Float64"`, `"large_utf8"`/`"string"`→`"Utf8"`, int/bool/date/…).
+  Pin against the kernel's accepted vocabulary + the existing golden classifier
+  vectors (which must NOT change).
+- [ ] Route the remaining `autoconfig.py` scalar accessors (`.height`/`.columns`/
+  `.dtype`), `df.filter(pl.col().is_not_null())`, and `auto_configure(files)` file
+  ingest (off `pl.read_csv/parquet/excel`+`pl.concat` → the io_arrow ingest) through
+  the seam. Do NOT touch the ~3595 unwrap yet (that's PR-6).
+- [ ] **Gate:** autoconfig's config decisions unchanged on the polars path
+  (existing autoconfig tests unedited) + the dtype map produces identical
+  `classify_columns` output arrow-vs-polars.
+- [ ] ruff + commit + review + land.
+
+**Risk: medium** (dtype contract is cross-surface; assert classify-output identity).
+
+---
+
+## PR-4 — controller residue
+
+**Files:** Modify `core/autoconfig_controller.py`; leave its tests unedited.
+
+- [ ] `pl.concat([df, reference], how="vertical_relaxed")` (2 sites) →
+  `concat_frames(relaxed=True)`; fix type hints; confirm sampling is fully seam.
+- [ ] **Gate:** controller tests unedited pass; arrow-path config-equivalence.
+- [ ] ruff + commit + review + land.
+
+**Risk: low-medium.**
+
+---
+
+## PR-5 — blocker measurement / block-key tail  [USER CHECKPOINT — recall-critical]
+
+**Files:** Modify `core/blocker.py`; new block-membership parity corpus + test.
+
+- [ ] **Before rewiring:** build a block-membership corpus that pins, byte-identical,
+  the block assignment (`build_blocks` / `_fast_static_block_sizes` /
+  `measure_blocking_profile`) native/polars-vs-arrow on a realistic multi-matchkey
+  fixture. This is the recall-critical gate.
+- [ ] Give `_build_block_key_expr` (`pl.Expr`) / `_fast_static_block_sizes` /
+  `measure_blocking_profile` an arrow twin via `derive_block_key` + `group_len`/
+  `run_lengths` (+ a grouped block-size op if genuinely needed). Handle the
+  `pl.concat_str`/`map_elements`/soundex fallbacks — hand-roll to match, no
+  `pl.Expr`. Remove the 2nd `pl.from_arrow` (blocker.py ~1191).
+- [ ] **Gate:** block membership byte-identical on the corpus; `test_blocker.py`
+  unedited passes.
+- [ ] **STOP — surface to the user** (block-key parity evidence + the diff) before
+  arming auto-merge. Only land after the user confirms.
+
+**Risk: HIGH.** `pl.Expr` has no direct seam analog; block-key parity is recall-critical.
+
+---
+
+## PR-6 — boundary flip + controller front-door  [the crux]
+
+**Files:** Modify `core/autoconfig.py` (remove ~3595 unwrap; widen sig),
+`core/pipeline.py` (`run_dedupe_df` front), `_api.py` (`dedupe_df` sig); new
+zero-config-no-polars tripwire test.
+
+- [ ] Remove the `auto_configure_df` unwrap (`pl.from_arrow`, ~3595). Widen
+  `auto_configure_df`/`dedupe_df` signatures to accept `pl.DataFrame | pa.Table |
+  Frame`; route through `to_frame(df)` at the top (idempotent-coercion, spine
+  pattern). Let `reference` flow arrow too.
+- [ ] Port `run_dedupe_df`'s front: `df.cast({...pl.Utf8})` (pipeline.py:439) →
+  `cast_all_str`; `_add_row_ids` on `pl.LazyFrame` (731/856) → `ensure_row_ids` on
+  the Frame; drop the `.lazy()/.collect()` polars round-trip. So the controller's
+  per-iteration sample re-run is polars-free.
+- [ ] **Acceptance test (the whole port's gate):** a subprocess tripwire — block
+  polars import (`sys.modules["polars"]=None` or a meta-path finder), assert
+  `native_available()==True`, then `dedupe_df(pa.Table, config=None)` (zero-config)
+  runs to completion and returns a result. Mirror the eviction's covered-spine
+  tripwire. Add to CI (`GOLDENMATCH_FRAME=arrow` lane).
+- [ ] **Gate:** all existing dedupe/autoconfig tests green (polars path unchanged);
+  the tripwire green; config-equivalence arrow-vs-polars on the differential harness.
+- [ ] ruff + commit + review + land (arm after review; the tripwire is the sign-off).
+
+**Risk: HIGH** — blast radius = every zero-config caller.
+
+---
+
+## PR-7 (follow-up) — drop the CI [polars] stopgap + docs sweep
+
+- [ ] Now that zero-config runs polars-free (PR-6 tripwire green on CI), revert the
+  #1747 `[polars]` additions on the goldenmatch-consuming lanes (rust/rust_pgrx/
+  duckdb/dbt) IN STAGES, confirming each lane green polars-free. (Keep [polars] only
+  where a lane genuinely exercises the polars backend by design.)
+- [ ] Docs sweep (rollout-docs-sweep): correct the eviction "COMPLETE" claim re:
+  zero-config; ADR for the autoconfig port; update `project_goldenmatch_polars_eviction`
+  + `project_goldenmatch_autoconfig_arrow_port` memory + the work tracker.
+
+---
+
+## Landmine checklist (per PR)
+
+- [ ] Module test file UNEDITED where the PR claims byte-parity (the proof).
+- [ ] Sampled paths assert config-equivalence, NOT row-identity.
+- [ ] Whole-package `ruff check` (isort).
+- [ ] New test file → verify pytest-split "N deselected" (rootdir-relative).
+- [ ] Fold origin/main before shipping (avoid stale-base dup).
+- [ ] PR-5: block-membership byte-identical corpus BEFORE rewire; user checkpoint.
+- [ ] PR-6: the no-polars tripwire is the acceptance gate; do not claim done without it green on CI.

--- a/docs/superpowers/specs/2026-07-13-goldenmatch-autoconfig-arrow-port-design.md
+++ b/docs/superpowers/specs/2026-07-13-goldenmatch-autoconfig-arrow-port-design.md
@@ -1,0 +1,235 @@
+# GoldenMatch autoconfig Arrow-port — the last polars island on zero-config
+
+**Date:** 2026-07-13
+**Status:** Design — approved (decisions locked), for spec review
+**Owner:** Ben Severn
+**Area:** `packages/python/goldenmatch/goldenmatch/core/{autoconfig.py, autoconfig_controller.py, blocker.py, profiler.py, indicators.py, pipeline.py, frame.py}`
+
+## Summary
+
+Make GoldenMatch's **zero-config** dedupe/autoconfig path run **Polars-free** by
+Arrow-porting the autoconfig stack (autoconfig body + controller + blocker
+measurement tail + profiler frame-fn) and the `run_dedupe_df` polars front-door
+that the controller re-runs per iteration. This closes the last polars island the
+ZERO-Polars eviction left: the dedupe SPINE is arrow-native, but
+`auto_configure_df` unwraps `ArrowFrame -> pl.from_arrow(...)` and runs its
+internals on polars, so `pip install goldenmatch` (no `[polars]`) + zero-config
+`dedupe_df` raises `ModuleNotFoundError: No module named 'polars'`.
+
+## Motivation
+
+The eviction (3.0.0 "polars optional", "COMPLETE") ported the dedupe spine and
+made `import goldenmatch` polars-free, but **autoconfig was only made
+arrow-ACCEPTING, not arrow-native** — `core/autoconfig.py:auto_configure_df`
+unwraps arrow to polars at the top (`df = cast("pl.DataFrame",
+pl.from_arrow(df.native))`, comment "REMOVE in W5 when arrow flows past ingest";
+W5 for autoconfig never landed). Consequences:
+
+- **Zero-config dedupe requires polars** (it always calls autoconfig first).
+- Multiple CI lanes that `pip install goldenmatch` without `[polars]` and run
+  zero-config (rust bridge, rust_pgrx, duckdb_extensions, dbt) fail; a `[polars]`
+  CI stopgap (#1747) masks it today.
+- The "polars-optional" headline overstates: it holds for *configured* arrow-lane
+  dedupe, not *zero-config*.
+
+This port delivers true zero-config-without-polars so the stopgap can be dropped
+and the eviction's claim becomes honest.
+
+## Decisions (locked)
+
+1. **Full scope — port the controller front-door.** The controller's
+   `_run_pipeline_sample` re-runs `run_dedupe_df`/`run_match_df` (pipeline.py)
+   whose FRONT still does `df.cast({...pl.Utf8...}).lazy()` + `_add_row_ids` +
+   `collect` (pipeline.py:439/731/856) — a polars front-door the spine flip left.
+   Port it (new `cast_all_str` frame op; `ensure_row_ids` exists) so the sample
+   re-run is polars-free. This is the only way zero-config actually runs without
+   polars.
+2. **Dtype contract — map arrow→polars-spelling at the boundary.** The native
+   `autoconfig_classify_columns` kernel expects the polars dtype spelling
+   (`"Float64"`); arrow spells it differently (`"double"`). Keep the Rust kernel's
+   vocabulary; map arrow→polars-spelling at the Python boundary (one localized
+   table). No Rust change, no classifier golden-vector regen.
+3. **Execution — autonomous, subagent-driven, per-PR reviewed**, mirroring the
+   goldenflow feature. Checkpoint the user on the high-risk block-key parity PR.
+
+## Current state (current main, 3.1.1)
+
+`frame.py` is a mature 2126-line dual-backend seam: `Frame`/`Column` Protocols,
+`PolarsFrame`/`ArrowFrame`, `arrow_derive.py` helpers, and the W3-era seam ops
+autoconfig already partly uses. **Most autoconfig helpers were already seam-routed
+by W3** (`docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w3.md`):
+`profile_columns`, `_union_coverage`, `_source_disjoint`, `_check_source_overlap`,
+all of `indicators.py`, `profiler.profile_column`, controller sampling. They
+delegate byte-identically **today** because they receive the unwrapped polars
+frame — the port removes the unwrap and lets them see an `ArrowFrame`.
+
+Remaining polars-bound surfaces (the real work):
+
+| Module | Remaining polars ops (KIND) |
+|--------|------------------------------|
+| `autoconfig.py` | boundary unwrap `pl.from_arrow` (~3595); `LazyFrame.collect`; `df.height`/`.columns` scalars (Frame exposes these); `str(df[col].dtype)` fed to native classify (dtype contract); `df.filter(pl.col().is_not_null())`; file readers `pl.read_csv/parquet/excel`+`pl.concat` in `auto_configure(files)` |
+| `autoconfig_controller.py` | mostly type hints; 2× `pl.concat([df, reference], how="vertical_relaxed")` → `concat_frames(relaxed=True)` exists |
+| `blocker.py` | **the deep tail**: `_build_block_key_expr` → `pl.Expr`; `_fast_static_block_sizes`/`measure_blocking_profile` → `pl.LazyFrame` + `group_by().agg(pl.len())` + `pl.concat_str`/`map_elements`; a 2nd `pl.from_arrow` (~1191) |
+| `profiler.py` | `profile_dataframe` (frame-level): `df.unique().height`, all-empty-row fold, `df.filter()`, `df[col].dtype in (pl.Utf8, pl.String)` |
+| `indicators.py` | none — fully seam-routed (done) |
+| `pipeline.py` (front-door) | `run_dedupe_df` front: `df.cast({...pl.Utf8})` (439), `_add_row_ids` on `pl.LazyFrame` (731/856), `.lazy()/.collect()` |
+
+## Architecture
+
+The port follows the eviction's established seam pattern: route every remaining
+frame op through `to_frame(df)` (the seam accepts polars DF / `pa.Table` /
+dict-of-arrays / a `Frame`), add the few missing seam ops, then flip the boundary
+last. No new abstraction — this extends `frame.py`.
+
+### New/extended seam ops (the additive foundation)
+
+- **`cast_all_str()`** — cast every non-`__`-prefixed column to Utf8 (arrow: cast
+  to LargeUtf8; polars: `df.cast({c: pl.Utf8})`). For the `run_dedupe_df` front.
+- **`count_duplicate_rows()`** — `height - distinct_row_count()` (both exist);
+  or a direct op. For `profiler.profile_dataframe`.
+- **all-empty-row count** — likely `select_dicts`/`to_list` + Python (cold path),
+  per the W3 plan's note ("declared PYTHON-SIDE over to_list"), not a new op.
+- **grouped block-size** convenience (if needed) — arrow twin of
+  `group_by(block_key).agg(pl.len())` via `derive_block_key` + `group_len`/
+  `run_lengths` (both exist).
+
+Each new op: added to the `Frame`/`Column` Protocol + BOTH backends, with a
+**fixtures-first** parity test in `tests/test_frame_relational_ops.py` pinning
+every semantic delta (null handling, order, dtype spelling, codepoint-vs-byte).
+
+### Boundary flip
+
+`auto_configure_df` (and `run_dedupe_df`) widen to accept `pl.DataFrame | pa.Table
+| Frame` and route through `to_frame(df)` at the top — the idempotent-coercion
+pattern the spine already uses. Remove the `pl.from_arrow` unwrap (autoconfig.py
+~3595) and the 2nd one in blocker.py (~1191). `reference` (match-mode) can also
+flow arrow now (the "can't flow until W5" constraint is what this lifts).
+Public back-compat preserved: existing polars callers hit the `PolarsFrame`
+branch unchanged; new callers pass arrow.
+
+### Dtype contract (decision 2)
+
+`profile_columns` feeds `str(df[col].dtype)` to the native
+`autoconfig_classify_columns`. On the arrow path, add an **arrow→polars-spelling
+map** (`"double"`→`"Float64"`, `"large_utf8"`/`"string"`→`"Utf8"`, etc.) at that
+boundary so the kernel sees the vocabulary it expects. One table, Python-side,
+no Rust/golden-vector change. A parity test pins the mapping against the polars
+dtype spellings the kernel already handles.
+
+## PR decomposition (6 PRs, front-loaded on foundation)
+
+1. **PR-1 — seam-op fixtures + gaps (S).** Add `cast_all_str`, duplicate-row
+   count, the all-empty-row decision, and (if needed) the grouped block-size op.
+   Fixtures-first in `test_frame_relational_ops.py`. Pure-additive; no call-site
+   change. *Risk: low.*
+2. **PR-2 — `profiler.profile_dataframe` port (S).** Route the frame-level
+   dup/empty/dtype detection through the seam. Gate: `test_profiler.py` unedited
+   (byte-parity proof). *Risk: low.*
+3. **PR-3 — dtype contract + `autoconfig.py` body residue (M).** The
+   arrow→polars-spelling map for native classify; route the remaining
+   `autoconfig.py` scalar accessors (`.height`/`.columns`/`.dtype`), the
+   `df.filter(is_not_null())`, and `auto_configure(files)` file-ingest (off
+   `pl.read_*`/`pl.concat` to the io_arrow ingest) through the seam. *Risk: medium
+   (dtype contract + golden classifier vectors are cross-surface; assert config
+   equivalence).*
+4. **PR-4 — controller residue (S-M).** The 2× `pl.concat(...vertical_relaxed)` →
+   `concat_frames(relaxed=True)`; type hints; confirm sampling is fully seam. Keep
+   `autoconfig_controller.py`'s own tests unedited. *Risk: low-medium.*
+5. **PR-5 — blocker measurement/block-key tail (L, HIGH risk — CHECKPOINT).**
+   Give `_build_block_key_expr`/`_fast_static_block_sizes`/`measure_blocking_profile`
+   an arrow twin via `derive_block_key` + `group_len`/`run_lengths`; remove the 2nd
+   `pl.from_arrow` (blocker.py ~1191). **Block-key parity is recall-critical** —
+   `pl.Expr` has no direct seam analog; `map_elements`/soundex fallbacks. Pin
+   block membership byte-identical on a corpus BEFORE rewiring. *Risk: HIGH —
+   surface to the user before landing.*
+6. **PR-6 — the boundary flip + controller front-door (M-L).** Remove the
+   `auto_configure_df` unwrap (~3595); widen `auto_configure_df`/`dedupe_df` sigs
+   to accept `pa.Table`/`Frame` via `to_frame`; port `run_dedupe_df`'s front
+   (`cast_all_str` + `ensure_row_ids`, off `.lazy()/.collect()`) so the controller
+   sample re-run is polars-free. Add a **zero-config-without-polars tripwire test**
+   (subprocess, polars import blocked, `dedupe_df(pa.Table)` succeeds) mirroring
+   the eviction's covered-spine tripwire. *Risk: HIGH — blast radius = every
+   zero-config caller; the controller re-run coupling is the crux.*
+
+## Parity contracts
+
+- **Byte-parity where deterministic; config-equivalence where sampled.** Per-module
+  ports keep the module's existing test file UNEDITED (byte-parity proof). BUT
+  `sample()` is **statistical-not-byte across backends BY DESIGN** (W3a) — the
+  controller's verdicts are per-backend. So the autoconfig differential harness
+  asserts **config-level equivalence** (same suggested matchkeys/thresholds/mode),
+  NOT row identity, on the sampled paths. Deterministic ops (profiler counts,
+  block membership, dtype classification) stay byte-identical.
+- **Block-key membership byte-identical** (PR-5) — recall-critical; a corpus pins
+  block assignment native-vs-polars before the rewire.
+- **Dtype classification identical** — the arrow→polars-spelling map must produce
+  the same `autoconfig_classify_columns` output as the polars path (golden vectors
+  unchanged).
+- **Public API back-compat** — polars callers unchanged (PolarsFrame branch);
+  the DedupeResult surface is NOT touched (the port accepts arrow, the spine
+  returns what it already returns).
+
+## Testing
+
+- **Fixtures-first seam-op parity** in `test_frame_relational_ops.py` for every
+  new op (both backends, semantic deltas pinned).
+- **Per-module byte-parity**: leave `test_profiler.py`/`test_indicators.py`/
+  `test_blocker.py`/controller tests UNEDITED as the proof each port is
+  output-identical on the polars path.
+- **Differential harness** (config-equivalence) for the autoconfig sampled path:
+  `auto_configure_df(PolarsFrame)` vs `auto_configure_df(ArrowFrame)` on a corpus
+  → same config decision.
+- **Block-key membership corpus** (PR-5): native-vs-polars block assignment
+  byte-identical.
+- **Zero-config-without-polars tripwire** (PR-6): subprocess with polars import
+  blocked, `native_available()==True`, `dedupe_df(pa.Table, config=None)` runs to
+  completion and returns a result — the acceptance test for the whole port.
+- Box constraints: goldenmatch tests via the workspace `.venv`; heavy/native lanes
+  are CI's job. `GOLDENMATCH_FRAME=arrow` / `=polars` toggles exercise both.
+
+## Recipe (from the W-waves — mirror it)
+
+1. Seam-op batch, **fixtures-first**, pure-additive (op to Protocol + both
+   backends; parity fixture pins semantics; SEMANTIC ops only, cite the call site).
+2. Per-module call-site batch: reroute through `to_frame(df)`; module test file
+   **unedited** = byte-parity proof.
+3. **No default flip during dual-backend prep** — `GOLDENMATCH_FRAME` unchanged;
+   arrow just *can* flow.
+4. Each batch = its own PR off the predecessor's merged main; fold origin/main
+   before shipping call-site batches; watch pytest-split shard-shift (new test
+   files → rootdir-relative deselects).
+5. **Boundary flip last** (PR-6), env-gated step-down.
+
+## Rollout
+
+After PR-6 lands and the tripwire is green on CI: the `[polars]` CI stopgap
+(#1747) can be reverted for the goldenmatch-consuming lanes (rust/rust_pgrx/
+duckdb/dbt) — a follow-up PR proving zero-config runs polars-free in those lanes.
+Docs sweep: correct the eviction "COMPLETE" claim; ADR for the autoconfig port;
+update the tracker.
+
+## Risks
+
+- **Block-key parity (PR-5)** — recall-critical; `pl.Expr` port has no direct
+  analog. Mitigation: byte-identical block-membership corpus before rewire;
+  user checkpoint.
+- **Controller re-run coupling (PR-6)** — the sample pipeline re-enters
+  `run_dedupe_df` per iteration; porting its front is the crux. Mitigation: the
+  front-door is a small, well-bounded surface (cast_all_str + ensure_row_ids);
+  the tripwire is the acceptance gate.
+- **Sampled non-determinism** — do NOT assert row-identity on sampled paths;
+  assert config-equivalence.
+- **Dtype spelling drift** — the arrow→polars map must be exhaustive for the
+  dtypes autoconfig sees; pin against the kernel's accepted vocabulary.
+
+## Out of scope
+
+- The DedupeResult output surface (already arrow via W5; untouched here).
+- Match-mode `reference` beyond letting it flow arrow (no new match-mode work).
+- Reverting the `[polars]` CI stopgap (a follow-up after the tripwire is green).
+
+## Links
+
+`docs/superpowers/plans/2026-07-11-goldenmatch-polars-eviction-w3.md` (the
+autoconfig/controller dual-backend recipe) · `...-w5.md` (boundary-flip step-down)
+· memory `project_goldenmatch_autoconfig_arrow_port`, `project_goldenmatch_polars_eviction`

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -187,6 +187,12 @@ class Frame(Protocol):
     def group_nunique(self, key: str, value: str) -> Frame: ...
     def coverage_ratio(self, pass_field_lists: Sequence[Sequence[str]]) -> float: ...
     def distinct_row_count(self) -> int: ...
+    # autoconfig arrow-port PR-1: cast every non-``__`` column to Utf8/string,
+    # leaving ``__``-prefixed internals (e.g. ``__row_id__``) untouched
+    # (run_dedupe_df front-door / autoconfig arrow-port); count of duplicate
+    # rows == ``height - distinct_row_count()`` (profiler.profile_dataframe).
+    def cast_all_str(self) -> Frame: ...
+    def count_duplicate_rows(self) -> int: ...
     # W2e-1: one field's standardizer chain (apply_standardization's
     # per-column derivation as a seam op; `address`/plugins fall back to the
     # pure-Python STANDARDIZERS oracle on the arrow backend).
@@ -632,6 +638,19 @@ class PolarsFrame:
 
     def distinct_row_count(self) -> int:
         return int(self._df.unique().height)
+
+    def cast_all_str(self) -> PolarsFrame:
+        # run_dedupe_df front-door / autoconfig arrow-port: byte-identical to
+        # run_dedupe_df's cast (pipeline.py:439) -- every non-__ column to Utf8,
+        # __-prefixed internals (e.g. __row_id__) untouched.
+        return self.__class__(
+            self._df.cast({c: pl.Utf8 for c in self._df.columns if not c.startswith("__")})
+        )
+
+    def count_duplicate_rows(self) -> int:
+        # profiler.profile_dataframe: rows that are duplicates ==
+        # height - unique().height (== distinct_row_count()).
+        return self.height - self.distinct_row_count()
 
     def derive_standardized_column(self, field: str, std_names: Sequence[str]) -> PolarsColumn:
         # Byte-identical to apply_standardization's three per-column branches
@@ -1467,6 +1486,26 @@ class ArrowFrame:
         cols = self._tbl.column_names
         rows = zip(*(self._tbl.column(c).to_pylist() for c in cols))
         return len(set(rows))
+
+    def cast_all_str(self) -> ArrowFrame:
+        # run_dedupe_df front-door / autoconfig arrow-port: every non-__ column
+        # to LargeUtf8 via arrow_derive.cast_utf8 (the pl.cast(pl.Utf8) twin --
+        # Polars exports Utf8 as LargeUtf8, floats formatted to match), leaving
+        # __-prefixed internals (e.g. __row_id__) untouched.
+        from goldenmatch.core import arrow_derive
+
+        tbl = self._tbl
+        for name in tbl.column_names:
+            if name.startswith("__"):
+                continue
+            idx = tbl.column_names.index(name)
+            tbl = tbl.set_column(idx, name, arrow_derive.cast_utf8(tbl.column(name)))
+        return ArrowFrame(tbl)
+
+    def count_duplicate_rows(self) -> int:
+        # profiler.profile_dataframe: rows that are duplicates ==
+        # height - distinct_row_count().
+        return self.height - self.distinct_row_count()
 
     def derive_standardized_column(self, field: str, std_names: Sequence[str]) -> ArrowColumn:
         from goldenmatch.core import arrow_derive

--- a/packages/python/goldenmatch/tests/test_frame_relational_ops.py
+++ b/packages/python/goldenmatch/tests/test_frame_relational_ops.py
@@ -731,3 +731,78 @@ def test_w3_distinct_row_count() -> None:
     )
     for frame in (pf, af):
         assert frame.distinct_row_count() == 3
+
+
+# ---- autoconfig arrow-port PR-1 seam ops -----------------------------------
+
+
+def _pr1_pair() -> tuple[PolarsFrame, ArrowFrame]:
+    # Mixed dtypes (int/float/str/bool), a __-prefixed row-id column, duplicate
+    # rows, and nulls in every non-__ column.
+    tbl = pa.table(
+        {
+            "__row_id__": pa.array([0, 1, 2, 3], type=pa.int64()),
+            "i": pa.array([10, 10, None, 20], type=pa.int64()),
+            "f": pa.array([1.5, 1.5, 2.0, None], type=pa.float64()),
+            "s": pa.array(["x", "x", None, "y"], type=pa.string()),
+            "b": pa.array([True, True, None, False], type=pa.bool_()),
+        }
+    )
+    return PolarsFrame(pl.from_arrow(tbl)), ArrowFrame(tbl)
+
+
+def test_pr1_cast_all_str_casts_non_underscore_columns() -> None:
+    pf, af = _pr1_pair()
+    pf_out = pf.cast_all_str()
+    af_out = af.cast_all_str()
+    for frame in (pf_out, af_out):
+        # every non-__ column is now string/text ...
+        assert frame.column("i").semantic_dtype() == "text"
+        assert frame.column("f").semantic_dtype() == "text"
+        assert frame.column("s").semantic_dtype() == "text"
+        assert frame.column("b").semantic_dtype() == "text"
+        # ... while the __-prefixed row-id column is UNTOUCHED (still numeric).
+        assert frame.column("__row_id__").semantic_dtype() == "numeric"
+    # per-cell string values identical across backends; null cells stay null.
+    for col in ("i", "f", "s", "b"):
+        pf_vals = pf_out.column(col).to_list()
+        af_vals = af_out.column(col).to_list()
+        assert pf_vals == af_vals
+        assert None in pf_vals  # the null cell survived the cast
+    # untouched row-id column keeps its integer values on both backends.
+    assert pf_out.column("__row_id__").to_list() == [0, 1, 2, 3]
+    assert af_out.column("__row_id__").to_list() == [0, 1, 2, 3]
+
+
+def test_pr1_cast_all_str_matches_run_dedupe_df_polars_semantics() -> None:
+    # PolarsFrame must equal run_dedupe_df's raw cast (pipeline.py:439).
+    pf, _ = _pr1_pair()
+    want = pf.native.cast({c: pl.Utf8 for c in pf.native.columns if not c.startswith("__")})
+    got = pf.cast_all_str().native
+    assert got.schema == want.schema
+    assert got.to_dicts() == want.to_dicts()
+
+
+def test_pr1_count_duplicate_rows_parity() -> None:
+    # Two fully-identical rows (all cells incl. nulls) -> one duplicate row.
+    pf, af = _w3_pair(
+        {
+            "a": pa.array([1, 1, 2, None], type=pa.int64()),
+            "b": pa.array(["x", "x", "y", "z"], type=pa.string()),
+        }
+    )
+    for frame in (pf, af):
+        assert frame.count_duplicate_rows() == frame.height - frame.distinct_row_count()
+    # 4 rows, 3 distinct -> exactly one duplicate; both backends agree.
+    assert pf.count_duplicate_rows() == af.count_duplicate_rows() == 1
+
+
+def test_pr1_count_duplicate_rows_no_dupes() -> None:
+    pf, af = _w3_pair(
+        {
+            "a": pa.array([1, 2, 3], type=pa.int64()),
+            "b": pa.array(["x", "y", "z"], type=pa.string()),
+        }
+    )
+    for frame in (pf, af):
+        assert frame.count_duplicate_rows() == 0


### PR DESCRIPTION
First of the autoconfig arrow-port (spec+plan included). Two additive dual-backend seam ops on the Frame seam, fixtures-first, no call-site changes:
- `cast_all_str()` -- cast non-`__` columns to Utf8, byte-identical to `run_dedupe_df`'s front (pipeline.py:439). For PR-6's controller front-door port.
- `count_duplicate_rows()` -- `height - distinct_row_count`. For PR-2's profiler port. (Counts full-row identity incl. `__`-cols.)

4 new parity tests (PolarsFrame == ArrowFrame); whole test_frame_relational_ops.py green; ruff clean. Spec: docs/superpowers/specs/2026-07-13-goldenmatch-autoconfig-arrow-port-design.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)