### PR TITLE
feat(goldenmatch): native FS negative-evidence + fused N-level (goldenmatch-native 0.1.15)

### DIFF
--- a/docs/superpowers/plans/2026-07-14-native-fs-ne-port.md
+++ b/docs/superpowers/plans/2026-07-14-native-fs-ne-port.md
@@ -1,0 +1,348 @@
+# Native FS_SUPPORTS_NE Port Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Port FS negative-evidence scoring into the native Rust kernels (`score_block_pairs_fs`
+AND `match_fused_fs`), close fused's `level_thresholds` gap, and widen the Python gates so
+NE-bearing matchkeys use the fast paths — shipped as goldenmatch-native 0.1.15.
+
+**Spec:** `docs/superpowers/specs/2026-07-14-native-fs-ne-port-design.md` — READ IT FIRST. It pins
+the FFI shape (flat optional kwargs), the `_ne_fired` semantics (both present post-transform +
+non-empty + STRICT `<`), the two capability consts, the fused derive_from decline, and the
+tolerance discipline.
+
+**Architecture:** Python precomputes everything semantic (transforms via
+`_field_values_for_block`/`_field_values_from_list`, `w_fired` from `__ne__` entries or
+`penalty_bits`); the kernels add one additive check per NE field per pair. Old wheels never see
+the new kwargs (send-only-when-present + capability-const gates).
+
+**Tech Stack:** Rust (pyo3 abi3, rayon, arrow), Python 3.12, pytest. In-tree kernel builds via
+`scripts/build_native.py`.
+
+---
+
+## Environment / repo mechanics (read before Task R0)
+
+- Work in a NEW worktree `D:\show_case\gm-native-ne`, branch `feat/native-fs-ne` off
+  freshly-fetched `origin/main`. **NEVER `git stash`.** (This feature has NO file overlap with
+  the in-flight fan-out lever PR #1771 — it touches probabilistic.py's scoring tail,
+  fused_match.py, and the Rust crate; #1771 touched splink_upgrade*/loader only.)
+- Python tests via the MAIN checkout's venv + worktree PYTHONPATH (Git Bash):
+  `cd /d/show_case/gm-native-ne/packages/python/goldenmatch && PYTHONPATH="D:/show_case/gm-native-ne/packages/python/goldenmatch" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <tests> -q`
+  NOTE: do NOT set `GOLDENMATCH_NATIVE=0` for the parity/native tests in this plan — they need
+  the kernel. Tests that don't need native are harmless either way.
+- **Rust toolchain on this box** (memory `reference_rustup_proxy_exfat_direct_binary` + root
+  CLAUDE.md): call cargo via the direct toolchain path with an explicit CARGO_HOME —
+  `export PATH="/d/.rustup/toolchains/1.94.0/bin:$PATH" CARGO_HOME="D:/.cargo"` (cargo defaults
+  CARGO_HOME to the drive root on D: otherwise). Verify with `cargo --version` before building.
+- **In-tree kernel build — WINDOWS GOTCHA (verified against the script):**
+  `scripts/build_native.py` only looks for `target/release/lib_native.{so,dylib}` and copies to
+  `_native.abi3.so` — on Windows the cdylib builds as `target\release\_native.dll` and CPython
+  imports `_native.pyd`, so the script exits 1 AFTER a successful cargo build. Task R0 patches
+  the script (drive-by fix that lands in the PR): add a win32 branch to the artifact lookup —
+  `target/release/_native.dll` → copy to `packages/python/goldenmatch/goldenmatch/_native.pyd`.
+  (The main checkout's `_native.pyd` proves prior sessions did this copy manually.) Build
+  command from the worktree root:
+  `PATH="/d/.rustup/toolchains/1.94.0/bin:$PATH" CARGO_HOME="D:/.cargo" D:/show_case/goldenmatch/.venv/Scripts/python.exe scripts/build_native.py`
+  The loader prefers `goldenmatch._native` (in-tree) over the wheel, and PYTHONPATH points at
+  the worktree, so tests see the fresh kernel. Rebuild after EVERY Rust change.
+  Verify each build explicitly (memory `feedback_verify_rust_builds_explicitly`): check exit
+  code AND probe, e.g.
+  `python -c "from goldenmatch.core._native_loader import native_module; print(native_module().__file__)"`
+  (and from R1 on, print the new const) — piped tails mask failures.
+- **Lint:** ruff on Python; `cargo clippy --all-targets -- -D warnings` from the crate dir
+  (CI runs `-D warnings`; local default doesn't — memory `feedback_ci_clippy_dwarnings_native_ext`);
+  `rustfmt <touched .rs files by name>` (NOT `cargo fmt` — repo-wide fmt is poisoned, memory
+  `reference_rust_fmt_box_and_nonrequired_gate`).
+- `docs/superpowers/` is gitignored: `git add -f` the spec + plan.
+- Push/PR auth dance: `unset GH_TOKEN`; push via
+  `git push "https://x-access-token:$(gh auth token --user benzsevern)@github.com/benseverndev-oss/goldenmatch.git" <branch>`;
+  PR via `GH_TOKEN=$(gh auth token --user benzsevern) gh pr create ...`; arm
+  `gh pr merge --auto <N>` and STOP (never poll CI).
+- Commit trailers on every commit:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs`
+
+**Key existing code (all paths worktree-relative):**
+- `packages/rust/extensions/native/src/score.rs` — `score_block_pairs_fs` (~273; signature ~268,
+  level_thresholds validation ~293-312, hoisted `field_thresholds` ~316, inner loop ~330-360),
+  `fs_level_from_sim` (~208), `fs_normalize`, `score_one` re-import (~15), `StrCol` (~380).
+- `packages/rust/extensions/native/src/fused.rs` — `match_fused_fs` (~219; signature ~214-233,
+  `read_ids_and_fields`/`read_key_cols`, `fused_gather` span loop ~253-285 with the
+  `fs_level_from_sim(..., None)` call ~269 and its "port the kwarg when the fused path goes
+  live" comment).
+- `packages/rust/extensions/native/src/lib.rs` — `m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)`
+  (line 30), function registrations.
+- `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` — `_ne_fired` (466),
+  `_fs_native_eligible` (2264: the `if mk.negative_evidence: return False` at 2287),
+  `score_probabilistic_native` (2311: NE comment ~2338-2343, `fs_weight_range` call 2344,
+  `_field_values_for_block` usage 2352, kwarg-send discipline 2363-2377),
+  `_NATIVE_FS_SCORER_IDS`, `fs_weight_range` (1468), `_field_values_for_block` (1710).
+- `packages/python/goldenmatch/goldenmatch/core/fused_match.py` — `match_fused_fs_ready` (255;
+  NE decline 283, level_thresholds condition 290), `run_match_fused_fs_arrow` (hand-rolled
+  min/max 341-342, `src_cols` 332, score_arrs prep loop ~355-360, kernel call ~362).
+- `packages/python/goldenmatch/tests/test_native_parity.py` — module-level
+  `pytest.mark.skipif` when the kernel is absent (line 16); FS parity test conventions.
+- `packages/python/goldenmatch/tests/test_fs_ne_e2e.py` — the homonym fixture (reuse its
+  builders for the native success bar).
+- Version files (bump ALL THREE in R5): `packages/rust/extensions/native/Cargo.toml`,
+  `packages/rust/extensions/native/pyproject.toml`,
+  `packages/rust/extensions/native/python/goldenmatch_native/__init__.py`.
+- `scripts/check_native_symbols.py` — `_MADD` regex already parses `m.add` consts.
+
+## File structure
+
+- Modify: `packages/rust/extensions/native/src/score.rs` (NE kwargs + validation + loop)
+- Modify: `packages/rust/extensions/native/src/fused.rs` (NE + level_thresholds kwargs)
+- Modify: `packages/rust/extensions/native/src/lib.rs` (two consts)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/probabilistic.py` (gate + caller)
+- Modify: `packages/python/goldenmatch/goldenmatch/core/fused_match.py` (gate + caller)
+- Create: `packages/python/goldenmatch/tests/test_native_fs_ne.py` (kernel-direct + gate +
+  parity + native success bar; module-level skipif-no-kernel like test_native_parity.py)
+- Modify: `packages/python/goldenmatch/tests/test_fused_match.py` (fused NE/level_thresholds
+  gate + parity additions — find the existing fused test file first: `ls tests/ | grep fused`;
+  if the fused tests live elsewhere, extend THAT file and note it)
+- Modify (R5): the three version files.
+
+---
+
+### Task R0: Worktree + baseline build + commit spec/plan
+
+- [ ] **Step 1:** From `D:\show_case\goldenmatch`: `git fetch origin main -q && git worktree add /d/show_case/gm-native-ne -b feat/native-fs-ne origin/main`
+- [ ] **Step 2:** Copy spec + this plan into the worktree under `docs/superpowers/{specs,plans}/`;
+  `git add -f` both; commit `docs: spec + plan for the native FS_SUPPORTS_NE port` (+ trailers).
+- [ ] **Step 3:** Patch `scripts/build_native.py` per the environment-block gotcha (win32
+  artifact `target/release/_native.dll` → dest `goldenmatch/_native.pyd`; keep the .so/.dylib
+  branches for Linux/mac), then run the baseline in-tree build → exit 0, artifact at
+  `packages/python/goldenmatch/goldenmatch/_native.pyd` in the WORKTREE, loader probe shows the
+  worktree path. Commit the script patch separately:
+  `fix(scripts): build_native.py produces the in-tree kernel on Windows` (+ trailers).
+- [ ] **Step 4:** Baseline sanity: run `pytest tests/test_native_parity.py -q` (worktree
+  PYTHONPATH, NO GOLDENMATCH_NATIVE=0) → all pass/skip-free (the kernel is present). Also
+  `pytest tests/test_fs_ne_e2e.py tests/test_fs_ne_scoring.py tests/test_fs_ne_guards.py -q` →
+  green. If ANY red, STOP and investigate before changing code.
+
+### Task R1: Rust — `score_block_pairs_fs` NE kwargs + `FS_SUPPORTS_NE`
+
+**Files:** Modify `packages/rust/extensions/native/src/score.rs`, `src/lib.rs`.
+**Test:** Create `packages/python/goldenmatch/tests/test_native_fs_ne.py` (kernel-direct tests).
+
+- [ ] **Step 1: Failing tests** (new file; module-level skipif copied from
+  test_native_parity.py:16). Call the kernel DIRECTLY via
+  `goldenmatch.core._native_loader.native_module()`:
+  - `test_kernel_exports_fs_supports_ne`: `getattr(mod, "FS_SUPPORTS_NE", False) is True`.
+  - `test_kernel_ne_fires_strictly_below_threshold`: one 3-row block, one regular exact field
+    (identical values → full agreement weight), one NE field with `ne_scorer_ids=[3]` (exact),
+    `ne_thresholds=[0.5]`, `ne_weights=[-4.0]`: rows with DIFFERENT ne values (sim 0.0 < 0.5 →
+    fires, total drops by 4.0) vs IDENTICAL ne values (sim 1.0 → no fire). Assert both pairs'
+    normalized scores against hand-computed expectations (pick min_weight/weight_range including
+    the NE contribution the way `fs_weight_range` would: min includes -4.0). Include a pair where
+    sim == threshold is NOT constructible with exact (sim ∈ {0,1}) — strictness is pinned in the
+    parity task with token_sort instead.
+  - `test_kernel_ne_null_and_empty_never_fire`: NE values `None` on one side, and `""` on one
+    side → no contribution (score equals the no-NE-field score).
+  - `test_kernel_ne_validation_errors`: mismatched lengths (ne_values vs ne_scorer_ids), partial
+    kwarg group (ne_values without ne_weights), ne_values row count != row_ids length → each
+    raises `ValueError` with a message naming `score_block_pairs_fs`.
+- [ ] **Step 2:** Run → FAIL (`FS_SUPPORTS_NE` missing / unexpected keyword).
+- [ ] **Step 3: Implement** in `score.rs`:
+  - Extend the `#[pyo3(signature = (...))]` with
+    `ne_values=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None` after
+    `level_thresholds=None`; parameters:
+    ```rust
+    ne_values: Option<Vec<Vec<Option<String>>>>,
+    ne_scorer_ids: Option<Vec<u8>>,
+    ne_thresholds: Option<Vec<f64>>,
+    ne_weights: Option<Vec<f64>>,
+    ```
+  - Upfront validation (before the spans loop, style-matching the level_thresholds block):
+    all four `Some`-or-`None` together (else PyValueError "ne_* kwargs must be passed
+    together"); equal lengths across the four; every `ne_values[k].len() == row_ids.len()`.
+    Bind a hoisted `ne: Vec<(&[Option<String>], u8, f64, f64)>` (or parallel slices) for the
+    hot loop — mirror the `field_thresholds` hoisting comment.
+  - Inner loop, after the regular-field sum, before `fs_normalize` (spec-pinned snippet):
+    ```rust
+    for k in 0..n_ne {
+        if let (Some(a), Some(b)) = (&ne_vals[k][i], &ne_vals[k][j]) {
+            if !a.is_empty() && !b.is_empty()
+                && score_one(ne_scorer_ids_v[k], a, b) < ne_thresholds_v[k] {
+                total_weight += ne_weights_v[k];
+            }
+        }
+    }
+    ```
+    with a doc-comment citing `_ne_fired` (core/probabilistic.py:466) and the empty-string =
+    inconclusive rule. Update the function's doc comment (NE paragraph + old-wheel note).
+  - `lib.rs`: `m.add("FS_SUPPORTS_NE", true)?;` next to `FS_SUPPORTS_LEVEL_THRESHOLDS`.
+- [ ] **Step 4:** Rebuild in-tree (verify explicitly); run the new tests → PASS; run
+  `pytest tests/test_native_parity.py -q` → still green (no regression on the extended
+  signature).
+- [ ] **Step 5:** `cargo clippy --all-targets -- -D warnings` (crate dir) → clean;
+  `rustfmt src/score.rs src/lib.rs`; ruff the test file. Commit
+  `feat(native): NE kwargs on score_block_pairs_fs + FS_SUPPORTS_NE` (+ trailers).
+
+### Task R2: Python — gate widening + native caller + parity + native success bar
+
+**Files:** Modify `packages/python/goldenmatch/goldenmatch/core/probabilistic.py`.
+**Test:** Extend `tests/test_native_fs_ne.py`.
+
+- [ ] **Step 1: Failing tests:**
+  - `test_fs_native_eligible_ne_supported`: NE-bearing mk (exact-scorer NE) → True with the
+    real kernel; `test_fs_native_eligible_ne_old_wheel_declines`: monkeypatch
+    `native_module` to a stub lacking `FS_SUPPORTS_NE` (but having `score_block_pairs_fs` +
+    `FS_SUPPORTS_LEVEL_THRESHOLDS`) → False; `test_fs_native_eligible_ensemble_ne_declines`:
+    NE field with scorer `ensemble` → False.
+  - `test_native_kwargs_not_sent_without_ne`: spy-wrap `score_block_pairs_fs` (monkeypatch the
+    module object) on a no-NE matchkey → call kwargs contain no `ne_values`.
+  - `test_native_numpy_parity_ne`: same blocks/mk/em scored by `score_probabilistic_native` and
+    `score_probabilistic_vectorized` → identical pair sets + scores (round 4) across: EM-learned
+    NE (`__ne__` entries), `penalty_bits` NE, a null-valued row, an empty-string-after-transform
+    row (e.g. value `"-"` with `digits_only`), NE combined with `level_thresholds` on a regular
+    field, and TWO NE fields. Fixture similarities away from thresholds (tolerance discipline;
+    token_sort strictness case uses a sim well below and well above, not at, the threshold).
+  - `test_native_success_bar_homonym`: build the homonym fixture via the builders in
+    `tests/test_fs_ne_e2e.py` (import its helpers), assert `_fs_native_eligible(mk)` is True
+    (so the test cannot silently run numpy), run the same dedupe as the E2E, assert the same
+    bar: traps separate, true dups merge, AND clustering identical to a
+    `GOLDENMATCH_FS_NATIVE=0` run of the same fixture (byte-identical membership).
+- [ ] **Step 2:** Run → FAIL (gate still declines NE).
+- [ ] **Step 3: Implement** in probabilistic.py:
+  - `_fs_native_eligible`: replace the unconditional NE decline with:
+    ```python
+    ne_fields = mk.negative_evidence or []
+    for ne in ne_fields:
+        if ne.scorer not in _NATIVE_FS_SCORER_IDS:
+            return False
+    ```
+    and inside the existing `try` block after the level_thresholds check:
+    `if ne_fields and not getattr(mod, "FS_SUPPORTS_NE", False): return False`.
+    Update the docstring (delete the "NE never crosses the FFI" paragraph; document the new
+    conditions + old-wheel decline).
+  - `score_probabilistic_native`: after the existing kwarg prep, when `mk.negative_evidence`:
+    ```python
+    ne_fields = mk.negative_evidence or []
+    if ne_fields:
+        ne_values = [_field_values_for_block(block_df, ne, n) for ne in ne_fields]
+        ne_scorer_ids = [_NATIVE_FS_SCORER_IDS[ne.scorer] for ne in ne_fields]
+        ne_thresholds = [float(ne.threshold) for ne in ne_fields]
+        ne_weights = [
+            -abs(float(ne.penalty_bits)) if ne.penalty_bits is not None
+            else float(em_result.match_weights[f"__ne__{ne.field}"][0])
+            for ne in ne_fields
+        ]
+    ```
+    and thread the four kwargs into the kernel call ONLY when `ne_fields` (extend the existing
+    two-branch call or build a kwargs dict — keep the "old wheel must NEVER see it" comment
+    pattern; the level_thresholds branch shows the shape). Update the stale NE comment above
+    `fs_weight_range` (it now sees NE fields for real on this path).
+- [ ] **Step 4:** Run new tests + `pytest tests/test_native_parity.py tests/test_fs_ne_scoring.py tests/test_fs_ne_guards.py tests/test_fs_ne_e2e.py -q` → PASS.
+- [ ] **Step 5:** Ruff; commit `feat(goldenmatch): native FS kernel scores negative evidence (FS_SUPPORTS_NE)` (+ trailers).
+
+### Task R3: Rust — `match_fused_fs` NE + level_thresholds
+
+**Files:** Modify `packages/rust/extensions/native/src/fused.rs`, `src/lib.rs`.
+**Test:** Extend `tests/test_native_fs_ne.py` (kernel-direct fused tests).
+
+- [ ] **Step 1: Failing tests** (kernel-direct, arrow inputs via `pyarrow`):
+  - `test_fused_exports_level_thresholds_const`:
+    `getattr(mod, "FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", False) is True`.
+  - `test_fused_fs_ne_fires`: tiny single-key-block dataset where an NE disagreement flips a
+    pair below threshold → cluster membership differs from the no-NE call on the same data.
+  - `test_fused_fs_level_thresholds_bands`: a field with custom `level_thresholds` +
+    3-entry weights produces the same clusters as `score_block_pairs_fs`-based classic scoring
+    on the same data (or hand-computed membership on a 4-row fixture).
+  - `test_fused_fs_ne_validation_errors`: partial NE kwarg group / length mismatches /
+    level_thresholds length != field count / weights-vs-thresholds arity → ValueError naming
+    `match_fused_fs`.
+- [ ] **Step 2:** Run → FAIL (unexpected keyword).
+- [ ] **Step 3: Implement** in fused.rs:
+  - Signature grows `level_thresholds=None, ne_fields=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None`:
+    `level_thresholds: Option<Vec<Option<Vec<f64>>>>`,
+    `ne_fields: Option<Vec<PyArrowType<ArrayData>>>`, the other three as in R1.
+  - Validation: reuse score.rs's level_thresholds checks verbatim (length == n_fields;
+    `match_weights[f].len() == ts.len() + 1` per Some field). NE group: all-or-none, equal
+    lengths; each `ne_fields[k]` read via `StrCol::from_data` and length == n_rows.
+  - IMPORTANT gather note: `match_fused_fs` sorts rows by block key (`fused_gather` produces
+    `rid_sorted` + reordered `vals`). NE columns must be gathered THE SAME WAY — read how
+    `fused_gather` reorders `score_cols` and apply the identical reordering to the NE columns —
+    extend `fused_gather` (or pass the NE `StrCol`s through the same gather alongside
+    `score_cols`); it returns `(rid_sorted, vals, spans)` with NO separate permutation vector,
+    so do NOT index NE columns by the unsorted row index. This is the one real trap in this task — verify with a fixture whose
+    block-key sort differs from input order (the R3 tests above must include out-of-order keys).
+  - Per-pair loop: `fs_level_from_sim(sim, levels[f], partial_thresholds[f], field_thresholds[f])`
+    (hoist like score.rs; delete the "port the kwarg when the fused path goes live" comment),
+    then the NE additive check (same both-present + non-empty + strict-`<` snippet over the
+    gathered NE values).
+  - `lib.rs`: `m.add("FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;`.
+- [ ] **Step 4:** Rebuild; new tests PASS; `pytest tests/test_native_parity.py -q` green.
+- [ ] **Step 5:** clippy `-D warnings`; `rustfmt src/fused.rs src/lib.rs`; ruff; commit
+  `feat(native): match_fused_fs scores NE + custom level_thresholds` (+ trailers).
+
+### Task R4: Python fused — gate + caller + parity
+
+**Files:** Modify `packages/python/goldenmatch/goldenmatch/core/fused_match.py`.
+**Test:** Extend the existing fused-FS test file (locate via `grep -rln "match_fused_fs_ready" tests/`) + `tests/test_native_fs_ne.py`.
+
+- [ ] **Step 1: Failing tests:**
+  - Gate matrix: NE + `FS_SUPPORTS_NE` present → ready; NE + const absent (monkeypatched stub
+    module) → declined; `derive_from`-bearing NE → declined EVEN with the const (and a
+    companion assert that `_fs_native_eligible` does NOT decline the same mk — the asymmetry
+    from the spec); ensemble-scorer NE → declined; `level_thresholds` +
+    `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS` present → ready, absent → declined; per-feature
+    independence (NE-supporting stub without the fused-level const: NE config ready,
+    level_thresholds config declined).
+  - `test_fused_weight_range_uses_fs_weight_range`: monkeypatch `fs_weight_range` where
+    fused_match looks it up to a sentinel raise → `run_match_fused_fs_arrow` on a ready config
+    hits it (proves the hand-rolled sums are gone).
+  - `test_fused_fs_ne_parity`: `run_match_fused_fs_arrow` vs the classic pipeline
+    (`probabilistic_block_scorer` + clustering) on a covered-boundary NE config → identical
+    cluster membership. Include a `level_thresholds` + NE combined case.
+- [ ] **Step 2:** Run → FAIL.
+- [ ] **Step 3: Implement:**
+  - `match_fused_fs_ready`: replace the two unconditional declines with per-feature checks —
+    NE: every `ne.scorer in _NATIVE_FS_SCORER_IDS`, no `ne.derive_from`, and (module probe)
+    `FS_SUPPORTS_NE`; level_thresholds: `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS`. The gate
+    currently does NOT import the module — add a guarded capability probe mirroring
+    `_fs_native_eligible`'s try/except (module absent → the existing `_match_fused_fs_symbol()`
+    None-check upstream already declines; keep the gate pure on config when both features are
+    absent so no-native environments don't pay an import). Rewrite the docstring to the new
+    covered boundary (incl. the derive_from rationale from the spec).
+  - `run_match_fused_fs_arrow`: `min_w, max_w` → `fs_weight_range(em_result, mk)` (import it);
+    extend `src_cols` with NE field names (`dict.fromkeys` dedup keeps order); build
+    `ne_arrs`/`ne_scorer_ids`/`ne_thresholds`/`ne_weights` mirroring R2's resolution (values via
+    `frame.utf8_values(ne.field) if ne.field in frame.columns else None` +
+    `_field_values_from_list(raw, ne, n)` → `pa.array(..., type=pa.large_string())` — absent
+    column degrades to all-null per spec); build `level_thresholds` list; pass each kwarg group
+    ONLY when non-trivial (NE list non-empty; any level_thresholds not None) — old wheels never
+    see them.
+- [ ] **Step 4:** Run new tests + the whole fused test file + `tests/test_native_fs_ne.py` →
+  PASS.
+- [ ] **Step 5:** Ruff; commit `feat(goldenmatch): fused FS path covers NE + level_thresholds` (+ trailers).
+
+### Task R5: Version bump ×3 + symbol gate + full sweep + PR
+
+**Files:** the three version files; no code changes.
+
+- [ ] **Step 1:** Bump 0.1.14 → 0.1.15 in `Cargo.toml` (`[package] version`),
+  `pyproject.toml` (`[project] version` — the one maturin reads), and
+  `python/goldenmatch_native/__init__.py` (fallback `__version__` string). Grep for any other
+  `0.1.14` in the crate.
+- [ ] **Step 2:** `python scripts/check_native_symbols.py` (main venv, worktree cwd) → the two
+  new consts + kwargs reconcile, exit 0.
+- [ ] **Step 3:** Full targeted sweep (worktree PYTHONPATH, native ON):
+  `pytest tests/test_native_fs_ne.py tests/test_native_parity.py tests/test_fs_ne_schema.py tests/test_fs_ne_em.py tests/test_fs_ne_scoring.py tests/test_fs_ne_guards.py tests/test_fs_ne_e2e.py <fused test file> tests/test_probabilistic.py -q`
+  → all pass. Then the pure-path sweep with `GOLDENMATCH_FS_NATIVE=0` → all pass (numpy/scalar
+  FS paths byte-unchanged). Design kernel-requiring tests' skipifs on module PRESENCE (the
+  test_native_parity.py:16 pattern), not on env vars — the in-tree kernel exists on this box,
+  so env-based skips would silently skip nothing locally and everything on a wheel-less CI lane.
+- [ ] **Step 4:** Final clippy `-D warnings` + rustfmt check on touched files; ruff on touched
+  Python.
+- [ ] **Step 5:** Push (auth dance), PR titled
+  `feat(goldenmatch): native FS negative-evidence + fused N-level (goldenmatch-native 0.1.15)`,
+  body: spec summary, parity/success-bar results, the wheel-skew note (0.1.15 tag +
+  `publish-goldenmatch-native.yml` must ship in this rollout — capability-gated fast paths are
+  invisible to `pip install goldenmatch[native]` envs until the wheel publishes; tag is Ben's
+  call or delegated post-merge). Arm `gh pr merge --auto` and STOP.
+- [ ] **Step 6:** After merge: memory updates (`project_fs_negative_evidence` open-items,
+  `project_goldenmatch_native_package`), work-tracker entry, and surface the tag decision to
+  Ben.

--- a/docs/superpowers/specs/2026-07-14-native-fs-ne-port-design.md
+++ b/docs/superpowers/specs/2026-07-14-native-fs-ne-port-design.md
@@ -1,0 +1,182 @@
+# Native FS_SUPPORTS_NE Port (+ fused level_thresholds)
+
+**Date:** 2026-07-14
+**Status:** Approved (design)
+**Thesis phase:** Rust/arrow-native port (phase 2) for FS negative evidence; TS/WASM surface is
+phase 3, out of scope.
+**Predecessors:**
+- FS negative evidence core (`specs/2026-07-14-fs-negative-evidence-design.md`, PR #1764) -- the
+  semantics being ported; its native/fused sections say "a future kernel port adds
+  `FS_SUPPORTS_NE`".
+- The N-level native port (PR #1752, goldenmatch-native 0.1.14) -- the playbook this port
+  follows: optional kwargs old wheels never see, capability const, per-feature gate detection,
+  real-kernel parity tests, 3-file version bump + wheel republish in the same rollout.
+- The fan-out upgrade lever (`specs/2026-07-14-fanout-ne-upgrade-lever-design.md`, PR #1771) --
+  now emits NE-bearing configs at migration time, so NE-bearing matchkeys are no longer a
+  hand-authored rarity: they land on the pure-Python FS path today.
+
+## Problem
+
+`negative_evidence` on probabilistic matchkeys (#1764) declines the native Rust FS kernel
+unconditionally (`_fs_native_eligible`) and the fused FS kernel (`match_fused_fs_ready`), so every
+NE-bearing matchkey -- including everything the fan-out migration lever now produces -- runs on
+the numpy/scalar fallback. The fused kernel additionally still declines custom `level_thresholds`
+(the #1752 port only reached `score_block_pairs_fs`), so converted Splink configs (which usually
+need N-level banding) can never use fused at all.
+
+## Decisions (from brainstorming)
+
+- **Scope: BOTH kernels** (`score_block_pairs_fs` + `match_fused_fs`), AND close fused's
+  `level_thresholds` gap in the same release -- one 0.1.15 wheel brings `match_fused_fs` to full
+  parity with `score_block_pairs_fs`. (User chose both over the score-only #1752-style scoping.)
+- **FFI shape: Approach A -- flat parallel optional kwargs.** Python precomputes everything
+  semantic (transforms, `w_fired` resolution); the kernel adds one dumb additive check per NE
+  field. Rejected: pseudo-field encoding in the existing arrays (sentinel `levels=0` overloads
+  the field arrays' meaning and breaks their validation); a structured dict/object param (PyO3
+  extraction ceremony for no expressiveness gain).
+- **Capability detection: two new module consts** -- `FS_SUPPORTS_NE` (NE in both kernels) and
+  `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS` -- so each Python gate detects per-feature and old wheels
+  keep declining exactly as today. `scripts/check_native_symbols.py` parses `m.add` consts since
+  #1753; no gate-script change needed.
+
+## Kernel: `score_block_pairs_fs` NE extension
+
+Four new trailing optional kwargs, all defaulting `None` (crate
+`packages/rust/extensions/native/src/score.rs`):
+
+```
+ne_values:     Option<Vec<Vec<Option<String>>>>   # per NE field, per row, POST-transform
+ne_scorer_ids: Option<Vec<u8>>                    # score_one ids (same 0..=3 vocabulary)
+ne_thresholds: Option<Vec<f64>>
+ne_weights:    Option<Vec<f64>>                   # resolved w_fired (normally negative)
+```
+
+Upfront validation (PyValueError, mirroring the existing `level_thresholds` validation style):
+all four present-or-absent together; equal lengths; each `ne_values[k]` length equals the row
+count of the regular field arrays.
+
+Inner loop, after the regular-field weight sum and before `fs_normalize`:
+
+```rust
+for k in 0..n_ne {
+    if let (Some(a), Some(b)) = (&ne_vals[k][i], &ne_vals[k][j]) {
+        if !a.is_empty() && !b.is_empty()
+            && score_one(ne_scorer_ids[k], a, b) < ne_thresholds[k] {
+            total_weight += ne_weights[k];
+        }
+    }
+}
+```
+
+This is byte-for-byte `_ne_fired` (core/probabilistic.py:466): fires iff both values present
+post-transform AND non-empty (empty string = inconclusive -- the deliberate NE null-handling that
+differs from regular fields' null->level-0) AND similarity STRICTLY `<` threshold; contributes
+exactly 0 otherwise. `fs_normalize` needs no change: the caller's `min_weight`/`weight_range`
+already come from the NE-aware `fs_weight_range` (the `score_probabilistic_native` site was
+centralized in #1764 precisely so it "can't drift" -- this port is where that pays off).
+
+New const: `m.add("FS_SUPPORTS_NE", true)`.
+
+## Kernel: `match_fused_fs` gets both gaps
+
+Same four NE kwargs in Arrow form -- `ne_fields: Option<Vec<PyArrowType<ArrayData>>>` read via
+the existing `StrCol` reader (Utf8/LargeUtf8), plus the three scalar vectors -- and a
+`level_thresholds: Option<Vec<Option<Vec<f64>>>>` kwarg with the same validation
+`score_block_pairs_fs` already performs (length == field count; `match_weights[f].len() ==
+ts.len() + 1` per custom-banded field), threaded into the `fs_level_from_sim` call that today
+hard-passes `None` (fused.rs ~line 269). NE firing uses the same both-present + non-empty +
+strict-`<` rule on the `StrCol` values.
+
+New const: `m.add("FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", true)`.
+
+The two kernels stay drift-locked through the shared `fs_level_from_sim` / `fs_normalize` /
+`score_one` (the property score.rs:179 documents).
+
+## Python gates and callers
+
+- **`_fs_native_eligible`** (core/probabilistic.py): the unconditional
+  `if mk.negative_evidence: return False` becomes conditional -- eligible when EVERY NE field's
+  scorer is in `_NATIVE_FS_SCORER_IDS` (an `ensemble`-scorer NE field, autoconfig's default pick
+  for unknown columns, still declines the whole matchkey to the numpy path) AND the loaded module
+  exposes `FS_SUPPORTS_NE`. Old wheels lack the const and decline exactly as today. The stale
+  "NE never crosses the FFI" comments here and at the `fs_weight_range` call site are updated.
+- **`score_probabilistic_native`**: when `mk.negative_evidence` is non-empty, build the NE args --
+  values via the same `_field_values_for_block(block_df, ne, n)` used for regular fields
+  (`NegativeEvidenceField` shares the `.field`/`.transforms` shape; `derive_from`-synthesized
+  columns already exist on the block frame by this stage), `w_fired = -abs(ne.penalty_bits)` when
+  set else `em.match_weights[f"__ne__{ne.field}"][0]` (`validate_for` guarantees the entry exists
+  for penalty_bits-free NE; a missing entry raising KeyError here matches the scalar path's
+  contract). The kwargs are sent ONLY when NE is present -- an old wheel must never see them even
+  if the eligibility gate ever drifted (the #1752 discipline, restated in a comment).
+- **`match_fused_fs_ready`** (core/fused_match.py): the two unconditional declines become
+  per-feature capability checks -- NE allowed when `FS_SUPPORTS_NE` + every NE scorer native
+  **+ no NE field uses `derive_from`**; `level_thresholds` allowed when
+  `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS`. The derive_from decline exists because
+  `run_match_fused_fs_arrow` takes a raw `columns` mapping and never runs
+  `precompute_matchkey_transforms` (fused_match.py:330-334 builds `src_cols` from blocking keys
+  + `mk.fields` only), so a derive_from-synthesized `ne.field` would not exist in the frame and
+  NE would silently never fire -- declining keeps parity with the classic path, which handles
+  derive_from upstream. (The Arrow-lane `derive_ne_joined` seam exists if a future change wants
+  to synthesize instead; out of scope here.) Docstring rewritten to the new covered boundary.
+- **`run_match_fused_fs_arrow`**: REPLACE the hand-rolled `max_w`/`min_w` sums (fused_match.py
+  ~341-342, the known "unreachable for NE, cleanup candidate" copy) with
+  `fs_weight_range(em_result, mk)` -- load-bearing now: the hand-rolled copy ignores `__ne__`
+  entries and would mis-normalize every fused NE score. `src_cols` extended with the NE field
+  names; NE value columns built through the same seam extraction + `_field_values_from_list`
+  transform loop the regular fields use; both new kwarg groups threaded. An NE field absent from
+  `columns` is unreachable given the gate (non-derive_from NE fields are data columns), but the
+  prep degrades to all-null (never fires) rather than raising, matching the classic path's
+  missing-column behavior.
+- **`backends/score_buckets.py`**: no change -- the slim-projection keep-list already carries NE
+  columns (#1764) and the bucket path routes through `probabilistic_block_scorer`, which picks
+  the native scorer via the widened gate.
+
+## Tolerance class (stated, not hidden)
+
+A similarity landing exactly at an NE threshold can flip firing between rapidfuzz-rs and
+Python-rapidfuzz -- the same documented boundary-tolerance class as FS level banding. Since the
+#1752 reference-mode note, the native result is the DEFINED answer when native is on
+(`GOLDENMATCH_FS_NATIVE=0` restores the reproducible numpy operating point). Parity tests use
+fixtures whose similarities sit away from thresholds.
+
+## Versioning + release discipline
+
+`goldenmatch-native` 0.1.14 -> **0.1.15**, bumped in ALL THREE files in lockstep:
+`packages/rust/extensions/native/Cargo.toml`, `packages/rust/extensions/native/pyproject.toml`
+(the version maturin/publish actually reads -- these two have drifted before), and
+`packages/rust/extensions/native/python/goldenmatch_native/__init__.py`. The wheel republish (tag
+`goldenmatch-native-v0.1.15` -> `publish-goldenmatch-native.yml`) happens in the same rollout as
+the merge: the Python caller gains capability-gated fast paths that every
+`pip install goldenmatch[native]` env silently misses until the wheel ships (the #688
+wheel-skew lesson). Tagging is Ben's call (or delegated post-merge). Rust CI runs clippy
+`-D warnings` (run locally pre-push); rustfmt on touched files by name.
+
+## Testing / success bar
+
+- **Real-kernel parity** (in-tree build via `scripts/build_native.py` on this box;
+  `tests/test_native_parity.py` conventions): native vs numpy identical pair sets + scores on
+  NE-bearing matchkeys -- EM-learned and `penalty_bits`, fired / not-fired / null-on-either-side /
+  empty-string-after-transform cases, NE combined with `level_thresholds`, multiple NE fields.
+  Fixtures keep similarities away from thresholds per the tolerance discipline.
+- **Fused parity**: `run_match_fused_fs_arrow` vs the classic pipeline on its covered boundary,
+  now including NE-bearing and `level_thresholds`-bearing configs.
+- **Gate tests**: module without the consts (monkeypatched) declines both gates; ensemble-scorer
+  NE declines `_fs_native_eligible`; a `derive_from`-bearing NE field declines
+  `match_fused_fs_ready` (but NOT `_fs_native_eligible` -- the classic path synthesizes it
+  upstream); NE kwargs never sent when `mk.negative_evidence` is empty (spy on the native call);
+  fused gate's per-feature independence (NE-supported + old level_thresholds and vice versa).
+- **Success bar:** the FS-NE homonym E2E semantics (12/12 traps separate, 36/36 true dups merge)
+  pass on the NATIVE path -- in-tree kernel, with an in-test assertion that
+  `_fs_native_eligible(mk)` is True for the fixture's matchkey (so the test cannot silently fall
+  back to numpy) -- and byte-identical clustering to the pure-Python run of the same fixture.
+- Rust unit tests for the new validation errors; clippy `-D warnings` + rustfmt on touched files;
+  `scripts/check_native_symbols.py` green (the two consts reconcile via the `_MADD` regex).
+
+## Out of scope
+
+- TS/WASM surface (thesis phase 3; must OPEN with a loud TS-side NE decline).
+- TF-adjustment in the kernel (`tf_adjustment` fields still decline -- the kernel carries no
+  per-value frequency tables).
+- The numpy/scalar FS paths (byte-unchanged) and any scoring-semantics change.
+- Continuous/Winkler path (already rejects NE).
+- Autoconfig changes (NE promotion on probabilistic matchkeys remains migration-lever-only).

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -256,19 +256,30 @@ def match_fused_fs_ready(config: Any) -> bool:
     """Covered boundary for the fused Fellegi-Sunter (probabilistic) path.
 
     Covered: `static` single-key blocking + exactly one `probabilistic` matchkey
-    whose fields all use an FS-native scorer (`_NATIVE_FS_SCORER_IDS`) and no
-    custom `level_thresholds` (the fused kernel, like `score_block_pairs_fs`,
-    only receives a level count + `partial_threshold` and bands similarities
-    with its hard-coded default banding (2/3-level partial_threshold rule +
-    even-spaced N-level); custom `level_thresholds` lists never cross the
-    FFI, so they must stay on the Python paths). Transforms covered (derived
-    host-side).
-    `run_match_fused_fs_arrow` takes a PRE-TRAINED `EMResult` — training is the
-    caller's O(n) model fit, unchanged.
+    whose fields all use an FS-native scorer (`_NATIVE_FS_SCORER_IDS`).
+    Transforms covered (derived host-side). `run_match_fused_fs_arrow` takes a
+    PRE-TRAINED `EMResult` — training is the caller's O(n) model fit, unchanged.
 
-    NE never crosses the FFI; a future kernel port adds `FS_SUPPORTS_NE`. Any
-    `mk.negative_evidence` declines here unconditionally, same playbook as
-    `_fs_native_eligible`.
+    Two features are additionally gated on the LOADED kernel's capability
+    consts (goldenmatch-native >= 0.1.15); when the config uses NEITHER, the
+    gate stays pure-config and never probes the native module:
+
+    - Custom `level_thresholds` banding: ready only when the kernel exposes
+      `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS`. Older wheels band with the
+      hard-coded default banding only, so the lists must never cross their
+      FFI — those environments decline to the Python paths.
+    - Negative evidence (`mk.negative_evidence`): ready only when the kernel
+      exposes `FS_SUPPORTS_NE` AND every NE scorer is FS-native (an
+      `ensemble`-scorer NE field declines) AND no NE field uses `derive_from`.
+      The derive_from decline exists because `run_match_fused_fs_arrow` takes
+      a raw `columns` mapping and never runs `precompute_matchkey_transforms`
+      (it builds `src_cols` from blocking keys + matchkey/NE fields only), so
+      a derive_from-SYNTHESIZED `ne.field` would not exist in the frame and
+      NE would silently never fire; declining keeps parity with the classic
+      path, which synthesizes derive_from columns upstream — that is why
+      `_fs_native_eligible` does NOT decline the same matchkey. (The
+      Arrow-lane `derive_ne_joined` seam is the future synthesize option if
+      fused derive_from coverage is ever wanted.)
     """
     b = getattr(config, "blocking", None)
     if b is None or getattr(b, "strategy", "static") != "static":
@@ -280,16 +291,37 @@ def match_fused_fs_ready(config: Any) -> bool:
     mks = get_mks() if callable(get_mks) else []
     if len(mks) != 1 or getattr(mks[0], "type", None) != "probabilistic" or not mks[0].fields:
         return False
-    if getattr(mks[0], "negative_evidence", None):
-        return False
     from goldenmatch.core.probabilistic import _NATIVE_FS_SCORER_IDS
 
-    return all(
-        f.field
-        and f.scorer in _NATIVE_FS_SCORER_IDS
-        and getattr(f, "level_thresholds", None) is None
-        for f in mks[0].fields
+    mk = mks[0]
+    ne_fields = getattr(mk, "negative_evidence", None) or []
+    uses_level_thresholds = any(
+        getattr(f, "level_thresholds", None) is not None for f in mk.fields
     )
+    if not all(f.field and f.scorer in _NATIVE_FS_SCORER_IDS for f in mk.fields):
+        return False
+    for ne in ne_fields:
+        if ne.scorer not in _NATIVE_FS_SCORER_IDS or ne.derive_from:
+            return False
+    if ne_fields or uses_level_thresholds:
+        # Capability probe ONLY when a gated feature is in play — the gate is
+        # pure-config otherwise. Local import (not the module-level binding)
+        # so the loaded module is resolved at call time.
+        try:
+            from goldenmatch.core._native_loader import native_module as _nm
+
+            mod = _nm()
+        except Exception:
+            return False
+        if mod is None:
+            return False
+        if ne_fields and not getattr(mod, "FS_SUPPORTS_NE", False):
+            return False
+        if uses_level_thresholds and not getattr(
+            mod, "FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", False
+        ):
+            return False
+    return True
 
 
 def _match_fused_fs_symbol() -> Any | None:
@@ -310,8 +342,9 @@ def run_match_fused_fs_arrow(
     Byte-parity by construction: the block key is derived via
     `_build_block_key_expr`, the score columns via `_field_values_for_block`, and
     the FS kernel args (levels/partial_thresholds/match_weights/calibration/
-    thresholds) are assembled EXACTLY as `score_probabilistic_native` does — so
-    the fused kernel scores identically to the pipeline's native FS block scorer.
+    thresholds, plus the capability-gated `level_thresholds` + NE kwarg groups)
+    are assembled EXACTLY as `score_probabilistic_native` does — so the fused
+    kernel scores identically to the pipeline's native FS block scorer.
     Returns a `(__row_id__, __cluster_id__)` Table, or None if uncovered / native
     absent.
     """
@@ -320,6 +353,7 @@ def run_match_fused_fs_arrow(
         _field_values_from_list,
         _fs_calibration_mode,
         compute_thresholds,
+        fs_weight_range,
         prior_weight,
     )
 
@@ -329,7 +363,18 @@ def run_match_fused_fs_arrow(
 
     key_cfg = config.blocking.keys[0]
     mk = config.get_matchkeys()[0]
-    src_cols = list(dict.fromkeys([*key_cfg.fields, *[f.field for f in mk.fields]]))
+    ne_fields = mk.negative_evidence or []
+    src_cols = list(
+        dict.fromkeys(
+            [
+                *key_cfg.fields,
+                *[f.field for f in mk.fields],
+                # NE columns ride along; an NE field absent from `columns` is
+                # skipped here and degrades to all-null below (never fires).
+                *[ne.field for ne in ne_fields if ne.field in columns],
+            ]
+        )
+    )
     n = n_rows if n_rows is not None else len(columns[src_cols[0]])
     frame = _prep_frame(columns, src_cols)
 
@@ -338,8 +383,10 @@ def run_match_fused_fs_arrow(
     # FS kernel args — mirrors score_probabilistic_native exactly.
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
-    max_w = sum(max(em_result.match_weights[f.field]) for f in mk.fields)
-    min_w = sum(min(em_result.match_weights[f.field]) for f in mk.fields)
+    # NE-aware weight envelope: the centralized fs_weight_range covers the
+    # `__ne__` entries / penalty_bits contributions a hand-rolled per-field
+    # min/max sum would miss (which would mis-normalize every fused NE score).
+    min_w, max_w = fs_weight_range(em_result, mk)
     weight_range = max_w - min_w
     if mk.link_threshold is not None:
         link_threshold = float(mk.link_threshold)
@@ -358,9 +405,51 @@ def run_match_fused_fs_arrow(
         vals = _field_values_from_list(raw, f, n)
         score_arrs.append(pa.array(vals, type=pa.large_string()))
 
+    # Optional capability kwargs — each group is sent ONLY when the matchkey
+    # actually uses the feature, so an old wheel never sees an unknown kwarg
+    # even if the readiness gate ever drifted (the #1752 discipline; same
+    # opt_kwargs shape as score_probabilistic_native).
+    opt_kwargs: dict = {}
+
+    # Custom banding (FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS).
+    level_thresholds = [
+        list(f.level_thresholds) if f.level_thresholds is not None else None
+        for f in mk.fields
+    ]
+    if any(t is not None for t in level_thresholds):
+        opt_kwargs["level_thresholds"] = level_thresholds
+
+    # Negative evidence (FS_SUPPORTS_NE). Prep mirrors the score_arrs loop:
+    # seam extraction + the same pure-Python transform pass. An NE field
+    # absent from `columns` is unreachable given the gate (non-derive_from NE
+    # fields are data columns), but degrades to all-null — NE never fires —
+    # rather than raising, matching the classic path's missing-column
+    # behavior. w_fired mirrors _ne_scalar_contribution: -abs(penalty_bits)
+    # when set, else the EM-learned __ne__<field> fired weight (a missing
+    # entry raising KeyError matches the scalar path's contract; validate_for
+    # guarantees it exists).
+    if ne_fields:
+        ne_arrs = []
+        for ne in ne_fields:
+            raw = frame.utf8_values(ne.field) if ne.field in frame.columns else None
+            ne_arrs.append(
+                pa.array(_field_values_from_list(raw, ne, n), type=pa.large_string())
+            )
+        opt_kwargs["ne_fields"] = ne_arrs
+        opt_kwargs["ne_scorer_ids"] = [
+            _NATIVE_FS_SCORER_IDS[ne.scorer] for ne in ne_fields
+        ]
+        opt_kwargs["ne_thresholds"] = [float(ne.threshold) for ne in ne_fields]
+        opt_kwargs["ne_weights"] = [
+            -abs(float(ne.penalty_bits)) if ne.penalty_bits is not None
+            else float(em_result.match_weights[f"__ne__{ne.field}"][0])
+            for ne in ne_fields
+        ]
+
     row_ids = pa.array(range(n), type=pa.int64())
     clusters = fn(
         row_ids, key_arrs, score_arrs, scorer_ids, levels, partials, weights,
         calibrated, prior_w, min_w, weight_range, link_threshold,
+        **opt_kwargs,
     )
     return _clusters_to_table(clusters)

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -421,10 +421,11 @@ def run_match_fused_fs_arrow(
 
     # Negative evidence (FS_SUPPORTS_NE). Prep mirrors the score_arrs loop:
     # seam extraction + the same pure-Python transform pass. An NE field
-    # absent from `columns` is unreachable given the gate (non-derive_from NE
-    # fields are data columns), but degrades to all-null — NE never fires —
-    # rather than raising, matching the classic path's missing-column
-    # behavior. w_fired mirrors _ne_scalar_contribution: -abs(penalty_bits)
+    # absent from `columns` IS reachable here — the readiness gate is
+    # pure-config and never validates the caller-supplied columns mapping —
+    # so the all-null fallback below is deliberate: NE never fires rather
+    # than raising, matching the classic path's missing-column behavior.
+    # w_fired mirrors _ne_scalar_contribution: -abs(penalty_bits)
     # when set, else the EM-learned __ne__<field> fired weight (a missing
     # entry raising KeyError matches the scalar path's contract; validate_for
     # guarantees it exists).

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -2276,16 +2276,21 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
     without it declines here, so those environments keep the pure-Python
     (numpy/scalar) fallback where `_levels_from_similarity` does the banding.
 
-    NE never crosses the FFI; a future kernel port adds ``FS_SUPPORTS_NE``.
-    Any ``mk.negative_evidence`` declines here unconditionally, keeping
-    NE-bearing matchkeys on the pure-Python (numpy/scalar) fallback.
+    Negative evidence (``mk.negative_evidence``) is native from
+    goldenmatch-native >= 0.1.15: eligible when EVERY NE field's scorer is in
+    ``_NATIVE_FS_SCORER_IDS`` (an ``ensemble``-scorer NE field — autoconfig's
+    default pick for unknown columns — declines the whole matchkey to the
+    numpy path) AND the loaded module exposes ``FS_SUPPORTS_NE``. Old wheels
+    lack the const and decline here exactly as before the port.
     """
     if not _fs_native_enabled():
         return False
     if not mk.fields:
         return False
-    if mk.negative_evidence:
-        return False
+    ne_fields = mk.negative_evidence or []
+    for ne in ne_fields:
+        if ne.scorer not in _NATIVE_FS_SCORER_IDS:
+            return False
     needs_level_thresholds = False
     for f in mk.fields:
         if f.scorer not in _NATIVE_FS_SCORER_IDS:
@@ -2303,6 +2308,8 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
             mod, "FS_SUPPORTS_LEVEL_THRESHOLDS", False
         ):
             return False  # old wheel: level_thresholds never crosses its FFI
+        if ne_fields and not getattr(mod, "FS_SUPPORTS_NE", False):
+            return False  # old wheel: NE never crosses its FFI
         return True
     except Exception:
         return False
@@ -2319,7 +2326,9 @@ def score_probabilistic_native(
     Output-equivalent (within rapidfuzz tolerance) to
     ``score_probabilistic_vectorized``: same transformed values
     (``_field_values_for_block``), same level mapping, same EM match weights,
-    same calibration + threshold. The kernel replaces the per-field numpy NxN
+    same negative-evidence firing rule + fired weights (EM-learned
+    ``__ne__<field>`` entries or the ``penalty_bits`` override), same
+    calibration + threshold. The kernel replaces the per-field numpy NxN
     matrices with a single GIL-released per-pair Rust loop. Caller gates on
     ``_fs_native_eligible``.
     """
@@ -2336,11 +2345,11 @@ def score_probabilistic_native(
 
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
-    # NE never crosses the FFI (the kernel's score_one doesn't implement it) --
-    # a future kernel port adds FS_SUPPORTS_NE. `_fs_native_eligible` declines
-    # NE-bearing matchkeys, so `fs_weight_range` sees no NE fields here in
-    # practice; centralized anyway so this site can't drift from the other
-    # scoring paths for non-NE configs.
+    # NE-aware weight envelope (FS_SUPPORTS_NE): NE fields cross the FFI on
+    # this path now, and `fs_weight_range` genuinely covers their (min, max)
+    # contribution here -- `-abs(penalty_bits)` or the EM-learned
+    # `__ne__<field>` fired weight -- the same centralized envelope the numpy
+    # and scalar paths normalize against.
     min_weight, max_weight = fs_weight_range(em_result, mk)
     weight_range = max_weight - min_weight
     if mk.link_threshold is not None:
@@ -2356,24 +2365,47 @@ def score_probabilistic_native(
     # Kernel canonicalizes pair_key to (min,max); pass exclude pre-canonicalized.
     excl = [(a, b) if a < b else (b, a) for a, b in exclude_pairs]
 
-    # Custom banding (goldenmatch-native >= 0.1.14). Only send the kwarg when a
-    # field actually sets level_thresholds — an old wheel must NEVER see it,
-    # even if the eligibility gate ever drifted.
+    # Optional capability kwargs. Each group is sent ONLY when the matchkey
+    # actually uses the feature — an old wheel must NEVER see the kwarg, even
+    # if the eligibility gate ever drifted.
+    opt_kwargs: dict = {}
+
+    # Custom banding (goldenmatch-native >= 0.1.14).
     level_thresholds = [
         list(f.level_thresholds) if f.level_thresholds is not None else None
         for f in mk.fields
     ]
     if any(t is not None for t in level_thresholds):
-        pairs = native_module().score_block_pairs_fs(
-            row_ids, [n], field_values, scorer_ids, levels, partials, weights,
-            calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
-            level_thresholds=level_thresholds,
-        )
-    else:
-        pairs = native_module().score_block_pairs_fs(
-            row_ids, [n], field_values, scorer_ids, levels, partials, weights,
-            calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
-        )
+        opt_kwargs["level_thresholds"] = level_thresholds
+
+    # Negative evidence (goldenmatch-native >= 0.1.15, FS_SUPPORTS_NE). Values
+    # go through the same _field_values_for_block transform path as regular
+    # fields (NegativeEvidenceField shares the .field/.transforms duck-type;
+    # derive_from-synthesized NE columns already exist on the block frame via
+    # precompute_matchkey_transforms upstream). w_fired resolution mirrors
+    # _ne_scalar_contribution: -abs(penalty_bits) when set, else the
+    # EM-learned __ne__<field> fired weight (a missing entry raising KeyError
+    # matches the scalar path's contract; validate_for guarantees it exists).
+    ne_fields = mk.negative_evidence or []
+    if ne_fields:
+        opt_kwargs["ne_values"] = [
+            _field_values_for_block(block_df, ne, n) for ne in ne_fields
+        ]
+        opt_kwargs["ne_scorer_ids"] = [
+            _NATIVE_FS_SCORER_IDS[ne.scorer] for ne in ne_fields
+        ]
+        opt_kwargs["ne_thresholds"] = [float(ne.threshold) for ne in ne_fields]
+        opt_kwargs["ne_weights"] = [
+            -abs(float(ne.penalty_bits)) if ne.penalty_bits is not None
+            else float(em_result.match_weights[f"__ne__{ne.field}"][0])
+            for ne in ne_fields
+        ]
+
+    pairs = native_module().score_block_pairs_fs(
+        row_ids, [n], field_values, scorer_ids, levels, partials, weights,
+        calibrated, prior_w, min_weight, weight_range, link_threshold, excl,
+        **opt_kwargs,
+    )
     return [(a, b, round(float(s), 4)) for a, b, s in pairs]
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py
@@ -20,8 +20,8 @@ Gate eligibility (`_resolve_probabilistic_fast_path`):
       - field.levels in {2, 3} (N>3 unsupported in fast path v1; falls back
         to the slow `score_probabilistic` path)
   - em_result has match_weights for every field
-  - mk.negative_evidence is empty (NE never crosses into this fast path;
-    a future kernel port adds FS_SUPPORTS_NE)
+  - mk.negative_evidence is empty (this pure-Python per-pair loop has no
+    NE support of its own, independent of the native kernel's capability)
 
 When the gate fails, callers fall back to `score_probabilistic`. The fast
 path produces bit-equivalent output within rapidfuzz tolerance (parity
@@ -78,9 +78,11 @@ def _resolve_probabilistic_fast_path(
     if not mk.fields:
         return None
     if mk.negative_evidence:
-        # NE never crosses into this fast path (the per-pair loop doesn't
-        # score NE fields); decline so the slow path -- which does -- stays
-        # the source of truth. Mirrors `_fs_native_eligible`.
+        # This fast path's own per-pair loop doesn't score NE fields, so
+        # decline and let the slow path -- which does -- stay the source of
+        # truth. Independent of the native kernel's FS_SUPPORTS_NE capability
+        # (`_fs_native_eligible` now accepts NE; this pure-Python path is a
+        # separate surface that simply hasn't implemented it).
         return None
 
     field_specs: list[ProbFieldSpec] = []

--- a/packages/python/goldenmatch/tests/test_fs_ne_guards.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_guards.py
@@ -1,4 +1,9 @@
-"""Guards: NE never crosses the native/fused/fast-path boundaries.
+"""Guards: NE capability boundaries for the native/fused/fast paths.
+
+Native (R2, FS_SUPPORTS_NE): the real kernel now scores NE, so the native
+gate ACCEPTS NE-bearing matchkeys when every NE scorer is native AND the
+module advertises ``FS_SUPPORTS_NE``; old wheels (the mocks below) lack the
+const and decline. The fused and probabilistic-fast paths still decline NE.
 
 Mirrors the level_thresholds gate-test scaffolding in
 tests/test_nlevel_banding.py -- synthetic native mocks + a real-kernel
@@ -56,10 +61,10 @@ def _mk_plain():
 
 
 def _fake_native_module_supporting():
-    """A kernel advertising every capability this suite might ask for
-    (mirrors test_nlevel_banding.py's supporting fake) -- NE must still
-    decline because the kernel never advertises FS_SUPPORTS_NE (it doesn't
-    exist yet; this is a future capability the kernel port will add)."""
+    """A kernel advertising every PRE-NE capability (mirrors
+    test_nlevel_banding.py's supporting fake) -- i.e. an OLD WHEEL: it has the
+    FS kernel + FS_SUPPORTS_LEVEL_THRESHOLDS but lacks FS_SUPPORTS_NE, so an
+    NE-bearing matchkey must decline (NE never crosses an old wheel's FFI)."""
     class _Fake:
         FS_SUPPORTS_LEVEL_THRESHOLDS = True
 
@@ -102,14 +107,17 @@ def _native_fs_available():
 
 
 @pytest.mark.skipif(not _native_fs_available(), reason="native FS kernel not built")
-def test_fs_native_eligible_declines_ne_real_kernel(monkeypatch):
-    """Against the real in-tree/wheel kernel: an NE-bearing matchkey is
-    declined regardless of what the kernel advertises (no FS_SUPPORTS_NE
-    exists yet)."""
+def test_fs_native_eligible_accepts_ne_real_kernel(monkeypatch):
+    """Against the real in-tree/wheel kernel: an NE-bearing matchkey whose NE
+    scorer is native IS eligible when the kernel advertises FS_SUPPORTS_NE
+    (R2 gate widening); a kernel without the const declines (mock test above).
+    Eligibility tracks the loaded kernel's capability, either way."""
     monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
     monkeypatch.setenv("GOLDENMATCH_NATIVE", "1")
 
-    assert _fs_native_eligible(_mk_ne()) is False
+    from goldenmatch.core import _native_loader
+    supports_ne = getattr(_native_loader.native_module(), "FS_SUPPORTS_NE", False)
+    assert _fs_native_eligible(_mk_ne()) is bool(supports_ne)
     assert _fs_native_eligible(_mk_plain()) is True
 
 

--- a/packages/python/goldenmatch/tests/test_fs_ne_guards.py
+++ b/packages/python/goldenmatch/tests/test_fs_ne_guards.py
@@ -3,7 +3,9 @@
 Native (R2, FS_SUPPORTS_NE): the real kernel now scores NE, so the native
 gate ACCEPTS NE-bearing matchkeys when every NE scorer is native AND the
 module advertises ``FS_SUPPORTS_NE``; old wheels (the mocks below) lack the
-const and decline. The fused and probabilistic-fast paths still decline NE.
+const and decline. The fused FS gate (R4) tracks the same capability (plus a
+derive_from decline of its own); the probabilistic-fast path still declines
+NE unconditionally.
 
 Mirrors the level_thresholds gate-test scaffolding in
 tests/test_nlevel_banding.py -- synthetic native mocks + a real-kernel
@@ -247,7 +249,7 @@ def test_batched_scorer_declines_vec_for_ne_with_unsupported_ne_scorer(monkeypat
             reg._scorers["record_embedding"] = prior
 
 
-# ── 4. match_fused_fs_ready: False on NE, True on plain probabilistic ───────
+# ── 4. match_fused_fs_ready: NE tracks the loaded kernel's capability ────────
 
 
 def _fused_config(negative_evidence=None):
@@ -263,13 +265,45 @@ def _fused_config(negative_evidence=None):
     )
 
 
-def test_match_fused_fs_ready_false_on_ne():
-    assert fused_match.match_fused_fs_ready(_fused_config()) is True
+def test_match_fused_fs_ready_tracks_ne_capability(monkeypatch):
+    """R4 FLIP: this test used to pin the UNCONDITIONAL fused NE decline. The
+    fused gate is now capability-tracking (same style as the R2 classic gate):
+    an old wheel lacking ``FS_SUPPORTS_NE`` (the supporting-but-pre-NE mock)
+    declines NE-bearing configs; a kernel advertising it accepts. Plain
+    configs stay pure-config ready either way."""
     ne_config = _fused_config(negative_evidence=[
         NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
     ])
+    # Old wheel: FS kernel + level_thresholds const, but no FS_SUPPORTS_NE.
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _fake_native_module_supporting
+    )
     assert fused_match.match_fused_fs_ready(ne_config) is False
-    # Plain config still ready (mirrors test_fused_match.py's gate tests).
+    assert fused_match.match_fused_fs_ready(_fused_config()) is True
+
+    # NE-capable kernel: the same config is now ready.
+    class _NeCapable:
+        FS_SUPPORTS_NE = True
+
+        def match_fused_fs(self, *a, **kw):  # pragma: no cover - not invoked
+            raise NotImplementedError
+
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", lambda: _NeCapable()
+    )
+    assert fused_match.match_fused_fs_ready(ne_config) is True
+
+
+@pytest.mark.skipif(not _native_fs_available(), reason="native FS kernel not built")
+def test_match_fused_fs_ready_ne_real_kernel():
+    """Against the real kernel, fused NE readiness tracks FS_SUPPORTS_NE."""
+    from goldenmatch.core import _native_loader
+
+    supports_ne = getattr(_native_loader.native_module(), "FS_SUPPORTS_NE", False)
+    ne_config = _fused_config(negative_evidence=[
+        NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0),
+    ])
+    assert fused_match.match_fused_fs_ready(ne_config) is bool(supports_ne)
     assert fused_match.match_fused_fs_ready(_fused_config()) is True
 
 

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -19,6 +19,7 @@ from goldenmatch.config.schemas import (
     GoldenMatchConfig,
     MatchkeyConfig,
     MatchkeyField,
+    NegativeEvidenceField,
 )
 from goldenmatch.core import fused_match
 from goldenmatch.core._native_loader import native_module
@@ -241,16 +242,24 @@ def test_fs_ready_true_on_probabilistic_false_on_weighted():
     assert fused_match.match_fused_fs_ready(_covered_config()) is False  # weighted
 
 
-def test_fs_ready_false_on_level_thresholds():
-    # The fused FS kernel only receives a level count + partial_threshold
-    # (see run_match_fused_fs_arrow) -- it can't band with a custom N-level
-    # threshold list, so level_thresholds matchkeys must stay on Python paths.
-    config = _probabilistic_config()
-    f = config.matchkeys[0].fields[0]
-    f.levels = 4
-    f.level_thresholds = [1.0, 0.92, 0.88]
+def test_fs_ready_level_thresholds_tracks_kernel_capability(monkeypatch):
+    # R4 FLIP: level_thresholds was an unconditional decline (the fused kernel
+    # could only band with the hard-coded default banding); it is now a
+    # per-feature capability gate on FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS --
+    # an old wheel (stub below, lacking the const) still declines so custom
+    # lists never cross its FFI; a supporting kernel accepts.
+    config = _lt_config()
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module",
+        lambda: _stub_kernel(),  # old wheel: no FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS
+    )
     assert fused_match.match_fused_fs_ready(config) is False
-    # A plain matchkey is unaffected.
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module",
+        lambda: _stub_kernel(FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS=True),
+    )
+    assert fused_match.match_fused_fs_ready(config) is True
+    # A plain matchkey is pure-config either way.
     assert fused_match.match_fused_fs_ready(_probabilistic_config()) is True
 
 
@@ -299,6 +308,276 @@ def test_match_fused_fs_matches_pipeline_fs_block_scorer():
         comps[find(i)].append(i)
     want = {frozenset(v) for v in comps.values() if len(v) >= 2}
     assert got == want
+
+
+# ---- Fellegi-Sunter fused path: NE + level_thresholds capability (R4) ----
+
+def _stub_kernel(**consts):
+    """A fake native module carrying the fused FS symbol + the given
+    capability consts -- i.e. some published wheel vintage. No consts =
+    an old wheel that predates both the NE and the fused-level_thresholds
+    ports."""
+    class _Stub:
+        def match_fused_fs(self, *a, **kw):  # pragma: no cover - not invoked
+            raise NotImplementedError
+
+        def score_block_pairs_fs(self, *a, **kw):  # pragma: no cover
+            raise NotImplementedError
+
+    stub = _Stub()
+    for k, v in consts.items():
+        setattr(stub, k, v)
+    return stub
+
+
+def _supporting_stub():
+    return _stub_kernel(
+        FS_SUPPORTS_NE=True,
+        FS_SUPPORTS_LEVEL_THRESHOLDS=True,
+        FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS=True,
+    )
+
+
+def _ne(**kw):
+    base = dict(field="phone", scorer="exact", threshold=1.0, penalty_bits=20.0)
+    base.update(kw)
+    return NegativeEvidenceField(**base)
+
+
+def _ne_config(*ne_fields):
+    config = _probabilistic_config()
+    config.matchkeys[0].negative_evidence = list(ne_fields) or [_ne()]
+    return config
+
+
+def _lt_config(ne=None):
+    config = _probabilistic_config()
+    f = config.matchkeys[0].fields[0]
+    f.levels = 4
+    f.level_thresholds = [1.0, 0.92, 0.88]
+    if ne is not None:
+        config.matchkeys[0].negative_evidence = [ne]
+    return config
+
+
+def _real_kernel():
+    try:
+        return native_module()
+    except Exception:
+        return None
+
+
+_HAS_FUSED_NE = bool(
+    _HAS_FUSED and getattr(_real_kernel(), "FS_SUPPORTS_NE", False)
+)
+_HAS_FUSED_LT = bool(
+    _HAS_FUSED
+    and getattr(_real_kernel(), "FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", False)
+)
+
+
+@pytest.mark.skipif(not _HAS_FUSED_NE, reason="kernel lacks fused FS_SUPPORTS_NE")
+def test_fs_ready_ne_true_on_real_kernel():
+    assert fused_match.match_fused_fs_ready(_ne_config()) is True
+
+
+@pytest.mark.skipif(not _HAS_FUSED_LT, reason="kernel lacks FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS")
+def test_fs_ready_level_thresholds_true_on_real_kernel():
+    assert fused_match.match_fused_fs_ready(_lt_config()) is True
+
+
+def test_fs_ready_ne_declines_on_old_wheel(monkeypatch):
+    # Old wheel: has the fused FS kernel but no FS_SUPPORTS_NE -> NE-bearing
+    # configs decline (NE never crosses its FFI); the SAME stub still accepts
+    # a no-NE config (the decline is NE-specific).
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", lambda: _stub_kernel()
+    )
+    assert fused_match.match_fused_fs_ready(_ne_config()) is False
+    assert fused_match.match_fused_fs_ready(_probabilistic_config()) is True
+
+
+def test_fs_ready_declines_derive_from_ne_even_when_kernel_supports_ne(monkeypatch):
+    # derive_from-synthesized NE columns never exist in the raw `columns`
+    # mapping run_match_fused_fs_arrow receives (it never runs
+    # precompute_matchkey_transforms), so NE would silently never fire ->
+    # decline EVEN with a fully-supporting kernel.
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _supporting_stub
+    )
+    cfg = _ne_config(
+        _ne(field="full_name", scorer="token_sort", threshold=0.6,
+            derive_from=["first_name", "last_name"])
+    )
+    assert fused_match.match_fused_fs_ready(cfg) is False
+
+    # The spec's asymmetry: the CLASSIC native gate does NOT decline the same
+    # matchkey -- derive_from columns are synthesized upstream
+    # (precompute_matchkey_transforms) before its block frames are scored.
+    from goldenmatch.core import probabilistic as p
+
+    monkeypatch.setattr(p, "_fs_native_enabled", lambda: True)
+    assert p._fs_native_eligible(cfg.matchkeys[0]) is True
+
+
+def test_fs_ready_declines_ensemble_ne_scorer(monkeypatch):
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module", _supporting_stub
+    )
+    cfg = _ne_config(_ne(scorer="ensemble", threshold=0.5))
+    assert fused_match.match_fused_fs_ready(cfg) is False
+
+
+def test_fs_ready_per_feature_capability_independence(monkeypatch):
+    # NE-only wheel: NE configs ready, level_thresholds configs declined.
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module",
+        lambda: _stub_kernel(FS_SUPPORTS_NE=True),
+    )
+    assert fused_match.match_fused_fs_ready(_ne_config()) is True
+    assert fused_match.match_fused_fs_ready(_lt_config()) is False
+    # level_thresholds-only wheel: the reverse.
+    monkeypatch.setattr(
+        "goldenmatch.core._native_loader.native_module",
+        lambda: _stub_kernel(FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS=True),
+    )
+    assert fused_match.match_fused_fs_ready(_ne_config()) is False
+    assert fused_match.match_fused_fs_ready(_lt_config()) is True
+
+
+def test_fs_ready_pure_config_without_gated_features(monkeypatch):
+    # A config using NEITHER gated feature must never probe the native module
+    # (the gate stays pure-config); feature-bearing configs decline gracefully
+    # when the loader raises, rather than propagating.
+    def _boom():
+        raise AssertionError("gate must not probe the native module")
+
+    monkeypatch.setattr("goldenmatch.core._native_loader.native_module", _boom)
+    assert fused_match.match_fused_fs_ready(_probabilistic_config()) is True
+    assert fused_match.match_fused_fs_ready(_ne_config()) is False
+    assert fused_match.match_fused_fs_ready(_lt_config()) is False
+
+
+def test_fused_weight_range_uses_fs_weight_range(monkeypatch):
+    # The hand-rolled min/max weight sums ignored __ne__ entries and would
+    # mis-normalize every fused NE score; the caller must resolve the weight
+    # envelope through the centralized fs_weight_range.
+    from goldenmatch.core import probabilistic as p
+
+    class _Sentinel(Exception):
+        pass
+
+    def _tripwire(em, mk):
+        raise _Sentinel
+
+    monkeypatch.setattr(p, "fs_weight_range", _tripwire)
+    monkeypatch.setattr(
+        fused_match, "_match_fused_fs_symbol", lambda: lambda *a, **kw: []
+    )
+    columns = {"blk": pa.array(["a", "a"]), "name": pa.array(["x", "y"])}
+    with pytest.raises(_Sentinel):
+        fused_match.run_match_fused_fs_arrow(columns, _probabilistic_config(), _em())
+
+
+def _classic_fs_clusters(df, config, em):
+    """Reference clusters via the classic pipeline: build_blocks + the routed
+    probabilistic block scorer + the same union-find the fused kernel applies
+    (mirrors test_match_fused_fs_matches_pipeline_fs_block_scorer)."""
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.probabilistic import probabilistic_block_scorer
+
+    scorer = probabilistic_block_scorer(config.get_matchkeys()[0], em)
+    pairs = []
+    for br in build_blocks(df.lazy(), config.blocking):
+        g = br.materialize().native if hasattr(br.df, "collect") else br.df
+        pairs += scorer(g)
+    parent = list(range(df.height))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for a, b, _s in pairs:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    comps = defaultdict(list)
+    for i in range(df.height):
+        comps[find(i)].append(i)
+    return {frozenset(v) for v in comps.values() if len(v) >= 2}
+
+
+@pytest.mark.skipif(not _HAS_FUSED_NE, reason="kernel lacks fused FS_SUPPORTS_NE")
+def test_fused_fs_ne_parity():
+    # NE (penalty_bits) parity vs the classic pipeline: same data, same EM,
+    # identical cluster membership. Similarities sit away from every banding /
+    # NE threshold (the documented boundary-tolerance class).
+    import polars as pl
+
+    config = _ne_config()  # phone exact-NE, penalty_bits=20
+    em = _em()
+    keys = ["a", "a", "a", "b", "b", "c"]
+    names = ["jonathan", "jonathon", "michael", "sarah", "sara", "solo"]
+    # jonathan/jonathon share a phone (NE never fires -> merge survives);
+    # sarah/sara disagree (NE fires: 2.585 - 20 normalizes < 0.5 -> suppressed).
+    phones = ["555", "555", "999", "111", "222", "000"]
+    df = (
+        pl.DataFrame({"blk": keys, "name": names, "phone": phones})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+    columns = {
+        "blk": pa.array(keys), "name": pa.array(names), "phone": pa.array(phones)
+    }
+
+    tbl = fused_match.run_match_fused_fs_arrow(columns, config, em)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    assert got == _classic_fs_clusters(df, config, em)
+    # NE actually changed the outcome on BOTH paths (guards vacuous parity).
+    assert frozenset({0, 1}) in got
+    assert frozenset({3, 4}) not in got
+
+
+@pytest.mark.skipif(
+    not (_HAS_FUSED_NE and _HAS_FUSED_LT),
+    reason="kernel lacks fused NE + level_thresholds",
+)
+def test_fused_fs_ne_with_level_thresholds_parity():
+    # Combined coverage: custom level_thresholds banding + an EM-learned NE
+    # weight (penalty_bits=None -> __ne__phone fired weight), fused vs classic.
+    import polars as pl
+    from goldenmatch.core.probabilistic import EMResult
+
+    config = _lt_config(ne=_ne(penalty_bits=None))
+    em = EMResult(
+        m_probs={"name": [0.05, 0.1, 0.25, 0.6], "__ne__phone": [0.0625, 0.9375]},
+        u_probs={"name": [0.6, 0.25, 0.1, 0.05], "__ne__phone": [0.5, 0.5]},
+        match_weights={"name": [-2.0, 0.5, 1.5, 2.585], "__ne__phone": [-8.0, 0.0]},
+        converged=True,
+        iterations=1,
+        proportion_matched=0.1,
+    )
+    keys = ["a", "a", "a", "b", "b", "c"]
+    names = ["jonathan", "jonathon", "michael", "sarah", "sara", "solo"]
+    phones = ["555", "555", "999", "111", "222", "000"]
+    df = (
+        pl.DataFrame({"blk": keys, "name": names, "phone": phones})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+    columns = {
+        "blk": pa.array(keys), "name": pa.array(names), "phone": pa.array(phones)
+    }
+
+    tbl = fused_match.run_match_fused_fs_arrow(columns, config, em)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    assert got == _classic_fs_clusters(df, config, em)
+    assert frozenset({0, 1}) in got  # banded level-2 agreement, NE silent
+    assert frozenset({3, 4}) not in got  # EM-learned NE fired -> suppressed
 
 
 # ---- multi-pass blocking fused path ------------------------------------

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -266,8 +266,6 @@ def test_fs_ready_level_thresholds_tracks_kernel_capability(monkeypatch):
 @pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused_fs not built")
 def test_match_fused_fs_matches_pipeline_fs_block_scorer():
     import polars as pl
-    from goldenmatch.core.blocker import build_blocks
-    from goldenmatch.core.probabilistic import probabilistic_block_scorer
 
     config = _probabilistic_config()
     em = _em()
@@ -286,28 +284,7 @@ def test_match_fused_fs_matches_pipeline_fs_block_scorer():
     got = _table_to_clusters(tbl)
 
     # reference: the pipeline FS block path (same em -> same kernel FS math)
-    scorer = probabilistic_block_scorer(config.get_matchkeys()[0], em)
-    pairs = []
-    for br in build_blocks(df.lazy(), config.blocking):
-        g = br.materialize().native if hasattr(br.df, "collect") else br.df
-        pairs += scorer(g)
-    parent = list(range(df.height))
-
-    def find(x):
-        while parent[x] != x:
-            parent[x] = parent[parent[x]]
-            x = parent[x]
-        return x
-
-    for a, b, _s in pairs:
-        ra, rb = find(a), find(b)
-        if ra != rb:
-            parent[ra] = rb
-    comps = defaultdict(list)
-    for i in range(df.height):
-        comps[find(i)].append(i)
-    want = {frozenset(v) for v in comps.values() if len(v) >= 2}
-    assert got == want
+    assert got == _classic_fs_clusters(df, config, em)
 
 
 # ---- Fellegi-Sunter fused path: NE + level_thresholds capability (R4) ----
@@ -482,7 +459,7 @@ def test_fused_weight_range_uses_fs_weight_range(monkeypatch):
 def _classic_fs_clusters(df, config, em):
     """Reference clusters via the classic pipeline: build_blocks + the routed
     probabilistic block scorer + the same union-find the fused kernel applies
-    (mirrors test_match_fused_fs_matches_pipeline_fs_block_scorer)."""
+    (shared by all three fused-FS parity tests)."""
     from goldenmatch.core.blocker import build_blocks
     from goldenmatch.core.probabilistic import probabilistic_block_scorer
 

--- a/packages/python/goldenmatch/tests/test_native_fs_ne.py
+++ b/packages/python/goldenmatch/tests/test_native_fs_ne.py
@@ -1,0 +1,125 @@
+"""Direct-kernel tests for the score_block_pairs_fs negative-evidence kwargs.
+
+Calls goldenmatch._native.score_block_pairs_fs directly (no Python scoring
+path) to pin the NE firing rule ported from ``_ne_fired``
+(core/probabilistic.py:466): fires iff BOTH values present AND non-empty AND
+similarity STRICTLY below the threshold; contributes exactly 0 otherwise.
+Skipped when the native extension isn't built.
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.core import _native_loader
+
+pytestmark = pytest.mark.skipif(
+    not _native_loader.native_available(),
+    reason="goldenmatch._native not built",
+)
+
+# _NATIVE_FS_SCORER_IDS (core/probabilistic.py): jaro_winkler=0, levenshtein=1,
+# token_sort=2, exact=3.
+_EXACT = 3
+
+
+def _base_args():
+    """3-row single block; one regular exact field with identical values.
+
+    Every pair gets the full agreement weight 2.0 (weights [[-2.0, 2.0]],
+    levels [2], partials [0.5]). calibrated=False, prior_w=0.0, threshold=0.0
+    (emit everything). min/max weights are hand-set NE-aware:
+    min = -2.0 + -4.0 = -6.0, max = 2.0, range = 8.0.
+    """
+    row_ids = [1, 2, 3]
+    field_values = [["same", "same", "same"]]
+    scorer_ids = [_EXACT]
+    levels = [2]
+    partials = [0.5]
+    weights = [[-2.0, 2.0]]
+    return (
+        row_ids,
+        [3],
+        field_values,
+        scorer_ids,
+        levels,
+        partials,
+        weights,
+        False,
+        0.0,
+        -6.0,
+        8.0,
+        0.0,
+        [],
+    )
+
+
+def test_kernel_exports_fs_supports_ne():
+    mod = _native_loader.native_module()
+    assert getattr(mod, "FS_SUPPORTS_NE", False) is True
+
+
+def test_kernel_ne_fires_strictly_below_threshold():
+    mod = _native_loader.native_module()
+    # Rows 1/2 share the NE value (sim 1.0 >= 0.5 -> no fire); rows 1/3 and
+    # 2/3 differ (sim 0.0 < 0.5 -> fires, adds -4.0).
+    pairs = mod.score_block_pairs_fs(
+        *_base_args(),
+        ne_values=[["X", "X", "Y"]],
+        ne_scorer_ids=[_EXACT],
+        ne_thresholds=[0.5],
+        ne_weights=[-4.0],
+    )
+    scores = {(a, b): s for a, b, s in pairs}
+    # no-fire pair: (2.0 - (-6.0)) / 8.0 = 1.0
+    assert scores[(1, 2)] == pytest.approx(1.0)
+    # fired pairs: (2.0 - 4.0 - (-6.0)) / 8.0 = 0.5
+    assert scores[(1, 3)] == pytest.approx(0.5)
+    assert scores[(2, 3)] == pytest.approx(0.5)
+    assert len(scores) == 3
+
+
+def test_kernel_ne_null_and_empty_never_fire():
+    mod = _native_loader.native_module()
+    # None on one side (pairs with row 1) and "" on one side (pairs with
+    # row 3) are inconclusive: NE must contribute exactly 0, so the result
+    # matches a call WITHOUT the ne kwargs entirely.
+    without_ne = mod.score_block_pairs_fs(*_base_args())
+    with_ne = mod.score_block_pairs_fs(
+        *_base_args(),
+        ne_values=[[None, "X", ""]],
+        ne_scorer_ids=[_EXACT],
+        ne_thresholds=[0.5],
+        ne_weights=[-4.0],
+    )
+    assert with_ne == without_ne
+
+
+def test_kernel_ne_validation_errors():
+    mod = _native_loader.native_module()
+
+    # Partial kwarg group: ne_values without the other three.
+    with pytest.raises(ValueError, match="score_block_pairs_fs"):
+        mod.score_block_pairs_fs(*_base_args(), ne_values=[["X", "X", "Y"]])
+    # Partial kwarg group: ne_weights without ne_values.
+    with pytest.raises(ValueError, match="score_block_pairs_fs"):
+        mod.score_block_pairs_fs(*_base_args(), ne_weights=[-4.0])
+
+    # Mismatched lengths across the four (2 values vs 1 of the rest).
+    with pytest.raises(ValueError, match="score_block_pairs_fs"):
+        mod.score_block_pairs_fs(
+            *_base_args(),
+            ne_values=[["X", "X", "Y"], ["A", "B", "C"]],
+            ne_scorer_ids=[_EXACT],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )
+
+    # ne_values[k] row count != len(row_ids).
+    with pytest.raises(ValueError, match="score_block_pairs_fs"):
+        mod.score_block_pairs_fs(
+            *_base_args(),
+            ne_values=[["X", "X"]],
+            ne_scorer_ids=[_EXACT],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )

--- a/packages/python/goldenmatch/tests/test_native_fs_ne.py
+++ b/packages/python/goldenmatch/tests/test_native_fs_ne.py
@@ -17,6 +17,7 @@ Skipped when the native extension isn't built.
 from __future__ import annotations
 
 import polars as pl
+import pyarrow as pa
 import pytest
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,
@@ -250,9 +251,7 @@ class TestFsNativeEligibleNE:
     def test_fs_native_eligible_ensemble_ne_declines(self, monkeypatch):
         monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
         monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
-        mk = _ne_mk(
-            [NegativeEvidenceField(field="phone", scorer="ensemble", threshold=0.5)]
-        )
+        mk = _ne_mk([NegativeEvidenceField(field="phone", scorer="ensemble", threshold=0.5)])
         assert _fs_native_eligible(mk) is False
 
 
@@ -272,9 +271,7 @@ def test_native_kwargs_not_sent_without_ne(monkeypatch):
 
     monkeypatch.setattr(_native_loader, "native_module", lambda: _Spy())
 
-    mk = MatchkeyConfig(
-        name="fs", type="probabilistic", fields=_base_fields(), link_threshold=0.0
-    )
+    mk = MatchkeyConfig(name="fs", type="probabilistic", fields=_base_fields(), link_threshold=0.0)
     df = _block_df()
     pairs = score_probabilistic_native(df, mk, _em(_BASE_WEIGHTS))
     assert pairs, "expected pairs at link_threshold=0.0"
@@ -401,9 +398,7 @@ def test_native_success_bar_homonym(monkeypatch):
             f"true duplicate pair {(a, b)} failed to merge on the native path"
         )
     for a, b in homonym_pairs:
-        assert not _same_cluster(mapping, a, b), (
-            f"homonym trap {(a, b)} merged on the native path"
-        )
+        assert not _same_cluster(mapping, a, b), f"homonym trap {(a, b)} merged on the native path"
 
     # Byte-identical clustering vs the pure-Python (numpy) run.
     monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
@@ -413,8 +408,254 @@ def test_native_success_bar_homonym(monkeypatch):
     def _membership(res) -> set[frozenset]:
         clusters = res.clusters
         infos = clusters.values() if isinstance(clusters, dict) else clusters
-        return {
-            frozenset(c["members"] if isinstance(c, dict) else c) for c in infos
-        }
+        return {frozenset(c["members"] if isinstance(c, dict) else c) for c in infos}
 
     assert _membership(native_result) == _membership(python_result)
+
+
+# ---------------------------------------------------------------------------
+# R3: fused kernel (match_fused_fs) — NE + level_thresholds, kernel-direct
+# ---------------------------------------------------------------------------
+
+
+def _fused_fs_call(
+    mod,
+    keys: list[str],
+    field_vals: list[list[str | None]],
+    *,
+    scorer_ids: list[int],
+    levels: list[int],
+    partials: list[float],
+    weights: list[list[float]],
+    min_w: float,
+    w_range: float,
+    threshold: float,
+    **kwargs,
+):
+    """Kernel-direct match_fused_fs call, positional shape mirroring
+    run_match_fused_fs_arrow (fused_match.py): row_ids int64, one large_string
+    block-key column, large_string score columns. calibrated=False, prior_w=0."""
+    n = len(keys)
+    row_ids = pa.array(range(n), type=pa.int64())
+    key_arrs = [pa.array(keys, type=pa.large_string())]
+    score_arrs = [pa.array(v, type=pa.large_string()) for v in field_vals]
+    return mod.match_fused_fs(
+        row_ids,
+        key_arrs,
+        score_arrs,
+        scorer_ids,
+        levels,
+        partials,
+        weights,
+        False,
+        0.0,
+        min_w,
+        w_range,
+        threshold,
+        **kwargs,
+    )
+
+
+def _memberships(clusters) -> set[frozenset]:
+    return {frozenset(c) for c in clusters}
+
+
+def _multi_memberships(clusters) -> set[frozenset]:
+    return {frozenset(c) for c in clusters if len(c) >= 2}
+
+
+def test_fused_exports_level_thresholds_const():
+    mod = _native_loader.native_module()
+    assert getattr(mod, "FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", False) is True
+
+
+# Interleaved block keys: rows of the same key are NOT adjacent in input order,
+# so the kernel's block gather REORDERS rows. Block "b" = rows {0, 2}, block
+# "a" = rows {1, 3}.
+_FUSED_KEYS = ["b", "a", "b", "a"]
+
+
+def _fused_ne_base_kwargs() -> dict:
+    """One exact regular field, all values identical (agreement weight 2.0 for
+    every within-block pair). NE-aware normalization range hand-set:
+    min = -2.0 + -4.0 = -6.0, max = 2.0, range = 8.0. No fire -> score 1.0;
+    fired (-4.0) -> score 0.5. threshold 0.75 sits between the two."""
+    return dict(
+        scorer_ids=[_EXACT],
+        levels=[2],
+        partials=[0.5],
+        weights=[[-2.0, 2.0]],
+        min_w=-6.0,
+        w_range=8.0,
+        threshold=0.75,
+    )
+
+
+def test_fused_fs_ne_fires():
+    """NE flips both within-block pairs below the threshold — and doubles as
+    the gather-trap test: NE values are chosen per ORIGINAL row index
+    (["P", "P", "Q", "Q"]) so that after the block gather (either block-order:
+    [0,2,1,3] or [1,3,0,2]) an unpermuted-NE bug would read same-valued
+    positions (no fire, pairs merge) instead of the true differing row values
+    (fire, all singletons)."""
+    mod = _native_loader.native_module()
+    kw = _fused_ne_base_kwargs()
+    field_vals = [["same", "same", "same", "same"]]
+
+    without_ne = _fused_fs_call(mod, _FUSED_KEYS, field_vals, **kw)
+    # No NE: both within-block pairs score 1.0 >= 0.75 -> {0,2} and {1,3} merge.
+    assert _multi_memberships(without_ne) == {frozenset({0, 2}), frozenset({1, 3})}
+
+    with_ne = _fused_fs_call(
+        mod,
+        _FUSED_KEYS,
+        field_vals,
+        **kw,
+        ne_fields=[pa.array(["P", "P", "Q", "Q"], type=pa.large_string())],
+        ne_scorer_ids=[_EXACT],
+        ne_thresholds=[0.5],
+        ne_weights=[-4.0],
+    )
+    # Correct NE indexing: row 0 ("P") vs row 2 ("Q") fires; row 1 ("P") vs
+    # row 3 ("Q") fires -> both pairs drop to 0.5 < 0.75 -> all singletons.
+    # An unpermuted-NE bug reads adjacent gathered positions (equal values,
+    # no fire) and wrongly keeps both merges.
+    assert _multi_memberships(with_ne) == set()
+    assert _memberships(with_ne) == {
+        frozenset({0}),
+        frozenset({1}),
+        frozenset({2}),
+        frozenset({3}),
+    }
+
+
+def test_fused_fs_ne_null_and_empty_never_fire():
+    mod = _native_loader.native_module()
+    kw = _fused_ne_base_kwargs()
+    field_vals = [["same", "same", "same", "same"]]
+    without_ne = _fused_fs_call(mod, _FUSED_KEYS, field_vals, **kw)
+    # None on one side / "" on one side: inconclusive, NE contributes 0.
+    with_ne = _fused_fs_call(
+        mod,
+        _FUSED_KEYS,
+        field_vals,
+        **kw,
+        ne_fields=[pa.array([None, "", "X", "Y"], type=pa.large_string())],
+        ne_scorer_ids=[_EXACT],
+        ne_thresholds=[0.5],
+        ne_weights=[-4.0],
+    )
+    assert _memberships(with_ne) == _memberships(without_ne)
+
+
+def test_fused_fs_level_thresholds_bands():
+    """Custom banding [[0.9, 0.5]] + 3-entry weights, hand-computed membership.
+
+    Single block, levenshtein sims: (0,1)=1.0, (0,2)=(1,2)=0.75, (2,3)=0.25,
+    (0,3)=(1,3)=0.0. Weights [-2.0, 1.0, 3.0], linear range [-2.0, 3.0]:
+    level 2 -> 1.0, level 1 -> 0.6, level 0 -> 0.0. threshold 0.55.
+
+    Custom banding: 0.75 >= 0.5 -> level 1 (0.6 links) -> cluster {0, 1, 2}.
+    Legacy 3-level banding (partial 0.8): 0.75 < 0.8 -> level 0 -> only (0,1)
+    links -> cluster {0, 1}. A kernel that ignores the kwarg fails the first
+    assertion; the second proves the difference is the kwarg."""
+    mod = _native_loader.native_module()
+    keys = ["k", "k", "k", "k"]
+    field_vals = [["aaaa", "aaaa", "aaab", "bbbb"]]
+    kw = dict(
+        scorer_ids=[1],  # levenshtein
+        levels=[3],
+        partials=[0.8],
+        weights=[[-2.0, 1.0, 3.0]],
+        min_w=-2.0,
+        w_range=5.0,
+        threshold=0.55,
+    )
+    custom = _fused_fs_call(mod, keys, field_vals, **kw, level_thresholds=[[0.9, 0.5]])
+    assert _multi_memberships(custom) == {frozenset({0, 1, 2})}
+
+    legacy = _fused_fs_call(mod, keys, field_vals, **kw)
+    assert _multi_memberships(legacy) == {frozenset({0, 1})}
+
+
+def test_fused_fs_ne_validation_errors():
+    mod = _native_loader.native_module()
+    kw = _fused_ne_base_kwargs()
+    field_vals = [["same", "same", "same", "same"]]
+    ne_col = pa.array(["P", "P", "Q", "Q"], type=pa.large_string())
+
+    # Partial NE kwarg group.
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(mod, _FUSED_KEYS, field_vals, **kw, ne_fields=[ne_col])
+
+    # Mismatched lengths across the four (2 fields vs 1 of the rest).
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(
+            mod,
+            _FUSED_KEYS,
+            field_vals,
+            **kw,
+            ne_fields=[ne_col, ne_col],
+            ne_scorer_ids=[_EXACT],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )
+
+    # ne_fields[k] length != row count.
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(
+            mod,
+            _FUSED_KEYS,
+            field_vals,
+            **kw,
+            ne_fields=[pa.array(["P", "Q"], type=pa.large_string())],
+            ne_scorer_ids=[_EXACT],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )
+
+    # NE scorer id outside score_one's implemented 0..=3 range.
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(
+            mod,
+            _FUSED_KEYS,
+            field_vals,
+            **kw,
+            ne_fields=[ne_col],
+            ne_scorer_ids=[9],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )
+
+    # level_thresholds length != field count.
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(
+            mod,
+            _FUSED_KEYS,
+            field_vals,
+            **kw,
+            level_thresholds=[[0.9, 0.5], [0.9]],
+        )
+
+    # weights-vs-thresholds arity: 2 thresholds need 3 weights, got 2.
+    with pytest.raises(ValueError, match="match_fused_fs"):
+        _fused_fs_call(
+            mod,
+            _FUSED_KEYS,
+            field_vals,
+            **kw,
+            level_thresholds=[[0.9, 0.5]],
+        )
+
+
+def test_kernel_ne_scorer_id_validated():
+    """Ride-along: score_block_pairs_fs rejects NE scorer ids outside 0..=3."""
+    mod = _native_loader.native_module()
+    with pytest.raises(ValueError, match="score_block_pairs_fs"):
+        mod.score_block_pairs_fs(
+            *_base_args(),
+            ne_values=[["X", "X", "Y"]],
+            ne_scorer_ids=[9],
+            ne_thresholds=[0.5],
+            ne_weights=[-4.0],
+        )

--- a/packages/python/goldenmatch/tests/test_native_fs_ne.py
+++ b/packages/python/goldenmatch/tests/test_native_fs_ne.py
@@ -1,16 +1,36 @@
-"""Direct-kernel tests for the score_block_pairs_fs negative-evidence kwargs.
+"""Native FS negative-evidence tests: kernel-direct + Python gate/caller/parity.
 
-Calls goldenmatch._native.score_block_pairs_fs directly (no Python scoring
-path) to pin the NE firing rule ported from ``_ne_fired``
+Kernel-direct tests call goldenmatch._native.score_block_pairs_fs directly (no
+Python scoring path) to pin the NE firing rule ported from ``_ne_fired``
 (core/probabilistic.py:466): fires iff BOTH values present AND non-empty AND
 similarity STRICTLY below the threshold; contributes exactly 0 otherwise.
+
+The gate/caller/parity tests cover the R2 Python side: ``_fs_native_eligible``
+widening (native NE scorers + ``FS_SUPPORTS_NE``; old wheels decline),
+``score_probabilistic_native`` NE kwarg construction (never sent without NE),
+native-vs-numpy parity on NE-bearing matchkeys, and the homonym E2E success
+bar on the NATIVE path with byte-identical clustering to the numpy run.
+
 Skipped when the native extension isn't built.
 """
 
 from __future__ import annotations
 
+import polars as pl
 import pytest
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    NegativeEvidenceField,
+)
 from goldenmatch.core import _native_loader
+from goldenmatch.core.probabilistic import (
+    EMResult,
+    _fs_native_eligible,
+    score_probabilistic_native,
+    score_probabilistic_vectorized,
+)
 
 pytestmark = pytest.mark.skipif(
     not _native_loader.native_available(),
@@ -123,3 +143,278 @@ def test_kernel_ne_validation_errors():
             ne_thresholds=[0.5],
             ne_weights=[-4.0],
         )
+
+
+def test_kernel_ne_at_threshold_does_not_fire():
+    """Strict comparator pin: sim == threshold (1.0 exact-match, threshold 1.0)
+    is ``1.0 < 1.0`` = False -> NE contributes 0, identical to the no-NE call."""
+    mod = _native_loader.native_module()
+    without_ne = mod.score_block_pairs_fs(*_base_args())
+    with_ne = mod.score_block_pairs_fs(
+        *_base_args(),
+        ne_values=[["X", "X", "X"]],
+        ne_scorer_ids=[_EXACT],
+        ne_thresholds=[1.0],
+        ne_weights=[-4.0],
+    )
+    assert with_ne == without_ne
+
+
+# ---------------------------------------------------------------------------
+# R2: Python gate widening + native caller + parity + native success bar
+# ---------------------------------------------------------------------------
+
+
+def _em(match_weights: dict[str, list[float]], proportion: float = 0.2) -> EMResult:
+    """Hand-built EMResult (no training); m/u probs are shape-matched dummies."""
+    dummy = {k: [0.5] * len(v) for k, v in match_weights.items()}
+    return EMResult(
+        m_probs=dummy,
+        u_probs=dummy,
+        match_weights=match_weights,
+        converged=True,
+        iterations=3,
+        proportion_matched=proportion,
+    )
+
+
+def _base_fields() -> list[MatchkeyField]:
+    return [
+        MatchkeyField(field="name", scorer="jaro_winkler", levels=2, partial_threshold=0.8),
+        MatchkeyField(field="city", scorer="exact", levels=2),
+    ]
+
+
+_BASE_WEIGHTS = {"name": [-2.0, 3.0], "city": [-1.5, 2.5]}
+
+# Names/cities keep all pairwise similarities well away from the 0.8 partial
+# threshold (identical, trailing-char corruption ~0.98, or fully distinct).
+_NAMES = ["Jonathan", "Jonathanx", "Michaela", "Michaela", "Robertson", "Robertson"]
+_CITIES = ["Boston", "Boston", "Denver", "Denver", "Austin", "Austin"]
+
+
+def _block_df(**extra_cols) -> pl.DataFrame:
+    return pl.DataFrame(
+        {"__row_id__": list(range(6)), "name": _NAMES, "city": _CITIES, **extra_cols}
+    )
+
+
+def _ne_mk(ne_fields: list[NegativeEvidenceField], fields=None) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="fs",
+        type="probabilistic",
+        fields=fields or _base_fields(),
+        negative_evidence=ne_fields,
+        link_threshold=0.0,  # emit every pair: parity compares the full sets
+    )
+
+
+def _phone_ne(**kw) -> NegativeEvidenceField:
+    # threshold 0.5 with an exact scorer: sims are only 0.0/1.0, both strictly
+    # away from the threshold (tolerance discipline).
+    return NegativeEvidenceField(field="phone", scorer="exact", threshold=0.5, **kw)
+
+
+class TestFsNativeEligibleNE:
+    def test_fs_native_eligible_ne_supported(self, monkeypatch):
+        monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+        monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+        mk = _ne_mk([_phone_ne()])
+        assert _fs_native_eligible(mk) is True
+
+    def test_fs_native_eligible_ne_old_wheel_declines(self, monkeypatch):
+        monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+        monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+
+        class _OldWheel:
+            """Has the FS kernel + level_thresholds capability, lacks FS_SUPPORTS_NE."""
+
+            FS_SUPPORTS_LEVEL_THRESHOLDS = True
+
+            @staticmethod
+            def score_block_pairs_fs(*args, **kwargs):
+                return []
+
+        monkeypatch.setattr(_native_loader, "native_module", lambda: _OldWheel())
+
+        ne_mk = _ne_mk([_phone_ne()])
+        assert _fs_native_eligible(ne_mk) is False
+
+        # The same stub with a no-NE matchkey is still eligible: the decline
+        # above is NE-specific, not a broken stub.
+        plain_mk = MatchkeyConfig(
+            name="fs", type="probabilistic", fields=_base_fields(), link_threshold=0.0
+        )
+        assert _fs_native_eligible(plain_mk) is True
+
+    def test_fs_native_eligible_ensemble_ne_declines(self, monkeypatch):
+        monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+        monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+        mk = _ne_mk(
+            [NegativeEvidenceField(field="phone", scorer="ensemble", threshold=0.5)]
+        )
+        assert _fs_native_eligible(mk) is False
+
+
+def test_native_kwargs_not_sent_without_ne(monkeypatch):
+    """A no-NE matchkey must never put ne_* kwargs on the FFI call (the old-wheel
+    discipline: an old wheel must never see the kwarg, even if the gate drifts)."""
+    real = _native_loader.native_module()
+    captured: dict = {}
+
+    class _Spy:
+        def __getattr__(self, name):
+            return getattr(real, name)
+
+        def score_block_pairs_fs(self, *args, **kwargs):
+            captured["kwargs"] = dict(kwargs)
+            return real.score_block_pairs_fs(*args, **kwargs)
+
+    monkeypatch.setattr(_native_loader, "native_module", lambda: _Spy())
+
+    mk = MatchkeyConfig(
+        name="fs", type="probabilistic", fields=_base_fields(), link_threshold=0.0
+    )
+    df = _block_df()
+    pairs = score_probabilistic_native(df, mk, _em(_BASE_WEIGHTS))
+    assert pairs, "expected pairs at link_threshold=0.0"
+    assert "kwargs" in captured, "spy never saw the kernel call"
+    assert "ne_values" not in captured["kwargs"]
+    assert "ne_scorer_ids" not in captured["kwargs"]
+    assert "ne_thresholds" not in captured["kwargs"]
+    assert "ne_weights" not in captured["kwargs"]
+
+
+def _parity_cases() -> dict[str, tuple[pl.DataFrame, MatchkeyConfig, EMResult]]:
+    ne_w = dict(_BASE_WEIGHTS)
+    ne_w["__ne__phone"] = [-4.0, 0.0]
+
+    two_ne_w = dict(ne_w)
+    two_ne_w["__ne__email"] = [-3.0, 0.0]
+
+    lt_w = {"name": [-2.0, 1.0, 3.0], "city": [-1.5, 2.5], "__ne__phone": [-4.0, 0.0]}
+    lt_fields = [
+        MatchkeyField(
+            field="name",
+            scorer="jaro_winkler",
+            levels=3,
+            partial_threshold=0.8,
+            level_thresholds=[0.9, 0.7],
+        ),
+        MatchkeyField(field="city", scorer="exact", levels=2),
+    ]
+
+    # Phones: rows 0/1 agree (dup, NE never fires); rows 2/3 differ (homonym
+    # shape, NE fires); rows 4/5 agree.
+    phones = ["5551111111", "5551111111", "5552222222", "5553333333", "5554444444", "5554444444"]
+    phones_null = list(phones)
+    phones_null[2] = None
+    # "-" with transforms=["digits_only"] -> "" after transform: inconclusive.
+    phones_dash = list(phones)
+    phones_dash[3] = "-"
+    emails = ["a@x.com", "a@x.com", "b@x.com", "c@x.com", "d@x.com", "d@x.com"]
+
+    return {
+        "em-learned": (_block_df(phone=phones), _ne_mk([_phone_ne()]), _em(ne_w)),
+        "penalty-bits": (
+            _block_df(phone=phones),
+            _ne_mk([_phone_ne(penalty_bits=5.0)]),
+            _em(_BASE_WEIGHTS),
+        ),
+        "null-ne-row": (_block_df(phone=phones_null), _ne_mk([_phone_ne()]), _em(ne_w)),
+        "empty-after-transform": (
+            _block_df(phone=phones_dash),
+            _ne_mk([_phone_ne(transforms=["digits_only"])]),
+            _em(ne_w),
+        ),
+        "ne-plus-level-thresholds": (
+            _block_df(phone=phones),
+            _ne_mk([_phone_ne()], fields=lt_fields),
+            _em(lt_w),
+        ),
+        "two-ne-fields": (
+            _block_df(phone=phones, email=emails),
+            _ne_mk(
+                [
+                    _phone_ne(),
+                    NegativeEvidenceField(field="email", scorer="exact", threshold=0.5),
+                ]
+            ),
+            _em(two_ne_w),
+        ),
+    }
+
+
+@pytest.mark.parametrize("case", sorted(_parity_cases()))
+def test_native_numpy_parity_ne(case, monkeypatch):
+    """Native kernel vs numpy vectorized path: identical pair sets + scores
+    (both round to 4 decimals; fixture sims sit away from every threshold)."""
+    monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+    df, mk, em = _parity_cases()[case]
+    assert _fs_native_eligible(mk) is True  # guard: really exercising the kernel
+
+    native = sorted(score_probabilistic_native(df, mk, em))
+    vec = sorted(score_probabilistic_vectorized(df, mk, em))
+    assert [(a, b) for a, b, _ in native] == [(a, b) for a, b, _ in vec]
+    for (na, nb, ns), (_, _, vs) in zip(native, vec):
+        assert ns == pytest.approx(vs, abs=1e-9), f"pair ({na}, {nb}) score diverged"
+
+
+def test_native_success_bar_homonym(monkeypatch):
+    """The FS-NE homonym E2E bar on the NATIVE path: traps separate, true dups
+    merge, and clustering is byte-identical to the numpy run of the same fixture."""
+    import goldenmatch as gm
+
+    from tests.test_fs_ne_e2e import (
+        LINK_THRESHOLD,
+        _blocking,
+        _build_fixture,
+        _fields,
+        _id_to_cluster,
+        _same_cluster,
+    )
+
+    monkeypatch.delenv("GOLDENMATCH_FS_NATIVE", raising=False)
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+
+    df, dup_pairs, homonym_pairs = _build_fixture()
+    mk = MatchkeyConfig(
+        name="fs",
+        type="probabilistic",
+        fields=_fields(),
+        negative_evidence=[
+            NegativeEvidenceField(field="phone", scorer="exact", threshold=1.0),
+        ],
+        link_threshold=LINK_THRESHOLD,
+    )
+    # In-test guard against a silent numpy fallback: the fixture's NE-bearing
+    # matchkey must be native-eligible before the native run means anything.
+    assert _fs_native_eligible(mk) is True
+
+    config = GoldenMatchConfig(matchkeys=[mk], blocking=_blocking())
+    native_result = gm.dedupe_df(df, config=config)
+    mapping = _id_to_cluster(native_result)
+
+    for a, b in dup_pairs:
+        assert _same_cluster(mapping, a, b), (
+            f"true duplicate pair {(a, b)} failed to merge on the native path"
+        )
+    for a, b in homonym_pairs:
+        assert not _same_cluster(mapping, a, b), (
+            f"homonym trap {(a, b)} merged on the native path"
+        )
+
+    # Byte-identical clustering vs the pure-Python (numpy) run.
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+    assert _fs_native_eligible(mk) is False  # guard: really the numpy path now
+    python_result = gm.dedupe_df(df, config=config)
+
+    def _membership(res) -> set[frozenset]:
+        clusters = res.clusters
+        infos = clusters.values() if isinstance(clusters, dict) else clusters
+        return {
+            frozenset(c["members"] if isinstance(c, dict) else c) for c in infos
+        }
+
+    assert _membership(native_result) == _membership(python_result)

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.14"
+version = "0.1.15"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.14"
+version = "0.1.15"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.14"
+    __version__ = "0.1.15"

--- a/packages/rust/extensions/native/src/fused.rs
+++ b/packages/rust/extensions/native/src/fused.rs
@@ -67,22 +67,33 @@ fn read_ids_and_fields(
 
 /// Block-formation + gather into block-CONTIGUOUS order (once, O(n)). Returns the
 /// block-sorted row ids, the per-field block-sorted values (borrowed from the
-/// Arrow buffers), and the per-block `(offset, size)` spans. The contiguous
+/// Arrow buffers), the per-NE-field block-sorted values (same permutation — NE
+/// columns MUST ride the same gather or the per-pair NE check would read the
+/// UNSORTED row index), and the per-block `(offset, size)` spans. The contiguous
 /// layout gives the O(k^2) inner scoring loop the same cache locality the
 /// pipeline gets from its Polars sort.
 #[allow(clippy::type_complexity)]
 fn fused_gather<'a>(
     key_cols: &[StrCol],
     score_cols: &'a [StrCol],
+    ne_cols: &'a [StrCol],
     n_rows: usize,
     all_ids: &[i64],
-) -> (Vec<i64>, Vec<Vec<Option<&'a str>>>, Vec<(usize, usize)>) {
+) -> (
+    Vec<i64>,
+    Vec<Vec<Option<&'a str>>>,
+    Vec<Vec<Option<&'a str>>>,
+    Vec<(usize, usize)>,
+) {
     let groups = group_block_positions(key_cols, n_rows);
     let n_blk: usize = groups.iter().map(|g| g.len()).sum();
     let n_fields = score_cols.len();
+    let n_ne = ne_cols.len();
     let mut rid_sorted: Vec<i64> = Vec::with_capacity(n_blk);
     let mut vals: Vec<Vec<Option<&str>>> =
         (0..n_fields).map(|_| Vec::with_capacity(n_blk)).collect();
+    let mut ne_vals: Vec<Vec<Option<&str>>> =
+        (0..n_ne).map(|_| Vec::with_capacity(n_blk)).collect();
     let mut spans: Vec<(usize, usize)> = Vec::with_capacity(groups.len());
     let mut off = 0usize;
     for block in &groups {
@@ -92,11 +103,14 @@ fn fused_gather<'a>(
             for (f, col) in score_cols.iter().enumerate() {
                 vals[f].push(col.get(p));
             }
+            for (k, col) in ne_cols.iter().enumerate() {
+                ne_vals[k].push(col.get(p));
+            }
         }
         spans.push((off, block.len()));
         off += block.len();
     }
-    (rid_sorted, vals, spans)
+    (rid_sorted, vals, ne_vals, spans)
 }
 
 /// Run a per-span scorer over the spans, with the #688 guarded-rayon posture:
@@ -170,7 +184,8 @@ pub fn match_fused(
     let n_fields = score_cols.len();
 
     Ok(py.detach(|| {
-        let (rid_sorted, vals, spans) = fused_gather(&key_cols, &score_cols, n_rows, &all_ids);
+        let (rid_sorted, vals, _, spans) =
+            fused_gather(&key_cols, &score_cols, &[], n_rows, &all_ids);
         let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
             let mut local = Vec::new();
             let end = offset + size;
@@ -210,11 +225,35 @@ pub fn match_fused(
 /// `(min,max, normalized)` when `normalized >= threshold`. `levels` /
 /// `partial_thresholds` / `match_weights` / `calibrated` / `prior_w` /
 /// `min_weight` / `weight_range` come from the host's EM-trained model.
+///
+/// `level_thresholds` (optional, one entry per field) carries a field's custom
+/// similarity->level banding (PR #1749): when `Some(ts)` for field `f`, its
+/// level is the count of thresholds `t` with `sim >= t` (inclusive), and
+/// `match_weights[f]` must have `ts.len() + 1` entries. `None` (whole kwarg or
+/// per field) keeps the legacy 2/3/N-even banding. Old wheels never see this
+/// kwarg (Python gates on the `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS` flag).
+///
+/// The `ne_*` kwargs (optional, all-or-none) carry Fellegi-Sunter negative
+/// evidence: `ne_fields[k]` is NE field `k`'s POST-transform Utf8/LargeUtf8
+/// column (row-aligned with the score columns; it rides the same block gather
+/// so the per-pair check reads the block-sorted permutation),
+/// `ne_scorer_ids`/`ne_thresholds`/`ne_weights` its scorer, firing threshold,
+/// and resolved fired-weight (normally negative). Firing follows `_ne_fired`
+/// (core/probabilistic.py:466) byte-for-byte: fires iff BOTH values are
+/// present AND non-empty (empty string = inconclusive — the deliberate NE
+/// null-handling that differs from regular fields' null -> level-0) AND
+/// similarity is STRICTLY below the threshold; a fired field adds
+/// `ne_weights[k]` to the pair's summed weight, otherwise it contributes
+/// exactly 0. `fs_normalize` is unchanged — the caller passes NE-aware
+/// `min_weight`/`weight_range`. Old wheels never see these kwargs (Python
+/// gates on the `FS_SUPPORTS_NE` capability flag).
 #[allow(clippy::too_many_arguments)]
 #[pyfunction]
 #[pyo3(signature = (
     row_ids, key_fields, score_fields, scorer_ids, levels, partial_thresholds,
     match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
+    level_thresholds=None,
+    ne_fields=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
 ))]
 pub fn match_fused_fs(
     py: Python<'_>,
@@ -230,6 +269,11 @@ pub fn match_fused_fs(
     min_weight: f64,
     weight_range: f64,
     threshold: f64,
+    level_thresholds: Option<Vec<Option<Vec<f64>>>>,
+    ne_fields: Option<Vec<PyArrowType<ArrayData>>>,
+    ne_scorer_ids: Option<Vec<u8>>,
+    ne_thresholds: Option<Vec<f64>>,
+    ne_weights: Option<Vec<f64>>,
 ) -> PyResult<Vec<Vec<i64>>> {
     let n = scorer_ids.len();
     if levels.len() != n || partial_thresholds.len() != n || match_weights.len() != n {
@@ -248,8 +292,95 @@ pub fn match_fused_fs(
     let all_ids: Vec<i64> = row_ids.values().to_vec();
     let n_fields = score_cols.len();
 
+    if let Some(lt) = &level_thresholds {
+        if lt.len() != n_fields {
+            return Err(PyValueError::new_err(format!(
+                "match_fused_fs: level_thresholds length {} != field count {n_fields}",
+                lt.len()
+            )));
+        }
+        for (f, ts) in lt.iter().enumerate() {
+            if let Some(ts) = ts {
+                if match_weights[f].len() != ts.len() + 1 {
+                    return Err(PyValueError::new_err(format!(
+                        "match_fused_fs: field {f} has {} match_weights but \
+                         {} level_thresholds (need thresholds + 1 weights)",
+                        match_weights[f].len(),
+                        ts.len()
+                    )));
+                }
+            }
+        }
+    }
+    // Per-field threshold slices hoisted out of the per-pair-per-field hot loop
+    // (no Option chasing / re-borrowing inside the scoring closure).
+    let field_thresholds: Vec<Option<&[f64]>> = match &level_thresholds {
+        Some(lt) => lt.iter().map(|ts| ts.as_deref()).collect(),
+        None => vec![None; n_fields],
+    };
+
+    // Negative-evidence kwargs: all four present or all four absent.
+    let n_present = [
+        ne_fields.is_some(),
+        ne_scorer_ids.is_some(),
+        ne_thresholds.is_some(),
+        ne_weights.is_some(),
+    ]
+    .iter()
+    .filter(|&&p| p)
+    .count();
+    if n_present != 0 && n_present != 4 {
+        return Err(PyValueError::new_err(
+            "match_fused_fs: ne_fields, ne_scorer_ids, ne_thresholds and \
+             ne_weights must be passed together (all four or none)",
+        ));
+    }
+    let ne_cols: Vec<StrCol> = match ne_fields {
+        Some(fields) => fields
+            .into_iter()
+            .map(|p| StrCol::from_data(p.0))
+            .collect::<PyResult<_>>()?,
+        None => Vec::new(),
+    };
+    if n_present == 4 {
+        let n_ne = ne_cols.len();
+        let ns = ne_scorer_ids.as_deref().unwrap_or(&[]);
+        let nt = ne_thresholds.as_deref().unwrap_or(&[]);
+        let nw = ne_weights.as_deref().unwrap_or(&[]);
+        if ns.len() != n_ne || nt.len() != n_ne || nw.len() != n_ne {
+            return Err(PyValueError::new_err(format!(
+                "match_fused_fs: ne_* lengths differ (ne_fields {}, \
+                 ne_scorer_ids {}, ne_thresholds {}, ne_weights {})",
+                n_ne,
+                ns.len(),
+                nt.len(),
+                nw.len()
+            )));
+        }
+        for (k, col) in ne_cols.iter().enumerate() {
+            if col.len() != n_rows {
+                return Err(PyValueError::new_err(format!(
+                    "match_fused_fs: ne_fields[{k}] length {} != row count {n_rows}",
+                    col.len()
+                )));
+            }
+        }
+        for (k, &sid) in ns.iter().enumerate() {
+            if sid > 3 {
+                return Err(PyValueError::new_err(format!(
+                    "match_fused_fs: ne_scorer_ids[{k}]={sid} out of range (valid: 0..=3)"
+                )));
+            }
+        }
+    }
+    let ne_scorer_ids_v: Vec<u8> = ne_scorer_ids.unwrap_or_default();
+    let ne_thresholds_v: Vec<f64> = ne_thresholds.unwrap_or_default();
+    let ne_weights_v: Vec<f64> = ne_weights.unwrap_or_default();
+    let n_ne = ne_cols.len();
+
     Ok(py.detach(|| {
-        let (rid_sorted, vals, spans) = fused_gather(&key_cols, &score_cols, n_rows, &all_ids);
+        let (rid_sorted, vals, ne_vals, spans) =
+            fused_gather(&key_cols, &score_cols, &ne_cols, n_rows, &all_ids);
         let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
             let mut local = Vec::new();
             let end = offset + size;
@@ -263,14 +394,32 @@ pub fn match_fused_fs(
                         let level = match (vals[f][i], vals[f][j]) {
                             (Some(a), Some(b)) => {
                                 let sim = score_one(scorer_ids[f], a, b);
-                                // Fused stays declined for level_thresholds via
-                                // match_fused_fs_ready (Python side); port the
-                                // kwarg when the fused path goes live.
-                                fs_level_from_sim(sim, levels[f], partial_thresholds[f], None)
+                                fs_level_from_sim(
+                                    sim,
+                                    levels[f],
+                                    partial_thresholds[f],
+                                    field_thresholds[f],
+                                )
                             }
                             _ => 0, // null on either side -> disagree (level 0)
                         };
                         total_w += match_weights[f][level];
+                    }
+                    // Negative evidence: exact `_ne_fired` semantics
+                    // (core/probabilistic.py:466) — fires iff both values
+                    // present AND non-empty AND similarity STRICTLY below
+                    // the threshold; contributes exactly 0 otherwise. The
+                    // ne_vals here are block-gathered alongside the score
+                    // columns, so i/j index the same permutation.
+                    for k in 0..n_ne {
+                        if let (Some(a), Some(b)) = (ne_vals[k][i], ne_vals[k][j]) {
+                            if !a.is_empty()
+                                && !b.is_empty()
+                                && score_one(ne_scorer_ids_v[k], a, b) < ne_thresholds_v[k]
+                            {
+                                total_w += ne_weights_v[k];
+                            }
+                        }
                     }
                     let normalized =
                         fs_normalize(total_w, calibrated, prior_w, min_weight, weight_range);

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -28,6 +28,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
     // level_thresholds matchkeys on this (old wheels never see the kwarg).
     m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
+    // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
+    // negative-evidence matchkeys on this (old wheels never see the ne_* kwargs).
+    m.add("FS_SUPPORTS_NE", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -31,6 +31,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
     // negative-evidence matchkeys on this (old wheels never see the ne_* kwargs).
     m.add("FS_SUPPORTS_NE", true)?;
+    // Wheel-skew capability flag: Python's `match_fused_fs_ready` gates custom
+    // level_thresholds on this (old wheels never see the kwarg).
+    m.add("FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -28,8 +28,10 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
     // level_thresholds matchkeys on this (old wheels never see the kwarg).
     m.add("FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
-    // Wheel-skew capability flag: Python's `_fs_native_eligible` gates
-    // negative-evidence matchkeys on this (old wheels never see the ne_* kwargs).
+    // Wheel-skew capability flag: Python's `_fs_native_eligible` (block scorer)
+    // AND `match_fused_fs_ready` (core/fused_match.py) both gate negative-evidence
+    // matchkeys on this (old wheels never see the ne_* kwargs). One const is
+    // accurate: both kernels' NE landed in the same 0.1.15 wheel.
     m.add("FS_SUPPORTS_NE", true)?;
     // Wheel-skew capability flag: Python's `match_fused_fs_ready` gates custom
     // level_thresholds on this (old wheels never see the kwarg).

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -260,6 +260,19 @@ pub(crate) fn fs_level_from_sim(
 /// banding. Old wheels never see this kwarg (Python gates on the
 /// `FS_SUPPORTS_LEVEL_THRESHOLDS` capability flag).
 ///
+/// The `ne_*` kwargs (optional, all-or-none) carry Fellegi-Sunter negative
+/// evidence: `ne_values[k][r]` is NE field `k`'s POST-transform value for row
+/// `r`, `ne_scorer_ids`/`ne_thresholds`/`ne_weights` its scorer, firing
+/// threshold, and resolved fired-weight (normally negative). Firing follows
+/// `_ne_fired` (core/probabilistic.py:466) byte-for-byte: fires iff BOTH
+/// values are present AND non-empty (empty string = inconclusive — the
+/// deliberate NE null-handling that differs from regular fields'
+/// null -> level-0) AND similarity is STRICTLY below the threshold; a fired
+/// field adds `ne_weights[k]` to the pair's summed weight, otherwise it
+/// contributes exactly 0. `fs_normalize` is unchanged — the caller passes
+/// NE-aware `min_weight`/`weight_range`. Old wheels never see these kwargs
+/// (Python gates on the `FS_SUPPORTS_NE` capability flag).
+///
 /// Parity with the numpy path is within rapidfuzz tolerance (same as the
 /// weighted kernel) — a pair could differ only if its normalized score sits
 /// within that tolerance of `threshold`. Asserted in tests/test_native_parity.py.
@@ -269,6 +282,7 @@ pub(crate) fn fs_level_from_sim(
     row_ids, block_sizes, field_values, scorer_ids, levels, partial_thresholds,
     match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
     exclude, level_thresholds=None,
+    ne_values=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
 ))]
 pub fn score_block_pairs_fs(
     py: Python<'_>,
@@ -286,6 +300,10 @@ pub fn score_block_pairs_fs(
     threshold: f64,
     exclude: Vec<(i64, i64)>,
     level_thresholds: Option<Vec<Option<Vec<f64>>>>,
+    ne_values: Option<Vec<Vec<Option<String>>>>,
+    ne_scorer_ids: Option<Vec<u8>>,
+    ne_thresholds: Option<Vec<f64>>,
+    ne_weights: Option<Vec<f64>>,
 ) -> PyResult<Vec<(i64, i64, f64)>> {
     let exclude: HashSet<(i64, i64)> = exclude.into_iter().collect();
     let n_fields = scorer_ids.len();
@@ -316,6 +334,54 @@ pub fn score_block_pairs_fs(
         Some(lt) => lt.iter().map(|ts| ts.as_deref()).collect(),
         None => vec![None; n_fields],
     };
+
+    // Negative-evidence kwargs: all four present or all four absent.
+    let n_present = [
+        ne_values.is_some(),
+        ne_scorer_ids.is_some(),
+        ne_thresholds.is_some(),
+        ne_weights.is_some(),
+    ]
+    .iter()
+    .filter(|&&p| p)
+    .count();
+    if n_present != 0 && n_present != 4 {
+        return Err(PyValueError::new_err(
+            "score_block_pairs_fs: ne_values, ne_scorer_ids, ne_thresholds and \
+             ne_weights must be passed together (all four or none)",
+        ));
+    }
+    let n_rows = row_ids.len();
+    if let (Some(nv), Some(ns), Some(nt), Some(nw)) =
+        (&ne_values, &ne_scorer_ids, &ne_thresholds, &ne_weights)
+    {
+        let n_ne = nv.len();
+        if ns.len() != n_ne || nt.len() != n_ne || nw.len() != n_ne {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs: ne_* lengths differ (ne_values {}, \
+                 ne_scorer_ids {}, ne_thresholds {}, ne_weights {})",
+                n_ne,
+                ns.len(),
+                nt.len(),
+                nw.len()
+            )));
+        }
+        for (k, vals) in nv.iter().enumerate() {
+            if vals.len() != n_rows {
+                return Err(PyValueError::new_err(format!(
+                    "score_block_pairs_fs: ne_values[{k}] length {} != row count {n_rows}",
+                    vals.len()
+                )));
+            }
+        }
+    }
+    // NE slices hoisted out of the rayon hot loop (same rationale as
+    // `field_thresholds` above); empty slices when NE is absent.
+    let ne_vals: &[Vec<Option<String>>] = ne_values.as_deref().unwrap_or(&[]);
+    let ne_scorer_ids_v: &[u8] = ne_scorer_ids.as_deref().unwrap_or(&[]);
+    let ne_thresholds_v: &[f64] = ne_thresholds.as_deref().unwrap_or(&[]);
+    let ne_weights_v: &[f64] = ne_weights.as_deref().unwrap_or(&[]);
+    let n_ne = ne_vals.len();
 
     let mut spans: Vec<(usize, usize)> = Vec::with_capacity(block_sizes.len());
     let mut offset = 0usize;
@@ -355,6 +421,21 @@ pub fn score_block_pairs_fs(
                                     _ => 0,
                                 };
                                 total_weight += match_weights[f][level];
+                            }
+                            // Negative evidence: exact `_ne_fired` semantics
+                            // (core/probabilistic.py:466) — fires iff both
+                            // values present AND non-empty AND similarity
+                            // STRICTLY below the threshold; contributes
+                            // exactly 0 otherwise.
+                            for k in 0..n_ne {
+                                if let (Some(a), Some(b)) = (&ne_vals[k][i], &ne_vals[k][j]) {
+                                    if !a.is_empty()
+                                        && !b.is_empty()
+                                        && score_one(ne_scorer_ids_v[k], a, b) < ne_thresholds_v[k]
+                                    {
+                                        total_weight += ne_weights_v[k];
+                                    }
+                                }
                             }
                             let normalized = fs_normalize(
                                 total_weight,

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -374,6 +374,13 @@ pub fn score_block_pairs_fs(
                 )));
             }
         }
+        for (k, &sid) in ns.iter().enumerate() {
+            if sid > 3 {
+                return Err(PyValueError::new_err(format!(
+                    "score_block_pairs_fs: ne_scorer_ids[{k}]={sid} out of range (valid: 0..=3)"
+                )));
+            }
+        }
     }
     // NE slices hoisted out of the rayon hot loop (same rationale as
     // `field_thresholds` above); empty slices when NE is absent.

--- a/scripts/build_native.py
+++ b/scripts/build_native.py
@@ -3,8 +3,8 @@
 
 Compiles the PyO3 crate at `packages/rust/extensions/native` (abi3) against the
 *current* interpreter and drops the artifact at
-`packages/python/goldenmatch/goldenmatch/_native.abi3.so` so `import
-goldenmatch._native` resolves.
+`packages/python/goldenmatch/goldenmatch/_native.abi3.so` (`_native.pyd` on
+Windows) so `import goldenmatch._native` resolves.
 
 Run via the project interpreter, e.g.:
     uv run python scripts/build_native.py
@@ -25,7 +25,8 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 CRATE = REPO / "packages" / "rust" / "extensions" / "native"
 PKG = REPO / "packages" / "python" / "goldenmatch" / "goldenmatch"
-DEST = PKG / "_native.abi3.so"
+# CPython loads `.pyd` on Windows, `.so` elsewhere (macOS included).
+DEST = PKG / ("_native.pyd" if sys.platform == "win32" else "_native.abi3.so")
 
 
 def main() -> int:
@@ -52,17 +53,24 @@ def main() -> int:
         print("ERROR: cargo build failed.", file=sys.stderr)
         return proc.returncode
 
-    built = CRATE / "target" / "release" / "lib_native.so"
-    if not built.exists():
-        # macOS produces .dylib; normalize to the .so name CPython loads.
-        dylib = CRATE / "target" / "release" / "lib_native.dylib"
-        if dylib.exists():
-            built = dylib
-        else:
+    if sys.platform == "win32":
+        # Windows produces `_native.dll` (no `lib` prefix); CPython imports `.pyd`.
+        built = CRATE / "target" / "release" / "_native.dll"
+        if not built.exists():
             print(f"ERROR: build artifact not found at {built}", file=sys.stderr)
             return 1
+    else:
+        built = CRATE / "target" / "release" / "lib_native.so"
+        if not built.exists():
+            # macOS produces .dylib; normalize to the .so name CPython loads.
+            dylib = CRATE / "target" / "release" / "lib_native.dylib"
+            if dylib.exists():
+                built = dylib
+            else:
+                print(f"ERROR: build artifact not found at {built}", file=sys.stderr)
+                return 1
 
-    tmp = DEST.with_suffix(".so.tmp")
+    tmp = DEST.with_suffix(DEST.suffix + ".tmp")
     shutil.copy2(built, tmp)
     os.replace(tmp, DEST)  # atomic; never a half-written .so
     suffix = sysconfig.get_config_var("EXT_SUFFIX")


### PR DESCRIPTION
## What

Thesis phase 2 for FS negative evidence (#1764): the native Rust kernels now score NE, and the fused FS kernel closes its `level_thresholds` gap — one 0.1.15 release brings `match_fused_fs` to full parity with `score_block_pairs_fs`.

- **`score_block_pairs_fs`** gains four trailing optional kwargs (`ne_values`/`ne_scorer_ids`/`ne_thresholds`/`ne_weights`) with all-or-none + length + scorer-id validation; the inner loop adds the exact `_ne_fired` semantics (both present post-transform, non-empty, STRICTLY `< threshold`) as one additive check per NE field. New const `FS_SUPPORTS_NE`.
- **`match_fused_fs`** gains the same NE group (Arrow columns) plus the `level_thresholds` kwarg its sibling got in #1752; NE columns ride `fused_gather`'s block-key sort so pair indices stay aligned (pinned by an interleaved-keys test designed so an unpermuted-NE bug fails loudly). New const `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS`.
- **Python gates widen per-feature:** `_fs_native_eligible` accepts NE when every NE scorer is kernel-native and the const is present; `match_fused_fs_ready` gates NE and banding independently (and declines `derive_from`-bearing NE — the fused lane never runs `precompute_matchkey_transforms`, so a synthesized NE column would silently never fire). Old wheels decline exactly as before; kwargs are sent only when the config uses the feature, so no wheel vintage ever sees an unknown kwarg.
- **`run_match_fused_fs_arrow`'s hand-rolled weight range → `fs_weight_range`** — load-bearing now (the hand-rolled copy ignored `__ne__` entries and would have mis-normalized every fused NE score).
- **Drive-by:** `scripts/build_native.py` now produces the in-tree kernel on Windows (`_native.dll` → `_native.pyd`; it previously exited 1 after a successful cargo build).

## Evidence

- 6-case native-vs-numpy parity (EM-learned NE, `penalty_bits`, null, empty-after-transform, NE+`level_thresholds`, two NE fields): identical pair sets + scores.
- Fused-vs-classic parity on NE and NE+banding configs: identical cluster membership, with non-vacuous guards (NE demonstrably suppresses one merge and spares another).
- The FS-NE homonym success bar passes on the NATIVE path with byte-identical membership to the numpy run; strict-`<` pinned at the boundary (sim == threshold does not fire).
- Sweeps: 286 tests green native-ON and again under `GOLDENMATCH_FS_NATIVE=0` (pure paths byte-unchanged); clippy `-D warnings` clean; `check_native_symbols.py` reconciles both new consts.

## Release note (wheel skew)

The Python callers gain capability-gated fast paths that every `pip install goldenmatch[native]` env silently misses until the wheel ships — tag `goldenmatch-native-v0.1.15` should follow this merge (the #688 lesson: republish in the same rollout). Version bumped in all three files + Cargo.lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs