### PR TITLE
feat: arrow-native match pipeline + drop the #1747 [polars] stopgap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2841,7 +2841,11 @@ jobs:
         # (and goldenflow, for the goldenflow_* transform functions) at
         # runtime. The package install here is what `init()` in the
         # bridge will find when Postgres starts.
-        run: pip install --break-system-packages 'goldenmatch[polars]>=1.1.0' goldenflow pyarrow
+        # Local base goldenmatch (NO [polars]) -- the bridge core-API surface is
+        # arrow-native, so the pgrx lane runs polars-free against current source
+        # too (drops the #1747 stopgap here as well). goldenflow's base has no
+        # polars dep (it's a [polars] extra), so this stays polars-free.
+        run: pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow pyarrow
 
       - name: Install cargo-pgrx
         # 0.12.9 pin matches the pgrx version in
@@ -2886,7 +2890,7 @@ jobs:
         run: |
           PYTHON_SITE=$(python -c "import site; print(site.getsitepackages()[0])")
           sudo rm -f /usr/lib/python3/dist-packages/typing_extensions.py
-          sudo pip install --break-system-packages 'goldenmatch[polars]>=1.1.0' goldenflow 2>/dev/null || true
+          sudo pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow 2>/dev/null || true
           echo "${PYTHON_SITE}" | sudo tee /usr/lib/python3/dist-packages/goldenmatch.pth
 
       - name: psql smoke (scalar scorer, dedupe, autoconfig)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1618,7 +1618,14 @@ jobs:
           python-version: "3.12"
       - name: Install goldenmatch + pin the pyo3 interpreter
         run: |
-          python -m pip install 'goldenmatch[polars]' pyarrow
+          # Install the LOCAL checkout's base goldenmatch (NO [polars] extra):
+          # the bridge's core-API surface is arrow-native (convert.rs feeds a
+          # pa.Table), so the #1747 [polars] stopgap is no longer needed. This
+          # also proves the bridge against CURRENT source instead of the last
+          # PyPI release. Base deps carry pyarrow but NOT polars / goldencheck /
+          # goldenflow -- the quality/transform steps degrade gracefully when
+          # those are absent, keeping the whole bridge path polars-free.
+          python -m pip install "${GITHUB_WORKSPACE}/packages/python/goldenmatch" pyarrow
           echo "PYO3_PYTHON=$(which python)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" >> "$GITHUB_ENV"
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
@@ -1760,7 +1767,10 @@ jobs:
           python-version: "3.12"
       - name: Install goldenmatch + pin the pyo3 interpreter
         run: |
-          python -m pip install 'goldenmatch[polars]' pyarrow
+          # Local, polars-free install (see the rust lane above): drops the
+          # #1747 [polars] stopgap now that the bridge core-API surface is
+          # arrow-native.
+          python -m pip install "${GITHUB_WORKSPACE}/packages/python/goldenmatch" pyarrow
           echo "PYO3_PYTHON=$(which python)" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=$(python -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')" >> "$GITHUB_ENV"
       - name: Install cargo-llvm-cov

--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -58,6 +58,36 @@ feature (recall-correctness sensitive, out of this plan's clean scope). The
 convert.rs→arrow + ci.yml drop are held for the follow-up that lands #1 + the
 match arrow-port together, verified in CI.
 
+### CORRECTED SCOPE (feasibility proven 2026-07-14) — the match port is FEASIBLE, not multi-week
+
+The needed arrow primitives ALREADY EXIST (verified by probe on this box, native=0):
+- `Frame.derive_matchkey([(field, transforms)…])` — arrow-native matchkey derivation
+  (the dedupe eager path uses it; `compute_matchkeys` is the OLD polars-only twin).
+- `Frame.derive_standardized_column(col, names)` — arrow standardize.
+- `find_exact_matches(frame, mk)` — DUAL-REP (accepts a seam Frame OR a `pa.Table`).
+- `build_blocks(pa.Table, blocking)` — arrow ✓; `score_buckets` — arrow ✓.
+- `_apply_domain_extraction` — already dual-rep.
+- Combined-frame build: `pyarrow.concat_tables` (the seam has no vstack).
+
+So the drop is NOT "replicate the multi-week dedupe eviction." It is a **focused
+arrow port of `run_match_df` + `_run_match_pipeline`** (~275 lines, pipeline.py
+3816-4092): build the combined frame as a `pa.Table`; thread it through the stages
+above (swap `compute_matchkeys`→`derive_matchkey`, `apply_standardization`→
+`derive_standardized_column`, and the output stage's `combined_df.filter(pl.col)`
+/`.to_dicts()`/`pl.DataFrame(rows)` → pyarrow-compute filters / `.to_pylist()` /
+`pa.Table.from_pylist`). Best done as a NEW frame-lane-gated arrow path (mirroring
+`_run_dedupe_pipeline`'s `_frame_lane_eligible` gate at pipeline.py:1000) so the
+existing polars path stays byte-identical, with the arrow path proven by a
+**linkage-parity harness** (arrow-input `match_df` must produce byte-identical
+matched pairs to polars-input — the eviction's own standard). Then #1 (bridge
+glue) + convert.rs→arrow + ci.yml drop land alongside. A partial exact-only port
+that only greens the two bridge match tests is NOT acceptable — it would leave
+fuzzy/weighted `match_df` broken polars-absent in production.
+
+Est: one focused session (design + parity harness + staged port + CI). Not this
+session's scope, but a well-defined next step — not the open-ended blocker the
+earlier notes implied.
+
 ## The central fact
 
 The `rust` / `rust_pgrx` / coverage lanes carry a `[polars]` extra (the #1747

--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -6,36 +6,50 @@
 > `convert.rs::json_to_polars_df` + the bridge's whole Python core-API surface.
 > Scope only; do NOT implement without approval.
 
-## STATUS 2026-07-14 — stopgap drop is CI-BLOCKED on native-present leaks
+## STATUS 2026-07-14 — aux fixes LANDED (PR #1770); DROP blocked on cross-source match arrow-port
 
-The aux SOURCE fixes (validate / anomaly / autoconfig_memory / profiler
-discriminators + seam routing) land — they are byte-identical on every
-polars-present lane and pass the `native=0` arrow tripwire.
+**Merged/merging (PR #1770):** the aux SOURCE fixes — validate / anomaly /
+autoconfig_memory / profiler discriminators + seam routing. Byte-identical on
+every polars-present lane; `native=0` arrow tripwire green.
 
-**The actual `[polars]` DROP is blocked.** PR #1770 tried the full drop
-(convert.rs→arrow + local polars-free install) and the `rust` bridge lane went
-RED with **5 failures that only appear with `goldenmatch-native` PRESENT +
-polars ABSENT** — a combination this dev box cannot reproduce (no native locally;
-`GOLDENMATCH_NATIVE=0` exercises the seam-safe pure paths, which pass):
+**The `[polars]` DROP itself is blocked — now diagnosed to exact lines** (the
+initial "native-present" reading was only half right; the real blockers are the
+bridge GLUE + a deliberate cross-source-match polars gap, both reproducible on a
+native-less box once you go through the bridge wrappers). PR #1770's first
+revision (convert.rs→arrow + local polars-free install) failed the `rust` lane on
+5 tests. Root causes, precisely:
 
-- `test_autofix_table` — `auto_fix_dataframe(pa.Table)` → `'pyarrow.lib.Table'
-  has no attribute 'height'` (native-gated auto_fix path)
-- `test_validate_table_no_rules` — same `.height` on the native validate path
-- `test_match_tables_basic` / `test_match_pairs_reference_id_is_zero_based` —
-  `'pyarrow.lib.ChunkedArray' has no attribute 'startswith'` (a raw `.columns`
-  iteration in the native match/dedupe path)
-- `test_autoconfig_mode_probabilistic_builds_probabilistic_matchkeys` —
-  `ModuleNotFoundError: No module named 'polars'` building the v0 virtual
-  history entry (autoconfig controller, native path)
+1. **Bridge Rust GLUE reads polars-only accessors on the returned frame — TRIVIAL.**
+   `validate_table` (api.rs:1513-1515) + `autofix_table` (api.rs:1536-1537) call
+   `.getattr("height")` + `.call_method0("to_dicts")`; the match path
+   (api.rs:476) calls `target_df.getattr("height")`. With convert.rs feeding a
+   `pa.Table`, these functions RETURN a `pa.Table` (`ArrowFrame.native`), which
+   has `.num_rows`/`.to_pylist()` — not `.height`/`.to_dicts()`. FIX: a robust
+   Rust helper (`hasattr num_rows -> num_rows else height`, same for
+   to_pylist/to_dicts) at those 4 sites. (My local aux probe called the Python
+   fns directly, bypassing the glue — that's why it missed these.)
 
-Root cause class: several bridge-reachable paths route a raw `pa.Table` through
-native-gated code that still expects a polars frame (`.height`/`.columns`) or
-imports polars (autoconfig v0 history). These are NOT the aux-fn leaks fixed
-here; they live in the native/fused + controller paths and belong to the broader
-autoconfig/engine arrow wave. **The drop requires those native-present paths
-arrow-clean first, verified in CI (they can't be exercised on a native-less box).**
-The convert.rs→arrow change + the ci.yml local-install drop are reverted from this
-PR and staged for that follow-up.
+2. **Cross-source match is DELIBERATELY not arrow-native — REAL FEATURE WORK.**
+   `autoconfig.py:3787-3792` force-disables `_arrow_native_ac` whenever
+   `reference is not None` (the warn message: "cross-source match (reference) is
+   not arrow-native yet"), so the target coerces to polars at `autoconfig.py:3802`
+   (`import polars; pl.from_arrow`), AND the reference itself is REQUIRED to be a
+   `pl.DataFrame` (`autoconfig.py:3841` raises `TypeError` otherwise). So
+   `match_df` cannot run with polars absent until the cross-source/reference
+   controller path is arrow-ported. This is recall-correctness-sensitive feature
+   work in the match controller, part of the broader arrow-native wave — NOT a
+   bridge-stopgap fix. It is the true blocker for dropping `[polars]`.
+
+3. **Probabilistic autoconfig v0 history** — `autoconfig_controller.py:390`
+   `_run_pipeline_sample` on a probabilistic config imports polars building the
+   v0 virtual history entry (`ModuleNotFoundError` in CI). Same class as #2 (the
+   FS sample pipeline isn't arrow-native for that path).
+
+**Verdict:** #1 is trivial; #2 (+#3) is the substantial blocker — the cross-source
+match / reference controller must go arrow-native first, which is its own scoped
+feature (recall-correctness sensitive, out of this plan's clean scope). The
+convert.rs→arrow + ci.yml drop are held for the follow-up that lands #1 + the
+match arrow-port together, verified in CI.
 
 ## The central fact
 

--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -29,16 +29,23 @@ revision (convert.rs→arrow + local polars-free install) failed the `rust` lane
    to_pylist/to_dicts) at those 4 sites. (My local aux probe called the Python
    fns directly, bypassing the glue — that's why it missed these.)
 
-2. **Cross-source match is DELIBERATELY not arrow-native — REAL FEATURE WORK.**
-   `autoconfig.py:3787-3792` force-disables `_arrow_native_ac` whenever
-   `reference is not None` (the warn message: "cross-source match (reference) is
-   not arrow-native yet"), so the target coerces to polars at `autoconfig.py:3802`
-   (`import polars; pl.from_arrow`), AND the reference itself is REQUIRED to be a
-   `pl.DataFrame` (`autoconfig.py:3841` raises `TypeError` otherwise). So
-   `match_df` cannot run with polars absent until the cross-source/reference
-   controller path is arrow-ported. This is recall-correctness-sensitive feature
-   work in the match controller, part of the broader arrow-native wave — NOT a
-   bridge-stopgap fix. It is the true blocker for dropping `[polars]`.
+2. **The WHOLE MATCH PIPELINE is polars — a large parallel feature port.**
+   Traced from the CI failure through the layers: `autoconfig.py:3787-3792`
+   force-coerces the target to polars when a reference is present + `:3841`
+   requires a `pl.DataFrame` reference (both easy to relax). But that only exposes
+   the real wall: `pipeline.py::run_match_df` (line ~4114) casts via `pl.Utf8`,
+   `.lazy()`, `pl.lit`, `_add_row_ids`, `pl.concat` into a **combined
+   `pl.LazyFrame`**, and `pipeline.py::_run_match_pipeline` (line 3816) takes that
+   `combined_lf: pl.LazyFrame` and runs the entire match on it (`.collect()`/
+   `.lazy()`). **The match pipeline is a SEPARATE pipeline from the arrow-ported
+   `_run_dedupe_pipeline` and was never included in the dedupe arrow eviction
+   (W1–W5 + the D-descent, dozens of PRs).** Verified locally: relaxing the
+   autoconfig coerce just moves the crash into `run_match_df`'s `pl.Utf8` cast on
+   a `pa.Table`. Arrow-porting match = replicating the dedupe-pipeline arrow
+   effort for `run_match_df` + `_run_match_pipeline` — a large, recall-correctness-
+   sensitive feature with its own design + linkage-parity harness, NOT a
+   bridge-stopgap change. **This is the true, non-negotiable blocker: `[polars]`
+   cannot drop while the bridge exposes `match` and the match pipeline is polars.**
 
 3. **Probabilistic autoconfig v0 history** — `autoconfig_controller.py:390`
    `_run_pipeline_sample` on a probabilistic config imports polars building the

--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -1,0 +1,193 @@
+# Scope: bridge core-API arrow-port → drop the `#1747 [polars]` stopgap
+
+> **Status:** scoped 2026-07-14. This is Wave 1 Stage 5 of
+> `2026-07-14-goldenmatch-zero-config-arrow-polars-free.md`, expanded after the
+> "just port convert.rs" prototype was reverted — the port is NOT one file. It's
+> `convert.rs::json_to_polars_df` + the bridge's whole Python core-API surface.
+> Scope only; do NOT implement without approval.
+
+## STATUS 2026-07-14 — stopgap drop is CI-BLOCKED on native-present leaks
+
+The aux SOURCE fixes (validate / anomaly / autoconfig_memory / profiler
+discriminators + seam routing) land — they are byte-identical on every
+polars-present lane and pass the `native=0` arrow tripwire.
+
+**The actual `[polars]` DROP is blocked.** PR #1770 tried the full drop
+(convert.rs→arrow + local polars-free install) and the `rust` bridge lane went
+RED with **5 failures that only appear with `goldenmatch-native` PRESENT +
+polars ABSENT** — a combination this dev box cannot reproduce (no native locally;
+`GOLDENMATCH_NATIVE=0` exercises the seam-safe pure paths, which pass):
+
+- `test_autofix_table` — `auto_fix_dataframe(pa.Table)` → `'pyarrow.lib.Table'
+  has no attribute 'height'` (native-gated auto_fix path)
+- `test_validate_table_no_rules` — same `.height` on the native validate path
+- `test_match_tables_basic` / `test_match_pairs_reference_id_is_zero_based` —
+  `'pyarrow.lib.ChunkedArray' has no attribute 'startswith'` (a raw `.columns`
+  iteration in the native match/dedupe path)
+- `test_autoconfig_mode_probabilistic_builds_probabilistic_matchkeys` —
+  `ModuleNotFoundError: No module named 'polars'` building the v0 virtual
+  history entry (autoconfig controller, native path)
+
+Root cause class: several bridge-reachable paths route a raw `pa.Table` through
+native-gated code that still expects a polars frame (`.height`/`.columns`) or
+imports polars (autoconfig v0 history). These are NOT the aux-fn leaks fixed
+here; they live in the native/fused + controller paths and belong to the broader
+autoconfig/engine arrow wave. **The drop requires those native-present paths
+arrow-clean first, verified in CI (they can't be exercised on a native-less box).**
+The convert.rs→arrow change + the ci.yml local-install drop are reverted from this
+PR and staged for that follow-up.
+
+## The central fact
+
+The `rust` / `rust_pgrx` / coverage lanes carry a `[polars]` extra (the #1747
+stopgap) purely so the bridge's Python side has polars at runtime. Dropping it
+**uninstalls polars**, so every place the bridge or the Python API it calls does
+`import polars` breaks.
+
+`packages/rust/extensions/bridge/src/convert.rs::json_to_polars_df` (line 14) is
+the ONE conversion helper every bridge entrypoint uses — 15 call sites in
+`api.rs` (172, 260, 335, 381, 382, 471, 472, 630, 681, 1256, 1480, 1530, 1552,
+1577, 1611) all call it. It does `py.import("polars")` → `pl.read_json`. So this
+is not an aux-only problem: **the primary dedupe/autoconfig/match path builds a
+polars frame here too**, then hands it to `dedupe_df`/`auto_configure_df` (which
+now ACCEPT arrow, but are being fed polars).
+
+So the port is two linked moves:
+
+1. **`convert.rs`**: `json_to_polars_df` → `json_to_arrow_df` (build a `pa.Table`
+   via `json.loads` + `pyarrow.Table.from_pylist`); `polars_df_to_json` →
+   arrow-first (`to_pylist` + `json.dumps`, keep the `write_json` branch for a
+   genuine polars frame passing through). No `import polars` anywhere in the
+   file.
+2. **Every Python API the 15 call sites feed** must accept a `pa.Table`. The
+   primary path already does; the aux core-API surface is the remaining work.
+
+The reverted prototype did (1) but not (2), so the aux fns got a `pa.Table` and
+died on `'pyarrow.lib.Table' has no attribute 'height'`.
+
+## P0 empirical findings (2026-07-14, polars-blocked probe on this box)
+
+Probed every bridge-invoked Python API with a `pa.Table` + `import polars`
+blocked. Result: the aux surface was SMALLER than the scope feared — most were
+already seam-ported. Leaks found + fixed in **PR-1**:
+
+- `validate_dataframe` — `isinstance(df, pl.DataFrame)` discriminator (flipped to
+  `isinstance(df, pa.Table)`; rest already seamed).
+- `detect_anomalies` — raw `df.columns`/`df.to_dicts()` → Arrow seam
+  (`.to_arrow().column_names` / `.to_pylist()`).
+- `autoconfig_memory.profile_signature` — raw `df.columns`/`df.schema[c]`
+  (the auto_configure primary path hit it) → arrow-schema branch, polars branch
+  byte-identical.
+- `profiler.profile_dataframe` — `_columns_as_polars_series` wrapped arrow cols
+  as `pl.Series`; now wraps only when polars importable (byte-identical for every
+  polars-present env, incl. bridge-with-polars) and threads name + semantic dtype
+  on the polars-free path. `profile_column` discriminator made polars-safe.
+
+Already arrow-safe (NO port): `auto_fix_dataframe`, `evaluate_clusters`,
+`compare_clusters`, `preflight`, `postflight`, `train_em`, `score_probabilistic`
+(the FS pair only builds polars on the Rust side via `build_probabilistic_frame`).
+
+Arrow tripwire: `tests/test_coreapi_aux_no_polars.py` (subprocess, polars blocked,
+runs all aux fns on a `pa.Table`, asserts `polars not in sys.modules`).
+
+The stopgap drop (**PR-2**, self-contained) — the Rust side + the CI flip:
+
+- `convert.rs`: `json_to_polars_df`→`json_to_arrow_df` (`json.loads` +
+  `pyarrow.Table.from_pylist`) + `polars_df_to_json`→`arrow_df_to_json`
+  (`to_pylist`+`json.dumps`; polars `write_json` kept for a genuine polars frame).
+  Dead polars-only IPC converters + their broken test deleted.
+- `api.rs`: `build_probabilistic_frame`→arrow (append an Int64 `__row_id__`);
+  the MatchResult column-extract (api.rs:500) `pl.from_arrow`→`table.column().to_pylist()`.
+- `ci.yml`: the `rust` + `rust_coverage` bridge lanes install the LOCAL base
+  goldenmatch (`pip install ${GITHUB_WORKSPACE}/packages/python/goldenmatch`) with
+  NO `[polars]` extra — so the drop is **self-validating against current source**
+  (no PyPI release needed). Base deps carry pyarrow but NOT polars / goldencheck /
+  goldenflow (the latter two were never in `[polars]` either, only `quality` /
+  `transform`), so the quality/transform steps degrade gracefully and the whole
+  bridge path runs polars-free. The `cargo test --workspace` bridge suite (dedupe
+  / match / autoconfig / validate / profile / autofix / anomaly / preflight /
+  postflight / FS) is the tripwire — `GOLDENMATCH_BRIDGE_REQUIRE_PY=1` makes any
+  polars ImportError a hard fail.
+
+Local validation: bridge builds + clippy/fmt clean; match/convert/probabilistic
+tests green (arrow column extract works, byte-identical). The full polars-absent +
+native-present run is CI-only (this box lacks native `golden_fused`).
+
+## Per-function classification (the bridge's Python core-API surface)
+
+Mapped bridge fn → Python API → polars footprint (from source inspection):
+
+| Bridge fn (api.rs) | Python API | Location | Arrow status | Port size |
+|---|---|---|---|---|
+| `run_dedupe`/`auto_configure`/`match_sources` (172/260/335/…) | `dedupe_df`/`auto_configure_df`/`match_df` | `_api.py` | **arrow-native already** (Wave-1 flag flip) | none (just feed arrow) |
+| `evaluate` (1367) | `evaluate_clusters` | `core/evaluate.py` | 0 `pl.*` — takes pairs/clusters JSON, not a row-df | none |
+| `compare_clusters` (1431) | `compare_clusters` | `cli/compare.py` | 0 `pl.*` — takes clusters JSON, not a row-df | none |
+| `validate_table` (1469→df@1480) | `validate_dataframe` | `core/validate.py` | **partially seamed** (has `isinstance(df, pl.DataFrame)`@84, `frame.height`/`.columns`; residual `pl.Series`/`pl.Utf8`@164) | **S** (discriminator flip + degrade 1 pl.Series) |
+| `autofix_table` (1522→df@1530) | `auto_fix_dataframe` | `core/autofix.py` | polars, unseamed (`df: pl.DataFrame`) | **M** (real port) |
+| `detect_anomalies` (1544→df@1552) | `detect_anomalies` | `core/anomaly.py` | polars, unseamed (`df.to_dicts()`@80, `df.columns`@70) | **S** (`.column_names`/`.to_pylist()`) |
+| `preflight` (1568→df@1577) | `autoconfig_verify.preflight` | `core/autoconfig_verify.py` | UNVERIFIED — inspect | ? |
+| `postflight` (1601→df@1611) | `autoconfig_verify` + `dedupe_df` | `core/autoconfig_verify.py` | `dedupe_df` arrow-native; wrapper UNVERIFIED | ? |
+| `profile_table` (1248→df@1256) | `profile_dataframe` | `core/profiler.py` | 3 `pl.*` sites — inspect (may be seamed by PR-2) | S–M |
+| `train_em` (1641) | FS EM (`config.schemas`) | `core/probabilistic.py` | UNVERIFIED — FS math, likely takes rows | ? |
+| `score_probabilistic` (1692) | FS scorer | `core/probabilistic.py` | UNVERIFIED | ? |
+
+**Confirmed-failing (measured this session):** `validate_table`, `autofix_table`,
+`detect_anomalies`. **Confirmed-clean (0 polars):** `evaluate`, `compare_clusters`.
+**Primary path:** already arrow-native. **Still to inspect (5):** `preflight`,
+`postflight`, `profile_table`, `train_em`, `score_probabilistic`.
+
+## Port pattern (established this session — reuse it verbatim)
+
+Every one of these follows the `transform.py`/`quality.py`/`blocker.py` fixes
+already merged this wave:
+
+1. Discriminator: `import pyarrow as _pa; _is_arrow = isinstance(df, _pa.Table)`
+   — NEVER `isinstance(df, pl.DataFrame)` (that triggers the lazy `pl` import and
+   fails when polars is uninstalled).
+2. Use the frame seam (`goldenmatch.core.frame.to_frame`) for `.height` /
+   `.columns` / `.column(c)` / `.filter_mask` so both lanes share one code path.
+3. Any residual raw-polars construction (`pl.Series`, `pl.Utf8`,
+   `pl.from_arrow`) either routes through the seam or is guarded with
+   `try: import polars except ImportError: <degrade + one-time WARNING>`.
+4. `.to_dicts()` → arrow `.to_pylist()`; `.columns` → `.column_names`.
+
+## Staging (each = one PR, parity gate + arrow-blocked tripwire + ruff)
+
+- **P0 — inspect the 5 unknowns.** Read `autoconfig_verify.preflight/postflight`,
+  `profiler.profile_dataframe`, `probabilistic.train_em`/`score_probabilistic`;
+  confirm arrow status + size. Cheap; do first so the train is fully sized.
+- **P1 — `convert.rs` arrow flip + primary-path proof.** `json_to_arrow_df` +
+  `arrow_df_to_json`; confirm the 9 primary call sites (dedupe/autoconfig/match)
+  run green with the arrow converter (they already accept arrow). Gate: bridge
+  primary tests green.
+- **P2 — port `validate_dataframe`** (S: discriminator + degrade the empty
+  `pl.Series` quarantine column).
+- **P3 — port `detect_anomalies`** (S: `.column_names` + `.to_pylist()`).
+- **P4 — port `auto_fix_dataframe`** (M: the real unseamed one).
+- **P5 — port the P0 unknowns** (profile/preflight/postflight/FS) — likely 1–2
+  PRs depending on P0 findings.
+- **P6 — drop the stopgap.** Remove `[polars]` from `rust`/`rust_pgrx`/coverage
+  lanes in `.github/workflows/ci.yml`; add a bridge tripwire (pip-installed
+  goldenmatch, native present, `import polars` blocked → `run_dedupe` +
+  `auto_configure` + each aux fn complete). Gate: bridge lanes green with no
+  `[polars]`; flip the tracker item to resolved.
+
+## Effort estimate
+
+~6–8 PRs. The Rust change (P1) is mechanical and prototyped. The Python ports
+are all the SAME small pattern already applied 4× this wave (transform/quality/
+blocker/block_analyzer). `evaluate`/`compare_clusters`/primary are free. The only
+unknown is the 5 P0 functions — most likely S each, but FS (`train_em`/
+`score_probabilistic`) could be M if they iterate rows in polars.
+
+## Risk / notes
+
+- Local box lacks native `match_fused`/`golden_fused`, so it exercises FALLBACK
+  paths — a local green is NOT proof for the full-native `rust` lane. Every stage
+  needs the arrow-blocked subprocess tripwire, and P6 must confirm in CI.
+- Bridge builds+tests locally on Windows (per extensions CLAUDE.md): `PYO3_PYTHON`
+  = venv python, python313.dll dir on PATH, venv `Lib/site-packages` on
+  PYTHONPATH, `ARROW_DEFAULT_MEMORY_POOL=system`.
+- `arrow_df_to_json` output must byte-match the current `polars_df_to_json`
+  (column order, null rendering, float formatting) or the bridge's JSON-contract
+  tests drift — parity-gate the round-trip.

--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -6,7 +6,31 @@
 > `convert.rs::json_to_polars_df` + the bridge's whole Python core-API surface.
 > Scope only; do NOT implement without approval.
 
-## STATUS 2026-07-14 — aux fixes LANDED (PR #1770); DROP blocked on cross-source match arrow-port
+## STATUS 2026-07-14 (FINAL) — DROP IMPLEMENTED + armed in PR #1772
+
+The match-pipeline arrow-flip turned out **tractable, not multi-week** (the seam
+primitives already existed) and is DONE. PR #1772 (supersedes #1770) is the
+complete `[polars]` drop:
+- **Match pipeline arrow-flip** (`pipeline.py`): `run_match_df` builds the
+  combined frame with pyarrow for `pa.Table` inputs; `_run_match_pipeline` gets an
+  arrow prep branch + a new arrow-native `_run_match_scoring_and_output`. Polars
+  path byte-identical.
+- **Autoconfig cross-source**: reference no longer force-coerced to polars; accepts
+  `pa.Table`; downstream `.columns`/`.height` leaks fixed (autoconfig_rules /
+  autoconfig_controller); scorer NE `to_dicts`→dual-rep.
+- **Aux fixes** (from #1770) + **bridge** convert.rs→arrow + api.rs glue
+  (`frame_row_count`/`frame_to_records`) + `build_probabilistic_frame`→arrow +
+  MatchResult extract→`to_pylist`.
+- **CI**: rust + rust_coverage install the LOCAL base goldenmatch (no `[polars]`).
+
+**Verified locally** (native=0): linkage-parity harness — arrow-input `match_df`
+== polars-input (exact + fuzzy), byte-identical; polars-free tripwires (match +
+aux) green; zero-config endgame tripwire xpasses; 39 match + 148 dedupe/autoconfig/
+scorer tests green; bridge 4 previously-failing tests pass, clippy/fmt clean. The
+full native-present + polars-absent run is what #1772's CI `rust` lane proves.
+The earlier "blocked on multi-week feature" reads below are SUPERSEDED.
+
+## (superseded) STATUS — aux fixes; DROP blocked on cross-source match arrow-port
 
 **Merged/merging (PR #1770):** the aux SOURCE fixes — validate / anomaly /
 autoconfig_memory / profiler discriminators + seam routing. Byte-identical on

--- a/packages/python/goldenmatch/goldenmatch/core/anomaly.py
+++ b/packages/python/goldenmatch/goldenmatch/core/anomaly.py
@@ -67,7 +67,14 @@ def detect_anomalies(
             "use 'low', 'medium', or 'high'."
         )
 
-    cols = [c for c in df.columns if not c.startswith("__")]
+    # Dual-rep (Frame lane): df may be a pl.DataFrame or a pa.Table. Read column
+    # names + rows through the Arrow seam so the path stays polars-free when
+    # polars is uninstalled (D6). `.to_pylist()` preserves row order + values,
+    # byte-identical to the polars `.to_dicts()` it replaces.
+    from goldenmatch.core.frame import to_frame
+
+    _arrow = to_frame(df).to_arrow()
+    cols = [c for c in _arrow.column_names if not c.startswith("__")]
     anomalies = []
 
     # Detect column types by name
@@ -77,7 +84,7 @@ def detect_anomalies(
     _name_cols = [c for c in cols if _is_likely_column(c, ["name", "first_name", "last_name", "full_name"])]
     _date_cols = [c for c in cols if _is_likely_column(c, ["date", "dob", "birth", "created"])]
 
-    rows = df.to_dicts()
+    rows = _arrow.to_pylist()
 
     for i, row in enumerate(rows):
         rid = row.get("__row_id__", i)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4669,8 +4669,10 @@ def auto_configure_probabilistic_df(
     optimizer (spec ``2026-05-25-agentic-config-optimizer-design``) is the
     intended place to *search* weighted-vs-probabilistic empirically.
     """
-    if isinstance(df, pl.LazyFrame):
-        df = df.collect()
+    from goldenmatch.core.frame import is_polars_lazyframe as _is_pl_lf_prob
+
+    if _is_pl_lf_prob(df):
+        df = cast("pl.LazyFrame", df).collect()
 
     profiles = profile_columns(df, llm_provider=llm_provider)
     matchkeys = build_probabilistic_matchkeys(profiles)

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3784,11 +3784,8 @@ def auto_configure_df(
     _arrow_native_ac = os.environ.get(
         "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE", "1"
     ).lower() in ("1", "true", "yes")
-    if _arrow_native_ac and (reference is not None or throughput is not None):
-        _warn_arrow_native_coerced_once(
-            "cross-source match (reference)" if reference is not None
-            else "throughput tier"
-        )
+    if _arrow_native_ac and throughput is not None:
+        _warn_arrow_native_coerced_once("throughput tier")
         _arrow_native_ac = False
     if not (
         _is_ray_boundary(df)
@@ -3836,11 +3833,15 @@ def auto_configure_df(
         # .height via the Frame seam; the controller consumes the arrow native.
         _n_rows_for_budget = to_frame(df).height
     if reference is not None:
-        if isinstance(reference, pl.LazyFrame):
-            reference = reference.collect()
-        elif not isinstance(reference, pl.DataFrame):
+        import pyarrow as _pa_ref
+
+        if isinstance(reference, _pa_ref.Table):
+            pass  # arrow reference flows natively (cross-source arrow lane)
+        elif is_polars_lazyframe(reference):
+            reference = cast("pl.LazyFrame", reference).collect()
+        elif not is_polars_dataframe(reference):
             raise TypeError(
-                f"reference requires pl.DataFrame or pl.LazyFrame, "
+                f"reference requires pl.DataFrame, pl.LazyFrame, or pa.Table, "
                 f"got {type(reference).__name__}"
             )
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4649,7 +4649,7 @@ def build_probabilistic_matchkeys(profiles: list[ColumnProfile]) -> list[Matchke
 
 
 def auto_configure_probabilistic_df(
-    df: pl.DataFrame | pl.LazyFrame,
+    df: Any,  # pl.DataFrame | pl.LazyFrame | pa.Table (arrow lane)
     llm_provider: str | None = None,
 ) -> GoldenMatchConfig:
     """Build a Fellegi-Sunter *probabilistic* config straight from a DataFrame.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -925,7 +925,7 @@ class AutoConfigController:
                         )
                         _diag(
                             f"ExpandSample({_factor}x): resampled to "
-                            f"height={sample.height}",
+                            f"height={_tf_exp(sample).height}",  # arrow-port
                         )
                     else:
                         _diag(

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_memory.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_memory.py
@@ -56,11 +56,25 @@ def profile_signature(df: pl.DataFrame, *, mode: str = "dedupe") -> str:
     """
     # Sort by name so column ORDER doesn't change the signature; it's the
     # set of (name, dtype) pairs that matters.
-    pairs = sorted(
-        (c, str(df.schema[c]))
-        for c in df.columns
-        if not c.startswith("__")
-    )
+    # Dual-rep (Frame lane): df may be a pl.DataFrame or a pa.Table. Read the
+    # schema via the Arrow seam on the arrow lane so the path stays polars-free
+    # (D6), and keep the polars branch byte-identical (the cache key is
+    # dtype-string-sensitive, so the two lanes hash to distinct keys -- a benign
+    # cache miss for a local cross-run cache, never a correctness issue).
+    import pyarrow as _pa
+
+    if isinstance(df, _pa.Table):
+        pairs = sorted(
+            (f.name, str(f.type))
+            for f in df.schema
+            if not f.name.startswith("__")
+        )
+    else:
+        pairs = sorted(
+            (c, str(df.schema[c]))
+            for c in df.columns
+            if not c.startswith("__")
+        )
     key = (mode, tuple(pairs))
     return hashlib.sha256(repr(key).encode()).hexdigest()[:16]
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_memory.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_memory.py
@@ -14,11 +14,9 @@ import sqlite3
 import threading
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    import polars as pl
-
     from goldenmatch.config.schemas import GoldenMatchConfig
 
 logger = logging.getLogger(__name__)
@@ -37,7 +35,7 @@ CREATE INDEX IF NOT EXISTS idx_autoconfig_sig ON autoconfig_runs (profile_signat
 """
 
 
-def profile_signature(df: pl.DataFrame, *, mode: str = "dedupe") -> str:
+def profile_signature(df: Any, *, mode: str = "dedupe") -> str:
     """Compute a per-column-name signature for a DataFrame.
 
     Two frames hash to the same signature only when they have the same

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -427,7 +427,8 @@ def rule_no_matches(
             # Identity column — try gentler alternatives before swap
             candidates.append(_with_lower_threshold(current, 0.05))
             candidates.append(_with_normalize_standardization(current, blocking_col))
-            df_cols = list(ctx._df.columns)
+            from goldenmatch.core.frame import to_frame as _tf_ac
+            df_cols = list(_tf_ac(ctx._df).columns)
             ortho = _orthogonal_key(current, df_cols)
             if ortho is not None:
                 candidates.append(_with_multi_pass(current, ortho))
@@ -1044,7 +1045,8 @@ def rule_cross_blocking_disagreement(
     if current.blocking is None or not current.blocking.keys:
         return None
     blocking_col = current.blocking.keys[0].fields[0]
-    df_cols = list(ctx._df.columns) if ctx._df is not None else []
+    from goldenmatch.core.frame import to_frame as _tf_ac2
+    df_cols = list(_tf_ac2(ctx._df).columns) if ctx._df is not None else []
     ortho = _orthogonal_key(current, df_cols)
     if ortho is None:
         return None

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3832,7 +3832,74 @@ def _run_match_pipeline(
     output. Both run_match() and run_match_df() delegate to this function.
     """
     memory_store = _open_memory_store(config)
-    # ── Step 2.5a: AUTO-FIX + VALIDATION ──
+    # Frame lane (arrow spine): when the caller handed us a seam Frame / pa.Table
+    # instead of a pl.LazyFrame, run the prep stages through the seam so the match
+    # pipeline stays polars-free -- mirrors _run_dedupe_pipeline's arrow prep
+    # (auto_fix -> validate -> standardize -> matchkeys -> domain -> precompute).
+    # quarantine_df_match is set on both lanes. The polars branch below is
+    # byte-identical to the classic path.
+    from goldenmatch.core.frame import is_polars_lazyframe as _is_pl_lf
+    from goldenmatch.core.frame import to_frame as _tf_match
+    from goldenmatch.core.matchkey import precompute_matchkey_transforms_frame
+
+    _match_arrow_lane = not _is_pl_lf(combined_lf) and not auto_config
+    if _match_arrow_lane:
+        _frame = _tf_match(combined_lf)
+        if config.validation and config.validation.auto_fix:
+            _fixed_native, _af_fixes = auto_fix_dataframe(_frame.native)
+            if _af_fixes:
+                logger.info("Auto-fix applied: %d fix type(s)", len(_af_fixes))
+            _frame = _tf_match(_fixed_native)
+        if config.validation and config.validation.rules:
+            _v_rules = [
+                ValidationRule(
+                    column=rc.column, rule_type=rc.rule_type,
+                    params=rc.params, action=rc.action,
+                )
+                for rc in config.validation.rules
+            ]
+            _valid_native, quarantine_df_match, _val_report = validate_dataframe(
+                _frame.native, _v_rules
+            )
+            logger.info(
+                "Validation: %d quarantined rows", _tf_match(quarantine_df_match).height
+            )
+            _frame = _tf_match(_valid_native)
+        else:
+            quarantine_df_match = None
+        if config.standardization and config.standardization.rules:
+            for _col, _std_names in config.standardization.rules.items():
+                if _col not in _frame.columns:
+                    continue
+                _frame = _frame.with_column(
+                    _col, _frame.derive_standardized_column(_col, _std_names)
+                )
+        _frame = _tf_match(_apply_domain_extraction(_frame.native, config))
+        _apply_memory_pre(memory_store, config, matchkeys)
+        for _mk in matchkeys:
+            if _mk.type != "exact":
+                continue
+            _frame = _frame.with_column(
+                f"__mk_{_mk.name}__",
+                _frame.derive_matchkey(
+                    [
+                        (f.field, list(f.transforms or []))
+                        for f in _mk.fields
+                        if f.field is not None
+                    ]
+                ),
+            )
+        combined_frame = precompute_matchkey_transforms_frame(_frame, matchkeys)
+        _run_auto_suggest(combined_frame.native, config)
+        return _run_match_scoring_and_output(
+            combined_frame, config, matchkeys, target_ids, memory_store,
+            quarantine_df_match,
+            output_matched=output_matched, output_unmatched=output_unmatched,
+            output_scores=output_scores, output_report=output_report,
+            match_mode=match_mode,
+        )
+
+    # ── Step 2.5a: AUTO-FIX + VALIDATION ── (classic polars lane)
     if config.validation and config.validation.auto_fix:
         combined_df_tmp = combined_lf.collect()
         combined_df_tmp, fix_log = auto_fix_dataframe(combined_df_tmp)
@@ -4099,6 +4166,201 @@ def _run_match_pipeline(
     }
 
 
+def _run_match_scoring_and_output(
+    combined_frame,
+    config: GoldenMatchConfig,
+    matchkeys: list,
+    target_ids: set,
+    memory_store,
+    quarantine_df_match,
+    *,
+    output_matched: bool = False,
+    output_unmatched: bool = False,
+    output_scores: bool = False,
+    output_report: bool = False,
+    match_mode: str = "best",
+) -> dict:
+    """Arrow-native match scoring + output (Frame lane).
+
+    Mirrors the polars scoring/output tail of ``_run_match_pipeline`` but threads
+    a seam ``Frame`` (``combined_frame``) so the path stays polars-free. Scoring
+    kernels (``find_exact_matches`` / ``build_blocks`` / block scorers) are
+    dual-rep and accept the seam frame; row/output bookkeeping runs on the arrow
+    native via ``to_pylist`` / pyarrow-compute. The classic polars tail is left
+    byte-identical.
+    """
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    combined_native = combined_frame.native  # pa.Table
+
+    all_pairs: list[tuple[int, int, float]] = []
+    matched_pairs: set[tuple[int, int]] = set()
+
+    # Phase 1: exact matchkeys
+    for mk in matchkeys:
+        if mk.type == "exact":
+            pairs = find_exact_matches(combined_frame, mk)
+            if mk.negative_evidence:
+                from goldenmatch.core.scorer import (
+                    _apply_negative_evidence_to_exact_pairs,
+                )
+                pairs = _apply_negative_evidence_to_exact_pairs(
+                    pairs, mk, combined_native
+                )
+            pairs = [
+                (a, b, s) for a, b, s in pairs
+                if (a in target_ids) != (b in target_ids)
+            ]
+            all_pairs.extend(pairs)
+            for a, b, _s in pairs:
+                matched_pairs.add((min(a, b), max(a, b)))
+
+    # Phase 2: fuzzy (weighted) matchkeys
+    for mk in matchkeys:
+        if mk.type == "weighted":
+            if config.blocking is None:
+                continue
+            blocks = build_blocks(combined_frame, config.blocking)
+            block_scorer = _get_block_scorer(config)
+            pairs = block_scorer(blocks, mk, matched_pairs, target_ids=target_ids)
+            all_pairs.extend(pairs)
+
+    # Phase 2b: probabilistic (Fellegi-Sunter) matchkeys
+    for mk in matchkeys:
+        if mk.type == "probabilistic":
+            if config.blocking is None:
+                continue
+            from goldenmatch.core.blocker import collect_blocking_fields
+            from goldenmatch.core.probabilistic import (
+                load_or_train_em,
+                score_probabilistic_blocks_batched,
+            )
+            blocks = build_blocks(combined_frame, config.blocking)
+            blocking_fields = (
+                collect_blocking_fields(config.blocking) if config.blocking else []
+            )
+            em_result = load_or_train_em(
+                combined_native, mk, blocks=blocks, blocking_fields=blocking_fields
+            )
+            pairs = score_probabilistic_blocks_batched(
+                blocks, mk, em_result, matched_pairs
+            )
+            all_pairs.extend(pairs)
+            for a, b, _s in pairs:
+                matched_pairs.add((min(a, b), max(a, b)))
+
+    # Step 4.5: cross-encoder reranking (optional)
+    for mk in matchkeys:
+        if mk.type == "weighted" and mk.rerank:
+            all_pairs = rerank_top_pairs(all_pairs, combined_native, mk)
+            break
+
+    # Step 4.6: LLM scorer (optional)
+    if config.llm_scorer and config.llm_scorer.enabled and all_pairs:
+        if config.llm_scorer.mode == "cluster":
+            from goldenmatch.core.llm_cluster import llm_cluster_pairs
+            all_pairs = _unwrap_llm_pairs(
+                llm_cluster_pairs(all_pairs, combined_native, config=config.llm_scorer)
+            )
+        else:
+            from goldenmatch.core.llm_scorer import llm_score_pairs
+            all_pairs = _unwrap_llm_pairs(
+                llm_score_pairs(all_pairs, combined_native, config=config.llm_scorer)
+            )
+        all_pairs = [(a, b, s) for a, b, s in all_pairs if s > 0.5]
+
+    # Learning Memory: post-scoring corrections overlay
+    all_pairs, memory_stats = _apply_memory_post(
+        memory_store, config, combined_native, all_pairs
+    )
+
+    # Step 4.7: postflight (auto-config only; no-op otherwise)
+    all_pairs, postflight_report = _apply_postflight(
+        combined_native, config, all_pairs
+    )
+
+    # Step 5: normalize so the target id is always first
+    normalized: list[tuple[int, int, float]] = []
+    for a, b, score in all_pairs:
+        normalized.append((a, b, score) if a in target_ids else (b, a, score))
+
+    # Step 6: group by target, apply match_mode
+    target_matches: dict[int, list[tuple[int, float]]] = defaultdict(list)
+    for target_id, ref_id, score in normalized:
+        target_matches[target_id].append((ref_id, score))
+    if match_mode == "best":
+        for tid in target_matches:
+            target_matches[tid] = [max(target_matches[tid], key=lambda x: x[1])]
+
+    # Step 7: build output (row lookup via a {row_id: row} map from arrow)
+    _rows_by_id = {r["__row_id__"]: r for r in combined_native.to_pylist()}
+    matched_rows: list[dict] = []
+    all_scores: list[float] = []
+    for target_id, matches in target_matches.items():
+        target_row = _rows_by_id[target_id]
+        for ref_id, score in matches:
+            ref_row = _rows_by_id[ref_id]
+            row = {
+                "__target_row_id__": target_id,
+                "__ref_row_id__": ref_id,
+                "__match_score__": score,
+            }
+            for col, val in target_row.items():
+                if not col.startswith("__"):
+                    row[f"target_{col}"] = val
+            for col, val in ref_row.items():
+                if not col.startswith("__"):
+                    row[f"ref_{col}"] = val
+            matched_rows.append(row)
+            all_scores.append(score)
+
+    matched_tbl = pa.Table.from_pylist(matched_rows) if matched_rows else None
+
+    matched_target_ids = set(target_matches.keys())
+    unmatched_ids = target_ids - matched_target_ids
+    _unmatched_mask = pc.is_in(
+        combined_native.column("__row_id__"),
+        value_set=pa.array(sorted(unmatched_ids)),
+    )
+    unmatched_tbl = combined_native.filter(_unmatched_mask)
+
+    report = None
+    if output_report:
+        report = generate_match_report(
+            total_targets=len(target_ids),
+            matched=len(matched_target_ids),
+            unmatched=len(unmatched_ids),
+            scores=all_scores,
+        )
+
+    if output_matched or output_unmatched or output_scores:
+        run_name = config.output.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
+        fmt = config.output.format or "csv"
+        directory = config.output.directory or config.output.path or "."
+        if output_matched and matched_tbl is not None:
+            write_output(matched_tbl, directory, run_name, "matched", fmt)
+        if output_unmatched and unmatched_tbl.num_rows > 0:
+            write_output(unmatched_tbl, directory, run_name, "unmatched", fmt)
+        if output_scores and matched_tbl is not None:
+            write_output(matched_tbl, directory, run_name, "scores", fmt)
+
+    try:
+        _enqueue_stale_pairs(memory_stats, all_pairs, config)
+    finally:
+        if memory_store is not None:
+            memory_store.close()
+
+    return {
+        "matched": _dict_frame_to_arrow(matched_tbl),
+        "unmatched": _dict_frame_to_arrow(unmatched_tbl),
+        "report": report,
+        "quarantine": quarantine_df_match,
+        "postflight_report": postflight_report,
+        "memory_stats": memory_stats,
+    }
+
+
 def run_match_df(
     target_df: pl.DataFrame,
     reference_df: pl.DataFrame,
@@ -4109,6 +4371,47 @@ def run_match_df(
     auto_config_llm_provider: str | None = None,
 ) -> dict:
     """Run match pipeline on DataFrames directly (no file I/O)."""
+    # Frame lane (arrow): when both inputs are pa.Tables, build the combined
+    # frame with pyarrow (cast user columns to string, tag __source__, assign
+    # __row_id__ per source, concat) and thread a seam Frame through the
+    # arrow-native match pipeline -- polars-free. Byte-identical linkage to the
+    # polars path (parity-gated in tests/test_match_arrow_parity.py).
+    import pyarrow as _pa_m
+
+    if isinstance(target_df, _pa_m.Table) and isinstance(reference_df, _pa_m.Table):
+        import pyarrow.compute as _pc_m
+
+        from goldenmatch.core.frame import to_frame as _tf_rmd
+
+        def _prep_arrow(tbl, source, offset):
+            n = tbl.num_rows
+            arrs, names = [], []
+            for name in tbl.column_names:
+                if name.startswith("__"):
+                    continue
+                arrs.append(_pc_m.cast(tbl.column(name), _pa_m.string()))
+                names.append(name)
+            arrs.append(_pa_m.array([source] * n, type=_pa_m.string()))
+            names.append("__source__")
+            arrs.append(
+                _pa_m.array(list(range(offset, offset + n)), type=_pa_m.int64())
+            )
+            names.append("__row_id__")
+            return _pa_m.table(arrs, names=names), n
+
+        _t_tbl, _t_n = _prep_arrow(target_df, target_name, 0)
+        _r_tbl, _ = _prep_arrow(reference_df, reference_name, _t_n)
+        combined_tbl = _pa_m.concat_tables(
+            [_t_tbl, _r_tbl], promote_options="permissive"
+        )
+        target_ids_a = set(range(_t_n))
+        matchkeys_a = [] if auto_config else config.get_matchkeys()
+        return _run_match_pipeline(
+            _tf_rmd(combined_tbl), config, matchkeys_a, target_ids_a,
+            auto_config=auto_config,
+            auto_config_llm_provider=auto_config_llm_provider,
+        )
+
     # Cast all columns to string to keep schema consistent with dedupe_df's
     # pre-pipeline behaviour — prevents mixed-type errors in zero-config paths.
     target_df = target_df.cast(

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -3814,7 +3814,7 @@ def run_match(
 
 
 def _run_match_pipeline(
-    combined_lf: pl.LazyFrame,
+    combined_lf: Any,  # pl.LazyFrame (classic) | seam Frame (arrow lane)
     config: GoldenMatchConfig,
     matchkeys: list,
     target_ids: set,
@@ -4167,12 +4167,12 @@ def _run_match_pipeline(
 
 
 def _run_match_scoring_and_output(
-    combined_frame,
+    combined_frame: Any,
     config: GoldenMatchConfig,
     matchkeys: list,
     target_ids: set,
-    memory_store,
-    quarantine_df_match,
+    memory_store: Any,
+    quarantine_df_match: Any,
     *,
     output_matched: bool = False,
     output_unmatched: bool = False,
@@ -4319,7 +4319,7 @@ def _run_match_scoring_and_output(
 
     matched_target_ids = set(target_matches.keys())
     unmatched_ids = target_ids - matched_target_ids
-    _unmatched_mask = pc.is_in(
+    _unmatched_mask = pc.is_in(  # pyright: ignore[reportAttributeAccessIssue]
         combined_native.column("__row_id__"),
         value_set=pa.array(sorted(unmatched_ids)),
     )
@@ -4383,7 +4383,7 @@ def run_match_df(
 
         from goldenmatch.core.frame import to_frame as _tf_rmd
 
-        def _prep_arrow(tbl, source, offset):
+        def _prep_arrow(tbl: Any, source: str, offset: int):
             n = tbl.num_rows
             arrs, names = [], []
             for name in tbl.column_names:

--- a/packages/python/goldenmatch/goldenmatch/core/profiler.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profiler.py
@@ -121,7 +121,7 @@ def _polars_importable() -> bool:
     Under the zero-polars import blocker the ``import polars`` raises
     ImportError, so this returns False and callers take the seam-native path."""
     try:
-        import polars  # noqa: F401
+        import polars  # noqa: F401  # pyright: ignore[reportUnusedImport]
 
         return True
     except ImportError:

--- a/packages/python/goldenmatch/goldenmatch/core/profiler.py
+++ b/packages/python/goldenmatch/goldenmatch/core/profiler.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sys
 from typing import TYPE_CHECKING, Any
 
 from rich.panel import Panel
@@ -114,18 +115,37 @@ def _as_column(series: Any) -> Column:
     return PolarsColumn(series)
 
 
-def profile_column(series: pl.Series) -> dict[str, Any]:
+def _polars_importable() -> bool:
+    """True when polars can be imported (False in the D6 zero-polars end-state).
+
+    Under the zero-polars import blocker the ``import polars`` raises
+    ImportError, so this returns False and callers take the seam-native path."""
+    try:
+        import polars  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def profile_column(series: Any, name: str | None = None) -> dict[str, Any]:
     """Profile a single column and return a statistics dict.
 
     W3c: internals route through the Column seam (PolarsColumn wraps the
     series -- byte-identical delegation; an ArrowColumn caller gets the same
-    stats via the parity-pinned pc twins)."""
+    stats via the parity-pinned pc twins).
+
+    ``series`` may be a ``pl.Series`` (name + dtype spelling read intrinsically,
+    byte-identical) or an already-seam ``Column`` (polars-free path); on the
+    latter the caller passes ``name`` and dtype falls back to the semantic
+    spelling (the ``pl.Series`` dtype string is unavailable without polars)."""
     col = _as_column(series)
-    if isinstance(series, pl.Series):
+    _is_pl_series = "polars" in sys.modules and isinstance(series, pl.Series)
+    if _is_pl_series:
         name = series.name
         dtype = str(series.dtype)
     else:
-        name = "<column>"
+        name = name if name is not None else "<column>"
         dtype = col.semantic_dtype()
     total = len(col)
     null_count = col.null_count()
@@ -199,7 +219,14 @@ def _columns_as_polars_series(frame: Any) -> list[Any]:
     if isinstance(frame, PolarsFrame):
         native = frame.native
         return [native[c] for c in frame.columns]
-    return [pl.Series(c, frame.column(c).to_arrow()) for c in frame.columns]
+    # Arrow frame: wrap each column as a pl.Series so profile_column reads the
+    # exact same name + polars dtype spelling as the polars lane (byte-identical)
+    # -- but ONLY when polars is importable. In the D6 zero-polars end-state the
+    # wrap is impossible, so hand the caller the seam Column instead (name is
+    # threaded separately in profile_dataframe).
+    if _polars_importable():
+        return [pl.Series(c, frame.column(c).to_arrow()) for c in frame.columns]
+    return [frame.column(c) for c in frame.columns]
 
 
 def _count_all_empty_rows(frame: Any) -> int:
@@ -243,7 +270,13 @@ def profile_dataframe(df: Any) -> dict[str, Any]:
     frame = to_frame(df)
     total_rows = frame.height
     total_columns = len(frame.columns)
-    columns = [profile_column(s) for s in _columns_as_polars_series(frame)]
+    # Thread the column name explicitly: profile_column reads it intrinsically
+    # from a pl.Series (name arg ignored, byte-identical) and from the arg on
+    # the polars-free seam-Column path.
+    columns = [
+        profile_column(s, name=c)
+        for s, c in zip(_columns_as_polars_series(frame), frame.columns)
+    ]
 
     # Duplicate rows: count of rows that appear more than once
     # (== total_rows - distinct_row_count(), full-row identity over all columns).

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1290,7 +1290,7 @@ def find_fuzzy_matches(
         # (to_pylist) on the arrow lane -- both yield a list[dict] of rows.
         block_rows = (
             block_df.to_dicts() if hasattr(block_df, "to_dicts")
-            else block_df.to_pylist()
+            else block_df.to_pylist()  # pyright: ignore[reportAttributeAccessIssue]
         )
         ne_scores = []
         for i, j, s in zip(rows_idx, cols_idx, scores):

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1286,7 +1286,12 @@ def find_fuzzy_matches(
     # v1.11: Apply negative-evidence penalty for weighted matchkeys.
     # NE is per-pair (not vectorized), applied only when mk.negative_evidence is set.
     if mk.negative_evidence:
-        block_rows = block_df.to_dicts()
+        # Dual-rep: block_df may be a pl.DataFrame (to_dicts) or a pa.Table
+        # (to_pylist) on the arrow lane -- both yield a list[dict] of rows.
+        block_rows = (
+            block_df.to_dicts() if hasattr(block_df, "to_dicts")
+            else block_df.to_pylist()
+        )
         ne_scores = []
         for i, j, s in zip(rows_idx, cols_idx, scores):
             row_a = block_rows[int(i)]

--- a/packages/python/goldenmatch/goldenmatch/core/validate.py
+++ b/packages/python/goldenmatch/goldenmatch/core/validate.py
@@ -81,11 +81,17 @@ def validate_dataframe(
     from goldenmatch.core.frame import PolarsFrame, column_from_values, to_frame
 
     validation_report: list[dict] = []
-    if isinstance(df, pl.DataFrame):
-        frame = to_frame(df.clone())
-        backend = "polars"
+    # Discriminate on pa.Table FIRST (never `isinstance(df, pl.DataFrame)` --
+    # that dereferences the lazy `pl` proxy and raises ImportError when polars
+    # is uninstalled, the D6 zero-polars end-state). Arrow tables are immutable
+    # (no clone needed); anything else is treated as the mutable polars lane.
+    import pyarrow as _pa
+
+    if isinstance(df, _pa.Table):
+        frame = to_frame(df)
+        backend = "arrow"
     else:
-        frame = to_frame(df)  # pa.Table is immutable; no clone needed
+        frame = to_frame(df.clone())
         backend = "polars" if isinstance(frame, PolarsFrame) else "arrow"
     height = frame.height
     quarantine_flags: list[bool] = [False] * height

--- a/packages/python/goldenmatch/tests/test_coreapi_aux_no_polars.py
+++ b/packages/python/goldenmatch/tests/test_coreapi_aux_no_polars.py
@@ -1,0 +1,110 @@
+"""Arrow tripwire for the bridge-invoked core-API aux functions.
+
+Runs each aux function the Rust bridge calls (`validate_dataframe`,
+`auto_fix_dataframe`, `detect_anomalies`, `profile_dataframe`, `preflight`,
+`postflight`, `train_em`/`score_probabilistic`) on a `pa.Table` in a
+subprocess with `import polars` BLOCKED (the D6 zero-polars end-state), proving
+the paths the `#1747 [polars]` stopgap covers stay polars-free once the extra is
+dropped from the rust bridge lanes.
+
+Mirrors the `_zero_polars_probe.py` mechanism (a `sys.meta_path` finder that
+raises ImportError on any `polars` import).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_PROBE = textwrap.dedent(
+    """
+    import os, sys
+
+    class _Blocker:
+        def find_module(self, name, path=None):
+            return self if (name == "polars" or name.startswith("polars.")) else None
+        def find_spec(self, name, path=None, target=None):
+            if name == "polars" or name.startswith("polars."):
+                raise ImportError("polars blocked (aux tripwire)")
+            return None
+        def load_module(self, name):
+            raise ImportError("polars blocked (aux tripwire)")
+
+    sys.meta_path.insert(0, _Blocker())
+    os.environ.update(
+        GOLDENMATCH_FRAME="arrow",
+        GOLDENMATCH_NATIVE=os.environ.get("GOLDENMATCH_NATIVE_GATE", "0"),
+        POLARS_SKIP_CPU_CHECK="1",
+        ARROW_DEFAULT_MEMORY_POOL="system",
+        GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE="1",
+        GOLDENMATCH_AUTOCONFIG_MEMORY="0",
+    )
+
+    import pyarrow as pa
+
+    tbl = pa.table({
+        "first": ["ann", "ann", "bob", "cara", "dan", "dan"],
+        "last": ["smith", "smith", "jones", "lee", "poe", "poe"],
+        "email": ["a@x.com", "a@x.com", "b@y.com", "c@z.com", "d@w.com", "d@w.com"],
+    })
+
+    # validate_dataframe
+    from goldenmatch.core.validate import validate_dataframe, ValidationRule
+    v = validate_dataframe(tbl, [ValidationRule(column="email", rule_type="not_null")])
+    assert isinstance(v, tuple), v
+
+    # auto_fix_dataframe
+    from goldenmatch.core.autofix import auto_fix_dataframe
+    fixed, fixes = auto_fix_dataframe(tbl)
+    assert isinstance(fixes, list), fixes
+
+    # detect_anomalies
+    from goldenmatch.core.anomaly import detect_anomalies
+    a = detect_anomalies(tbl)
+    assert isinstance(a, list), a
+
+    # profile_dataframe
+    from goldenmatch.core.profiler import profile_dataframe
+    p = profile_dataframe(tbl)
+    assert p["total_columns"] == 3, p
+    assert [c["name"] for c in p["columns"]] == ["first", "last", "email"], p
+
+    # preflight + postflight over an auto-built config
+    from goldenmatch import auto_configure_df
+    cfg = auto_configure_df(tbl)
+    from goldenmatch.core.autoconfig_verify import preflight
+    pr = preflight(tbl, cfg)
+    assert pr is not None
+
+    # Fellegi-Sunter train_em / score_probabilistic on an arrow block
+    from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+    from goldenmatch.core.probabilistic import train_em, score_probabilistic
+    t = tbl.append_column("__row_id__", pa.array([0, 1, 2, 3, 4, 5], type=pa.int64()))
+    mk = MatchkeyConfig(
+        name="p", type="probabilistic",
+        fields=[MatchkeyField(field="first", scorer="jaro_winkler")],
+    )
+    em = train_em(t, mk, n_sample_pairs=10, max_iterations=2)
+    pairs = score_probabilistic(t, mk, em)
+    assert isinstance(pairs, list), pairs
+
+    # Hard proof: polars never entered sys.modules.
+    assert "polars" not in sys.modules, sorted(m for m in sys.modules if "polars" in m)
+    print("AUX_NO_POLARS_OK")
+    """
+)
+
+
+def test_coreapi_aux_functions_are_polars_free() -> None:
+    """Every bridge-invoked aux core-API function runs on arrow with polars blocked."""
+    res = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert res.returncode == 0, (
+        f"aux tripwire failed (rc={res.returncode})\n"
+        f"STDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+    )
+    assert "AUX_NO_POLARS_OK" in res.stdout, res.stdout

--- a/packages/python/goldenmatch/tests/test_match_arrow_parity.py
+++ b/packages/python/goldenmatch/tests/test_match_arrow_parity.py
@@ -1,0 +1,113 @@
+"""Linkage-parity + polars-free harness for the match pipeline arrow-flip.
+
+Two guarantees, the eviction's own standard:
+1. PARITY: arrow-input `match_df` produces byte-identical linkage (the set of
+   (target_row_id, ref_row_id) matched pairs) to polars-input `match_df`, across
+   diverse shapes.
+2. POLARS-FREE: an arrow-input `match_df` completes in a subprocess with
+   `import polars` BLOCKED (the D6 zero-polars end-state).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pyarrow as pa
+import pytest
+
+# (target, reference) shapes exercising exact + fuzzy linkage.
+_SHAPES = {
+    "exact_email": (
+        {
+            "first": ["ann", "bob", "cara", "dan", "eve"],
+            "last": ["smith", "jones", "lee", "poe", "adams"],
+            "email": ["a@x.com", "b@y.com", "c@z.com", "d@w.com", "e@v.com"],
+        },
+        {
+            "first": ["ann", "cara", "xavier"],
+            "last": ["smith", "lee", "zim"],
+            "email": ["a@x.com", "c@z.com", "x@q.com"],
+        },
+    ),
+    "fuzzy_names": (
+        {
+            "name": ["Jonathan Smith", "Robert Jones", "Catherine Lee", "Daniel Poe"],
+            "city": ["nyc", "la", "sf", "dc"],
+        },
+        {
+            "name": ["Jon Smith", "Cathy Lee", "Xavier Zim"],
+            "city": ["nyc", "sf", "bos"],
+        },
+    ),
+}
+
+
+def _pairs_from_result(result) -> set[tuple]:
+    m = result.matched
+    if m is None:
+        return set()
+    tbl = m if isinstance(m, pa.Table) else m.to_arrow()
+    rows = tbl.to_pylist()
+    return {
+        (r.get("__target_row_id__"), r.get("__ref_row_id__")) for r in rows
+    }
+
+
+@pytest.mark.parametrize("shape", sorted(_SHAPES))
+def test_match_df_arrow_polars_linkage_parity(shape: str) -> None:
+    """Arrow-input match_df yields byte-identical linkage to polars-input."""
+    pl = pytest.importorskip("polars")
+    from goldenmatch import match_df
+
+    tgt, ref = _SHAPES[shape]
+    rp = match_df(pl.DataFrame(tgt), pl.DataFrame(ref))
+    ra = match_df(pa.table(tgt), pa.table(ref))
+    assert _pairs_from_result(ra) == _pairs_from_result(rp), (
+        f"{shape}: arrow linkage {_pairs_from_result(ra)} != "
+        f"polars linkage {_pairs_from_result(rp)}"
+    )
+
+
+_NO_POLARS_PROBE = textwrap.dedent(
+    """
+    import os, sys
+    class _B:
+        def find_spec(self, n, p=None, t=None):
+            if n == "polars" or n.startswith("polars."):
+                raise ImportError("polars blocked (match arrow tripwire)")
+            return None
+        def find_module(self, n, p=None): return None
+        def load_module(self, n): raise ImportError("blocked")
+    sys.meta_path.insert(0, _B())
+    os.environ.update(
+        GOLDENMATCH_FRAME="arrow", POLARS_SKIP_CPU_CHECK="1",
+        ARROW_DEFAULT_MEMORY_POOL="system", GOLDENMATCH_AUTOCONFIG_MEMORY="0",
+        GOLDENMATCH_NATIVE=os.environ.get("GOLDENMATCH_NATIVE_GATE", "0"),
+    )
+    import pyarrow as pa
+    from goldenmatch import match_df
+    tgt = pa.table({"first":["ann","bob","cara","dan","eve"],
+                    "last":["smith","jones","lee","poe","adams"],
+                    "email":["a@x.com","b@y.com","c@z.com","d@w.com","e@v.com"]})
+    ref = pa.table({"first":["ann","cara","xavier"],
+                    "last":["smith","lee","zim"],
+                    "email":["a@x.com","c@z.com","x@q.com"]})
+    res = match_df(tgt, ref)
+    assert res.matched is not None
+    assert "polars" not in sys.modules, sorted(m for m in sys.modules if "polars" in m)
+    print("MATCH_NO_POLARS_OK")
+    """
+)
+
+
+def test_match_df_arrow_is_polars_free() -> None:
+    """Arrow-input match_df completes with `import polars` blocked."""
+    res = subprocess.run(
+        [sys.executable, "-c", _NO_POLARS_PROBE],
+        capture_output=True, text=True, timeout=180,
+    )
+    assert res.returncode == 0 and "MATCH_NO_POLARS_OK" in res.stdout, (
+        f"match arrow tripwire failed (rc={res.returncode})\n"
+        f"STDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
+    )

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -9,6 +9,27 @@ use pyo3::types::{PyAnyMethods, PyDict};
 use crate::convert;
 use crate::error::BridgeError;
 
+/// Row count of a returned frame, dual-rep: a pyarrow Table exposes `num_rows`,
+/// a polars DataFrame exposes `height`. The core-API functions return arrow
+/// tables (their `.native`) on the arrow lane, so `num_rows` is the default.
+fn frame_row_count<'py>(df: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    if df.hasattr("num_rows")? {
+        df.getattr("num_rows")
+    } else {
+        df.getattr("height")
+    }
+}
+
+/// Records of a returned frame as a Python list[dict], dual-rep: pyarrow
+/// `to_pylist` vs polars `to_dicts`.
+fn frame_to_records<'py>(df: &Bound<'py, PyAny>) -> PyResult<Bound<'py, PyAny>> {
+    if df.hasattr("to_pylist")? {
+        df.call_method0("to_pylist")
+    } else {
+        df.call_method0("to_dicts")
+    }
+}
+
 /// Best-effort serialisation of an AutoConfigController `(profile, history,
 /// committed_config)` triple into the JSON shape consumed by the SQL layer.
 ///
@@ -169,7 +190,7 @@ pub fn dedupe(rows_json: &str, config_json: &str) -> Result<DedupeResult, Bridge
         let json_mod = py.import("json")?;
 
         // Build DataFrame from JSON
-        let df = convert::json_to_polars_df(py, rows_json)?;
+        let df = convert::json_to_arrow_df(py, rows_json)?;
 
         // Parse config JSON to kwargs
         let config_dict = json_mod.call_method1("loads", (config_json,))?;
@@ -203,7 +224,7 @@ pub fn dedupe(rows_json: &str, config_json: &str) -> Result<DedupeResult, Bridge
         // Extract golden DataFrame as JSON
         let golden_json = if let Ok(golden) = result.getattr("golden") {
             if !golden.is_none() {
-                Some(convert::polars_df_to_json(
+                Some(convert::arrow_df_to_json(
                     py,
                     &golden.into_pyobject(py).unwrap().unbind(),
                 )?)
@@ -257,7 +278,7 @@ pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, B
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
-        let df = convert::json_to_polars_df(py, rows_json)?;
+        let df = convert::json_to_arrow_df(py, rows_json)?;
         let cfg = build_full_config(py, config_json)?;
 
         let kwargs = PyDict::new(py);
@@ -266,7 +287,7 @@ pub fn dedupe_full(rows_json: &str, config_json: &str) -> Result<DedupeResult, B
 
         let golden_json = if let Ok(golden) = result.getattr("golden") {
             if !golden.is_none() {
-                Some(convert::polars_df_to_json(
+                Some(convert::arrow_df_to_json(
                     py,
                     &golden.into_pyobject(py).unwrap().unbind(),
                 )?)
@@ -332,7 +353,7 @@ pub fn autoconfig(rows_json: &str, mode: &str) -> Result<AutoConfigResult, Bridg
     };
 
     Python::with_gil(|py| {
-        let df = convert::json_to_polars_df(py, rows_json)?;
+        let df = convert::json_to_arrow_df(py, rows_json)?;
         let autoconfig_mod = py.import("goldenmatch.core.autoconfig")?;
         let cfg = autoconfig_mod.call_method1(fn_name, (df,))?;
 
@@ -378,8 +399,8 @@ pub fn match_tables(
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
-        let target_df = convert::json_to_polars_df(py, target_json)?;
-        let ref_df = convert::json_to_polars_df(py, reference_json)?;
+        let target_df = convert::json_to_arrow_df(py, target_json)?;
+        let ref_df = convert::json_to_arrow_df(py, reference_json)?;
 
         let config_dict = json_mod.call_method1("loads", (config_json,))?;
 
@@ -404,7 +425,7 @@ pub fn match_tables(
 
         let matched_json = if let Ok(matched) = result.getattr("matched") {
             if !matched.is_none() {
-                Some(convert::polars_df_to_json(
+                Some(convert::arrow_df_to_json(
                     py,
                     &matched.into_pyobject(py).unwrap().unbind(),
                 )?)
@@ -417,7 +438,7 @@ pub fn match_tables(
 
         let unmatched_json = if let Ok(unmatched) = result.getattr("unmatched") {
             if !unmatched.is_none() {
-                Some(convert::polars_df_to_json(
+                Some(convert::arrow_df_to_json(
                     py,
                     &unmatched.into_pyobject(py).unwrap().unbind(),
                 )?)
@@ -468,12 +489,12 @@ pub fn match_pairs(
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
-        let target_df = convert::json_to_polars_df(py, target_json)?;
-        let ref_df = convert::json_to_polars_df(py, reference_json)?;
+        let target_df = convert::json_to_arrow_df(py, target_json)?;
+        let ref_df = convert::json_to_arrow_df(py, reference_json)?;
 
         // target rows occupy combined __row_id__ space 0..target_len-1; the
         // reference's __ref_row_id__ is offset by target_len.
-        let target_len: i64 = target_df.getattr(py, "height")?.extract(py)?;
+        let target_len: i64 = frame_row_count(target_df.bind(py))?.extract()?;
 
         let config_dict = json_mod.call_method1("loads", (config_json,))?;
 
@@ -493,30 +514,21 @@ pub fn match_pairs(
         if matched.is_none() {
             return Ok(vec![]);
         }
-        // v3.0.0: `MatchResult.matched` is a pyarrow Table (indexing yields a
-        // ChunkedArray, which has no `to_list`). Convert to polars at the seam so
-        // the column-extract below (`[col].to_list()`) keeps working unchanged.
-        let matched = {
-            let pl = matched.py().import("polars")?;
-            pl.call_method1("from_arrow", (&matched,))?
-        };
-
-        // Pull the three linkage columns off the matched Polars DataFrame as
-        // Python lists (matched[col].to_list()). The id columns are Int64; the
-        // score column is float. This mirrors the existing pyo3 column-extract
-        // style used elsewhere in the bridge and avoids a serde dependency in
-        // the runtime crate.
+        // v3.0.0: `MatchResult.matched` is a pyarrow Table. Pull the three
+        // linkage columns off it directly, polars-free (arrow-native bridge):
+        // `table.column(name)` -> ChunkedArray -> `to_pylist()` -> Python list.
+        // The id columns are Int64; the score column is float.
         let t_ids: Vec<i64> = matched
-            .get_item("__target_row_id__")?
-            .call_method0("to_list")?
+            .call_method1("column", ("__target_row_id__",))?
+            .call_method0("to_pylist")?
             .extract()?;
         let r_ids: Vec<i64> = matched
-            .get_item("__ref_row_id__")?
-            .call_method0("to_list")?
+            .call_method1("column", ("__ref_row_id__",))?
+            .call_method0("to_pylist")?
             .extract()?;
         let scores: Vec<f64> = matched
-            .get_item("__match_score__")?
-            .call_method0("to_list")?
+            .call_method1("column", ("__match_score__",))?
+            .call_method0("to_pylist")?
             .extract()?;
 
         let mut out = Vec::with_capacity(t_ids.len());
@@ -627,7 +639,7 @@ pub fn dedupe_pairs(rows_json: &str, config_json: &str) -> Result<Vec<ScoredPair
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
-        let df = convert::json_to_polars_df(py, rows_json)?;
+        let df = convert::json_to_arrow_df(py, rows_json)?;
         let config_dict = json_mod.call_method1("loads", (config_json,))?;
 
         let kwargs = PyDict::new(py);
@@ -678,7 +690,7 @@ pub fn dedupe_clusters(
         let gm = py.import("goldenmatch")?;
         let json_mod = py.import("json")?;
 
-        let df = convert::json_to_polars_df(py, rows_json)?;
+        let df = convert::json_to_arrow_df(py, rows_json)?;
         let config_dict = json_mod.call_method1("loads", (config_json,))?;
 
         let kwargs = PyDict::new(py);
@@ -1228,20 +1240,24 @@ fn build_probabilistic_frame<'py>(
     py: Python<'py>,
     rows_json: &str,
 ) -> Result<Bound<'py, PyAny>, BridgeError> {
-    let pl = py.import("polars")?;
-    let io = py.import("io")?;
-    let string_io = io.call_method1("StringIO", (rows_json,))?;
-    let df = pl.call_method1("read_json", (string_io,))?;
-    let columns: Vec<String> = df.getattr("columns")?.extract()?;
-    if columns.iter().any(|c| c == "__row_id__") {
-        return Ok(df);
+    // Arrow-native (no polars): build a pa.Table and append an Int64
+    // `__row_id__` position column when absent. The FS `train_em` /
+    // `score_probabilistic` core functions accept a pa.Table directly.
+    let pa = py.import("pyarrow")?;
+    let table = convert::json_to_arrow_df(py, rows_json)?.into_bound(py);
+    let names: Vec<String> = table.getattr("column_names")?.extract()?;
+    if names.iter().any(|c| c == "__row_id__") {
+        return Ok(table);
     }
-    let df = df.call_method1("with_row_index", ("__row_id__",))?;
-    let int64 = pl.getattr("Int64")?;
-    let col = pl.call_method1("col", ("__row_id__",))?;
-    let cast = col.call_method1("cast", (int64,))?;
-    let df = df.call_method1("with_columns", (cast,))?;
-    Ok(df)
+    let n_rows: usize = table.getattr("num_rows")?.extract()?;
+    let builtins = py.import("builtins")?;
+    let rng = builtins.call_method1("range", (n_rows,))?;
+    let int64 = pa.getattr("int64")?.call0()?;
+    let kwargs = PyDict::new(py);
+    kwargs.set_item("type", int64)?;
+    let row_ids = pa.call_method("array", (rng,), Some(&kwargs))?;
+    let table = table.call_method1("append_column", ("__row_id__", row_ids))?;
+    Ok(table)
 }
 
 /// Wrap `goldenmatch.profile_dataframe` -- comprehensive table profile.
@@ -1253,7 +1269,7 @@ pub fn profile_table(rows_json: &str) -> Result<String, BridgeError> {
     Python::with_gil(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let report = gm.call_method1("profile_dataframe", (df,))?;
             py_json_dumps(py, report)
         })();
@@ -1477,7 +1493,7 @@ pub fn validate_table(rows_json: &str, rules_json: &str) -> Result<String, Bridg
             let json_mod = py.import("json")?;
             let builtins = py.import("builtins")?;
 
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let rules_spec = if rules_json.is_empty() {
                 builtins.call_method0("list")?
             } else {
@@ -1510,9 +1526,9 @@ pub fn validate_table(rows_json: &str, rules_json: &str) -> Result<String, Bridg
 
             let result = PyDict::new(py);
             result.set_item("report", report)?;
-            result.set_item("valid_rows", valid_df.getattr("height")?)?;
-            result.set_item("quarantine_rows", quarantine_df.getattr("height")?)?;
-            result.set_item("quarantine", quarantine_df.call_method0("to_dicts")?)?;
+            result.set_item("valid_rows", frame_row_count(&valid_df)?)?;
+            result.set_item("quarantine_rows", frame_row_count(&quarantine_df)?)?;
+            result.set_item("quarantine", frame_to_records(&quarantine_df)?)?;
             py_json_dumps(py, result.into_any())
         })();
         Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
@@ -1527,14 +1543,14 @@ pub fn autofix_table(rows_json: &str) -> Result<String, BridgeError> {
     Python::with_gil(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let out = gm.call_method1("auto_fix_dataframe", (df,))?;
             let fixed_df = out.get_item(0)?;
             let fixes = out.get_item(1)?;
             let result = PyDict::new(py);
             result.set_item("fixes", fixes)?;
-            result.set_item("fixed_rows", fixed_df.getattr("height")?)?;
-            result.set_item("rows", fixed_df.call_method0("to_dicts")?)?;
+            result.set_item("fixed_rows", frame_row_count(&fixed_df)?)?;
+            result.set_item("rows", frame_to_records(&fixed_df)?)?;
             py_json_dumps(py, result.into_any())
         })();
         Ok(result.unwrap_or_else(|e| error_json(&e.to_string())))
@@ -1549,7 +1565,7 @@ pub fn detect_anomalies(rows_json: &str, sensitivity: &str) -> Result<String, Br
     Python::with_gil(|py| {
         let result: Result<String, BridgeError> = (|| {
             let gm = py.import("goldenmatch")?;
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let sens = if sensitivity.is_empty() {
                 "medium"
             } else {
@@ -1574,7 +1590,7 @@ pub fn preflight(rows_json: &str, config_json: &str) -> Result<String, BridgeErr
         let result: Result<String, BridgeError> = (|| {
             let verify = py.import("goldenmatch.core.autoconfig_verify")?;
             let dataclasses = py.import("dataclasses")?;
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let config = build_full_config(py, config_json)?;
             let report = verify.call_method1("preflight", (df, config))?;
 
@@ -1608,7 +1624,7 @@ pub fn postflight(rows_json: &str, config_json: &str) -> Result<String, BridgeEr
             let gm = py.import("goldenmatch")?;
             let verify = py.import("goldenmatch.core.autoconfig_verify")?;
             let dataclasses = py.import("dataclasses")?;
-            let df = convert::json_to_polars_df(py, rows_json)?;
+            let df = convert::json_to_arrow_df(py, rows_json)?;
             let config = build_full_config(py, config_json)?;
 
             let dedupe_kwargs = PyDict::new(py);

--- a/packages/rust/extensions/bridge/src/convert.rs
+++ b/packages/rust/extensions/bridge/src/convert.rs
@@ -7,63 +7,48 @@
 use crate::error::BridgeError;
 use pyo3::prelude::*;
 
-/// Convert a JSON string of records into a Python Polars DataFrame.
+/// Convert a JSON string of records into a Python **pyarrow Table**.
 ///
-/// Uses Polars' native JSON reader. For table data from Postgres SPI
-/// (which comes as JSON via row_to_json), this is the natural path.
-pub fn json_to_polars_df(py: Python<'_>, json_records: &str) -> Result<PyObject, BridgeError> {
-    let pl = py.import("polars")?;
-    let io = py.import("io")?;
+/// Arrow-native (no polars): `json.loads` -> `pyarrow.Table.from_pylist`. The
+/// goldenmatch core-API surface (dedupe / auto_configure / match + the aux
+/// validate/autofix/anomaly/profile/preflight/postflight functions) is
+/// arrow-native, so a `pa.Table` feeds every call site directly. This is what
+/// lets the bridge lanes run without the `[polars]` extra (D6 zero-polars).
+///
+/// For table data from Postgres SPI (JSON via `row_to_json`), `from_pylist`
+/// infers the schema the same way `pl.read_json` did.
+pub fn json_to_arrow_df(py: Python<'_>, json_records: &str) -> Result<PyObject, BridgeError> {
+    let json_mod = py.import("json")?;
+    let pa = py.import("pyarrow")?;
 
-    let string_io = io.call_method1("StringIO", (json_records,))?;
-    let df = pl.call_method1("read_json", (string_io,))?;
+    let records = json_mod.call_method1("loads", (json_records,))?;
+    let table = pa
+        .getattr("Table")?
+        .call_method1("from_pylist", (records,))?;
 
-    Ok(df.into_pyobject(py).unwrap().unbind())
+    Ok(table.into_pyobject(py).unwrap().unbind())
 }
 
-/// Convert a Python Polars DataFrame (or a pyarrow Table) to a JSON string of records.
+/// Convert a pyarrow Table (or a genuine Polars DataFrame) to a JSON string of records.
 ///
-/// v3.0.0: `DedupeResult.golden` / `MatchResult.matched` are now pyarrow Tables
-/// (no `write_json`). Convert arrow -> polars at this seam; a genuine polars frame
-/// (which has `write_json`) passes through unchanged.
-pub fn polars_df_to_json(py: Python<'_>, df: &PyObject) -> Result<String, BridgeError> {
+/// Arrow-native (no polars): a `pa.Table` goes `to_pylist` -> `json.dumps`. A
+/// genuine polars frame (which still has `write_json`, e.g. when a caller passes
+/// one on the polars lane) passes through `write_json` unchanged for
+/// byte-identical output. `DedupeResult.golden` / `MatchResult.matched` are
+/// pyarrow Tables since v3.0.0, so the arrow branch is the default.
+pub fn arrow_df_to_json(py: Python<'_>, df: &PyObject) -> Result<String, BridgeError> {
     let bound = df.bind(py);
-    let frame = if bound.hasattr("write_json")? {
-        bound.clone()
-    } else {
-        let pl = py.import("polars")?;
-        pl.call_method1("from_arrow", (bound,))?
-    };
-    let json_bytes = frame.call_method0("write_json")?;
-    let json_str: String = json_bytes.extract()?;
+    if bound.hasattr("write_json")? {
+        // Genuine polars frame -> byte-identical legacy path (polars present).
+        let json_bytes = bound.call_method0("write_json")?;
+        let json_str: String = json_bytes.extract()?;
+        return Ok(json_str);
+    }
+    // pa.Table -> list[dict] -> JSON array of record objects.
+    let json_mod = py.import("json")?;
+    let records = bound.call_method0("to_pylist")?;
+    let json_str: String = json_mod.call_method1("dumps", (records,))?.extract()?;
     Ok(json_str)
-}
-
-/// Convert a Python Polars DataFrame to Arrow IPC bytes.
-///
-/// Uses Polars' native `write_ipc` to serialize as Arrow IPC format.
-/// This is much faster than JSON for large DataFrames (avoids string
-/// conversion for every cell).
-pub fn polars_df_to_arrow_ipc(py: Python<'_>, df: &PyObject) -> Result<Vec<u8>, BridgeError> {
-    let io = py.import("io")?;
-    let buf = io.call_method0("BytesIO")?;
-    df.call_method1(py, "write_ipc", (&buf,))?;
-    buf.call_method1("seek", (0,))?;
-    let bytes: Vec<u8> = buf.call_method0("read")?.extract()?;
-    Ok(bytes)
-}
-
-/// Convert Arrow IPC bytes to a Python Polars DataFrame.
-///
-/// Uses Polars' native `read_ipc` to deserialize Arrow IPC format.
-pub fn arrow_ipc_to_polars_df(py: Python<'_>, ipc_bytes: &[u8]) -> Result<PyObject, BridgeError> {
-    let pl = py.import("polars")?;
-    let io = py.import("io")?;
-
-    let buf = io.call_method1("BytesIO", (ipc_bytes,))?;
-    let df = pl.call_method1("read_ipc", (buf,))?;
-
-    Ok(df.into_pyobject(py).unwrap().unbind())
 }
 
 #[cfg(test)]
@@ -75,44 +60,21 @@ mod tests {
         pyo3::prepare_freethreaded_python();
 
         Python::with_gil(|py| {
-            if py.import("polars").is_err() {
-                eprintln!("Skipping test (polars not installed)");
+            // Arrow-native path: needs pyarrow (a hard goldenmatch dep), NOT polars.
+            if py.import("pyarrow").is_err() {
+                eprintln!("Skipping test (pyarrow not installed)");
                 return;
             }
 
             let json = r#"[{"name": "John", "email": "j@x.com"}, {"name": "Jane", "email": "jane@y.com"}]"#;
-            let df = json_to_polars_df(py, json).unwrap();
-            let back = polars_df_to_json(py, &df).unwrap();
+            let df = json_to_arrow_df(py, json).unwrap();
+            // Proof the frame is arrow, not polars.
+            let ty: String = df.bind(py).get_type().name().unwrap().extract().unwrap();
+            assert_eq!(ty, "Table", "json_to_arrow_df must return a pyarrow Table");
 
+            let back = arrow_df_to_json(py, &df).unwrap();
             assert!(back.contains("John"));
             assert!(back.contains("Jane"));
-        });
-    }
-
-    #[test]
-    fn test_arrow_ipc_roundtrip() {
-        pyo3::prepare_freethreaded_python();
-
-        Python::with_gil(|py| {
-            if py.import("polars").is_err() {
-                eprintln!("Skipping test (polars not installed)");
-                return;
-            }
-
-            // Create a DataFrame via JSON
-            let json = r#"[{"name": "John", "score": 0.95}, {"name": "Jane", "score": 0.87}]"#;
-            let df = json_to_polars_df(py, json).unwrap();
-
-            // Roundtrip through Arrow IPC
-            let ipc_bytes = polars_df_to_arrow_ipc(py, &df).unwrap();
-            assert!(!ipc_bytes.is_empty());
-
-            let df2 = arrow_ipc_to_polars_df(py, &ipc_bytes).unwrap();
-            let json2 = polars_df_to_json(py, &df2).unwrap();
-
-            assert!(json2.contains("John"));
-            assert!(json2.contains("Jane"));
-            assert!(json2.contains("0.95"));
         });
     }
 }


### PR DESCRIPTION
Completes the bridge core-API arrow-port and **drops the #1747 `[polars]` CI stopgap** — self-validating against current source (no PyPI release needed). Supersedes #1770.

## The real blocker, solved
The drop was gated on the **match pipeline** being polars — `run_match_df` + `_run_match_pipeline` are a separate pipeline from the arrow-ported dedupe one and were still fully polars. This PR arrow-flips them (mirroring the dedupe frame-lane), so cross-source `match_df` runs polars-free.

## What
- **Match pipeline arrow-flip** (`pipeline.py`): `run_match_df` builds the combined frame with pyarrow when inputs are `pa.Table`; `_run_match_pipeline` gets an arrow prep branch + a new arrow-native `_run_match_scoring_and_output` (exact/fuzzy/FS/rerank/llm/memory/postflight/output on the seam frame + pyarrow). Polars path byte-identical.
- **Autoconfig cross-source**: stop force-coercing the `reference` run to polars; accept a `pa.Table` reference. Fixed downstream `.columns`/`.height` leaks (`autoconfig_rules`, `autoconfig_controller`) + scorer NE `to_dicts`→dual-rep.
- **Aux core-API fixes** (from #1770): `validate_dataframe`/`detect_anomalies`/`autoconfig_memory`/`profiler` discriminators + seam routing.
- **Bridge** (`convert.rs`/`api.rs`): `json_to_arrow_df`/`arrow_df_to_json`; `build_probabilistic_frame`→arrow; MatchResult extract→`column().to_pylist()`; **glue fix** — `validate_table`/`autofix_table`/match `target_len` read `.height`/`.to_dicts` on the now-arrow return (new `frame_row_count`/`frame_to_records` dual-rep helpers).
- **CI**: `rust` + `rust_coverage` bridge lanes install the LOCAL base goldenmatch (no `[polars]`).

## Validation
- **Linkage parity harness** (`tests/test_match_arrow_parity.py`): arrow-input `match_df` yields **byte-identical** matched pairs to polars-input (exact + fuzzy), AND completes with `import polars` BLOCKED (`polars not in sys.modules`).
- Aux arrow tripwire (`tests/test_coreapi_aux_no_polars.py`).
- 39 match + 148 dedupe/autoconfig/scorer tests green (polars path unchanged). Bridge: the 4 previously-arrow-failing tests now pass locally; clippy `-D warnings` + fmt clean. The full polars-absent + native-present run is what this PR's `rust` lane proves.

Scope + the layer-by-layer diagnosis: `docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)