### PR TITLE
fix(blocker): auto-split oversized mega-blocks on the default path (skip_oversized=False)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -99,11 +99,12 @@ def _fast_static_block_sizes(
 
     Returns ``None`` — caller falls back to the exact ``build_blocks`` loop —
     whenever the vectorized result would NOT be byte-identical to
-    ``_build_static_blocks``: a non-static strategy, or oversized blocks that
-    ``_build_static_blocks`` would ANN/auto-split (``skip_oversized=True``).
-    With ``skip_oversized=False`` oversized blocks are kept whole, so the raw
-    group-by sizes still match. Singletons (size < 2) are dropped to mirror the
-    ``if size < 2: continue`` skip in ``_build_static_blocks``.
+    ``_build_static_blocks``: a non-static strategy, or the presence of ANY
+    oversized block (``_build_static_blocks`` sub-splits it under both
+    ``skip_oversized`` values now -- ANN/auto-split/skip when True, zero-config
+    auto-split when False+splittable, #372 -- so the raw group-by sizes diverge).
+    Singletons (size < 2) are dropped to mirror the ``if size < 2: continue``
+    skip in ``_build_static_blocks``.
     """
     if getattr(config, "strategy", "static") != "static":
         return None
@@ -129,7 +130,6 @@ def _fast_static_block_sizes(
     frame = to_frame(lf.collect()) if is_polars_lazyframe(lf) else to_frame(lf)
 
     max_block_size = config.max_block_size
-    skip_oversized = config.skip_oversized
     all_sizes: list[int] = []
     # Chao1 inputs for n_blocks richness extrapolation (S1): counted from the
     # raw per-key sizes BEFORE the size<2 drop (singletons feed F1).
@@ -146,9 +146,11 @@ def _fast_static_block_sizes(
         f1 += sum(1 for s in all_key_sizes if s == 1)
         f2 += sum(1 for s in all_key_sizes if s == 2)
         sizes = [s for s in all_key_sizes if s >= 2]
-        # If _build_static_blocks WOULD sub-split/skip an oversized block, the
-        # vectorized sizes diverge — bail to the exact path.
-        if skip_oversized and any(s > max_block_size for s in sizes):
+        # An oversized block is sub-split by _build_static_blocks under BOTH
+        # skip_oversized values now (True -> ANN/auto-split/skip; False ->
+        # zero-config auto-split when splittable, see #372), so the raw group-by
+        # sizes no longer match the built blocks. Bail to the exact path.
+        if any(s > max_block_size for s in sizes):
             return None
         all_sizes.extend(sizes)
     return all_sizes, f1, f2
@@ -498,20 +500,65 @@ def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
                     )
                     hot_blocks_skipped += 1
                     continue
+                elif config.sub_block_keys:
+                    # The adaptive strategy splits this oversized block by its
+                    # configured ``sub_block_keys`` downstream (build_blocks'
+                    # adaptive path calls _sub_block). Leave it intact here so we
+                    # don't pre-empt that with the zero-config auto-split; the
+                    # block is NOT scored whole because the caller sub-blocks it.
+                    logger.debug(
+                        "Oversized block %r (%d records) left intact for "
+                        "configured sub_block_keys splitting.",
+                        key_str, size,
+                    )
                 else:
-                    # skip_oversized=False -- the caller explicitly opted
-                    # into processing oversized blocks. We honor that but
-                    # log at ERROR so the OOM-vs-correctness tradeoff is
-                    # obvious in the run log. The actionable recovery is
-                    # always `skip_oversized=True` (drops the offending
-                    # block but lets the rest of the run land).
+                    # skip_oversized=False. Attempt the SAME zero-config
+                    # hot-block auto-split first (sub-partition by the
+                    # highest-cardinality column) -- splitting preserves recall
+                    # AND avoids the O(n^2) scoring OOM, so it is strictly better
+                    # than scoring the whole mega-block. This is the default path
+                    # (auto-config's FS year-diversify pass and the #1784-kept
+                    # common-surname block produce 10k+ record blocks whose
+                    # ~100M+ pairs OOM'd the runner when scored whole). Only when
+                    # auto-split can't help do we honor the opt-in "process
+                    # anyway".
+                    try:
+                        sub_blocks = _auto_split_block(
+                            group_df, config.max_block_size, key_str,
+                        )
+                    except Exception:
+                        logger.error(
+                            "Hot-block auto-split failed for %r (%d records).",
+                            key_str, size, exc_info=True,
+                        )
+                        sub_blocks = []
+                    useful_subs = []
+                    for b in sub_blocks:
+                        try:
+                            sub_size = b.n_rows()
+                        except Exception:
+                            sub_size = size + 1  # treat unknown as not-useful
+                        if sub_size < size and sub_size >= 2:
+                            useful_subs.append(b)
+                    if useful_subs:
+                        results.extend(useful_subs)
+                        hot_blocks_split += 1
+                        logger.info(
+                            "Hot-block split %r (%d records) → %d sub-blocks",
+                            key_str, size, len(useful_subs),
+                        )
+                        continue
+                    # Auto-split couldn't help -- honor the opt-in and process
+                    # the whole block (log at ERROR so the OOM-vs-correctness
+                    # tradeoff is obvious in the run log).
                     logger.error(
                         f"Block {key_str!r} has {size} records "
                         f"(exceeds max_block_size={config.max_block_size}, "
-                        f"~{size * (size - 1) // 2:,} pairs to score). "
-                        f"Processing anyway because skip_oversized=False; "
-                        f"set blocking.skip_oversized=True to skip oversized "
-                        f"blocks instead of risking OOM. See #372."
+                        f"~{size * (size - 1) // 2:,} pairs to score) and "
+                        f"auto-split produced no useful sub-blocks. Processing "
+                        f"anyway because skip_oversized=False; set "
+                        f"blocking.skip_oversized=True to skip oversized blocks "
+                        f"instead of risking OOM. See #372."
                     )
 
             results.append(BlockResult(

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -764,7 +764,7 @@ def _sub_block(
 
 
 def _auto_split_block(
-    block_df: pl.DataFrame,
+    block_df: Any,  # pl.DataFrame | pa.Table | seam Frame -- normalized via to_frame
     max_block_size: int,
     parent_key: str,
 ) -> list[BlockResult]:
@@ -773,26 +773,30 @@ def _auto_split_block(
     When no sub_block_keys are configured, this provides a zero-config fallback
     that splits by the column with the most unique values.
     """
-    # Find non-internal columns
-    candidates = [c for c in block_df.columns if not c.startswith("__")]
+    from goldenmatch.core.frame import to_frame
+
+    # Seam-normalize FIRST: block_df may be a pa.Table (arrow-native path) whose
+    # ``.columns`` are ChunkedArrays, not names -- ``bframe.columns`` returns
+    # NAMES on both backends. (The raw ``block_df.columns`` here was the
+    # arrow-path AttributeError that made auto-split silently no-op and let the
+    # mega-block fall through to be scored whole -> OOM. See #372/#1790.)
+    bframe = to_frame(block_df)
+    candidates = [c for c in bframe.columns if not c.startswith("__")]
     if not candidates:
         logger.warning(
             "Auto-split of %r: no non-internal columns available. Processing as-is.",
             parent_key,
         )
-        return [BlockResult(block_key=parent_key, df=block_df.lazy(), strategy="adaptive", depth=1, parent_key=parent_key)]
+        return [BlockResult(block_key=parent_key, df=bframe.native, strategy="adaptive", depth=1, parent_key=parent_key)]
 
     # Pick column whose cardinality best splits blocks near max_block_size.
     # Ideal: each group has ~max_block_size records.
     # Score = number of groups with >= 2 records (useful groups).
-    n = len(block_df)
+    n = bframe.height
     best_col = candidates[0]
     best_useful_groups = 0
     best_nunique = 0
 
-    from goldenmatch.core.frame import to_frame
-
-    bframe = to_frame(block_df)
     for col in candidates:
         nunique = bframe.column(col).n_unique()
         # Estimate: if we split by this column, avg group size = n / nunique
@@ -828,7 +832,7 @@ def _auto_split_block(
             )
         results.append(BlockResult(
             block_key=f"{parent_key}||{key_str}",
-            df=group_frame.drop(["__auto_split__"]).native.lazy(),
+            df=group_frame.drop(["__auto_split__"]).native,
             strategy="adaptive",
             depth=1,
             parent_key=parent_key,
@@ -836,9 +840,9 @@ def _auto_split_block(
 
     logger.info(
         "Auto-split %r (%d records) into %d sub-blocks using column %r (cardinality=%d)",
-        parent_key, len(block_df), len(results), best_col, best_nunique,
+        parent_key, bframe.height, len(results), best_col, best_nunique,
     )
-    return results if results else [BlockResult(block_key=parent_key, df=block_df.lazy(), strategy="adaptive", depth=1, parent_key=parent_key)]
+    return results if results else [BlockResult(block_key=parent_key, df=bframe.native, strategy="adaptive", depth=1, parent_key=parent_key)]
 
 
 def _build_sorted_neighborhood_blocks(

--- a/packages/python/goldenmatch/tests/test_hot_block_split.py
+++ b/packages/python/goldenmatch/tests/test_hot_block_split.py
@@ -126,6 +126,36 @@ class TestHotBlockSplit:
         assert results[0].block_key == "19382"
         assert results[0].materialize().native.height == 3
 
+    def test_arrow_backed_frame_auto_splits(self):
+        """Auto-split must work on an ARROW-native (pa.Table) frame.
+
+        Regression for #1790: `_auto_split_block` used raw `block_df.columns`,
+        which on a `pa.Table` returns ChunkedArrays (not names) ->
+        AttributeError -> the split silently no-op'd (caught by the caller's
+        try/except) and the mega-block was scored whole -> OOM at scale. Every
+        OTHER test here passes `df.lazy()` (polars-backed), which masked the
+        arrow-path crash. Exercise the seam Frame (arrow) path explicitly.
+        """
+        import pyarrow as pa
+        from goldenmatch.core.frame import to_frame
+        tbl = pa.table({
+            "id": list(range(8)),
+            "zip": ["19382"] * 8,
+            "city": ["A", "A", "B", "B", "C", "C", "D", "D"],
+        })
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=[])],
+            max_block_size=3,
+            skip_oversized=False,
+        )
+        results = build_blocks(to_frame(tbl), config)
+        block_keys = sorted(r.block_key for r in results)
+        split_subs = [k for k in block_keys if k.startswith("19382||")]
+        assert len(split_subs) == 4, f"arrow-path auto-split failed: {block_keys}"
+        for r in results:
+            size = to_frame(r.materialize().native).height
+            assert size <= 3, f"Block {r.block_key} has {size} rows > max=3"
+
     def test_bench_records_split_count(self):
         """`hot_blocks_split_count` should land on the active recorder."""
         config = BlockingConfig(

--- a/packages/python/goldenmatch/tests/test_hot_block_split.py
+++ b/packages/python/goldenmatch/tests/test_hot_block_split.py
@@ -72,11 +72,15 @@ class TestHotBlockSplit:
             f"got {[r.block_key for r in results]}"
         )
 
-    def test_skip_oversized_false_still_processes_anyway(self):
-        """`skip_oversized=False` is an explicit "keep big blocks" mode.
+    def test_skip_oversized_false_auto_splits_splittable_block(self):
+        """`skip_oversized=False` now auto-splits a splittable mega-block first.
 
-        Auto-split should NOT fire when the user has opted into processing
-        oversized blocks intact (preserves the prior semantic).
+        Sub-partitioning preserves recall AND avoids the O(n^2) scoring OOM,
+        so it is the default recovery even when the caller opted into
+        processing oversized blocks. (Previously this mode scored the whole
+        block, which OOM'd the runner on coarse auto-config keys -- e.g. the
+        FS year-diversify pass and the #1784-kept common-surname block, which
+        produce 10k+ record blocks. See #372.)
         """
         config = BlockingConfig(
             keys=[BlockingKeyConfig(fields=["zip"], transforms=[])],
@@ -89,10 +93,38 @@ class TestHotBlockSplit:
             "city": ["A", "A", "B", "B", "C", "C", "D", "D"],
         })
         results = build_blocks(df.lazy(), config)
-        # One single 8-row block, intact.
+        block_keys = sorted(r.block_key for r in results)
+        split_subs = [k for k in block_keys if k.startswith("19382||")]
+        assert len(split_subs) == 4, (
+            f"Expected 4 city sub-blocks under skip_oversized=False; got {block_keys}"
+        )
+        for r in results:
+            size = r.materialize().native.height
+            assert size <= 3, f"Block {r.block_key} has {size} rows > max=3"
+
+    def test_skip_oversized_false_processes_unsplittable_block_anyway(self):
+        """`skip_oversized=False` keeps the opt-in fallback for UNSPLITTABLE blocks.
+
+        When auto-split can't reduce the block (no in-block column varies), the
+        explicit `skip_oversized=False` still processes it whole -- whereas
+        `skip_oversized=True` would skip it. This preserves the "keep big
+        blocks" escape hatch for the genuinely-unsplittable case.
+        """
+        config = BlockingConfig(
+            keys=[BlockingKeyConfig(fields=["zip"], transforms=[])],
+            max_block_size=2,
+            skip_oversized=False,
+        )
+        df = pl.DataFrame({
+            "id": [1, 2, 3],
+            "zip": ["19382", "19382", "19382"],
+            "city": ["Westfield", "Westfield", "Westfield"],
+        })
+        results = build_blocks(df.lazy(), config)
+        # Unsplittable + opt-in => processed whole (NOT skipped).
         assert len(results) == 1
         assert results[0].block_key == "19382"
-        assert results[0].materialize().native.height == 8
+        assert results[0].materialize().native.height == 3
 
     def test_bench_records_split_count(self):
         """`hot_blocks_split_count` should land on the active recorder."""

--- a/packages/python/goldenmatch/tests/test_measure_blocking_fast_path.py
+++ b/packages/python/goldenmatch/tests/test_measure_blocking_fast_path.py
@@ -102,15 +102,11 @@ _PARITY_CONFIGS = {
         max_block_size=1_000_000,
         skip_oversized=False,
     ),
-    # Oversized blocks present but skip_oversized=False => kept whole => the raw
-    # group-by sizes still match the fallback. This is the regime the planner
-    # cares about (fixed-cardinality blocks that grow with N).
-    "oversized_kept_whole": dict(
-        strategy="static",
-        keys=[BlockingKeyConfig(fields=["last_name"], transforms=[])],
-        max_block_size=10,
-        skip_oversized=False,
-    ),
+    # NOTE: an oversized-block config is intentionally NOT here -- since #372
+    # (default-path auto-split), oversized blocks are sub-split under BOTH
+    # skip_oversized values, so the fast path bails to the exact loop rather than
+    # trusting the raw group-by sizes. That bail is asserted in
+    # test_bails_on_oversized_split below.
 }
 
 
@@ -145,14 +141,17 @@ def test_bails_on_non_static_strategy() -> None:
     assert _fast_static_block_sizes(_person_df(50).lazy(), cfg.blocking) is None
 
 
-def test_bails_on_oversized_with_skip_oversized() -> None:
-    # skip_oversized=True => oversized blocks get ANN/auto-split => sizes diverge
-    # from a raw group-by => must bail so the exact path runs.
+@pytest.mark.parametrize("skip_oversized", [True, False])
+def test_bails_on_oversized_split(skip_oversized: bool) -> None:
+    # Oversized blocks are sub-split under BOTH skip_oversized values now
+    # (True => ANN/auto-split/skip; False => zero-config auto-split, #372), so
+    # the raw group-by sizes diverge from the built blocks => must bail so the
+    # exact path runs.
     cfg = _cfg(
         strategy="static",
         keys=[BlockingKeyConfig(fields=["last_name"], transforms=[])],
         max_block_size=10,
-        skip_oversized=True,
+        skip_oversized=skip_oversized,
     )
     assert _fast_static_block_sizes(_person_df(2000).lazy(), cfg.blocking) is None
 


### PR DESCRIPTION
## What

The zero-config hot-block auto-split (`_auto_split_block`) only fired when `skip_oversized=True`. On the **default** `skip_oversized=False`, `_build_static_blocks` logged an ERROR and scored the oversized block **whole** — so a coarse blocking key produced 10k+ record mega-blocks whose ~100M+ pairs OOM-killed the runner.

Caught by the scale-envelope sweep: the biblio FS lane degenerated to year-only blocking (every year 1965–2024 a ~16k-record block, ~135M pairs each) → runner shutdown. The person 1M lane dies the same way (#1784 *keeps* the common-surname block, which is then a mega-block scored whole).

## Fix

`skip_oversized=False` now attempts the same auto-split first (sub-partition by the highest-cardinality column) — preserving recall AND avoiding the O(n²) OOM — and only processes-anyway when the block is genuinely unsplittable.

- `skip_oversized=True` path is **byte-identical** (untouched branches).
- Guarded so the **adaptive** strategy's configured `sub_block_keys` still win — auto-split doesn't pre-empt them.
- `measure_blocking_profile`'s fast path (`_fast_static_block_sizes`) now bails to the exact loop on **any** oversized block (both `skip_oversized` values sub-split now), keeping its raw group-by sizes byte-identical to `build_blocks`.

## Tests

`test_hot_block_split.py` updated (skip_oversized=False now auto-splits splittable blocks; still processes unsplittable ones whole). `test_measure_blocking_fast_path.py` moves the oversized case to the must-bail set. 136 blocking/pipeline/FS tests green locally, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)