### PR TITLE
fix(ts): route probabilistic pipeline through FS

### DIFF
--- a/packages/typescript/goldenmatch/src/core/pipeline.ts
+++ b/packages/typescript/goldenmatch/src/core/pipeline.ts
@@ -27,7 +27,7 @@ import {
   scoreBlocksSequential,
 } from "./scorer.js";
 import { applyNegativeEvidenceToExactPairs } from "./autoconfigNegativeEvidence.js";
-import { NegativeEvidenceUnsupportedError } from "./probabilistic.js";
+import { scoreProbabilistic, trainEM } from "./probabilistic.js";
 import { buildClusters, pairKey } from "./cluster.js";
 import { buildGoldenRecord } from "./golden.js";
 import { postflight } from "./autoconfigVerify.js";
@@ -75,31 +75,72 @@ function buildSourceLookup(rows: readonly Row[]): Map<number, string> {
 }
 
 /**
- * Loud decline: the pipeline cannot honor FS negative evidence on
- * probabilistic matchkeys. The pipeline's fuzzy phase scores probabilistic
- * matchkeys through `findFuzzyMatches` (a simplified weighted-style
- * averaging, a pre-existing TS scope gap — no EM training, no FS log-odds),
- * and that path has no NE veto. Rather than silently scoring WITHOUT the
- * veto, throw before any scoring work. Exact and weighted matchkeys honor
- * NE in the pipeline (Path Y / scorer penalty) and pass through untouched.
+ * Collect comparison fields constrained by the configured blocker.
  */
-function assertPipelineSupportsNegativeEvidence(
-  matchkeys: readonly MatchkeyConfig[],
-): void {
-  for (const mk of matchkeys) {
-    if (mk.type !== "probabilistic") continue;
-    const ne = mk.negativeEvidence;
-    if (ne !== undefined && ne.length > 0) {
-      const names = ne.map((n) => n.field).join(", ");
-      throw new NegativeEvidenceUnsupportedError(
-        `matchkey '${mk.name}': the TS pipeline scores probabilistic ` +
-          `matchkeys with simplified (weighted-style) scoring that cannot ` +
-          `honor negative evidence (${names}) -- use the FS API directly ` +
-          `(trainEM + scoreProbabilistic), or remove negativeEvidence ` +
-          `from this matchkey`,
+function collectBlockingFields(
+  config: ReturnType<typeof makeBlockingConfig>,
+): string[] {
+  const fields = new Set<string>();
+  for (const key of config.keys) {
+    for (const field of key.fields) fields.add(field);
+  }
+  for (const key of config.passes ?? []) {
+    for (const field of key.fields) fields.add(field);
+  }
+  for (const key of config.subBlockKeys ?? []) {
+    for (const field of key.fields) fields.add(field);
+  }
+  for (const field of config.sortKey ?? []) fields.add(field.column);
+  return [...fields];
+}
+
+function scoreProbabilisticBlocks(
+  rows: readonly Row[],
+  blocks: ReturnType<typeof buildBlocks>,
+  mk: Extract<MatchkeyConfig, { type: "probabilistic" }>,
+  matchedPairs: Set<PairKey>,
+  blockingConfig: ReturnType<typeof makeBlockingConfig>,
+  options: {
+    readonly acrossFilesOnly: boolean;
+    readonly sourceLookup: ReadonlyMap<number, string>;
+  },
+): ScoredPair[] {
+  const em = trainEM(rows, mk, {
+    blockingFields: collectBlockingFields(blockingConfig),
+  });
+  const threshold = mk.linkThreshold ?? mk.threshold ?? 0.5;
+  const allPairs: ScoredPair[] = [];
+
+  for (const block of blocks) {
+    if (options.acrossFilesOnly) {
+      const sources = new Set(
+        block.rows.map((row) =>
+          options.sourceLookup.get(row.__row_id__ as number),
+        ),
+      );
+      sources.delete(undefined);
+      if (sources.size < 2) continue;
+    }
+
+    let pairs = scoreProbabilistic(block.rows, mk, em, {
+      excludePairs: matchedPairs,
+      threshold,
+    });
+    if (options.acrossFilesOnly) {
+      pairs = pairs.filter(
+        (pair) =>
+          options.sourceLookup.get(pair.idA) !==
+          options.sourceLookup.get(pair.idB),
       );
     }
+    for (const pair of pairs) {
+      const key = pairKey(pair.idA, pair.idB);
+      if (matchedPairs.has(key)) continue;
+      matchedPairs.add(key);
+      allPairs.push(pair);
+    }
   }
+  return allPairs;
 }
 
 /** Collect all row IDs from rows. */
@@ -325,10 +366,6 @@ export async function runDedupePipeline(
   config: GoldenMatchConfig,
   options?: DedupeOptions,
 ): Promise<DedupeResult> {
-  // Loud decline BEFORE any work (even on empty input): probabilistic+NE
-  // configs must never reach the simplified fuzzy scorer silently.
-  assertPipelineSupportsNegativeEvidence(getMatchkeys(config));
-
   if (rows.length === 0) {
     return _emptyDedupeResult(config);
   }
@@ -392,8 +429,8 @@ export async function runDedupePipeline(
           allPairs.push(p);
         }
       }
-    } else {
-      // Phase 2: Fuzzy (weighted/probabilistic) — block then score
+    } else if (mk.type === "weighted") {
+      // Phase 2: weighted fuzzy matching — block then score
       const blocks = buildBlocks(processed, blockingConfig);
 
       const pairs = scoreBlocksSequential(blocks, mk, matchedPairKeys, {
@@ -404,6 +441,19 @@ export async function runDedupePipeline(
       for (const p of pairs) {
         allPairs.push(p);
       }
+    } else {
+      // Phase 2b: genuine Fellegi-Sunter training + blocked scoring.
+      const blocks = buildBlocks(processed, blockingConfig);
+      allPairs.push(
+        ...scoreProbabilisticBlocks(
+          processed,
+          blocks,
+          mk,
+          matchedPairKeys,
+          blockingConfig,
+          { acrossFilesOnly, sourceLookup },
+        ),
+      );
     }
   }
 
@@ -534,10 +584,6 @@ export async function runMatchPipeline(
   config: GoldenMatchConfig,
   options?: DedupeOptions,
 ): Promise<MatchResult> {
-  // Same loud decline as runDedupePipeline — fires here too so an empty
-  // target/reference early-return can't skip it.
-  assertPipelineSupportsNegativeEvidence(getMatchkeys(config));
-
   if (targetRows.length === 0 || referenceRows.length === 0) {
     return {
       matched: [],

--- a/packages/typescript/goldenmatch/tests/unit/fs-negative-evidence.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/fs-negative-evidence.test.ts
@@ -826,7 +826,7 @@ describe("homonym E2E: NE separates traps, true dups still merge (#1764 bar)", (
   }
 });
 
-describe("weighted NE scoring is untouched by the decline", () => {
+describe("weighted NE scoring is untouched by FS pipeline wiring", () => {
   it("weighted matchkey with NE still scores via findFuzzyMatches", () => {
     const wRows: Row[] = [
       { __row_id__: 0, name: "Alice Smith", phone: "555-1111" } as Row,
@@ -856,14 +856,11 @@ describe("weighted NE scoring is untouched by the decline", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PIPELINE decline: the full pipeline (dedupe/match) scores probabilistic
-// matchkeys with simplified weighted-style averaging that cannot honor NE.
-// It must throw NegativeEvidenceUnsupportedError BEFORE any scoring work —
-// never silently score without the veto. Exact/weighted NE and NE-free
-// probabilistic configs run in the pipeline unchanged.
+// PIPELINE wiring: dedupe/match route probabilistic matchkeys through the
+// discrete FS implementation, including negative evidence.
 // ---------------------------------------------------------------------------
 
-describe("pipeline declines probabilistic+NE loudly", () => {
+describe("pipeline scores probabilistic matchkeys with FS", () => {
   const pipeRows: Row[] = [
     { id: 1, name: "Alice Smith", phone: "555-1111", zip: "111" },
     { id: 2, name: "Alice Smith", phone: "555-9999", zip: "111" },
@@ -886,33 +883,87 @@ describe("pipeline declines probabilistic+NE loudly", () => {
     ],
   };
 
-  async function expectPipelineDecline(run: () => Promise<unknown>): Promise<void> {
-    const err = await run().then(
-      () => undefined,
-      (e: unknown) => e,
-    );
-    expect(err).toBeInstanceOf(NegativeEvidenceUnsupportedError);
-    const e = err as Error;
-    expect(e.message).toContain("phone");
-    expect(e.message).toContain("simplified");
-    expect(e.message).toContain("trainEM");
-  }
+  it("routes probabilistic matchkeys through FS so negative evidence is honored", async () => {
+    const mk = makeMatchkeyConfig({
+      name: "p",
+      type: "probabilistic",
+      fields: [makeMatchkeyField({ field: "name", scorer: "exact" })],
+      linkThreshold: 0.9,
+      negativeEvidence: [
+        makeNegativeEvidenceField({
+          field: "phone",
+          scorer: "exact",
+          threshold: 1,
+          penaltyBits: 6,
+        }),
+      ],
+    });
+    const blocking = makeBlockingConfig({
+      strategy: "static",
+      keys: [{ fields: ["zip"], transforms: [] }],
+    });
+    const config = makeConfig({ matchkeys: [mk], blocking });
 
-  it("loader-parsed probabilistic+NE config -> runDedupePipeline throws", async () => {
-    const config = parseConfig(rawNeConfig);
-    await expectPipelineDecline(() => runDedupePipeline(pipeRows, config));
+    const result = await runDedupePipeline(
+      [
+        { id: 1, name: "Alice Smith", phone: "555-1111", zip: "111" },
+        { id: 2, name: "Alice Smith", phone: "555-1111", zip: "111" },
+        { id: 3, name: "Alice Smith", phone: "555-9999", zip: "111" },
+      ],
+      config,
+    );
+
+    expect(result.scoredPairs.map((p) => [p.idA, p.idB])).toEqual([[0, 1]]);
   });
 
-  it("loader-parsed probabilistic+NE config -> runMatchPipeline throws", async () => {
+  it("loader-parsed probabilistic+NE config runs in dedupe", async () => {
     const config = parseConfig(rawNeConfig);
-    await expectPipelineDecline(() =>
-      runMatchPipeline(pipeRows.slice(0, 1), pipeRows.slice(1), config),
-    );
+    const result = await runDedupePipeline(pipeRows, config);
+    expect(result.stats.totalRecords).toBe(3);
   });
 
-  it("runMatchPipeline declines even when the target is empty (no silent early-return)", async () => {
+  it("loader-parsed probabilistic+NE config runs in match", async () => {
     const config = parseConfig(rawNeConfig);
-    await expectPipelineDecline(() => runMatchPipeline([], pipeRows, config));
+    const result = await runMatchPipeline(
+      pipeRows.slice(0, 1),
+      pipeRows.slice(1),
+      config,
+    );
+    expect(result.stats.totalTarget).toBe(1);
+  });
+
+  it("preserves cross-source filtering on the FS pipeline path", async () => {
+    const mk = makeMatchkeyConfig({
+      name: "p",
+      type: "probabilistic",
+      fields: [makeMatchkeyField({ field: "name", scorer: "exact" })],
+      linkThreshold: 0.9,
+    });
+    const blocking = makeBlockingConfig({
+      strategy: "static",
+      keys: [{ fields: ["zip"], transforms: [] }],
+    });
+    const result = await runDedupePipeline(
+      [
+        { __row_id__: 0, __source__: "target", name: "Alice", zip: "111" },
+        { __row_id__: 1, __source__: "target", name: "Alice", zip: "111" },
+        { __row_id__: 2, __source__: "reference", name: "Alice", zip: "111" },
+      ],
+      makeConfig({ matchkeys: [mk], blocking }),
+      { acrossFilesOnly: true },
+    );
+
+    expect(result.scoredPairs.map((p) => [p.idA, p.idB])).toEqual([
+      [0, 2],
+      [1, 2],
+    ]);
+  });
+
+  it("empty match input returns the normal empty result", async () => {
+    const config = parseConfig(rawNeConfig);
+    const result = await runMatchPipeline([], pipeRows, config);
+    expect(result.matched).toEqual([]);
+    expect(result.stats.totalTarget).toBe(0);
   });
 
   it("weighted+NE config still runs through the pipeline (existing behavior untouched)", async () => {
@@ -963,7 +1014,7 @@ describe("pipeline declines probabilistic+NE loudly", () => {
     const config = makeConfig({ matchkeys: [mk], blocking });
     const result = await runDedupePipeline(pipeRows, config);
     expect(result.stats.totalRecords).toBe(3);
-    // The two same-name rows still pair up on the simplified path.
+    // The two same-name rows pair up through the FS path.
     const hasMatch = result.scoredPairs.some(
       (p) =>
         (p.idA === 0 && p.idB === 1) || (p.idA === 1 && p.idB === 0),


### PR DESCRIPTION
## Summary

- route TypeScript probabilistic matchkeys through `trainEM` and `scoreProbabilistic`
- train one EM model per matchkey and score only blocked candidates
- preserve cascade exclusion, blocking-field context, legacy threshold fallback, and cross-source filtering
- replace the pipeline negative-evidence decline with end-to-end FS coverage

Closes #1812

## Verification

- `pnpm --filter goldenmatch test -- tests/unit/fs-negative-evidence.test.ts tests/unit/probabilistic.test.ts tests/unit/api.test.ts` (66 passed)
- `pnpm --filter goldenmatch typecheck`
- `pnpm --filter goldenmatch build`
- `git diff --check`

Full `pnpm --filter goldenmatch test`: 2,900 passed, 1 expected failure, 17 skipped; one unrelated Windows checkout failure remains in `warehouse-bigquery.parity.test.ts` because its SQL body regex requires LF while the checked-out fixture uses CRLF.