### PR TITLE
feat(goldenmatch): precision-anchor threshold raise -- closes the #1207 over-merge (#1319)

### DIFF
--- a/docs/superpowers/plans/2026-07-15-precision-anchor-threshold-raise.md
+++ b/docs/superpowers/plans/2026-07-15-precision-anchor-threshold-raise.md
@@ -145,6 +145,50 @@ unit-test file; one controller-integration test; a scratchpad success-bar re-mea
 - [ ] **Step 4:** Green + adjacent controller tests (`tests/test_autoconfig_regressions.py -q`)
   still green. **Step 5:** Commit `test(autoconfig): precision-anchor fires through the real controller` (+ trailers).
 
+### Task P2.5: Commit-dynamics fixes (spec Addendum -- READ IT FIRST)
+
+P2 proved the rule fires on the original Leg-A fixture but `pick_committed` discards the raised
+entry (dip false-RED on 2 scored pairs + iteration tiebreak). The spec's Addendum section pins
+both fixes and the probe evidence; this task implements them. Both are required -- either alone
+still commits 0.8 (validated via `probe_dipfix.py` / `probe_demote.py` in the session
+scratchpad `.../scratchpad/1319/`).
+
+**Files:**
+- Modify: `goldenmatch/core/complexity_profile.py` (ScoringProfile.health dip clause, ~385)
+- Modify: `goldenmatch/core/autoconfig_rules.py` (extract `precision_anchor_would_fire` helper)
+- Modify: `goldenmatch/core/autoconfig_history.py` (pick_committed `demote_suspect` param)
+- Modify: `goldenmatch/core/autoconfig_controller.py` (~957: pass the closure when the rule fired)
+- Test: extend `tests/test_precision_anchor_1319.py` (+ the health/history unit-test homes --
+  locate with `grep -rln "ScoringProfile(" tests/` and `grep -rln "pick_committed" tests/`)
+
+- [ ] **Step 1: Failing unit tests (TDD).**
+  - Health: `ScoringProfile(n_pairs_scored=2, dip_statistic=0.0, mass_above_threshold=1.0,
+    candidates_compared=..., mass_in_borderline=1.0).health()` is NOT RED (borderline clause
+    decides: bord==mass -> GREEN); same profile with `n_pairs_scored=30` IS RED (boundary
+    pinned at the constant); `n_pairs_scored=0, candidates_compared=0` stays RED (unchanged
+    clause).
+  - pick_committed: hand-built RunHistory with two YELLOW entries (equal separation), suspect
+    one at iteration -1, non-suspect at iteration 1: bare call commits -1 (pins today's
+    tiebreak); with `demote_suspect` flagging the -1 entry, commits 1; RED-raise safety (suspect
+    YELLOW at -1 vs non-suspect RED at 1 -> -1 still wins); all-suspect -> same pick as bare.
+  - Trigger helper: `precision_anchor_would_fire` returns True/False on the same fixtures as the
+    P1 trigger matrix's fire/no-fire cases (import and call directly; the rule must delegate to
+    it -- assert via a small monkeypatch-spy or by checking the rule fires iff the helper is
+    True on 2-3 matrix rows).
+- [ ] **Step 2:** Run -> all new tests FAIL in the predicted modes.
+- [ ] **Step 3: Implement** exactly per the spec Addendum: `_MIN_DIP_SUPPORT = 30` constant +
+  dip clause `>= _MIN_DIP_SUPPORT`; helper extraction (pure refactor of the five conditions --
+  the rule body calls it, byte-equivalent trigger semantics); `demote_suspect` param with
+  `demoted` added to rank in ALL THREE key() return paths (collapse-floor, zero-label, normal);
+  controller closure gated on the rule having fired in `history.decisions`. Update
+  `pick_committed`'s docstring (the lex-key description) for the new param.
+- [ ] **Step 4:** New tests green; P1/P2 file fully green (the 399-row integration test must
+  still commit 0.9); blast-radius sweep: any existing test constructing tiny-n_pairs
+  ScoringProfiles expecting RED via the dip gate (grep `dip_statistic` in tests/) -- fix ONLY by
+  raising their `n_pairs_scored` to >= 30 where the test's intent is "flat dip -> RED", never by
+  weakening assertions; `tests/test_autoconfig_regressions.py` + rules test file green; ruff.
+- [ ] **Step 5:** Commit `feat(autoconfig): dip min-support guard + precision-suspect commit demotion (#1319)` (+ trailers).
+
 ### Task P3: Success bar + PR + close-out
 
 - [ ] **Step 1:** Re-run the #1319 Leg-A harness against THIS worktree (PYTHONPATH swap), flag

--- a/docs/superpowers/plans/2026-07-15-precision-anchor-threshold-raise.md
+++ b/docs/superpowers/plans/2026-07-15-precision-anchor-threshold-raise.md
@@ -1,0 +1,166 @@
+# Precision-Anchor Threshold Raise (#1319 PR2b) Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A controller rule that raises a name-only weighted matchkey's threshold to 0.9 when the
+measured #1207 over-merge shape is present, closing #1319 (and, with the bar held, #1207).
+
+**Spec:** `docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md` — READ
+FIRST. It pins the five trigger conditions (incl. the concrete mechanisms), the single-shot 0.9
+remedy, the copy-on-write template, and the registration position.
+
+**Architecture:** One new `rule_*` function in `core/autoconfig_rules.py` + registration; one new
+unit-test file; one controller-integration test; a scratchpad success-bar re-measure.
+
+**Tech Stack:** Python 3.12, pytest.
+
+---
+
+## Environment / repo mechanics
+
+- **PREREQUISITE:** PR #1782 (bucket tf_freqs fix) must be MERGED before the worktree is cut —
+  the success bar depends on it. Check `gh pr view 1782 --json state` first; if still open, wait
+  for the queue (do NOT stack).
+- NEW worktree `D:\show_case\gm-pr2b`, branch `feat/1319-precision-anchor-raise` off
+  freshly-fetched `origin/main`. **NEVER `git stash`.**
+- Tests via main venv + worktree PYTHONPATH (Git Bash):
+  `cd /d/show_case/gm-pr2b/packages/python/goldenmatch && PYTHONPATH="D:/show_case/gm-pr2b/packages/python/goldenmatch" POLARS_SKIP_CPU_CHECK=1 PYTHONIOENCODING=utf-8 GOLDENMATCH_NATIVE=0 D:/show_case/goldenmatch/.venv/Scripts/python.exe -m pytest <tests> -q`
+- Ruff before commits. `docs/superpowers/` gitignored → `git add -f`. Commit trailers:
+  `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`
+  `Claude-Session: https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs`
+- Push/PR: the standard benzsevern token dance; arm `gh pr merge --auto`; STOP.
+
+**Key code (verified on origin/main):**
+- `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py`:
+  - The COPY template: `rule_matchkey_demote_high_cardinality_field` (line 1106) — 3-arg
+    signature, iterates `current.matchkeys`, shallow `mk.model_copy(update={...})`, rebuilds the
+    matchkeys list via identity (`new_mk if m is mk else m`), `current.model_copy(update=...)`,
+    returns `(new_cfg, PolicyDecision(rule_name=..., rationale=..., config_diff=...))`.
+  - The CTX template: `rule_sparse_match_expand` (line 1067) — 4-arg signature with
+    `ctx: IndicatorContext | None = None`, `if ctx is None: return None` (line 1078).
+  - `DEFAULT_RULES` (line 1245): ordered list with per-entry comments; insert the new rule
+    directly BEFORE `rule_sparse_match_expand` (currently last), with a comment in the list's
+    voice (e.g. `# 17 NEW #1319: raise name-only weighted threshold on over-merge shape (before sparse-expand's loosen)`).
+  - Module constants convention: `_DEMOTE_CARD_THRESHOLD`-style names near the top of the rule's
+    section.
+- `ColumnPrior` (`core/complexity_profile.py:44`): `identity_score` attr;
+  `ctx.column_priors: dict[str, ColumnPrior]`.
+- `profile.scoring.mass_above_threshold` (`complexity_profile.py:368`).
+- Matchkey shapes: `mk.type` ("weighted"/"exact"), `mk.fields` (`MatchkeyField.field`/`.scorer`/
+  `.tf_freqs`), `mk.threshold`.
+- The controller-integration + success-bar fixture: the #1319 harness at
+  `C:/Users/bsevern/AppData/Local/Temp/claude/D--show-case-goldenmatch/2af6f77e-d6b2-41c0-ad88-08d7fd3f306e/scratchpad/1319/measure_1319.py`
+  (its `build_fixture()`-equivalent builds the 2600-row common-name/strong-email frame; READ it
+  to lift the fixture shape for the in-repo integration test at a smaller row count).
+  Post-#1782 baseline on that harness: bucket ON P 0.0305, strangers 15,058, mass 1.0.
+- Existing controller-run test patterns: `tests/test_autoconfig_regressions.py` (`_person_df`,
+  rerank-off pattern, reading `result.postflight_report.controller_history`).
+
+## File structure
+
+- Modify: `packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py` (the rule +
+  constants + DEFAULT_RULES entry)
+- Create: `packages/python/goldenmatch/tests/test_precision_anchor_1319.py` (trigger matrix +
+  controller integration)
+
+---
+
+### Task P0: Verify prerequisite + worktree
+
+- [ ] **Step 1:** `unset GH_TOKEN; GH_TOKEN=$(gh auth token --user benzsevern) gh pr view 1782 --repo benseverndev-oss/goldenmatch --json state -q .state` → must print MERGED. If OPEN, STOP and wait (report back).
+- [ ] **Step 2:** `git fetch origin main -q && git worktree add /d/show_case/gm-pr2b -b feat/1319-precision-anchor-raise origin/main`; confirm `git -C /d/show_case/gm-pr2b log --oneline -3` shows the #1782 merge.
+- [ ] **Step 3:** Copy spec+plan into the worktree docs/superpowers/{specs,plans}; `git add -f`; commit `docs: spec + plan for the #1319 precision-anchor threshold raise` (+ trailers).
+
+### Task P1: The rule + trigger-matrix unit tests (TDD)
+
+**Files:** Modify `core/autoconfig_rules.py`; Create `tests/test_precision_anchor_1319.py`.
+
+- [ ] **Step 1: Failing tests** — the trigger matrix, calling the rule DIRECTLY with hand-built
+  `ComplexityProfile`/config/`RunHistory`/ctx fixtures (mirror how other rule unit tests build
+  them — grep `rule_sparse_match_expand` or `rule_matchkey_demote` in tests/ for the fixture
+  idiom; a faked ctx whose `column_priors` is a plain dict of stub objects with
+  `identity_score` attrs is fine if IndicatorContext is heavy to construct — read
+  `IndicatorContext` first and prefer the real thing when cheap):
+  - all five conditions satisfied → returns `(new_cfg, decision)`; new_cfg's weighted matchkey
+    threshold == 0.9; INPUT config unmutated (its threshold still 0.8); decision.rule_name set;
+    rationale mentions the shape.
+  - mass 0.94 → None. Weighted mk containing one non-name scorer (e.g. `jaro_winkler` address
+    field, the NCVR shape) → None. No exact matchkey with identity_score >= 0.75 (either no
+    exact mk, or its field's prior below 0.75, or field missing from column_priors) → None.
+    No `tf_freqs` on any name field → None. Exactly ONE of two name fields carrying the table →
+    FIRES (the measured fixture shape: only last_name carries tf_freqs; the ANY-field
+    formulation is load-bearing). threshold already 0.9 → None (convergence).
+    `ctx is None` → None.
+  - Registration: `DEFAULT_RULES.index(rule_precision_anchor_threshold_raise) == DEFAULT_RULES.index(rule_sparse_match_expand) - 1`.
+- [ ] **Step 2:** Run → FAIL (rule doesn't exist).
+- [ ] **Step 3: Implement** in autoconfig_rules.py (section constants + the rule; mirror the
+  demote rule's structure and docstring voice):
+  ```python
+  _ANCHOR_NAME_SCORERS = {"name_freq_weighted_jw", "given_name_aliased_jw"}
+  _ANCHOR_IDENTITY_MIN = 0.75
+  _ANCHOR_MASS_MIN = 0.95
+  _ANCHOR_RAISED_THRESHOLD = 0.9
+  ```
+  Rule skeleton: 4-arg signature (ctx optional, None → return None); find the first weighted
+  matchkey with non-empty fields, ALL scorers in `_ANCHOR_NAME_SCORERS`, threshold not None and
+  `< _ANCHOR_RAISED_THRESHOLD`, and ANY field with truthy `tf_freqs`; require
+  `profile.scoring.mass_above_threshold >= _ANCHOR_MASS_MIN`; require any exact matchkey with a
+  field whose `ctx.column_priors.get(field)` has `identity_score >= _ANCHOR_IDENTITY_MIN`;
+  remedy via the demote rule's shallow model_copy pattern setting
+  `{"threshold": _ANCHOR_RAISED_THRESHOLD}`; PolicyDecision rationale citing the measured
+  evidence shape (mass, the name-only fields, the anchor field) and #1319. Docstring: the
+  measurement numbers (P 0.009 pre-#1782 / 0.0305 post-#1782 → 0.987 raised to 0.9 on the
+  crafted fixture — state BOTH baselines), why the trigger is the config shape not mass alone
+  (healthy NCVR reads mass 1.0), why tf_freqs is required (identical names without the table
+  clear any threshold), why single-fire converges, the parked-B1 history (designed shape never
+  emitted by the controller — this rule fires on what the controller actually commits), AND the
+  policy's implicit gate: HeuristicRefitPolicy.decide() returns None on an overall-GREEN profile
+  (autoconfig_policy.py:78), so this rule structurally cannot fire on healthy commits — the
+  crafted fixture measures overall_health YELLOW, which is why rules run there. Register in DEFAULT_RULES before sparse_match_expand.
+- [ ] **Step 4:** Matrix passes; `pytest tests/test_autoconfig_rules.py -q` (or wherever
+  existing rule tests live — locate first) still green; ruff clean.
+- [ ] **Step 5:** Commit `feat(autoconfig): precision-anchor threshold raise on the #1207 over-merge shape (#1319)` (+ trailers).
+
+### Task P2: Through-the-real-controller integration test
+
+**Files:** extend `tests/test_precision_anchor_1319.py`.
+
+- [ ] **Step 1: Failing test** `test_rule_fires_through_real_controller`: build the #1319
+  fixture shape IN-REPO at reduced scale (~400-600 rows: a common-name pool with unique strong
+  emails + planted dups — lift the generator logic from the scratchpad harness, keep it
+  deterministic and fast; heed the repo fixture gotchas: emails unique per person so the email
+  column profiles as an identity anchor). Run `auto_configure_df(df)` (with
+  `GOLDENMATCH_AUTOCONFIG_MEMORY=0` via monkeypatch env) → assert the committed config's
+  weighted matchkey threshold == 0.9 AND the rule's decision appears in
+  `_LAST_CONTROLLER_RUN`/`controller_history.decisions` (rule_name match). Also assert the
+  weighted mk's fields all carry name scorers (fixture-validity guard: if auto-config stops
+  emitting the shape, the test must say so rather than vacuously pass).
+  NOTE the parked-B1 lesson in the test docstring: this test exists because the previous rule
+  passed unit fixtures and could never fire on real controller output.
+- [ ] **Step 2:** FAIL (threshold stays 0.8). **Step 3:** No production change expected beyond
+  P1 — if the rule does NOT fire through the controller, DIAGNOSE (which condition fails on the
+  real profile/ctx?) and fix the RULE within spec semantics; report prominently if a spec
+  condition proves unfireable on real output (that's the B1 failure mode recurring — STOP and
+  escalate rather than loosening silently).
+- [ ] **Step 4:** Green + adjacent controller tests (`tests/test_autoconfig_regressions.py -q`)
+  still green. **Step 5:** Commit `test(autoconfig): precision-anchor fires through the real controller` (+ trailers).
+
+### Task P3: Success bar + PR + close-out
+
+- [ ] **Step 1:** Re-run the #1319 Leg-A harness against THIS worktree (PYTHONPATH swap), flag
+  default (on): expect precision ~0.99, recall 1.0, threshold 0.9 in the committed config.
+  Record exact numbers. Run the NCVR control (`measure_1319.py b on`) TWICE — once with
+  PYTHONPATH at current main (gm-train330 after fetch) and once at this worktree — and compare
+  the committed configs (thresholds identical; the rule did not fire). RE-DERIVE the main-side
+  run rather than trusting the stored `leg_b_on.json` (it predates the #1782 merge).
+- [ ] **Step 2:** Targeted sweep: the new test file + `tests/test_autoconfig_regressions.py` +
+  the rules test file + `tests/test_autoconfig_blocking_union_1207.py` +
+  `tests/test_tf_name_weighting_1207.py` → green.
+- [ ] **Step 3:** Push; PR `feat(goldenmatch): precision-anchor threshold raise -- closes the #1207 over-merge (#1319)`
+  with the before/after numbers (P 0.009 → measured, R 1.0, NCVR unaffected), `Closes #1319`
+  and `Closes #1207` (the umbrella's observation 1 lives on in #1316/#1317 — say so in the
+  body). Arm auto-merge, STOP.
+- [ ] **Step 4:** After merge: post the close-out numbers as a final comment on #1319 and #1207
+  (they auto-close via the PR); delete the parked branch `feat/1207-pr2b-precision-anchor`
+  (local only — `git branch -D`); update memory (`project_1207_autoconfig_blocking_union`) +
+  work tracker.

--- a/docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md
+++ b/docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md
@@ -93,9 +93,89 @@ its siblings; the CI regression net is the same as for every controller-rule cha
 - **Close-out:** post the numbers to #1319 and #1207; close BOTH when the bar holds (#1316 and
   #1317 remain open as their own tracks).
 
+## Addendum (2026-07-15, approved): commit dynamics -- fired-then-discarded
+
+P2's through-the-controller work found that on the ORIGINAL Leg-A fixture the rule FIRES but
+`pick_committed` discards the raised entry. Probe evidence (entry table, gm-pr2b at f1cfba2db):
+
+- iter0 (thr 0.8): rule fires; overall YELLOW; 18,769 pairs scored; dip 0.0619.
+- iter1 (thr 0.9, the raise): only **2 pairs** survive scoring (kernel prefilter at the raised
+  threshold) -> `dip_statistic = 0.0` -> the `< 0.005` unimodality gate
+  (complexity_profile.py:385) reads RED -> entry rank 2, discarded.
+- Even with the dip gate neutralized, iter1 ties v0 at (YELLOW, separation 0) and loses the
+  ascending-iteration tiebreak (`autoconfig_history.py:209`) -- the profile metrics cannot
+  distinguish the over-merged v0 from the correct raise (both read mass=1.0, bord=1.0).
+
+Both patches were validated empirically through the real controller on the original fixture
+(scratchpad probes `probe_dipfix.py`, `probe_demote.py`): with the two changes below the
+committed weighted threshold is **0.9**; either change alone still commits 0.8.
+
+### Change A: dip minimum-support guard (production, `complexity_profile.py`)
+
+A dip statistic over a handful of pairs is sampling noise, not a unimodality signal -- the same
+rationale as `_MIN_TRIPLE_SUPPORT = 30` for transitivity (`_profile_helpers.py:43-46`). In
+`ScoringProfile.health()`, the dip clause becomes:
+
+```python
+if self.dip_statistic < 0.005 and self.n_pairs_scored >= _MIN_DIP_SUPPORT:
+    return HealthVerdict.RED
+```
+
+with `_MIN_DIP_SUPPORT = 30` (module-level constant next to the class, comment citing the
+`_MIN_TRIPLE_SUPPORT` precedent). Profiles with 1-29 scored pairs and a flat dip fall through to
+the borderline/GREEN clauses instead of hard-RED. The `n_pairs_scored == 0` "nothing happened"
+clause above it is unchanged.
+
+### Change B: precision-suspect commit demotion (production, three files)
+
+The rule's trigger is a labels-free precision-collapse detector; the commit stage must not
+discard that knowledge. Mirrors the existing `precision_collapse_floor` philosophy (demote
+pathological entries at commit).
+
+- `autoconfig_rules.py`: extract the five trigger conditions into a module-level helper
+  `precision_anchor_would_fire(cfg, profile, ctx) -> bool`; the rule becomes
+  trigger-helper + remedy (single source of truth -- no drift possible).
+- `autoconfig_history.py`: `pick_committed` gains
+  `demote_suspect: Callable[[HistoryEntry], bool] | None = None`. In `key()`, compute
+  `demoted = 1 if (demote_suspect is not None and demote_suspect(e)) else 0`; the
+  collapse-floor branch returns `(3 + demoted, 0.0, e.iteration)` and the normal path returns
+  `(rank + demoted, -sep, e.iteration)` (zero-label branch likewise `rank + demoted`).
+  Default None -> byte-identical to today.
+- `autoconfig_controller.py` (~957): pass the closure ONLY when
+  `any(d.rule_name == "precision_anchor_threshold_raise" for d in history.decisions)`:
+  `demote_suspect=lambda e: precision_anchor_would_fire(e.config, e.profile, ctx)`.
+
+Dynamics on the fixture: v0/iter0 (thr 0.8, trigger still holds) demote YELLOW->rank 2; iter1
+(thr 0.9, condition 5 false) stays rank 1 -> commits. Safety: if the raised entry profiled RED
+(raise genuinely hurt), it sits at rank 2 alongside the demoted v0 and v0 wins the iteration
+tiebreak -- the remedy never beats v0 unless its measured profile is at least as healthy. If the
+rule fired on the final budget iteration (raise never profiled), every entry is suspect, ranks
+shift uniformly, commit unchanged. Runs where the rule never fires (NCVR): closure not passed,
+byte-identical.
+
+Known pre-existing inconsistency (unchanged): `autoconfig_verify.py:302` and
+`suggest/surface.py:59` re-run `pick_committed()` bare (already omitting collapse floor and
+zero-label); they keep doing so.
+
+### Addendum testing
+
+- Unit (health): `n_pairs_scored=2, dip=0.0` -> not RED; `n_pairs_scored=30, dip=0.0` -> RED
+  (boundary unchanged); the zero-pairs clause unchanged.
+- Unit (pick_committed): hand-built history -- two YELLOW entries where the suspect one is
+  earlier-iteration: without `demote_suspect` the earlier wins (pins today's tiebreak); with it
+  the non-suspect wins; RED-raise safety case (suspect YELLOW v0 vs RED raise -> v0 still wins);
+  all-suspect -> same pick as without.
+- Integration: the success bar itself -- the ORIGINAL Leg-A harness commits threshold 0.9
+  (covered by P3's measurement; the existing 399-row integration test must stay green).
+
 ## Out of scope
 
 - #1316 (learned-blocking vs union reconciliation at >= 50k) and #1317 (TS parity of the
   blocking union).
 - The parked B1 branch (discarded).
 - Any TF-weighting changes beyond what #1318/#1782 shipped; any new env flags.
+- The `unimodal_scoring` RULE still fires on the raised iteration's raw dip (it reads
+  `dip_statistic` directly, not `health()`), burning budget iterations 2-3 on the fixture. The
+  entries it produces are RED/discarded; harmless. Candidate follow-up, not this feature.
+- Making `autoconfig_verify`/`suggest` pass commit-selection args to their bare
+  `pick_committed()` calls (pre-existing).

--- a/docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md
+++ b/docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md
@@ -1,0 +1,101 @@
+# Precision-Anchor Threshold Raise (#1319 PR2b, redesigned)
+
+**Date:** 2026-07-15
+**Status:** Approved (design)
+**Issue:** #1319 (the #1207 precision-collapse follow-up). Prerequisite: #1781 fixed via PR #1782
+(bucket fast path threads tf_freqs) -- this rule's remedy is inert without it.
+**Supersedes:** the parked B1 rule on branch `feat/1207-pr2b-precision-anchor` (commits
+2b36a8dc + d2ca98a9) -- proven unable to fire on real controller output (#1319's deferral
+analysis); DISCARD, do not merge or extend it.
+
+## Problem
+
+On null-sparse multi-source person data (#1207 observation 2), the controller commits a config
+whose weighted matchkey scores names only, and identical common full names over-merge distinct
+people. The 2026-07-15 measurement pass (#1319 comment) quantified it on a crafted 2600-row
+common-name/strong-email fixture: precision 0.009 at the committed 0.8 threshold, all 15,058
+same-name-stranger pairs merged, `mass_above_threshold` pinned at 1.0. With #1782's fix live and
+the weighted threshold raised to 0.9, the same fixture measures P 0.987 / R 1.0 / F1 0.993 --
+the recall stays free because the controller's own `exact_email` matchkey anchors every true
+duplicate. The remedy is validated; this feature makes the controller apply it.
+
+## Decisions (from brainstorming + the measurement)
+
+- **Approach A: single-shot raise to 0.9.** The trigger includes `threshold < 0.9`, so the rule
+  fires at most once (trivial convergence). Rejected: incremental +0.05 steps (burns controller
+  budget iterations -- the #1654/#1680 lesson -- and the measurement shows intermediate points
+  don't help: 0.85 left P at 0.03); reviving the parked demote/promote rule (cannot fire).
+- **The trigger is the CONFIG SHAPE, not the mass signal alone**: the healthy NCVR run (P 0.96)
+  also reads `mass_above_threshold = 1.0`, so mass is necessary but not sufficient. NCVR is
+  excluded by the shape condition instead (its weighted matchkey carries address/gender -- not
+  name-only).
+
+## The rule
+
+`rule_precision_anchor_threshold_raise` in `core/autoconfig_rules.py`, matching the existing
+`rule_*` signature/registration pattern, registered in `DEFAULT_RULES` (position: see Registration order below).
+
+The rule takes the 4-arg signature (accepting the optional `ctx: IndicatorContext | None` --
+`_call_rule` in autoconfig_policy.py only passes `ctx` when the signature accepts it) and
+returns `None` when `ctx is None` (the `rule_sparse_match_expand` precedent; condition 3 needs
+`ctx.column_priors`).
+
+**Trigger -- ALL of:**
+1. `profile.scoring.mass_above_threshold >= 0.95` (pathology gate; necessary, not sufficient --
+   the healthy NCVR run also reads 1.0).
+2. The config has a weighted matchkey whose fields ALL carry a NAME-CLASS SCORER --
+   membership in `{"name_freq_weighted_jw", "given_name_aliased_jw"}` (rules do NOT receive the
+   auto-config column classifier's output; scorer names are the config-visible proxy, and
+   auto-config assigns these scorers exactly to name fields. The fixture's
+   `first_name`/`last_name` qualifies; NCVR's 5-field weighted with address/gender scorers does
+   not -- the shape exclusion that keeps healthy real data safe).
+3. At least one EXACT matchkey whose field has `ctx.column_priors[field].identity_score >= 0.75`
+   coexists (the strong-identifier recall anchor that makes the raise safe -- without it the
+   raise could cost recall and the rule must not fire).
+4. At least one of the weighted matchkey's name fields carries `tf_freqs` (the #1318 downweight
+   must be live for the raise to separate same-name strangers; identical names without the
+   table score 1.0 and clear any threshold < 1, so firing would be pure recall risk for typo'd
+   dups with zero precision gain).
+5. That weighted matchkey's `threshold < 0.9`.
+
+**Remedy:** propose a copy-on-write config with the name-only weighted matchkey's threshold set
+to 0.9 (the measured operating point). Copy-on-write template: the shallow
+`mk.model_copy(update=...)` + rebuilt matchkeys list + `current.model_copy` pattern of
+`rule_matchkey_demote_high_cardinality_field` (autoconfig_rules.py:1106) -- NOT the parked
+branch's deep-copy-then-mutate. Decision recorded through the rule's standard decision-trail
+mechanics (`RunHistory.decisions`) with the trigger evidence in the reason.
+
+**Registration order:** place the rule BEFORE `rule_sparse_match_expand` in `DEFAULT_RULES`
+(the parked branch's deliberate placement): sparse-expand LOWERS thresholds, and the policy's
+first-proposal-wins ordering must let the precision raise pre-empt a loosen on the pathological
+shape.
+
+**Convergence:** single-fire by construction (condition 5). No env flag -- a default rule like
+its siblings; the CI regression net is the same as for every controller-rule change
+(DQbench/#528/synthetic gates), and the NCVR shape structurally cannot trigger it.
+
+## Testing / success bar
+
+- **Unit trigger matrix** (new file `tests/test_precision_anchor_1319.py` -- the parked
+  branch's `test_precision_anchor_1207.py` name stays free since that branch is discarded):
+  each of the five conditions independently falsified -> rule returns None; all satisfied ->
+  proposal with threshold 0.9; threshold already >= 0.9 -> None (convergence); `ctx is None` ->
+  None. The matrix builds a `ctx` (or a faked `column_priors` mapping) since condition 3 reads
+  it. Copy-on-write pinned (input config unmutated).
+- **Through the REAL controller** (the parked-B1 lesson: verify via `auto_configure_df`, never
+  only hand-built configs): the #1319 crafted-fixture shape commits a config whose weighted
+  matchkey threshold is 0.9, with the rule's decision visible in
+  `result.postflight_report.controller_history.decisions`.
+- **Success bar (the measurement close-out):** re-run the #1319 Leg-A harness on the branch
+  (which includes #1782 via fresh main): bucket path, flag default-on -> precision recovers to
+  ~0.99 with recall 1.0 on the crafted fixture. NCVR 10k control: the rule did NOT fire
+  (committed config identical to main's).
+- **Close-out:** post the numbers to #1319 and #1207; close BOTH when the bar holds (#1316 and
+  #1317 remain open as their own tracks).
+
+## Out of scope
+
+- #1316 (learned-blocking vs union reconciliation at >= 50k) and #1317 (TS parity of the
+  blocking union).
+- The parked B1 branch (discarded).
+- Any TF-weighting changes beyond what #1318/#1782 shipped; any new env flags.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -971,9 +971,8 @@ class AutoConfigController:
         ):
             from goldenmatch.core.autoconfig_rules import precision_anchor_would_fire
 
-            _demote_suspect = (
-                lambda e: precision_anchor_would_fire(e.config, e.profile, ctx)
-            )
+            def _demote_suspect(e: HistoryEntry) -> bool:
+                return precision_anchor_would_fire(e.config, e.profile, ctx)
         best_entry = history.pick_committed(
             precision_collapse_floor=0.9,
             use_zero_label_confidence=_zero_label_commit_enabled(),

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -30,6 +30,8 @@ from goldenmatch.core.complexity_profile import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from goldenmatch.core.autoconfig_history import HistoryEntry
     from goldenmatch.distributed.record_store import PreparedRecordStore
 from goldenmatch.core.autoconfig_memory import AutoConfigMemory, profile_signature
@@ -964,15 +966,17 @@ class AutoConfigController:
         # precision-collapse detector; when the rule fired this run, commit
         # must not prefer an entry the rule would still flag (mirrors
         # precision_collapse_floor). Otherwise pass None (byte-identical).
-        _demote_suspect = None
+        _demote_suspect: Callable[[HistoryEntry], bool] | None = None
         if any(
             d.rule_name == "precision_anchor_threshold_raise"
             for d in history.decisions
         ):
             from goldenmatch.core.autoconfig_rules import precision_anchor_would_fire
 
-            def _demote_suspect(e: HistoryEntry) -> bool:
+            def _demote_precision_suspect(e: HistoryEntry) -> bool:
                 return precision_anchor_would_fire(e.config, e.profile, ctx)
+
+            _demote_suspect = _demote_precision_suspect
         best_entry = history.pick_committed(
             precision_collapse_floor=0.9,
             use_zero_label_confidence=_zero_label_commit_enabled(),

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py
@@ -858,13 +858,19 @@ class AutoConfigController:
                     # Allow the policy to check recall-aware rules before committing.
                     sp = profile_n.scoring
                     bp = profile_n.blocking
-                    n_rows = profile_n.data.n_rows
+                    # NOTE: deliberately NOT named `n_rows` -- that's the
+                    # function-level FULL df height the RED-refuse gate
+                    # (REFUSE_AT_N) compares against after the loop.
+                    # Rebinding it here to the sample height silently
+                    # disabled the at-scale refuse whenever the loop broke
+                    # through this GREEN branch (#1319 P2.5 found the shadow).
+                    _sample_n_rows = profile_n.data.n_rows
                     _suspicious_tight_blocking = (
                         iteration == 0
                         and sp.mass_above_threshold >= 1.0
                         and sp.candidates_compared > 0
-                        and n_rows > 0
-                        and sp.candidates_compared < n_rows * 0.5
+                        and _sample_n_rows > 0
+                        and sp.candidates_compared < _sample_n_rows * 0.5
                         and bp.reduction_ratio > 0.995
                     )
                     if not _suspicious_tight_blocking:
@@ -954,9 +960,24 @@ class AutoConfigController:
         # Pick committed config. Zero-label Phase 2: commit by zero-label
         # confidence instead of the -mass_separation tiebreaker (default ON,
         # see _zero_label_commit_enabled).
+        # #1319: the precision-anchor rule's trigger is a labels-free
+        # precision-collapse detector; when the rule fired this run, commit
+        # must not prefer an entry the rule would still flag (mirrors
+        # precision_collapse_floor). Otherwise pass None (byte-identical).
+        _demote_suspect = None
+        if any(
+            d.rule_name == "precision_anchor_threshold_raise"
+            for d in history.decisions
+        ):
+            from goldenmatch.core.autoconfig_rules import precision_anchor_would_fire
+
+            _demote_suspect = (
+                lambda e: precision_anchor_would_fire(e.config, e.profile, ctx)
+            )
         best_entry = history.pick_committed(
             precision_collapse_floor=0.9,
             use_zero_label_confidence=_zero_label_commit_enabled(),
+            demote_suspect=_demote_suspect,
         )
         if best_entry is None:
             # Every iteration errored — no usable profile produced. Fall back to v0.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -164,7 +164,13 @@ class RunHistory:
         iteration tiebreak resolves it). Mirrors the
         ``precision_collapse_floor`` philosophy: commit must not prefer an
         entry the precision-anchor rule would still flag. Default None ->
-        byte-identical behavior.
+        byte-identical behavior. Known rank-3 collision: a demoted RED
+        entry (2+1) shares rank with a non-demoted collapse-floor entry
+        (3) but keeps its ``-sep`` tiebreaker while the collapse branch
+        neutralises sep to 0.0, so the demoted RED can now outrank the
+        collapsed entry — both are last-resort entries that v0 outranks
+        in practice, accepted as-is. The callable must not raise on any
+        surviving entry; exceptions propagate out of ``pick_committed``.
         """
         if (precision_collapse_floor is not None
                 and not (0.0 <= precision_collapse_floor <= 1.0)):

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py
@@ -6,6 +6,7 @@ Spec: docs/superpowers/specs/2026-05-06-autoconfig-introspective-controller-desi
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from typing import Any
@@ -116,6 +117,7 @@ class RunHistory:
         self,
         precision_collapse_floor: float | None = None,
         use_zero_label_confidence: bool = False,
+        demote_suspect: Callable[[HistoryEntry], bool] | None = None,
     ) -> HistoryEntry | None:
         """Pick the entry to commit. Returns None ONLY if every entry
         errored or has no profile — otherwise returns the best entry by
@@ -127,9 +129,11 @@ class RunHistory:
         that profile is RED. The user-visible health verdict on the
         returned entry tells them what they got.
 
-        Lex key: ``(health_rank, -mass_separation, iteration)`` where
-        ``health_rank`` is 0/1/2 for GREEN/YELLOW/RED and
-        ``mass_separation = mass_above_threshold - mass_in_borderline``.
+        Lex key: ``(health_rank + demoted, -mass_separation, iteration)``
+        where ``health_rank`` is 0/1/2 for GREEN/YELLOW/RED,
+        ``mass_separation = mass_above_threshold - mass_in_borderline``,
+        and ``demoted`` is 1 when ``demote_suspect`` flags the entry
+        (0 otherwise; always 0 when ``demote_suspect`` is None).
 
         Filter: ``e.error is None and e.profile is not None`` (per the
         ``HistoryEntry`` invariant — guards the sentinel-mismatch case
@@ -151,6 +155,16 @@ class RunHistory:
         the everything-matches / no-matches / cluster-collapse guards, so this
         is defense-in-depth alongside ``precision_collapse_floor`` (which still
         applies). Default False -> identical behavior to before (no change).
+
+        ``demote_suspect`` (#1319): optional labels-free precision-collapse
+        detector evaluated per entry. Flagged entries get ``+1`` added to
+        their health rank in every branch of the lex key, so a non-suspect
+        entry of equal health/separation beats a suspect one, while a
+        genuinely healthier suspect still wins (YELLOW+1 ties RED+0 and the
+        iteration tiebreak resolves it). Mirrors the
+        ``precision_collapse_floor`` philosophy: commit must not prefer an
+        entry the precision-anchor rule would still flag. Default None ->
+        byte-identical behavior.
         """
         if (precision_collapse_floor is not None
                 and not (0.0 <= precision_collapse_floor <= 1.0)):
@@ -172,6 +186,7 @@ class RunHistory:
                 HealthVerdict.YELLOW: 1,
                 HealthVerdict.RED: 2,
             }[verdict]
+            demoted = 1 if (demote_suspect is not None and demote_suspect(e)) else 0
             sp = e.profile.scoring
             sep = sp.mass_above_threshold - sp.mass_in_borderline
             if (precision_collapse_floor is not None
@@ -201,12 +216,12 @@ class RunHistory:
                 # most-lowered iteration; downstream pipeline produced 2,570
                 # clusters vs the ~145K v0 would have produced.
                 rank = 3
-                return (rank, 0.0, e.iteration)
+                return (rank + demoted, 0.0, e.iteration)
             # Zero-label Phase 2: prefer the most-plausible unlabeled structure
             # over the -sep heuristic (which is biased toward lower thresholds).
             if use_zero_label_confidence and e.profile.zero_label is not None:
-                return (rank, -e.profile.zero_label.overall_confidence, e.iteration)
-            return (rank, -sep, e.iteration)
+                return (rank + demoted, -e.profile.zero_label.overall_confidence, e.iteration)
+            return (rank + demoted, -sep, e.iteration)
 
         return min(survivors, key=key)
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1222,7 +1222,11 @@ def rule_precision_anchor_threshold_raise(
     - An exact matchkey with a field whose ``ctx.column_priors`` entry has
       ``identity_score >= 0.75`` coexists (the strong-identifier recall
       anchor that makes the raise safe; without it the raise could cost
-      recall and the rule must not fire).
+      recall and the rule must not fire). This assumes the anchor is
+      disjoint from the over-merging name columns: an exact matchkey on
+      the name column itself would satisfy the check, but in practice the
+      priors classifier does not score name columns >= 0.75, which is
+      what keeps the assumption safe.
     - ANY of the weighted matchkey's name fields carries ``tf_freqs`` (the
       #1318 downweight must be live for the raise to separate same-name
       strangers; identical names WITHOUT the table score 1.0 and clear any
@@ -1378,7 +1382,7 @@ DEFAULT_RULES = [
     rule_no_matches,                       # 13 tuning: nothing matches
     rule_matchkey_demote_high_cardinality_field,  # 14 NEW 2026-05-29: matchkey YELLOW from uniquely-identifying field
     rule_select_probabilistic_matchkey,    # NEW #491: wide fuzzy-only weighted mk + recall-limited + no exact anchor -> probabilistic
-    rule_recall_gap_suspected,             # 15 tuning: random pair probe high OR over-tight signature (kept second-to-last)
+    rule_recall_gap_suspected,             # 15 tuning: random pair probe high OR over-tight signature (kept after the structural rules; only the precision-raise + sparse-expand threshold rules follow)
     rule_precision_anchor_threshold_raise, # 17 NEW #1319: raise name-only weighted threshold on the over-merge shape (before sparse-expand's loosen)
     rule_sparse_match_expand,              # 16 NEW v1.10: lower threshold proxy for sparse datasets (kept last)
     # NOTE: rule_enable_llm_scorer is intentionally NOT in DEFAULT_RULES.

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1188,6 +1188,65 @@ _ANCHOR_MASS_MIN = 0.95
 _ANCHOR_RAISED_THRESHOLD = 0.9
 
 
+def _precision_anchor_trigger(
+    cfg: GoldenMatchConfig,
+    profile: ComplexityProfile,
+    ctx: IndicatorContext | None,
+) -> tuple[MatchkeyConfig, str] | None:
+    """Evaluate the five #1319 trigger conditions (see
+    ``rule_precision_anchor_threshold_raise`` for the full rationale).
+
+    Returns ``(target_weighted_mk, anchor_field)`` when ALL five hold,
+    else None. Single source of truth: the rule delegates here for its
+    trigger, and ``precision_anchor_would_fire`` re-exposes it as the
+    labels-free precision-collapse detector the commit stage uses.
+    """
+    if ctx is None:
+        return None
+    if profile.scoring.mass_above_threshold < _ANCHOR_MASS_MIN:
+        return None
+    target = None
+    for mk in cfg.matchkeys or []:
+        if mk.type != "weighted" or not mk.fields:
+            continue
+        if any(f.scorer not in _ANCHOR_NAME_SCORERS for f in mk.fields):
+            continue
+        if mk.threshold is None or mk.threshold >= _ANCHOR_RAISED_THRESHOLD:
+            continue
+        if not any(f.tf_freqs for f in mk.fields):
+            continue
+        target = mk
+        break
+    if target is None:
+        return None
+    for mk in cfg.matchkeys or []:
+        if mk.type != "exact":
+            continue
+        for f in mk.fields or []:
+            if f.field is None:
+                continue
+            prior = ctx.column_priors.get(f.field)
+            if prior is not None and prior.identity_score >= _ANCHOR_IDENTITY_MIN:
+                return target, f.field
+    return None
+
+
+def precision_anchor_would_fire(
+    cfg: GoldenMatchConfig,
+    profile: ComplexityProfile,
+    ctx: IndicatorContext | None,
+) -> bool:
+    """True when the #1319 over-merge trigger shape holds on ``cfg`` +
+    ``profile`` (all five conditions of
+    ``rule_precision_anchor_threshold_raise``; ``ctx is None`` -> False).
+
+    Used by the controller's commit stage as a labels-free
+    precision-collapse detector (``pick_committed(demote_suspect=...)``):
+    commit must not prefer an entry the rule would still flag.
+    """
+    return _precision_anchor_trigger(cfg, profile, ctx) is not None
+
+
 def rule_precision_anchor_threshold_raise(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
     ctx: IndicatorContext | None = None,
@@ -1251,39 +1310,10 @@ def rule_precision_anchor_threshold_raise(
     this rule structurally cannot fire on healthy commits -- the crafted
     fixture measures overall_health YELLOW.
     """
-    if ctx is None:
+    trigger = _precision_anchor_trigger(current, profile, ctx)
+    if trigger is None:
         return None
-    if profile.scoring.mass_above_threshold < _ANCHOR_MASS_MIN:
-        return None
-    target = None
-    for mk in current.matchkeys or []:
-        if mk.type != "weighted" or not mk.fields:
-            continue
-        if any(f.scorer not in _ANCHOR_NAME_SCORERS for f in mk.fields):
-            continue
-        if mk.threshold is None or mk.threshold >= _ANCHOR_RAISED_THRESHOLD:
-            continue
-        if not any(f.tf_freqs for f in mk.fields):
-            continue
-        target = mk
-        break
-    if target is None:
-        return None
-    anchor_field = None
-    for mk in current.matchkeys or []:
-        if mk.type != "exact":
-            continue
-        for f in mk.fields or []:
-            if f.field is None:
-                continue
-            prior = ctx.column_priors.get(f.field)
-            if prior is not None and prior.identity_score >= _ANCHOR_IDENTITY_MIN:
-                anchor_field = f.field
-                break
-        if anchor_field is not None:
-            break
-    if anchor_field is None:
-        return None
+    target, anchor_field = trigger
     new_mk = target.model_copy(update={"threshold": _ANCHOR_RAISED_THRESHOLD})
     new_matchkeys = [new_mk if m is target else m for m in (current.matchkeys or [])]
     new_cfg = current.model_copy(update={"matchkeys": new_matchkeys})

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py
@@ -1182,6 +1182,127 @@ def rule_matchkey_demote_high_cardinality_field(
     return None
 
 
+_ANCHOR_NAME_SCORERS = {"name_freq_weighted_jw", "given_name_aliased_jw"}
+_ANCHOR_IDENTITY_MIN = 0.75
+_ANCHOR_MASS_MIN = 0.95
+_ANCHOR_RAISED_THRESHOLD = 0.9
+
+
+def rule_precision_anchor_threshold_raise(
+    profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
+    ctx: IndicatorContext | None = None,
+) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
+    """Raise a name-only weighted matchkey's threshold to 0.9 on the #1207
+    over-merge shape (#1319).
+
+    Background: on null-sparse multi-source person data (#1207 observation
+    2), the controller commits a config whose weighted matchkey scores
+    names only, and identical common full names over-merge distinct people.
+    The 2026-07-15 measurement pass quantified it on a crafted 2600-row
+    common-name/strong-email fixture: precision 0.009 at the committed 0.8
+    threshold pre-#1782 (0.0305 with #1782's tf_freqs threading live), all
+    15,058 same-name-stranger pairs merged. With the threshold raised to
+    0.9 the same fixture measures P 0.987 / R 1.0 -- recall stays free
+    because the controller's own exact_email matchkey anchors every true
+    duplicate.
+
+    The trigger is the CONFIG SHAPE, not the mass signal alone: the healthy
+    NCVR run (P 0.96) also reads ``mass_above_threshold = 1.0``, so mass is
+    necessary but not sufficient. NCVR is excluded by the shape condition
+    instead -- its weighted matchkey carries address/gender scorers, not
+    name-class scorers only.
+
+    Triggers when ALL of:
+
+    - ``profile.scoring.mass_above_threshold >= 0.95`` (pathology gate).
+    - A weighted matchkey whose fields ALL carry a name-class scorer
+      (membership in ``_ANCHOR_NAME_SCORERS`` -- rules don't receive the
+      column classifier's output; scorer names are the config-visible
+      proxy, and auto-config assigns these scorers exactly to name fields).
+    - An exact matchkey with a field whose ``ctx.column_priors`` entry has
+      ``identity_score >= 0.75`` coexists (the strong-identifier recall
+      anchor that makes the raise safe; without it the raise could cost
+      recall and the rule must not fire).
+    - ANY of the weighted matchkey's name fields carries ``tf_freqs`` (the
+      #1318 downweight must be live for the raise to separate same-name
+      strangers; identical names WITHOUT the table score 1.0 and clear any
+      threshold < 1, so firing would be pure recall risk for typo'd dups
+      with zero precision gain).
+    - That weighted matchkey's ``threshold < 0.9``.
+
+    Single-shot remedy: threshold -> 0.9 (the measured operating point).
+    Convergence is by construction -- after firing, the ``threshold < 0.9``
+    condition is false, so the rule fires at most once (no incremental
+    steps burning controller budget, the #1654/#1680 lesson; the
+    measurement shows intermediate points don't help -- 0.85 left P at
+    0.03).
+
+    History: supersedes the parked B1 rule on
+    ``feat/1207-pr2b-precision-anchor`` -- that rule's designed shape
+    (demote/promote) was never emitted by the real controller, so it could
+    never fire. This rule triggers on what the controller actually commits.
+
+    Note the policy's implicit gate: ``HeuristicRefitPolicy.decide()``
+    returns None on an overall-GREEN profile (autoconfig_policy.py), so
+    this rule structurally cannot fire on healthy commits -- the crafted
+    fixture measures overall_health YELLOW.
+    """
+    if ctx is None:
+        return None
+    if profile.scoring.mass_above_threshold < _ANCHOR_MASS_MIN:
+        return None
+    target = None
+    for mk in current.matchkeys or []:
+        if mk.type != "weighted" or not mk.fields:
+            continue
+        if any(f.scorer not in _ANCHOR_NAME_SCORERS for f in mk.fields):
+            continue
+        if mk.threshold is None or mk.threshold >= _ANCHOR_RAISED_THRESHOLD:
+            continue
+        if not any(f.tf_freqs for f in mk.fields):
+            continue
+        target = mk
+        break
+    if target is None:
+        return None
+    anchor_field = None
+    for mk in current.matchkeys or []:
+        if mk.type != "exact":
+            continue
+        for f in mk.fields or []:
+            if f.field is None:
+                continue
+            prior = ctx.column_priors.get(f.field)
+            if prior is not None and prior.identity_score >= _ANCHOR_IDENTITY_MIN:
+                anchor_field = f.field
+                break
+        if anchor_field is not None:
+            break
+    if anchor_field is None:
+        return None
+    new_mk = target.model_copy(update={"threshold": _ANCHOR_RAISED_THRESHOLD})
+    new_matchkeys = [new_mk if m is target else m for m in (current.matchkeys or [])]
+    new_cfg = current.model_copy(update={"matchkeys": new_matchkeys})
+    name_fields = ", ".join(f.field or "" for f in target.fields)
+    decision = PolicyDecision(
+        rule_name="precision_anchor_threshold_raise",
+        rationale=(
+            f"#1319 over-merge shape: mass_above_threshold="
+            f"{profile.scoring.mass_above_threshold:.2f} >= {_ANCHOR_MASS_MIN} "
+            f"with name-only weighted matchkey '{target.name}' "
+            f"(fields: {name_fields}) at threshold {target.threshold}; "
+            f"strong-id exact anchor '{anchor_field}' keeps recall free; "
+            f"tf_freqs live on the name fields; raising threshold to "
+            f"{_ANCHOR_RAISED_THRESHOLD} (measured operating point)"
+        ),
+        config_diff={
+            f"matchkeys[{target.name}].threshold":
+                f"{target.threshold} -> {_ANCHOR_RAISED_THRESHOLD}",
+        },
+    )
+    return new_cfg, decision
+
+
 def rule_blocking_adaptive_on_p99_outlier(
     profile: ComplexityProfile, current: GoldenMatchConfig, history: RunHistory,
 ) -> tuple[GoldenMatchConfig, PolicyDecision] | None:
@@ -1258,6 +1379,7 @@ DEFAULT_RULES = [
     rule_matchkey_demote_high_cardinality_field,  # 14 NEW 2026-05-29: matchkey YELLOW from uniquely-identifying field
     rule_select_probabilistic_matchkey,    # NEW #491: wide fuzzy-only weighted mk + recall-limited + no exact anchor -> probabilistic
     rule_recall_gap_suspected,             # 15 tuning: random pair probe high OR over-tight signature (kept second-to-last)
+    rule_precision_anchor_threshold_raise, # 17 NEW #1319: raise name-only weighted threshold on the over-merge shape (before sparse-expand's loosen)
     rule_sparse_match_expand,              # 16 NEW v1.10: lower threshold proxy for sparse datasets (kept last)
     # NOTE: rule_enable_llm_scorer is intentionally NOT in DEFAULT_RULES.
     # LLM scorer decoration happens post-iteration via

--- a/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
+++ b/packages/python/goldenmatch/goldenmatch/core/complexity_profile.py
@@ -358,6 +358,15 @@ class BlockingProfile:
         return HealthVerdict.GREEN
 
 
+# Minimum scored-pair count for the dip statistic to count as a unimodality
+# signal. Below this, a flat dip is sampling noise, not evidence -- the same
+# rationale as _MIN_TRIPLE_SUPPORT = 30 for transitivity estimates
+# (core/_profile_helpers.py:43-46): a statistic over a handful of samples is
+# noise, not signal. (#1319: a raised threshold can leave only 2 pairs above
+# the kernel prefilter; dip=0.0 over 2 pairs must not hard-RED the entry.)
+_MIN_DIP_SUPPORT = 30
+
+
 @dataclass(frozen=True)
 class ScoringProfile:
     _version: int = 1
@@ -382,7 +391,7 @@ class ScoringProfile:
             return HealthVerdict.RED
         if self.mass_above_threshold == 0.0:
             return HealthVerdict.RED
-        if self.dip_statistic < 0.005 and self.n_pairs_scored > 0:
+        if self.dip_statistic < 0.005 and self.n_pairs_scored >= _MIN_DIP_SUPPORT:
             return HealthVerdict.RED
         # YELLOW only when the borderline band outweighs the above-threshold
         # tail. The legacy `mass_in_borderline > 0.3` rule fired YELLOW on any

--- a/packages/python/goldenmatch/tests/test_autoconfig_history.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_history.py
@@ -469,3 +469,71 @@ def test_pick_committed_floor_rejects_out_of_range():
     # Boundary values are valid
     h.pick_committed(precision_collapse_floor=0.0)   # no raise
     h.pick_committed(precision_collapse_floor=1.0)   # no raise
+
+
+# ============================================================
+# demote_suspect (#1319 Change B: precision-suspect commit demotion)
+# ============================================================
+
+def _yellow_entry(iteration: int, config) -> HistoryEntry:
+    """Overall-YELLOW entry via scoring (borderline swamps above-mass);
+    every entry built here has IDENTICAL separation (-0.15)."""
+    return _entry(iteration, config, _profile(scoring=ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0] * 15 + [100] * 5,
+        dip_statistic=0.05, mass_above_threshold=0.2, mass_in_borderline=0.35,
+    )))
+
+
+def _red_entry_same_sep(iteration: int, config) -> HistoryEntry:
+    """Overall-RED entry (flat dip) with the SAME separation (-0.15) as
+    ``_yellow_entry`` so rank alone decides."""
+    return _entry(iteration, config, _profile(scoring=ScoringProfile(
+        n_pairs_scored=500, score_histogram=[0] * 15 + [100] * 5,
+        dip_statistic=0.001, mass_above_threshold=0.2, mass_in_borderline=0.35,
+    )))
+
+
+def test_pick_committed_bare_tiebreak_prefers_earlier_iteration_yellow():
+    """Pins today's behavior: two YELLOW entries at equal separation ->
+    the earlier iteration (v0 = -1) wins the ascending-iteration tiebreak.
+    This is exactly the tie the #1319 raised entry loses without
+    demote_suspect."""
+    h = RunHistory()
+    h.entries.append(_yellow_entry(-1, "suspect_v0"))
+    h.entries.append(_yellow_entry(1, "raised"))
+    assert h.entries[0].profile.health() == HealthVerdict.YELLOW
+    assert h.entries[1].profile.health() == HealthVerdict.YELLOW
+    assert h.pick_committed().config == "suspect_v0"
+
+
+def test_pick_committed_demote_suspect_flips_the_yellow_tie():
+    """#1319: with demote_suspect flagging the v0 entry, the non-suspect
+    later iteration wins the commit."""
+    h = RunHistory()
+    h.entries.append(_yellow_entry(-1, "suspect_v0"))
+    h.entries.append(_yellow_entry(1, "raised"))
+    best = h.pick_committed(demote_suspect=lambda e: e.config == "suspect_v0")
+    assert best.config == "raised"
+
+
+def test_pick_committed_demote_suspect_never_beats_a_red_raise():
+    """Safety: a suspect YELLOW (rank 1+1=2) vs a non-suspect RED (rank
+    2+0=2) at equal separation -> the earlier iteration still wins. The
+    demotion cannot promote a genuinely unhealthy raise over v0."""
+    h = RunHistory()
+    h.entries.append(_yellow_entry(-1, "suspect_v0"))
+    h.entries.append(_red_entry_same_sep(1, "red_raise"))
+    assert h.entries[1].profile.health() == HealthVerdict.RED
+    best = h.pick_committed(demote_suspect=lambda e: e.config == "suspect_v0")
+    assert best.config == "suspect_v0"
+
+
+def test_pick_committed_all_suspect_matches_bare_pick():
+    """When every entry is suspect (rule fired on the final budget
+    iteration), ranks shift uniformly and the pick is unchanged."""
+    h = RunHistory()
+    h.entries.append(_yellow_entry(-1, "suspect_v0"))
+    h.entries.append(_yellow_entry(1, "also_suspect"))
+    bare = h.pick_committed()
+    demoted = h.pick_committed(demote_suspect=lambda e: True)
+    assert demoted.config == bare.config == "suspect_v0"

--- a/packages/python/goldenmatch/tests/test_autoconfig_policy.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_policy.py
@@ -436,7 +436,7 @@ def test_default_rules_list_has_five_entries():
     # Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1)
     # Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     # rule_sparse_match_expand (v1.10)
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 def test_heuristic_policy_with_default_rules_fires_on_red_blocking():
@@ -619,7 +619,7 @@ def test_default_rules_now_has_six_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 def test_singleton_trap_runs_before_blocking_too_coarse():
@@ -835,7 +835,7 @@ def test_default_rules_now_has_seven_entries():
     Updated to 10: rule_uniform_heavy_blocking added (Fix 2) + rule_blocking_key_swap reordered (Fix 1).
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 def test_rule_key_swap_is_before_rule_no_matches():
@@ -1159,7 +1159,7 @@ def test_default_rules_now_has_nine_entries():
     AutoConfigController._maybe_decorate_with_llm_scorer post-iteration decoration.)
     Updated to 13: Phase 5 added 3 new rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
@@ -1179,7 +1179,7 @@ def test_null_heavy_runs_before_no_matches_and_recall_gap_runs_last():
     assert idx_null_heavy < idx_no_matches, "null_heavy must run before no_matches"
     assert idx_recall_gap > idx_no_matches, "recall_gap must run after no_matches"
     # v1.11: recall_gap is second-to-last; sparse_match_expand is last; demote_clustered_identity moved to position 7
-    assert idx_recall_gap == len(DEFAULT_RULES) - 2, "recall_gap must be second-to-last (sparse_match_expand last, demote_clustered_identity at position 7)"
+    assert idx_recall_gap == len(DEFAULT_RULES) - 3, "recall_gap must be third-to-last (#1319 precision_anchor_threshold_raise then sparse_match_expand last)"
 
 
 # ============================================================
@@ -1300,7 +1300,7 @@ def test_default_rules_now_has_ten_entries():
     Updated to 13: Phase 5 added rule_corruption_normalize, rule_cross_blocking_disagreement,
     rule_sparse_match_expand (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 def test_rule_enable_llm_scorer_not_in_default_rules():
@@ -1548,7 +1548,7 @@ def test_default_rules_now_has_ten_entries_final():
     """Fix 1 (reorder) + Fix 2 (new rule) → 10 rules total.
     Updated to 13: Phase 5 added 3 new indicator-aware rules (v1.10)."""
     from goldenmatch.core.autoconfig_rules import DEFAULT_RULES
-    assert len(DEFAULT_RULES) == 16  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey
+    assert len(DEFAULT_RULES) == 17  # v1.20.x #124/#458: demote_clustered_identity removed from rotation; #491 added select_probabilistic_matchkey; #1319 added precision_anchor_threshold_raise
 
 
 # ============================================================

--- a/packages/python/goldenmatch/tests/test_complexity_profile.py
+++ b/packages/python/goldenmatch/tests/test_complexity_profile.py
@@ -162,6 +162,35 @@ def test_scoring_red_when_unimodal():
     assert sp.health() == HealthVerdict.RED
 
 
+def test_scoring_flat_dip_with_tiny_pair_support_is_not_red():
+    """#1319 Change A: a dip statistic over a handful of scored pairs is
+    sampling noise, not a unimodality signal (the _MIN_TRIPLE_SUPPORT
+    precedent). 2 pairs with a flat dip must NOT read RED; with bord ==
+    mass the borderline clause doesn't fire either -> GREEN."""
+    sp = ScoringProfile(
+        n_pairs_scored=2, candidates_compared=100,
+        dip_statistic=0.0, mass_above_threshold=1.0, mass_in_borderline=1.0,
+    )
+    assert sp.health() == HealthVerdict.GREEN
+
+
+def test_scoring_flat_dip_at_min_support_boundary_is_red():
+    """#1319 Change A boundary pin: at exactly _MIN_DIP_SUPPORT (30) scored
+    pairs the flat-dip unimodality gate applies again (>=, not >)."""
+    sp = ScoringProfile(
+        n_pairs_scored=30, candidates_compared=100,
+        dip_statistic=0.0, mass_above_threshold=1.0, mass_in_borderline=1.0,
+    )
+    assert sp.health() == HealthVerdict.RED
+
+
+def test_scoring_zero_pairs_zero_candidates_still_red():
+    """#1319 Change A must not touch the zero-pairs 'nothing happened'
+    clause."""
+    sp = ScoringProfile(n_pairs_scored=0, candidates_compared=0)
+    assert sp.health() == HealthVerdict.RED
+
+
 def test_scoring_yellow_when_borderline_heavy():
     sp = ScoringProfile(
         n_pairs_scored=500, score_histogram=[0] * 14 + [100, 100, 100] + [0] * 3,

--- a/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
+++ b/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
@@ -7,10 +7,13 @@ threshold). The rule raises the name-only weighted threshold to 0.9 in a
 single shot when the config shape is pathological AND a strong-identifier
 exact anchor keeps recall free AND the #1318 tf_freqs downweight is live.
 
-Each of the five trigger conditions is independently falsified here; the
-through-the-controller verification lives in the P2 task.
+Each of the five trigger conditions is independently falsified here, and
+the through-the-real-controller integration lives at the bottom of the
+file (``TestThroughRealController``).
 """
 from __future__ import annotations
+
+import random
 
 import polars as pl
 from goldenmatch.config.schemas import (
@@ -96,12 +99,20 @@ def _profile_with_mass_above(mass_above: float) -> ComplexityProfile:
         ),
         cluster=ClusterProfile(transitivity_rate=0.95),
         matchkey=MatchkeyProfile(per_field={
-            "last_name": FieldStats(0.1, 0.0, 8),
+            "last_name": FieldStats(
+                post_transform_cardinality_ratio=0.1,
+                post_transform_null_rate=0.0,
+                post_transform_value_length_p50=8,
+            ),
         }),
     )
 
 
 def _ctx_with_priors(priors: dict[str, ColumnPrior]):
+    # Function-scoped import: the repo test idiom for IndicatorContext
+    # (see test_autoconfig_rules.py / test_autoconfig_controller.py) --
+    # keeps the heavy autoconfig_controller module off collection-time
+    # import paths for runs that never build a ctx.
     from goldenmatch.core.autoconfig_controller import IndicatorContext
     return IndicatorContext(
         df=pl.DataFrame(),
@@ -192,6 +203,17 @@ class TestConditionFalsification:
         ])])
         assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
 
+    def test_threshold_none_returns_none(self):
+        """The rule's ``threshold is None`` guard. The schema validator
+        rejects a weighted mk constructed with threshold=None, so this can
+        only arise via post-construction mutation (the validator-bypass
+        case the MatchkeyConfig docstring warns about) -- the rule must
+        decline rather than crash comparing None < 0.9."""
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.8)])
+        weighted = [mk for mk in cfg.matchkeys if mk.type == "weighted"][0]
+        weighted.threshold = None
+        assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
+
     def test_threshold_already_raised_returns_none(self):
         """Convergence: single-fire by construction."""
         cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.9)])
@@ -209,4 +231,227 @@ class TestRegistration:
         assert (
             DEFAULT_RULES.index(rule_precision_anchor_threshold_raise)
             == DEFAULT_RULES.index(rule_sparse_match_expand) - 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# Through the REAL controller (#1319 P2).
+#
+# WHY THIS EXISTS: the parked B1 rule (feat/1207-pr2b-precision-anchor)
+# passed its unit fixtures but triggered on a config shape the real
+# controller never emits, so it could never fire in production. These tests
+# pin the rule to what `auto_configure_df` actually commits, so that
+# failure mode cannot recur silently.
+# ---------------------------------------------------------------------------
+
+# Reduced-scale (#1319) over-merge fixture. Shape lifted from the 2600-row
+# measurement harness (scratchpad 1319/measure_1319.py, 2026-07-15
+# measurement pass: P 0.0305 post-#1782 at the committed 0.8 threshold,
+# overall_health YELLOW, mass_above_threshold 1.0): a common first/last
+# name pool over DISTINCT people, each with a UNIQUE strong email (so the
+# email column profiles as an identity anchor, priors identity_score >=
+# 0.75), plus planted true duplicates that keep the email.
+#
+# Reduction to ~400 rows changes the controller dynamics (measured with
+# the P2 probe, 2026-07-15), so the reduced fixture is stratified to keep
+# every non-target subprofile healthy at BOTH thresholds:
+#
+# - one MEGA same-name group (80 distinct "John Smith"s + 20 exact-copy
+#   dups): union-find merges it into a 100-record cluster at threshold
+#   0.8 -> cluster RED via cluster_size_max > 0.1*n_rows (the over-merge
+#   pathology that makes the controller iterate). Exact copies only, so
+#   in-cluster triangles stay closed and transitivity stays >= 0.85
+#   (otherwise rule_low_transitivity, earlier in DEFAULT_RULES, wins the
+#   iteration instead).
+# - 8 medium common-name groups (10 people each + 24 exact dups): more
+#   same-name over-merge mass; small enough (< 0.1*n) to stay below the
+#   cluster RED line on their own.
+# - 130 rare-surname people (soundex-spread pool, repo fixture
+#   discipline) with 33 exact + 32 light-typo dups: after the raise these
+#   are the pairs still above 0.9, keeping the post-raise score
+#   distribution populated and multi-modal (dip_statistic >= 0.005 --
+#   without them the raised profile reads scoring RED via the unimodality
+#   gate and pick_committed walks back to the 0.8 config).
+# - 20 cities so last_name+city blocks stay small (block_sizes_p99 must
+#   hold p99 <= 10 * n_rows/n_blocks, else blocking reads RED at every
+#   iteration and no raise can ever be committed).
+#
+# Measured trajectory (P2 probe): iter0 RED (cluster, max_cl=100,
+# trans=1.0, dip=0.048) -> rule fires -> iter1 at 0.9: max_cl=15,
+# dip=0.12, everything GREEN except the mk-cardinality YELLOW ->
+# POLICY_SATISFIED, raised entry outranks the RED v0 -> committed
+# threshold 0.9.
+
+_FIRSTS = ["John", "Jane", "Mary", "James", "Robert", "Linda",
+           "Michael", "Patricia", "David", "Susan", "William", "Karen"]
+_COMMON_LASTS = ["Johnson", "Williams", "Brown", "Jones", "Garcia",
+                 "Miller", "Davis", "Rodriguez", "Martinez", "Wilson"]
+_RARE_LASTS = [
+    "Abernathy", "Balthazar", "Cavendish", "Delacroix", "Ellsworth",
+    "Fairbanks", "Galbraith", "Hollingsworth", "Ibarra", "Jankowski",
+    "Kowalczyk", "Lindqvist", "Mercier", "Nakamura", "Oyelaran",
+    "Pemberton", "Quintanilla", "Rutherford", "Szymanski", "Thackeray",
+    "Umberger", "Vasquez", "Wetherell", "Xiong", "Yamaguchi", "Zelinski",
+    "Ashcroft", "Bergstrom", "Castellano", "Drummond", "Eastwood",
+    "Feldman", "Goldberg", "Hathaway", "Ingersoll", "Jorgensen",
+    "Kettering", "Lombardi", "Montgomery", "Norwood", "Ostrowski",
+    "Prendergast", "Quimby", "Ravenscroft", "Silverstein", "Tremblay",
+    "Underhill", "Villanueva", "Whitfield", "Yarborough",
+]
+_CITIES = ["Springfield", "Madison", "Franklin", "Georgetown", "Clinton",
+           "Salem", "Fairview", "Bristol", "Dover", "Hudson",
+           "Arlington", "Burlington", "Chester", "Dayton", "Easton",
+           "Florence", "Greenville", "Harrison", "Jackson", "Kingston"]
+
+
+def _light_typo(rng: random.Random, val: str) -> str:
+    if len(val) < 3:
+        return val
+    op = rng.choice(["typo", "swap", "drop"])
+    pos = rng.randint(1, len(val) - 2)
+    if op == "typo":
+        return val[:pos] + rng.choice("abcdefghijklmnopqrstuvwxyz") + val[pos + 1:]
+    if op == "swap":
+        return val[:pos] + val[pos + 1] + val[pos] + val[pos + 2:]
+    return val[:pos] + val[pos + 1:]
+
+
+def _overmerge_fixture_df() -> pl.DataFrame:
+    """Deterministic 399-row #1319 over-merge frame (see block comment)."""
+    rng = random.Random(1319)
+    rows: list[dict] = []
+    pid = 0
+
+    def person(first: str, last: str) -> dict:
+        nonlocal pid
+        row = {"first_name": first, "last_name": last,
+               "email": f"{first[0].lower()}{last.lower()}{pid}@example.com",
+               "city": rng.choice(_CITIES)}
+        pid += 1
+        rows.append(row)
+        return row
+
+    mega = [person("John", "Smith") for _ in range(80)]
+    medium: list[dict] = []
+    for i in range(8):
+        first = _FIRSTS[(i + 1) % len(_FIRSTS)]
+        last = _COMMON_LASTS[i % len(_COMMON_LASTS)]
+        medium += [person(first, last) for _ in range(10)]
+    rare = [
+        person(_FIRSTS[i % len(_FIRSTS)], _RARE_LASTS[i % len(_RARE_LASTS)])
+        for i in range(130)
+    ]
+
+    for p in rng.sample(mega, 20):
+        rows.append(dict(p))
+    for p in rng.sample(medium, 24):
+        rows.append(dict(p))
+    rare_dups = rng.sample(rare, 65)
+    for p in rare_dups[:33]:
+        rows.append(dict(p))
+    for p in rare_dups[33:]:
+        d = dict(p)
+        d["last_name"] = _light_typo(rng, d["last_name"])
+        rows.append(d)
+    return pl.DataFrame(rows)
+
+
+def _committed_name_only_weighted_mk(cfg):
+    """Fixture-validity guard shared by both controller tests.
+
+    Returns the committed weighted matchkey after asserting the fixture
+    still produces the #1319 trigger shape. If auto-config stops emitting
+    this shape, these tests must say so loudly instead of vacuously
+    passing on assertions about a config that no longer looks like the
+    measured pathology."""
+    from goldenmatch.core.autoconfig_rules import (
+        _ANCHOR_NAME_SCORERS,  # pyright: ignore[reportPrivateUsage]
+    )
+
+    matchkeys = cfg.get_matchkeys()
+    weighted = [mk for mk in matchkeys if mk.type == "weighted"]
+    assert weighted, (
+        "FIXTURE INVALID: auto-config no longer commits a weighted "
+        "matchkey on the #1319 over-merge fixture; the trigger shape is "
+        "gone and these controller tests no longer test the rule."
+    )
+    mk = weighted[0]
+    scorers = [f.scorer for f in mk.fields or []]
+    assert scorers and all(s in _ANCHOR_NAME_SCORERS for s in scorers), (
+        f"FIXTURE INVALID: committed weighted matchkey is no longer "
+        f"name-only (scorers={scorers}); auto-config stopped emitting "
+        f"the #1319 trigger shape on this fixture."
+    )
+    assert any(f.tf_freqs for f in mk.fields or []), (
+        "FIXTURE INVALID: no tf_freqs on any name field of the committed "
+        "weighted matchkey; the #1318 downweight is not live on this "
+        "fixture and the rule's trigger shape is gone."
+    )
+    assert any(m.type == "exact" for m in matchkeys), (
+        "FIXTURE INVALID: no exact matchkey committed; the strong-email "
+        "anchor half of the #1319 trigger shape is gone."
+    )
+    return mk
+
+
+class TestThroughRealController:
+    def test_rule_fires_through_real_controller(self, monkeypatch):
+        """The parked-B1 lesson, executable: the previous precision-anchor
+        rule passed its unit fixtures but triggered on a config shape the
+        real controller never emitted, so it could never fire. This test
+        runs the rule through `auto_configure_df` on the reduced #1319
+        over-merge fixture and requires the RAISED config to be the one
+        the controller actually COMMITS (not merely that the rule fired
+        mid-loop -- a fired-then-discarded raise is the same failure mode
+        wearing a different hat)."""
+        monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+        from goldenmatch.core.autoconfig import (
+            _LAST_CONTROLLER_RUN,
+            auto_configure_df,
+        )
+        from goldenmatch.core.autoconfig_rules import _ANCHOR_RAISED_THRESHOLD
+
+        cfg = auto_configure_df(_overmerge_fixture_df())
+
+        mk = _committed_name_only_weighted_mk(cfg)
+        assert mk.threshold == _ANCHOR_RAISED_THRESHOLD, (
+            f"rule did not land through the real controller: committed "
+            f"weighted matchkey threshold is {mk.threshold}, expected "
+            f"{_ANCHOR_RAISED_THRESHOLD}"
+        )
+
+        run = _LAST_CONTROLLER_RUN.get()
+        assert run is not None, "controller run left no telemetry"
+        _profile, history = run
+        rule_names = [d.rule_name for d in history.decisions]
+        assert "precision_anchor_threshold_raise" in rule_names, (
+            f"raise committed but the rule's decision is missing from "
+            f"controller history (decisions={rule_names})"
+        )
+
+    def test_without_rule_controller_commits_low_threshold(self, monkeypatch):
+        """Sensitivity pin for the test above: the same fixture through
+        the same controller with the rule removed from DEFAULT_RULES must
+        commit a threshold below 0.9. Proves the integration test is
+        genuinely sensitive to the rule (it cannot pass because the
+        controller lands at 0.9 for some unrelated reason)."""
+        monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
+        import goldenmatch.core.autoconfig_rules as rules_mod
+        from goldenmatch.core.autoconfig import auto_configure_df
+        from goldenmatch.core.autoconfig_rules import _ANCHOR_RAISED_THRESHOLD
+
+        monkeypatch.setattr(
+            rules_mod,
+            "DEFAULT_RULES",
+            [r for r in rules_mod.DEFAULT_RULES
+             if r is not rule_precision_anchor_threshold_raise],
+        )
+
+        cfg = auto_configure_df(_overmerge_fixture_df())
+
+        mk = _committed_name_only_weighted_mk(cfg)
+        assert mk.threshold is not None
+        assert mk.threshold < _ANCHOR_RAISED_THRESHOLD, (
+            f"threshold reached {mk.threshold} WITHOUT the rule -- the "
+            f"integration test above is not sensitive to the rule"
         )

--- a/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
+++ b/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
@@ -226,6 +226,60 @@ class TestConditionFalsification:
         ) is None
 
 
+class TestTriggerHelper:
+    """#1319 Change B: ``precision_anchor_would_fire`` is the extracted
+    single source of truth for the five trigger conditions -- the rule
+    delegates to it, and the commit stage re-evaluates it as a
+    labels-free precision-collapse detector (``demote_suspect``)."""
+
+    def _helper(self):
+        from goldenmatch.core.autoconfig_rules import precision_anchor_would_fire
+        return precision_anchor_would_fire
+
+    def test_true_on_should_fire_shape(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.8)])
+        assert self._helper()(cfg, _profile_with_mass_above(1.0), _strong_email_ctx()) is True
+
+    def test_false_on_mass_below_gate(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        assert self._helper()(cfg, _profile_with_mass_above(0.94), _strong_email_ctx()) is False
+
+    def test_false_without_tf_freqs(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(fields=[
+            _name_field("first_name", "given_name_aliased_jw", None),
+            _name_field("last_name", "name_freq_weighted_jw", None),
+        ])])
+        assert self._helper()(cfg, _profile_with_mass_above(1.0), _strong_email_ctx()) is False
+
+    def test_false_on_threshold_already_raised(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.9)])
+        assert self._helper()(cfg, _profile_with_mass_above(1.0), _strong_email_ctx()) is False
+
+    def test_false_on_ctx_none(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        assert self._helper()(cfg, _profile_with_mass_above(1.0), None) is False
+
+    def test_rule_fires_iff_helper_true(self):
+        """The rule must return a proposal exactly when the helper says
+        the trigger holds -- pins the delegation (no drift possible)."""
+        helper = self._helper()
+        ctx = _strong_email_ctx()
+        rows = [
+            (_cfg([_exact_mk("email"), _weighted_mk(threshold=0.8)]),
+             _profile_with_mass_above(1.0)),           # fires
+            (_cfg([_exact_mk("email"), _weighted_mk()]),
+             _profile_with_mass_above(0.94)),          # mass gate fails
+            (_cfg([_weighted_mk()]),
+             _profile_with_mass_above(1.0)),           # no exact anchor
+        ]
+        for cfg, profile in rows:
+            fired = _call(profile, cfg, ctx) is not None
+            assert fired == helper(cfg, profile, ctx), (
+                f"rule fired={fired} but helper says "
+                f"{helper(cfg, profile, ctx)} on {[m.name for m in cfg.matchkeys]}"
+            )
+
+
 class TestRegistration:
     def test_registered_directly_before_sparse_match_expand(self):
         assert (

--- a/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
+++ b/packages/python/goldenmatch/tests/test_precision_anchor_1319.py
@@ -1,0 +1,212 @@
+"""rule_precision_anchor_threshold_raise trigger-matrix tests (#1319).
+
+The #1207 over-merge shape: the controller commits a config whose weighted
+matchkey scores NAMES ONLY, and identical common full names over-merge
+distinct people (crafted 2600-row fixture: P 0.009 at the committed 0.8
+threshold). The rule raises the name-only weighted threshold to 0.9 in a
+single shot when the config shape is pathological AND a strong-identifier
+exact anchor keeps recall free AND the #1318 tf_freqs downweight is live.
+
+Each of the five trigger conditions is independently falsified here; the
+through-the-controller verification lives in the P2 task.
+"""
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.autoconfig_history import RunHistory
+from goldenmatch.core.autoconfig_rules import (
+    DEFAULT_RULES,
+    rule_precision_anchor_threshold_raise,
+    rule_sparse_match_expand,
+)
+from goldenmatch.core.complexity_profile import (
+    BlockingProfile,
+    ClusterProfile,
+    ColumnPrior,
+    ComplexityProfile,
+    DataProfile,
+    FieldStats,
+    MatchkeyProfile,
+    ScoringProfile,
+    SparsityVerdict,
+)
+
+_TF_FREQS = {"smith": 0.21, "jones": 0.15, "zelinski": 0.001}
+
+
+def _name_field(field: str, scorer: str, tf_freqs: dict[str, float] | None) -> MatchkeyField:
+    return MatchkeyField(field=field, scorer=scorer, weight=1.0, tf_freqs=tf_freqs)
+
+
+def _weighted_mk(
+    fields: list[MatchkeyField] | None = None,
+    threshold: float = 0.8,
+) -> MatchkeyConfig:
+    if fields is None:
+        fields = [
+            _name_field("first_name", "given_name_aliased_jw", None),
+            _name_field("last_name", "name_freq_weighted_jw", _TF_FREQS),
+        ]
+    return MatchkeyConfig(
+        name="fuzzy_name", type="weighted", threshold=threshold, fields=fields,
+    )
+
+
+def _exact_mk(field: str = "email") -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name=f"exact_{field}", type="exact",
+        fields=[MatchkeyField(field=field)],
+    )
+
+
+def _cfg(matchkeys: list[MatchkeyConfig]) -> GoldenMatchConfig:
+    """Minimal valid config. Pydantic requires `blocking` whenever a
+    weighted matchkey is configured; the rule under test doesn't read it."""
+    return GoldenMatchConfig(
+        matchkeys=matchkeys,
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["last_name"])],
+        ),
+    )
+
+
+def _profile_with_mass_above(mass_above: float) -> ComplexityProfile:
+    return ComplexityProfile(
+        data=DataProfile(
+            n_rows=2600, n_cols=4,
+            column_types={"email": "id-like", "first_name": "text",
+                          "last_name": "text", "city": "geo"},
+        ),
+        blocking=BlockingProfile(
+            keys_used=[["last_name"]], n_blocks=100,
+            total_comparisons=15058, reduction_ratio=0.95, block_sizes_p99=40,
+        ),
+        scoring=ScoringProfile(
+            n_pairs_scored=15058, candidates_compared=15058,
+            mass_above_threshold=mass_above,
+            mass_in_borderline=0.02, dip_statistic=0.05,
+        ),
+        cluster=ClusterProfile(transitivity_rate=0.95),
+        matchkey=MatchkeyProfile(per_field={
+            "last_name": FieldStats(0.1, 0.0, 8),
+        }),
+    )
+
+
+def _ctx_with_priors(priors: dict[str, ColumnPrior]):
+    from goldenmatch.core.autoconfig_controller import IndicatorContext
+    return IndicatorContext(
+        df=pl.DataFrame(),
+        column_priors=priors,
+        sparsity_verdict=SparsityVerdict(is_sparse=False, estimated_n_true_pairs=100),
+    )
+
+
+def _strong_email_ctx():
+    return _ctx_with_priors(
+        {"email": ColumnPrior(identity_score=0.9, corruption_score=0.0)}
+    )
+
+
+def _call(profile, cfg, ctx):
+    return rule_precision_anchor_threshold_raise(profile, cfg, RunHistory(), ctx=ctx)
+
+
+class TestFires:
+    def test_all_five_conditions_satisfied(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.8)])
+        result = _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx())
+        assert result is not None
+        new_cfg, decision = result
+        raised = [mk for mk in new_cfg.matchkeys if mk.type == "weighted"][0]
+        assert raised.threshold == 0.9
+        # copy-on-write: input config unmutated
+        original = [mk for mk in cfg.matchkeys if mk.type == "weighted"][0]
+        assert original.threshold == 0.8
+        assert decision.rule_name == "precision_anchor_threshold_raise"
+        assert "name-only" in decision.rationale
+        assert "#1319" in decision.rationale
+        assert "email" in decision.rationale
+        assert decision.config_diff  # names the threshold change
+        assert any("threshold" in k for k in decision.config_diff)
+
+    def test_single_name_field_carrying_tf_freqs_fires(self):
+        """The measured fixture shape: only last_name carries the table.
+        The ANY-field formulation is load-bearing."""
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(fields=[
+            _name_field("first_name", "given_name_aliased_jw", None),
+            _name_field("last_name", "name_freq_weighted_jw", _TF_FREQS),
+        ])])
+        result = _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx())
+        assert result is not None
+        new_cfg, _ = result
+        assert [mk for mk in new_cfg.matchkeys if mk.type == "weighted"][0].threshold == 0.9
+
+
+class TestConditionFalsification:
+    def test_mass_below_gate_returns_none(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        assert _call(_profile_with_mass_above(0.94), cfg, _strong_email_ctx()) is None
+
+    def test_non_name_scorer_in_weighted_mk_returns_none(self):
+        """The NCVR shape: weighted mk carries an address field too."""
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(fields=[
+            _name_field("first_name", "given_name_aliased_jw", None),
+            _name_field("last_name", "name_freq_weighted_jw", _TF_FREQS),
+            _name_field("address", "jaro_winkler", None),
+        ])])
+        assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
+
+    def test_no_exact_matchkey_returns_none(self):
+        cfg = _cfg([_weighted_mk()])
+        assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
+
+    def test_exact_anchor_identity_score_too_low_returns_none(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        ctx = _ctx_with_priors(
+            {"email": ColumnPrior(identity_score=0.5, corruption_score=0.0)}
+        )
+        assert _call(_profile_with_mass_above(1.0), cfg, ctx) is None
+
+    def test_exact_anchor_field_missing_from_priors_returns_none(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        ctx = _ctx_with_priors(
+            {"phone": ColumnPrior(identity_score=0.9, corruption_score=0.0)}
+        )
+        assert _call(_profile_with_mass_above(1.0), cfg, ctx) is None
+
+    def test_no_tf_freqs_on_any_name_field_returns_none(self):
+        """Identical names without the table score 1.0 and clear any
+        threshold < 1 -- the raise would be pure recall risk."""
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(fields=[
+            _name_field("first_name", "given_name_aliased_jw", None),
+            _name_field("last_name", "name_freq_weighted_jw", None),
+        ])])
+        assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
+
+    def test_threshold_already_raised_returns_none(self):
+        """Convergence: single-fire by construction."""
+        cfg = _cfg([_exact_mk("email"), _weighted_mk(threshold=0.9)])
+        assert _call(_profile_with_mass_above(1.0), cfg, _strong_email_ctx()) is None
+
+    def test_ctx_none_returns_none(self):
+        cfg = _cfg([_exact_mk("email"), _weighted_mk()])
+        assert rule_precision_anchor_threshold_raise(
+            _profile_with_mass_above(1.0), cfg, RunHistory()
+        ) is None
+
+
+class TestRegistration:
+    def test_registered_directly_before_sparse_match_expand(self):
+        assert (
+            DEFAULT_RULES.index(rule_precision_anchor_threshold_raise)
+            == DEFAULT_RULES.index(rule_sparse_match_expand) - 1
+        )


### PR DESCRIPTION
## What

The controller now detects the #1207 precision-collapse shape (name-only weighted matchkey on common-name data with a strong exact anchor) and raises the weighted threshold to 0.9 -- and the commit stage now actually keeps the raise.

Three pieces:

1. **`rule_precision_anchor_threshold_raise`** (`core/autoconfig_rules.py`): fires when ALL of (a) `mass_above_threshold >= 0.95`, (b) every weighted-matchkey field carries a name-class scorer (`name_freq_weighted_jw` / `given_name_aliased_jw`), (c) an exact matchkey with `identity_score >= 0.75` anchors recall, (d) a name field carries `tf_freqs` (#1318/#1782 live), (e) `threshold < 0.9`. Single-shot raise to 0.9; registered before `rule_sparse_match_expand` so the raise pre-empts a loosen.
2. **Dip minimum-support guard** (`core/complexity_profile.py`): the `dip < 0.005 -> RED` unimodality gate now requires `n_pairs_scored >= 30` (`_MIN_DIP_SUPPORT`, same rationale as `_MIN_TRIPLE_SUPPORT`). On the #1319 fixture the raised iteration scores 2 pairs; a dip over 2 pairs is noise, and the false-RED was discarding the correct config.
3. **Precision-suspect commit demotion** (`core/autoconfig_history.py` + controller): when the anchor rule fired, `pick_committed` demotes (+1 rank) entries whose config the rule's trigger still flags -- the trigger is a labels-free precision-collapse detector and the commit stage must not prefer an entry it would still fire on (mirrors `precision_collapse_floor`). A raise that profiles RED still never beats v0; runs where the rule never fires are byte-identical.

Ride-alongs (review-vetted): a latent `n_rows` shadow in `AutoConfigController.run()` that silently disabled the `REFUSE_AT_N` refuse gate after the suspicious-tight-blocking GREEN branch (renamed to `_sample_n_rows`); `test_autoconfig_policy.py` rule-count assertions were stale since the rule registration (16 -> 17).

## Measured (the #1319 close-out numbers)

**Leg A** (crafted 2600-row common-name/strong-email fixture, bucket path, TF flag default-on):

| | main (post-#1782) | this branch |
|---|---|---|
| committed weighted threshold | 0.8 | **0.9** |
| precision | 0.009 (0.031 legacy) | **0.9868** |
| recall | 1.0 | **1.0** |
| F1 | 0.018 | **0.9934** |
| same-name-stranger pairs merged | 15,058 | **4** |

**Leg B control** (NCVR 10k, seed 42): committed configs **identical** main vs branch (thresholds 0.8, rule did not fire); metrics byte-identical (P 0.9613 / R 0.9828 / F1 0.9719).

Sweep: 214 passed across the anchor/rules/policy/history/profile/regression/1207 files; 331-test sweep during implementation; ruff clean.

## Why the commit-dynamics changes

P2's through-the-controller test exposed a fired-then-discarded failure: the rule fired but `pick_committed` kept v0 (dip false-RED on 2 pairs + the raised entry tie-losing on the ascending-iteration tiebreak -- unlabeled profile metrics read the over-merged v0 and the correct raise identically at mass=1.0/bord=1.0). Both fixes were probe-validated through the real controller; either alone still commits 0.8. Spec + addendum: `docs/superpowers/specs/2026-07-15-precision-anchor-threshold-raise-design.md`.

Known follow-up (not this PR): `rule_unimodal_scoring` still fires on the raised iteration's raw dip, burning budget iterations on discarded RED entries.

#1207's observation 1 (blocking union at >= 50k) lives on in #1316/#1317.

Closes #1319
Closes #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs