### PR TITLE
feat(native): N-level custom-threshold scoring in the Rust FS kernel (goldenmatch-native 0.1.14)

### DIFF
--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -108,8 +108,10 @@ number of levels: pass descending similarity cutoffs (`len == levels - 1`), and
 a pair's comparison level is the count of thresholds its similarity satisfies
 (satisfying all of them = the top "agree" level, none = "disagree"). Omit it to
 keep the classic 2/3-level behavior (`partial_threshold` covers the 3-level
-case). The native FS kernel and the fused-match path decline
-`level_thresholds` matchkeys and fall back to the standard scoring path.
+case). The native FS kernel scores `level_thresholds` matchkeys natively from
+`goldenmatch-native` >= 0.1.14 (older wheels fall back to the pure-Python
+scoring path automatically); the fused-match path still declines them and
+falls back.
 
 ```python
 import goldenmatch as gm

--- a/docs/superpowers/plans/2026-07-13-nlevel-native-scoring.md
+++ b/docs/superpowers/plans/2026-07-13-nlevel-native-scoring.md
@@ -1,0 +1,53 @@
+# N-level Native Scoring (Rust/arrow-native port) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port custom `level_thresholds` banding into the native Rust FS kernel so N-level probabilistic matchkeys score natively (byte-identical to the Python path) instead of falling back to pure Python; merge to main.
+
+**Architecture:** Thesis phase 2 for the Splink-converter feature (PR #1749, in merge queue). `fs_level_from_sim` in `packages/rust/extensions/native/src/score.rs` gains a custom-thresholds branch (level = count of satisfied descending thresholds — the exact `_levels_from_similarity` semantics). `score_block_pairs_fs` gains an OPTIONAL trailing `level_thresholds` kwarg (pyo3 signature default `None`) plus a module const `FS_SUPPORTS_LEVEL_THRESHOLDS = True` for wheel-skew-safe capability detection. Python's `_fs_native_eligible` flips from "always decline level_thresholds" to "eligible iff the loaded kernel advertises support" — old wheels keep the pure-Python fallback with zero behavior change. The dormant fused kernel (`match_fused_fs`) passes `None` and its `match_fused_fs_ready` guard stays (YAGNI: dormant path).
+
+**Tech Stack:** Rust (pyo3 abi3, rayon), maturin in-tree build via `scripts/build_native.py`, pytest parity tests.
+
+**Working branch:** `feat/nlevel-native-scoring` (stacked on `feat/splink-config-converter` @ 5c4ff66cc in worktree `..\goldenmatch-wt-splink-converter`; rebase onto origin/main after #1749 squash-merges: `git rebase --onto origin/main 5c4ff66cc`).
+
+**Wheel-skew contract (from CLAUDE.md):** new kernel capability must be detectable by the caller; callers must never pass the new kwarg to an old wheel. The `FS_SUPPORTS_LEVEL_THRESHOLDS` const + eligibility gate is that detection. Wheel republish (tag `goldenmatch-native-v0.1.14`) is a post-merge release step flagged to the user — in-tree builds and CI pick the change up immediately.
+
+**Env notes:** cargo/rustup per memory (`D:\.rustup\toolchains\1.94.0\bin` on PATH, `CARGO_HOME=D:\.cargo`). Native-ext CI runs `clippy -D warnings`; run it locally pre-push. rustfmt TOUCHED files by name (not `cargo fmt`). Verify builds explicitly (`grep ^error`). ort/onnxruntime don't link locally — use `cargo check`/`cargo clippy` for validation and the maturin build for the importable module.
+
+---
+
+### Task N1: Rust kernel — custom banding + optional kwarg + capability const
+
+**Files:**
+- Modify: `packages/rust/extensions/native/src/score.rs` (`fs_level_from_sim`, `score_block_pairs_fs`), `packages/rust/extensions/native/src/fused.rs` (pass `None`), `packages/rust/extensions/native/src/lib.rs` (export const)
+- Modify (version bumps, lockstep): `packages/rust/extensions/native/Cargo.toml`, `packages/rust/extensions/native/pyproject.toml`, `packages/rust/extensions/native/python/goldenmatch_native/__init__.py` — all `0.1.13` → `0.1.14`
+
+- [ ] **Step 1:** `fs_level_from_sim(sim, n_levels, partial_threshold, level_thresholds: Option<&[f64]>)`: when `Some(ts)`, return `ts.iter().filter(|&&t| sim >= t).count()` (order-independent count, identical to Python `_levels_from_similarity` custom branch, `>=` inclusive); when `None`, existing 2/3/N-even branches unchanged. Update the doc comment. Rust unit tests in the same file's test module (or wherever kernel unit tests live — check for `#[cfg(test)]`): custom `[1.0, 0.92, 0.88]` over sims `[1.0, 0.95, 0.90, 0.5, 0.88]` → `[3,2,1,0,1]` (mirror the Python test), legacy branches unchanged.
+- [ ] **Step 2:** `score_block_pairs_fs`: add `#[pyo3(signature = (row_ids, block_sizes, field_values, scorer_ids, levels, partial_thresholds, match_weights, calibrated, prior_w, min_weight, weight_range, threshold, exclude, level_thresholds=None))]` with `level_thresholds: Option<Vec<Option<Vec<f64>>>>` (one entry per field). Inside the pair loop pass `level_thresholds.as_ref().and_then(|lt| lt[f].as_deref())`. Validate length == n_fields when Some (PyValueError like fused does). Update doc comment (incl. that match_weights[f] length must equal the field's level count — unchanged invariant).
+- [ ] **Step 3:** `fused.rs` `match_fused_fs`: pass `None` at the `fs_level_from_sim` call site + one-line comment (fused stays declined for level_thresholds via `match_fused_fs_ready`; port when the fused path goes live).
+- [ ] **Step 4:** Export capability const: in the pymodule registration (find `#[pymodule]` in lib.rs / score.rs), `m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;`.
+- [ ] **Step 5:** Bump the 3 version files 0.1.13 → 0.1.14 (lockstep — pyproject drives the wheel republish, Cargo drives the crate, `__init__.py` is the fallback `__version__`).
+- [ ] **Step 6:** Validate: `cargo check` + `cargo clippy --all-targets -- -D warnings` + `cargo test` in the crate dir (capture output, `grep -E "^error"` must be empty); rustfmt the touched .rs files BY NAME. Fix everything.
+- [ ] **Step 7:** In-tree build so Python tests can load it: `python scripts/build_native.py` (repo root; check its --help/source for invocation), confirm `python -c "from goldenmatch._native import ...; import goldenmatch"` sees `FS_SUPPORTS_LEVEL_THRESHOLDS` — check the loader order in `goldenmatch/core/_native_loader.py` (in-tree `goldenmatch._native` wins).
+- [ ] **Step 8:** Commit.
+
+### Task N2: Python routing + test updates
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (`_fs_native_eligible`, `score_probabilistic_native`), `packages/python/goldenmatch/tests/test_nlevel_banding.py` (eligibility/router tests), from_splink docstring/comment touch-ups
+- Test: extend `tests/test_nlevel_banding.py` + new real-kernel parity test in `tests/test_nlevel_em.py` or `tests/test_probabilistic.py` (follow `TestNativeFSParity`'s home)
+
+- [ ] **Step 1 (TDD):** rewrite `test_level_thresholds_not_native_eligible_synthetic` → two tests: (a) mock native WITHOUT the const → not eligible (old-wheel behavior pinned); (b) mock native WITH `FS_SUPPORTS_LEVEL_THRESHOLDS=True` → ELIGIBLE. Update the real-kernel test to assert eligible (the in-tree build now has the const). Update `test_level_thresholds_router_selects_non_native_scorer` → with supporting native mock the router selects `_native`; keep a variant pinning the non-supporting fallback.
+- [ ] **Step 2:** `_fs_native_eligible`: replace the unconditional decline with `if any(f.level_thresholds is not None for f in mk.fields) and not getattr(mod, "FS_SUPPORTS_LEVEL_THRESHOLDS", False): return False` (careful: `mod` = `native_module()` — check how the function currently obtains it; keep the existing lazy-import pattern). Update docstring.
+- [ ] **Step 3:** `score_probabilistic_native`: build `level_thresholds = [list(f.level_thresholds) if f.level_thresholds else None for f in mk.fields]`; pass the kwarg ONLY when any entry is non-None (never sends the kwarg to an old wheel even if eligibility drifted).
+- [ ] **Step 4:** Real-kernel parity test (skipif on native availability AND the const): a 4-level `level_thresholds` matchkey scored through `probabilistic_block_scorer` with native forced vs numpy forced → identical pair sets and scores (rounding tolerance per existing parity tests — copy `TestNativeFSParity`'s comparison idiom).
+- [ ] **Step 5:** Doc touch-ups: `_fs_native_eligible` docstring; the comment block in `tests/test_nlevel_banding.py`; `docs-site/goldenmatch/scoring.mdx` ("native/fused fall back" → native scores level_thresholds from goldenmatch-native >= 0.1.14, fused falls back); CHANGELOG Unreleased entry. `match_fused_fs_ready` docstring stays (fused still declines).
+- [ ] **Step 6:** Run `tests/test_nlevel_banding.py tests/test_nlevel_em.py tests/test_probabilistic.py tests/test_probabilistic_vectorized.py tests/test_fused_match.py` with the fresh in-tree build, NO `GOLDENMATCH_NATIVE=0` → all pass incl. the new parity test actually RUNNING (not skipping). Also run once WITH `GOLDENMATCH_NATIVE=0` → pure-Python still green.
+- [ ] **Step 7:** Commit.
+
+### Task N3: land it on main
+
+- [ ] **Step 1:** Wait for #1749 to merge (poll `gh pr view 1749 --json state` at ≥3-min intervals — this is external state, not CI-babysitting of our own PR).
+- [ ] **Step 2:** `git fetch origin main`; rebase: `git rebase --onto origin/main 5c4ff66cc feat/nlevel-native-scoring` (squash-merge rebase per memory). Resolve conflicts (expect none — the stack only ADDS on top of #1749's files).
+- [ ] **Step 3:** Re-run the Task N2 test set post-rebase (in-tree native rebuild if the rebase touched the crate).
+- [ ] **Step 4:** Push (benzsevern token-URL dance), `gh pr create` (base main) with the parity evidence in the body, enqueue `gh pr merge --auto`, STOP (no CI polling). Flag in the final message: `goldenmatch-native-v0.1.14` tag/republish is a user decision (PyPI wheel users stay on pure-Python fallback until republished — safe, not broken).

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -11,8 +11,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   matchkey fields accept explicit per-level similarity cutoffs (descending,
   `len == levels - 1`; a pair's level = the count of thresholds its similarity
   satisfies), generalizing the fixed 2/3-level agree/partial/disagree banding.
-  Scalar and vectorized scoring paths both honor them; the native FS kernel and
-  the fused-match path decline `level_thresholds` matchkeys and fall back.
+  Scalar and vectorized scoring paths both honor them; the fused-match path
+  declines `level_thresholds` matchkeys and falls back.
+- **Native N-level scoring** (`goldenmatch-native` 0.1.14): the native Rust FS
+  kernel scores custom `level_thresholds` banding natively — byte-identical to
+  the pure-Python `_levels_from_similarity` semantics — via an optional
+  per-field `level_thresholds` kwarg on `score_block_pairs_fs`. Capability is
+  detected through the kernel's `FS_SUPPORTS_LEVEL_THRESHOLDS` const, so older
+  wheels keep the automatic pure-Python fallback (no behavior change).
 - **Splink config converter**: `from_splink()` (top-level export) converts a
   Splink settings or trained-model JSON (dict or path) into a validated
   GoldenMatch config plus a `ConversionReport` of lossy findings; trained m/u

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1899,31 +1899,38 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
 
     Every field scorer must be one the kernel's score_one implements, and no
     field may opt into TF adjustment (the kernel doesn't carry the per-value
-    frequency tables — those fields stay on the numpy path). No field may set
-    ``level_thresholds`` either: the Rust kernel (``score_block_pairs_fs``)
-    only receives ``levels`` (a level *count*) and ``partial_threshold`` and
-    bands raw similarities into levels itself using its own hard-coded default
-    banding (2/3-level partial_threshold rule + even-spaced N-level; see
-    ``score.rs fs_level_from_sim`` and ``score_probabilistic_native``, which
-    never passes ``level_thresholds`` across the FFI boundary). Custom
-    ``level_thresholds`` lists never cross the FFI, so an N-level matchkey
-    with a custom threshold list must fall back to the numpy/scalar path
-    where `_levels_from_similarity` does the banding in Python.
+    frequency tables — those fields stay on the numpy path). Custom
+    ``level_thresholds`` banding is native from goldenmatch-native >= 0.1.14:
+    the kernel's ``score_block_pairs_fs`` takes an optional per-field
+    ``level_thresholds`` kwarg and ``score.rs fs_level_from_sim`` bands with
+    the exact ``_levels_from_similarity`` custom semantics (level = count of
+    satisfied thresholds, ``>=`` inclusive). Support is detected via the
+    kernel's ``FS_SUPPORTS_LEVEL_THRESHOLDS`` module const — an older wheel
+    without it declines here, so those environments keep the pure-Python
+    (numpy/scalar) fallback where `_levels_from_similarity` does the banding.
     """
     if not _fs_native_enabled():
         return False
     if not mk.fields:
         return False
+    needs_level_thresholds = False
     for f in mk.fields:
         if f.scorer not in _NATIVE_FS_SCORER_IDS:
             return False
         if getattr(f, "tf_adjustment", False):
             return False
         if getattr(f, "level_thresholds", None) is not None:
-            return False
+            needs_level_thresholds = True
     try:
         from goldenmatch.core._native_loader import native_module
-        return hasattr(native_module(), "score_block_pairs_fs")
+        mod = native_module()
+        if not hasattr(mod, "score_block_pairs_fs"):
+            return False
+        if needs_level_thresholds and not getattr(
+            mod, "FS_SUPPORTS_LEVEL_THRESHOLDS", False
+        ):
+            return False  # old wheel: level_thresholds never crosses its FFI
+        return True
     except Exception:
         return False
 
@@ -1972,10 +1979,24 @@ def score_probabilistic_native(
     # Kernel canonicalizes pair_key to (min,max); pass exclude pre-canonicalized.
     excl = [(a, b) if a < b else (b, a) for a, b in exclude_pairs]
 
-    pairs = native_module().score_block_pairs_fs(
-        row_ids, [n], field_values, scorer_ids, levels, partials, weights,
-        calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
-    )
+    # Custom banding (goldenmatch-native >= 0.1.14). Only send the kwarg when a
+    # field actually sets level_thresholds — an old wheel must NEVER see it,
+    # even if the eligibility gate ever drifted.
+    level_thresholds = [
+        list(f.level_thresholds) if f.level_thresholds is not None else None
+        for f in mk.fields
+    ]
+    if any(t is not None for t in level_thresholds):
+        pairs = native_module().score_block_pairs_fs(
+            row_ids, [n], field_values, scorer_ids, levels, partials, weights,
+            calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
+            level_thresholds=level_thresholds,
+        )
+    else:
+        pairs = native_module().score_block_pairs_fs(
+            row_ids, [n], field_values, scorer_ids, levels, partials, weights,
+            calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
+        )
     return [(a, b, round(float(s), 4)) for a, b, s in pairs]
 
 

--- a/packages/python/goldenmatch/tests/test_nlevel_banding.py
+++ b/packages/python/goldenmatch/tests/test_nlevel_banding.py
@@ -152,8 +152,8 @@ def test_level_thresholds_eligible_on_supporting_kernel_synthetic(monkeypatch):
 def test_level_thresholds_router_selects_native_when_supported(monkeypatch):
     """With a supporting kernel, probabilistic_block_scorer hands a
     level_thresholds matchkey to the native closure (``_native``)."""
-    from goldenmatch.core.probabilistic import _fallback_result
     from goldenmatch.core import probabilistic as p
+    from goldenmatch.core.probabilistic import _fallback_result
 
     monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
     monkeypatch.setattr(

--- a/packages/python/goldenmatch/tests/test_nlevel_banding.py
+++ b/packages/python/goldenmatch/tests/test_nlevel_banding.py
@@ -1,4 +1,6 @@
 """N-level banding tests: comparison_vector + _levels_from_similarity."""
+import os
+
 import numpy as np
 import pydantic
 import pytest
@@ -74,28 +76,24 @@ def test_fallback_2_and_3_level_literals_unchanged():
     assert r3.u_probs["x"] == [0.80, 0.15, 0.05]
 
 
-# --- Native FS kernel guard for level_thresholds -----------------------------
+# --- Native FS kernel routing for level_thresholds ---------------------------
 #
-# Investigation verdict (Task 4): the Rust kernel assigns comparison levels
-# itself, NOT Python. `score_probabilistic_native` (goldenmatch/core/
-# probabilistic.py ~1956-1968) builds `levels = [int(f.levels) for f in
-# mk.fields]` and `partials = [float(f.partial_threshold) for f in mk.fields]`
-# and passes only those two (a level *count* + a single partial threshold) to
-# `native_module().score_block_pairs_fs(...)` -- `f.level_thresholds` is never
-# read or passed across the FFI boundary anywhere in that function. The kernel
-# therefore bands raw rapidfuzz-rs similarities into levels using its own
-# hard-coded default banding (2/3-level partial_threshold rule + even-spaced
-# N-level; see score.rs fs_level_from_sim), with no notion of an arbitrary
-# N-level CUSTOM threshold list -- custom level_thresholds lists never cross
-# the FFI. This differs from the vectorized/scalar paths, where
-# `f.level_thresholds` is threaded straight into `_levels_from_similarity`
-# (probabilistic.py lines 1579, 1691) and `comparison_vector` (line 325-330).
-# Since the kernel can't reproduce N-level custom banding, `_fs_native_eligible`
-# must decline (fall back to numpy/scalar) whenever any field sets
-# `level_thresholds`.
+# The Rust kernel assigns comparison levels itself. `score_probabilistic_native`
+# passes `levels` (a level count) + `partial_threshold` per field, and -- since
+# goldenmatch-native 0.1.14 -- an optional per-field `level_thresholds` list
+# that `score.rs fs_level_from_sim` bands with the exact
+# `_levels_from_similarity` custom semantics (level = count of satisfied
+# descending thresholds, `>=` inclusive). Support is advertised by the module
+# const `FS_SUPPORTS_LEVEL_THRESHOLDS`; `_fs_native_eligible` declines a
+# level_thresholds matchkey only when the loaded kernel does NOT advertise it
+# (a pre-0.1.14 wheel), keeping the pure-Python fallback for stale
+# `pip install goldenmatch[native]` environments while routing everything else
+# natively. The vectorized/scalar paths still thread `f.level_thresholds` into
+# `_levels_from_similarity` / `comparison_vector` directly.
 
 
-def _fake_native_module():
+def _fake_native_module_old_wheel():
+    """A kernel WITHOUT FS_SUPPORTS_LEVEL_THRESHOLDS (pre-0.1.14 wheel)."""
     class _Fake:
         def score_block_pairs_fs(self, *a, **kw):  # pragma: no cover - not invoked
             raise NotImplementedError
@@ -103,51 +101,103 @@ def _fake_native_module():
     return _Fake()
 
 
-def test_level_thresholds_not_native_eligible_synthetic(monkeypatch):
-    """Guard logic in isolation: force "native enabled" without a real build.
+def _fake_native_module_supporting():
+    """A kernel advertising level_thresholds support (goldenmatch-native >= 0.1.14)."""
+    class _Fake:
+        FS_SUPPORTS_LEVEL_THRESHOLDS = True
 
-    Runs in every environment (this worktree has no native module), unlike the
-    skipif-guarded real-kernel test below.
+        def score_block_pairs_fs(self, *a, **kw):  # pragma: no cover - not invoked
+            raise NotImplementedError
+
+    return _Fake()
+
+
+def _mk_custom():
+    return _mk(field="name", scorer="jaro_winkler", levels=4,
+               level_thresholds=[1.0, 0.92, 0.88])
+
+
+def test_level_thresholds_not_eligible_on_old_wheel_synthetic(monkeypatch):
+    """Old-wheel behavior pinned: a kernel that does NOT advertise
+    FS_SUPPORTS_LEVEL_THRESHOLDS must decline level_thresholds matchkeys
+    (plain matchkeys stay eligible). Runs in every environment.
     """
     from goldenmatch.core import probabilistic as p
 
     monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
     monkeypatch.setattr(
-        "goldenmatch.core._native_loader.native_module", _fake_native_module
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_old_wheel
     )
 
     mk_plain = _mk(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)
     assert p._fs_native_eligible(mk_plain) is True
-
-    mk_custom = _mk(field="name", scorer="jaro_winkler", levels=4,
-                    level_thresholds=[1.0, 0.92, 0.88])
-    assert p._fs_native_eligible(mk_custom) is False
+    assert p._fs_native_eligible(_mk_custom()) is False
 
 
-def test_level_thresholds_router_selects_non_native_scorer(monkeypatch):
-    """Router-level guard: probabilistic_block_scorer must not hand a
-    level_thresholds matchkey to the native closure, even with native mocked
-    "available". It should fall through to the vectorized numpy scorer
-    (jaro_winkler is vectorized_scorer_supported), named ``_scorer`` --
-    see probabilistic_block_scorer's ``_native`` / ``_scorer`` / ``_scalar``
-    closures.
+def test_level_thresholds_eligible_on_supporting_kernel_synthetic(monkeypatch):
+    """A kernel advertising FS_SUPPORTS_LEVEL_THRESHOLDS accepts
+    level_thresholds matchkeys (and plain matchkeys stay eligible too)."""
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_supporting
+    )
+
+    mk_plain = _mk(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)
+    assert p._fs_native_eligible(mk_plain) is True
+    assert p._fs_native_eligible(_mk_custom()) is True
+
+
+def test_level_thresholds_router_selects_native_when_supported(monkeypatch):
+    """With a supporting kernel, probabilistic_block_scorer hands a
+    level_thresholds matchkey to the native closure (``_native``)."""
+    from goldenmatch.core.probabilistic import _fallback_result
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_supporting
+    )
+
+    mk_custom = _mk_custom()
+    em = _fallback_result(mk_custom)
+    scorer = p.probabilistic_block_scorer(mk_custom, em)
+    assert scorer.__name__ == "_native"
+
+
+def test_level_thresholds_router_falls_back_on_old_wheel(monkeypatch):
+    """With a NON-supporting kernel, the router must not hand a
+    level_thresholds matchkey to the native closure. It falls through to the
+    vectorized numpy scorer (jaro_winkler is vectorized_scorer_supported),
+    named ``_scorer`` -- see probabilistic_block_scorer's ``_native`` /
+    ``_scorer`` / ``_scalar`` closures.
     """
     from goldenmatch.core import probabilistic as p
     from goldenmatch.core.probabilistic import _fallback_result
 
     monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
     monkeypatch.setattr(
-        "goldenmatch.core._native_loader.native_module", _fake_native_module
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_old_wheel
     )
 
-    mk_custom = _mk(field="name", scorer="jaro_winkler", levels=4,
-                    level_thresholds=[1.0, 0.92, 0.88])
+    mk_custom = _mk_custom()
     em = _fallback_result(mk_custom)
     scorer = p.probabilistic_block_scorer(mk_custom, em)
     assert scorer.__name__ == "_scorer"
 
 
+# native_available() is importability only -- it does NOT read GOLDENMATCH_NATIVE.
+# Honor an explicit forced-off run (pure-Python lane) by skipping the
+# real-kernel tests below instead of failing their native assertions.
+_NATIVE_FORCED_OFF = os.environ.get("GOLDENMATCH_NATIVE", "").strip().lower() in (
+    "0", "false", "no", "off", "disabled"
+)
+
+
 def _native_fs_available():
+    if _NATIVE_FORCED_OFF:
+        return False
     try:
         from goldenmatch.core import _native_loader
         return _native_loader.native_available() and hasattr(
@@ -157,9 +207,24 @@ def _native_fs_available():
         return False
 
 
+def _native_fs_supports_level_thresholds():
+    try:
+        from goldenmatch.core import _native_loader
+        return bool(getattr(
+            _native_loader.native_module(), "FS_SUPPORTS_LEVEL_THRESHOLDS", False
+        ))
+    except Exception:
+        return False
+
+
 @pytest.mark.skipif(not _native_fs_available(), reason="native FS kernel not built")
-def test_level_thresholds_not_native_eligible_real_kernel(monkeypatch):
-    """Same assertion against the real native build, when one is present (CI)."""
+@pytest.mark.skipif(
+    not _native_fs_supports_level_thresholds(),
+    reason="native FS kernel predates level_thresholds support (< 0.1.14)",
+)
+def test_level_thresholds_native_eligible_real_kernel(monkeypatch):
+    """Against the real native build (>= 0.1.14): level_thresholds matchkeys
+    ARE native-eligible now that the kernel advertises the capability."""
     from goldenmatch.core import probabilistic as p
 
     monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
@@ -167,7 +232,114 @@ def test_level_thresholds_not_native_eligible_real_kernel(monkeypatch):
 
     mk_plain = _mk(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)
     assert p._fs_native_eligible(mk_plain) is True
+    assert p._fs_native_eligible(_mk_custom()) is True
 
-    mk_custom = _mk(field="name", scorer="jaro_winkler", levels=4,
-                    level_thresholds=[1.0, 0.92, 0.88])
-    assert p._fs_native_eligible(mk_custom) is False
+
+@pytest.mark.skipif(not _native_fs_available(), reason="native FS kernel not built")
+@pytest.mark.skipif(
+    not _native_fs_supports_level_thresholds(),
+    reason="native FS kernel predates level_thresholds support (< 0.1.14)",
+)
+class TestNativeNLevelParity:
+    """Real-kernel parity: custom level_thresholds banding native vs numpy.
+
+    Comparison idiom mirrors TestNativeFSParity (test_probabilistic.py):
+    scores depend only on the LEVEL a similarity bands into, so as long as no
+    pair sits on a threshold boundary, native == numpy exactly (both round
+    to 4 decimals).
+    """
+
+    def _df(self):
+        import polars as pl
+        # Engineered bands for jaro_winkler with [1.0, 0.92, 0.88]:
+        #   smith/smith          -> 1.0    -> level 3
+        #   martha/marhta        -> ~0.961 -> level 2
+        #   jellyfish/smellyfish -> ~0.896 -> level 1
+        #   cross-block pairs    -> low    -> level 0
+        return pl.DataFrame({
+            "__row_id__": [0, 1, 2, 3, 4, 5],
+            "name": ["smith", "smith", "martha", "marhta",
+                     "jellyfish", "smellyfish"],
+            "city": ["aa", "aa", "bb", "bb", "cc", "zz"],
+        })
+
+    def _mk_mixed(self):
+        # MIXED matchkey: one field WITH custom thresholds, one WITHOUT --
+        # exercises the per-field Option across the FFI.
+        return MatchkeyConfig(
+            name="nl", type="probabilistic", link_threshold=0.05,
+            fields=[
+                MatchkeyField(field="name", scorer="jaro_winkler", levels=4,
+                              level_thresholds=[1.0, 0.92, 0.88]),
+                MatchkeyField(field="city", scorer="exact", levels=2),
+            ],
+        )
+
+    def test_native_matches_numpy_mixed_matchkey(self, monkeypatch):
+        from goldenmatch.core import probabilistic as p
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+        df, mk = self._df(), self._mk_mixed()
+        em = p._fallback_result(mk)
+        assert p._fs_native_eligible(mk) is True
+        native_pairs = sorted(p.score_probabilistic_native(df, mk, em, set()))
+        numpy_pairs = sorted(p.score_probabilistic_vectorized(df, mk, em, set()))
+        assert native_pairs == numpy_pairs
+        assert native_pairs  # the engineered bands must actually score pairs
+        # Multiple distinct bands hit -> more than one distinct score.
+        assert len({s for _a, _b, s in native_pairs}) > 1
+
+    def test_native_matches_numpy_all_custom(self, monkeypatch):
+        from goldenmatch.core import probabilistic as p
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+        df = self._df()
+        mk = MatchkeyConfig(
+            name="nl2", type="probabilistic", link_threshold=0.05,
+            fields=[
+                MatchkeyField(field="name", scorer="jaro_winkler", levels=4,
+                              level_thresholds=[1.0, 0.92, 0.88]),
+                MatchkeyField(field="city", scorer="jaro_winkler", levels=3,
+                              level_thresholds=[1.0, 0.75]),
+            ],
+        )
+        em = p._fallback_result(mk)
+        native_pairs = sorted(p.score_probabilistic_native(df, mk, em, set()))
+        numpy_pairs = sorted(p.score_probabilistic_vectorized(df, mk, em, set()))
+        assert native_pairs == numpy_pairs
+        assert native_pairs
+
+    def test_block_scorer_selects_native_for_level_thresholds(self, monkeypatch):
+        from goldenmatch.core import probabilistic as p
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+        mk = self._mk_mixed()
+        em = p._fallback_result(mk)
+        scorer = p.probabilistic_block_scorer(mk, em)
+        assert scorer.__name__ == "_native"
+
+    # -- kernel-level ValueError invariants (called directly across the FFI) --
+
+    @staticmethod
+    def _kernel_args(match_weights, level_thresholds):
+        # (row_ids, block_sizes, field_values, scorer_ids, levels,
+        #  partial_thresholds, match_weights, calibrated, prior_w, min_weight,
+        #  weight_range, threshold, exclude, level_thresholds)
+        return ([0, 1], [2], [["abc", "abd"]], [0], [4], [0.8], match_weights,
+                False, 0.0, 0.0, 1.0, 0.0, [], level_thresholds)
+
+    def test_kernel_rejects_thresholds_field_count_mismatch(self):
+        from goldenmatch.core._native_loader import native_module
+        with pytest.raises(ValueError,
+                           match="level_thresholds length 2 != field count 1"):
+            native_module().score_block_pairs_fs(
+                *self._kernel_args([[0.0, 1.0, 2.0, 3.0]],
+                                   [[1.0], [0.9]])
+            )
+
+    def test_kernel_rejects_weight_threshold_length_mismatch(self):
+        from goldenmatch.core._native_loader import native_module
+        # 2 thresholds need 3 weights; 4 given.
+        with pytest.raises(ValueError,
+                           match=r"need thresholds \+ 1 weights"):
+            native_module().score_block_pairs_fs(
+                *self._kernel_args([[0.0, 1.0, 2.0, 3.0]],
+                                   [[1.0, 0.9]])
+            )

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -1188,6 +1188,10 @@ class TestNativeFSParity:
     def test_block_scorer_picks_native_when_opted_in(self, monkeypatch):
         from goldenmatch.core import probabilistic as p
         monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+        # _fs_native_enabled also consults native_enabled("block_scoring"),
+        # which reads GOLDENMATCH_NATIVE; force it so an outer =0 run (the
+        # pure-Python lane) doesn't flip this native-routing assertion.
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
         mk = _make_probabilistic_mk()
         em = p.train_em(_make_dedupe_df(), mk, n_sample_pairs=100, blocking_fields=["zip"])
         scorer = p.probabilistic_block_scorer(mk, em)

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.13"
+version = "0.1.14"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.13"
+    __version__ = "0.1.14"

--- a/packages/rust/extensions/native/src/fused.rs
+++ b/packages/rust/extensions/native/src/fused.rs
@@ -263,7 +263,10 @@ pub fn match_fused_fs(
                         let level = match (vals[f][i], vals[f][j]) {
                             (Some(a), Some(b)) => {
                                 let sim = score_one(scorer_ids[f], a, b);
-                                fs_level_from_sim(sim, levels[f], partial_thresholds[f])
+                                // Fused stays declined for level_thresholds via
+                                // match_fused_fs_ready (Python side); port the
+                                // kwarg when the fused path goes live.
+                                fs_level_from_sim(sim, levels[f], partial_thresholds[f], None)
                             }
                             _ => 0, // null on either side -> disagree (level 0)
                         };

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -25,6 +25,9 @@ mod suggest;
 #[pymodule]
 fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
+    // level_thresholds matchkeys on this (old wheels never see the kwarg).
+    m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -12,8 +12,8 @@
 use arrow::array::{Array, ArrayData, Int64Array, LargeStringArray, StringArray};
 use arrow::datatypes::DataType;
 use arrow::pyarrow::PyArrowType;
-use numpy::{IntoPyArray, PyArray1, PyArray2};
 use goldenmatch_score_core::score_one;
+use numpy::{IntoPyArray, PyArray1, PyArray2};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rayon::prelude::*;
@@ -175,11 +175,6 @@ pub fn score_block_pairs(
     })
 }
 
-/// Map a per-field similarity to a comparison level, matching
-/// `core/probabilistic._levels_from_similarity`:
-///   2 levels: 1 if sim >= partial_threshold else 0
-///   3 levels: 2 if sim >= 0.95, elif sim >= partial_threshold -> 1, else 0
-///   N levels: count of k in 1..N with sim >= k/N (even spacing)
 /// Normalize a summed Fellegi-Sunter match weight to a [0,1] score. Shared by
 /// `score_block_pairs_fs` and the fused `match_fused_fs` so the two cannot drift.
 /// `calibrated` = posterior probability `1/(1+2^-(prior_w+w))`; else linear
@@ -201,8 +196,24 @@ pub(crate) fn fs_normalize(
     }
 }
 
+/// Map a per-field similarity to a comparison level, matching
+/// `core/probabilistic._levels_from_similarity`:
+///   custom `level_thresholds`: level = count of thresholds t with sim >= t
+///     (inclusive, order-independent — mirrors the Python custom branch
+///     byte-for-byte; len(thresholds)+1 levels total)
+///   2 levels: 1 if sim >= partial_threshold else 0
+///   3 levels: 2 if sim >= 0.95, elif sim >= partial_threshold -> 1, else 0
+///   N levels: count of k in 1..N with sim >= k/N (even spacing)
 #[inline]
-pub(crate) fn fs_level_from_sim(sim: f64, n_levels: u8, partial_threshold: f64) -> usize {
+pub(crate) fn fs_level_from_sim(
+    sim: f64,
+    n_levels: u8,
+    partial_threshold: f64,
+    level_thresholds: Option<&[f64]>,
+) -> usize {
+    if let Some(ts) = level_thresholds {
+        return ts.iter().filter(|&&t| sim >= t).count();
+    }
     match n_levels {
         2 => usize::from(sim >= partial_threshold),
         3 => {
@@ -241,11 +252,24 @@ pub(crate) fn fs_level_from_sim(sim: f64, n_levels: u8, partial_threshold: f64) 
 /// Scorers are score_one ids 0..=3 (jaro_winkler/levenshtein/token_sort/exact);
 /// soundex/embedding fields aren't native-eligible (caller falls back to numpy).
 ///
+/// `level_thresholds` (optional, one entry per field) carries a field's custom
+/// similarity->level banding (PR #1749's `level_thresholds`): when
+/// `Some(ts)` for field `f`, its level is the count of thresholds `t` with
+/// `sim >= t` (inclusive), and `match_weights[f]` must have `ts.len() + 1`
+/// entries. `None` (whole kwarg or per field) keeps the legacy 2/3/N-even
+/// banding. Old wheels never see this kwarg (Python gates on the
+/// `FS_SUPPORTS_LEVEL_THRESHOLDS` capability flag).
+///
 /// Parity with the numpy path is within rapidfuzz tolerance (same as the
 /// weighted kernel) — a pair could differ only if its normalized score sits
 /// within that tolerance of `threshold`. Asserted in tests/test_native_parity.py.
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
+#[pyo3(signature = (
+    row_ids, block_sizes, field_values, scorer_ids, levels, partial_thresholds,
+    match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
+    exclude, level_thresholds=None,
+))]
 pub fn score_block_pairs_fs(
     py: Python<'_>,
     row_ids: Vec<i64>,
@@ -261,9 +285,37 @@ pub fn score_block_pairs_fs(
     weight_range: f64,
     threshold: f64,
     exclude: Vec<(i64, i64)>,
-) -> Vec<(i64, i64, f64)> {
+    level_thresholds: Option<Vec<Option<Vec<f64>>>>,
+) -> PyResult<Vec<(i64, i64, f64)>> {
     let exclude: HashSet<(i64, i64)> = exclude.into_iter().collect();
     let n_fields = scorer_ids.len();
+
+    if let Some(lt) = &level_thresholds {
+        if lt.len() != n_fields {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs: level_thresholds length {} != field count {n_fields}",
+                lt.len()
+            )));
+        }
+        for (f, ts) in lt.iter().enumerate() {
+            if let Some(ts) = ts {
+                if match_weights[f].len() != ts.len() + 1 {
+                    return Err(PyValueError::new_err(format!(
+                        "score_block_pairs_fs: field {f} has {} match_weights but \
+                         {} level_thresholds (need thresholds + 1 weights)",
+                        match_weights[f].len(),
+                        ts.len()
+                    )));
+                }
+            }
+        }
+    }
+    // Per-field threshold slices hoisted out of the per-pair-per-field hot loop
+    // (no Option chasing / re-borrowing inside the rayon closure).
+    let field_thresholds: Vec<Option<&[f64]>> = match &level_thresholds {
+        Some(lt) => lt.iter().map(|ts| ts.as_deref()).collect(),
+        None => vec![None; n_fields],
+    };
 
     let mut spans: Vec<(usize, usize)> = Vec::with_capacity(block_sizes.len());
     let mut offset = 0usize;
@@ -272,7 +324,7 @@ pub fn score_block_pairs_fs(
         offset += size;
     }
 
-    py.detach(|| {
+    let result = py.detach(|| {
         spans
             .par_iter()
             .flat_map_iter(|&(offset, size)| {
@@ -292,7 +344,12 @@ pub fn score_block_pairs_fs(
                                 let level = match (&field_values[f][i], &field_values[f][j]) {
                                     (Some(a), Some(b)) => {
                                         let sim = score_one(scorer_ids[f], a, b);
-                                        fs_level_from_sim(sim, levels[f], partial_thresholds[f])
+                                        fs_level_from_sim(
+                                            sim,
+                                            levels[f],
+                                            partial_thresholds[f],
+                                            field_thresholds[f],
+                                        )
                                     }
                                     // Null on either side -> disagree (level 0).
                                     _ => 0,
@@ -315,7 +372,8 @@ pub fn score_block_pairs_fs(
                 local
             })
             .collect()
-    })
+    });
+    Ok(result)
 }
 
 /// A block-sorted Utf8 column read zero-copy from an Arrow buffer. Polars emits
@@ -657,9 +715,7 @@ pub fn score_field_matrix(
         // score_one returns [0,1] for ids 0-3 already (id=2 calls
         // fuzz::ratio which is [0,1] in rapidfuzz-rs, NOT the *100 scale
         // the PyO3-exposed token_sort_ratio uses).
-        0..=3 => compute_pairwise(&a, &b, symmetric, |x, y| {
-            score_one(scorer_id, x, y) as f32
-        }),
+        0..=3 => compute_pairwise(&a, &b, symmetric, |x, y| score_one(scorer_id, x, y) as f32),
         _ => {
             // 4 = soundex_match. Precompute soundex codes once per string
             // -- N*M comparisons would otherwise re-soundex every row pair.
@@ -824,6 +880,32 @@ mod tests {
         assert_eq!(soundex_code('M'), b'5'); // M N
         assert_eq!(soundex_code('R'), b'6'); // R
         assert_eq!(soundex_code('A'), b'0'); // vowels / other
+    }
+
+    #[test]
+    fn fs_level_from_sim_custom_thresholds_count_inclusive() {
+        // level = count of thresholds t with sim >= t (inclusive), matching
+        // Python _levels_from_similarity's custom branch byte-for-byte.
+        let ts = [1.0, 0.92, 0.88];
+        let sims = [1.0, 0.95, 0.90, 0.5, 0.88];
+        let expected = [3usize, 2, 1, 0, 1];
+        for (sim, want) in sims.iter().zip(expected.iter()) {
+            assert_eq!(fs_level_from_sim(*sim, 4, 0.8, Some(&ts)), *want);
+        }
+    }
+
+    #[test]
+    fn fs_level_from_sim_none_keeps_legacy_banding() {
+        // 2-level: 1 if sim >= partial_threshold else 0.
+        assert_eq!(fs_level_from_sim(0.9, 2, 0.8, None), 1);
+        assert_eq!(fs_level_from_sim(0.7, 2, 0.8, None), 0);
+        // 3-level: 0.95 exact band, partial band, else 0.
+        assert_eq!(fs_level_from_sim(1.0, 3, 0.8, None), 2);
+        assert_eq!(fs_level_from_sim(0.9, 3, 0.8, None), 1);
+        assert_eq!(fs_level_from_sim(0.5, 3, 0.8, None), 0);
+        // N-even (5 levels): count of k in 1..5 with sim >= k/5.
+        assert_eq!(fs_level_from_sim(0.85, 5, 0.8, None), 4);
+        assert_eq!(fs_level_from_sim(0.4, 5, 0.8, None), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Thesis phase 2 for the Splink converter (#1749): custom \`level_thresholds\` banding now scores in the native Rust FS kernel instead of falling back to pure Python.

- **Kernel** (\`goldenmatch-native\` 0.1.13 -> 0.1.14, three version files in lockstep): \`fs_level_from_sim\` gains an \`Option<&[f64]>\` custom branch (level = count of \`sim >= t\`, identical semantics to \`_levels_from_similarity\`); \`score_block_pairs_fs\` gains an optional trailing \`level_thresholds\` kwarg (pyo3 signature default \`None\`) with input validation (PyValueError on field-count or weights-length mismatch); per-field threshold slices hoisted outside the rayon hot loop.
- **Wheel-skew safety** (double gate): the module exports \`FS_SUPPORTS_LEVEL_THRESHOLDS = True\`; Python's \`_fs_native_eligible\` routes \`level_thresholds\` matchkeys natively only when the loaded kernel advertises it, and \`score_probabilistic_native\` sends the kwarg only when a field actually uses custom thresholds. Old wheels keep the pure-Python fallback with zero behavior change and can never receive the unknown kwarg.
- **Fused kernel** (\`match_fused_fs\`) deliberately unchanged: passes \`None\` and \`match_fused_fs_ready\` still declines — the path is dormant; port when it goes live.
- Also fixes a pre-existing env-dependent failure in \`TestNativeFSParity::test_block_scorer_picks_native_when_opted_in\` (needed \`GOLDENMATCH_NATIVE=1\` alongside \`GOLDENMATCH_FS_NATIVE=1\`).

## Verification

- Rust: \`cargo clippy --all-targets -- -D warnings\` clean; \`cargo test\` 76 passed (incl. new banding unit tests mirroring the Python test vectors).
- Python (in-tree 0.1.14 build): real-kernel parity tests — mixed (custom + plain field) and all-custom matchkeys produce identical pair sets/scores native vs pure-Python, incl. exact-boundary sims; kernel ValueError paths pinned end-to-end. Native lane 148 passed / 0 skipped; \`GOLDENMATCH_NATIVE=0\` lane 142 passed / 6 skipped (the real-kernel tests). Post-rebase: 169 passed across the touched suites.

## Release note

PyPI users stay on the (correct) pure-Python fallback until \`goldenmatch-native-v0.1.14\` is tagged and republished — flagged separately; in-tree and CI builds pick this up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqWK7rUZ4MqXnA47BdhjS