### PR TITLE
feat(ts): Splink converter + N-level fields on the TypeScript surface (thesis phase 3)

### DIFF
--- a/docs-site/goldenmatch/typescript.mdx
+++ b/docs-site/goldenmatch/typescript.mdx
@@ -241,6 +241,7 @@ install whichever you need directly: `pg` (Postgres), `@duckdb/node-api`
 ## Advanced Features
 
 - **Probabilistic matching** — Fellegi-Sunter with Splink-style EM
+- **Splink config converter** — `import-splink` CLI / `convert_splink_config` MCP tool / `fromSplink()` API converts a Splink settings (or trained-model) JSON into a GoldenMatch config, importing trained m/u probabilities directly
 - **PPRL** — Privacy-preserving record linkage with SHA-256 bloom filters (3 security levels: standard, high, paranoid)
 - **Graph ER** — Multi-table entity resolution with evidence propagation
 - **Streaming** — Incremental single-record matching
@@ -264,6 +265,7 @@ See [`packages/goldenmatch-js/examples/`](https://github.com/benseverndev-oss/go
 | Core matching | Polars + rapidfuzz | Pure TS |
 | Refdata name scorers | `given_name_aliased_jw` + `name_freq_weighted_jw` | Both (bundled tables, 4-decimal parity) |
 | Fellegi-Sunter | Yes | Yes |
+| Splink config converter (`import-splink` / `convert_splink_config`) | Yes | Yes |
 | PPRL | SHA-256 | SHA-256 (interop verified byte-for-byte) |
 | Graph ER | Yes | Yes |
 | LLM scorer | Yes | Yes (via fetch, edge-safe) |

--- a/docs/superpowers/plans/2026-07-13-splink-converter-ts.md
+++ b/docs/superpowers/plans/2026-07-13-splink-converter-ts.md
@@ -1,0 +1,75 @@
+# Splink Converter + N-level Fields: TypeScript Surface (Thesis Phase 3) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port the Splink→GoldenMatch config converter and N-level `level_thresholds` probabilistic fields to the TypeScript package (`packages/typescript/goldenmatch`), moving `import-splink` and `convert_splink_config` from `python_only` to `shared` in the parity manifest; merge to main.
+
+**Architecture:** Pure-TS port — investigation confirmed NO WASM path does FS level banding (probabilistic.ts imports only types/scorer/transforms), so no capability guard is needed; the WASM half of "TS/WASM surface" is a documented no-op verdict. Four work fronts: (1) `levelThresholds` banding in `types.ts`/`loader.ts`/`probabilistic.ts`; (2) `EMResult` JSON (de)serialization **byte-compatible with Python's `EMResult.to_dict()` schema v1** so trained-model files round-trip across surfaces; (3) `src/core/config/from-splink.ts` porting `from_splink.py` (recognizers → comparison assembly → blocking → scalars → trained-model import → `fromSplink()` + strict mode); (4) CLI `import-splink` + MCP `convert_splink_config` + parity manifest flip.
+
+**Tech Stack:** TypeScript (edge-safe core, no `node:` imports in `src/core`), commander CLI, vitest. **Box constraint:** full vitest/tsup OOMs — run vitest per-file (`npx vitest run <path>`), never build locally; CI validates build + parity emitters.
+
+**Working branch:** `feat/splink-converter-ts` off fresh origin/main, in worktree `..\goldenmatch-wt-splink-converter`.
+
+**Porting sources (Python, all on main):** `goldenmatch/config/from_splink.py` (authoritative semantics incl. `_strip_outer_parens`, `_LEV_ASSUMED_LEN=10`, level-order reversal, re-normalization warnings), `goldenmatch/cli/import_splink.py`, `goldenmatch/config/schemas.py` (level_thresholds validation), `goldenmatch/core/probabilistic.py` (banding + EMResult schema v1), the six `tests/test_from_splink_*.py` files (port the TEST VECTORS — they encode every reviewed edge case: paren-wrapped conjuncts, out-of-range threshold drops, collapsed-level summing, partial m/u epsilon fills, mixed bare/trained skips).
+
+**Known drift, do NOT fix here:** TS `partialThreshold` default is 0.7 vs Python 0.8 (pre-existing; changing it is a behavior change out of scope — note in PR body).
+
+---
+
+### Task T1: `levelThresholds` in the TS core
+
+**Files:**
+- Modify: `packages/typescript/goldenmatch/src/core/types.ts` (MatchkeyField ~line 26), `src/core/config/loader.ts` (`parseMatchkeyField` ~239, `configToYaml` snake_case emit), `src/core/probabilistic.ts` (`buildComparisonVector` ~81)
+- Test: `tests/unit/nlevel.test.ts` (create; vitest.config.ts only includes `tests/**/*.test.ts` — src-side test files are NOT picked up; all tests go under tests/unit/ per package convention)
+
+- [ ] Add `levelThresholds?: readonly number[]` to `MatchkeyField` (doc comment mirroring the Python semantics: descending cutoffs, level = count satisfied, length must equal `levels-1`).
+- [ ] `parseMatchkeyField`: parse `levelThresholds` (loader camelizes `level_thresholds`) + validate exactly like Python schemas.py: length == levels-1, every value in (0,1], strictly descending — throw the loader's established error type with messages matching its style.
+- [ ] `buildComparisonVector`: insert the custom branch BEFORE `n === 2` (after the null check): `let level = 0; for (const t of f.levelThresholds) if (s >= t) level += 1;`.
+- [ ] `configToYaml`: emit `level_thresholds` back (verify the camelize/snake round-trip helper handles it automatically or add explicitly).
+- [ ] Tests (port the Python vectors from tests/test_nlevel_banding.py + test_nlevel_schema.py): `[1.0,0.92,0.88]` over sims `[1.0,0.95,0.90,0.5,0.88]` → `[3,2,1,0,1]` (drive via buildComparisonVector with a stub scorer or exact values); legacy 2/3 unchanged; loader validation failures (wrong length / non-descending / out-of-range); YAML round-trip.
+- [ ] Run: `npx vitest run src/core/nlevel.test.ts` + the existing probabilistic test file only. Commit.
+
+### Task T2: `EMResult` JSON (de)serialization, Python-schema-compatible
+
+**Files:**
+- Modify: `src/core/probabilistic.ts` (EMResult interface ~31)
+- Test: `tests/unit/em-serde.test.ts` (create)
+
+- [ ] `emResultToJson(em: EMResult): object` and `emResultFromJson(data: object): EMResult` matching Python `EMResult.to_dict()`/`from_dict()` EXACTLY: `{"__type__": "goldenmatch.EMResult", "__version__": 1, "m_probs": {field: number[]}, "u_probs": ..., "match_weights": ..., "converged": bool, "iterations": int, "proportion_matched": float, "tf_freqs": null, "tf_collision": null}`. NOTE the Python field names are snake_case and keyed by FIELD NAME — check how TS `EMResult.m`/`u`/`matchWeights` are keyed (per-field record? array?) and map accordingly; reject `__version__ > 1` with a clear error (mirror Python's forward-compat message). TS `EMResult` has no TF fields: `emResultFromJson` must PRESERVE non-null `tf_freqs`/`tf_collision` through a round-trip (carry them on the returned object as optional fields, e.g. `tfFreqs?`/`tfCollision?` added to the interface) rather than silently dropping Python-trained TF tables — losing them would corrupt a Python-produced model file on TS re-save.
+- [ ] `validateEmResultFor(em, matchkey)` port of Python `EMResult.validate_for` (every field has weights; length == field level count).
+- [ ] Tests: round-trip TS→JSON→TS; cross-surface fixture — embed a JSON literal PRODUCED BY PYTHON (copy one from tests/test_from_splink_model_import.py's expected shape or generate once with the Python venv and paste as a const) and assert TS loads it; version-too-new rejection; validateFor mismatch cases.
+- [ ] Run the new test file. Commit.
+
+### Task T3: `fromSplink()` — the converter port
+
+**Files:**
+- Create: `src/core/config/from-splink.ts`
+- Test: `tests/unit/from-splink.test.ts` (create; one file, sectioned describe blocks mirroring the six Python `test_from_splink_*.py` files; T4 vectors come from `test_cli_import_splink.py` + `test_mcp_splink_convert.py`)
+
+Port `from_splink.py` faithfully — same recognizers, same warning/info/error findings (message text may be shared verbatim), same structure:
+- [ ] `ConversionFinding`/`ConversionReport` (severity, splinkPath, message, mappedTo; hasWarnings/hasErrors/summary) + `SplinkConversionError`.
+- [ ] `recognizeLevel(sql, isNullLevel)`: the anchored case-insensitive regexes (null / ELSE / exact / jaro_winkler_similarity|jaro_winkler / jaro_similarity (approx) / jaccard / levenshtein|damerau_levenshtein distance→similarity with `LEV_ASSUMED_LEN=10` + clamp, approx). Same column-atom rules (`"col_l"`/bare, l/r base names must match).
+- [ ] `convertComparison`: null-skip + info, ELSE disagree, per-level warn on unrecognized, out-of-range band drop + warn, single-family rule (exact rides at 1.0; mixed non-exact families drop), column consistency, threshold dedupe/desc-sort, 2-level legacy shape vs levelThresholds, TF warnings (tf_adjustment_column same-column only, weight != 1 dropped), approx warnings WITH the conversion formula.
+- [ ] `convertBlocking`: `_strip_outer_parens` port (balance-checked; strip whole rule, then per-conjunct), split on `/ AND /i` (case-INSENSITIVE literal-pattern regex, exactly Python's `re.split(r' AND ', ..., flags=re.IGNORECASE)` — no `\s+` (ReDoS), input whitespace-collapsed first; a plain `.split(" AND ")` would miss lowercase ` and `), `l."col"`/SUBSTR conjunct recognizers (SUBSTR(x,1,4) → `substring:0:4`; start<1 or len<1 rejected), non-string rule guard, field dedupe, mixed-rule widening WARNING, multi_pass (keys AND passes both set — check how TS BlockingConfig models passes; mirror the TS loader's shapes), zero-survivors → error finding + null.
+- [ ] `importEm` + `detectTrained` + `convertScalars`: level-order reversal (Splink strongest-first → index N-1; ELSE → 0), collapsed-level SUM + warn, partial m/u epsilon (1e-6) + warn naming the missing side, re-normalize + warn, unassigned epsilon fill + warn, matchWeights = log2(m/u) floored 1e-10, proportionMatched default 0.05 + info, em_convergence/max_iterations/unique_id_column_name/link_type/infra-key findings, TF-tables-absent info.
+- [ ] `fromSplink(source: object, opts?: {strict?: boolean}): SplinkConversion` — TS core is edge-safe: take the PARSED settings object only (no file reading in core; the CLI does file I/O). Strict raises on warnings+; default raises on errors; findings preview capped at 10; placeholder patching (`matchkeys[?].fields[?]` → real indices) with the shared-constant pattern.
+- [ ] Tests: port the Python vectors — the 4-level JW fixture → field with levelThresholds [1.0,0.92,0.88]; pure-exact → 2-level; mixed families → null+warn; paren-wrapped Splink-4 conjuncts convert; `(a OR b)` → dropped; trained import exact-copy + reversal asserts; strict mode; zero comparisons/blocking → throws. Aim for the same edge coverage, not the same test count.
+- [ ] Run per-file. Commit (split into 2-3 commits if natural: report+recognizers / comparison+blocking / model+fromSplink).
+
+### Task T4: CLI + MCP + parity flip + docs
+
+**Files:**
+- Modify: `src/cli.ts` (new `program.command("import-splink")`), `src/node/mcp/server.ts` (TOOLS + handler), `parity/goldenmatch.yaml`, package exports if needed (`src/index.ts` or package.json exports — check how core/config modules are exported)
+- Test: extend from-splink.test.ts or a node-side test file per package convention
+
+- [ ] CLI `import-splink <input> [-o out.yaml] [--model-out m.json] [--strict]` mirroring the Python command exactly: reads JSON file (node side), calls fromSplink, findings table (match the CLI's existing output style — plain console, no rich), config-before-model write order, partial-model refusal, exit 1 on errors/strict, dropped-probabilities warning without --model-out. Export `fromSplink` from the package's public surface the same way other core/config APIs are exported.
+- [ ] MCP tool `convert_splink_config` in TOOLS: `settings_json: string`, `strict?: boolean` → `{config_yaml, findings, summary, em_model, usage_note}` matching the Python tool's response shape (cross-surface parity); error convention per the TS server's existing tools.
+- [ ] `parity/goldenmatch.yaml`: MOVE `convert_splink_config` from `mcp_tools.python_only` → `mcp_tools.shared`, `import-splink` from `cli_commands.python_only` → `cli_commands.shared` (keep list sorting).
+- [ ] Docs: packages/typescript/goldenmatch/README.md (if it lists commands/features, add the converter; match tone), CHANGELOG if the TS package keeps one (check), docs-site TS/parity page if one mentions the converter as Python-only (grep docs-site for "import-splink").
+- [ ] Tests: CLI command registered (`program.commands` contains it — same enumeration the parity emitter uses); MCP TOOLS contains the tool + handler happy path & error path.
+- [ ] Run per-file vitest + `npx tsc --noEmit` IF it doesn't OOM (try once; if OOM, note it and rely on CI typecheck). Commit.
+
+### Task T5: land it
+
+- [ ] Push `feat/splink-converter-ts` (benzsevern token-URL), open PR (base main) noting: WASM no-op verdict (no WASM FS path exists), partialThreshold 0.7/0.8 pre-existing drift NOT changed, parity manifest flip, cross-surface EMResult JSON compatibility. `gh pr merge --auto`.
+- [ ] CI validates the TS build + parity emitters (can't run locally). Watch the PR to merged (background watcher; fix CI failures if any — TS job is single non-matrix; PPRL tests have long timeouts; new test files don't shift Python shards).

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+- Splink -> GoldenMatch config converter, ported from Python: `fromSplink()` (edge-safe core, `src/core/config/from-splink.ts`), the `import-splink` CLI command, and the `convert_splink_config` MCP tool. Converts Splink comparison levels, blocking rules, and trained m/u probabilities (via a Python-schema-compatible `EMResult` JSON round-trip) into a GoldenMatch config, with a findings report for lossy mappings and an opt-in `--strict` mode. `mcp_tools`/`cli_commands` parity manifest entries moved from `python_only` to `shared`.
+- `levelThresholds` N-level custom banding on `MatchkeyField`, and `modelPath` on probabilistic matchkeys (persisted EM model path, Splink-style train-once -> reuse).
+
 ## [1.1.0] - 2026-06-27
 
 ### Added

--- a/packages/typescript/goldenmatch/README.md
+++ b/packages/typescript/goldenmatch/README.md
@@ -174,6 +174,7 @@ import { readFile, writeCsv } from "goldenmatch/node";              // Node-only
 - Full provenance tracking
 
 ### Pipeline features
+- Splink config converter (`import-splink` CLI, `convert_splink_config` MCP tool, `fromSplink()` API) — converts a Splink settings or trained-model JSON into a GoldenMatch config, importing trained m/u probabilities directly
 - PPRL (privacy-preserving record linkage, 3 security levels with HMAC-SHA256)
 - Graph ER (multi-table entity resolution with evidence propagation)
 - Sensitivity analysis (parameter sweep with CCMS/TWI)
@@ -244,6 +245,8 @@ goldenmatch-js mcp-serve            Start MCP server (stdio)
 goldenmatch-js serve                Start REST API
 goldenmatch-js agent-serve          Start A2A agent
 goldenmatch-js tui                  Interactive terminal UI
+goldenmatch-js import-splink <settings.json> [-o out.yaml] [--model-out model.json] [--strict]
+                                     Convert a Splink settings/trained-model JSON into a GoldenMatch config
 ```
 
 ## Examples

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -922,6 +922,36 @@ identityCmd
     },
   );
 
+// ---------- import-splink ----------
+program
+  .command("import-splink")
+  .description("Convert a Splink settings (or trained-model) JSON file into a GoldenMatch YAML config")
+  .argument("<input>", "Splink settings or trained-model JSON file")
+  .option("-o, --output <path>", "Output YAML config path", "goldenmatch.yaml")
+  .option(
+    "--model-out <path>",
+    "Persist imported trained m/u as an FS model JSON; sets model_path in the config",
+  )
+  .option("--strict", "Fail on any lossy mapping (warnings), not just errors")
+  .action(
+    async (
+      input: string,
+      opts: { output: string; modelOut?: string; strict?: boolean },
+    ) => {
+      const { runImportSplinkCli } = await import("./node/cli-import-splink.js");
+      const splinkOpts: { output: string; modelOut?: string; strict?: boolean } = {
+        output: opts.output,
+      };
+      if (opts.modelOut !== undefined) splinkOpts.modelOut = opts.modelOut;
+      if (opts.strict !== undefined) splinkOpts.strict = opts.strict;
+      const code = runImportSplinkCli(input, splinkOpts, {
+        out: (s: string) => process.stdout.write(s),
+        err: (s: string) => process.stderr.write(s),
+      });
+      if (code !== 0) process.exit(code);
+    },
+  );
+
 // ---------- mcp-serve ----------
 program
   .command("mcp-serve")

--- a/packages/typescript/goldenmatch/src/core/config/from-splink.ts
+++ b/packages/typescript/goldenmatch/src/core/config/from-splink.ts
@@ -1,0 +1,1075 @@
+/**
+ * config/from-splink.ts — Splink -> GoldenMatch config converter.
+ *
+ * Faithful port of `goldenmatch/config/from_splink.py`. Accepts an already
+ * PARSED Splink settings object (bare or trained) and produces a validated
+ * GoldenMatchConfig + ConversionReport (+ EMResult when the input carried
+ * trained m/u probabilities).
+ *
+ * Edge-safe: no `node:` imports, no file I/O — the core takes the parsed
+ * settings object only; the CLI does file reading on the Node side.
+ */
+
+import type {
+  GoldenMatchConfig,
+  MatchkeyConfig,
+  MatchkeyField,
+  BlockingConfig,
+  BlockingKeyConfig,
+} from "../types.js";
+import { makeMatchkeyField, makeBlockingConfig } from "../types.js";
+import { parseConfig } from "./loader.js";
+import type { EMResult } from "../probabilistic.js";
+
+export type Severity = "info" | "warning" | "error";
+
+type RawObj = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// recognizeLevel: Splink comparison-level `sql_condition` recognizer
+// ---------------------------------------------------------------------------
+
+// Splink's levenshtein/damerau_levenshtein comparison levels express a raw
+// edit distance threshold (e.g. "<= 1"), while GoldenMatch scorers are
+// normalized 0-1 similarities. There is no exact distance->similarity mapping
+// without the actual string lengths, so we approximate against an assumed
+// average column length: sim = max(0.0, 1 - distance / LEV_ASSUMED_LEN). This
+// is flagged via RecognizedLevel.approx=true so callers can surface it as a
+// lossy conversion.
+const LEV_ASSUMED_LEN = 10;
+
+// convertComparison emits its per-comparison success finding with this
+// mappedTo placeholder; fromSplink()'s patchFieldPlaceholders resolves it to
+// the field's final position once the matchkey is assembled. One shared
+// constant so producer and consumer can't drift.
+const PLACEHOLDER_PREFIX = "matchkeys[?].fields[?]";
+
+// Column atom: Splink serializes comparison-level columns as "col_l" / "col_r"
+// (the _l/_r suffix INSIDE the quotes) or bare col_l / col_r.
+const COL_L = String.raw`"?([A-Za-z_]\w*)_l"?`;
+const COL_R = String.raw`"?([A-Za-z_]\w*)_r"?`;
+
+const ELSE_RE = /^ELSE$/i;
+const NULL_RE = new RegExp(`^${COL_L}\\s+IS\\s+NULL\\s+OR\\s+${COL_R}\\s+IS\\s+NULL$`, "i");
+const EXACT_RE = new RegExp(`^${COL_L}\\s*=\\s*${COL_R}$`, "i");
+const SIM_RE = new RegExp(
+  `^(jaro_winkler_similarity|jaro_winkler|jaro_similarity|jaccard)` +
+    `\\s*\\(\\s*${COL_L}\\s*,\\s*${COL_R}\\s*\\)\\s*>=\\s*([0-9]*\\.?[0-9]+)$`,
+  "i",
+);
+const DIST_RE = new RegExp(
+  `^(levenshtein|damerau_levenshtein)\\s*\\(\\s*${COL_L}\\s*,\\s*${COL_R}\\s*\\)\\s*<=\\s*([0-9]+)$`,
+  "i",
+);
+
+export type LevelKind = "null" | "exact" | "else" | "jaro_winkler" | "levenshtein" | "jaccard";
+
+const SIM_KIND: Readonly<Record<string, readonly [LevelKind, boolean]>> = {
+  jaro_winkler_similarity: ["jaro_winkler", false],
+  jaro_winkler: ["jaro_winkler", false],
+  jaro_similarity: ["jaro_winkler", true],
+  jaccard: ["jaccard", false],
+};
+
+export interface RecognizedLevel {
+  readonly kind: LevelKind;
+  readonly column: string | null;
+  readonly simThreshold: number | null;
+  /** True when the mapping is an approximation (jaro->jw, distance->similarity). */
+  readonly approx: boolean;
+}
+
+/**
+ * Recognize a Splink comparison-level `sql_condition` string.
+ *
+ * Returns `null` when the SQL doesn't match any recognized shape (e.g.
+ * cross-column comparisons, mismatched columns, or arbitrary SQL) so the
+ * caller can report a warning and drop the level.
+ */
+export function recognizeLevel(sql: string, isNullLevel = false): RecognizedLevel | null {
+  const sqlNorm = sql.trim().length === 0 ? "" : sql.trim().split(/\s+/).join(" ");
+
+  if (isNullLevel) {
+    // Prefer extracting the column from the SQL shape even when the
+    // is_null_level flag is what really tells us this is a null level (some
+    // Splink serializations put non-null-shaped SQL on the null level, e.g.
+    // custom null handling) -- fall back to column=null.
+    const m = NULL_RE.exec(sqlNorm);
+    if (m) {
+      const colL = m[1]!;
+      const colR = m[2]!;
+      return { kind: "null", column: colL === colR ? colL : null, simThreshold: null, approx: false };
+    }
+    return { kind: "null", column: null, simThreshold: null, approx: false };
+  }
+
+  if (ELSE_RE.test(sqlNorm)) {
+    return { kind: "else", column: null, simThreshold: null, approx: false };
+  }
+
+  let m = NULL_RE.exec(sqlNorm);
+  if (m) {
+    const colL = m[1]!;
+    const colR = m[2]!;
+    return colL === colR ? { kind: "null", column: colL, simThreshold: null, approx: false } : null;
+  }
+
+  m = EXACT_RE.exec(sqlNorm);
+  if (m) {
+    const colL = m[1]!;
+    const colR = m[2]!;
+    return colL === colR ? { kind: "exact", column: colL, simThreshold: 1.0, approx: false } : null;
+  }
+
+  m = SIM_RE.exec(sqlNorm);
+  if (m) {
+    const func = m[1]!;
+    const colL = m[2]!;
+    const colR = m[3]!;
+    const threshold = Number.parseFloat(m[4]!);
+    if (colL !== colR) return null;
+    const [kind, approx] = SIM_KIND[func.toLowerCase()]!;
+    return { kind, column: colL, simThreshold: threshold, approx };
+  }
+
+  m = DIST_RE.exec(sqlNorm);
+  if (m) {
+    const colL = m[2]!;
+    const colR = m[3]!;
+    const distance = Number.parseInt(m[4]!, 10);
+    if (colL !== colR) return null;
+    const sim = Math.max(0.0, 1 - distance / LEV_ASSUMED_LEN);
+    return { kind: "levenshtein", column: colL, simThreshold: sim, approx: true };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// ConversionFinding / ConversionReport / SplinkConversionError
+// ---------------------------------------------------------------------------
+
+export interface ConversionFinding {
+  readonly severity: Severity;
+  readonly splinkPath: string; // where in the Splink input, e.g. "comparisons[1].comparison_levels[3]"
+  readonly message: string;
+  mappedTo: string | null; // GoldenMatch destination, e.g. "matchkeys[0].fields[1]" (mutated during placeholder patching)
+}
+
+export class ConversionReport {
+  readonly findings: ConversionFinding[] = [];
+
+  info(splinkPath: string, message: string, mappedTo: string | null): void {
+    this.findings.push({ severity: "info", splinkPath, message, mappedTo });
+  }
+
+  warn(splinkPath: string, message: string, mappedTo: string | null): void {
+    this.findings.push({ severity: "warning", splinkPath, message, mappedTo });
+  }
+
+  error(splinkPath: string, message: string, mappedTo: string | null): void {
+    this.findings.push({ severity: "error", splinkPath, message, mappedTo });
+  }
+
+  get hasWarnings(): boolean {
+    return this.findings.some((f) => f.severity === "warning");
+  }
+
+  get hasErrors(): boolean {
+    return this.findings.some((f) => f.severity === "error");
+  }
+
+  summary(): string {
+    const counts = { info: 0, warning: 0, error: 0 };
+    for (const f of this.findings) counts[f.severity] += 1;
+    return `${counts.error} error(s), ${counts.warning} warning(s), ${counts.info} info note(s)`;
+  }
+}
+
+/** Raised in strict mode on any lossy mapping, or always on error-severity. */
+export class SplinkConversionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SplinkConversionError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// convertComparison: one Splink comparisons[idx] -> MatchkeyField
+// ---------------------------------------------------------------------------
+
+interface Band {
+  readonly r: RecognizedLevel;
+  readonly level: RawObj;
+  readonly j: number;
+}
+
+/**
+ * Convert one Splink `comparisons[idx]` dict into a MatchkeyField.
+ *
+ * Returns `null` (with a warning finding) when the comparison can't be
+ * represented as a single GoldenMatch scorer family -- e.g. mixed comparator
+ * families, inconsistent columns, or no usable agree levels.
+ */
+export function convertComparison(comp: RawObj, idx: number, report: ConversionReport): MatchkeyField | null {
+  const compPath = `comparisons[${idx}]`;
+  const outputColumnName =
+    (comp["output_column_name"] as string | undefined) ||
+    (comp["column_name"] as string | undefined) ||
+    null;
+
+  const rawLevels: RawObj[] = Array.isArray(comp["comparison_levels"])
+    ? (comp["comparison_levels"] as RawObj[])
+    : [];
+
+  const recognized: Array<{ j: number; r: RecognizedLevel; level: RawObj }> = [];
+  for (let j = 0; j < rawLevels.length; j++) {
+    const level = rawLevels[j]!;
+    const levelPath = `${compPath}.comparison_levels[${j}]`;
+    const sql = typeof level["sql_condition"] === "string" ? (level["sql_condition"] as string) : "";
+    const isNull = Boolean(level["is_null_level"]);
+    const r = recognizeLevel(sql, isNull);
+    if (r === null) {
+      report.warn(levelPath, `unrecognized sql_condition, level dropped: ${sql}`, null);
+      continue;
+    }
+    recognized.push({ j, r, level });
+  }
+
+  let nullSeen = false;
+  const bands: Band[] = [];
+  for (const { j, r, level } of recognized) {
+    if (r.kind === "null") {
+      nullSeen = true;
+    } else if (r.kind === "else") {
+      continue;
+    } else {
+      // MatchkeyField thresholds must be in (0, 1]; a converted value outside
+      // that range (degenerate levenshtein distance -> sim 0.0, or a
+      // nonsense >= 1.5 threshold) can't be represented -- drop the band with
+      // a warning rather than let the loader raise downstream.
+      const t = r.simThreshold;
+      if (t !== null && !(t > 0.0 && t <= 1.0)) {
+        report.warn(
+          `${compPath}.comparison_levels[${j}]`,
+          `converted threshold ${t} out of range (0, 1], level dropped: ${
+            (level["sql_condition"] as string | undefined) ?? ""
+          }`,
+          null,
+        );
+        continue;
+      }
+      bands.push({ r, level, j });
+    }
+  }
+
+  if (nullSeen) {
+    report.info(
+      compPath,
+      "Splink null level = no evidence; GoldenMatch scores nulls as disagree -- " +
+        "behavior differs on sparse fields",
+      null,
+    );
+  }
+
+  const families = new Set<LevelKind>(bands.filter((b) => b.r.kind !== "exact").map((b) => b.r.kind));
+  if (families.size > 1) {
+    report.warn(
+      compPath,
+      `mixed comparator families ${JSON.stringify([...families].sort())} in one comparison, comparison dropped`,
+      null,
+    );
+    return null;
+  }
+
+  if (bands.length === 0) {
+    report.warn(compPath, "no usable agree levels, comparison dropped", null);
+    return null;
+  }
+
+  const scorer: string = families.size > 0 ? [...families][0]! : "exact";
+
+  const columns = new Set<string>(
+    bands.filter((b) => b.r.column !== null).map((b) => b.r.column as string),
+  );
+  if (columns.size > 1) {
+    report.warn(
+      compPath,
+      `inconsistent columns across levels ${JSON.stringify([...columns].sort())}, comparison dropped`,
+      null,
+    );
+    return null;
+  }
+  const col = columns.size > 0 ? [...columns][0]! : outputColumnName;
+  if (col === null) {
+    report.warn(compPath, "no column could be determined, comparison dropped", null);
+    return null;
+  }
+
+  for (const { r, level, j } of bands) {
+    if (r.approx) {
+      const levelPath = `${compPath}.comparison_levels[${j}]`;
+      const sql = (level["sql_condition"] as string | undefined) ?? "";
+      let message: string;
+      if (r.kind === "levenshtein") {
+        // Reconstruct the original distance from the converted sim.
+        const distance = Math.round((1 - (r.simThreshold ?? 0.0)) * LEV_ASSUMED_LEN);
+        message =
+          `approximate mapping: edit distance <= ${distance} converted via ` +
+          `sim = 1 - distance/${LEV_ASSUMED_LEN} -> ${r.simThreshold} (${sql})`;
+      } else {
+        message =
+          `approximate mapping: jaro_similarity treated as jaro_winkler ` +
+          `(threshold=${r.simThreshold}) (${sql})`;
+      }
+      report.warn(levelPath, message, null);
+    }
+  }
+
+  const thresholdSet = new Set<number>();
+  for (const { r } of bands) {
+    if (r.simThreshold !== null) thresholdSet.add(r.simThreshold);
+  }
+  const thresholds = [...thresholdSet].sort((a, b) => b - a);
+  const levelsCount = thresholds.length + 1;
+
+  let tfAdjustment = false;
+  for (const { level, j } of bands) {
+    const levelPath = `${compPath}.comparison_levels[${j}]`;
+    const tfCol = level["tf_adjustment_column"];
+    if (tfCol) {
+      if (tfCol !== col) {
+        report.warn(
+          levelPath,
+          `tf_adjustment_column '${String(tfCol)}' differs from field column '${col}', ` +
+            "dropped (GoldenMatch TF adjustment is same-column only)",
+          null,
+        );
+      } else {
+        tfAdjustment = true;
+      }
+    }
+    const tfWeight = level["tf_adjustment_weight"];
+    if (tfWeight !== undefined && tfWeight !== null && tfWeight !== 1.0) {
+      report.warn(levelPath, `tf_adjustment_weight=${String(tfWeight)} dropped (not supported)`, null);
+    }
+  }
+
+  const mappedTo = `${PLACEHOLDER_PREFIX} (${col})`;
+
+  let field: MatchkeyField;
+  if (levelsCount === 2) {
+    if (scorer === "exact") {
+      field = makeMatchkeyField({ field: col, scorer: "exact", levels: 2, tfAdjustment });
+    } else {
+      field = makeMatchkeyField({
+        field: col,
+        scorer,
+        levels: 2,
+        partialThreshold: thresholds[0],
+        tfAdjustment,
+      });
+    }
+  } else {
+    field = makeMatchkeyField({
+      field: col,
+      scorer,
+      levels: levelsCount,
+      levelThresholds: thresholds,
+      tfAdjustment,
+    });
+  }
+
+  report.info(compPath, `converted to field '${col}' (scorer=${scorer})`, mappedTo);
+  return field;
+}
+
+// ── Blocking rules -> BlockingConfig ─────────────────────────────────────────
+//
+// Splink blocking rules use the l."col" / r."col" PREFIX style (unlike
+// comparison levels, which use the col_l / col_r SUFFIX style handled above).
+const BLOCK_COL_L = String.raw`l\."?(\w+)"?`;
+const BLOCK_COL_R = String.raw`r\."?(\w+)"?`;
+const BLOCK_EXACT_RE = new RegExp(`^${BLOCK_COL_L}\\s*=\\s*${BLOCK_COL_R}$`, "i");
+// SUBSTR(col, start, len) is SQL's 1-based, inclusive-length form. The repo's
+// `substring:<start>:<end>` transform is a Python/JS slice: value.slice(start,
+// end). So SUBSTR(x, 1, 4) (chars 1-4) maps to substring:0:4 (py_start =
+// sql_start - 1, py_end = py_start + sql_len).
+const BLOCK_SUBSTR_RE = new RegExp(
+  `^SUBSTR(?:ING)?\\s*\\(\\s*${BLOCK_COL_L}\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)` +
+    `\\s*=\\s*SUBSTR(?:ING)?\\s*\\(\\s*${BLOCK_COL_R}\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)$`,
+  "i",
+);
+
+interface BlockConjunct {
+  readonly field: string;
+  readonly transform: string | null; // e.g. "substring:0:4", or null for plain equality
+}
+
+/**
+ * Strip balanced outer parentheses: '(l.a = r.a)' -> 'l.a = r.a'.
+ *
+ * Splink 4's `block_on(...)` serialization wraps every AND-conjunct in
+ * parentheses, so after splitting on AND each conjunct arrives paren-wrapped.
+ * Only strips when the opening paren's match is the final character (so
+ * `SUBSTR(a) = SUBSTR(b)` is untouched).
+ */
+function stripOuterParens(input: string): string {
+  let s = input.trim();
+  while (s.startsWith("(") && s.endsWith(")")) {
+    let depth = 0;
+    let closesAtEnd = false;
+    for (let i = 0; i < s.length; i++) {
+      const ch = s[i];
+      if (ch === "(") {
+        depth += 1;
+      } else if (ch === ")") {
+        depth -= 1;
+        if (depth === 0) {
+          closesAtEnd = i === s.length - 1;
+          break;
+        }
+      }
+    }
+    if (!closesAtEnd) break;
+    s = s.slice(1, -1).trim();
+  }
+  return s;
+}
+
+/**
+ * Recognize one top-level AND-conjunct of a Splink blocking_rule.
+ *
+ * Returns `null` for anything not a same-column equality or a same-column/
+ * same-offset SUBSTR(...) equality (OR, cross-column, arithmetic, ranges,
+ * etc. all fail to match and are rejected here). Balanced outer parentheses
+ * (Splink 4 `block_on` serialization style) are stripped before matching.
+ */
+function recognizeBlockingConjunct(conjunctRaw: string): BlockConjunct | null {
+  const conjunct = stripOuterParens(conjunctRaw);
+
+  let m = BLOCK_SUBSTR_RE.exec(conjunct);
+  if (m) {
+    const colL = m[1]!;
+    const startL = m[2]!;
+    const lenL = m[3]!;
+    const colR = m[4]!;
+    const startR = m[5]!;
+    const lenR = m[6]!;
+    if (colL !== colR || startL !== startR || lenL !== lenR) return null;
+    const sqlStart = Number.parseInt(startL, 10);
+    const sqlLen = Number.parseInt(lenL, 10);
+    // Degenerate args: SQL SUBSTR is 1-based, so start < 1 has no clean
+    // slice equivalent (py_start=-1 would wrap); length 0 would produce an
+    // empty key (one mega-block). Reject as unrecognized.
+    if (sqlStart < 1 || sqlLen < 1) return null;
+    const pyStart = sqlStart - 1;
+    const pyEnd = pyStart + sqlLen;
+    return { field: colL, transform: `substring:${pyStart}:${pyEnd}` };
+  }
+
+  m = BLOCK_EXACT_RE.exec(conjunct);
+  if (m) {
+    const colL = m[1]!;
+    const colR = m[2]!;
+    if (colL !== colR) return null;
+    return { field: colL, transform: null };
+  }
+
+  return null;
+}
+
+function convertOneBlockingRule(rule: unknown, idx: number, report: ConversionReport): BlockingKeyConfig | null {
+  const rulePath = `blocking_rules[${idx}]`;
+  let sql: unknown;
+  if (typeof rule === "object" && rule !== null && !Array.isArray(rule)) {
+    const obj = rule as RawObj;
+    sql = "blocking_rule" in obj ? obj["blocking_rule"] : rule;
+  } else {
+    sql = rule;
+  }
+  if (typeof sql !== "string") {
+    report.warn(rulePath, `blocking rule is not a SQL string, dropped: ${JSON.stringify(sql) ?? String(sql)}`, null);
+    return null;
+  }
+  const sqlNorm = sql.trim().length === 0 ? "" : sql.trim().split(/\s+/).join(" ");
+
+  // Whole-rule strip handles the double-wrapped case; each conjunct is
+  // deliberately stripped AGAIN inside recognizeBlockingConjunct, so neither
+  // call can be "simplified" away.
+  // sqlNorm collapsed all whitespace runs to single spaces above, so a
+  // literal ' AND ' split is exact -- and unlike a whitespace-tolerant
+  // pattern it cannot backtrack polynomially on adversarial whitespace.
+  const conjuncts = stripOuterParens(sqlNorm).split(/ AND /i);
+  const recognized: BlockConjunct[] = [];
+  for (const conjunct of conjuncts) {
+    const r = recognizeBlockingConjunct(conjunct);
+    if (r === null) {
+      report.warn(rulePath, `unrecognized blocking rule, dropped: ${sqlNorm}`, null);
+      return null;
+    }
+    recognized.push(r);
+  }
+
+  // Dedupe repeated fields (order-preserving): `l.a = r.a AND l.a = r.a` is
+  // one field, not two identical key components.
+  const fields: string[] = [];
+  for (const r of recognized) if (!fields.includes(r.field)) fields.push(r.field);
+
+  // BlockingKeyConfig.transforms is ONE chain applied uniformly to every
+  // field in the key -- there is no per-field transform slot. A mixed rule
+  // (plain equality on one column + SUBSTR on another) is therefore
+  // approximated as a single key carrying the substring transform for ALL
+  // fields. This is safe for blocking (candidate generation only needs to be
+  // a superset of true matches). If two conjuncts specify SUBSTR at
+  // different offsets, there is no single chain that represents both, so the
+  // rule is dropped.
+  const transformValues = new Set<string>(
+    recognized.filter((r) => r.transform !== null).map((r) => r.transform as string),
+  );
+  if (transformValues.size > 1) {
+    report.warn(rulePath, `conflicting SUBSTR offsets across fields, rule dropped: ${sqlNorm}`, null);
+    return null;
+  }
+  const transforms = transformValues.size > 0 ? [[...transformValues][0]!] : [];
+
+  const key: BlockingKeyConfig = { fields, transforms };
+  const plainFields: string[] = [];
+  for (const r of recognized) {
+    if (r.transform === null && !plainFields.includes(r.field)) plainFields.push(r.field);
+  }
+  if (transforms.length > 0 && plainFields.length > 0) {
+    // LOSSY: the key-level chain applies the substring transform to field(s)
+    // Splink compared with plain equality. Warn (not info) so strict=true
+    // gates on it, matching the approx-warn convention used for comparison
+    // levels above.
+    report.warn(
+      rulePath,
+      `approximate mapping, blocking key widened: ${transforms[0]} applied to all fields ` +
+        `including plain-equality field(s) ${JSON.stringify(plainFields)} (GoldenMatch transforms ` +
+        "are key-level); candidates are a superset of Splink's, precision may drop (superset " +
+        "guarantee assumes skip_oversized stays False, the converter's emitted default) " +
+        `(${sqlNorm})`,
+      null,
+    );
+  } else {
+    report.info(
+      rulePath,
+      `converted to blocking key fields=${JSON.stringify(fields)} transforms=${JSON.stringify(transforms)}`,
+      null,
+    );
+  }
+  return key;
+}
+
+/**
+ * Convert Splink `blocking_rules_to_generate_predictions` into a GoldenMatch
+ * `BlockingConfig`.
+ *
+ * Each rule is a string (or a Splink 4 dict `{"blocking_rule": ..., ...}`).
+ * One surviving rule -> `strategy="static"`; two or more -> `strategy=
+ * "multi_pass"` with both `keys` and `passes` set to the same list. If every
+ * rule is dropped, this is fatal: GoldenMatch probabilistic matchkeys require
+ * a blocking config, so an error finding is recorded and `null` is returned
+ * rather than an invalid config.
+ */
+export function convertBlocking(rules: readonly unknown[], report: ConversionReport): BlockingConfig | null {
+  const keys: BlockingKeyConfig[] = [];
+  for (let idx = 0; idx < rules.length; idx++) {
+    const key = convertOneBlockingRule(rules[idx], idx, report);
+    if (key !== null) keys.push(key);
+  }
+
+  if (keys.length === 0) {
+    report.error("blocking_rules", "no blocking rule could be converted to a BlockingConfig key", null);
+    return null;
+  }
+
+  if (keys.length === 1) {
+    return makeBlockingConfig({ strategy: "static", keys });
+  }
+  return makeBlockingConfig({ strategy: "multi_pass", keys, passes: keys });
+}
+
+// ── Trained-model (m/u) import ───────────────────────────────────────────────
+//
+// Splink lists comparison levels strongest -> weakest (after the null level),
+// and each non-null level MAY carry an EM-trained "m_probability" /
+// "u_probability". GoldenMatch's EMResult is the mirror image: level index 0
+// is disagree (Splink's ELSE), index N-1 is the strongest agree level. So
+// importing m/u is a re-indexing exercise, not a re-fit.
+
+/**
+ * True if any comparison level anywhere in `settings` carries m/u.
+ *
+ * A bare (untrained) Splink settings dict has comparison levels with only
+ * `sql_condition` (+ metadata); a trained model additionally carries
+ * `m_probability` / `u_probability` floats on every non-null level. Checking
+ * for the presence of the key anywhere is enough to distinguish the two
+ * shapes without assuming every level was populated.
+ */
+export function detectTrained(settings: RawObj): boolean {
+  const comparisons: RawObj[] = Array.isArray(settings["comparisons"]) ? (settings["comparisons"] as RawObj[]) : [];
+  for (const comp of comparisons) {
+    const levels: RawObj[] = Array.isArray(comp["comparison_levels"]) ? (comp["comparison_levels"] as RawObj[]) : [];
+    for (const level of levels) {
+      if ("m_probability" in level || "u_probability" in level) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve a recognized agree-band level to its GoldenMatch level index.
+ *
+ * Resolution is by position in the field's own (already-deduped, descending)
+ * thresholds -- mirrors `convertComparison`'s threshold derivation. Returns
+ * `null` when the level's threshold matches none of the field's converted
+ * thresholds (its m/u mass is dropped by the caller).
+ */
+function agreeIndexFor(r: RecognizedLevel, fld: MatchkeyField): number | null {
+  const levels = fld.levels ?? 2;
+  if (levels === 2) {
+    if (fld.scorer === "exact") {
+      return r.kind === "exact" ? 1 : null;
+    }
+    if (r.simThreshold === null || fld.partialThreshold === undefined) return null;
+    return Math.abs(r.simThreshold - fld.partialThreshold) < 1e-9 ? 1 : null;
+  }
+  if (r.simThreshold === null) return null;
+  const thresholds = fld.levelThresholds ?? [];
+  for (let i = 0; i < thresholds.length; i++) {
+    if (Math.abs(thresholds[i]! - r.simThreshold) < 1e-9) return levels - 1 - i;
+  }
+  return null;
+}
+
+export interface ImportEmComparison {
+  readonly comp: RawObj;
+  readonly compIdx: number;
+  readonly field: MatchkeyField;
+}
+
+/**
+ * Import trained m/u probabilities into an `EMResult`.
+ *
+ * `comparisons` is the explicit alignment the caller (`fromSplink`) must
+ * build: one `{comp, compIdx, field}` per Splink comparison that
+ * `convertComparison` successfully turned into a `MatchkeyField`.
+ *
+ * Returns `null` when no level in any comparison carries m/u at all (a bare,
+ * untrained settings dict) or when nothing importable survives.
+ */
+export function importEm(
+  comparisons: readonly ImportEmComparison[],
+  settings: RawObj,
+  report: ConversionReport,
+): EMResult | null {
+  if (!detectTrained(settings)) return null;
+
+  const mProbs: Record<string, number[]> = {};
+  const uProbs: Record<string, number[]> = {};
+  const epsilon = 1e-6;
+
+  for (const { comp, compIdx, field: fld } of comparisons) {
+    const fieldName = fld.field;
+    const n = fld.levels ?? 2;
+    const mAcc = new Array<number>(n).fill(0);
+    const uAcc = new Array<number>(n).fill(0);
+    const assigned = new Array<boolean>(n).fill(false);
+    let lostM = 0;
+    let lostU = 0;
+    let hadAnyProb = false;
+    const compPath = `comparisons[${compIdx}]`;
+
+    const levels: RawObj[] = Array.isArray(comp["comparison_levels"]) ? (comp["comparison_levels"] as RawObj[]) : [];
+    for (let j = 0; j < levels.length; j++) {
+      const level = levels[j]!;
+      const levelPath = `${compPath}.comparison_levels[${j}]`;
+      let mP = typeof level["m_probability"] === "number" ? (level["m_probability"] as number) : undefined;
+      let uP = typeof level["u_probability"] === "number" ? (level["u_probability"] as number) : undefined;
+      if (mP === undefined && uP === undefined) continue;
+      hadAnyProb = true;
+
+      // Partial data: a level carrying only one side (m without u, or u
+      // without m). Silently treating the missing side as 0.0 would skew
+      // log2(m/u) hard; floor it with epsilon and warn instead.
+      if (mP === undefined || uP === undefined) {
+        const missingSide = mP === undefined ? "m_probability" : "u_probability";
+        const mappedPrefix = missingSide === "m_probability" ? "em.m_probs" : "em.u_probs";
+        report.warn(
+          levelPath,
+          `level carries partial trained data (${missingSide} missing) for field '${fld.field}'; ` +
+            `missing side filled with epsilon (${epsilon})`,
+          `${mappedPrefix}.${fld.field}`,
+        );
+        if (mP === undefined) mP = epsilon;
+        else uP = epsilon;
+      }
+
+      const isNull = Boolean(level["is_null_level"]);
+      const sql = typeof level["sql_condition"] === "string" ? (level["sql_condition"] as string) : "";
+      const r = recognizeLevel(sql, isNull);
+
+      if (r === null) {
+        // Unrecognized level (already dropped by convertComparison when
+        // building the field) -- its m/u mass is lost.
+        lostM += mP ?? 0;
+        lostU += uP ?? 0;
+        report.warn(
+          levelPath,
+          `unrecognized level carried m/u probabilities; dropped, surviving levels for ` +
+            `field '${fld.field}' re-normalized`,
+          `em.m_probs.${fld.field}`,
+        );
+        continue;
+      }
+
+      if (r.kind === "null") {
+        // Splink convention: null levels carry no evidentiary m/u. Ignore
+        // even if present rather than let them participate.
+        continue;
+      }
+
+      let idx: number;
+      if (r.kind === "else") {
+        idx = 0;
+      } else {
+        const resolved = agreeIndexFor(r, fld);
+        if (resolved === null) {
+          lostM += mP ?? 0;
+          lostU += uP ?? 0;
+          report.warn(
+            levelPath,
+            `level threshold ${r.simThreshold} does not match any converted threshold for ` +
+              `field '${fld.field}'; m/u dropped, surviving levels re-normalized`,
+            `em.m_probs.${fld.field}`,
+          );
+          continue;
+        }
+        idx = resolved;
+      }
+
+      // Two Splink levels can collapse onto the same GoldenMatch index
+      // (threshold dedupe) -- sum their m/u rather than overwrite, and warn:
+      // the collapse is lossy (two Splink levels become one GoldenMatch
+      // level).
+      if (assigned[idx]) {
+        report.warn(
+          levelPath,
+          `level collapsed onto GoldenMatch level ${idx} of field '${fld.field}' ` +
+            "(duplicate threshold after dedupe); m/u probabilities summed with the earlier level's",
+          `em.m_probs.${fld.field}`,
+        );
+      }
+      mAcc[idx] = mAcc[idx]! + (mP ?? 0);
+      uAcc[idx] = uAcc[idx]! + (uP ?? 0);
+      assigned[idx] = true;
+    }
+
+    if (!hadAnyProb) {
+      // This comparison carried no trained data at all (mixed bare/trained
+      // input); nothing to import for this field. The resulting model is
+      // PARTIAL, so surface it loudly rather than skipping silently.
+      report.warn(
+        compPath,
+        `comparison for field '${fld.field}' carries no trained m/u while other comparisons ` +
+          `do (mixed bare/trained input); the imported model will NOT cover field '${fld.field}', ` +
+          "and using it via model_path with this partial model will fail validation at runtime",
+        null,
+      );
+      continue;
+    }
+
+    if (lostM || lostU) {
+      report.warn(
+        compPath,
+        `re-normalizing m/u probabilities for field '${fld.field}' after dropping unrecognized level(s)`,
+        `em.m_probs.${fld.field}`,
+      );
+    }
+
+    for (let i = 0; i < n; i++) {
+      if (!assigned[i]) {
+        mAcc[i] = epsilon;
+        uAcc[i] = epsilon;
+        report.warn(
+          compPath,
+          `field '${fld.field}' level ${i} had no m/u probability assigned from the Splink model; ` +
+            "filled with epsilon",
+          `em.m_probs.${fld.field}`,
+        );
+      }
+    }
+
+    const sumM = mAcc.reduce((a, b) => a + b, 0);
+    const sumU = uAcc.reduce((a, b) => a + b, 0);
+    const mFinal = sumM > 0 ? mAcc.map((v) => v / sumM) : new Array<number>(n).fill(1 / n);
+    const uFinal = sumU > 0 ? uAcc.map((v) => v / sumU) : new Array<number>(n).fill(1 / n);
+
+    mProbs[fieldName] = mFinal;
+    uProbs[fieldName] = uFinal;
+  }
+
+  if (Object.keys(mProbs).length === 0) return null;
+
+  // Splink model exports carry no term-frequency tables, so an imported
+  // EMResult always has tfFreqs=null -- tfAdjustment on a converted field
+  // silently no-ops until the model is retrained. Say so.
+  const tfFields = comparisons.filter((c) => c.field.tfAdjustment).map((c) => c.field.field);
+  if (tfFields.length > 0) {
+    const uniqueSorted = [...new Set(tfFields)].sort();
+    report.info(
+      "comparisons",
+      "term-frequency tables are not part of a Splink model export; tf_adjustment on field(s) " +
+        `${uniqueSorted.join(", ")} will only take effect after retraining`,
+      "em.tf_freqs",
+    );
+  }
+
+  const matchWeights: Record<string, number[]> = {};
+  for (const f of Object.keys(mProbs)) {
+    matchWeights[f] = mProbs[f]!.map((m, i) => Math.log2(Math.max(m, 1e-10) / Math.max(uProbs[f]![i]!, 1e-10)));
+  }
+
+  let proportionMatched: number;
+  if (typeof settings["probability_two_random_records_match"] === "number") {
+    proportionMatched = settings["probability_two_random_records_match"] as number;
+  } else {
+    proportionMatched = 0.05;
+    report.info(
+      "probability_two_random_records_match",
+      "probability_two_random_records_match absent from trained settings; assumed default 0.05",
+      "em.proportion_matched",
+    );
+  }
+
+  return {
+    m: mProbs,
+    u: uProbs,
+    matchWeights,
+    converged: true,
+    iterations: 0,
+    proportionMatched,
+    tfFreqs: null,
+    tfCollision: null,
+  };
+}
+
+// ── Settings scalar mapping ──────────────────────────────────────────────────
+
+const INFRA_IGNORED_KEYS = [
+  "sql_dialect",
+  "retain_matching_columns",
+  "retain_intermediate_calculation_columns",
+  "bayes_factor_column_prefix",
+] as const;
+
+export interface ScalarKwargs {
+  convergenceThreshold?: number;
+  emIterations?: number;
+}
+
+/**
+ * Map top-level Splink settings scalars onto ProbabilisticMatchkey kwargs.
+ *
+ * Returns a kwargs object suitable for spreading into the matchkey; only keys
+ * actually present in `settings` are included. Everything not representable
+ * as a GoldenMatch config field (file paths, engine infra) is surfaced as a
+ * report finding instead.
+ */
+export function convertScalars(settings: RawObj, report: ConversionReport): ScalarKwargs {
+  const kwargs: ScalarKwargs = {};
+
+  if ("em_convergence" in settings) {
+    kwargs.convergenceThreshold = settings["em_convergence"] as number;
+    report.info(
+      "em_convergence",
+      `em_convergence=${String(settings["em_convergence"])} -> convergence_threshold`,
+      "matchkeys[?].convergence_threshold",
+    );
+  }
+
+  if ("max_iterations" in settings) {
+    kwargs.emIterations = settings["max_iterations"] as number;
+    report.info(
+      "max_iterations",
+      `max_iterations=${String(settings["max_iterations"])} -> em_iterations`,
+      "matchkeys[?].em_iterations",
+    );
+  }
+
+  if ("unique_id_column_name" in settings) {
+    const col = settings["unique_id_column_name"];
+    report.info(
+      "unique_id_column_name",
+      `unique_id_column_name='${String(col)}' -> set input.files[*].id_column to '${String(col)}' ` +
+        "(no InputConfig emitted; Splink settings carry no file paths)",
+      "input.files[*].id_column",
+    );
+  }
+
+  const linkType = settings["link_type"];
+  if (linkType === "link_and_dedupe") {
+    report.warn(
+      "link_type",
+      "link_type='link_and_dedupe' has no single GoldenMatch entry point -- run dedupe() on " +
+        "each source then match() across sources (or vice versa) and combine the results",
+      null,
+    );
+  } else if (linkType === "dedupe_only" || linkType === "link_only") {
+    const entryPoint = linkType === "dedupe_only" ? "dedupe()" : "match()";
+    report.info("link_type", `link_type='${linkType}' -> use GoldenMatch's ${entryPoint}`, entryPoint);
+  } else if (linkType !== undefined && linkType !== null) {
+    report.info("link_type", `unrecognized link_type=${JSON.stringify(linkType)}, ignored`, null);
+  }
+
+  for (const key of INFRA_IGNORED_KEYS) {
+    if (key in settings) {
+      report.info(key, `'${key}' ignored (engine infra)`, null);
+    }
+  }
+
+  return kwargs;
+}
+
+// ── Public entry point ───────────────────────────────────────────────────────
+
+const MATCHKEY_NAME = "splink_import";
+
+/**
+ * Result of `fromSplink()`.
+ *
+ * `emModel` (when present) is an in-memory `EMResult` only -- this call never
+ * touches disk. Callers who want EM-skip-on-reuse behavior must persist it
+ * themselves (`emResultToJson` + write) and set the resulting path on
+ * `config.matchkeys[0].model_path` (via a subsequent config edit).
+ */
+export interface SplinkConversion {
+  readonly config: GoldenMatchConfig;
+  readonly report: ConversionReport;
+  readonly emModel: EMResult | null;
+}
+
+const PREVIEW_MAX_FINDINGS = 10;
+
+/**
+ * Render findings for an exception message, capped at the first
+ * PREVIEW_MAX_FINDINGS so a pathological input can't produce a multi-page
+ * exception. The full report is on SplinkConversion.report (or re-runnable
+ * with strict=false).
+ */
+function findingsPreview(findings: readonly ConversionFinding[]): string {
+  const shown = findings.slice(0, PREVIEW_MAX_FINDINGS);
+  let preview = shown.map((f) => `[${f.severity}] ${f.splinkPath}: ${f.message}`).join("; ");
+  const remaining = findings.length - shown.length;
+  if (remaining > 0) {
+    preview += `; ... and ${remaining} more; rerun with strict=false for the full report`;
+  }
+  return preview;
+}
+
+/**
+ * Resolve the `matchkeys[?].fields[?]` placeholder `convertComparison` leaves
+ * on its own findings, now that the field's final position in the assembled
+ * matchkey is known.
+ */
+function patchFieldPlaceholders(report: ConversionReport, compPath: string, fieldIdx: number): void {
+  const resolved = `matchkeys[0].fields[${fieldIdx}]`;
+  for (const f of report.findings) {
+    if (f.splinkPath === compPath && f.mappedTo && f.mappedTo.startsWith(PLACEHOLDER_PREFIX)) {
+      f.mappedTo = resolved + f.mappedTo.slice(PLACEHOLDER_PREFIX.length);
+    }
+  }
+}
+
+/**
+ * Convert a Splink settings object into a GoldenMatch config.
+ *
+ * @param source - A Splink settings object (already parsed from JSON). Bare
+ *   (untrained) or trained (carrying m_probability/u_probability) settings
+ *   are both accepted. This core function does no file I/O -- Node-side
+ *   callers (the CLI) read the file and pass the parsed object.
+ * @param opts.strict - When true, ANY warning or error finding raises
+ *   SplinkConversionError (a fully lossless conversion is required). When
+ *   false (default), only error-severity findings raise -- e.g. zero
+ *   convertible comparisons or blocking rules.
+ *
+ * @returns A SplinkConversion with a validated GoldenMatchConfig, the full
+ *   ConversionReport, and an EMResult when the input settings were trained
+ *   (null for bare settings).
+ *
+ * @throws SplinkConversionError on malformed input, zero convertible
+ *   comparisons, zero convertible blocking rules, or (in strict mode) any
+ *   lossy finding.
+ */
+export function fromSplink(source: unknown, opts?: { strict?: boolean }): SplinkConversion {
+  const strict = opts?.strict ?? false;
+
+  if (typeof source !== "object" || source === null || Array.isArray(source)) {
+    const got = source === null ? "null" : Array.isArray(source) ? "array" : typeof source;
+    throw new SplinkConversionError(`fromSplink() source must be a non-null object, got ${got}`);
+  }
+  const settings = source as RawObj;
+  const report = new ConversionReport();
+
+  const rawComparisons: RawObj[] = Array.isArray(settings["comparisons"])
+    ? (settings["comparisons"] as RawObj[])
+    : [];
+  const survivors: ImportEmComparison[] = [];
+  for (let idx = 0; idx < rawComparisons.length; idx++) {
+    const comp = rawComparisons[idx]!;
+    const field = convertComparison(comp, idx, report);
+    if (field !== null) survivors.push({ comp, compIdx: idx, field });
+  }
+
+  if (survivors.length === 0) {
+    report.error("comparisons", "no comparison could be converted to a MatchkeyField", null);
+    throw new SplinkConversionError(`fromSplink(): zero convertible comparisons -- ${report.summary()}`);
+  }
+
+  survivors.forEach(({ compIdx }, fieldIdx) => {
+    patchFieldPlaceholders(report, `comparisons[${compIdx}]`, fieldIdx);
+  });
+
+  const rawBlockingRules: unknown[] = Array.isArray(settings["blocking_rules_to_generate_predictions"])
+    ? (settings["blocking_rules_to_generate_predictions"] as unknown[])
+    : [];
+  const blocking = convertBlocking(rawBlockingRules, report);
+  if (blocking === null) {
+    throw new SplinkConversionError(`fromSplink(): zero convertible blocking rules -- ${report.summary()}`);
+  }
+
+  const scalarKwargs = convertScalars(settings, report);
+
+  const mk: MatchkeyConfig = {
+    name: MATCHKEY_NAME,
+    type: "probabilistic",
+    fields: survivors.map((s) => s.field),
+    ...(scalarKwargs.convergenceThreshold !== undefined
+      ? { convergenceThreshold: scalarKwargs.convergenceThreshold }
+      : {}),
+    ...(scalarKwargs.emIterations !== undefined ? { emIterations: scalarKwargs.emIterations } : {}),
+  };
+
+  const emModel = importEm(survivors, settings, report);
+
+  // parseConfig() re-validates the assembled config against the loader's own
+  // invariants (transform shapes, levelThresholds descending/range, etc.) --
+  // a failure here is a bug in this converter, so let it propagate loudly
+  // rather than wrapping it in SplinkConversionError.
+  const config = parseConfig({ matchkeys: [mk], blocking });
+
+  if (strict && (report.hasWarnings || report.hasErrors)) {
+    const preview = findingsPreview(
+      report.findings.filter((f) => f.severity === "warning" || f.severity === "error"),
+    );
+    throw new SplinkConversionError(`fromSplink(strict=true): lossy conversion -- ${report.summary()}. ${preview}`);
+  }
+  if (report.hasErrors) {
+    const preview = findingsPreview(report.findings.filter((f) => f.severity === "error"));
+    throw new SplinkConversionError(`fromSplink(): conversion error -- ${report.summary()}. ${preview}`);
+  }
+
+  return { config, report, emModel };
+}

--- a/packages/typescript/goldenmatch/src/core/config/from-splink.ts
+++ b/packages/typescript/goldenmatch/src/core/config/from-splink.ts
@@ -366,7 +366,9 @@ export function convertComparison(comp: RawObj, idx: number, report: ConversionR
         field: col,
         scorer,
         levels: 2,
-        partialThreshold: thresholds[0],
+        // levelsCount === 2 => thresholds.length === 1 (levelsCount =
+        // thresholds.length + 1), so index 0 is always present here.
+        partialThreshold: thresholds[0]!,
         tfAdjustment,
       });
     }

--- a/packages/typescript/goldenmatch/src/core/config/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/config/loader.ts
@@ -277,6 +277,48 @@ function parseMatchkeyField(raw: unknown, ctx: string): MatchkeyField {
     }
   }
 
+  const levels = optNum(obj.levels);
+  if (levels !== undefined && levels < 2) {
+    throw new Error(
+      `${ctx}.levels: must be >= 2 on field '${fieldName}', got ${levels}.`,
+    );
+  }
+
+  const levelThresholds: number[] | undefined = Array.isArray(
+    obj.levelThresholds,
+  )
+    ? (obj.levelThresholds as unknown[]).map((t, i) => {
+        if (typeof t !== "number") {
+          throw new Error(
+            `${ctx}.levelThresholds[${i}]: expected number, got ${typeof t}`,
+          );
+        }
+        return t;
+      })
+    : undefined;
+
+  if (levelThresholds !== undefined) {
+    const expectedLen = (levels ?? 2) - 1;
+    if (levelThresholds.length !== expectedLen) {
+      throw new Error(
+        `level_thresholds must have levels-1=${expectedLen} entries, ` +
+          `got ${levelThresholds.length}.`,
+      );
+    }
+    if (levelThresholds.some((t) => !(t > 0.0 && t <= 1.0))) {
+      throw new Error(
+        `level_thresholds values must be in (0, 1]. Got: [${levelThresholds.join(", ")}]`,
+      );
+    }
+    for (let i = 0; i < levelThresholds.length - 1; i++) {
+      if (levelThresholds[i]! <= levelThresholds[i + 1]!) {
+        throw new Error(
+          `level_thresholds must be strictly descending. Got: [${levelThresholds.join(", ")}]`,
+        );
+      }
+    }
+  }
+
   return stripUndefined({
     field: asStr(obj.field, `${ctx}.field`),
     transforms,
@@ -290,8 +332,9 @@ function parseMatchkeyField(raw: unknown, ctx: string): MatchkeyField {
       typeof obj.columnWeights === "object" && obj.columnWeights !== null
         ? (obj.columnWeights as Record<string, number>)
         : undefined,
-    levels: optNum(obj.levels),
+    levels,
     partialThreshold: optNum(obj.partialThreshold),
+    levelThresholds,
   }) as MatchkeyField;
 }
 

--- a/packages/typescript/goldenmatch/src/core/config/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/config/loader.ts
@@ -368,6 +368,7 @@ function parseMatchkeyConfig(raw: unknown, ctx: string): MatchkeyConfig {
       convergenceThreshold: optNum(obj.convergenceThreshold),
       linkThreshold: optNum(obj.linkThreshold),
       reviewThreshold: optNum(obj.reviewThreshold),
+      modelPath: optStr(obj.modelPath),
     }) as MatchkeyConfig;
   }
   // weighted

--- a/packages/typescript/goldenmatch/src/core/config/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/config/loader.ts
@@ -335,6 +335,7 @@ function parseMatchkeyField(raw: unknown, ctx: string): MatchkeyField {
     levels,
     partialThreshold: optNum(obj.partialThreshold),
     levelThresholds,
+    tfAdjustment: optBool(obj.tfAdjustment),
   }) as MatchkeyField;
 }
 

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -270,6 +270,11 @@ export {
   trainEMContinuous,
   scoreProbabilisticContinuous,
   continuousScores,
+  emResultToJson,
+  emResultFromJson,
+  validateEmResultFor,
+  FSModelMismatchError,
+  EM_RESULT_SCHEMA_VERSION,
 } from "./probabilistic.js";
 export type { EMResult, EMOptions, ContinuousEMResult } from "./probabilistic.js";
 

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -240,6 +240,31 @@ export { dedupe, match, scoreStrings, scorePairRecord } from "./api.js";
 export { parseConfig, parseConfigYaml, configToYaml } from "./config/loader.js";
 
 // ---------------------------------------------------------------------------
+// Config: Splink -> GoldenMatch converter
+// ---------------------------------------------------------------------------
+
+export {
+  recognizeLevel,
+  ConversionReport,
+  SplinkConversionError,
+  convertComparison,
+  convertBlocking,
+  detectTrained,
+  importEm,
+  convertScalars,
+  fromSplink,
+} from "./config/from-splink.js";
+export type {
+  Severity as SplinkFindingSeverity,
+  LevelKind as SplinkLevelKind,
+  RecognizedLevel,
+  ConversionFinding,
+  ImportEmComparison,
+  ScalarKwargs,
+  SplinkConversion,
+} from "./config/from-splink.js";
+
+// ---------------------------------------------------------------------------
 // LLM
 // ---------------------------------------------------------------------------
 

--- a/packages/typescript/goldenmatch/src/core/probabilistic.ts
+++ b/packages/typescript/goldenmatch/src/core/probabilistic.ts
@@ -77,6 +77,8 @@ function fieldPartialThreshold(f: MatchkeyField): number {
  *   levels=2: 0=disagree, 1=agree
  *   levels=3: 0=disagree, 1=partial, 2=agree (>= 0.95)
  *   levels=N: evenly spaced thresholds k/N for k in 1..N-1
+ *   levelThresholds set: custom descending cutoffs; level = count satisfied
+ *   (takes priority over the levels-based legacy banding above).
  */
 export function buildComparisonVector(
   rowA: Row,
@@ -100,7 +102,11 @@ export function buildComparisonVector(
       continue;
     }
 
-    if (n === 2) {
+    if (f.levelThresholds !== undefined) {
+      let level = 0;
+      for (const t of f.levelThresholds) if (s >= t) level += 1;
+      levels.push(level);
+    } else if (n === 2) {
       levels.push(s >= partial ? 1 : 0);
     } else if (n === 3) {
       if (s >= 0.95) levels.push(2);

--- a/packages/typescript/goldenmatch/src/core/probabilistic.ts
+++ b/packages/typescript/goldenmatch/src/core/probabilistic.ts
@@ -39,6 +39,157 @@ export interface EMResult {
   readonly proportionMatched: number;
   readonly iterations: number;
   readonly converged: boolean;
+  /** Term-frequency (Winkler) adjustment data, populated only for fields with
+   * tf_adjustment=True on the Python side. TS scoring does not consume these;
+   * they are PRESERVED through JSON round-trips (emResultToJson/emResultFromJson)
+   * so a Python-trained model file is never corrupted by a TS re-save.
+   * field -> {transformed_value -> relative frequency}. */
+  readonly tfFreqs?: Readonly<Record<string, Readonly<Record<string, number>>>> | null;
+  /** field -> sum(freq(v)^2) (expected exact-match collision rate baseline). */
+  readonly tfCollision?: Readonly<Record<string, number>> | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public: EMResult JSON (de)serialization — byte-compatible with Python's
+// EMResult.to_dict()/from_dict() (goldenmatch/core/probabilistic.py, schema
+// v1). A trained-model JSON file must be loadable by either surface, so the
+// wire shape (snake_case keys, __type__/__version__ markers) is authoritative
+// on the Python side; this is a faithful mirror, not a TS-native shape.
+// ---------------------------------------------------------------------------
+
+/** Current EMResult JSON schema version. Bumped when the wire shape changes
+ *  incompatibly (mirrors Python `EMResult.SCHEMA_VERSION`). */
+export const EM_RESULT_SCHEMA_VERSION = 1;
+
+/**
+ * A persisted FS model is incompatible with the matchkey being scored, or
+ * with a JSON blob that fails to parse as an EMResult. Mirrors Python
+ * `FSModelMismatchError` / `EMResult.from_dict`'s `ValueError`s.
+ */
+export class FSModelMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FSModelMismatchError";
+  }
+}
+
+/**
+ * Serialize an EMResult to the exact JSON shape Python's `EMResult.to_dict()`
+ * produces: snake_case keys, `__type__`/`__version__` markers, `tf_freqs`/
+ * `tf_collision` as `null` when absent (not omitted — matches Python's
+ * dataclass default of `None` surviving `json.dump`).
+ */
+export function emResultToJson(em: EMResult): Record<string, unknown> {
+  return {
+    __type__: "goldenmatch.EMResult",
+    __version__: EM_RESULT_SCHEMA_VERSION,
+    m_probs: em.m,
+    u_probs: em.u,
+    match_weights: em.matchWeights,
+    converged: em.converged,
+    iterations: em.iterations,
+    proportion_matched: em.proportionMatched,
+    tf_freqs: em.tfFreqs ?? null,
+    tf_collision: em.tfCollision ?? null,
+  };
+}
+
+/**
+ * Reconstruct an EMResult from JSON previously produced by `emResultToJson`
+ * (TS) or `EMResult.to_dict()` (Python) — the two must be interchangeable.
+ * Mirrors Python `EMResult.from_dict`: rejects a schema version newer than
+ * this build supports, and raises a clear error naming the first missing
+ * required key.
+ *
+ * `tf_freqs`/`tf_collision` round-trip as `null` when the source set them to
+ * `null` (rather than being coerced to `undefined`), so
+ * `emResultToJson(emResultFromJson(x))` is byte-identical to `x` for both the
+ * tf-present and tf-absent cases.
+ */
+export function emResultFromJson(data: unknown): EMResult {
+  if (typeof data !== "object" || data === null) {
+    throw new FSModelMismatchError("FS model dict is missing required key: data must be an object");
+  }
+  const obj = data as Record<string, unknown>;
+
+  const version = typeof obj["__version__"] === "number" ? obj["__version__"] : 1;
+  if (version > EM_RESULT_SCHEMA_VERSION) {
+    throw new FSModelMismatchError(
+      `FS model schema version ${version} is newer than this goldenmatch ` +
+        `supports (${EM_RESULT_SCHEMA_VERSION}); upgrade goldenmatch.`,
+    );
+  }
+
+  const requiredKeys = [
+    "m_probs",
+    "u_probs",
+    "match_weights",
+    "converged",
+    "iterations",
+    "proportion_matched",
+  ] as const;
+  for (const key of requiredKeys) {
+    if (!(key in obj)) {
+      throw new FSModelMismatchError(`FS model dict is missing required key: '${key}'`);
+    }
+  }
+
+  const tfFreqsRaw = obj["tf_freqs"];
+  const tfCollisionRaw = obj["tf_collision"];
+
+  return {
+    m: obj["m_probs"] as Readonly<Record<string, readonly number[]>>,
+    u: obj["u_probs"] as Readonly<Record<string, readonly number[]>>,
+    matchWeights: obj["match_weights"] as Readonly<Record<string, readonly number[]>>,
+    converged: obj["converged"] as boolean,
+    iterations: obj["iterations"] as number,
+    proportionMatched: obj["proportion_matched"] as number,
+    tfFreqs:
+      tfFreqsRaw === null || tfFreqsRaw === undefined
+        ? (tfFreqsRaw as null | undefined) ?? null
+        : (tfFreqsRaw as Readonly<Record<string, Readonly<Record<string, number>>>>),
+    tfCollision:
+      tfCollisionRaw === null || tfCollisionRaw === undefined
+        ? (tfCollisionRaw as null | undefined) ?? null
+        : (tfCollisionRaw as Readonly<Record<string, number>>),
+  };
+}
+
+/**
+ * Field level count as EM/scoring sees it: `levelThresholds` (when present)
+ * always wins — its length + 1 is the authoritative level count, matching
+ * the loader's `levels === levelThresholds.length + 1` validation invariant.
+ */
+function matchkeyFieldLevelCount(f: MatchkeyField): number {
+  return f.levelThresholds !== undefined ? f.levelThresholds.length + 1 : (f.levels ?? 2);
+}
+
+/**
+ * Raise if `em` can't score `mk` (field / level mismatch). Ports Python
+ * `EMResult.validate_for`: a persisted model is only reusable against the
+ * same matchkey shape — every field must have a match-weight vector whose
+ * length equals the field's level count. Mismatch means the config changed
+ * since training, so fail loudly rather than silently scoring with a stale
+ * model.
+ */
+export function validateEmResultFor(em: EMResult, mk: MatchkeyConfig): void {
+  for (const f of mk.fields) {
+    const weights = em.matchWeights[f.field];
+    if (weights === undefined) {
+      throw new FSModelMismatchError(
+        `Persisted FS model has no weights for field '${f.field}'. ` +
+          `The matchkey changed since training -- retrain or clear the model_path.`,
+      );
+    }
+    const expected = matchkeyFieldLevelCount(f);
+    if (weights.length !== expected) {
+      throw new FSModelMismatchError(
+        `Persisted FS model for field '${f.field}' has ${weights.length} ` +
+          `levels but the matchkey expects ${expected}. Retrain or clear ` +
+          `the model_path.`,
+      );
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -100,6 +100,16 @@ export interface ProbabilisticMatchkey {
   /** v1.11: negative evidence — unused at scoring time on probabilistic but
    *  preserved here for round-trip parity with Python's MatchkeyConfig. */
   readonly negativeEvidence?: readonly NegativeEvidenceField[];
+  /**
+   * Persisted EM model path (Splink-style train-once -> reuse). Mirrors
+   * Python `MatchkeyConfig.model_path`: when set and the file exists, the
+   * trained EMResult is loaded and EM training is skipped; when set and
+   * absent, EM runs and the result is saved there. TS scoring/EM does not
+   * currently consume this itself — it is a pass-through/round-trip field so
+   * a Splink-imported trained model's `model_path` survives the TS config
+   * layer for the Python runtime (or a future TS consumer) to honor.
+   */
+  readonly modelPath?: string;
 }
 
 export type MatchkeyConfig =
@@ -568,6 +578,8 @@ export interface MakeMatchkeyConfigInput {
   readonly reviewThreshold?: number;
   /** v1.11: negative evidence (round-trips through the factory). */
   readonly negativeEvidence?: readonly NegativeEvidenceField[];
+  /** Persisted EM model path (probabilistic-only; round-trips through the factory). */
+  readonly modelPath?: string;
 }
 
 /** Create a MatchkeyConfig with sensible defaults. Produces the correct variant. */
@@ -613,6 +625,7 @@ export function makeMatchkeyConfig(
       ...(partial.negativeEvidence !== undefined
         ? { negativeEvidence: partial.negativeEvidence }
         : {}),
+      ...(partial.modelPath !== undefined ? { modelPath: partial.modelPath } : {}),
     };
     return out;
   }

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -40,6 +40,14 @@ export interface MatchkeyField {
    * 2/3 levels, even k/N spacing for N>3). Mirrors Python MatchkeyField.level_thresholds.
    */
   readonly levelThresholds?: readonly number[];
+  /**
+   * Winkler term-frequency adjustment flag (Splink-converter). Mirrors the
+   * Python `MatchkeyField.tf_adjustment`. TS scoring/EM training does not
+   * currently consume this — it is a pass-through so a Splink-imported field
+   * with `tf_adjustment_column` set round-trips through the TS config layer
+   * without silently losing the flag.
+   */
+  readonly tfAdjustment?: boolean;
 }
 
 /**

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -33,6 +33,13 @@ export interface MatchkeyField {
   readonly columnWeights?: Readonly<Record<string, number>>;
   readonly levels?: number;
   readonly partialThreshold?: number;
+  /**
+   * N-level custom banding (Splink-converter). Descending similarity cutoffs;
+   * level = count of satisfied thresholds (0 = disagree, levels-1 = top agree).
+   * Length must equal levels-1. Absent => legacy banding (partialThreshold for
+   * 2/3 levels, even k/N spacing for N>3). Mirrors Python MatchkeyField.level_thresholds.
+   */
+  readonly levelThresholds?: readonly number[];
 }
 
 /**

--- a/packages/typescript/goldenmatch/src/node/cli-import-splink.ts
+++ b/packages/typescript/goldenmatch/src/node/cli-import-splink.ts
@@ -1,0 +1,205 @@
+/**
+ * cli-import-splink.ts -- the `import-splink` CLI subcommand logic.
+ *
+ * Mirrors `goldenmatch/cli/import_splink.py` exactly: reads a Splink
+ * settings/trained-model JSON file from disk, converts it via `fromSplink()`
+ * (edge-safe core, no file I/O of its own), then writes the GoldenMatch YAML
+ * config and (optionally) the persisted EM model -- in that order, so a
+ * failed model write never orphans a config that references a missing
+ * model_path, and a failed config write never leaves a stray model file
+ * behind.
+ *
+ * Writer-injected (like `cli-healer.ts`) so this is unit-testable without
+ * driving the commander tree or shelling out to `dist/`.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+
+import { fromSplink, SplinkConversionError, type ConversionFinding } from "../core/config/from-splink.js";
+import { emResultToJson } from "../core/probabilistic.js";
+import { stringifyConfigYaml } from "./config-file.js";
+import type { GoldenMatchConfig, MatchkeyConfig, ProbabilisticMatchkey } from "../core/types.js";
+
+export interface ImportSplinkCliOptions {
+  readonly output: string;
+  readonly modelOut?: string;
+  readonly strict?: boolean;
+}
+
+export interface ImportSplinkWriters {
+  readonly out: (s: string) => void;
+  readonly err: (s: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(obj).sort()) {
+      out[key] = sortKeysDeep(obj[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** JSON.stringify with recursively sorted keys -- matches Python's
+ *  `json.dump(..., indent=2, sort_keys=True)` byte-for-byte on key order. */
+function stringifySorted(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value), null, 2);
+}
+
+function renderFindingsTable(findings: readonly ConversionFinding[]): string {
+  if (findings.length === 0) return "";
+  const headers = ["Severity", "Splink Path", "Message", "Mapped To"];
+  const rows = findings.map((f) => [f.severity, f.splinkPath, f.message, f.mappedTo ?? ""]);
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i]!.length)));
+  const pad = (s: string, w: number) => s + " ".repeat(Math.max(0, w - s.length));
+  const line = (cells: readonly string[]) => cells.map((c, i) => pad(c, widths[i]!)).join("  ");
+  const sep = widths.map((w) => "-".repeat(w)).join("  ");
+  return (
+    "Splink Conversion Findings\n" +
+    `${line(headers)}\n${sep}\n` +
+    rows.map((r) => line(r)).join("\n") +
+    "\n"
+  );
+}
+
+function withModelPath(mk: MatchkeyConfig, modelPath: string): MatchkeyConfig {
+  // fromSplink() always emits matchkeys[0] as type "probabilistic" -- model_path
+  // is a probabilistic-only concept (Splink-style train-once -> reuse).
+  if (mk.type !== "probabilistic") return mk;
+  const patched: ProbabilisticMatchkey = { ...mk, modelPath };
+  return patched;
+}
+
+// ---------------------------------------------------------------------------
+// entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `import-splink`. Returns the process exit code (0 success, 1 failure)
+ * rather than calling `process.exit` itself, so callers (tests, the
+ * commander action) control the process lifecycle.
+ */
+export function runImportSplinkCli(
+  inputPath: string,
+  opts: ImportSplinkCliOptions,
+  writers: ImportSplinkWriters,
+): number {
+  const resolvedInput = resolve(inputPath);
+  let raw: string;
+  try {
+    raw = readFileSync(resolvedInput, "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    writers.err(`Could not read Splink input file ${resolvedInput}: ${msg}\n`);
+    return 1;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    writers.err(`${resolvedInput} is not valid JSON: ${msg}\n`);
+    return 1;
+  }
+
+  let conversion;
+  try {
+    conversion = fromSplink(parsed, { strict: opts.strict ?? false });
+  } catch (err) {
+    if (err instanceof SplinkConversionError) {
+      writers.err(`Splink conversion failed: ${err.message}\n`);
+      return 1;
+    }
+    throw err;
+  }
+
+  const output = opts.output;
+  const modelOut = opts.modelOut;
+  const matchkeysIn: readonly MatchkeyConfig[] = conversion.config.matchkeys ?? [];
+  const mk0 = matchkeysIn[0]!;
+
+  // Ordering: set model_path in-memory first, write the YAML config, THEN
+  // persist the model -- a failed YAML write must not leave an orphaned
+  // model.json behind.
+  let persistModel = conversion.emModel !== null && Boolean(modelOut);
+
+  // Partial-model guard: mixed bare/trained Splink input yields a model that
+  // does not cover every converted field. Shipping that config+model pair
+  // would fail at runtime with a misleading FSModelMismatchError ("matchkey
+  // changed since training"), so refuse --model-out instead: the config is
+  // still written, WITHOUT model_path (re-trains via EM).
+  let missingFields: string[] = [];
+  if (persistModel && conversion.emModel !== null) {
+    const covered = new Set(Object.keys(conversion.emModel.matchWeights));
+    missingFields = mk0.fields.map((f) => f.field).filter((f) => f && !covered.has(f));
+    if (missingFields.length > 0) persistModel = false;
+  }
+
+  let matchkeys: readonly MatchkeyConfig[] = matchkeysIn;
+  if (conversion.emModel !== null) {
+    if (persistModel && modelOut) {
+      matchkeys = [withModelPath(mk0, modelOut), ...matchkeys.slice(1)];
+    } else if (!modelOut) {
+      writers.out(
+        "Warning: the Splink input carried trained m/u probabilities, but they were " +
+          "NOT persisted -- pass --model-out <path> to keep them. The output config " +
+          "will re-train via EM on first run instead.\n",
+      );
+    }
+  }
+
+  const finalConfig: GoldenMatchConfig = { ...conversion.config, matchkeys };
+
+  const resolvedOutput = resolve(output);
+  try {
+    writeFileSync(resolvedOutput, stringifyConfigYaml(finalConfig), "utf8");
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    writers.err(`Could not write config to ${output}: ${msg}\n`);
+    return 1;
+  }
+
+  if (missingFields.length > 0) {
+    writers.err(
+      `--model-out refused: the imported Splink model does not cover field(s) ` +
+        `${missingFields.join(", ")} of matchkeys[0] (mixed bare/trained input). ` +
+        "A partial model would fail FS model validation at runtime. The config " +
+        `was written to ${output} WITHOUT model_path; it will re-train via EM on ` +
+        "first run. No model file was written.\n",
+    );
+    return 1;
+  }
+
+  if (persistModel && modelOut && conversion.emModel !== null) {
+    const resolvedModelOut = resolve(modelOut);
+    try {
+      const dir = dirname(resolvedModelOut);
+      if (dir && dir !== "." && !existsSync(dir)) mkdirSync(dir, { recursive: true });
+      writeFileSync(resolvedModelOut, stringifySorted(emResultToJson(conversion.emModel)), "utf8");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      writers.err(
+        `Could not write trained model to ${modelOut}: ${msg}. Note: the config ` +
+          `written to ${output} references this model via matchkeys[0].model_path, ` +
+          "but the model file failed to write.\n",
+      );
+      return 1;
+    }
+    writers.out(`Trained model persisted to ${modelOut} (set as matchkeys[0].model_path).\n`);
+  }
+
+  const table = renderFindingsTable(conversion.report.findings);
+  if (table) writers.out(table);
+  writers.out(`Wrote config to ${output}. ${conversion.report.summary()}\n`);
+  return 0;
+}

--- a/packages/typescript/goldenmatch/src/node/config-file.ts
+++ b/packages/typescript/goldenmatch/src/node/config-file.ts
@@ -51,6 +51,16 @@ export function loadConfigFile(path: string): GoldenMatchConfig {
 }
 
 /**
+ * Serialize a GoldenMatchConfig to a YAML string (no file I/O). Shared by
+ * `writeConfigFile` and any caller (e.g. the Splink-import CLI) that needs to
+ * control the write itself (ordering, error messages).
+ */
+export function stringifyConfigYaml(config: GoldenMatchConfig): string {
+  const yamlMod = loadYamlModule();
+  return configToYaml(config, yamlMod.stringify);
+}
+
+/**
  * Serialize a GoldenMatchConfig to YAML and write it to disk.
  * Creates parent directories as needed.
  */
@@ -60,7 +70,5 @@ export function writeConfigFile(path: string, config: GoldenMatchConfig): void {
   if (dir && dir !== "." && !existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
   }
-  const yamlMod = loadYamlModule();
-  const yamlStr = configToYaml(config, yamlMod.stringify);
-  writeFileSync(resolved, yamlStr, "utf8");
+  writeFileSync(resolved, stringifyConfigYaml(config), "utf8");
 }

--- a/packages/typescript/goldenmatch/src/node/index.ts
+++ b/packages/typescript/goldenmatch/src/node/index.ts
@@ -39,7 +39,11 @@ export {
 } from "./agent/session-file.js";
 
 // YAML config file I/O
-export { loadConfigFile, writeConfigFile } from "./config-file.js";
+export { loadConfigFile, writeConfigFile, stringifyConfigYaml } from "./config-file.js";
+
+// Splink -> GoldenMatch config converter: CLI-side file I/O wrapper
+export { runImportSplinkCli } from "./cli-import-splink.js";
+export type { ImportSplinkCliOptions, ImportSplinkWriters } from "./cli-import-splink.js";
 
 // Cloud connectors (registers built-in connectors as a side-effect)
 export {

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -4,8 +4,9 @@
  *
  * Node-only: uses node:fs, node:path, node:readline. NOT edge-safe.
  *
- * Exposes 49 tools covering dedupe, match, scoring, explanation,
- * profiling, auto-config (shorthand), evaluation, listings, Learning
+ * Exposes 50 tools covering dedupe, match, scoring, explanation,
+ * profiling, auto-config (shorthand), evaluation, listings, the Splink ->
+ * GoldenMatch config converter (convert_splink_config), Learning
  * Memory (5 memory tools via MEMORY_TOOLS), the Identity Graph
  * (6 identity tools via IDENTITY_TOOLS), and the AgentSession skills
  * (15 agent tools via AGENT_MCP_TOOLS, incl. the healer's review_config).
@@ -42,6 +43,9 @@ import { buildClusters } from "../../core/cluster.js";
 import { explainPair, explainCluster } from "../../core/explain.js";
 import { profileRows } from "../../core/profiler.js";
 import { evaluatePairs, loadGroundTruthPairs } from "../../core/evaluate.js";
+import { fromSplink, SplinkConversionError } from "../../core/config/from-splink.js";
+import { emResultToJson } from "../../core/probabilistic.js";
+import { stringifyConfigYaml } from "../config-file.js";
 import {
   MEMORY_TOOLS,
   MEMORY_TOOL_NAMES,
@@ -362,6 +366,31 @@ const EXISTING_TOOLS: readonly Tool[] = [
         rows: { type: "array", items: { type: "object", additionalProperties: true } },
       },
       required: ["path", "rows"],
+    },
+  },
+  {
+    name: "convert_splink_config",
+    description:
+      "Convert a Splink settings JSON (bare or trained) into a GoldenMatch " +
+      "config. Pass the settings as an inline JSON string -- no filesystem " +
+      "access needed. Returns the config as YAML, a findings report " +
+      "(severity/splink_path/message/mapped_to per finding), a summary, and " +
+      "-- when the Splink input carried trained m/u probabilities -- the " +
+      "imported EM model as a dict you can persist yourself. strict=True " +
+      "fails on ANY lossy mapping (not just hard errors).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        settings_json: {
+          type: "string",
+          description: "Splink settings (bare or trained model) as a JSON string",
+        },
+        strict: {
+          type: "boolean",
+          description: "Fail on any lossy mapping (warnings), not just errors",
+        },
+      },
+      required: ["settings_json"],
     },
   },
 ];
@@ -889,6 +918,63 @@ export async function handleTool(
         }
         writeCsv(path, rowsArg as Row[]);
         return { written: rowsArg.length, path };
+      }
+
+      case "convert_splink_config": {
+        const settingsJson = args["settings_json"];
+        const strict = args["strict"] === true;
+
+        let settings: unknown;
+        try {
+          settings = JSON.parse(String(settingsJson));
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return { error: `settings_json is not valid JSON: ${msg}` };
+        }
+
+        if (typeof settings !== "object" || settings === null || Array.isArray(settings)) {
+          const got = settings === null ? "null" : Array.isArray(settings) ? "array" : typeof settings;
+          return {
+            error:
+              "settings_json must decode to a JSON object (Splink settings dict), " +
+              `got ${got}`,
+          };
+        }
+
+        let conversion;
+        try {
+          conversion = fromSplink(settings, { strict });
+        } catch (err) {
+          if (err instanceof SplinkConversionError) {
+            return { error: err.message };
+          }
+          throw err;
+        }
+
+        const configYaml = stringifyConfigYaml(conversion.config);
+        const findings = conversion.report.findings.map((f) => ({
+          severity: f.severity,
+          splink_path: f.splinkPath,
+          message: f.message,
+          mapped_to: f.mappedTo,
+        }));
+        const emModel = conversion.emModel !== null ? emResultToJson(conversion.emModel) : null;
+        const usageNote =
+          "Save config_yaml to a file and load it as the GoldenMatch config. " +
+          (emModel !== null
+            ? "This model carries trained m/u probabilities: save em_model as JSON " +
+              "and set matchkeys[0].model_path to that file's path so GoldenMatch " +
+              "reuses it instead of re-training via EM."
+            : "No trained model was carried by this input; GoldenMatch will train " +
+              "via EM on first run.");
+
+        return {
+          config_yaml: configYaml,
+          findings,
+          summary: conversion.report.summary(),
+          em_model: emModel,
+          usage_note: usageNote,
+        };
       }
 
       default:

--- a/packages/typescript/goldenmatch/tests/unit/cli-import-splink-registration.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-import-splink-registration.test.ts
@@ -1,0 +1,28 @@
+/**
+ * cli-import-splink-registration.test.ts -- Task T4: the `import-splink`
+ * command must be registered on the commander `program` -- the same
+ * enumeration `scripts/emit_ts_surface.mjs` (the parity emitter) reads via
+ * `program.commands.map((x) => x.name())`.
+ *
+ * Importing src/cli.ts is safe here: the `program.parseAsync` entry point is
+ * guarded by an `import.meta.url === pathToFileURL(process.argv[1])` check
+ * that never matches under vitest.
+ */
+import { describe, it, expect } from "vitest";
+import { program } from "../../src/cli.js";
+
+describe("cli.ts — program registration", () => {
+  it("registers import-splink as a top-level command", () => {
+    const names = program.commands.map((c) => c.name());
+    expect(names).toContain("import-splink");
+  });
+
+  it("import-splink declares --output, --model-out, --strict", () => {
+    const cmd = program.commands.find((c) => c.name() === "import-splink");
+    expect(cmd).toBeDefined();
+    const optionFlags = cmd!.options.map((o) => o.long);
+    expect(optionFlags).toContain("--output");
+    expect(optionFlags).toContain("--model-out");
+    expect(optionFlags).toContain("--strict");
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/cli-import-splink.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-import-splink.test.ts
@@ -1,0 +1,233 @@
+/**
+ * cli-import-splink.test.ts -- Task T4: the `import-splink` CLI subcommand.
+ *
+ * Per repo convention (cli-memory.test.ts / cli-suggest.test.ts) we drive the
+ * extracted, writer-injected `runImportSplinkCli` directly rather than the
+ * commander tree, using real tmp files (the box constraint means we can't
+ * build dist/ and shell out).
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { runImportSplinkCli } from "../../src/node/cli-import-splink.js";
+import { parseConfigYaml } from "../../src/core/config/loader.js";
+import { emResultFromJson } from "../../src/core/probabilistic.js";
+import { parse as parseYaml } from "yaml";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "gm-cli-import-splink-"));
+});
+
+afterEach(() => {
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {
+    /* ignore */
+  }
+});
+
+function writers() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return { out, err, w: { out: (s: string) => out.push(s), err: (s: string) => err.push(s) } };
+}
+
+function bareSettings(): Record<string, unknown> {
+  return {
+    comparisons: [
+      {
+        output_column_name: "first_name",
+        comparison_levels: [
+          { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+          { sql_condition: '"first_name_l" = "first_name_r"' },
+          { sql_condition: "ELSE" },
+        ],
+      },
+    ],
+    blocking_rules_to_generate_predictions: ['l."first_name" = r."first_name"'],
+  };
+}
+
+function trainedSettings(): Record<string, unknown> {
+  return {
+    comparisons: [
+      {
+        output_column_name: "first_name",
+        comparison_levels: [
+          { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+          { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.8, u_probability: 0.02 },
+          { sql_condition: "ELSE", m_probability: 0.2, u_probability: 0.98 },
+        ],
+      },
+    ],
+    blocking_rules_to_generate_predictions: ['l."first_name" = r."first_name"'],
+    probability_two_random_records_match: 0.001,
+  };
+}
+
+// Mixed bare/trained: field "surname" carries no m/u while "first_name" does
+// -> a partial model that must be refused for --model-out.
+function mixedSettings(): Record<string, unknown> {
+  const trained = (trainedSettings()["comparisons"] as unknown[])[0];
+  const bareSurname = {
+    output_column_name: "surname",
+    comparison_levels: [
+      { sql_condition: '"surname_l" IS NULL OR "surname_r" IS NULL', is_null_level: true },
+      { sql_condition: '"surname_l" = "surname_r"' },
+      { sql_condition: "ELSE" },
+    ],
+  };
+  return {
+    comparisons: [trained, bareSurname],
+    blocking_rules_to_generate_predictions: ['l."first_name" = r."first_name"'],
+    probability_two_random_records_match: 0.001,
+  };
+}
+
+describe("runImportSplinkCli — happy path (bare settings)", () => {
+  it("writes a valid GoldenMatch YAML config and prints a summary", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    writeFileSync(inputPath, JSON.stringify(bareSettings()), "utf8");
+
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath }, w.w);
+
+    expect(code).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    const yamlText = readFileSync(outputPath, "utf8");
+    const config = parseConfigYaml(yamlText, parseYaml);
+    expect(config.matchkeys?.[0]?.type).toBe("probabilistic");
+    expect(w.out.join("")).toContain("Wrote config to");
+    expect(w.out.join("")).toContain("error(s)");
+  });
+});
+
+describe("runImportSplinkCli — bad input", () => {
+  it("exits 1 with a clean message on missing file (no config written)", () => {
+    const inputPath = join(dir, "does-not-exist.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath }, w.w);
+    expect(code).toBe(1);
+    expect(existsSync(outputPath)).toBe(false);
+    expect(w.err.join("")).toMatch(/Could not read Splink input file/);
+  });
+
+  it("exits 1 with a clean message on malformed JSON (no config written)", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    writeFileSync(inputPath, "{not valid json", "utf8");
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath }, w.w);
+    expect(code).toBe(1);
+    expect(existsSync(outputPath)).toBe(false);
+    expect(w.err.join("")).toMatch(/not valid JSON/);
+  });
+
+  it("exits 1 on zero-convertible-comparisons (SplinkConversionError), no files written", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    writeFileSync(inputPath, JSON.stringify({ comparisons: [] }), "utf8");
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath }, w.w);
+    expect(code).toBe(1);
+    expect(existsSync(outputPath)).toBe(false);
+    expect(w.err.join("")).toContain("Splink conversion failed");
+  });
+});
+
+describe("runImportSplinkCli — strict mode", () => {
+  it("exits 1 when strict and the input carries lossy findings", () => {
+    // A dropped OR-blocking-rule after the single usable one -> a warning
+    // finding (unrecognized blocking rule) that strict mode gates on... use
+    // an unrecognized comparison-level SQL to force a warning finding.
+    const settings = bareSettings();
+    (settings["comparisons"] as Record<string, unknown>[])[0]!["comparison_levels"] = [
+      ...((settings["comparisons"] as Record<string, unknown>[])[0]!["comparison_levels"] as unknown[]),
+      { sql_condition: "some_weird_condition(x, y)" },
+    ];
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    writeFileSync(inputPath, JSON.stringify(settings), "utf8");
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath, strict: true }, w.w);
+    expect(code).toBe(1);
+    expect(existsSync(outputPath)).toBe(false);
+    expect(w.err.join("")).toContain("Splink conversion failed");
+  });
+});
+
+describe("runImportSplinkCli — trained model + --model-out (cross-surface file)", () => {
+  it("writes config with matchkeys[0].model_path set, and a model file emResultFromJson can read back", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    const modelOutPath = join(dir, "model.json");
+    writeFileSync(inputPath, JSON.stringify(trainedSettings()), "utf8");
+
+    const w = writers();
+    const code = runImportSplinkCli(
+      inputPath,
+      { output: outputPath, modelOut: modelOutPath },
+      w.w,
+    );
+
+    expect(code).toBe(0);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(modelOutPath)).toBe(true);
+
+    const config = parseConfigYaml(readFileSync(outputPath, "utf8"), parseYaml);
+    const mk = config.matchkeys?.[0];
+    expect(mk?.type).toBe("probabilistic");
+    expect((mk as { modelPath?: string }).modelPath).toBe(modelOutPath);
+
+    const modelJson = JSON.parse(readFileSync(modelOutPath, "utf8"));
+    expect(modelJson.__type__).toBe("goldenmatch.EMResult");
+    const em = emResultFromJson(modelJson);
+    expect(em.matchWeights["first_name"]).toBeDefined();
+    expect(w.out.join("")).toContain("Trained model persisted to");
+  });
+
+  it("prints a dropped-probabilities warning when trained but no --model-out is given", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    writeFileSync(inputPath, JSON.stringify(trainedSettings()), "utf8");
+
+    const w = writers();
+    const code = runImportSplinkCli(inputPath, { output: outputPath }, w.w);
+
+    expect(code).toBe(0);
+    const config = parseConfigYaml(readFileSync(outputPath, "utf8"), parseYaml);
+    expect((config.matchkeys?.[0] as { modelPath?: string }).modelPath).toBeUndefined();
+    expect(w.out.join("")).toMatch(/NOT persisted/);
+  });
+});
+
+describe("runImportSplinkCli — partial-model refusal (mixed bare/trained)", () => {
+  it("writes the config WITHOUT model_path, writes no model file, and exits 1", () => {
+    const inputPath = join(dir, "settings.json");
+    const outputPath = join(dir, "goldenmatch.yaml");
+    const modelOutPath = join(dir, "model.json");
+    writeFileSync(inputPath, JSON.stringify(mixedSettings()), "utf8");
+
+    const w = writers();
+    const code = runImportSplinkCli(
+      inputPath,
+      { output: outputPath, modelOut: modelOutPath },
+      w.w,
+    );
+
+    expect(code).toBe(1);
+    expect(existsSync(outputPath)).toBe(true);
+    expect(existsSync(modelOutPath)).toBe(false);
+
+    const config = parseConfigYaml(readFileSync(outputPath, "utf8"), parseYaml);
+    expect((config.matchkeys?.[0] as { modelPath?: string }).modelPath).toBeUndefined();
+    expect(w.err.join("")).toContain("--model-out refused");
+    expect(w.err.join("")).toContain("surname");
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/em-serde.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/em-serde.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect } from "vitest";
+import {
+  emResultToJson,
+  emResultFromJson,
+  validateEmResultFor,
+  FSModelMismatchError,
+  type EMResult,
+  makeMatchkeyConfig,
+  makeMatchkeyField,
+} from "../../src/core/index.js";
+
+// ---------------------------------------------------------------------------
+// Round-trip TS -> JSON -> TS
+// ---------------------------------------------------------------------------
+
+describe("emResultToJson / emResultFromJson: round-trip", () => {
+  it("round-trips without tf fields", () => {
+    const em: EMResult = {
+      m: { first_name: [0.05, 0.1, 0.25, 0.6], postcode: [0.1, 0.9] },
+      u: { first_name: [0.85, 0.1, 0.04, 0.01], postcode: [0.9, 0.1] },
+      matchWeights: {
+        first_name: [-4.09, 0.0, 2.64, 5.91],
+        postcode: [-3.17, 3.17],
+      },
+      converged: true,
+      iterations: 12,
+      proportionMatched: 0.0002,
+    };
+    const json = emResultToJson(em);
+    expect(json).toMatchObject({
+      __type__: "goldenmatch.EMResult",
+      __version__: 1,
+      m_probs: em.m,
+      u_probs: em.u,
+      match_weights: em.matchWeights,
+      converged: true,
+      iterations: 12,
+      proportion_matched: 0.0002,
+      tf_freqs: null,
+      tf_collision: null,
+    });
+
+    const back = emResultFromJson(json);
+    expect(back.m).toEqual(em.m);
+    expect(back.u).toEqual(em.u);
+    expect(back.matchWeights).toEqual(em.matchWeights);
+    expect(back.converged).toBe(em.converged);
+    expect(back.iterations).toBe(em.iterations);
+    expect(back.proportionMatched).toBe(em.proportionMatched);
+    expect(back.tfFreqs ?? null).toBeNull();
+    expect(back.tfCollision ?? null).toBeNull();
+  });
+
+  it("round-trips with tf fields present", () => {
+    const em: EMResult = {
+      m: { city: [0.1, 0.9] },
+      u: { city: [0.7, 0.3] },
+      matchWeights: { city: [-2.8, 1.58] },
+      converged: false,
+      iterations: 5,
+      proportionMatched: 0.01,
+      tfFreqs: { city: { springfield: 0.02, columbus: 0.015 } },
+      tfCollision: { city: 0.0009 },
+    };
+    const json = emResultToJson(em);
+    const back = emResultFromJson(json);
+    expect(back.tfFreqs).toEqual(em.tfFreqs);
+    expect(back.tfCollision).toEqual(em.tfCollision);
+
+    // Re-serializing must be byte-identical (JSON.stringify equal) — a
+    // Python-trained model's tf tables must survive a TS re-save untouched.
+    const rejson = emResultToJson(back);
+    expect(JSON.stringify(rejson)).toBe(JSON.stringify(json));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-surface fixture: exact shape Python's EMResult.to_dict()/save_json
+// produces (goldenmatch/core/probabilistic.py, SCHEMA_VERSION=1).
+// ---------------------------------------------------------------------------
+
+describe("emResultFromJson: cross-surface Python fixture", () => {
+  const pythonFixture = {
+    __type__: "goldenmatch.EMResult",
+    __version__: 1,
+    m_probs: {
+      first_name: [0.05, 0.1, 0.25, 0.6],
+      postcode: [0.1, 0.9],
+    },
+    u_probs: {
+      first_name: [0.85, 0.1, 0.04, 0.01],
+      postcode: [0.9, 0.1],
+    },
+    match_weights: {
+      first_name: [-4.09, 0.0, 2.64, 5.91],
+      postcode: [-3.17, 3.17],
+    },
+    converged: true,
+    iterations: 0,
+    proportion_matched: 0.0002,
+    tf_freqs: null,
+    tf_collision: null,
+  };
+
+  it("loads a Python-produced JSON blob and lands fields correctly", () => {
+    const em = emResultFromJson(pythonFixture);
+    expect(em.m["first_name"]).toEqual([0.05, 0.1, 0.25, 0.6]);
+    expect(em.u["postcode"]).toEqual([0.9, 0.1]);
+    expect(em.matchWeights["first_name"]).toEqual([-4.09, 0.0, 2.64, 5.91]);
+    expect(em.converged).toBe(true);
+    expect(em.iterations).toBe(0);
+    expect(em.proportionMatched).toBe(0.0002);
+    expect(em.tfFreqs ?? null).toBeNull();
+    expect(em.tfCollision ?? null).toBeNull();
+  });
+
+  it("re-serializes to the same wire shape", () => {
+    const em = emResultFromJson(pythonFixture);
+    const json = emResultToJson(em);
+    expect(json).toEqual(pythonFixture);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Version / missing-key rejection
+// ---------------------------------------------------------------------------
+
+describe("emResultFromJson: forward-compat + validation errors", () => {
+  it("rejects a schema version newer than supported", () => {
+    const data = {
+      __type__: "goldenmatch.EMResult",
+      __version__: 2,
+      m_probs: {},
+      u_probs: {},
+      match_weights: {},
+      converged: true,
+      iterations: 0,
+      proportion_matched: 0.0,
+    };
+    expect(() => emResultFromJson(data)).toThrow(
+      /schema version 2 is newer than this goldenmatch supports \(1\)/,
+    );
+  });
+
+  it("rejects a dict missing a required key", () => {
+    const data = {
+      __version__: 1,
+      m_probs: {},
+      u_probs: {},
+      match_weights: {},
+      converged: true,
+      // iterations missing
+      proportion_matched: 0.0,
+    };
+    expect(() => emResultFromJson(data)).toThrow(/missing required key: 'iterations'/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateEmResultFor
+// ---------------------------------------------------------------------------
+
+describe("validateEmResultFor", () => {
+  it("passes when a 4-level levelThresholds field matches", () => {
+    const mk = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [
+        makeMatchkeyField({
+          field: "first_name",
+          scorer: "jaro_winkler",
+          levels: 4,
+          levelThresholds: [1.0, 0.92, 0.88],
+        }),
+      ],
+    });
+    const em: EMResult = {
+      m: { first_name: [0.05, 0.1, 0.25, 0.6] },
+      u: { first_name: [0.85, 0.1, 0.04, 0.01] },
+      matchWeights: { first_name: [-4.09, 0.0, 2.64, 5.91] },
+      converged: true,
+      iterations: 3,
+      proportionMatched: 0.01,
+    };
+    expect(() => validateEmResultFor(em, mk)).not.toThrow();
+  });
+
+  it("throws when the level count mismatches", () => {
+    const mk = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [
+        makeMatchkeyField({
+          field: "first_name",
+          scorer: "jaro_winkler",
+          levels: 4,
+          levelThresholds: [1.0, 0.92, 0.88],
+        }),
+      ],
+    });
+    const em: EMResult = {
+      m: { first_name: [0.05, 0.95] },
+      u: { first_name: [0.85, 0.15] },
+      matchWeights: { first_name: [-4.09, 5.91] },
+      converged: true,
+      iterations: 3,
+      proportionMatched: 0.01,
+    };
+    expect(() => validateEmResultFor(em, mk)).toThrow(FSModelMismatchError);
+    expect(() => validateEmResultFor(em, mk)).toThrow(
+      /has 2 levels but the matchkey expects 4/,
+    );
+  });
+
+  it("throws when a field has no weights at all", () => {
+    const mk = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [
+        makeMatchkeyField({ field: "postcode", scorer: "exact", levels: 2 }),
+      ],
+    });
+    const em: EMResult = {
+      m: {},
+      u: {},
+      matchWeights: {},
+      converged: true,
+      iterations: 1,
+      proportionMatched: 0.01,
+    };
+    expect(() => validateEmResultFor(em, mk)).toThrow(
+      /Persisted FS model has no weights for field 'postcode'/,
+    );
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/from-splink.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/from-splink.test.ts
@@ -1,0 +1,1314 @@
+import { describe, it, expect } from "vitest";
+import {
+  recognizeLevel,
+  ConversionReport,
+  SplinkConversionError,
+  convertComparison,
+  convertBlocking,
+  detectTrained,
+  importEm,
+  convertScalars,
+  fromSplink,
+  type RecognizedLevel,
+} from "../../src/core/config/from-splink.js";
+import { getMatchkeys } from "../../src/core/index.js";
+import type { MatchkeyField, ProbabilisticMatchkey } from "../../src/core/types.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures (mirroring the Python tests' helper functions)
+// ---------------------------------------------------------------------------
+
+function jwComparison(): Record<string, unknown> {
+  return {
+    output_column_name: "first_name",
+    comparison_levels: [
+      { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+      { sql_condition: '"first_name_l" = "first_name_r"' },
+      { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+      { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.88' },
+      { sql_condition: "ELSE" },
+    ],
+  };
+}
+
+function exactOnlyComparison(column = "surname"): Record<string, unknown> {
+  return {
+    output_column_name: column,
+    comparison_levels: [
+      { sql_condition: `"${column}_l" IS NULL OR "${column}_r" IS NULL`, is_null_level: true },
+      { sql_condition: `"${column}_l" = "${column}_r"` },
+      { sql_condition: "ELSE" },
+    ],
+  };
+}
+
+function trainedJwComparison(): Record<string, unknown> {
+  return {
+    output_column_name: "first_name",
+    comparison_levels: [
+      { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+      { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.5, u_probability: 0.02 },
+      {
+        sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92',
+        m_probability: 0.3,
+        u_probability: 0.08,
+      },
+      {
+        sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.88',
+        m_probability: 0.15,
+        u_probability: 0.2,
+      },
+      { sql_condition: "ELSE", m_probability: 0.05, u_probability: 0.7 },
+    ],
+  };
+}
+
+function trainedSettings(comparisons: unknown[]): Record<string, unknown> {
+  return { comparisons, probability_two_random_records_match: 0.0002 };
+}
+
+function fullSettings(opts?: { comparisons?: unknown[]; blockingRules?: unknown[] }): Record<string, unknown> {
+  return {
+    comparisons: opts?.comparisons ?? [jwComparison(), exactOnlyComparison("surname")],
+    blocking_rules_to_generate_predictions: opts?.blockingRules ?? [
+      'l."first_name" = r."first_name"',
+      'l."surname" = r."surname"',
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// test_from_splink_recognizers.py -> recognizeLevel
+// ---------------------------------------------------------------------------
+
+describe("recognizeLevel", () => {
+  it.each([
+    '"first_name_l" IS NULL OR "first_name_r" IS NULL',
+    "first_name_l IS NULL OR first_name_r IS NULL",
+    '"first_name_l"   is   null   or   "first_name_r"   is   null',
+  ])("recognizes a null level: %s", (sql) => {
+    expect(recognizeLevel(sql)).toEqual({
+      kind: "null",
+      column: "first_name",
+      simThreshold: null,
+      approx: false,
+    } satisfies RecognizedLevel);
+  });
+
+  it("is_null_level flag forces null regardless of sql", () => {
+    const result = recognizeLevel('"amount_l" > "amount_r"', true);
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("null");
+  });
+
+  it.each([
+    '"first_name_l" = "first_name_r"',
+    "first_name_l = first_name_r",
+    '"first_name_l"    =    "first_name_r"',
+  ])("recognizes an exact level: %s", (sql) => {
+    expect(recognizeLevel(sql)).toEqual({
+      kind: "exact",
+      column: "first_name",
+      simThreshold: 1.0,
+      approx: false,
+    } satisfies RecognizedLevel);
+  });
+
+  it.each([
+    'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92',
+    "JARO_WINKLER_SIMILARITY(first_name_l, first_name_r) >= 0.92",
+    '  jaro_winkler_similarity(  "first_name_l" ,  "first_name_r"  )   >=   0.92  ',
+  ])("recognizes a jaro_winkler_similarity level: %s", (sql) => {
+    expect(recognizeLevel(sql)).toEqual({
+      kind: "jaro_winkler",
+      column: "first_name",
+      simThreshold: 0.92,
+      approx: false,
+    } satisfies RecognizedLevel);
+  });
+
+  it("handles a leading-dot float threshold", () => {
+    const result = recognizeLevel('jaro_winkler_similarity("first_name_l", "first_name_r") >= .92');
+    expect(result).toEqual({ kind: "jaro_winkler", column: "first_name", simThreshold: 0.92, approx: false });
+  });
+
+  it("rejects strict greater-than", () => {
+    expect(recognizeLevel('jaro_winkler_similarity("first_name_l", "first_name_r") > 0.92')).toBeNull();
+  });
+
+  it.each(['jaro_winkler("a_l","a_r") >= 0.9', "JARO_WINKLER(a_l, a_r) >= 0.9"])(
+    "recognizes the Spark-dialect jaro_winkler alias: %s",
+    (sql) => {
+      expect(recognizeLevel(sql)).toEqual({ kind: "jaro_winkler", column: "a", simThreshold: 0.9, approx: false });
+    },
+  );
+
+  it("approximates jaro_similarity as jaro_winkler", () => {
+    const result = recognizeLevel('jaro_similarity("x_l", "x_r") >= 0.9');
+    expect(result).toEqual({ kind: "jaro_winkler", column: "x", simThreshold: 0.9, approx: true });
+  });
+
+  it("recognizes levenshtein as an approximate similarity", () => {
+    const result = recognizeLevel('levenshtein("dob_l", "dob_r") <= 1');
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("levenshtein");
+    expect(result?.column).toBe("dob");
+    expect(result?.simThreshold).toBeCloseTo(1 - 1 / 10, 9);
+    expect(result?.approx).toBe(true);
+  });
+
+  it("recognizes damerau_levenshtein", () => {
+    const result = recognizeLevel('damerau_levenshtein("dob_l", "dob_r") <= 2');
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("levenshtein");
+    expect(result?.simThreshold).toBeCloseTo(1 - 2 / 10, 9);
+    expect(result?.approx).toBe(true);
+  });
+
+  it("recognizes jaccard", () => {
+    expect(recognizeLevel('jaccard("email_l", "email_r") >= 0.9')).toEqual({
+      kind: "jaccard",
+      column: "email",
+      simThreshold: 0.9,
+      approx: false,
+    });
+  });
+
+  it("recognizes ELSE (case-insensitive)", () => {
+    expect(recognizeLevel("ELSE")).toEqual({ kind: "else", column: null, simThreshold: null, approx: false });
+    expect(recognizeLevel("else")).toEqual({ kind: "else", column: null, simThreshold: null, approx: false });
+  });
+
+  it("returns null for cross-column comparisons", () => {
+    expect(recognizeLevel('"first_name_l" = "surname_r" AND "surname_l" = "first_name_r"')).toBeNull();
+  });
+
+  it("returns null for mismatched columns in a function call", () => {
+    expect(recognizeLevel('jaro_winkler_similarity("a_l", "b_r") >= 0.9')).toBeNull();
+  });
+
+  it("returns null for arbitrary SQL", () => {
+    expect(recognizeLevel('abs("amount_l" - "amount_r") < 5')).toBeNull();
+  });
+
+  it("clamps the levenshtein distance floor to zero", () => {
+    const result = recognizeLevel('levenshtein("dob_l", "dob_r") <= 15');
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("levenshtein");
+    expect(result?.simThreshold).toBe(0.0);
+    expect(result?.approx).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test_from_splink_report.py -> ConversionReport
+// ---------------------------------------------------------------------------
+
+describe("ConversionReport", () => {
+  it("filters by severity", () => {
+    const r = new ConversionReport();
+    r.info("settings.sql_dialect", "ignored (engine infra)", null);
+    r.warn("comparisons[0].levels[2]", "unrecognized SQL, level dropped", null);
+    expect(r.findings.length).toBe(2);
+    expect(r.hasWarnings).toBe(true);
+    expect(r.hasErrors).toBe(false);
+    expect(r.summary().toLowerCase()).toContain("warning");
+  });
+
+  it("tracks error findings", () => {
+    const r = new ConversionReport();
+    r.error("blocking_rules", "no blocking rule could be converted", null);
+    expect(r.hasErrors).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test_from_splink_comparisons.py -> convertComparison
+// ---------------------------------------------------------------------------
+
+describe("convertComparison", () => {
+  it("converts a JW comparison with exact + two bands to a 4-level field", () => {
+    const report = new ConversionReport();
+    const field = convertComparison(jwComparison(), 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.field).toBe("first_name");
+    expect(field?.scorer).toBe("jaro_winkler");
+    expect(field?.levels).toBe(4);
+    expect(field?.levelThresholds).toEqual([1.0, 0.92, 0.88]);
+
+    const infos = report.findings.filter((f) => f.severity === "info");
+    expect(infos.some((f) => f.message.toLowerCase().includes("null"))).toBe(true);
+  });
+
+  it("converts a pure-exact comparison to a legacy 2-level field", () => {
+    const report = new ConversionReport();
+    const field = convertComparison(exactOnlyComparison(), 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.field).toBe("surname");
+    expect(field?.scorer).toBe("exact");
+    expect(field?.levels).toBe(2);
+    expect(field?.levelThresholds).toBeUndefined();
+  });
+
+  it("converts exact + one JW band to a 3-level field", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: '"first_name_l" = "first_name_r"' },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.scorer).toBe("jaro_winkler");
+    expect(field?.levels).toBe(3);
+    expect(field?.levelThresholds).toEqual([1.0, 0.92]);
+  });
+
+  it("drops a comparison with mixed comparator families", () => {
+    const comp = {
+      output_column_name: "dob",
+      comparison_levels: [
+        { sql_condition: '"dob_l" IS NULL OR "dob_r" IS NULL', is_null_level: true },
+        { sql_condition: 'jaro_winkler_similarity("dob_l", "dob_r") >= 0.92' },
+        { sql_condition: 'levenshtein("dob_l", "dob_r") <= 1' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).toBeNull();
+    expect(report.hasWarnings).toBe(true);
+    expect(report.findings.some((f) => f.message.includes("mixed comparator families"))).toBe(true);
+  });
+
+  it("re-derives thresholds when one level is unrecognized and dropped", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+        // cross-column condition between two JW bands, unrecognized
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "surname_r") >= 0.85' },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.80' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.scorer).toBe("jaro_winkler");
+    expect(field?.levelThresholds).toEqual([0.92, 0.8]);
+    expect(field?.levels).toBe(3);
+    expect(report.findings.some((f) => f.message.includes("unrecognized sql_condition"))).toBe(true);
+  });
+
+  it("drops a comparison with inconsistent columns", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+        { sql_condition: 'jaro_winkler_similarity("surname_l", "surname_r") >= 0.88' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).toBeNull();
+    expect(report.findings.some((f) => f.message.includes("inconsistent columns"))).toBe(true);
+  });
+
+  it("sets tfAdjustment when tf_adjustment_column matches the field column", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: '"first_name_l" = "first_name_r"', tf_adjustment_column: "first_name" },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.tfAdjustment).toBe(true);
+    expect(report.hasWarnings).toBe(false);
+  });
+
+  it("drops tf_adjustment_weight != 1 with a warning", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        {
+          sql_condition: '"first_name_l" = "first_name_r"',
+          tf_adjustment_column: "first_name",
+          tf_adjustment_weight: 0.5,
+        },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.tfAdjustment).toBe(true);
+    expect(report.findings.some((f) => f.message.includes("tf_adjustment_weight"))).toBe(true);
+  });
+
+  it("dedupes duplicate thresholds (spark-dialect alias)", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+        { sql_condition: 'jaro_winkler("first_name_l", "first_name_r") >= 0.92' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(2);
+    expect(field?.partialThreshold).toBe(0.92);
+    expect(field?.levelThresholds).toBeUndefined();
+  });
+
+  it("drops an out-of-range levenshtein band among surviving bands", () => {
+    const comp = {
+      output_column_name: "address",
+      comparison_levels: [
+        { sql_condition: '"address_l" IS NULL OR "address_r" IS NULL', is_null_level: true },
+        { sql_condition: 'levenshtein("address_l", "address_r") <= 10' },
+        { sql_condition: 'levenshtein("address_l", "address_r") <= 2' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.scorer).toBe("levenshtein");
+    expect(field?.levels).toBe(2);
+    expect(field?.partialThreshold).toBeCloseTo(0.8, 9);
+    expect(report.findings.some((f) => f.message.includes("out of range") && f.message.includes("<= 10"))).toBe(
+      true,
+    );
+  });
+
+  it("returns null when the only band is out of range", () => {
+    const comp = {
+      output_column_name: "address",
+      comparison_levels: [
+        { sql_condition: '"address_l" IS NULL OR "address_r" IS NULL', is_null_level: true },
+        { sql_condition: 'levenshtein("address_l", "address_r") <= 10' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).toBeNull();
+    expect(report.findings.some((f) => f.message.includes("out of range"))).toBe(true);
+    expect(report.findings.some((f) => f.message.includes("no usable agree levels"))).toBe(true);
+  });
+
+  it("drops an out-of-range jw threshold (>= 1.5)", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 1.5' },
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.9' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(2);
+    expect(field?.partialThreshold).toBe(0.9);
+    expect(report.findings.some((f) => f.message.includes("out of range") && f.message.includes("1.5"))).toBe(true);
+  });
+
+  it("includes the formula + source in approx warnings", () => {
+    const comp = {
+      output_column_name: "dob",
+      comparison_levels: [{ sql_condition: 'levenshtein("dob_l", "dob_r") <= 2' }, { sql_condition: "ELSE" }],
+    };
+    const report = new ConversionReport();
+    convertComparison(comp, 0, report);
+    const levWarns = report.findings.filter((f) => f.message.includes("approximate mapping"));
+    expect(levWarns.length).toBe(1);
+    expect(levWarns[0]!.message).toContain("distance <= 2");
+    expect(levWarns[0]!.message).toContain("sim = 1 - distance/10");
+    expect(levWarns[0]!.message).toContain('levenshtein("dob_l", "dob_r") <= 2');
+
+    const compJaro = {
+      output_column_name: "x",
+      comparison_levels: [{ sql_condition: 'jaro_similarity("x_l", "x_r") >= 0.9' }, { sql_condition: "ELSE" }],
+    };
+    const report2 = new ConversionReport();
+    convertComparison(compJaro, 0, report2);
+    const jaroWarns = report2.findings.filter((f) => f.message.includes("approximate mapping"));
+    expect(jaroWarns.length).toBe(1);
+    expect(jaroWarns[0]!.message).toContain("jaro_similarity");
+    expect(jaroWarns[0]!.message).toContain("jaro_winkler");
+  });
+
+  it("returns null when all levels are unrecognized", () => {
+    const comp = {
+      output_column_name: "amount",
+      comparison_levels: [
+        { sql_condition: 'abs("amount_l" - "amount_r") < 5' },
+        { sql_condition: '"amount_l" > "amount_r"' },
+      ],
+    };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+
+    expect(field).toBeNull();
+    expect(report.hasWarnings).toBe(true);
+    expect(report.findings.some((f) => f.message.includes("unrecognized sql_condition"))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test_from_splink_blocking.py -> convertBlocking
+// ---------------------------------------------------------------------------
+
+describe("convertBlocking", () => {
+  it("converts a single equality rule to static", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(['l."postcode" = r."postcode"'], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.strategy).toBe("static");
+    expect(config?.keys.length).toBe(1);
+    expect(config?.keys[0]!.fields).toEqual(["postcode"]);
+    expect(config?.keys[0]!.transforms).toEqual([]);
+    expect(report.hasWarnings).toBe(false);
+    expect(report.hasErrors).toBe(false);
+  });
+
+  it("accepts bare unquoted columns", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(["l.postcode = r.postcode"], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.strategy).toBe("static");
+    expect(config?.keys[0]!.fields).toEqual(["postcode"]);
+    expect(report.hasWarnings).toBe(false);
+  });
+
+  it("widens a mixed equality+SUBSTR conjunction with a warning", () => {
+    const rule = 'l."surname" = r."surname" AND SUBSTR(l."dob", 1, 4) = SUBSTR(r."dob", 1, 4)';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.strategy).toBe("static");
+    expect(config?.keys.length).toBe(1);
+    const key = config!.keys[0]!;
+    expect(key.fields).toEqual(["surname", "dob"]);
+    expect(key.transforms).toEqual(["substring:0:4"]);
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(report.hasWarnings).toBe(true);
+    const msg = warnings[0]!.message;
+    expect(msg.includes("widened") || msg.includes("approximate")).toBe(true);
+    expect(msg).toContain("surname");
+    expect(msg).toContain("skip_oversized");
+  });
+
+  it("treats a pure SUBSTR rule as info-only", () => {
+    const rule = 'SUBSTR(l."dob", 1, 4) = SUBSTR(r."dob", 1, 4)';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["dob"]);
+    expect(config?.keys[0]!.transforms).toEqual(["substring:0:4"]);
+    expect(report.hasWarnings).toBe(false);
+    expect(report.findings.filter((f) => f.severity === "info").length).toBe(1);
+  });
+
+  it("treats a pure equality conjunction as info-only", () => {
+    const rule = 'l."surname" = r."surname" AND l."city" = r."city"';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["surname", "city"]);
+    expect(config?.keys[0]!.transforms).toEqual([]);
+    expect(report.hasWarnings).toBe(false);
+    expect(report.findings.filter((f) => f.severity === "info").length).toBe(1);
+  });
+
+  it("produces multi_pass for two rules with keys === passes", () => {
+    const rules = ['l."postcode" = r."postcode"', 'l."surname" = r."surname"'];
+    const report = new ConversionReport();
+    const config = convertBlocking(rules, report);
+
+    expect(config).not.toBeNull();
+    expect(config?.strategy).toBe("multi_pass");
+    expect(config?.keys.length).toBe(2);
+    expect(config?.keys[0]!.fields).toEqual(["postcode"]);
+    expect(config?.keys[1]!.fields).toEqual(["surname"]);
+    expect(config?.passes).toBe(config?.keys);
+  });
+
+  it("keeps a single rule as static, not multi_pass", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(['l."postcode" = r."postcode"'], report);
+    expect(config?.strategy).toBe("static");
+    expect(config?.passes).toBeUndefined();
+  });
+
+  it("handles the Splink 4 dict form the same as a string", () => {
+    const rule = { blocking_rule: 'l."postcode" = r."postcode"', sql_dialect: "duckdb" };
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.strategy).toBe("static");
+    expect(config?.keys[0]!.fields).toEqual(["postcode"]);
+    expect(report.hasWarnings).toBe(false);
+  });
+
+  it("drops an arithmetic rule with a warning and errors overall", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(["l.amount / r.amount > 0.7"], report);
+
+    expect(config).toBeNull();
+    expect(report.hasErrors).toBe(true);
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("amount");
+  });
+
+  it("drops an OR rule with a warning", () => {
+    const rule = 'l."postcode" = r."postcode" OR l."dob" = r."dob"';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).toBeNull();
+    expect(report.findings.filter((f) => f.severity === "warning").length).toBe(1);
+  });
+
+  it("converts a paren-wrapped rule", () => {
+    const rule = '(l."postcode" = r."postcode")';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["postcode"]);
+    expect(report.hasWarnings).toBe(false);
+  });
+
+  it("returns null and errors when all rules are dropped", () => {
+    const rules = ["l.amount / r.amount > 0.7", '(l."x" = r."x") OR (l."y" = r."y")'];
+    const report = new ConversionReport();
+    const config = convertBlocking(rules, report);
+
+    expect(config).toBeNull();
+    expect(report.hasErrors).toBe(true);
+    const errors = report.findings.filter((f) => f.severity === "error");
+    expect(errors.length).toBe(1);
+    expect(errors[0]!.splinkPath).toBe("blocking_rules");
+  });
+
+  it("drops a dict rule missing the blocking_rule key", () => {
+    const rule = { sql_dialect: "duckdb" };
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("not a SQL string");
+  });
+
+  it("drops a null rule", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking([null], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("not a SQL string");
+  });
+
+  it("drops a rule with conflicting SUBSTR offsets", () => {
+    const rule = "SUBSTR(l.a, 1, 4) = SUBSTR(r.a, 1, 4) AND SUBSTR(l.b, 1, 2) = SUBSTR(r.b, 1, 2)";
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("conflicting SUBSTR offsets");
+  });
+
+  it("drops SUBSTR with start=0", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(["SUBSTR(l.x, 0, 3) = SUBSTR(r.x, 0, 3)"], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("unrecognized");
+  });
+
+  it("drops SUBSTR with length=0", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(["SUBSTR(l.x, 1, 0) = SUBSTR(r.x, 1, 0)"], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("unrecognized");
+  });
+
+  it("dedupes a repeated field order-preserving", () => {
+    const rule = "l.a = r.a AND l.a = r.a";
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["a"]);
+    expect(report.hasWarnings).toBe(false);
+  });
+
+  it("drops cross-column equality with a warning", () => {
+    const rule = 'l."first_name" = r."surname"';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message.includes("first_name") || warnings[0]!.message.includes("surname")).toBe(true);
+  });
+
+  it("converts Splink 4 serialized paren-wrapped conjuncts", () => {
+    const rule = '(l."surname" = r."surname") AND (SUBSTRING(l.dob, 1, 4) = SUBSTRING(r.dob, 1, 4))';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["surname", "dob"]);
+    expect(config?.keys[0]!.transforms).toEqual(["substring:0:4"]);
+  });
+
+  it("strips whole-rule paren wrapping", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(['((l."a" = r."a") AND (l."b" = r."b"))'], report);
+
+    expect(config).not.toBeNull();
+    expect(config?.keys[0]!.fields).toEqual(["a", "b"]);
+  });
+
+  it("still drops unbalanced parens", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(['(l."a" = r."a"'], report);
+
+    expect(config).toBeNull();
+    expect(report.hasErrors).toBe(true);
+  });
+
+  it("drops a paren-wrapped unrecognizable OR conjunct", () => {
+    const report = new ConversionReport();
+    const config = convertBlocking(['(l."a" = r."a" OR l."b" = r."b")'], report);
+
+    expect(config).toBeNull();
+    const warnings = report.findings.filter((f) => f.severity === "warning");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]!.message).toContain("unrecognized");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test_from_splink_model_import.py -> detectTrained / importEm / convertScalars
+// ---------------------------------------------------------------------------
+
+describe("detectTrained / importEm", () => {
+  it("reverses level order and copies m/u exactly", () => {
+    const comp = trainedJwComparison();
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(4);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+    expect(em).not.toBeNull();
+
+    const m = em!.m["first_name"]!;
+    expect(m[3]).toBeCloseTo(0.5, 9);
+    expect(m[2]).toBeCloseTo(0.3, 9);
+    expect(m[1]).toBeCloseTo(0.15, 9);
+    expect(m[0]).toBeCloseTo(0.05, 9);
+
+    const u = em!.u["first_name"]!;
+    expect(u[3]).toBeCloseTo(0.02, 9);
+    expect(u[2]).toBeCloseTo(0.08, 9);
+    expect(u[1]).toBeCloseTo(0.2, 9);
+    expect(u[0]).toBeCloseTo(0.7, 9);
+  });
+
+  it("computes match weights as log2(m/u)", () => {
+    const comp = trainedJwComparison();
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report)!;
+    const em = importEm([{ comp, compIdx: 0, field }], settings, report)!;
+
+    const m = em.m["first_name"]!;
+    const u = em.u["first_name"]!;
+    const w = em.matchWeights["first_name"]!;
+    for (let i = 0; i < 4; i++) {
+      expect(w[i]).toBeCloseTo(Math.log2(m[i]! / u[i]!), 9);
+    }
+  });
+
+  it("reads proportionMatched from settings", () => {
+    const comp = trainedJwComparison();
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report)!;
+    const em = importEm([{ comp, compIdx: 0, field }], settings, report)!;
+
+    expect(em.proportionMatched).toBeCloseTo(0.0002, 9);
+  });
+
+  it("marks converged=true, iterations=0, tfFreqs=null", () => {
+    const comp = trainedJwComparison();
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report)!;
+    const em = importEm([{ comp, compIdx: 0, field }], settings, report)!;
+
+    expect(em.converged).toBe(true);
+    expect(em.iterations).toBe(0);
+    expect(em.tfFreqs ?? null).toBeNull();
+  });
+
+  it("renormalizes and warns when a level is dropped", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.5, u_probability: 0.02 },
+        {
+          // unrecognized cross-column condition, but carries m/u anyway
+          sql_condition: 'jaro_winkler_similarity("first_name_l", "surname_r") >= 0.85',
+          m_probability: 0.2,
+          u_probability: 0.1,
+        },
+        {
+          sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.88',
+          m_probability: 0.2,
+          u_probability: 0.18,
+        },
+        { sql_condition: "ELSE", m_probability: 0.1, u_probability: 0.7 },
+      ],
+    };
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(3);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+    expect(em).not.toBeNull();
+
+    const m = em!.m["first_name"]!;
+    expect(m.reduce((a, b) => a + b, 0)).toBeCloseTo(1.0, 9);
+    const u = em!.u["first_name"]!;
+    expect(u.reduce((a, b) => a + b, 0)).toBeCloseTo(1.0, 9);
+
+    // surviving mass: m = 0.5 (exact) + 0.2 (jw 0.88) + 0.1 (ELSE) = 0.8
+    expect(m[2]).toBeCloseTo(0.5 / 0.8, 9);
+    expect(m[1]).toBeCloseTo(0.2 / 0.8, 9);
+    expect(m[0]).toBeCloseTo(0.1 / 0.8, 9);
+
+    expect(report.findings.some((f) => f.message.toLowerCase().includes("re-normaliz"))).toBe(true);
+  });
+
+  it("ignores m/u on null levels", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        {
+          sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL',
+          is_null_level: true,
+          m_probability: 0.9,
+          u_probability: 0.9,
+        },
+        { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.8, u_probability: 0.1 },
+        { sql_condition: "ELSE", m_probability: 0.2, u_probability: 0.9 },
+      ],
+    };
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(2);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report)!;
+    const m = em.m["first_name"]!;
+    const u = em.u["first_name"]!;
+    expect(m[1]).toBeCloseTo(0.8, 9);
+    expect(m[0]).toBeCloseTo(0.2, 9);
+    expect(u[1]).toBeCloseTo(0.1, 9);
+    expect(u[0]).toBeCloseTo(0.9, 9);
+  });
+
+  it("sums collapsed duplicate levels and warns", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        {
+          sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.9',
+          m_probability: 0.5,
+          u_probability: 0.05,
+        },
+        // Same threshold via the spark-dialect alias: dedupe collapses this
+        // onto the same GoldenMatch level.
+        {
+          sql_condition: 'jaro_winkler("first_name_l", "first_name_r") >= 0.9',
+          m_probability: 0.3,
+          u_probability: 0.15,
+        },
+        { sql_condition: "ELSE", m_probability: 0.2, u_probability: 0.8 },
+      ],
+    };
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(2);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+    expect(em).not.toBeNull();
+
+    const m = em!.m["first_name"]!;
+    const u = em!.u["first_name"]!;
+    expect(m[1]).toBeCloseTo(0.8, 9);
+    expect(m[0]).toBeCloseTo(0.2, 9);
+    expect(u[1]).toBeCloseTo(0.2, 9);
+    expect(u[0]).toBeCloseTo(0.8, 9);
+
+    const collapseWarns = report.findings.filter(
+      (f) => f.severity === "warning" && f.message.includes("collapsed") && f.message.includes("summed"),
+    );
+    expect(collapseWarns.length).toBe(1);
+  });
+
+  it.each(["m_probability", "u_probability"] as const)(
+    "fills partial data (%s missing) with epsilon and warns",
+    (missingSide) => {
+      const exactLevel: Record<string, unknown> = {
+        sql_condition: '"first_name_l" = "first_name_r"',
+        m_probability: 0.8,
+        u_probability: 0.1,
+      };
+      delete exactLevel[missingSide];
+      const comp = {
+        output_column_name: "first_name",
+        comparison_levels: [
+          { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+          exactLevel,
+          { sql_condition: "ELSE", m_probability: 0.2, u_probability: 0.9 },
+        ],
+      };
+      const settings = trainedSettings([comp]);
+      const report = new ConversionReport();
+      const field = convertComparison(comp, 0, report);
+      expect(field).not.toBeNull();
+
+      const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+      expect(em).not.toBeNull();
+
+      const epsilon = 1e-6;
+      if (missingSide === "m_probability") {
+        const vals = em!.m["first_name"]!;
+        expect(vals[1]).toBeCloseTo(epsilon / (epsilon + 0.2), 6);
+        expect(vals[1]!).toBeGreaterThan(0.0);
+      } else {
+        const vals = em!.u["first_name"]!;
+        expect(vals[1]).toBeCloseTo(epsilon / (epsilon + 0.9), 6);
+        expect(vals[1]!).toBeGreaterThan(0.0);
+      }
+
+      const partialWarns = report.findings.filter(
+        (f) => f.severity === "warning" && f.message.includes("partial trained data") && f.message.includes(missingSide),
+      );
+      expect(partialWarns.length).toBe(1);
+      expect(partialWarns[0]!.splinkPath).toContain("comparison_levels[1]");
+    },
+  );
+
+  it("returns null for bare settings with no m_probability", () => {
+    const comp = {
+      output_column_name: "surname",
+      comparison_levels: [
+        { sql_condition: '"surname_l" IS NULL OR "surname_r" IS NULL', is_null_level: true },
+        { sql_condition: '"surname_l" = "surname_r"' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const settings = { comparisons: [comp] };
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+
+    expect(detectTrained(settings)).toBe(false);
+    expect(importEm([{ comp, compIdx: 0, field: field! }], settings, report)).toBeNull();
+  });
+
+  it("detects trained when any level has m_probability", () => {
+    const settings = trainedSettings([trainedJwComparison()]);
+    expect(detectTrained(settings)).toBe(true);
+  });
+
+  it("fills an unassigned level with epsilon and warns", () => {
+    const comp = {
+      output_column_name: "first_name",
+      comparison_levels: [
+        { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+        { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.5, u_probability: 0.02 },
+        // Recognized (jw >= 0.92) but carries no m/u at all.
+        { sql_condition: 'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92' },
+        { sql_condition: "ELSE", m_probability: 0.1, u_probability: 0.7 },
+      ],
+    };
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(3);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+    expect(em).not.toBeNull();
+
+    const m = em!.m["first_name"]!;
+    const u = em!.u["first_name"]!;
+    const epsilon = 1e-6;
+    const totalM = 0.5 + epsilon + 0.1;
+    const totalU = 0.02 + epsilon + 0.7;
+    expect(m[1]).toBeCloseTo(epsilon / totalM, 6);
+    expect(u[1]).toBeCloseTo(epsilon / totalU, 6);
+
+    const fillWarns = report.findings.filter(
+      (f) => f.severity === "warning" && f.message.includes("no m/u probability"),
+    );
+    expect(fillWarns.length).toBe(1);
+  });
+
+  it("drops and renormalizes an out-of-range band that still carries m/u", () => {
+    const comp = {
+      output_column_name: "surname",
+      comparison_levels: [
+        { sql_condition: '"surname_l" IS NULL OR "surname_r" IS NULL', is_null_level: true },
+        { sql_condition: '"surname_l" = "surname_r"', m_probability: 0.6, u_probability: 0.05 },
+        {
+          // levenshtein <= 20 converts to sim = 1 - 20/10 = -1.0, out of
+          // range -> dropped by convertComparison, but still carries m/u.
+          sql_condition: 'levenshtein("surname_l", "surname_r") <= 20',
+          m_probability: 0.3,
+          u_probability: 0.15,
+        },
+        { sql_condition: "ELSE", m_probability: 0.1, u_probability: 0.8 },
+      ],
+    };
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.levels).toBe(2);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+    expect(em).not.toBeNull();
+
+    const m = em!.m["surname"]!;
+    const u = em!.u["surname"]!;
+    expect(m.reduce((a, b) => a + b, 0)).toBeCloseTo(1.0, 9);
+    expect(u.reduce((a, b) => a + b, 0)).toBeCloseTo(1.0, 9);
+    expect(m[1]).toBeCloseTo(0.6 / 0.7, 9);
+    expect(m[0]).toBeCloseTo(0.1 / 0.7, 9);
+
+    const lostWarns = report.findings.filter(
+      (f) => f.severity === "warning" && f.message.includes("does not match any"),
+    );
+    expect(lostWarns.length).toBe(1);
+  });
+
+  it("skips a bare comparison mixed with a trained one and warns coverage", () => {
+    const trainedComp = trainedJwComparison();
+    const bareComp = {
+      output_column_name: "surname",
+      comparison_levels: [
+        { sql_condition: '"surname_l" IS NULL OR "surname_r" IS NULL', is_null_level: true },
+        { sql_condition: '"surname_l" = "surname_r"' },
+        { sql_condition: "ELSE" },
+      ],
+    };
+    const settings = trainedSettings([trainedComp, bareComp]);
+    const report = new ConversionReport();
+
+    const trainedField = convertComparison(trainedComp, 0, report);
+    const bareField = convertComparison(bareComp, 1, report);
+    expect(trainedField).not.toBeNull();
+    expect(bareField).not.toBeNull();
+
+    const em = importEm(
+      [
+        { comp: trainedComp, compIdx: 0, field: trainedField! },
+        { comp: bareComp, compIdx: 1, field: bareField! },
+      ],
+      settings,
+      report,
+    );
+
+    expect(em).not.toBeNull();
+    expect("first_name" in em!.m).toBe(true);
+    expect("surname" in em!.m).toBe(false);
+    expect("surname" in em!.u).toBe(false);
+    const partial = report.findings.filter(
+      (f) => f.severity === "warning" && f.message.includes("will NOT cover field 'surname'"),
+    );
+    expect(partial.length).toBe(1);
+    expect(partial[0]!.message).toContain("model_path");
+  });
+
+  it("infos that TF tables are absent for an imported tfAdjustment field", () => {
+    const comp = trainedJwComparison();
+    (comp["comparison_levels"] as Record<string, unknown>[])[1]!["tf_adjustment_column"] = "first_name";
+    const settings = trainedSettings([comp]);
+    const report = new ConversionReport();
+
+    const field = convertComparison(comp, 0, report);
+    expect(field).not.toBeNull();
+    expect(field?.tfAdjustment).toBe(true);
+
+    const em = importEm([{ comp, compIdx: 0, field: field! }], settings, report);
+
+    expect(em).not.toBeNull();
+    expect(em!.tfFreqs ?? null).toBeNull();
+    const infos = report.findings.filter((f) => f.severity === "info" && f.message.includes("term-frequency"));
+    expect(infos.length).toBe(1);
+    expect(infos[0]!.message).toContain("first_name");
+    expect(infos[0]!.message).toContain("retraining");
+  });
+});
+
+describe("convertScalars", () => {
+  it("maps em_convergence and max_iterations", () => {
+    const settings = { em_convergence: 0.0001, max_iterations: 15 };
+    const report = new ConversionReport();
+    const kwargs = convertScalars(settings, report);
+
+    expect(kwargs).toEqual({ convergenceThreshold: 0.0001, emIterations: 15 });
+    const infos = report.findings.filter((f) => f.severity === "info");
+    expect(infos.some((f) => f.message.includes("em_convergence"))).toBe(true);
+    expect(infos.some((f) => f.message.includes("max_iterations"))).toBe(true);
+  });
+
+  it("treats unique_id_column_name as advisory only", () => {
+    const settings = { unique_id_column_name: "record_id" };
+    const report = new ConversionReport();
+    const kwargs = convertScalars(settings, report);
+
+    expect(Object.keys(kwargs).length).toBe(0);
+    expect(report.findings.some((f) => f.message.includes("record_id") && f.message.includes("id_column"))).toBe(
+      true,
+    );
+  });
+
+  it("warns on link_and_dedupe", () => {
+    const settings = { link_type: "link_and_dedupe" };
+    const report = new ConversionReport();
+    convertScalars(settings, report);
+
+    expect(report.hasWarnings).toBe(true);
+    expect(report.findings.some((f) => f.message.includes("link_and_dedupe"))).toBe(true);
+  });
+
+  it.each([
+    ["dedupe_only", "dedupe()"],
+    ["link_only", "match()"],
+  ] as const)("infos dedupe_only/link_only (%s -> %s)", (linkType, expectedEntryPoint) => {
+    const settings = { link_type: linkType };
+    const report = new ConversionReport();
+    convertScalars(settings, report);
+
+    expect(report.hasWarnings).toBe(false);
+    expect(report.findings.some((f) => f.message.includes(expectedEntryPoint))).toBe(true);
+  });
+
+  it("infos and ignores infra keys", () => {
+    const settings = {
+      sql_dialect: "duckdb",
+      retain_matching_columns: true,
+      retain_intermediate_calculation_columns: false,
+      bayes_factor_column_prefix: "bf_",
+    };
+    const report = new ConversionReport();
+    const kwargs = convertScalars(settings, report);
+
+    expect(kwargs).toEqual({});
+    const infos = report.findings.filter((f) => f.severity === "info");
+    expect(infos.length).toBe(4);
+    for (const key of [
+      "sql_dialect",
+      "retain_matching_columns",
+      "retain_intermediate_calculation_columns",
+      "bayes_factor_column_prefix",
+    ]) {
+      expect(infos.some((f) => f.message.includes(key) && f.message.includes("ignored"))).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// test_from_splink_api.py -> fromSplink
+// ---------------------------------------------------------------------------
+
+describe("fromSplink", () => {
+  it("produces a valid config from a full settings object", () => {
+    const settings = fullSettings();
+    const conversion = fromSplink(settings);
+
+    const mks = getMatchkeys(conversion.config);
+    expect(mks.length).toBe(1);
+    const mk = mks[0] as ProbabilisticMatchkey;
+    expect(mk.name).toBe("splink_import");
+    expect(mk.type).toBe("probabilistic");
+    const fieldNames = new Set(mk.fields.map((f: MatchkeyField) => f.field));
+    expect(fieldNames).toEqual(new Set(["first_name", "surname"]));
+
+    expect(conversion.config.blocking).toBeDefined();
+    expect(conversion.config.blocking!.strategy).toBe("multi_pass");
+    expect(conversion.config.blocking!.passes?.length).toBe(2);
+  });
+
+  it("does not mutate the input settings object", () => {
+    const settings = fullSettings();
+    const original = JSON.parse(JSON.stringify(settings));
+    fromSplink(settings);
+    expect(settings).toEqual(original);
+  });
+
+  it("produces an em_model for trained settings", () => {
+    const settings = fullSettings({ comparisons: [trainedJwComparison()] });
+    settings["probability_two_random_records_match"] = 0.0002;
+    const conversion = fromSplink(settings);
+
+    expect(conversion.emModel).not.toBeNull();
+    expect("first_name" in conversion.emModel!.m).toBe(true);
+  });
+
+  it("has a null em_model for bare settings", () => {
+    const settings = fullSettings();
+    const conversion = fromSplink(settings);
+    expect(conversion.emModel).toBeNull();
+  });
+
+  it("raises in strict mode on an unmappable level", () => {
+    const comp = jwComparison();
+    (comp["comparison_levels"] as unknown[]).splice(4, 0, {
+      sql_condition: 'jaro_winkler_similarity("first_name_l", "surname_r") >= 0.85',
+    });
+    const settings = fullSettings({ comparisons: [comp, exactOnlyComparison("surname")] });
+
+    expect(() => fromSplink(settings, { strict: true })).toThrow(SplinkConversionError);
+    try {
+      fromSplink(settings, { strict: true });
+      expect.unreachable();
+    } catch (e) {
+      const msg = String((e as Error).message);
+      expect(msg.toLowerCase().includes("warning") || msg.toLowerCase().includes("error")).toBe(true);
+      expect(msg).toContain("error(s)");
+      expect(msg).toContain("warning(s)");
+    }
+  });
+
+  it("does not raise in default mode on the same lossy input", () => {
+    const comp = jwComparison();
+    (comp["comparison_levels"] as unknown[]).splice(4, 0, {
+      sql_condition: 'jaro_winkler_similarity("first_name_l", "surname_r") >= 0.85',
+    });
+    const settings = fullSettings({ comparisons: [comp, exactOnlyComparison("surname")] });
+
+    const conversion = fromSplink(settings, { strict: false });
+    expect(conversion.report.hasWarnings).toBe(true);
+  });
+
+  it("raises with zero convertible comparisons", () => {
+    const settings = fullSettings({ comparisons: [] });
+    expect(() => fromSplink(settings, { strict: false })).toThrow(SplinkConversionError);
+  });
+
+  it("raises when all comparisons are unrecognized", () => {
+    const badComp = {
+      output_column_name: "first_name",
+      comparison_levels: [{ sql_condition: "some_weird_udf(first_name_l, first_name_r) > 3" }],
+    };
+    const settings = fullSettings({ comparisons: [badComp] });
+    expect(() => fromSplink(settings, { strict: false })).toThrow(SplinkConversionError);
+  });
+
+  it("raises with zero convertible blocking rules", () => {
+    const settings = fullSettings({ blockingRules: ["l.a > r.a OR l.b < r.b"] });
+    expect(() => fromSplink(settings, { strict: false })).toThrow(SplinkConversionError);
+  });
+
+  it("resolves the mappedTo placeholder to the survivor's final position", () => {
+    const droppedComp = {
+      output_column_name: "first_name",
+      comparison_levels: [{ sql_condition: 'jaro_winkler_similarity("first_name_l", "surname_r") >= 0.85' }],
+    };
+    const settings = fullSettings({ comparisons: [droppedComp, exactOnlyComparison("surname")] });
+
+    const conversion = fromSplink(settings);
+
+    const survivorFindings = conversion.report.findings.filter(
+      (f) => f.splinkPath === "comparisons[1]" && f.mappedTo,
+    );
+    expect(survivorFindings.length).toBeGreaterThan(0);
+    expect(survivorFindings.some((f) => f.mappedTo!.startsWith("matchkeys[0].fields[0]"))).toBe(true);
+    expect(conversion.report.findings.some((f) => (f.mappedTo ?? "").includes("matchkeys[?]"))).toBe(false);
+  });
+
+  it("lands em_iterations and convergence_threshold on the matchkey", () => {
+    const settings = fullSettings();
+    settings["em_convergence"] = 0.0005;
+    settings["max_iterations"] = 12;
+
+    const conversion = fromSplink(settings);
+    const mk = getMatchkeys(conversion.config)[0] as ProbabilisticMatchkey;
+    expect(mk.convergenceThreshold).toBeCloseTo(0.0005, 9);
+    expect(mk.emIterations).toBe(12);
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => fromSplink("not an object")).toThrow(SplinkConversionError);
+    expect(() => fromSplink(null)).toThrow(SplinkConversionError);
+    expect(() => fromSplink(42)).toThrow(SplinkConversionError);
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/mcp-convert-splink.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-convert-splink.test.ts
@@ -1,0 +1,123 @@
+/**
+ * mcp-convert-splink.test.ts -- Task T4: the `convert_splink_config` MCP tool.
+ *
+ * Mirrors the response shape assembled by the Python tool
+ * (`_tool_convert_splink_config` in goldenmatch/mcp/server.py): settings
+ * arrive as an inline JSON string (no filesystem access), and the tool
+ * returns `config_yaml` / `findings` (snake_case) / `summary` / `em_model` /
+ * `usage_note`.
+ */
+import { describe, it, expect } from "vitest";
+import { TOOLS, handleTool } from "../../src/node/mcp/server.js";
+
+function bareSettings(): Record<string, unknown> {
+  return {
+    comparisons: [
+      {
+        output_column_name: "first_name",
+        comparison_levels: [
+          { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+          { sql_condition: '"first_name_l" = "first_name_r"' },
+          { sql_condition: "ELSE" },
+        ],
+      },
+    ],
+    blocking_rules_to_generate_predictions: ['l."first_name" = r."first_name"'],
+  };
+}
+
+function trainedSettings(): Record<string, unknown> {
+  return {
+    comparisons: [
+      {
+        output_column_name: "first_name",
+        comparison_levels: [
+          { sql_condition: '"first_name_l" IS NULL OR "first_name_r" IS NULL', is_null_level: true },
+          { sql_condition: '"first_name_l" = "first_name_r"', m_probability: 0.8, u_probability: 0.02 },
+          { sql_condition: "ELSE", m_probability: 0.2, u_probability: 0.98 },
+        ],
+      },
+    ],
+    blocking_rules_to_generate_predictions: ['l."first_name" = r."first_name"'],
+    probability_two_random_records_match: 0.001,
+  };
+}
+
+describe("MCP server — TOOLS includes convert_splink_config", () => {
+  it("is registered with settings_json required", () => {
+    const tool = TOOLS.find((t) => t.name === "convert_splink_config");
+    expect(tool).toBeDefined();
+    const schema = tool!.inputSchema as { required?: string[] };
+    expect(schema.required).toContain("settings_json");
+  });
+});
+
+describe("MCP server — convert_splink_config handler", () => {
+  it("happy path (bare settings) returns the full response shape", async () => {
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: JSON.stringify(bareSettings()),
+    })) as Record<string, unknown>;
+
+    expect(typeof result["config_yaml"]).toBe("string");
+    expect((result["config_yaml"] as string)).toContain("matchkeys");
+    expect(Array.isArray(result["findings"])).toBe(true);
+    const findings = result["findings"] as Record<string, unknown>[];
+    expect(findings.length).toBeGreaterThan(0);
+    expect(findings[0]).toHaveProperty("severity");
+    expect(findings[0]).toHaveProperty("splink_path");
+    expect(findings[0]).toHaveProperty("message");
+    expect(findings[0]).toHaveProperty("mapped_to");
+    expect(typeof result["summary"]).toBe("string");
+    expect(result["em_model"]).toBeNull();
+    expect(typeof result["usage_note"]).toBe("string");
+    expect(result["usage_note"] as string).toContain("No trained model");
+  });
+
+  it("trained settings return a non-null em_model dict", async () => {
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: JSON.stringify(trainedSettings()),
+    })) as Record<string, unknown>;
+
+    expect(result["em_model"]).not.toBeNull();
+    const em = result["em_model"] as Record<string, unknown>;
+    expect(em["__type__"]).toBe("goldenmatch.EMResult");
+    expect(em["match_weights"]).toBeDefined();
+    expect(result["usage_note"] as string).toContain("trained m/u probabilities");
+  });
+
+  it("bad JSON returns the error convention", async () => {
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: "{not valid json",
+    })) as Record<string, unknown>;
+    expect(typeof result["error"]).toBe("string");
+    expect(result["error"] as string).toMatch(/not valid JSON/);
+  });
+
+  it("non-object JSON returns the error convention", async () => {
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: JSON.stringify([1, 2, 3]),
+    })) as Record<string, unknown>;
+    expect(typeof result["error"]).toBe("string");
+    expect(result["error"] as string).toMatch(/must decode to a JSON object/);
+  });
+
+  it("zero-convertible-comparisons returns the error convention", async () => {
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: JSON.stringify({ comparisons: [] }),
+    })) as Record<string, unknown>;
+    expect(typeof result["error"]).toBe("string");
+  });
+
+  it("strict=true fails on lossy findings", async () => {
+    const settings = bareSettings();
+    (settings["comparisons"] as Record<string, unknown>[])[0]!["comparison_levels"] = [
+      ...((settings["comparisons"] as Record<string, unknown>[])[0]!["comparison_levels"] as unknown[]),
+      { sql_condition: "some_weird_condition(x, y)" },
+    ];
+    const result = (await handleTool("convert_splink_config", {
+      settings_json: JSON.stringify(settings),
+      strict: true,
+    })) as Record<string, unknown>;
+    expect(typeof result["error"]).toBe("string");
+  });
+});

--- a/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/mcp-server.test.ts
@@ -183,8 +183,8 @@ describe("MCP server — handleTool dispatcher", () => {
 });
 
 describe("MCP server — agent tools wiring", () => {
-  it("TOOLS exposes 49 tools (45 + 4 cross-language naming aliases, #1451)", () => {
-    expect(TOOLS.length).toBe(49);
+  it("TOOLS exposes 50 tools (46 + 4 cross-language naming aliases, #1451; +convert_splink_config)", () => {
+    expect(TOOLS.length).toBe(50);
   });
 
   it("TOOLS includes the agent skill names", () => {

--- a/packages/typescript/goldenmatch/tests/unit/nlevel.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/nlevel.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import * as YAML from "yaml";
+import {
+  buildComparisonVector,
+  type Row,
+} from "../../src/core/index.js";
+import { makeMatchkeyField } from "../../src/core/index.js";
+import { parseConfig, parseConfigYaml, configToYaml } from "../../src/core/index.js";
+
+// ---------------------------------------------------------------------------
+// Custom levelThresholds banding (ports tests/test_nlevel_banding.py vectors)
+// ---------------------------------------------------------------------------
+
+describe("buildComparisonVector: levelThresholds custom banding", () => {
+  it("scalar: identical strings -> top level, totally different -> level 0", () => {
+    const field = makeMatchkeyField({
+      field: "name",
+      scorer: "jaro_winkler",
+      levels: 4,
+      levelThresholds: [1.0, 0.92, 0.88],
+    });
+    const rowA: Row = { name: "smith" };
+    const rowB: Row = { name: "smith" };
+    const rowC: Row = { name: "qqqqq" };
+    expect(buildComparisonVector(rowA, rowB, [field])).toEqual([3]);
+    expect(buildComparisonVector(rowA, rowC, [field])).toEqual([0]);
+  });
+
+  it("mid-band real jaro_winkler similarity (martha/marhta ~0.9611)", () => {
+    // score_field('martha', 'marhta', 'jaro_winkler') measures ~0.9611.
+    // With level_thresholds=[1.0, 0.9] on a 3-level field: 0.9611 >= 0.9 but
+    // < 1.0 -> 1 threshold satisfied -> level 1 (the middle band).
+    const field = makeMatchkeyField({
+      field: "name",
+      scorer: "jaro_winkler",
+      levels: 3,
+      levelThresholds: [1.0, 0.9],
+    });
+    const martha: Row = { name: "martha" };
+    const marhta: Row = { name: "marhta" };
+    const zzz: Row = { name: "zzzzzz" };
+    expect(buildComparisonVector(martha, marhta, [field])).toEqual([1]);
+    expect(buildComparisonVector(martha, martha, [field])).toEqual([2]);
+    expect(buildComparisonVector(martha, zzz, [field])).toEqual([0]);
+  });
+
+  it("banding over a sweep of similarities -> [3,2,1,0,1] (thresholds [1.0,0.92,0.88])", () => {
+    // Ports test_levels_from_similarity_custom: Python's private
+    // _levels_from_similarity([1.0, 0.95, 0.90, 0.5, 0.88], 4, ...,
+    // level_thresholds=[1.0, 0.92, 0.88]) == [3, 2, 1, 0, 1]. TS has no
+    // separate exported helper (the count-satisfied-thresholds formula is
+    // inlined directly in buildComparisonVector's levelThresholds branch —
+    // see probabilistic.ts), so this exercises that exact formula against
+    // the same similarity sweep to pin the parity vector.
+    const thresholds = [1.0, 0.92, 0.88];
+    const sims = [1.0, 0.95, 0.9, 0.5, 0.88];
+    const expected = [3, 2, 1, 0, 1];
+    const levels = sims.map((s) => {
+      let level = 0;
+      for (const t of thresholds) if (s >= t) level += 1;
+      return level;
+    });
+    expect(levels).toEqual(expected);
+  });
+
+  it("levelThresholds takes priority over levels-based legacy banding", () => {
+    // n=3 legacy banding would use 0.95/partial cutoffs; levelThresholds
+    // overrides that entirely once present.
+    const field = makeMatchkeyField({
+      field: "name",
+      scorer: "exact",
+      levels: 3,
+      levelThresholds: [1.0, 0.5],
+    });
+    const rowA: Row = { name: "abc" };
+    const rowB: Row = { name: "abc" };
+    const rowC: Row = { name: "xyz" };
+    // exact scorer returns 1.0 or 0.0 only
+    expect(buildComparisonVector(rowA, rowB, [field])).toEqual([2]);
+    expect(buildComparisonVector(rowA, rowC, [field])).toEqual([0]);
+  });
+});
+
+describe("buildComparisonVector: legacy 2/3-level banding unchanged", () => {
+  it("levels=3: sim sweep [1.0, 0.9, 0.5] with partial=0.8 -> [2,1,0]", () => {
+    const field = makeMatchkeyField({
+      field: "name",
+      scorer: "jaro_winkler",
+      levels: 3,
+      partialThreshold: 0.8,
+    });
+    const base: Row = { name: "martha" };
+    // 1.0: identical
+    expect(buildComparisonVector(base, base, [field])).toEqual([2]);
+  });
+
+  it("levels=2: agree/disagree at partial threshold", () => {
+    const field = makeMatchkeyField({
+      field: "name",
+      scorer: "jaro_winkler",
+      levels: 2,
+      partialThreshold: 0.8,
+    });
+    const rowA: Row = { name: "John Smith" };
+    const rowB: Row = { name: "John Smith" };
+    const rowC: Row = { name: "Zxqwer" };
+    expect(buildComparisonVector(rowA, rowB, [field])).toEqual([1]);
+    expect(buildComparisonVector(rowA, rowC, [field])).toEqual([0]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Loader validation (ports tests/test_nlevel_schema.py vectors)
+// ---------------------------------------------------------------------------
+
+describe("parseConfig: levelThresholds validation", () => {
+  function rawConfigWith(fieldExtra: Record<string, unknown>) {
+    return {
+      matchkeys: [
+        {
+          name: "mk",
+          type: "probabilistic",
+          fields: [
+            {
+              field: "first_name",
+              scorer: "jaro_winkler",
+              weight: 1.0,
+              ...fieldExtra,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  it("accepts a valid level_thresholds config", () => {
+    const raw = rawConfigWith({
+      levels: 4,
+      level_thresholds: [1.0, 0.92, 0.88],
+    });
+    const config = parseConfig(raw);
+    expect(config.matchkeys?.[0]?.fields[0]?.levelThresholds).toEqual([
+      1.0, 0.92, 0.88,
+    ]);
+  });
+
+  it("rejects wrong length (levels-1 mismatch)", () => {
+    const raw = rawConfigWith({
+      levels: 4,
+      level_thresholds: [1.0, 0.9], // needs levels-1 = 3
+    });
+    expect(() => parseConfig(raw)).toThrow(/level_thresholds/);
+  });
+
+  it("rejects non-descending thresholds", () => {
+    const raw = rawConfigWith({
+      levels: 3,
+      level_thresholds: [0.8, 0.9],
+    });
+    expect(() => parseConfig(raw)).toThrow(/descending/);
+  });
+
+  it("rejects out-of-range thresholds (> 1)", () => {
+    const raw = rawConfigWith({
+      levels: 3,
+      level_thresholds: [1.2, 0.9],
+    });
+    expect(() => parseConfig(raw)).toThrow(/\(0, 1\]/);
+  });
+
+  it("default is undefined (back-compat)", () => {
+    const raw = rawConfigWith({ levels: 3 });
+    const config = parseConfig(raw);
+    expect(config.matchkeys?.[0]?.fields[0]?.levelThresholds).toBeUndefined();
+  });
+
+  it("rejects levels < 2", () => {
+    const raw = rawConfigWith({ levels: 1 });
+    expect(() => parseConfig(raw)).toThrow(/levels/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// YAML round-trip
+// ---------------------------------------------------------------------------
+
+describe("levelThresholds YAML round-trip", () => {
+  it("parseConfigYaml -> configToYaml -> parseConfigYaml preserves level_thresholds", () => {
+    const yamlIn = `
+matchkeys:
+  - name: mk
+    type: probabilistic
+    fields:
+      - field: first_name
+        scorer: jaro_winkler
+        weight: 1.0
+        levels: 4
+        level_thresholds: [1.0, 0.92, 0.88]
+`;
+    const config1 = parseConfigYaml(yamlIn, (s) => YAML.parse(s));
+    expect(config1.matchkeys?.[0]?.fields[0]?.levelThresholds).toEqual([
+      1.0, 0.92, 0.88,
+    ]);
+
+    const yamlOut = configToYaml(config1, (obj) => YAML.stringify(obj));
+    expect(yamlOut).toContain("level_thresholds");
+
+    const config2 = parseConfigYaml(yamlOut, (s) => YAML.parse(s));
+    expect(config2.matchkeys?.[0]?.fields[0]?.levelThresholds).toEqual([
+      1.0, 0.92, 0.88,
+    ]);
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -55,6 +55,7 @@ mcp_tools:
   - analyze_data
   - auto_configure
   - controller_telemetry
+  - convert_splink_config
   - dedupe
   - evaluate
   - explain_cluster
@@ -86,7 +87,6 @@ mcp_tools:
   - certify_recall
   - compare_clusters
   - config_weaknesses
-  - convert_splink_config
   - create_domain
   - documents_ingest
   - documents_suggest_schema
@@ -143,6 +143,7 @@ cli_commands:
   - demo
   - evaluate
   - identity
+  - import-splink
   - match
   - mcp-serve
   - memory
@@ -155,7 +156,6 @@ cli_commands:
   - compare-clusters
   - config
   - explain
-  - import-splink
   - incremental
   - ingest-docs
   - init


### PR DESCRIPTION
## Summary

Thesis phase 3 for the Splink converter (#1749 Python POC, #1752 Rust native port): the TypeScript surface.

- **N-level fields**: \`levelThresholds\` on \`MatchkeyField\` (loader validation identical to Python: length == levels-1, (0,1], strictly descending, levels >= 2 floor) + the custom banding branch in \`buildComparisonVector\` — same count-of-satisfied semantics.
- **EMResult JSON serde**, Python schema-v1 byte-compatible (\`emResultToJson\`/\`emResultFromJson\`/\`validateEmResultFor\`, TF-table passthrough) — a trained-model file round-trips across surfaces; verified live in BOTH directions against the real Python \`EMResult\`.
- **\`fromSplink()\`** (\`src/core/config/from-splink.ts\`, edge-safe, parsed-object-only): faithful port of \`from_splink.py\` — recognizers, comparison assembly, blocking (paren-stripping, SUBSTR mapping, widening warnings), trained m/u import (level-order reversal, collapse-summing, epsilon fills, renormalization), scalars, strict mode. Cross-surface equivalence probe: one rich settings JSON through both converters → matchkeys, blocking, scalars, EM m/u and match weights EQUAL to full float precision; findings multiset equal by (severity, path).
- **Surfaces**: CLI \`import-splink\` (mirrors the Python command branch-for-branch incl. partial-model refusal and config-before-model write order) and MCP \`convert_splink_config\` (snake_case response shape matching the Python tool verbatim). \`modelPath\` added to \`ProbabilisticMatchkey\` as a documented round-trip-only field.
- **Parity manifest**: \`import-splink\` and \`convert_splink_config\` moved \`python_only\` → \`shared\`.
- **WASM verdict**: no-op — no WASM path performs FS level banding (TS FS scoring is pure-TS), so no capability guard is needed on this surface.

## Cross-surface proof

TS-written \`goldenmatch.yaml\` + \`model.json\` consumed by the PYTHON loader: \`load_config\` parses it, \`EMResult.load_json\` loads the model, \`validate_for\` passes. TS model JSON structurally identical to what the Python CLI writes on the same input.

## Testing

175 tests across 9 files (per-file vitest; the box can't run the full suite): nlevel banding, EM serde incl. live Python↔TS fixtures, 95 converter tests porting all six Python test files' vectors, CLI (8+2) and MCP (7) tests. \`tsc --noEmit\` clean. CI validates the tsup build + parity emitters (dist-dependent, CI-only by design).

Known pre-existing drift NOT changed: TS \`partialThreshold\` default 0.7 vs Python 0.8.

Plan: docs/superpowers/plans/2026-07-13-splink-converter-ts.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqWK7rUZ4MqXnA47BdhjS