### PR TITLE
fix(probabilistic): bind persisted models to config

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -23,7 +23,7 @@ from goldenmatch.config.schemas import (
     MatchkeyField,
 )
 from goldenmatch.core._paths import safe_path
-from goldenmatch.core.probabilistic import EMResult
+from goldenmatch.core.probabilistic import EMResult, _training_config_manifest
 
 Severity = Literal["info", "warning", "error"]
 
@@ -1076,6 +1076,11 @@ def from_splink(source: dict | str | Path, *, strict: bool = False) -> SplinkCon
     # doesn't satisfy GoldenMatchConfig's own invariants) -- let it propagate
     # loudly rather than wrapping it in SplinkConversionError.
     config = GoldenMatchConfig(matchkeys=[mk], blocking=blocking)
+    if em_model is not None:
+        # Imported weights are immediately persisted by the CLI/MCP upgrade
+        # paths. Bind them to the converted comparison semantics so they use
+        # schema v2 and remain safely reusable after the round trip.
+        em_model.training_config = _training_config_manifest(mk)
 
     if strict and (report.has_warnings or report.has_errors):
         preview = _findings_preview(

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -29,7 +29,7 @@ from goldenmatch._polars_lazy import pl
 from goldenmatch.config.from_splink import ConversionReport, SplinkConversion
 from goldenmatch.config.schemas import GoldenMatchConfig
 from goldenmatch.core._paths import safe_path
-from goldenmatch.core.probabilistic import EMResult
+from goldenmatch.core.probabilistic import EMResult, _training_config_manifest
 
 
 class SplinkUpgradeError(ValueError):
@@ -819,6 +819,14 @@ def upgrade_splink_conversion(
 
     for name in lever_names:
         _LEVER_REGISTRY[name](ctx)
+
+    if ctx.em_model is not None:
+        # Levers can change comparison semantics (TF tables, thresholds, or
+        # negative evidence). Rebind the copied model before measurement or
+        # persistence so schema-v2 validation sees the upgraded manifest.
+        ctx.em_model.training_config = _training_config_manifest(
+            ctx.upgraded_config.get_matchkeys()[0]
+        )
 
     measurement: MeasurementResult | None = None
     if measure:

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -182,6 +182,45 @@ def enforce_weight_monotonicity(
     return out, adjusted
 
 
+def _training_config_manifest(mk: MatchkeyConfig) -> dict:
+    """Canonical comparison semantics that a persisted model was trained for."""
+    return {
+        "fields": [
+            {
+                "field": f.resolved_field,
+                "scorer": f.scorer,
+                "transforms": list(f.transforms),
+                "model": f.model,
+                "columns": list(f.columns) if f.columns is not None else None,
+                "column_weights": f.column_weights,
+                "levels": f.levels,
+                "partial_threshold": f.partial_threshold,
+                "level_thresholds": (
+                    list(f.level_thresholds)
+                    if f.level_thresholds is not None
+                    else None
+                ),
+                "tf_adjustment": f.tf_adjustment,
+                "tf_freqs": f.tf_freqs,
+            }
+            for f in mk.fields
+        ],
+        "negative_evidence": [
+            {
+                "field": ne.field,
+                "scorer": ne.scorer,
+                "transforms": list(ne.transforms),
+                "threshold": ne.threshold,
+                "penalty_bits": ne.penalty_bits,
+                "derive_from": (
+                    list(ne.derive_from) if ne.derive_from is not None else None
+                ),
+            }
+            for ne in (mk.negative_evidence or [])
+        ],
+    }
+
+
 @dataclass
 class EMResult:
     """Result of EM training for Fellegi-Sunter model."""
@@ -198,9 +237,13 @@ class EMResult:
     # collision rate; the baseline an agreement is adjusted against).
     tf_freqs: dict[str, dict[str, float]] | None = None
     tf_collision: dict[str, float] | None = None
+    training_config: dict | None = None
+    # Non-serialized marker distinguishing a loaded schema-v1 model from an
+    # in-memory result constructed before manifests existed.
+    _source_schema_version: int | None = None
 
     # Bumped when the serialized shape changes incompatibly.
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION = 2
 
     def to_dict(self) -> dict:
         """JSON-serializable snapshot of the trained model.
@@ -209,9 +252,10 @@ class EMResult:
         so this is a plain projection plus a version/type marker for
         forward-compatible loading.
         """
-        return {
+        version = 2 if self.training_config is not None else 1
+        data = {
             "__type__": "goldenmatch.EMResult",
-            "__version__": EMResult.SCHEMA_VERSION,
+            "__version__": version,
             "m_probs": self.m_probs,
             "u_probs": self.u_probs,
             "match_weights": self.match_weights,
@@ -221,6 +265,9 @@ class EMResult:
             "tf_freqs": self.tf_freqs,
             "tf_collision": self.tf_collision,
         }
+        if self.training_config is not None:
+            data["training_config"] = self.training_config
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> EMResult:
@@ -232,6 +279,8 @@ class EMResult:
                 f"goldenmatch supports ({cls.SCHEMA_VERSION}); upgrade goldenmatch."
             )
         try:
+            if version >= 2 and "training_config" not in data:
+                raise KeyError("training_config")
             return cls(
                 m_probs=data["m_probs"],
                 u_probs=data["u_probs"],
@@ -241,6 +290,8 @@ class EMResult:
                 proportion_matched=data["proportion_matched"],
                 tf_freqs=data.get("tf_freqs"),
                 tf_collision=data.get("tf_collision"),
+                training_config=data.get("training_config"),
+                _source_schema_version=version,
             )
         except KeyError as exc:
             raise ValueError(f"FS model dict is missing required key: {exc}") from exc
@@ -271,12 +322,11 @@ class EMResult:
             return cls.from_dict(json.load(fh))
 
     def validate_for(self, mk: MatchkeyConfig) -> None:
-        """Raise if this model can't score ``mk`` (field / level mismatch).
+        """Raise if this model can't score ``mk`` safely.
 
-        A persisted model is only reusable against the same matchkey shape:
-        every field must have a match-weight vector whose length equals the
-        field's level count. Mismatch means the config changed since training,
-        so fail loudly rather than silently scoring with a stale model.
+        Schema-v2 models bind weights to a canonical comparison-semantics
+        manifest in addition to field/level shape. Schema-v1 files can still
+        be deserialized, but cannot be reused because they carry no manifest.
         """
         for f in mk.fields:
             weights = self.match_weights.get(f.field)
@@ -312,6 +362,21 @@ class EMResult:
                     f"NE weights must be a 2-element [fired, not_fired] list. "
                     f"Retrain or clear the model_path."
                 )
+        if self.training_config is None:
+            if self._source_schema_version == 1:
+                raise FSModelMismatchError(
+                    "Persisted FS model uses schema v1, which has no training "
+                    "configuration manifest and cannot be safely reused. Retrain "
+                    "the model to write schema v2, or clear the model_path."
+                )
+            return
+        if self.training_config != _training_config_manifest(mk):
+            raise FSModelMismatchError(
+                "Persisted FS model training configuration does not match the "
+                "current probabilistic matchkey. A comparison field's scorer, "
+                "transforms, thresholds, TF settings, or order changed; retrain "
+                "or clear the model_path."
+            )
 
 
 class FSModelMismatchError(ValueError):
@@ -1119,6 +1184,7 @@ def train_em(
         proportion_matched=p_match,
         tf_freqs=tf_freqs,
         tf_collision=tf_collision,
+        training_config=_training_config_manifest(mk),
     )
 
 
@@ -1149,8 +1215,9 @@ def load_or_train_em(
     """Return a trained EMResult, reusing ``mk.model_path`` when present.
 
     Splink-style train-once -> reuse: when ``mk.model_path`` is set and the
-    file exists, the persisted model is loaded, validated against ``mk`` (field
-    / level shape), and EM is skipped. When the path is set but absent, EM runs
+    file exists, the persisted model is loaded, validated against ``mk``
+    (field/level shape and comparison semantics), and EM is skipped. When the
+    path is set but absent, EM runs
     and the trained model is saved there for next time. With no ``model_path``
     this is exactly ``train_em``. The single seam all three pipeline call sites
     (core pipeline x2, TUI engine) share.
@@ -1355,6 +1422,7 @@ def estimate_m_from_labels(
         proportion_matched=proportion_matched if proportion_matched is not None else 0.02,
         tf_freqs=tf_freqs,
         tf_collision=tf_collision,
+        training_config=_training_config_manifest(mk),
     )
 
 
@@ -1704,6 +1772,7 @@ def _fallback_result(mk: MatchkeyConfig) -> EMResult:
     return EMResult(
         m_probs=m_probs, u_probs=u_probs, match_weights=match_weights,
         converged=False, iterations=0, proportion_matched=0.05,
+        training_config=_training_config_manifest(mk),
     )
 
 

--- a/packages/python/goldenmatch/tests/test_from_splink_api.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_api.py
@@ -169,6 +169,8 @@ def test_trained_settings_produce_em_model():
 
     assert conversion.em_model is not None
     assert "first_name" in conversion.em_model.m_probs
+    assert conversion.em_model.to_dict()["__version__"] == 2
+    conversion.em_model.validate_for(conversion.config.get_matchkeys()[0])
 
 
 def test_bare_settings_em_model_is_none():

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -888,7 +888,8 @@ class TestModelPersistence:
         em = self._trained()
         d = em.to_dict()
         assert d["__type__"] == "goldenmatch.EMResult"
-        assert d["__version__"] == 1
+        assert d["__version__"] == 2
+        assert d["training_config"]["fields"][0]["field"] == "first_name"
 
     def test_from_dict_rejects_future_version(self):
         from goldenmatch.core.probabilistic import EMResult
@@ -915,6 +916,95 @@ class TestModelPersistence:
         ])
         with pytest.raises(FSModelMismatchError, match="levels"):
             em.validate_for(mk)
+
+    @pytest.mark.parametrize(
+        "fields",
+        [
+            [
+                MatchkeyField(field="first_name", scorer="token_sort", levels=3),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+            [
+                MatchkeyField(
+                    field="first_name",
+                    scorer="jaro_winkler",
+                    transforms=["lowercase"],
+                    levels=3,
+                ),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+            [
+                MatchkeyField(
+                    field="first_name",
+                    scorer="jaro_winkler",
+                    levels=3,
+                    partial_threshold=0.9,
+                ),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+            [
+                MatchkeyField(
+                    field="first_name",
+                    scorer="jaro_winkler",
+                    levels=3,
+                    level_thresholds=[1.0, 0.9],
+                ),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+            [
+                MatchkeyField(
+                    field="first_name",
+                    scorer="jaro_winkler",
+                    levels=3,
+                    partial_threshold=0.8,
+                    tf_adjustment=True,
+                ),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+            [
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2),
+                MatchkeyField(
+                    field="first_name",
+                    scorer="jaro_winkler",
+                    levels=3,
+                    partial_threshold=0.8,
+                ),
+                MatchkeyField(field="zip", scorer="exact", levels=2),
+            ],
+        ],
+        ids=[
+            "scorer",
+            "transforms",
+            "partial-threshold",
+            "custom-thresholds",
+            "tf",
+            "field-order",
+        ],
+    )
+    def test_validate_for_detects_comparison_semantics_change(self, fields):
+        from goldenmatch.core.probabilistic import FSModelMismatchError
+
+        em = self._trained()
+        changed = _make_probabilistic_mk(fields=fields)
+
+        with pytest.raises(FSModelMismatchError, match="training configuration"):
+            em.validate_for(changed)
+
+    def test_schema_v1_model_requires_retraining_before_reuse(self):
+        from goldenmatch.core.probabilistic import EMResult, FSModelMismatchError
+
+        legacy = self._trained().to_dict()
+        legacy["__version__"] = 1
+        legacy.pop("training_config")
+        loaded = EMResult.from_dict(legacy)
+
+        with pytest.raises(FSModelMismatchError, match="(?i)schema v1.*retrain"):
+            loaded.validate_for(_make_probabilistic_mk())
 
     def test_load_or_train_saves_then_loads(self, tmp_path):
         # First call (cache miss): trains and writes the file.

--- a/packages/typescript/goldenmatch/src/core/config/from-splink.ts
+++ b/packages/typescript/goldenmatch/src/core/config/from-splink.ts
@@ -19,7 +19,7 @@ import type {
 } from "../types.js";
 import { makeMatchkeyField, makeBlockingConfig } from "../types.js";
 import { parseConfig } from "./loader.js";
-import type { EMResult } from "../probabilistic.js";
+import { trainingConfigManifest, type EMResult } from "../probabilistic.js";
 
 export type Severity = "info" | "warning" | "error";
 
@@ -855,6 +855,11 @@ export function importEm(
     proportionMatched,
     tfFreqs: null,
     tfCollision: null,
+    trainingConfig: trainingConfigManifest({
+      name: "splink_import",
+      type: "probabilistic",
+      fields: comparisons.map((comparison) => comparison.field),
+    }),
   };
 }
 

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -300,6 +300,7 @@ export {
   emResultToJson,
   emResultFromJson,
   validateEmResultFor,
+  trainingConfigManifest,
   FSModelMismatchError,
   NegativeEvidenceUnsupportedError,
   EM_RESULT_SCHEMA_VERSION,

--- a/packages/typescript/goldenmatch/src/core/probabilistic.ts
+++ b/packages/typescript/goldenmatch/src/core/probabilistic.ts
@@ -53,19 +53,62 @@ export interface EMResult {
   readonly tfFreqs?: Readonly<Record<string, Readonly<Record<string, number>>>> | null;
   /** field -> sum(freq(v)^2) (expected exact-match collision rate baseline). */
   readonly tfCollision?: Readonly<Record<string, number>> | null;
+  /** Canonical schema-v2 comparison semantics used to train this model. */
+  readonly trainingConfig?: Readonly<Record<string, unknown>> | null;
+  /** Source wire version, populated only by emResultFromJson. */
+  readonly sourceSchemaVersion?: number;
 }
 
 // ---------------------------------------------------------------------------
 // Public: EMResult JSON (de)serialization — byte-compatible with Python's
-// EMResult.to_dict()/from_dict() (goldenmatch/core/probabilistic.py, schema
-// v1). A trained-model JSON file must be loadable by either surface, so the
+// EMResult.to_dict()/from_dict() (goldenmatch/core/probabilistic.py, schemas
+// v1/v2). A trained-model JSON file must be loadable by either surface, so the
 // wire shape (snake_case keys, __type__/__version__ markers) is authoritative
 // on the Python side; this is a faithful mirror, not a TS-native shape.
 // ---------------------------------------------------------------------------
 
 /** Current EMResult JSON schema version. Bumped when the wire shape changes
  *  incompatibly (mirrors Python `EMResult.SCHEMA_VERSION`). */
-export const EM_RESULT_SCHEMA_VERSION = 1;
+export const EM_RESULT_SCHEMA_VERSION = 2;
+
+/** Canonical cross-runtime manifest of every comparison-vector-affecting setting. */
+export function trainingConfigManifest(mk: MatchkeyConfig): Readonly<Record<string, unknown>> {
+  return {
+    fields: mk.fields.map((f) => ({
+      field: f.field,
+      scorer: f.scorer,
+      transforms: [...f.transforms],
+      model: f.model ?? null,
+      columns: f.columns === undefined ? null : [...f.columns],
+      column_weights: f.columnWeights ?? null,
+      levels: f.levels ?? 2,
+      partial_threshold: f.partialThreshold ?? 0.8,
+      level_thresholds: f.levelThresholds === undefined ? null : [...f.levelThresholds],
+      tf_adjustment: f.tfAdjustment ?? false,
+      tf_freqs: f.tfFreqs ?? null,
+    })),
+    negative_evidence: (mk.negativeEvidence ?? []).map((ne) => ({
+      field: ne.field,
+      scorer: ne.scorer,
+      transforms: [...ne.transforms],
+      threshold: ne.threshold,
+      penalty_bits: ne.penaltyBits ?? null,
+      derive_from: null,
+    })),
+  };
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    return `{${Object.keys(obj)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(obj[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
 
 /**
  * A persisted FS model is incompatible with the matchkey being scored, or
@@ -122,9 +165,10 @@ function assertNoNegativeEvidence(mk: MatchkeyConfig, path: string): void {
  * dataclass default of `None` surviving `json.dump`).
  */
 export function emResultToJson(em: EMResult): Record<string, unknown> {
-  return {
+  const version = em.trainingConfig == null ? 1 : 2;
+  const data: Record<string, unknown> = {
     __type__: "goldenmatch.EMResult",
-    __version__: EM_RESULT_SCHEMA_VERSION,
+    __version__: version,
     m_probs: em.m,
     u_probs: em.u,
     match_weights: em.matchWeights,
@@ -134,6 +178,8 @@ export function emResultToJson(em: EMResult): Record<string, unknown> {
     tf_freqs: em.tfFreqs ?? null,
     tf_collision: em.tfCollision ?? null,
   };
+  if (em.trainingConfig != null) data["training_config"] = em.trainingConfig;
+  return data;
 }
 
 /**
@@ -178,8 +224,11 @@ export function emResultFromJson(data: unknown): EMResult {
 
   const tfFreqsRaw = obj["tf_freqs"];
   const tfCollisionRaw = obj["tf_collision"];
+  if (version >= 2 && !("training_config" in obj)) {
+    throw new FSModelMismatchError("FS model dict is missing required key: 'training_config'");
+  }
 
-  return {
+  const result: EMResult = {
     m: obj["m_probs"] as Readonly<Record<string, readonly number[]>>,
     u: obj["u_probs"] as Readonly<Record<string, readonly number[]>>,
     matchWeights: obj["match_weights"] as Readonly<Record<string, readonly number[]>>,
@@ -194,7 +243,17 @@ export function emResultFromJson(data: unknown): EMResult {
       tfCollisionRaw === null || tfCollisionRaw === undefined
         ? (tfCollisionRaw as null | undefined) ?? null
         : (tfCollisionRaw as Readonly<Record<string, number>>),
+    ...(obj["training_config"] === undefined
+      ? {}
+      : {
+          trainingConfig: obj["training_config"] as Readonly<Record<string, unknown>>,
+        }),
   };
+  Object.defineProperty(result, "sourceSchemaVersion", {
+    value: version,
+    enumerable: false,
+  });
+  return result;
 }
 
 /**
@@ -255,6 +314,23 @@ export function validateEmResultFor(em: EMResult, mk: MatchkeyConfig): void {
           `model_path.`,
       );
     }
+  }
+  if (em.trainingConfig == null) {
+    if (em.sourceSchemaVersion === 1) {
+      throw new FSModelMismatchError(
+        "Persisted FS model uses schema v1, which has no training configuration " +
+          "manifest and cannot be safely reused. Retrain the model to write " +
+          "schema v2, or clear the model_path.",
+      );
+    }
+    return;
+  }
+  if (canonicalJson(em.trainingConfig) !== canonicalJson(trainingConfigManifest(mk))) {
+    throw new FSModelMismatchError(
+      "Persisted FS model training configuration does not match the current " +
+        "probabilistic matchkey. A comparison field's scorer, transforms, " +
+        "thresholds, TF settings, or order changed; retrain or clear the model_path.",
+    );
   }
 }
 
@@ -1055,6 +1131,7 @@ export function trainEM(
     proportionMatched: pMatch,
     iterations,
     converged,
+    trainingConfig: trainingConfigManifest(mk),
   };
 }
 
@@ -1286,5 +1363,6 @@ export function fallbackResult(mk: MatchkeyConfig): EMResult {
     proportionMatched: 0.05,
     iterations: 0,
     converged: false,
+    trainingConfig: trainingConfigManifest(mk),
   };
 }

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -48,6 +48,8 @@ export interface MatchkeyField {
    * without silently losing the flag.
    */
   readonly tfAdjustment?: boolean;
+  /** Optional data-driven frequency table consumed by frequency-aware scorers. */
+  readonly tfFreqs?: Readonly<Record<string, number>>;
 }
 
 /**

--- a/packages/typescript/goldenmatch/tests/parity/fs-negative-evidence-fixtures.json
+++ b/packages/typescript/goldenmatch/tests/parity/fs-negative-evidence-fixtures.json
@@ -569,7 +569,55 @@
       },
       "em_model": {
         "__type__": "goldenmatch.EMResult",
-        "__version__": 1,
+        "__version__": 2,
+        "training_config": {
+          "fields": [
+            {
+              "column_weights": null,
+              "columns": null,
+              "field": "given_name",
+              "level_thresholds": null,
+              "levels": 2,
+              "model": null,
+              "partial_threshold": 0.8,
+              "scorer": "jaro_winkler",
+              "tf_adjustment": false,
+              "tf_freqs": null,
+              "transforms": [
+                "lowercase",
+                "strip"
+              ]
+            },
+            {
+              "column_weights": null,
+              "columns": null,
+              "field": "city",
+              "level_thresholds": null,
+              "levels": 2,
+              "model": null,
+              "partial_threshold": 0.8,
+              "scorer": "exact",
+              "tf_adjustment": false,
+              "tf_freqs": null,
+              "transforms": [
+                "lowercase",
+                "strip"
+              ]
+            }
+          ],
+          "negative_evidence": [
+            {
+              "derive_from": null,
+              "field": "phone",
+              "penalty_bits": null,
+              "scorer": "exact",
+              "threshold": 1.0,
+              "transforms": [
+                "digits_only"
+              ]
+            }
+          ]
+        },
         "converged": true,
         "iterations": 5,
         "m_probs": {
@@ -756,7 +804,55 @@
       },
       "em_model": {
         "__type__": "goldenmatch.EMResult",
-        "__version__": 1,
+        "__version__": 2,
+        "training_config": {
+          "fields": [
+            {
+              "column_weights": null,
+              "columns": null,
+              "field": "given_name",
+              "level_thresholds": null,
+              "levels": 2,
+              "model": null,
+              "partial_threshold": 0.8,
+              "scorer": "jaro_winkler",
+              "tf_adjustment": false,
+              "tf_freqs": null,
+              "transforms": [
+                "lowercase",
+                "strip"
+              ]
+            },
+            {
+              "column_weights": null,
+              "columns": null,
+              "field": "city",
+              "level_thresholds": null,
+              "levels": 2,
+              "model": null,
+              "partial_threshold": 0.8,
+              "scorer": "exact",
+              "tf_adjustment": false,
+              "tf_freqs": null,
+              "transforms": [
+                "lowercase",
+                "strip"
+              ]
+            }
+          ],
+          "negative_evidence": [
+            {
+              "derive_from": null,
+              "field": "phone",
+              "penalty_bits": 6.0,
+              "scorer": "exact",
+              "threshold": 1.0,
+              "transforms": [
+                "digits_only"
+              ]
+            }
+          ]
+        },
         "converged": true,
         "iterations": 5,
         "m_probs": {

--- a/packages/typescript/goldenmatch/tests/unit/em-serde.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/em-serde.test.ts
@@ -3,6 +3,7 @@ import {
   emResultToJson,
   emResultFromJson,
   validateEmResultFor,
+  trainingConfigManifest,
   FSModelMismatchError,
   type EMResult,
   makeMatchkeyConfig,
@@ -14,6 +15,28 @@ import {
 // ---------------------------------------------------------------------------
 
 describe("emResultToJson / emResultFromJson: round-trip", () => {
+  it("writes schema v2 when a training manifest is present", () => {
+    const mk = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [makeMatchkeyField({ field: "name", scorer: "exact" })],
+    });
+    const em: EMResult = {
+      m: { name: [0.1, 0.9] },
+      u: { name: [0.9, 0.1] },
+      matchWeights: { name: [-3, 3] },
+      converged: true,
+      iterations: 2,
+      proportionMatched: 0.01,
+      trainingConfig: trainingConfigManifest(mk),
+    };
+
+    const json = emResultToJson(em);
+    expect(json["__version__"]).toBe(2);
+    expect(json["training_config"]).toEqual(em.trainingConfig);
+    expect(() => validateEmResultFor(emResultFromJson(json), mk)).not.toThrow();
+  });
+
   it("round-trips without tf fields", () => {
     const em: EMResult = {
       m: { first_name: [0.05, 0.1, 0.25, 0.6], postcode: [0.1, 0.9] },
@@ -129,7 +152,7 @@ describe("emResultFromJson: forward-compat + validation errors", () => {
   it("rejects a schema version newer than supported", () => {
     const data = {
       __type__: "goldenmatch.EMResult",
-      __version__: 2,
+      __version__: 3,
       m_probs: {},
       u_probs: {},
       match_weights: {},
@@ -138,7 +161,7 @@ describe("emResultFromJson: forward-compat + validation errors", () => {
       proportion_matched: 0.0,
     };
     expect(() => emResultFromJson(data)).toThrow(
-      /schema version 2 is newer than this goldenmatch supports \(1\)/,
+      /schema version 3 is newer than this goldenmatch supports \(2\)/,
     );
   });
 
@@ -161,6 +184,90 @@ describe("emResultFromJson: forward-compat + validation errors", () => {
 // ---------------------------------------------------------------------------
 
 describe("validateEmResultFor", () => {
+  it.each([
+    ["scorer", { scorer: "token_sort" }],
+    ["transforms", { transforms: ["lowercase"] }],
+    ["threshold", { partialThreshold: 0.9 }],
+    ["custom thresholds", { levelThresholds: [1.0, 0.9] }],
+    ["tf", { tfAdjustment: true }],
+  ])("rejects a persisted model after a %s change", (_name, fieldChange) => {
+    const original = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [
+        makeMatchkeyField({
+          field: "first_name",
+          scorer: "jaro_winkler",
+          levels: 3,
+          partialThreshold: 0.8,
+        }),
+      ],
+    });
+    const changed = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [makeMatchkeyField({
+        field: "first_name",
+        scorer: "jaro_winkler",
+        levels: 3,
+        partialThreshold: 0.8,
+        ...fieldChange,
+      })],
+    });
+    const em: EMResult = {
+      m: { first_name: [0.05, 0.15, 0.8] },
+      u: { first_name: [0.8, 0.15, 0.05] },
+      matchWeights: { first_name: [-4, 0, 4] },
+      converged: true,
+      iterations: 3,
+      proportionMatched: 0.01,
+      trainingConfig: trainingConfigManifest(original),
+    };
+
+    expect(() => validateEmResultFor(em, changed)).toThrow(/training configuration/);
+  });
+
+  it("rejects a persisted model after field order changes", () => {
+    const first = makeMatchkeyField({ field: "first_name", scorer: "exact" });
+    const last = makeMatchkeyField({ field: "last_name", scorer: "exact" });
+    const original = makeMatchkeyConfig({
+      name: "mk", type: "probabilistic", fields: [first, last],
+    });
+    const changed = makeMatchkeyConfig({
+      name: "mk", type: "probabilistic", fields: [last, first],
+    });
+    const em: EMResult = {
+      m: { first_name: [0.1, 0.9], last_name: [0.1, 0.9] },
+      u: { first_name: [0.9, 0.1], last_name: [0.9, 0.1] },
+      matchWeights: { first_name: [-3, 3], last_name: [-3, 3] },
+      converged: true,
+      iterations: 3,
+      proportionMatched: 0.01,
+      trainingConfig: trainingConfigManifest(original),
+    };
+
+    expect(() => validateEmResultFor(em, changed)).toThrow(/training configuration/);
+  });
+
+  it("requires schema-v1 persisted models to be retrained before reuse", () => {
+    const legacy = emResultFromJson({
+      __version__: 1,
+      m_probs: { name: [0.1, 0.9] },
+      u_probs: { name: [0.9, 0.1] },
+      match_weights: { name: [-3, 3] },
+      converged: true,
+      iterations: 2,
+      proportion_matched: 0.01,
+    });
+    const mk = makeMatchkeyConfig({
+      name: "mk",
+      type: "probabilistic",
+      fields: [makeMatchkeyField({ field: "name", scorer: "exact" })],
+    });
+
+    expect(() => validateEmResultFor(legacy, mk)).toThrow(/schema v1.*Retrain/);
+  });
+
   it("passes when a 4-level levelThresholds field matches", () => {
     const mk = makeMatchkeyConfig({
       name: "mk",


### PR DESCRIPTION
## Summary
- persist a canonical schema-v2 comparison manifest with trained FS models
- reject stale models when scorer, transforms, thresholds, TF settings, negative evidence, or field order changes
- keep schema-v1 files readable and round-trippable, but require retraining before reuse
- mirror the wire format, validation, training, fallback, and Splink-import behavior in TypeScript

## Verification
- Python probabilistic tests: 101 passed
- Ruff: clean
- TypeScript FS/serde/import tests: 184 passed
- TypeScript typecheck: passed
- TypeScript production build: passed
- git diff check: clean

Closes #1817