### PR TITLE
fix(probabilistic): constrain linkage EM samples

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -4123,6 +4123,7 @@ def _run_match_pipeline(
                 combined_df, mk,
                 blocks=blocks,
                 blocking_fields=blocking_fields,
+                target_ids=target_ids,
             )
             # Default-route FS to the memory-bounded bucket scorer when the
             # native FS kernel is available (issue #1792) or backend='bucket'
@@ -4357,7 +4358,11 @@ def _run_match_scoring_and_output(
                 collect_blocking_fields(config.blocking) if config.blocking else []
             )
             em_result = load_or_train_em(
-                combined_native, mk, blocks=blocks, blocking_fields=blocking_fields
+                combined_native,
+                mk,
+                blocks=blocks,
+                blocking_fields=blocking_fields,
+                target_ids=target_ids,
             )
             # Default-route FS to the memory-bounded bucket scorer when the
             # native FS kernel is available (issue #1792) or backend='bucket'

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -446,8 +446,13 @@ def _sample_pairs(
     df: pl.DataFrame,
     n_pairs: int = 10000,
     seed: int = 42,
+    target_ids: set[int] | None = None,
 ) -> list[tuple[int, int]]:
-    """Sample random pairs for EM training."""
+    """Sample random pairs for EM training.
+
+    ``target_ids`` selects two-table linkage mode: the pair universe is the
+    target x reference Cartesian product, never either table's self-pairs.
+    """
     from goldenmatch.core.frame import to_frame as _tf_w6
 
     row_ids = _tf_w6(df).column("__row_id__").to_list()
@@ -455,6 +460,28 @@ def _sample_pairs(
 
     if len(row_ids) < 2:
         return []
+
+    if target_ids is not None:
+        targets = sorted(row_id for row_id in row_ids if row_id in target_ids)
+        references = sorted(row_id for row_id in row_ids if row_id not in target_ids)
+        max_possible = len(targets) * len(references)
+        if max_possible == 0:
+            return []
+        if max_possible <= n_pairs:
+            return [
+                (min(target, reference), max(target, reference))
+                for target in targets
+                for reference in references
+            ]
+        sampled_offsets = rng.sample(range(max_possible), n_pairs)
+        n_references = len(references)
+        return [
+            (
+                min(targets[offset // n_references], references[offset % n_references]),
+                max(targets[offset // n_references], references[offset % n_references]),
+            )
+            for offset in sampled_offsets
+        ]
 
     # For small datasets, use all pairs
     max_possible = len(row_ids) * (len(row_ids) - 1) // 2
@@ -594,6 +621,7 @@ def _sample_blocked_pairs(
     blocks: list,
     n_pairs: int = 10000,
     seed: int = 42,
+    target_ids: set[int] | None = None,
 ) -> list[tuple[int, int]]:
     """Sample within-block pairs for EM training.
 
@@ -629,20 +657,46 @@ def _sample_blocked_pairs(
         )  # canonical order before the seeded sample
         if len(row_ids) < 2:
             continue
-        # Limit per-block pairs for large blocks
-        if len(row_ids) > 100:
+        # Limit per-block pairs for large blocks. In linkage mode preserve both
+        # sides even on highly imbalanced blocks instead of sampling 100 ids
+        # from the combined population and potentially missing the small side.
+        if target_ids is not None:
+            target_rows = [row_id for row_id in row_ids if row_id in target_ids]
+            reference_rows = [row_id for row_id in row_ids if row_id not in target_ids]
+            if not target_rows or not reference_rows:
+                continue
+            if len(row_ids) > 100:
+                n_target = min(len(target_rows), 50)
+                n_reference = min(len(reference_rows), 50)
+                remaining = 100 - n_target - n_reference
+                add_target = min(remaining, len(target_rows) - n_target)
+                n_target += add_target
+                remaining -= add_target
+                n_reference += min(remaining, len(reference_rows) - n_reference)
+                target_rows = rng.sample(target_rows, n_target)
+                reference_rows = rng.sample(reference_rows, n_reference)
+            for target in target_rows:
+                for reference in reference_rows:
+                    all_block_pairs.append(
+                        (min(target, reference), max(target, reference))
+                    )
+        elif len(row_ids) > 100:
             sampled_ids = rng.sample(row_ids, 100)
         else:
             sampled_ids = row_ids
-        for i in range(len(sampled_ids)):
-            for j in range(i + 1, len(sampled_ids)):
-                all_block_pairs.append((min(sampled_ids[i], sampled_ids[j]),
-                                        max(sampled_ids[i], sampled_ids[j])))
+        if target_ids is None:
+            for i in range(len(sampled_ids)):
+                for j in range(i + 1, len(sampled_ids)):
+                    all_block_pairs.append((min(sampled_ids[i], sampled_ids[j]),
+                                            max(sampled_ids[i], sampled_ids[j])))
         if len(all_block_pairs) >= target:
             break
 
     # Deduplicate and sample down if too many
-    all_block_pairs = list(set(all_block_pairs))
+    unique_pairs = set(all_block_pairs)
+    all_block_pairs = (
+        sorted(unique_pairs) if target_ids is not None else list(unique_pairs)
+    )
     if len(all_block_pairs) > n_pairs:
         all_block_pairs = rng.sample(all_block_pairs, n_pairs)
 
@@ -658,6 +712,7 @@ def train_em(
     seed: int = 42,
     blocks: list | None = None,
     blocking_fields: list[str] | None = None,
+    target_ids: set[int] | None = None,
 ) -> EMResult:
     """Train Fellegi-Sunter model using Expectation-Maximization.
 
@@ -678,6 +733,9 @@ def train_em(
         seed: Random seed for pair sampling.
         blocks: Optional list of BlockResult for within-block sampling.
         blocking_fields: Fields used for blocking (excluded from EM training).
+        target_ids: Target-side row ids for two-table linkage training. When
+            provided, random and blocked samples contain only target-reference
+            pairs.
 
     Returns:
         EMResult with trained m/u probabilities and match weights.
@@ -702,7 +760,12 @@ def train_em(
     # ── Step 1: Estimate u from RANDOM pairs (Splink approach) ──
     # Random pairs are overwhelmingly non-matches, so the observed
     # level distribution approximates u directly. No EM needed for u.
-    random_pairs = _sample_pairs(df, min(n_sample_pairs, 5000), seed)
+    random_pairs = _sample_pairs(
+        df,
+        min(n_sample_pairs, 5000),
+        seed,
+        target_ids=target_ids,
+    )
     if len(random_pairs) < 10:
         logger.warning("Too few pairs (%d) for EM training", len(random_pairs))
         return _fallback_result(mk)
@@ -713,7 +776,12 @@ def train_em(
     # ``__row_id__`` / the blocks, never the lookup, so the sampled pairs — and
     # the trained model — are unchanged by this reordering.
     if blocks:
-        blocked_pairs = _sample_blocked_pairs(blocks, n_sample_pairs, seed)
+        blocked_pairs = _sample_blocked_pairs(
+            blocks,
+            n_sample_pairs,
+            seed,
+            target_ids=target_ids,
+        )
     else:
         blocked_pairs = random_pairs
     row_lookup = _row_lookup_for_pairs(df, cols, [random_pairs, blocked_pairs])
@@ -956,6 +1024,7 @@ def load_or_train_em(
     blocking_fields: list[str] | None = None,
     max_iterations: int | None = None,
     convergence: float | None = None,
+    target_ids: set[int] | None = None,
 ) -> EMResult:
     """Return a trained EMResult, reusing ``mk.model_path`` when present.
 
@@ -979,6 +1048,7 @@ def load_or_train_em(
         convergence=convergence if convergence is not None else mk.convergence_threshold,
         blocks=blocks,
         blocking_fields=blocking_fields,
+        target_ids=target_ids,
     )
     if path:
         em.save_json(path)

--- a/packages/python/goldenmatch/tests/test_probabilistic_determinism.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic_determinism.py
@@ -1,7 +1,7 @@
 import polars as pl
 from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
 from goldenmatch.core.blocker import build_blocks
-from goldenmatch.core.probabilistic import _sample_blocked_pairs
+from goldenmatch.core.probabilistic import _sample_blocked_pairs, _sample_pairs
 
 
 def _person_df():
@@ -32,3 +32,48 @@ def test_sample_blocked_pairs_is_order_independent():
     s3 = _sample_blocked_pairs(b3, n_pairs=200, seed=42)
     assert set(s1) == set(s2) == set(s3), "sample must be invariant to block input order"
     assert len(s1) > 0
+
+
+def test_sample_pairs_linkage_enumerates_only_cross_table_pairs():
+    df = pl.DataFrame({"__row_id__": [0, 1, 2, 3, 4]})
+    target_ids = {0, 1, 2}
+
+    pairs = _sample_pairs(df, n_pairs=100, seed=42, target_ids=target_ids)
+
+    assert set(pairs) == {
+        (0, 3), (0, 4),
+        (1, 3), (1, 4),
+        (2, 3), (2, 4),
+    }
+
+
+def test_sample_pairs_linkage_is_bounded_and_deterministic_when_imbalanced():
+    df = pl.DataFrame({"__row_id__": list(range(102))})
+    target_ids = set(range(100))
+
+    first = _sample_pairs(df, n_pairs=50, seed=7, target_ids=target_ids)
+    second = _sample_pairs(df, n_pairs=50, seed=7, target_ids=target_ids)
+
+    assert first == second
+    assert len(first) == 50
+    assert all((a in target_ids) != (b in target_ids) for a, b in first)
+
+
+def test_sample_blocked_pairs_linkage_drops_same_side_pairs():
+    df = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "surname": ["Smith"] * 6,
+    })
+    cfg = BlockingConfig(keys=[BlockingKeyConfig(fields=["surname"])])
+    blocks = build_blocks(df.lazy(), cfg)
+    target_ids = {0, 1, 2}
+
+    pairs = _sample_blocked_pairs(
+        blocks,
+        n_pairs=100,
+        seed=42,
+        target_ids=target_ids,
+    )
+
+    assert len(pairs) == 9
+    assert all((a in target_ids) != (b in target_ids) for a, b in pairs)


### PR DESCRIPTION
## Summary

- add an explicit target-side linkage mode to random and blocked EM sampling
- sample directly from the target x reference Cartesian universe, including imbalanced tables
- preserve deterministic bounded blocked sampling while retaining both sides under the row cap
- thread linkage scope through both Python two-table pipeline implementations

Closes #1814

## Verification

- `uv run pytest --tb=short packages/python/goldenmatch/tests/test_probabilistic_determinism.py packages/python/goldenmatch/tests/test_probabilistic.py packages/python/goldenmatch/tests/test_fs_bucket_native.py packages/python/goldenmatch/tests/test_pipeline.py` (118 passed)
- changed-file Ruff checks passed
- `git diff --check`