### PR TITLE
fix(pipeline): skip build_blocks on the preloaded-model FS bucket route (#1798)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -2586,9 +2586,34 @@ def _run_dedupe_pipeline(
             if config.blocking is None:
                 continue
             from goldenmatch.core.blocker import collect_blocking_fields
-            from goldenmatch.core.probabilistic import load_or_train_em, probabilistic_block_scorer
+            from goldenmatch.core.probabilistic import (
+                fs_model_preloaded,
+                load_or_train_em,
+                probabilistic_block_scorer,
+            )
+            # Resolve the bucket route BEFORE building blocks: the blocks feed
+            # (a) EM training — skipped when the model is preloaded from
+            # mk.model_path, (b) the legacy per-block scorer — skipped on the
+            # bucket route (score_buckets partitions internally, memory-
+            # bounded), and (c) the opt-in bench dump. When all three are out
+            # of play, skip build_blocks entirely: at 14M rows its
+            # partition_by materializes millions of tiny eager frames (the
+            # dataset duplicated per blocking pass) and SIGKILLed the runner
+            # BEFORE scoring ever started — issue #1798.
+            _fs_use_bucket = _use_bucket_scorer(
+                config, collected_df
+            ) or _fs_default_bucket(config, mk)
+            _fs_need_blocks = (
+                bool(_bench_dump_dir)
+                or not _fs_use_bucket
+                or not fs_model_preloaded(mk)
+            )
             # Build blocks first, then train EM on within-block pairs
-            blocks = build_blocks(combined_lf, config.blocking)
+            blocks = (
+                build_blocks(combined_lf, config.blocking)
+                if _fs_need_blocks
+                else []
+            )
             # Collect from keys AND passes (multi_pass puts keys in `.passes`).
             blocking_fields = collect_blocking_fields(config.blocking) if config.blocking else []
             # Reuses mk.model_path when set (Splink-style train-once), else trains.
@@ -2608,10 +2633,13 @@ def _run_dedupe_pipeline(
             # (parity asserted in scripts/bench_fs_and_stages.py). EM still
             # samples within-block pairs above; at true scale pair train-once via
             # mk.model_path so EM is skipped on reuse.
-            if _use_bucket_scorer(config, collected_df) or _fs_default_bucket(
-                config, mk
-            ):
+            if _fs_use_bucket:
                 from goldenmatch.backends.score_buckets import score_buckets
+                # Free EM's training blocks before the bucket partition builds
+                # (score_buckets repartitions internally; the bench dump below
+                # is the only remaining reader).
+                if not _bench_dump_dir:
+                    blocks = []
                 pairs = score_buckets(
                     collected_df,
                     config.blocking,
@@ -4073,10 +4101,21 @@ def _run_match_pipeline(
                 continue
             from goldenmatch.core.blocker import collect_blocking_fields
             from goldenmatch.core.probabilistic import (
+                fs_model_preloaded,
                 load_or_train_em,
                 score_probabilistic_blocks_batched,
             )
-            blocks = build_blocks(combined_lf, config.blocking)
+            # Bucket route + preloaded model -> blocks are never read (EM is
+            # skipped and score_buckets partitions internally); skip the
+            # full-frame block materialization that OOM'd at 14M (#1798).
+            _fs_use_bucket = config.backend == "bucket" or _fs_default_bucket(
+                config, mk
+            )
+            blocks = (
+                []
+                if _fs_use_bucket and fs_model_preloaded(mk)
+                else build_blocks(combined_lf, config.blocking)
+            )
             # Collect from keys AND passes (multi_pass puts keys in `.passes`).
             blocking_fields = collect_blocking_fields(config.blocking) if config.blocking else []
             # Reuses mk.model_path when set (Splink-style train-once), else trains.
@@ -4088,8 +4127,10 @@ def _run_match_pipeline(
             # Default-route FS to the memory-bounded bucket scorer when the
             # native FS kernel is available (issue #1792) or backend='bucket'
             # is explicit; else the per-block batched scorer (legacy default).
-            if config.backend == "bucket" or _fs_default_bucket(config, mk):
+            if _fs_use_bucket:
                 from goldenmatch.backends.score_buckets import score_buckets
+                # Free EM's training blocks before the bucket partition builds.
+                blocks = []
                 pairs = score_buckets(
                     combined_df,
                     config.blocking,
@@ -4299,10 +4340,21 @@ def _run_match_scoring_and_output(
                 continue
             from goldenmatch.core.blocker import collect_blocking_fields
             from goldenmatch.core.probabilistic import (
+                fs_model_preloaded,
                 load_or_train_em,
                 score_probabilistic_blocks_batched,
             )
-            blocks = build_blocks(combined_frame, config.blocking)
+            # Bucket route + preloaded model -> blocks are never read (EM is
+            # skipped and score_buckets partitions internally); skip the
+            # full-frame block materialization that OOM'd at 14M (#1798).
+            _fs_use_bucket = config.backend == "bucket" or _fs_default_bucket(
+                config, mk
+            )
+            blocks = (
+                []
+                if _fs_use_bucket and fs_model_preloaded(mk)
+                else build_blocks(combined_frame, config.blocking)
+            )
             blocking_fields = (
                 collect_blocking_fields(config.blocking) if config.blocking else []
             )
@@ -4313,8 +4365,10 @@ def _run_match_scoring_and_output(
             # native FS kernel is available (issue #1792) or backend='bucket'
             # is explicit; else the per-block batched scorer (legacy default).
             # score_buckets is dual-rep -- the pa.Table native passes through.
-            if config.backend == "bucket" or _fs_default_bucket(config, mk):
+            if _fs_use_bucket:
                 from goldenmatch.backends.score_buckets import score_buckets
+                # Free EM's training blocks before the bucket partition builds.
+                blocks = []
                 pairs = score_buckets(
                     combined_native,
                     config.blocking,

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -899,6 +899,20 @@ def train_em(
     )
 
 
+def fs_model_preloaded(mk: MatchkeyConfig) -> bool:
+    """True when :func:`load_or_train_em` will load ``mk.model_path`` from
+    disk and skip EM training entirely (same check it performs internally).
+
+    Callers use this to avoid building the within-block training pairs that
+    only EM consumes: at scale ``build_blocks``'s partition materializes
+    millions of tiny eager frames (the dataset duplicated per blocking pass),
+    which SIGKILLed a 14M-row FS dedupe before scoring started even though
+    the loaded-model path never reads them (issue #1798).
+    """
+    path = getattr(mk, "model_path", None)
+    return bool(path and os.path.exists(path))
+
+
 def load_or_train_em(
     df: pl.DataFrame,
     mk: MatchkeyConfig,

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -905,6 +905,107 @@ class TestDedupeWithPersistedModel:
         assert _parts(second) == _parts(baseline)
 
 
+class TestModelReuseSkipsBuildBlocks:
+    """Issue #1798: preloaded FS model + bucket route must skip build_blocks.
+
+    At 14M rows, build_blocks' partition_by materializes millions of tiny
+    eager per-block frames (the whole dataset duplicated per blocking pass)
+    and SIGKILLed the runner BEFORE scoring started. On the train-once/reuse
+    path those blocks are thrown away unused: load_or_train_em loads
+    mk.model_path (EM skipped) and score_buckets partitions internally,
+    memory-bounded. The pipeline must not build them.
+    """
+
+    def _cfg(self, model_path=None, **kwargs):
+        from goldenmatch.config.schemas import (
+            BlockingConfig,
+            BlockingKeyConfig,
+            GoldenMatchConfig,
+        )
+        return GoldenMatchConfig(
+            matchkeys=[_make_probabilistic_mk(model_path=model_path)],
+            blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])]),
+            **kwargs,
+        )
+
+    @staticmethod
+    def _parts(r):
+        return sorted(
+            tuple(sorted(c["members"]))
+            for c in r.clusters.values() if len(c.get("members", [])) > 1
+        )
+
+    def _counting_build_blocks(self, monkeypatch):
+        from goldenmatch.core import pipeline as pipeline_mod
+
+        calls = {"n": 0}
+        real = pipeline_mod.build_blocks
+
+        def _counting(*a, **k):
+            calls["n"] += 1
+            return real(*a, **k)
+
+        monkeypatch.setattr(pipeline_mod, "build_blocks", _counting)
+        return calls
+
+    def test_preloaded_model_bucket_route_skips_build_blocks(
+        self, tmp_path, monkeypatch
+    ):
+        from goldenmatch import dedupe_df
+
+        calls = self._counting_build_blocks(monkeypatch)
+        df = _make_dedupe_df().drop("__row_id__")
+        path = str(tmp_path / "m.json")
+        # First run: no model on disk yet -> EM trains -> blocks ARE built.
+        first = dedupe_df(df, config=self._cfg(path, backend="bucket"))
+        assert (tmp_path / "m.json").exists()
+        assert calls["n"] >= 1
+        n_after_first = calls["n"]
+        # Second run: model preloaded + bucket route -> build_blocks skipped.
+        second = dedupe_df(df, config=self._cfg(path, backend="bucket"))
+        assert calls["n"] == n_after_first, (
+            "build_blocks ran on the preloaded-model bucket route (#1798)"
+        )
+        # Identical output with and without the skip.
+        assert self._parts(second) == self._parts(first)
+
+    def test_legacy_route_still_builds_blocks(self, tmp_path, monkeypatch):
+        # The per-block scorer consumes blocks even when EM is skipped, so a
+        # preloaded model on the LEGACY route must still build them. Force
+        # legacy: kill both bucket defaults (backend=None would otherwise
+        # bucket-route in-band / via native FS).
+        from goldenmatch import dedupe_df
+
+        monkeypatch.setenv("GOLDENMATCH_BUCKET_DEFAULT", "0")
+        monkeypatch.setenv("GOLDENMATCH_FS_DEFAULT_BUCKET", "0")
+        calls = self._counting_build_blocks(monkeypatch)
+        df = _make_dedupe_df().drop("__row_id__")
+        path = str(tmp_path / "m.json")
+        first = dedupe_df(df, config=self._cfg(path))
+        n_after_first = calls["n"]
+        assert n_after_first >= 1
+        second = dedupe_df(df, config=self._cfg(path))
+        assert calls["n"] == 2 * n_after_first  # built again on reuse run
+        assert self._parts(second) == self._parts(first)
+
+    def test_bench_dump_still_builds_blocks(self, tmp_path, monkeypatch):
+        # The opt-in GOLDENMATCH_BENCH_DUMP_PAIRS hook enumerates candidate
+        # pairs from the blocks, so it must keep building them even on the
+        # preloaded-model bucket route.
+        from goldenmatch import dedupe_df
+
+        dump_dir = tmp_path / "dump"
+        dump_dir.mkdir()
+        monkeypatch.setenv("GOLDENMATCH_BENCH_DUMP_PAIRS", str(dump_dir))
+        calls = self._counting_build_blocks(monkeypatch)
+        df = _make_dedupe_df().drop("__row_id__")
+        path = str(tmp_path / "m.json")
+        dedupe_df(df, config=self._cfg(path, backend="bucket"))
+        n_after_first = calls["n"]
+        dedupe_df(df, config=self._cfg(path, backend="bucket"))
+        assert calls["n"] == 2 * n_after_first
+
+
 # ── Supervised m-training (Phase 1b) ───────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #1798: a probabilistic (Fellegi-Sunter) dedupe at 14M rows SIGKILLed ~67s into `dedupe_df`, upstream of scoring, even with #1794 + #1790 confirmed on the code path.

**Root cause.** All three FS pipeline sites (dedupe, match polars-lane, match arrow-lane) ran `build_blocks(combined, config.blocking)` unconditionally BEFORE routing. With tight compound union blocking (`npi`, `email`, `phone+last`, `last+first+zip5`), `partition_by` materializes one eager frame per distinct block key per pass -- millions of tiny frames on near-unique keys, the dataset duplicated per pass, all resident in one list. On the issue's exact config (train-once via `mk.model_path`) those blocks are then never read: `load_or_train_em` loads the persisted model and skips EM, and `score_buckets` re-partitions internally with bounded memory. This also explains why the earlier `backend=\"duckdb\"` attempt OOM'd the same way: that route runs `build_blocks` too.

**Fix.** Resolve the bucket route and model availability first (new `fs_model_preloaded` helper in `probabilistic.py`, the same check `load_or_train_em` performs internally), and only build blocks when at least one consumer needs them:
- EM must train (no model on disk), or
- the legacy per-block scorer will consume them (non-bucket route), or
- the opt-in `GOLDENMATCH_BENCH_DUMP_PAIRS` hook is active (dedupe site).

On the bucket route the EM-training blocks are also dropped before the bucket partition builds, so the trained-first-run peak improves as well.

## Measured

FS matchkey + the issue's 4-key union blocking shape, model preloaded, `backend=bucket` (Windows dev box, memory-constrained):

| Rows | baseline `bdd5071` | fixed |
|---|---|---|
| 500K | **MemoryError** inside `build_blocks` -> `group_partitions` (`pipeline.py:2591`) | 1.32 GB peak / 52.7s |
| 1M | not run | 2.47 GB peak / 102s |

The baseline traceback lands on the exact line this PR gates, and the fixed peak scales near-linearly -- extrapolating to roughly ~35 GB at 14M, inside a 64 GB node. @issue reporter: the offered one-command 14M repro on the 64GB runner would be the definitive end-to-end confirmation.

## Tests

New `TestModelReuseSkipsBuildBlocks` in `tests/test_probabilistic.py` (existing file, no shard shift):
- preloaded model + bucket route -> `build_blocks` NOT called, clusters identical to the trained run
- legacy route (bucket defaults killed) -> blocks still built on reuse
- `GOLDENMATCH_BENCH_DUMP_PAIRS` -> blocks still built on the bucket route

145 related tests green locally (`test_probabilistic`, `test_bucket_default_routing`, `test_probabilistic_bench_dump`, `test_fs_bucket_native`, `test_from_splink_model_import`, `test_bucket_legacy_parity_matrix`, `test_match_arrow_parity`, `test_inhouse_pipeline_integration`, `test_bucket_febrl3_parity`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFxRDxEAhtdd1B6QcPMD