### PR TITLE
docs: mark the #1747 [polars] drop complete + track the follow-up

### DIFF
--- a/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
+++ b/docs/superpowers/plans/2026-07-14-bridge-coreapi-arrow-port-stopgap-drop.md
@@ -6,7 +6,21 @@
 > `convert.rs::json_to_polars_df` + the bridge's whole Python core-API surface.
 > Scope only; do NOT implement without approval.
 
-## STATUS 2026-07-14 (FINAL) — DROP IMPLEMENTED + armed in PR #1772
+## STATUS 2026-07-14 (COMPLETE) — DROP MERGED to main (PR #1772, 21:04Z)
+
+`[polars]` stopgap DROPPED across all three bridge lanes (rust/rust_coverage/
+rust_pgrx); `ci-required` green. The match-pipeline arrow-flip landed. Plan
+COMPLETE.
+
+**One tracked follow-up (NOT a regression, pre-existing, out of scope):** a direct
+caller holding BOTH the `[polars]` extra AND `goldenmatch-native`, calling
+`dedupe_df(pa.Table)`, hits a `_polars_importable()`-gated "polars-present WALL
+optimization" that does `.height` on the arrow frame (surfaced in the pgrx lane
+before it too dropped `[polars]`; needs a native box to reproduce). Fix in the
+golden/pipeline `_polars_importable()` path separately. The bridge lanes are
+polars-free so this never fires there.
+
+## (superseded) STATUS — DROP IMPLEMENTED + armed in PR #1772
 
 The match-pipeline arrow-flip turned out **tractable, not multi-week** (the seam
 primitives already existed) and is DONE. PR #1772 (supersedes #1770) is the


### PR DESCRIPTION
Doc-only. Records that the bridge core-API arrow-port + match-pipeline arrow-flip + `[polars]` stopgap drop landed in #1772, and tracks the one follow-up (dedupe_df(pa.Table) with both the `[polars]` extra + `goldenmatch-native` hits a `_polars_importable()`-gated `.height`-on-arrow path; bridge lanes are polars-free so it never fires there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)