### PR TITLE
feat(goldenmatch): autoconfig arrow-port (plan PR-3..6b) -- remove the autoconfig Polars island

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -472,7 +472,7 @@ def dedupe(
 
 
 def dedupe_df(
-    df: pl.DataFrame,
+    df: Any,  # pl.DataFrame | pa.Table | Frame -- coerced via to_frame downstream (PR-6)
     *,
     config: Any | None = None,
     exact: list[str] | None = None,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3647,14 +3647,14 @@ def _maybe_detect_field_groups(df: Any, config: Any) -> None:
 
 
 def auto_configure_df(
-    df: pl.DataFrame | pl.LazyFrame,
+    df: Any,  # pl.DataFrame | pl.LazyFrame | pa.Table | Frame | ray.data.Dataset
     llm_provider: str | None = None,
     domain_config: Any = None,
     llm_auto: bool = False,
     strict: bool = False,
     allow_remote_assets: bool = False,
     *,
-    reference: pl.DataFrame | pl.LazyFrame | None = None,
+    reference: Any = None,  # pl.DataFrame | pl.LazyFrame | pa.Table | Frame | None
     _skip_finalize: bool = False,
     confidence_required: bool = True,
     allow_red_config: bool = False,
@@ -3692,24 +3692,40 @@ def auto_configure_df(
         ConfigValidationError: from the controller, when input is unworkable
             (empty, all-null, etc.).
     """
-    # W3e entry boundary: accept a Frame, unwrapped AT THE TOP -- the
-    # throughput early-check and the exclusions gate below are both
-    # isinstance-DataFrame-guarded; a still-wrapped Frame would silently
-    # skip them. PolarsFrame unwraps to today's path; ArrowFrame goes
-    # through the pl.from_arrow shim (W2d explicit-boundary pattern --
-    # REMOVE in W5 when arrow flows past ingest). `reference` stays
-    # Polars-only deliberately: match-mode arrow can't flow until W5.
-    from goldenmatch.core.frame import ArrowFrame, Frame, PolarsFrame
+    # W5/PR-6 boundary flip: accept pl.DataFrame | pl.LazyFrame | pa.Table |
+    # dict-of-arrays | Frame | ray.data.Dataset. A polars / ray / lazy input is
+    # left for the existing coercion block below (byte-identical); a Frame /
+    # pa.Table / dict is coerced to a polars DataFrame HERE.
+    #
+    # HONEST NOTE -- the remaining polars island: the profile/exclusion helpers
+    # below are already Frame-capable (each re-coerces via to_frame), but the
+    # CONTROLLER and the v0 heuristic are NOT arrow-ported yet --
+    # `AutoConfigController.run`'s all-null gate subscripts `df[col]`, and
+    # `_legacy_auto_configure_v0` has ~15 `df[col]` / `df.filter(pl.col(...))`
+    # sites. So an arrow input is bridged to polars HERE via `pl.from_arrow`.
+    # This bridge is the reason zero-config is not YET fully polars-free; lifting
+    # it needs the controller + v0-heuristic arrow port (tracked follow-up). The
+    # old W2d ArrowFrame-only shim (which also raised TypeError on a bare
+    # pa.Table public input) is subsumed by this general seam coercion.
+    from goldenmatch.core.frame import (
+        PolarsFrame,
+        is_polars_dataframe,
+        is_polars_lazyframe,
+        to_frame,
+    )
+    from goldenmatch.distributed._utils import is_ray_dataset as _is_ray_boundary
 
-    if isinstance(df, Frame):
-        if isinstance(df, ArrowFrame):
-            df = cast("pl.DataFrame", pl.from_arrow(df.native))
-        elif isinstance(df, PolarsFrame):
-            df = df.native
-        else:  # pragma: no cover -- future backend without a shim
-            raise TypeError(
-                f"auto_configure_df cannot unwrap Frame backend {type(df).__name__}"
-            )
+    if not (
+        _is_ray_boundary(df)
+        or is_polars_lazyframe(df)
+        or is_polars_dataframe(df)
+    ):
+        _boundary_frame = to_frame(df)
+        df = (
+            _boundary_frame.native
+            if isinstance(_boundary_frame, PolarsFrame)
+            else cast("pl.DataFrame", pl.from_arrow(_boundary_frame.native))
+        )
 
     # Throughput tier (#1083): early validation -- check text column exists BEFORE
     # the expensive controller run to give a clean ThroughputNotApplicableError.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3700,13 +3700,20 @@ def auto_configure_df(
         ConfigValidationError: from the controller, when input is unworkable
             (empty, all-null, etc.).
     """
-    # PR-6b boundary flip: accept pl.DataFrame | pl.LazyFrame | pa.Table |
-    # dict-of-arrays | Frame | ray.data.Dataset. A polars / ray / lazy input is
-    # left for the existing coercion block below (byte-identical); a Frame /
-    # pa.Table / dict is coerced to its ARROW native and flows through the
-    # controller + v0 heuristic polars-free (both are now Frame-seam ported).
-    # No more `pl.from_arrow` bridge -- the zero-config arrow path never imports
-    # polars.
+    # Boundary: accept pl.DataFrame | pl.LazyFrame | pa.Table | dict-of-arrays |
+    # Frame | ray.data.Dataset. PR-3..6b landed the autoconfig-LAYER arrow seam
+    # (arrow->polars dtype map, controller gates, sampling, blocking-size
+    # measurement, v0 heuristic). The zero-config SCORING lane is NOT fully
+    # arrow-ported yet, though: the eager indicators' empty/column guards
+    # (indicators.py), the GoldenCheck exclusion detectors, and the legacy
+    # `build_blocks(combined_lf)` scoring spine (pipeline.py:2284) still assume
+    # polars -- a bare pa.Table there raises (e.g. `pa.Table.is_empty`) and the
+    # controller degrades to a RED v0 fallback. So a non-polars input is coerced
+    # to polars HERE (byte-identical to the same data passed as a pl.DataFrame --
+    # no silent RED fallback / regression). Making this a true `.native` arrow
+    # pass-through (Polars-free zero-config, tripwire green, [polars] stopgap
+    # dropped) is the pipeline-spine follow-up; the seam routing above is its
+    # foundation. (ray / lazy / polars inputs are handled by the block below.)
     from goldenmatch.core.frame import (
         is_polars_dataframe,
         is_polars_lazyframe,
@@ -3719,10 +3726,13 @@ def auto_configure_df(
         or is_polars_lazyframe(df)
         or is_polars_dataframe(df)
     ):
-        # arrow / pa.Table / dict-of-arrays / Frame -> keep the native (arrow on
-        # the arrow backend, polars on the polars backend). to_frame is
-        # idempotent; .native is a pa.Table (no polars) on the arrow lane.
-        df = to_frame(df).native
+        _boundary_native = to_frame(df).native
+        if is_polars_dataframe(_boundary_native):
+            df = _boundary_native
+        else:
+            import polars as _pl_boundary
+
+            df = cast("pl.DataFrame", _pl_boundary.from_arrow(_boundary_native))
 
     # Throughput tier (#1083): early validation -- check text column exists BEFORE
     # the expensive controller run to give a clean ThroughputNotApplicableError.
@@ -3777,6 +3787,16 @@ def auto_configure_df(
     # partition kernel layer separately.
     _ms_partition: str | None = None  # #858 source partition (None => feature off)
     if not _is_ray_dataset(df) and is_polars_dataframe(df):
+        # df is always a pl.DataFrame here: the boundary above coerces every
+        # non-ray / non-lazy input (incl. pa.Table) to polars until the scoring
+        # lane is arrow-ported, and a LazyFrame was collected. So a pa.Table
+        # zero-config input runs the SAME exclusions / exclude_columns / #858
+        # guard as an equivalent pl.DataFrame -- the detectors below
+        # (detect_autoconfig_exclusions / _detect_source_partition /
+        # _source_correlated_exclusions) are not seam-ported, and don't need to
+        # be while the boundary coerces. Seam-porting them is part of the
+        # pipeline-spine follow-up that makes the boundary a true arrow
+        # pass-through.
         from goldenmatch.core.quality_exclusions import (
             detect_autoconfig_exclusions,
         )

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -300,10 +300,29 @@ def _polars_scalar_spelling(build: Any, fallback: str) -> str:
         return fallback
 
 
-# "String" on modern polars (``str(pl.Utf8)``), "Utf8" on older builds.
-_POLARS_STRING_SPELLING = _polars_scalar_spelling(lambda p: p.Utf8, "Utf8")
-# "Datetime(time_unit='us', time_zone=None)" on modern polars.
-_POLARS_DATETIME_SPELLING = _polars_scalar_spelling(lambda p: p.Datetime("us"), "Datetime")
+# LAZY: computing these at MODULE level touches ``pl.Utf8`` / ``pl.Datetime`` on
+# the _polars_lazy proxy, which eagerly imports polars at ``import goldenmatch``
+# time -- a zero-polars-eviction gate violation (test_lazy_import_gate). Compute
+# + cache on first USE instead (the arrow classify path, never at import).
+_POLARS_SCALAR_SPELLING_CACHE: dict[str, str] = {}
+
+
+def _polars_string_spelling() -> str:
+    """``str(pl.Utf8)`` ("String" on modern polars, "Utf8" older), cached."""
+    cached = _POLARS_SCALAR_SPELLING_CACHE.get("string")
+    if cached is None:
+        cached = _polars_scalar_spelling(lambda p: p.Utf8, "Utf8")
+        _POLARS_SCALAR_SPELLING_CACHE["string"] = cached
+    return cached
+
+
+def _polars_datetime_spelling() -> str:
+    """``str(pl.Datetime("us"))`` ("Datetime(time_unit='us', ...)"), cached."""
+    cached = _POLARS_SCALAR_SPELLING_CACHE.get("datetime")
+    if cached is None:
+        cached = _polars_scalar_spelling(lambda p: p.Datetime("us"), "Datetime")
+        _POLARS_SCALAR_SPELLING_CACHE["datetime"] = cached
+    return cached
 
 # Exact arrow-spelling → polars-spelling. Keys are arrow's ``str(type)`` (all
 # lowercase); polars spellings are TitleCase, so they are never keys and pass
@@ -348,10 +367,10 @@ def _arrow_to_polars_dtype_spelling(raw: object) -> str:
         return mapped
     # string family (arrow: string / large_string / utf8 / large_utf8)
     if s in ("string", "large_string", "utf8", "large_utf8"):
-        return _POLARS_STRING_SPELLING
+        return _polars_string_spelling()
     # timestamp[..] / date[..] families are unit-parametrized (not single keys)
     if s.startswith("timestamp"):
-        return _POLARS_DATETIME_SPELLING
+        return _polars_datetime_spelling()
     if s.startswith("date"):
         return "Date"
     # Unknown (incl. every polars spelling) -> unchanged.
@@ -3758,7 +3777,7 @@ def auto_configure_df(
         # Dataset stays as-is; controller.run() handles it natively.
         _n_rows_for_budget: int = df.count()  # type: ignore[union-attr]
     elif is_polars_lazyframe(df):
-        df = df.collect()
+        df = cast("pl.LazyFrame", df).collect()
         _n_rows_for_budget = df.height
     elif is_polars_dataframe(df):
         _n_rows_for_budget = df.height

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1946,16 +1946,16 @@ def _check_source_overlap(
     ``__source__`` so existing callers are unchanged; #858 passes a detected
     user source column when there is no ``__source__``.
     """
-    if partition_col not in df.columns:
-        return 1.0
-
-    sources = df[partition_col].unique().to_list()
-    if len(sources) < 2:
-        return 1.0
-
     from goldenmatch.core.frame import to_frame
 
     frame = to_frame(df)
+    if partition_col not in frame.columns:
+        return 1.0
+
+    sources = frame.column(partition_col).unique().to_list()
+    if len(sources) < 2:
+        return 1.0
+
     value_sets = []
     for src in sources:
         vals = set(
@@ -2710,12 +2710,20 @@ def build_blocking(
             None, defaults to ``df.height`` (backward-compat for direct
             callers like tests that pass a full-table df).
     """
+    # Arrow-port: coerce to the Frame seam once (build_blocking never reassigns
+    # df) so column/height/group_by ops run polars-free on a pa.Table. Idempotent
+    # for the polars backend -> byte-identical.
+    from goldenmatch.core.frame import to_frame as _tf
+
+    _bf = _tf(df)
+    _bf_height = _bf.height
+
     # Filter out high-null columns (>20% null) — they create oversized null blocks
     # that cause O(N^2) comparison explosions
     max_null_rate = 0.20
 
     def _null_rate(col_name: str) -> float:
-        return df[col_name].null_count() / df.height if df.height > 0 else 0.0
+        return _bf.column(col_name).null_count() / _bf_height if _bf_height > 0 else 0.0
 
     # Tier 2 (autoconfig-tier1-tier2): null-aware v0 blocking selection.
     # Columns with null_rate > NULL_RATE_CEILING are skipped as blocking keys:
@@ -2739,8 +2747,8 @@ def build_blocking(
     # profiles run on a small sample; at sample N=1000, real
     # mid-cardinality columns (zip) look near-unique. Chao1 correction
     # uses the sample's distinct count + sample_n vs full_n to project.
-    effective_n_full = n_rows_full if n_rows_full is not None else df.height
-    sample_n = max(df.height, 1)
+    effective_n_full = n_rows_full if n_rows_full is not None else _bf_height
+    sample_n = max(_bf_height, 1)
 
     # #1082: ANN is no longer AUTO-selected for description columns. A free-
     # text corpus (description column, no blockable structured key) is routed
@@ -2803,7 +2811,7 @@ def build_blocking(
                 and _null_rate(p.name) <= max_null_rate
                 and _projected_ratio(p) <= blocking_max_ratio
                 and _check_source_overlap(df, p.name) == 0.0):
-            sources = df["__source__"].unique().to_list() if "__source__" in df.columns else []
+            sources = _bf.column("__source__").unique().to_list() if "__source__" in _bf.columns else []
             logger.warning(
                 "Blocking key '%s' has 0%% overlap between sources %s -- skipping",
                 p.name, ", ".join(str(s) for s in sources),
@@ -2835,7 +2843,7 @@ def build_blocking(
     # and headroom to 10K for 2M+. Cap at 10K because a 10K-row block
     # under float32 ensemble is ~400 MB per scorer call which is the
     # practical OOM ceiling on a 16 GB runner.
-    max_safe_block = max(1000, min(10_000, int(df.height) // 200))
+    max_safe_block = max(1000, min(10_000, int(_bf_height) // 200))
 
     # #715: gate every emitted blocking key/pass by its PROJECTED full-N max
     # block size. build_blocking runs on a sample (or, in the v0 path, the
@@ -2858,8 +2866,8 @@ def build_blocking(
         maximally oversized AND concentrated (dropped) — fail-safe.
         """
         try:
-            g = df.group_by(fields).len()
-            mb = int(g.get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" is int64 at runtime
+            g = _bf.group_len(fields)
+            mb = int(g.column("len").max() or 0)  # "len" is int64 at runtime
             return mb, int(g.height)
         except Exception:  # pragma: no cover -- defensive
             return effective_n_full, 1
@@ -2937,7 +2945,7 @@ def build_blocking(
     # Best case: block on highest-cardinality exact column (with low null rate + safe block size)
     if exact_cols:
         # Pre-filter: only evaluate top 5 by cardinality to avoid expensive group_by on all columns
-        exact_cols_sorted = sorted(exact_cols, key=lambda p: df[p.name].n_unique(), reverse=True)
+        exact_cols_sorted = sorted(exact_cols, key=lambda p: _bf.column(p.name).n_unique(), reverse=True)
         # #876: drop a unique-per-row SURROGATE (id) before picking the best
         # exact key.  A surrogate creates singleton blocks (block size 1 → 0
         # candidate pairs → finds nothing) and was the degenerate fallback. Gate
@@ -2958,7 +2966,7 @@ def build_blocking(
         # kept.
         safe_exact = [p for p in candidates if _is_scale_safe([p.name])]
         if safe_exact:
-            best = max(safe_exact, key=lambda p: df[p.name].n_unique())
+            best = max(safe_exact, key=lambda p: _bf.column(p.name).n_unique())
             transforms = ["lowercase", "strip"] if best.col_type == "email" else ["strip"]
             return BlockingConfig(
                 keys=[BlockingKeyConfig(fields=[best.name], transforms=transforms)],
@@ -3692,23 +3700,14 @@ def auto_configure_df(
         ConfigValidationError: from the controller, when input is unworkable
             (empty, all-null, etc.).
     """
-    # W5/PR-6 boundary flip: accept pl.DataFrame | pl.LazyFrame | pa.Table |
+    # PR-6b boundary flip: accept pl.DataFrame | pl.LazyFrame | pa.Table |
     # dict-of-arrays | Frame | ray.data.Dataset. A polars / ray / lazy input is
     # left for the existing coercion block below (byte-identical); a Frame /
-    # pa.Table / dict is coerced to a polars DataFrame HERE.
-    #
-    # HONEST NOTE -- the remaining polars island: the profile/exclusion helpers
-    # below are already Frame-capable (each re-coerces via to_frame), but the
-    # CONTROLLER and the v0 heuristic are NOT arrow-ported yet --
-    # `AutoConfigController.run`'s all-null gate subscripts `df[col]`, and
-    # `_legacy_auto_configure_v0` has ~15 `df[col]` / `df.filter(pl.col(...))`
-    # sites. So an arrow input is bridged to polars HERE via `pl.from_arrow`.
-    # This bridge is the reason zero-config is not YET fully polars-free; lifting
-    # it needs the controller + v0-heuristic arrow port (tracked follow-up). The
-    # old W2d ArrowFrame-only shim (which also raised TypeError on a bare
-    # pa.Table public input) is subsumed by this general seam coercion.
+    # pa.Table / dict is coerced to its ARROW native and flows through the
+    # controller + v0 heuristic polars-free (both are now Frame-seam ported).
+    # No more `pl.from_arrow` bridge -- the zero-config arrow path never imports
+    # polars.
     from goldenmatch.core.frame import (
-        PolarsFrame,
         is_polars_dataframe,
         is_polars_lazyframe,
         to_frame,
@@ -3720,12 +3719,10 @@ def auto_configure_df(
         or is_polars_lazyframe(df)
         or is_polars_dataframe(df)
     ):
-        _boundary_frame = to_frame(df)
-        df = (
-            _boundary_frame.native
-            if isinstance(_boundary_frame, PolarsFrame)
-            else cast("pl.DataFrame", pl.from_arrow(_boundary_frame.native))
-        )
+        # arrow / pa.Table / dict-of-arrays / Frame -> keep the native (arrow on
+        # the arrow backend, polars on the polars backend). to_frame is
+        # idempotent; .native is a pa.Table (no polars) on the arrow lane.
+        df = to_frame(df).native
 
     # Throughput tier (#1083): early validation -- check text column exists BEFORE
     # the expensive controller run to give a clean ThroughputNotApplicableError.
@@ -3750,16 +3747,15 @@ def auto_configure_df(
     if _is_ray_dataset(df):
         # Dataset stays as-is; controller.run() handles it natively.
         _n_rows_for_budget: int = df.count()  # type: ignore[union-attr]
-    elif isinstance(df, pl.LazyFrame):
+    elif is_polars_lazyframe(df):
         df = df.collect()
         _n_rows_for_budget = df.height
-    elif isinstance(df, pl.DataFrame):
+    elif is_polars_dataframe(df):
         _n_rows_for_budget = df.height
     else:
-        raise TypeError(
-            f"auto_configure_df requires pl.DataFrame, pl.LazyFrame, or "
-            f"ray.data.Dataset, got {type(df).__name__}"
-        )
+        # Arrow-native boundary (pa.Table) -- the zero-config polars-free lane.
+        # .height via the Frame seam; the controller consumes the arrow native.
+        _n_rows_for_budget = to_frame(df).height
     if reference is not None:
         if isinstance(reference, pl.LazyFrame):
             reference = reference.collect()
@@ -3780,7 +3776,7 @@ def auto_configure_df(
     # their own column-selection story; exclusions land at the per-
     # partition kernel layer separately.
     _ms_partition: str | None = None  # #858 source partition (None => feature off)
-    if not _is_ray_dataset(df) and isinstance(df, pl.DataFrame):
+    if not _is_ray_dataset(df) and is_polars_dataframe(df):
         from goldenmatch.core.quality_exclusions import (
             detect_autoconfig_exclusions,
         )
@@ -3937,8 +3933,8 @@ def auto_configure_df(
     # audio fingerprint) and append a phash/audio_fp matchkey (+ perceptual
     # blocking for an image column when nothing else blocks). Byte-identical when
     # the flag is off.
-    if os.environ.get("GOLDENMATCH_PERCEPTUAL_AUTOCONFIG", "0") == "1" and isinstance(
-        df, pl.DataFrame
+    if os.environ.get("GOLDENMATCH_PERCEPTUAL_AUTOCONFIG", "0") == "1" and is_polars_dataframe(
+        df
     ):
         try:
             from goldenmatch.core.perceptual_autoconfig import apply_perceptual_autoconfig
@@ -3985,6 +3981,11 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     # safely test `if domain_profile is not None` even when the domain
     # branch below is skipped (e.g. user-provided domain_config).
     domain_profile = None
+    # Arrow-port: route the v0 heuristic's frame ops through the seam so a bare
+    # pa.Table (zero-config polars-free path) is never subscripted with df[col]
+    # / df.height / df.columns / df.with_row_index (all crash on pa.Table).
+    # to_frame is idempotent -> byte-identical for the polars backend.
+    from goldenmatch.core.frame import to_frame as _tf
     # Preserve the raw input df for preflight. The in-function `df` variable
     # gets enriched with __row_id__ / domain-extracted columns; preflight
     # needs to check against the shape the pipeline will see.
@@ -3994,9 +3995,9 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     # but the gate needs 1.13M to scale via Chao1. Caller threads the
     # true count via n_rows_full; falls back to df.height for direct
     # callers (tests / non-controller paths) that pass full frames.
-    total_rows = n_rows_full if n_rows_full is not None else df.height
+    total_rows = n_rows_full if n_rows_full is not None else _tf(df).height
 
-    logger.info("Auto-configuring %d rows, %d columns", total_rows, len(df.columns))
+    logger.info("Auto-configuring %d rows, %d columns", total_rows, len(_tf(df).columns))
 
     _emit_data_profile(df)
 
@@ -4026,16 +4027,16 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     else:
         from goldenmatch.core.domain import detect_domain, extract_features
 
-        user_cols = [c for c in df.columns if not c.startswith("__")]
+        user_cols = [c for c in _tf(df).columns if not c.startswith("__")]
         domain_profile = detect_domain(user_cols)
 
         if domain_profile.confidence > 0.7:
-            original_cols = set(df.columns)
+            original_cols = set(_tf(df).columns)
             # extract_features requires __row_id__ column
-            if "__row_id__" not in df.columns:
-                df = df.with_row_index("__row_id__")
+            if "__row_id__" not in _tf(df).columns:
+                df = _tf(df).with_row_index("__row_id__").native
             df, _low_conf_ids = extract_features(df, domain_profile)
-            extracted_columns = [c for c in df.columns if c.startswith("__") and c not in original_cols]
+            extracted_columns = [c for c in _tf(df).columns if c.startswith("__") and c not in original_cols]
             logger.info(
                 "Domain '%s' detected (confidence=%.2f), extracted %d feature columns",
                 domain_profile.name, domain_profile.confidence, len(extracted_columns),
@@ -4071,8 +4072,10 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             if col not in _DOMAIN_SCORER_MAP:
                 continue
             scorer, weight, transforms = _DOMAIN_SCORER_MAP[col]
-            null_rate = df[col].null_count() / df.height if df.height > 0 else 0
-            cardinality_ratio = df[col].n_unique() / df.height if df.height > 0 else 0
+            _fcol = _tf(df)
+            _h = _fcol.height
+            null_rate = _fcol.column(col).null_count() / _h if _h > 0 else 0
+            cardinality_ratio = _fcol.column(col).n_unique() / _h if _h > 0 else 0
             if null_rate > 0.5:
                 continue
             if scorer == "exact" and cardinality_ratio < 0.01:
@@ -4127,8 +4130,10 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             scorer, _weight, _transforms = _DOMAIN_SCORER_MAP[col]
             if scorer != "exact":
                 continue
-            null_rate = df[col].null_count() / df.height if df.height > 0 else 0
-            cardinality_ratio = df[col].n_unique() / df.height if df.height > 0 else 0
+            _fcol2 = _tf(df)
+            _h2 = _fcol2.height
+            null_rate = _fcol2.column(col).null_count() / _h2 if _h2 > 0 else 0
+            cardinality_ratio = _fcol2.column(col).n_unique() / _h2 if _h2 > 0 else 0
             if null_rate > 0.5:
                 continue
             profiles.append(ColumnProfile(
@@ -4158,7 +4163,7 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
     # At 1M+ rows, swap static blocking for adaptive so blocker.py's
     # _sub_block / _auto_split_block paths bound oversized buckets at
     # runtime. No-op for multi_pass / canopy / ann / learned / sorted_neighborhood.
-    blocking = _maybe_promote_blocking_to_adaptive(blocking, df.height)
+    blocking = _maybe_promote_blocking_to_adaptive(blocking, _tf(df).height)
     # Opt-in (GOLDENMATCH_BLOCKING_PRUNE_PASSES=1): drop redundant/all-noise
     # multi-pass passes by likely-match yield.
     blocking = _maybe_prune_blocking_passes(blocking, df)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -275,6 +275,111 @@ def _classify_by_data(values: list[str]) -> tuple[str, float]:
     return col_type, confidence
 
 
+# ── Arrow→polars dtype-spelling contract (autoconfig arrow-port PR-3) ──────────
+# The native ``autoconfig_classify_columns`` kernel is fed ``str(dtype)`` and its
+# golden vectors + the downstream string-column check
+# (``p.dtype.startswith("String"/"Utf8")`` further down) expect the POLARS dtype
+# spelling ("Float64"/"Int64"/"String"/"Boolean"). Polars renders those directly;
+# an ``ArrowFrame``'s ``str(dtype)`` spells the SAME types differently
+# ("double"/"int64"/"large_string"/"bool"). We keep the Rust kernel's vocabulary
+# and map arrow→polars-spelling at this ONE Python boundary so the kernel sees its
+# own vocabulary regardless of backend -- no Rust change, no golden-vector regen.
+# A polars spelling passed in is returned UNCHANGED (identity), so the polars path
+# is byte-for-byte what it was before the port.
+
+
+def _polars_scalar_spelling(build: Any, fallback: str) -> str:
+    """``str()`` of a polars dtype, matched exactly so the arrow path's classify
+    input equals the polars path's. Falls back when polars is unavailable
+    (pure-arrow install); the fallback is still accepted downstream."""
+    try:
+        from goldenmatch._polars_lazy import pl as _pl  # noqa: PLC0415
+
+        return str(build(_pl))
+    except Exception:  # noqa: BLE001 -- polars absent / API drift: use the fallback
+        return fallback
+
+
+# "String" on modern polars (``str(pl.Utf8)``), "Utf8" on older builds.
+_POLARS_STRING_SPELLING = _polars_scalar_spelling(lambda p: p.Utf8, "Utf8")
+# "Datetime(time_unit='us', time_zone=None)" on modern polars.
+_POLARS_DATETIME_SPELLING = _polars_scalar_spelling(lambda p: p.Datetime("us"), "Datetime")
+
+# Exact arrow-spelling → polars-spelling. Keys are arrow's ``str(type)`` (all
+# lowercase); polars spellings are TitleCase, so they are never keys and pass
+# through ``.get`` unchanged (the identity guarantee).
+_ARROW_TO_POLARS_DTYPE: dict[str, str] = {
+    # floats
+    "double": "Float64",
+    "float": "Float32",
+    "halffloat": "Float32",
+    # signed ints
+    "int64": "Int64",
+    "int32": "Int32",
+    "int16": "Int16",
+    "int8": "Int8",
+    # unsigned ints
+    "uint64": "UInt64",
+    "uint32": "UInt32",
+    "uint16": "UInt16",
+    "uint8": "UInt8",
+    # bool
+    "bool": "Boolean",
+    # date (day / ms variants both render as polars Date)
+    "date32[day]": "Date",
+    "date64[ms]": "Date",
+    # null
+    "null": "Null",
+}
+
+
+def _arrow_to_polars_dtype_spelling(raw: object) -> str:
+    """Turn a concrete column dtype string into the polars spelling the native
+    ``autoconfig_classify_columns`` kernel expects.
+
+    Identity for polars spellings (they are never arrow keys), translation for
+    arrow spellings, and ``str(raw)`` passthrough for any dtype not covered
+    (documented fallback -- keeps the pre-port ``str(dtype)`` behavior for exotic
+    types).
+    """
+    s = str(raw)
+    mapped = _ARROW_TO_POLARS_DTYPE.get(s)
+    if mapped is not None:
+        return mapped
+    # string family (arrow: string / large_string / utf8 / large_utf8)
+    if s in ("string", "large_string", "utf8", "large_utf8"):
+        return _POLARS_STRING_SPELLING
+    # timestamp[..] / date[..] families are unit-parametrized (not single keys)
+    if s.startswith("timestamp"):
+        return _POLARS_DATETIME_SPELLING
+    if s.startswith("date"):
+        return "Date"
+    # Unknown (incl. every polars spelling) -> unchanged.
+    return s
+
+
+def _concrete_dtype_spelling(frame: Any, col_name: str) -> str:
+    """Read ``frame``'s concrete column dtype (native spelling per backend) and
+    map it to the polars spelling for the classify kernel.
+
+    - ``PolarsFrame`` -> its own ``str(dtype)`` (the map is identity, so this is
+      byte-identical to the pre-port ``str(df[col].dtype)``).
+    - ``ArrowFrame`` -> the pyarrow field type, mapped arrow→polars.
+
+    NOTE: the seam ``Column`` Protocol exposes no concrete-dtype accessor (only the
+    coarse ``semantic_dtype()``), so this reaches ``frame.native``. A clean seam op
+    (e.g. ``Column.dtype_str()``) would drop the ``.native`` branch -- flagged for a
+    PR-1-style follow-up.
+    """
+    from goldenmatch.core.frame import ArrowFrame  # noqa: PLC0415
+
+    if isinstance(frame, ArrowFrame):
+        raw = str(frame.native.schema.field(col_name).type)
+    else:
+        raw = str(frame.native[col_name].dtype)
+    return _arrow_to_polars_dtype_spelling(raw)
+
+
 def profile_columns(
     df: pl.DataFrame, sample_size: int = 1000, max_columns: int = 40,
     llm_provider: str | None = None,
@@ -286,17 +391,21 @@ def profile_columns(
     (name, email, phone, zip, address) are prioritized, then remaining columns
     fill up to the cap.
     """
-    # Sample randomly (W3c: via the seam; polars rows unchanged -- exact
-    # delegation, shuffle=False default matches the old call)
+    # Route through the Frame seam so profile_columns runs on a polars frame
+    # (today) OR an ArrowFrame (post-PR-6) -- `to_frame` is idempotent and accepts
+    # pl.DataFrame / pa.Table / Frame. (W3c: polars rows unchanged; sample is exact
+    # delegation, shuffle=False default matches the old call.)
     from goldenmatch.core.frame import to_frame
 
-    if df.height > sample_size:
-        sample = to_frame(df).sample(sample_size, seed=42).native
+    frame = to_frame(df)
+
+    if frame.height > sample_size:
+        sample_frame = frame.sample(sample_size, seed=42)
     else:
-        sample = df
+        sample_frame = frame
 
     # For wide datasets, prioritize columns likely useful for matching
-    columns = [c for c in df.columns if not c.startswith("__")]
+    columns = [c for c in frame.columns if not c.startswith("__")]
     if len(columns) > max_columns:
         # Phase 1: keep columns matching known patterns
         priority = []
@@ -312,7 +421,7 @@ def profile_columns(
         logger.info(
             "Wide dataset (%d columns), auto-configure limited to %d columns "
             "(%d pattern-matched, %d additional)",
-            len(df.columns), len(columns), len(priority), remaining_slots,
+            len(frame.columns), len(columns), len(priority), remaining_slots,
         )
 
     # Collect per-column stats using Polars (shared by both the native and
@@ -322,10 +431,12 @@ def profile_columns(
         if col_name.startswith("__"):
             continue
 
-        dtype = str(df[col_name].dtype)  # raw polars spelling: feeds the
-        # native classify JSON byte-identically (W3c: pinned, not normalized)
+        # Concrete column dtype in the POLARS spelling the native classify kernel
+        # expects, regardless of backend: identity on a PolarsFrame (byte-identical
+        # to the old `str(df[col].dtype)`), arrow→polars-mapped on an ArrowFrame.
+        dtype = _concrete_dtype_spelling(frame, col_name)
 
-        col_series = to_frame(sample).column(col_name)
+        col_series = sample_frame.column(col_name)
         total_rows = len(col_series)
         null_count = col_series.null_count()
         null_rate = null_count / total_rows if total_rows > 0 else 0.0

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -585,6 +585,7 @@ class AutoConfigController:
         always consumes Polars samples.
         """
         # --- Phase 2: distributed branch detection --------------------------
+        from goldenmatch.core.frame import to_frame  # arrow-port: seam coercions
         from goldenmatch.distributed._utils import is_ray_dataset
         distributed = is_ray_dataset(df)
 
@@ -596,8 +597,13 @@ class AutoConfigController:
             n_rows: int = df.count()  # type: ignore[union-attr]
             _df_for_gates = init_sample
         else:
+            from goldenmatch.core.frame import to_frame as _to_frame_gate
+
             _df_for_gates = df  # type: ignore[assignment]
-            n_rows = df.height  # type: ignore[union-attr]
+            # Arrow-port: route the pathological gates through the Frame seam so a
+            # bare pa.Table (zero-config polars-free path) is not subscripted with
+            # df[col] (crashes) -- byte-identical for the polars backend.
+            n_rows = _to_frame_gate(df).height  # type: ignore[union-attr]
             init_sample = df  # type: ignore[assignment]  # alias; never collected twice
         # Stash the full dataset row count for _assemble_profile() so per-
         # iteration profiles carry data.n_full_rows. Chao1 extrapolation in
@@ -606,17 +612,24 @@ class AutoConfigController:
         self._current_run_full_n_rows = n_rows
 
         # Pathological gates ------------------------------------------------
-        if _df_for_gates.height == 0:
+        # Arrow-port: coerce to the Frame seam once so the gate ops (.height,
+        # .columns, per-column drop_nulls) run polars-free on a pa.Table. On the
+        # distributed path _df_for_gates is a polars sample; to_frame is
+        # idempotent so the polars backend is byte-identical.
+        from goldenmatch.core.frame import to_frame as _to_frame_gate2
+
+        _gate_frame = _to_frame_gate2(_df_for_gates)
+        if _gate_frame.height == 0:
             raise ConfigValidationError("no data to configure on")
 
-        user_cols = [c for c in _df_for_gates.columns if not c.startswith("__")]
+        user_cols = [c for c in _gate_frame.columns if not c.startswith("__")]
         if not user_cols:
             raise ConfigValidationError("no usable columns")
 
         # Check all-null defensively across user columns
         all_null = True
         for col in user_cols:
-            if _df_for_gates[col].drop_nulls().len() > 0:
+            if len(_gate_frame.column(col).drop_nulls()) > 0:
                 all_null = False
                 break
         if all_null:
@@ -677,7 +690,7 @@ class AutoConfigController:
             _diag("_initial_config done")
             with stage("controller_pre_take_sample"):
                 sample, sample_ref = self._take_sample(df, reference=reference)  # type: ignore[arg-type]
-            _diag(f"_take_sample done (sample.height={sample.height})")
+            _diag(f"_take_sample done (sample.height={to_frame(sample).height})")
         history = RunHistory()
         config_n = config_v0
         start = time.time()
@@ -896,10 +909,13 @@ class AutoConfigController:
                     if _last_decision is not None else None
                 )
                 if _expand_factor is not None and not distributed:
+                    from goldenmatch.core.frame import to_frame as _tf_exp
+
                     _factor = float(_expand_factor)
+                    _sample_height = _tf_exp(sample).height  # arrow-port
                     if not hasattr(self, "_initial_sample_cap"):
-                        self._initial_sample_cap = sample.height  # type: ignore[has-type]
-                    new_cap = int(sample.height * _factor)
+                        self._initial_sample_cap = _sample_height  # type: ignore[has-type]
+                    new_cap = int(_sample_height * _factor)
                     if new_cap <= 5 * self._initial_sample_cap:
                         # Bump budget + resample. Polars path only;
                         # distributed sample shape is fixed at take time.
@@ -1615,10 +1631,13 @@ class AutoConfigController:
         )
 
     def _sample_one(self, df: pl.DataFrame) -> pl.DataFrame:
-        if df.height < self.budget.sample_skip_below:
+        from goldenmatch.core.frame import to_frame as _tf
+
+        _height = _tf(df).height  # arrow-port: pa.Table has no .height
+        if _height < self.budget.sample_skip_below:
             return df
         seed = self._seed_for(df)
-        n = min(self.budget.sample_size_default, df.height)
+        n = min(self.budget.sample_size_default, _height)
 
         # #131: stratified sampling. When a mid-cardinality column is
         # available (typically zip, state, or similar blocking-shaped
@@ -1641,7 +1660,10 @@ class AutoConfigController:
 
     def _seed_for(self, df: pl.DataFrame) -> int:
         """Hash of data shape for reproducible sampling."""
-        key = f"{df.height}|{','.join(df.columns)}".encode()
+        from goldenmatch.core.frame import to_frame as _tf
+
+        _f = _tf(df)  # arrow-port: .height/.columns via the seam
+        key = f"{_f.height}|{','.join(_f.columns)}".encode()
         digest = hashlib.sha256(key).hexdigest()
         return int(digest[:8], 16)
 
@@ -1731,13 +1753,16 @@ class AutoConfigController:
         )
         if weighted_mk is None:
             return None
-        if sample.height < 4:
+        from goldenmatch.core.frame import to_frame as _tf
+
+        _sf = _tf(sample)  # arrow-port: seam .height + select_dicts (pa.Table has no .to_dicts)
+        if _sf.height < 4:
             return None
 
         threshold = weighted_mk.threshold or 0.7
         rng = random.Random(self._seed_for(sample))
-        n_rows = sample.height
-        rows = sample.to_dicts()
+        n_rows = _sf.height
+        rows = _sf.select_dicts(_sf.columns)
 
         above = 0
         total = 0
@@ -1809,6 +1834,9 @@ class AutoConfigController:
             ProfileMeta,
             ScoringProfile,
         )
+        from goldenmatch.core.frame import to_frame as _tf
+
+        _df_height = _tf(df).height  # arrow-port: pa.Table has no .height
 
         data = emitter.data or self._compute_data_profile(df, reference=reference)
         # Stamp the full dataset row count when the caller knows it. Prefer
@@ -1841,7 +1869,7 @@ class AutoConfigController:
             cluster=emitter.cluster or ClusterProfile(),
             meta=ProfileMeta(
                 iteration=iteration, is_sample=is_sample,
-                sample_size=df.height, n_rows_full=df.height,
+                sample_size=_df_height, n_rows_full=_df_height,
             ),
         )
         # Zero-label (ZeroER-inspired) confidence. Phase 1: observational only —
@@ -1883,8 +1911,11 @@ class AutoConfigController:
                     exc,
                 )
 
-        user_cols = [c for c in df.columns if not c.startswith("__")]
-        n_rows = df.height
+        from goldenmatch.core.frame import to_frame as _tf
+
+        _f = _tf(df)  # arrow-port: seam .columns/.height
+        user_cols = [c for c in _f.columns if not c.startswith("__")]
+        n_rows = _f.height
         # W3c: shared seam-routed body with autoconfig._emit_data_profile
         # (the twins were byte-identical; mirror retired).
         from goldenmatch.core._profile_helpers import data_profile_column_stats

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -1535,7 +1535,14 @@ class AutoConfigController:
         # placeholder that produces a workable starting config.
         if reference is not None:
             try:
-                merged = pl.concat([df, reference], how="vertical_relaxed")
+                from goldenmatch.core.frame import concat_frames, to_frame
+
+                # relaxed=True == polars vertical_relaxed == arrow permissive;
+                # .native keeps the current polars-in/polars-out contract while
+                # making the site backend-agnostic for the boundary flip.
+                merged = concat_frames(
+                    [to_frame(df), to_frame(reference)], relaxed=True
+                ).native
             except Exception:
                 merged = df
             return _legacy(merged, **kw)
@@ -1864,7 +1871,11 @@ class AutoConfigController:
 
         if reference is not None:
             try:
-                df = pl.concat([df, reference], how="vertical_relaxed")
+                from goldenmatch.core.frame import concat_frames, to_frame
+
+                df = concat_frames(
+                    [to_frame(df), to_frame(reference)], relaxed=True
+                ).native
             except Exception as exc:
                 logger.warning(
                     "match-mode n_rows fallback: concat target+reference failed (%s); "

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py
@@ -125,7 +125,11 @@ def promote_negative_evidence(
     Returns a new GoldenMatchConfig (via model_copy); does not mutate input.
     Empty df or empty column_priors → returns config unchanged.
     """
-    if df.is_empty() or not column_priors:
+    from goldenmatch.core.frame import to_frame
+
+    _f = to_frame(df)  # arrow-port: seam is_empty/columns/column
+    _f_height = _f.height
+    if _f_height == 0 or not column_priors:
         return config
 
     all_matchkeys = list(config.matchkeys or [])
@@ -177,11 +181,11 @@ def promote_negative_evidence(
             if _is_in_blocking(col, config.blocking):
                 continue
             # Column must exist in df for cardinality check
-            if col not in df.columns:
+            if col not in _f.columns:
                 continue
             # Cardinality gate
             try:
-                cardinality_ratio = df[col].n_unique() / max(1, df.height)
+                cardinality_ratio = _f.column(col).n_unique() / max(1, _f_height)
             except Exception:
                 continue
             if cardinality_ratio < _CARDINALITY_THRESHOLD:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -468,8 +468,9 @@ def _check_columns(
     or is a domain-extracted column recoverable via domain repair.
     """
     from goldenmatch.core.domain import _DOMAIN_EXTRACTED_COLS
+    from goldenmatch.core.frame import to_frame
 
-    df_cols = set(df.columns)
+    df_cols = set(to_frame(df).columns)  # arrow-port: pa.Table.columns != names
     referenced = _collect_referenced_columns(config)
     domain_profile = getattr(config, "_domain_profile", None)
 
@@ -548,12 +549,16 @@ def _check_cardinality(
     - ratio >= 0.99 → near-unique, no pair ever agrees (warning + drop).
     - ratio <  0.01 → always-same, every pair agrees trivially (warning + drop).
     """
-    if df.height == 0:
+    from goldenmatch.core.frame import to_frame
+
+    _f = to_frame(df)  # arrow-port: seam .height/.columns/.column
+    _f_height = _f.height
+    if _f_height == 0:
         return
 
     mks = config.get_matchkeys()
     kept: list = []
-    df_cols = set(df.columns)
+    df_cols = set(_f.columns)
 
     for mk in mks:
         if mk.type != "exact":
@@ -571,8 +576,8 @@ def _check_cardinality(
             if not col or col not in df_cols:
                 continue
             checked += 1
-            n_unique = df[col].n_unique()
-            ratio = n_unique / df.height
+            n_unique = _f.column(col).n_unique()
+            ratio = n_unique / _f_height
             if ratio >= 0.99:
                 high_hits.append(col)
             elif ratio <= 0.01:
@@ -643,10 +648,13 @@ def _check_block_sizes(
     Warns — does not auto-repair. Blocking strategy choice is usually
     intentional; preflight's job is to surface the trade-off, not override it.
     """
-    if config.blocking is None or df.height == 0:
+    from goldenmatch.core.frame import to_frame
+
+    _f_height = to_frame(df).height  # arrow-port
+    if config.blocking is None or _f_height == 0:
         return
 
-    n = min(df.height, 10_000)
+    n = min(_f_height, 10_000)
     per_key = _sample_block_sizes_per_key(df, config.blocking, sample_cap=10_000)
 
     for key, sizes_list, exc in per_key:

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -115,6 +115,19 @@ def _fast_static_block_sizes(
     if not keys:
         return None
 
+    # PR-5 (autoconfig arrow-port): the per-key block-SIZE reduction now runs on
+    # the proven seam ops -- ``derive_block_key`` (the parity-tested twin of
+    # ``_build_block_key_expr``), ``filter_valid_key`` (the null/sentinel guard
+    # VERBATIM), ``group_len`` (the ``group_by(key).agg(pl.len())`` sizes) --
+    # instead of a raw ``pl.Expr`` group_by. Same output on polars AND arrow
+    # (pinned by tests/test_blocker_arrow_size_parity.py). Sentinel drop moves
+    # AHEAD of the group_by, but that is output-identical here: every row in a
+    # block shares the key, so dropping the sentinel/null group == dropping its
+    # rows first.
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+    frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
+
     max_block_size = config.max_block_size
     skip_oversized = config.skip_oversized
     all_sizes: list[int] = []
@@ -123,31 +136,13 @@ def _fast_static_block_sizes(
     f1 = 0
     f2 = 0
     for key_config in keys:
-        block_key_expr = _build_block_key_expr(key_config)
-        # Aggregate sizes per key in one lazy group_by, then drop null/sentinel
-        # keys EAGERLY on the collected per-key table. The drop must run after
-        # collect: applied as a lazy .filter() it references a group key, so
-        # Polars' predicate pushdown moves it AHEAD of the group_by and the
-        # strip/lowercase/is_in string ops run over all n_rows instead of the
-        # n_blocks keys (measured 74 ms vs 6 ms at 1M). Dropping a sentinel/null
-        # group is identical to dropping its rows — every row in the group shares
-        # the key. Singletons (size < 2) are dropped to mirror _build_static_blocks.
-        agg = (
-            lf
-            .group_by(block_key_expr)
-            .agg(pl.len().alias("__sz__"))
-            .collect()
+        keyed = frame.with_column(
+            "__block_key__",
+            frame.derive_block_key(key_config.fields, key_config.transforms or []),
         )
-        agg = agg.filter(
-            pl.col("__block_key__").is_not_null()
-            & ~pl.col("__block_key__")
-                .str.strip_chars()
-                .str.to_lowercase()
-                .is_in(["nan", "null", "none"])
-        )
-        # Count F1/F2 from the filtered (null/sentinel-dropped) per-key sizes,
-        # BEFORE the size>=2 drop, so null-key groups don't inflate F1.
-        all_key_sizes = agg.get_column("__sz__").to_list()
+        valid = keyed.filter_valid_key("__block_key__")
+        # Per-key sizes AFTER the null/sentinel drop, BEFORE the size<2 drop.
+        all_key_sizes = [int(v) for v in valid.group_len(["__block_key__"]).column("len").to_list()]
         f1 += sum(1 for s in all_key_sizes if s == 1)
         f2 += sum(1 for s in all_key_sizes if s == 2)
         sizes = [s for s in all_key_sizes if s >= 2]
@@ -182,8 +177,15 @@ def measure_blocking_profile(
         blocking_cfg = getattr(config, "blocking", None)
         if blocking_cfg is None:
             return None
-        lf = df.lazy() if isinstance(df, pl.DataFrame) else df
-        n_rows: int = lf.select(pl.len()).collect().item()
+        # PR-5 (autoconfig arrow-port): normalize the input through the seam so
+        # a polars frame/lazyframe OR an arrow Table/Frame all measure the same.
+        # n_rows comes from ``Frame.height`` (no ``pl.len()`` collect); the seam
+        # frame flows into ``_fast_static_block_sizes`` (dual-rep) and, on the
+        # exact fallback, into ``build_blocks`` (which ingests a Frame/arrow).
+        from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+
+        frame = to_frame(df.collect()) if is_polars_lazyframe(df) else to_frame(df)
+        n_rows: int = frame.height
 
         if blocking_cfg.passes:
             keys_used = [list(k.fields) for k in blocking_cfg.passes]
@@ -192,13 +194,13 @@ def measure_blocking_profile(
         else:
             keys_used = []
 
-        fast = _fast_static_block_sizes(lf, blocking_cfg)
+        fast = _fast_static_block_sizes(frame, blocking_cfg)
         if fast is None:
             # Exact fallback: build every block and collect its length. This path
             # cannot recover the pre-drop singleton/doubleton counts, so the Chao1
             # inputs stay None and extrapolate_to uses the linear n_blocks fallback.
             sizes = []
-            for b in build_blocks(lf, blocking_cfg):
+            for b in build_blocks(frame, blocking_cfg):
                 try:
                     sizes.append(b.n_rows())
                 except Exception:
@@ -1182,14 +1184,31 @@ def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
 
     _lf_entry = lf
     if not is_polars_lazyframe(lf):
-        from goldenmatch.core.frame import Frame
+        from goldenmatch.core.frame import Frame, to_frame
 
         native = lf.native if isinstance(lf, Frame) else lf
-        lf = (
-            native.lazy()
-            if is_polars_dataframe(native)
-            else cast(pl.DataFrame, pl.from_arrow(native)).lazy()
-        )
+        if is_polars_dataframe(native):
+            lf = native.lazy()
+        else:
+            # PR-5 (autoconfig arrow-port): arrow ingest routes through the seam
+            # (no manual ``pl.from_arrow`` unwrap). The static/adaptive primary
+            # builder consumes ``_lf_entry`` directly via ``derive_block_key``
+            # (~line 406), so the polars round-trip is only needed by the
+            # non-static strategies, ``select_best_blocking_key`` auto-select,
+            # and an active profile emitter. When none of those apply, keep a
+            # seam Frame and skip the materialization entirely; otherwise fall
+            # back to the arrow->polars conversion (the seam has no arrow->polars
+            # op, so that conversion still uses pyarrow under the hood).
+            _needs_polars = (
+                config.strategy not in ("static", "adaptive")
+                or (config.auto_select and config.keys and len(config.keys) > 1)
+                or bool(_emitter_stack.get())
+            )
+            lf = (
+                cast(pl.DataFrame, pl.from_arrow(native)).lazy()
+                if _needs_polars
+                else to_frame(native)
+            )
 
     # Auto-select: pick best key based on histogram analysis
     if config.auto_select and config.keys and len(config.keys) > 1:

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -259,12 +259,12 @@ class BlockResult:
 
     def materialize(self):
         """The block's rows as a seam Frame (collects a legacy LazyFrame once)."""
-        from goldenmatch.core.frame import Frame, to_frame
+        from goldenmatch.core.frame import Frame, is_polars_lazyframe, to_frame
 
         d = self.df
         if isinstance(d, Frame):
             return d
-        if isinstance(d, pl.LazyFrame):
+        if is_polars_lazyframe(d):  # arrow-port: import-safe LazyFrame guard
             d = d.collect()
         return to_frame(d)
 
@@ -356,8 +356,6 @@ def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
     hot_blocks_skipped = 0
 
     for key_config in config.keys:
-        block_key_expr = _build_block_key_expr(key_config)
-
         # Add block key column AND filter null/sentinel keys in a single
         # lazy pipeline so Polars' optimizer fuses the filter with the
         # projection. The eager `df.filter(...)` after `.collect()` form
@@ -382,6 +380,9 @@ def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
         from goldenmatch.core.frame import is_polars_lazyframe
 
         if is_polars_lazyframe(lf):
+            # Polars-only: the native expr chain (pl.col) is built lazily here so
+            # the arrow branch below (derive_block_key) never imports polars.
+            block_key_expr = _build_block_key_expr(key_config)
             df_with_key = (
                 lf
                 .with_columns(block_key_expr)

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -85,7 +85,7 @@ def _emit_blocking_profile(
 
 
 def _fast_static_block_sizes(
-    lf: pl.LazyFrame, config: Any
+    lf: Any, config: Any  # Frame (seam) or pl.LazyFrame -- PR-6b dual-rep
 ) -> tuple[list[int], int, int] | None:
     """Vectorized block-size distribution for the ``static`` strategy.
 
@@ -184,7 +184,11 @@ def measure_blocking_profile(
         # exact fallback, into ``build_blocks`` (which ingests a Frame/arrow).
         from goldenmatch.core.frame import is_polars_lazyframe, to_frame
 
-        frame = to_frame(df.collect()) if is_polars_lazyframe(df) else to_frame(df)
+        frame = (
+            to_frame(cast("pl.LazyFrame", df).collect())
+            if is_polars_lazyframe(df)
+            else to_frame(df)
+        )
         n_rows: int = frame.height
 
         if blocking_cfg.passes:

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -70,14 +70,14 @@ def compute_column_priors(df: pl.DataFrame) -> dict[str, ColumnPrior]:
     priors: dict[str, ColumnPrior] = {}
     sample = frame.head(1000).native if frame.height > 1000 else df
 
-    for col in df.columns:
+    for col in frame.columns:  # arrow-port: pa.Table.columns is arrays, not names
         if (time.time() - start) > BUDGET_COLUMN_PRIORS:
             logger.info(
                 "compute_column_priors: budget %ss exceeded; "
                 "remaining %d columns get default priors",
-                BUDGET_COLUMN_PRIORS, len(df.columns) - len(priors),
+                BUDGET_COLUMN_PRIORS, len(frame.columns) - len(priors),
             )
-            for remaining in df.columns:
+            for remaining in frame.columns:
                 if remaining not in priors:
                     priors[remaining] = ColumnPrior(0.0, 0.0)
             break

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3555,7 +3555,7 @@ def _run_dedupe_pipeline(
 
 
 def run_dedupe_df(
-    df: pl.DataFrame,
+    df: Any,  # pl.DataFrame | pa.Table | Frame -- coerced via to_frame (PR-6)
     config: GoldenMatchConfig,
     source_name: str = "dataframe",
     output_golden: bool = False,
@@ -3575,32 +3575,58 @@ def run_dedupe_df(
     When None and ``config.prepared_record_store=True``, opens a
     per-call store (Phase 2 stopgap for non-controller paths).
     """
-    # Attack C cache seed: stash the caller's df id BEFORE the .cast() below
-    # creates a new DataFrame. The seed is the stable identity the controller's
+    # Boundary flip (autoconfig arrow-port PR-6): route the front-door through
+    # the frame seam so an arrow input (zero-config `dedupe_df(pa.Table)`) never
+    # touches polars. `to_frame` is idempotent-coercion (pl.DataFrame ->
+    # PolarsFrame, pa.Table/dict -> ArrowFrame, Frame -> itself), so existing
+    # polars callers are unchanged.
+    from goldenmatch.core.frame import PolarsFrame as _PolarsFrame
+    from goldenmatch.core.frame import to_frame as _to_frame
+
+    frame = _to_frame(df)
+    # Attack C cache seed: stash the caller's df id BEFORE cast_all_str below
+    # creates a new frame. The seed is the stable identity the controller's
     # iteration loop reuses across 5 dedupe_df calls on the same `sample`.
-    # Without it, each iteration's freshly-wrapped LazyFrame had a different
-    # id() and the cache never hit.
+    # Without it, each iteration's freshly-wrapped frame had a different id()
+    # and the cache never hit.
     #
-    # `df.height` (O(1) on an eager frame) is folded into the seed so a
-    # recycled id() slot can't serve a stale prep across logically distinct
-    # inputs. The schema-name fingerprint in the key alone does NOT defend
-    # against this: an empty df and a populated df of the same schema share
-    # column names AND can land on the same id() slot after GC, producing a
-    # stale cache HIT (the source of the `test_dedupe_df_empty` `assert 3 == 0`
-    # flake under `pytest -n auto`). Height distinguishes them.
-    cache_seed = (id(df), df.height)
-    # Cast all columns to string to prevent schema mismatch errors when
-    # mixed-type columns (e.g. birth_year inferred as i64 in some rows,
-    # str in others) reach blocking/scoring operations.
-    df = df.cast({col: pl.Utf8 for col in df.columns if not col.startswith("__")})
+    # `frame.height` (O(1) on both backends -- pa.Table has no `.height`) is
+    # folded into the seed so a recycled id() slot can't serve a stale prep
+    # across logically distinct inputs. The schema-name fingerprint in the key
+    # alone does NOT defend against this: an empty df and a populated df of the
+    # same schema share column names AND can land on the same id() slot after
+    # GC, producing a stale cache HIT (the source of the `test_dedupe_df_empty`
+    # `assert 3 == 0` flake under `pytest -n auto`). Height distinguishes them.
+    cache_seed = (id(df), frame.height)
+    # Cast all non-`__` columns to string to prevent schema mismatch errors when
+    # mixed-type columns (e.g. birth_year inferred as i64 in some rows, str in
+    # others) reach blocking/scoring operations. Byte-identical to the pre-flip
+    # `df.cast({c: pl.Utf8 ...})` (PR-1 seam op).
+    frame = frame.cast_all_str()
     matchkeys = [] if auto_config else config.get_matchkeys()
-    lf = df.lazy()
     if not auto_config:
+        # Column-existence check (was `validate_columns(lf, required)` on the
+        # LazyFrame -- a pure name check, so it runs off `frame.columns` with no
+        # polars round-trip; same error-message shape).
         required = _get_required_columns(config)
-        validate_columns(lf, required)
-    lf = lf.with_columns(pl.lit(source_name).alias("__source__"))
-    lf = _add_row_ids(lf, offset=0)
-    combined_lf = lf.collect().lazy()
+        _available = list(frame.columns)
+        _missing = [c for c in required if c not in _available]
+        if _missing:
+            raise ValueError(
+                f"Missing required columns: {_missing}. "
+                f"Available columns: {_available}"
+            )
+    frame = frame.with_literal_column("__source__", source_name)
+    frame = frame.ensure_row_ids(offset=0)
+
+    # Back-compat routing: a polars input keeps the classic polars-LazyFrame
+    # path (byte-identical to the pre-flip `lf.collect().lazy()` -- the seam ops
+    # above are the verbatim polars twins); an arrow input flows through as a
+    # seam Frame so `_run_dedupe_pipeline`'s arrow lane (the
+    # `is_polars_lazyframe` router) carries it polars-free.
+    combined_lf: Any = (
+        frame.native.lazy() if isinstance(frame, _PolarsFrame) else frame
+    )
 
     # Phase 2 stopgap: when prepared_record_store=True and no caller-provided
     # _prep_store (Phase 3's controller will supply one), open our own store

--- a/packages/python/goldenmatch/tests/test_autoconfig_dtype_arrow_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_dtype_arrow_parity.py
@@ -1,0 +1,129 @@
+"""autoconfig arrow-port PR-3: arrow->polars dtype-spelling contract + profile_columns
+seam-routing parity.
+
+The native ``autoconfig_classify_columns`` kernel (and the downstream string-column
+check ``p.dtype.startswith("String"/"Utf8")``) is fed ``str(dtype)`` and expects the
+POLARS dtype spelling. On an ``ArrowFrame`` ``str(dtype)`` spells the same types
+differently ("double" vs "Float64", "large_string" vs "String", ...). ``profile_columns``
+maps arrow->polars-spelling at the classify boundary so both backends feed the kernel
+an identical dtype. These tests pin:
+
+1. ``_arrow_to_polars_dtype_spelling`` per-dtype (arrow->polars; identity on polars
+   spellings; ``str(raw)`` passthrough for unknowns).
+2. ``profile_columns(pl.DataFrame)`` vs ``profile_columns(pa.Table)`` built from the
+   SAME data produce byte-identical ``ColumnProfile``s INCLUDING the dtype fed to
+   classify (the classify-input dtype string is the polars spelling on both).
+
+Run with ``GOLDENMATCH_NATIVE=0`` so the native kernel is not required on the box;
+the dtype-map + profile-dict equality hold on the pure-Python classify path too.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import polars as pl
+import pytest
+from goldenmatch.core.autoconfig import (
+    _arrow_to_polars_dtype_spelling,
+    profile_columns,
+)
+
+
+def _data() -> dict:
+    # float / int / str / bool / null columns (the dtypes autoconfig sees).
+    return {
+        "amount": [1.0, 2.0, 3.0, 4.0],
+        "count": [10, 20, 30, 40],
+        "name": ["Alice", "Bob", "Carol", "Dave"],
+        "flag": [True, False, True, False],
+        "empty": [None, None, None, None],
+    }
+
+
+# ── the dtype-spelling map ────────────────────────────────────────────────────
+
+
+def test_arrow_spellings_map_to_polars() -> None:
+    assert _arrow_to_polars_dtype_spelling("double") == "Float64"
+    assert _arrow_to_polars_dtype_spelling("float") == "Float32"
+    assert _arrow_to_polars_dtype_spelling("int64") == "Int64"
+    assert _arrow_to_polars_dtype_spelling("int32") == "Int32"
+    assert _arrow_to_polars_dtype_spelling("bool") == "Boolean"
+    assert _arrow_to_polars_dtype_spelling("null") == "Null"
+    # string family -> the polars Utf8 spelling ("String" on modern polars)
+    for arrow_str in ("string", "large_string", "utf8", "large_utf8"):
+        assert _arrow_to_polars_dtype_spelling(arrow_str) in ("String", "Utf8")
+    # date / timestamp families (unit-parametrized)
+    assert _arrow_to_polars_dtype_spelling("date32[day]") == "Date"
+    assert _arrow_to_polars_dtype_spelling("date64[ms]") == "Date"
+    assert _arrow_to_polars_dtype_spelling("timestamp[us]").startswith("Datetime")
+    assert _arrow_to_polars_dtype_spelling("timestamp[ns]").startswith("Datetime")
+
+
+def test_map_is_identity_on_polars_spellings() -> None:
+    # A polars spelling passed in comes back UNCHANGED -- this is what keeps the
+    # polars path byte-for-byte what it was before the port.
+    for pol in ("Float64", "Float32", "Int64", "Int32", "String", "Utf8", "Boolean",
+                "Date", "Null", "Datetime(time_unit='us', time_zone=None)"):
+        assert _arrow_to_polars_dtype_spelling(pol) == pol
+
+
+def test_map_unknown_falls_back_to_str() -> None:
+    assert _arrow_to_polars_dtype_spelling("some_future_dtype") == "some_future_dtype"
+    assert _arrow_to_polars_dtype_spelling(123) == "123"
+
+
+def test_map_string_target_matches_polars_native() -> None:
+    # Arrow string maps to EXACTLY what polars renders Utf8 as, so the arrow
+    # classify input equals the polars one (the differential-parity contract).
+    native = str(pl.Series(["x"]).dtype)
+    assert _arrow_to_polars_dtype_spelling("large_string") == native
+    assert _arrow_to_polars_dtype_spelling("string") == native
+
+
+# ── profile_columns cross-backend parity ──────────────────────────────────────
+
+
+def test_profile_columns_dtype_is_polars_spelling_on_both_backends() -> None:
+    pdf = pl.DataFrame(_data())
+    tbl = pdf.to_arrow()  # SAME data as a pa.Table, bypassing the auto_configure unwrap
+
+    by_name_pol = {p.name: p for p in profile_columns(pdf)}
+    by_name_arr = {p.name: p for p in profile_columns(tbl)}
+
+    assert set(by_name_pol) == set(by_name_arr) == {"amount", "count", "name", "flag", "empty"}
+
+    # The dtype fed to classify is the polars spelling on BOTH backends.
+    assert by_name_pol["amount"].dtype == "Float64"
+    assert by_name_pol["count"].dtype == "Int64"
+    assert by_name_pol["flag"].dtype == "Boolean"
+    assert by_name_pol["empty"].dtype == "Null"
+    assert by_name_pol["name"].dtype in ("String", "Utf8")
+
+    for name in by_name_pol:
+        assert by_name_arr[name].dtype == by_name_pol[name].dtype, name
+
+
+def test_profile_columns_full_profile_parity_polars_vs_arrow() -> None:
+    pdf = pl.DataFrame(_data())
+    tbl = pdf.to_arrow()
+
+    prof_pol = {p.name: dataclasses.asdict(p) for p in profile_columns(pdf)}
+    prof_arr = {p.name: dataclasses.asdict(p) for p in profile_columns(tbl)}
+
+    # Byte-identical column profiles (dtype, col_type, confidence, null_rate,
+    # cardinality_ratio, avg_len, sample_values) regardless of backend.
+    assert prof_pol == prof_arr
+
+
+def test_profile_columns_accepts_pa_table_directly() -> None:
+    # The routing (to_frame at the top) lets profile_columns run on a pa.Table
+    # without the auto_configure_df unwrap -- the post-PR-6 shape, exercised now.
+    tbl = pl.DataFrame(_data()).to_arrow()
+    profiles = profile_columns(tbl)
+    assert {p.name for p in profiles} == {"amount", "count", "name", "flag", "empty"}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/python/goldenmatch/tests/test_blocker_arrow_size_parity.py
+++ b/packages/python/goldenmatch/tests/test_blocker_arrow_size_parity.py
@@ -1,0 +1,267 @@
+"""Block-SIZE measurement parity gate (autoconfig arrow-port PR-5).
+
+The block-size measurement functions (``_fast_static_block_sizes`` /
+``measure_blocking_profile``) were rewired off ``pl.Expr`` / lazy ``group_by``
+onto the proven ``frame.derive_block_key`` seam op + ``filter_valid_key`` +
+``group_len``. This is recall-adjacent: the block key decides which records are
+ever compared, so a silent divergence between the seam key and the legacy
+``_build_block_key_expr`` key would drop true pairs.
+
+Two gates:
+
+(a) ``derive_block_key(fields, transforms)`` must produce byte-identical
+    per-row keys on ``PolarsFrame`` vs ``ArrowFrame`` (same data) AND both must
+    equal the legacy ``_build_block_key_expr`` output on the polars path, across
+    every transform in the corpus (incl. soundex/phonetic map_elements chains,
+    numeric fields, substring, nulls, sentinels, duplicates). A mismatch on ANY
+    transform is a recall break -- STOP, do not ship.
+
+(b) ``_fast_static_block_sizes`` / ``measure_blocking_profile`` must produce
+    identical block-size results on a polars frame vs an arrow frame AND both
+    must equal the pinned pre-rewire polars oracle (the exact legacy
+    ``group_by(block_key_expr).agg(pl.len())`` reduction, replicated inline).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.blocker import (
+    _build_block_key_expr,
+    _fast_static_block_sizes,
+    measure_blocking_profile,
+)
+from goldenmatch.core.frame import ArrowFrame, PolarsFrame
+
+# ---- realistic multi-matchkey corpus -------------------------------------
+# Several fields, mixed dtypes (string + numeric), transforms including
+# soundex (map_elements), nulls, stringified sentinels, and duplicates that
+# form real (size >= 2) blocks.
+
+_DATA = {
+    "first": ["John", "john", "JANE", None, "Bob", "Bob", "söund", "Bob"],
+    "last": ["Smith", "Smith", "Doe", "Doe", "nan", "Nan", None, "smith"],
+    "zip": [12345, 12345, 67890, 67890, None, 11111, 11111, 12345],
+    "dob": [
+        "1990-01-02", "1990-01-02", "1985-05-05", None,
+        "2000-12-31", "2000-12-31", "1970-01-01", "1990-01-02",
+    ],
+}
+
+
+def _df() -> pl.DataFrame:
+    return pl.DataFrame(_DATA)
+
+
+# (fields, transforms) covering native chains + map_elements (soundex) +
+# numeric fields + multi-field composites.
+_KEY_CASES = [
+    (["first"], ["lowercase"]),
+    (["first"], ["soundex"]),
+    (["last"], ["lowercase", "soundex"]),
+    (["first", "last"], ["lowercase", "strip"]),
+    (["zip"], []),
+    (["zip"], ["digits_only"]),
+    (["first", "zip"], ["lowercase"]),
+    (["dob"], ["substring:0:4"]),
+    (["first", "last", "zip"], ["lowercase"]),
+]
+
+
+# ---- gate (a): key parity -------------------------------------------------
+
+
+def _legacy_key(df: pl.DataFrame, fields, transforms) -> list:
+    cfg = SimpleNamespace(fields=list(fields), transforms=list(transforms))
+    return (
+        df.lazy()
+        .select(_build_block_key_expr(cfg))
+        .collect()
+        .get_column("__block_key__")
+        .to_list()
+    )
+
+
+@pytest.mark.parametrize("fields,transforms", _KEY_CASES)
+def test_derive_block_key_matches_legacy_and_cross_backend(fields, transforms):
+    """derive_block_key (polars AND arrow) == legacy _build_block_key_expr.
+
+    A divergence here is a silent recall break -- this assertion IS the gate.
+    """
+    df = _df()
+    legacy = _legacy_key(df, fields, transforms)
+    seam_polars = PolarsFrame(df).derive_block_key(fields, transforms).to_list()
+    seam_arrow = ArrowFrame(df.to_arrow()).derive_block_key(fields, transforms).to_list()
+
+    assert seam_polars == legacy, (
+        f"PolarsFrame.derive_block_key diverged from _build_block_key_expr on "
+        f"{fields} / {transforms} -- RECALL BREAK"
+    )
+    assert seam_arrow == legacy, (
+        f"ArrowFrame.derive_block_key diverged from _build_block_key_expr on "
+        f"{fields} / {transforms} -- RECALL BREAK"
+    )
+
+
+# ---- gate (b): block-size measurement parity ------------------------------
+
+
+def _oracle_fast_static(df: pl.DataFrame, config) -> tuple[list[int], int, int]:
+    """Replica of the PRE-rewire ``_fast_static_block_sizes`` polars path.
+
+    Pinned inline as the oracle so the rewired implementation is compared
+    against the exact legacy reduction, independent of the rewire.
+    """
+    lf = df.lazy()
+    keys = config.keys
+    max_block_size = config.max_block_size
+    skip_oversized = config.skip_oversized
+    all_sizes: list[int] = []
+    f1 = 0
+    f2 = 0
+    for key_config in keys:
+        block_key_expr = _build_block_key_expr(key_config)
+        agg = lf.group_by(block_key_expr).agg(pl.len().alias("__sz__")).collect()
+        agg = agg.filter(
+            pl.col("__block_key__").is_not_null()
+            & ~pl.col("__block_key__")
+            .str.strip_chars()
+            .str.to_lowercase()
+            .is_in(["nan", "null", "none"])
+        )
+        all_key_sizes = agg.get_column("__sz__").to_list()
+        f1 += sum(1 for s in all_key_sizes if s == 1)
+        f2 += sum(1 for s in all_key_sizes if s == 2)
+        sizes = [s for s in all_key_sizes if s >= 2]
+        if skip_oversized and any(s > max_block_size for s in sizes):
+            return None  # type: ignore[return-value]
+        all_sizes.extend(sizes)
+    return all_sizes, f1, f2
+
+
+def _norm(result):
+    """Sort the sizes list so oracle/impl compare as an order-free multiset.
+
+    The seam's group_len and the legacy group_by both yield an unordered set of
+    per-key sizes (block order is never contractual downstream); sort to compare
+    the multiset + the Chao1 counts.
+    """
+    if result is None:
+        return None
+    sizes, f1, f2 = result
+    return sorted(sizes), f1, f2
+
+
+_SIZE_CONFIGS = [
+    # single string key, native transform
+    BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["first"], transforms=["lowercase"])],
+        max_block_size=1000,
+        skip_oversized=False,
+        auto_select=False,
+    ),
+    # soundex (map_elements) key
+    BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["last"], transforms=["lowercase", "soundex"])],
+        max_block_size=1000,
+        skip_oversized=False,
+        auto_select=False,
+    ),
+    # numeric key, no transform
+    BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["zip"], transforms=[])],
+        max_block_size=1000,
+        skip_oversized=False,
+        auto_select=False,
+    ),
+    # multi-field composite
+    BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["first", "zip"], transforms=["lowercase"])],
+        max_block_size=1000,
+        skip_oversized=False,
+        auto_select=False,
+    ),
+    # multiple keys at once (f1/f2 accumulate across keys)
+    BlockingConfig(
+        strategy="static",
+        keys=[
+            BlockingKeyConfig(fields=["first"], transforms=["lowercase"]),
+            BlockingKeyConfig(fields=["dob"], transforms=["substring:0:4"]),
+        ],
+        max_block_size=1000,
+        skip_oversized=False,
+        auto_select=False,
+    ),
+]
+
+
+@pytest.mark.parametrize("config", _SIZE_CONFIGS)
+def test_fast_static_block_sizes_polars_arrow_vs_oracle(config):
+    df = _df()
+    oracle = _norm(_oracle_fast_static(df, config))
+
+    # polars input (DataFrame + LazyFrame both accepted)
+    got_pl_lf = _norm(_fast_static_block_sizes(df.lazy(), config))
+    got_pl_df = _norm(_fast_static_block_sizes(PolarsFrame(df), config))
+    # arrow input via the seam
+    got_arrow = _norm(_fast_static_block_sizes(ArrowFrame(df.to_arrow()), config))
+
+    assert got_pl_lf == oracle, "polars LazyFrame result diverged from pre-rewire oracle"
+    assert got_pl_df == oracle, "PolarsFrame result diverged from pre-rewire oracle"
+    assert got_arrow == oracle, "ArrowFrame result diverged from polars/oracle"
+
+
+@pytest.mark.parametrize("config", _SIZE_CONFIGS)
+def test_measure_blocking_profile_polars_arrow_identical(config):
+    df = _df()
+    # measure_blocking_profile reads ``config.blocking`` (a GoldenMatchConfig),
+    # not a bare BlockingConfig.
+    top = SimpleNamespace(blocking=config)
+
+    prof_pl = measure_blocking_profile(df, top)
+    prof_arrow = measure_blocking_profile(ArrowFrame(df.to_arrow()), top)
+
+    assert prof_pl is not None
+    assert prof_arrow is not None
+
+    # The full block-size distribution must be identical arrow-vs-polars.
+    for attr in (
+        "n_blocks",
+        "total_comparisons",
+        "reduction_ratio",
+        "block_sizes_p50",
+        "block_sizes_p95",
+        "block_sizes_p99",
+        "block_sizes_max",
+        "singleton_block_count",
+        "oversized_block_count",
+        "chao1_f1",
+        "chao1_f2",
+    ):
+        assert getattr(prof_pl, attr) == getattr(prof_arrow, attr), (
+            f"measure_blocking_profile.{attr} diverged arrow-vs-polars"
+        )
+
+
+def test_measure_blocking_profile_oversized_skip_falls_back():
+    """skip_oversized=True + an oversized block => _fast_static returns None,
+    measure_blocking_profile falls back to the exact build_blocks loop (which
+    still produces a profile). Locks the oversized-bail semantics survive."""
+    df = _df()
+    config = BlockingConfig(
+        strategy="static",
+        keys=[BlockingKeyConfig(fields=["first"], transforms=["lowercase"])],
+        max_block_size=1,  # any real block is "oversized"
+        skip_oversized=True,
+        auto_select=False,
+    )
+    # _fast_static bails (returns None) on both backends.
+    assert _fast_static_block_sizes(df.lazy(), config) is None
+    assert _fast_static_block_sizes(ArrowFrame(df.to_arrow()), config) is None

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -1,0 +1,206 @@
+"""PR-6 acceptance gate: zero-config / arrow ``dedupe_df`` and polars.
+
+The autoconfig arrow-port (PR-6) flips the ``run_dedupe_df`` front-door onto the
+frame seam (``cast_all_str`` + ``ensure_row_ids``, no ``.lazy()/.collect()``
+polars round-trip) and widens ``dedupe_df`` / ``auto_configure_df`` to accept
+``pa.Table`` / ``Frame``. Three tiers, in increasing strictness:
+
+1. **Functional (in-process, polars present):** ``dedupe_df(pa.Table,
+   config=None)`` runs zero-config to completion and returns a result whose
+   dup-count matches the polars path (config-equivalence, not row-identity).
+
+2. **Front-door polars-free (subprocess, polars import BLOCKED):** with an
+   EXPLICIT config and the pure backend (``GOLDENMATCH_NATIVE=0``),
+   ``dedupe_df(pa.Table, config=cfg)`` runs to completion WITHOUT importing
+   polars. This is the concrete PR-6 win -- the seam front-door plus the
+   pipeline's arrow lane carry a full arrow dedupe with polars absent.
+
+3. **Zero-config polars-free (subprocess, the TRUE endgame gate):** with polars
+   BLOCKED, ``dedupe_df(pa.Table, config=None)`` runs to completion. This is
+   ``xfail`` today: ``auto_configure_df`` still bridges arrow -> polars for the
+   controller + ``_legacy_auto_configure_v0`` heuristic (NEITHER is arrow-ported
+   -- ``AutoConfigController.run``'s all-null gate subscripts ``df[col]`` and v0
+   has ~15 ``df[col]`` / ``df.filter(pl.col(...))`` sites). It flips to green
+   once that controller/v0 arrow port lands. See the boundary note at
+   ``core/autoconfig.py`` ``auto_configure_df``.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pyarrow as pa
+import pytest
+
+_PKG_ROOT = Path(__file__).parent.parent
+
+
+def _person_table(n: int = 48) -> pa.Table:
+    firsts = ["ann", "ann", "bob", "bobby", "cara", "dan", "dan", "eve"]
+    lasts = ["smith", "smith", "jones", "jones", "lee", "poe", "poe", "ray"]
+    reps = (n + len(firsts) - 1) // len(firsts)
+    return pa.table(
+        {
+            "first": (firsts * reps)[:n],
+            "last": (lasts * reps)[:n],
+            "email": [f"e{i % 10}@x.com" for i in range(n)],
+        }
+    )
+
+
+def _run_subprocess(body: str, extra_env: dict[str, str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_PKG_ROOT)
+    env.update(extra_env)
+    # Meta-path finder that makes `import polars` raise -- the D6 zero-polars
+    # gate mechanism (see tests/_zero_polars_probe.py / test_zero_polars_gate.py).
+    prelude = (
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'polars' or name.startswith('polars.'):\n"
+        "            raise ImportError('polars blocked (PR-6 tripwire)')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", prelude + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=300,
+    )
+
+
+# -- Tier 1: functional (polars present) ------------------------------------
+
+
+def test_zero_config_dedupe_df_arrow_functional():
+    """`dedupe_df(pa.Table, config=None)` runs zero-config to completion and
+    returns a result whose dup-count matches the polars path (arrow-vs-polars
+    config-equivalence). Runs with polars present; native disabled for the box."""
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    import polars as pl
+    from goldenmatch import dedupe_df
+
+    tbl = _person_table(48)
+    res_arrow = dedupe_df(tbl, config=None)
+    assert res_arrow is not None
+    # A result frame is produced (dupes may be empty but must not be None-crash).
+    arrow_dupes = res_arrow.dupes.num_rows if res_arrow.dupes is not None else 0
+
+    res_pl = dedupe_df(pl.from_arrow(tbl), config=None)
+    pl_dupes = res_pl.dupes.num_rows if res_pl.dupes is not None else 0
+
+    # Config-equivalence, not row-identity: the same zero-config decisions on the
+    # same data must find the same number of duplicate rows on both backends.
+    assert arrow_dupes == pl_dupes
+
+
+def test_auto_configure_df_accepts_arrow_table():
+    """`auto_configure_df(pa.Table)` no longer raises TypeError (the pre-PR-6
+    ArrowFrame-only shim rejected a bare pa.Table) and returns a config."""
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    cfg = auto_configure_df(_person_table(48), _skip_finalize=True)
+    assert cfg is not None
+    assert cfg.get_matchkeys()  # produced at least one matchkey
+
+
+# -- Tier 2: front-door polars-free (the concrete PR-6 win) -----------------
+
+
+def test_explicit_config_arrow_dedupe_is_polars_free():
+    """SUBPROCESS, polars import BLOCKED: `dedupe_df(pa.Table, config=cfg)` with
+    an explicit config + the pure backend runs a full arrow dedupe to completion
+    WITHOUT importing polars. This proves the PR-6 front-door seam port (no
+    `df.cast(...).lazy()` / `_add_row_ids` / `collect` polars round-trip) plus
+    the pipeline arrow lane carry an arrow dedupe polars-free."""
+    body = """
+        import os
+        import pyarrow as pa
+        from goldenmatch import dedupe_df
+        from goldenmatch.config.schemas import (
+            GoldenMatchConfig, MatchkeyConfig, MatchkeyField,
+            QualityConfig, TransformConfig,
+        )
+        tbl = pa.table({
+            "first": ["ann", "ann", "bob", "bobby", "cara"] * 4,
+            "last": ["smith", "smith", "jones", "jones", "lee"] * 4,
+        })
+        cfg = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="k", type="exact",
+                fields=[MatchkeyField(field="first"), MatchkeyField(field="last")],
+            )],
+            quality=QualityConfig(mode="disabled"),
+            transform=TransformConfig(mode="disabled"),
+        )
+        res = dedupe_df(tbl, config=cfg)
+        assert res is not None
+        import sys
+        assert "polars" not in sys.modules, "polars leaked on the arrow front-door"
+        print("FRONT-DOOR POLARS-FREE OK")
+    """
+    proc = _run_subprocess(
+        body,
+        {
+            "GOLDENMATCH_FRAME": "arrow",
+            "GOLDENMATCH_NATIVE": "0",
+            "POLARS_SKIP_CPU_CHECK": "1",
+            "GOLDENMATCH_AUTOCONFIG_MEMORY": "0",
+        },
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "FRONT-DOOR POLARS-FREE OK" in proc.stdout
+
+
+# -- Tier 3: zero-config polars-free (the TRUE endgame gate) ----------------
+
+
+@pytest.mark.xfail(
+    reason=(
+        "auto_configure_df still bridges arrow->polars for the controller + "
+        "_legacy_auto_configure_v0 heuristic (neither arrow-ported: controller "
+        "run()'s all-null gate subscripts df[col]; v0 has ~15 df[col] sites). "
+        "Flips green when the controller/v0 arrow port lands."
+    ),
+    strict=False,
+)
+def test_zero_config_dedupe_df_is_polars_free():
+    """SUBPROCESS, polars import BLOCKED: assert the native path is present, then
+    run ZERO-CONFIG `dedupe_df(pa.Table, config=None)` to completion WITHOUT
+    importing polars. The whole port's acceptance gate. Currently xfails at the
+    controller/v0 polars bridge (autoconfig.py boundary)."""
+    body = """
+        import os
+        import pyarrow as pa
+        from goldenmatch.core._native_loader import native_available
+        assert native_available(), "native kernel unavailable -- true tripwire needs it"
+        from goldenmatch import dedupe_df
+        tbl = pa.table({
+            "first": ["ann", "ann", "bob", "bobby", "cara", "dan", "dan", "eve"] * 4,
+            "last": ["smith", "smith", "jones", "jones", "lee", "poe", "poe", "ray"] * 4,
+            "email": ["e%d@x.com" % (i % 10) for i in range(32)],
+        })
+        res = dedupe_df(tbl, config=None)
+        assert res is not None
+        import sys
+        assert "polars" not in sys.modules, "polars leaked on zero-config arrow path"
+        print("ZERO-CONFIG POLARS-FREE OK")
+    """
+    proc = _run_subprocess(
+        body,
+        {
+            "GOLDENMATCH_FRAME": "arrow",
+            "GOLDENMATCH_NATIVE": "1",
+            "POLARS_SKIP_CPU_CHECK": "1",
+            "GOLDENMATCH_AUTOCONFIG_MEMORY": "0",
+        },
+    )
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "ZERO-CONFIG POLARS-FREE OK" in proc.stdout

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -111,6 +111,50 @@ def test_auto_configure_df_accepts_arrow_table():
     assert cfg.get_matchkeys()  # produced at least one matchkey
 
 
+def test_zero_config_arrow_with_exact_column_matches_polars():
+    """Regression: `auto_configure_df(pa.Table)` on data WITH an exact-eligible
+    identifier column must produce the SAME config as the equivalent
+    pl.DataFrame. The eager indicator `estimate_sparse_match_signal` runs only
+    when exact columns exist and used to crash on a bare pa.Table
+    (`'pyarrow.lib.Table' object has no attribute 'is_empty'`), degrading arrow
+    zero-config to a RED v0 fallback -- a divergence the all-fuzzy 48-row
+    fixtures above never exercised. The boundary now coerces non-polars input to
+    polars until the scoring lane is arrow-ported, so the two must agree."""
+    os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+    import polars as pl
+
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    data = {
+        "cust_id": [f"C{i:05d}" for i in range(400)],  # unique -> exact-eligible
+        "first": (["ann", "bob", "cara", "dan", "eve", "fay"] * 67)[:400],
+        "last": (["smith", "jones", "lee", "poe", "ray", "kim"] * 67)[:400],
+        "zip": [str(10000 + (i % 50)) for i in range(400)],
+    }
+
+    def _summary(cfg):
+        mks = sorted(
+            (mk.type, tuple(sorted(f.field for f in (mk.fields or []) if f.field)))
+            for mk in cfg.get_matchkeys()
+        )
+        blk = None
+        if cfg.blocking:
+            blk = (
+                cfg.blocking.strategy,
+                tuple(
+                    sorted(
+                        k.fields[0] if k.fields else "?"
+                        for k in (cfg.blocking.keys or [])
+                    )
+                ),
+            )
+        return (getattr(cfg, "backend", None), mks, blk)
+
+    cfg_pl = auto_configure_df(pl.DataFrame(data), _skip_finalize=True)
+    cfg_pa = auto_configure_df(pa.table(data), _skip_finalize=True)
+    assert _summary(cfg_pl) == _summary(cfg_pa)
+
+
 # -- Tier 2: front-door polars-free (the concrete PR-6 win) -----------------
 
 
@@ -164,26 +208,26 @@ def test_explicit_config_arrow_dedupe_is_polars_free():
 
 @pytest.mark.xfail(
     reason=(
-        "The autoconfig stack is arrow-ported (PR-3..6b: unwrap removed, controller "
-        "gates / sampling / v0 heuristic route through the seam), so the COMMITTED "
-        "zero-config backend is 'bucket' (arrow-native, Polars-free). But the "
-        "controller's per-iteration SAMPLE dedupes evaluate non-bucket candidate "
-        "configs, which still hit the legacy scoring spine `build_blocks(combined_lf)` "
-        "at pipeline.py:2284 (a polars LazyFrame path). With polars ABSENT those "
-        "iterations error and the controller silently falls back to a RED v0 config. "
-        "Flips green when the legacy build_blocks/combined_lf scoring spine is "
-        "arrow-ported (the separately-tracked pipeline-spine follow-up), or the "
-        "arrow+native path forces the bucket scorer on every controller iteration."
+        "PR-3..6b landed the autoconfig-LAYER arrow seam (dtype map, controller "
+        "gates, sampling, blocking-size measurement, v0 heuristic), but the "
+        "zero-config SCORING lane is not fully arrow-ported: the eager indicators' "
+        "empty/column guards (indicators.py), the GoldenCheck exclusion detectors, "
+        "and the legacy `build_blocks(combined_lf)` scoring spine (pipeline.py:2284) "
+        "still assume polars. So `auto_configure_df` COERCES a non-polars input to "
+        "polars at its boundary for now (correct + no RED fallback), which imports "
+        "polars. Flips green when the scoring spine + indicators guards + exclusion "
+        "detectors are arrow-ported (the separately-tracked pipeline-spine follow-up) "
+        "and the boundary becomes a true `.native` arrow pass-through."
     ),
     strict=False,
 )
 def test_zero_config_dedupe_df_is_polars_free():
     """SUBPROCESS, polars import BLOCKED: assert the native path is present, then
     run ZERO-CONFIG `dedupe_df(pa.Table, config=None)` to completion WITHOUT
-    importing polars. The whole port's acceptance gate. Currently xfails at the
-    legacy `build_blocks(combined_lf)` scoring spine (pipeline.py:2284) reached by
-    the controller's per-iteration sample dedupes -- NOT the autoconfig boundary,
-    which PR-3..6b ported."""
+    importing polars. The whole port's acceptance gate. Currently xfails because
+    `auto_configure_df` coerces a non-polars input to polars at its boundary until
+    the scoring spine (indicators guards + exclusion detectors +
+    `build_blocks(combined_lf)`, pipeline.py:2284) is arrow-ported."""
     body = """
         import os
         import pyarrow as pa

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -164,10 +164,16 @@ def test_explicit_config_arrow_dedupe_is_polars_free():
 
 @pytest.mark.xfail(
     reason=(
-        "auto_configure_df still bridges arrow->polars for the controller + "
-        "_legacy_auto_configure_v0 heuristic (neither arrow-ported: controller "
-        "run()'s all-null gate subscripts df[col]; v0 has ~15 df[col] sites). "
-        "Flips green when the controller/v0 arrow port lands."
+        "The autoconfig stack is arrow-ported (PR-3..6b: unwrap removed, controller "
+        "gates / sampling / v0 heuristic route through the seam), so the COMMITTED "
+        "zero-config backend is 'bucket' (arrow-native, Polars-free). But the "
+        "controller's per-iteration SAMPLE dedupes evaluate non-bucket candidate "
+        "configs, which still hit the legacy scoring spine `build_blocks(combined_lf)` "
+        "at pipeline.py:2284 (a polars LazyFrame path). With polars ABSENT those "
+        "iterations error and the controller silently falls back to a RED v0 config. "
+        "Flips green when the legacy build_blocks/combined_lf scoring spine is "
+        "arrow-ported (the separately-tracked pipeline-spine follow-up), or the "
+        "arrow+native path forces the bucket scorer on every controller iteration."
     ),
     strict=False,
 )
@@ -175,7 +181,9 @@ def test_zero_config_dedupe_df_is_polars_free():
     """SUBPROCESS, polars import BLOCKED: assert the native path is present, then
     run ZERO-CONFIG `dedupe_df(pa.Table, config=None)` to completion WITHOUT
     importing polars. The whole port's acceptance gate. Currently xfails at the
-    controller/v0 polars bridge (autoconfig.py boundary)."""
+    legacy `build_blocks(combined_lf)` scoring spine (pipeline.py:2284) reached by
+    the controller's per-iteration sample dedupes -- NOT the autoconfig boundary,
+    which PR-3..6b ported."""
     body = """
         import os
         import pyarrow as pa

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -122,7 +122,6 @@ def test_zero_config_arrow_with_exact_column_matches_polars():
     polars until the scoring lane is arrow-ported, so the two must agree."""
     os.environ.setdefault("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
     import polars as pl
-
     from goldenmatch.core.autoconfig import auto_configure_df
 
     data = {


### PR DESCRIPTION
## Autoconfig arrow-port (plan PRs 3-6b, consolidated) — the seam foundation

Ports the **autoconfig-LAYER** to the `frame.py` Arrow/Polars seam. Consolidates plan PRs 3-6b (`docs/superpowers/plans/2026-07-13-goldenmatch-autoconfig-arrow-port-plan.md`); PR-1 (#1750) + PR-2 (#1751) already merged.

### What landed
- **PR-3** arrow->polars dtype-spelling map + `profile_columns` via the seam (`test_autoconfig_dtype_arrow_parity.py` pins classify-output identity).
- **PR-4** controller `vertical_relaxed` concat via `concat_frames(relaxed=True)`.
- **PR-5** blocker block-size measurement via `derive_block_key` + `group_len`; dropped the 2nd `pl.from_arrow`. Recall-critical parity corpus `test_blocker_arrow_size_parity.py`.
- **PR-6 / 6b** widened `dedupe_df`/`auto_configure_df` to accept `pa.Table | Frame`; ported `run_dedupe_df`'s front-door (`cast_all_str` + `ensure_row_ids`); routed controller gates / sampling / `build_blocking` / v0 heuristic / negative-evidence / verify through the seam.

### Honest scope + a regression this PR fixes in itself
A holistic review + direct probing found the PR-6b boundary flip (keep a bare `pa.Table` native through the controller) was **premature**: the zero-config SCORING lane is not fully arrow-ported — the eager indicators' `is_empty`/`columns` guards (`indicators.py`), the GoldenCheck exclusion detectors, and the legacy `build_blocks(combined_lf)` spine (`pipeline.py:2284`) still assume polars. A `pa.Table` zero-config input therefore **crashed** (`pa.Table.is_empty`) and degraded to a RED v0 fallback — a regression the all-fuzzy 48-row test fixtures never exercised (they short-circuit before the indicator path).

**Fix in this PR:** `auto_configure_df` coerces a non-polars input to polars at its boundary (byte-identical config to the same data as a `pl.DataFrame` — verified `EQUIVALENT: True`, native on and off; new `test_zero_config_arrow_with_exact_column_matches_polars` locks it). This also closes the reviewer's "arrow silently skips `exclude_columns` / #858" finding (that block runs on polars again).

### NOT yet zero-config Polars-free
The tripwire `test_zero_config_dedupe_df_is_polars_free` stays **xfail**: the boundary coerces to polars, so zero-config still imports polars. Making it a true `.native` arrow pass-through (Polars-free zero-config, tripwire green, **#1747 `[polars]` stopgap dropped**) is the recall-critical pipeline-spine follow-up — indicators guards + exclusion detectors + `build_blocks`/pipeline body arrow-port, with a block-membership + config-equivalence parity gate. **The #1747 stopgap MUST stay** until that lands. This PR does not touch it.

This PR is the tested seam foundation for that follow-up; on the Polars backend every routed op is byte-identical (module test files unedited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
