### PR TITLE
perf(goldenmatch): default-on arrow-native autoconfig (zero-config arrow W1S1)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-goldenmatch-zero-config-arrow-polars-free.md
+++ b/docs/superpowers/plans/2026-07-14-goldenmatch-zero-config-arrow-polars-free.md
@@ -1,0 +1,162 @@
+# Zero-config dedupe: finish the arrow-lane polars eviction
+
+> **Status:** planned 2026-07-14. Continues the 3.x engine-descent eviction
+> (`project_goldenmatch_polars_eviction`). Two waves, staged. Wave 1 unblocks the
+> `#1747 [polars]` bridge stopgap; Wave 2 flips the D6 "polars not installed"
+> gate green.
+
+## Corrected premise (from the leak catalog, 2026-07-14)
+
+A traced zero-config `dedupe_df(pa.Table, config=None)` on the arrow lane with
+`GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` + native on shows the **controller and
+scoring spine are already polars-free** (score_buckets runs arrow-native; zero
+`blocker.py`/`scorer.py`/`indicators.py` leaks). The stale Tier-3 xfail comment
+naming `build_blocks(combined_lf)` + indicator guards was overtaken by the
+arrow-native autoconfig work. The 26 remaining `pl.*` access sites are:
+
+| Cluster | Sites | Fires when |
+|---|---|---|
+| **Golden fallback builder** | `golden.py` `_stable_value_expr`, `build_golden_records_df`, `build_golden_records_from_frames` (~150 accesses) | native `golden_fused` ABSENT (falls back to polars builder). Present in bridge/CI → arrow-native, no leak. |
+| **Golden bridge** | `pipeline.py:990 _as_polars_df`, `frame.py:1959 to_frame(pl.DataFrame)`, `frame.py:569 select_eligible_clusters` | feeds/wraps the polars golden builder; gone once golden fallback is arrow-native |
+| **Quality prep bridge** | `quality.py:323/325 _scan_and_fix` (`pl.from_arrow`→goldencheck `apply_fixes`→`.to_arrow`) | ONLY when goldencheck returns findings to fix (clean arrow data skips polars) |
+| **Transform prep bridge** | `transform.py:80/113 run_transform` (`pl.from_arrow`→apply→arrow) | whenever a transform runs on the arrow lane |
+| **Autoconfig scalar-spelling** | `autoconfig.py:314 _polars_scalar_spelling` / `_polars_string_spelling` (1× `pl.Utf8`) | the only autoconfig-layer leak left |
+| **Flag default** | `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE` defaults OFF → `auto_configure_df` coerces arrow→polars at the boundary | production default; the biggest single leak |
+
+**The fork:** in the bridge/CI env native `golden_fused` is present, so the golden
+leaks don't fire — Wave 1 (bridge-stopgap-drop) does NOT need the golden port. The
+full D6 "polars uninstalled" gate DOES need the golden fallback ported — Wave 2.
+
+## Invariants (every stage)
+
+- **Byte-identical on the polars path.** Each stage keeps a parity gate proving the
+  polars lane output is unchanged (config-equivalence for autoconfig; cluster
+  membership + golden rows for pipeline stages).
+- **Arrow-lane tripwire.** Each stage that closes a leak adds/extends a subprocess
+  test with `import polars` BLOCKED (the `_zero_polars_probe.py` mechanism) proving
+  the closed path stays polars-free.
+- Whole-package `ruff check packages/python/goldenmatch` before every push.
+- Feature branch off fresh `origin/main`; squash-merge via the queue; arm auto-merge
+  and stop. `benzsevern` auth for `benseverndev-oss`.
+- Box note: this dev box lacks native `match_fused`/`golden_fused` (golden falls to
+  the polars builder locally) — the fused-present paths (bridge/CI) can only be
+  verified in CI. Local runs use the pure/fallback paths + `GOLDENMATCH_NATIVE=0`.
+
+---
+
+## WAVE 1 — Unblock the `#1747` bridge stopgap (native present)
+
+Goal: the bridge `run_dedupe`/`auto_configure` entrypoints run polars-free WITH
+native present, so the `rust`/`rust_pgrx`/coverage lanes can drop the `[polars]`
+extra (`packages/rust` path-filtered lanes; `GOLDENMATCH_BRIDGE_REQUIRE_PY=1`).
+
+### Stage 1 — Flip `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE` default-on (removes the boundary coercion)
+
+- **Prereq — broaden the parity gate.** `test_autoconfig_arrow_native_parity.py`
+  today covers exact-id-plus-names / multi-source / shared-email-switchboard. Add
+  shapes that exercise the whole config surface: NE-promotion, date/dob fields,
+  probabilistic-eligible, high-null blocking, learned-blocking (≥50k gate),
+  all-fuzzy no-anchor. Assert config-equivalence (matchkeys + blocking + backend)
+  AND cluster-membership equivalence arrow-vs-polars for each.
+- Flip `_autoconfig_arrow_native_enabled()` default true (env `=0` restores the
+  coerce path). Keep the boundary coercion as a **guarded fallback**: only for
+  shapes the arrow-native path declines (log a one-time WARNING so declines are
+  visible, never silent).
+- Update `test_zero_config_no_polars.py` Tier-3 xfail reason (the coercion is no
+  longer the default blocker; golden fallback + quality/transform remain).
+- **Gate:** the broadened parity gate + the full autoconfig suite green.
+
+### Stage 2 — Port the autoconfig scalar-spelling helper (tiny)
+
+- `autoconfig.py:298-314` `_polars_scalar_spelling` / `_polars_string_spelling`
+  build a `pl.Series`/`pl.Utf8` to normalize a scalar's spelling. Replace with a
+  pure-Python / pyarrow-compute equivalent (single-value normalization — no frame).
+- **Gate:** existing autoconfig tests unchanged + the leak drops from the catalog.
+
+### Stage 3 — De-bridge quality prep (`quality._scan_and_fix`)
+
+- Route `apply_fixes` through goldencheck's arrow-native fixer surface instead of
+  `pl.from_arrow(df)`→polars→`.to_arrow()`. goldencheck 3.0 is the Arrow Flip
+  (`project_goldencheck_arrow_fused_scan`) — confirm `engine.fixer.apply_fixes`
+  has an arrow entry (or add a thin arrow adapter there); if not, this stage forks
+  to a goldencheck PR first (lockstep floor bump).
+- Preserve the clean-data fast path (no findings → no polars, already true).
+- **Gate:** quality parity (same fixes applied) on both lanes + arrow tripwire over
+  a dirty fixture (forces the fixer path).
+
+### Stage 4 — De-bridge transform prep (`transform.run_transform`)
+
+- Route the transform application through goldenflow's arrow transform surface
+  (`project_goldenflow_fused_columnar_apply` — fused apply is arrow-native) instead
+  of `pl.from_arrow`. Keep the polars path for the `_is_pl_in` (polars-lane) caller
+  byte-identically.
+- **Gate:** transform parity on both lanes + arrow tripwire over a fixture that
+  runs a real transform chain.
+
+### Stage 5 — Prove the bridge path polars-free + drop the stopgap
+
+- Add a bridge-oriented tripwire mirroring the `rust` lane: `pip`-installed
+  goldenmatch (native present, `golden_fused` available) runs `run_dedupe` +
+  `auto_configure` with `import polars` blocked → completes.
+- Drop the `[polars]` extra from the `rust`/`rust_pgrx`/coverage lanes in
+  `.github/workflows/ci.yml` (revert the `#1747` stopgap). Confirm the bridge lanes
+  green without it.
+- **Gate:** the rust bridge lanes green with no `[polars]`. Update the tracker's
+  "Bridge dedupe/autoconfig path still needs polars" item → resolved.
+
+---
+
+## WAVE 2 — Full D6 "polars not installed" gate (fallback paths too)
+
+Goal: `test_zero_config_dedupe_df_is_polars_free` flips xfail→green (strict) — a
+whole zero-config dedupe with polars uninstallable.
+
+### Stage 6 — Port the golden FALLBACK builder to arrow-native
+
+- The hard one. `build_golden_records_df` + `_stable_value_expr` evaluate
+  survivorship (most_frequent / longest / first / struct tie-breaks) via polars
+  expressions. When native `golden_fused` declines, this is the path. Options:
+  (a) a pyarrow-compute survivorship builder mirroring the polars expressions
+  byte-for-byte; (b) make the pure-Python golden builder the decline path (row
+  loop over arrow) — slower but polars-free and only hit when the kernel declines.
+  Choose (b) for correctness-first (matches the "pure = lossy-but-correct fallback"
+  thesis), measure, then (a) if the fallback is a real hot path.
+- Remove `_as_polars_df` (pipeline.py:990) + `build_golden_records_from_frames`
+  polars construction + `frame.py:569 select_eligible_clusters` polars once the
+  builders no longer need a PolarsFrame.
+- **Gate:** golden byte-parity (rows + per-cell survivorship) vs the polars builder
+  on a corpus incl. correlated survivorship + field_rules + quality-weighting; arrow
+  tripwire running golden with `golden_fused` forced-absent + polars blocked.
+
+### Stage 7 — Quality/transform with zero polars even when uninstalled
+
+- Stages 3-4 de-bridge WHEN goldencheck/goldenflow have arrow surfaces, but those
+  packages may still `import polars` internally. For the D6 "uninstalled" gate they
+  must be polars-optional on the paths goldenmatch calls. goldencheck 3.0 is
+  polars-optional; confirm goldenflow's arrow transform path is too (`[polars]`
+  extra, not a hard import). Bump floors as needed (lockstep releases).
+- **Gate:** the arrow tripwire from Stages 3-4 run with polars BLOCKED (not just
+  "not-on-the-lane") — dirty fixture + transform chain both complete.
+
+### Stage 8 — Flip the endgame gate + D6 deletion prep
+
+- `test_zero_config_dedupe_df_is_polars_free`: xfail→green, `strict=True`. Add an
+  import-hook assertion (`polars not in sys.modules`) over the full zero-config run.
+- D6 deletion prep (tracked, needs the ~8-PR train + goldencheck/goldenflow floors):
+  move polars to a `goldenmatch[polars]` optional extra, drop it from core deps,
+  add the subprocess import-gate to `ci-required`. This is the 3.x minor cut —
+  coordinate with `feedback_golden_suite_lockstep_release`.
+- **Gate:** the D6 gate green in CI (native on) + the zero-polars-installed gate.
+
+---
+
+## Execution notes
+
+- Wave 1 ships value at Stage 5 (stopgap drop) independent of Wave 2.
+- Stages 3/4/7 may spawn goldencheck/goldenflow PRs (arrow fixer / arrow transform
+  surface + polars-optional) — sequence those FIRST with a floor bump, per the
+  lockstep rule, so goldenmatch's floor is satisfiable on PyPI before it tags.
+- Each stage is one PR. Parity gate + arrow tripwire + ruff, then arm auto-merge.
+- Golden fallback (Stage 6) is the critical-path risk — scope a byte-parity harness
+  BEFORE touching `build_golden_records_df` (mirror the ClusterFrames Tier A
+  discipline: prove equivalence on a corpus, then port).

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -42,6 +42,26 @@ from goldenmatch.core.profiler import _guess_type
 
 logger = logging.getLogger(__name__)
 
+# One-time guard for the arrow-native autoconfig coercion-fallback warning
+# (GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE default-on): a sub-feature that still
+# assumes a polars target (match/throughput) coerces the arrow input to polars.
+# Warn once per feature per process instead of once per auto_configure_df call.
+_ARROW_NATIVE_COERCED_WARNED: set[str] = set()
+
+
+def _warn_arrow_native_coerced_once(feature: str) -> None:
+    if feature in _ARROW_NATIVE_COERCED_WARNED:
+        return
+    _ARROW_NATIVE_COERCED_WARNED.add(feature)
+    logger.warning(
+        "auto_configure_df: %s is not arrow-native yet; coercing the arrow input "
+        "to polars for this run (config-equivalent, imports polars). The "
+        "zero-config dedupe path stays arrow-native. Set "
+        "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=0 to always coerce.",
+        feature,
+    )
+
+
 # Refdata-aware matchkey-field refinement. Hoisted to module-top so the
 # per-iteration loop in build_matchkeys / build_probabilistic_matchkeys
 # doesn't pay the `from X import Y` lookup cost or re-run the try/except
@@ -3747,13 +3767,29 @@ def auto_configure_df(
     )
     from goldenmatch.distributed._utils import is_ray_dataset as _is_ray_boundary
 
-    # GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1 (default 0) skips the coercion and
-    # keeps a pa.Table native through the controller -- the in-progress scoring-
-    # lane port (indicators guards done; exclusion detectors + build_blocks spine
-    # pending). Default OFF: coerce, so production zero-config is unchanged.
+    # GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE default-ON (2026-07-14): a non-polars
+    # input (pa.Table / Frame / dict-of-arrays) stays NATIVE through the
+    # controller -- the zero-config config-GENERATION lane is arrow-native
+    # (indicators guards + exclusion / discriminative-veto / source-partition
+    # detectors seam-ported, sample scoring on the arrow-native bucket scorer;
+    # parity-gated in test_autoconfig_arrow_native_parity.py). `=0` restores the
+    # legacy arrow->polars boundary coercion.
+    #
+    # GUARDED FALLBACK: two sub-features are NOT arrow-native yet and still assume
+    # a polars target -- cross-source match (`reference`, coerced to polars below
+    # and whose match-scoring path is unproven on arrow) and the throughput tier
+    # (its early text-column validation only fires for a polars df). For those we
+    # coerce to polars (legacy behaviour) and WARN once, so a decline is visible
+    # rather than a silent divergence.
     _arrow_native_ac = os.environ.get(
-        "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", "0"
+        "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", "1"
     ).lower() in ("1", "true", "yes")
+    if _arrow_native_ac and (reference is not None or throughput is not None):
+        _warn_arrow_native_coerced_once(
+            "cross-source match (reference)" if reference is not None
+            else "throughput tier"
+        )
+        _arrow_native_ac = False
     if not (
         _is_ray_boundary(df)
         or is_polars_lazyframe(df)

--- a/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/block_analyzer.py
@@ -327,9 +327,12 @@ def estimate_recall(
     if not pairs_above:
         return 1.0  # No pairs to miss
 
-    # Apply candidate transforms to sample and get block keys
+    # Apply candidate transforms to sample and get block keys. The helper
+    # returns a seam Frame (not a raw frame), so read the column through the
+    # seam -- a raw `["__block_key__"]` subscript raises on the arrow-native
+    # lane ('PolarsFrame'/'ArrowFrame' object is not subscriptable).
     sample_with_key = _apply_candidate_transforms(sample_frame.native, candidate)
-    block_keys = sample_with_key["__block_key__"].to_list()
+    block_keys = to_frame(sample_with_key).column("__block_key__").to_list()
 
     # Check how many pairs share the same block key
     pairs_in_same_block = sum(

--- a/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
@@ -43,10 +43,10 @@ def _no_autoconfig_memory():
 
 
 def _arrow_native(on: bool):
-    if on:
-        os.environ["GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE"] = "1"
-    else:
-        os.environ.pop("GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", None)
+    # Set BOTH values explicitly. Since the flag now defaults ON (2026-07-14),
+    # the polars baseline (`on=False`) must set "0" -- popping would inherit the
+    # new default and stop being a real polars-vs-arrow comparison.
+    os.environ["GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE"] = "1" if on else "0"
 
 
 def _dupe_count(res) -> int:
@@ -83,6 +83,27 @@ _SHAPES = {
         "first": (["ann", "bob", "cy"] * 100),
         "last": (["smith", "jones", "lee"] * 100),
     },
+    "dob-person": {
+        # a date/dob column -- the FS-v2 date-admission + date-year blocking
+        # detectors must decide identically arrow-vs-polars.
+        "first": (["ann", "bob", "cara", "dan"] * 75),
+        "last": (["smith", "jones", "lee", "poe"] * 75),
+        "dob": [f"19{60 + (i % 40):02d}-0{1 + (i % 9)}-1{i % 10}" for i in range(300)],
+    },
+    "high-null-aux": {
+        # a mostly-null auxiliary column -- the blocking null-rate guard (>20%
+        # skip) must fire identically on both backends.
+        "first": (["ann", "bob", "cara"] * 100),
+        "last": (["smith", "jones", "lee"] * 100),
+        "aux": [(f"x{i}" if i % 10 == 0 else None) for i in range(300)],
+    },
+    "typo-names": {
+        # systematic near-dups (typo'd first name, same last) -> the fuzzy
+        # name-scorer path drives the dup count; must match cross-backend.
+        "first": (["michael", "micheal", "sara", "sarah"] * 75),
+        "last": (["brown", "brown", "davis", "davis"] * 75),
+        "zip": [str(20000 + (i % 40)) for i in range(300)],
+    },
 }
 
 
@@ -110,6 +131,29 @@ def test_arrow_native_cluster_equivalence(shape):
     assert _dupe_count(res_pl) == _dupe_count(res_pa), (
         f"{shape}: polars dupes={_dupe_count(res_pl)} != arrow dupes={_dupe_count(res_pa)}"
     )
+
+
+def test_arrow_native_is_the_default():
+    """With GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE UNSET, a pa.Table zero-config run
+    engages the arrow-native path by default (2026-07-14 flip) -- i.e. its config
+    equals an explicitly-flag-on run and its dupes equal the polars baseline."""
+    from goldenmatch import dedupe_df
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    data = _SHAPES["exact-id-plus-names"]
+    os.environ.pop("GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", None)  # rely on the default
+    cfg_default = auto_configure_df(pa.table(data), _skip_finalize=True)
+    res_default = dedupe_df(pa.table(data), config=None)
+
+    _arrow_native(True)  # explicit on
+    try:
+        cfg_explicit = auto_configure_df(pa.table(data), _skip_finalize=True)
+    finally:
+        _arrow_native(False)
+    res_pl = dedupe_df(pl.DataFrame(data), config=None)
+
+    assert _config_matchkeys(cfg_default) == _config_matchkeys(cfg_explicit)
+    assert _dupe_count(res_default) == _dupe_count(res_pl)
 
 
 @pytest.mark.parametrize("shape", ["exact-id-plus-names", "shared-email-switchboard"])

--- a/packages/python/goldenmatch/tests/test_autoconfig_facade.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_facade.py
@@ -155,8 +155,17 @@ def test_auto_configure_df_accepts_polars_frame_wrapper():
 
 
 def test_auto_configure_df_accepts_arrow_frame_wrapper():
-    """An ArrowFrame-wrapped df goes through the pl.from_arrow shim (W5
-    removes the shim; until then the config must match the polars call)."""
+    """An ArrowFrame-wrapped df produces an EQUIVALENT config to the polars call.
+
+    Since GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE defaults on (2026-07-14), the arrow
+    path stays native through the controller instead of coercing to polars. It is
+    CLUSTER-equivalent to the polars path (proven comprehensively in
+    test_autoconfig_arrow_native_parity.py) but NOT byte-identical in the
+    committed config: the sample dedupe routes to the bucket scorer, so `backend`
+    reads "bucket" vs None; and blocking-COLUMN selection can differ on a near-tie
+    because `Frame.sample` is statistical-not-byte across backends by design. So
+    assert the identity-determining part (matchkeys) matches and the config is
+    valid, rather than a full model_dump byte-match."""
     from goldenmatch.core.frame import ArrowFrame
     df = pl.DataFrame({
         "name": ["alice", "bob", "carol"] * 4,
@@ -165,4 +174,11 @@ def test_auto_configure_df_accepts_arrow_frame_wrapper():
     raw = goldenmatch.auto_configure_df(df)
     wrapped = goldenmatch.auto_configure_df(ArrowFrame(df.to_arrow()))
     assert isinstance(wrapped, GoldenMatchConfig)
-    assert wrapped.model_dump() == raw.model_dump()
+
+    def _mks(cfg):
+        return sorted(
+            (mk.type, tuple(sorted(f.field for f in (mk.fields or []) if f.field)))
+            for mk in cfg.get_matchkeys()
+        )
+
+    assert _mks(wrapped) == _mks(raw)

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -147,7 +147,12 @@ def test_zero_config_arrow_with_exact_column_matches_polars():
                     )
                 ),
             )
-        return (getattr(cfg, "backend", None), mks, blk)
+        # `backend` EXCLUDED: with GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE default-on
+        # the arrow sample routes to the bucket scorer, so `backend` reads
+        # "bucket" on arrow vs None on polars -- a benign difference (identical
+        # clusters, #526). Everything that decides the output (mks + blocking)
+        # must still agree.
+        return (mks, blk)
 
     cfg_pl = auto_configure_df(pl.DataFrame(data), _skip_finalize=True)
     cfg_pa = auto_configure_df(pa.table(data), _skip_finalize=True)

--- a/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_zero_config_no_polars.py
@@ -207,18 +207,21 @@ def test_explicit_config_arrow_dedupe_is_polars_free():
 
 @pytest.mark.xfail(
     reason=(
-        "`auto_configure_df` config-GENERATION is now Polars-free on the arrow-native "
-        "path (GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1: indicators guards + exclusion "
-        "detectors + discriminative-veto + source-partition seam-ported, sample "
-        "scoring routed to the arrow-native bucket scorer -- config- and cluster-"
-        "equivalent to polars, see test_autoconfig_arrow_native_parity.py). Two things "
-        "keep this DEFAULT tripwire xfail: (1) the flag defaults OFF, so "
-        "`auto_configure_df` coerces a non-polars input to polars at its boundary "
-        "(imports polars) -- safe production default until (2) lands; (2) even with the "
-        "flag on, the FINAL dedupe's clustering `build_clusters_arrow_native` "
-        "(cluster.py:2027) wraps the arrow Rust-kernel output into polars ClusterFrames "
-        "-> imports polars. Flips green when ClusterFrames is Arrow-native (the 3.x "
-        "engine-descent eviction, NOT the autoconfig port) and the flag defaults on."
+        "`auto_configure_df` config-GENERATION is Polars-free on the arrow-native "
+        "path, now DEFAULT-ON (GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE default=1, "
+        "2026-07-14 -- indicators guards + exclusion / discriminative-veto / "
+        "source-partition detectors seam-ported, sample scoring on the arrow-native "
+        "bucket scorer; parity-gated in test_autoconfig_arrow_native_parity.py). The "
+        "ClusterFrames stage is arrow-native too (build_cluster_frames threads "
+        "backend='arrow'; the emitter is seam-routed -- see "
+        "test_cluster_frames_no_polars.py). Remaining zero-config polars leaks that "
+        "keep this endgame tripwire xfail (per the 2026-07-14 leak catalog): (1) the "
+        "GOLDEN fallback builder (golden.py build_golden_records_df / "
+        "_stable_value_expr) when native golden_fused declines -- Wave 2 Stage 6; and "
+        "(2) the quality / transform prep bridges (quality._scan_and_fix, "
+        "transform.run_transform pa->pl->pa) -- Wave 1 Stages 3-4. Flips green when "
+        "those land (plan: docs/superpowers/plans/"
+        "2026-07-14-goldenmatch-zero-config-arrow-polars-free.md)."
     ),
     strict=False,
 )


### PR DESCRIPTION
## What

Flips `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE` default **OFF → ON**. A non-polars zero-config input (`pa.Table` / `Frame` / dict-of-arrays) now stays **native** through the controller instead of being coerced to polars at the `auto_configure_df` boundary.

Stage 1 of the zero-config arrow-lane polars eviction (`docs/superpowers/plans/2026-07-14-goldenmatch-zero-config-arrow-polars-free.md`). The config-generation lane is already arrow-native (indicators guards + exclusion / discriminative-veto / source-partition detectors seam-ported, sample scoring on the arrow-native bucket scorer). Making it the default means the later stages (golden fallback, quality/transform bridges) are measured against the real arrow path instead of being masked by the coercion.

## Why this is safe

- **Parity-gated.** `test_autoconfig_arrow_native_parity.py` broadened before the flip: +3 shapes (dob/dates, high-null-aux, typo-names) on cluster-equivalence, plus a new `test_arrow_native_is_the_default` locking that the env-unset default engages arrow. 10 parity tests pass.
- **Guarded fallback.** Two sub-features aren't arrow-native yet — cross-source match (`reference`, coerced to polars downstream) and the throughput tier (early text validation only fires for a polars df). Those coerce to polars (legacy behaviour) and **warn once**, so a decline is visible, never a silent divergence.
- **Escape hatch.** `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=0` restores the legacy always-coerce boundary.

## Note

This does NOT make zero-config polars-free yet — the golden fallback builder + quality/transform prep bridges still import polars (Wave 1 Stages 3-4 + Wave 2 Stage 6). The Tier-3 endgame xfail (`test_zero_config_dedupe_df_is_polars_free`) stays xfail with an updated reason.

Local: 10 parity + 76 api/gates/frame-env + autoconfig regressions all green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)