### PR TITLE
perf(native): FS exclude-set Arc handle + zero-copy arrow FS kernel entry (#1803 items 1+2)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -742,6 +742,36 @@ def score_buckets(
         # sizes list). GOLDENMATCH_FS_BUCKET_NATIVE=0 forces the per-block loop.
         fs_bucket_native = _fs_bucket_native_enabled() and _fs_native_eligible(mk)
 
+    # #1803 item 1: build the FS exclude handle ONCE here, before the bucket
+    # worker loop — the FS analog of the weighted path's Track 1 Fix B below.
+    # Without it every bucket call re-marshals frozen_exclude as a Vec and the
+    # kernel rebuilds a Rust HashSet per call (O(buckets x |exclude|), the
+    # #552/#688 pathology). Old wheels (no FS_SUPPORTS_ARROW / _EXCLUDE_SET)
+    # keep the legacy Vec path — _score_fs_native_frame checks the consts and
+    # falls back byte-identically.
+    fs_exclude_handle = None
+    if fs_bucket_native and frozen_exclude:
+        try:
+            _mod = native_module()
+            _fs_build = getattr(_mod, "build_exclude_set", None)
+            if _fs_build is not None and (
+                getattr(_mod, "FS_SUPPORTS_ARROW", False)
+                or getattr(_mod, "FS_SUPPORTS_EXCLUDE_SET", False)
+            ):
+                _t_feb = time.perf_counter()
+                fs_exclude_handle = _fs_build(list(frozen_exclude))
+                if _bkt_debug_on():
+                    print(
+                        f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: "
+                        f"fs build_exclude_set({len(frozen_exclude)} pairs) in "
+                        f"{time.perf_counter()-_t_feb:.2f}s",
+                        flush=True,
+                    )
+            else:
+                _warn_stale_native_wheel_once(len(frozen_exclude))
+        except Exception:
+            fs_exclude_handle = None
+
     # Native fast-path eligibility resolved ONCE: gated on, and every field's
     # scorer implemented by the native kernel. None -> Python per-pair loop.
     # When NE has resolvable entries, force the Python path -- the native
@@ -1100,7 +1130,8 @@ def score_buckets(
             )
 
             pairs = score_probabilistic_bucket_native(
-                fs_sorted_df, kept_size_list, mk, em_result, frozen_exclude
+                fs_sorted_df, kept_size_list, mk, em_result, frozen_exclude,
+                exclude_handle=fs_exclude_handle,
             )
             # Same post-filters as the per-block loop below (the native kernel
             # doesn't know about source_lookup / target_ids).

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -2329,12 +2329,44 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
         return False
 
 
+def _fs_arrow_column(native_df, f, n: int):
+    """Arrow column of transformed values for one field (#1803 item 2).
+
+    Zero-copy when the column is already utf8/large_utf8 AND the field has no
+    transforms (``str(v)`` on a string is the identity, so the raw arrow
+    buffer IS the Vec entry's value list). Otherwise materialize exactly the
+    values the Vec entry would receive (``_field_values_from_list``) into one
+    arrow array — still one C-level build instead of the per-element PyO3
+    ``Vec<Vec<Option<String>>>`` clone. Byte-identical either way.
+    """
+    import pyarrow as _pa
+
+    from goldenmatch.core.frame import is_polars_dataframe as _ipd
+    from goldenmatch.core.frame import to_frame as _tf
+
+    _bf = _tf(native_df)
+    if f.field not in _bf.columns:
+        return _pa.nulls(n, type=_pa.large_string())
+    native = _bf.native
+    if _ipd(native):
+        arr = native[f.field].to_arrow()
+    else:  # pa.Table lane
+        arr = native.column(f.field).combine_chunks()
+    if not f.transforms and (
+        _pa.types.is_string(arr.type) or _pa.types.is_large_string(arr.type)
+    ):
+        return arr
+    vals = _field_values_from_list(_bf.column(f.field).to_list(), f, n)
+    return _pa.array(vals, type=_pa.large_string())
+
+
 def _score_fs_native_frame(
     frame,
     size_list,
     mk: MatchkeyConfig,
     em_result: EMResult,
     exclude_pairs: set[tuple[int, int]] | None = None,
+    exclude_handle=None,
 ) -> list[tuple[int, int, float]]:
     """Shared native FS kernel call over ``frame`` with per-block ``size_list``.
 
@@ -2377,13 +2409,27 @@ def _score_fs_native_frame(
     else:
         link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
 
-    field_values = [_field_values_for_block(frame, f, n) for f in mk.fields]
+    mod = native_module()
+    # Zero-copy arrow entry (#1803 item 2): route to score_block_pairs_fs_arrow
+    # when the wheel carries it; old wheels keep the Vec entry byte-identically.
+    use_arrow = bool(getattr(mod, "FS_SUPPORTS_ARROW", False))
     scorer_ids = [_NATIVE_FS_SCORER_IDS[f.scorer] for f in mk.fields]
     levels = [int(f.levels) for f in mk.fields]
     partials = [float(f.partial_threshold) for f in mk.fields]
     weights = [[float(w) for w in em_result.match_weights[f.field]] for f in mk.fields]
-    # Kernel canonicalizes pair_key to (min,max); pass exclude pre-canonicalized.
-    excl = [(a, b) if a < b else (b, a) for a, b in exclude_pairs]
+    # Shared exclude handle (#1803 item 1, the #552/#688 fix on the FS side):
+    # when the caller prebuilt an ExcludeSet (score_buckets, once per call),
+    # skip the per-call canonicalize + marshal entirely. Handle only usable
+    # when the wheel supports it (arrow entry always does; the Vec entry needs
+    # FS_SUPPORTS_EXCLUDE_SET); otherwise fall back to the Vec contract.
+    use_handle = exclude_handle is not None and (
+        use_arrow or bool(getattr(mod, "FS_SUPPORTS_EXCLUDE_SET", False))
+    )
+    if use_handle:
+        excl: list[tuple[int, int]] = []
+    else:
+        # Kernel canonicalizes pair_key to (min,max); pass pre-canonicalized.
+        excl = [(a, b) if a < b else (b, a) for a, b in exclude_pairs]
 
     # Optional capability kwargs. Each group is sent ONLY when the matchkey
     # actually uses the feature — an old wheel must NEVER see the kwarg, even
@@ -2408,9 +2454,14 @@ def _score_fs_native_frame(
     # matches the scalar path's contract; validate_for guarantees it exists).
     ne_fields = mk.negative_evidence or []
     if ne_fields:
-        opt_kwargs["ne_values"] = [
-            _field_values_for_block(frame, ne, n) for ne in ne_fields
-        ]
+        if use_arrow:
+            opt_kwargs["ne_arrays"] = [
+                _fs_arrow_column(frame, ne, n) for ne in ne_fields
+            ]
+        else:
+            opt_kwargs["ne_values"] = [
+                _field_values_for_block(frame, ne, n) for ne in ne_fields
+            ]
         opt_kwargs["ne_scorer_ids"] = [
             _NATIVE_FS_SCORER_IDS[ne.scorer] for ne in ne_fields
         ]
@@ -2421,7 +2472,36 @@ def _score_fs_native_frame(
             for ne in ne_fields
         ]
 
-    pairs = native_module().score_block_pairs_fs(
+    if use_arrow:
+        import pyarrow as _pa
+
+        from goldenmatch.core.frame import is_polars_dataframe as _ipd
+
+        native_df = _tf_w6(frame).native
+        if _ipd(native_df):
+            row_ids_arrow = native_df["__row_id__"].cast(pl.Int64).to_arrow()
+        else:  # pa.Table lane: combine chunks for the FFI
+            import pyarrow.compute as _pc
+
+            row_ids_arrow = _pc.cast(
+                native_df.column("__row_id__").combine_chunks(), _pa.int64()
+            )
+        field_arrays = [_fs_arrow_column(frame, f, n) for f in mk.fields]
+        if use_handle:
+            opt_kwargs["exclude_set"] = exclude_handle
+        pairs = mod.score_block_pairs_fs_arrow(
+            row_ids_arrow, field_arrays, [int(s) for s in size_list],
+            scorer_ids, levels, partials, weights, calibrated, prior_w,
+            min_weight, weight_range, link_threshold,
+            exclude=excl if excl else None,
+            **opt_kwargs,
+        )
+        return [(a, b, round(float(s), 4)) for a, b, s in pairs]
+
+    field_values = [_field_values_for_block(frame, f, n) for f in mk.fields]
+    if use_handle:
+        opt_kwargs["exclude_set"] = exclude_handle
+    pairs = mod.score_block_pairs_fs(
         row_ids, [int(s) for s in size_list], field_values, scorer_ids, levels,
         partials, weights, calibrated, prior_w, min_weight, weight_range,
         link_threshold, excl,
@@ -2460,6 +2540,7 @@ def score_probabilistic_bucket_native(
     mk: MatchkeyConfig,
     em_result: EMResult,
     exclude_pairs: set[tuple[int, int]] | None = None,
+    exclude_handle=None,
 ) -> list[tuple[int, int, float]]:
     """Score a WHOLE block-sorted bucket in ONE native FS kernel call.
 
@@ -2483,7 +2564,8 @@ def score_probabilistic_bucket_native(
     ``tests/test_fs_bucket_native.py``.
     """
     return _score_fs_native_frame(
-        sorted_bucket_df, size_list, mk, em_result, exclude_pairs
+        sorted_bucket_df, size_list, mk, em_result, exclude_pairs,
+        exclude_handle=exclude_handle,
     )
 
 

--- a/packages/python/goldenmatch/tests/test_fs_bucket_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_native.py
@@ -253,6 +253,34 @@ def test_fs_default_bucket_decision(monkeypatch):
 
 
 @native_required
+def test_score_buckets_exclude_handle_parity(monkeypatch):
+    """#1803 item 1: score_buckets with a non-empty exclude set must produce
+    identical FS pairs on the batched-native path (which now builds the shared
+    ExcludeSet handle once at entry) and the per-block path
+    (GOLDENMATCH_FS_BUCKET_NATIVE=0), and both must drop the excluded pair."""
+    from goldenmatch.backends.score_buckets import score_buckets
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+
+    df = _multiblock_df()
+    mk = _mk()
+    em = train_em(df, mk, n_sample_pairs=200)
+    blocking = BlockingConfig(keys=[BlockingKeyConfig(fields=["grp"])])
+
+    def _run():
+        matched = {(1, 2)}  # pre-matched pair: must be excluded from FS emit
+        pairs = score_buckets(df, blocking, mk, matched, em_result=em)
+        return _pairset(pairs)
+
+    monkeypatch.delenv("GOLDENMATCH_FS_BUCKET_NATIVE", raising=False)
+    native_batched = _run()
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", "0")
+    per_block = _run()
+
+    assert native_batched == per_block
+    assert (1, 2) not in native_batched
+
+
+@native_required
 def test_routing_backend_none_uses_bucket_when_native(monkeypatch):
     """With _use_bucket_scorer killed (GOLDENMATCH_BUCKET_DEFAULT=0), a
     backend=None FS matchkey still reaches score_buckets purely via

--- a/packages/python/goldenmatch/tests/test_native_fs_ne.py
+++ b/packages/python/goldenmatch/tests/test_native_fs_ne.py
@@ -79,6 +79,137 @@ def test_kernel_exports_fs_supports_ne():
     assert getattr(mod, "FS_SUPPORTS_NE", False) is True
 
 
+# ── #1803: zero-copy arrow FS entry + shared exclude handle ────────────────
+
+
+def _arrow_args():
+    """The _base_args fixture with row_ids/field columns as arrow arrays,
+    in score_block_pairs_fs_arrow's argument order."""
+    (row_ids, sizes, field_values, scorer_ids, levels, partials, weights,
+     calibrated, prior_w, min_w, w_range, threshold, _excl) = _base_args()
+    return (
+        pa.array(row_ids, type=pa.int64()),
+        [pa.array(v, type=pa.large_string()) for v in field_values],
+        sizes, scorer_ids, levels, partials, weights,
+        calibrated, prior_w, min_w, w_range, threshold,
+    )
+
+
+def test_kernel_exports_fs_arrow_and_exclude_consts():
+    mod = _native_loader.native_module()
+    assert getattr(mod, "FS_SUPPORTS_ARROW", False) is True
+    assert getattr(mod, "FS_SUPPORTS_EXCLUDE_SET", False) is True
+
+
+def test_fs_arrow_entry_matches_vec_entry():
+    mod = _native_loader.native_module()
+    vec = mod.score_block_pairs_fs(*_base_args())
+    arrow = mod.score_block_pairs_fs_arrow(*_arrow_args())
+    assert arrow == vec
+
+
+def test_fs_arrow_entry_matches_vec_entry_ne():
+    mod = _native_loader.native_module()
+    ne_kw = dict(ne_scorer_ids=[_EXACT], ne_thresholds=[0.5], ne_weights=[-4.0])
+    vec = mod.score_block_pairs_fs(
+        *_base_args(), ne_values=[["X", "X", "Y"]], **ne_kw
+    )
+    arrow = mod.score_block_pairs_fs_arrow(
+        *_arrow_args(),
+        ne_arrays=[pa.array(["X", "X", "Y"], type=pa.large_string())],
+        **ne_kw,
+    )
+    assert arrow == vec
+    # Null / empty-string NE values contribute exactly 0 on both entries.
+    vec2 = mod.score_block_pairs_fs(
+        *_base_args(), ne_values=[[None, "X", ""]], **ne_kw
+    )
+    arrow2 = mod.score_block_pairs_fs_arrow(
+        *_arrow_args(),
+        ne_arrays=[pa.array([None, "X", ""], type=pa.large_string())],
+        **ne_kw,
+    )
+    assert arrow2 == vec2
+
+
+def test_fs_arrow_entry_matches_vec_entry_level_thresholds():
+    mod = _native_loader.native_module()
+    # 3-weight field with custom 2-threshold banding.
+    (row_ids, sizes, _fv, scorer_ids, levels, partials, _w,
+     calibrated, prior_w, _minw, _range, threshold, excl) = _base_args()
+    field_values = [["smith", "smyth", "jones"]]
+    weights = [[-2.0, 0.5, 2.0]]
+    lt = [[0.7, 0.95]]
+    vec = mod.score_block_pairs_fs(
+        row_ids, sizes, field_values, [0], levels, partials, weights,
+        calibrated, prior_w, -2.0, 4.0, threshold, excl,
+        level_thresholds=lt,
+    )
+    arrow = mod.score_block_pairs_fs_arrow(
+        pa.array(row_ids, type=pa.int64()),
+        [pa.array(v, type=pa.large_string()) for v in field_values],
+        sizes, [0], levels, partials, weights,
+        calibrated, prior_w, -2.0, 4.0, threshold,
+        level_thresholds=lt,
+    )
+    assert arrow == vec
+
+
+def test_fs_exclude_handle_parity_both_entries():
+    mod = _native_loader.native_module()
+    handle = mod.build_exclude_set([(2, 1)])  # canonicalized to (1, 2)
+    base = _base_args()
+    vec_list = mod.score_block_pairs_fs(*base[:-1], [(1, 2)])
+    vec_handle = mod.score_block_pairs_fs(*base, exclude_set=handle)
+    arrow_handle = mod.score_block_pairs_fs_arrow(*_arrow_args(), exclude_set=handle)
+    assert vec_handle == vec_list
+    assert arrow_handle == vec_list
+    assert (1, 2) not in {(a, b) for a, b, _ in vec_handle}
+
+
+class _FakeNativeRecorder:
+    """Duck-typed native module recording which FS entry was called."""
+
+    def __init__(self, consts: dict, result=None):
+        self._consts = consts
+        self.calls: list[tuple[str, dict]] = []
+        self._result = result if result is not None else []
+
+    def __getattr__(self, name):
+        if name in self._consts:
+            return self._consts[name]
+        raise AttributeError(name)
+
+    def score_block_pairs_fs(self, *a, **kw):
+        self.calls.append(("vec", kw))
+        return list(self._result)
+
+    def score_block_pairs_fs_arrow(self, *a, **kw):
+        self.calls.append(("arrow", kw))
+        return list(self._result)
+
+
+def test_score_fs_native_frame_routes_to_arrow(monkeypatch):
+    from goldenmatch.core import probabilistic as p
+
+    fake = _FakeNativeRecorder({"FS_SUPPORTS_ARROW": True, "FS_SUPPORTS_EXCLUDE_SET": True})
+    monkeypatch.setattr(_native_loader, "native_module", lambda: fake)
+    df = _block_df()
+    p._score_fs_native_frame(df, [df.height], _ne_mk([]), _em(_BASE_WEIGHTS), set())
+    assert [c[0] for c in fake.calls] == ["arrow"]
+
+
+def test_score_fs_native_frame_old_wheel_uses_vec(monkeypatch):
+    from goldenmatch.core import probabilistic as p
+
+    fake = _FakeNativeRecorder({})  # neither const -> legacy vec entry
+    monkeypatch.setattr(_native_loader, "native_module", lambda: fake)
+    df = _block_df()
+    p._score_fs_native_frame(df, [df.height], _ne_mk([]), _em(_BASE_WEIGHTS), {(1, 2)})
+    assert [c[0] for c in fake.calls] == ["vec"]
+    assert "exclude_set" not in fake.calls[0][1]  # old wheel never sees the kwarg
+
+
 def test_kernel_ne_fires_strictly_below_threshold():
     mod = _native_loader.native_module()
     # Rows 1/2 share the NE value (sim 1.0 >= 0.5 -> no fire); rows 1/3 and
@@ -269,6 +400,11 @@ def test_native_kwargs_not_sent_without_ne(monkeypatch):
             captured["kwargs"] = dict(kwargs)
             return real.score_block_pairs_fs(*args, **kwargs)
 
+        def score_block_pairs_fs_arrow(self, *args, **kwargs):
+            # New wheels route here (#1803); same no-NE-kwargs discipline.
+            captured["kwargs"] = dict(kwargs)
+            return real.score_block_pairs_fs_arrow(*args, **kwargs)
+
     monkeypatch.setattr(_native_loader, "native_module", lambda: _Spy())
 
     mk = MatchkeyConfig(name="fs", type="probabilistic", fields=_base_fields(), link_threshold=0.0)
@@ -276,6 +412,7 @@ def test_native_kwargs_not_sent_without_ne(monkeypatch):
     pairs = score_probabilistic_native(df, mk, _em(_BASE_WEIGHTS))
     assert pairs, "expected pairs at link_threshold=0.0"
     assert "kwargs" in captured, "spy never saw the kernel call"
+    assert "ne_arrays" not in captured["kwargs"]
     assert "ne_values" not in captured["kwargs"]
     assert "ne_scorer_ids" not in captured["kwargs"]
     assert "ne_thresholds" not in captured["kwargs"]

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.15"
+version = "0.1.16"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.15"
+    __version__ = "0.1.16"

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -36,6 +36,14 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Wheel-skew capability flag: Python's `match_fused_fs_ready` gates custom
     // level_thresholds on this (old wheels never see the kwarg).
     m.add("FUSED_FS_SUPPORTS_LEVEL_THRESHOLDS", true)?;
+    // Wheel-skew capability flag: `score_block_pairs_fs` accepts the shared
+    // `exclude_set=` Arc handle (the #552/#688 fix, FS side). Old wheels keep
+    // the legacy Vec-per-call path (#1803).
+    m.add("FS_SUPPORTS_EXCLUDE_SET", true)?;
+    // Wheel-skew capability flag: the zero-copy `score_block_pairs_fs_arrow`
+    // entry exists. Python's `_score_fs_native_frame` routes to it when set;
+    // old wheels keep the Vec entry (#1803).
+    m.add("FS_SUPPORTS_ARROW", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;
@@ -59,6 +67,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::token_sort_ratio, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
+    m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_arrow, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_field_matrix, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_field_pairwise, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -283,6 +283,7 @@ pub(crate) fn fs_level_from_sim(
     match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
     exclude, level_thresholds=None,
     ne_values=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
+    exclude_set=None,
 ))]
 pub fn score_block_pairs_fs(
     py: Python<'_>,
@@ -304,8 +305,21 @@ pub fn score_block_pairs_fs(
     ne_scorer_ids: Option<Vec<u8>>,
     ne_thresholds: Option<Vec<f64>>,
     ne_weights: Option<Vec<f64>>,
+    exclude_set: Option<PyRef<'_, ExcludeSet>>,
 ) -> PyResult<Vec<(i64, i64, f64)>> {
-    let exclude: HashSet<(i64, i64)> = exclude.into_iter().collect();
+    // FS_SUPPORTS_EXCLUDE_SET: prefer the shared Arc handle (built once per
+    // score_buckets call via `build_exclude_set`), fall back to the legacy
+    // Vec-rebuilt-per-call path. Same resolution as score_block_pairs_arrow --
+    // the per-call HashSet rebuild was the #552/#688 pathology, previously
+    // fixed for weighted only.
+    let local_set: HashSet<(i64, i64)>;
+    let exclude: &HashSet<(i64, i64)> = match &exclude_set {
+        Some(handle) => &handle.set,
+        None => {
+            local_set = exclude.into_iter().collect();
+            &local_set
+        }
+    };
     let n_fields = scorer_ids.len();
 
     if let Some(lt) = &level_thresholds {
@@ -632,6 +646,261 @@ pub fn score_block_pairs_arrow(
     // large value = always sequential). Both paths walk spans in order, so the
     // emitted (min,max) pair sequence is byte-identical either way (parity
     // asserted in tests/test_native_block_seq_parity.py).
+    let total_pairs: u128 = block_sizes
+        .iter()
+        .map(|&s| {
+            let s = s as u128;
+            if s >= 2 {
+                s * (s - 1) / 2
+            } else {
+                0
+            }
+        })
+        .sum();
+    let rayon_min_pairs: u128 = std::env::var("GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(20_000_000);
+
+    Ok(py.detach(|| {
+        if total_pairs >= rayon_min_pairs {
+            spans
+                .par_iter()
+                .flat_map_iter(|&(offset, size)| score_span(offset, size))
+                .collect()
+        } else {
+            spans
+                .iter()
+                .flat_map(|&(offset, size)| score_span(offset, size))
+                .collect()
+        }
+    }))
+}
+
+/// Arrow-native sibling of [`score_block_pairs_fs`]: identical Fellegi-Sunter
+/// scoring (levels / custom `level_thresholds` banding / negative evidence /
+/// `fs_normalize`), but `row_ids` (Int64) and the field/NE columns
+/// (Utf8/LargeUtf8) are read zero-copy from Arrow buffers via the C Data
+/// Interface — skipping the per-element `.to_list()` materialization + PyO3
+/// `Vec<Vec<Option<String>>>` clone the Vec entry pays (the same win
+/// `score_block_pairs_arrow` gave the weighted path, ~58% of native wall at
+/// 1M rows). Also takes the shared [`ExcludeSet`] handle and the issue #688
+/// sequential-vs-rayon dispatch gate, both of which the Vec entry historically
+/// lacked. Byte-identical output to the Vec entry for the same inputs (parity
+/// asserted in tests/test_native_fs_ne.py).
+#[allow(clippy::too_many_arguments)]
+#[pyfunction]
+#[pyo3(signature = (
+    row_ids, field_arrays, block_sizes, scorer_ids, levels, partial_thresholds,
+    match_weights, calibrated, prior_w, min_weight, weight_range, threshold,
+    exclude=None, exclude_set=None, level_thresholds=None,
+    ne_arrays=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
+))]
+pub fn score_block_pairs_fs_arrow(
+    py: Python<'_>,
+    row_ids: PyArrowType<ArrayData>,
+    field_arrays: Vec<PyArrowType<ArrayData>>,
+    block_sizes: Vec<usize>,
+    scorer_ids: Vec<u8>,
+    levels: Vec<u8>,
+    partial_thresholds: Vec<f64>,
+    match_weights: Vec<Vec<f64>>,
+    calibrated: bool,
+    prior_w: f64,
+    min_weight: f64,
+    weight_range: f64,
+    threshold: f64,
+    exclude: Option<Vec<(i64, i64)>>,
+    exclude_set: Option<PyRef<'_, ExcludeSet>>,
+    level_thresholds: Option<Vec<Option<Vec<f64>>>>,
+    ne_arrays: Option<Vec<PyArrowType<ArrayData>>>,
+    ne_scorer_ids: Option<Vec<u8>>,
+    ne_thresholds: Option<Vec<f64>>,
+    ne_weights: Option<Vec<f64>>,
+) -> PyResult<Vec<(i64, i64, f64)>> {
+    let row_data = row_ids.0;
+    if row_data.data_type() != &DataType::Int64 {
+        return Err(PyValueError::new_err(format!(
+            "score_block_pairs_fs_arrow: row_ids must be int64, got {:?}",
+            row_data.data_type()
+        )));
+    }
+    let row_ids = Int64Array::from(row_data);
+    let fields: Vec<StrCol> = field_arrays
+        .into_iter()
+        .map(|p| StrCol::from_data(p.0))
+        .collect::<PyResult<_>>()?;
+    let n_rows = row_ids.len();
+    let n_fields = scorer_ids.len();
+    for (f, col) in fields.iter().enumerate() {
+        if col.len() != n_rows {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs_arrow: field {f} length {} != row count {n_rows}",
+                col.len()
+            )));
+        }
+    }
+
+    // Custom-banding validation, verbatim from score_block_pairs_fs.
+    if let Some(lt) = &level_thresholds {
+        if lt.len() != n_fields {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs_arrow: level_thresholds length {} != field count {n_fields}",
+                lt.len()
+            )));
+        }
+        for (f, ts) in lt.iter().enumerate() {
+            if let Some(ts) = ts {
+                if match_weights[f].len() != ts.len() + 1 {
+                    return Err(PyValueError::new_err(format!(
+                        "score_block_pairs_fs_arrow: field {f} has {} match_weights but \
+                         {} level_thresholds (need thresholds + 1 weights)",
+                        match_weights[f].len(),
+                        ts.len()
+                    )));
+                }
+            }
+        }
+    }
+    let field_thresholds: Vec<Option<&[f64]>> = match &level_thresholds {
+        Some(lt) => lt.iter().map(|ts| ts.as_deref()).collect(),
+        None => vec![None; n_fields],
+    };
+
+    // Negative-evidence kwargs: all four present or all four absent
+    // (score_block_pairs_fs contract, arrow column type).
+    let n_present = [
+        ne_arrays.is_some(),
+        ne_scorer_ids.is_some(),
+        ne_thresholds.is_some(),
+        ne_weights.is_some(),
+    ]
+    .iter()
+    .filter(|&&p| p)
+    .count();
+    if n_present != 0 && n_present != 4 {
+        return Err(PyValueError::new_err(
+            "score_block_pairs_fs_arrow: ne_arrays, ne_scorer_ids, ne_thresholds \
+             and ne_weights must be passed together (all four or none)",
+        ));
+    }
+    let ne_cols: Vec<StrCol> = match ne_arrays {
+        Some(arrays) => arrays
+            .into_iter()
+            .map(|p| StrCol::from_data(p.0))
+            .collect::<PyResult<_>>()?,
+        None => Vec::new(),
+    };
+    let ne_scorer_ids_v: &[u8] = ne_scorer_ids.as_deref().unwrap_or(&[]);
+    let ne_thresholds_v: &[f64] = ne_thresholds.as_deref().unwrap_or(&[]);
+    let ne_weights_v: &[f64] = ne_weights.as_deref().unwrap_or(&[]);
+    let n_ne = ne_cols.len();
+    if ne_scorer_ids_v.len() != n_ne || ne_thresholds_v.len() != n_ne || ne_weights_v.len() != n_ne
+    {
+        return Err(PyValueError::new_err(format!(
+            "score_block_pairs_fs_arrow: ne_* lengths differ (ne_arrays {}, \
+             ne_scorer_ids {}, ne_thresholds {}, ne_weights {})",
+            n_ne,
+            ne_scorer_ids_v.len(),
+            ne_thresholds_v.len(),
+            ne_weights_v.len()
+        )));
+    }
+    for (k, col) in ne_cols.iter().enumerate() {
+        if col.len() != n_rows {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs_arrow: ne_arrays[{k}] length {} != row count {n_rows}",
+                col.len()
+            )));
+        }
+    }
+    for (k, &sid) in ne_scorer_ids_v.iter().enumerate() {
+        if sid > 3 {
+            return Err(PyValueError::new_err(format!(
+                "score_block_pairs_fs_arrow: ne_scorer_ids[{k}]={sid} out of range (valid: 0..=3)"
+            )));
+        }
+    }
+
+    // Exclude resolution: shared Arc handle preferred, legacy Vec fallback
+    // (same as score_block_pairs_arrow).
+    let local_set: HashSet<(i64, i64)>;
+    let exclude_ref: &HashSet<(i64, i64)> = match (&exclude_set, exclude) {
+        (Some(handle), _) => &handle.set,
+        (None, Some(v)) => {
+            local_set = v.into_iter().collect();
+            &local_set
+        }
+        (None, None) => {
+            local_set = HashSet::new();
+            &local_set
+        }
+    };
+
+    let mut spans: Vec<(usize, usize)> = Vec::with_capacity(block_sizes.len());
+    let mut offset = 0usize;
+    for &size in &block_sizes {
+        spans.push((offset, size));
+        offset += size;
+    }
+
+    // Per-block FS scorer shared by the sequential and rayon paths (mirrors
+    // score_block_pairs_arrow's score_span; FS math verbatim from
+    // score_block_pairs_fs, including the `_ne_fired` strict-< semantics).
+    let score_span = |offset: usize, size: usize| -> Vec<(i64, i64, f64)> {
+        let mut local: Vec<(i64, i64, f64)> = Vec::new();
+        if size >= 2 {
+            let end = offset + size;
+            for i in offset..end - 1 {
+                let ri = row_ids.value(i);
+                for j in (i + 1)..end {
+                    let rj = row_ids.value(j);
+                    let pair_key = if ri < rj { (ri, rj) } else { (rj, ri) };
+                    if exclude_ref.contains(&pair_key) {
+                        continue;
+                    }
+                    let mut total_weight = 0.0_f64;
+                    for f in 0..n_fields {
+                        let level = match (fields[f].get(i), fields[f].get(j)) {
+                            (Some(a), Some(b)) => {
+                                let sim = score_one(scorer_ids[f], a, b);
+                                fs_level_from_sim(
+                                    sim,
+                                    levels[f],
+                                    partial_thresholds[f],
+                                    field_thresholds[f],
+                                )
+                            }
+                            // Null on either side -> disagree (level 0).
+                            _ => 0,
+                        };
+                        total_weight += match_weights[f][level];
+                    }
+                    for k in 0..n_ne {
+                        if let (Some(a), Some(b)) = (ne_cols[k].get(i), ne_cols[k].get(j)) {
+                            if !a.is_empty()
+                                && !b.is_empty()
+                                && score_one(ne_scorer_ids_v[k], a, b) < ne_thresholds_v[k]
+                            {
+                                total_weight += ne_weights_v[k];
+                            }
+                        }
+                    }
+                    let normalized =
+                        fs_normalize(total_weight, calibrated, prior_w, min_weight, weight_range);
+                    if normalized >= threshold {
+                        local.push((pair_key.0, pair_key.1, normalized));
+                    }
+                }
+            }
+        }
+        local
+    };
+
+    // Issue #688 dispatch gate (see score_block_pairs_arrow): score in the
+    // calling thread unless a single call carries enough intra-call work that
+    // rayon's dispatch beats the LockLatch-park risk. Both paths walk spans in
+    // order, so the emitted (min,max) sequence is byte-identical either way.
     let total_pairs: u128 = block_sizes
         .iter()
         .map(|&s| {


### PR DESCRIPTION
Second PR of epic #1803 (plan: docs/superpowers/plans/2026-07-15-fs-scale-parity-1803.md, riding PR #1806).

**Item 1 -- exclude handle:** the FS bucket-native lane passed `frozen_exclude` as a raw Vec into `score_block_pairs_fs`, which rebuilt a Rust HashSet on EVERY bucket call (the #552/#688 pathology, fixed for weighted in `score_block_pairs_arrow` but never for FS). `score_buckets` now builds the `ExcludeSet` Arc handle once at entry and threads it through; `score_block_pairs_fs` accepts a backward-compatible `exclude_set=` kwarg.

**Item 2 -- zero-copy arrow entry:** new `score_block_pairs_fs_arrow` reads row_ids + field/NE columns from Arrow buffers via the C Data Interface (transform-free utf8 columns pass zero-copy; transformed/non-string fields materialize the exact Vec-entry values into one `pa.array`). Same FS math verbatim; also carries the issue-#688 sequential-vs-rayon dispatch gate the Vec entry always lacked.

**Wheel-skew discipline:** `FS_SUPPORTS_EXCLUDE_SET` + `FS_SUPPORTS_ARROW` consts; Python probes them, old wheels keep the Vec path byte-identically and never see new kwargs. Version bumped 0.1.15 -> 0.1.16 in `Cargo.toml` + `pyproject.toml` lockstep. **A `goldenmatch-native` PyPI republish (tag `goldenmatch-native-v0.1.16`) is needed for pip-installed envs to benefit -- Ben's call, flagging per the #688 lesson.**

**Tests:** kernel-direct arrow==vec parity (base, NE incl. null/empty-string, custom level_thresholds, exclude handle==list), routing spies (new wheel -> arrow entry; old wheel -> vec entry with no new kwargs), E2E `score_buckets` native-batched == per-block with a non-empty exclude set. 185 tests green across the FS native/bucket/NE/nlevel suites + pure-Python lane; `cargo clippy -D warnings` + fmt clean; native-symbol reconciliation OK.

Part of #1803.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFxRDxEAhtdd1B6QcPMD