### PR TITLE
fix(probabilistic): filter linkage pairs in batched FS

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -4148,6 +4148,7 @@ def _run_match_pipeline(
             # Does not mutate matched_pairs; fold the returned pairs in below.
             pairs = score_probabilistic_blocks_batched(
                 blocks, mk, em_result, matched_pairs,
+                target_ids=target_ids,
             )
             all_pairs.extend(pairs)
             for a, b, _s in pairs:
@@ -4381,7 +4382,8 @@ def _run_match_scoring_and_output(
                     matched_pairs.add((min(a, b), max(a, b)))
                 continue
             pairs = score_probabilistic_blocks_batched(
-                blocks, mk, em_result, matched_pairs
+                blocks, mk, em_result, matched_pairs,
+                target_ids=target_ids,
             )
             all_pairs.extend(pairs)
             for a, b, _s in pairs:

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -2214,6 +2214,7 @@ def score_probabilistic_blocks_batched(
     em_result: EMResult,
     exclude_pairs: set[tuple[int, int]] | None = None,
     cap: int | None = None,
+    target_ids: set[int] | None = None,
 ):
     """Collect + score ``blocks`` in row-capped batches via the SxS batch scorer.
 
@@ -2222,8 +2223,10 @@ def score_probabilistic_blocks_batched(
     block-by-block ``matched_pairs`` dedup. Falls back to the per-block scorer
     when the vectorized numpy path isn't active (native FS kernel / scalar /
     model-backed scorers), since the batching is a numpy-path optimization.
-    Does NOT mutate the caller's ``exclude_pairs``; the caller folds the returned
-    pairs into ``matched_pairs`` as before.
+    When ``target_ids`` is provided (two-table linkage), only pairs with exactly
+    one target-side id are returned. Does NOT mutate the caller's
+    ``exclude_pairs``; the caller folds the returned pairs into ``matched_pairs``
+    as before.
     """
     from concurrent.futures import ThreadPoolExecutor
 
@@ -2242,6 +2245,15 @@ def score_probabilistic_blocks_batched(
 
     def _bdf(block):
         return block.materialize().native
+
+    def _eligible(pairs):
+        if target_ids is None:
+            return pairs
+        return [
+            (a, b, score)
+            for a, b, score in pairs
+            if (a in target_ids) != (b in target_ids)
+        ]
 
     # Split the work into independent scoring units + a per-unit scorer. Native/
     # scalar path: one unit per block. Vectorized path: row-capped batches of
@@ -2281,7 +2293,7 @@ def score_probabilistic_blocks_batched(
     if workers <= 1 or len(units) <= 1:
         excl = set(base_excl)
         for unit in units:
-            pairs = _score_unit(unit, excl)
+            pairs = _eligible(_score_unit(unit, excl))
             for a, b, _s in pairs:
                 excl.add((min(a, b), max(a, b)))
             results.extend(pairs)
@@ -2298,7 +2310,7 @@ def score_probabilistic_blocks_batched(
     seen: set[tuple[int, int]] = set(frozen)
     with ThreadPoolExecutor(max_workers=workers) as executor:
         for pairs in executor.map(lambda u: _score_unit(u, frozen), units):
-            for a, b, s in pairs:
+            for a, b, s in _eligible(pairs):
                 key = (a, b) if a < b else (b, a)
                 if key in seen:
                     continue

--- a/packages/python/goldenmatch/tests/test_probabilistic_parallel.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic_parallel.py
@@ -104,5 +104,40 @@ def test_batched_pairs_match_sequential(monkeypatch):
     assert len(par_pairs) == len(set(par_pairs))  # no duplicate emissions
 
 
+@pytest.mark.parametrize("workers", [1, 8])
+@pytest.mark.parametrize("vectorized", [False, True])
+def test_batched_target_ids_drop_same_side_pairs(monkeypatch, workers, vectorized):
+    """Every fallback FS execution mode must honor two-table linkage scope."""
+    df = _frame().with_row_index("__row_id__")
+    cfg = _config()
+    mk = cfg.matchkeys[0]
+    blocks = build_blocks(df.lazy(), cfg.blocking)
+    em = load_or_train_em(df, mk, blocks=blocks, blocking_fields=["name", "zip"])
+    target_ids = set(range(0, df.height, 2))
+
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+    monkeypatch.setenv("GOLDENMATCH_FS_VECTORIZED", "1" if vectorized else "0")
+    _fs_workers(monkeypatch, workers)
+
+    unfiltered = score_probabilistic_blocks_batched(blocks, mk, em, set())
+    assert any(
+        (a in target_ids) == (b in target_ids)
+        for a, b, _score in unfiltered
+    ), "fixture must expose at least one same-side pair"
+
+    filtered = score_probabilistic_blocks_batched(
+        blocks,
+        mk,
+        em,
+        set(),
+        target_ids=target_ids,
+    )
+    assert filtered
+    assert all(
+        (a in target_ids) != (b in target_ids)
+        for a, b, _score in filtered
+    )
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- add an optional `target_ids` linkage constraint to the shared batched FS scorer
- apply it consistently in scalar/vectorized and sequential/threaded fallback modes
- thread the target set through both two-table Python pipeline implementations
- add a four-mode regression proving same-side pairs are excluded

Closes #1813

## Verification

- `uv run pytest --tb=short packages/python/goldenmatch/tests/test_probabilistic_parallel.py packages/python/goldenmatch/tests/test_probabilistic_vectorized.py packages/python/goldenmatch/tests/test_fs_bucket_native.py packages/python/goldenmatch/tests/test_pipeline.py` (45 passed)
- `uv run ruff check ...` on changed Python files
- `git diff --check`

The repository-wide suite cannot collect in the minimal package environment: 19 collection errors require optional MCP/web/document dependencies, and `test_metrics_harness.py` imports Unix-only `resource` on Windows.