### PR TITLE
chore(release): goldenmatch 3.3.0 + golden-suite 0.2.5

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.5] - 2026-07-14
+
+### Changed
+- goldenmatch floor to `goldenmatch[polars]>=3.3` (3.3.0: Arrow-native
+  auto-config input -- `auto_configure_df` / zero-config `dedupe_df` accept a
+  bare `pyarrow.Table`; the auto-config stack drops its own hard Polars
+  dependency -- plus the fused golden kernel reachable on the Polars-free lane).
+
 ## [0.2.4] - 2026-07-13
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.4"
+version = "0.2.5"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.2",         # entity resolution: dedupe, match, golden records (>=3.2: Splink config converter + N-level level_thresholds fields; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.3",         # entity resolution: dedupe, match, golden records (>=3.3: Arrow-native auto-config input (pa.Table) + fused golden on the polars-free lane; >=3.2 added the Splink converter + N-level level_thresholds fields; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to GoldenMatch are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [3.3.0] - 2026-07-14
+
+### Added
+- **Arrow-native auto-config input**: `auto_configure_df` (and `dedupe_df` /
+  `match_df` zero-config) now accept a bare `pyarrow.Table` (or any Frame) in
+  addition to a `polars.DataFrame` / `LazyFrame`; the pre-3.3 Arrow shim rejected
+  a bare `pa.Table` with a `TypeError`. The auto-config layer (arrow-to-polars
+  dtype classification, controller gates, sampling, blocking-size measurement,
+  the v0 heuristic, negative-evidence, and preflight verify) is ported onto the
+  Frame seam, so the auto-config stack no longer carries a hard Polars dependency
+  of its own -- the last Polars island the 3.0.0 eviction left in the zero-config
+  path's config layer. A non-Polars input is coerced to Polars once at the
+  boundary, producing a byte-identical config to the same data passed as a
+  `polars.DataFrame`.
+
+### Performance
+- **Fused golden kernel reachable on the Polars-free lane**: the Arrow-native
+  fused golden-record kernel was silently unreachable on the Polars-free path;
+  wiring it up makes the Polars-free lane beat the Polars-present lane on the
+  golden-record build.
+
 ## [3.2.0] - 2026-07-13
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.2.0"
+version = "3.3.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump only. Cuts **goldenmatch 3.3.0** (Arrow-native auto-config input #1754 + fused golden on the polars-free lane #1745) and the **golden-suite 0.2.5** lockstep floor bump (goldenmatch >=3.3).

After merge: push tag `v3.3.0` (fires publish-goldenmatch.yml -> PyPI), then `golden-suite-v0.2.5` once goldenmatch 3.3.0 is live on PyPI (satisfiable-floor ordering).

Does NOT include #1758 (config-building arrow-port, still in the queue) -- that rides the next release with the ClusterFrames eviction + [polars] stopgap drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)