### PR TITLE
perf(goldenmatch): quality auto-fix degrades to scan-only without polars (zero-config arrow W1S3)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/quality.py
+++ b/packages/python/goldenmatch/goldenmatch/core/quality.py
@@ -9,6 +9,25 @@ from goldenmatch._polars_lazy import pl
 
 logger = logging.getLogger(__name__)
 
+# One-time guard for the arrow-lane quality-fix polars-absent warning.
+_QUALITY_FIX_POLARS_WARNED = False
+
+
+def _warn_quality_fix_needs_polars_once() -> None:
+    """Warn (once) that auto-fix is skipped on the arrow lane because polars is
+    absent. The arrow-native SCAN still ran; only the polars-native goldencheck
+    fixer is unavailable. Install ``goldenmatch[polars]`` to re-enable auto-fix."""
+    global _QUALITY_FIX_POLARS_WARNED
+    if _QUALITY_FIX_POLARS_WARNED:
+        return
+    _QUALITY_FIX_POLARS_WARNED = True
+    logger.warning(
+        "GoldenCheck auto-fix skipped: the fixer is polars-native and polars is "
+        "not installed. The arrow-native quality SCAN still ran; detected issues "
+        "are reported but not auto-fixed. Install goldenmatch[polars] to re-enable "
+        "auto-fix on the arrow lane."
+    )
+
 
 def _scan_findings(df, domain: str | None):
     """Run the goldencheck scan and confidence-downgrade pass.
@@ -307,22 +326,41 @@ def _scan_and_fix(
     """Run GoldenCheck scan + apply fixes.
 
     A1: the SCAN runs arrow-native on a pa.Table; ``apply_fixes`` is the
-    single remaining polars surface in goldencheck's fix engine, so the
-    bridge narrows to exactly that call -- and only when the scan found
-    anything (a clean frame stays polars-free). goldencheck-side arrow
-    port of apply_fixes is filed in the endgame plan.
+    single remaining polars surface in goldencheck's fix engine (goldencheck's
+    fixer is polars-native -- its ``[polars]`` extra), so the bridge narrows to
+    exactly that call, and only when the scan found anything (a clean frame
+    stays polars-free).
+
+    Polars-absent degradation (zero-config arrow eviction): on the arrow lane
+    when polars is not importable, keep the arrow-native SCAN but SKIP auto-fix,
+    degrading to scan-only (report the detected issues, apply none) instead of
+    crashing -- auto-fix on the arrow lane requires ``goldenmatch[polars]``. The
+    polars-present path is byte-identical to before.
     """
+    import pyarrow as _pa  # noqa: PLC0415
     from goldencheck.engine.fixer import apply_fixes
 
     findings = _scan_findings(df, domain=domain)
 
-    if not findings and not isinstance(df, pl.DataFrame):
+    # `isinstance(df, pa.Table)` is the arrow-lane discriminator and never imports
+    # polars (pyarrow is always present). A non-arrow frame is the polars lane.
+    _is_arrow = isinstance(df, _pa.Table)
+
+    if not findings and _is_arrow:
         return df, []
 
-    # Apply fixes (polars surface; bridge the table here only)
-    _df_pl = df if isinstance(df, pl.DataFrame) else pl.from_arrow(df)
+    if _is_arrow:
+        try:
+            import polars as _pl_fix  # noqa: PLC0415
+        except ImportError:
+            _warn_quality_fix_needs_polars_once()
+            return _scan_only(df, mode, domain)
+        _df_pl = _pl_fix.from_arrow(df)
+    else:
+        _df_pl = df  # already a polars frame
+
     fixed_df, report = apply_fixes(_df_pl, findings, mode=fix_mode)
-    if not isinstance(df, pl.DataFrame):
+    if _is_arrow:
         fixed_df = fixed_df.to_arrow()  # stay on the caller's lane
 
     # Convert to autofix-compatible format

--- a/packages/python/goldenmatch/tests/test_quality_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_quality_no_polars.py
@@ -1,0 +1,65 @@
+"""Quality-fix arrow-lane polars-absent degradation (zero-config arrow eviction).
+
+goldencheck's SCAN is arrow-native, but its fix engine (``apply_fixes``) is
+polars-native (goldencheck's ``[polars]`` extra). So on the arrow lane, when
+polars is not installed, ``core.quality._scan_and_fix`` keeps the native scan but
+DEGRADES auto-fix to scan-only (report the detected issues, apply none) instead
+of crashing. The polars-present path is byte-identical to before.
+
+This subprocess test blocks ``import polars`` (the D6 zero-polars gate mechanism)
+and asserts a dirty arrow frame runs the quality check to completion polars-free.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+_PKG_ROOT = Path(__file__).parent.parent
+
+
+def _run_polars_blocked(body: str) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(_PKG_ROOT)
+    env["POLARS_SKIP_CPU_CHECK"] = "1"
+    prelude = (
+        "import sys\n"
+        "class _Block:\n"
+        "    def find_spec(self, name, path=None, target=None):\n"
+        "        if name == 'polars' or name.startswith('polars.'):\n"
+        "            raise ImportError('polars blocked (quality-fix gate)')\n"
+        "        return None\n"
+        "sys.meta_path.insert(0, _Block())\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", prelude + textwrap.dedent(body)],
+        capture_output=True, text=True, env=env, timeout=120,
+    )
+
+
+def test_quality_fix_degrades_to_scan_only_without_polars():
+    """SUBPROCESS, polars BLOCKED: run_quality_check on a DIRTY arrow frame
+    (whitespace/smart-quote issues the scan flags) completes without importing
+    polars -- the fix step degrades to scan-only rather than crashing."""
+    body = """
+        import sys
+        import pyarrow as pa
+        from goldenmatch.core.quality import run_quality_check
+        # Leading/trailing whitespace + a smart quote -> goldencheck finds fixes,
+        # which would trip the polars fix bridge if it weren't degraded.
+        tbl = pa.table({
+            "name": ["  Alice ", "Bob\\u2019s", "  Alice ", "Carol", "Bob\\u2019s"],
+            "city": ["NYC", "LA", "NYC", "SF", "LA"],
+        })
+        fixed, fixes = run_quality_check(tbl, config=None)
+        # Frame comes back (unchanged arrow, since fixes were skipped) + no crash.
+        assert fixed is not None
+        assert isinstance(fixes, list)
+        assert "polars" not in sys.modules, "polars leaked in the quality path"
+        print("QUALITY-NO-POLARS OK")
+    """
+    proc = _run_polars_blocked(body)
+    assert proc.returncode == 0, f"stdout={proc.stdout}\\nstderr={proc.stderr[-2500:]}"
+    assert "QUALITY-NO-POLARS OK" in proc.stdout


### PR DESCRIPTION
## What

On the arrow lane, goldencheck's quality **SCAN** is already arrow-native, but its **FIX** engine (`apply_fixes`) is polars-native (goldencheck's `[polars]` extra). The zero-config arrow eviction removes polars from `pip install goldenmatch`, so the fix bridge (`pl.from_arrow(df)` → `apply_fixes`) crashed with `ModuleNotFoundError: No module named 'polars'` whenever the scan found something to fix.

Stage 3 of the zero-config arrow-lane polars eviction (`docs/superpowers/plans/2026-07-14-goldenmatch-zero-config-arrow-polars-free.md`).

## Fix

`_scan_and_fix` now discriminates the arrow lane via `isinstance(df, pa.Table)` (never imports polars) and, when polars can't be imported for the fix bridge, **degrades to scan-only** (reports the detected issues, applies none) + warns once — instead of crashing. This mirrors goldencheck's own contract (arrow scan + polars fixer). Auto-fix on the arrow lane requires `goldenmatch[polars]`; the scan still runs and issues are still surfaced.

## Safety

- **Byte-identical when polars is present** — 78 quality tests green. The polars lane (`_is_arrow=False`) and the arrow-lane-with-polars path both apply fixes exactly as before.
- **Regression tripwire** (`test_quality_no_polars.py`): with `import polars` BLOCKED, a dirty arrow frame (whitespace + smart-quote issues) runs `run_quality_check` to completion polars-free.

Note: Stage 2 (the autoconfig scalar-spelling helper) was a no-op — it already falls back correctly when polars is absent and produces byte-identical config (verified in the flag-on present-vs-blocked comparison).

🤖 Generated with [Claude Code](https://claude.com/claude-code)