### PR TITLE
chore(release): goldenmatch 3.3.0 / goldenmatch-js 1.3.0 / golden-suite 0.2.5

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.2.5] - 2026-07-14
+
+- Floor bump: `goldenmatch[polars]>=3.3` (FS negative evidence on probabilistic
+  matchkeys, Splink migration upgrade pass incl. the fan-out/NE lever) and
+  `goldenmatch-native>=0.1.15` (native FS negative evidence + fused N-level
+  banding, `FS_SUPPORTS_NE`).
+
 ## [0.2.4] - 2026-07-13
 
 ### Changed

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.4"
+__version__ = "0.2.5"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.4"
+version = "0.2.5"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,14 +37,14 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.2",         # entity resolution: dedupe, match, golden records (>=3.2: Splink config converter + N-level level_thresholds fields; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.3",         # entity resolution: dedupe, match, golden records (>=3.3: FS negative evidence + Splink migration upgrade pass w/ fan-out lever; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.1",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.14",       # >=0.1.14 carries N-level level_thresholds scoring (FS_SUPPORTS_LEVEL_THRESHOLDS)
+    "goldenmatch-native>=0.1.15",       # >=0.1.15 carries native FS negative evidence + fused N-level (FS_SUPPORTS_NE)
     "goldencheck-native>=0.1",
     "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
     "goldenanalysis-native>=0.1",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to GoldenMatch are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
-## [Unreleased]
+## [3.3.0] - 2026-07-14
 
 ### Added
 - **Negative evidence on Fellegi-Sunter (`type: probabilistic`) matchkeys**
@@ -57,6 +57,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   **0.707 → 0.740** (Splink: 0.686) — the upgraded conversion beats native
   Splink on all three pairs.
 
+- **Fan-out / negative-evidence upgrade lever** (`fan_out`, in the default
+  `import-splink --upgrade` lever set, between `distance_thresholds` and
+  `calibration`): detects unused identity-grade columns (phone/email/id-named,
+  high-cardinality, non-matchkey, non-blocking) whose disagreement contradicts
+  pairs the imported model would confidently merge (posterior >= 0.9), and —
+  when the contradiction rate clears the risk gate (>= 2%, >= 10 firing
+  pairs) — adds the column as `negative_evidence` with posterior-weighted
+  EM-shape weights written into the upgraded model (`__ne__<field>` entries).
+  Also tunes `golden_rules.max_cluster_size = max(10, 2 * reference max
+  cluster size)` from `--labels` (preferred) or `--splink-clusters`, so
+  `auto_split` catches mid-size homonym snowballs the static default (100)
+  ignores on person-shaped data. The calibration lever is now NE-aware
+  (`fs_weight_range` + per-pair NE contributions; its warn+skip tripwire is
+  removed). Wild-bench: no regressions; `model_h50k` improved 0.7396 -> 0.7421
+  on guard tuning alone.
+- **Native negative-evidence scoring** (`goldenmatch-native >= 0.1.15`): the
+  Rust kernels now score FS negative evidence — `score_block_pairs_fs` AND the
+  fused `match_fused_fs`, which also gained custom `level_thresholds` banding
+  (full kernel parity). Detection is capability-gated (`FS_SUPPORTS_NE`,
+  `FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS`), so older wheels keep the pure-Python
+  fallback with no behavior change; NE-bearing matchkeys previously always
+  took the pure-Python path. The fused path declines `derive_from` NE (its
+  raw-columns entry never materializes derived columns).
+
 ### Fixed
 - **Threshold calibration on imported Splink models**: the calibration lever
   now re-estimates the within-block match rate from the model's likelihood
@@ -65,6 +89,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   orders of magnitude below the post-blocking rate the percentile math
   expects. Trusting it cut at the extreme top of the score distribution and
   collapsed recall (F1 0.482 → 0.157 on the bench pair above).
+- **Tuned `max_cluster_size` survives the YAML loader round-trip**: the
+  config loader's `golden_rules` normalization swept `max_cluster_size` into
+  `field_rules` (the "set programmatically, never via YAML" assumption went
+  stale when the fan-out lever started writing it), so `import-splink
+  --upgrade` output failed to reload. It is now a recognized top-level
+  golden_rules key.
 
 ## [3.2.0] - 2026-07-13
 

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.2.0"
+__version__ = "3.3.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.2.0"
+version = "3.3.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
-## [Unreleased]
+## [1.3.0] - 2026-07-14
 
 ### Added
 - **Fellegi-Sunter negative evidence** (full mirror of Python #1764): the FS API surface now honors `negative_evidence` on probabilistic matchkeys end-to-end (`trainEM` -> `scoreProbabilistic` -> validation -> fallback). `trainEM` learns each penalty-bits-free NE field as a constrained 2-state dimension (separate NE matrix, u from the same random-pair sample, full likelihood inside the EM loop, `[wFired, 0.0]` clamp applied at STORAGE only under `__ne__<field>`); scoring (`scoreProbabilistic` / `scoreProbabilisticPair`) adds the fired weight (or `-abs(penalty_bits)` for the fixed override) and normalizes against the NE-aware `fsWeightRange` envelope; `validateEmResultFor` requires a 2-entry `__ne__<field>` model entry per EM-learned NE field; the tiny-dataset fallback ships Python's exact NE entries (`[-3.0, 0.0]`). New exports: `neFired`, `fsWeightRange`, `NegativeEvidenceUnsupportedError`.

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {


### PR DESCRIPTION
Release-prep for the FS-NE train: goldenmatch 3.3.0 (pyproject + __init__ + server.json + CHANGELOG cut, incl. added entries for the fan-out lever #1771, native NE #1775, and the loader max_cluster_size fix), goldenmatch-js 1.3.0 (package.json + CHANGELOG cut), golden-suite 0.2.5 (version x2 + floor bumps goldenmatch[polars]>=3.3 / goldenmatch-native>=0.1.15 + CHANGELOG). Tags after merge: v3.3.0, goldenmatch-js-v1.3.0, then golden-suite-v0.2.5 once members are live on registries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs