### PR TITLE
perf(goldenmatch): ClusterFrames eviction Tier A — cluster stage polars-free on the arrow lane

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -784,13 +784,18 @@ def _emit_cluster_profile_frames(
     if not _emitter_stack.get():
         return  # fast path: no capture active
 
-    import polars as _pl
+    # arrow-port (ClusterFrames eviction): this telemetry emitter runs during the
+    # autoconfig sample capture, where metadata/assignments are arrow on the
+    # arrow-native lane -- route every read through the Frame seam so it never
+    # imports polars / subscripts a pa.Table. Byte-identical on the polars path.
+    from goldenmatch.core.frame import to_frame as _tf_prof
 
-    if metadata.is_empty():
+    _mf = _tf_prof(metadata)
+    if _mf.height == 0:
         current_emitter().set_cluster(ClusterProfile())
         return
 
-    sizes = sorted(metadata["size"].to_list())
+    sizes = sorted(_mf.column("size").to_list())
 
     def percentile(xs: list, q: float) -> int:
         if not xs:
@@ -799,14 +804,15 @@ def _emit_cluster_profile_frames(
         return xs[idx]
 
     confidences = sorted(
-        v for v in metadata["confidence"].to_list() if v is not None
+        v for v in _mf.column("confidence").to_list() if v is not None
     )
 
     members_by_cluster: dict[int, list[int]] = {}
-    if not assignments.is_empty():
+    _af = _tf_prof(assignments)
+    if _af.height > 0:
         for cid, mid in zip(
-            assignments["cluster_id"].to_list(),
-            assignments["member_id"].to_list(),
+            _af.column("cluster_id").to_list(),
+            _af.column("member_id").to_list(),
             strict=True,
         ):
             members_by_cluster.setdefault(int(cid), []).append(int(mid))
@@ -829,11 +835,11 @@ def _emit_cluster_profile_frames(
     threshold = min(aggregated_scores.values()) if aggregated_scores else 0.5
 
     oversized_count = int(
-        metadata.filter(_pl.col("oversized")).height
+        _mf.filter_mask(_mf.column("oversized")).height
     )
 
     profile = ClusterProfile(
-        n_clusters=metadata.height,
+        n_clusters=_mf.height,
         cluster_size_p50=percentile(sizes, 0.50),
         cluster_size_p99=percentile(sizes, 0.99),
         cluster_size_max=sizes[-1] if sizes else 0,

--- a/packages/python/goldenmatch/tests/test_cluster_frames_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_cluster_frames_no_polars.py
@@ -1,0 +1,136 @@
+"""ClusterFrames-eviction (Tier A) gate: the cluster stage is polars-free on the
+arrow lane.
+
+The default cluster stage is ``build_cluster_frames`` (frames-out), which threads
+``backend='arrow'`` when the collected frame is an ``ArrowFrame`` (pipeline.py).
+On that lane the assignments/metadata frames are ``pa.Table`` and every read must
+go through the Frame seam -- no ``import polars`` / ``pl.col`` / ``pa.Table``
+subscript. Two clustering paths + the telemetry emitter are exercised with polars
+import BLOCKED (the D6 zero-polars gate mechanism, see ``_zero_polars_probe.py``):
+
+1. ``build_cluster_frames(backend='arrow')`` with auto-split -> arrow ClusterFrames.
+2. ``build_clusters_arrow_native(backend='arrow')`` (Rust-kernel arrow output).
+3. ``_emit_cluster_profile_frames`` under an ACTIVE ``profile_capture`` -- the
+   autoconfig sample-capture path that used to ``import polars`` + subscript the
+   arrow metadata frame (the concrete Tier A leak this branch fixed).
+
+Parity (byte-identical clusters on the polars path) is covered separately by
+``test_cluster_frames_out_parity`` / ``test_build_clusters_arrow_native_parity``;
+this file only locks the arrow-lane polars-freeness so it can't silently regress.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_PKG_ROOT = Path(__file__).parent.parent
+
+
+def _run_polars_blocked(body: str, extra_env: dict[str, str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_PKG_ROOT)
+    env.update(extra_env)
+    prelude = (
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'polars' or name.startswith('polars.'):\n"
+        "            raise ImportError('polars blocked (ClusterFrames Tier A gate)')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", prelude + textwrap.dedent(body)],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=180,
+    )
+
+
+_ENV = {
+    "GOLDENMATCH_FRAME": "arrow",
+    "GOLDENMATCH_NATIVE": "1",
+    "POLARS_SKIP_CPU_CHECK": "1",
+    "GOLDENMATCH_AUTOCONFIG_MEMORY": "0",
+}
+
+
+def test_build_cluster_frames_arrow_is_polars_free():
+    """SUBPROCESS, polars BLOCKED: the frames-out cluster stage on the arrow
+    backend (auto-split ON) runs to completion without importing polars and
+    returns arrow ClusterFrames."""
+    body = """
+        import sys
+        from goldenmatch.core.cluster import build_cluster_frames
+        import pyarrow as pa
+        pairs = [(1, 2, 0.95), (2, 3, 0.9), (4, 5, 0.8), (1, 1, 0.99)]
+        cf = build_cluster_frames(
+            pairs, [1, 2, 3, 4, 5],
+            max_cluster_size=100, weak_cluster_threshold=0.3,
+            auto_split=True, backend="arrow",
+        )
+        assert isinstance(cf.assignments, pa.Table), type(cf.assignments)
+        assert isinstance(cf.metadata, pa.Table), type(cf.metadata)
+        assert cf.metadata.num_rows >= 1
+        assert "polars" not in sys.modules, "polars leaked in build_cluster_frames(arrow)"
+        print("CLUSTER-FRAMES ARROW OK")
+    """
+    proc = _run_polars_blocked(body, _ENV)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "CLUSTER-FRAMES ARROW OK" in proc.stdout
+
+
+def test_emit_cluster_profile_frames_arrow_is_polars_free():
+    """SUBPROCESS, polars BLOCKED: the telemetry emitter (the autoconfig
+    sample-capture path) runs under an ACTIVE ``profile_capture`` on arrow frames
+    without importing polars -- the concrete leak this branch fixed. Asserts the
+    ClusterProfile is populated (a no-op emitter would defeat the test)."""
+    body = """
+        import sys
+        from goldenmatch.core.cluster import build_cluster_frames
+        from goldenmatch.core.profile_emitter import profile_capture, current_emitter
+        pairs = [(1, 2, 0.95), (2, 3, 0.9), (4, 5, 0.8)]
+        with profile_capture():
+            build_cluster_frames(
+                pairs, [1, 2, 3, 4, 5],
+                max_cluster_size=100, weak_cluster_threshold=0.3,
+                auto_split=True, backend="arrow",
+            )
+            prof = current_emitter().cluster
+        assert prof is not None and prof.n_clusters == 2, prof
+        # transitivity is reconstructed from pairs+assignments (a frames-path 0.0
+        # would silently change the autoconfig controller's decisions).
+        assert prof.transitivity_rate == 1.0, prof.transitivity_rate
+        assert "polars" not in sys.modules, "polars leaked in _emit_cluster_profile_frames"
+        print("CLUSTER-EMIT ARROW OK")
+    """
+    proc = _run_polars_blocked(body, _ENV)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "CLUSTER-EMIT ARROW OK" in proc.stdout
+
+
+def test_build_clusters_arrow_native_is_polars_free():
+    """SUBPROCESS, polars BLOCKED: the Rust-kernel arrow cluster builder on the
+    arrow backend emits arrow ClusterFrames without importing polars. Skips
+    gracefully (still asserts polars-free) if the native ``build_clusters_arrow``
+    symbol isn't in this build."""
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.cluster import build_clusters_arrow_native
+        pairs = pa.table({"id_a": [1, 2, 4], "id_b": [2, 3, 5], "score": [0.95, 0.9, 0.8]})
+        cf = build_clusters_arrow_native(
+            pairs, all_ids=[1, 2, 3, 4, 5], max_cluster_size=100, backend="arrow",
+        )
+        assert isinstance(cf.assignments, pa.Table), type(cf.assignments)
+        assert isinstance(cf.metadata, pa.Table), type(cf.metadata)
+        assert "polars" not in sys.modules, "polars leaked in build_clusters_arrow_native(arrow)"
+        print("CLUSTER-ARROW-NATIVE OK")
+    """
+    proc = _run_polars_blocked(body, _ENV)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr[-2500:]}"
+    assert "CLUSTER-ARROW-NATIVE OK" in proc.stdout


### PR DESCRIPTION
## What

Closes the last **clustering-stage** polars leak on the arrow-native lane, so the cluster stage of a dedupe imports zero polars when `GOLDENMATCH_FRAME=arrow`. This is one of the two conditions the D6 endgame gate (`test_zero_config_dedupe_df_is_polars_free`) documents as blocking the zero-polars finish line — the other (autoconfig controller/scoring arrow-port) is tracked separately.

## The leak

`_emit_cluster_profile_frames` (the cluster-stage telemetry emitter, runs during autoconfig **sample capture**) did an unconditional `import polars` + raw `metadata[...]` / `.is_empty()` / `filter(pl.col(...))` reads. On the arrow lane the metadata/assignments frames are `pa.Table`, so it imported polars / would crash. Routed every read through the Frame seam (`to_frame` + `.column` / `.height` / `.filter_mask`). Byte-identical on the polars path.

The ClusterFrames **builders** were already arrow-native on main (#1745): `build_cluster_frames` and `build_clusters_arrow_native` thread `backend`, and the pipeline cluster stage (pipeline.py:2921) already passes `backend="arrow"` when the collected frame is an `ArrowFrame`. This emitter was the remaining leak on the fuzzy/autoconfig-sample path.

## Verification

New subprocess tripwire (`test_cluster_frames_no_polars.py`) runs each arrow-lane clustering path with `import polars` **blocked** and asserts polars never lands in `sys.modules`:
- `build_cluster_frames(backend="arrow")` with auto-split → arrow ClusterFrames
- `build_clusters_arrow_native(backend="arrow")` → Rust-kernel arrow output
- `_emit_cluster_profile_frames` under an **active** `profile_capture` on arrow frames — the concrete leak this branch fixed (asserts the `ClusterProfile` is populated + `transitivity_rate == 1.0`, so a no-op emitter can't defeat the test)

Byte-identical cluster parity on the polars path stays covered by `test_cluster_frames_out_parity` / `test_build_clusters_arrow_native_parity`.

Local: 34 cluster + gate tests pass, new tripwire green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)