### PR TITLE
fix(native-symbols): recognize m.add() const exports in the reconciliation gate

### DIFF
--- a/scripts/check_native_symbols.py
+++ b/scripts/check_native_symbols.py
@@ -59,11 +59,15 @@ REGISTRY = {
 
 # wrap_pyfunction!( <optional module:: paths> <symbol> , m )   -- \s spans newlines
 _WRAP = re.compile(r"wrap_pyfunction!\(\s*(?:\w+::)*(\w+)")
+# m.add("NAME", value)? -- module-level consts (e.g. capability flags like
+# FS_SUPPORTS_LEVEL_THRESHOLDS) are kernel exports too; hosts probe them via
+# getattr(native_module(), "NAME", ...) so they must reconcile like functions.
+_MADD = re.compile(r'm\.add\(\s*"(\w+)"')
 _BIND = re.compile(r"(\w+)\s*=\s*(?:native_module\(\)|_ensure_native\(\))(?!\s*\.)")
 
 
 def parse_registrations_text(text: str) -> set[str]:
-    return set(_WRAP.findall(text))
+    return set(_WRAP.findall(text)) | set(_MADD.findall(text))
 
 
 def parse_registrations(paths) -> set[str]:

--- a/scripts/test_native_symbols.py
+++ b/scripts/test_native_symbols.py
@@ -21,6 +21,19 @@ def test_parse_registrations_extracts_final_segment():
     assert mod.parse_registrations_text(src) == {"connected_components", "record_fingerprint"}
 
 
+def test_parse_registrations_extracts_madd_consts():
+    # m.add("NAME", ...) consts (capability flags) are exports and must
+    # reconcile against getattr(native_module(), "NAME", ...) host probes.
+    src = """
+    m.add("__version__", env!("CARGO_PKG_VERSION"))?;
+    m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
+    m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
+    """
+    assert mod.parse_registrations_text(src) == {
+        "__version__", "FS_SUPPORTS_LEVEL_THRESHOLDS", "score_block_pairs_fs",
+    }
+
+
 def test_scan_refs_direct_form():
     src = 'from goldenmatch.core._native_loader import native_module\nx = native_module().quantile(a)\n'
     assert mod.scan_file_refs(src) == {"quantile"}


### PR DESCRIPTION
The native-symbols gate only parsed wrap_pyfunction! registrations, so the FS_SUPPORTS_LEVEL_THRESHOLDS capability const shipped in #1752 (a real kernel export the host probes via getattr) reports as MISSING and reds the lane on every goldenmatch-path PR. Consts registered via m.add("NAME", ...) now reconcile like functions — a typo'd const name in lib.rs is caught the same way. 12/12 gate unit tests pass; the real reconciliation exits 0 on main+this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqWK7rUZ4MqXnA47BdhjS