### PR TITLE
fix(autoconfig): scale-proportional max_safe_block (fixes >=90k FS over-merge)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2737,6 +2737,40 @@ def _throughput_blocking(
         column=col, mode="word", k=2, num_perms=128, threshold=0.5, seed=0))
 
 
+def _compute_max_safe_block(height: int, native_scoring: bool) -> int:
+    """The largest per-block size auto-config will accept for a blocking key.
+
+    Scale-proportional (``height // 40``) with a 1000 floor and a scorer-aware
+    ceiling. Rationale:
+
+    - **Why proportional, not a fixed cap.** The old ``max(1000, height // 200)``
+      pinned at 1000 for every dataset <= 200K rows. On census-Zipfian surnames the
+      top surname-soundex block grows ~``0.013 * height`` and crosses 1000 between
+      ~70K-90K rows; there the strong-identity surname pass was rejected as
+      "oversized", which silently promoted surname into Fellegi-Sunter SCORING
+      (blocking fields are excluded from scoring) where its weight over-merged
+      same-block distinct people -- person F1 collapsed 0.97 -> 0.34 at 100K.
+      ``height // 40`` (= ``0.025 * height``) grows faster than the surname block,
+      so the pass is kept (validated: F1 back to ~0.96 at 100K/200K, at no wall
+      cost -- the over-merged baseline is actually slower).
+
+    - **Why the 1000 floor.** Below 40K rows ``height // 40 < 1000``, so the cap
+      stays exactly 1000 -- byte-identical to the old behavior on the small
+      datasets the accuracy gates use (DQbench/Febrl are unaffected; a 5000-row
+      block on a 5K dataset would be the whole dataset in one degenerate block).
+
+    - **Why the ceiling is scorer-aware.** The cap's original purpose was bounding
+      the NUMPY ensemble scorer's NxN block matrix (float32 10K-block ~= 400 MB;
+      50K OOMs). The native FS / bucket scorer scores PER-PAIR with no matrix, so
+      memory is O(N) not O(N^2) and that basis doesn't bind -- when native
+      block-scoring is active the ceiling lifts to 50K (wall/pair budget, not
+      memory, then governs via the #715 projected-pair guard). Pure-numpy keeps
+      the conservative 10K matrix ceiling.
+    """
+    ceiling = 50_000 if native_scoring else 10_000
+    return max(1000, min(ceiling, height // 40))
+
+
 def build_blocking(
     profiles: list[ColumnProfile],
     df: pl.DataFrame,
@@ -2883,13 +2917,18 @@ def build_blocking(
     # full scale that the pipeline filtered at max_block_size=5000 —
     # leaving no candidate pairs and ~99% singleton output.
     #
-    # Row-count-aware scaling: total_rows // 200, clamped to [1000, 10000].
-    # Preserves existing behavior at 200K and below (where 1000 always
-    # wins the clamp), bumps to 5000 at 1M (matches the pipeline default),
-    # and headroom to 10K for 2M+. Cap at 10K because a 10K-row block
-    # under float32 ensemble is ~400 MB per scorer call which is the
-    # practical OOM ceiling on a 16 GB runner.
-    max_safe_block = max(1000, min(10_000, int(_bf_height) // 200))
+    # Auto-config's "is this blocking key safe?" ceiling. See _compute_max_safe_block:
+    # scale-proportional (height // 40) with a 1000 floor and a scorer-aware cap.
+    # Fixes the >=~90K over-merge (the census-Zipfian surname-soundex block crosses
+    # the old fixed 1000 between 70K-90K rows, so the strong-identity surname pass
+    # was DROPPED as "oversized" -> surname silently entered FS scoring -> person F1
+    # collapsed 0.97 -> 0.34 at 100K); keeps small data (< 40K) at exactly 1000 so
+    # DQbench/Febrl are byte-unchanged.
+    from goldenmatch.core._native_loader import native_enabled as _native_enabled
+
+    max_safe_block = _compute_max_safe_block(
+        int(_bf_height), _native_enabled("block_scoring")
+    )
 
     # #715: gate every emitted blocking key/pass by its PROJECTED full-N max
     # block size. build_blocking runs on a sample (or, in the v0 path, the

--- a/packages/python/goldenmatch/tests/test_autoconfig_maxsafeblock_scale.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_maxsafeblock_scale.py
@@ -1,0 +1,104 @@
+"""Regression guard for the max_safe_block scale over-merge bug.
+
+The census-Zipfian surname-soundex block grows ~0.013*N and crossed the OLD fixed
+`max(1000, N//200)` cap between ~70K-90K rows. When it crossed, the strong-identity
+surname blocking pass was rejected as "oversized", which silently promoted surname
+into Fellegi-Sunter SCORING (blocking fields are excluded from scoring) where its
+weight over-merged same-block distinct people -- person F1 collapsed 0.97 -> 0.34 at
+100K. Fixed by the scale-proportional `_compute_max_safe_block` (height//40, 1000
+floor, scorer-aware ceiling): the cap now outgrows the surname block, so the pass is
+kept, while small datasets stay at exactly 1000 (DQbench/Febrl byte-unchanged).
+"""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+from goldenmatch.core.autoconfig import (
+    _compute_max_safe_block,
+    auto_configure_probabilistic_df,
+)
+
+
+class TestMaxSafeBlockFormula:
+    def test_small_data_unchanged_at_1000(self):
+        # < 40K rows: cap stays exactly 1000, byte-identical to the pre-fix
+        # behavior on the small datasets the accuracy gates (DQbench/Febrl) use.
+        assert _compute_max_safe_block(5_000, native_scoring=False) == 1000
+        assert _compute_max_safe_block(20_000, native_scoring=False) == 1000
+        assert _compute_max_safe_block(39_000, native_scoring=False) == 1000
+
+    def test_grows_to_hold_surname_soundex_block(self):
+        # The surname-soundex block is ~0.013*N. The cap must exceed it so the
+        # strong-identity surname pass is not dropped at scale.
+        for n, surname_block in [(90_000, 1_143), (100_000, 1_270), (200_000, 2_540)]:
+            cap = _compute_max_safe_block(n, native_scoring=False)
+            assert cap > surname_block, (
+                f"cap {cap} at N={n} must exceed the surname-soundex block "
+                f"{surname_block} so the pass is kept, not dropped into scoring"
+            )
+
+    def test_monotonic_non_decreasing_in_height(self):
+        prev = 0
+        for n in (1_000, 40_000, 100_000, 500_000, 1_000_000, 5_000_000):
+            cur = _compute_max_safe_block(n, native_scoring=False)
+            assert cur >= prev
+            prev = cur
+
+    def test_numpy_ceiling_bounds_the_nxn_matrix(self):
+        # Pure-numpy keeps the conservative 10K ceiling (float32 10K matrix ~400MB).
+        assert _compute_max_safe_block(100_000_000, native_scoring=False) == 10_000
+
+    def test_native_ceiling_is_higher_than_numpy(self):
+        # The native FS/bucket scorer has no NxN matrix -> memory basis doesn't
+        # bind -> the ceiling lifts (50K) so strong-id passes survive past ~1M.
+        big = 5_000_000
+        assert _compute_max_safe_block(big, native_scoring=True) > _compute_max_safe_block(
+            big, native_scoring=False
+        )
+        assert _compute_max_safe_block(100_000_000, native_scoring=True) == 50_000
+
+
+def _zipfian_surname_person_df(n: int, seed: int = 42) -> pl.DataFrame:
+    """Person-shaped frame where one surname soundex-collides on ~1.5% of rows --
+    enough that its block (~0.015*N) exceeds the OLD 1000 cap but stays under the
+    NEW cap at 100K, so it exercises the exact drop-vs-keep boundary."""
+    rng = np.random.default_rng(seed)
+    # ~1.5% share the hot surname (all soundex S530), rest spread across many.
+    hot = int(n * 0.015)
+    surnames = np.array(
+        ["Smith"] * hot
+        + [f"Zzz{rng.integers(0, 10**6)}" for _ in range(n - hot)],
+        dtype=object,
+    )
+    rng.shuffle(surnames)
+    firsts = np.array([f"F{i % 5000}" for i in range(n)], dtype=object)
+    # distinct dob per person (year spread) + a postcode pool
+    years = 1940 + rng.integers(0, 70, n)
+    dob = np.array([f"{y}-01-{1 + (i % 28):02d}" for i, y in enumerate(years)], dtype=object)
+    postcode = np.array([f"P{rng.integers(0, 200_000)}" for _ in range(n)], dtype=object)
+    return pl.DataFrame(
+        {
+            "record_id": np.arange(n, dtype=np.int64),
+            "first_name": firsts,
+            "surname": surnames,
+            "dob": dob,
+            "postcode": postcode,
+        }
+    )
+
+
+@pytest.mark.slow
+def test_surname_pass_survives_at_100k():
+    """At 100K with a Zipfian hot surname, auto-config must KEEP a surname blocking
+    pass (so surname stays out of FS scoring). Pre-fix this pass was dropped."""
+    df = _zipfian_surname_person_df(100_000)
+    cfg = auto_configure_probabilistic_df(df)
+    passes = getattr(cfg.blocking, "passes", None) or []
+    surname_pass = any(
+        (getattr(p, "fields", None) or []) == ["surname"] for p in passes
+    )
+    assert surname_pass, (
+        "surname blocking pass was dropped at 100K -- the max_safe_block "
+        "regression is back (surname will over-merge in FS scoring)"
+    )


### PR DESCRIPTION
## What and why

The scale-envelope benchmark (#1779) surfaced a real auto-config scale bug: GoldenMatch's probabilistic (FS) and zero-config paths **over-merge at >=~90k rows** on realistic person data. Recall stays ~1.0 but precision craters (person F1 collapsed **0.97 -> 0.34** at 100k, P 0.95 -> 0.21). Root-caused by systematic debugging.

**Root cause:** `max_safe_block = max(1000, height // 200)` in the shared `build_blocking` was **pinned at 1000 for every dataset <= 200k rows**. On census-Zipfian surnames the top surname-soundex block grows ~`0.013 * N` and crosses 1000 between ~70k-90k rows. There the strong-identity **surname blocking pass is rejected as "oversized" and dropped** -- which silently **promotes surname into Fellegi-Sunter scoring** (blocking fields are excluded from scoring), where its EM weight over-merges same-block distinct people (e.g. same birth-year, common surname).

Validated behaviorally: re-keeping surname as a blocking pass recovers person F1 **0.34 -> 0.96 at 100k and 200k, at no wall cost** (the over-merged baseline is actually *slower* -- giant clusters bog down clustering/golden).

## The fix

`_compute_max_safe_block(height, native_scoring)` -- scale-proportional with a 1000 floor and a scorer-aware ceiling:

- **`height // 40`** (= `0.025 * N`) outgrows the `~0.013 * N` surname block, so the pass is kept -> surname stays out of scoring -> no over-merge.
- **1000 floor:** `< 40k` rows stay at exactly 1000, **byte-identical** to the prior behavior on the small datasets the accuracy gates (DQbench/Febrl) use -- so those cannot regress.
- **scorer-aware ceiling:** the cap's purpose was bounding the *numpy* ensemble scorer's NxN block matrix (float32 10k-block ~400 MB; 50k OOMs). The native FS/bucket scorer scores **per-pair with no matrix** -- memory is O(N) not O(N^2) -- so when native block-scoring is active the ceiling lifts to 50k (the #715 projected-pair guard, not memory, then governs). Pure-numpy keeps the conservative 10k ceiling.

## Testing

`tests/test_autoconfig_maxsafeblock_scale.py` -- 6 tests (formula + a behavioral "surname pass survives at 100k" guard). Existing suites green: FS-autoconfig-v2 + autoconfig regressions (37), blocking 715/1207/multipass/learned/adaptive (60). **103 passing, ruff clean.**

Behavioral spot-check (person, numpy FS): 100k F1 0.343 -> **0.956**, 200k 0.351 -> **0.957**; FP at 100k 92,145 -> 2,147.

## Before merge -- quality gates to run (not in ci-required)

Because this touches shared `build_blocking`, run these before merging:
- `bench-probabilistic.yml` (FS panel: historical_50k/febrl3/synthetic/dblp_acm) -- historical_50k (50k) is the one panel dataset whose cap moves (1000 -> 1250).
- `bench-quality-scale.yml` / `qis_gate` (zero-config 50k-1M) -- this is the exact scale range the fix targets; expected to improve.

DQbench (small data) is byte-unchanged by construction (cap stays 1000 < 40k).

## Follow-ups (documented, not in this PR)

- **Per-pass auto-split (compound) rescue** for a dropped strong-id pass is blocked by `BlockingKeyConfig` applying one uniform transform chain to all fields (can't express `soundex(surname) + year(dob)`) and by runtime ANN sub-blocking needing an embedding column. A per-field-transform key would unlock it.
- **Safety net:** never let a *dropped* blocking field silently enter FS scoring (belt-and-suspenders; the cap fix keeps surname in blocking in the validated range).

Root cause + repro detail: `docs/superpowers/` investigation; found via the scale-envelope bench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)