### PR TITLE
feat(pipeline): bucket is the default FS route (one shared gate, no native requirement, no row cap) + data-scaled n_buckets (#1803 items 3+5)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -208,10 +208,20 @@ BUCKET_HASH_SEED = 0xC2B5C0BBE7ED5E5D
 xxHash seed so block_key -> bucket assignment is stable across runs."""
 
 
-def _default_n_buckets() -> int:
-    """Default bucket count. min(cpu_count() * 4, 1024). Same heuristic as
-    Component 2 v2's materialize_bucketed_blocks."""
-    return min((os.cpu_count() or 4) * 4, 1024)
+def _default_n_buckets(height: int | None = None) -> int:
+    """CPU-derived floor, data-scaled above it (#1803 item 5).
+
+    Bucket count tracks rows upward (target ~50K rows/bucket, capped at 4096
+    to bound partition bookkeeping) so per-bucket frame size stays bounded at
+    10M+ instead of growing linearly under the old CPU-only cap. Output pairs
+    are invariant to the bucket count (blocks hash wholly into one bucket);
+    only the partition granularity changes. ``height=None`` keeps the legacy
+    CPU-only formula for callers without a frame in hand.
+    """
+    base = min((os.cpu_count() or 4) * 4, 1024)
+    if height is None:
+        return base
+    return min(max(base, height // 50_000), 4096)
 
 
 def _resolve_score_pair_callable(
@@ -581,7 +591,7 @@ def score_buckets(
     max_block_size = blocking_config.max_block_size
 
     if n_buckets is None:
-        n_buckets = _default_n_buckets()
+        n_buckets = _default_n_buckets(_prep_frame.height)
 
     # Diag prints (flushed) so we can see substep timing on runner heartbeats
     # independent of the bench stage recorder, which only logs CLOSED stages.

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -142,28 +142,38 @@ def _use_bucket_scorer(config: GoldenMatchConfig, collected_df: Any) -> bool:
     return to_frame(collected_df).height <= _BUCKET_DEFAULT_MAX_ROWS
 
 
-def _fs_default_bucket(config: GoldenMatchConfig, mk: Any) -> bool:
-    """Whether to default-route this probabilistic (Fellegi-Sunter) matchkey to
-    the memory-bounded bucket scorer (issue #1792).
+def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
+    """Whether a probabilistic (Fellegi-Sunter) matchkey scores via the
+    memory-bounded bucket scorer -- the DEFAULT FS route (#1803 item 3,
+    superseding #1792's native-gated ``_fs_default_bucket``) -- vs the legacy
+    per-block batched scorer. The ONE routing decision shared by all three
+    pipeline FS sites (dedupe + both match lanes), so the gates cannot drift
+    between them again.
 
-    The bucket backend bounds *frame* memory (two-level hash partition, one pass
-    resident) AND -- with the batched native FS scorer -- scores a whole bucket
-    in one kernel call, so an FS matchkey gets a path that is both memory-bounded
-    and fast at scale (the default/native-FS per-block path OOMs by materializing
-    the full candidate-pair set). Fires ONLY when:
+    Bucket is the default because it partitions the frame internally (two-level
+    hash partition, one pass resident, slim projection) while the batched
+    fallback consumes eagerly-materialized ``build_blocks`` output -- the #1798
+    OOM path. Unlike the pre-#1803 gate this does NOT require the native FS
+    kernel (the non-native bucket lane scores via the vectorized per-block
+    scorer and is still frame-memory-bounded; measured at 1M: cluster-identical,
+    RSS at parity, wall within noise of the batched route) and has NO row cap.
+    The exclusions that remain are correctness- or contract-driven:
 
-      - ``config.backend`` is None/unset (an EXPLICIT non-bucket backend --
-        polars-direct / ray / duckdb / ... -- keeps its own routing; an explicit
-        ``backend="bucket"`` is already handled by the caller), AND
-      - the native FS kernel is available (``native_enabled("block_scoring")``)
-        AND every field/NE scorer is native-eligible (``_fs_native_eligible``).
-
-    Non-native / model-backed / TF-adjusted matchkeys fall through to the
-    per-block batched scorer (the legacy default route), so this never regresses
-    a workload the native kernel can't accelerate. Escape hatch:
-    ``GOLDENMATCH_FS_DEFAULT_BUCKET=0`` forces the legacy per-block route.
+      - an EXPLICIT scale backend (ray / duckdb / datafusion / chunked) keeps
+        its own routing; ``polars-direct`` is the planner's in-band choice and
+        keeps the default (same band semantics as ``_use_bucket_scorer``);
+      - ``GOLDENMATCH_FS_DEFAULT_BUCKET=0`` escape hatch (legacy batched);
+      - ``GOLDENMATCH_COLUMNAR_PIPELINE`` opt-in wins;
+      - active profile emitter: auto-config reads the legacy block-size
+        signals during sample runs (the final committed dedupe gets bucket);
+      - blocking strategies bucket cannot replicate (non static/multi_pass --
+        lsh / ann / learned / canopy / sorted_neighborhood candidates are not
+        field-hash reproducible).
     """
-    if getattr(config, "backend", None) is not None:
+    backend = getattr(config, "backend", None)
+    if backend == "bucket":
+        return True  # explicit choice -- honored at any size
+    if backend not in (None, "polars-direct"):
         return False
     if (
         os.environ.get("GOLDENMATCH_FS_DEFAULT_BUCKET", "1").strip().lower()
@@ -172,20 +182,14 @@ def _fs_default_bucket(config: GoldenMatchConfig, mk: Any) -> bool:
         return False
     if _columnar_pipeline_enabled():
         return False
-    # Keep controller-profiled sample runs on the legacy route so auto-config
-    # reads the same block-size signals it always has (mirrors _use_bucket_scorer);
-    # the final committed dedupe runs with no active emitter and gets bucket.
+    _blk = getattr(config, "blocking", None)
+    if _blk is not None and getattr(_blk, "strategy", None) not in (
+        None, "static", "multi_pass",
+    ):
+        return False
     from goldenmatch.core.profile_emitter import has_active_emitter
 
-    if has_active_emitter():
-        return False
-    from goldenmatch.core._native_loader import native_enabled
-
-    if not native_enabled("block_scoring"):
-        return False
-    from goldenmatch.core.probabilistic import _fs_native_eligible
-
-    return _fs_native_eligible(mk)
+    return not has_active_emitter()
 
 
 def _get_block_scorer(config: GoldenMatchConfig):
@@ -2600,9 +2604,7 @@ def _run_dedupe_pipeline(
             # partition_by materializes millions of tiny eager frames (the
             # dataset duplicated per blocking pass) and SIGKILLed the runner
             # BEFORE scoring ever started — issue #1798.
-            _fs_use_bucket = _use_bucket_scorer(
-                config, collected_df
-            ) or _fs_default_bucket(config, mk)
+            _fs_use_bucket = _fs_use_bucket_route(config, mk)
             _fs_need_blocks = (
                 bool(_bench_dump_dir)
                 or not _fs_use_bucket
@@ -4108,9 +4110,7 @@ def _run_match_pipeline(
             # Bucket route + preloaded model -> blocks are never read (EM is
             # skipped and score_buckets partitions internally); skip the
             # full-frame block materialization that OOM'd at 14M (#1798).
-            _fs_use_bucket = config.backend == "bucket" or _fs_default_bucket(
-                config, mk
-            )
+            _fs_use_bucket = _fs_use_bucket_route(config, mk)
             blocks = (
                 []
                 if _fs_use_bucket and fs_model_preloaded(mk)
@@ -4347,9 +4347,7 @@ def _run_match_scoring_and_output(
             # Bucket route + preloaded model -> blocks are never read (EM is
             # skipped and score_buckets partitions internally); skip the
             # full-frame block materialization that OOM'd at 14M (#1798).
-            _fs_use_bucket = config.backend == "bucket" or _fs_default_bucket(
-                config, mk
-            )
+            _fs_use_bucket = _fs_use_bucket_route(config, mk)
             blocks = (
                 []
                 if _fs_use_bucket and fs_model_preloaded(mk)

--- a/packages/python/goldenmatch/tests/test_bucket_default_routing.py
+++ b/packages/python/goldenmatch/tests/test_bucket_default_routing.py
@@ -116,3 +116,30 @@ def test_bucket_default_output_identical_to_legacy(monkeypatch):
     bucket_dupes = res_bucket.dupes.num_rows if res_bucket.dupes is not None else 0
 
     assert bucket_dupes == legacy_dupes
+
+
+class TestDataScaledNBuckets:
+    """#1803 item 5: n_buckets grows with data size above the CPU-derived
+    floor (target ~50K rows/bucket, capped 4096); legacy formula when the
+    caller gives no height."""
+
+    def test_no_height_keeps_cpu_formula(self):
+        import os
+
+        from goldenmatch.backends.score_buckets import _default_n_buckets
+        assert _default_n_buckets() == min((os.cpu_count() or 4) * 4, 1024)
+
+    def test_small_height_uses_cpu_floor(self):
+        import os
+
+        from goldenmatch.backends.score_buckets import _default_n_buckets
+        floor = min((os.cpu_count() or 4) * 4, 1024)
+        assert _default_n_buckets(10_000) == floor
+
+    def test_large_height_scales_up(self):
+        from goldenmatch.backends.score_buckets import _default_n_buckets
+        assert _default_n_buckets(100_000_000) == 2000  # 100M / 50K
+
+    def test_capped_at_4096(self):
+        from goldenmatch.backends.score_buckets import _default_n_buckets
+        assert _default_n_buckets(1_000_000_000) == 4096

--- a/packages/python/goldenmatch/tests/test_fs_bucket_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_native.py
@@ -28,7 +28,6 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
 )
 from goldenmatch.core.probabilistic import (
-    _fs_native_eligible,
     _fs_native_enabled,
     score_probabilistic_bucket_native,
     score_probabilistic_native,
@@ -232,24 +231,70 @@ def _prob_config(backend=None) -> GoldenMatchConfig:
     )
 
 
-def test_fs_default_bucket_decision(monkeypatch):
-    from goldenmatch.core.pipeline import _fs_default_bucket
+def test_fs_bucket_route_decision(monkeypatch):
+    """#1803 item 3: bucket is the FS route by default -- NO native-kernel
+    requirement, NO row cap. Exclusions: explicit scale backends, the
+    escape hatch, non-field blocking strategies, active profile emitter."""
+    from goldenmatch.core.pipeline import _fs_use_bucket_route
 
     mk = _mk()
     cfg = _prob_config(backend=None)
 
     monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
-    # Fires exactly when the native FS kernel would accept the matchkey.
-    assert _fs_default_bucket(cfg, mk) == _fs_native_eligible(mk)
+    # Default route regardless of the native kernel (the batched fallback
+    # needs eager build_blocks -- the #1798 OOM path; non-native bucket is
+    # still frame-memory-bounded).
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    assert _fs_use_bucket_route(cfg, mk) is True
+    monkeypatch.delenv("GOLDENMATCH_NATIVE", raising=False)
+    assert _fs_use_bucket_route(cfg, mk) is True
+
+    # polars-direct is the planner's in-band choice -> same default as None
+    # (parity with _use_bucket_scorer's band semantics).
+    assert _fs_use_bucket_route(_prob_config(backend="polars-direct"), mk) is True
+    # Explicit bucket honored, explicit scale backends keep their routing.
+    assert _fs_use_bucket_route(_prob_config(backend="bucket"), mk) is True
+    for be in ("ray", "duckdb", "datafusion"):
+        assert _fs_use_bucket_route(_prob_config(backend=be), mk) is False
 
     # Escape hatch always wins.
     monkeypatch.setenv("GOLDENMATCH_FS_DEFAULT_BUCKET", "0")
-    assert _fs_default_bucket(cfg, mk) is False
-
-    # Explicit non-bucket backends keep their own routing (never FS-default).
+    assert _fs_use_bucket_route(cfg, mk) is False
     monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
-    for be in ("polars-direct", "ray", "duckdb"):
-        assert _fs_default_bucket(_prob_config(backend=be), mk) is False
+
+    # Blocking strategies bucket can't replicate stay legacy.
+    lsh_cfg = _prob_config(backend=None)
+    lsh_cfg.blocking.strategy = "lsh"
+    assert _fs_use_bucket_route(lsh_cfg, mk) is False
+
+    # Controller-profiled sample runs keep legacy block-size signals.
+    from goldenmatch.core.profile_emitter import profile_capture
+
+    with profile_capture():
+        assert _fs_use_bucket_route(cfg, mk) is False
+
+
+def test_fs_bucket_route_nonnative_e2e(monkeypatch):
+    """A backend=None FS dedupe with the native kernel OFF must still score
+    via score_buckets (pre-#1803 it fell back to the batched legacy path)."""
+    import goldenmatch as gm
+    import goldenmatch.backends.score_buckets as sb_mod
+
+    monkeypatch.setenv("GOLDENMATCH_NATIVE", "0")
+    monkeypatch.setenv("GOLDENMATCH_BUCKET_DEFAULT", "0")  # isolate the FS route
+    monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
+
+    calls = {"bucket": 0}
+    real_sb = sb_mod.score_buckets
+
+    def spy_sb(*a, **k):
+        calls["bucket"] += 1
+        return real_sb(*a, **k)
+
+    monkeypatch.setattr(sb_mod, "score_buckets", spy_sb)
+    df = _multiblock_df().drop("__row_id__")
+    gm.dedupe_df(df, config=_prob_config(backend=None))
+    assert calls["bucket"] >= 1
 
 
 @native_required


### PR DESCRIPTION
Third PR of epic #1803 (plan: docs/superpowers/plans/2026-07-15-fs-scale-parity-1803.md). Direction confirmed with Ben 2026-07-15: bucket by default unless the user overrides.

**Item 3 -- one routing gate.** `_fs_use_bucket_route(config, mk)` replaces the native-gated `_fs_default_bucket` AND the three per-site conditions that had already drifted (dedupe consulted `_use_bucket_scorer`; the match lanes did not). Bucket is now the FS default with NO native-kernel requirement and NO row cap -- the batched fallback consumes eagerly-materialized `build_blocks` output (the #1798 OOM path), while bucket partitions internally, memory-bounded, native or not. Remaining exclusions are correctness/contract-driven: explicit scale backends (`polars-direct` keeps the default -- planner in-band choice), `GOLDENMATCH_FS_DEFAULT_BUCKET=0`, columnar opt-in, active profile emitter, non-static/multi_pass blocking strategies. The weighted `_use_bucket_scorer` band is deliberately untouched (separate measured decision).

**Item 5 -- data-scaled n_buckets.** `_default_n_buckets(height)` grows above the CPU floor (~50K rows/bucket target, cap 4096). Emitted pairs are invariant to bucket count (blocks hash wholly into one bucket).

**Measured** (the newly-defaulted lane: `backend=None`, `GOLDENMATCH_NATIVE=0`, model preloaded, compound 2-key union blocking, memory-constrained Windows box):

| Rows | new default (bucket, non-native) | legacy batched (`FS_DEFAULT_BUCKET=0`) |
|---|---|---|
| 200K | 23.3s / 665 MB / 18,976 clusters | 25.5s / 2,388 MB / 18,976 clusters (identical) |
| 1M | 139s / 1.72 GB | **MemoryError** inside `build_blocks` |

5M CI validation of the non-native bucket lane triggered on this branch: bench-fs-distributed run 29457379715 (`large-new-64GB`, fs_native=false).

**Tests:** new `_fs_use_bucket_route` decision matrix (native-off default, polars-direct/bucket/scale backends, escape hatch, lsh strategy, active emitter), non-native E2E route spy (dedupe with NATIVE=0 must hit score_buckets), `TestDataScaledNBuckets`. 119 native-lane + 128 pure-Python-lane tests green, including all bucket/batched/native parity suites.

Part of #1803. Stacks cleanly next to #1806/#1808 (different regions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFxRDxEAhtdd1B6QcPMD