### PR TITLE
feat(goldenmatch): autoconfig config-building arrow-port (Route B bucket scoring, default-off)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2010,13 +2010,14 @@ def _source_disjoint(df: pl.DataFrame, col: str, partition_col: str) -> bool:
     max-pairwise test: a genuine shared identifier (the same person appearing in
     two sources with the same value) is NOT disjoint, so it is kept.
     """
-    if partition_col not in df.columns:
+    from goldenmatch.core.frame import to_frame
+
+    _sd_frame = to_frame(df)  # arrow-port: seam columns (pa.Table.columns != names)
+    if partition_col not in _sd_frame.columns:
         return False
     # W3d: group_nunique pins the either-col-null row drop this site's
     # frame-level drop_nulls performed.
-    from goldenmatch.core.frame import to_frame
-
-    per_value = to_frame(df).group_nunique(col, partition_col)
+    per_value = _sd_frame.group_nunique(col, partition_col)
     if per_value.height == 0:
         return False
     max_parts = cast("int | None", per_value.column("n_unique").max())
@@ -2046,8 +2047,14 @@ def _detect_source_partition(
         return None
     if _AUTOCONFIG_MATCH_MODE.get():
         return None
+    from goldenmatch.core.frame import to_frame
+
+    _sp_frame = to_frame(df)  # arrow-port: seam columns/height/n_unique
     # 1) internal __source__ with >= 2 distinct values (multi-file dedupe).
-    if "__source__" in df.columns and df["__source__"].n_unique() >= 2:
+    if (
+        "__source__" in _sp_frame.columns
+        and _sp_frame.column("__source__").n_unique() >= 2
+    ):
         return "__source__"
     # 2) a name-pattern user column: low cardinality + >= 2 distinct + a
     #    disjoint-id co-signature (>= 1 other column 0-overlap vs it). The
@@ -2055,11 +2062,11 @@ def _detect_source_partition(
     #    floor of 20, else 10% of rows) excludes free-text "source"-ish fields
     #    while staying robust on small frames.
     other_cols = [p.name for p in profiles if not p.name.startswith("__")]
-    card_cap = max(20, int(0.1 * df.height))
+    card_cap = max(20, int(0.1 * _sp_frame.height))
     for p in profiles:
         if p.name.startswith("__") or not _SOURCE_NAME_RE.search(p.name):
             continue
-        n_unique = df[p.name].n_unique()
+        n_unique = _sp_frame.column(p.name).n_unique()
         if n_unique < 2 or n_unique > card_cap:
             continue
         has_cosig = any(
@@ -3812,20 +3819,23 @@ def auto_configure_df(
     # their own column-selection story; exclusions land at the per-
     # partition kernel layer separately.
     _ms_partition: str | None = None  # #858 source partition (None => feature off)
-    if not _is_ray_dataset(df) and is_polars_dataframe(df):
-        # df is always a pl.DataFrame here: the boundary above coerces every
-        # non-ray / non-lazy input (incl. pa.Table) to polars until the scoring
-        # lane is arrow-ported, and a LazyFrame was collected. So a pa.Table
-        # zero-config input runs the SAME exclusions / exclude_columns / #858
-        # guard as an equivalent pl.DataFrame -- the detectors below
-        # (detect_autoconfig_exclusions / _detect_source_partition /
-        # _source_correlated_exclusions) are not seam-ported, and don't need to
-        # be while the boundary coerces. Seam-porting them is part of the
-        # pipeline-spine follow-up that makes the boundary a true arrow
-        # pass-through.
+    if not _is_ray_dataset(df):
+        # Arrow-port: the exclusion + source-partition detectors are now seam-
+        # ported (detect_autoconfig_exclusions / _detect_source_partition /
+        # _source_correlated_exclusions all route Column stats through the seam),
+        # so this block runs identically for a pl.DataFrame AND a bare pa.Table
+        # (the arrow-native path). A pa.Table zero-config input therefore gets
+        # the SAME exclusions / exclude_columns / #858 guard as an equivalent
+        # pl.DataFrame -- config-equivalence, not the silent skip Finding 1
+        # flagged. `df` may be arrow (GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE) or
+        # polars (default coercion); `_excl_frame` gives backend-agnostic
+        # columns/drop.
+        from goldenmatch.core.frame import to_frame as _to_frame_excl
         from goldenmatch.core.quality_exclusions import (
             detect_autoconfig_exclusions,
         )
+
+        _excl_frame = _to_frame_excl(df)
         # Combine every exclusion source: top-level config.exclude_columns
         # (this PR), dedupe_df / match_df kwarg via _RUNTIME_EXCLUDE_COLUMNS
         # ContextVar, QualityConfig.autoconfig_force_{exclude,include}
@@ -3849,7 +3859,7 @@ def auto_configure_df(
             ]
         # Internal bookkeeping columns are invisible to detectors.
         skip = {"__row_id__", "__source__"}
-        for col in df.columns:
+        for col in _excl_frame.columns:
             if col.startswith("__") and col.endswith("__"):
                 skip.add(col)
         exclusions = detect_autoconfig_exclusions(
@@ -3859,8 +3869,9 @@ def auto_configure_df(
             skip_columns=skip,
         )
         if exclusions:
+            _existing_cols = set(_excl_frame.columns)
             cols_to_drop = [
-                ec.column for ec in exclusions if ec.column in df.columns
+                ec.column for ec in exclusions if ec.column in _existing_cols
             ]
             for ec in exclusions:
                 logger.info(
@@ -3868,7 +3879,7 @@ def auto_configure_df(
                     ec.column, ec.detector, ec.reason,
                 )
             if cols_to_drop:
-                df = df.drop(cols_to_drop)
+                df = _excl_frame.drop(cols_to_drop).native
             _LAST_AUTOCONFIG_EXCLUSIONS.set(list(exclusions))
         else:
             _LAST_AUTOCONFIG_EXCLUSIONS.set([])

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3740,13 +3740,20 @@ def auto_configure_df(
     )
     from goldenmatch.distributed._utils import is_ray_dataset as _is_ray_boundary
 
+    # GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1 (default 0) skips the coercion and
+    # keeps a pa.Table native through the controller -- the in-progress scoring-
+    # lane port (indicators guards done; exclusion detectors + build_blocks spine
+    # pending). Default OFF: coerce, so production zero-config is unchanged.
+    _arrow_native_ac = os.environ.get(
+        "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", "0"
+    ).lower() in ("1", "true", "yes")
     if not (
         _is_ray_boundary(df)
         or is_polars_lazyframe(df)
         or is_polars_dataframe(df)
     ):
         _boundary_native = to_frame(df).native
-        if is_polars_dataframe(_boundary_native):
+        if is_polars_dataframe(_boundary_native) or _arrow_native_ac:
             df = _boundary_native
         else:
             import polars as _pl_boundary

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -1686,10 +1686,43 @@ class AutoConfigController:
         owns the store lifecycle.
         """
         from goldenmatch.core.pipeline import run_dedupe_df, run_match_df
+
+        # Arrow-native zero-config: route an ARROW sample's dedupe to the bucket
+        # scorer (arrow-native, Polars-free) rather than the legacy fuzzy scorer
+        # (`find_fuzzy_matches`/`_score_one_block`, which does `.to_dicts()` and is
+        # not arrow-ported). bucket produces identical clusters at 1k-60k (#526)
+        # and the controller sample is <=20K, so this is cluster-equivalent for
+        # the sample profile. A polars / ray sample is untouched (byte-identical).
+        config = self._maybe_bucket_route_arrow(sample, config)
         if reference is None:
             run_dedupe_df(sample, config=config, _prep_store=_prep_store)
         else:
             run_match_df(sample, reference, config=config)
+
+    @staticmethod
+    def _maybe_bucket_route_arrow(
+        sample: Any, config: GoldenMatchConfig
+    ) -> GoldenMatchConfig:
+        """Force ``backend='bucket'`` when ``sample`` is a bare Arrow table.
+
+        The bucket scorer is the arrow-native, Polars-free scoring path; the
+        legacy fuzzy scorer is not arrow-ported. No-op for polars / ray samples
+        and when the config already targets bucket.
+        """
+        from goldenmatch.core.frame import (
+            is_polars_dataframe,
+            is_polars_lazyframe,
+        )
+        from goldenmatch.distributed._utils import is_ray_dataset
+
+        if (
+            config.backend == "bucket"
+            or is_polars_dataframe(sample)
+            or is_polars_lazyframe(sample)
+            or is_ray_dataset(sample)
+        ):
+            return config
+        return config.model_copy(update={"backend": "bucket"})
 
     def _perturbation_stability(
         self,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py
@@ -101,15 +101,18 @@ def discriminative_power(
     skipped. Returns (mean over measured pairs, count of measured pairs);
     (0.0, 0) when basket empty, candidate absent, or no measurable pair exists.
     """
-    if not basket or candidate_col not in df.columns:
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)  # arrow-port: seam columns + select_dicts (row order preserved)
+    if not basket or candidate_col not in frame.columns:
         return 0.0, 0
-    basket_cols = [(c, fuzzy) for (c, fuzzy) in basket if c in df.columns]
+    basket_cols = [(c, fuzzy) for (c, fuzzy) in basket if c in frame.columns]
     if not basket_cols:
         return 0.0, 0
-    sub = df.select([candidate_col, *[c for (c, _f) in basket_cols]])
+    sub_cols = [candidate_col, *[c for (c, _f) in basket_cols]]
 
     groups: dict[str, list[dict[str, Any]]] = {}
-    for row in sub.iter_rows(named=True):
+    for row in frame.select_dicts(sub_cols):
         cv = _norm(row[candidate_col])
         if cv is None:
             continue
@@ -260,7 +263,10 @@ def should_demote_attribute_field(
     )
     if not is_eligible:
         return False
-    basket = [(c, f) for (c, f) in name_basket if c != candidate_col and c in df.columns]
+    from goldenmatch.core.frame import to_frame
+
+    _dcols = to_frame(df).columns  # arrow-port: pa.Table.columns != names
+    basket = [(c, f) for (c, f) in name_basket if c != candidate_col and c in _dcols]
     if not basket:
         return False
     power, support = discriminative_power(

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -684,7 +684,7 @@ def build_cluster_frames(
                 int(cid): _af.filter_eq("cluster_id", cid).column("member_id").to_list()
                 for cid in oversized
             }
-            live_cids = set(range(1, metadata.height + 1))
+            live_cids = set(range(1, _mf.height + 1))  # arrow-port: seam .height (pa.Table has none)
             split_result: dict[int, dict] = {}
             drop_cids = set()                      # ORIGINAL cids that split
             edge_work, edge_budget, budget_tripped = 0, _split_edge_work_budget(len(all_ids), split_edge_budget), False
@@ -747,13 +747,16 @@ def build_cluster_frames(
                 from goldenmatch.core.frame import concat_frames as _cf
                 from goldenmatch.core.frame import frame_from_rows as _ffr
 
+                # arrow-port: split rows must match the frame backend (concat_frames
+                # refuses mixed arrow/polars) -- `backend` is the same one the
+                # assignments/metadata frames were built with above.
                 assignments = _cf([
                     _tf2(assignments),
-                    _ffr(split_assign_rows, {"cluster_id": "int64", "member_id": "int64"}, backend="polars"),
+                    _ffr(split_assign_rows, {"cluster_id": "int64", "member_id": "int64"}, backend=backend),
                 ]).native
                 metadata = _cf([
                     _tf2(metadata),
-                    _ffr(split_meta_rows, _META_SPEC, backend="polars"),
+                    _ffr(split_meta_rows, _META_SPEC, backend=backend),
                 ]).native
 
     # Step 3: vectorized weak/quality (excludes "split" rows -- none in Task 1).

--- a/packages/python/goldenmatch/goldenmatch/core/indicators.py
+++ b/packages/python/goldenmatch/goldenmatch/core/indicators.py
@@ -200,16 +200,16 @@ def estimate_sparse_match_signal(
     sparse-match expansion is not over-triggered. When None, the fixed
     `sparse_threshold` is used (backward-compatible default).
     """
-    if not exact_columns or df.is_empty():
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)  # arrow-port: seam guards -- pa.Table has no is_empty
+    if not exact_columns or frame.height == 0:
         return SparsityVerdict(is_sparse=True, estimated_n_true_pairs=0)
     threshold = (
         sparse_match_floor(estimated_pairs)
         if estimated_pairs is not None
         else sparse_threshold
     )
-    from goldenmatch.core.frame import to_frame
-
-    frame = to_frame(df)
     sample_frame = frame.head(sample_size) if frame.height > sample_size else frame
     n_pairs = 0
     for col in exact_columns:
@@ -233,9 +233,12 @@ def compute_corruption_score(df: pl.DataFrame, col: str) -> float:
 
     See _compute_corruption_score_inline for the heuristic.
     """
-    if col not in df.columns or df.is_empty():
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)  # arrow-port: seam guards
+    if col not in frame.columns or frame.height == 0:
         return 0.0
-    sample = df.head(1000) if df.height > 1000 else df
+    sample = (frame.head(1000) if frame.height > 1000 else frame).native
     return _compute_corruption_score_inline(sample, col)
 
 
@@ -251,7 +254,10 @@ def estimate_full_pop_hits(df: pl.DataFrame, blocking_col: str) -> int | None:
         logger.info("estimate_full_pop_hits: budget is zero; returning None")
         return None
     start = time.time()
-    if blocking_col not in df.columns or df.is_empty():
+    from goldenmatch.core.frame import to_frame
+
+    _guard_frame = to_frame(df)  # arrow-port: seam guards
+    if blocking_col not in _guard_frame.columns or _guard_frame.height == 0:
         return 0
     if (time.time() - start) > BUDGET_FULL_POP_HITS:
         return None
@@ -288,7 +294,14 @@ def compute_cross_blocking_overlap(
         logger.info("compute_cross_blocking_overlap: budget is zero; returning None")
         return None
     start = time.time()
-    if key_a not in df.columns or key_b not in df.columns or df.is_empty():
+    from goldenmatch.core.frame import to_frame
+
+    _guard_frame = to_frame(df)  # arrow-port: seam guards
+    if (
+        key_a not in _guard_frame.columns
+        or key_b not in _guard_frame.columns
+        or _guard_frame.height == 0
+    ):
         return None
     if (time.time() - start) > BUDGET_CROSS_BLOCKING:
         return None

--- a/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py
@@ -448,6 +448,58 @@ def _sample_non_null_values(
     return non_null.head(sample_size).to_list()
 
 
+# semantic_dtype() returns normalized categories; map them to a polars-style
+# dtype repr so the ONE dtype-reading detector (the temporal check keys on
+# date/datetime/time substrings) fires identically on the arrow path. date and
+# datetime both normalize to "date" -> "Date" (carries the "date" substring);
+# numeric/bool/text carry no temporal substring, matching the polars str(dtype)
+# behavior. profile.dtype otherwise appears only as cosmetic evidence.
+_SEMANTIC_TO_PL_DTYPE = {
+    "text": "String",
+    "numeric": "Float64",
+    "bool": "Boolean",
+    "date": "Date",
+}
+
+
+def _build_column_profile_seam(column: Any, total_rows: int) -> ColumnProfile:
+    """Arrow-safe twin of ``_build_column_profile`` over a seam ``Column``.
+
+    Decisions are byte-identical to the ``pl.Series`` path: the only detector
+    that reads ``profile.dtype`` (the temporal check) keys on date/datetime/time
+    substrings, and ``mean_string_length`` is set for text columns exactly as the
+    polars path. Used only on the arrow lane (``detect_autoconfig_exclusions``
+    keeps the polars branch unchanged = byte-parity).
+    """
+    null_count = int(column.null_count())
+    non_null = total_rows - null_count
+    distinct_count = int(column.n_unique())
+    cardinality_ratio = (distinct_count / non_null) if non_null > 0 else 0.0
+    null_rate = (null_count / total_rows) if total_rows > 0 else 0.0
+    semantic = column.semantic_dtype()
+    dtype_str = _SEMANTIC_TO_PL_DTYPE.get(semantic, semantic)
+    mean_string_length: float | None = None
+    if semantic == "text":
+        try:
+            mean = column.drop_nulls().str_len_chars().mean()
+            mean_string_length = float(mean) if mean is not None else None
+        except Exception:  # pragma: no cover - defensive
+            mean_string_length = None
+    return ColumnProfile(
+        cardinality_ratio=cardinality_ratio,
+        null_rate=null_rate,
+        distinct_count=distinct_count,
+        dtype=dtype_str,
+        mean_string_length=mean_string_length,
+    )
+
+
+def _sample_non_null_seam(column: Any, sample_size: int = 1000) -> list:
+    """Arrow-safe twin of ``_sample_non_null_values``. Drop-nulls THEN take the
+    first ``sample_size`` (order matters for detector reproducibility)."""
+    return column.drop_nulls().to_list()[:sample_size]
+
+
 def detect_autoconfig_exclusions(
     df: pl.DataFrame,
     *,
@@ -482,9 +534,22 @@ def detect_autoconfig_exclusions(
     force_include_set = set(force_include or [])
     skip_set = set(skip_columns or [])
 
-    total_rows = df.height
+    # Arrow-port: the polars branch is UNCHANGED (byte-parity, unedited test);
+    # a pa.Table is scanned through the Frame seam (Column stats via the arrow-
+    # safe profile/sample twins) so the exclusion DECISIONS match.
+    from goldenmatch.core.frame import is_polars_dataframe, to_frame
+
+    _is_polars = is_polars_dataframe(df)
+    if _is_polars:
+        columns = df.columns
+        total_rows = df.height
+    else:
+        _frame = to_frame(df)
+        columns = _frame.columns
+        total_rows = _frame.height
+
     excluded: list[ExcludedColumn] = []
-    for col in df.columns:
+    for col in columns:
         if col in skip_set:
             continue
         if col in force_include_set:
@@ -499,9 +564,14 @@ def detect_autoconfig_exclusions(
             ))
             continue
 
-        series = df[col]
-        profile = _build_column_profile(series, total_rows)
-        sampled = _sample_non_null_values(series, sample_size=sample_size)
+        if _is_polars:
+            series = df[col]
+            profile = _build_column_profile(series, total_rows)
+            sampled = _sample_non_null_values(series, sample_size=sample_size)
+        else:
+            column = _frame.column(col)
+            profile = _build_column_profile_seam(column, total_rows)
+            sampled = _sample_non_null_seam(column, sample_size=sample_size)
 
         for detector in _DETECTORS:
             result = detector(col, sampled, profile)

--- a/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
@@ -1,0 +1,130 @@
+"""Arrow-native zero-config parity gate (spine-port Route B).
+
+`GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` skips the `auto_configure_df` boundary
+coercion and keeps a bare ``pa.Table`` native through the controller, which routes
+sample dedupes to the arrow-native ``bucket`` scorer (`_maybe_bucket_route_arrow`)
+and runs the config-building detectors (exclusions / discriminative demotion /
+source-partition / indicators) through the Frame seam.
+
+These tests assert the arrow-native path is EQUIVALENT to the polars path:
+- **cluster-equivalence** (the outcome that matters): zero-config ``dedupe_df``
+  finds the same number of duplicate rows on a ``pa.Table`` (flag on) as on the
+  equivalent ``pl.DataFrame``. Robust across dataset shapes.
+- **config-equivalence** on shapes without a near-tie: same matchkeys.
+
+Note: blocking-COLUMN selection can differ on a genuine near-tie between two
+equally-valid low-cardinality keys because ``Frame.sample`` is statistical-not-byte
+across backends BY DESIGN (see the polars-eviction design) -- so we assert
+cluster-equivalence (unaffected) rather than byte-identical blocking there.
+
+The full zero-config Polars-FREE tripwire (`test_zero_config_no_polars.py`) stays
+xfail on a separate blocker: the clustering result-wrapping
+`cluster.build_clusters_arrow_native` (cluster.py:2027) still builds polars
+``ClusterFrames`` from the arrow kernel output -- the 3.x engine-descent eviction,
+not the autoconfig port. This gate runs with polars PRESENT.
+"""
+
+import os
+
+import polars as pl
+import pyarrow as pa
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_autoconfig_memory():
+    prev = os.environ.get("GOLDENMATCH_AUTOCONFIG_MEMORY")
+    os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = "0"
+    yield
+    if prev is None:
+        os.environ.pop("GOLDENMATCH_AUTOCONFIG_MEMORY", None)
+    else:
+        os.environ["GOLDENMATCH_AUTOCONFIG_MEMORY"] = prev
+
+
+def _arrow_native(on: bool):
+    if on:
+        os.environ["GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE"] = "1"
+    else:
+        os.environ.pop("GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", None)
+
+
+def _dupe_count(res) -> int:
+    d = res.dupes
+    if d is None:
+        return 0
+    return d.num_rows if hasattr(d, "num_rows") else d.height
+
+
+# Dataset shapes: (name, data-dict). Deterministic (no RNG so arrow==polars
+# construction is identical).
+_SHAPES = {
+    "exact-id-plus-names": {
+        "cust_id": [f"C{i:05d}" for i in range(400)],
+        "first": (["ann", "bob", "cara", "dan", "eve", "fay"] * 67)[:400],
+        "last": (["smith", "jones", "lee", "poe", "ray", "kim"] * 67)[:400],
+        "zip": [str(10000 + (i % 50)) for i in range(400)],
+    },
+    "all-fuzzy": {
+        "first": (["ann", "bob", "cara"] * 100),
+        "last": (["smith", "jones", "lee"] * 100),
+    },
+    "shared-email-switchboard": {
+        # email shared across different-name records -> discriminative veto path
+        "email": [f"user{i % 250}@x.com" for i in range(300)],
+        "first": (["ann", "bob"] * 150),
+        "last": (["smith", "jones"] * 150),
+    },
+    "multi-source": {
+        # "src" is a user source-indicator column (matches _SOURCE_NAME_RE for
+        # #858), NOT the internal "__source__" bookkeeping name.
+        "src": (["A", "B"] * 150),
+        "acct": [f"A{i % 280:04d}" for i in range(300)],
+        "first": (["ann", "bob", "cy"] * 100),
+        "last": (["smith", "jones", "lee"] * 100),
+    },
+}
+
+
+def _config_matchkeys(cfg):
+    return sorted(
+        (mk.type, tuple(sorted(f.field for f in (mk.fields or []) if f.field)))
+        for mk in cfg.get_matchkeys()
+    )
+
+
+@pytest.mark.parametrize("shape", list(_SHAPES))
+def test_arrow_native_cluster_equivalence(shape):
+    """Zero-config ``dedupe_df`` finds the same duplicate count on a pa.Table
+    (arrow-native flag on) as on the equivalent pl.DataFrame."""
+    from goldenmatch import dedupe_df
+
+    data = _SHAPES[shape]
+    _arrow_native(False)
+    res_pl = dedupe_df(pl.DataFrame(data), config=None)
+    _arrow_native(True)
+    try:
+        res_pa = dedupe_df(pa.table(data), config=None)
+    finally:
+        _arrow_native(False)
+    assert _dupe_count(res_pl) == _dupe_count(res_pa), (
+        f"{shape}: polars dupes={_dupe_count(res_pl)} != arrow dupes={_dupe_count(res_pa)}"
+    )
+
+
+@pytest.mark.parametrize("shape", ["exact-id-plus-names", "shared-email-switchboard"])
+def test_arrow_native_config_matchkey_equivalence(shape):
+    """On shapes without a near-tie blocking choice, the arrow-native config's
+    matchkeys match the polars config exactly (the discriminative veto /
+    exclusion / source-partition detectors decide identically)."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    data = _SHAPES[shape]
+    _arrow_native(False)
+    cfg_pl = auto_configure_df(pl.DataFrame(data), _skip_finalize=True)
+    _arrow_native(True)
+    try:
+        cfg_pa = auto_configure_df(pa.table(data), _skip_finalize=True)
+    finally:
+        _arrow_native(False)
+    assert _config_matchkeys(cfg_pl) == _config_matchkeys(cfg_pa)

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -207,16 +207,18 @@ def test_explicit_config_arrow_dedupe_is_polars_free():
 
 @pytest.mark.xfail(
     reason=(
-        "PR-3..6b landed the autoconfig-LAYER arrow seam (dtype map, controller "
-        "gates, sampling, blocking-size measurement, v0 heuristic), but the "
-        "zero-config SCORING lane is not fully arrow-ported: the eager indicators' "
-        "empty/column guards (indicators.py), the GoldenCheck exclusion detectors, "
-        "and the legacy `build_blocks(combined_lf)` scoring spine (pipeline.py:2284) "
-        "still assume polars. So `auto_configure_df` COERCES a non-polars input to "
-        "polars at its boundary for now (correct + no RED fallback), which imports "
-        "polars. Flips green when the scoring spine + indicators guards + exclusion "
-        "detectors are arrow-ported (the separately-tracked pipeline-spine follow-up) "
-        "and the boundary becomes a true `.native` arrow pass-through."
+        "`auto_configure_df` config-GENERATION is now Polars-free on the arrow-native "
+        "path (GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1: indicators guards + exclusion "
+        "detectors + discriminative-veto + source-partition seam-ported, sample "
+        "scoring routed to the arrow-native bucket scorer -- config- and cluster-"
+        "equivalent to polars, see test_autoconfig_arrow_native_parity.py). Two things "
+        "keep this DEFAULT tripwire xfail: (1) the flag defaults OFF, so "
+        "`auto_configure_df` coerces a non-polars input to polars at its boundary "
+        "(imports polars) -- safe production default until (2) lands; (2) even with the "
+        "flag on, the FINAL dedupe's clustering `build_clusters_arrow_native` "
+        "(cluster.py:2027) wraps the arrow Rust-kernel output into polars ClusterFrames "
+        "-> imports polars. Flips green when ClusterFrames is Arrow-native (the 3.x "
+        "engine-descent eviction, NOT the autoconfig port) and the flag defaults on."
     ),
     strict=False,
 )


### PR DESCRIPTION
## Autoconfig config-building arrow-port (Route B: bucket scoring)

Follow-up to #1754 (the autoconfig seam foundation). Makes `auto_configure_df` config-**generation** run **Polars-free** on the arrow-native path, config- and cluster-equivalent to polars. Behind a **default-off** flag (`GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1`), so production zero-config is byte-unchanged.

### What it does
- **Indicators** (`indicators.py`): the 4 eager/lazy guards (`is_empty`/`df[col]`/`df.columns` at 203/236/254/291) route through the Frame seam — a bare `pa.Table` no longer crashes / silently short-circuits.
- **Route B bucket routing** (`autoconfig_controller._maybe_bucket_route_arrow`): an ARROW sample's controller dedupe is scored by the arrow-native **bucket** scorer (identical clusters at 1k-60k per #526; sample ≤20K) instead of the legacy fuzzy scorer (`find_fuzzy_matches`/`_score_one_block`, not arrow-ported). No-op for polars/ray.
- **Config-building detectors seam-ported** so arrow config == polars config:
  - **Discriminative veto** (`discriminative_power`) — the actual divergence source: `should_veto_exact` short-circuited on arrow, so arrow kept an `exact(email)` matchkey polars vetoes (shared-email-across-different-names).
  - GoldenCheck exclusion detectors (polars branch UNCHANGED = byte-parity; arrow branch via seam Column stats + a semantic→pl dtype map), source-partition (`_detect_source_partition`/`_source_disjoint`).
- **`build_cluster_frames` arrow auto-split fix** (`cluster.py`): seam `.height` + backend-matched split rows (the D-series arrow ClusterFrames path crashed on oversized clusters; default-off so main's default lane never hit it).

### Verified
- New `test_autoconfig_arrow_native_parity.py` — **6 passed**: cluster-equivalence (arrow vs polars) across 4 shapes + config-matchkey-equivalence on 2. Near-tie blocking-column selection can differ by cross-backend `sample()` (design), so the gate asserts cluster-equivalence.
- **181 unedited** autoconfig/exclusion/discriminative/indicator/controller + 21 cluster contract tests green = byte-parity on the polars path. Whole-package ruff clean. `import goldenmatch` loads no polars.

### Not yet: full zero-config Polars-free
The tripwire `test_zero_config_no_polars.py::test_zero_config_dedupe_df_is_polars_free` stays **xfail** and the flag stays **default-off**: the FINAL dedupe's clustering `build_clusters_arrow_native` (cluster.py:2027) still wraps the arrow Rust-kernel output into polars `ClusterFrames`. Flipping the flag default + tripwire green + dropping the #1747 `[polars]` stopgap is gated on the **`ClusterFrames` eviction** (scoped separately — a contained builder fix + consumer sweep, recall-neutral). This PR does not touch the stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
