### PR TITLE
fix(bench): pyarrow-ize test_datasets_loader after #1785 harness eviction

### DIFF
--- a/packages/python/goldenmatch/tests/bench/test_datasets_loader.py
+++ b/packages/python/goldenmatch/tests/bench/test_datasets_loader.py
@@ -22,12 +22,12 @@ def test_load_historical_50k_shape_or_skip():
         records, truth = mod.load_dataset("historical_50k")
     except mod.DatasetUnavailable as e:
         pytest.skip(f"historical_50k unavailable: {e}")
-    # records: polars DF with a 'record_id' col; truth: {record_id, cluster_id}
-    assert "record_id" in records.columns
-    assert set(truth.columns) >= {"record_id", "cluster_id"}
-    assert records.height > 1000
-    rec_ids = set(records["record_id"].to_list())
-    assert set(truth["record_id"].to_list()).issubset(rec_ids)
+    # records: pa.Table with a 'record_id' col; truth: {record_id, cluster_id}
+    assert "record_id" in records.column_names
+    assert set(truth.column_names) >= {"record_id", "cluster_id"}
+    assert records.num_rows > 1000
+    rec_ids = set(records.column("record_id").to_pylist())
+    assert set(truth.column("record_id").to_pylist()).issubset(rec_ids)
 
 
 @pytest.mark.benchmark
@@ -38,6 +38,8 @@ def test_adapter_contract_or_skip(name: str):
         records, truth = mod.load_dataset(name)
     except mod.DatasetUnavailable as e:
         pytest.skip(f"{name} unavailable: {e}")
-    assert "record_id" in records.columns
-    assert set(truth.columns) >= {"record_id", "cluster_id"}
-    assert set(truth["record_id"].to_list()).issubset(set(records["record_id"].to_list()))
+    assert "record_id" in records.column_names
+    assert set(truth.column_names) >= {"record_id", "cluster_id"}
+    assert set(truth.column("record_id").to_pylist()).issubset(
+        set(records.column("record_id").to_pylist())
+    )


### PR DESCRIPTION
## What

`tests/bench/test_datasets_loader.py` used polars-isms (`.columns`, `.height`, `["c"].to_list()`) that break on `pa.Table` since #1785 converted the bench harness (`scripts/bench_er_headtohead/datasets.py`) to return `pa.Table`. For a `pa.Table`, `.columns` is the column *arrays* (not names), so `"record_id" in records.columns` failed.

## Why it landed silently

The test lives outside `scripts/`, so the #1785 harness refactor didn't touch it, and #1785's path filter never ran the `python_goldenmatch` lane (it only touched `scripts/`). So the break landed on main invisibly and now fails every PR touching `packages/python/goldenmatch`. Classic path-filter-hides-cross-package-break.

## Fix

`.columns` -> `.column_names`, `.height` -> `.num_rows`, `["c"].to_list()` -> `.column("c").to_pylist()` in both test functions. Verified: `3 passed, 2 skipped` locally (the previously-failing `synthetic_person` case now passes; skips are absent vendor data only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)