### PR TITLE
fix: apply TF adjustment on the scalar FS path (route-parity) (#1801)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1664,6 +1664,21 @@ def score_probabilistic(
     else:
         link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
 
+    # Precompute per-row transformed values for TF-adjustment fields so the
+    # per-pair loop can apply the same Winkler adjustment the vectorized path
+    # does (#1801). Keyed identically to the freq table (str() + transforms).
+    tf_row_vals: dict[str, dict[int, str | None]] = {}
+    if em_result.tf_freqs:
+        for f in mk.fields:
+            if not getattr(f, "tf_adjustment", False):
+                continue
+            if f.field not in em_result.tf_freqs:
+                continue
+            tf_row_vals[f.field] = {
+                rid: _transform_field_value(row_lookup.get(rid, {}).get(f.field), f)
+                for rid in row_ids
+            }
+
     ne_fields = mk.negative_evidence or []
     results = []
     for i in range(len(row_ids)):
@@ -1677,17 +1692,25 @@ def score_probabilistic(
             row_b = row_lookup.get(b, {})
             vec = comparison_vector(row_a, row_b, mk)
 
-            # Sum match weights
+            # Sum match weights (+ Winkler TF adjustment where opted in).
             total_weight = 0.0
             for k, f in enumerate(mk.fields):
                 total_weight += em_result.match_weights[f.field][vec[k]]
+                per_row = tf_row_vals.get(f.field)
+                if per_row is not None:
+                    total_weight += _scalar_tf_contribution(
+                        per_row.get(a), per_row.get(b), vec[k], f, em_result,
+                    )
             for ne in ne_fields:
                 total_weight += _ne_scalar_contribution(row_a, row_b, ne, em_result)
 
             if calibrated:
                 normalized = posterior_from_weight(total_weight, prior_w)
             elif weight_range > 0:
-                normalized = (total_weight - min_weight) / weight_range
+                # Clip into [0, 1]: TF (and NE) can push the summed weight
+                # past the per-level max/min, matching the vectorized path's
+                # np.clip so the two routes score identically (#1801).
+                normalized = min(1.0, max(0.0, (total_weight - min_weight) / weight_range))
             else:
                 normalized = 0.5
 
@@ -1865,6 +1888,47 @@ def _apply_tf_adjustment(total_weight, vals, lvl, f, em_result, n) -> None:
     apply = equal & (lvl == top)
     if apply.any():
         total_weight += np.where(apply, adj[:, None], 0.0)
+
+
+def _transform_field_value(raw, f) -> str | None:
+    """One value transformed the way ``comparison_vector`` and the TF freq
+    table do: ``str()``-coerce a non-null value then apply the field
+    transforms. ``None`` stays ``None`` (treated as disagree)."""
+    if raw is None:
+        return None
+    from goldenmatch.utils.transforms import apply_transforms
+    s = str(raw)
+    if f.transforms:
+        s = apply_transforms(s, f.transforms)
+    return s
+
+
+def _scalar_tf_contribution(va, vb, level: int, f, em_result) -> float:
+    """Winkler term-frequency adjustment for a single scalar pair on ``f``.
+
+    Scalar mirror of the vectorized ``_apply_tf_adjustment`` (#1801): a rare
+    exact agreement gets a positive bump, a common one a penalty, applied
+    ONLY on an exact-equal, top-level agreement (``level == f.levels - 1``
+    and ``va == vb`` non-null -- matching the vectorized ``equal & (lvl ==
+    top)`` mask). ``va``/``vb`` are the field values transformed identically
+    to the freq table (via ``_transform_field_value``). Returns 0.0 unless
+    the field opted into ``tf_adjustment`` and EM produced a table.
+    """
+    if not getattr(f, "tf_adjustment", False):
+        return 0.0
+    if not em_result.tf_freqs or f.field not in em_result.tf_freqs:
+        return 0.0
+    collision = (em_result.tf_collision or {}).get(f.field)
+    if not collision:
+        return 0.0
+    if level != int(f.levels) - 1:
+        return 0.0
+    if va is None or va != vb:
+        return 0.0
+    fv = em_result.tf_freqs[f.field].get(va)
+    if not fv:
+        return 0.0
+    return float(np.clip(math.log2(collision / fv), -_TF_CLAMP, _TF_CLAMP))
 
 
 def vectorized_scorer_supported(scorer: str) -> bool:
@@ -2528,13 +2592,20 @@ def score_pair_probabilistic(
     total_weight = 0.0
     for k, f in enumerate(mk.fields):
         total_weight += em_result.match_weights[f.field][vec[k]]
+        if getattr(f, "tf_adjustment", False):
+            total_weight += _scalar_tf_contribution(
+                _transform_field_value(row_a.get(f.field), f),
+                _transform_field_value(row_b.get(f.field), f),
+                vec[k], f, em_result,
+            )
     for ne in (mk.negative_evidence or []):
         total_weight += _ne_scalar_contribution(row_a, row_b, ne, em_result)
 
     if _fs_calibration_mode() == "posterior":
         return posterior_from_weight(total_weight, prior_weight(em_result.proportion_matched))
     if weight_range > 0:
-        return (total_weight - min_weight) / weight_range
+        # Clip into [0, 1] so a TF/NE overshoot can't leave the score contract.
+        return min(1.0, max(0.0, (total_weight - min_weight) / weight_range))
     return 0.5
 
 

--- a/packages/python/goldenmatch/tests/test_fs_tf_scalar_parity_1801.py
+++ b/packages/python/goldenmatch/tests/test_fs_tf_scalar_parity_1801.py
@@ -1,0 +1,174 @@
+"""Issue #1801 — term-frequency (Winkler) adjustment must apply on the
+scalar FS path too, not only the vectorized path.
+
+`tf_adjustment=True` was applied by `score_probabilistic_vectorized`
+(`_apply_tf_adjustment`) but silently skipped by the scalar
+`score_probabilistic` weight loop and `score_pair_probabilistic`, so the
+SAME config scored differently depending on the route (scalar is forced by
+a model-backed scorer or `GOLDENMATCH_FS_VECTORIZED=0`). These tests pin
+scalar==vectorized TF parity, TF on the single-pair path, and a route-parity
+check through the block-scorer selector + `dedupe_df`.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+    OutputConfig,
+)
+from goldenmatch.core.probabilistic import (
+    EMResult,
+    probabilistic_block_scorer,
+    score_pair_probabilistic,
+    score_probabilistic,
+    score_probabilistic_vectorized,
+)
+
+
+def _surname_df() -> pl.DataFrame:
+    # "smith" common (6), "jones" mid (3), "zelinski" rare (2).
+    names = ["smith"] * 6 + ["jones"] * 3 + ["zelinski"] * 2
+    return pl.DataFrame(
+        {"__row_id__": list(range(len(names))), "surname": names},
+    )
+
+
+def _tf_em(df: pl.DataFrame) -> EMResult:
+    n = df.height
+    freqs = {k: v / n for k, v in Counter(df["surname"].to_list()).items()}
+    collision = sum(p * p for p in freqs.values())
+    return EMResult(
+        m_probs={"surname": [0.05, 0.95]},
+        u_probs={"surname": [0.9, 0.1]},
+        match_weights={"surname": [-4.0, 3.0]},
+        converged=True, iterations=5, proportion_matched=0.1,
+        tf_freqs={"surname": freqs}, tf_collision={"surname": collision},
+    )
+
+
+def _tf_mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="fs", type="probabilistic", link_threshold=0.0,
+        fields=[MatchkeyField(
+            field="surname", scorer="exact", levels=2, tf_adjustment=True,
+        )],
+    )
+
+
+def _scores(pairs):
+    return {(min(a, b), max(a, b)): s for a, b, s in pairs}
+
+
+def test_scalar_matches_vectorized_on_tf():
+    """The whole point of #1801: identical scores on both routes."""
+    df, mk = _surname_df(), _tf_mk()
+    em = _tf_em(df)
+    vec = _scores(score_probabilistic_vectorized(df, mk, em))
+    sca = _scores(score_probabilistic(df, mk, em))
+    assert sca.keys() == vec.keys()
+    for key in vec:
+        assert sca[key] == pytest.approx(vec[key], abs=1e-9), key
+
+
+def test_scalar_tf_rare_agreement_outscores_common():
+    """Scalar path must reward the rare-value agreement, like vectorized."""
+    df, mk = _surname_df(), _tf_mk()
+    em = _tf_em(df)
+    sca = _scores(score_probabilistic(df, mk, em))
+    # zelinski-zelinski (9,10) rarer than smith-smith (0,1).
+    assert sca[(9, 10)] > sca[(0, 1)]
+
+
+def test_scalar_tf_is_noop_without_table():
+    """No TF table -> common and rare agreements score identically (scalar)."""
+    df, mk = _surname_df(), _tf_mk()
+    em = _tf_em(df)
+    em.tf_freqs = None
+    em.tf_collision = None
+    sca = _scores(score_probabilistic(df, mk, em))
+    assert sca[(9, 10)] == pytest.approx(sca[(0, 1)])
+
+
+def test_score_pair_probabilistic_applies_tf():
+    """The single-pair path (match_one) must apply TF: a rare exact agreement
+    outscores a common one."""
+    df = _surname_df()
+    mk = _tf_mk()
+    em = _tf_em(df)
+    rare = score_pair_probabilistic(
+        {"surname": "zelinski"}, {"surname": "zelinski"}, mk, em,
+    )
+    common = score_pair_probabilistic(
+        {"surname": "smith"}, {"surname": "smith"}, mk, em,
+    )
+    assert rare > common
+
+
+def test_block_scorer_route_parity_vectorized_vs_scalar(monkeypatch):
+    """`probabilistic_block_scorer` must produce identical scores whether it
+    routes to the vectorized or scalar path (the seam the bug lived on)."""
+    df, mk = _surname_df(), _tf_mk()
+    em = _tf_em(df)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_VECTORIZED", "1")
+    vec = _scores(probabilistic_block_scorer(mk, em)(df))
+    monkeypatch.setenv("GOLDENMATCH_FS_VECTORIZED", "0")
+    sca = _scores(probabilistic_block_scorer(mk, em)(df))
+
+    assert sca.keys() == vec.keys()
+    for key in vec:
+        assert sca[key] == pytest.approx(vec[key], abs=1e-9), key
+
+
+def _tf_config() -> GoldenMatchConfig:
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="fs", type="probabilistic", link_threshold=0.0,
+            fields=[MatchkeyField(
+                field="surname", scorer="exact", levels=2, tf_adjustment=True,
+            )],
+        )],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["block"])]),
+        output=OutputConfig(),
+    )
+
+
+def _e2e_df() -> pl.DataFrame:
+    # One block; rare + common exact-duplicate pairs.
+    names = ["smith"] * 6 + ["jones"] * 3 + ["zelinski"] * 2
+    return pl.DataFrame({
+        "surname": names,
+        "block": ["b"] * len(names),
+    })
+
+
+def test_tf_matchkey_e2e_dedupe_df_route_parity(monkeypatch):
+    """End-to-end through `dedupe_df` with an explicit TF matchkey: the
+    scalar and vectorized routes must yield the same scored pairs."""
+    from goldenmatch import dedupe_df
+
+    df = _e2e_df()
+    cfg = _tf_config()
+
+    def _pairs(vec_flag: str):
+        monkeypatch.setenv("GOLDENMATCH_FS_VECTORIZED", vec_flag)
+        res = dedupe_df(df, config=cfg)
+        return _scores(res.scored_pairs)
+
+    vec = _pairs("1")
+    sca = _pairs("0")
+    assert sca.keys() == vec.keys()
+    for key in vec:
+        assert sca[key] == pytest.approx(vec[key], abs=1e-9), key
+
+
+if __name__ == "__main__":  # pragma: no cover
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1801.

## Problem (P0, silent quality divergence)

`tf_adjustment=True` (Winkler term-frequency downweighting) was applied by the vectorized FS scorer (`_apply_tf_adjustment`) but **silently skipped** by the scalar `score_probabilistic` weight loop and `score_pair_probabilistic`. The same config therefore scored **differently depending on the route** — scalar is forced whenever a field uses a model-backed scorer (`embedding` / `record_embedding`) or `GOLDENMATCH_FS_VECTORIZED=0` — with no warning anywhere.

## Fix

Implement TF in the scalar per-pair loop and in `score_pair_probabilistic` via a shared `_scalar_tf_contribution` helper — the scalar mirror of `_apply_tf_adjustment`:
- same trigger: exact-equal, **top-level** agreement only (`level == f.levels - 1` and `va == vb` non-null, matching the vectorized `equal & (lvl == top)` mask),
- same math: `clip(log2(collision / freq(value)), ±10)`,
- same freq-table keying via `_transform_field_value` (`str()` + field transforms, identical to `comparison_vector` and `value_frequencies`).

Also **clip** the scalar linear-normalization branch into `[0, 1]` to match the vectorized path's `np.clip` (TF/NE can push the summed weight past the per-level max) — so the two routes score identically. This incidentally aligns scalar NE normalization with vectorized as well; it's a no-op when weights are already in range.

The native kernel already declines TF (`_fs_native_eligible` → `False`, falling back to vectorized/scalar), so all three routes are now consistent.

## Tests

`tests/test_fs_tf_scalar_parity_1801.py` (the coverage gap that let this live — TF was tested on exactly one route):
- **scalar == vectorized** TF parity (identical scores),
- scalar rare-agreement outscores common,
- `score_pair_probabilistic` applies TF (match_one path),
- **block-scorer route parity** (`GOLDENMATCH_FS_VECTORIZED` 1 vs 0),
- **TF-matchkey E2E through `dedupe_df`** comparing both routes.

Regression: full pure-Python FS suite green (239 passed). The `test_native_fs_ne.py` failures on my worktree are the known native-`.pyd`-absent worktree skew — identical failures on clean `origin/main`, unrelated to this change (they pass in CI where the native kernel is built).

🤖 Generated with [Claude Code](https://claude.com/claude-code)