### PR TITLE
feat(blocking): per-field transform chains on blocking keys; from_splink maps mixed SUBSTR rules exactly (#1826)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1232,7 +1232,10 @@ def score_buckets(
             _slim_frame = _tf(slim_df)
             keyed = _slim_frame.with_column(
                 "__block_key__",
-                _slim_frame.derive_block_key(key.fields, key.transforms or []),
+                _slim_frame.derive_block_key(
+                    key.fields, key.transforms or [],
+                    field_transforms=getattr(key, "field_transforms", None),
+                ),
             ).native
             if _bkt_debug_on():
                 print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: keyed (with_columns key_expr) in {time.perf_counter()-_ta:.2f}s", flush=True)

--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -478,27 +478,39 @@ def _convert_one_blocking_rule(
         return None
 
     # Dedupe repeated fields (order-preserving): `l.a = r.a AND l.a = r.a`
-    # is one field, not two identical key components.
+    # is one field, not two identical key components. A field appearing with
+    # CONFLICTING transforms (e.g. plain equality AND a SUBSTR on the same
+    # column) keeps the strictest reading by dropping the rule -- ambiguous.
     fields = list(dict.fromkeys(r.field for r in recognized))
-    # BlockingKeyConfig.transforms is ONE chain applied uniformly to every
-    # field in the key (core/blocker.py:_build_block_key_expr) -- there is no
-    # per-field transform slot. A mixed rule (plain equality on one column +
-    # SUBSTR on another) is therefore approximated as a single key carrying
-    # the substring transform for ALL fields. This is safe for blocking
-    # (candidate generation only needs to be a superset of true matches;
-    # applying substring to the plain-equality field just widens that block
-    # slightly -- no recall loss, just looser precision at the blocking
-    # stage). If two conjuncts specify SUBSTR at different offsets, there is
-    # no single chain that represents both, so the rule is dropped.
-    transform_values = {r.transform for r in recognized if r.transform is not None}
-    if len(transform_values) > 1:
-        report.warn(
-            rule_path,
-            f"conflicting SUBSTR offsets across fields, rule dropped: {sql_norm}",
-            mapped_to=None,
-        )
-        return None
-    transforms = [next(iter(transform_values))] if transform_values else []
+    per_field: dict[str, str | None] = {}
+    for r in recognized:
+        if r.field in per_field and per_field[r.field] != r.transform:
+            report.warn(
+                rule_path,
+                f"conflicting transforms on field {r.field!r}, rule dropped: "
+                f"{sql_norm}",
+                mapped_to=None,
+            )
+            return None
+        per_field[r.field] = r.transform
+
+    # Exact per-field mapping (#1826). BlockingKeyConfig.field_transforms
+    # carries each SUBSTR'd field's own chain, so a mixed rule (plain
+    # equality on one column + SUBSTR on another) no longer widens the whole
+    # key to the substring -- pre-#1826 that collapsed e.g. last+zip5+
+    # first-initial into first-initials-only and produced a 388K-row
+    # mega-block at 1M rows. Uniform rules keep the legacy key-level
+    # `transforms` shape (backward-compatible config output).
+    transform_values = {t for t in per_field.values() if t is not None}
+    all_transformed = all(t is not None for t in per_field.values())
+    if len(transform_values) == 1 and all_transformed:
+        transforms = [next(iter(transform_values))]
+        field_transforms: dict[str, list[str]] = {}
+    else:
+        transforms = []
+        field_transforms = {
+            f: [t] for f, t in per_field.items() if t is not None
+        }
 
     # IS NOT NULL guards (#1783): GM's blocker already nulls the whole key
     # when any key field is null (concat_str default) and filters null keys
@@ -527,29 +539,17 @@ def _convert_one_blocking_rule(
             mapped_to=None,
         )
 
-    key = BlockingKeyConfig(fields=fields, transforms=transforms)
-    plain_fields = list(dict.fromkeys(r.field for r in recognized if r.transform is None))
-    if transforms and plain_fields:
-        # LOSSY: the key-level chain applies the substring transform to
-        # field(s) Splink compared with plain equality. Warn (not info) so
-        # strict=True gates on it, matching the approx-warn convention used
-        # for comparison levels above.
-        report.warn(
-            rule_path,
-            f"approximate mapping, blocking key widened: {transforms[0]} "
-            f"applied to all fields including plain-equality field(s) "
-            f"{plain_fields} (GoldenMatch transforms are key-level); "
-            "candidates are a superset of Splink's, precision may drop "
-            "(superset guarantee assumes skip_oversized stays False, the "
-            f"converter's emitted default) ({sql_norm})",
-            mapped_to=None,
-        )
-    else:
-        report.info(
-            rule_path,
-            f"converted to blocking key fields={fields} transforms={transforms}",
-            mapped_to=None,
-        )
+    key = BlockingKeyConfig(
+        fields=fields, transforms=transforms, field_transforms=field_transforms
+    )
+    # Exact mapping either way now (#1826): uniform rules ride the key-level
+    # chain, mixed rules ride field_transforms -- no widening, no warning.
+    report.info(
+        rule_path,
+        f"converted to blocking key fields={fields} transforms={transforms}"
+        + (f" field_transforms={field_transforms}" if field_transforms else ""),
+        mapped_to=None,
+    )
     return key
 
 

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -441,11 +441,24 @@ class MatchkeyConfig(BaseModel):
 class BlockingKeyConfig(BaseModel):
     fields: list[str]
     transforms: list[str] = Field(default_factory=list)
+    # Per-field transform chains (#1826). A field present here uses ITS chain
+    # for the block-key derivation; fields absent keep the key-level
+    # ``transforms`` chain. This is what lets a mixed Splink rule
+    # (``l.last=r.last AND SUBSTR(l.first,1,1)=SUBSTR(r.first,1,1)``) map
+    # exactly instead of widening every field to the substring (the
+    # 388K-mega-block footgun).
+    field_transforms: dict[str, list[str]] = Field(default_factory=dict)
 
     @model_validator(mode="after")
     def _validate_fields_nonempty(self) -> BlockingKeyConfig:
         if not self.fields:
             raise ValueError("Blocking key must have at least one field.")
+        unknown = [f for f in self.field_transforms if f not in self.fields]
+        if unknown:
+            raise ValueError(
+                f"field_transforms references field(s) not in this key's "
+                f"fields: {unknown} (fields: {self.fields})"
+            )
         return self
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
+++ b/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
@@ -192,14 +192,26 @@ def transformed_column(arr: Any, transforms: Sequence[str]) -> Any:
     return pa.array(vals, type=pa.large_string())
 
 
-def block_key(field_arrs: Sequence[Any], transforms: Sequence[str], sep: str = "||") -> Any:
-    """``blocker._build_block_key_expr`` twin: the SAME transform chain applies
-    to every key field, then fields concat with ``sep`` (any-null -> null,
-    matching ``pl.concat_str``); a single field skips the join entirely."""
+def block_key(
+    field_arrs: Sequence[Any],
+    transforms: Sequence[str],
+    sep: str = "||",
+    field_chains: Sequence[Sequence[str]] | None = None,
+) -> Any:
+    """``blocker._build_block_key_expr`` twin: each field's transform chain
+    applies (``field_chains[i]`` when given -- the per-field slot, #1826 --
+    else the shared ``transforms`` chain), then fields concat with ``sep``
+    (any-null -> null, matching ``pl.concat_str``); a single field skips the
+    join entirely."""
     import pyarrow as pa
     import pyarrow.compute as pc
 
-    cols = [transformed_column(a, transforms) for a in field_arrs]
+    chains = (
+        list(field_chains)
+        if field_chains is not None
+        else [transforms] * len(field_arrs)
+    )
+    cols = [transformed_column(a, c) for a, c in zip(field_arrs, chains)]
     if len(cols) == 1:
         return cols[0]
     sep_scalar = pa.scalar(sep, type=pa.large_string())  # match the column type

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -88,7 +88,10 @@ def _sample_block_sizes_per_key(
         try:
             keyed = sample.with_column(
                 "__block_key__",
-                sample.derive_block_key(key.fields, key.transforms or []),
+                sample.derive_block_key(
+                    key.fields, key.transforms or [],
+                    field_transforms=getattr(key, "field_transforms", None),
+                ),
             )
             sizes = keyed.group_len(["__block_key__"]).column("len").to_list()
         except Exception as exc:

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -138,7 +138,10 @@ def _fast_static_block_sizes(
     for key_config in keys:
         keyed = frame.with_column(
             "__block_key__",
-            frame.derive_block_key(key_config.fields, key_config.transforms or []),
+            frame.derive_block_key(
+                key_config.fields, key_config.transforms or [],
+                field_transforms=getattr(key_config, "field_transforms", None),
+            ),
         )
         valid = keyed.filter_valid_key("__block_key__")
         # Per-key sizes AFTER the null/sentinel drop, BEFORE the size<2 drop.
@@ -318,9 +321,13 @@ def _build_block_key_expr(key_config: BlockingKeyConfig) -> pl.Expr:
     """
     from goldenmatch.core.matchkey import _try_native_chain
 
+    # Per-field chains (#1826): a field listed in field_transforms uses its
+    # OWN chain; others keep the key-level chain. getattr keeps the
+    # SimpleNamespace duck-type callers (frame.derive_block_key) working.
+    per_field = getattr(key_config, "field_transforms", None) or {}
     field_exprs: list[pl.Expr] = []
     for field_name in key_config.fields:
-        transforms = key_config.transforms or []
+        transforms = per_field.get(field_name, key_config.transforms or [])
         native = _try_native_chain(field_name, transforms) if transforms else None
         if native is not None:
             field_exprs.append(native)
@@ -413,7 +420,8 @@ def _build_static_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
             _f = _f.with_column(
                 "__block_key__",
                 _f.derive_block_key(
-                    key_config.fields, key_config.transforms or []
+                    key_config.fields, key_config.transforms or [],
+                    field_transforms=getattr(key_config, "field_transforms", None)
                 ),
             )
             df_with_key = _f.filter_valid_key("__block_key__").native

--- a/packages/python/goldenmatch/goldenmatch/core/frame.py
+++ b/packages/python/goldenmatch/goldenmatch/core/frame.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import Any, Protocol, runtime_checkable
 
 from goldenmatch._polars_lazy import pl
@@ -126,7 +126,11 @@ class Frame(Protocol):
     def column(self, name: str) -> Column: ...
     def to_arrow_columns(self, names: list[str]) -> dict[str, Any]: ...
     def derive_block_key(
-        self, fields: Sequence[str], transforms: Sequence[str], sep: str = "||"
+        self,
+        fields: Sequence[str],
+        transforms: Sequence[str],
+        sep: str = "||",
+        field_transforms: Mapping[str, Sequence[str]] | None = None,
     ) -> Column: ...
     def derive_transformed_column(self, field: str, transforms: Sequence[str]) -> Column: ...
     def utf8_values(self, field: str) -> list[str | None]: ...
@@ -371,7 +375,11 @@ class PolarsFrame:
         return {n: self._df[n].to_arrow() for n in names}
 
     def derive_block_key(
-        self, fields: Sequence[str], transforms: Sequence[str], sep: str = "||"
+        self,
+        fields: Sequence[str],
+        transforms: Sequence[str],
+        sep: str = "||",
+        field_transforms: Mapping[str, Sequence[str]] | None = None,
     ) -> PolarsColumn:
         # Byte-identical by construction: delegates to the pipeline's own
         # _build_block_key_expr over a Utf8 pre-cast frame (the fused prep's
@@ -380,7 +388,15 @@ class PolarsFrame:
 
         from goldenmatch.core.blocker import _build_block_key_expr
 
-        key_cfg = SimpleNamespace(fields=list(fields), transforms=list(transforms))
+        key_cfg = SimpleNamespace(
+            fields=list(fields),
+            transforms=list(transforms),
+            field_transforms=(
+                {k: list(v) for k, v in field_transforms.items()}
+                if field_transforms
+                else {}
+            ),
+        )
         df = self._df.with_columns([pl.col(f).cast(pl.Utf8) for f in fields])
         s = df.lazy().select(_build_block_key_expr(key_cfg)).collect().get_column("__block_key__")
         return PolarsColumn(s)
@@ -1145,12 +1161,20 @@ class ArrowFrame:
         return {n: self._tbl.column(n) for n in names}
 
     def derive_block_key(
-        self, fields: Sequence[str], transforms: Sequence[str], sep: str = "||"
+        self,
+        fields: Sequence[str],
+        transforms: Sequence[str],
+        sep: str = "||",
+        field_transforms: Mapping[str, Sequence[str]] | None = None,
     ) -> ArrowColumn:
         from goldenmatch.core import arrow_derive
 
         arrs = [self._tbl.column(f) for f in fields]
-        return ArrowColumn(arrow_derive.block_key(arrs, list(transforms), sep=sep))
+        per_field = field_transforms or {}
+        chains = [list(per_field.get(f, transforms)) for f in fields]
+        return ArrowColumn(
+            arrow_derive.block_key(arrs, list(transforms), sep=sep, field_chains=chains)
+        )
 
     def derive_transformed_column(self, field: str, transforms: Sequence[str]) -> ArrowColumn:
         from goldenmatch.core import arrow_derive

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -163,7 +163,10 @@ def run_match_fused_arrow(
     frame = _prep_frame(columns, src_cols)
 
     key_arrs = [
-        frame.derive_block_key(key_cfg.fields, key_cfg.transforms or []).to_arrow()
+        frame.derive_block_key(
+            key_cfg.fields, key_cfg.transforms or [],
+            field_transforms=getattr(key_cfg, "field_transforms", None),
+        ).to_arrow()
     ]  # already transformed + "||"-concatenated
     score_arrs = [
         frame.derive_transformed_column(f.field, f.transforms or []).to_arrow()
@@ -378,7 +381,12 @@ def run_match_fused_fs_arrow(
     n = n_rows if n_rows is not None else len(columns[src_cols[0]])
     frame = _prep_frame(columns, src_cols)
 
-    key_arrs = [frame.derive_block_key(key_cfg.fields, key_cfg.transforms or []).to_arrow()]
+    key_arrs = [
+        frame.derive_block_key(
+            key_cfg.fields, key_cfg.transforms or [],
+            field_transforms=getattr(key_cfg, "field_transforms", None),
+        ).to_arrow()
+    ]
 
     # FS kernel args — mirrors score_probabilistic_native exactly.
     calibrated = _fs_calibration_mode() == "posterior"

--- a/packages/python/goldenmatch/tests/test_blocker.py
+++ b/packages/python/goldenmatch/tests/test_blocker.py
@@ -414,3 +414,72 @@ class TestNullBlockKeyFilter:
             f"Found 'nan' block in {keys}: NaN records should be "
             "filtered before group_by. See #372."
         )
+
+
+class TestPerFieldBlockingTransforms:
+    """#1826: BlockingKeyConfig.field_transforms applies a per-field chain
+    (fields absent from the map keep the key-level ``transforms`` chain), so
+    a Splink ``last=last AND SUBSTR(first,1,1)=...`` rule maps exactly
+    instead of widening every field to the substring."""
+
+    def _df(self):
+        import polars as pl
+        return pl.DataFrame({
+            "__row_id__": [1, 2, 3, 4],
+            "last": ["Smith", "Smith", "Smith", "Jones"],
+            "first": ["Anna", "Albert", "Bella", "Anna"],
+        })
+
+    def _key(self):
+        from goldenmatch.config.schemas import BlockingKeyConfig
+        return BlockingKeyConfig(
+            fields=["last", "first"],
+            field_transforms={"first": ["substring:0:1"]},
+        )
+
+    def test_schema_validates_unknown_field(self):
+        import pytest as _pytest
+        from goldenmatch.config.schemas import BlockingKeyConfig
+        with _pytest.raises(ValueError, match="field_transforms"):
+            BlockingKeyConfig(
+                fields=["last"], field_transforms={"nope": ["lowercase"]}
+            )
+
+    def test_build_blocks_honors_field_transforms(self):
+        from goldenmatch.config.schemas import BlockingConfig
+        from goldenmatch.core.blocker import build_blocks
+
+        cfg = BlockingConfig(keys=[self._key()])
+        blocks = build_blocks(self._df().lazy(), cfg)
+        keys = sorted(b.block_key for b in blocks)
+        # last stays FULL (plain equality); first collapses to its initial:
+        # rows 1+2 share (Smith, A); row 3 is (Smith, B); row 4 (Jones, A).
+        assert keys == ["Smith||A"]
+        members = {tuple(sorted(b.materialize().column("__row_id__").to_list()))
+                   for b in blocks}
+        assert members == {(1, 2)}
+
+    def test_polars_and_arrow_derive_agree(self):
+        import pyarrow as pa
+        from goldenmatch.core.frame import to_frame
+
+        df = self._df()
+        key = self._key()
+        p = to_frame(df).derive_block_key(
+            key.fields, key.transforms or [], field_transforms=key.field_transforms
+        ).to_list()
+        a = to_frame(pa.Table.from_pandas(df.to_pandas())).derive_block_key(
+            key.fields, key.transforms or [], field_transforms=key.field_transforms
+        ).to_list()
+        assert p == a == ["Smith||A", "Smith||A", "Smith||B", "Jones||A"]
+
+    def test_key_level_transforms_still_apply_to_unmapped_fields(self):
+        from goldenmatch.core.frame import to_frame
+
+        df = self._df()
+        vals = to_frame(df).derive_block_key(
+            ["last", "first"], ["lowercase"],
+            field_transforms={"first": ["substring:0:1"]},
+        ).to_list()
+        # last gets the key-level lowercase; first gets ONLY its own chain.
+        assert vals == ["smith||A", "smith||A", "smith||B", "jones||A"]

--- a/packages/python/goldenmatch/tests/test_blocker.py
+++ b/packages/python/goldenmatch/tests/test_blocker.py
@@ -460,7 +460,6 @@ class TestPerFieldBlockingTransforms:
         assert members == {(1, 2)}
 
     def test_polars_and_arrow_derive_agree(self):
-        import pyarrow as pa
         from goldenmatch.core.frame import to_frame
 
         df = self._df()
@@ -468,7 +467,7 @@ class TestPerFieldBlockingTransforms:
         p = to_frame(df).derive_block_key(
             key.fields, key.transforms or [], field_transforms=key.field_transforms
         ).to_list()
-        a = to_frame(pa.Table.from_pandas(df.to_pandas())).derive_block_key(
+        a = to_frame(df.to_arrow()).derive_block_key(
             key.fields, key.transforms or [], field_transforms=key.field_transforms
         ).to_list()
         assert p == a == ["Smith||A", "Smith||A", "Smith||B", "Jones||A"]

--- a/packages/python/goldenmatch/tests/test_from_splink_blocking.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_blocking.py
@@ -41,7 +41,11 @@ def test_bare_unquoted_columns_work():
     assert not report.has_warnings
 
 
-def test_surname_and_dob_substring_conjunction():
+def test_surname_and_dob_substring_conjunction_exact():
+    # #1826: mixed plain-equality + SUBSTR rules map EXACTLY via per-field
+    # transforms -- surname stays plain equality, dob gets its substring.
+    # (Pre-#1826 this widened the whole key to first-initials and produced
+    # the 388K mega-block.)
     rule = 'l."surname" = r."surname" AND SUBSTR(l."dob", 1, 4) = SUBSTR(r."dob", 1, 4)'
     report = ConversionReport()
     config = convert_blocking([rule], report)
@@ -51,21 +55,10 @@ def test_surname_and_dob_substring_conjunction():
     assert len(config.keys) == 1
     key = config.keys[0]
     assert key.fields == ["surname", "dob"]
-    # BlockingKeyConfig.transforms is a single chain applied to every field in
-    # the key (no per-field slot) -- the dob-only SUBSTR is carried as the
-    # key's one transform. SUBSTR(x, 1, 4) -> substring:0:4 per the verified
-    # convention above.
-    assert key.transforms == ["substring:0:4"]
-    # This is LOSSY: surname was plain equality in Splink but gets the
-    # substring transform here (key-level chain). It must be a WARNING so
-    # strict=True gates on it, not a silent info.
-    warnings = [f for f in report.findings if f.severity == "warning"]
-    assert len(warnings) == 1
-    assert report.has_warnings
-    msg = warnings[0].message
-    assert "widened" in msg or "approximate" in msg
-    assert "surname" in msg
-    assert "skip_oversized" in msg
+    assert key.transforms == []
+    assert key.field_transforms == {"dob": ["substring:0:4"]}
+    # Exact mapping: no lossy-widening warning anymore.
+    assert not report.has_warnings
 
 
 def test_pure_substr_rule_is_info_only():
@@ -197,15 +190,22 @@ def test_none_rule_dropped():
     assert "not a SQL string" in warnings[0].message
 
 
-def test_conflicting_substr_offsets_rule_dropped():
+def test_per_field_substr_offsets_convert_exactly():
+    # Pre-#1826 different offsets across fields dropped the whole rule (one
+    # key-level chain could not represent both). Per-field transforms can.
     rule = "SUBSTR(l.a, 1, 4) = SUBSTR(r.a, 1, 4) AND SUBSTR(l.b, 1, 2) = SUBSTR(r.b, 1, 2)"
     report = ConversionReport()
     config = convert_blocking([rule], report)
 
-    assert config is None
-    warnings = [f for f in report.findings if f.severity == "warning"]
-    assert len(warnings) == 1
-    assert "conflicting SUBSTR offsets" in warnings[0].message
+    assert config is not None
+    key = config.keys[0]
+    assert key.fields == ["a", "b"]
+    assert key.transforms == []
+    assert key.field_transforms == {
+        "a": ["substring:0:4"],
+        "b": ["substring:0:2"],
+    }
+    assert not report.has_warnings
 
 
 def test_substr_start_zero_dropped():
@@ -265,7 +265,10 @@ def test_splink4_serialized_parenthesized_conjuncts():
 
     assert config is not None
     assert config.keys[0].fields == ["surname", "dob"]
-    assert config.keys[0].transforms == ["substring:0:4"]
+    # Exact per-field mapping (#1826): dob carries its own chain, surname
+    # keeps plain equality.
+    assert config.keys[0].transforms == []
+    assert config.keys[0].field_transforms == {"dob": ["substring:0:4"]}
 
 
 def test_whole_rule_paren_wrapped():


### PR DESCRIPTION
Converter side of #1826 (the scorer side landed in #1829).

**Why per-field transforms and not the other options:** a Splink blocking rule is a CONJUNCTION, so splitting a mixed rule into separate passes would union the conditions (massive widening); warn-harder leaves the 388K mega-block in place. The exact translation needs each field to carry its own chain.

**Schema:** `BlockingKeyConfig.field_transforms: dict[str, list[str]]` -- a listed field uses its own chain; others keep the key-level `transforms`. Validator rejects fields not in the key.

**Derivation surfaces:** `_build_block_key_expr` (per-field resolution in its existing loop), `Frame.derive_block_key` on BOTH backends (arrow via a new `field_chains` param on `arrow_derive.block_key`), and all six call sites (static blocks polars+arrow lanes, bucket `_score_single_pass`, autoconfig_verify, fused single-key gate, measure_blocking_profile fast path). Polars==arrow derive parity pinned by test.

**Converter:** mixed rules map exactly (`last+zip5+first-initial` stays `last` + `zip5` + `first[0]` instead of collapsing everything to initials); per-field SUBSTR offsets (previously dropped) now convert; uniform rules keep the legacy key-level shape so existing configs/goldens are unchanged; the lossy-widening warning is gone because nothing is lossy anymore. Same-field conflicting transforms still drop the rule.

**Tests:** 235 + 148 green across converter / blocking (incl. multipass + arrow parity) / bucket / FS suites; the two pre-#1826 widening tests rewritten to the exact contract.

**Cross-surface note:** TS `BlockingKeyConfig` + `fromSplink` don't know `field_transforms` yet -- a TS runtime ignores the field (finer blocks, no crash); TS port tracked as a follow-up issue.

Closes #1826.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018iZFxRDxEAhtdd1B6QcPMD