### PR TITLE
chore(release): goldenmatch 3.3.1

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-07-15
+
+### Fixed
+
+- **Linear identity golden-record resolution**: incremental identity resolution
+  now builds each golden record from the row payload index prepared once per
+  batch, rather than filtering the entire input frame once per cluster. This
+  removes the quadratic singleton-heavy archive ingestion path.
+
 ### Added
 
 - **Anomaly diagnostics with prefilled GitHub issue prompts** (in-tree:

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.3.0"
+__version__ = "3.3.1"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.3.0"
+version = "3.3.1"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Summary: release Goldenmatch 3.3.1 with linear identity golden-record resolution. This removes the per-cluster full-frame scan that stalls singleton-heavy incremental batches. Test plan: pytest tests/identity/test_resolve.py --tb=short -q (16 passed); ruff check goldenmatch/identity/resolve.py tests/identity/test_resolve.py.