### PR TITLE
fix(probabilistic): validate EM configuration

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -93,7 +93,9 @@ class MatchkeyField(BaseModel):
     columns: list[str] | None = None  # for record_embedding scorer
     column_weights: dict[str, float] | None = None  # per-field weights for record_embedding
     levels: int = Field(default=2, ge=2)  # comparison levels for probabilistic: 2=agree/disagree, 3=agree/partial/disagree
-    partial_threshold: float = 0.8  # score >= this = partial agree (when levels=3)
+    partial_threshold: float = Field(
+        default=0.8, ge=0.0, le=1.0
+    )  # score >= this = partial agree (when levels=3)
     # Probabilistic-only: term-frequency (Winkler) weight adjustment. When True,
     # an exact agreement on a *rare* value carries more match weight than on a
     # *common* one (matching on "Zelinski" is stronger evidence than on
@@ -118,7 +120,7 @@ class MatchkeyField(BaseModel):
     # `None` (not 20) is the default so `model_dump(exclude_none=True)` doesn't
     # leak the value into saved YAML for non-probabilistic matchkeys; the
     # workbench → engine translation in web/preview.py coerces None → 20.
-    em_iterations: int | None = None
+    em_iterations: int | None = Field(default=None, ge=1)
     # N-level custom banding (Splink-converter Stage 1). Descending similarity
     # cutoffs; level index = count of satisfied thresholds (0 = disagree,
     # levels-1 = top agree). None => legacy banding (partial_threshold for
@@ -348,10 +350,10 @@ class MatchkeyConfig(BaseModel):
     # ``docs/superpowers/specs/2026-07-14-fs-negative-evidence-design.md``.
     negative_evidence: list[NegativeEvidenceField] | None = None
     # Fellegi-Sunter EM parameters
-    em_iterations: int = 20
-    convergence_threshold: float = 0.001
-    link_threshold: float | None = None  # auto-computed if None
-    review_threshold: float | None = None  # auto-computed if None
+    em_iterations: int = Field(default=20, ge=1)
+    convergence_threshold: float = Field(default=0.001, gt=0.0)
+    link_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
+    review_threshold: float | None = Field(default=None, ge=0.0, le=1.0)
     # Probabilistic-only: persisted EM model (Splink-style train-once -> reuse).
     # When set and the file exists, the trained EMResult is loaded and EM is
     # skipped; when set and absent, EM runs and the result is saved there.
@@ -381,6 +383,27 @@ class MatchkeyConfig(BaseModel):
                         f"Field '{f.field}' is missing one or both."
                     )
         elif self.type == "probabilistic":
+            if not self.fields:
+                raise ValueError(
+                    "Probabilistic matchkeys require at least one comparison field."
+                )
+            field_names = [f.resolved_field for f in self.fields]
+            duplicates = sorted(
+                name for name in set(field_names) if field_names.count(name) > 1
+            )
+            if duplicates:
+                raise ValueError(
+                    "Probabilistic matchkeys cannot contain duplicate comparison "
+                    f"fields: {', '.join(duplicates)}."
+                )
+            if (
+                self.link_threshold is not None
+                and self.review_threshold is not None
+                and self.review_threshold > self.link_threshold
+            ):
+                raise ValueError(
+                    "review_threshold must be less than or equal to link_threshold."
+                )
             for f in self.fields:
                 if f.scorer is None:
                     raise ValueError(

--- a/packages/python/goldenmatch/tests/test_config.py
+++ b/packages/python/goldenmatch/tests/test_config.py
@@ -385,6 +385,49 @@ class TestLoadConfig:
         with pytest.raises(ValueError):
             load_config(path)
 
+    @pytest.mark.parametrize(
+        ("overrides", "message"),
+        [
+            ({"fields": []}, "at least one comparison field"),
+            (
+                {
+                    "fields": [
+                        {"field": "name", "scorer": "exact"},
+                        {"field": "name", "scorer": "jaro_winkler"},
+                    ]
+                },
+                "duplicate comparison fields.*name",
+            ),
+            ({"em_iterations": 0}, "em_iterations"),
+            (
+                {"link_threshold": 0.7, "review_threshold": 0.8},
+                "review_threshold.*less than or equal to.*link_threshold",
+            ),
+        ],
+    )
+    def test_load_rejects_invalid_probabilistic_config(
+        self, tmp_path, overrides, message
+    ):
+        matchkey = {
+            "name": "fs",
+            "type": "probabilistic",
+            "fields": [{"field": "name", "scorer": "exact"}],
+            **overrides,
+        }
+        path = tmp_path / "invalid-probabilistic.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "match_settings": {"matchkeys": [matchkey]},
+                    "blocking": {"keys": [{"fields": ["name"]}]},
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(ValueError, match=message):
+            load_config(path)
+
 
 def test_golden_rules_cluster_quality_defaults():
     """New cluster quality config fields have correct defaults."""

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -92,6 +92,59 @@ class TestProbabilisticSchema:
         assert mk.link_threshold is None
         assert mk.review_threshold is None
 
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"fields": []}, "at least one comparison field"),
+            (
+                {
+                    "fields": [
+                        MatchkeyField(field="name", scorer="exact"),
+                        MatchkeyField(field="name", scorer="jaro_winkler"),
+                    ]
+                },
+                "duplicate comparison fields.*name",
+            ),
+            ({"em_iterations": 0}, "em_iterations"),
+            ({"em_iterations": -1}, "em_iterations"),
+            ({"convergence_threshold": 0}, "convergence_threshold"),
+            ({"convergence_threshold": -0.1}, "convergence_threshold"),
+            ({"link_threshold": -0.1}, "link_threshold"),
+            ({"link_threshold": 1.1}, "link_threshold"),
+            ({"review_threshold": -0.1}, "review_threshold"),
+            ({"review_threshold": 1.1}, "review_threshold"),
+            (
+                {"link_threshold": 0.8, "review_threshold": 0.9},
+                "review_threshold.*less than or equal to.*link_threshold",
+            ),
+        ],
+    )
+    def test_invalid_probabilistic_controls_are_rejected(self, kwargs, message):
+        values = {
+            "name": "fs_test",
+            "type": "probabilistic",
+            "fields": [MatchkeyField(field="name", scorer="exact")],
+            **kwargs,
+        }
+
+        with pytest.raises(ValueError, match=message):
+            MatchkeyConfig(**values)
+
+    @pytest.mark.parametrize("partial_threshold", [-0.1, 1.1])
+    def test_partial_threshold_must_be_probability(self, partial_threshold):
+        with pytest.raises(ValueError, match="partial_threshold"):
+            MatchkeyField(
+                field="name",
+                scorer="jaro_winkler",
+                levels=3,
+                partial_threshold=partial_threshold,
+            )
+
+    @pytest.mark.parametrize("em_iterations", [0, -1])
+    def test_workbench_em_iterations_must_be_positive(self, em_iterations):
+        with pytest.raises(ValueError, match="em_iterations"):
+            MatchkeyField(field="name", scorer="exact", em_iterations=em_iterations)
+
 
 # ── EM Core Tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- reject empty and duplicate probabilistic comparison fields before EM training
- constrain EM iteration counts, convergence tolerance, and probability thresholds
- enforce review threshold at or below the link threshold
- cover direct schema construction and YAML-loader validation

## Verification
- probabilistic + config tests: 153 passed
- Ruff: clean
- git diff check: clean

Closes #1816