### PR TITLE
bench: --fs-basic-scorers so both FS lanes engage the native kernel

### DIFF
--- a/docs/superpowers/specs/2026-07-14-scale-envelope-splink-v2-design.md
+++ b/docs/superpowers/specs/2026-07-14-scale-envelope-splink-v2-design.md
@@ -115,6 +115,19 @@ would silently run native and the two FS lanes would be native-vs-native, guttin
 the "numpy fallback vs native kernel" comparison. The `zeroconfig` lane inherits
 whatever the controller picks (default native) and does not force the env.
 
+**Both FS lanes pass `--fs-basic-scorers`.** Autoconfig's probabilistic path picks
+specialized name scorers (`given_name_aliased_jw` for first_name,
+`name_freq_weighted_jw` for surname) that are NOT in the native FS kernel's set
+(`{exact, jaro_winkler, levenshtein, token_sort}`), so `_fs_native_eligible()`
+declines the matchkey and the `gm_probabilistic_native` lane silently runs numpy —
+identical to `gm_probabilistic`. The flag rewrites any field scorer outside the
+kernel set to `jaro_winkler`, which (a) makes the matchkey native-eligible so the
+native lane actually engages the Rust kernel and the two lanes form a real matched
+numpy-vs-native pair, and (b) matches Splink's own JaroWinkler-based FS model for a
+more apples-to-apples comparison. The rewrite happens before the eligibility
+telemetry is counted, and the `(field, old_scorer)` pairs are recorded on
+`fs_basic_scorers_rewritten`.
+
 Lanes are selectable at the workflow level (`lanes` input), so any subset can be
 dispatched. `splink` is not privileged in code — it is just another lane — but
 the results doc always reports it as the reference column.

--- a/scripts/bench_er_headtohead/README.md
+++ b/scripts/bench_er_headtohead/README.md
@@ -23,8 +23,8 @@ column.
 |---|---|---|---|---|
 | `splink` | `run_splink.py` | - | - | Fellegi-Sunter reference engine (pinned `splink==4.0.16`) |
 | `gm_hand_built` | `run_goldenmatch.py` | hand_built | - | GM fast weighted bucket+native path (speed reference) |
-| `gm_probabilistic` | `run_goldenmatch.py` | probabilistic | `GOLDENMATCH_FS_NATIVE=0` | EM-trained FS, **numpy fallback** - like-for-like vs Splink FS |
-| `gm_probabilistic_native` | `run_goldenmatch.py` | probabilistic | `GOLDENMATCH_FS_NATIVE=1` | same, **Rust FS kernel** (reference-mode default, made explicit) |
+| `gm_probabilistic` | `run_goldenmatch.py` | probabilistic (`--fs-basic-scorers`) | `GOLDENMATCH_FS_NATIVE=0` | EM-trained FS, **numpy fallback** - like-for-like vs Splink FS |
+| `gm_probabilistic_native` | `run_goldenmatch.py` | probabilistic (`--fs-basic-scorers`) | `GOLDENMATCH_FS_NATIVE=1` | same, **Rust FS kernel** (reference-mode default, made explicit) |
 | `gm_zeroconfig` | `run_goldenmatch.py` | zeroconfig | - | zero-effort controller vs a tuned Splink spec |
 | `gm_converted_splink` | `run_gm_converted.py` | - | - | GM running Splink's own spec, auto-converted via `from_splink` |
 
@@ -44,6 +44,19 @@ two lanes would be native-vs-native, gutting the comparison. FS's discrete
 comparison levels amplify tiny rapidfuzz float differences at exact thresholds,
 so the two are reported as separate lanes rather than one silently substituting
 the other.
+
+**Both FS lanes pass `--fs-basic-scorers` (name fields forced to `jaro_winkler`).**
+Autoconfig picks specialized name scorers (`given_name_aliased_jw` for first_name,
+`name_freq_weighted_jw` for surname) that the native FS kernel does NOT implement
+(its set is `{exact, jaro_winkler, levenshtein, token_sort}`), so
+`_fs_native_eligible()` declines the matchkey and the native lane silently runs
+numpy - identical to the numpy lane. `--fs-basic-scorers` rewrites any field scorer
+outside the kernel set to `jaro_winkler`, which makes the matchkey native-eligible
+so the two lanes form a real matched numpy-vs-native pair that actually exercises
+the Rust kernel. It also makes the FS model JaroWinkler-comparable to Splink's own
+JaroWinkler FS. The rewrite runs before the eligibility telemetry below, so the
+counts reflect the config actually scored; the rewritten `(field, old_scorer)`
+pairs are recorded on `fs_basic_scorers_rewritten`.
 
 **Proof-of-execution field (`fs_native_eligible_matchkeys`).** The global gate is
 NOT sufficient proof that a `gm_probabilistic_native` row actually ran the kernel:

--- a/scripts/bench_er_headtohead/orchestrate.py
+++ b/scripts/bench_er_headtohead/orchestrate.py
@@ -42,6 +42,7 @@ class Lane:
     script: str
     mode: str | None = None
     env: dict[str, str] = field(default_factory=dict)
+    extra_args: tuple[str, ...] = ()
 
 
 # The four run_goldenmatch.py-backed GM lanes: run_goldenmatch.py calls
@@ -55,9 +56,11 @@ LANES: dict[str, Lane] = {
     "splink": Lane("splink", "run_splink.py"),
     "gm_hand_built": Lane("gm_hand_built", "run_goldenmatch.py", mode="hand_built"),
     "gm_probabilistic": Lane("gm_probabilistic", "run_goldenmatch.py",
-                             mode="probabilistic", env={"GOLDENMATCH_FS_NATIVE": "0"}),
+                             mode="probabilistic", env={"GOLDENMATCH_FS_NATIVE": "0"},
+                             extra_args=("--fs-basic-scorers",)),
     "gm_probabilistic_native": Lane("gm_probabilistic_native", "run_goldenmatch.py",
-                                    mode="probabilistic", env={"GOLDENMATCH_FS_NATIVE": "1"}),
+                                    mode="probabilistic", env={"GOLDENMATCH_FS_NATIVE": "1"},
+                                    extra_args=("--fs-basic-scorers",)),
     "gm_zeroconfig": Lane("gm_zeroconfig", "run_goldenmatch.py", mode="zeroconfig"),
     "gm_converted_splink": Lane("gm_converted_splink", "run_gm_converted.py"),
 }
@@ -82,6 +85,7 @@ def build_cmd(lane: Lane, *, input, rows: int, out, pred, threshold: float,
     # native gate raises for ALL its modes, not just hand_built.
     if allow_pure_python and lane.name in _GM_RUN_LANES:
         cmd.append("--allow-pure-python")
+    cmd += list(lane.extra_args)
     return cmd
 
 # Per-scale subprocess wall-clock cap (seconds). Raised after the first run so a

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -84,6 +84,10 @@ def main() -> None:
                     help="fixture shape; selects the hand_built config from shapes.py")
     ap.add_argument("--require-native", action="store_true", default=True)
     ap.add_argument("--allow-pure-python", dest="require_native", action="store_false")
+    ap.add_argument("--fs-basic-scorers", action="store_true", default=False,
+                    help="probabilistic mode only: rewrite any FS field scorer NOT in "
+                         "the native FS kernel set to jaro_winkler, so both FS lanes "
+                         "engage the Rust kernel and match Splink's JaroWinkler model")
     args = ap.parse_args()
 
     os.environ["GOLDENMATCH_NATIVE"] = "1" if args.require_native else "auto"
@@ -196,6 +200,26 @@ def main() -> None:
             for mk in cfg.get_matchkeys():
                 if getattr(mk, "type", None) == "weighted":
                     mk.rerank = False
+            # Optionally force any specialized name scorer autoconfig picked
+            # (given_name_aliased_jw / name_freq_weighted_jw) that the native FS
+            # kernel doesn't implement to jaro_winkler. This makes BOTH FS lanes
+            # native-eligible (a matched numpy-vs-native pair) and comparable to
+            # Splink's JaroWinkler FS model. Runs BEFORE the eligibility telemetry
+            # below so the counts reflect the config actually scored.
+            rewritten: list = []
+            if args.fs_basic_scorers:
+                try:
+                    from goldenmatch.core.probabilistic import _NATIVE_FS_SCORER_IDS
+
+                    for mk in cfg.get_matchkeys():
+                        for f in getattr(mk, "fields", None) or []:
+                            sc = getattr(f, "scorer", None)
+                            if sc is not None and sc not in _NATIVE_FS_SCORER_IDS:
+                                rewritten.append((getattr(f, "field", None), sc))
+                                f.scorer = "jaro_winkler"
+                except (ImportError, AttributeError):
+                    pass
+            result["fs_basic_scorers_rewritten"] = rewritten
             # FS-native per-matchkey eligibility telemetry (spec section 8): count
             # how many resolved matchkeys the native FS kernel could score. Under
             # the numpy lane (GOLDENMATCH_FS_NATIVE=0) _fs_native_enabled()

--- a/scripts/bench_er_headtohead/test_scale_envelope.py
+++ b/scripts/bench_er_headtohead/test_scale_envelope.py
@@ -147,6 +147,36 @@ def test_probabilistic_numpy_lane_zero_native_eligible(tmp_path):
     assert r["fs_matchkeys_total"] >= 1
 
 
+def test_fs_basic_scorers_rewrite_engages_native(tmp_path):
+    # --fs-basic-scorers must rewrite autoconfig's specialized name scorers
+    # (given_name_aliased_jw / name_freq_weighted_jw) to jaro_winkler, which the
+    # native FS kernel implements -- so with native LOADED the matchkey becomes
+    # _fs_native_eligible and the Rust kernel engages.
+    gen = _load("generate_fixture")
+    fx, tr = tmp_path / "p.parquet", tmp_path / "p.truth.parquet"
+    gen.generate(2000, 0.3, fx, tr, 42, 2000, shape="person")
+    out, pred = tmp_path / "r.json", tmp_path / "r.pred.parquet"
+    e = _env(); e["GOLDENMATCH_FS_NATIVE"] = "1"       # native lane
+    rc = subprocess.run([sys.executable, str(HERE / "run_goldenmatch.py"),
+        "--input", str(fx), "--rows", "2000", "--out", str(out), "--pred-out", str(pred),
+        "--threshold", "0.85", "--mode", "probabilistic", "--shape", "person",
+        "--fs-basic-scorers", "--allow-pure-python"],  # allow-pure-python so a
+                                 # missing native build doesn't RAISE; the kernel
+                                 # still engages when native IS loaded
+        env=e).returncode
+    assert rc == 0
+    r = json.loads(out.read_text())
+    assert r["status"] == "ok"
+    # The two name scorers get rewritten regardless of whether native is built.
+    assert r["fs_basic_scorers_rewritten"], "expected name scorers to be rewritten"
+    # Only when native is actually loaded can the kernel become eligible.
+    if r.get("native_loaded"):
+        assert r["fs_native_eligible_matchkeys"] >= 1, (
+            "basic scorers should make >=1 matchkey native-eligible when native "
+            "is loaded -- something else is declining it"
+        )
+
+
 def test_run_splink_shape_biblio(tmp_path):
     gen = _load("generate_fixture")
     fx, tr = tmp_path / "b.parquet", tmp_path / "b.truth.parquet"
@@ -199,6 +229,19 @@ def test_lane_registry_and_cmd():
                          out="o.json", pred="p.parquet", threshold=0.85, shape="person")
     assert "run_goldenmatch.py" in " ".join(cmd)
     assert "--mode" in cmd and "probabilistic" in cmd and "--shape" in cmd
+
+
+def test_fs_basic_scorers_flag_only_on_fs_lanes():
+    orch = _load("orchestrate")
+    lanes = orch.LANES
+    kw = dict(input="f.parquet", rows=100, out="o.json", pred="p.parquet",
+              threshold=0.85, shape="person")
+    # BOTH FS lanes carry --fs-basic-scorers ...
+    for name in ("gm_probabilistic", "gm_probabilistic_native"):
+        assert "--fs-basic-scorers" in orch.build_cmd(lanes[name], **kw), name
+    # ... and no other lane does.
+    for name in ("gm_hand_built", "gm_zeroconfig", "splink", "gm_converted_splink"):
+        assert "--fs-basic-scorers" not in orch.build_cmd(lanes[name], **kw), name
 
 
 def test_lane_env_is_merged_not_mutating(monkeypatch):


### PR DESCRIPTION
## What and why

Follow-up to #1779. The scale-envelope harness's own FS telemetry surfaced that on auto-configured data, GoldenMatch's probabilistic path picks specialized name scorers (`given_name_aliased_jw`, `name_freq_weighted_jw`) that are NOT in the native FS kernel's set (`exact / jaro_winkler / levenshtein / token_sort`). So `_fs_native_eligible` declined the matchkey and the `gm_probabilistic_native` lane silently ran numpy - identical to `gm_probabilistic`, measuring nothing.

This adds `--fs-basic-scorers`, which rewrites any off-kernel field scorer to `jaro_winkler`. Both FS lanes now pass it, forming a matched numpy-vs-native pair that actually exercises the Rust kernel - and, since Splink's own FS model uses JaroWinkler comparisons, this is *more* apples-to-apples with Splink than the specialized scorers.

## Changes

- `run_goldenmatch.py`: `--fs-basic-scorers` flag; after `auto_configure_probabilistic_df`, rewrite only field scorers NOT in `_NATIVE_FS_SCORER_IDS` to `jaro_winkler` (dob=levenshtein, postcode=exact stay untouched); record `fs_basic_scorers_rewritten`; eligibility telemetry computed AFTER the rewrite so it reflects the scored config.
- `orchestrate.py`: `Lane.extra_args`; `--fs-basic-scorers` on `gm_probabilistic` + `gm_probabilistic_native` only.
- Tests + README + spec note.

## Testing

`python -m pytest scripts/bench_er_headtohead/test_scale_envelope.py` -> **20 passed, 1 skipped**. Verified end-to-end on both shapes (native IS built in the dev venv): `gm_probabilistic` -> `fs_native_eligible_matchkeys=0/1` (forced numpy via `FS_NATIVE=0`), `gm_probabilistic_native` -> `1/1` (kernel engages), both output-equivalent (person F1=1.0, biblio F1=0.969, identical scored-pair counts).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed (N/A - bench harness)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (bench README + spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)