### PR TITLE
chore(bench): make the ER head-to-head harness pyarrow-based (polars-free)

### DIFF
--- a/scripts/bench_er_headtohead/attribution.py
+++ b/scripts/bench_er_headtohead/attribution.py
@@ -47,11 +47,18 @@ def attribution(
 
 
 def truth_to_pairs(truth: Any) -> set[Pair]:
-    """Expand a {record_id, cluster_id} frame into within-cluster GT pairs."""
+    """Expand a {record_id, cluster_id} pa.Table into within-cluster GT pairs."""
+    from collections import defaultdict
     from itertools import combinations
+
+    groups: dict[Any, list] = defaultdict(list)
+    rids = truth.column("record_id").to_pylist()
+    cids = truth.column("cluster_id").to_pylist()
+    for rid, cid in zip(rids, cids):
+        groups[cid].append(rid)
+
     pairs = set()
-    for _cid, grp in truth.group_by("cluster_id"):
-        ids = grp["record_id"].to_list()
+    for ids in groups.values():
         if len(ids) > 1:
             pairs.update((min(a, b), max(a, b)) for a, b in combinations(ids, 2))
     return pairs

--- a/scripts/bench_er_headtohead/datasets.py
+++ b/scripts/bench_er_headtohead/datasets.py
@@ -2,8 +2,8 @@
 """Dataset loaders for the probabilistic accuracy panel.
 
 Each loader returns (records, truth):
-  records: polars.DataFrame with a 'record_id' column + matchable fields
-  truth:   polars.DataFrame with columns {record_id, cluster_id}
+  records: pyarrow.Table with a 'record_id' column + matchable fields
+  truth:   pyarrow.Table with columns {record_id, cluster_id}
 
 historical_50k is Splink's home-turf biographical dataset (Wikidata historical
 people, with a ground-truth cluster label). Loaded via splink_datasets when
@@ -17,9 +17,24 @@ import tempfile
 from collections.abc import Hashable
 from pathlib import Path
 
-import polars as pl
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
 
 logger = logging.getLogger(__name__)
+
+
+def _rename_columns(table: pa.Table, mapping: dict[str, str]) -> pa.Table:
+    """Rename columns via a {old: new} mapping (pyarrow renames by full list)."""
+    return table.rename_columns(
+        [mapping.get(name, name) for name in table.column_names]
+    )
+
+
+def _cast_column_to_string(table: pa.Table, name: str) -> pa.Table:
+    """Return a copy of ``table`` with column ``name`` cast to pa.string()."""
+    idx = table.schema.get_field_index(name)
+    return table.set_column(idx, name, pc.cast(table.column(name), pa.string()))
 
 REPO = Path(__file__).resolve().parents[2]
 DATASETS_DIR = REPO / "packages" / "python" / "goldenmatch" / "tests" / "benchmarks" / "datasets"
@@ -69,7 +84,7 @@ def _cluster_ids_from_pairs(
     return cluster_id
 
 
-def _historical_50k() -> tuple[pl.DataFrame, pl.DataFrame]:
+def _historical_50k() -> tuple[pa.Table, pa.Table]:
     df = None
     try:
         from splink import splink_datasets  # type: ignore
@@ -77,7 +92,9 @@ def _historical_50k() -> tuple[pl.DataFrame, pl.DataFrame]:
         splink_datasets = None  # type: ignore
     if splink_datasets is not None:
         try:
-            df = pl.from_pandas(splink_datasets.historical_50k)  # type: ignore
+            df = pa.Table.from_pandas(
+                splink_datasets.historical_50k, preserve_index=False  # type: ignore
+            )
         except Exception as e:  # splink present but dataset unusable -> try vendored
             logger.warning(
                 "splink_datasets.historical_50k failed (%s); trying vendored parquet", e
@@ -90,17 +107,17 @@ def _historical_50k() -> tuple[pl.DataFrame, pl.DataFrame]:
                 "install `goldenmatch[bench]` (for splink_datasets) or vendor "
                 f"{vendored}"
             )
-        df = pl.read_parquet(vendored)
+        df = pq.read_table(vendored)
 
     # historical_50k columns: unique_id, cluster, first_name, surname, dob,
     # birth_place, postcode_fake, occupation, ...
-    df = df.rename({"unique_id": "record_id", "cluster": "cluster_id"})
+    df = _rename_columns(df, {"unique_id": "record_id", "cluster": "cluster_id"})
     truth = df.select(["record_id", "cluster_id"])
-    records = df.drop("cluster_id")
+    records = df.drop_columns(["cluster_id"])
     return records, truth
 
 
-def _dblp_acm() -> tuple[pl.DataFrame, pl.DataFrame]:
+def _dblp_acm() -> tuple[pa.Table, pa.Table]:
     """Leipzig DBLP-ACM bibliographic ER (cross-source dedupe).
 
     Unions DBLP2.csv + ACM.csv into one records frame with source-prefixed
@@ -118,28 +135,40 @@ def _dblp_acm() -> tuple[pl.DataFrame, pl.DataFrame]:
             f"{base}); missing: {[p.name for p in missing]}"
         )
 
-    # latin-1 / utf8-lossy: the Leipzig CSVs carry invalid UTF-8 bytes.
-    dblp = pl.read_csv(dblp_path, encoding="utf8-lossy", infer_schema_length=0)
-    acm = pl.read_csv(acm_path, encoding="utf8-lossy", infer_schema_length=0)
+    # utf8-lossy: the Leipzig CSVs carry invalid UTF-8 bytes; replace them (mirrors
+    # polars' utf8-lossy). dtype=str + keep_default_na=False keeps every field a
+    # string (matching the prior infer_schema_length=0 all-Utf8 read).
+    import pandas as pd
 
-    def _prefix(df: pl.DataFrame, src: str) -> pl.DataFrame:
-        return df.with_columns(
-            (pl.lit(f"{src}:") + pl.col("id").cast(pl.Utf8)).alias("record_id")
-        ).drop("id")
+    def _read_csv(path: Path):
+        return pd.read_csv(
+            path,
+            dtype=str,
+            keep_default_na=False,
+            encoding="utf-8",
+            encoding_errors="replace",
+        )
 
-    records = pl.concat(
-        [_prefix(dblp, "dblp"), _prefix(acm, "acm")], how="diagonal"
+    def _prefix(pdf, src: str):
+        pdf = pdf.copy()
+        pdf["record_id"] = f"{src}:" + pdf["id"].astype(str)
+        return pdf.drop(columns=["id"])
+
+    records_pdf = pd.concat(
+        [_prefix(_read_csv(dblp_path), "dblp"), _prefix(_read_csv(acm_path), "acm")],
+        ignore_index=True,
+        sort=False,
     )
+    records = pa.Table.from_pandas(records_pdf, preserve_index=False)
 
-    gt = pl.read_csv(gt_path, encoding="utf8-lossy", infer_schema_length=0)
+    gt = _read_csv(gt_path)
     pairs: list[tuple[Hashable, Hashable]] = [
-        (f"dblp:{row['idDBLP']}", f"acm:{row['idACM']}")
-        for row in gt.iter_rows(named=True)
+        (f"dblp:{d}", f"acm:{a}") for d, a in zip(gt["idDBLP"], gt["idACM"])
     ]
 
-    all_ids = records["record_id"].to_list()
+    all_ids = records.column("record_id").to_pylist()
     cmap = _cluster_ids_from_pairs(all_ids, pairs)
-    truth = pl.DataFrame(
+    truth = pa.table(
         {
             "record_id": all_ids,
             "cluster_id": [cmap[r] for r in all_ids],
@@ -148,7 +177,7 @@ def _dblp_acm() -> tuple[pl.DataFrame, pl.DataFrame]:
     return records, truth
 
 
-def _febrl3() -> tuple[pl.DataFrame, pl.DataFrame]:
+def _febrl3() -> tuple[pa.Table, pa.Table]:
     """recordlinkage's Febrl3 synthetic person dataset (with duplicates).
 
     Records come from the dataframe (index reset into ``record_id``);
@@ -168,15 +197,16 @@ def _febrl3() -> tuple[pl.DataFrame, pl.DataFrame]:
     pdf = df.reset_index()
     # The reset index column is the febrl record id (e.g. 'rec-123-org').
     id_col = str(pdf.columns[0])
-    records = pl.from_pandas(pdf).rename({id_col: "record_id"})
-    records = records.with_columns(pl.col("record_id").cast(pl.Utf8))
+    records = pa.Table.from_pandas(pdf, preserve_index=False)
+    records = _rename_columns(records, {id_col: "record_id"})
+    records = _cast_column_to_string(records, "record_id")
 
-    all_ids = records["record_id"].to_list()
+    all_ids = records.column("record_id").to_pylist()
     pairs: list[tuple[Hashable, Hashable]] = [
         (str(a), str(b)) for a, b in links
     ]
     cmap = _cluster_ids_from_pairs(all_ids, pairs)
-    truth = pl.DataFrame(
+    truth = pa.table(
         {
             "record_id": all_ids,
             "cluster_id": [cmap[r] for r in all_ids],
@@ -185,7 +215,7 @@ def _febrl3() -> tuple[pl.DataFrame, pl.DataFrame]:
     return records, truth
 
 
-def _ncvr() -> tuple[pl.DataFrame, pl.DataFrame]:
+def _ncvr() -> tuple[pa.Table, pa.Table]:
     """NC Voter Registration 10K sample.
 
     The raw NCVR sample is one row per voter (``ncid`` is unique across all
@@ -208,7 +238,7 @@ def _ncvr() -> tuple[pl.DataFrame, pl.DataFrame]:
     )
 
 
-def _synthetic_person() -> tuple[pl.DataFrame, pl.DataFrame]:
+def _synthetic_person() -> tuple[pa.Table, pa.Table]:
     """Synthetic person rows from the bench fixture generator.
 
     Reuses ``generate_fixture.generate`` (writes records + truth parquet to a
@@ -240,8 +270,8 @@ def _synthetic_person() -> tuple[pl.DataFrame, pl.DataFrame]:
             seed=42,
             batch=1_000_000,
         )
-        records = pl.read_parquet(out)
-        truth = pl.read_parquet(truth_path)
+        records = pq.read_table(out)
+        truth = pq.read_table(truth_path)
     return records, truth
 
 
@@ -254,7 +284,7 @@ _LOADERS = {
 }
 
 
-def load_dataset(name: str) -> tuple[pl.DataFrame, pl.DataFrame]:
+def load_dataset(name: str) -> tuple[pa.Table, pa.Table]:
     if name not in _LOADERS:
         raise KeyError(f"unknown dataset {name!r}; have {sorted(_LOADERS)}")
     return _LOADERS[name]()

--- a/scripts/bench_er_headtohead/run_bakeoff.py
+++ b/scripts/bench_er_headtohead/run_bakeoff.py
@@ -423,7 +423,9 @@ def main(argv: list[str] | None = None) -> None:
 
     datasets = _import_sibling("datasets")
 
-    import polars as pl
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
 
     per_engine_results: dict[str, dict[str, tuple[dict, dict | None]]] = {}
     for name in names:
@@ -449,13 +451,17 @@ def main(argv: list[str] | None = None) -> None:
 
         # Records: preserve the REAL record_id verbatim for the engine subprocess.
         records_parquet = ds_dir / "records.parquet"
-        records.write_parquet(records_parquet)
+        pq.write_table(records, records_parquet)
         # Truth in STRING record_id space so it joins both GM (string preds) and
         # Splink (real-id preds) under the shared evaluator.
         truth_path = ds_dir / "truth.parquet"
-        truth.with_columns(pl.col("record_id").cast(pl.Utf8)).write_parquet(truth_path)
+        _tidx = truth.schema.get_field_index("record_id")
+        truth_str = truth.set_column(
+            _tidx, "record_id", pc.cast(truth.column("record_id"), pa.string())
+        )
+        pq.write_table(truth_str, truth_path)
 
-        rows_n = records.height
+        rows_n = records.num_rows
 
         for eng in ("gm_zeroconfig", "gm_probabilistic", "gm_prob_native"):
             result, metrics = _run_gm(

--- a/scripts/bench_er_headtohead/run_converted_splink.py
+++ b/scripts/bench_er_headtohead/run_converted_splink.py
@@ -52,6 +52,10 @@ import time
 import types
 from pathlib import Path
 
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.parquet as pq
+
 _HERE = Path(__file__).resolve().parent
 
 # Must be set before goldenmatch/polars imports (Windows WMI hang guard is a
@@ -111,7 +115,7 @@ def _run_native_splink(run_splink_mod, settings, training_rules, s,
     )
     with tempfile.TemporaryDirectory(prefix="conv_splink_") as td:
         input_path = Path(td) / "records.parquet"
-        records.write_parquet(input_path)
+        pq.write_table(records, input_path)
         db_api = DuckDBAPI()
         db_api._con.execute(
             f"CREATE OR REPLACE VIEW bench_input AS "
@@ -130,15 +134,13 @@ def _run_converted_goldenmatch(config, records, pred_out: Path) -> float:
     pred_cluster_id} parquet in STRING record_id space (mirrors run_panel.py's
     __row_id__ -> record_id remap). Returns the dedupe wall."""
     import numpy as np
-    import pyarrow as pa
-    import pyarrow.parquet as pq
 
     try:
         from goldenmatch import dedupe_df
     except ImportError:  # older layouts expose this on _api
         from goldenmatch._api import dedupe_df
 
-    rid = records["record_id"].to_list()
+    rid = records.column("record_id").to_pylist()
     t0 = time.perf_counter()
     ded = dedupe_df(records, config=config)
     wall = time.perf_counter() - t0
@@ -185,7 +187,6 @@ def main() -> int:
     datasets = _import_sibling("datasets")
     evaluate_mod = _import_sibling("evaluate")
 
-    import polars as pl
     import splink.comparison_library as cl
     from splink import DuckDBAPI, Linker, SettingsCreator, block_on
 
@@ -201,11 +202,16 @@ def main() -> int:
 
     # 1. Dataset.
     records, truth = datasets.load_dataset(args.dataset)
-    if args.max_rows and records.height > args.max_rows:
-        records = records.head(args.max_rows)
-        truth = truth.filter(pl.col("record_id").is_in(records["record_id"]))
-    print(f"[dataset] {args.dataset}: {records.height} records, "
-          f"{truth['cluster_id'].n_unique()} true clusters")
+    if args.max_rows and records.num_rows > args.max_rows:
+        records = records.slice(0, args.max_rows)
+        truth = truth.filter(
+            pc.is_in(
+                truth.column("record_id"),
+                value_set=records.column("record_id").combine_chunks(),
+            )
+        )
+    print(f"[dataset] {args.dataset}: {records.num_rows} records, "
+          f"{len(pc.unique(truth.column('cluster_id')))} true clusters")
 
     # 2. The SAME settings run_splink.py uses for this dataset.
     spec = run_splink_mod._SETTINGS_BY_DATASET.get(args.dataset)
@@ -215,7 +221,7 @@ def main() -> int:
         return 2
     kind, builder = spec
     if kind == "person":
-        settings, training_rules = builder(s, records.columns)
+        settings, training_rules = builder(s, records.column_names)
     else:
         settings, training_rules = builder(s)
 
@@ -227,7 +233,13 @@ def main() -> int:
     out_dir: Path = args.out_dir / args.dataset
     out_dir.mkdir(parents=True, exist_ok=True)
     truth_path = out_dir / "truth.parquet"
-    truth.with_columns(pl.col("record_id").cast(pl.Utf8)).write_parquet(truth_path)
+    _tidx = truth.schema.get_field_index("record_id")
+    pq.write_table(
+        truth.set_column(
+            _tidx, "record_id", pc.cast(truth.column("record_id"), pa.string())
+        ),
+        truth_path,
+    )
 
     # 4. Native Splink.
     splink_pred = out_dir / "splink_pred.parquet"
@@ -238,9 +250,14 @@ def main() -> int:
     )
     splink_wall = time.perf_counter() - t0
     # String record_id space to join the string-keyed truth.
-    pl.read_parquet(splink_pred).with_columns(
-        pl.col("record_id").cast(pl.Utf8)
-    ).write_parquet(splink_pred)
+    _sp = pq.read_table(splink_pred)
+    _spidx = _sp.schema.get_field_index("record_id")
+    pq.write_table(
+        _sp.set_column(
+            _spidx, "record_id", pc.cast(_sp.column("record_id"), pa.string())
+        ),
+        splink_pred,
+    )
     print(f"[splink] wall={splink_wall:.1f}s "
           f"scored_pairs={splink_result.get('scored_pairs')} "
           f"clusters={splink_result.get('cluster_count')}")

--- a/scripts/bench_er_headtohead/run_gm_converted.py
+++ b/scripts/bench_er_headtohead/run_gm_converted.py
@@ -120,7 +120,7 @@ def main() -> None:
         return
 
     try:
-        import polars as pl
+        import pyarrow.parquet as pq
 
         from goldenmatch.config.from_splink import SplinkConversionError, from_splink
         from goldenmatch.core.bench import bench_capture
@@ -166,8 +166,8 @@ def main() -> None:
                 mk.rerank = False
 
         t0 = time.perf_counter()
-        df = pl.read_parquet(args.input)
-        result["rows_loaded"] = df.height
+        df = pq.read_table(args.input)
+        result["rows_loaded"] = df.num_rows
         load_wall = time.perf_counter() - t0
 
         t0 = time.perf_counter()
@@ -183,7 +183,7 @@ def main() -> None:
             import pyarrow.parquet as pq
 
             clusters = getattr(ded, "clusters", None) or {}
-            rid = df["record_id"].to_list()
+            rid = df.column("record_id").to_pylist()
             rids, cids = [], []
             for cid, c in clusters.items():
                 members = c["members"] if isinstance(c, dict) else c.members

--- a/scripts/bench_er_headtohead/run_goldenmatch.py
+++ b/scripts/bench_er_headtohead/run_goldenmatch.py
@@ -103,7 +103,7 @@ def main() -> None:
     }
     t_start = time.perf_counter()
     try:
-        import polars as pl
+        import pyarrow.parquet as pq
         from goldenmatch.core._native_loader import native_enabled, native_module
         from goldenmatch.core.bench import bench_capture
 
@@ -144,8 +144,8 @@ def main() -> None:
             )
 
         t0 = time.perf_counter()
-        df = pl.read_parquet(args.input)
-        result["rows_loaded"] = df.height
+        df = pq.read_table(args.input)
+        result["rows_loaded"] = df.num_rows
         load_wall = time.perf_counter() - t0
 
         if args.mode == "hand_built":
@@ -279,7 +279,7 @@ def main() -> None:
                 # REAL record_id as a STRING column (mirrors run_panel.py:83-108).
                 # The real benchmark datasets carry STRING record_ids (historical_50k
                 # Q-ids, dblp_acm 'dblp:123', febrl3 'rec-123-org').
-                rid = df["record_id"].to_list()
+                rid = df.column("record_id").to_pylist()
                 rids, cids = [], []
                 for cid, c in clusters.items():
                     members = c["members"] if isinstance(c, dict) else c.members
@@ -310,8 +310,8 @@ def main() -> None:
             # Splink's `count(distinct cluster_id)`. multi-member tracked separately.
             cluster_count=metrics.get("cluster_count"),
             multi_member_clusters=metrics.get("multi_member_cluster_count"),
-            duplicate_rows_found=getattr(getattr(ded, "dupes", None), "height", None),
-            unique_records=getattr(getattr(ded, "unique", None), "height", None),
+            duplicate_rows_found=getattr(getattr(ded, "dupes", None), "num_rows", None),
+            unique_records=getattr(getattr(ded, "unique", None), "num_rows", None),
             bench=bench_blob,
         )
     except MemoryError as e:

--- a/scripts/bench_er_headtohead/run_panel.py
+++ b/scripts/bench_er_headtohead/run_panel.py
@@ -52,6 +52,18 @@ def _import_sibling(name: str):
         return mod
 
 
+def _truth_string_record_id(truth):
+    """Cast the truth table's record_id column to string (join key parity with
+    the string-keyed pred parquets)."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+
+    idx = truth.schema.get_field_index("record_id")
+    return truth.set_column(
+        idx, "record_id", pc.cast(truth.column("record_id"), pa.string())
+    )
+
+
 def _gm_predictions_path(records, truth, gm_pred_path: Path, dump_dir: Path):
     """Run the GoldenMatch probabilistic path, write predictions, return the
     (candidate_recordid, emitted_recordid) pair sets in dataset record_id space.
@@ -60,7 +72,6 @@ def _gm_predictions_path(records, truth, gm_pred_path: Path, dump_dir: Path):
     an `error` row for the dataset.
     """
     import numpy as np
-    import polars as pl  # noqa: F401  (ensures polars import errors surface here)
     import pyarrow as pa
     import pyarrow.parquet as pq
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
@@ -70,7 +81,7 @@ def _gm_predictions_path(records, truth, gm_pred_path: Path, dump_dir: Path):
     except ImportError:  # older layouts expose this on _api
         from goldenmatch._api import dedupe_df
 
-    rid = records["record_id"].to_list()
+    rid = records.column("record_id").to_pylist()
 
     dump_dir.mkdir(parents=True, exist_ok=True)
     os.environ["GOLDENMATCH_BENCH_DUMP_PAIRS"] = str(dump_dir)
@@ -119,11 +130,11 @@ def _remap_pairs(path: Path, rid: list) -> set:
     """
     if not path.exists():
         return set()
-    import polars as pl
+    import pyarrow.parquet as pq
 
-    df = pl.read_parquet(path)
+    df = pq.read_table(path)
     out: set = set()
-    for a, b in zip(df["a"].to_list(), df["b"].to_list()):
+    for a, b in zip(df.column("a").to_pylist(), df.column("b").to_pylist()):
         ra, rb = rid[a], rid[b]
         # canonical (min, max) in string space (record_ids may be int or str).
         sa, sb = str(ra), str(rb)
@@ -198,7 +209,7 @@ def _run_splink(name, records, out_dir, truth_path, threshold):
             sys.executable,
             str(_HERE / "run_splink.py"),
             "--dataset", name,
-            "--rows", str(records.height),
+            "--rows", str(records.num_rows),
             "--out", str(splink_json),
             "--pred-out", str(splink_pred),
             "--threshold", str(threshold),
@@ -349,13 +360,13 @@ def main() -> None:
                 )
             continue
 
-        import polars as pl
+        import pyarrow.parquet as pq
 
         ds_dir = out_dir / name
         ds_dir.mkdir(parents=True, exist_ok=True)
         truth_path = ds_dir / "truth.parquet"
         # Truth written in string record_id space to join the string-keyed preds.
-        truth.with_columns(pl.col("record_id").cast(pl.Utf8)).write_parquet(truth_path)
+        pq.write_table(_truth_string_record_id(truth), truth_path)
 
         if "goldenmatch" in engines:
             rows.append(

--- a/scripts/bench_er_headtohead/run_splink.py
+++ b/scripts/bench_er_headtohead/run_splink.py
@@ -31,6 +31,8 @@ import tempfile
 import time
 from pathlib import Path
 
+import pyarrow.parquet as pq
+
 try:
     import resource  # Unix-only; absent on Windows dev boxes (CI/bench runs on Linux)
 except ImportError:  # pragma: no cover - Windows fallback path
@@ -364,16 +366,16 @@ def main() -> None:
             # Materialize records to a temp parquet (Splink reads parquet via view).
             tmpdir = tempfile.TemporaryDirectory(prefix="splink_ds_")
             input_path = Path(tmpdir.name) / "records.parquet"
-            records.write_parquet(input_path)
-            result["rows_requested"] = records.height
+            pq.write_table(records, input_path)
+            result["rows_requested"] = records.num_rows
             if args.truth_out is not None:
                 args.truth_out.parent.mkdir(parents=True, exist_ok=True)
-                truth.write_parquet(args.truth_out)
+                pq.write_table(truth, args.truth_out)
 
             kind, builder = spec
             try:
                 if kind == "person":
-                    settings, training_rules = builder(s, records.columns)
+                    settings, training_rules = builder(s, records.column_names)
                 else:
                     settings, training_rules = builder(s)
             except KeyError as e:

--- a/scripts/bench_er_headtohead/shapes.py
+++ b/scripts/bench_er_headtohead/shapes.py
@@ -110,7 +110,7 @@ def _person_splink_settings(s):
 # ---------------------------------------------------------------------------
 # Block-key choice: the 2-field COMPOSITE (venue, year). VERIFIED supported by
 # the bucket single-key path -- blocker._build_block_key_expr / derive_block_key
-# concatenate multiple fields into one "__block_key__" via pl.concat_str, so a
+# concatenate multiple fields into one "__block_key__" via a concat_str expr, so a
 # BlockingKeyConfig(fields=["venue","year"]) is transparent to the eager bucket
 # pass (no single-column fallback needed). C = N_VENUE * N_YEAR ~ 210K, mirroring
 # person's ~200K distinct blocks.

--- a/scripts/bench_er_headtohead/test_bakeoff.py
+++ b/scripts/bench_er_headtohead/test_bakeoff.py
@@ -4,7 +4,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import polars as pl
 import pyarrow as pa
 import pyarrow.parquet as pq
 
@@ -12,14 +11,14 @@ HERE = Path(__file__).resolve().parent
 RUN_GM = HERE / "run_goldenmatch.py"
 
 def _tiny_parquet(tmp_path):
-    df = pl.DataFrame({
+    df = pa.table({
         "record_id": ["r0","r1","r2","r3","r4","r5"],
         "first_name": ["ann","ann","bob","bob","cara","dan"],
         "surname":    ["lee","lee","kim","kim","ng","ono"],
         "dob":        ["1990-01-01","1990-01-01","1985-02-02","1985-02-02","1972-03-03","1965-04-04"],
         "postcode":   ["AA1","AA1","BB2","BB2","CC3","DD4"],
     })
-    p = tmp_path / "tiny.parquet"; df.write_parquet(p); return p, df
+    p = tmp_path / "tiny.parquet"; pq.write_table(df, p); return p, df
 
 def _run(p, mode, tmp_path):
     out = tmp_path / "res.json"; pred = tmp_path / "pred.parquet"
@@ -43,7 +42,7 @@ def test_zeroconfig_emits_string_record_id_preds(tmp_path):
         t = pq.read_table(pred)
         assert t.column_names == ["record_id", "pred_cluster_id"]
         rids = set(t.column("record_id").to_pylist())
-        assert rids <= set(df["record_id"].to_list())
+        assert rids <= set(df.column("record_id").to_pylist())
         assert all(isinstance(x, str) for x in rids)
 
 def test_probabilistic_mode_runs_and_string_preds(tmp_path):

--- a/scripts/bench_er_headtohead/test_scale_envelope.py
+++ b/scripts/bench_er_headtohead/test_scale_envelope.py
@@ -65,26 +65,46 @@ def test_generate_biblio_schema_and_stable_block_key(tmp_path):
     assert t.column_names == ["record_id", "title", "authors", "venue", "year"]
     # Within every truth cluster, venue+year (block key) must be identical across
     # members -- that's the stability guarantee that avoids the recall trap.
-    import polars as pl
-    df = pl.read_parquet(out).join(pl.read_parquet(truth), on="record_id")
-    per_cluster = df.group_by("cluster_id").agg(
-        pl.col("venue").n_unique().alias("nv"),
-        pl.col("year").drop_nulls().n_unique().alias("ny"))
-    # allow year null (dropna) but non-null year must be unique per cluster; venue always unique
-    assert per_cluster["nv"].max() == 1
-    assert per_cluster["ny"].max() == 1   # year stable per cluster where non-null
+    from collections import defaultdict
+
+    truth_t = pq.read_table(truth)
+    rids = t.column("record_id").to_pylist()
+    venue_by_id = dict(zip(rids, t.column("venue").to_pylist()))
+    year_by_id = dict(zip(rids, t.column("year").to_pylist()))
+    cl_venues: dict = defaultdict(set)
+    cl_years: dict = defaultdict(set)
+    for r, c in zip(truth_t.column("record_id").to_pylist(),
+                    truth_t.column("cluster_id").to_pylist()):
+        cl_venues[c].add(venue_by_id.get(r))
+        y = year_by_id.get(r)
+        if y is not None:  # allow year null (dropna equivalent)
+            cl_years[c].add(y)
+    # venue always unique per cluster; non-null year unique per cluster
+    assert max(len(v) for v in cl_venues.values()) == 1
+    assert max(len(y) for y in cl_years.values()) == 1   # year stable where non-null
 
 
 def test_generate_biblio_titles_actually_vary(tmp_path):
     gen = _load("generate_fixture")
     out, truth = tmp_path / "b.parquet", tmp_path / "b.truth.parquet"
     gen.generate(3000, 0.3, out, truth, 42, 1000, shape="biblio")
-    import polars as pl
-    df = pl.read_parquet(out).join(pl.read_parquet(truth), on="record_id")
-    multi = df.filter(pl.col("cluster_id").is_in(
-        df.group_by("cluster_id").len().filter(pl.col("len") > 1)["cluster_id"]))
+    import pyarrow.parquet as pq
+    from collections import defaultdict
+
+    t = pq.read_table(out)
+    truth_t = pq.read_table(truth)
+    title_by_id = dict(zip(t.column("record_id").to_pylist(),
+                           t.column("title").to_pylist()))
+    cl_members: dict = defaultdict(list)
+    for r, c in zip(truth_t.column("record_id").to_pylist(),
+                    truth_t.column("cluster_id").to_pylist()):
+        cl_members[c].append(r)
     # at least some multi-member clusters have >1 distinct title (corruption happened)
-    assert multi.group_by("cluster_id").agg(pl.col("title").n_unique().alias("nt"))["nt"].max() > 1
+    max_titles = 0
+    for members in cl_members.values():
+        if len(members) > 1:
+            max_titles = max(max_titles, len({title_by_id.get(m) for m in members}))
+    assert max_titles > 1
 
 
 def test_generator_projection_check_rejects_small_C():


### PR DESCRIPTION
## What and why

The `scripts/bench_er_headtohead/` harness still imported **polars** throughout (datasets.py + all runners), inconsistent with GoldenMatch's Polars eviction (core is arrow-native; polars is an optional `[polars]` extra). Because `[bench]` doesn't pull polars, `bench-probabilistic`'s panel jobs **ImportError at `datasets.py` import** (`No module named 'polars'`). The eviction-consistent fix is to make the harness pyarrow-based -- not to re-add polars to the extra.

`dedupe_df` accepts a `pyarrow.Table` natively (v3.0.0 result frames are already `pa.Table`; cluster members are plain ints), so the harness never needs polars.

## Changes (11 files, polars -> pyarrow)

- **`datasets.py`**: loaders return `(pa.Table, pa.Table)`; `pq.read_table`/`pa.Table.from_pandas`; string-record_id cast + column rename via `pyarrow.compute`; the invalid-UTF-8 Leipzig DBLP-ACM CSVs read via `pandas(encoding_errors="replace", dtype=str)` -> `pa.Table.from_pandas` (faithful to the old `utf8-lossy` + `infer_schema_length=0`).
- **Runners** (`run_goldenmatch`, `run_gm_converted`, `run_converted_splink`, `run_splink`, `run_panel`, `run_bakeoff`): `pl.read_parquet`->`pq.read_table`, `write_parquet`->`pq.write_table`, `.height`->`.num_rows`, `.columns`->`.column_names`, `["c"].to_list()`->`.column("c").to_pylist()`, `is_in`->`pc.is_in`, `head`->`slice`, `n_unique`->`len(pc.unique(...))`.
- **Tests + attribution.py**: `group_by`/`join`/`agg` replaced with Python-side aggregation over `.to_pylist()`.
- No `import polars` remains (AST-verified). `evaluate.py`/`generate_fixture.py`/`orchestrate.py`/`merge_results.py`/`compare_panels.py` were already polars-free.

`[bench]` extra unchanged (`splink`/`duckdb`/`pyarrow`) -- the point is the harness needs no polars.

## Testing

- `test_scale_envelope.py` 20 passed / 1 skipped; `test_bakeoff.py` 5 passed.
- `orchestrate.py --scales 1500 --shapes person biblio --lanes gm_hand_built gm_probabilistic gm_zeroconfig gm_converted_splink`: exit 0, all 8 datapoints `status=ok`.
- Real-dataset loaders verified end-to-end: `historical_50k` (50578 rows) + `febrl3` (5000) both return `pa.Table`s.
- This also unblocks `bench-probabilistic` (the panel can now run without polars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)