### PR TITLE
fix(goldenmatch): bucket fast path threads tf_freqs -- #1318 downweight was a no-op on the default path (#1781)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-bucket-tf-freqs-fix.md
+++ b/docs/superpowers/plans/2026-07-15-bucket-tf-freqs-fix.md
@@ -1,0 +1,155 @@
+# Bucket tf_freqs Fix (#1781) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Thread `MatchkeyField.tf_freqs` through the bucket fast path so #1318's TF name
+downweight actually applies on the default scoring path, with the parity-matrix case that should
+have caught the gap.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-bucket-tf-freqs-fix-design.md` — READ FIRST. Pins:
+Approach A (resolver gains the kwarg; plugin branch only; TypeError-fallback wrapper as the
+score_pair-side twin of `_fuzzy_score_matrix`'s score_matrix posture), the NE site untouched,
+the float32-vs-float64 fixture caveat, and the #1319 Leg-A success bar.
+
+**Architecture:** One production file (`backends/score_buckets.py`: `_resolve_score_pair_callable`
++ its weighted-field call site), three test additions.
+
+**Tech Stack:** Python 3.12, pytest. No Rust/TS.
+
+---
+
+## Environment / repo mechanics
+
+- NEW worktree `D:\show_case\gm-1781`, branch `fix/1781-bucket-tf-freqs` off freshly-fetched
+  `origin/main`. **NEVER `git stash`.**
+- Tests via main venv + worktree PYTHONPATH (Git Bash):
+  `cd /d/show_case/gm-1781/packages/python/goldenmatch && PYTHONPATH="D:/show_case/gm-1781/packages/python/goldenmatch" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <tests> -q`
+- Ruff: `D:/show_case/goldenmatch/.venv/Scripts/python.exe -m ruff check <files>`.
+- `docs/superpowers/` gitignored → `git add -f` spec + plan. Commit trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs`
+- Push/PR: `unset GH_TOKEN`; push via
+  `git push "https://x-access-token:$(gh auth token --user benzsevern)@github.com/benseverndev-oss/goldenmatch.git" <branch>`;
+  `GH_TOKEN=$(gh auth token --user benzsevern) gh pr create/merge --auto`; STOP after arming.
+
+**Key code (verified on origin/main):**
+- `packages/python/goldenmatch/goldenmatch/backends/score_buckets.py` —
+  `_resolve_score_pair_callable(scorer_name)` at ~204 (plugin branch at the END, ~260-266:
+  `plugin = PluginRegistry.instance().get_scorer(...)`, `fn = getattr(plugin, "score_pair", None)`,
+  `return fn`); weighted-field call site ~427 (`fn = _resolve_score_pair_callable(scorer)` inside
+  `for f in mk.fields` — `f` in scope); NE-spec call site ~342 (gated on
+  `_SCORE_FIELD_DIRECT_SCORERS`, builtins only — the plugin branch never fires there; UNTOUCHED);
+  per-pair use in `_score_one_bucket_fast` ~964 (`score_fns[f_idx](va, vb)`); the float32/float64
+  borderline note at ~92-97; `_NATIVE_SCORER_IDS` at ~188.
+- `packages/python/goldenmatch/goldenmatch/refdata/scorer.py:86-125` —
+  `NameFreqWeightedJW.score_pair(val_a, val_b, *, tf_freqs=None)`: with a table → whole-range
+  data-driven downweight; without → static census fallback.
+- `packages/python/goldenmatch/goldenmatch/core/scorer.py:594-597` — the legacy
+  try/except-TypeError posture being mirrored; `:1236` — the legacy per-field threading
+  (`tf_freqs=getattr(f, "tf_freqs", None)`).
+- `packages/python/goldenmatch/tests/test_bucket_legacy_parity_matrix.py` — scorer matrix
+  parameterized at ~108 (`["jaro_winkler", "token_sort", "levenshtein", "soundex_match",
+  "ensemble"]`); READ the file to see how a case builds data+config and asserts byte-identical
+  multi-member clustering across bucket/legacy.
+- The #1319 measurement harness (success bar): session scratchpad
+  `C:/Users/bsevern/AppData/Local/Temp/claude/D--show-case-goldenmatch/2af6f77e-d6b2-41c0-ad88-08d7fd3f306e/scratchpad/1319/measure_1319.py`
+  (args `a on|off`; builds the 2600-row fixture, runs auto_configure_df + dedupe_df, emits JSON
+  with precision/mass). Baseline numbers to beat: bucket ON == OFF byte-identical (P 0.0091);
+  legacy ON P 0.0305 at committed threshold 0.8.
+
+## File structure
+
+- Modify: `packages/python/goldenmatch/goldenmatch/backends/score_buckets.py`
+- Modify: `packages/python/goldenmatch/tests/test_bucket_legacy_parity_matrix.py`
+- Modify or create (implementer's call by where bucket unit tests live — locate with
+  `grep -rln "_resolve_score_pair_callable" tests/`): the applied-table regression + back-compat
+  wrapper tests.
+
+---
+
+### Task B0: Worktree + baseline
+
+- [ ] **Step 1:** From `D:\show_case\goldenmatch`:
+  `git fetch origin main -q && git worktree add /d/show_case/gm-1781 -b fix/1781-bucket-tf-freqs origin/main`
+- [ ] **Step 2:** Copy spec + this plan into the worktree `docs/superpowers/{specs,plans}/`;
+  `git add -f` both; commit `docs: spec + plan for the #1781 bucket tf_freqs fix` (+ trailers).
+- [ ] **Step 3:** Baseline: `pytest tests/test_bucket_legacy_parity_matrix.py -q` → green (note
+  the count). If red, STOP.
+
+### Task B1: The fix + all three test layers (TDD)
+
+**Files:** as in File structure.
+
+- [ ] **Step 1: Failing tests.** EVERY new test that constructs a
+  `MatchkeyField(scorer="name_freq_weighted_jw")` must `import goldenmatch.refdata` INSIDE the
+  test first (the scorer registers only on that import — `refdata/__init__.py:96`; without it
+  config construction raises ValueError at schemas.py:158-166 and the test ERRORS instead of
+  failing in the predicted mode; xdist self-containment rule).
+  - **Parity-matrix TF case** (`test_bucket_legacy_parity_matrix.py`): extend the harness with a
+    case whose weighted matchkey has a `name_freq_weighted_jw` field carrying a hand-built
+    `tf_freqs` table (e.g. `{"smith": 0.4, "jones": 0.3, "quixote": 0.01, ...}` over the
+    fixture's post-transform surname values — READ how the harness builds fields; set
+    `f.tf_freqs = {...}` after construction or via the field kwargs if supported). Fixture rules:
+    pair scores must sit AWAY from the matchkey threshold (the spec's float32-vs-float64
+    caveat) — build names whose downweighted scores are clearly above/below. Assert the harness's
+    standard byte-identical bucket-vs-legacy clustering.
+  - **Applied-table regression test** (bucket-path unit test): a small common-name fixture (~40
+    rows, shared common full names on distinct people + strong unique emails; miniaturized
+    #1319 shape) scored through the BUCKET path twice — once with `tf_freqs` populated on the
+    name field, once with the table stripped — assert the outputs DIFFER (the table demonstrably
+    applied; ON==OFF byte-identical was the bug's signature). Force the bucket path the way the
+    parity harness does (read it; `backend="bucket"` or the default-envelope conditions).
+  - **Back-compat wrapper unit test:** register a fake plugin scorer whose `score_pair(a, b)`
+    LACKS the `tf_freqs` keyword (register inside the test — xdist self-containment rule), put it
+    on a field WITH `tf_freqs` set, resolve via `_resolve_score_pair_callable(name, tf_freqs=...)`
+    and call it → returns the plugin's score (TypeError fallback engaged, no crash), and a second
+    call keeps working (the "permanently degrades" contract).
+- [ ] **Step 2:** Run → parity TF case FAILS (bucket ignores the table → clustering diverges from
+  legacy) or the regression test FAILS (ON == OFF); back-compat test fails on the missing kwarg.
+  (If the parity case unexpectedly PASSES, the fixture's downweight isn't biting — strengthen
+  the table skew until legacy's clustering visibly depends on it, THEN confirm bucket diverges.)
+- [ ] **Step 3: Implement** in `score_buckets.py`:
+  - `_resolve_score_pair_callable(scorer_name: str, tf_freqs: dict[str, float] | None = None)`.
+    Built-in branches untouched. Plugin branch:
+    ```python
+    fn = getattr(plugin, "score_pair", None)
+    if fn is None or not tf_freqs:
+        return fn
+    # #1781: bind the field's TF table so the fast path matches the legacy
+    # matrix path (core/scorer.py:1236). TypeError fallback = the
+    # score_pair-side twin of _fuzzy_score_matrix's score_matrix posture
+    # (core/scorer.py:594-597): a legacy plugin without the keyword degrades
+    # permanently to the bare call.
+    def _with_tf(a, b, _fn=fn, _tf=tf_freqs):
+        try:
+            return _fn(a, b, tf_freqs=_tf)
+        except TypeError:
+            return _fn(a, b)
+
+    return _with_tf
+    ```
+    (A once-latched flag instead of per-call try is fine too — implementer's call; per-call
+    try on the happy path costs nothing when no exception is raised. Keep whichever reads best
+    with a comment.) Update the resolver docstring: #1781, the sample-telemetry-vs-final-dedupe
+    skew, and that only the plugin branch consumes the kwarg.
+  - Weighted call site (~427): `fn = _resolve_score_pair_callable(scorer, getattr(f, "tf_freqs", None))`.
+  - NE call site (~342): UNTOUCHED (add no kwarg; the spec documents why).
+- [ ] **Step 4:** All three test layers PASS; whole parity file green; ruff clean.
+- [ ] **Step 5:** Commit `fix(goldenmatch): bucket fast path threads MatchkeyField.tf_freqs (#1781)` (+ trailers).
+
+### Task B2: Success bar + PR
+
+- [ ] **Step 1: #1319 Leg-A re-measure** on the fix branch: run the scratchpad harness (path in
+  Key code) with PYTHONPATH pointed at THIS worktree, `a on` and `a off`:
+  expected — bucket ON now DIVERGES from bucket OFF, and bucket ON's precision matches legacy
+  ON (~0.0305 at the committed 0.8 threshold; NOT the ~0.99 full recovery — that lands with
+  PR2b). Record the numbers.
+- [ ] **Step 2:** Targeted sweep: the parity file + the bucket unit-test file(s) +
+  `tests/test_tf_name_weighting_1207.py` + `pytest tests/test_scorer.py -q` (adjacent) → green.
+- [ ] **Step 3:** Push (auth dance); PR titled
+  `fix(goldenmatch): bucket fast path threads tf_freqs -- #1318 downweight was a no-op on the default path (#1781)`,
+  body: the bug (telemetry-yes/output-no skew), the fix shape, the three test layers, the
+  re-measure numbers (bucket ON == legacy ON), `Closes #1781`, and a note that the redesigned
+  PR2b (#1319) builds on this. Arm `gh pr merge --auto`, STOP.
+- [ ] **Step 4:** After merge: update memory (`project_1207_autoconfig_blocking_union`) +
+  work tracker; comment on #1319 that the prerequisite landed.

--- a/docs/superpowers/specs/2026-07-15-bucket-tf-freqs-fix-design.md
+++ b/docs/superpowers/specs/2026-07-15-bucket-tf-freqs-fix-design.md
@@ -1,0 +1,78 @@
+# Bucket Fast Path Threads tf_freqs (#1781)
+
+**Date:** 2026-07-15
+**Status:** Approved (design)
+**Issue:** #1781 (found by #1319's measurement pass). Blocks the redesigned PR2b (#1319).
+
+## Problem
+
+`GOLDENMATCH_TF_NAME_WEIGHTING` (#1318, default-on) attaches a per-dataset value-frequency table
+as `MatchkeyField.tf_freqs`; `NameFreqWeightedJW.score_pair` accepts and uses it as a keyword
+(`refdata/scorer.py:86-107` -- the data-driven whole-range downweight). But the DEFAULT scoring
+path since #1761 -- the bucket backend's fast path -- resolves scorers via
+`_resolve_score_pair_callable(scorer_name)` (`backends/score_buckets.py:204`) and, on the plugin
+branch, grabs `plugin.score_pair` BARE. Called as `(a, b)`, `tf_freqs` defaults to None and the
+scorer silently falls back to the static census path. #1318 is therefore a no-op on the default
+path: the #1319 measurement proved fixture dedupe output ON vs OFF is byte-identical, while the
+controller's SAMPLE telemetry shows the downweight biting (samples run the legacy path via the
+active profile emitter) -- the telemetry-yes/output-no skew class.
+
+The legacy path threads it correctly: `core/scorer.py:1236` passes
+`tf_freqs=getattr(f, "tf_freqs", None)` into `_fuzzy_score_matrix`, which forwards it to plugin
+scorers with try/except-TypeError back-compat.
+
+## Decision (Approach A)
+
+Extend the resolver: `_resolve_score_pair_callable(scorer_name, tf_freqs=None)`.
+
+- Built-in branches (jaro_winkler/levenshtein/token_sort/exact/soundex_match/dice/jaccard) are
+  UNTOUCHED -- `tf_freqs` only ever flows to plugin scorers, mirroring the legacy path where it
+  travels only through the plugin protocol (`plugins/base.py:33`: every conforming plugin
+  accepts the keyword and ignores it if unused).
+- Plugin branch: when `tf_freqs` is provided (non-None, non-empty), return a wrapper that calls
+  `fn(a, b, tf_freqs=tf_freqs)` and, on `TypeError` (a non-conforming legacy plugin without the
+  keyword), permanently degrades to bare `fn(a, b)`. Precision note: this MIRRORS the
+  try/except-TypeError posture `_fuzzy_score_matrix` applies to `score_matrix` forwarding
+  (core/scorer.py:594-597); the legacy per-pair `score_pair` fallback (scorer.py:611) never
+  forwards `tf_freqs` at all -- but it also never fires for `name_freq_weighted_jw`, which
+  exposes `score_matrix`. This wrapper is therefore the score_pair-side twin of the established
+  posture, not a byte-copy of an existing one. When `tf_freqs` is None, return `fn` bare (zero
+  change for the overwhelmingly common case).
+- Call sites: the weighted-field site (~427) passes `getattr(f, "tf_freqs", None)`. The NE-spec
+  site (~342) is untouched -- `NegativeEvidenceField` has no `tf_freqs` attribute.
+- Docstring on the resolver notes #1781 and the sample-telemetry-vs-final-dedupe skew this
+  closes.
+
+Rejected: binding at the call sites via `functools.partial` (spreads binding + back-compat
+across two sites); passing the whole field object into the resolver (wider contract than one
+attribute needs).
+
+## Testing / success bar
+
+1. **Parity-matrix case (the gap that should have caught this):**
+   `tests/test_bucket_legacy_parity_matrix.py` gains a `name_freq_weighted_jw` field WITH a
+   populated `tf_freqs` table -- same data+config through the bucket and legacy paths on the
+   polars lane, byte-identical multi-member clustering. FIXTURE CAVEAT: legacy scores this
+   plugin via `score_matrix` (float32) while the bucket per-pair loop accumulates float64
+   (score_buckets.py:92-97 documents the borderline-flip risk) -- keep the fixture's pair scores
+   away from the threshold boundary.
+2. **Applied-table regression test:** a miniaturized #1319 common-name fixture where the bucket
+   path's dedupe output WITH the table present differs from the same config with the table
+   stripped (pins that the table is actually applied; the ON==OFF byte-identical state was the
+   bug's signature).
+3. **Back-compat unit test:** a fake plugin whose `score_pair` lacks the `tf_freqs` keyword
+   still scores through the wrapper (TypeError fallback), matching the legacy posture.
+4. **Success bar:** re-run the #1319 measurement's Leg A (crafted 2600-row fixture) on the fix
+   branch -- bucket ON now diverges from bucket OFF and matches legacy ON (P 0.031 at the
+   committed 0.8 threshold; the FULL precision recovery to ~0.99 lands with the redesigned PR2b,
+   not this fix).
+
+## Out of scope
+
+- The redesigned PR2b controller rule (#1319, next feature).
+- NE-field tf_freqs (the schema has no such knob).
+- The native kernel: the bucket weighted path's kernel gate is `_NATIVE_SCORER_IDS`
+  (score_buckets.py:188, four built-in scorers only), which excludes every plugin scorer --
+  `name_freq_weighted_jw` never reaches the kernel; unchanged.
+- Any scoring-semantics change beyond delivering the already-shipped table to the
+  already-shipped scorer.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -201,13 +201,25 @@ def _default_n_buckets() -> int:
     return min((os.cpu_count() or 4) * 4, 1024)
 
 
-def _resolve_score_pair_callable(scorer_name: str) -> Any:
+def _resolve_score_pair_callable(
+    scorer_name: str, tf_freqs: dict[str, float] | None = None
+) -> Any:
     """Return a (str_a, str_b) -> float | None callable for a scorer name.
 
     Used by the bucket scorer's fast path so per-pair work skips the
     PluginRegistry / dispatch overhead that ``_fuzzy_score_matrix`` does
     per (block x field). None when the scorer isn't fast-path safe
     (embedding, ensemble, record_embedding, unknown).
+
+    ``tf_freqs`` (#1781): the field's per-dataset value-frequency table
+    (``MatchkeyField.tf_freqs``). Only the PLUGIN branch consumes it --
+    built-in scorers ignore frequency tables, mirroring the legacy path
+    where the table travels only through the plugin protocol. When set,
+    the returned callable binds it as ``fn(a, b, tf_freqs=...)`` so the
+    fast path matches the legacy matrix path (core/scorer.py:1236);
+    pre-fix the table was silently dropped here, which is why the
+    sample-time controller telemetry showed the downweight biting while
+    the final dedupe output was byte-identical with it OFF.
     """
     if scorer_name == "jaro_winkler":
         from rapidfuzz.distance import JaroWinkler
@@ -264,7 +276,23 @@ def _resolve_score_pair_callable(scorer_name: str) -> Any:
     if plugin is None:
         return None
     fn = getattr(plugin, "score_pair", None)
-    return fn  # may itself be None for matrix-only plugins
+    if fn is None or not tf_freqs:
+        return fn  # may itself be None for matrix-only plugins
+    # #1781: bind the field's TF table so the fast path matches the legacy
+    # matrix path (core/scorer.py:1236). Without this, the sample-time
+    # controller telemetry shows the downweight biting (samples run legacy)
+    # while the final dedupe silently drops it. TypeError fallback = the
+    # score_pair-side twin of _fuzzy_score_matrix's score_matrix posture
+    # (core/scorer.py:594-597): a legacy plugin without the keyword degrades
+    # to the bare call. Per-call try is fine -- zero cost on the happy path.
+
+    def _with_tf(a, b, _fn=fn, _tf=tf_freqs):
+        try:
+            return _fn(a, b, tf_freqs=_tf)
+        except TypeError:
+            return _fn(a, b)
+
+    return _with_tf
 
 
 # Scorers that score_field() handles directly (without raising). NE entries
@@ -424,7 +452,7 @@ def _resolve_fast_path(
         if scorer is None or weight is None:
             _decline(f"field has scorer={scorer!r} weight={weight!r}")
             return None
-        fn = _resolve_score_pair_callable(scorer)
+        fn = _resolve_score_pair_callable(scorer, getattr(f, "tf_freqs", None))
         if fn is None:
             _decline(f"_resolve_score_pair_callable({scorer!r}) is None")
             return None

--- a/packages/python/goldenmatch/tests/test_bucket_legacy_parity_matrix.py
+++ b/packages/python/goldenmatch/tests/test_bucket_legacy_parity_matrix.py
@@ -115,6 +115,53 @@ def test_bucket_equals_legacy_weighted(scorer, blocking):
     )
 
 
+def test_bucket_equals_legacy_tf_freqs_weighted():
+    """#1781: the bucket fast path must thread MatchkeyField.tf_freqs to plugin
+    scorers. Legacy scores name_freq_weighted_jw via score_matrix(values,
+    tf_freqs=...) (core/scorer.py:1236); pre-fix the bucket resolver grabbed
+    plugin.score_pair BARE, so the data-driven downweight was silently dropped.
+
+    Fixture: the table skews 'smith' COMMON (rarity ~0.13 -> weight ~0.65 ->
+    identical-pair score ~0.65, clearly BELOW the 0.8 threshold) and 'zorvath'
+    RARE (weight 1.0 -> score 1.0, clearly ABOVE). Legacy therefore clusters
+    ONLY the zorvath pair -- its clustering depends on the downweight. Pre-fix
+    bucket also clusters the smith pair (plain jw=1.0 short-circuit), diverging.
+    Scores sit >=0.1 away from the threshold on both sides (legacy float32
+    matrix vs bucket float64 per-pair; score_buckets.py:86-97 borderline-flip
+    caveat)."""
+    import goldenmatch.refdata  # noqa: F401  (registers name_freq_weighted_jw)
+    import polars as pl
+
+    df = pl.DataFrame({
+        "last": ["smith", "smith", "zorvath", "zorvath", "lee", "poe"],
+        "zip": ["10001", "10001", "10002", "10002", "10003", "10004"],
+    })
+    tf_freqs = {"smith": 0.4, "zorvath": 0.001}
+    cfg = GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="k", type="weighted", threshold=0.8,
+            fields=[MatchkeyField(
+                field="last", scorer="name_freq_weighted_jw",
+                weight=1.0, tf_freqs=tf_freqs,
+            )],
+        )],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=["strip"])],
+        ),
+    )
+    legacy, bucket = _bucket_vs_legacy(cfg, df)
+    # Anchor: legacy's clustering must actually depend on the downweight --
+    # exactly ONE multi-member cluster (the rare zorvath pair). Without the
+    # table both same-name pairs would cluster (2 clusters) and this test
+    # couldn't detect the bucket-side drop.
+    assert len(legacy) == 1, f"fixture anchor broken: legacy={legacy}"
+    assert bucket == legacy, (
+        f"bucket != legacy with tf_freqs: only-legacy={legacy - bucket} "
+        f"only-bucket={bucket - legacy}"
+    )
+
+
 # ── Known gaps (bucket NOT yet identical -> routed to legacy by _use_bucket_scorer) ──
 
 

--- a/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
+++ b/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
@@ -72,3 +72,101 @@ def test_jaccard_matches_matrix_path():
     ]
     for a, b in pairs:
         assert math.isclose(fn(a, b), _jaccard_score_single(a, b))
+
+
+# ── #1781: tf_freqs threading through the bucket fast path ──────────────────
+
+
+def _members_1781(res) -> frozenset:
+    cl = res.clusters or {}
+    return frozenset(
+        frozenset(int(m) for m in c.get("members", []))
+        for c in cl.values()
+        if len(c.get("members", [])) > 1
+    )
+
+
+def test_bucket_path_applies_tf_freqs_table_1781():
+    """#1781 signature regression: dedupe through the BUCKET path with
+    MatchkeyField.tf_freqs populated vs stripped must produce DIFFERENT
+    output. Pre-fix the resolver dropped the table, so ON == OFF
+    byte-identical (the bug's signature).
+
+    Miniaturized #1319 common-name fixture (~40 rows): 20 distinct people
+    all sharing the common surname 'smith' (unique emails), one genuine
+    'zorvath' duplicate pair, 18 unique fillers. With the table applied,
+    identical-'smith' pairs score ~0.68 (< 0.8 threshold, no cluster) while
+    the rare zorvath pair scores 1.0 (clusters either way)."""
+    import goldenmatch.refdata  # noqa: F401  (registers name_freq_weighted_jw)
+    import polars as pl
+    from goldenmatch import dedupe_df
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    last = ["smith"] * 20 + ["zorvath"] * 2 + [f"filler{i}" for i in range(18)]
+    email = (
+        [f"s{i}@x.com" for i in range(20)]
+        + ["z@x.com", "z@x.com"]
+        + [f"f{i}@x.com" for i in range(18)]
+    )
+    df = pl.DataFrame({"last": last, "email": email})
+    # Real relative frequencies over the 40 rows: smith 0.5, zorvath 0.05,
+    # fillers 0.025 each. log_ref = log(40); rarity(smith) ~= 0.19 ->
+    # weight ~= 0.675 -> identical-pair score ~= 0.675 < 0.8.
+    tf_freqs = {"smith": 0.5, "zorvath": 0.05}
+    tf_freqs.update({f"filler{i}": 0.025 for i in range(18)})
+
+    def _cfg(table):
+        return GoldenMatchConfig(
+            backend="bucket",
+            matchkeys=[MatchkeyConfig(
+                name="k", type="weighted", threshold=0.8,
+                fields=[MatchkeyField(
+                    field="last", scorer="name_freq_weighted_jw",
+                    weight=1.0, tf_freqs=table,
+                )],
+            )],
+            blocking=BlockingConfig(
+                strategy="static",
+                keys=[BlockingKeyConfig(fields=["last"], transforms=["lowercase"])],
+            ),
+        )
+
+    on = _members_1781(dedupe_df(df, config=_cfg(tf_freqs)))
+    off = _members_1781(dedupe_df(df, config=_cfg(None)))
+    # The rare-name duplicate pair clusters in BOTH runs (weight 1.0 with the
+    # table; plain jw=1.0 without) -- so the diff below is table-driven, not
+    # empty-vs-empty.
+    assert any(len(c) == 2 for c in on), f"zorvath pair missing from ON: {on}"
+    assert any(len(c) == 20 for c in off), f"20-smith cluster missing from OFF: {off}"
+    assert on != off, (
+        "bucket path ignored tf_freqs: ON == OFF byte-identical "
+        f"(the #1781 signature). clusters={on}"
+    )
+
+
+def test_resolver_tf_freqs_typeerror_fallback_1781():
+    """#1781 back-compat: a legacy plugin whose score_pair LACKS the tf_freqs
+    keyword must still score through the resolver when a table is supplied --
+    TypeError fallback to the bare call, twinning the score_matrix posture in
+    core/scorer.py:594-597. Registered inside the test (xdist self-contained)."""
+    from goldenmatch.plugins.registry import PluginRegistry
+
+    class _LegacyNoKwScorer:
+        name = "legacy_no_tf_kw_1781"
+
+        def score_pair(self, a, b):
+            return 0.42
+
+    PluginRegistry.instance().register_scorer(
+        "legacy_no_tf_kw_1781", _LegacyNoKwScorer()
+    )
+    fn = _resolve_score_pair_callable("legacy_no_tf_kw_1781", {"x": 0.5})
+    assert fn is not None
+    assert fn("a", "b") == 0.42  # TypeError fallback, no crash
+    assert fn("c", "d") == 0.42  # second call still works

--- a/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
+++ b/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
@@ -96,7 +96,8 @@ def test_bucket_path_applies_tf_freqs_table_1781():
     all sharing the common surname 'smith' (unique emails), one genuine
     'zorvath' duplicate pair, 18 unique fillers. With the table applied,
     identical-'smith' pairs score ~0.68 (< 0.8 threshold, no cluster) while
-    the rare zorvath pair scores 1.0 (clusters either way)."""
+    the rare zorvath pair scores ~0.925 (rarity log(20)/log(40) ~= 0.81 ->
+    weight ~= 0.925; still > 0.8, so it clusters either way)."""
     import goldenmatch.refdata  # noqa: F401  (registers name_freq_weighted_jw)
     import polars as pl
     from goldenmatch import dedupe_df
@@ -139,9 +140,9 @@ def test_bucket_path_applies_tf_freqs_table_1781():
 
     on = _members_1781(dedupe_df(df, config=_cfg(tf_freqs)))
     off = _members_1781(dedupe_df(df, config=_cfg(None)))
-    # The rare-name duplicate pair clusters in BOTH runs (weight 1.0 with the
-    # table; plain jw=1.0 without) -- so the diff below is table-driven, not
-    # empty-vs-empty.
+    # The rare-name duplicate pair clusters in BOTH runs (score ~0.925 > 0.8
+    # with the table; plain jw=1.0 without) -- so the diff below is
+    # table-driven, not empty-vs-empty.
     assert any(len(c) == 2 for c in on), f"zorvath pair missing from ON: {on}"
     assert any(len(c) == 20 for c in off), f"20-smith cluster missing from OFF: {off}"
     assert on != off, (


### PR DESCRIPTION
Closes #1781. Found by #1319's measurement pass.

## The bug

The bucket backend's fast path (the DEFAULT scoring path since #1761) resolved plugin scorers to bare `score_pair` callables, so `MatchkeyField.tf_freqs` (#1318's data-driven TF name downweight, default-on) never reached `NameFreqWeightedJW` -- it silently fell back to the static census path. The cruel part: the controller's SAMPLE iterations run the legacy path, so telemetry showed the downweight biting while the committed final dedupe never applied it (telemetry-yes/output-no skew). Proven pre-fix: fixture dedupe output with the flag on vs off was byte-identical.

## The fix

`_resolve_score_pair_callable(scorer_name, tf_freqs=None)`: the plugin branch, when a table is present, returns a wrapper calling `score_pair(a, b, tf_freqs=...)` with a per-call TypeError fallback to the bare call -- the score_pair-side twin of `_fuzzy_score_matrix`'s established score_matrix posture (core/scorer.py:594-597). Built-in branches untouched; the NE call site is builtins-gated and unchanged; empty/None tables return the bare callable (zero change on every existing path).

## Tests (three layers, all reproduced failing pre-fix)

- Parity-matrix TF case (the gap that let this ship): `name_freq_weighted_jw` + a hand-built table through bucket AND legacy -- byte-identical clustering, with hand-verified downweight math and scores kept >=0.1 from the threshold (legacy scores this plugin in float32, bucket in float64).
- Applied-table regression: bucket output with the table present DIFFERS from the table stripped (ON==OFF byte-identical was the bug's signature).
- Back-compat: a legacy plugin lacking the keyword still scores through the wrapper.

## Success bar (the #1319 Leg-A re-measure on this branch)

Bucket ON now: P 0.0305 (was 0.0091, byte-identical to OFF) -- matching legacy ON exactly; ON diverges from OFF (fp 19,099 vs 65,103). The full precision recovery to ~0.99 lands with the redesigned PR2b (#1319), which this unblocks.

102 tests green across the parity matrix, bucket unit file, TF weighting suite, and scorer suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs