### PR TITLE
feat(goldenmatch): fan-out/negative-evidence upgrade lever for Splink migration

### DIFF
--- a/docs/superpowers/plans/2026-07-14-fanout-ne-upgrade-lever.md
+++ b/docs/superpowers/plans/2026-07-14-fanout-ne-upgrade-lever.md
@@ -1,0 +1,458 @@
+# Fan-out / Negative-Evidence Upgrade Lever Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a risk-gated `fan_out` lever to the Splink migration upgrade pass that suggests
+negative-evidence fields (with posterior-estimated `__ne__` weights) and tunes
+`golden_rules.max_cluster_size` from reference clusters — and teach the calibration lever
+`fs_weight_range` so NE-bearing configs calibrate instead of tripwiring.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md` (read it first; it
+pins every semantic decision: posterior definition, gate thresholds, storage schema, guard formula).
+
+**Architecture:** New module `goldenmatch/config/splink_upgrade_fanout.py` holds the lever body
+(mirroring the `splink_upgrade_measure.py` precedent); `splink_upgrade.py` registers a thin
+lazy-import wrapper as lever `"fan_out"`, ordered between `distance_thresholds` and
+`calibration`. `_LeverContext` gains `splink_clusters`/`labels`/`id_column` (previously
+measurement-only). The calibration lever's within-block prior re-estimation is extracted to a
+shared helper both levers call.
+
+**Tech Stack:** Python 3.12, polars (via `goldenmatch._polars_lazy` ONLY in production modules),
+pydantic config models, pytest. No Rust/TS work in this plan.
+
+---
+
+## Environment / repo mechanics (read before Task F0)
+
+- The main checkout `D:\show_case\goldenmatch` sits on an unrelated branch with a dirty tree.
+  Work in a NEW worktree off freshly-fetched `origin/main` (Task F0). **NEVER `git stash`**
+  (repo-global across worktrees).
+- Run worktree Python tests via the MAIN checkout's venv with `PYTHONPATH` pointing at the
+  worktree package:
+  `PYTHONPATH="<worktree>/packages/python/goldenmatch" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <tests> -v`
+- Production modules MUST import polars as `from goldenmatch._polars_lazy import pl` — a bare
+  top-level `import polars` reds every zero-polars CI gate (bit PR #1760). Test files may import
+  polars directly (repo norm).
+- Lint before each commit: `.venv/Scripts/python.exe -m ruff check <touched files>` from the
+  worktree package dir.
+- `docs/superpowers/` is gitignored: commit spec + plan with `git add -f`.
+- Push/PR auth dance: `unset GH_TOKEN`; push via
+  `git push "https://x-access-token:$(gh auth token --user benzsevern)@github.com/benseverndev-oss/goldenmatch.git" <branch>`;
+  `GH_TOKEN=$(gh auth token --user benzsevern) gh pr create ...`; arm
+  `gh pr merge --auto <N>` (merge queue sets the strategy) and STOP — do not poll CI.
+
+**Key existing code (all on origin/main — verify against the worktree, not the stale main checkout):**
+- `goldenmatch/config/splink_upgrade.py` — lever registry (`_LEVER_REGISTRY`, `_LEVER_ORDER`),
+  `_LeverContext`, `_lever_calibration` (contains the NE tripwire ~line 493 and the inline
+  within-block prior re-estimation ~line 632), orchestrator `upgrade_splink_conversion`
+  (threads `splink_clusters`/`labels`/`id_column` to measurement only).
+- `goldenmatch/config/splink_upgrade_measure.py` — `_resolve_ids(df, id_column)`,
+  `_load_reference(...)`, cluster-size helpers.
+- `goldenmatch/core/probabilistic.py` — `_ne_fired(row_a, row_b, ne_field)` (line ~466),
+  `_ne_scalar_contribution(row_a, row_b, ne, em_result)` (~1509), `fs_weight_range(em, mk)`
+  (~1468), `_sample_blocked_pairs(blocks, n_pairs, seed)` (~563),
+  `prior_weight(proportion_matched)` (~77), `posterior_from_weight(total_weight, prior_w)` (~88),
+  `comparison_vector`, `compute_thresholds`.
+- `goldenmatch/core/autoconfig_negative_evidence.py` — `_pick_scorer_for_column(col_name,
+  col_type) -> (transforms, scorer)`, `_DEFAULT_NE_THRESHOLD = 0.4`.
+- `goldenmatch/core/blocker.py` — `build_blocks(lf, blocking_config)`,
+  `collect_blocking_fields(blocking_config)`.
+- `goldenmatch/config/schemas.py` — `NegativeEvidenceField` (probabilistic matchkeys REJECT
+  `penalty`, accept `penalty_bits` or NEITHER — the lever emits NEITHER), `GoldenRulesConfig`
+  (`max_cluster_size=100`, `auto_split=True`).
+- Existing tests to mirror style from: `tests/test_splink_upgrade_levers.py`,
+  `tests/test_splink_upgrade_measure.py`, `tests/test_fs_ne_e2e.py` (homonym fixture patterns:
+  blocks need MIXED identities or EM/posteriors saturate; spread surnames across soundex codes).
+
+## File structure
+
+- Create: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py`
+  (lever body: candidate eligibility, risk gate, posterior-weighted NE estimation, guard tuning)
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py`
+  (ctx fields, shared prior helper, registry entry, calibration NE-awareness)
+- Create: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py` (unit)
+- Create: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout_e2e.py` (success bar)
+- Modify: `packages/python/goldenmatch/tests/test_splink_upgrade_levers.py`
+  (calibration NE-awareness tests; tripwire test replaced; lever-order assertion updated in F1)
+- Modify: `packages/python/goldenmatch/goldenmatch/cli/import_splink.py` (help text only)
+
+Module constants (in `splink_upgrade_fanout.py`, all with rationale comments):
+
+```python
+_FANOUT_POSTERIOR_CONFIDENT = 0.9   # "confident merge" posterior floor for the risk gate
+_FANOUT_MIN_FIRE_RATE = 0.02        # min NE firing rate among confident-merge pairs
+_FANOUT_MIN_FIRING_PAIRS = 10       # min absolute firing confident pairs (estimation support)
+_FANOUT_MIN_NONNULL = 0.5           # candidate columns sparser than this are not suggested
+_FANOUT_MIN_CARDINALITY = 0.5       # mirrors autoconfig NE's _CARDINALITY_THRESHOLD
+_FANOUT_MAX_CARDINALITY = 0.999     # a perfect surrogate key has zero shared-identity signal
+                                     # (mirrors #721's uniform exact-scorer gate); it would also
+                                     # fire on true dups and be dropped by the w>=0 check, but
+                                     # excluding it up front keeps findings clean
+_FANOUT_RANDOM_PAIRS = 10_000       # u_fire sample size (train_em's random-pair u route scale)
+_PROB_CLAMP = 1e-4                  # m/u clamp away from 0/1 before log2
+_GUARD_MIN_CAP = 10                 # floor of max(10, 2 * reference_max)
+_NE_NAME_PATTERNS = (
+    "phone", "mobile", "email", "e-mail", "e_mail", "address", "addr",
+    "ssn", "npi", "license", "licence", "passport",
+)
+```
+
+---
+
+### Task F0: Worktree + branch + commit spec/plan
+
+**Files:** none (repo mechanics)
+
+- [ ] **Step 1:** From `D:\show_case\goldenmatch`: `git fetch origin main` then
+  `git worktree add D:\show_case\gm-fanout-lever -b feat/splink-upgrade-fanout-lever origin/main`
+- [ ] **Step 2:** Copy the spec + this plan into the worktree (same paths under
+  `docs/superpowers/`), `git add -f docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md docs/superpowers/plans/2026-07-14-fanout-ne-upgrade-lever.md`
+- [ ] **Step 3:** Commit: `git commit -m "docs: spec + plan for the fan-out/NE upgrade lever"`
+- [ ] **Step 4:** Sanity: run the existing lever tests against the worktree via the PYTHONPATH
+  pattern above: `pytest tests/test_splink_upgrade_levers.py -x -q` → all pass. If red, STOP and
+  investigate before building.
+
+---
+
+### Task F1: Context threading + shared prior helper + registry stub
+
+Thread `splink_clusters`/`labels`/`id_column` into `_LeverContext`; extract the calibration
+lever's inline within-block prior re-estimation into `_estimate_within_block_prior`; register
+`fan_out` in the registry/order with a lazy-import wrapper; create the new module with ONLY the
+bare-settings skip implemented.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py`
+- Create: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py`
+- Create: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py`
+- Modify: `packages/python/goldenmatch/tests/test_splink_upgrade_levers.py` — the existing
+  `test_lever_order_tf_tables_then_distance_then_calibration` (~line 985) asserts the exact
+  3-tuple `_LEVER_ORDER`; update it (and any first-occurrence ordering assertion around it) to
+  the new 4-lever order as part of THIS task. Its failure before that edit is expected and
+  mechanical, not a leak.
+
+- [ ] **Step 1: Failing tests** — in the new test file:
+  - `test_fan_out_in_default_lever_order`: `_resolve_levers(None) == ["tf_tables",
+    "distance_thresholds", "fan_out", "calibration"]`.
+  - `test_fan_out_selectable_alone`: `_resolve_levers({"fan_out"}) == ["fan_out"]`; unknown name
+    still raises.
+  - `test_fan_out_bare_settings_skip`: build a bare-settings `SplinkConversion` (no em_model —
+    mirror the existing bare-settings fixtures in `test_splink_upgrade_levers.py`), run
+    `upgrade_splink_conversion(conv, df, levers={"fan_out"}, measure=False)` → exactly one
+    `upgrade:fan_out` info finding containing "no imported model"; config unchanged
+    (`upgraded_config.model_dump() == baseline model_dump()`).
+  - `test_estimate_within_block_prior`: pure-math check —
+    `_estimate_within_block_prior([0.0]) == 0.5` (2^0/(1+2^0)); a strongly negative and strongly
+    positive weight average to ~0.5; empty list raises ValueError.
+  - `test_lever_context_carries_reference_inputs`: `upgrade_splink_conversion(...,
+    splink_clusters=<df>, labels=<df>, id_column="rec_id", measure=False)` — assert via a
+    monkeypatched fan_out lever that `ctx.splink_clusters`/`ctx.labels`/`ctx.id_column` arrive.
+- [ ] **Step 2:** Run: `pytest tests/test_splink_upgrade_fanout.py -v` → FAIL (attribute/name errors).
+- [ ] **Step 3: Implement.**
+  - `_LeverContext`: add fields `splink_clusters: object | None = None`,
+    `labels: object | None = None`, `id_column: str | None = None` (typed loose — they're
+    DataFrame-or-path passthroughs, same as the orchestrator signature). Orchestrator passes
+    them into the ctx it builds (measurement keeps receiving them as today — no measurement
+    change).
+  - Extract into `splink_upgrade.py` module level:
+    ```python
+    def _estimate_within_block_prior(total_weights: list[float]) -> float:
+        """Within-block match-rate estimate from model likelihood ratios under an
+        equal-odds prior: mean of 2^w/(1+2^w). (Extracted from _lever_calibration;
+        see its comment block for the errs-HIGH safety rationale.)"""
+        if not total_weights:
+            raise ValueError("cannot estimate a within-block prior from zero pairs")
+        return sum(posterior_from_weight(w, 0.0) for w in total_weights) / len(total_weights)
+    ```
+    Replace the inline computation in `_lever_calibration` with a call (keep the big rationale
+    comment on the helper). `posterior_from_weight` is function-local-imported today — move that
+    import to where the helper needs it (function-local inside the helper, matching module style).
+  - New module `splink_upgrade_fanout.py`: docstring citing the spec; constants block;
+    `run_fan_out_lever(ctx) -> None` that for now ONLY implements the bare-settings skip:
+    ```python
+    def run_fan_out_lever(ctx) -> None:
+        if ctx.conversion.em_model is None:
+            ctx.report.info("upgrade:fan_out", _BARE_SETTINGS_SKIP_MSG_FANOUT, mapped_to=None)
+            return
+        _suggest_negative_evidence(ctx)   # Task F3
+        _tune_cluster_guard(ctx)          # Task F4
+    ```
+    with both helpers as no-op `pass` stubs for now (NOT NotImplementedError — fan_out is in the
+    default lever set from this commit on, and every existing trained-model lever test runs it).
+  - In `splink_upgrade.py`: registry wrapper with lazy import (keeps the module import-light,
+    mirroring the measurement import):
+    ```python
+    def _lever_fan_out(ctx: _LeverContext) -> None:
+        from goldenmatch.config.splink_upgrade_fanout import run_fan_out_lever
+        run_fan_out_lever(ctx)
+    ```
+    `_LEVER_REGISTRY["fan_out"] = _lever_fan_out`;
+    `_LEVER_ORDER = ("tf_tables", "distance_thresholds", "fan_out", "calibration")`.
+    Update the `upgrade_splink_conversion` docstring's lever list.
+- [ ] **Step 4:** Update the lever-order assertion(s) in `test_splink_upgrade_levers.py` to the
+  4-lever tuple, then run new tests → PASS, and `pytest tests/test_splink_upgrade_levers.py
+  tests/test_cli_import_splink_upgrade.py -q` → all pass (existing fixtures have no NE candidates,
+  so the stub no-ops; any OTHER failure means the registry change leaked).
+- [ ] **Step 5:** ruff both touched modules + test file; commit
+  `feat(splink-upgrade): register fan_out lever scaffold + shared prior helper`.
+
+---
+
+### Task F2: NE candidate eligibility
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py`
+- Test: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py`
+
+- [ ] **Step 1: Failing tests** for `_ne_candidates(df, mk, blocking) -> list[_NECandidate]`
+  (`_NECandidate` = small dataclass: `column`, `transforms`, `scorer`). Build a df with columns:
+  `given_name`, `surname`, `city` (comparison/blocking fields on a probabilistic matchkey),
+  `phone` (eligible), `email_null_heavy` (>50% null → excluded), `phone_low_card` (a phone-named
+  column with ~3 distinct values → excluded), `ssn` (identity-NAMED but all-unique, ratio 1.0 →
+  excluded by `_FANOUT_MAX_CARDINALITY`; a plain `rec_id` surrogate would be excluded by the
+  name filter first and never exercise the gate), `notes` (non-identity name → excluded). Cases:
+  - returns exactly `phone`, with `(["digits_only"], "exact")` from `_pick_scorer_for_column`;
+  - a `phone2` column that IS a comparison field on mk → excluded;
+  - a `phone3` column used as a blocking key (in `collect_blocking_fields(blocking)`) → excluded;
+  - name matching is case-insensitive (`Phone_Number` eligible).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement.** Pure function; polars via `goldenmatch._polars_lazy`. Cardinality
+  ratio = `df[col].n_unique() / max(1, len(df))` on the (already sampled) frame; non-null rate =
+  `1 - df[col].null_count() / max(1, len(df))`. Identity-grade = any `_NE_NAME_PATTERNS` substring
+  in `col.lower()`. Scorer/transforms from
+  `autoconfig_negative_evidence._pick_scorer_for_column(col, "")` (import at module top — it's a
+  light module). Exclusions per the spec + constants block.
+- [ ] **Step 4:** Run → PASS. Ruff.
+- [ ] **Step 5:** Commit `feat(splink-upgrade): fan_out NE candidate eligibility`.
+
+---
+
+### Task F3: Risk gate + posterior-weighted NE estimation + attachment
+
+The core. Fills `_suggest_negative_evidence(ctx)`.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py`
+- Test: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py`
+
+**Algorithm (all semantics pinned by the spec — deviations need a spec edit):**
+
+```python
+def _suggest_negative_evidence(ctx) -> None:
+    mk = ctx.upgraded_config.get_matchkeys()[0]
+    em = ctx.em_model
+    blocking = ctx.upgraded_config.blocking
+    if blocking is None:
+        warn "skipped: config has no blocking configuration ..." ; return
+    # Partial imported model: posteriors need every comparison field covered
+    # (mirror _lever_calibration's uncovered-fields warn+skip verbatim; guard
+    # tuning is unaffected and still runs after us).
+    candidates = _ne_candidates(ctx.df, mk, blocking)
+    if not candidates:
+        info "no eligible NE candidate columns" ; return
+    # Blocked pairs: same route as calibration (build_blocks on __row_id__ lf +
+    # _sample_blocked_pairs with _CALIBRATION_MAX_PAIRS / ctx.seed). Also emit the
+    # block-size findings here (p50/p95/max over materialized block heights) --
+    # spec: findings only, max_block_size untouched.
+    if len(pairs) <= _CALIBRATION_MIN_PAIRS:
+        warn "skipped: only N blocked candidate pair(s) ..." ; return
+    # row_lookup over matchkey fields + candidate columns (extend calibration's pattern)
+    # total_weights: regular-field FS sums (same indexed_fields pattern as calibration)
+    prior = _estimate_within_block_prior(total_weights)      # shared helper (F1)
+    prior_w = prior_weight(prior)
+    posteriors = [posterior_from_weight(w, prior_w) for w in total_weights]
+    confident = [p >= _FANOUT_POSTERIOR_CONFIDENT for p in posteriors]
+    for cand in candidates:
+        ne = NegativeEvidenceField(field=cand.column, transforms=cand.transforms,
+                                   scorer=cand.scorer, threshold=_DEFAULT_NE_THRESHOLD)
+        fired = [_ne_fired(row_lookup[a], row_lookup[b], ne) for (a, b) in pairs]
+        n_conf = sum(confident); n_fired_conf = sum(f and c for f, c in zip(fired, confident))
+        rate = n_fired_conf / n_conf if n_conf else 0.0
+        info finding: measured contradiction rate + counts (ALWAYS, gated or not)
+        if n_conf == 0 or rate < _FANOUT_MIN_FIRE_RATE or n_fired_conf < _FANOUT_MIN_FIRING_PAIRS:
+            continue   # the info finding above already reports why
+        m_fire = clamp(sum(p*f)/sum(p), _PROB_CLAMP, 1-_PROB_CLAMP)   # posterior-weighted
+        u_fire = clamp(_random_pair_firing_rate(row_lookup, ne, ctx.seed), ...)
+        w_fired = log2(m_fire / u_fire)
+        if w_fired >= 0:
+            warn "column does not discriminate on this data (w_fired=...) -- dropped" ; continue
+        mk.negative_evidence = (mk.negative_evidence or []) + [ne]
+        em.m_probs[f"__ne__{cand.column}"] = [m_fire, 1 - m_fire]
+        em.u_probs[f"__ne__{cand.column}"] = [u_fire, 1 - u_fire]
+        em.match_weights[f"__ne__{cand.column}"] = [w_fired, 0.0]
+        info finding: field added, m/u/bits + contradiction rate
+```
+
+`_random_pair_firing_rate`: `random.Random(seed)` sampling up to `_FANOUT_RANDOM_PAIRS` pairs of
+distinct row ids from `row_lookup` keys (with replacement over pairs is fine; skip a==b), return
+mean `_ne_fired`. NO penalty / NO penalty_bits on the emitted field (probabilistic validation
+matrix: EM-learned shape).
+
+- [ ] **Step 1: Failing tests.** Synthetic frame (~200 rows) engineered so the imported model is
+  hand-built (construct `EMResult` directly with known m/u per field — no EM training in unit
+  tests) and blocking on `city` yields mixed blocks:
+  - `test_fan_out_adds_ne_when_risk_present`: homonym pairs (same name+city, different phone)
+    inside blocks → NE field `phone` appended; `__ne__phone` entries present with
+    `match_weights[0] < 0`, `[1] == 0.0`; m/u 2-lists sum to 1 (within clamp); the emitted
+    `NegativeEvidenceField` has `penalty is None and penalty_bits is None`; config still
+    validates: `GoldenMatchConfig(**upgraded.model_dump())` round-trips.
+  - `test_fan_out_no_risk_no_ne`: same frame but phones AGREE on confident pairs → no NE, info
+    finding with the measured (near-zero) rate.
+  - `test_fan_out_insufficient_support_skips`: risk present but < `_FANOUT_MIN_FIRING_PAIRS`
+    firing confident pairs → no NE.
+  - `test_fan_out_nondiscriminating_dropped`: phone differs on EVERYTHING (fires on random pairs
+    at ≥ the match rate → `w_fired >= 0`) → warn finding, no NE.
+  - `test_fan_out_no_blocking_warns`: config with `blocking=None` → warn+skip, no crash.
+  - `test_fan_out_partial_model_skips_ne`: drop one comparison field from `em.match_weights` →
+    warn+skip (message mirrors calibration's partial-model wording).
+  - `test_fan_out_copy_on_write`: baseline `conversion.em_model` has NO `__ne__` keys and
+    baseline config has no NE after the pass.
+  - `test_fan_out_block_size_findings`: an `upgrade:fan_out` info finding reports block-size
+    p50/p95/max.
+  - `test_fan_out_runs_under_posterior_mode`: `GOLDENMATCH_FS_CALIBRATED=posterior`
+    (monkeypatch env) → NE still suggested (lever is mode-independent).
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3:** Implement per the algorithm block.
+- [ ] **Step 4:** Run new tests + full `pytest tests/test_splink_upgrade_fanout.py
+  tests/test_splink_upgrade_levers.py -q` → PASS.
+- [ ] **Step 5:** Ruff; commit `feat(splink-upgrade): risk-gated posterior-estimated NE suggestion`.
+
+---
+
+### Task F4: Guard tuning
+
+Fills `_tune_cluster_guard(ctx)`.
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py`
+- Test: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py`
+
+Reference priority `labels -> splink_clusters -> skip(info)`. Load via lazy import of
+`splink_upgrade_measure._load_reference` and resolve ids via `_resolve_ids(ctx.df,
+ctx.id_column)`; when the resolved ids are positional (the `_resolve_ids` fallback) or the
+id-join overlap with the reference is zero, skip with an info finding naming `id_column=` (the
+`_checked_reference` posture, but info-level — guard tuning is optional, not a measurement
+integrity failure). Restricted to joined ids: sizes = reference cluster sizes;
+`new_cap = max(_GUARD_MIN_CAP, 2 * max(sizes))`. Create `GoldenRulesConfig()` on the upgraded
+config when absent, set `max_cluster_size`, finding reports old → new + max/p99 + which
+reference. `_load_reference` failures (bad path/shape) → warn+skip. NOTE: `_resolve_ids` RAISES
+`SplinkUpgradeError` on a missing or duplicate-valued explicit `id_column`; the lever contract is
+never-fail, so wrap the `_resolve_ids` call in try/except → warn+skip (measurement's later
+identical call is separately caught by the orchestrator's try/except and surfaces the same
+problem there).
+
+- [ ] **Step 1: Failing tests.**
+  - `test_guard_tuned_from_labels`: labels df (`rec_id`,`cluster`) with max true cluster 4 +
+    `id_column="rec_id"` → `max_cluster_size == 10` (floor wins over 2×4);
+    with max cluster 30 → `60` (2× wins, loosening allowed when > default? here 60 < 100 —
+    also add a case with reference max 80 → cap 160 > default 100, asserting the symmetric raise).
+  - `test_guard_prefers_labels_over_splink_clusters`: both provided, different maxima → labels win;
+    finding names "labels".
+  - `test_guard_skips_without_reference`: neither provided → info finding, `golden_rules`
+    max_cluster_size untouched (still default).
+  - `test_guard_skips_on_unjoinable_ids`: reference ids share nothing with the data ids (or no
+    id_column + no id-ish column → positional) → info finding mentioning `id_column`, no change.
+  - `test_guard_baseline_untouched`: baseline config's golden_rules unchanged (copy-on-write).
+- [ ] **Step 2:** Run → FAIL.  **Step 3:** Implement.  **Step 4:** Run → PASS; ruff.
+- [ ] **Step 5:** Commit `feat(splink-upgrade): data-driven max_cluster_size guard tuning`.
+
+---
+
+### Task F5: Calibration lever NE-awareness (tripwire payoff)
+
+**Files:**
+- Modify: `packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py` (`_lever_calibration`)
+- Test: `packages/python/goldenmatch/tests/test_splink_upgrade_levers.py`
+
+- [ ] **Step 1: Failing tests.**
+  - Replace the existing tripwire test (find it: `grep -n "negative_evidence" tests/test_splink_upgrade_levers.py`)
+    with `test_calibration_runs_on_ne_bearing_config`: hand-build a conversion whose matchkey
+    carries an NE field + `__ne__` model entries (the F3 output shape) → calibration sets
+    `link_threshold`/`review_threshold` in (0, 1], no warn finding about NE.
+  - `test_calibration_ne_parity_when_never_fires`: same config but the NE column all-null in the
+    data (NE never fires; `fs_weight_range` max unchanged, min extended) → thresholds computed;
+    assert normalized weights stayed in [0,1] (indirectly: link/review in range) and equal the
+    no-NE run's thresholds when the NE weight range contribution is zero
+    (`penalty_bits`-free, `w_fired=0.0` entry edge: use `match_weights["__ne__x"]=[0.0, 0.0]`).
+  - `test_calibration_uses_fs_weight_range`: monkeypatch `fs_weight_range` to a sentinel raising
+    → calibration hits it (proves the hand-rolled sums are gone).
+- [ ] **Step 2:** Run → FAIL (tripwire still skips).
+- [ ] **Step 3: Implement** in `_lever_calibration`:
+  - DELETE the tripwire block (the `if mk.negative_evidence:` warn+skip).
+  - Extend `cols` (row_lookup projection) with NE field names:
+    `cols += [ne.field for ne in (mk.negative_evidence or []) if ne.field not in cols]`.
+  - Per-pair weight: add `sum(_ne_scalar_contribution(row_a, row_b, ne, em) for ne in
+    (mk.negative_evidence or []))` (import `_ne_scalar_contribution` in the function-local
+    import block).
+  - Replace the hand-rolled `max_weight`/`min_weight` sums with
+    `min_weight, max_weight = fs_weight_range(em, mk)`. NOTE: `fs_weight_range` iterates ALL
+    `mk.fields` (no `__record__` exclusion), but converted configs never emit `__record__`
+    pseudo-fields and the existing uncovered-fields guard runs first — leave a one-line comment
+    saying exactly that.
+- [ ] **Step 4:** Run the whole lever test file → PASS.  Ruff.
+- [ ] **Step 5:** Commit `feat(splink-upgrade): calibration lever is NE-aware (fs_weight_range); tripwire removed`.
+
+---
+
+### Task F6: E2E success bar + CLI help text
+
+**Files:**
+- Create: `packages/python/goldenmatch/tests/test_splink_upgrade_fanout_e2e.py`
+- Modify: `packages/python/goldenmatch/goldenmatch/cli/import_splink.py` (docstring/help for
+  `--upgrade` mentioning the fan_out lever; NO behavior change)
+- Test: `packages/python/goldenmatch/tests/test_cli_import_splink_upgrade.py` (only if an
+  existing help-text assertion breaks — do NOT add Rich-help substring scraping tests)
+
+- [ ] **Step 1: Failing E2E test** (`test_fanout_lever_success_bar`). Build:
+  - A Splink settings dict (trained: comparison levels carry `m_probability`/`u_probability`)
+    over `given_name`+`surname`+`city` with blocking on `city` — mirror the settings-building
+    helpers in `tests/test_from_splink_model_import.py`.
+  - A dataframe in the `test_fs_ne_e2e.py` style: N true-duplicate pairs (same person, small
+    perturbations, SAME phone) + K homonym traps (distinct people, same name+city, DIFFERENT
+    phone) + filler singletons; `rec_id` id column; `labels` df with true cluster ids; blocks
+    MUST mix identities (fixture lesson from #1764) and surnames must spread across soundex
+    codes (memory: synthetic surname fixtures).
+  - `phone` appears in the DATA but NOT in the Splink settings.
+  Then: `conv = from_splink(settings)`;
+  `res = upgrade_splink_conversion(conv, df, labels=labels_df, id_column="rec_id")`.
+  Assert:
+  - upgraded matchkey has a phone NE field; `__ne__phone` in `res.em_model.match_weights` with
+    negative fired weight; baseline config/model untouched;
+  - `res.measurement.vs_labels` present and upgraded pairwise F1 > baseline pairwise F1
+    (STRICT — this is the success bar);
+  - guard finding present (labels reference) and `max_cluster_size` tuned.
+  Mark the test with a generous but bounded runtime expectation (runs two dedupes on a small
+  frame; keep the fixture ≤ ~300 rows so the pure-Python NE path stays fast).
+- [ ] **Step 2:** Run → FAIL (or, if it unexpectedly PASSES before F3-F5 semantics settle,
+  tighten the fixture until baseline demonstrably merges the traps — assert baseline F1 < 1.0
+  as a fixture-validity precondition inside the test).
+- [ ] **Step 3:** Fix whatever the E2E surfaces (this is the integration shakeout — expect
+  fixture tuning, not production rewrites; if production changes ARE needed, keep them within
+  the spec's semantics).
+- [ ] **Step 4:** CLI help text: extend the `--upgrade` option help to name the four levers.
+  Run `pytest tests/test_cli_import_splink_upgrade.py -q` → PASS (stdout byte-compat matters on
+  the NON-upgrade path only; help text is fine to change).
+- [ ] **Step 5:** Full targeted sweep:
+  `pytest tests/test_splink_upgrade_fanout.py tests/test_splink_upgrade_fanout_e2e.py tests/test_splink_upgrade_levers.py tests/test_splink_upgrade_measure.py tests/test_cli_import_splink.py tests/test_cli_import_splink_upgrade.py tests/test_from_splink_api.py -q`
+  → all pass. Ruff. Commit `test(splink-upgrade): fan-out lever E2E success bar`.
+
+---
+
+### Task F7: Wild-bench regression check + PR
+
+**Files:** none in-repo (bench assets live in `D:\ER\splink_convert_dogfood`)
+
+- [ ] **Step 1:** Re-run the 3 wild bench pairs through `--upgrade` (see
+  `D:\ER\splink_convert_dogfood\bench\run_upgrade_bar.py` — extend/reuse; it compares baseline vs
+  upgraded pairwise F1 per pair). Requirement: NO pair's upgraded F1 regresses below its current
+  upgraded F1 (0.6328 / 0.7656 / 0.7396). Risk-not-detected no-ops are passes. Record the three
+  numbers in the PR body.
+- [ ] **Step 2:** If a pair regresses: the lever mis-fired — diagnose (most likely a too-loose
+  gate or a bad u_fire estimate), fix within spec semantics, re-run.
+- [ ] **Step 3:** Final review pass over the whole branch diff
+  (superpowers:subagent-driven-development's final review stage).
+- [ ] **Step 4:** Push (auth dance above), open PR titled
+  `feat(goldenmatch): fan-out/negative-evidence upgrade lever for Splink migration`, body:
+  spec summary + bench numbers + the tripwire-removal note. Arm `gh pr merge --auto` and stop.
+- [ ] **Step 5:** After merge: update memory (`project_splink_converter` /
+  `project_fs_negative_evidence` open-items) + `D:\Work-Tracking\work-tracker-personal.md`.

--- a/docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
+++ b/docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
@@ -1,0 +1,224 @@
+# Fan-out / Negative-Evidence Upgrade Lever (Splink Migration v2)
+
+**Date:** 2026-07-14
+**Status:** Approved (design)
+**Thesis phase:** Python POC (Rust/TS surfaces are later phases, out of scope)
+**Predecessors:**
+- The Splink migration upgrade pass (`specs/2026-07-14-splink-migration-upgrade-design.md`,
+  shipped as PR #1760) -- this lever is the "v2 lever" that spec deferred.
+- FS negative evidence (`specs/2026-07-14-fs-negative-evidence-design.md`, shipped as PR #1764) --
+  the core capability this lever consumes; that spec's "fan-out upgrade lever will compute
+  `__ne__` entries at import time" pointer is THIS design.
+
+## Problem
+
+Converted Splink configs have no defense against fan-out/homonym snowballs: two distinct people
+sharing name+city merge because name evidence dominates, and a hard phone/email disagreement --
+present in the user's data but absent from the Splink comparison set -- never gets a vote. The
+converter can't fix this (a settings file has no data); FS-NE (#1764) provides the mechanism but
+nothing suggests or parameterizes NE fields at migration time. Additionally,
+`golden_rules.max_cluster_size` defaults to 100, so on person-shaped data (true clusters of 2-5)
+an 80-record snowball sails under the existing `auto_split` guard untouched.
+
+The upgrade pass's calibration lever carries an explicit tripwire for this feature: it warns +
+skips on any NE-bearing matchkey because its pair-weight sum and model range cover regular fields
+only ("skip until this lever is taught `fs_weight_range`"). This lever emits exactly that shape,
+so the tripwire is replaced as part of this work.
+
+## Decisions (from brainstorming)
+
+- **Scope (v1):** NE suggestions with computed `__ne__` weights + data-driven cluster-guard
+  tuning. Calibration NE-awareness comes along as required plumbing. Fan-out diagnosis evidence
+  ships as findings (the gate's measurements), not as a separate report-only sub-lever.
+- **NE weights:** posterior-weighted estimation from the imported model (chosen over fixed
+  `penalty_bits` and over estimate-with-fallback). Writes REAL `__ne__` entries into the upgraded
+  model copy; imported regular-field m/u untouched; no full retrain.
+- **Gating:** NE fields are added only when the data shows measured fan-out risk (confident-merge
+  pairs contradicted by a hard identity signal). No risk = no NE + info finding.
+- **Default-on:** the lever joins the default lever set (`levers=None` runs all four). The pass is
+  already opt-in via `--upgrade`, the faithful baseline is always kept, measurement reports the
+  delta, and risk-gating keeps it quiet on clean data.
+- **Approach A:** ONE `fan_out` lever (shared risk diagnosis feeds both NE and guards) + teaching
+  the calibration lever `fs_weight_range`. Rejected: two separate levers (duplicated diagnosis or
+  a cross-lever context object, multiplied ordering constraints); guard tuning inside the
+  measurement stage (measurement is deliberately read-only and runs after the upgraded config is
+  final).
+
+## Shape and placement
+
+New lever `fan_out` in `goldenmatch/config/splink_upgrade.py`'s registry, ordered:
+
+```
+tf_tables -> distance_thresholds -> fan_out -> calibration
+```
+
+so calibration always calibrates the final (possibly NE-bearing) model. Same contract as the
+existing levers: findings under an `upgrade:fan_out` splink_path, warn+skip on anything
+unrecoverable, never fails the pass, individually skippable via the `levers` set (new valid name
+`"fan_out"`). No new CLI flags: `--upgrade` picks it up; the existing `--splink-clusters` /
+`--labels` inputs gain a second job as the guard-tuning reference (they must therefore be
+threaded from `upgrade_splink_conversion`'s measurement-stage arguments into the lever context --
+today they are measurement-only).
+
+**Bare-settings inputs (`conversion.em_model is None`):** the lever skips with the standard
+bare-settings info note (posterior estimation needs a model; run-time EM training + autoconfig
+own that case). Guard tuning also skips in this case -- keeping the lever's activation condition
+single and simple.
+
+## The shared risk diagnosis
+
+Reuses the exact pair machinery the calibration lever already uses: `build_blocks` on the sampled
+frame (same `__row_id__` wiring) + `_sample_blocked_pairs(blocks, n_pairs=_CALIBRATION_MAX_PAIRS,
+seed)`. For each sampled pair, compute the match posterior under the imported model: total FS
+weight over regular fields + `posterior_from_weight` with the equal-odds within-block prior
+re-estimation that the calibration lever introduced (dogfood-bench lesson: the imported
+`probability_two_random_records_match` is a random-pair prior, NOT the within-block rate).
+**That prior re-estimation is extracted into a shared module-level helper** both levers call,
+since `fan_out` now runs first. Pinned reading: the per-pair posterior is
+`posterior_from_weight(total_weight, prior_weight(within_block_rate))` where `within_block_rate`
+comes from the extracted re-estimation helper -- NOT the equal-odds (prior_w=0) posterior the
+re-estimation uses internally as its own bootstrap. Blocked-pair scoring work is computed once
+per pass and shared where practical (the two levers run back-to-back on the same sample and
+seed).
+
+The lever's internal posterior math is independent of the runtime scoring-calibration mode:
+`fan_out` RUNS (does not skip) under `GOLDENMATCH_FS_CALIBRATED=posterior` -- only the
+calibration lever's existing posterior-mode skip is mode-sensitive.
+
+**NE candidate columns** -- ALL of:
+- present in the data, NOT a comparison field (`f.field` of the matchkey), NOT `__record__`,
+  NOT a blocking-key field (via `core.blocker.collect_blocking_fields(config.blocking)` --
+  the helper takes the `BlockingConfig`; when the config has no blocking at all the lever
+  warn+skips before any pair work, mirroring the calibration lever's no-blocking guard);
+- cardinality ratio (n_unique / n_rows on the sample) >= 0.5;
+- identity-grade name/type, reusing the `_pick_scorer_for_column` name-matching pattern from
+  `core/autoconfig_negative_evidence.py` (phone/email/address/id vocabularies) -- the same
+  function supplies the suggested transforms + scorer for the NE field;
+- non-null rate >= a floor (default 0.5) so mostly-empty columns are not suggested (NE requires
+  both sides present, so a sparse column would rarely fire anyway -- the floor keeps the config
+  clean rather than protecting correctness).
+
+**The risk gate, per candidate:** among *confident-merge* pairs (posterior >= 0.9), measure the
+NE firing rate, where firing = both values present post-transform AND scorer similarity STRICTLY
+`<` threshold -- via the shipped `_ne_fired` predicate from `core/probabilistic.py` (no
+re-implementation). Risk is confirmed when:
+- firing rate among confident-merge pairs >= a floor (default 2%), AND
+- absolute count of firing confident-merge pairs >= 10 (estimation support).
+
+This directly measures the failure mode: "the imported config would merge pairs that a hard
+identity signal contradicts." Findings report the measured contradiction rate and counts whether
+or not the gate passes. No gated candidate -> info finding ("no fan-out risk detected"), no NE;
+guard tuning still runs.
+
+## NE weight estimation (posterior-weighted)
+
+For each gated candidate, over the sampled blocked pairs (posteriors `p_i`, firing indicator
+`fired_i`):
+
+```
+m_fire = sum(p_i * fired_i) / sum(p_i)          # posterior-weighted firing rate
+u_fire = firing rate on RANDOM row pairs          # same random-pair route train_em uses for u
+```
+
+both epsilon-clamped away from 0/1 (mirroring train_em's floors). Entries written into the
+UPGRADED model copy exactly in the FS-NE storage schema (so `validate_for` passes and TS serde
+round-trips):
+
+```
+m_probs["__ne__<field>"]       = [m_fire, 1 - m_fire]     # [fired, not_fired]
+u_probs["__ne__<field>"]       = [u_fire, 1 - u_fire]
+match_weights["__ne__<field>"] = [log2(m_fire / u_fire), 0.0]
+```
+
+**Sanity check:** if the estimated `w_fired` comes out >= 0 (firing is not rarer among matches --
+the column doesn't discriminate on this data), warn + drop that candidate (no NE field, no model
+entries). The NE field lands on the matchkey as
+`NegativeEvidenceField(field=..., transforms=..., scorer=..., threshold=...)` with the
+`_pick_scorer_for_column`-derived scorer/transforms and the default NE threshold (0.4, matching
+autoconfig's `_DEFAULT_NE_THRESHOLD`); no `penalty` / no `penalty_bits` (EM-learned shape).
+Finding per field: m/u/bits + the observed contradiction rate.
+
+The same threshold/scorer/transform tuple used by the GATE must be used at RUNTIME (the
+NegativeEvidenceField carries them) -- the gate measures the exact predicate that will fire in
+scoring.
+
+## Guard tuning
+
+Reference priority: `labels` (true cluster sizes; group by label id) -> `splink_clusters` (the
+user's old output's cluster sizes) -> skip with an info finding (no invented reference). With a
+reference: join the reference to the sampled rows the same way measurement does (the
+`id_column` mechanism; when ids cannot be joined, skip guard tuning with the same info finding
+measurement emits for an unjoinable reference), compute the reference max cluster size
+restricted to the sampled ids, and set
+
+```
+golden_rules.max_cluster_size = max(10, 2 * reference_max_cluster_size)
+```
+
+on the upgraded config -- symmetric: person-shaped data tightens the default 100 down to ~10-20
+(letting the existing `auto_split` MST-split actually catch mid-size snowballs), while
+genuinely-large-cluster domains loosen the cap and avoid wrongly splitting real clusters. Finding
+reports old -> new cap and the reference evidence (max/p99 sizes, which reference was used).
+`GoldenRulesConfig` is created on the upgraded config when absent.
+
+Block-size distribution (p50/p95/max over the built blocks on the sample) is reported as findings
+only -- `blocking.max_block_size` stays untouched in v1 (oversized blocks are processed, not
+dropped, so tuning it has murky semantics; YAGNI).
+
+## Calibration lever NE-awareness (the tripwire payoff)
+
+In `_lever_calibration`:
+- Replace the hand-rolled `max_weight`/`min_weight` sums with `fs_weight_range(em, mk)` from
+  `core/probabilistic.py`.
+- Extend the per-pair total-weight sum with NE contributions: fired -> `w_fired` (from the
+  `__ne__` entry) or `-abs(penalty_bits)`, else exactly 0 -- reusing the core scalar NE
+  contribution helper (`_ne_scalar_contribution` / `_ne_fired`), not a re-implementation.
+- DELETE the warn+skip tripwire.
+
+Calibrated thresholds then live on the same normalized scale runtime scoring uses for NE-bearing
+configs. (Runtime scoring already normalizes via `fs_weight_range` since #1764 -- this closes the
+last consumer.)
+
+## Measurement, errors
+
+Measurement needs zero changes: it already runs baseline + upgraded configs, and the upgraded one
+now carries NE. Note: NE declines native/fused kernels (per #1764's capability gates), so the
+upgraded measurement run takes the pure-Python FS path -- acceptable at the 100K sample cap; the
+wall delta is visible in `RunStats.wall_seconds`. Error posture identical to existing levers
+(warn+skip per candidate / per sub-step; the lever never fails the pass).
+
+## Testing / success bar
+
+Unit tests per component:
+- candidate eligibility matrix (comparison-field / blocking-field / low-cardinality / high-null /
+  non-identity-name exclusions);
+- risk gate on/off (rate floor, support floor) on synthetic pairs with known posteriors;
+- estimation math against hand-computed m/u/w on tiny fixtures; the w >= 0 drop;
+- guard tuning from labels vs splink_clusters vs neither; the max(10, 2x) clamp both directions;
+- calibration on an NE-bearing config: thresholds in range, tripwire gone, parity with a
+  no-NE config when no NE field fires;
+- copy-on-write invariants (baseline config + baseline EMResult untouched; deepcopy semantics);
+- skip paths: bare settings, posterior calibration mode ordering, no candidates, insufficient
+  pairs.
+
+**Success bar (deterministic E2E test):** a homonym-shaped fixture in the `test_fs_ne_e2e` style
+-- distinct people sharing name+city but differing on a phone column that the Splink settings
+never referenced -- run through convert -> `upgrade_splink_conversion` with labels: the baseline
+conversion merges the homonym traps; the lever detects the risk, adds phone NE with estimated
+weights; the measured upgraded run separates the traps while true duplicates still merge; and
+`vs_labels` pairwise F1 strictly improves baseline -> upgraded.
+
+Integration: the 3 wild bench pairs (D:\ER\splink_convert_dogfood) re-run under `--upgrade` with
+no pairwise-F1 regression (no-op passes -- risk not detected -- count as passes).
+
+## Out of scope
+
+- Rust/TS ports (thesis phases 2-3 for this feature); the TS phase must OPEN with a loud NE
+  decline (TS FS scoring silently ignores NE today).
+- MCP surface for the upgrade pass.
+- Autoconfig-time NE promotion on probabilistic matchkeys (this lever is migration-path only;
+  `promote_negative_evidence` keeps skipping probabilistic).
+- `blocking.max_block_size` tuning (findings only in v1).
+- Corrections-based refinement of the m/u estimates.
+- Multi-matchkey configs (converted configs always carry exactly one probabilistic matchkey; the
+  lever asserts this like the other levers do).

--- a/packages/python/goldenmatch/goldenmatch/cli/import_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/import_splink.py
@@ -175,7 +175,9 @@ def import_splink_cmd(
         None,
         "--upgrade",
         help=(
-            "Run the data-aware upgrade pass against this dataset (parquet/csv). "
+            "Run the data-aware upgrade pass against this dataset (parquet/csv): "
+            "four levers -- tf_tables, distance_thresholds, fan_out (negative "
+            "evidence + cluster-guard tuning), calibration. "
             "Writes the UPGRADED config/model to --output/--model-out and the "
             "faithful baseline alongside as out.baseline.yaml/model.baseline.json."
         ),

--- a/packages/python/goldenmatch/goldenmatch/config/loader.py
+++ b/packages/python/goldenmatch/goldenmatch/config/loader.py
@@ -10,14 +10,20 @@ import yaml
 from goldenmatch.config.schemas import GoldenMatchConfig
 
 # Keys in golden_rules that are part of the schema (not field names).
-# NOTE: max_cluster_size / auto_split / quality_weighting / weak_cluster_threshold /
-# split_edge_budget / adaptive / use_llm_for_ambiguous / cluster_overrides are
-# intentionally omitted -- those are set programmatically, not via flat YAML;
-# adding them here is out of scope for this change. The two new keys below
-# (field_groups, field_group_detection) are added so the YAML loader does not
-# sweep them into field_rules where they fail validation.
+# NOTE: max_cluster_size WAS historically omitted as "set programmatically,
+# not via flat YAML" -- that assumption is stale: the Splink upgrade pass's
+# fan_out guard lever (config/splink_upgrade_fanout.py) now writes it into
+# the upgraded YAML, so it must not be swept into field_rules (where it
+# fails GoldenFieldRule validation on reload). The other programmatic keys
+# (auto_split, quality_weighting, weak_cluster_threshold, split_edge_budget,
+# adaptive, use_llm_for_ambiguous, cluster_overrides) remain omitted
+# DELIBERATELY -- adding them would change behavior for data columns that
+# happen to share those names. field_groups / field_group_detection are here
+# so the loader does not sweep them into field_rules where they fail
+# validation.
 _GOLDEN_RULES_SPECIAL_KEYS = frozenset({
     "default_strategy", "field_rules", "field_groups", "field_group_detection",
+    "max_cluster_size",
 })
 
 

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -179,8 +179,8 @@ class _LeverContext:
     report: ConversionReport
     df: pl.DataFrame
     seed: int
-    splink_clusters: object | None = None
-    labels: object | None = None
+    splink_clusters: pl.DataFrame | str | Path | None = None
+    labels: pl.DataFrame | str | Path | None = None
     id_column: str | None = None
     # True when ``df`` is a subsample of the full input (sample_cap hit) --
     # lets sample-sensitive levers (fan_out's guard tuning) caveat findings

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -182,6 +182,10 @@ class _LeverContext:
     splink_clusters: object | None = None
     labels: object | None = None
     id_column: str | None = None
+    # True when ``df`` is a subsample of the full input (sample_cap hit) --
+    # lets sample-sensitive levers (fan_out's guard tuning) caveat findings
+    # whose reference statistics may be fragmented by the subsampling.
+    sampled: bool = False
 
 
 _BARE_SETTINGS_SKIP_MSG = (
@@ -496,9 +500,11 @@ def _lever_calibration(ctx: _LeverContext) -> None:
 
     from goldenmatch.core.probabilistic import (
         _fs_calibration_mode,
+        _ne_scalar_contribution,
         _sample_blocked_pairs,
         comparison_vector,
         compute_thresholds,
+        fs_weight_range,
     )
 
     mapped_to = "matchkeys[0].link_threshold/review_threshold"
@@ -521,24 +527,6 @@ def _lever_calibration(ctx: _LeverContext) -> None:
     assert ctx.em_model is not None  # copy of conversion.em_model (checked above)
     em = ctx.em_model
     mk = ctx.upgraded_config.get_matchkeys()[0]
-
-    # Tripwire for the planned fan-out upgrade lever: this lever's per-pair
-    # weight sum and hand-rolled model min/max range below cover REGULAR
-    # fields only -- they do not include negative-evidence contributions
-    # (`__ne__<field>` entries / penalty_bits). Unreachable today
-    # (from_splink never emits negative_evidence), but the fan-out lever
-    # will emit exactly that shape; calibrating while ignoring NE weights
-    # would put the thresholds on the wrong scale. Warn + skip until this
-    # lever is taught fs_weight_range (core/probabilistic.py).
-    if mk.negative_evidence:
-        ctx.report.warn(
-            "upgrade:calibration",
-            "skipped: calibration does not yet account for negative_evidence "
-            "weights (the pair-weight sum and model range cover regular "
-            "fields only; see fs_weight_range) -- thresholds left unset",
-            mapped_to=mapped_to,
-        )
-        return
 
     # Mixed bare/trained input produces a PARTIAL imported model (import_em
     # skips bare comparisons with a warning), so em.match_weights does not
@@ -609,6 +597,9 @@ def _lever_calibration(ctx: _LeverContext) -> None:
     from goldenmatch.core.frame import to_frame
 
     cols = [f.field for f in mk.fields if f.field is not None and f.field != "__record__"]
+    # NE fields (the fan_out lever's output shape) join the projection so
+    # _ne_fired can see the values when summing per-pair NE contributions.
+    cols += [ne.field for ne in (mk.negative_evidence or []) if ne.field not in cols]
     row_lookup: dict[int, dict] = {}
     for row in to_frame(lf.collect()).select_dicts(["__row_id__"] + cols):
         row_lookup[row["__row_id__"]] = row
@@ -626,17 +617,29 @@ def _lever_calibration(ctx: _LeverContext) -> None:
 
     total_weights: list[float] = []
     for a, b in pairs:
-        vec = comparison_vector(row_lookup.get(a, {}), row_lookup.get(b, {}), mk)
+        row_a = row_lookup.get(a, {})
+        row_b = row_lookup.get(b, {})
+        vec = comparison_vector(row_a, row_b, mk)
         total_weights.append(
             sum(em.match_weights[name][vec[k]] for k, name in indexed_fields)
+            # NE contributions: 0.0 unless the field FIRES (core scalar
+            # helper -- penalty_bits override or the EM-learned `__ne__`
+            # fired-weight), matching runtime FS scoring.
+            + sum(
+                _ne_scalar_contribution(row_a, row_b, ne, em)
+                for ne in (mk.negative_evidence or [])
+            )
         )
 
     # Normalize the SAME way runtime scoring does (score_probabilistic):
     # against the MODEL-derived min/max total weight, not the observed
     # min/max -- at run time mk.link_threshold is compared to model-range
     # normalized scores, so the calibrated cuts must live on that scale.
-    max_weight = sum(max(em.match_weights[name]) for _, name in indexed_fields)
-    min_weight = sum(min(em.match_weights[name]) for _, name in indexed_fields)
+    # fs_weight_range covers regular fields AND negative_evidence
+    # (`__ne__` entries / penalty_bits). It iterates ALL mk.fields (no
+    # __record__ exclusion), but converted configs never emit __record__
+    # pseudo-fields and the uncovered-fields guard above already ran.
+    min_weight, max_weight = fs_weight_range(em, mk)
     weight_range = max_weight - min_weight
     if weight_range <= 0:
         ctx.report.warn(
@@ -807,6 +810,7 @@ def upgrade_splink_conversion(
         splink_clusters=splink_clusters,
         labels=labels,
         id_column=id_column,
+        sampled=sampled,
     )
 
     for name in lever_names:

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -4,9 +4,9 @@ Spec: docs/superpowers/specs/2026-07-14-splink-migration-upgrade-design.md
 
 A faithful Splink -> GoldenMatch conversion (``from_splink``) is the trust
 anchor: pure, deterministic, data-free. This module runs AFTER conversion,
-with the user's data in hand, and applies three independent, individually
-skippable levers (TF tables, measured distance thresholds, threshold
-calibration) to produce an upgraded config -- plus (optionally) a measured
+with the user's data in hand, and applies four independent, individually
+skippable levers (TF tables, measured distance thresholds, fan-out/negative
+evidence, threshold calibration) to produce an upgraded config -- plus (optionally) a measured
 baseline-vs-upgraded comparison. The converter itself is never modified or
 imported for its side effects; this module only reads its public result
 shape (``SplinkConversion``).
@@ -165,6 +165,12 @@ class _LeverContext:
     ``upgraded_config`` / ``em_model`` are the copy-on-write targets levers
     mutate in place; ``report`` accumulates findings (all under an
     ``upgrade:``-prefixed splink_path); ``df`` is the (already sampled) data.
+
+    ``splink_clusters``/``labels``/``id_column`` are the orchestrator's
+    reference-input args passed through untouched (DataFrame-or-path, same
+    loose typing as the orchestrator signature) so reference-aware levers
+    (fan_out) can read them; measurement keeps receiving them separately,
+    exactly as before.
     """
 
     conversion: SplinkConversion
@@ -173,6 +179,9 @@ class _LeverContext:
     report: ConversionReport
     df: pl.DataFrame
     seed: int
+    splink_clusters: object | None = None
+    labels: object | None = None
+    id_column: str | None = None
 
 
 _BARE_SETTINGS_SKIP_MSG = (
@@ -447,6 +456,37 @@ _CALIBRATION_MAX_PAIRS = 10_000
 _CALIBRATION_MIN_PAIRS = 50
 
 
+def _estimate_within_block_prior(total_weights: list[float]) -> float:
+    """Within-block match-rate estimate from model likelihood ratios under an
+    equal-odds prior: mean of 2^w/(1+2^w).
+
+    Extracted from ``_lever_calibration`` (shared with the fan_out lever).
+    Rationale: em.proportion_matched has TWO different semantics depending on
+    origin: GM's own train_em estimates it ON BLOCKED PAIRS (the within-block
+    match rate compute_thresholds' percentile math expects), while an imported
+    Splink model carries probability_two_random_records_match -- a RANDOM-
+    PAIR prior, orders of magnitude below the post-blocking rate. Feeding
+    the raw prior into the percentile cut pushes link into the extreme top
+    of the blocked-pair distribution and collapses recall (dogfood bench,
+    real_time_settings/fake_1000: F1 0.482 -> 0.157). So re-estimate the
+    within-block rate from the model's own likelihood ratios under an
+    equal-odds prior (prior weight 0): the mean pair posterior
+    2^w / (1 + 2^w) over the scored candidates. The mis-scaled imported
+    prior is deliberately discarded rather than trusted; when it errs, this
+    estimator errs HIGH (uninformative pairs pull toward 0.5), which only
+    loosens the percentile cut toward compute_thresholds' 0.40 link floor
+    -- the safe direction (erring low reproduces the recall collapse).
+    Bench validation vs truth: 0.539 est / 0.547 true and 0.485 / 0.484 on
+    the two well-separated pairs; 0.708 / 0.307 (high, floor-safe) on the
+    borderline-heavy one.
+    """
+    from goldenmatch.core.probabilistic import posterior_from_weight
+
+    if not total_weights:
+        raise ValueError("cannot estimate a within-block prior from zero pairs")
+    return sum(posterior_from_weight(w, 0.0) for w in total_weights) / len(total_weights)
+
+
 def _lever_calibration(ctx: _LeverContext) -> None:
     # Runs AFTER levers 1-2 by design (registry order): it calibrates the
     # thresholds against the model users will actually run.
@@ -459,7 +499,6 @@ def _lever_calibration(ctx: _LeverContext) -> None:
         _sample_blocked_pairs,
         comparison_vector,
         compute_thresholds,
-        posterior_from_weight,
     )
 
     mapped_to = "matchkeys[0].link_threshold/review_threshold"
@@ -609,29 +648,12 @@ def _lever_calibration(ctx: _LeverContext) -> None:
         return
     normalized = [(w - min_weight) / weight_range for w in total_weights]
 
-    # em.proportion_matched has TWO different semantics depending on origin:
-    # GM's own train_em estimates it ON BLOCKED PAIRS (the within-block match
-    # rate compute_thresholds' percentile math expects), while an imported
-    # Splink model carries probability_two_random_records_match -- a RANDOM-
-    # PAIR prior, orders of magnitude below the post-blocking rate. Feeding
-    # the raw prior into the percentile cut pushes link into the extreme top
-    # of the blocked-pair distribution and collapses recall (dogfood bench,
-    # real_time_settings/fake_1000: F1 0.482 -> 0.157). Re-estimate the
-    # within-block rate from the model's own likelihood ratios under an
-    # equal-odds prior (prior weight 0): the mean pair posterior
-    # 2^w / (1 + 2^w) over the scored candidates. The mis-scaled imported
-    # prior is deliberately discarded rather than trusted; when it errs, this
-    # estimator errs HIGH (uninformative pairs pull toward 0.5), which only
-    # loosens the percentile cut toward compute_thresholds' 0.40 link floor
-    # -- the safe direction (erring low reproduces the recall collapse).
-    # Bench validation vs truth: 0.539 est / 0.547 true and 0.485 / 0.484 on
-    # the two well-separated pairs; 0.708 / 0.307 (high, floor-safe) on the
-    # borderline-heavy one. The scratch copy keeps the SHIPPED model's
-    # proportion_matched untouched: the re-estimated rate only parameterizes
-    # this threshold computation.
-    within_block_rate = sum(
-        posterior_from_weight(w, 0.0) for w in total_weights
-    ) / len(total_weights)
+    # The imported random-pair prior is deliberately discarded in favor of an
+    # errs-HIGH within-block re-estimate; see _estimate_within_block_prior's
+    # docstring for the full safety rationale. The scratch copy keeps the
+    # SHIPPED model's proportion_matched untouched: the re-estimated rate only
+    # parameterizes this threshold computation.
+    within_block_rate = _estimate_within_block_prior(total_weights)
     em_scratch = _dc_replace(em, proportion_matched=within_block_rate)
 
     link, review = compute_thresholds(em_scratch, scored_weights=normalized)
@@ -654,13 +676,27 @@ def _lever_calibration(ctx: _LeverContext) -> None:
     )
 
 
+def _lever_fan_out(ctx: _LeverContext) -> None:
+    # Lazy import (mirrors the measurement lazy import): the fan_out lever
+    # body lives in its own module; this one stays import-light without it.
+    from goldenmatch.config.splink_upgrade_fanout import run_fan_out_lever
+
+    run_fan_out_lever(ctx)
+
+
 _LEVER_REGISTRY: dict[str, Callable[[_LeverContext], None]] = {
     "tf_tables": _lever_tf_tables,
     "distance_thresholds": _lever_distance_thresholds,
+    "fan_out": _lever_fan_out,
     "calibration": _lever_calibration,
 }
 
-_LEVER_ORDER: tuple[str, ...] = ("tf_tables", "distance_thresholds", "calibration")
+_LEVER_ORDER: tuple[str, ...] = (
+    "tf_tables",
+    "distance_thresholds",
+    "fan_out",
+    "calibration",
+)
 
 
 def _resolve_levers(levers: Iterable[str] | None) -> list[str]:
@@ -708,8 +744,8 @@ def upgrade_splink_conversion(
             prior Splink output) for pairwise-agreement measurement.
         labels: Optional ground-truth id -> cluster_id for true P/R/F1 +
             B-cubed measurement.
-        levers: Subset of ``{"tf_tables", "distance_thresholds",
-            "calibration"}`` to run; ``None`` (default) runs all three in
+        levers: Subset of ``{"tf_tables", "distance_thresholds", "fan_out",
+            "calibration"}`` to run; ``None`` (default) runs all four in
             that order. Unknown names raise :class:`SplinkUpgradeError`.
         measure: When True (default), runs baseline-vs-upgraded measurement
             on the sample. ``False`` skips measurement (an info finding
@@ -768,6 +804,9 @@ def upgrade_splink_conversion(
         report=report,
         df=sampled_df,
         seed=seed,
+        splink_clusters=splink_clusters,
+        labels=labels,
+        id_column=id_column,
     )
 
     for name in lever_names:

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -653,7 +653,11 @@ def _lever_calibration(ctx: _LeverContext) -> None:
 
     # The imported random-pair prior is deliberately discarded in favor of an
     # errs-HIGH within-block re-estimate; see _estimate_within_block_prior's
-    # docstring for the full safety rationale. The scratch copy keeps the
+    # docstring for the full safety rationale. This estimate is NE-INCLUSIVE
+    # by design (total_weights above already carry per-pair NE contributions,
+    # matching runtime scoring); the fan_out lever's regular-only estimate is
+    # different on purpose -- it runs pre-NE, gating whether NE should exist
+    # at all (see splink_upgrade_fanout). The scratch copy keeps the
     # SHIPPED model's proportion_matched untouched: the re-estimated rate only
     # parameterizes this threshold computation.
     within_block_rate = _estimate_within_block_prior(total_weights)

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -11,6 +11,8 @@ cluster-guard tuning body in Task F4.
 """
 from __future__ import annotations
 
+from goldenmatch.config.splink_upgrade import _LeverContext
+
 # ── Tuning constants ─────────────────────────────────────────────────────────
 
 _FANOUT_POSTERIOR_CONFIDENT = 0.9   # "confident merge" posterior floor for the risk gate
@@ -36,7 +38,7 @@ _BARE_SETTINGS_SKIP_MSG_FANOUT = (
 )
 
 
-def run_fan_out_lever(ctx) -> None:
+def run_fan_out_lever(ctx: _LeverContext) -> None:
     if ctx.conversion.em_model is None:
         ctx.report.info("upgrade:fan_out", _BARE_SETTINGS_SKIP_MSG_FANOUT, mapped_to=None)
         return
@@ -44,9 +46,9 @@ def run_fan_out_lever(ctx) -> None:
     _tune_cluster_guard(ctx)          # Task F4
 
 
-def _suggest_negative_evidence(ctx) -> None:
+def _suggest_negative_evidence(ctx: _LeverContext) -> None:
     pass  # Task F3
 
 
-def _tune_cluster_guard(ctx) -> None:
+def _tune_cluster_guard(ctx: _LeverContext) -> None:
     pass  # Task F4

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -6,18 +6,33 @@ Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
 Runs between ``distance_thresholds`` and ``calibration`` in the upgrade pass
 (see ``goldenmatch/config/splink_upgrade.py``'s lever registry, which lazily
 imports this module). Task F1 landed the scaffold (bare-settings skip, no-op
-stub bodies); Task F2 the NE candidate eligibility (``_ne_candidates``). The
-NE-suggestion body arrives in Task F3 and the cluster-guard tuning body in
+stub bodies); Task F2 the NE candidate eligibility (``_ne_candidates``);
+Task F3 the risk gate + posterior-weighted NE estimation
+(``_suggest_negative_evidence``). The cluster-guard tuning body arrives in
 Task F4.
 """
 from __future__ import annotations
 
+import math
+import random
 from dataclasses import dataclass
 
 from goldenmatch._polars_lazy import pl
-from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig
-from goldenmatch.config.splink_upgrade import _LeverContext
-from goldenmatch.core.autoconfig_negative_evidence import _pick_scorer_for_column
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    MatchkeyConfig,
+    NegativeEvidenceField,
+)
+from goldenmatch.config.splink_upgrade import (
+    _CALIBRATION_MAX_PAIRS,
+    _CALIBRATION_MIN_PAIRS,
+    _estimate_within_block_prior,
+    _LeverContext,
+)
+from goldenmatch.core.autoconfig_negative_evidence import (
+    _DEFAULT_NE_THRESHOLD,
+    _pick_scorer_for_column,
+)
 from goldenmatch.core.blocker import collect_blocking_fields
 
 # ── Tuning constants ─────────────────────────────────────────────────────────
@@ -107,13 +122,254 @@ def _ne_candidates(
         cardinality = series.n_unique() / n_rows
         if not (_FANOUT_MIN_CARDINALITY <= cardinality <= _FANOUT_MAX_CARDINALITY):
             continue
+        # col_type "" on purpose -- see NOTE in autoconfig_negative_evidence.py
+        # (the dtype-vocabulary mismatch).
         transforms, scorer = _pick_scorer_for_column(col, "")
         candidates.append(_NECandidate(column=col, transforms=transforms, scorer=scorer))
     return candidates
 
 
+_NE_MAPPED_TO = "matchkeys[0].negative_evidence"
+
+
 def _suggest_negative_evidence(ctx: _LeverContext) -> None:
-    pass  # Task F3
+    """Risk-gated, posterior-weighted NE suggestion (spec: "The shared risk
+    diagnosis" + "NE weight estimation (posterior-weighted)").
+
+    Mirrors ``_lever_calibration``'s pair machinery (blocked-pair sampling,
+    row lookup, regular-field FS weight sums), then per candidate measures
+    the NE firing rate among CONFIDENT-merge pairs (posterior >=
+    ``_FANOUT_POSTERIOR_CONFIDENT`` under the shared within-block prior
+    re-estimate -- NOT the equal-odds posterior the re-estimation uses
+    internally). Gated candidates get real ``__ne__<field>`` entries written
+    into the upgraded model copy (FS-NE storage schema) and an EM-learned
+    shape ``NegativeEvidenceField`` on the matchkey. Every skip is a finding;
+    the lever never fails the pass. Guard tuning (Task F4) runs after us
+    regardless of any skip here.
+    """
+    # Heavy module: import function-locally, matching _lever_calibration.
+    from goldenmatch.core.probabilistic import (
+        _ne_fired,
+        _sample_blocked_pairs,
+        comparison_vector,
+        posterior_from_weight,
+        prior_weight,
+    )
+
+    mk = ctx.upgraded_config.get_matchkeys()[0]
+    em = ctx.em_model
+    assert em is not None  # run_fan_out_lever gates on conversion.em_model
+
+    blocking = ctx.upgraded_config.blocking
+    if blocking is None:
+        ctx.report.warn(
+            "upgrade:fan_out",
+            "skipped: config has no blocking configuration, cannot enumerate "
+            "blocked candidate pairs -- no negative evidence suggested",
+            mapped_to=_NE_MAPPED_TO,
+        )
+        return
+
+    # Partial imported model (mixed bare/trained input): posteriors need
+    # every comparison field covered by imported m/u -- mirrors
+    # _lever_calibration's uncovered-fields guard. Guard tuning is
+    # unaffected and still runs after us.
+    uncovered = [
+        f.field
+        for f in mk.fields
+        if f.field and f.field != "__record__" and f.field not in em.match_weights
+    ]
+    if uncovered:
+        ctx.report.warn(
+            "upgrade:fan_out",
+            "skipped: the imported Splink model is partial (mixed bare/"
+            "trained input) -- matchkey field(s) "
+            f"{', '.join(uncovered)} carry no imported m/u, so blocked "
+            "candidate pairs cannot be scored -- no negative evidence "
+            "suggested",
+            mapped_to=_NE_MAPPED_TO,
+        )
+        return
+
+    candidates = _ne_candidates(ctx.df, mk, blocking)
+    if not candidates:
+        ctx.report.info(
+            "upgrade:fan_out",
+            "no eligible NE candidate columns on the sample (identity-grade "
+            "name, non-null-rate and cardinality gates); no negative "
+            "evidence suggested",
+            mapped_to=_NE_MAPPED_TO,
+        )
+        return
+
+    # Candidate pairs: the exact route _lever_calibration uses (build_blocks
+    # on a __row_id__ LazyFrame + _sample_blocked_pairs), same cap and seed.
+    from goldenmatch.core.blocker import build_blocks
+
+    lf = ctx.df.lazy()
+    if "__row_id__" not in ctx.df.columns:
+        lf = lf.with_row_index("__row_id__")
+    lf = lf.with_columns(pl.col("__row_id__").cast(pl.Int64))
+    blocks = build_blocks(lf, blocking)
+
+    # Block-size distribution is FINDINGS ONLY -- blocking.max_block_size
+    # stays untouched in v1 (oversized blocks are processed, not dropped, so
+    # tuning it has murky semantics; spec).
+    sizes = sorted(b.materialize().height for b in blocks)
+    if sizes:
+        n_blocks = len(sizes)
+        b50 = sizes[n_blocks // 2]
+        b95 = sizes[min(n_blocks - 1, int(round(0.95 * (n_blocks - 1))))]
+        ctx.report.info(
+            "upgrade:fan_out",
+            f"block size distribution on the sample: p50={b50}, p95={b95}, "
+            f"max={sizes[-1]} over {n_blocks} block(s) "
+            "(blocking.max_block_size untouched)",
+            mapped_to=None,
+        )
+
+    pairs = _sample_blocked_pairs(blocks, n_pairs=_CALIBRATION_MAX_PAIRS, seed=ctx.seed)
+    if len(pairs) <= _CALIBRATION_MIN_PAIRS:
+        ctx.report.warn(
+            "upgrade:fan_out",
+            f"skipped: only {len(pairs)} blocked candidate pair(s) on the "
+            f"sample; the fan-out risk gate needs more than "
+            f"{_CALIBRATION_MIN_PAIRS} scored pairs -- no negative evidence "
+            "suggested",
+            mapped_to=_NE_MAPPED_TO,
+        )
+        return
+
+    # Row lookup over matchkey fields + candidate columns (mirrors
+    # _lever_calibration / train_em).
+    from goldenmatch.core.frame import to_frame
+
+    cols = [f.field for f in mk.fields if f.field is not None and f.field != "__record__"]
+    lookup_cols = ["__row_id__"] + cols + [
+        c.column for c in candidates if c.column not in cols
+    ]
+    row_lookup: dict[int, dict] = {}
+    for row in to_frame(lf.collect()).select_dicts(lookup_cols):
+        row_lookup[row["__row_id__"]] = row
+
+    indexed_fields = [
+        (k, f.field)
+        for k, f in enumerate(mk.fields)
+        if f.field is not None and f.field != "__record__"
+    ]
+
+    # Regular-field FS weight sums -- NE candidates contribute nothing here
+    # (they are not comparison fields by construction).
+    total_weights: list[float] = []
+    for a, b in pairs:
+        vec = comparison_vector(row_lookup.get(a, {}), row_lookup.get(b, {}), mk)
+        total_weights.append(
+            sum(em.match_weights[name][vec[k]] for k, name in indexed_fields)
+        )
+
+    # Per-pair posterior under the shared within-block prior re-estimate.
+    prior = _estimate_within_block_prior(total_weights)
+    prior_w = prior_weight(prior)
+    posteriors = [posterior_from_weight(w, prior_w) for w in total_weights]
+    confident = [p >= _FANOUT_POSTERIOR_CONFIDENT for p in posteriors]
+    n_conf = sum(confident)
+    posterior_sum = sum(posteriors)
+
+    for cand in candidates:
+        # The gate measures the EXACT predicate that will fire at runtime:
+        # the NegativeEvidenceField carries the same threshold/scorer/
+        # transforms tuple it is emitted with.
+        ne = NegativeEvidenceField(
+            field=cand.column,
+            transforms=cand.transforms,
+            scorer=cand.scorer,
+            threshold=_DEFAULT_NE_THRESHOLD,
+        )
+        fired = [
+            _ne_fired(row_lookup.get(a, {}), row_lookup.get(b, {}), ne)
+            for a, b in pairs
+        ]
+        n_fired_conf = sum(1 for f, c in zip(fired, confident) if f and c)
+        rate = n_fired_conf / n_conf if n_conf else 0.0
+        # The measured contradiction rate is ALWAYS reported, gated or not
+        # -- it is the fan-out diagnosis evidence.
+        ctx.report.info(
+            "upgrade:fan_out",
+            f"candidate '{cand.column}': contradiction rate {rate:.4f} "
+            f"among {n_conf} confident-merge pair(s) (posterior >= "
+            f"{_FANOUT_POSTERIOR_CONFIDENT}); {n_fired_conf} firing (gate: "
+            f"rate >= {_FANOUT_MIN_FIRE_RATE} and >= "
+            f"{_FANOUT_MIN_FIRING_PAIRS} firing pairs)",
+            mapped_to=_NE_MAPPED_TO,
+        )
+        if (
+            n_conf == 0
+            or rate < _FANOUT_MIN_FIRE_RATE
+            or n_fired_conf < _FANOUT_MIN_FIRING_PAIRS
+        ):
+            continue  # the info finding above already reports why
+
+        # Posterior-weighted m estimate + random-pair u estimate (train_em's
+        # u route), both epsilon-clamped away from 0/1 before log2.
+        m_fire = sum(p for p, f in zip(posteriors, fired) if f) / posterior_sum
+        m_fire = min(max(m_fire, _PROB_CLAMP), 1.0 - _PROB_CLAMP)
+        u_fire = _random_pair_firing_rate(row_lookup, ne, ctx.seed)
+        u_fire = min(max(u_fire, _PROB_CLAMP), 1.0 - _PROB_CLAMP)
+        w_fired = math.log2(m_fire / u_fire)
+        if w_fired >= 0:
+            ctx.report.warn(
+                "upgrade:fan_out",
+                f"candidate '{cand.column}': column does not discriminate "
+                f"on this data (w_fired={w_fired:.4f} >= 0: firing is not "
+                "rarer among likely matches than among random pairs) -- "
+                "dropped",
+                mapped_to=_NE_MAPPED_TO,
+            )
+            continue
+
+        mk.negative_evidence = (mk.negative_evidence or []) + [ne]
+        key = f"__ne__{cand.column}"
+        em.m_probs[key] = [m_fire, 1.0 - m_fire]
+        em.u_probs[key] = [u_fire, 1.0 - u_fire]
+        em.match_weights[key] = [w_fired, 0.0]
+        ctx.report.info(
+            "upgrade:fan_out",
+            f"negative-evidence field '{cand.column}' added "
+            f"(scorer={cand.scorer}, threshold={_DEFAULT_NE_THRESHOLD}): "
+            f"m_fire={m_fire:.4f}, u_fire={u_fire:.4f}, "
+            f"w_fired={w_fired:.4f} bits (contradiction rate {rate:.4f})",
+            mapped_to=_NE_MAPPED_TO,
+        )
+
+
+def _random_pair_firing_rate(
+    row_lookup: dict[int, dict], ne: NegativeEvidenceField, seed: int
+) -> float:
+    """NE firing rate over random pairs of DISTINCT rows -- the u estimate
+    (the same random-pair route ``train_em`` uses for u, scaled to
+    ``_FANOUT_RANDOM_PAIRS`` draws; same-row draws are skipped, so "up to").
+
+    Deterministic: the row ids are sorted before the seeded RNG samples
+    (dict order follows insertion which follows a stable collect, but sort
+    anyway for safety).
+    """
+    from goldenmatch.core.probabilistic import _ne_fired
+
+    ids = sorted(row_lookup)
+    if len(ids) < 2:
+        return 0.0
+    rng = random.Random(seed)
+    drawn = 0
+    n_fired = 0
+    for _ in range(_FANOUT_RANDOM_PAIRS):
+        a = rng.choice(ids)
+        b = rng.choice(ids)
+        if a == b:
+            continue
+        drawn += 1
+        if _ne_fired(row_lookup[a], row_lookup[b], ne):
+            n_fired += 1
+    return n_fired / drawn if drawn else 0.0
 
 
 def _tune_cluster_guard(ctx: _LeverContext) -> None:

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -8,24 +8,27 @@ Runs between ``distance_thresholds`` and ``calibration`` in the upgrade pass
 imports this module). Task F1 landed the scaffold (bare-settings skip, no-op
 stub bodies); Task F2 the NE candidate eligibility (``_ne_candidates``);
 Task F3 the risk gate + posterior-weighted NE estimation
-(``_suggest_negative_evidence``). The cluster-guard tuning body arrives in
-Task F4.
+(``_suggest_negative_evidence``); Task F4 the reference-driven cluster-guard
+tuning (``_tune_cluster_guard``).
 """
 from __future__ import annotations
 
 import math
 import random
+from collections import Counter
 from dataclasses import dataclass
 
 from goldenmatch._polars_lazy import pl
 from goldenmatch.config.schemas import (
     BlockingConfig,
+    GoldenRulesConfig,
     MatchkeyConfig,
     NegativeEvidenceField,
 )
 from goldenmatch.config.splink_upgrade import (
     _CALIBRATION_MAX_PAIRS,
     _CALIBRATION_MIN_PAIRS,
+    SplinkUpgradeError,
     _estimate_within_block_prior,
     _LeverContext,
 )
@@ -372,5 +375,111 @@ def _random_pair_firing_rate(
     return n_fired / drawn if drawn else 0.0
 
 
+_GUARD_MAPPED_TO = "golden_rules.max_cluster_size"
+
+
 def _tune_cluster_guard(ctx: _LeverContext) -> None:
-    pass  # Task F4
+    """Reference-driven ``golden_rules.max_cluster_size`` tuning (spec:
+    "Guard tuning").
+
+    Reference priority: ``ctx.labels`` (true cluster sizes) ->
+    ``ctx.splink_clusters`` (the user's old Splink output sizes) -> skip with
+    an info finding (no invented reference). The reference joins the sampled
+    rows through the same ``id_column`` mechanism measurement uses; when ids
+    cannot be joined (positional fallback, zero overlap) the guard skips with
+    an info finding naming ``id_column=``. With a joined reference the cap is
+    SYMMETRIC -- ``max(_GUARD_MIN_CAP, 2 * reference_max_cluster_size)`` may
+    tighten below or loosen above the default 100. Never fails the pass:
+    ``_resolve_ids`` raises on a missing/duplicate explicit ``id_column`` and
+    ``_load_reference`` on a bad path/shape; both become warn+skip here
+    (measurement's later identical calls surface the same problems there).
+    """
+    # Lazy: the measure module pulls in metric helpers (mirrors how
+    # splink_upgrade lazy-imports run_measurement; keeps fanout import-light).
+    from goldenmatch.config.splink_upgrade_measure import (
+        _POSITIONAL_ID_SOURCE,
+        _load_reference,
+        _resolve_ids,
+    )
+
+    if ctx.labels is not None:
+        reference, ref_name = ctx.labels, "labels"
+    elif ctx.splink_clusters is not None:
+        reference, ref_name = ctx.splink_clusters, "splink_clusters"
+    else:
+        ctx.report.info(
+            "upgrade:fan_out",
+            "guard tuning skipped: no reference provided (pass labels= or "
+            "splink_clusters=); golden_rules.max_cluster_size untouched",
+            mapped_to=_GUARD_MAPPED_TO,
+        )
+        return
+
+    try:
+        ids, id_source = _resolve_ids(ctx.df, ctx.id_column)
+    except SplinkUpgradeError as exc:
+        ctx.report.warn(
+            "upgrade:fan_out",
+            f"guard tuning skipped: {exc} -- golden_rules.max_cluster_size "
+            "untouched",
+            mapped_to=_GUARD_MAPPED_TO,
+        )
+        return
+    if id_source == _POSITIONAL_ID_SOURCE:
+        ctx.report.info(
+            "upgrade:fan_out",
+            "guard tuning skipped: sample ids are positional row indices, "
+            f"which cannot join the {ref_name} reference -- pass id_column= "
+            "naming the data column that matches the reference ids",
+            mapped_to=_GUARD_MAPPED_TO,
+        )
+        return
+
+    try:
+        mapping, n_ref_rows = _load_reference(reference, set(ids))
+    except Exception as exc:  # bad path/shape: the lever never fails the pass
+        ctx.report.warn(
+            "upgrade:fan_out",
+            f"guard tuning skipped: could not load the {ref_name} reference "
+            f"({exc}) -- golden_rules.max_cluster_size untouched",
+            mapped_to=_GUARD_MAPPED_TO,
+        )
+        return
+    if not mapping:
+        # Zero id overlap (or an empty reference) is an id-join failure, not
+        # a clustering signal -- same posture as measurement's
+        # _checked_reference.
+        ctx.report.info(
+            "upgrade:fan_out",
+            f"guard tuning skipped: the {ref_name} reference "
+            f"({n_ref_rows} row(s)) shares no ids with the sample (ids came "
+            f"from column '{id_source}') -- pass id_column= naming the data "
+            "column that matches the reference ids",
+            mapped_to=_GUARD_MAPPED_TO,
+        )
+        return
+
+    # Cluster sizes restricted to the sampled ids.
+    sizes = sorted(Counter(mapping.values()).values())
+    ref_max = sizes[-1]
+    ref_p99 = sizes[min(len(sizes) - 1, round(0.99 * (len(sizes) - 1)))]
+    new_cap = max(_GUARD_MIN_CAP, 2 * ref_max)
+
+    if ctx.upgraded_config.golden_rules is None:
+        # "most_complete" is what the pipeline substitutes when golden_rules
+        # is absent (core/pipeline.py), so creating the config with it
+        # changes nothing but the cap we are about to set.
+        ctx.upgraded_config.golden_rules = GoldenRulesConfig(
+            default_strategy="most_complete"
+        )
+    rules = ctx.upgraded_config.golden_rules
+    old_cap = rules.max_cluster_size
+    rules.max_cluster_size = new_cap
+    ctx.report.info(
+        "upgrade:fan_out",
+        f"golden_rules.max_cluster_size tuned {old_cap} -> {new_cap} = "
+        f"max({_GUARD_MIN_CAP}, 2 * {ref_max}) from the {ref_name} "
+        f"reference (max cluster size {ref_max}, p99 {ref_p99}, over "
+        f"{len(mapping)} joined sample id(s))",
+        mapped_to=_GUARD_MAPPED_TO,
+    )

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -1,0 +1,52 @@
+"""The ``fan_out`` upgrade lever: negative-evidence suggestion + cluster-guard
+tuning for imported Splink models.
+
+Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
+
+Runs between ``distance_thresholds`` and ``calibration`` in the upgrade pass
+(see ``goldenmatch/config/splink_upgrade.py``'s lever registry, which lazily
+imports this module). Task F1 lands the scaffold: the bare-settings skip and
+no-op stub bodies. The NE-suggestion body arrives in Task F3 and the
+cluster-guard tuning body in Task F4.
+"""
+from __future__ import annotations
+
+# ── Tuning constants ─────────────────────────────────────────────────────────
+
+_FANOUT_POSTERIOR_CONFIDENT = 0.9   # "confident merge" posterior floor for the risk gate
+_FANOUT_MIN_FIRE_RATE = 0.02        # min NE firing rate among confident-merge pairs
+_FANOUT_MIN_FIRING_PAIRS = 10       # min absolute firing confident pairs (estimation support)
+_FANOUT_MIN_NONNULL = 0.5           # candidate columns sparser than this are not suggested
+_FANOUT_MIN_CARDINALITY = 0.5       # mirrors autoconfig NE's _CARDINALITY_THRESHOLD
+_FANOUT_MAX_CARDINALITY = 0.999     # a perfect surrogate key has zero shared-identity signal
+_FANOUT_RANDOM_PAIRS = 10_000       # u_fire sample size (train_em's random-pair u route scale)
+_PROB_CLAMP = 1e-4                  # m/u clamp away from 0/1 before log2
+_GUARD_MIN_CAP = 10                 # floor of max(10, 2 * reference_max)
+_NE_NAME_PATTERNS = (
+    "phone", "mobile", "email", "e-mail", "e_mail", "address", "addr",
+    "ssn", "npi", "license", "licence", "passport",
+)
+
+
+# ── Lever entrypoint ─────────────────────────────────────────────────────────
+
+_BARE_SETTINGS_SKIP_MSG_FANOUT = (
+    "skipped: no imported model; run-time EM training and auto-config own "
+    "negative-evidence and guard decisions natively"
+)
+
+
+def run_fan_out_lever(ctx) -> None:
+    if ctx.conversion.em_model is None:
+        ctx.report.info("upgrade:fan_out", _BARE_SETTINGS_SKIP_MSG_FANOUT, mapped_to=None)
+        return
+    _suggest_negative_evidence(ctx)   # Task F3
+    _tune_cluster_guard(ctx)          # Task F4
+
+
+def _suggest_negative_evidence(ctx) -> None:
+    pass  # Task F3
+
+
+def _tune_cluster_guard(ctx) -> None:
+    pass  # Task F4

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -375,6 +375,8 @@ def _random_pair_firing_rate(
     return n_fired / drawn if drawn else 0.0
 
 
+# ── Cluster-guard tuning (Task F4) ───────────────────────────────────────────
+
 _GUARD_MAPPED_TO = "golden_rules.max_cluster_size"
 
 
@@ -448,7 +450,9 @@ def _tune_cluster_guard(ctx: _LeverContext) -> None:
     if not mapping:
         # Zero id overlap (or an empty reference) is an id-join failure, not
         # a clustering signal -- same posture as measurement's
-        # _checked_reference.
+        # _checked_reference. The info-vs-warn severity downgrade vs that
+        # helper is INTENTIONAL: a skipped tune is lower-stakes than absent
+        # metrics, and measurement's own later call still warns.
         ctx.report.info(
             "upgrade:fan_out",
             f"guard tuning skipped: the {ref_name} reference "
@@ -475,11 +479,16 @@ def _tune_cluster_guard(ctx: _LeverContext) -> None:
     rules = ctx.upgraded_config.golden_rules
     old_cap = rules.max_cluster_size
     rules.max_cluster_size = new_cap
+    caveat = (
+        " (data was subsampled; reference max may be understated)"
+        if ctx.sampled
+        else ""
+    )
     ctx.report.info(
         "upgrade:fan_out",
         f"golden_rules.max_cluster_size tuned {old_cap} -> {new_cap} = "
         f"max({_GUARD_MIN_CAP}, 2 * {ref_max}) from the {ref_name} "
         f"reference (max cluster size {ref_max}, p99 {ref_p99}, over "
-        f"{len(mapping)} joined sample id(s))",
+        f"{len(mapping)} joined sample id(s))" + caveat,
         mapped_to=_GUARD_MAPPED_TO,
     )

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -5,13 +5,20 @@ Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
 
 Runs between ``distance_thresholds`` and ``calibration`` in the upgrade pass
 (see ``goldenmatch/config/splink_upgrade.py``'s lever registry, which lazily
-imports this module). Task F1 lands the scaffold: the bare-settings skip and
-no-op stub bodies. The NE-suggestion body arrives in Task F3 and the
-cluster-guard tuning body in Task F4.
+imports this module). Task F1 landed the scaffold (bare-settings skip, no-op
+stub bodies); Task F2 the NE candidate eligibility (``_ne_candidates``). The
+NE-suggestion body arrives in Task F3 and the cluster-guard tuning body in
+Task F4.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+
+from goldenmatch._polars_lazy import pl
+from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig
 from goldenmatch.config.splink_upgrade import _LeverContext
+from goldenmatch.core.autoconfig_negative_evidence import _pick_scorer_for_column
+from goldenmatch.core.blocker import collect_blocking_fields
 
 # ── Tuning constants ─────────────────────────────────────────────────────────
 
@@ -20,7 +27,10 @@ _FANOUT_MIN_FIRE_RATE = 0.02        # min NE firing rate among confident-merge p
 _FANOUT_MIN_FIRING_PAIRS = 10       # min absolute firing confident pairs (estimation support)
 _FANOUT_MIN_NONNULL = 0.5           # candidate columns sparser than this are not suggested
 _FANOUT_MIN_CARDINALITY = 0.5       # mirrors autoconfig NE's _CARDINALITY_THRESHOLD
-_FANOUT_MAX_CARDINALITY = 0.999     # a perfect surrogate key has zero shared-identity signal
+# A perfect surrogate key has zero shared-identity signal (mirrors #721's
+# uniform exact-scorer gate); it would also fire on true dups and be dropped by
+# the w>=0 check, but excluding it up front keeps findings clean.
+_FANOUT_MAX_CARDINALITY = 0.999
 _FANOUT_RANDOM_PAIRS = 10_000       # u_fire sample size (train_em's random-pair u route scale)
 _PROB_CLAMP = 1e-4                  # m/u clamp away from 0/1 before log2
 _GUARD_MIN_CAP = 10                 # floor of max(10, 2 * reference_max)
@@ -44,6 +54,62 @@ def run_fan_out_lever(ctx: _LeverContext) -> None:
         return
     _suggest_negative_evidence(ctx)   # Task F3
     _tune_cluster_guard(ctx)          # Task F4
+
+
+# ── NE candidate eligibility ─────────────────────────────────────────────────
+
+
+@dataclass
+class _NECandidate:
+    """A column eligible for a negative-evidence suggestion, with the
+    transforms + scorer ``_pick_scorer_for_column`` assigned it."""
+
+    column: str
+    transforms: list[str]
+    scorer: str
+
+
+def _ne_candidates(
+    df: pl.DataFrame, mk: MatchkeyConfig, blocking: BlockingConfig
+) -> list[_NECandidate]:
+    """Select NE candidate columns from the (already sampled) frame.
+
+    A column is a candidate when ALL of (spec: "NE candidate columns"):
+
+    - it is not a comparison field of ``mk``, not ``__record__``, and not a
+      blocking-key field (via ``collect_blocking_fields``);
+    - its name is identity-grade (any ``_NE_NAME_PATTERNS`` substring,
+      case-insensitive);
+    - its non-null rate is >= ``_FANOUT_MIN_NONNULL`` (NE needs both sides
+      present, so a sparse column would rarely fire);
+    - its cardinality ratio (n_unique / n_rows) lies within
+      [``_FANOUT_MIN_CARDINALITY``, ``_FANOUT_MAX_CARDINALITY``].
+
+    Returns candidates in df column order (deterministic). The risk gate that
+    consumes them is Task F3.
+    """
+    n_rows = max(1, len(df))
+    excluded = {f.field for f in mk.fields}
+    excluded.add("__record__")
+    excluded.update(collect_blocking_fields(blocking))
+
+    candidates: list[_NECandidate] = []
+    for col in df.columns:
+        if col in excluded:
+            continue
+        col_lower = col.lower()
+        if not any(pattern in col_lower for pattern in _NE_NAME_PATTERNS):
+            continue
+        series = df[col]
+        non_null_rate = 1 - series.null_count() / n_rows
+        if non_null_rate < _FANOUT_MIN_NONNULL:
+            continue
+        cardinality = series.n_unique() / n_rows
+        if not (_FANOUT_MIN_CARDINALITY <= cardinality <= _FANOUT_MAX_CARDINALITY):
+            continue
+        transforms, scorer = _pick_scorer_for_column(col, "")
+        candidates.append(_NECandidate(column=col, transforms=transforms, scorer=scorer))
+    return candidates
 
 
 def _suggest_negative_evidence(ctx: _LeverContext) -> None:

--- a/packages/python/goldenmatch/tests/test_cli_import_splink_upgrade.py
+++ b/packages/python/goldenmatch/tests/test_cli_import_splink_upgrade.py
@@ -428,3 +428,71 @@ def test_non_upgrade_combined_line_after_table(tmp_path):
         # And the summary is not printed anywhere on its own BEFORE the
         # combined line (pre-refactor printed it exactly once, combined).
         assert normalized.count("error(s)") == 1
+
+
+# ── 8. Regression: the upgraded YAML survives a load_config round-trip when
+# the fan_out lever fired (NE fields + tuned max_cluster_size) ───────────────
+
+
+def test_upgraded_yaml_with_fanout_output_reloads(tmp_path):
+    """Wild-bench regression: the fan_out guard lever writes
+    ``golden_rules.max_cluster_size`` into the upgraded YAML, but
+    ``loader._normalize_golden_rules`` used to sweep any key outside
+    ``_GOLDEN_RULES_SPECIAL_KEYS`` into ``field_rules`` (the key was omitted
+    on a now-stale "set programmatically, never via YAML" assumption), so
+    reloading the CLI's own output failed schema validation
+    (``field_rules.max_cluster_size ... should be ... GoldenFieldRule``).
+
+    Reuses the Task F6 homonym fixture (tests/test_splink_upgrade_fanout_e2e)
+    so the fan_out lever genuinely fires end-to-end through the CLI: NE on
+    phone AND guard tuning from --labels. --no-measure skips the two dedupe
+    runs -- the lever outputs (not the measurement) are what must round-trip.
+    Doubles as the CLI-level NE YAML regression test: the written matchkey's
+    negative_evidence must survive the reload in EM-learned shape.
+    """
+    from goldenmatch.config.loader import load_config
+
+    from tests.test_splink_upgrade_fanout_e2e import (
+        _build_fixture,
+    )
+    from tests.test_splink_upgrade_fanout_e2e import (
+        _trained_settings as _fanout_trained_settings,
+    )
+
+    settings_path = _write_settings(tmp_path, _fanout_trained_settings())
+    df, labels = _build_fixture()
+    data_path = _write_parquet(tmp_path, df)
+    labels_path = _write_parquet(tmp_path, labels, name="labels.parquet")
+    out_path = tmp_path / "out.yaml"
+    model_path = tmp_path / "model.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "import-splink", str(settings_path),
+            "-o", str(out_path),
+            "--model-out", str(model_path),
+            "--upgrade", str(data_path),
+            "--labels", str(labels_path),
+            "--id-column", "rec_id",
+            "--no-measure",
+        ],
+    )
+    assert result.exit_code == 0, result.stdout
+
+    # Sanity: the lever really fired -- the raw YAML carries both outputs.
+    raw = yaml.safe_load(out_path.read_text(encoding="utf-8"))
+    assert raw["golden_rules"]["max_cluster_size"] == 10
+    assert raw["matchkeys"][0]["negative_evidence"][0]["field"] == "phone"
+
+    # THE regression: the CLI's own output must reload through load_config.
+    cfg = load_config(str(out_path))
+    gr = cfg.golden_rules
+    assert gr is not None
+    assert gr.max_cluster_size == 10  # tuned value, NOT swept into field_rules
+    assert "max_cluster_size" not in (gr.field_rules or {})
+
+    ne = cfg.get_matchkeys()[0].negative_evidence
+    assert ne, "negative_evidence did not survive the YAML round-trip"
+    assert [n.field for n in ne] == ["phone"]
+    assert ne[0].penalty is None and ne[0].penalty_bits is None  # EM-learned

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -1,8 +1,8 @@
 """Tests for the fan_out upgrade lever -- Task F1 scaffold (registry wiring,
 lever ordering, bare-settings skip, the shared within-block prior helper,
-reference-input context threading), Task F2 NE candidate eligibility, and
-Task F3 risk gate + posterior-weighted NE estimation. The cluster-guard
-tuning body is a no-op stub until Task F4.
+reference-input context threading), Task F2 NE candidate eligibility, Task
+F3 risk gate + posterior-weighted NE estimation, and Task F4 cluster-guard
+tuning.
 
 Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
 """
@@ -590,6 +590,168 @@ def test_fan_out_block_size_findings():
     assert res.upgraded_config.blocking.max_block_size == conversion.config.blocking.max_block_size
 
 
+# ── Posterior definition + weighting pin (F3 ride-along) ─────────────────────
+
+
+def _mixed_pair_df():
+    """One ``city`` block designed so the pinned within-block-prior posterior
+    and an equal-odds (prior_w=0) posterior genuinely diverge around the 0.9
+    confidence floor:
+
+    - 6 homonym groups of 3 (both names shared, phones differ): confident
+      FIRING pairs under either prior.
+    - 10 true-duplicate groups of 3 (names + phone shared): confident
+      non-firing pairs.
+    - 4 MIXED rows (shared surname, distinct first names, distinct phones):
+      C(4,2)=6 pairs whose total weight (+10 surname-agree, -6 first_name-
+      disagree = +4 bits under ``_mixed_pair_em_model``) sits ABOVE the 0.9
+      floor equal-odds (posterior ~0.94) but BELOW it under the re-estimated
+      within-block prior -- an equal-odds substitution would misclassify
+      them AND weight them differently in m_fire.
+    """
+    rows: list[dict] = []
+    counter = 0
+
+    def next_phone() -> str:
+        nonlocal counter
+        counter += 1
+        return f"555-{counter:07d}"
+
+    for g in range(6):
+        for _ in range(3):
+            rows.append(
+                {
+                    "first_name": f"homfn{g}",
+                    "surname": f"homsn{g}",
+                    "city": "c1",
+                    "phone": next_phone(),
+                }
+            )
+    for g in range(10):
+        shared = next_phone()
+        for _ in range(3):
+            rows.append(
+                {
+                    "first_name": f"dupfn{g}",
+                    "surname": f"dupsn{g}",
+                    "city": "c1",
+                    "phone": shared,
+                }
+            )
+    for k in range(4):
+        rows.append(
+            {
+                "first_name": f"mixfn{k}",
+                "surname": "mixshared",
+                "city": "c1",
+                "phone": next_phone(),
+            }
+        )
+    return pl.DataFrame(rows)
+
+
+def _mixed_pair_em_model():
+    """Asymmetric hand-built weights: surname-agree-only pairs land at
+    10 - 6 = +4 bits -- confident equal-odds (0.941 >= 0.9) but not under
+    the within-block prior re-estimate (prior << 0.5 on this block)."""
+    return EMResult(
+        m_probs={"first_name": [0.05, 0.95], "surname": [0.02, 0.98]},
+        u_probs={"first_name": [0.9, 0.1], "surname": [0.95, 0.05]},
+        match_weights={"first_name": [-6.0, 4.0], "surname": [-6.0, 10.0]},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.01,
+    )
+
+
+def test_fan_out_posterior_definition_pinned():
+    """Pin the POSTERIOR DEFINITION (within-block prior re-estimate, not
+    equal-odds) and the posterior WEIGHTING of m_fire (not count-based):
+    replicate the pinned math by hand in the test and require the stored
+    ``match_weights["__ne__phone"][0]`` to match it to 1e-9, while both an
+    equal-odds substitution and a count-based m_fire come out different."""
+    from goldenmatch.config.schemas import NegativeEvidenceField
+    from goldenmatch.config.splink_upgrade import _CALIBRATION_MAX_PAIRS
+    from goldenmatch.config.splink_upgrade_fanout import (
+        _PROB_CLAMP,
+        _random_pair_firing_rate,
+    )
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.probabilistic import (
+        _ne_fired,
+        _sample_blocked_pairs,
+        comparison_vector,
+        posterior_from_weight,
+        prior_weight,
+    )
+
+    df = _mixed_pair_df()
+    conversion = _fanout_conversion(em=_mixed_pair_em_model())
+
+    res = upgrade_splink_conversion(
+        conversion, df, levers={"fan_out"}, measure=False
+    )
+
+    key = "__ne__phone"
+    assert res.em_model is not None and key in res.em_model.match_weights
+    stored_w = res.em_model.match_weights[key][0]
+
+    # ── Hand-replicate the pinned math on the same pair sample ──────────
+    mk = res.upgraded_config.get_matchkeys()[0]
+    em_weights = {"first_name": [-6.0, 4.0], "surname": [-6.0, 10.0]}
+    lf = (
+        df.lazy()
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+    blocks = build_blocks(lf, _blocking("city"))
+    pairs = _sample_blocked_pairs(blocks, n_pairs=_CALIBRATION_MAX_PAIRS, seed=42)
+    row_lookup = {
+        i: {**row, "__row_id__": i} for i, row in enumerate(df.to_dicts())
+    }
+    indexed = [(k, f.field) for k, f in enumerate(mk.fields)]
+    totals = []
+    for a, b in pairs:
+        vec = comparison_vector(row_lookup[a], row_lookup[b], mk)
+        totals.append(sum(em_weights[name][vec[k]] for k, name in indexed))
+
+    # Pinned posterior: within-block prior re-estimate, NOT equal-odds.
+    prior = _estimate_within_block_prior(totals)
+    prior_w = prior_weight(prior)
+    posteriors = [posterior_from_weight(w, prior_w) for w in totals]
+    ne = NegativeEvidenceField(
+        field="phone", transforms=["digits_only"], scorer="exact", threshold=0.4
+    )
+    fired = [_ne_fired(row_lookup[a], row_lookup[b], ne) for a, b in pairs]
+
+    def clamp(p):
+        return min(max(p, _PROB_CLAMP), 1.0 - _PROB_CLAMP)
+
+    m_fire = clamp(
+        sum(p for p, f in zip(posteriors, fired) if f) / sum(posteriors)
+    )
+    u_fire = clamp(_random_pair_firing_rate(row_lookup, ne, 42))
+    expected_w = math.log2(m_fire / u_fire)
+    assert stored_w == pytest.approx(expected_w, abs=1e-9)
+
+    # ── The fixture genuinely separates the two priors at the 0.9 floor ──
+    post_eq = [posterior_from_weight(w, 0.0) for w in totals]
+    assert any(pe >= 0.9 > pp for pe, pp in zip(post_eq, posteriors))
+
+    # ── An equal-odds substitution would change the stored value ────────
+    m_eq = clamp(sum(p for p, f in zip(post_eq, fired) if f) / sum(post_eq))
+    w_eq = math.log2(m_eq / u_fire)
+    assert abs(w_eq - stored_w) > 1e-6
+
+    # ── A count-based m_fire (fired/confident counts) would too ─────────
+    confident = [p >= 0.9 for p in posteriors]
+    m_count = clamp(
+        sum(1 for f, c in zip(fired, confident) if f and c) / sum(confident)
+    )
+    w_count = math.log2(m_count / u_fire)
+    assert abs(w_count - stored_w) > 1e-6
+
+
 def test_fan_out_runs_under_posterior_mode(monkeypatch):
     """The lever's posterior math is mode-independent: it RUNS (does not
     skip) under GOLDENMATCH_FS_CALIBRATED=posterior -- only the calibration
@@ -603,3 +765,171 @@ def test_fan_out_runs_under_posterior_mode(monkeypatch):
 
     mk = res.upgraded_config.get_matchkeys()[0]
     assert [ne.field for ne in (mk.negative_evidence or [])] == ["phone"]
+
+
+# ── Cluster-guard tuning (Task F4) ───────────────────────────────────────────
+
+
+def _guard_df():
+    """The F3 fixture frame with a unique ``rec_id`` id column (0..199) so
+    guard tuning can join a reference (``rec_id`` is not a default id-column
+    name, so tests pass ``id_column="rec_id"`` explicitly)."""
+    return _fanout_df().with_row_index("rec_id")
+
+
+def _labels_df(n_rows, big_cluster_size, prefix="c"):
+    """rec_id 0..n-1: one cluster of ``big_cluster_size``, rest singletons."""
+    clusters = [
+        f"{prefix}big" if i < big_cluster_size else f"{prefix}{i}"
+        for i in range(n_rows)
+    ]
+    return pl.DataFrame({"rec_id": list(range(n_rows)), "cluster": clusters})
+
+
+def _guard_findings(result, severity=None):
+    return [
+        f
+        for f in _fan_out_findings(result, severity)
+        if "max_cluster_size" in f.message or "guard tuning" in f.message
+    ]
+
+
+def test_guard_tuned_from_labels():
+    # Symmetric clamp: the floor wins (max(10, 2*4)=10), mid-size doubles
+    # (30 -> 60), and a genuinely-large reference RAISES the default 100
+    # (80 -> 160).
+    for ref_max, expected in ((4, 10), (30, 60), (80, 160)):
+        res = upgrade_splink_conversion(
+            _fanout_conversion(),
+            _guard_df(),
+            labels=_labels_df(200, ref_max),
+            id_column="rec_id",
+            levers={"fan_out"},
+            measure=False,
+        )
+
+        gr = res.upgraded_config.golden_rules
+        assert gr is not None
+        assert gr.max_cluster_size == expected
+
+        tuned = [
+            f for f in _guard_findings(res, "info") if "->" in f.message
+        ]
+        assert len(tuned) == 1
+        msg = tuned[0].message
+        assert f"100 -> {expected}" in msg
+        assert "labels" in msg
+        assert str(ref_max) in msg
+
+
+def test_guard_prefers_labels_over_splink_clusters():
+    res = upgrade_splink_conversion(
+        _fanout_conversion(),
+        _guard_df(),
+        labels=_labels_df(200, 4),
+        splink_clusters=_labels_df(200, 30, prefix="s"),
+        id_column="rec_id",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    gr = res.upgraded_config.golden_rules
+    assert gr is not None
+    # labels (max 4 -> cap 10) win over splink_clusters (max 30 -> cap 60).
+    assert gr.max_cluster_size == 10
+    tuned = [f for f in _guard_findings(res, "info") if "->" in f.message]
+    assert len(tuned) == 1
+    assert "labels" in tuned[0].message
+    assert "splink_clusters" not in tuned[0].message
+
+
+def test_guard_skips_without_reference():
+    res = upgrade_splink_conversion(
+        _fanout_conversion(), _guard_df(), id_column="rec_id",
+        levers={"fan_out"}, measure=False,
+    )
+
+    # BASELINE default semantics preserved: no golden_rules invented, so the
+    # runtime default max_cluster_size=100 stays in effect.
+    assert res.upgraded_config.golden_rules is None
+    skips = [
+        f for f in _guard_findings(res, "info") if "no reference" in f.message
+    ]
+    assert len(skips) == 1
+
+
+def test_guard_skips_on_unjoinable_ids():
+    # Reference ids share nothing with the data's rec_id values.
+    disjoint = pl.DataFrame(
+        {"rec_id": [f"X{i}" for i in range(200)], "cluster": ["c"] * 200}
+    )
+    res = upgrade_splink_conversion(
+        _fanout_conversion(),
+        _guard_df(),
+        labels=disjoint,
+        id_column="rec_id",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert res.upgraded_config.golden_rules is None
+    skips = [
+        f for f in _guard_findings(res, "info") if "id_column" in f.message
+    ]
+    assert len(skips) == 1
+    assert "labels" in skips[0].message
+
+    # Positional fallback: no id_column and no id-ish column in the df --
+    # positional indices cannot join a reference, even one keyed 0..n-1.
+    res2 = upgrade_splink_conversion(
+        _fanout_conversion(),
+        _fanout_df(),  # first_name/surname/city/phone only
+        labels=_labels_df(200, 30),
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert res2.upgraded_config.golden_rules is None
+    skips2 = [
+        f for f in _guard_findings(res2, "info") if "id_column" in f.message
+    ]
+    assert len(skips2) == 1
+    assert "positional" in skips2[0].message
+
+
+def test_guard_baseline_untouched():
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion,
+        _guard_df(),
+        labels=_labels_df(200, 30),
+        id_column="rec_id",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    # The guard DID tune the upgraded copy...
+    assert res.upgraded_config.golden_rules is not None
+    assert res.upgraded_config.golden_rules.max_cluster_size == 60
+    # ...while baseline + original conversion stay untouched (copy-on-write).
+    assert conversion.config.golden_rules is None
+    assert res.baseline_config.golden_rules is None
+
+
+def test_guard_bad_id_column_warns():
+    res = upgrade_splink_conversion(
+        _fanout_conversion(),
+        _guard_df(),
+        labels=_labels_df(200, 30),
+        id_column="nope",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    # Never-fail contract: _resolve_ids raises SplinkUpgradeError for a
+    # missing id_column; the guard wraps it into a warn+skip.
+    assert res.upgraded_config.golden_rules is None
+    warns = [f for f in _guard_findings(res, "warning") if "nope" in f.message]
+    assert len(warns) == 1
+    assert "skipped" in warns[0].message.lower()

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -10,12 +10,19 @@ from __future__ import annotations
 import polars as pl
 import pytest
 from goldenmatch.config.from_splink import from_splink
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
 from goldenmatch.config.splink_upgrade import (
     SplinkUpgradeError,
     _estimate_within_block_prior,
     _resolve_levers,
     upgrade_splink_conversion,
 )
+from goldenmatch.config.splink_upgrade_fanout import _ne_candidates
 
 # ── Fixtures (mirror tests/test_splink_upgrade_levers.py bare-settings) ──────
 
@@ -164,3 +171,88 @@ def test_lever_context_carries_reference_inputs(monkeypatch):
     assert seen["splink_clusters"] is clusters_df
     assert seen["labels"] is labels_df
     assert seen["id_column"] == "rec_id"
+
+
+# ── NE candidate eligibility (Task F2) ───────────────────────────────────────
+
+
+def _prob_matchkey(field_names=("given_name", "surname", "city")):
+    return MatchkeyConfig(
+        name="prob",
+        type="probabilistic",
+        fields=[MatchkeyField(field=f, scorer="jaro_winkler") for f in field_names],
+    )
+
+
+def _blocking(*key_fields):
+    return BlockingConfig(keys=[BlockingKeyConfig(fields=[f]) for f in key_fields])
+
+
+def _candidate_df(n=20, extra=None):
+    """Sampled-frame stand-in exercising every eligibility gate.
+
+    - ``phone``: identity-named, fully populated, 19/20 distinct -> ELIGIBLE.
+    - ``email_null_heavy``: identity-named but 75% null -> excluded (non-null floor).
+    - ``phone_low_card``: identity-named but 3 distinct values -> excluded
+      (min-cardinality floor).
+    - ``ssn``: identity-named but all-unique (ratio 1.0) -> excluded by the
+      max-cardinality gate (a plain ``rec_id`` surrogate would be excluded by
+      the name filter first and never exercise it).
+    - ``notes``: non-identity name -> excluded.
+    - ``given_name``/``surname``/``city``: comparison/blocking fields on the
+      default matchkey/blocking used by the tests.
+    """
+    data = {
+        "given_name": [f"name{i}" for i in range(n)],
+        "surname": [f"sur{i % 6}" for i in range(n)],
+        "city": [f"city{i % 4}" for i in range(n)],
+        # One duplicate value -> 19/20 = 0.95, inside [0.5, 0.999].
+        "phone": [f"555-01{max(i, 1):02d}" for i in range(n)],
+        "email_null_heavy": [f"a{i}@x.com" if i < 5 else None for i in range(n)],
+        "phone_low_card": [f"555-000{i % 3}" for i in range(n)],
+        "ssn": [f"{i:09d}" for i in range(n)],
+        "notes": [f"note {i}" for i in range(n)],
+    }
+    if extra:
+        data.update(extra)
+    return pl.DataFrame(data)
+
+
+def test_ne_candidates_returns_only_eligible_phone():
+    cands = _ne_candidates(_candidate_df(), _prob_matchkey(), _blocking("surname"))
+
+    assert [c.column for c in cands] == ["phone"]
+    # Transforms/scorer come from _pick_scorer_for_column.
+    assert cands[0].transforms == ["digits_only"]
+    assert cands[0].scorer == "exact"
+
+
+def test_ne_candidates_excludes_matchkey_comparison_field():
+    n = 20
+    df = _candidate_df(extra={"phone2": [f"555-02{max(i, 1):02d}" for i in range(n)]})
+    mk = _prob_matchkey(("given_name", "surname", "city", "phone2"))
+
+    cands = _ne_candidates(df, mk, _blocking("surname"))
+
+    assert [c.column for c in cands] == ["phone"]
+
+
+def test_ne_candidates_excludes_blocking_key_field():
+    n = 20
+    df = _candidate_df(extra={"phone3": [f"555-03{max(i, 1):02d}" for i in range(n)]})
+
+    cands = _ne_candidates(df, _prob_matchkey(), _blocking("surname", "phone3"))
+
+    assert [c.column for c in cands] == ["phone"]
+
+
+def test_ne_candidates_name_match_is_case_insensitive():
+    n = 20
+    df = _candidate_df(
+        extra={"Phone_Number": [f"555-04{max(i, 1):02d}" for i in range(n)]}
+    )
+
+    cands = _ne_candidates(df, _prob_matchkey(), _blocking("surname"))
+
+    # Deterministic df-column order: phone before Phone_Number.
+    assert [c.column for c in cands] == ["phone", "Phone_Number"]

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -933,3 +933,30 @@ def test_guard_bad_id_column_warns():
     warns = [f for f in _guard_findings(res, "warning") if "nope" in f.message]
     assert len(warns) == 1
     assert "skipped" in warns[0].message.lower()
+
+
+def test_guard_tuning_caveats_sampled_data():
+    """Sample fragmentation: when the data was subsampled (sample_cap hit),
+    the reference's max cluster size restricted to the sampled ids can
+    understate the true max -- the tuned finding carries an explicit caveat.
+    Below the cap (no subsampling) the caveat is absent."""
+    common = dict(
+        labels=_labels_df(200, 30),
+        id_column="rec_id",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    over_cap = upgrade_splink_conversion(
+        _fanout_conversion(), _guard_df(), sample_cap=100, **common
+    )
+    tuned = [f for f in _guard_findings(over_cap, "info") if "->" in f.message]
+    assert len(tuned) == 1
+    assert "subsampled" in tuned[0].message
+
+    under_cap = upgrade_splink_conversion(
+        _fanout_conversion(), _guard_df(), **common
+    )
+    tuned = [f for f in _guard_findings(under_cap, "info") if "->" in f.message]
+    assert len(tuned) == 1
+    assert "subsampled" not in tuned[0].message

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -1,18 +1,26 @@
-"""Tests for the fan_out upgrade lever -- Task F1 scaffold: registry wiring,
-lever ordering, bare-settings skip, the shared within-block prior helper, and
-reference-input context threading. The lever BODIES (NE suggestion, guard
-tuning) are no-op stubs until Tasks F3-F4.
+"""Tests for the fan_out upgrade lever -- Task F1 scaffold (registry wiring,
+lever ordering, bare-settings skip, the shared within-block prior helper,
+reference-input context threading), Task F2 NE candidate eligibility, and
+Task F3 risk gate + posterior-weighted NE estimation. The cluster-guard
+tuning body is a no-op stub until Task F4.
 
 Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
 """
 from __future__ import annotations
 
+import math
+
 import polars as pl
 import pytest
-from goldenmatch.config.from_splink import from_splink
+from goldenmatch.config.from_splink import (
+    ConversionReport,
+    SplinkConversion,
+    from_splink,
+)
 from goldenmatch.config.schemas import (
     BlockingConfig,
     BlockingKeyConfig,
+    GoldenMatchConfig,
     MatchkeyConfig,
     MatchkeyField,
 )
@@ -23,6 +31,7 @@ from goldenmatch.config.splink_upgrade import (
     upgrade_splink_conversion,
 )
 from goldenmatch.config.splink_upgrade_fanout import _ne_candidates
+from goldenmatch.core.probabilistic import EMResult
 
 # ── Fixtures (mirror tests/test_splink_upgrade_levers.py bare-settings) ──────
 
@@ -256,3 +265,341 @@ def test_ne_candidates_name_match_is_case_insensitive():
 
     # Deterministic df-column order: phone before Phone_Number.
     assert [c.column for c in cands] == ["phone", "Phone_Number"]
+
+
+def test_ne_candidates_excludes_record_pseudo_column():
+    """Third leg of the exclusion set: a df column literally named
+    ``__record__`` (the synthesized record_embedding pseudo-field name) is
+    never a candidate."""
+    n = 20
+    df = _candidate_df(
+        extra={"__record__": [f"555-09{max(i, 1):02d}" for i in range(n)]}
+    )
+
+    cands = _ne_candidates(df, _prob_matchkey(), _blocking("surname"))
+
+    assert [c.column for c in cands] == ["phone"]
+
+
+# ── Risk gate + posterior-weighted NE estimation (Task F3) ───────────────────
+
+
+def _fanout_matchkey():
+    return MatchkeyConfig(
+        name="prob",
+        type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="exact"),
+            MatchkeyField(field="surname", scorer="exact"),
+        ],
+    )
+
+
+def _fanout_em_model(fields=("first_name", "surname")):
+    """Hand-built trained model (NO EM training in unit tests): each field
+    contributes +-log2(0.99/0.01) ~ +-6.63 bits, so a both-agree pair sits
+    ~13.3 bits above a both-disagree pair -- comfortably confident under the
+    within-block prior re-estimate on the fixtures below."""
+    agree_w = math.log2(0.99 / 0.01)
+    return EMResult(
+        m_probs={f: [0.01, 0.99] for f in fields},
+        u_probs={f: [0.99, 0.01] for f in fields},
+        match_weights={f: [-agree_w, agree_w] for f in fields},
+        converged=True,
+        iterations=5,
+        proportion_matched=0.01,
+    )
+
+
+def _fanout_conversion(*, em=None):
+    config = GoldenMatchConfig(
+        matchkeys=[_fanout_matchkey()],
+        blocking=_blocking("city"),
+    )
+    return SplinkConversion(
+        config=config,
+        report=ConversionReport(),
+        em_model=em if em is not None else _fanout_em_model(),
+    )
+
+
+def _fanout_df(*, homonym_groups=6, homonym_phones_differ=True, dup_phones_differ=False):
+    """200 rows over 4 ``city`` blocks (53/53/47/47 with the defaults):
+
+    - ``homonym_groups`` groups of 3 sharing first_name+surname+city -- the
+      fan-out traps. Phones DIFFER within a group when
+      ``homonym_phones_differ`` (risk present), else the group shares one.
+    - 10 true-duplicate groups of 3 sharing first_name+surname+city AND
+      phone (unless ``dup_phones_differ`` -- the nondiscriminating shape
+      where phone differs on everything).
+    - fillers with unique names and unique phones.
+
+    Every confident-merge pair (both fields agree) is a within-group pair;
+    fillers never collide on either comparison field.
+    """
+    cities = [f"city{c}" for c in range(4)]
+    rows: list[dict] = []
+    counter = 0
+
+    def next_phone() -> str:
+        nonlocal counter
+        counter += 1
+        return f"555-{counter:07d}"
+
+    for g in range(homonym_groups):
+        shared = None if homonym_phones_differ else next_phone()
+        for _ in range(3):
+            rows.append(
+                {
+                    "first_name": f"homfn{g}",
+                    "surname": f"homsn{g}",
+                    "city": cities[g % 4],
+                    "phone": next_phone() if homonym_phones_differ else shared,
+                }
+            )
+    for g in range(10):
+        shared = None if dup_phones_differ else next_phone()
+        for _ in range(3):
+            rows.append(
+                {
+                    "first_name": f"dupfn{g}",
+                    "surname": f"dupsn{g}",
+                    "city": cities[g % 4],
+                    "phone": next_phone() if dup_phones_differ else shared,
+                }
+            )
+    i = 0
+    while len(rows) < 200:
+        rows.append(
+            {
+                "first_name": f"fillfn{i}",
+                "surname": f"fillsn{i}",
+                "city": cities[i % 4],
+                "phone": next_phone(),
+            }
+        )
+        i += 1
+    if homonym_phones_differ and dup_phones_differ:
+        # All-distinct phones would trip the max-cardinality candidate gate
+        # (ratio 1.0 > 0.999). Duplicate one phone across two FILLERS in
+        # DIFFERENT cities (never blocked together, never a confident pair)
+        # so the column stays eligible while still firing on every blocked
+        # confident pair.
+        rows[-1]["phone"] = rows[-2]["phone"]
+    return pl.DataFrame(rows)
+
+
+def _fan_out_findings(result, severity=None):
+    return [
+        f
+        for f in result.report.findings
+        if f.splink_path == "upgrade:fan_out"
+        and (severity is None or f.severity == severity)
+    ]
+
+
+def test_fan_out_adds_ne_when_risk_present():
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion, _fanout_df(), levers={"fan_out"}, measure=False
+    )
+
+    mk = res.upgraded_config.get_matchkeys()[0]
+    assert mk.negative_evidence is not None
+    assert [ne.field for ne in mk.negative_evidence] == ["phone"]
+    ne = mk.negative_evidence[0]
+    # EM-learned shape: no penalty, no penalty_bits; gate tuple from the
+    # F2 candidate + the autoconfig default NE threshold.
+    assert ne.penalty is None and ne.penalty_bits is None
+    assert ne.threshold == pytest.approx(0.4)
+    assert ne.transforms == ["digits_only"]
+    assert ne.scorer == "exact"
+
+    assert res.em_model is not None
+    key = "__ne__phone"
+    assert key in res.em_model.m_probs
+    assert key in res.em_model.u_probs
+    assert key in res.em_model.match_weights
+    assert res.em_model.match_weights[key][0] < 0
+    assert res.em_model.match_weights[key][1] == 0.0
+    # [fired, not_fired] 2-lists sum to 1 (within clamp tolerance).
+    assert sum(res.em_model.m_probs[key]) == pytest.approx(1.0, abs=1e-3)
+    assert sum(res.em_model.u_probs[key]) == pytest.approx(1.0, abs=1e-3)
+
+    # The upgraded config round-trips schema validation with NE attached.
+    GoldenMatchConfig(**res.upgraded_config.model_dump())
+
+    added = [f for f in _fan_out_findings(res, "info") if "added" in f.message]
+    assert len(added) == 1
+    assert "phone" in added[0].message
+    assert "m_fire" in added[0].message
+
+
+def test_fan_out_no_risk_no_ne():
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion,
+        _fanout_df(homonym_phones_differ=False),
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert not res.upgraded_config.get_matchkeys()[0].negative_evidence
+    assert res.em_model is not None
+    assert not any(k.startswith("__ne__") for k in res.em_model.match_weights)
+    # The measured (zero) contradiction rate is reported even when gated.
+    rate_findings = [
+        f for f in _fan_out_findings(res, "info") if "contradiction rate" in f.message
+    ]
+    assert len(rate_findings) == 1
+    assert "contradiction rate 0.0000" in rate_findings[0].message
+
+
+def test_fan_out_insufficient_support_skips():
+    # 2 homonym groups of 3 -> only 6 firing confident pairs, below the
+    # _FANOUT_MIN_FIRING_PAIRS=10 support floor (rate 6/36 clears the 2%
+    # rate floor, so this isolates the support leg).
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion,
+        _fanout_df(homonym_groups=2),
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert not res.upgraded_config.get_matchkeys()[0].negative_evidence
+    assert res.em_model is not None
+    assert not any(k.startswith("__ne__") for k in res.em_model.match_weights)
+    rate_findings = [
+        f for f in _fan_out_findings(res, "info") if "contradiction rate" in f.message
+    ]
+    assert len(rate_findings) == 1
+
+
+def test_fan_out_nondiscriminating_dropped():
+    # Phone differs on EVERYTHING (true dups included): the gate passes
+    # (confident pairs fire), but the random-pair firing rate is just as
+    # high -> w_fired >= 0 -> warn + drop, no NE.
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion,
+        _fanout_df(dup_phones_differ=True),
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert not res.upgraded_config.get_matchkeys()[0].negative_evidence
+    assert res.em_model is not None
+    assert not any(k.startswith("__ne__") for k in res.em_model.match_weights)
+    warns = _fan_out_findings(res, "warning")
+    assert len(warns) == 1
+    assert "does not discriminate" in warns[0].message
+    assert "phone" in warns[0].message
+
+
+def test_fan_out_no_blocking_warns():
+    """GoldenMatchConfig forbids probabilistic matchkeys without blocking at
+    construction time, so the no-blocking shape can only arise from
+    post-construction mutation -- drive the lever directly through a
+    hand-built _LeverContext to prove the guard warns + skips, no crash."""
+    from goldenmatch.config.splink_upgrade import _LeverContext
+    from goldenmatch.config.splink_upgrade_fanout import run_fan_out_lever
+
+    conversion = _fanout_conversion()
+    upgraded = GoldenMatchConfig(**conversion.config.model_dump())
+    upgraded.blocking = None
+    report = ConversionReport()
+    ctx = _LeverContext(
+        conversion=conversion,
+        upgraded_config=upgraded,
+        em_model=_fanout_em_model(),
+        report=report,
+        df=_fanout_df(),
+        seed=42,
+    )
+
+    run_fan_out_lever(ctx)
+
+    assert not upgraded.get_matchkeys()[0].negative_evidence
+    warns = [
+        f
+        for f in report.findings
+        if f.splink_path == "upgrade:fan_out" and f.severity == "warning"
+    ]
+    assert len(warns) == 1
+    assert "blocking configuration" in warns[0].message
+    assert "skipped" in warns[0].message.lower()
+
+
+def test_fan_out_partial_model_skips_ne():
+    # Only first_name carries imported m/u -- surname is uncovered (mixed
+    # bare/trained input shape), so pairs cannot be scored.
+    conversion = _fanout_conversion(em=_fanout_em_model(fields=("first_name",)))
+
+    res = upgrade_splink_conversion(
+        conversion, _fanout_df(), levers={"fan_out"}, measure=False
+    )
+
+    assert not res.upgraded_config.get_matchkeys()[0].negative_evidence
+    warns = _fan_out_findings(res, "warning")
+    assert len(warns) == 1
+    assert "partial" in warns[0].message
+    assert "surname" in warns[0].message
+    assert "skipped" in warns[0].message.lower()
+
+
+def test_fan_out_copy_on_write():
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion, _fanout_df(), levers={"fan_out"}, measure=False
+    )
+
+    # The lever DID add NE on the upgraded copies...
+    assert res.upgraded_config.get_matchkeys()[0].negative_evidence
+    # ...while the baseline conversion stays untouched.
+    assert conversion.config.get_matchkeys()[0].negative_evidence is None
+    assert conversion.em_model is not None
+    assert not any(k.startswith("__ne__") for k in conversion.em_model.m_probs)
+    assert not any(k.startswith("__ne__") for k in conversion.em_model.u_probs)
+    assert not any(k.startswith("__ne__") for k in conversion.em_model.match_weights)
+    assert res.baseline_config.get_matchkeys()[0].negative_evidence is None
+
+
+def test_fan_out_block_size_findings():
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion, _fanout_df(), levers={"fan_out"}, measure=False
+    )
+
+    block_findings = [
+        f for f in _fan_out_findings(res, "info") if "block size" in f.message
+    ]
+    assert len(block_findings) == 1
+    msg = block_findings[0].message
+    # 4 city blocks of 53/53/47/47 rows.
+    assert "p50=53" in msg
+    assert "p95=" in msg
+    assert "max=53" in msg
+    # Findings only -- max_block_size is untouched in v1.
+    assert res.upgraded_config.blocking.max_block_size == conversion.config.blocking.max_block_size
+
+
+def test_fan_out_runs_under_posterior_mode(monkeypatch):
+    """The lever's posterior math is mode-independent: it RUNS (does not
+    skip) under GOLDENMATCH_FS_CALIBRATED=posterior -- only the calibration
+    lever's skip is mode-sensitive."""
+    monkeypatch.setenv("GOLDENMATCH_FS_CALIBRATED", "posterior")
+    conversion = _fanout_conversion()
+
+    res = upgrade_splink_conversion(
+        conversion, _fanout_df(), levers={"fan_out"}, measure=False
+    )
+
+    mk = res.upgraded_config.get_matchkeys()[0]
+    assert [ne.field for ne in (mk.negative_evidence or [])] == ["phone"]

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout.py
@@ -1,0 +1,166 @@
+"""Tests for the fan_out upgrade lever -- Task F1 scaffold: registry wiring,
+lever ordering, bare-settings skip, the shared within-block prior helper, and
+reference-input context threading. The lever BODIES (NE suggestion, guard
+tuning) are no-op stubs until Tasks F3-F4.
+
+Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.from_splink import from_splink
+from goldenmatch.config.splink_upgrade import (
+    SplinkUpgradeError,
+    _estimate_within_block_prior,
+    _resolve_levers,
+    upgrade_splink_conversion,
+)
+
+# ── Fixtures (mirror tests/test_splink_upgrade_levers.py bare-settings) ──────
+
+
+def _jw_comparison():
+    return {
+        "output_column_name": "first_name",
+        "comparison_levels": [
+            {
+                "sql_condition": '"first_name_l" IS NULL OR "first_name_r" IS NULL',
+                "is_null_level": True,
+            },
+            {"sql_condition": '"first_name_l" = "first_name_r"'},
+            {
+                "sql_condition": (
+                    'jaro_winkler_similarity("first_name_l", "first_name_r") >= 0.92'
+                )
+            },
+            {"sql_condition": "ELSE"},
+        ],
+    }
+
+
+def _exact_only_comparison(column="surname"):
+    return {
+        "output_column_name": column,
+        "comparison_levels": [
+            {
+                "sql_condition": f'"{column}_l" IS NULL OR "{column}_r" IS NULL',
+                "is_null_level": True,
+            },
+            {"sql_condition": f'"{column}_l" = "{column}_r"'},
+            {"sql_condition": "ELSE"},
+        ],
+    }
+
+
+def _bare_settings():
+    return {
+        "comparisons": [_jw_comparison(), _exact_only_comparison("surname")],
+        "blocking_rules_to_generate_predictions": [
+            'l."first_name" = r."first_name"',
+            'l."surname" = r."surname"',
+        ],
+    }
+
+
+def _sample_df(n=30):
+    first_names = ["alice", "bob", "carol", "dave", "erin", "frank"]
+    surnames = ["smith", "jones", "brown", "davis", "wilson", "moore"]
+    return pl.DataFrame(
+        {
+            "rec_id": list(range(n)),
+            "first_name": [first_names[i % len(first_names)] for i in range(n)],
+            "surname": [surnames[i % len(surnames)] for i in range(n)],
+        }
+    )
+
+
+# ── Registry wiring / lever order ─────────────────────────────────────────────
+
+
+def test_fan_out_in_default_lever_order():
+    assert _resolve_levers(None) == [
+        "tf_tables",
+        "distance_thresholds",
+        "fan_out",
+        "calibration",
+    ]
+
+
+def test_fan_out_selectable_alone():
+    assert _resolve_levers({"fan_out"}) == ["fan_out"]
+
+    with pytest.raises(SplinkUpgradeError):
+        _resolve_levers({"fan_out", "nope"})
+
+
+# ── Bare-settings skip ────────────────────────────────────────────────────────
+
+
+def test_fan_out_bare_settings_skip():
+    conversion = from_splink(_bare_settings())
+    baseline_dump = conversion.config.model_dump()
+
+    result = upgrade_splink_conversion(
+        conversion, _sample_df(), levers={"fan_out"}, measure=False
+    )
+
+    findings = [
+        f for f in result.report.findings if f.splink_path == "upgrade:fan_out"
+    ]
+    assert len(findings) == 1
+    assert findings[0].severity == "info"
+    assert "no imported model" in findings[0].message
+    # A skipped lever must leave the config untouched.
+    assert result.upgraded_config.model_dump() == baseline_dump
+
+
+# ── Shared within-block prior helper ─────────────────────────────────────────
+
+
+def test_estimate_within_block_prior():
+    # 2^0 / (1 + 2^0) == 0.5 exactly.
+    assert _estimate_within_block_prior([0.0]) == pytest.approx(0.5)
+
+    # A strongly negative weight (~0) and a strongly positive one (~1)
+    # average to ~0.5.
+    assert _estimate_within_block_prior([-20.0, 20.0]) == pytest.approx(
+        0.5, abs=1e-5
+    )
+
+    with pytest.raises(ValueError):
+        _estimate_within_block_prior([])
+
+
+# ── Context threading of reference inputs ────────────────────────────────────
+
+
+def test_lever_context_carries_reference_inputs(monkeypatch):
+    from goldenmatch.config import splink_upgrade
+
+    conversion = from_splink(_bare_settings())
+    clusters_df = pl.DataFrame({"rec_id": [0, 1], "cluster_id": [0, 0]})
+    labels_df = pl.DataFrame({"rec_id": [0, 1], "cluster_id": [0, 1]})
+
+    seen = {}
+
+    def _spy_fan_out(ctx):
+        seen["splink_clusters"] = ctx.splink_clusters
+        seen["labels"] = ctx.labels
+        seen["id_column"] = ctx.id_column
+
+    monkeypatch.setitem(splink_upgrade._LEVER_REGISTRY, "fan_out", _spy_fan_out)
+
+    upgrade_splink_conversion(
+        conversion,
+        _sample_df(),
+        splink_clusters=clusters_df,
+        labels=labels_df,
+        id_column="rec_id",
+        levers={"fan_out"},
+        measure=False,
+    )
+
+    assert seen["splink_clusters"] is clusters_df
+    assert seen["labels"] is labels_df
+    assert seen["id_column"] == "rec_id"

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_fanout_e2e.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_fanout_e2e.py
@@ -1,0 +1,250 @@
+"""Task F6: the fan-out lever E2E success bar.
+
+Spec: docs/superpowers/specs/2026-07-14-fanout-ne-upgrade-lever-design.md
+("Testing / success bar")
+
+The deterministic end-to-end test the fan_out lever exists to satisfy: a
+homonym-shaped fixture in the ``tests/test_fs_ne_e2e.py`` style -- distinct
+people sharing name+city but differing on a ``phone`` column the Splink
+settings never referenced -- run through convert -> ``upgrade_splink_conversion``
+with labels. The baseline conversion merges the homonym traps; the lever
+detects the risk and adds phone negative evidence with estimated weights; the
+measured upgraded run separates the traps while true duplicates still merge;
+and ``vs_labels`` pairwise F1 STRICTLY improves baseline -> upgraded.
+
+Fixture design (why the upgraded run genuinely separates the traps -- every
+number below is load-bearing, worked out against the real calibration
+geometry rather than hoped for):
+
+- The lever pipeline separates traps through the CALIBRATED link threshold:
+  runtime FS scoring merges pairs with normalized score >= link, where
+  normalized = (total_weight - min) / (max - min) over ``fs_weight_range``
+  (NE-inclusive). Trap pairs (all regular fields agree, NE fires) normalize
+  to R / (R + W) where R is the regular-field weight range and W = |w_fired|;
+  true-duplicate pairs (NE never fires) normalize to exactly 1.0. The
+  calibration lever's percentile cut (``compute_thresholds``: rank
+  ``1 - 2 * match_rate`` clamped to [0.40, 0.95]) always lands AT or BELOW
+  the trap band -- the 2x headroom factor guarantees it -- so the only
+  reliable separation regime is trap_norm < 0.40 (the link clamp floor),
+  i.e. W > 1.5 * R. The whole fixture is engineered to reach that regime.
+- W is estimated from the data as |log2(m_fire / u_fire)| with m_fire ~= the
+  trap fraction among confident pairs and u_fire ~= 1 (random pairs almost
+  always differ on phone), so W tops out near log2(1/0.02) ~= 5.6 (the risk
+  gate's 2% rate floor caps how small m_fire can be). With 12 trap pairs
+  among 192 blocked pairs, m_fire ~= 0.0625 -> W ~= 4 bits. R must therefore
+  stay well under ~2.7 bits.
+- Weak-agreement / near-zero-disagreement trained weights keep R tiny while
+  the model stays usable: exact-agree m=0.10/u=0.05 (+1.0 bit) with ELSE
+  m=0.90/u=0.95 (-0.078 bits) per name field. A LOW m is a model that says
+  "agreement is rare even among matches" -- the data's true duplicates still
+  agree on everything; m/u only set the weights. R ~= 2.22, so
+  trap_norm ~= 2.22 / (2.22 + 4.0) ~= 0.36 < 0.40 while dup pairs sit at 1.0
+  and the calibrated link lands exactly on the 0.40 floor.
+- Every block is one identity group (each group gets a unique city; blocking
+  is on city). Weak fields cannot tell background pairs from matches (an
+  all-differ pair scores ~-0.16 bits -> equal-odds posterior ~0.47), so
+  mixed blocks would wreck the within-block prior estimate and drop group
+  pairs below the fan-out gate's 0.9 confidence floor. Pure-group blocks
+  keep every blocked pair at the same (agreeing) weight: the equal-odds
+  prior estimate lands at ~0.81, and group-pair posteriors at ~0.945 >= 0.9,
+  so the risk gate sees all 192 pairs as confident merges. (This differs
+  from ``test_fs_ne_e2e``'s mixed-identity-block rule, which exists for
+  EM-TRAINED configs where saturation is the failure mode; here the model
+  is IMPORTED, never trained, so there is no EM to starve.)
+- ``phone`` appears in the DATA but not in the Splink settings, is fully
+  populated, and lands mid-range on the candidate cardinality gate
+  (144 distinct / 264 rows = 0.545 in [0.5, 0.999]); the 60 unique-phone
+  filler singletons exist to hold that ratio up (dup groups share phones,
+  which alone would sink it below 0.5). Fillers get unique cities ->
+  singleton blocks -> zero pairs, so they never disturb the pair geometry.
+- Baseline failure is real, not vacuous: the baseline config has no
+  link_threshold, so runtime falls back to the fixed 0.50 default, and both
+  trap and dup pairs normalize to 1.0 -> both merge -> baseline pairwise F1
+  = 180/(180+12) precision < 1.0. An in-test precondition assert pins this.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.from_splink import from_splink
+from goldenmatch.config.splink_upgrade import upgrade_splink_conversion
+
+# ── Trained Splink settings (given_name + surname + city, blocking on city) ──
+# Level m/u values sum to 1.0 across the non-null levels of each comparison,
+# so import_em's re-normalization is a no-op (mirrors
+# tests/test_from_splink_model_import.py's settings shape).
+
+N_DUP_GROUPS = 60      # true-duplicate groups of 3 (one city block each)
+N_TRAP_GROUPS = 12     # homonym-trap pairs of 2 (one city block each)
+N_FILLERS = 60         # unique-everything singletons (cardinality ballast)
+
+
+def _trained_exact_comparison(column: str, m_agree: float, u_agree: float) -> dict:
+    return {
+        "output_column_name": column,
+        "comparison_levels": [
+            {
+                "sql_condition": f'"{column}_l" IS NULL OR "{column}_r" IS NULL',
+                "is_null_level": True,
+            },
+            {
+                "sql_condition": f'"{column}_l" = "{column}_r"',
+                "m_probability": m_agree,
+                "u_probability": u_agree,
+            },
+            {
+                "sql_condition": "ELSE",
+                "m_probability": round(1.0 - m_agree, 12),
+                "u_probability": round(1.0 - u_agree, 12),
+            },
+        ],
+    }
+
+
+def _trained_settings() -> dict:
+    return {
+        "comparisons": [
+            # +1.0 / -0.078 bits: weak agree, near-zero disagree (see module
+            # docstring for why R must stay small).
+            _trained_exact_comparison("given_name", 0.10, 0.05),
+            _trained_exact_comparison("surname", 0.10, 0.05),
+            # city always agrees within a block; keep its span negligible.
+            _trained_exact_comparison("city", 0.05, 0.048),
+        ],
+        "blocking_rules_to_generate_predictions": ['l."city" = r."city"'],
+        "probability_two_random_records_match": 0.01,
+    }
+
+
+def _build_fixture() -> tuple[pl.DataFrame, pl.DataFrame]:
+    """264-row frame + ground-truth labels (see module docstring).
+
+    - 60 true-duplicate groups of 3: identical given_name/surname/city and
+      the SAME phone (NE never fires) -> one labeled cluster each.
+    - 12 homonym traps of 2: identical given_name/surname/city (two distinct
+      people colliding on name+city) but DIFFERENT phones -> two singleton
+      labels each.
+    - 60 fillers: unique everything (incl. city -> singleton blocks).
+    """
+    rows: list[dict] = []
+    clusters: list[str] = []
+
+    for g in range(N_DUP_GROUPS):
+        for _ in range(3):
+            rows.append(
+                {
+                    "given_name": f"dupfn{g}",
+                    "surname": f"dupsn{g}",
+                    "city": f"dupcity{g}",
+                    "phone": f"555-1{g:06d}",
+                }
+            )
+            clusters.append(f"dup{g}")
+
+    for t in range(N_TRAP_GROUPS):
+        for side in ("a", "b"):
+            rows.append(
+                {
+                    "given_name": f"trapfn{t}",
+                    "surname": f"trapsn{t}",
+                    "city": f"trapcity{t}",
+                    "phone": f"555-2{t:04d}{'1' if side == 'a' else '2'}",
+                }
+            )
+            clusters.append(f"trap{t}{side}")
+
+    for i in range(N_FILLERS):
+        rows.append(
+            {
+                "given_name": f"fillfn{i}",
+                "surname": f"fillsn{i}",
+                "city": f"fillcity{i}",
+                "phone": f"555-3{i:06d}",
+            }
+        )
+        clusters.append(f"fill{i}")
+
+    df = pl.DataFrame(rows).with_row_index("rec_id")
+    labels = pl.DataFrame(
+        {"rec_id": list(range(len(rows))), "cluster": clusters}
+    ).with_columns(pl.col("rec_id").cast(df["rec_id"].dtype))
+    return df, labels
+
+
+def test_fanout_lever_success_bar():
+    df, labels = _build_fixture()
+    conversion = from_splink(_trained_settings())
+    assert conversion.em_model is not None  # trained input imported a model
+
+    res = upgrade_splink_conversion(
+        conversion, df, labels=labels, id_column="rec_id"
+    )  # measure=True default: full baseline + upgraded dedupe runs
+
+    # ── The lever added phone negative evidence with estimated weights ──────
+    mk = res.upgraded_config.get_matchkeys()[0]
+    assert mk.negative_evidence is not None, (
+        "fan_out lever did not add negative evidence -- the risk gate "
+        "(confident-pair contradiction rate / support floors) did not fire "
+        "on the homonym fixture"
+    )
+    assert [ne.field for ne in mk.negative_evidence] == ["phone"]
+    ne = mk.negative_evidence[0]
+    assert ne.penalty_bits is None  # EM-learned shape, not a fixed override
+
+    assert res.em_model is not None
+    key = "__ne__phone"
+    assert key in res.em_model.match_weights
+    assert res.em_model.match_weights[key][0] < 0, (
+        "estimated NE fired-weight must be negative (firing is rarer among "
+        "likely matches than among random pairs)"
+    )
+    assert res.em_model.match_weights[key][1] == 0.0
+
+    # ── Copy-on-write: baseline config + model stay untouched ───────────────
+    assert conversion.config.get_matchkeys()[0].negative_evidence is None
+    assert res.baseline_config.get_matchkeys()[0].negative_evidence is None
+    assert not any(
+        k.startswith("__ne__") for k in conversion.em_model.match_weights
+    )
+    assert not any(k.startswith("__ne__") for k in conversion.em_model.m_probs)
+    assert not any(k.startswith("__ne__") for k in conversion.em_model.u_probs)
+
+    # ── Guard tuning from labels ─────────────────────────────────────────────
+    gr = res.upgraded_config.golden_rules
+    assert gr is not None
+    # Largest true cluster is a 3-row dup group -> max(10, 2 * 3) = 10.
+    assert gr.max_cluster_size == 10
+    guard_findings = [
+        f
+        for f in res.report.findings
+        if f.splink_path == "upgrade:fan_out"
+        and "max_cluster_size" in f.message
+        and "labels" in f.message
+    ]
+    assert len(guard_findings) == 1
+
+    # ── The measured success bar ─────────────────────────────────────────────
+    m = res.measurement
+    assert m is not None
+    assert m.vs_labels is not None
+
+    baseline_f1 = m.vs_labels.baseline["pairwise_f1"]
+    upgraded_f1 = m.vs_labels.upgraded["pairwise_f1"]
+
+    # Fixture-validity PRECONDITION: the baseline run demonstrably merges the
+    # homonym traps (otherwise the improvement below would be vacuous).
+    assert baseline_f1 < 1.0, (
+        f"baseline pairwise F1 is {baseline_f1} -- the baseline conversion "
+        "no longer merges the homonym traps, so the fixture no longer "
+        "demonstrates the fan-out failure this lever exists to fix; "
+        "strengthen the shared name+city evidence"
+    )
+    # The baseline still finds the true duplicates (recall failure would be a
+    # different, unrelated fixture defect).
+    assert baseline_f1 > 0.5
+
+    # THE BAR (spec "Testing / success bar"): strict pairwise-F1 improvement.
+    assert upgraded_f1 > baseline_f1, (
+        f"upgraded pairwise F1 ({upgraded_f1}) did not strictly improve on "
+        f"baseline ({baseline_f1}) -- the suggested negative evidence and "
+        "calibrated threshold failed to separate the homonym traps"
+    )

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -977,7 +977,7 @@ def test_calibration_lever_reestimates_within_block_rate_from_tiny_prior():
     assert "within-block" in findings[0].message
 
 
-def test_lever_order_tf_tables_then_distance_then_calibration():
+def test_lever_order_canonical():
     """The finding-emitting levers' first occurrences must appear in canonical
     registry order. (fan_out sits between distance_thresholds and calibration
     but its stub bodies emit no finding on trained input, so it is asserted

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -978,11 +978,18 @@ def test_calibration_lever_reestimates_within_block_rate_from_tiny_prior():
 
 
 def test_lever_order_tf_tables_then_distance_then_calibration():
-    """All three levers emit at least one finding on any trained run; their
-    first occurrences must appear in canonical registry order."""
+    """The finding-emitting levers' first occurrences must appear in canonical
+    registry order. (fan_out sits between distance_thresholds and calibration
+    but its stub bodies emit no finding on trained input, so it is asserted
+    via _LEVER_ORDER only.)"""
     from goldenmatch.config.splink_upgrade import _LEVER_ORDER
 
-    assert _LEVER_ORDER == ("tf_tables", "distance_thresholds", "calibration")
+    assert _LEVER_ORDER == (
+        "tf_tables",
+        "distance_thresholds",
+        "fan_out",
+        "calibration",
+    )
 
     conversion = from_splink(_trained_settings_with_levenshtein())
     # 15 identical emails -> one block of 15 -> 105 blocked pairs (> 50), so

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -945,6 +945,20 @@ def test_calibration_runs_on_ne_bearing_config():
     assert len(info_findings) == 1
     assert "570" in info_findings[0].message  # n blocked candidate pairs
 
+    # Mutation square: the NE contributions genuinely MOVE the calibrated
+    # cuts. An implementation that silently dropped NE from the per-pair
+    # weight sums / normalization range would still produce in-range floats
+    # above -- but it would land exactly where the plain (no-NE) conversion
+    # lands on the same data, and this assert would catch it.
+    plain_result = upgrade_splink_conversion(
+        from_splink(_calibration_settings()),
+        _calibration_df_with_phone(phones),
+        levers={"calibration"},
+        measure=False,
+    )
+    plain_mk = plain_result.upgraded_config.get_matchkeys()[0]
+    assert upgraded_mk.link_threshold != plain_mk.link_threshold
+
 
 def test_calibration_ne_parity_when_never_fires():
     """A zero-contribution NE (``__ne__`` weight range [0.0, 0.0]) on an

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -882,41 +882,113 @@ def test_calibration_lever_partial_model_skips():
     assert "surname" in warn_findings[0].message
 
 
-def test_calibration_lever_ne_bearing_matchkey_skips():
-    """Tripwire for the planned fan-out upgrade lever: the calibration
-    lever's pair-weight sum and model min/max range cover REGULAR fields
-    only -- no negative-evidence contributions. ``from_splink`` never emits
-    ``negative_evidence`` today, but the fan-out lever will; until the
-    lever is taught ``fs_weight_range``, an NE-bearing matchkey must warn +
-    skip (levers never fail the pass) rather than calibrate thresholds on
-    the wrong weight scale. Hand-built: a normal trained conversion with NE
-    injected onto the matchkey."""
+def _ne_bearing_conversion(*, w_fired=-3.0):
+    """A trained conversion in the F3 fan_out-lever output shape: the
+    matchkey carries an EM-learned ``NegativeEvidenceField`` on ``phone``
+    plus the matching ``__ne__phone`` model entries (``match_weights``
+    stored as ``[w_fired, 0.0]``)."""
     from goldenmatch.config.schemas import NegativeEvidenceField
 
     conversion = from_splink(_calibration_settings())
     assert conversion.em_model is not None
     conversion.config.get_matchkeys()[0].negative_evidence = [
-        NegativeEvidenceField(field="first_name", scorer="exact", threshold=1.0, penalty_bits=6.0),
+        NegativeEvidenceField(field="phone", scorer="exact", threshold=0.95),
     ]
+    key = "__ne__phone"
+    conversion.em_model.m_probs[key] = [0.0625, 0.9375]
+    conversion.em_model.u_probs[key] = [0.5, 0.5]
+    conversion.em_model.match_weights[key] = [w_fired, 0.0]
+    return conversion
 
-    # _calibration_df yields 570 blocked pairs -- calibration WOULD run if
-    # the NE tripwire didn't skip first.
+
+def _calibration_df_with_phone(values=None):
+    """``_calibration_df`` plus a ``phone`` column (all-null by default)."""
+    df = _calibration_df()
+    if values is None:
+        values = [None] * len(df)
+    return df.with_columns(pl.Series("phone", values, dtype=pl.Utf8))
+
+
+def test_calibration_runs_on_ne_bearing_config():
+    """The NE tripwire is GONE (Task F5): an NE-bearing matchkey (the F3
+    fan_out output shape -- NE field + ``__ne__`` model entries) calibrates
+    thresholds instead of warn+skipping. The per-pair weight sum includes
+    NE contributions (``_ne_scalar_contribution``) and the normalization
+    range comes from ``fs_weight_range``, so the calibrated cuts live on
+    the same scale runtime scoring uses for NE-bearing configs."""
+    conversion = _ne_bearing_conversion()
+    # Distinct phones within every block -> the NE FIRES on blocked pairs.
+    phones = [f"555-{i:07d}" for i in range(60)]
     result = upgrade_splink_conversion(
-        conversion, _calibration_df(), levers={"calibration"}, measure=False
+        conversion,
+        _calibration_df_with_phone(phones),
+        levers={"calibration"},
+        measure=False,
     )
 
     upgraded_mk = result.upgraded_config.get_matchkeys()[0]
-    assert upgraded_mk.link_threshold is None
-    assert upgraded_mk.review_threshold is None
+    assert isinstance(upgraded_mk.link_threshold, float)
+    assert isinstance(upgraded_mk.review_threshold, float)
+    assert 0.0 < upgraded_mk.link_threshold <= 1.0
+    assert 0.0 < upgraded_mk.review_threshold <= 1.0
 
+    # No warn finding about negative evidence -- the tripwire is gone.
     warn_findings = [
         f for f in result.report.findings
         if f.splink_path == "upgrade:calibration" and f.severity == "warning"
     ]
-    assert len(warn_findings) == 1
-    assert "negative_evidence" in warn_findings[0].message
-    assert "fs_weight_range" in warn_findings[0].message
-    assert "skip" in warn_findings[0].message.lower()
+    assert warn_findings == []
+    info_findings = [
+        f for f in result.report.findings
+        if f.splink_path == "upgrade:calibration" and f.severity == "info"
+    ]
+    assert len(info_findings) == 1
+    assert "570" in info_findings[0].message  # n blocked candidate pairs
+
+
+def test_calibration_ne_parity_when_never_fires():
+    """A zero-contribution NE (``__ne__`` weight range [0.0, 0.0]) on an
+    all-null NE column (never fires) must leave calibration EXACTLY where
+    an otherwise-identical no-NE run lands: fs_weight_range adds (0, 0) to
+    the model range and _ne_scalar_contribution adds 0.0 to every pair."""
+    df = _calibration_df_with_phone()  # phone all-null: NE never fires
+
+    ne_result = upgrade_splink_conversion(
+        _ne_bearing_conversion(w_fired=0.0), df,
+        levers={"calibration"}, measure=False,
+    )
+    plain_result = upgrade_splink_conversion(
+        from_splink(_calibration_settings()), df,
+        levers={"calibration"}, measure=False,
+    )
+
+    ne_mk = ne_result.upgraded_config.get_matchkeys()[0]
+    plain_mk = plain_result.upgraded_config.get_matchkeys()[0]
+    assert ne_mk.link_threshold is not None
+    assert ne_mk.link_threshold == plain_mk.link_threshold
+    assert ne_mk.review_threshold == plain_mk.review_threshold
+
+
+def test_calibration_uses_fs_weight_range(monkeypatch):
+    """The hand-rolled min/max weight sums are gone: calibration reaches
+    the shared ``fs_weight_range`` (core/probabilistic) for its
+    normalization range. Monkeypatched to raise a sentinel -> the lever
+    hits it."""
+    import goldenmatch.core.probabilistic as prob
+
+    class _Sentinel(Exception):
+        pass
+
+    def _boom(em, mk):
+        raise _Sentinel("fs_weight_range reached")
+
+    monkeypatch.setattr(prob, "fs_weight_range", _boom)
+
+    conversion = from_splink(_calibration_settings())
+    with pytest.raises(_Sentinel):
+        upgrade_splink_conversion(
+            conversion, _calibration_df(), levers={"calibration"}, measure=False
+        )
 
 
 def test_calibration_lever_reestimates_within_block_rate_from_tiny_prior():


### PR DESCRIPTION
## What

The v2 lever the migration upgrade pass (#1760) deferred: a risk-gated `fan_out` lever that defends converted Splink configs against homonym/fan-out snowballs, consuming the FS negative-evidence capability (#1764).

- **NE suggestion:** detects unused identity-grade columns (phone/email/id; high-cardinality, non-matchkey, non-blocking), measures the contradiction rate among confident-merge blocked pairs (posterior >= 0.9 under the imported model), and when risk clears the gate (rate >= 2%, >= 10 firing pairs) adds the column as `negative_evidence` with posterior-weighted EM-shape weights: `m_fire = sum(p*fired)/sum(p)`, `u_fire` from seeded random pairs, `__ne__<field>` entries written in the exact FS-NE storage schema. Non-discriminating estimates (`w_fired >= 0`) are dropped with a warning.
- **Guard tuning:** `golden_rules.max_cluster_size = max(10, 2 * reference max cluster size)` from `labels` (preferred) or `--splink-clusters`, joined via the measurement `id_column` mechanism; symmetric (tightens person-shaped data below the static 100 so `auto_split` actually catches mid-size snowballs, loosens genuinely-large-cluster domains).
- **Calibration tripwire paid off:** the calibration lever now uses `fs_weight_range` + `_ne_scalar_contribution` (per-pair NE terms; NE columns join the row projection) and the warn+skip tripwire is deleted — calibrated thresholds live on the runtime score scale for NE-bearing configs.
- **Loader fix the bench caught:** `_normalize_golden_rules` swept the lever-written `max_cluster_size` into `field_rules`, so the CLI's upgraded YAML failed to reload — `max_cluster_size` is now a special key (the "set programmatically, never via YAML" NOTE was stale). CLI-level round-trip regression test added.

## Evidence

- **E2E success bar** (`test_splink_upgrade_fanout_e2e.py`): homonym fixture where the baseline conversion merges all 12 name+city traps -> lever adds phone NE (`w_fired = -3.99` bits) + tunes the guard -> measured pairwise F1 **0.9677 -> 1.0** vs labels, true dups intact. Module docstring derives the calibration geometry that shapes the fixture.
- **Wild-bench regression run** (3 real Splink configs + datasets, full-dataset eval vs truth): **no regressions** — real_time 0.6328 (unchanged), saved_model 0.7656 (unchanged), h50k **0.7421 vs 0.7396 (+0.0025)**. No eligible NE columns on these datasets (expected no-op); the guard lever fired on all three and the h50k gain is guard-only.
- 153 tests green across the upgrade-pass suite; ruff clean; every task went through spec + quality review, plus a whole-branch final review.

## Notes / follow-ups

- Bare-settings inputs skip the whole lever including guard tuning (documented intent; run-time EM + autoconfig own that case).
- Known geometry limit (documented in the E2E docstring): threshold-based trap separation requires the NE penalty to be large relative to the regular weight range; on strong-field configs the lever still detects risk, adds NE, and reports findings, but the calibrated cut may not separate traps. The cluster guard is the complementary defense.
- Deferred cleanups from the final review: shared pair-machinery helper between fan_out and calibration; single block-materialization pass; TS phase must open with a loud NE decline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs