### PR TITLE
feat: negative evidence on Fellegi-Sunter matchkeys (Formulation B, EM-learned)

### DIFF
--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -52,6 +52,15 @@ matchkeys:
       - field: zip
         scorer: exact
         levels: 2
+    negative_evidence:
+      # Fires (and subtracts weight) when both values are present AND
+      # scorer(a, b) < threshold; agreement/missing never adds weight.
+      # Omit penalty_bits for EM-learned; probabilistic matchkeys reject
+      # `penalty` (that knob is weighted/exact-only) -- see Scoring.
+      - field: phone
+        scorer: exact
+        threshold: 1.0
+        # penalty_bits: 6.0   # optional: fixed log2 LLR override, skips EM
 
   - name: semantic
     type: weighted

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -155,7 +155,7 @@ Two ways to set the fired weight:
 
 `penalty` (the weighted/exact knob) and `penalty_bits` are mutually exclusive by matchkey type: weighted/exact matchkeys still require `penalty` and reject `penalty_bits`; probabilistic matchkeys reject `penalty` and accept `penalty_bits` (or neither, for EM-learned).
 
-An unregistered/unknown NE scorer on a probabilistic matchkey **fails loudly** at validation time — unlike the weighted path, which silently swallows a broken NE scorer and warns. This is intentional: FS negative evidence is new enough that a silent no-op would be worse than a hard error.
+An unregistered/unknown NE scorer on a probabilistic matchkey **fails loudly** at train/score time (`score_field` raises on unknown scorers; there is no `_NE_BROKEN` swallow on FS) — unlike the weighted path, which silently swallows a broken NE scorer and warns. This is intentional: FS negative evidence is new enough that a silent no-op would be worse than a hard error.
 
 Guards: the native kernel, the fused-match path, and the fast-path scorer all decline NE-bearing FS matchkeys (pure-Python fallback only; a kernel port is a future phase). Persisted/imported EM models trained before this feature (including imported Splink models) fail loudly on load if the matchkey has NE fields without `penalty_bits` and the model lacks the corresponding trained weights, rather than silently scoring NE at weight 0 — retrain, or set `penalty_bits` to bypass EM entirely. NE is not supported on the continuous/Winkler EM path (`train_em_continuous`), which rejects it with a clear error.
 

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -126,6 +126,39 @@ Key details:
 - Comparison vectors apply field transforms before scoring
 - **Achieves P=0.978 / R=0.958 / F1=0.968 on DBLP-ACM** (full-block vectorized scoring). The old "98.8% / 57.6%" figure was a benchmark artifact — a per-block size cap, not the scorer.
 
+### Negative evidence on Fellegi-Sunter matchkeys
+
+`negative_evidence` is valid on `type: probabilistic` matchkeys (not just `weighted`/`exact`). Each NE field is a constrained EM-learned dimension: it **fires** when both values are present and `scorer(a, b) < threshold` (strict `<`), contributing `log2(m_fired/u_fired)` bits when fired and **exactly 0 when not fired** — that fired-else-zero clamp is what makes it negative evidence rather than a normal scored field (agreement never adds weight; only a hard disagreement subtracts it).
+
+```yaml
+matchkeys:
+  - name: fs_person
+    type: probabilistic
+    fields:
+      - field: first_name
+        scorer: jaro_winkler
+        levels: 2
+        partial_threshold: 0.8
+      - field: city
+        scorer: exact
+        levels: 2
+    negative_evidence:
+      - field: phone
+        scorer: exact
+        threshold: 1.0
+        # penalty_bits: 6.0   # optional fixed override, see below
+```
+
+Two ways to set the fired weight:
+- **EM-learned (default):** omit `penalty_bits`. The weight is estimated from data during `train_em` the same way every other field's m/u is — `m_fired = P(fired | match)`, `u_fired = P(fired | non-match)`, both from the same EM loop and random-pair sample as the regular fields.
+- **`penalty_bits` (fixed override):** a literal log2 LLR in bits; the fired contribution is exactly `-abs(penalty_bits)`, no EM training for that dimension. Useful when you know the right veto strength (e.g. migrating a Splink config) without waiting on EM to converge on enough data.
+
+`penalty` (the weighted/exact knob) and `penalty_bits` are mutually exclusive by matchkey type: weighted/exact matchkeys still require `penalty` and reject `penalty_bits`; probabilistic matchkeys reject `penalty` and accept `penalty_bits` (or neither, for EM-learned).
+
+An unregistered/unknown NE scorer on a probabilistic matchkey **fails loudly** at validation time — unlike the weighted path, which silently swallows a broken NE scorer and warns. This is intentional: FS negative evidence is new enough that a silent no-op would be worse than a hard error.
+
+Guards: the native kernel, the fused-match path, and the fast-path scorer all decline NE-bearing FS matchkeys (pure-Python fallback only; a kernel port is a future phase). Persisted/imported EM models trained before this feature (including imported Splink models) fail loudly on load if the matchkey has NE fields without `penalty_bits` and the model lacks the corresponding trained weights, rather than silently scoring NE at weight 0 — retrain, or set `penalty_bits` to bypass EM entirely. NE is not supported on the continuous/Winkler EM path (`train_em_continuous`), which rejects it with a clear error.
+
 ### Splink-parity surface
 
 The Fellegi-Sunter matchkey is a full probabilistic-linkage engine, not just a scorer:

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -591,8 +591,7 @@ Every `GOLDENMATCH_*` variable the package reads, grouped by who should care. De
 | `GOLDENMATCH_FS_VECTORIZED` | on | Vectorized FS block scoring (~9x). `0` = scalar. |
 | `GOLDENMATCH_FS_CALIBRATED` | `linear` | `posterior` = true-probability calibration (frontier-neutral). |
 | `GOLDENMATCH_FS_MONOTONIC` | on | Enforce monotonic EM weights. |
-| `GOLDENMATCH_FS_NATIVE` | on | Native FS kernel when available. |
-| `GOLDENMATCH_NE_FS_ESCAPE_MODE` | — | Negative-evidence FS escape mode. |
+| `GOLDENMATCH_FS_NATIVE` | on | Native FS kernel when available (declines NE-bearing matchkeys; pure-Python fallback). |
 | `GOLDENMATCH_NOISE_AWARE_SCORERS` | `1` (on) | Auto-upgrade `token_sort`→`jaro_winkler` on noisy text. `0` = legacy. |
 | `GOLDENMATCH_NOISE_AWARE_TARGET` | `jaro_winkler` | Override the noise-aware target scorer. |
 | `GOLDENMATCH_GOLDEN_STRATEGY_STRICT` | `0` | Strict golden survivorship. |

--- a/docs/superpowers/plans/2026-07-14-fs-negative-evidence.md
+++ b/docs/superpowers/plans/2026-07-14-fs-negative-evidence.md
@@ -1,0 +1,134 @@
+# FS Negative Evidence (Formulation B) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `negative_evidence` works on probabilistic matchkeys: each NE field is an EM-learned constrained dimension contributing `log2(m_fire/u_fire)` when it FIRES (both present + `scorer < threshold`) and exactly 0 otherwise, with a `penalty_bits` fixed override — killing the homonym/fan-out snowball failure mode for FS configs (incl. every Splink-converted config).
+
+**Architecture:** Extend `train_em` with appended NE dimensions stored as `__ne__<field>` entries in the existing EMResult dicts (schema-v1-transparent, cross-surface free). Scoring paths (scalar/vectorized/batch/bucket) add the fired-else-zero contribution; weight-range normalization is CENTRALIZED into one helper replacing six hand-rolled sites. Native/fused/fast paths decline NE matchkeys (capability-gate playbook). `validate_for` fails loudly on models lacking NE parameters.
+
+**Tech Stack:** Pure Python (thesis phase 1). No new modules — all changes ride existing files, so the zero-polars import gates are not at risk (still: never add a top-level `import polars`; the lazy proxy is the law).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md` (worktree — READ FIRST; every mechanism is pinned there with verified code anchors).
+
+**Working branch:** `feat/fs-negative-evidence` (worktree `..\goldenmatch-wt-splink-converter`, off current main). Package root: `packages/python/goldenmatch/`.
+
+**Env (Windows box):**
+```powershell
+cd D:\show_case\goldenmatch-wt-splink-converter\packages\python\goldenmatch
+$env:PYTHONPATH = "D:\show_case\goldenmatch-wt-splink-converter\packages\python\goldenmatch"
+$env:POLARS_SKIP_CPU_CHECK = "1"; $env:PYTHONIOENCODING = "utf-8"
+D:\show_case\goldenmatch\.venv\Scripts\python.exe -m pytest tests/<file> -v
+```
+Targeted test files ONLY. NEVER `git stash`. Pre-push: ruff (0.15.12) + pyright 1.1.409 (config/ + core are strict CI surfaces — but check pyrightconfig include for core/; write strict-clean regardless). The worktree has an in-tree native build — do NOT set `GOLDENMATCH_NATIVE=0` on final runs so native-gated tests exercise the real gates.
+
+**Verified anchors (from spec review):** weighted-NE firing is STRICT `<` (`core/scorer.py:292`, `backends/score_buckets.py:942`); `NegativeEvidenceField` `config/schemas.py:204` (validator `_validate_transforms_and_scorer` ~:225); matchkey validator `_validate_weighted` `schemas.py:341-369`; `train_em` matrix build `core/probabilistic.py:537-640` (int8 matrix `:435`); monotone repair `skip_fields` hook `:153`; weight-range hand-rolled at `probabilistic.py` ~1305, ~1563, ~1675, ~1966, ~2040 + `core/probabilistic_fast.py` ~79; `validate_for` `:272`; `_fs_native_eligible` `:1897`; `match_fused_fs_ready` `core/fused_match.py:255`; bucket slim projection `backends/score_buckets.py:583-604`; `derive_from` materialization is already type-agnostic (`core/matchkey.py:366-401` + frame twin `:448-479`); `train_em_continuous` `:989`.
+
+---
+
+## File structure (no new modules)
+
+- `goldenmatch/config/schemas.py` — NegativeEvidenceField (`penalty` optional, `penalty_bits` new, validator matrix), MatchkeyConfig validator, stale-doc removal.
+- `goldenmatch/core/probabilistic.py` — NE event encoding + EM dimensions, scoring contributions, centralized weight-range helper, validate_for, native gate, monotone skip, continuous rejection.
+- `goldenmatch/core/probabilistic_fast.py` — gate decline.
+- `goldenmatch/core/fused_match.py` — ready-gate decline.
+- `goldenmatch/backends/score_buckets.py` — slim-projection keep-list + bucket-path NE contribution (VERIFY in N3 whether the bucket path routes through score_probabilistic or scores independently — if independent, it needs the same contribution logic or must route to the non-bucket path for NE matchkeys; investigate and pick, mirroring how level_thresholds was handled there if at all).
+- Tests: `tests/test_fs_ne_schema.py`, `tests/test_fs_ne_em.py`, `tests/test_fs_ne_scoring.py`, `tests/test_fs_ne_guards.py`, `tests/test_fs_ne_e2e.py` (all new).
+
+---
+
+### Task N1: schema surface
+
+**Files:** Modify `goldenmatch/config/schemas.py`; create `tests/test_fs_ne_schema.py`.
+
+- [ ] **Failing tests (TDD):**
+  - probabilistic matchkey + NE field with `penalty_bits=3.0` (no `penalty`) → validates.
+  - probabilistic + NE with `penalty=0.4` → ValidationError naming `penalty_bits` ("probabilistic matchkeys use EM-learned weights; set penalty_bits to override").
+  - weighted + NE WITHOUT `penalty` → ValidationError (existing requirement now enforced in the matchkey validator).
+  - weighted + NE with `penalty_bits` → ValidationError (weighted rejects it).
+  - exact + NE with `penalty=0.4` → validates (byte-unchanged).
+  - probabilistic + NE with NEITHER penalty nor penalty_bits → validates (EM-learned default).
+  - `penalty_bits=-2` → validates (abs taken at scoring; or reject negatives — pick: ACCEPT any float, document abs; test pins it).
+  - Existing YAML round-trip: a weighted-NE config dict from the current test suite still parses identically.
+- [ ] **Implement:** `NegativeEvidenceField.penalty: float | None = Field(default=None, ge=0.0, le=1.0)`; add `penalty_bits: float | None = None` with doc comment (log2 LLR override, probabilistic-only, abs() applied, fires-else-zero). Per-type rules go in `MatchkeyConfig._validate_weighted` (it already branches on type): weighted/exact NE entries require `penalty is not None` + reject `penalty_bits`; probabilistic NE entries reject `penalty` + allow `penalty_bits` None-or-float. REMOVE the stale v1.13 comment block (`schemas.py:315-327`) incl. the `GOLDENMATCH_NE_FS_ESCAPE_MODE` line; replace with 3 lines pointing at the new spec.
+- [ ] Run `tests/test_fs_ne_schema.py tests/test_config.py` → PASS (if any existing test constructed weighted NE relying on schema-level required `penalty` error TYPE, adjust expectations only if the error still raises — it must, just from the matchkey validator now).
+- [ ] **Commit** `feat(schemas): negative_evidence on probabilistic matchkeys + penalty_bits`.
+
+### Task N2: EM learns NE dimensions
+
+**Files:** Modify `goldenmatch/core/probabilistic.py`; create `tests/test_fs_ne_em.py`.
+
+- [ ] **Failing tests:**
+  - `_ne_fired(row_a, row_b, ne_field)` unit: both present + `score < threshold` → True; score == threshold → False (STRICT); either side null/empty → False; transforms applied before scoring.
+  - `train_em` on a ~200-row fixture (planted duplicate pairs where the NE field — phone — agrees within true matches, plus cross-entity name collisions where phone differs): result contains `m_probs["__ne__phone"]`/`u_probs["__ne__phone"]`/`match_weights["__ne__phone"]`; m/u lists are length 2 [fired, not_fired] summing to ~1; `match_weights["__ne__phone"] == [log2(m0/u0), 0.0]` — the not-fired weight is EXACTLY 0.0 (the clamp), NOT log2(m1/u1); w_fired < 0 on this fixture (matches rarely fire).
+  - `penalty_bits` NE field → NO `__ne__` entries in the result (excluded from EM).
+  - NE field also a blocking field → a warning is logged (`caplog`) naming the field + degeneracy.
+  - Monotone repair — BOTH modes tested: `enforce` (monkeypatched) → `__ne__` entries untouched; `warn` (default) with a contrived positive w_fired → no detection message names the __ne__ key. Implementation: UNION the __ne__ keys with the existing `skip_fields=blocking_fields` at both call sites (probabilistic.py:691, :878; hook signature `skip_fields: list[str] | None` at :151-154).
+  - Regular-field results unchanged by adding an NE field (compare m_probs for regular fields with/without NE present, same seed — EM posteriors WILL shift because NE evidence enters the E-step; so assert instead: without-NE run is byte-identical to pre-change behavior via an existing test staying green, and document that adding NE legitimately changes posteriors).
+- [ ] **Implement:**
+  - `_ne_fired(...)` helper reusing `apply_transforms` + `score_field`, strict `<`.
+  - **row_lookup projection (stall-preventer):** `train_em` builds `row_lookup` from
+    `cols = [f.field for f in mk.fields ...]` (probabilistic.py:543-546) — NE-ONLY fields (the
+    canonical phone case) are NOT in it, so `_ne_fired` would see missing keys → treated as null →
+    NE never fires in EM → degenerate m/u. EXTEND the select with NE field names + `derive_from`
+    synthesized names.
+  - `_build_comparison_matrix` / `comparison_vector` extension: NE dims appended AFTER regular fields — cleanest: a parallel `_build_ne_matrix(pairs, row_lookup, mk) -> np.ndarray (n_pairs x n_ne)` of {0=fired, 1=not_fired} int8, rather than overloading comparison_vector's contract (its consumers assume len == len(mk.fields)); train_em consumes both matrices.
+  - `train_em`: u for NE dims from the same random-pair matrix; m initialized (prior: fired rare in matches — e.g. [0.05, 0.95]) and updated in the SAME E/M loop (the E-step per-pair log-likelihood sums must include NE dims). Blocking-field neutralization does NOT apply to NE dims. `penalty_bits` fields skipped entirely. After convergence: `match_weights["__ne__<f>"] = [log2(max(m0,1e-10)/max(u0,1e-10)), 0.0]`.
+  - Blocking-overlap warning: compare NE field names against `blocking_fields` param + (when blocks came from config) the blocking key fields — emit `logger.warning` once per offending field.
+  - Monotone repair: pass `skip_fields={k for k in weights if k.startswith("__ne__")}` via the existing hook.
+  - `_fallback_result` (DECIDED): emits a fixed conservative `w_fired = -3.0` bits entry
+    (`match_weights["__ne__<f>"] = [-3.0, 0.0]`, m/u backfilled consistently) per
+    non-penalty_bits NE field, WITH a logged warning — keeps the pipeline runnable on tiny data
+    instead of tripping validate_for. Pin with a test.
+- [ ] Run `tests/test_fs_ne_em.py tests/test_probabilistic.py tests/test_nlevel_em.py` → PASS (existing suites prove no-NE behavior unchanged).
+- [ ] **Commit** `feat(probabilistic): EM-learned NE dimensions (__ne__ entries, strict-< firing)`.
+
+### Task N3: scoring + centralized weight range + bucket path
+
+**Files:** Modify `goldenmatch/core/probabilistic.py`, `goldenmatch/backends/score_buckets.py`; create `tests/test_fs_ne_scoring.py`.
+
+- [ ] **Investigate first (report in commit):** how the DEFAULT bucket backend scores probabilistic matchkeys — does `score_buckets.py` route through `score_probabilistic`/the vectorized scorer (then only the slim-projection keep-list needs fixing) or does it have its own scoring? Also how `level_thresholds` reached the bucket path (it did — the parity tests pass on the default backend). Mirror that route.
+- [ ] **Failing tests:**
+  - Centralized range helper `fs_weight_range(em, mk) -> (min_weight, max_weight)`: unit test with regular + NE + penalty_bits fields (penalty_bits contributes `-abs(bits)` to min, 0 to max; missing `__ne__` entry with penalty_bits set is fine; regular fields contribute min/max of their weight lists).
+  - Scalar scoring: a pair where NE fires → total = regular sum + w_fired; not fired → regular sum exactly; null on one side → regular sum exactly.
+  - `penalty_bits=3.0` → fired contribution == -3.0 even with no `__ne__` entry in em.
+  - Scalar vs vectorized parity: same block, NE-bearing matchkey → identical pair sets + scores (mirror TestNativeFSParity's idiom).
+  - Normalized scores stay in [0,1] when NE fires at the extremes (all-fire pair at min weight).
+  - Bucket/default-backend: dedupe_df on a small df with an NE-ONLY field (phone not in mk.fields) → NE demonstrably fires (pair that would merge without NE does not merge with it) — THIS is the slim-projection pin; run WITHOUT env overrides (default backend, native enabled — native declines NE so it falls back pure-Python; that's fine and separately pinned in N4).
+  - Continuous path: `train_em_continuous`/`score_probabilistic_continuous` with NE present → clear error (`NotImplementedError` or ValueError naming the limitation).
+- [ ] **Implement:**
+  - `fs_weight_range(em, mk)` in probabilistic.py; REPLACE the hand-rolled sums at probabilistic.py ~1305, ~1563, ~1675, ~1966, ~2040 and probabilistic_fast.py ~79 (the native-prep sites ~1966/~2040 feed the kernel — since native DECLINES NE matchkeys, those sites see no NE fields, but centralizing them anyway prevents drift; verify kernel args unchanged for non-NE configs via existing native parity tests).
+  - Scalar path: after the regular-field weight sum, loop `mk.negative_evidence or []`: penalty_bits → `-abs(bits)` if `_ne_fired` else 0; else `em.match_weights["__ne__"+f.field][0]` if fired else 0.
+  - Vectorized path: per NE field build the similarity matrix via the existing `_field_score_matrix_dedup` machinery + null masks → fired mask (`sim < threshold` & both-present) → add `w_fired * fired_mask` to the total-weight matrix. Same for the batch scorer if it's a distinct code path (check ~1675 site).
+  - Bucket: slim-projection keep-list extended with NE field names + `derive_from` sources + synthesized names (`score_buckets.py:583-604`); plus whatever the Step-1 investigation says about the scoring route.
+  - Continuous: reject NE at entry with a clear message.
+- [ ] Run `tests/test_fs_ne_scoring.py tests/test_fs_ne_em.py tests/test_probabilistic.py tests/test_probabilistic_vectorized.py tests/test_nlevel_banding.py` → PASS.
+- [ ] **Commit** `feat(probabilistic): NE scoring contributions + centralized fs_weight_range + bucket keep-list`.
+
+### Task N4: guards + validate_for
+
+**Files:** Modify `goldenmatch/core/probabilistic.py`, `goldenmatch/core/probabilistic_fast.py`, `goldenmatch/core/fused_match.py`; create `tests/test_fs_ne_guards.py`.
+
+- [ ] **Failing tests:**
+  - `_fs_native_eligible` False for NE-bearing matchkey (synthetic supporting-native mock — reuse the level_thresholds test scaffolding in tests/test_nlevel_banding.py); plain matchkey unaffected; REAL kernel test (skipif) also declines.
+  - Router selects the non-native scorer for NE matchkeys with native mocked available.
+  - `match_fused_fs_ready` False on NE (mirror test_fused_match.py's gate tests).
+  - `_resolve_probabilistic_fast_path` declines NE.
+  - `validate_for`: model WITHOUT `__ne__phone` + matchkey with NE phone (no penalty_bits) → FSModelMismatchError naming the field + both remedies; WITH penalty_bits → passes without the key; model WITH the key → passes; wrong length (not 2) → error.
+- [ ] **Implement:** one-line gate additions following each gate's existing style (docstrings updated: "NE never crosses the FFI; future kernel port adds FS_SUPPORTS_NE"); `validate_for` extension per spec.
+- [ ] Run `tests/test_fs_ne_guards.py tests/test_fused_match.py tests/test_nlevel_banding.py` (native enabled) → PASS.
+- [ ] **Commit** `feat(probabilistic): NE guards -- native/fused/fast decline + validate_for`.
+
+### Task N5: E2E success bar + docs + back-compat sweep
+
+**Files:** Create `tests/test_fs_ne_e2e.py`; modify CHANGELOG, docs-site, the 2026-05-21 investigation doc.
+
+- [ ] **The success-bar test (deterministic, DEFAULT backend, native enabled):** synthetic fixture — N true duplicate pairs (name+city+phone agree) PLUS homonym traps (distinct people sharing name+city, DIFFERENT phone). Config A: probabilistic matchkey on name+city (no NE) → assert the homonyms MERGE (the failure). Config B: same + phone as NE → assert homonyms SEPARATE and true duplicates STILL MERGE. Drive via `dedupe_df`. Make the fixture surname-soundex-diverse (project rule). If Config A doesn't merge homonyms naturally, strengthen the name/city evidence (more agreeing fields) until it does — the test must demonstrate the DELTA, not a vacuous pass; document the fixture reasoning in its docstring.
+  - Same test parametrized with `penalty_bits` instead of EM-learned → same qualitative outcome.
+- [ ] **Docs:** CHANGELOG Unreleased (NE on FS, Formulation B, EM-learned, penalty_bits, guards); `docs/superpowers/specs/2026-05-21-ne-fs-investigation.md` gets a SUPERSEDED header block pointing at the new spec ("Formulation B implemented 2026-07-14 with EM-learned parameters; the labeled-data deferral rationale was stale"); docs-site scoring.mdx (NE section: now valid on probabilistic, semantics, penalty_bits) + configuration.mdx if it documents negative_evidence; grep docs-site for "weighted + exact" NE claims and fix.
+- [ ] **Back-compat sweep:** run the EXISTING weighted/exact NE tests untouched (`grep -rln "negative_evidence" tests/ | head` → run those files) + `tests/test_fs_autoconfig_v2.py tests/test_from_splink_api.py tests/test_splink_upgrade_levers.py` → all green, zero edits to existing NE tests.
+- [ ] **Commit** `test(probabilistic): FS-NE homonym success bar + docs`.
+
+### Task N6: land it
+
+- [ ] Pre-push: `ruff check packages/python/goldenmatch`; pyright (repo config); the full new-test set + regression files in ONE invocation; confirm NO new module-level polars imports (`git diff origin/main..HEAD | grep -n "^+import polars\|^+from polars"` → empty).
+- [ ] Push (benzsevern token-URL), PR titled `feat: negative evidence on Fellegi-Sunter matchkeys (Formulation B, EM-learned)` with the homonym-fixture evidence + the supersession story in the body, `gh pr merge --auto`, background-watch to merged; fix CI reds (lessons: zero-polars gates, ruff import sorts, pyright strict on config//core, shard timeouts).

--- a/docs/superpowers/specs/2026-05-21-ne-fs-investigation.md
+++ b/docs/superpowers/specs/2026-05-21-ne-fs-investigation.md
@@ -1,6 +1,15 @@
 # Wave D investigation: Negative Evidence on Fellegi-Sunter matchkeys
 
-**Status:** investigation outcome (Wave D)
+> **SUPERSEDED (2026-07-14):** Formulation B (the Bayesian-factor approach this
+> doc judged mathematically correct) was implemented with EM-learned
+> parameters — see
+> `docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md`. The
+> labeled-data deferral rationale below is stale: EM estimates
+> match-conditional probabilities (`P(disagree_NE | match)`) for every regular
+> FS field without labels, and the same machinery estimates them for NE
+> dimensions. This doc is retained for historical context only.
+
+**Status:** investigation outcome (Wave D) — superseded, see above
 **Issue:** https://github.com/benseverndev-oss/goldenmatch/issues/126
 **Date:** 2026-05-21
 **Spec:** `docs/superpowers/specs/2026-05-21-ne-fellegi-sunter-design.md`

--- a/docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
+++ b/docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
@@ -24,7 +24,9 @@ The planned fan-out upgrade lever (v2) is blocked on this core capability.
 Treat an NE disagreement as an additional likelihood factor preserving LLR additivity:
 
 ```
-fired      = both values present (post-transform) AND scorer(a, b) <= threshold
+fired      = both values present (post-transform) AND scorer(a, b) < threshold   # STRICT <, matching
+                                                                                  # weighted NE (core/scorer.py:292,
+                                                                                  # backends/score_buckets.py:942)
 m_ne       = P(fired | match)        # EM-learned (or penalty_bits override)
 u_ne       = P(fired | non-match)    # from random pairs, like every u
 w_fired    = log2(m_ne / u_ne)       # negative when matches rarely fire
@@ -65,9 +67,16 @@ would credit agreement.
   stores `[w_fired, 0.0]`. This rides EMResult schema v1 unchanged (plain dict entries; TS serde
   passes them through; `to_dict`/`from_dict`/`save_json` untouched) -- cross-surface compatible
   for free.
-- The monotone-weights repair (`GOLDENMATCH_FS_MONOTONIC`) must NOT touch `__ne__` entries
-  ([w_fired, 0.0] is intentionally "decreasing" when w_fired < 0... it is [fired, not_fired]
-  ordered, not level-ordered -- exclude NE keys from the repair pass).
+- The monotone-weights repair (`GOLDENMATCH_FS_MONOTONIC`) must exclude `__ne__` entries.
+  Rationale: `[w_fired, 0.0]` is [fired, not_fired]-ordered, not level-ordered. In the normal
+  case (w_fired < 0) the list is non-decreasing and PAV would leave it alone anyway; the
+  exclusion is defensive for the degenerate w_fired > 0 case AND kills the false detection
+  warning `warn` mode would emit. The repair helper already has a `skip_fields` hook
+  (probabilistic.py:153) -- use it.
+- NE field names must NOT appear among the blocking key fields: within-block m-estimation is
+  degenerate when blocking guarantees the NE field agrees (NE never fires in the EM sample).
+  Validation: warning finding/log at train time when an NE field is also a blocking field
+  (not a hard error -- multi-pass blocking may only partially overlap).
 
 ## Scoring
 
@@ -78,8 +87,23 @@ would credit agreement.
   threshold.
 - Normalization/calibration: the min/max total-weight range used by linear normalization and
   `compute_thresholds` must include NE ranges -- min includes `sum(min(w_fired, 0))`, max includes
-  `sum(max(w_fired, 0))` (w_fired is normally negative, so max adds 0). Posterior calibration
-  needs no change (weights are weights).
+  `sum(max(w_fired, 0))` (w_fired is normally negative, so max adds 0). Storing
+  `[w_fired, 0.0]` means `min(list)`/`max(list)` over the `__ne__` entry reproduces these bounds
+  for free IF the range computation iterates all match_weights entries relevant to the matchkey.
+  The range sum is HAND-ROLLED at ~6 sites -- probabilistic.py ~1305, ~1563, ~1675, ~1966, ~2040
+  and probabilistic_fast.py ~79 -- the plan must either centralize it or enumerate and update
+  EVERY site (a missed site produces out-of-[0,1] normalized scores only when NE fires).
+  Posterior calibration needs no change (weights are weights).
+- **Bucket backend slim projection (CRITICAL, easy to miss):** `backends/score_buckets.py:583-604`
+  keeps raw source columns for probabilistic scoring only for `f in mk.fields`; an NE-only field
+  (the canonical phone example) is projected away under the default-on
+  `GOLDENMATCH_BUCKET_SLIM_PROJECTION`, so FS NE would silently never fire on the default bucket
+  backend. Extend the keep-list with `mk.negative_evidence` fields (incl. `derive_from` source
+  columns and synthesized names). The E2E success-bar test must run on the DEFAULT backend to
+  pin this.
+- `core/probabilistic_fast.py` `_resolve_probabilistic_fast_path`: add a negative_evidence
+  decline to its gate (parity-tested fast path currently test-only; a future re-wire must not
+  resurrect the silent-ignore).
 - Continuous/Winkler path (`train_em_continuous` / `score_probabilistic_continuous`): OUT of
   scope -- NE fields are rejected with a clear error if that path is selected with NE present
   (document; that path is already N-level-untested).
@@ -122,3 +146,6 @@ import time -- out of scope here.)
   mechanism).
 - Autoconfig suggesting NE fields on probabilistic matchkeys.
 - Continuous/Winkler-path NE.
+- Explain/evaluate surfaces showing NE contributions (probabilistic.py ~2112, core/evaluate.py
+  ~242 -- they won't break, they just won't itemize NE; follow-up so explain output doesn't
+  misstate totals).

--- a/docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
+++ b/docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
@@ -1,0 +1,124 @@
+# Negative Evidence on Fellegi-Sunter Matchkeys (Formulation B, EM-learned)
+
+**Date:** 2026-07-14
+**Status:** Approved (design)
+**Thesis phase:** Python POC (Rust kernel port + TS surface are later phases, out of scope)
+**Supersedes:** the deferral in `docs/superpowers/specs/2026-05-21-ne-fs-investigation.md` (Wave D,
+issue #126). That doc ruled Formulation B (Bayesian factor) mathematically correct but deferred it
+because `P(disagree_NE | match)` was thought to require labeled pairs. The rationale is stale: EM
+estimates match-conditional probabilities for every regular FS field without labels -- the same
+machinery estimates them for NE dimensions. This spec implements Formulation B with EM-learned
+parameters. The investigation doc gets a superseded-by note; the vaporware
+`GOLDENMATCH_NE_FS_ESCAPE_MODE` doc line (never implemented) is removed rather than implemented.
+
+## Problem
+
+`negative_evidence` is silently ignored on `type: probabilistic` matchkeys (weighted/exact only).
+The Splink-converter output is exactly one probabilistic matchkey, so migrated configs have no
+negative-evidence defense against fan-out/homonym snowballs (two distinct people sharing
+name+city merge because name evidence dominates; a hard phone/email disagreement should veto).
+The planned fan-out upgrade lever (v2) is blocked on this core capability.
+
+## Formulation (from the Wave D investigation, Formulation B)
+
+Treat an NE disagreement as an additional likelihood factor preserving LLR additivity:
+
+```
+fired      = both values present (post-transform) AND scorer(a, b) <= threshold
+m_ne       = P(fired | match)        # EM-learned (or penalty_bits override)
+u_ne       = P(fired | non-match)    # from random pairs, like every u
+w_fired    = log2(m_ne / u_ne)       # negative when matches rarely fire
+contribution = w_fired if fired else 0.0
+```
+
+The `else 0.0` clamp is what makes it NEGATIVE evidence: agreement (or a missing value on either
+side) never boosts the score. This differs from adding the field as a regular FS dimension, which
+would credit agreement.
+
+## Config surface
+
+- `MatchkeyConfig._validate_weighted`: probabilistic matchkeys may carry `negative_evidence`.
+- `NegativeEvidenceField` changes (`config/schemas.py:204`):
+  - `penalty: float | None` -- RELAXED to optional at the schema level. The matchkey validator
+    enforces per-type rules: weighted/exact REQUIRE `penalty` (existing semantics, byte-untouched);
+    probabilistic REJECTS `penalty` (validation error with a message naming `penalty_bits`) --
+    no silent no-op knobs.
+  - NEW `penalty_bits: float | None` -- fixed LLR override in log2 units, probabilistic-only
+    (weighted/exact REJECT it). When set, the NE dimension skips EM and contributes
+    `-abs(penalty_bits)` when fired.
+- Stale docs removed: the v1.13 "intentionally NOT extended" comment block and the
+  `GOLDENMATCH_NE_FS_ESCAPE_MODE` mention in `config/schemas.py`.
+- `derive_from` (synthesized columns) works for FS NE the same way it does for weighted NE.
+
+## EM integration
+
+- NE dimensions join `train_em` as constrained 2-state dimensions appended after the regular
+  fields in the comparison matrix. Event encoding: state 0 = fired, state 1 = not-fired
+  (INCLUDING nulls -- NE requires both sides present; v1.11 semantics preserved). Note this null
+  handling deliberately differs from regular fields (where null -> disagree).
+- u for NE dimensions comes from the same random-pair sample as regular u; m via the same EM loop.
+  Blocking-field neutralization does NOT apply to NE dimensions (they are never blocking keys).
+- `penalty_bits` NE fields are excluded from EM entirely.
+- Storage: entries in the EXISTING `m_probs` / `u_probs` / `match_weights` dicts keyed
+  `__ne__<field>` (no collision when a field is both a comparison field and an NE field; e.g.
+  phone). Two-element lists indexed [fired, not_fired] for m/u; `match_weights["__ne__<field>"]`
+  stores `[w_fired, 0.0]`. This rides EMResult schema v1 unchanged (plain dict entries; TS serde
+  passes them through; `to_dict`/`from_dict`/`save_json` untouched) -- cross-surface compatible
+  for free.
+- The monotone-weights repair (`GOLDENMATCH_FS_MONOTONIC`) must NOT touch `__ne__` entries
+  ([w_fired, 0.0] is intentionally "decreasing" when w_fired < 0... it is [fired, not_fired]
+  ordered, not level-ordered -- exclude NE keys from the repair pass).
+
+## Scoring
+
+- Scalar path (`comparison_vector` consumers) and vectorized path (`score_probabilistic` /
+  `score_probabilistic_vectorized` / the block scorer): after summing regular field weights, add
+  the NE contributions (`w_fired` when fired else 0). NE firing uses the SAME scorer machinery
+  (`score_field` / the vectorized similarity matrices) with the NE field's transforms + scorer +
+  threshold.
+- Normalization/calibration: the min/max total-weight range used by linear normalization and
+  `compute_thresholds` must include NE ranges -- min includes `sum(min(w_fired, 0))`, max includes
+  `sum(max(w_fired, 0))` (w_fired is normally negative, so max adds 0). Posterior calibration
+  needs no change (weights are weights).
+- Continuous/Winkler path (`train_em_continuous` / `score_probabilistic_continuous`): OUT of
+  scope -- NE fields are rejected with a clear error if that path is selected with NE present
+  (document; that path is already N-level-untested).
+
+## Native + fused guards
+
+Same playbook as level_thresholds: `_fs_native_eligible` declines matchkeys with
+`negative_evidence` (pure-Python fallback; a future kernel port adds `FS_SUPPORTS_NE`);
+`match_fused_fs_ready` declines likewise. Both pinned by tests.
+
+## Persisted / imported models
+
+`EMResult.validate_for` extended: a probabilistic matchkey with NE fields requires
+`match_weights["__ne__<field>"]` for each NE field WITHOUT `penalty_bits`; missing ->
+`FSModelMismatchError` naming the field and the two remedies (retrain, or set `penalty_bits`).
+Models trained before this feature and imported Splink models therefore fail loudly instead of
+silently scoring NE at weight 0. (The fan-out upgrade lever will compute `__ne__` entries at
+import time -- out of scope here.)
+
+## Testing / success bar
+
+- Schema validation matrix (penalty/penalty_bits x matchkey types; both-set; neither-set).
+- Event encoding unit tests: fired / not-fired / null-on-either-side / transforms applied.
+- EM: `__ne__` m/u entries sum to 1 across [fired, not_fired]; penalty_bits fields absent from
+  EM; monotone repair leaves `__ne__` entries alone.
+- Scoring parity: scalar vs vectorized identical totals on NE-bearing matchkeys; penalty_bits
+  override honored; normalization range includes NE.
+- Guards: native + fused decline; validate_for missing-NE-keys error; continuous-path rejection.
+- Back-compat: weighted/exact NE behavior byte-untouched (existing NE tests green, no edits).
+- **Success bar (deterministic E2E test):** a synthetic homonym fixture -- two distinct people
+  sharing name+city but differing on phone -- where FS WITHOUT NE merges them and FS WITH NE
+  (phone as NE field) separates them while true duplicate pairs still merge. The fan-out failure
+  mode this feature exists to kill, pinned as a test.
+
+## Out of scope
+
+- Rust kernel port (`FS_SUPPORTS_NE`) and TS surface (thesis phases 2-3).
+- The fan-out upgrade lever (next feature; consumes this).
+- Corrections-based refinement of m_ne (compatible later -- improves the estimate, not the
+  mechanism).
+- Autoconfig suggesting NE fields on probabilistic matchkeys.
+- Continuous/Winkler-path NE.

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -7,6 +7,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ## [Unreleased]
 
 ### Added
+- **Negative evidence on Fellegi-Sunter (`type: probabilistic`) matchkeys**
+  (Formulation B, EM-learned): `negative_evidence` was previously silently
+  ignored on probabilistic matchkeys (weighted/exact only), which meant every
+  Splink-converted config — exactly one FS matchkey — had no defense against
+  the fan-out/homonym snowball (two distinct people sharing name+city merging
+  because name evidence dominates). Each NE field now joins `train_em` as a
+  constrained EM-learned dimension contributing `log2(m_fired/u_fired)` when
+  it FIRES (both values present + `scorer(a, b) < threshold`, strict `<`) and
+  exactly 0 otherwise — the fired-else-zero clamp is what makes it negative
+  evidence rather than a regular scored field. `NegativeEvidenceField` gets a
+  new `penalty_bits` (log2 LLR fixed override, probabilistic-only, `abs()`
+  applied) alongside the existing `penalty` (still required on weighted/exact,
+  now rejected on probabilistic — set `penalty_bits` instead). Guards: native,
+  fused, and the fast-path scorer all decline NE-bearing FS matchkeys (pure
+  Python fallback; a future kernel port adds `FS_SUPPORTS_NE`); the bucket
+  backend's slim-projection keep-list was extended so an NE-only field (e.g.
+  `phone`, never a regular matchkey field) survives the default
+  `GOLDENMATCH_BUCKET_SLIM_PROJECTION`. `EMResult.validate_for` now requires
+  `match_weights["__ne__<field>"]` for every NE field without `penalty_bits`,
+  so a model trained (or a Splink model imported) before this feature fails
+  loudly instead of silently scoring NE at weight 0. An unregistered/unknown
+  NE scorer on FS fails loud at validation time — unlike weighted's swallow-
+  and-warn `_NE_BROKEN` fallback, this is intentional. Continuous/Winkler-path
+  (`train_em_continuous`) NE is out of scope and rejected with a clear error.
+  Supersedes the deferral in `docs/superpowers/specs/2026-05-21-ne-fs-investigation.md`
+  (Wave D): that investigation judged the Bayesian-factor formulation correct
+  but deferred it believing `P(disagree_NE | match)` needed labeled pairs —
+  stale, since EM already estimates match-conditional probabilities for every
+  regular FS field without labels, and the same machinery estimates them for
+  NE dimensions.
 - **Splink migration upgrade pass** (`goldenmatch import-splink SETTINGS.json
   --upgrade DATA.parquet --model-out MODEL.json`, or
   `gm.upgrade_splink_conversion(conversion, data)` from Python): a data-aware

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -28,8 +28,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `match_weights["__ne__<field>"]` for every NE field without `penalty_bits`,
   so a model trained (or a Splink model imported) before this feature fails
   loudly instead of silently scoring NE at weight 0. An unregistered/unknown
-  NE scorer on FS fails loud at validation time — unlike weighted's swallow-
-  and-warn `_NE_BROKEN` fallback, this is intentional. Continuous/Winkler-path
+  NE scorer on FS fails loud at train/score time (`score_field` raises on
+  unknown scorers; no `_NE_BROKEN` swallow on FS) — unlike weighted's
+  swallow-and-warn fallback, this is intentional. Continuous/Winkler-path
   (`train_em_continuous`) NE is out of scope and rejected with a clear error.
   Supersedes the deferral in `docs/superpowers/specs/2026-05-21-ne-fs-investigation.md`
   (Wave D): that investigation judged the Bayesian-factor formulation correct

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -593,6 +593,21 @@ def score_buckets(
                 for f in mk.fields:
                     if f.field in _prep_frame.columns and f.field not in keep:
                         keep.append(f.field)
+                # FS negative-evidence fields: the probabilistic scorer path
+                # reads these the same raw-column way (_ne_fired /
+                # _field_values_for_block), and an NE-only field (the
+                # canonical phone example -- not in mk.fields) would
+                # otherwise be projected away here and never fire on the
+                # default bucket backend. Also keep derive_from source
+                # columns for completeness, though precompute_matchkey_
+                # transforms already materializes the synthesized ne.field
+                # column upstream of this projection.
+                for ne in (mk.negative_evidence or []):
+                    if ne.field in _prep_frame.columns and ne.field not in keep:
+                        keep.append(ne.field)
+                    for src in (ne.derive_from or []):
+                        if src in _prep_frame.columns and src not in keep:
+                            keep.append(src)
             # Source fields the block-key expression reads. Multi-key blocking
             # (rare today) accumulates fields across every key in the config.
             block_key_sources: set[str] = set()

--- a/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/_controller_render.py
@@ -143,6 +143,21 @@ def _committed_matchkeys(committed_config: Any) -> RenderableType | None:
     return table
 
 
+def _ne_penalty_label(nf: Any) -> str:
+    """Truthful penalty display for all three NE shapes.
+
+    weighted/exact carry a flat ``penalty``; probabilistic NE carries either
+    a fixed ``penalty_bits`` override or nothing (EM-learned weight).
+    """
+    penalty = getattr(nf, "penalty", None)
+    if penalty is not None:
+        return f"-{penalty:.2f}"
+    penalty_bits = getattr(nf, "penalty_bits", None)
+    if penalty_bits is not None:
+        return f"-{abs(penalty_bits):.1f} bits"
+    return "EM-learned"
+
+
 def _negative_evidence(committed_config: Any) -> RenderableType | None:
     if committed_config is None:
         return None
@@ -158,7 +173,7 @@ def _negative_evidence(committed_config: Any) -> RenderableType | None:
                 nf.field,
                 nf.scorer,
                 f"{nf.threshold:.2f}",
-                f"-{nf.penalty:.2f}",
+                _ne_penalty_label(nf),
             ))
     if not rows:
         return None

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -214,7 +214,18 @@ class NegativeEvidenceField(BaseModel):
     transforms: list[str] = Field(default_factory=list)
     scorer: str
     threshold: float = Field(ge=0.0, le=1.0)
-    penalty: float = Field(ge=0.0, le=1.0)
+    # Weighted/exact only: flat 0-1 penalty subtracted from the score when
+    # this field disagrees. REQUIRED for weighted/exact (enforced by
+    # ``MatchkeyConfig._validate_weighted``, not here); REJECTED for
+    # probabilistic matchkeys, which use EM-learned weights instead (or the
+    # ``penalty_bits`` override below).
+    penalty: float | None = Field(default=None, ge=0.0, le=1.0)
+    # Probabilistic-only: fixed LLR override in log2 units. When set, the NE
+    # dimension skips EM and contributes -abs(penalty_bits) when FIRED (both
+    # values present and scorer similarity STRICTLY below threshold), else 0.
+    # Absent => the weight is EM-learned (see core/probabilistic.py).
+    # Rejected on weighted/exact matchkeys (they use `penalty`).
+    penalty_bits: float | None = None
     # When set, ``field`` is a SYNTHESIZED column the pipeline materializes
     # before scoring by space-joining ``derive_from`` (e.g. a person full name
     # from ['first_name', 'last_name']). Lets an NE score a composite the raw
@@ -241,6 +252,22 @@ class NegativeEvidenceField(BaseModel):
                 f"{sorted(VALID_SCORERS)}"
             )
         return self
+
+    @property
+    def flat_penalty(self) -> float:
+        """``penalty`` narrowed to ``float`` for weighted/exact matchkeys.
+
+        Raises ``ValueError`` if unset — ``MatchkeyConfig._validate_weighted``
+        guarantees this never fires on a Pydantic-validated weighted/exact
+        matchkey's NE entries.
+        """
+        if self.penalty is None:
+            raise ValueError(
+                f"NegativeEvidenceField (field={self.field!r}): flat_penalty accessed "
+                "but penalty is None. Only weighted/exact matchkeys are guaranteed to "
+                "have a penalty."
+            )
+        return self.penalty
 
 
 class RulesPayload(BaseModel):
@@ -314,17 +341,11 @@ class MatchkeyConfig(BaseModel):
     rerank_band: float = 0.1
     # v1.11: negative evidence fields — default-None for v1.10 cache compat.
     #
-    # #126 / Wave D: NE applies to ``weighted`` + ``exact`` matchkey types
-    # only. ``probabilistic`` (Fellegi-Sunter) matchkeys are intentionally
-    # NOT extended with NE under v1.13 — the LLR-additivity of FS doesn't
-    # cleanly compose with a flat penalty on the [0,1] score. See
-    # ``docs/superpowers/specs/2026-05-21-ne-fs-investigation.md`` for the
-    # formulation comparison; the Bayesian-factor (Formulation B) approach
-    # becomes viable once #129's labeled-correction substrate is available.
-    # Users who explicitly need NE-on-FS in v1.13 can opt into the
-    # calibration-losing post-FS floor via
-    # ``GOLDENMATCH_NE_FS_ESCAPE_MODE=floor`` (escape hatch; not the
-    # default; semantics not preserved across versions).
+    # Valid on all three matchkey types. ``weighted``/``exact`` use a flat
+    # ``penalty`` (0-1, unchanged since v1.11). ``probabilistic`` (Fellegi-
+    # Sunter) uses EM-learned NE weights (Formulation B), with an optional
+    # ``penalty_bits`` fixed override. See
+    # ``docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md``.
     negative_evidence: list[NegativeEvidenceField] | None = None
     # Fellegi-Sunter EM parameters
     em_iterations: int = 20
@@ -365,6 +386,27 @@ class MatchkeyConfig(BaseModel):
                     raise ValueError(
                         f"All fields in a probabilistic matchkey must have 'scorer'. "
                         f"Field '{f.field}' is missing it."
+                    )
+        if self.type in ("weighted", "exact"):
+            for ne in self.negative_evidence or []:
+                if ne.penalty is None:
+                    raise ValueError(
+                        f"Matchkey '{self.name}' (type={self.type!r}): negative_evidence "
+                        f"field '{ne.field}' requires 'penalty' for weighted/exact matchkeys."
+                    )
+                if ne.penalty_bits is not None:
+                    raise ValueError(
+                        f"Matchkey '{self.name}' (type={self.type!r}): negative_evidence "
+                        f"field '{ne.field}' sets 'penalty_bits', which is only valid on "
+                        "probabilistic matchkeys. Use 'penalty' instead."
+                    )
+        elif self.type == "probabilistic":
+            for ne in self.negative_evidence or []:
+                if ne.penalty is not None:
+                    raise ValueError(
+                        f"Matchkey '{self.name}' (type={self.type!r}): negative_evidence "
+                        f"field '{ne.field}' sets 'penalty', but probabilistic matchkeys use "
+                        "EM-learned NE weights; set penalty_bits to override."
                     )
         return self
 

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -483,6 +483,24 @@ def _lever_calibration(ctx: _LeverContext) -> None:
     em = ctx.em_model
     mk = ctx.upgraded_config.get_matchkeys()[0]
 
+    # Tripwire for the planned fan-out upgrade lever: this lever's per-pair
+    # weight sum and hand-rolled model min/max range below cover REGULAR
+    # fields only -- they do not include negative-evidence contributions
+    # (`__ne__<field>` entries / penalty_bits). Unreachable today
+    # (from_splink never emits negative_evidence), but the fan-out lever
+    # will emit exactly that shape; calibrating while ignoring NE weights
+    # would put the thresholds on the wrong scale. Warn + skip until this
+    # lever is taught fs_weight_range (core/probabilistic.py).
+    if mk.negative_evidence:
+        ctx.report.warn(
+            "upgrade:calibration",
+            "skipped: calibration does not yet account for negative_evidence "
+            "weights (the pair-weight sum and model range cover regular "
+            "fields only; see fs_weight_range) -- thresholds left unset",
+            mapped_to=mapped_to,
+        )
+        return
+
     # Mixed bare/trained input produces a PARTIAL imported model (import_em
     # skips bare comparisons with a warning), so em.match_weights does not
     # cover every matchkey field -- candidate pairs cannot be scored with

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -265,6 +265,10 @@ def match_fused_fs_ready(config: Any) -> bool:
     host-side).
     `run_match_fused_fs_arrow` takes a PRE-TRAINED `EMResult` — training is the
     caller's O(n) model fit, unchanged.
+
+    NE never crosses the FFI; a future kernel port adds `FS_SUPPORTS_NE`. Any
+    `mk.negative_evidence` declines here unconditionally, same playbook as
+    `_fs_native_eligible`.
     """
     b = getattr(config, "blocking", None)
     if b is None or getattr(b, "strategy", "static") != "static":
@@ -275,6 +279,8 @@ def match_fused_fs_ready(config: Any) -> bool:
     get_mks = getattr(config, "get_matchkeys", None)
     mks = get_mks() if callable(get_mks) else []
     if len(mks) != 1 or getattr(mks[0], "type", None) != "probabilistic" or not mks[0].fields:
+        return False
+    if getattr(mks[0], "negative_evidence", None):
         return False
     from goldenmatch.core.probabilistic import _NATIVE_FS_SCORER_IDS
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -23,7 +23,7 @@ from itertools import combinations
 import numpy as np
 
 from goldenmatch._polars_lazy import pl
-from goldenmatch.config.schemas import MatchkeyConfig
+from goldenmatch.config.schemas import MatchkeyConfig, NegativeEvidenceField
 from goldenmatch.core.scorer import score_field
 
 logger = logging.getLogger(__name__)
@@ -443,6 +443,103 @@ def _build_comparison_matrix(
     return matrix
 
 
+def _ne_fired(row_a: dict, row_b: dict, ne_field: NegativeEvidenceField) -> bool:
+    """Return True iff a Fellegi-Sunter negative-evidence field FIRES.
+
+    Fires when BOTH values are present (post-transform, non-empty) AND the
+    scorer similarity is STRICTLY below ``ne_field.threshold`` — matching the
+    weighted-NE firing rule (``core/scorer.py:292``,
+    ``backends/score_buckets.py:942``). Any missing/empty value on either
+    side (including nulls, which is the deliberate NE null-handling that
+    differs from regular FS fields where null -> disagree/level-0) means the
+    dimension does NOT fire — negative evidence never boosts a pair, so an
+    inconclusive comparison must not count against a match either.
+    """
+    from goldenmatch.utils.transforms import apply_transforms
+
+    val_a = row_a.get(ne_field.field)
+    val_b = row_b.get(ne_field.field)
+    if val_a is None or val_b is None:
+        return False
+    val_a = str(val_a)
+    val_b = str(val_b)
+    if ne_field.transforms:
+        val_a = apply_transforms(val_a, ne_field.transforms)
+        val_b = apply_transforms(val_b, ne_field.transforms)
+    if not val_a or not val_b:
+        return False
+    sim = score_field(val_a, val_b, ne_field.scorer)
+    if sim is None:
+        return False
+    return sim < ne_field.threshold
+
+
+def _em_ne_fields(mk: MatchkeyConfig) -> list:
+    """NE fields that participate in EM (excludes ``penalty_bits`` overrides,
+    which skip EM entirely and contribute a fixed weight at scoring time)."""
+    return [ne for ne in (mk.negative_evidence or []) if ne.penalty_bits is None]
+
+
+def _build_ne_matrix(
+    pairs: list[tuple[int, int]],
+    row_lookup: dict[int, dict],
+    mk: MatchkeyConfig,
+) -> np.ndarray:
+    """Build an n_pairs x n_ne int8 matrix of NE firing state for EM.
+
+    0 = fired, 1 = not-fired (including nulls on either side). A SEPARATE
+    matrix from :func:`_build_comparison_matrix` — NE dimensions are not
+    regular FS fields, and comparison-matrix consumers assume
+    ``len(row) == len(mk.fields)``. Only ``penalty_bits``-free NE fields are
+    included (penalty_bits fields skip EM entirely); the column order
+    matches :func:`_em_ne_fields`.
+    """
+    ne_fields = _em_ne_fields(mk)
+    n_pairs = len(pairs)
+    n_ne = len(ne_fields)
+    matrix = np.ones((n_pairs, n_ne), dtype=np.int8)  # default: not-fired
+    for i, (a, b) in enumerate(pairs):
+        row_a = row_lookup.get(a, {})
+        row_b = row_lookup.get(b, {})
+        for j, ne in enumerate(ne_fields):
+            if _ne_fired(row_a, row_b, ne):
+                matrix[i, j] = 0
+    return matrix
+
+
+def _ne_u_probs_from_matrix(ne_matrix: np.ndarray, ne_fields: list) -> dict[str, list[float]]:
+    """Observed [fired, not_fired] rates from a NE matrix — the u estimate.
+
+    Same smoothing style as the regular-field u estimate in :func:`train_em`
+    (additive 1e-6 per state).
+    """
+    out: dict[str, list[float]] = {}
+    for j, ne in enumerate(ne_fields):
+        fired = float((ne_matrix[:, j] == 0).sum())
+        not_fired = float((ne_matrix[:, j] == 1).sum())
+        total = fired + not_fired + 2 * 1e-6
+        out[ne.field] = [(fired + 1e-6) / total, (not_fired + 1e-6) / total]
+    return out
+
+
+def _warn_ne_blocking_overlap(ne_fields: list, blocking_fields: list[str]) -> None:
+    """Log a warning per NE field that also names a blocking field.
+
+    Within-block pairs are guaranteed to agree on blocking fields, so an NE
+    field that is also a blocking key never fires in the EM training sample
+    — a degenerate m/u estimate. Not a hard error: multi-pass blocking may
+    only partially overlap.
+    """
+    for ne in ne_fields:
+        if ne.field in blocking_fields:
+            logger.warning(
+                "FS negative-evidence field '%s' is also a blocking field; "
+                "within-block pairs are guaranteed to agree on it, so it will "
+                "never fire during EM training (degenerate m/u estimate).",
+                ne.field,
+            )
+
+
 def _sample_blocked_pairs(
     blocks: list,
     n_pairs: int = 10000,
@@ -540,7 +637,19 @@ def train_em(
 
     from goldenmatch.core.frame import to_frame as _tf_w6
 
+    ne_fields_em = _em_ne_fields(mk)
+    _warn_ne_blocking_overlap(ne_fields_em, blocking_fields)
+
     cols = [f.field for f in mk.fields if f.field != "__record__"]
+    # Extend with NE field names (incl. derive_from-synthesized columns,
+    # which are materialized under the NE field's own name by
+    # precompute_matchkey_transforms before train_em ever sees the frame) —
+    # else NE-only fields (the canonical phone example) are absent from
+    # row_lookup, read as missing/null, and NE never fires during EM
+    # (degenerate m/u estimate).
+    for ne in (mk.negative_evidence or []):
+        if ne.field not in cols:
+            cols.append(ne.field)
     row_lookup: dict[int, dict] = {}
     for row in _tf_w6(df).select_dicts(["__row_id__"] + cols):
         row_lookup[row["__row_id__"]] = row
@@ -575,6 +684,13 @@ def train_em(
 
     logger.info("u-probabilities estimated from %d random pairs", len(random_pairs))
 
+    # NE dims: u from the SAME random-pair sample as regular fields (an NE
+    # dimension is never a blocking key by construction, so no neutral-u
+    # override is needed here — see _warn_ne_blocking_overlap above for the
+    # degenerate case where it accidentally is one).
+    random_ne_matrix = _build_ne_matrix(random_pairs, row_lookup, mk)
+    u_probs_ne = _ne_u_probs_from_matrix(random_ne_matrix, ne_fields_em)
+
     # ── Step 2: Get blocked pairs for m estimation ──
     if blocks:
         pairs = _sample_blocked_pairs(blocks, n_sample_pairs, seed)
@@ -587,6 +703,7 @@ def train_em(
         return _fallback_result(mk)
 
     comp_matrix = _build_comparison_matrix(pairs, row_lookup, mk)
+    ne_matrix = _build_ne_matrix(pairs, row_lookup, mk)
     n_pairs = len(pairs)
     _n_fields = len(mk.fields)
 
@@ -600,10 +717,15 @@ def train_em(
         total = sum(raw)
         m_probs[f.field] = [r / total for r in raw]
 
+    # NE dims: fired is rare in matches (a true match usually agrees on the
+    # NE field), so seed m with a low fired-probability prior.
+    m_probs_ne: dict[str, list[float]] = {ne.field: [0.05, 0.95] for ne in ne_fields_em}
+
     # ── Step 3: EM iterations — only update m, fix u ──
     converged = False
     for iteration in range(max_iterations):
         old_m = {k: list(v) for k, v in m_probs.items()}
+        old_m_ne = {k: list(v) for k, v in m_probs_ne.items()}
 
         # E-step: compute posterior P(match | comparison vector).
         # Vectorized over pairs (this was the FS-training bottleneck: a
@@ -618,6 +740,15 @@ def train_em(
             levels_j = comp_matrix[:, j]
             m_table = np.log(np.maximum(np.asarray(m_probs[f.field], dtype=np.float64), 1e-10))
             u_table = np.log(np.maximum(np.asarray(u_probs[f.field], dtype=np.float64), 1e-10))
+            log_m += m_table[levels_j]
+            log_u += u_table[levels_j]
+
+        # NE dims: same E-step accumulation, 2-entry [fired, not_fired]
+        # lookup tables indexed by the NE matrix's {0, 1} columns.
+        for j, ne in enumerate(ne_fields_em):
+            levels_j = ne_matrix[:, j]
+            m_table = np.log(np.maximum(np.asarray(m_probs_ne[ne.field], dtype=np.float64), 1e-10))
+            u_table = np.log(np.maximum(np.asarray(u_probs_ne[ne.field], dtype=np.float64), 1e-10))
             log_m += m_table[levels_j]
             log_u += u_table[levels_j]
 
@@ -643,6 +774,15 @@ def train_em(
                 new_m[level] = (posteriors[mask].sum() + 1e-6) / (total_match + n_levels * 1e-6)
             m_probs[f.field] = new_m
 
+        # NE dims: same M-step update. Blocking-field neutralization does NOT
+        # apply here — an NE dimension is never a blocking key.
+        for j, ne in enumerate(ne_fields_em):
+            new_m_ne = [0.0, 0.0]
+            for level in range(2):
+                mask = ne_matrix[:, j] == level
+                new_m_ne[level] = (posteriors[mask].sum() + 1e-6) / (total_match + 2 * 1e-6)
+            m_probs_ne[ne.field] = new_m_ne
+
         # Check convergence (only m changes)
         max_delta = 0.0
         for f in mk.fields:
@@ -650,6 +790,9 @@ def train_em(
                 continue
             for k in range(f.levels):
                 max_delta = max(max_delta, abs(m_probs[f.field][k] - old_m[f.field][k]))
+        for ne in ne_fields_em:
+            for k in range(2):
+                max_delta = max(max_delta, abs(m_probs_ne[ne.field][k] - old_m_ne[ne.field][k]))
 
         if max_delta < convergence:
             converged = True
@@ -681,15 +824,30 @@ def train_em(
             weights.append(math.log2(m_val / u_val))
         match_weights[f.field] = weights
 
+    # NE dims: store under __ne__<field> — [w_fired, 0.0]. The 0.0 for
+    # not-fired is the NEGATIVE-EVIDENCE CLAMP (not log2(m1/u1)): agreement
+    # or an inconclusive comparison never boosts the score, only a
+    # confident disagreement subtracts from it.
+    for ne in ne_fields_em:
+        key = f"__ne__{ne.field}"
+        m0 = max(m_probs_ne[ne.field][0], 1e-10)
+        u0 = max(u_probs_ne[ne.field][0], 1e-10)
+        m_probs[key] = list(m_probs_ne[ne.field])
+        u_probs[key] = list(u_probs_ne[ne.field])
+        match_weights[key] = [math.log2(m0 / u0), 0.0]
+
     # Guard: FS match weights are expected non-decreasing in agreement level.
     # EM can invert a rare-but-discriminative middle level above exact
     # agreement. Default 'warn' surfaces it (Splink posture) without changing
     # the weights; 'enforce' isotonically repairs them (measured to trade F1
-    # on some data — opt in deliberately).
+    # on some data — opt in deliberately). __ne__ entries are [fired,
+    # not_fired]-ordered, not level-ordered, so they must never be repaired —
+    # skip_fields excludes them (mirrors blocking_fields' exclusion).
     _mono_mode = _fs_monotonic_mode()
     if _mono_mode != "off":
+        _ne_skip = {k for k in match_weights if k.startswith("__ne__")}
         repaired, adjusted = enforce_weight_monotonicity(
-            match_weights, skip_fields=blocking_fields,
+            match_weights, skip_fields=list(blocking_fields) + list(_ne_skip),
         )
         if adjusted and _mono_mode == "enforce":
             match_weights = repaired
@@ -807,7 +965,13 @@ def estimate_m_from_labels(
 
     from goldenmatch.core.frame import to_frame as _tf_w6
 
+    ne_fields_em = _em_ne_fields(mk)
+    _warn_ne_blocking_overlap(ne_fields_em, blocking_fields)
+
     cols = [f.field for f in mk.fields if f.field != "__record__"]
+    for ne in (mk.negative_evidence or []):
+        if ne.field not in cols:
+            cols.append(ne.field)
     row_lookup: dict[int, dict] = {}
     for row in _tf_w6(df).select_dicts(["__row_id__"] + cols):
         row_lookup[row["__row_id__"]] = row
@@ -833,14 +997,21 @@ def estimate_m_from_labels(
     # ── u from RANDOM pairs (mirrors train_em Step 1) ──
     random_pairs = _sample_pairs(df, min(n_sample_pairs, 5000), seed)
     u_probs: dict[str, list[float]] = {}
+    u_probs_ne: dict[str, list[float]] = {}
     if len(random_pairs) >= 10:
         random_matrix = _build_comparison_matrix(random_pairs, row_lookup, mk)
         for j, f in enumerate(mk.fields):
             counts = [float((random_matrix[:, j] == lvl).sum()) for lvl in range(f.levels)]
             total = sum(counts) + f.levels * 1e-6
             u_probs[f.field] = [(c + 1e-6) / total for c in counts]
+        random_ne_matrix = _build_ne_matrix(random_pairs, row_lookup, mk)
+        u_probs_ne = _ne_u_probs_from_matrix(random_ne_matrix, ne_fields_em)
     else:
-        u_probs = _fallback_result(mk).u_probs
+        fallback = _fallback_result(mk)
+        u_probs = fallback.u_probs
+        u_probs_ne = {
+            ne.field: fallback.u_probs[f"__ne__{ne.field}"] for ne in ne_fields_em
+        }
     # Blocking fields: neutral u (random pairs give a biased u for them).
     for f in mk.fields:
         if f.field in blocking_fields:
@@ -859,6 +1030,17 @@ def estimate_m_from_labels(
         total = sum(counts) + f.levels * smoothing
         m_probs[f.field] = [(c + smoothing) / total for c in counts]
 
+    # NE dims: m from the observed fired-rate among LABELED matches (the
+    # supervised twin of train_em's EM-estimated m); u from the same
+    # random-pair sample as regular fields, computed above.
+    label_ne_matrix = _build_ne_matrix(label_pairs, row_lookup, mk)
+    for j, ne in enumerate(ne_fields_em):
+        fired = float((label_ne_matrix[:, j] == 0).sum())
+        not_fired = float((label_ne_matrix[:, j] == 1).sum())
+        total = fired + not_fired + 2 * smoothing
+        m_probs[f"__ne__{ne.field}"] = [(fired + smoothing) / total, (not_fired + smoothing) / total]
+        u_probs[f"__ne__{ne.field}"] = list(u_probs_ne.get(ne.field, [0.5, 0.5]))
+
     # ── match weights (blocking fixed) — mirrors train_em ──
     match_weights: dict[str, list[float]] = {}
     for f in mk.fields:
@@ -873,10 +1055,19 @@ def estimate_m_from_labels(
             for k in range(f.levels)
         ]
 
+    # NE dims: [w_fired, 0.0] — the not-fired weight is the negative-evidence
+    # clamp, not log2(m1/u1). Mirrors train_em's storage exactly.
+    for ne in ne_fields_em:
+        key = f"__ne__{ne.field}"
+        m0 = max(m_probs[key][0], 1e-10)
+        u0 = max(u_probs[key][0], 1e-10)
+        match_weights[key] = [math.log2(m0 / u0), 0.0]
+
     _mono_mode = _fs_monotonic_mode()
     if _mono_mode != "off":
+        _ne_skip = {k for k in match_weights if k.startswith("__ne__")}
         repaired, adjusted = enforce_weight_monotonicity(
-            match_weights, skip_fields=blocking_fields,
+            match_weights, skip_fields=list(blocking_fields) + list(_ne_skip),
         )
         if adjusted and _mono_mode == "enforce":
             match_weights = repaired
@@ -1216,6 +1407,24 @@ def _fallback_result(mk: MatchkeyConfig) -> EMResult:
             m_probs[f.field] = m
             u_probs[f.field] = u
             match_weights[f.field] = [math.log2(m_i / u_i) for m_i, u_i in zip(m, u)]
+
+    ne_fields_em = _em_ne_fields(mk)
+    if ne_fields_em:
+        logger.warning(
+            "FS EM training fell back to conservative defaults (too few pairs); "
+            "negative-evidence field(s) %s get a fixed -3.0 bit weight instead of "
+            "an EM-learned one.",
+            ", ".join(ne.field for ne in ne_fields_em),
+        )
+    for ne in ne_fields_em:
+        key = f"__ne__{ne.field}"
+        # m=0.0625, u=0.5 -> log2(0.0625/0.5) == -3.0 exactly (a conservative
+        # fixed weight consistent with a symmetric u=[0.5, 0.5] non-match
+        # prior, mirroring the pipeline-wide fallback posture).
+        m_probs[key] = [0.0625, 0.9375]
+        u_probs[key] = [0.5, 0.5]
+        match_weights[key] = [-3.0, 0.0]
+
     return EMResult(
         m_probs=m_probs, u_probs=u_probs, match_weights=match_weights,
         converged=False, iterations=0, proportion_matched=0.05,

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1863,6 +1863,25 @@ def vectorized_scorer_supported(scorer: str) -> bool:
     return scorer not in ("embedding", "record_embedding")
 
 
+def _fs_vectorized_supported(mk: MatchkeyConfig) -> bool:
+    """Whether every scorer (mk) needs is expressible on the NxN matrix path.
+
+    Covers BOTH regular fields and NE fields: NE routes through the same
+    matrix machinery (``_add_ne_matrix_contribution`` ->
+    ``_field_score_matrix_dedup``), so an NE scorer the matrix path can't
+    express (embedding / record_embedding) must force the scalar path too,
+    mirroring how an unsupported REGULAR field scorer already does. The ONE
+    shared gate for every use_vec decision -- a per-site copy that checks
+    only ``mk.fields`` crashes in ``_field_score_matrix_dedup`` as soon as
+    an NE field carries a model-backed scorer.
+    """
+    return all(
+        vectorized_scorer_supported(f.scorer) for f in mk.fields
+    ) and all(
+        vectorized_scorer_supported(ne.scorer) for ne in (mk.negative_evidence or [])
+    )
+
+
 def score_probabilistic_vectorized(
     block_df: pl.DataFrame,
     mk: MatchkeyConfig,
@@ -2104,7 +2123,7 @@ def score_probabilistic_blocks_batched(
     use_vec = (
         not _fs_native_eligible(mk)
         and _fs_vectorized_enabled()
-        and all(vectorized_scorer_supported(f.scorer) for f in mk.fields)
+        and _fs_vectorized_supported(mk)
     )
     base_excl = set(exclude_pairs)
 
@@ -2371,16 +2390,7 @@ def probabilistic_block_scorer(mk: MatchkeyConfig, em_result: EMResult):
             return score_probabilistic_native(block_df, mk, em_result, exclude_pairs)
         return _native
 
-    # NE fields also route through the vectorized matrix path
-    # (_add_ne_matrix_contribution -> _field_score_matrix_dedup) when use_vec
-    # is chosen -- an NE scorer the matrix path can't express (embedding /
-    # record_embedding) must force the scalar path too, mirroring how an
-    # unsupported REGULAR field scorer already does.
-    use_vec = _fs_vectorized_enabled() and all(
-        vectorized_scorer_supported(f.scorer) for f in mk.fields
-    ) and all(
-        vectorized_scorer_supported(ne.scorer) for ne in (mk.negative_evidence or [])
-    )
+    use_vec = _fs_vectorized_enabled() and _fs_vectorized_supported(mk)
     if use_vec:
         def _scorer(block_df, exclude_pairs=None):
             return score_probabilistic_vectorized(block_df, mk, em_result, exclude_pairs)

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -291,6 +291,26 @@ class EMResult:
                     f"levels but the matchkey expects {f.levels}. Retrain or clear "
                     f"the model_path."
                 )
+        for ne in (mk.negative_evidence or []):
+            if ne.penalty_bits is not None:
+                continue  # fixed override -- no EM entry needed
+            key = f"__ne__{ne.field}"
+            weights = self.match_weights.get(key)
+            if weights is None:
+                raise FSModelMismatchError(
+                    f"Persisted FS model has no weights for negative_evidence "
+                    f"field '{ne.field}' (expected key '{key}'). The matchkey "
+                    f"added this NE field since training — retrain the model, "
+                    f"or set `penalty_bits` on the negative_evidence entry to "
+                    f"skip EM for this field."
+                )
+            if len(weights) != 2:
+                raise FSModelMismatchError(
+                    f"Persisted FS model for negative_evidence field "
+                    f"'{ne.field}' (key '{key}') has {len(weights)} entries but "
+                    f"NE weights must be a 2-element [fired, not_fired] list. "
+                    f"Retrain or clear the model_path."
+                )
 
 
 class FSModelMismatchError(ValueError):
@@ -2234,10 +2254,16 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
     kernel's ``FS_SUPPORTS_LEVEL_THRESHOLDS`` module const — an older wheel
     without it declines here, so those environments keep the pure-Python
     (numpy/scalar) fallback where `_levels_from_similarity` does the banding.
+
+    NE never crosses the FFI; a future kernel port adds ``FS_SUPPORTS_NE``.
+    Any ``mk.negative_evidence`` declines here unconditionally, keeping
+    NE-bearing matchkeys on the pure-Python (numpy/scalar) fallback.
     """
     if not _fs_native_enabled():
         return False
     if not mk.fields:
+        return False
+    if mk.negative_evidence:
         return False
     needs_level_thresholds = False
     for f in mk.fields:
@@ -2345,8 +2371,15 @@ def probabilistic_block_scorer(mk: MatchkeyConfig, em_result: EMResult):
             return score_probabilistic_native(block_df, mk, em_result, exclude_pairs)
         return _native
 
+    # NE fields also route through the vectorized matrix path
+    # (_add_ne_matrix_contribution -> _field_score_matrix_dedup) when use_vec
+    # is chosen -- an NE scorer the matrix path can't express (embedding /
+    # record_embedding) must force the scalar path too, mirroring how an
+    # unsupported REGULAR field scorer already does.
     use_vec = _fs_vectorized_enabled() and all(
         vectorized_scorer_supported(f.scorer) for f in mk.fields
+    ) and all(
+        vectorized_scorer_supported(ne.scorer) for ne in (mk.negative_evidence or [])
     )
     if use_vec:
         def _scorer(block_df, exclude_pairs=None):

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1193,6 +1193,13 @@ def train_em_continuous(
     P(score|non-match) as Gaussians per field. This preserves the full
     continuous signal and produces better likelihood ratios.
     """
+    if mk.negative_evidence:
+        raise ValueError(
+            "negative_evidence is not supported on the continuous/Winkler FS "
+            "path (train_em_continuous / score_probabilistic_continuous). Use "
+            "the discrete probabilistic path (train_em / load_or_train_em) "
+            "for a matchkey with negative_evidence."
+        )
     if blocking_fields is None:
         blocking_fields = []
 
@@ -1331,6 +1338,13 @@ def score_probabilistic_continuous(
     Computes log-likelihood ratios from Gaussian models of match/non-match
     score distributions. Returns pairs above threshold as normalized 0-1 scores.
     """
+    if mk.negative_evidence:
+        raise ValueError(
+            "negative_evidence is not supported on the continuous/Winkler FS "
+            "path (train_em_continuous / score_probabilistic_continuous). Use "
+            "the discrete probabilistic path (train_em / load_or_train_em) "
+            "for a matchkey with negative_evidence."
+        )
     if exclude_pairs is None:
         exclude_pairs = set()
 
@@ -1431,6 +1445,92 @@ def _fallback_result(mk: MatchkeyConfig) -> EMResult:
     )
 
 
+def fs_weight_range(em: EMResult, mk: MatchkeyConfig) -> tuple[float, float]:
+    """Achievable Fellegi-Sunter total-weight range ``(min_weight, max_weight)``.
+
+    Centralizes the min/max weight-sum computation used for linear-score
+    normalization and threshold calibration -- previously hand-rolled at every
+    scoring/prep site, which meant a missed site silently produced
+    out-of-[0,1] normalized scores as soon as an NE field fired.
+
+    Regular fields: ``sum(min(weights))`` / ``sum(max(weights))`` over
+    ``em.match_weights[f.field]`` for each ``f in mk.fields`` -- unchanged
+    from the pre-NE behavior.
+
+    NE fields (``mk.negative_evidence``):
+      - ``penalty_bits`` set: contributes ``(-abs(penalty_bits), 0.0)`` to
+        (min, max) directly -- no EM entry needed (the fixed-override case).
+      - else: uses the EM-learned ``em.match_weights["__ne__<field>"]``
+        entry, which is stored as ``[w_fired, 0.0]``. ``min``/``max`` over
+        that 2-entry list reproduces ``(min(w_fired, 0), max(w_fired, 0))``
+        for free regardless of ``w_fired``'s sign (it's normally negative).
+      - An NE field with NEITHER (shouldn't happen once ``validate_for``
+        enforces model/matchkey shape parity) is defensively skipped --
+        contributes ``(0.0, 0.0)`` rather than raising.
+    """
+    min_weight = 0.0
+    max_weight = 0.0
+    for f in mk.fields:
+        weights = em.match_weights[f.field]
+        min_weight += min(weights)
+        max_weight += max(weights)
+    for ne in (mk.negative_evidence or []):
+        if ne.penalty_bits is not None:
+            min_weight += -abs(ne.penalty_bits)
+            continue
+        entry = em.match_weights.get(f"__ne__{ne.field}")
+        if entry is None:
+            continue
+        min_weight += min(entry)
+        max_weight += max(entry)
+    return min_weight, max_weight
+
+
+def _ne_scalar_contribution(
+    row_a: dict, row_b: dict, ne: NegativeEvidenceField, em_result: EMResult,
+) -> float:
+    """One NE field's scalar weight contribution for a single pair.
+
+    0.0 unless the field FIRES (:func:`_ne_fired`); when fired, ``-abs(bits)``
+    for the ``penalty_bits`` fixed override, else the EM-learned
+    ``__ne__<field>`` fired-weight (``match_weights[...][0]``).
+    """
+    if not _ne_fired(row_a, row_b, ne):
+        return 0.0
+    if ne.penalty_bits is not None:
+        return -abs(ne.penalty_bits)
+    return em_result.match_weights[f"__ne__{ne.field}"][0]
+
+
+def _add_ne_matrix_contribution(
+    total_weight: np.ndarray,
+    vals: list[str | None],
+    ne: NegativeEvidenceField,
+    em_result: EMResult,
+) -> None:
+    """Add one NE field's fired-weight contribution to an NxN/SxS weight matrix.
+
+    ``vals`` is the NE field's per-row values, already transformed the same
+    way :func:`_ne_fired` transforms them (callers pass the output of
+    :func:`_field_values_for_block` / the batched equivalent, which apply
+    ``ne.transforms`` -- ``NegativeEvidenceField`` has the same ``.field`` /
+    ``.transforms`` shape as ``MatchkeyField``). Fired iff BOTH sides are
+    present + non-empty AND similarity is STRICTLY below ``ne.threshold`` --
+    the same rule as :func:`_ne_fired`, vectorized.
+    """
+    sim = _field_score_matrix_dedup(vals, ne.scorer)
+    inconclusive = np.array([v is None or v == "" for v in vals], dtype=bool)
+    fired = sim < ne.threshold
+    if inconclusive.any():
+        either = inconclusive[:, None] | inconclusive[None, :]
+        fired = fired & ~either
+    if ne.penalty_bits is not None:
+        w_fired = -abs(ne.penalty_bits)
+    else:
+        w_fired = em_result.match_weights[f"__ne__{ne.field}"][0]
+    total_weight += np.where(fired, w_fired, 0.0)
+
+
 def compute_thresholds(
     em_result: EMResult,
     scored_weights: list[float] | None = None,
@@ -1498,8 +1598,15 @@ def score_probabilistic(
     if exclude_pairs is None:
         exclude_pairs = set()
 
-    # Build row lookup
+    # Build row lookup. Extend with NE field names (incl. derive_from
+    # synthesized columns, materialized under the NE field's own name by
+    # precompute_matchkey_transforms) so an NE-only field (the canonical
+    # phone example -- not in mk.fields) is present for _ne_fired to read,
+    # mirroring train_em's row_lookup projection.
     cols = [f.field for f in mk.fields if f.field != "__record__"]
+    for ne in (mk.negative_evidence or []):
+        if ne.field not in cols:
+            cols.append(ne.field)
     row_lookup: dict[int, dict] = {}
     from goldenmatch.core.frame import to_frame as _tf_d5c
 
@@ -1511,8 +1618,7 @@ def score_probabilistic(
     row_ids = _to_frame_d5(block_df).column("__row_id__").to_list()
 
     # Compute weight range for normalization
-    max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_weight = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
 
     calibrated = _fs_calibration_mode() == "posterior"
@@ -1524,6 +1630,7 @@ def score_probabilistic(
     else:
         link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
 
+    ne_fields = mk.negative_evidence or []
     results = []
     for i in range(len(row_ids)):
         for j in range(i + 1, len(row_ids)):
@@ -1540,6 +1647,8 @@ def score_probabilistic(
             total_weight = 0.0
             for k, f in enumerate(mk.fields):
                 total_weight += em_result.match_weights[f.field][vec[k]]
+            for ne in ne_fields:
+                total_weight += _ne_scalar_contribution(row_a, row_b, ne, em_result)
 
             if calibrated:
                 normalized = posterior_from_weight(total_weight, prior_w)
@@ -1769,8 +1878,7 @@ def score_probabilistic_vectorized(
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
 
-    max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_weight = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
 
     if mk.link_threshold is not None:
@@ -1794,6 +1902,10 @@ def score_probabilistic_vectorized(
             lvl = np.where(either_null, 0, lvl)
         total_weight += weights[lvl]
         _apply_tf_adjustment(total_weight, vals, lvl, f, em_result, n)
+
+    for ne in (mk.negative_evidence or []):
+        ne_vals = _field_values_for_block(block_df, ne, n)
+        _add_ne_matrix_contribution(total_weight, ne_vals, ne, em_result)
 
     if calibrated:
         logodds = prior_w + total_weight
@@ -1881,8 +1993,7 @@ def score_probabilistic_vectorized_batch(
 
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
-    max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_weight = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
     if mk.link_threshold is not None:
         link_threshold = mk.link_threshold
@@ -1905,6 +2016,12 @@ def score_probabilistic_vectorized_batch(
             lvl = np.where(either_null, 0, lvl)
         total_weight += weights[lvl]
         _apply_tf_adjustment(total_weight, vals, lvl, f, em_result, S)
+
+    for ne in (mk.negative_evidence or []):
+        ne_vals: list[str | None] = []
+        for bdf, (s, e) in zip(block_dfs, spans):
+            ne_vals.extend(_field_values_for_block(bdf, ne, e - s))
+        _add_ne_matrix_contribution(total_weight, ne_vals, ne, em_result)
 
     if calibrated:
         logodds = prior_w + total_weight
@@ -2172,8 +2289,12 @@ def score_probabilistic_native(
 
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
-    max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_weight = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    # NE never crosses the FFI (the kernel's score_one doesn't implement it) --
+    # a future kernel port adds FS_SUPPORTS_NE. `_fs_native_eligible` declines
+    # NE-bearing matchkeys, so `fs_weight_range` sees no NE fields here in
+    # practice; centralized anyway so this site can't drift from the other
+    # scoring paths for non-NE configs.
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
     if mk.link_threshold is not None:
         link_threshold = float(mk.link_threshold)
@@ -2246,13 +2367,14 @@ def score_pair_probabilistic(
     """Score a single pair using Fellegi-Sunter weights. For match_one."""
     vec = comparison_vector(row_a, row_b, mk)
 
-    max_weight = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_weight = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
 
     total_weight = 0.0
     for k, f in enumerate(mk.fields):
         total_weight += em_result.match_weights[f.field][vec[k]]
+    for ne in (mk.negative_evidence or []):
+        total_weight += _ne_scalar_contribution(row_a, row_b, ne, em_result)
 
     if _fs_calibration_mode() == "posterior":
         return posterior_from_weight(total_weight, prior_weight(em_result.proportion_matched))

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1864,7 +1864,9 @@ def vectorized_scorer_supported(scorer: str) -> bool:
 
 
 def _fs_vectorized_supported(mk: MatchkeyConfig) -> bool:
-    """Whether every scorer (mk) needs is expressible on the NxN matrix path.
+    """Whether every scorer the matchkey needs (regular fields +
+    negative-evidence fields) is expressible on the vectorized NxN matrix
+    path.
 
     Covers BOTH regular fields and NE fields: NE routes through the same
     matrix machinery (``_add_ne_matrix_contribution`` ->

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -68,7 +68,7 @@ def _resolve_probabilistic_fast_path(
       - em_result has match_weights for every field.
     """
     from goldenmatch.core.matchkey import _xform_sig
-    from goldenmatch.core.probabilistic import compute_thresholds
+    from goldenmatch.core.probabilistic import compute_thresholds, fs_weight_range
 
     if mk.type != "probabilistic":
         return None
@@ -76,8 +76,6 @@ def _resolve_probabilistic_fast_path(
         return None
 
     field_specs: list[ProbFieldSpec] = []
-    max_weight = 0.0
-    min_weight = 0.0
     for f in mk.fields:
         # Per-pair callable. None when scorer is model-backed or unknown.
         fn = _resolve_score_pair_callable(f.scorer)
@@ -103,8 +101,6 @@ def _resolve_probabilistic_fast_path(
             float(f.partial_threshold),
             [float(w) for w in weights],
         ))
-        max_weight += max(weights)
-        min_weight += min(weights)
 
     # Resolve threshold the same way the slow path does.
     if mk.link_threshold is not None:
@@ -113,6 +109,11 @@ def _resolve_probabilistic_fast_path(
         link_threshold, _ = compute_thresholds(em_result)
         link_threshold = float(link_threshold)
 
+    # Centralized range (fs_weight_range) rather than a hand-rolled sum --
+    # this fast path's per-pair loop doesn't score NE fields (N4 adds the
+    # negative_evidence decline to this gate), so this only changes behavior
+    # once an NE-bearing matchkey reaches here, which N4 closes.
+    min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
     return field_specs, link_threshold, max_weight, min_weight, weight_range
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -20,6 +20,8 @@ Gate eligibility (`_resolve_probabilistic_fast_path`):
       - field.levels in {2, 3} (N>3 unsupported in fast path v1; falls back
         to the slow `score_probabilistic` path)
   - em_result has match_weights for every field
+  - mk.negative_evidence is empty (NE never crosses into this fast path;
+    a future kernel port adds FS_SUPPORTS_NE)
 
 When the gate fails, callers fall back to `score_probabilistic`. The fast
 path produces bit-equivalent output within rapidfuzz tolerance (parity
@@ -66,6 +68,7 @@ def _resolve_probabilistic_fast_path(
         (rules out embedding/record_embedding/unknown plugins) AND its
         precomputed xform column is in prepared_df AND levels in {2, 3}.
       - em_result has match_weights for every field.
+      - mk.negative_evidence is empty.
     """
     from goldenmatch.core.matchkey import _xform_sig
     from goldenmatch.core.probabilistic import compute_thresholds, fs_weight_range
@@ -73,6 +76,11 @@ def _resolve_probabilistic_fast_path(
     if mk.type != "probabilistic":
         return None
     if not mk.fields:
+        return None
+    if mk.negative_evidence:
+        # NE never crosses into this fast path (the per-pair loop doesn't
+        # score NE fields); decline so the slow path -- which does -- stays
+        # the source of truth. Mirrors `_fs_native_eligible`.
         return None
 
     field_specs: list[ProbFieldSpec] = []
@@ -110,9 +118,9 @@ def _resolve_probabilistic_fast_path(
         link_threshold = float(link_threshold)
 
     # Centralized range (fs_weight_range) rather than a hand-rolled sum --
-    # this fast path's per-pair loop doesn't score NE fields (N4 adds the
-    # negative_evidence decline to this gate), so this only changes behavior
-    # once an NE-bearing matchkey reaches here, which N4 closes.
+    # this fast path's per-pair loop doesn't score NE fields, but the
+    # negative_evidence decline above means no NE-bearing matchkey ever
+    # reaches this point in practice; kept centralized so it can't drift.
     min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
     return field_specs, link_threshold, max_weight, min_weight, weight_range

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -290,7 +290,7 @@ def _apply_negative_evidence(matchkey: MatchkeyConfig, pair: dict) -> float:
             # One or both values are None — can't score, skip
             continue
         if sim < ne.threshold:
-            total_penalty += ne.penalty
+            total_penalty += ne.flat_penalty
     return total_penalty
 
 

--- a/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py
@@ -230,10 +230,18 @@ class ControllerTab(Static):
             if field_bits:
                 lines.append(f"    [dim]{' '.join(field_bits)}[/dim]")
             for nf in ne:
+                # weighted/exact NE carries a flat penalty; probabilistic NE
+                # carries penalty_bits (fixed LLR override) or neither
+                # (EM-learned weight).
+                if nf.penalty is not None:
+                    penalty_str = f"penalty [magenta]-{nf.penalty:.2f}[/]"
+                elif getattr(nf, "penalty_bits", None) is not None:
+                    penalty_str = f"penalty_bits [magenta]-{abs(nf.penalty_bits):.1f}[/]"
+                else:
+                    penalty_str = "weight [magenta]EM-learned[/]"
                 lines.append(
                     f"    [magenta]NE[/] {nf.field} · {nf.scorer} · "
-                    f"threshold {nf.threshold:.2f} · "
-                    f"penalty [magenta]-{nf.penalty:.2f}[/]"
+                    f"threshold {nf.threshold:.2f} · {penalty_str}"
                 )
         return "\n".join(lines)
 

--- a/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
+++ b/packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py
@@ -204,13 +204,28 @@ def _negative_evidence(config: Any) -> list[dict[str, Any]]:
         if not ne:
             continue
         for field in ne:
+            # weighted/exact NE carries a flat penalty; probabilistic NE
+            # carries penalty_bits (fixed LLR override) or neither (the
+            # weight is EM-learned). Keep "penalty" nullable rather than
+            # crashing on float(None); "weight_source" tells the panel
+            # which form to render.
+            penalty = getattr(field, "penalty", None)
+            penalty_bits = getattr(field, "penalty_bits", None)
+            if penalty is not None:
+                weight_source = "penalty"
+            elif penalty_bits is not None:
+                weight_source = "penalty_bits"
+            else:
+                weight_source = "em_learned"
             out.append({
                 "matchkey_name": mk.name,
                 "matchkey_type": mk.type,
                 "field": field.field,
                 "scorer": field.scorer,
                 "threshold": float(field.threshold),
-                "penalty": float(field.penalty),
+                "penalty": float(penalty) if penalty is not None else None,
+                "penalty_bits": float(penalty_bits) if penalty_bits is not None else None,
+                "weight_source": weight_source,
                 "transforms": list(field.transforms or []),
             })
     return out

--- a/packages/python/goldenmatch/tests/test_fs_ne_e2e.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_e2e.py
@@ -1,0 +1,273 @@
+"""Task N5: the FS negative-evidence homonym success bar (E2E, default backend).
+
+Spec: docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md ("Testing /
+success bar")
+Plan: docs/superpowers/plans/2026-07-14-fs-negative-evidence.md (Task N5)
+
+This is the deterministic end-to-end test the whole feature exists to satisfy: a
+Fellegi-Sunter (probabilistic) matchkey on agreeing name/city evidence merges two
+DISTINCT people who happen to share a name and a city (the "homonym trap" /
+fan-out failure mode) unless a hard-disagreeing field (phone) is wired in as
+negative evidence. Both the EM-learned path and the fixed ``penalty_bits``
+override must kill the trap while leaving genuine duplicates merged.
+
+Run via ``dedupe_df`` on the DEFAULT backend (no ``backend=`` override) with
+native ENABLED (no ``GOLDENMATCH_NATIVE=0``) -- the N4 native/fused/fast guards
+decline NE-bearing matchkeys, so this exercises the real capability-gate
+fallback rather than an env override standing in for it, and pins the N3
+bucket-backend slim-projection fix (an NE-only field like ``phone`` must
+survive ``GOLDENMATCH_BUCKET_SLIM_PROJECTION``, which defaults on).
+
+Fixture design (why Config A genuinely merges the homonyms -- the delta this
+test demonstrates, not a vacuous pass):
+
+- 12 surnames, spread across distinct soundex codes (project fixture rule --
+  see ``feedback_synthetic_surname_fixtures``) so blocking on ``last_name``
+  produces one block per surname without an all-in-one-block blocking hang.
+  Each block holds 4 distinct identities (3 true-duplicate pairs + 1 homonym
+  trap), so within-block EM pair sampling sees genuine disagreement examples
+  (different identities sharing a surname) alongside the agreement examples --
+  without that variety, ``first_name``/``city`` saturate to m ~= 1 / u ~= 0 and
+  swamp the EM-learned NE contribution in normalized [0, 1] space (verified
+  empirically while building this fixture: a 2-row-per-block version produces
+  extreme per-field weights that dwarf a real, correctly-signed NE veto).
+- First names and cities are drawn from large (60-entry) real-word pools with
+  no modulo-driven reuse across unrelated identities, so ``u`` (the
+  random-pair, non-match rate) for those fields reflects genuine low
+  incidental agreement -- small/reused pools inflate ``u`` and invert the
+  field's discriminative power.
+- True-duplicate pairs: same surname/city/phone, first name has a trailing
+  single-character corruption (``"Jonathan"`` vs ``"Jonathanx"``) that still
+  clears the ``jaro_winkler`` 0.8 partial threshold -- a realistic "same
+  person, slightly different capture" pair.
+- Homonym-trap pairs: same surname/first name/city (a genuine name+city
+  collision between two DIFFERENT people) but a DIFFERENT phone number.
+- ``link_threshold=0.98``: chosen because in this fixture, without NE, BOTH
+  the true-duplicate and homonym-trap pairs normalize to 1.0 (both fields
+  fully agree either way) -- there is no threshold that would separate them
+  without NE, which is exactly the failure mode. With NE wired in (EM-learned
+  or ``penalty_bits``), the true-duplicate pairs still normalize to 1.0 (phone
+  agrees, NE never fires) while the homonym-trap pairs drop measurably below
+  1.0 (phone disagrees, NE fires) -- 0.98 sits strictly between the two,
+  demonstrating the same matchkey (all fields, blocking, threshold identical)
+  flips behavior on the trap pairs purely from the ``negative_evidence`` block.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+import yaml
+from goldenmatch.config.loader import load_config
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+
+SURNAMES = [
+    "Smith", "Johnson", "Williams", "Brown", "Garcia", "Nguyen", "Okafor", "Petrov",
+    "Alvarez", "Kowalski", "Haddad", "Kim",
+]
+CITIES = [
+    "Boston", "Denver", "Austin", "Seattle", "Phoenix", "Atlanta", "Portland", "Chicago",
+    "Miami", "Dallas", "Newark", "Tampa", "Reno", "Salem", "Fresno", "Toledo", "Akron",
+    "Eugene", "Boise", "Tulsa", "Naples", "Modesto", "Waco", "Provo", "Yuma", "Erie",
+    "Wichita", "Duluth", "Macon", "Biloxi", "Laredo", "Odessa", "Bangor", "Casper",
+    "Sheridan", "Helena", "Butte", "Pierre", "Fargo", "Rapid", "Topeka", "Salina", "Hays",
+    "Enid", "Ardmore", "Muskogee", "Shawnee", "Ponca", "Guymon", "Woodward", "Alva",
+    "Clinton", "Elgin", "Chandler", "Coalgate", "Wagoner", "Vinita", "Sallisaw", "Poteau",
+    "Idabel",
+]
+FIRST_NAMES = [
+    "Jonathan", "Michael", "Robert", "Susan", "Karen", "David", "Linda", "Steven", "Nancy",
+    "Brian", "Patricia", "Kevin", "Laura", "Edward", "Diane", "Gregory", "Sandra", "Peter",
+    "Carol", "Frank", "Deborah", "Raymond", "Cynthia", "Jack", "Amy", "Dennis", "Angela",
+    "Jerry", "Melissa", "Tyler", "Brenda", "Aaron", "Emma", "Henry", "Julie", "Adam",
+    "Joyce", "Douglas", "Virginia", "Nathan", "Victoria", "Zachary", "Kelly", "Kyle",
+    "Christina", "Walter", "Joan", "Harold", "Evelyn", "Carl", "Judith", "Arthur", "Megan",
+    "Roger", "Cheryl", "Keith", "Andrea", "Willie", "Hannah", "Roy",
+]
+
+LINK_THRESHOLD = 0.98
+DUP_GROUPS_PER_SURNAME = 3
+
+
+def _build_fixture() -> tuple[pl.DataFrame, list[tuple[int, int]], list[tuple[int, int]]]:
+    """~96-row fixture: per surname, 3 true-duplicate pairs + 1 homonym trap.
+
+    Returns (df, dup_row_id_pairs, homonym_row_id_pairs) where the pair ids
+    are 0-based positional row indices matching ``dedupe_df``'s cluster
+    ``members`` convention (see tests/test_exact_blank_exclusion.py for the
+    same convention).
+    """
+    rows: list[dict] = []
+    row_id = 0
+    name_idx = 0
+    dup_pairs: list[tuple[int, int]] = []
+    homonym_pairs: list[tuple[int, int]] = []
+
+    for surname in SURNAMES:
+        for _ in range(DUP_GROUPS_PER_SURNAME):
+            fn = FIRST_NAMES[name_idx % len(FIRST_NAMES)]
+            name_idx += 1
+            city = CITIES[name_idx % len(CITIES)]
+            phone = f"555{1_000_000 + row_id:07d}"
+            r1, r2 = row_id, row_id + 1
+            row_id += 2
+            rows.append({"first_name": fn, "last_name": surname, "city": city, "phone": phone})
+            rows.append({"first_name": fn + "x", "last_name": surname, "city": city, "phone": phone})
+            dup_pairs.append((r1, r2))
+
+        # Homonym trap: same first_name + surname + city, DIFFERENT phone.
+        fn = FIRST_NAMES[name_idx % len(FIRST_NAMES)]
+        name_idx += 1
+        city = CITIES[name_idx % len(CITIES)]
+        phone_a = f"555{2_000_000 + row_id:07d}"
+        phone_b = f"555{2_000_000 + row_id + 1:07d}"
+        r1, r2 = row_id, row_id + 1
+        row_id += 2
+        rows.append({"first_name": fn, "last_name": surname, "city": city, "phone": phone_a})
+        rows.append({"first_name": fn, "last_name": surname, "city": city, "phone": phone_b})
+        homonym_pairs.append((r1, r2))
+
+    return pl.DataFrame(rows), dup_pairs, homonym_pairs
+
+
+def _fields() -> list[MatchkeyField]:
+    return [
+        MatchkeyField(field="first_name", scorer="jaro_winkler", levels=2, partial_threshold=0.8),
+        MatchkeyField(field="city", scorer="exact", levels=2),
+    ]
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(
+        strategy="static", keys=[BlockingKeyConfig(fields=["last_name"])],
+        max_block_size=1000, skip_oversized=False,
+    )
+
+
+def _id_to_cluster(res) -> dict[int, int]:
+    """Build a precise row-id -> cluster-id map from a DedupeResult."""
+    clusters = res.clusters
+    items = clusters.items() if isinstance(clusters, dict) else enumerate(clusters)
+    mapping: dict[int, int] = {}
+    for cid, info in items:
+        members = info["members"] if isinstance(info, dict) else info
+        for member_id in members:
+            mapping[member_id] = cid
+    return mapping
+
+
+def _same_cluster(mapping: dict[int, int], a: int, b: int) -> bool:
+    return a in mapping and b in mapping and mapping[a] == mapping[b]
+
+
+class TestControlConfigADemonstratesTheFailure:
+    """Without NE, the homonym trap genuinely merges -- the delta baseline."""
+
+    def test_homonyms_merge_and_duplicates_merge(self):
+        import goldenmatch as gm
+
+        df, dup_pairs, homonym_pairs = _build_fixture()
+        config = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs", type="probabilistic", fields=_fields(), link_threshold=LINK_THRESHOLD,
+            )],
+            blocking=_blocking(),
+        )
+        result = gm.dedupe_df(df, config=config)
+        mapping = _id_to_cluster(result)
+
+        for a, b in dup_pairs:
+            assert _same_cluster(mapping, a, b), f"true duplicate pair {(a, b)} failed to merge"
+        for a, b in homonym_pairs:
+            assert _same_cluster(mapping, a, b), (
+                f"homonym trap {(a, b)} did not merge under Config A -- fixture no longer "
+                "demonstrates the failure this feature exists to fix; strengthen the "
+                "shared evidence"
+            )
+
+
+class TestNegativeEvidenceSeparatesHomonyms:
+    """Config B (EM-learned) and Config C (penalty_bits) both fix the trap."""
+
+    @pytest.mark.parametrize(
+        "ne_field",
+        [
+            pytest.param(
+                NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0),
+                id="em-learned",
+            ),
+            pytest.param(
+                NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=6.0),
+                id="penalty-bits",
+            ),
+        ],
+    )
+    def test_homonyms_separate_duplicates_still_merge(self, ne_field):
+        import goldenmatch as gm
+
+        df, dup_pairs, homonym_pairs = _build_fixture()
+        config = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs", type="probabilistic", fields=_fields(),
+                negative_evidence=[ne_field], link_threshold=LINK_THRESHOLD,
+            )],
+            blocking=_blocking(),
+        )
+        result = gm.dedupe_df(df, config=config)
+        mapping = _id_to_cluster(result)
+
+        for a, b in dup_pairs:
+            assert _same_cluster(mapping, a, b), (
+                f"true duplicate pair {(a, b)} STOPPED merging once NE was added -- "
+                "NE fired on a genuine duplicate (should never happen: phone agrees)"
+            )
+        for a, b in homonym_pairs:
+            assert not _same_cluster(mapping, a, b), (
+                f"homonym trap {(a, b)} still merged with NE wired in -- "
+                "the fan-out defense this feature exists to provide did not fire"
+            )
+
+
+class TestYamlRoundTripPreservesNegativeEvidence:
+    """The EM-learned NE config surface round-trips through YAML (dump ->
+    load_config) and still produces the fixed behavior end-to-end."""
+
+    def test_ne_config_round_trips_and_still_separates_homonyms(self, tmp_path: Path):
+        import goldenmatch as gm
+
+        df, dup_pairs, homonym_pairs = _build_fixture()
+        config = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs", type="probabilistic", fields=_fields(),
+                negative_evidence=[
+                    NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0),
+                ],
+                link_threshold=LINK_THRESHOLD,
+            )],
+            blocking=_blocking(),
+        )
+
+        yaml_path = tmp_path / "fs_ne_config.yml"
+        yaml_path.write_text(yaml.safe_dump(config.model_dump(exclude_none=True)), encoding="utf-8")
+
+        reloaded = load_config(str(yaml_path))
+        reloaded_mk = reloaded.matchkeys[0]
+        assert reloaded_mk.negative_evidence is not None
+        assert reloaded_mk.negative_evidence[0].field == "phone"
+        assert reloaded_mk.negative_evidence[0].penalty_bits is None  # EM-learned, not fixed
+
+        result = gm.dedupe_df(df, config=reloaded)
+        mapping = _id_to_cluster(result)
+
+        for a, b in dup_pairs:
+            assert _same_cluster(mapping, a, b)
+        for a, b in homonym_pairs:
+            assert not _same_cluster(mapping, a, b)

--- a/packages/python/goldenmatch/tests/test_fs_ne_em.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_em.py
@@ -1,0 +1,352 @@
+"""Task N2: EM-learned negative-evidence dimensions in the FS trainer.
+
+Spec: docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
+Plan: docs/superpowers/plans/2026-07-14-fs-negative-evidence.md (Task N2)
+
+Fixture rule (feedback_synthetic_surname_fixtures): surnames are spread
+across distinct values so blocking-style within-group sampling doesn't hang
+or degenerate on a single soundex code.
+"""
+from __future__ import annotations
+
+import logging
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField, NegativeEvidenceField
+from goldenmatch.core.blocker import BlockResult
+from goldenmatch.core.probabilistic import (
+    _fallback_result,
+    _ne_fired,
+    enforce_weight_monotonicity,
+    train_em,
+)
+
+# ── Fixture helpers ─────────────────────────────────────────────────────────
+
+# Distinct surnames spread across different soundex codes, per the synthetic-
+# fixture rule -- avoids any blocking-adjacent hang/degeneracy in this test.
+_SURNAMES = [
+    "Nguyen", "Okafor", "Petrov", "Alvarez", "Kowalski",
+    "Haddad", "Mendez", "Tanaka", "Larsen", "Fitzgerald",
+]
+_FIRST_NAMES = [
+    "Alex", "Priya", "Marco", "Fatima", "Liam",
+    "Sofia", "Ken", "Nadia", "Omar", "Grace",
+]
+_ZIPS = ["10001", "20002", "30303", "40404", "50505"]
+
+
+def _phone(seed: int) -> str:
+    """A digits-only-stable 10-digit phone string derived from seed."""
+    return f"{2000000000 + seed}"
+
+
+def _make_ne_mk(**ne_kwargs) -> MatchkeyConfig:
+    """Probabilistic matchkey on name+last_name+zip with phone as NE."""
+    ne = NegativeEvidenceField(
+        field="phone", transforms=["digits_only"], scorer="exact",
+        threshold=1.0, **ne_kwargs,
+    )
+    return MatchkeyConfig(
+        name="fs_ne",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=2),
+            MatchkeyField(field="last_name", scorer="exact", levels=2),
+            MatchkeyField(field="zip", scorer="exact", levels=2),
+        ],
+        negative_evidence=[ne],
+    )
+
+
+def _make_homonym_fixture():
+    """~200 rows: planted true-duplicate pairs (name+last+zip+phone all
+    agree) + cross-entity homonym traps (name+last+zip agree, phone
+    DIFFERS) + a diverse background of singleton rows.
+
+    Returns (df, blocks) where ``blocks`` groups exactly the 40 duplicate
+    pairs + 10 homonym-trap pairs -- the m-estimation sample train_em uses
+    when ``blocks`` is provided. Random pairs (used for u) are drawn from
+    the full 200-row df, so u reflects the background population where
+    NE-field (phone) firing is common (distinct people, distinct phones).
+    """
+    rows: list[dict] = []
+    blocks: list[BlockResult] = []
+    row_id = 1
+
+    # 40 true-duplicate pairs: agree on everything, including phone.
+    for i in range(40):
+        fn = _FIRST_NAMES[i % len(_FIRST_NAMES)]
+        ln = _SURNAMES[i % len(_SURNAMES)]
+        zip_ = _ZIPS[i % len(_ZIPS)]
+        phone = _phone(1_000_000 + i)
+        pair_ids = []
+        for _ in range(2):
+            rows.append({
+                "__row_id__": row_id, "first_name": fn, "last_name": ln,
+                "zip": zip_, "phone": phone,
+            })
+            pair_ids.append(row_id)
+            row_id += 1
+        blocks.append(BlockResult(
+            block_key=f"dup-{i}",
+            df=pl.DataFrame({"__row_id__": pair_ids}),
+        ))
+
+    # 10 homonym traps: agree on name/last/zip, DIFFERENT phone.
+    for i in range(10):
+        fn = _FIRST_NAMES[i % len(_FIRST_NAMES)]
+        ln = _SURNAMES[(i + 3) % len(_SURNAMES)]
+        zip_ = _ZIPS[(i + 1) % len(_ZIPS)]
+        pair_ids = []
+        for k in range(2):
+            rows.append({
+                "__row_id__": row_id, "first_name": fn, "last_name": ln,
+                "zip": zip_, "phone": _phone(2_000_000 + i * 10 + k),
+            })
+            pair_ids.append(row_id)
+            row_id += 1
+        blocks.append(BlockResult(
+            block_key=f"homonym-{i}",
+            df=pl.DataFrame({"__row_id__": pair_ids}),
+        ))
+
+    # 100 diverse background singletons -- distinct name/last/zip/phone
+    # combinations so random-pair sampling sees a realistic non-match
+    # population (phone almost never coincidentally matches -> NE fires).
+    for i in range(100):
+        rows.append({
+            "__row_id__": row_id,
+            "first_name": _FIRST_NAMES[(i * 7) % len(_FIRST_NAMES)],
+            "last_name": _SURNAMES[(i * 3 + 1) % len(_SURNAMES)],
+            "zip": _ZIPS[(i * 5 + 2) % len(_ZIPS)],
+            "phone": _phone(3_000_000 + i),
+        })
+        row_id += 1
+
+    df = pl.DataFrame(rows)
+    return df, blocks
+
+
+# ── 1. _ne_fired unit tests ─────────────────────────────────────────────────
+
+
+def _phone_ne(threshold: float = 1.0, transforms: list[str] | None = None) -> NegativeEvidenceField:
+    return NegativeEvidenceField(
+        field="phone",
+        transforms=transforms if transforms is not None else ["digits_only"],
+        scorer="exact",
+        threshold=threshold,
+    )
+
+
+class TestNeFired:
+    def test_fires_when_both_present_and_score_below_threshold(self):
+        ne = _phone_ne(threshold=1.0)
+        assert _ne_fired(
+            {"phone": "555-1234"}, {"phone": "555-9999"}, ne,
+        ) is True  # exact score 0.0 < 1.0
+
+    def test_does_not_fire_at_exact_threshold_boundary(self):
+        ne = _phone_ne(threshold=1.0)
+        # Same phone -> exact score 1.0, NOT < 1.0 (strict).
+        assert _ne_fired(
+            {"phone": "555-1234"}, {"phone": "555-1234"}, ne,
+        ) is False
+
+    def test_does_not_fire_on_null_either_side(self):
+        ne = _phone_ne(threshold=1.0)
+        assert _ne_fired({"phone": None}, {"phone": "555-1234"}, ne) is False
+        assert _ne_fired({"phone": "555-1234"}, {"phone": None}, ne) is False
+        assert _ne_fired({}, {"phone": "555-1234"}, ne) is False
+
+    def test_does_not_fire_on_empty_string_either_side(self):
+        ne = _phone_ne(threshold=1.0)
+        assert _ne_fired({"phone": ""}, {"phone": "555-1234"}, ne) is False
+
+    def test_transforms_applied_before_scoring(self):
+        # digits_only normalizes formatting differences away -> same digits
+        # -> exact score 1.0 -> NOT fired despite different raw formatting.
+        ne = _phone_ne(threshold=1.0, transforms=["digits_only"])
+        assert _ne_fired(
+            {"phone": "(555) 123-4567"}, {"phone": "555-123-4567"}, ne,
+        ) is False
+
+
+# ── 2. train_em on the homonym fixture ──────────────────────────────────────
+
+
+class TestTrainEmNeDimensions:
+    def test_ne_entries_present_and_well_formed(self):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        assert "__ne__phone" in result.m_probs
+        assert "__ne__phone" in result.u_probs
+        assert "__ne__phone" in result.match_weights
+
+    def test_ne_m_and_u_sum_to_one(self):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        assert abs(sum(result.m_probs["__ne__phone"]) - 1.0) < 1e-6
+        assert abs(sum(result.u_probs["__ne__phone"]) - 1.0) < 1e-6
+        assert len(result.m_probs["__ne__phone"]) == 2
+        assert len(result.u_probs["__ne__phone"]) == 2
+
+    def test_not_fired_weight_is_exactly_zero(self):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        weights = result.match_weights["__ne__phone"]
+        assert len(weights) == 2
+        assert weights[1] == 0.0  # the negative-evidence clamp, not log2(m1/u1)
+
+    def test_fired_weight_is_negative_on_this_fixture(self):
+        # True duplicates dominate the "match" sample and mostly agree on
+        # phone (not fired), while random background pairs fire often
+        # (distinct people, distinct phones) -> fired is rarer in matches.
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        assert result.match_weights["__ne__phone"][0] < 0.0
+
+
+# ── 3. penalty_bits NE fields are excluded from EM entirely ─────────────────
+
+
+class TestPenaltyBitsExcludedFromEm:
+    def test_no_ne_entries_for_penalty_bits_field(self):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk(penalty_bits=3.0)
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        assert "__ne__phone" not in result.m_probs
+        assert "__ne__phone" not in result.u_probs
+        assert "__ne__phone" not in result.match_weights
+
+
+# ── 4. NE field also a blocking field -> warning ─────────────────────────────
+
+
+class TestBlockingOverlapWarning:
+    def test_warns_when_ne_field_is_also_blocking_field(self, caplog):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        with caplog.at_level(logging.WARNING):
+            train_em(
+                df, mk, n_sample_pairs=2000, blocks=blocks,
+                blocking_fields=["phone"],
+            )
+        assert any(
+            "phone" in rec.message and "blocking" in rec.message.lower()
+            for rec in caplog.records
+        )
+
+    def test_no_warning_when_ne_field_not_a_blocking_field(self, caplog):
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        with caplog.at_level(logging.WARNING):
+            train_em(
+                df, mk, n_sample_pairs=2000, blocks=blocks,
+                blocking_fields=["last_name", "zip"],
+            )
+        assert not any(
+            "phone" in rec.message and "blocking field" in rec.message.lower()
+            for rec in caplog.records
+        )
+
+
+# ── 5. Monotone repair leaves __ne__ entries alone ──────────────────────────
+
+
+class TestMonotoneRepairSkipsNe:
+    def test_enforce_mode_leaves_ne_entries_untouched(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FS_MONOTONIC", "enforce")
+        df, blocks = _make_homonym_fixture()
+        mk = _make_ne_mk()
+        result = train_em(
+            df, mk, n_sample_pairs=2000, blocks=blocks,
+            blocking_fields=["last_name", "zip"],
+        )
+        # [w_fired, 0.0] with w_fired < 0 is already non-decreasing, so
+        # "untouched" and "PAV would leave it alone anyway" coincide here;
+        # the load-bearing assertion is the exact clamp value survives.
+        assert result.match_weights["__ne__phone"][1] == 0.0
+
+    def test_warn_mode_detection_never_names_ne_key(self):
+        # Construct an EMResult by hand with a contrived positive w_fired
+        # (a degenerate case that would look "non-monotonic" to a level-
+        # ordered check) and call the repair helper directly -- skip_fields
+        # must exclude __ne__ keys so no detection message names one.
+        match_weights = {
+            "first_name": [-1.0, 1.0],
+            "__ne__phone": [2.5, 0.0],  # w_fired > 0: pathological but must
+                                        # still be skipped, not "detected".
+        }
+        repaired, adjusted = enforce_weight_monotonicity(
+            match_weights, skip_fields=["__ne__phone"],
+        )
+        assert "__ne__phone" not in adjusted
+        assert repaired["__ne__phone"] == [2.5, 0.0]  # untouched
+
+
+# ── 6. _fallback_result NE entries ──────────────────────────────────────────
+
+
+class TestFallbackResultNe:
+    def test_fallback_emits_fixed_ne_entry_with_warning(self, caplog):
+        mk = _make_ne_mk()
+        with caplog.at_level(logging.WARNING):
+            result = _fallback_result(mk)
+        assert result.match_weights["__ne__phone"] == [-3.0, 0.0]
+        assert abs(sum(result.m_probs["__ne__phone"]) - 1.0) < 1e-9
+        assert abs(sum(result.u_probs["__ne__phone"]) - 1.0) < 1e-9
+        # log2(m0/u0) == -3.0 exactly given the chosen m/u pair.
+        import math
+        m0 = result.m_probs["__ne__phone"][0]
+        u0 = result.u_probs["__ne__phone"][0]
+        assert math.log2(m0 / u0) == pytest.approx(-3.0)
+        assert any("negative-evidence" in rec.message.lower() for rec in caplog.records)
+
+    def test_fallback_penalty_bits_field_absent(self):
+        mk = _make_ne_mk(penalty_bits=3.0)
+        result = _fallback_result(mk)
+        assert "__ne__phone" not in result.match_weights
+
+    def test_fallback_triggered_by_train_em_on_tiny_data(self):
+        df = pl.DataFrame({
+            "__row_id__": [1, 2],
+            "first_name": ["Alex", "Alex"],
+            "last_name": ["Nguyen", "Nguyen"],
+            "zip": ["10001", "10001"],
+            "phone": ["2000000001", "2000000001"],
+        })
+        mk = _make_ne_mk()
+        result = train_em(df, mk, n_sample_pairs=10)
+        assert result.match_weights["__ne__phone"] == [-3.0, 0.0]
+
+
+# ── 7. Without-NE behavior is unchanged ──────────────────────────────────────
+# Regular-field EM posteriors legitimately SHIFT when NE evidence enters the
+# E-step (the NE dimension contributes real log-likelihood mass), so this is
+# NOT pinned by a byte-identical with/without-NE comparison here. Instead,
+# the existing (unmodified) test_probabilistic.py / test_nlevel_em.py /
+# test_nlevel_banding.py suites stay green -- proving the no-NE code path
+# (mk.negative_evidence is None/empty) is untouched. See the test run in the
+# PR/commit description for confirmation those suites pass unmodified.

--- a/packages/python/goldenmatch/tests/test_fs_ne_em.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_em.py
@@ -19,6 +19,7 @@ from goldenmatch.core.probabilistic import (
     _fallback_result,
     _ne_fired,
     enforce_weight_monotonicity,
+    estimate_m_from_labels,
     train_em,
 )
 
@@ -342,7 +343,65 @@ class TestFallbackResultNe:
         assert result.match_weights["__ne__phone"] == [-3.0, 0.0]
 
 
-# ── 7. Without-NE behavior is unchanged ──────────────────────────────────────
+# ── 7. estimate_m_from_labels (the supervised twin) NE handling ──────────────
+
+
+class TestEstimateMFromLabelsNe:
+    def test_ne_m_from_labeled_fired_count_is_exact(self):
+        """20 labeled pairs, exactly 5 firing on phone -> m0 is the Laplace-
+        smoothed fired rate: (5 + smoothing) / (20 + 2*smoothing) with the
+        function's default smoothing=1.0, i.e. 6/22. The weight entry is
+        [log2(m0/u0), 0.0] with u0 the trained random-pair fired rate."""
+        import math
+
+        rows: list[dict] = []
+        labels: list[tuple[int, int]] = []
+        row_id = 1
+        # 20 labeled pairs: the first 5 differ on phone (NE fires), the
+        # remaining 15 share it (not fired). Names/zips vary per pair so the
+        # random-pair u sample sees a diverse background.
+        for i in range(20):
+            fn = _FIRST_NAMES[i % len(_FIRST_NAMES)]
+            ln = _SURNAMES[i % len(_SURNAMES)]
+            zip_ = _ZIPS[i % len(_ZIPS)]
+            if i < 5:
+                phones = [_phone(4_000_000 + i * 10), _phone(4_000_000 + i * 10 + 1)]
+            else:
+                phones = [_phone(5_000_000 + i)] * 2
+            pair_ids = []
+            for k in range(2):
+                rows.append({
+                    "__row_id__": row_id, "first_name": fn, "last_name": ln,
+                    "zip": zip_, "phone": phones[k],
+                })
+                pair_ids.append(row_id)
+                row_id += 1
+            labels.append((pair_ids[0], pair_ids[1]))
+        df = pl.DataFrame(rows)
+        mk = _make_ne_mk()
+
+        smoothing = 1.0  # the function's default; pinned here so the exact
+        result = estimate_m_from_labels(df, mk, labels, smoothing=smoothing)
+
+        expected_m0 = (5 + smoothing) / (20 + 2 * smoothing)  # 6/22
+        assert result.m_probs["__ne__phone"][0] == expected_m0
+        assert result.m_probs["__ne__phone"][1] == (15 + smoothing) / (20 + 2 * smoothing)
+
+        u0 = result.u_probs["__ne__phone"][0]
+        weights = result.match_weights["__ne__phone"]
+        assert weights[0] == math.log2(max(expected_m0, 1e-10) / max(u0, 1e-10))
+        assert weights[1] == 0.0  # the clamp, exactly
+
+    def test_penalty_bits_field_absent_from_supervised_result(self):
+        df, _blocks = _make_homonym_fixture()
+        labels = [(1, 2), (3, 4), (5, 6)]
+        mk = _make_ne_mk(penalty_bits=3.0)
+        result = estimate_m_from_labels(df, mk, labels)
+        assert "__ne__phone" not in result.m_probs
+        assert "__ne__phone" not in result.match_weights
+
+
+# ── 8. Without-NE behavior is unchanged ──────────────────────────────────────
 # Regular-field EM posteriors legitimately SHIFT when NE evidence enters the
 # E-step (the NE dimension contributes real log-likelihood mass), so this is
 # NOT pinned by a byte-identical with/without-NE comparison here. Instead,

--- a/packages/python/goldenmatch/tests/test_fs_ne_guards.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_guards.py
@@ -158,6 +158,87 @@ def test_router_falls_to_scalar_for_ne_with_unsupported_ne_scorer(monkeypatch):
     assert scorer.__name__ == "_scalar"
 
 
+def test_batched_scorer_declines_vec_for_ne_with_unsupported_ne_scorer(monkeypatch):
+    """The batched sibling of the router test above:
+    ``score_probabilistic_blocks_batched`` has its OWN ``use_vec`` computation
+    (now the shared ``_fs_vectorized_supported``); pre-fix it checked only
+    ``mk.fields``, so an NE field with a matrix-incapable scorer
+    (record_embedding) wrongly took the SxS batch path and crashed in
+    ``_field_score_matrix_dedup`` (ValueError: unknown fuzzy scorer) on a live
+    pipeline.py path. Pins: (1) the batched vectorized unit scorer is never
+    selected for such a matchkey, (2) no crash, (3) the scalar fallback scores
+    correctly (NE suppresses the differing-value pair; same-value pair kept).
+
+    A minimal score_pair-only plugin is registered under 'record_embedding'
+    (restored in ``finally``) so the scalar fallback can resolve the scorer the
+    way a live pipeline with the embedding plugin registered does -- without
+    the spy in (1) that registration would let the pre-fix double-loop matrix
+    fallback pass vacuously.
+    """
+    import polars as pl
+    from goldenmatch.core import probabilistic as p
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: False)  # isolate use_vec gate
+    monkeypatch.setenv("GOLDENMATCH_FS_WORKERS", "1")
+
+    def _never_batched(*a, **kw):
+        raise AssertionError(
+            "score_probabilistic_vectorized_batch must not be selected for a "
+            "matchkey whose NE scorer is not vectorized_scorer_supported"
+        )
+
+    monkeypatch.setattr(p, "score_probabilistic_vectorized_batch", _never_batched)
+
+    class _ExactLikeScorer:
+        name = "record_embedding"
+
+        def score_pair(self, a, b):
+            if a is None or b is None:
+                return None
+            return 1.0 if a == b else 0.0
+
+    reg = PluginRegistry.instance()
+    prior = reg.get_scorer("record_embedding")
+    reg.register_scorer("record_embedding", _ExactLikeScorer())
+    try:
+        mk = _mk(
+            field="name", scorer="exact", levels=2,
+            negative_evidence=[
+                NegativeEvidenceField(
+                    field="emb", scorer="record_embedding", threshold=1.0, penalty_bits=20.0,
+                ),
+            ],
+        )
+        mk.link_threshold = 0.5
+        em = EMResult(
+            m_probs={"name": [0.1, 0.9]}, u_probs={"name": [0.9, 0.1]},
+            match_weights={"name": [-3.0, 3.0]},
+            converged=True, iterations=1, proportion_matched=0.1,
+        )
+        df = pl.DataFrame({
+            "__row_id__": [0, 1, 2, 3],
+            "name": ["alice"] * 4,
+            "city": ["springfield"] * 4,
+            # rows 0/1 share emb (NE never fires); rows 2/3 differ from
+            # everyone (NE fires on every pair involving them).
+            "emb": ["X", "X", "Y", "Z"],
+        })
+        blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=["city"])])
+        blocks = build_blocks(df.lazy(), blocking)
+        pairs = p.score_probabilistic_blocks_batched(blocks, mk, em, set())
+        kept = {(a, b) for a, b, _s in pairs}
+        # weights: agree=+3; fired NE adds -20 -> normalized (3-20+23)/26 ~ 0.23
+        # < 0.5 suppressed; un-fired pair normalizes to 1.0 -> kept.
+        assert kept == {(0, 1)}
+    finally:
+        if prior is None:
+            reg._scorers.pop("record_embedding", None)
+        else:
+            reg._scorers["record_embedding"] = prior
+
+
 # ── 4. match_fused_fs_ready: False on NE, True on plain probabilistic ───────
 
 

--- a/packages/python/goldenmatch/tests/test_fs_ne_guards.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_guards.py
@@ -1,0 +1,269 @@
+"""Guards: NE never crosses the native/fused/fast-path boundaries.
+
+Mirrors the level_thresholds gate-test scaffolding in
+tests/test_nlevel_banding.py -- synthetic native mocks + a real-kernel
+skipif helper + router __name__ assertions -- for negative_evidence
+instead of level_thresholds. Also pins EMResult.validate_for's NE-aware
+extension (missing __ne__<field> key -> FSModelMismatchError naming the
+field and both remedies: retrain / set penalty_bits).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+from goldenmatch.core import fused_match
+from goldenmatch.core.probabilistic import (
+    EMResult,
+    FSModelMismatchError,
+    _fallback_result,
+    _fs_native_eligible,
+    probabilistic_block_scorer,
+)
+from goldenmatch.core.probabilistic_fast import _resolve_probabilistic_fast_path
+
+
+def _mk(negative_evidence=None, **field_kw):
+    return MatchkeyConfig(
+        name="t", type="probabilistic",
+        fields=[MatchkeyField(**field_kw)],
+        negative_evidence=negative_evidence,
+    )
+
+
+def _mk_ne():
+    return _mk(
+        field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8,
+        negative_evidence=[
+            NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+        ],
+    )
+
+
+def _mk_plain():
+    return _mk(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)
+
+
+# ── 1. _fs_native_eligible: NE declines even with a fully-supporting mock ───
+
+
+def _fake_native_module_supporting():
+    """A kernel advertising every capability this suite might ask for
+    (mirrors test_nlevel_banding.py's supporting fake) -- NE must still
+    decline because the kernel never advertises FS_SUPPORTS_NE (it doesn't
+    exist yet; this is a future capability the kernel port will add)."""
+    class _Fake:
+        FS_SUPPORTS_LEVEL_THRESHOLDS = True
+
+        def score_block_pairs_fs(self, *a, **kw):  # pragma: no cover - not invoked
+            raise NotImplementedError
+
+    return _Fake()
+
+
+def test_fs_native_eligible_declines_ne_with_supporting_mock(monkeypatch):
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_supporting
+    )
+
+    assert _fs_native_eligible(_mk_ne()) is False
+    # Plain matchkey unaffected -- still eligible against the same mock.
+    assert _fs_native_eligible(_mk_plain()) is True
+
+
+# ── 2. Real-kernel variant (skipif native unavailable) ──────────────────────
+
+_NATIVE_FORCED_OFF = os.environ.get("GOLDENMATCH_NATIVE", "").strip().lower() in (
+    "0", "false", "no", "off", "disabled"
+)
+
+
+def _native_fs_available():
+    if _NATIVE_FORCED_OFF:
+        return False
+    try:
+        from goldenmatch.core import _native_loader
+        return _native_loader.native_available() and hasattr(
+            _native_loader.native_module(), "score_block_pairs_fs"
+        )
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _native_fs_available(), reason="native FS kernel not built")
+def test_fs_native_eligible_declines_ne_real_kernel(monkeypatch):
+    """Against the real in-tree/wheel kernel: an NE-bearing matchkey is
+    declined regardless of what the kernel advertises (no FS_SUPPORTS_NE
+    exists yet)."""
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
+
+    assert _fs_native_eligible(_mk_ne()) is False
+    assert _fs_native_eligible(_mk_plain()) is True
+
+
+# ── 3. Router: probabilistic_block_scorer selects the non-native scorer ────
+
+
+def test_router_selects_non_native_scorer_for_ne_with_native_mocked(monkeypatch):
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_supporting
+    )
+
+    mk = _mk_ne()
+    em = _fallback_result(mk)
+    scorer = probabilistic_block_scorer(mk, em)
+    # jaro_winkler + exact (the NE scorer) are both vectorized_scorer_supported
+    # -> falls through to the vectorized numpy path, NOT native.
+    assert scorer.__name__ == "_scorer"
+
+    # Plain matchkey, same mock: still routes native.
+    mk_plain = _mk_plain()
+    em_plain = _fallback_result(mk_plain)
+    assert probabilistic_block_scorer(mk_plain, em_plain).__name__ == "_native"
+
+
+def test_router_falls_to_scalar_for_ne_with_unsupported_ne_scorer(monkeypatch):
+    """N3-reviewer nit: the use_vec gate must also check NE scorers, not just
+    regular field scorers. An NE field with an unsupported (matrix-incapable)
+    scorer -- record_embedding -- must force the scalar path even though the
+    regular field's scorer IS vectorized_scorer_supported."""
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: False)  # isolate use_vec gate
+    mk = _mk(
+        field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8,
+        negative_evidence=[
+            NegativeEvidenceField(
+                field="embedding_field", scorer="record_embedding", threshold=0.5, penalty_bits=10.0,
+            ),
+        ],
+    )
+    em = _fallback_result(mk)
+    scorer = probabilistic_block_scorer(mk, em)
+    assert scorer.__name__ == "_scalar"
+
+
+# ── 4. match_fused_fs_ready: False on NE, True on plain probabilistic ───────
+
+
+def _fused_config(negative_evidence=None):
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk", type="probabilistic", link_threshold=0.5,
+                fields=[MatchkeyField(field="name", scorer="jaro_winkler", levels=3, partial_threshold=0.8)],
+                negative_evidence=negative_evidence,
+            )
+        ],
+    )
+
+
+def test_match_fused_fs_ready_false_on_ne():
+    assert fused_match.match_fused_fs_ready(_fused_config()) is True
+    ne_config = _fused_config(negative_evidence=[
+        NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+    ])
+    assert fused_match.match_fused_fs_ready(ne_config) is False
+    # Plain config still ready (mirrors test_fused_match.py's gate tests).
+    assert fused_match.match_fused_fs_ready(_fused_config()) is True
+
+
+# ── 5. _resolve_probabilistic_fast_path declines NE ─────────────────────────
+
+
+def test_resolve_probabilistic_fast_path_declines_ne():
+    import polars as pl
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms
+
+    mk = _mk(
+        field="first_name", scorer="jaro_winkler", levels=2, partial_threshold=0.8,
+        negative_evidence=[
+            NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+        ],
+    )
+    df = pl.DataFrame({"__row_id__": [0, 1], "first_name": ["alice", "alice"], "phone": ["555", "666"]})
+    prepared = precompute_matchkey_transforms(df, [mk])
+    em = EMResult(
+        m_probs={"first_name": [0.1, 0.9]}, u_probs={"first_name": [0.9, 0.1]},
+        match_weights={"first_name": [-3.0, 3.0]},
+        converged=True, iterations=1, proportion_matched=0.1,
+    )
+    assert _resolve_probabilistic_fast_path(mk, prepared, em) is None
+
+    # Plain (no NE) matchkey with the same shape stays eligible.
+    mk_plain = _mk(field="first_name", scorer="jaro_winkler", levels=2, partial_threshold=0.8)
+    prepared_plain = precompute_matchkey_transforms(df, [mk_plain])
+    assert _resolve_probabilistic_fast_path(mk_plain, prepared_plain, em) is not None
+
+
+# ── 6. validate_for: NE field key requirements ──────────────────────────────
+
+
+def _mk_ne_phone(penalty_bits=None):
+    return _mk(
+        field="name", scorer="jaro_winkler", levels=2, partial_threshold=0.8,
+        negative_evidence=[
+            NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=penalty_bits),
+        ],
+    )
+
+
+def _em_no_ne():
+    return EMResult(
+        m_probs={"name": [0.1, 0.9]}, u_probs={"name": [0.9, 0.1]},
+        match_weights={"name": [-3.0, 3.0]},
+        converged=True, iterations=1, proportion_matched=0.1,
+    )
+
+
+def test_validate_for_missing_ne_key_without_penalty_bits_raises():
+    em = _em_no_ne()  # no __ne__phone entry, no penalty_bits on the matchkey
+    mk = _mk_ne_phone(penalty_bits=None)
+    with pytest.raises(FSModelMismatchError, match="phone") as exc_info:
+        em.validate_for(mk)
+    msg = str(exc_info.value)
+    assert "retrain" in msg.lower()
+    assert "penalty_bits" in msg
+
+
+def test_validate_for_missing_ne_key_with_penalty_bits_passes():
+    em = _em_no_ne()  # still no __ne__phone entry
+    mk = _mk_ne_phone(penalty_bits=20.0)  # fixed override skips EM -> no key needed
+    em.validate_for(mk)  # must not raise
+
+
+def test_validate_for_ne_key_present_passes():
+    em = EMResult(
+        m_probs={"name": [0.1, 0.9]}, u_probs={"name": [0.9, 0.1]},
+        match_weights={"name": [-3.0, 3.0], "__ne__phone": [-5.0, 0.0]},
+        converged=True, iterations=1, proportion_matched=0.1,
+    )
+    mk = _mk_ne_phone(penalty_bits=None)
+    em.validate_for(mk)  # must not raise
+
+
+def test_validate_for_ne_key_wrong_length_raises():
+    em = EMResult(
+        m_probs={"name": [0.1, 0.9]}, u_probs={"name": [0.9, 0.1]},
+        match_weights={"name": [-3.0, 3.0], "__ne__phone": [-5.0, 0.0, 1.0]},
+        converged=True, iterations=1, proportion_matched=0.1,
+    )
+    mk = _mk_ne_phone(penalty_bits=None)
+    with pytest.raises(FSModelMismatchError, match="phone"):
+        em.validate_for(mk)

--- a/packages/python/goldenmatch/tests/test_fs_ne_schema.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_schema.py
@@ -1,0 +1,130 @@
+"""Task N1: schema surface for negative evidence on FS (probabilistic) matchkeys.
+
+Spec: docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
+Plan: docs/superpowers/plans/2026-07-14-fs-negative-evidence.md (Task N1)
+
+Validation matrix: penalty/penalty_bits x matchkey type (weighted/exact/
+probabilistic), both-set-is-impossible-by-construction, neither-set.
+"""
+import pydantic
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField, NegativeEvidenceField
+
+
+def _mk(mk_type: str, **ne_kwargs) -> MatchkeyConfig:
+    """Build a single-field matchkey of ``mk_type`` with one NE field on 'phone'."""
+    field_kwargs: dict = {"field": "name"}
+    if mk_type == "weighted":
+        field_kwargs.update(scorer="ensemble", weight=1.0)
+        threshold = 0.85
+    elif mk_type == "probabilistic":
+        field_kwargs.update(scorer="ensemble")
+        threshold = None
+    else:  # exact
+        threshold = None
+
+    ne = NegativeEvidenceField(
+        field="phone", transforms=["digits_only"], scorer="exact",
+        threshold=0.5, **ne_kwargs,
+    )
+    return MatchkeyConfig(
+        name="mk",
+        type=mk_type,
+        threshold=threshold,
+        fields=[MatchkeyField(**field_kwargs)],
+        negative_evidence=[ne],
+    )
+
+
+# 1. probabilistic + NE with penalty_bits=3.0 (no penalty) -> validates
+def test_probabilistic_ne_penalty_bits_validates():
+    mk = _mk("probabilistic", penalty_bits=3.0)
+    assert mk.negative_evidence is not None
+    assert mk.negative_evidence[0].penalty_bits == 3.0
+    assert mk.negative_evidence[0].penalty is None
+
+
+# 2. probabilistic + NE with penalty=0.4 -> ValidationError naming penalty_bits
+def test_probabilistic_ne_penalty_rejected():
+    with pytest.raises(pydantic.ValidationError, match=r"penalty_bits"):
+        _mk("probabilistic", penalty=0.4)
+
+
+# 3. weighted + NE WITHOUT penalty -> ValidationError (moved to matchkey validator)
+def test_weighted_ne_missing_penalty_rejected():
+    with pytest.raises(pydantic.ValidationError, match=r"penalty"):
+        _mk("weighted")
+
+
+# 4. weighted + NE with penalty_bits=2.0 -> ValidationError (weighted rejects penalty_bits)
+def test_weighted_ne_penalty_bits_rejected():
+    with pytest.raises(pydantic.ValidationError, match=r"penalty_bits"):
+        _mk("weighted", penalty=0.4, penalty_bits=2.0)
+
+
+# 5. exact + NE with penalty=0.4 -> validates (byte-unchanged semantics)
+def test_exact_ne_penalty_validates():
+    mk = _mk("exact", penalty=0.4)
+    assert mk.negative_evidence is not None
+    assert mk.negative_evidence[0].penalty == 0.4
+
+
+def test_exact_ne_missing_penalty_rejected():
+    with pytest.raises(pydantic.ValidationError, match=r"penalty"):
+        _mk("exact")
+
+
+def test_exact_ne_penalty_bits_rejected():
+    with pytest.raises(pydantic.ValidationError, match=r"penalty_bits"):
+        _mk("exact", penalty=0.4, penalty_bits=1.0)
+
+
+# 6. probabilistic + NE with NEITHER penalty nor penalty_bits -> validates (EM-learned default)
+def test_probabilistic_ne_neither_set_validates():
+    mk = _mk("probabilistic")
+    assert mk.negative_evidence is not None
+    assert mk.negative_evidence[0].penalty is None
+    assert mk.negative_evidence[0].penalty_bits is None
+
+
+# 7. penalty_bits=-2.0 on probabilistic -> validates (any float accepted; abs() at scoring)
+def test_probabilistic_ne_negative_penalty_bits_validates():
+    mk = _mk("probabilistic", penalty_bits=-2.0)
+    assert mk.negative_evidence is not None
+    assert mk.negative_evidence[0].penalty_bits == -2.0
+
+
+# 8. Existing-shape round-trip: a weighted matchkey dict with NE parses identically
+def test_weighted_ne_round_trip_unchanged():
+    payload = {
+        "name": "test",
+        "type": "weighted",
+        "threshold": 0.85,
+        "fields": [
+            {"field": "email", "transforms": ["lowercase"], "scorer": "ensemble", "weight": 1.0}
+        ],
+        "negative_evidence": [
+            {
+                "field": "phone",
+                "transforms": ["digits_only"],
+                "scorer": "exact",
+                "threshold": 0.5,
+                "penalty": 0.3,
+            }
+        ],
+    }
+    mk = MatchkeyConfig.model_validate(payload)
+    dumped = mk.model_dump(exclude_none=True)
+    # The negative_evidence shape is the load-bearing back-compat surface this
+    # task touches; compare it exactly (byte-unchanged for weighted/exact).
+    assert dumped["negative_evidence"] == [
+        {
+            "field": "phone",
+            "transforms": ["digits_only"],
+            "scorer": "exact",
+            "threshold": 0.5,
+            "penalty": 0.3,
+        }
+    ]
+    assert dumped["type"] == "weighted"
+    assert dumped["threshold"] == 0.85

--- a/packages/python/goldenmatch/tests/test_fs_ne_schema.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_schema.py
@@ -128,3 +128,66 @@ def test_weighted_ne_round_trip_unchanged():
     ]
     assert dumped["type"] == "weighted"
     assert dumped["threshold"] == 0.85
+
+
+# ── Render/telemetry surfaces must not crash on probabilistic NE shapes ─────
+# (penalty=None is now a valid schema state; these surfaces previously did
+# float(field.penalty) / f"-{nf.penalty:.2f}" unconditionally.)
+
+
+class _StubConfig:
+    def __init__(self, matchkeys):
+        self._matchkeys = matchkeys
+
+    def get_matchkeys(self):
+        return self._matchkeys
+
+
+def _render_fixture_matchkeys() -> list[MatchkeyConfig]:
+    """One matchkey per NE shape: weighted+penalty, probabilistic+penalty_bits,
+    probabilistic EM-learned (neither set)."""
+    return [
+        _mk("weighted", penalty=0.4),
+        _mk("probabilistic", penalty_bits=3.0),
+        _mk("probabilistic"),
+    ]
+
+
+def test_web_telemetry_negative_evidence_handles_all_ne_shapes():
+    from goldenmatch.web.controller_telemetry import _negative_evidence
+
+    out = _negative_evidence(_StubConfig(_render_fixture_matchkeys()))
+    assert len(out) == 3
+    by_source = {row["weight_source"]: row for row in out}
+    assert set(by_source) == {"penalty", "penalty_bits", "em_learned"}
+    assert all(row["field"] == "phone" for row in out)
+    assert by_source["penalty"]["penalty"] == 0.4
+    assert by_source["penalty"]["penalty_bits"] is None
+    assert by_source["penalty_bits"]["penalty"] is None
+    assert by_source["penalty_bits"]["penalty_bits"] == 3.0
+    assert by_source["em_learned"]["penalty"] is None
+    assert by_source["em_learned"]["penalty_bits"] is None
+
+
+def test_cli_controller_render_negative_evidence_handles_all_ne_shapes():
+    from goldenmatch.cli._controller_render import _ne_penalty_label, _negative_evidence
+
+    table = _negative_evidence(_StubConfig(_render_fixture_matchkeys()))
+    assert table is not None  # built without crashing on penalty=None
+    labels = [_ne_penalty_label(ne) for mk in _render_fixture_matchkeys()
+              for ne in (mk.negative_evidence or [])]
+    assert labels == ["-0.40", "-3.0 bits", "EM-learned"]
+
+
+def test_tui_controller_tab_render_committed_handles_all_ne_shapes():
+    textual = pytest.importorskip("textual")  # noqa: F841
+    from goldenmatch.tui.engine import ControllerTelemetry
+    from goldenmatch.tui.tabs.controller_tab import ControllerTab
+
+    t = ControllerTelemetry(committed_config=_StubConfig(_render_fixture_matchkeys()))
+    # _render_committed only reads `t`; call unbound so no widget mount needed.
+    rendered = ControllerTab._render_committed(None, t)  # type: ignore[arg-type]
+    assert "phone" in rendered
+    assert "penalty" in rendered            # weighted flat penalty
+    assert "penalty_bits" in rendered       # probabilistic fixed override
+    assert "EM-learned" in rendered         # probabilistic learned weight

--- a/packages/python/goldenmatch/tests/test_fs_ne_scoring.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_scoring.py
@@ -280,13 +280,11 @@ class TestBucketSlimProjectionKeepsNeField:
             converged=True, iterations=0, proportion_matched=0.02,
         )
 
-    def test_ne_only_field_fires_through_default_slim_projection(self, monkeypatch):
-        # TODO(N4): remove once `_fs_native_eligible` declines NE-bearing
-        # matchkeys -- pre-N4 the native FS kernel doesn't score NE at all, so
-        # forcing it off here isolates the slim-projection fix under test
-        # from that separate (already-known, N4-scoped) gap.
-        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
-        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    def test_ne_only_field_fires_through_default_slim_projection(self):
+        # Native ENABLED: `_fs_native_eligible` declines NE-bearing matchkeys
+        # (N4), so this exercises the real decline routing to the pure-Python
+        # path rather than relying on env overrides to isolate the
+        # slim-projection fix under test.
         from goldenmatch.backends.score_buckets import score_buckets
 
         mk_no_ne = MatchkeyConfig(
@@ -338,11 +336,10 @@ class TestDedupeDfDefaultBackendNe:
             MatchkeyField(field="last_name", scorer="exact", levels=2),
         ]
 
-    def test_homonym_pair_merges_without_ne_and_separates_with_ne(self, monkeypatch):
-        # TODO(N4): remove once `_fs_native_eligible` declines NE-bearing
-        # matchkeys -- see TestBucketSlimProjectionKeepsNeField above.
-        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
-        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    def test_homonym_pair_merges_without_ne_and_separates_with_ne(self):
+        # Native ENABLED: see TestBucketSlimProjectionKeepsNeField above --
+        # `_fs_native_eligible` declines NE-bearing matchkeys (N4), so this
+        # runs the real decline rather than an env override.
         from goldenmatch import dedupe_df
 
         config_a = GoldenMatchConfig(

--- a/packages/python/goldenmatch/tests/test_fs_ne_scoring.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_scoring.py
@@ -1,0 +1,368 @@
+"""Task N3: FS negative-evidence scoring contributions + centralized
+``fs_weight_range`` + the bucket-backend slim-projection keep-list.
+
+Spec: docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
+Plan: docs/superpowers/plans/2026-07-14-fs-negative-evidence.md (Task N3)
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
+from goldenmatch.core.probabilistic import (
+    ContinuousEMResult,
+    EMResult,
+    _ne_scalar_contribution,
+    fs_weight_range,
+    score_probabilistic,
+    score_probabilistic_continuous,
+    score_probabilistic_vectorized,
+    train_em,
+    train_em_continuous,
+)
+
+# ── 1. fs_weight_range ───────────────────────────────────────────────────────
+
+
+class TestFsWeightRange:
+    def test_mixed_regular_ne_learned_and_penalty_bits(self):
+        mk = MatchkeyConfig(
+            name="mix", type="probabilistic",
+            fields=[
+                MatchkeyField(field="a", scorer="exact", levels=2),
+                MatchkeyField(field="b", scorer="exact", levels=2),
+            ],
+            negative_evidence=[
+                # EM-learned (no penalty_bits) -- uses the __ne__ entry below.
+                NegativeEvidenceField(field="ne1", scorer="exact", threshold=1.0),
+                # Fixed override, positive bits (abs taken).
+                NegativeEvidenceField(field="ne2", scorer="exact", threshold=1.0, penalty_bits=5.0),
+                # Fixed override, negative bits (abs taken -- same magnitude).
+                NegativeEvidenceField(field="ne3", scorer="exact", threshold=1.0, penalty_bits=-2.5),
+            ],
+        )
+        em = EMResult(
+            m_probs={}, u_probs={},
+            match_weights={
+                "a": [-2.0, 3.0],
+                "b": [-1.0, 1.0],
+                "__ne__ne1": [-4.0, 0.0],
+            },
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+        min_w, max_w = fs_weight_range(em, mk)
+        # min: -2.0 (a) + -1.0 (b) + -4.0 (ne1 learned) + -5.0 (ne2) + -2.5 (ne3)
+        assert min_w == pytest.approx(-14.5)
+        # max: 3.0 (a) + 1.0 (b) + 0.0 (ne1) + 0.0 (ne2, penalty_bits never adds to max) + 0.0 (ne3)
+        assert max_w == pytest.approx(4.0)
+
+    def test_regular_fields_only_unchanged(self):
+        mk = MatchkeyConfig(
+            name="plain", type="probabilistic",
+            fields=[MatchkeyField(field="a", scorer="exact", levels=3)],
+        )
+        em = EMResult(
+            m_probs={}, u_probs={}, match_weights={"a": [-2.0, 0.5, 3.0]},
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+        assert fs_weight_range(em, mk) == (-2.0, 3.0)
+
+    def test_ne_field_with_neither_penalty_bits_nor_em_entry_contributes_zero(self):
+        # Defensive: shouldn't happen post validate_for (N4), but must not KeyError.
+        mk = MatchkeyConfig(
+            name="defensive", type="probabilistic",
+            fields=[MatchkeyField(field="a", scorer="exact", levels=2)],
+            negative_evidence=[NegativeEvidenceField(field="ne4", scorer="exact", threshold=1.0)],
+        )
+        em = EMResult(
+            m_probs={}, u_probs={}, match_weights={"a": [-1.0, 1.0]},  # no "__ne__ne4" key
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+        assert fs_weight_range(em, mk) == (-1.0, 1.0)
+
+
+# ── 2. Scalar scoring (score_probabilistic) ─────────────────────────────────
+
+
+def _scalar_mk_and_em(link_threshold: float = 0.0) -> tuple[MatchkeyConfig, EMResult]:
+    mk = MatchkeyConfig(
+        name="fs_scalar", type="probabilistic",
+        fields=[MatchkeyField(field="name", scorer="exact", levels=2)],
+        negative_evidence=[NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0)],
+        link_threshold=link_threshold,
+    )
+    em = EMResult(
+        m_probs={}, u_probs={},
+        match_weights={"name": [-1.0, 2.0], "__ne__phone": [-3.0, 0.0]},
+        converged=True, iterations=0, proportion_matched=0.02,
+    )
+    return mk, em
+
+
+class TestScalarScoring:
+    def _df(self):
+        return pl.DataFrame({
+            "__row_id__": [1, 2, 3, 4, 5, 6],
+            "name": ["a", "a", "b", "b", "c", "c"],
+            "phone": ["111", "222", "333", "333", "444", None],
+        })
+
+    def test_ne_fires_adds_w_fired(self):
+        mk, em = _scalar_mk_and_em()
+        pairs = {(a, b): s for a, b, s in score_probabilistic(self._df(), mk, em, set())}
+        # name agrees (weight 2.0), phone differs -> NE fires (-3.0) -> total -1.0.
+        # min=-1.0-3.0=-4.0, max=2.0+0.0=2.0, range=6.0 -> normalized (−1+4)/6 = 0.5
+        assert pairs[(1, 2)] == pytest.approx(0.5)
+
+    def test_ne_not_fired_is_regular_sum_exactly(self):
+        mk, em = _scalar_mk_and_em()
+        pairs = {(a, b): s for a, b, s in score_probabilistic(self._df(), mk, em, set())}
+        # name agrees, phone agrees -> NE not fired -> total = 2.0 exactly -> normalized 1.0
+        assert pairs[(3, 4)] == pytest.approx(1.0)
+
+    def test_ne_null_on_one_side_is_regular_sum_exactly(self):
+        mk, em = _scalar_mk_and_em()
+        pairs = {(a, b): s for a, b, s in score_probabilistic(self._df(), mk, em, set())}
+        # name agrees, phone null on row 6 -> NE inconclusive (not fired) -> total = 2.0
+        assert pairs[(5, 6)] == pytest.approx(1.0)
+
+
+# ── 3. penalty_bits fixed override (no __ne__ entry needed) ────────────────
+
+
+class TestPenaltyBitsFixedOverride:
+    def test_fired_contribution_is_exactly_negative_bits(self):
+        ne = NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=3.0)
+        em = EMResult(
+            m_probs={}, u_probs={}, match_weights={"name": [-1.0, 2.0]},  # no __ne__phone
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+        row_a = {"phone": "111"}
+        row_b = {"phone": "999"}
+        assert _ne_scalar_contribution(row_a, row_b, ne, em) == -3.0
+
+    def test_negative_penalty_bits_takes_abs(self):
+        ne = NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=-3.0)
+        em = EMResult(
+            m_probs={}, u_probs={}, match_weights={}, converged=True,
+            iterations=0, proportion_matched=0.02,
+        )
+        assert _ne_scalar_contribution({"phone": "111"}, {"phone": "999"}, ne, em) == -3.0
+
+    def test_not_fired_contributes_zero(self):
+        ne = NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=3.0)
+        em = EMResult(
+            m_probs={}, u_probs={}, match_weights={}, converged=True,
+            iterations=0, proportion_matched=0.02,
+        )
+        assert _ne_scalar_contribution({"phone": "111"}, {"phone": "111"}, ne, em) == 0.0
+
+
+# ── 4. Scalar vs vectorized parity on an NE-bearing matchkey ────────────────
+
+
+class TestScalarVectorizedParity:
+    def _fixture(self):
+        # Distinct name groups (soundex-diverse per project fixture rule), each
+        # pair member with a DIFFERENT phone -- NE fires on every same-name
+        # pair too, exercising the NE math on both scorer paths uniformly.
+        names = [
+            "Nguyen", "Nguyen", "Okafor", "Okafor", "Petrov", "Petrov",
+            "Alvarez", "Alvarez", "Kowalski", "Kowalski", "Haddad", "Haddad",
+        ]
+        phones = [f"{1_000_000_000 + i}" for i in range(len(names))]
+        return pl.DataFrame({
+            "__row_id__": list(range(1, len(names) + 1)),
+            "name": names,
+            "phone": phones,
+        })
+
+    def _mk(self):
+        return MatchkeyConfig(
+            name="fs_parity", type="probabilistic",
+            fields=[MatchkeyField(field="name", scorer="exact", levels=2)],
+            negative_evidence=[NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0)],
+        )
+
+    def test_identical_pairs_and_scores(self):
+        df = self._fixture()
+        mk = self._mk()
+        em = train_em(df, mk, n_sample_pairs=200)
+        assert "__ne__phone" in em.match_weights
+
+        scalar_pairs = sorted(score_probabilistic(df, mk, em, set()))
+        vector_pairs = sorted(score_probabilistic_vectorized(df, mk, em, set()))
+        assert scalar_pairs == vector_pairs
+
+
+# ── 5. Normalized scores stay in [0, 1] at the extremes ─────────────────────
+
+
+class TestNormalizedBounds:
+    def test_all_disagree_and_all_fire_normalizes_to_zero_not_negative(self):
+        mk = MatchkeyConfig(
+            name="fs_extreme", type="probabilistic",
+            fields=[MatchkeyField(field="name", scorer="exact", levels=2)],
+            negative_evidence=[NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0)],
+            link_threshold=0.0,
+        )
+        em = EMResult(
+            m_probs={}, u_probs={},
+            match_weights={"name": [-1.0, 2.0], "__ne__phone": [-3.0, 0.0]},
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+        df = pl.DataFrame({
+            "__row_id__": [1, 2],
+            "name": ["a", "b"],       # disagree -> level 0 -> weight -1.0 (the min)
+            "phone": ["111", "222"],  # differ -> NE fires -> -3.0 (the min)
+        })
+        pairs = {(a, b): s for a, b, s in score_probabilistic(df, mk, em, set())}
+        score = pairs[(1, 2)]
+        assert score == pytest.approx(0.0)
+        assert 0.0 <= score <= 1.0
+
+
+# ── 6. Continuous path rejects NE ────────────────────────────────────────────
+
+
+class TestContinuousPathRejectsNe:
+    def _mk_and_df(self):
+        mk = MatchkeyConfig(
+            name="fs_cont", type="probabilistic",
+            fields=[MatchkeyField(field="a", scorer="exact", levels=2)],
+            negative_evidence=[NegativeEvidenceField(field="b", scorer="exact", threshold=1.0)],
+        )
+        df = pl.DataFrame({"__row_id__": [1, 2], "a": ["x", "x"], "b": ["1", "2"]})
+        return mk, df
+
+    def test_train_em_continuous_raises(self):
+        mk, df = self._mk_and_df()
+        with pytest.raises(ValueError, match="negative_evidence"):
+            train_em_continuous(df, mk)
+
+    def test_score_probabilistic_continuous_raises(self):
+        mk, df = self._mk_and_df()
+        dummy_em = ContinuousEMResult(
+            m_mean={"a": 0.9}, m_var={"a": 0.01}, u_mean={"a": 0.2}, u_var={"a": 0.04},
+            converged=True, iterations=1, proportion_matched=0.05,
+        )
+        with pytest.raises(ValueError, match="negative_evidence"):
+            score_probabilistic_continuous(df, mk, dummy_em)
+
+
+# ── 7. Bucket backend: slim-projection keep-list pin (unit level) ──────────
+
+
+class TestBucketSlimProjectionKeepsNeField:
+    def _df(self):
+        return pl.DataFrame({
+            "__row_id__": [1, 2, 3, 4],
+            "name": ["homer", "homer", "homer", "homer"],
+            "city": ["springfield"] * 4,
+            # row 2's phone differs from everyone else's -- NE should fire
+            # only on pairs involving row 2.
+            "phone": ["5551111", "5559999", "5551111", "5551111"],
+        })
+
+    def _blocking(self):
+        return BlockingConfig(keys=[BlockingKeyConfig(fields=["city"])])
+
+    def _em(self):
+        return EMResult(
+            m_probs={}, u_probs={}, match_weights={"name": [-1.0, 1.0]},
+            converged=True, iterations=0, proportion_matched=0.02,
+        )
+
+    def test_ne_only_field_fires_through_default_slim_projection(self, monkeypatch):
+        # TODO(N4): remove once `_fs_native_eligible` declines NE-bearing
+        # matchkeys -- pre-N4 the native FS kernel doesn't score NE at all, so
+        # forcing it off here isolates the slim-projection fix under test
+        # from that separate (already-known, N4-scoped) gap.
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+        from goldenmatch.backends.score_buckets import score_buckets
+
+        mk_no_ne = MatchkeyConfig(
+            name="fs", type="probabilistic",
+            fields=[MatchkeyField(field="name", scorer="exact", levels=2)],
+            link_threshold=0.5,
+        )
+        mk_ne = MatchkeyConfig(
+            name="fs", type="probabilistic",
+            fields=[MatchkeyField(field="name", scorer="exact", levels=2)],
+            negative_evidence=[
+                NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+            ],
+            link_threshold=0.5,
+        )
+        em = self._em()
+        blocking = self._blocking()
+
+        # GOLDENMATCH_BUCKET_SLIM_PROJECTION defaults ON (unset here on purpose
+        # -- this is the default-backend pin the spec calls out).
+        no_ne_pairs = {(a, b) for a, b, _s in score_buckets(self._df(), blocking, mk_no_ne, set(), em_result=em)}
+        ne_pairs = {(a, b) for a, b, _s in score_buckets(self._df(), blocking, mk_ne, set(), em_result=em)}
+
+        assert (1, 2) in no_ne_pairs  # without NE, the differing-phone pair still merges
+        assert (1, 2) not in ne_pairs  # with NE (and the keep-list fix), it's suppressed
+
+
+# ── 8. Default-backend E2E: NE-only field survives slim projection ─────────
+
+
+class TestDedupeDfDefaultBackendNe:
+    def _df(self):
+        return pl.DataFrame({
+            "first_name": ["Homer", "Homer"],
+            "last_name": ["Simpson", "Simpson"],
+            "city": ["Springfield", "Springfield"],
+            "phone": ["5551111", "5559999"],
+        })
+
+    def _blocking(self):
+        return BlockingConfig(
+            strategy="static", keys=[BlockingKeyConfig(fields=["city"])],
+            max_block_size=1000, skip_oversized=False,
+        )
+
+    def _fields(self):
+        return [
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=2, partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="exact", levels=2),
+        ]
+
+    def test_homonym_pair_merges_without_ne_and_separates_with_ne(self, monkeypatch):
+        # TODO(N4): remove once `_fs_native_eligible` declines NE-bearing
+        # matchkeys -- see TestBucketSlimProjectionKeepsNeField above.
+        monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+        monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+        from goldenmatch import dedupe_df
+
+        config_a = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs", type="probabilistic", fields=self._fields(), link_threshold=0.5,
+            )],
+            blocking=self._blocking(),
+        )
+        result_a = dedupe_df(self._df(), config=config_a)
+        assert len(result_a.clusters) == 1  # homonyms merge -- the failure NE exists to fix
+
+        config_b = GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs", type="probabilistic", fields=self._fields(),
+                negative_evidence=[
+                    NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+                ],
+                link_threshold=0.5,
+            )],
+            blocking=self._blocking(),
+        )
+        result_b = dedupe_df(self._df(), config=config_b)
+        assert len(result_b.clusters) == 2 or result_b.clusters == {}  # NE separates them

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -882,6 +882,43 @@ def test_calibration_lever_partial_model_skips():
     assert "surname" in warn_findings[0].message
 
 
+def test_calibration_lever_ne_bearing_matchkey_skips():
+    """Tripwire for the planned fan-out upgrade lever: the calibration
+    lever's pair-weight sum and model min/max range cover REGULAR fields
+    only -- no negative-evidence contributions. ``from_splink`` never emits
+    ``negative_evidence`` today, but the fan-out lever will; until the
+    lever is taught ``fs_weight_range``, an NE-bearing matchkey must warn +
+    skip (levers never fail the pass) rather than calibrate thresholds on
+    the wrong weight scale. Hand-built: a normal trained conversion with NE
+    injected onto the matchkey."""
+    from goldenmatch.config.schemas import NegativeEvidenceField
+
+    conversion = from_splink(_calibration_settings())
+    assert conversion.em_model is not None
+    conversion.config.get_matchkeys()[0].negative_evidence = [
+        NegativeEvidenceField(field="first_name", scorer="exact", threshold=1.0, penalty_bits=6.0),
+    ]
+
+    # _calibration_df yields 570 blocked pairs -- calibration WOULD run if
+    # the NE tripwire didn't skip first.
+    result = upgrade_splink_conversion(
+        conversion, _calibration_df(), levers={"calibration"}, measure=False
+    )
+
+    upgraded_mk = result.upgraded_config.get_matchkeys()[0]
+    assert upgraded_mk.link_threshold is None
+    assert upgraded_mk.review_threshold is None
+
+    warn_findings = [
+        f for f in result.report.findings
+        if f.splink_path == "upgrade:calibration" and f.severity == "warning"
+    ]
+    assert len(warn_findings) == 1
+    assert "negative_evidence" in warn_findings[0].message
+    assert "fs_weight_range" in warn_findings[0].message
+    assert "skip" in warn_findings[0].message.lower()
+
+
 def test_calibration_lever_reestimates_within_block_rate_from_tiny_prior():
     """An imported Splink model carries probability_two_random_records_match
     -- a RANDOM-PAIR prior -- in proportion_matched, not the within-block

--- a/packages/python/goldenmatch/web/frontend/src/components/ControllerPanel.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/ControllerPanel.tsx
@@ -186,10 +186,24 @@ function CommittedConfig({
                     {neFields.map((nf, i) => (
                       <li key={i} className="font-mono text-ink-600">
                         {nf.field} · {nf.scorer} · threshold{" "}
-                        {nf.threshold.toFixed(2)} · penalty{" "}
-                        <span className="text-violet-700">
-                          -{nf.penalty.toFixed(2)}
-                        </span>
+                        {nf.threshold.toFixed(2)} ·{" "}
+                        {nf.penalty != null ? (
+                          <>
+                            penalty{" "}
+                            <span className="text-violet-700">
+                              -{nf.penalty.toFixed(2)}
+                            </span>
+                          </>
+                        ) : nf.penalty_bits != null ? (
+                          <>
+                            penalty_bits{" "}
+                            <span className="text-violet-700">
+                              -{Math.abs(nf.penalty_bits).toFixed(1)}
+                            </span>
+                          </>
+                        ) : (
+                          <span className="text-violet-700">EM-learned</span>
+                        )}
                       </li>
                     ))}
                   </ul>

--- a/packages/python/goldenmatch/web/frontend/src/lib/api.ts
+++ b/packages/python/goldenmatch/web/frontend/src/lib/api.ts
@@ -390,7 +390,13 @@ export type ControllerNegativeEvidence = {
   field: string;
   scorer: string;
   threshold: number;
-  penalty: number;
+  // weighted/exact NE: flat penalty (weight_source "penalty").
+  // probabilistic NE: penalty is null; either penalty_bits is set
+  // (weight_source "penalty_bits") or the weight is EM-learned
+  // (weight_source "em_learned").
+  penalty: number | null;
+  penalty_bits: number | null;
+  weight_source: "penalty" | "penalty_bits" | "em_learned";
   transforms: string[];
 };
 


### PR DESCRIPTION
## Summary

\`negative_evidence\` now works on \`type: probabilistic\` matchkeys — previously silently ignored (weighted/exact only). Implements the Wave D investigation's Formulation B (Bayesian factor preserving LLR additivity) with a key update to its deferral rationale: EM estimates match-conditional probabilities WITHOUT labels — the same machinery that trains every regular FS field trains the NE dimensions. The 2026-05-21 investigation doc is superseded (banner added); the never-implemented \`GOLDENMATCH_NE_FS_ESCAPE_MODE\` escape hatch is removed from docs rather than built.

**Semantics:** an NE field is an EM-learned constrained dimension — it contributes \`log2(m_fire/u_fire)\` when it FIRES (both values present post-transform AND scorer similarity STRICTLY below threshold, matching weighted NE) and exactly 0 otherwise. The else-zero clamp is what makes it negative evidence: agreement never boosts. \`penalty_bits\` gives a fixed override (contributes \`-abs(bits)\` when fired, skips EM).

- **Schema:** \`penalty\` relaxed to optional with a per-type validation matrix (weighted/exact require \`penalty\`, reject \`penalty_bits\`; probabilistic the inverse) — no silent knobs. Render/telemetry surfaces (CLI, TUI, web + workbench TS) handle all three NE shapes.
- **EM:** NE dims join training as separate 2-state dimensions (\`__ne__<field>\` entries riding EMResult schema v1 — TS serde round-trips them losslessly); u from random pairs, m via the EM loop with FULL likelihood internally (the clamp is storage-only — verified by exact numeric probes); supervised twin handled; fallback emits a conservative -3.0 bits; monotone repair excludes \`__ne__\` keys; blocking-overlap degeneracy warns.
- **Scoring:** scalar + vectorized + batch contributions with proven parity (incl. empty-string/null edge probes); \`fs_weight_range\` centralizes SIX previously hand-rolled normalization-range sites (bit-identical for non-NE configs, proven); bucket slim-projection keep-list extended so NE-only fields survive; continuous/Winkler path rejects NE loudly.
- **Guards:** native, fused, and fast paths decline NE (capability-gate playbook; future kernel port adds \`FS_SUPPORTS_NE\`); a shared \`_fs_vectorized_supported\` unifies the two use_vec gates after review caught the batched sibling unguarded; \`validate_for\` fails loudly on models lacking NE parameters (naming both remedies); the splink-upgrade calibration lever gained a tripwire skip for the successor fan-out feature.

## Success bar (deterministic E2E, default backend, native enabled)

Synthetic homonym fixture: distinct people sharing name+city with different phones. WITHOUT NE the FS config merges all 12 homonym traps (the fan-out failure). WITH phone as NE (EM-learned or penalty_bits) all 12 separate while all 36 true-duplicate pairs still merge. Pinned as tests incl. a YAML round-trip.

## Cross-surface note

TS FS scoring has no NE path yet (thesis phase 3); \`__ne__\` model entries round-trip losslessly through the TS serde, but a shared probabilistic+NE config scores differently Py vs TS until the port — phase-3 work should open with a loud TS-side decline.

## Testing

61 new tests across 5 files (schema/EM/scoring/guards/E2E) + back-compat sweep: 404 passed across 32 files, zero edits to pre-existing NE tests. E-step math, scalar↔vectorized parity, and range-centralization no-op all verified by independent numeric probes during review.

Spec: docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md
Plan: docs/superpowers/plans/2026-07-14-fs-negative-evidence.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqWK7rUZ4MqXnA47BdhjS