### PR TITLE
feat(goldenpipe): in-process moves -- scan the loaded frame, one-run clean_and_dedupe

### DIFF
--- a/docs/design/2026-07-12-goldenpipe-inprocess-moves.md
+++ b/docs/design/2026-07-12-goldenpipe-inprocess-moves.md
@@ -1,0 +1,361 @@
+# Spec: GoldenPipe in-process moves (Move 1 + Move 2)
+
+**Status:** Design. Not yet implemented.
+**Branch:** `spec/goldenpipe-inprocess` (off `origin/main` HEAD).
+**Author context:** architect sounding-board follow-up to the "arrow-native suite opens pipeline optimization" thread.
+
+> **Implementation note (2026-07-12).** Move 1 and the `clean_and_dedupe` half of
+> Move 2 are implemented (PR #1704). Running the real pipeline corrected two
+> details below: (1) `artifacts["golden"]` is a **`pa.Table`** on the current
+> goldenmatch build (not always a `pl.DataFrame`), so the composite normalizes
+> via `pl.from_arrow` before writing; (2) `dedupe_file` was **left as-is** — it
+> writes no intermediate CSV (its `auto_configure` step only reads), so the
+> disk-round-trip win is marginal and converting it would either change its
+> dedupe-only semantics or drop its `auto_configure` config-transparency block.
+> Only `clean_and_dedupe` (the true CSV-chaining composite) was converted.
+
+## Thesis
+
+The suite's in-process currency is already a `pl.DataFrame` (Arrow-backed), so
+frame handoffs between check/flow/match are cheap. The remaining *disk* tax is
+in two specific places, and each closes with a small, local edit:
+
+- **Move 1** — GoldenPipe's own check stage re-reads the source file from disk
+  (`scan_file(path)`) mid-pipeline instead of scanning the frame it already
+  holds (`scan_dataframe(ctx.df)`). This is *also a latent correctness bug*: the
+  check stage silently produces no profile whenever the pipeline source is a
+  DataFrame or a DuckDB table (not a file path). Fixing it is the prerequisite
+  for profile-sharing (Move 3, out of scope here).
+- **Move 2** — the `goldensuite-mcp` composite tools chain check→flow→match by
+  writing intermediate CSVs to disk and re-reading them through separate MCP
+  tool calls. Calling GoldenPipe **in-process** collapses those round-trips to a
+  single frame kept in memory, with one CSV write at the end.
+
+Neither move changes any published algorithm; both are wiring + one real bug fix.
+
+---
+
+## Move 1 — close GoldenPipe's check-stage file seam
+
+### Current behavior (the seam + the bug)
+
+`packages/python/goldenpipe/goldenpipe/pipeline.py` loads the source into
+`ctx.df` before any stage runs, and records the origin string in
+`ctx.metadata["source"]`:
+
+| source kind        | `ctx.df`                              | `ctx.metadata["source"]` |
+|--------------------|----------------------------------------|--------------------------|
+| file path          | `pl.read_csv(source, …)` (`:95`)       | the path (`:96`)         |
+| `run_df(df)`        | `df` (`:90`)                           | `"<DataFrame>"` (`:91`)  |
+| DuckDB table       | engine-resident `DuckDBFrame` (`:74`)  | `"duckdb:<table>"` (`:76`) |
+
+`packages/python/goldenpipe/goldenpipe/adapters/check.py::ScanStage.run`
+then **ignores `ctx.df`** and re-reads from the source string:
+
+```python
+source = ctx.metadata.get("source", "")   # :28
+result = _scan(source, **stage_cfg)        # :32  (_scan = goldencheck.scan_file)
+# ...
+result = _scan(source)                     # :34
+```
+
+Two problems:
+
+1. **Redundant disk round-trip (the perf seam).** For a file source, the file
+   is parsed twice — once by `pl.read_csv` into `ctx.df`, once again by
+   `scan_file`. GoldenCheck's own `scan_dataframe` docstring cites a bench where
+   this redundant CSV round-trip cost **121s of `pipeline_prep_quality_scan`
+   wall at 10M rows**. It also means the scan sees GoldenCheck's parse of the
+   bytes while the dedupe stage sees GoldenPipe's `utf8-lossy, ignore_errors`
+   parse — on dirty government CSVs those can diverge.
+2. **Silent no-profile bug (the correctness seam).** For the `run_df` and DuckDB
+   paths, `source` is `"<DataFrame>"` / `"duckdb:<table>"` — not a readable path.
+   `scan_file("<DataFrame>")` raises; the `isinstance(result, tuple)` guard at
+   `check.py:37` falls through to `profile = None` (`:41`), `column_contexts`
+   becomes `[]` (`:70`), and the downstream dedupe loses the profile-driven
+   config path entirely (`adapters/match.py:58` `column_contexts` is empty →
+   Priority 3 blind auto-configure). So today the check stage only actually
+   works for **file** sources; `goldenpipe.run_df(df)` runs a degraded pipeline.
+
+### Target behavior
+
+Scan the in-memory frame the pipeline already holds:
+
+```python
+# adapters/check.py — replace the _scan(source, …) block
+from goldencheck import scan_dataframe as _scan_df  # module-top, guarded by HAS_CHECK
+
+source = ctx.metadata.get("source", "")
+if ctx.df is not None:
+    if stage_cfg:
+        result = _scan_df(ctx.df, file_path=source, **stage_cfg)
+    else:
+        result = _scan_df(ctx.df, file_path=source)
+else:
+    # Defensive fallback: no in-memory frame (should not happen for a LOCAL
+    # stage — the Runner materializes an engine frame to df on the
+    # remote→local transition — but keep the old path readable if it does).
+    result = _scan(source, **stage_cfg) if stage_cfg else _scan(source)
+```
+
+`scan_dataframe` is already exported by GoldenCheck and is a drop-in:
+
+```
+scan_dataframe(df, file_path="<dataframe>", sample_size=100_000,
+               return_sample=False, domain=None, baseline=None,
+               schema=None, deep=False, denial=False)
+    -> (findings, profile[, sample])
+```
+
+- Accepts a `pl.DataFrame` **or** a `pa.Table` natively (Arrow-native; the
+  polars overload converts via `.to_arrow()`). So when GoldenPipe's currency
+  becomes Arrow (the W5 flip), this call needs **no change** — pass the Table.
+- Same `(findings, profile)` return shape `scan_file` produces, so the entire
+  downstream block in `ScanStage.run` (`:37`–`:85`, the tuple unpack, findings
+  normalization, `build_contexts_from_check`, `attach_repair_plan`) is untouched.
+- `file_path=source` keeps `DatasetProfile.file_path` populated (cosmetic; some
+  repair/context code reads it) even when `source` is `"<DataFrame>"`.
+- Every `scan_dataframe` kwarg is a superset-match of `scan_file`'s except the
+  leading positional, so `**stage_cfg` forwards unchanged (guard: `stage_cfg`
+  must not carry a `path`/`df` key — it never does today; add a defensive pop
+  or a validate-time check if we want belt-and-suspenders).
+
+### Edge cases
+
+- **`ctx.df is None`.** `ScanStage` is a `location="local"` stage
+  (`StageInfo(consumes=["df"])`). The Runner materializes an engine-resident
+  `_frame` → `df` on the remote→local transition *before* a local stage runs
+  (Phase C contract, `models/context.py:65`–`79` + runner). So `ctx.df` is
+  populated when `ScanStage.run` executes. The fallback branch above is
+  belt-and-suspenders only.
+- **`HAS_CHECK` false.** `validate()` already raises before `run()`; unchanged.
+- **Byte-parity on the file path.** `scan_dataframe` is documented as "same
+  semantics as `scan_file` but skips the CSV round-trip." Findings on a *clean*
+  fixture are equivalent. On a *dirty* fixture, findings may differ slightly
+  because the scan now sees GoldenPipe's own `utf8-lossy` frame rather than
+  GoldenCheck's independent parse — this is the intended consistency win (the
+  scan and the dedupe now agree on the bytes), but it is a behavior change and
+  gets its own test.
+
+### Tests (`packages/python/goldenpipe/tests/`)
+
+1. **Regression for the bug:** `goldenpipe.run_df(df)` over a frame with a known
+   quality issue now yields a non-empty `result.artifacts["profile"]` and
+   non-empty `column_contexts` (today: empty).
+2. **File-path equivalence:** on a clean CSV fixture, findings/profile from the
+   new path match the pre-change file-scan (or an explicitly-blessed diff).
+3. **stage_cfg forwarding:** `deep=True` / `domain=…` in the stage config reach
+   `scan_dataframe`.
+4. **`ctx.df is None` fallback** doesn't raise.
+
+### Blast radius
+
+One file (`adapters/check.py`), ~8 lines. No public API change. No new
+dependency (both `scan_file` and `scan_dataframe` are already exported by the
+`goldencheck` the adapter imports).
+
+---
+
+## Move 2 — MCP composites call GoldenPipe in-process
+
+### Current behavior (the disk tax)
+
+`packages/python/goldensuite-mcp/goldensuite_mcp/composites.py` chains suite
+tools by writing `.csv` files between every stage
+(`_gen_output_path` → `f"{stem}.{suffix}.csv"`) and re-reading them through
+separate MCP tool dispatches:
+
+- `orchestrate_clean_and_dedupe`: `upload` → `run_transforms(file → cleaned.csv)`
+  → `agent_deduplicate(cleaned.csv → golden.csv)`. **Two** intermediate CSV
+  writes + reads (write cleaned, read cleaned, write golden).
+- `orchestrate_dedupe_file`: `upload` → `auto_configure(file)` →
+  `agent_deduplicate(file → golden.csv)`. `auto_configure` reads the file, then
+  `agent_deduplicate` reads the **same file again**.
+
+Each `run_step` routes to a sub-package MCP dispatcher (goldenmatch /
+goldenflow), each of which is a `read_csv → work → write_csv` boundary.
+
+### Target behavior
+
+GoldenPipe **is importable** here — `goldensuite-mcp` depends on
+`goldenpipe[mcp]`. Its `run()` already does check→flow→dedupe in-process on one
+`ctx.df`, and surfaces the golden output as a **full `pl.DataFrame`** on
+`PipeResult.artifacts["golden"]` (the `DedupeStage` casts every column to
+string, so it's CSV/JSON-safe). Replace the internal CSV chain with a single
+in-process pipeline call, and write golden **once**:
+
+```python
+# composites.py — new helper, guarded like the adapters
+try:
+    import goldenpipe as _gp
+    HAS_PIPE = True
+except ImportError:
+    HAS_PIPE = False
+
+def _run_pipeline_inprocess(path, excl, golden_path):
+    """check→flow→dedupe in one process; write golden once. Returns the
+    (golden_records, total_records, confidence_distribution) the composite
+    summary needs, reconstructing the review buckets from scored_pairs."""
+    from contextlib import nullcontext
+    _excl_ctx = nullcontext()
+    if excl:
+        from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+        # same mechanism agent_deduplicate uses; threads into GoldenPipe's
+        # internal auto-config because DedupeStage calls goldenmatch's controller.
+        token = _RUNTIME_EXCLUDE_COLUMNS.set(list(excl))
+    try:
+        result = _gp.run(path)               # zero-config check→flow→dedupe
+    finally:
+        if excl:
+            _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    golden = result.artifacts.get("golden")
+    stats = result.artifacts.get("match_stats") or {}
+    scored = result.artifacts.get("scored_pairs")
+    if golden is not None:
+        golden.write_csv(golden_path)        # the ONE write
+    conf = _confidence_from_scored_pairs(scored)   # gate_pairs reconstruction
+    return {
+        "golden_path": golden_path if golden is not None else None,
+        "golden_records": golden.height if golden is not None else None,
+        "total_records": stats.get("total_records"),
+        "confidence_distribution": conf,
+        "status": result.status.value,
+        "errors": result.errors,
+    }
+```
+
+`clean_and_dedupe` then becomes `upload → _run_pipeline_inprocess` (the
+GoldenFlow transform is part of GoldenPipe's default chain, so "clean" happens
+in-memory — the `cleaned.csv` disappears entirely). `dedupe_file` becomes
+`upload → _run_pipeline_inprocess` (the double file-read collapses to one).
+
+### The three compatibility gaps (the real design decisions)
+
+The composites' return contract is what LLM callers depend on, so the gaps
+between `agent_deduplicate`'s return and GoldenPipe's artifacts must be closed,
+not papered over.
+
+1. **`confidence_distribution` (auto_merged / review / auto_rejected).**
+   `agent_deduplicate` returns these from the AgentSession review-gating layer;
+   plain `dedupe_df` (what GoldenPipe's `DedupeStage` runs) does **not** gate —
+   it surfaces `match_stats` (total_records/clusters/match_rate) but no buckets.
+   The composite summary's "*X merged, Y to review*" line loses its source.
+   **Resolution:** reconstruct from `artifacts["scored_pairs"]` (GoldenPipe
+   already surfaces it, `adapters/match.py:84`) via
+   `goldenmatch.core.review_queue.gate_pairs` (the same >0.95 auto-merge /
+   0.75–0.95 review / <0.75 reject thresholds the AgentSession uses). This keeps
+   the summary contract whole. If `scored_pairs` is absent, degrade the summary
+   to golden/total counts rather than fabricating buckets.
+
+2. **`exclude_columns`.** `agent_deduplicate`/`auto_configure` honor it through
+   the `goldenmatch.core.autoconfig._RUNTIME_EXCLUDE_COLUMNS` ContextVar
+   (`agent_tools.py:618`–`657`). GoldenPipe's `run()` has no such param.
+   **Resolution:** set the *same* ContextVar around the `_gp.run(path)` call in a
+   `try/finally` (shown above). It threads through because `DedupeStage` calls
+   goldenmatch's controller internally — byte-for-byte the mechanism
+   `agent_deduplicate` uses. (Rejected alternative: `run_df(df.drop(excl))` —
+   works but drops the columns from the golden output too, changing the file
+   schema; the ContextVar excludes them from *matching* only, which is the
+   agent_deduplicate semantics.)
+
+3. **`config` transparency block (dedupe_file only).** Today sourced from
+   `auto_configure`'s display dict; the code already deliberately does **not**
+   pass it to the deduper (`composites.py:85`–`90`). GoldenPipe doesn't return
+   the goldenmatch config object. **Resolution:** drop the display `config` block
+   on the in-process path (it was display-only), or reconstruct a thin summary
+   from `match_stats` + `artifacts["matchkey_used"]`. Recommend dropping it and
+   noting the removed field in the composite description — it never fed anything.
+
+### Which composites change, and which don't
+
+| composite         | change | why |
+|-------------------|--------|-----|
+| `clean_and_dedupe` | **convert** | biggest win — kills the `cleaned.csv` write+read *and* the double dedupe read |
+| `dedupe_file`      | **convert** | kills the `auto_configure`+`agent_deduplicate` double file-read |
+| `match_sources`    | leave as-is | GoldenPipe has no cross-source *match* stage (it's a dedupe orchestrator); not convertible today |
+| `assess_file`      | leave as-is | read-only (`analyze` + `scan`), no CSV chaining tax; benefits indirectly from Move 1 only if routed through GoldenPipe, which it isn't |
+
+### Rejected alternative: dispatch to GoldenPipe's `run_pipeline` MCP tool
+
+GoldenPipe already registers a `run_pipeline` MCP tool (surfaced by the
+aggregator). Calling it via `run_step(dispatch, "run_pipeline", …)` would keep
+everything dict-based, but:
+
+- `run_pipeline` returns golden as a **≤100-row `golden_preview`** over the wire,
+  not the full frame — it **cannot** produce the full `golden.csv` file the
+  composite's `outputs.golden_path` contract promises.
+- It re-serializes to a dict, forcing a re-parse.
+
+So Move 2 uses the **direct in-process import** (`goldenpipe.run`), reading the
+full `artifacts["golden"]` frame and writing it once. The dispatch route is the
+wrong tool for a file-producing composite.
+
+### Contract stability
+
+The composite return schema (`workflow`, `ok`, `summary`, `steps`, `outputs`,
+`config`) is the LLM-facing contract. Keep `outputs.*` and the `summary` string
+**stable**; the visible change is the `steps[]` shape (fewer steps — one
+`"pipeline"` step replaces `"clean"`+`"deduplicate"`, or `"auto_configure"`+
+`"deduplicate"`). Options:
+
+- **(a)** emit a single `"pipeline"` step and update `_summarize` for the new
+  name — simplest, one visible break in `steps[]`.
+- **(b)** synthesize the old step entries from the single GoldenPipe result so
+  `steps[]` looks unchanged — more code, zero visible break.
+
+Recommend **(a)** with `outputs`/`summary` held stable; document the `steps[]`
+change in the composite description.
+
+### Operational note — mimalloc guard
+
+`goldenpipe.run` spawns polars/`ThreadPoolExecutor` workers (the goldenmatch
+pipeline) — the recurring pyarrow-mimalloc SIGSEGV class. `goldensuite-mcp` on
+Railway installs from the workspace (not a fresh PyPI wheel), which historically
+does *not* trip it, but this composite is exactly the "install + run the
+pipeline" shape the standing rule covers. **Action:** confirm the
+`goldensuite-mcp` Railway service / `Dockerfile.mcp` sets
+`ARROW_DEFAULT_MEMORY_POOL=system` at the env level; add it if absent. Harmless
+where unneeded.
+
+### Tests (`packages/python/goldensuite-mcp/tests/`)
+
+1. `clean_and_dedupe` produces `outputs.golden_path` with the same
+   `golden_records` as the old chain on a fixture — **and asserts no
+   intermediate `*.cleaned.csv` is written** (the disk-tax removal is the point).
+2. `dedupe_file` in-process matches the old golden count on a fixture.
+3. `exclude_columns` honored (ContextVar path) — an excluded column does not
+   drive matching.
+4. `confidence_distribution` reconstructed from `scored_pairs` matches
+   `gate_pairs` buckets.
+5. `HAS_PIPE` false → graceful fallback to the current dispatch chain (or a clean
+   composite failure), never a crash.
+6. Return schema: `outputs` keys and `summary` shape unchanged; `steps[]`
+   documented change asserted.
+
+### Blast radius
+
+One file (`composites.py`) plus a guarded import and one helper. No change to
+any sub-package MCP tool. `match_sources`/`assess_file` untouched.
+
+---
+
+## Sequencing
+
+1. **Move 1 first.** It's a one-file bug fix, independent, and it makes
+   GoldenPipe's own check stage correct on an in-memory frame — which is exactly
+   what Move 2's in-process runs exercise. Landing it first de-risks Move 2 and
+   unblocks Move 3 (profile-sharing).
+2. **Move 2 second.** Depends on nothing from Move 1 mechanically, but benefits
+   from the check stage being correct.
+
+## Explicitly out of scope
+
+- **Move 3 (profile-sharing):** have GoldenPipe pass the GoldenCheck
+  `DatasetProfile` into GoldenMatch's autoconfig so the frame is profiled once,
+  not twice. Blocked on GoldenCheck's `DatasetProfile` exposing the semantic
+  `col_type` + `avg_len` fields GoldenMatch's `ColumnProfile` needs — a separate
+  spec. Move 1 is its prerequisite (the check stage must profile the same frame
+  the deduper will consume).
+- The Arrow W5 flip (removing autoconfig's arrow→polars bounce). `scan_dataframe`
+  already accepts `pa.Table`, so Move 1 is forward-compatible with it.

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **The `goldencheck.scan` stage now scans the in-memory frame** (`ctx.df` via
+  `goldencheck.scan_dataframe`) instead of re-reading the source path with
+  `scan_file`. This removes a redundant CSV parse mid-pipeline on file sources
+  and fixes a latent bug: for `run_df(df)` and DuckDB-table sources the "source"
+  string (`"<DataFrame>"` / `"duckdb:..."`) is not a readable path, so the old
+  `scan_file(source)` produced no profile and the downstream dedupe silently
+  lost its profile-driven config. A defensive `scan_file` fallback remains for
+  the rare no-frame case. `scan_dataframe` accepts a `pa.Table` natively, so the
+  stage is forward-compatible with the Arrow-native frame flip.
+
 ## 1.3.0 (2026-06-24)
 
 **Analysis reporting + a live TUI.** GoldenPipe gains an optional terminal reporting stage so one chain runs `Check -> Flow -> Match -> Identity -> Analysis`, and the 4-tab TUI is now wired to the real pipeline.

--- a/packages/python/goldenpipe/CLAUDE.md
+++ b/packages/python/goldenpipe/CLAUDE.md
@@ -101,7 +101,7 @@ distributed/polyglot workload before building — none exists today.
 
 ## Pipeline Flow
 ```
-load_file -> GoldenCheck.scan_file(path) -> decide_flow(findings)
+load_file -> GoldenCheck.scan_dataframe(ctx.df) -> decide_flow(findings)
   -> if fixable: GoldenFlow.transform_df(df) -> updated df
   -> decide_match(findings, row_count, strategy_override)
   -> GoldenMatch.dedupe_df(df) or AgentSession.deduplicate(path)

--- a/packages/python/goldenpipe/goldenpipe/adapters/check.py
+++ b/packages/python/goldenpipe/goldenpipe/adapters/check.py
@@ -1,4 +1,5 @@
-"""GoldenCheck adapter -- wraps scan_file()."""
+"""GoldenCheck adapter -- scans the in-memory frame (scan_dataframe), falling
+back to scan_file() only when no frame is available."""
 from __future__ import annotations
 
 import logging
@@ -9,11 +10,13 @@ from goldenpipe.models.stage import StageInfo
 logger = logging.getLogger(__name__)
 
 try:
+    from goldencheck import scan_dataframe as _scan_df
     from goldencheck import scan_file as _scan
     HAS_CHECK = True
 except ImportError:
     HAS_CHECK = False
     _scan = None
+    _scan_df = None
 
 
 class ScanStage:
@@ -27,20 +30,31 @@ class ScanStage:
     def run(self, ctx: PipeContext) -> StageResult:
         source = ctx.metadata.get("source", "")
         stage_cfg = ctx.stage_config
-        if stage_cfg:
-            logger.info("Passing stage config to GoldenCheck scan")
-            result = _scan(source, **stage_cfg)
+        if ctx.df is not None:
+            # Scan the frame the pipeline already loaded -- no redundant disk
+            # re-read, and it works for DataFrame/DuckDB sources whose `source`
+            # string ("<DataFrame>"/"duckdb:...") is not a readable path.
+            # `file_path` is cosmetic (populates DatasetProfile.file_path).
+            if stage_cfg:
+                logger.info("Passing stage config to GoldenCheck scan_dataframe")
+                result = _scan_df(ctx.df, file_path=source, **stage_cfg)
+            else:
+                result = _scan_df(ctx.df, file_path=source)
         else:
-            result = _scan(source)
+            # Defensive fallback: no in-memory frame. A local stage normally has
+            # ctx.df materialized by the Runner before it runs, so this path is
+            # rare; keep the file scan for it.
+            logger.info("ScanStage: no ctx.df; falling back to scan_file(%s)", source)
+            result = _scan(source, **stage_cfg) if stage_cfg else _scan(source)
 
-        # scan_file returns (findings, profile) tuple
+        # scan_dataframe/scan_file both return a (findings, profile) tuple
         if isinstance(result, tuple) and len(result) >= 2:
             raw_findings, profile = result[0], result[1]
         else:
             raw_findings = result.findings if hasattr(result, "findings") else []
             profile = None
             logger.warning(
-                "ScanStage: scan_file returned %s (expected tuple). "
+                "ScanStage: scan returned %s (expected tuple). "
                 "Profile will be None — column context pipeline may not produce contexts.",
                 type(result).__name__,
             )

--- a/packages/python/goldenpipe/tests/test_adapters.py
+++ b/packages/python/goldenpipe/tests/test_adapters.py
@@ -21,17 +21,67 @@ class TestScanStage:
             s.validate(PipeContext())
 
     @patch("goldenpipe.adapters.check.HAS_CHECK", True)
-    def test_run_success(self, sample_df):
+    def test_run_scans_frame_not_file(self, sample_df):
+        # With a frame present, the stage scans ctx.df via scan_dataframe --
+        # NOT the source path via scan_file (the redundant-re-read seam).
         from goldenpipe.adapters import check
-        mock_result = MagicMock()
-        mock_result.findings = [{"severity": "warning", "check": "nulls"}]
-        with patch.object(check, "_scan", return_value=mock_result):
+        findings = [{"severity": "warning", "check": "nulls"}]
+        profile = MagicMock()
+        with patch.object(check, "_scan_df", return_value=(findings, profile)) as m_df, \
+                patch.object(check, "_scan") as m_file:
             from goldenpipe.adapters.check import ScanStage
             s = ScanStage()
             ctx = PipeContext(df=sample_df, metadata={"source": "test.csv"})
             result = s.run(ctx)
             assert result.status == StageStatus.SUCCESS
-            assert "findings" in ctx.artifacts
+            assert ctx.artifacts["findings"] == findings
+            assert ctx.artifacts["profile"] is profile
+            # scanned the frame, not the path
+            m_df.assert_called_once()
+            assert m_df.call_args.args[0] is sample_df
+            assert m_df.call_args.kwargs.get("file_path") == "test.csv"
+            m_file.assert_not_called()
+
+    @patch("goldenpipe.adapters.check.HAS_CHECK", True)
+    def test_run_dataframe_source_still_scans(self, sample_df):
+        # Regression: a "<DataFrame>" source is not a readable path, so the old
+        # scan_file(source) produced no profile. Scanning ctx.df fixes it.
+        from goldenpipe.adapters import check
+        with patch.object(check, "_scan_df", return_value=([], MagicMock())) as m_df, \
+                patch.object(check, "_scan") as m_file:
+            from goldenpipe.adapters.check import ScanStage
+            s = ScanStage()
+            ctx = PipeContext(df=sample_df, metadata={"source": "<DataFrame>"})
+            result = s.run(ctx)
+            assert result.status == StageStatus.SUCCESS
+            assert ctx.artifacts["profile"] is not None
+            m_df.assert_called_once()
+            m_file.assert_not_called()
+
+    @patch("goldenpipe.adapters.check.HAS_CHECK", True)
+    def test_run_forwards_stage_config(self, sample_df):
+        from goldenpipe.adapters import check
+        with patch.object(check, "_scan_df", return_value=([], MagicMock())) as m_df:
+            from goldenpipe.adapters.check import ScanStage
+            s = ScanStage()
+            ctx = PipeContext(df=sample_df, metadata={"source": "test.csv"},
+                              stage_config={"deep": True})
+            s.run(ctx)
+            assert m_df.call_args.kwargs.get("deep") is True
+
+    @patch("goldenpipe.adapters.check.HAS_CHECK", True)
+    def test_run_falls_back_to_scan_file_without_frame(self):
+        # No ctx.df (defensive path) -> scan_file(source).
+        from goldenpipe.adapters import check
+        with patch.object(check, "_scan", return_value=([], MagicMock())) as m_file, \
+                patch.object(check, "_scan_df") as m_df:
+            from goldenpipe.adapters.check import ScanStage
+            s = ScanStage()
+            ctx = PipeContext(df=None, metadata={"source": "test.csv"})
+            result = s.run(ctx)
+            assert result.status == StageStatus.SUCCESS
+            m_file.assert_called_once()
+            m_df.assert_not_called()
 
 
 class TestTransformStage:

--- a/packages/python/goldensuite-mcp/CHANGELOG.md
+++ b/packages/python/goldensuite-mcp/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- **`clean_and_dedupe` now runs check→flow→dedupe in-process via GoldenPipe**
+  instead of chaining `run_transforms` → `agent_deduplicate` through an
+  intermediate `cleaned.csv` on disk. One `goldenpipe.run` call keeps the frame
+  in memory across cleaning and dedupe, writing golden once (no `cleaned.csv`).
+  The `steps[]` list carries a single `pipeline` step (was `clean` +
+  `deduplicate`); `outputs` (`golden_path`/`golden_records`/`total_records`) and
+  the `summary` are unchanged, and `exclude_columns` is honored (threaded via the
+  same `_RUNTIME_EXCLUDE_COLUMNS` ContextVar `agent_deduplicate` uses). The
+  confidence buckets in the summary are reconstructed from the pipeline's
+  `scored_pairs` via `review_queue.gate_pairs`. If GoldenPipe is unavailable, the
+  composite falls back to the previous tool-dispatch CSV chain. `dedupe_file`,
+  `match_sources`, and `assess_file` are unchanged.
+
 ## 0.5.0 (2026-07-11)
 
 ### Added

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/composites.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Callable
 
 from mcp.types import Tool
 
+logger = logging.getLogger(__name__)
+
 Dispatch = dict[str, Callable[[str, dict], dict]]
+
+# GoldenPipe runs check->flow->dedupe in ONE process on an in-memory frame, so a
+# composite can chain the stages without writing intermediate CSVs to disk. It is
+# a hard dependency of this package (`goldenpipe[mcp]`); the guard only matters in
+# a stripped build, where the composite falls back to the tool-dispatch chain.
+try:
+    import goldenpipe as _gp
+
+    HAS_PIPE = True
+except ImportError:  # pragma: no cover - goldenpipe is a declared dependency
+    HAS_PIPE = False
+    _gp = None
 
 
 def run_step(dispatch: Dispatch, tool_name: str, args: dict) -> tuple[bool, dict]:
@@ -105,17 +120,118 @@ def orchestrate_dedupe_file(dispatch, args):
     return _finish("dedupe_file", steps, config=config, outputs=outputs)
 
 
-def orchestrate_clean_and_dedupe(dispatch, args):
-    """Normalize then dedupe: upload -> run_transforms -> agent_deduplicate.
-    The cleaned file that run_transforms writes is threaded into the dedupe."""
-    steps = []
-    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
+def _golden_to_polars(golden):
+    """Normalize a DedupeStage `golden` artifact to a Polars frame for writing.
 
+    Depending on the goldenmatch build, `result.golden` is a `pl.DataFrame`
+    (has `.write_csv`) or a `pa.Table` (Arrow-native path). Returns None for an
+    unrecognized/absent value so the caller degrades cleanly."""
+    if golden is None:
+        return None
+    if hasattr(golden, "write_csv"):  # polars.DataFrame
+        return golden
+    try:
+        import polars as pl
+        import pyarrow as pa
+
+        if isinstance(golden, pa.Table):
+            return pl.from_arrow(golden)
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("clean_and_dedupe: could not normalize golden artifact")
+    return None
+
+
+def _confidence_from_scored_pairs(scored_pairs):
+    """Reconstruct the auto_merge/review/reject buckets agent_deduplicate reports.
+
+    GoldenPipe runs plain `dedupe_df` (no review gating), so it surfaces
+    `scored_pairs` but not the confidence distribution. Re-derive it with the
+    same thresholds AgentSession uses (gate_pairs: >0.95 merge, 0.75-0.95
+    review, <0.75 reject). Returns {} if pairs are absent or gating is
+    unavailable."""
+    if not scored_pairs:
+        return {}
+    try:
+        from goldenmatch.core.review_queue import gate_pairs
+
+        merged, review, rejected = gate_pairs(list(scored_pairs))
+        return {"auto_merged": len(merged), "review": len(review), "auto_rejected": len(rejected)}
+    except Exception:  # pragma: no cover - defensive
+        logger.exception("clean_and_dedupe: could not reconstruct confidence distribution")
+        return {}
+
+
+def _run_pipeline_inprocess(path, exclude_columns, golden_path):
+    """Run GoldenPipe's check->flow->dedupe chain in-process on `path` and write
+    golden once. No intermediate CSVs. Returns the fields the composite summary
+    needs, or {"error": ...} on failure."""
+    token = None
+    if exclude_columns:
+        # Same mechanism agent_deduplicate uses to exclude columns from matching;
+        # threads into GoldenPipe's internal auto-config (DedupeStage calls the
+        # goldenmatch controller).
+        from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+
+        token = _RUNTIME_EXCLUDE_COLUMNS.set(list(exclude_columns))
+    try:
+        result = _gp.run(path)
+    except Exception as exc:  # noqa: BLE001
+        return {"error": f"{type(exc).__name__}: {exc}"}
+    finally:
+        if token is not None:
+            from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+
+            _RUNTIME_EXCLUDE_COLUMNS.reset(token)
+
+    if result.status.value == "failed":
+        return {"error": "; ".join(result.errors) or "pipeline failed"}
+
+    golden = _golden_to_polars(result.artifacts.get("golden"))
+    stats = result.artifacts.get("match_stats") or {}
+    conf = _confidence_from_scored_pairs(result.artifacts.get("scored_pairs"))
+    if golden is not None:
+        golden.write_csv(golden_path)
+    return {
+        "golden_path": golden_path if golden is not None else None,
+        "golden_records": golden.height if golden is not None else None,
+        "total_records": stats.get("total_records"),
+        "confidence_distribution": conf,
+    }
+
+
+def orchestrate_clean_and_dedupe(dispatch, args):
+    """Normalize then dedupe. In-process (default): upload -> one GoldenPipe
+    check->flow->dedupe run, no intermediate CSV. Fallback (no goldenpipe):
+    upload -> run_transforms -> agent_deduplicate over a cleaned CSV on disk."""
+    steps = []
     ok, res, label = _upload(dispatch, args)
     steps.append({"step": label, "ok": ok, **({"path": res.get("path")} if ok else {"error": res.get("error")})})
     if not ok:
         return _finish("clean_and_dedupe", steps)
     path = res["path"]
+
+    if not HAS_PIPE:
+        return _clean_and_dedupe_via_dispatch(dispatch, args, path, steps)
+
+    golden_path = _gen_output_path(path, "golden")
+    pr = _run_pipeline_inprocess(path, args.get("exclude_columns"), golden_path)
+    if "error" in pr:
+        steps.append({"step": "pipeline", "ok": False, "error": pr["error"]})
+        return _finish("clean_and_dedupe", steps)
+    cd = pr["confidence_distribution"]
+    steps.append({"step": "pipeline", "ok": True,
+                  "golden_path": pr["golden_path"], "auto_merge": cd.get("auto_merged"),
+                  "review": cd.get("review"), "reject": cd.get("auto_rejected")})
+    outputs = {"golden_path": pr["golden_path"], "golden_records": pr["golden_records"],
+               "total_records": pr["total_records"]}
+    return _finish("clean_and_dedupe", steps, outputs=outputs)
+
+
+def _clean_and_dedupe_via_dispatch(dispatch, args, path, steps):
+    """Legacy tool-dispatch chain (run_transforms -> agent_deduplicate over a
+    cleaned CSV). Used only when goldenpipe is unavailable. `steps` already
+    carries the upload step."""
+    excl = {"exclude_columns": args["exclude_columns"]} if args.get("exclude_columns") else {}
 
     cleaned_path = _gen_output_path(path, "cleaned")
     ok, res = run_step(dispatch, "run_transforms", {"file_path": path, "output_path": cleaned_path})
@@ -234,6 +350,11 @@ def _summarize(workflow, steps, outputs, degraded_steps=frozenset()):
         tail = f" Written to {dest}." if dest else ""
         return f"Matched two sources: {pairs} matched pairs.{tail}"
     if workflow == "clean_and_dedupe" and outputs:
+        p = next((s for s in steps if s["step"] == "pipeline"), None)
+        if p:  # in-process GoldenPipe path
+            return (f"{outputs.get('total_records')} records cleaned + deduped in-process -> "
+                    f"{outputs.get('golden_records')} golden; {p.get('auto_merge')} merged, "
+                    f"{p.get('review')} to review. Written to {outputs.get('golden_path')}.")
         c = next((s for s in steps if s["step"] == "clean"), {})
         d = next((s for s in steps if s["step"] == "deduplicate"), {})
         return (f"{outputs.get('total_records')} records cleaned "

--- a/packages/python/goldensuite-mcp/tests/test_composites.py
+++ b/packages/python/goldensuite-mcp/tests/test_composites.py
@@ -1,5 +1,7 @@
 import csv as _csv
 import os
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 from goldensuite_mcp.composites import run_step
@@ -7,6 +9,11 @@ from goldensuite_mcp.composites import run_step
 
 def _table(**tools):
     return dict(tools)
+
+
+def _pipe_available():
+    import importlib.util
+    return importlib.util.find_spec("goldenpipe") is not None
 
 
 def test_run_step_success():
@@ -220,7 +227,10 @@ def _fake_clean_table(rec, transforms_ok=True):
     return {"upload_dataset": upload, "run_transforms": transforms, "agent_deduplicate": dedup}
 
 
-def test_clean_and_dedupe_happy():
+@patch("goldensuite_mcp.composites.HAS_PIPE", False)
+def test_clean_and_dedupe_happy_fallback_chain():
+    # Fallback (no goldenpipe): the legacy run_transforms -> agent_deduplicate
+    # CSV chain still works and threads the cleaned path into the dedupe.
     from goldensuite_mcp.composites import build_composites
     rec = []
     _, dispatch = build_composites(_fake_clean_table(rec))
@@ -237,6 +247,7 @@ def test_clean_and_dedupe_happy():
     assert isinstance(out["summary"], str) and out["summary"]
 
 
+@patch("goldensuite_mcp.composites.HAS_PIPE", False)
 def test_clean_and_dedupe_soft_dep_short_circuit():
     from goldensuite_mcp.composites import build_composites
     rec = []
@@ -246,6 +257,102 @@ def test_clean_and_dedupe_soft_dep_short_circuit():
     assert [s["step"] for s in out["steps"]] == ["upload", "clean"]
     # deduplicate never ran
     assert not any(k == "dedup" for k, _ in rec)
+
+
+def _fake_pipe_result(golden_rows=2, total=5, pairs=((0, 1, 1.0), (2, 3, 1.0))):
+    import polars as pl
+    golden = pl.DataFrame({"id": [str(i) for i in range(golden_rows)]})
+    return SimpleNamespace(
+        status=SimpleNamespace(value="success"),
+        errors=[],
+        artifacts={"golden": golden, "match_stats": {"total_records": total},
+                   "scored_pairs": list(pairs)},
+    )
+
+
+def test_clean_and_dedupe_inprocess_single_step(tmp_path):
+    # In-process path: one "pipeline" step, golden written once, NO cleaned.csv,
+    # confidence buckets reconstructed from scored_pairs. run_transforms and
+    # agent_deduplicate are NEVER dispatched.
+    from goldensuite_mcp.composites import build_composites
+    src = tmp_path / "in.csv"
+    src.write_text("id\n1\n2\n")
+    rec = []
+    fake = _fake_clean_table(rec)  # dispatch fakes that must NOT be called
+    fake_gp = SimpleNamespace(run=lambda p: _fake_pipe_result())
+    with patch("goldensuite_mcp.composites.HAS_PIPE", True), \
+            patch("goldensuite_mcp.composites._gp", fake_gp):
+        _, dispatch = build_composites(fake)
+        out = dispatch["clean_and_dedupe"]("clean_and_dedupe", {"file_path": str(src)})
+    assert out["ok"] is True
+    assert [s["step"] for s in out["steps"]] == ["upload", "pipeline"]
+    assert not any(k in ("clean", "dedup") for k, _ in rec)  # legacy tools untouched
+    assert out["outputs"]["golden_records"] == 2
+    assert out["outputs"]["total_records"] == 5
+    assert "cleaned_path" not in out["outputs"]  # no intermediate CSV
+    gp = out["outputs"]["golden_path"]
+    assert os.path.exists(gp)
+    assert not os.path.exists(str(src).replace(".csv", ".cleaned.csv"))
+    pipe_step = next(s for s in out["steps"] if s["step"] == "pipeline")
+    assert pipe_step["auto_merge"] == 2 and pipe_step["review"] == 0  # gate_pairs buckets
+
+
+def test_clean_and_dedupe_inprocess_pipeline_failure(tmp_path):
+    from goldensuite_mcp.composites import build_composites
+    src = tmp_path / "in.csv"
+    src.write_text("id\n1\n")
+    failed = SimpleNamespace(status=SimpleNamespace(value="failed"), errors=["boom"], artifacts={})
+    fake_gp = SimpleNamespace(run=lambda p: failed)
+    with patch("goldensuite_mcp.composites.HAS_PIPE", True), \
+            patch("goldensuite_mcp.composites._gp", fake_gp):
+        _, dispatch = build_composites({})
+        out = dispatch["clean_and_dedupe"]("clean_and_dedupe", {"file_path": str(src)})
+    assert out["ok"] is False
+    assert [s["step"] for s in out["steps"]] == ["upload", "pipeline"]
+    assert "boom" in out["summary"]
+
+
+@pytest.mark.skipif(not _pipe_available(), reason="goldenmatch autoconfig not available")
+def test_clean_and_dedupe_inprocess_threads_exclude_columns(tmp_path):
+    # exclude_columns must reach goldenmatch's auto-config via the same
+    # _RUNTIME_EXCLUDE_COLUMNS ContextVar agent_deduplicate uses.
+    from goldenmatch.core.autoconfig import _RUNTIME_EXCLUDE_COLUMNS
+    from goldensuite_mcp.composites import build_composites
+    src = tmp_path / "in.csv"
+    src.write_text("id\n1\n")
+    seen = {}
+
+    def _run(p):
+        seen["excl"] = _RUNTIME_EXCLUDE_COLUMNS.get()  # captured mid-run
+        return _fake_pipe_result()
+
+    fake_gp = SimpleNamespace(run=_run)
+    with patch("goldensuite_mcp.composites.HAS_PIPE", True), \
+            patch("goldensuite_mcp.composites._gp", fake_gp):
+        _, dispatch = build_composites({})
+        dispatch["clean_and_dedupe"]("clean_and_dedupe",
+                                     {"file_path": str(src), "exclude_columns": ["ssn"]})
+    assert seen["excl"] == ["ssn"]
+    # and it's reset afterward (no leak into the next call)
+    assert _RUNTIME_EXCLUDE_COLUMNS.get() != ["ssn"]
+
+
+@pytest.mark.skipif(not _pipe_available(), reason="goldenpipe not installed")
+def test_clean_and_dedupe_inprocess_end_to_end(tmp_path):
+    """Real GoldenPipe run through the composite: golden CSV lands, no cleaned.csv."""
+    from goldensuite_mcp.composites import orchestrate_clean_and_dedupe
+    csv_path = tmp_path / "people.csv"
+    _write_people_csv(csv_path)
+    # _upload short-circuits on a file_path arg, so an empty dispatch is fine.
+    out = orchestrate_clean_and_dedupe({}, {"file_path": str(csv_path)})
+    assert out["ok"] is True, out
+    assert [s["step"] for s in out["steps"]] == ["upload", "pipeline"]
+    golden = out["outputs"]["golden_path"]
+    assert golden and os.path.exists(golden)
+    assert not os.path.exists(str(csv_path).replace(".csv", ".cleaned.csv"))
+    with open(golden, encoding="utf-8") as fh:
+        rows = sum(1 for _ in fh)
+    assert rows >= 2  # header + >=1 golden record
 
 
 def test_all_four_composites_exist_no_dangling_curated():


### PR DESCRIPTION
Part A of draft #1704, extracted unchanged (zero drift on these files since that branch point). Part B (anomaly diagnostics) follows separately, reworked per review to avoid a new required package.

## Move 1 -- check stage scans the in-memory frame

`goldenpipe`'s ScanStage now calls `goldencheck.scan_dataframe(ctx.df)` instead of re-reading the source path with `scan_file`. Removes a redundant CSV parse and fixes a latent bug: for `run_df(df)` / DuckDB sources the "source" string (`"<DataFrame>"` / `"duckdb:..."`) is not a readable path, so the old `scan_file` produced no profile and the downstream dedupe silently lost its profile-driven config. `scan_file` kept as the defensive no-frame fallback.

## Move 2 -- one-run clean_and_dedupe

`goldensuite-mcp`'s `clean_and_dedupe` runs one in-process `goldenpipe.run()` (check -> flow -> dedupe) instead of chaining `run_transforms` -> `agent_deduplicate` through an intermediate `cleaned.csv`. `outputs`/`summary` held stable; `exclude_columns` + confidence buckets preserved; golden normalized from `pa.Table`/`pl.DataFrame`. `dedupe_file`/`match_sources`/`assess_file` intentionally unchanged.

Spec: `docs/design/2026-07-12-goldenpipe-inprocess-moves.md` (included).

## Testing

`test_adapters.py` (16) + `test_composites.py` (19 pass / 1 skip) green. Full goldenpipe + goldensuite-mcp sweep: 355 passed; the 9 fails + 3 errors (native-wheel parity, TUI/textual, a2a/fastapi) reproduce byte-identically on pristine origin/main in the same local env -- pre-existing, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R8MSaGwsjdxzf6Z7Bt3BXs