### PR TITLE
fix(probabilistic): surface review candidates

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -213,6 +213,9 @@ class DedupeResult:
     unique: Any | None = None  # pa.Table (v3.0.0)
     stats: dict = field(default_factory=dict)
     scored_pairs: list[tuple[int, int, float]] = field(default_factory=list)
+    # Probabilistic pairs in [review_threshold, link_threshold). They are
+    # attached for stewardship and never participate in clustering.
+    review_pairs: list[tuple[int, int, float]] = field(default_factory=list)
     config: Any = None
     postflight_report: PostflightReport | None = None
     # Note: memory_stats is also attached to postflight_report.memory_stats by
@@ -350,6 +353,7 @@ class MatchResult:
     matched: Any | None = None  # pa.Table (v3.0.0)
     unmatched: Any | None = None  # pa.Table (v3.0.0)
     stats: dict = field(default_factory=dict)
+    review_pairs: list[tuple[int, int, float]] = field(default_factory=list)
     postflight_report: PostflightReport | None = None
     # See DedupeResult.memory_stats note — same intentional duplication.
     memory_stats: CorrectionStats | None = None
@@ -513,6 +517,7 @@ def dedupe(
         unique=_to_result_table(result.get("unique")),
         stats=_extract_stats(result),
         scored_pairs=result.get("scored_pairs", []),
+        review_pairs=result.get("review_pairs", []),
         config=cfg,
         postflight_report=_attach_memory_to_postflight(
             result.get("postflight_report"), _mem
@@ -774,6 +779,7 @@ def dedupe_df(
         unique=_to_result_table(result.get("unique")),
         stats=_extract_stats(result),
         scored_pairs=result.get("scored_pairs", []),
+        review_pairs=result.get("review_pairs", []),
         config=config,
         postflight_report=pf,
         memory_stats=_mem,
@@ -979,6 +985,7 @@ def match_df(
         matched=_to_result_table(result.get("matched")),
         unmatched=_to_result_table(result.get("unmatched")),
         stats=_extract_stats(result),
+        review_pairs=result.get("review_pairs", []),
         postflight_report=pf,
         memory_stats=_mem,
         lint_findings=_lint_findings,
@@ -1171,6 +1178,7 @@ def match(
         matched=_to_result_table(result.get("matched")),
         unmatched=_to_result_table(result.get("unmatched")),
         stats=_extract_stats(result),
+        review_pairs=result.get("review_pairs", []),
         postflight_report=_attach_memory_to_postflight(
             result.get("postflight_report"), _mem
         ),

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -83,6 +83,38 @@ def _unwrap_llm_pairs(
     return result
 
 
+def _prepare_probabilistic_review_scoring(mk: Any, em_result: Any) -> tuple[Any, float]:
+    """Score down to the review cut while preserving the real link cutoff."""
+    from goldenmatch.core.probabilistic import resolve_thresholds
+
+    link_threshold, review_threshold = resolve_thresholds(mk, em_result)
+    scoring_mk = mk.model_copy(update={"link_threshold": review_threshold})
+    return scoring_mk, link_threshold
+
+
+def _split_probabilistic_pairs(
+    pairs: list[tuple[int, int, float]], link_threshold: float
+) -> tuple[list[tuple[int, int, float]], list[tuple[int, int, float]]]:
+    linked = [pair for pair in pairs if pair[2] >= link_threshold]
+    review = [pair for pair in pairs if pair[2] < link_threshold]
+    return linked, review
+
+
+def _finalize_review_pairs(
+    review_pairs: list[tuple[int, int, float]],
+    linked_pairs: list[tuple[int, int, float]],
+) -> list[tuple[int, int, float]]:
+    """Max-dedupe candidates and remove anything linked by another rule."""
+    from goldenmatch.core.pairs import dedup_pairs_max_score
+
+    linked_keys = {(min(a, b), max(a, b)) for a, b, _ in linked_pairs}
+    return [
+        pair
+        for pair in dedup_pairs_max_score(review_pairs)
+        if (pair[0], pair[1]) not in linked_keys
+    ]
+
+
 # Bucket is the DEFAULT fuzzy scorer within a memory-safe row band. It scores all
 # blocks in one batched pass (block-key + bucket assignment off the collected frame,
 # no per-block LazyFrame), where the legacy per-block ``score_blocks_parallel`` spins
@@ -2248,6 +2280,7 @@ def _run_dedupe_pipeline(
 
     # ── Step 3: BLOCK + COMPARE (cascading: exact first, then fuzzy) ──
     all_pairs: list[tuple[int, int, float]] = []
+    review_pairs: list[tuple[int, int, float]] = []
     matched_pairs: set[tuple[int, int]] = set()
 
     # Arrow roadmap Phase A: when GOLDENMATCH_COLUMNAR_PIPELINE=1 and the config
@@ -2624,6 +2657,9 @@ def _run_dedupe_pipeline(
                 blocks=blocks,
                 blocking_fields=blocking_fields,
             )
+            scoring_mk, link_threshold = _prepare_probabilistic_review_scoring(
+                mk, em_result
+            )
             logger.info(
                 "F-S EM: converged=%s, iterations=%d, match_rate=%.4f",
                 em_result.converged, em_result.iterations, em_result.proportion_matched,
@@ -2645,13 +2681,17 @@ def _run_dedupe_pipeline(
                 pairs = score_buckets(
                     collected_df,
                     config.blocking,
-                    mk,
+                    scoring_mk,
                     matched_pairs,
                     n_buckets=config.n_buckets,
                     across_files_only=across_files_only,
                     source_lookup=source_lookup if across_files_only else None,
                     em_result=em_result,
                 )
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
                 all_pairs.extend(pairs)
                 fuzzy_pair_count += len(pairs)
                 for a, b, _s in pairs:
@@ -2680,7 +2720,7 @@ def _run_dedupe_pipeline(
             if _bench_dump_dir:
                 # Bench path stays per-block so candidate/emitted pair accounting
                 # is exact (the batched path doesn't expose per-block candidates).
-                block_scorer = probabilistic_block_scorer(mk, em_result)
+                block_scorer = probabilistic_block_scorer(scoring_mk, em_result)
                 for block in blocks:
                     block_df = block.materialize().native
                     _accumulate_block_candidate_pairs(
@@ -2692,6 +2732,10 @@ def _run_dedupe_pipeline(
                             (a, b, s) for a, b, s in pairs
                             if source_lookup.get(a) != source_lookup.get(b)
                         ]
+                    pairs, candidates = _split_probabilistic_pairs(
+                        pairs, link_threshold
+                    )
+                    review_pairs.extend(candidates)
                     all_pairs.extend(pairs)
                     for a, b, _s in pairs:
                         matched_pairs.add((min(a, b), max(a, b)))
@@ -2707,13 +2751,17 @@ def _run_dedupe_pipeline(
                     score_probabilistic_blocks_batched,
                 )
                 pairs = score_probabilistic_blocks_batched(
-                    blocks, mk, em_result, matched_pairs
+                    blocks, scoring_mk, em_result, matched_pairs
                 )
                 if across_files_only:
                     pairs = [
                         (a, b, s) for a, b, s in pairs
                         if source_lookup.get(a) != source_lookup.get(b)
                     ]
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
                 all_pairs.extend(pairs)
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
@@ -3685,6 +3733,7 @@ def _run_dedupe_pipeline(
         "memory_stats": memory_stats,
         "identity_summary": identity_summary,
         "scored_pairs": scored_pairs,
+        "review_pairs": _finalize_review_pairs(review_pairs, scored_pairs),
         "llm_cost": llm_budget_summary,
         "throughput_posture": _throughput_posture,
         "golden_fused_used": golden_fused_used,
@@ -4062,6 +4111,7 @@ def _run_match_pipeline(
 
     # ── Step 4: Find matches (cascading: exact first, then fuzzy) ──
     all_pairs: list[tuple[int, int, float]] = []
+    review_pairs: list[tuple[int, int, float]] = []
     matched_pairs: set[tuple[int, int]] = set()
 
     # Phase 1: Exact matchkeys (fast)
@@ -4125,6 +4175,9 @@ def _run_match_pipeline(
                 blocking_fields=blocking_fields,
                 target_ids=target_ids,
             )
+            scoring_mk, link_threshold = _prepare_probabilistic_review_scoring(
+                mk, em_result
+            )
             # Default-route FS to the memory-bounded bucket scorer when the
             # native FS kernel is available (issue #1792) or backend='bucket'
             # is explicit; else the per-block batched scorer (legacy default).
@@ -4135,12 +4188,16 @@ def _run_match_pipeline(
                 pairs = score_buckets(
                     combined_df,
                     config.blocking,
-                    mk,
+                    scoring_mk,
                     matched_pairs,
                     n_buckets=config.n_buckets,
                     target_ids=target_ids,
                     em_result=em_result,
                 )
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
                 all_pairs.extend(pairs)
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
@@ -4148,9 +4205,11 @@ def _run_match_pipeline(
             # Blocks scored in parallel across cores (GIL-releasing FS kernels).
             # Does not mutate matched_pairs; fold the returned pairs in below.
             pairs = score_probabilistic_blocks_batched(
-                blocks, mk, em_result, matched_pairs,
+                blocks, scoring_mk, em_result, matched_pairs,
                 target_ids=target_ids,
             )
+            pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
+            review_pairs.extend(candidates)
             all_pairs.extend(pairs)
             for a, b, _s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
@@ -4272,6 +4331,7 @@ def _run_match_pipeline(
         "quarantine": quarantine_df_match,
         "postflight_report": postflight_report,
         "memory_stats": memory_stats,
+        "review_pairs": _finalize_review_pairs(review_pairs, all_pairs),
     }
 
 
@@ -4304,6 +4364,7 @@ def _run_match_scoring_and_output(
     combined_native = combined_frame.native  # pa.Table
 
     all_pairs: list[tuple[int, int, float]] = []
+    review_pairs: list[tuple[int, int, float]] = []
     matched_pairs: set[tuple[int, int]] = set()
 
     # Phase 1: exact matchkeys
@@ -4365,6 +4426,9 @@ def _run_match_scoring_and_output(
                 blocking_fields=blocking_fields,
                 target_ids=target_ids,
             )
+            scoring_mk, link_threshold = _prepare_probabilistic_review_scoring(
+                mk, em_result
+            )
             # Default-route FS to the memory-bounded bucket scorer when the
             # native FS kernel is available (issue #1792) or backend='bucket'
             # is explicit; else the per-block batched scorer (legacy default).
@@ -4376,20 +4440,26 @@ def _run_match_scoring_and_output(
                 pairs = score_buckets(
                     combined_native,
                     config.blocking,
-                    mk,
+                    scoring_mk,
                     matched_pairs,
                     n_buckets=config.n_buckets,
                     target_ids=target_ids,
                     em_result=em_result,
                 )
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
                 all_pairs.extend(pairs)
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
                 continue
             pairs = score_probabilistic_blocks_batched(
-                blocks, mk, em_result, matched_pairs,
+                blocks, scoring_mk, em_result, matched_pairs,
                 target_ids=target_ids,
             )
+            pairs, candidates = _split_probabilistic_pairs(pairs, link_threshold)
+            review_pairs.extend(candidates)
             all_pairs.extend(pairs)
             for a, b, _s in pairs:
                 matched_pairs.add((min(a, b), max(a, b)))
@@ -4502,6 +4572,7 @@ def _run_match_scoring_and_output(
         "quarantine": quarantine_df_match,
         "postflight_report": postflight_report,
         "memory_stats": memory_stats,
+        "review_pairs": _finalize_review_pairs(review_pairs, all_pairs),
     }
 
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1839,6 +1839,7 @@ def _run_fused_match_short_circuit(
         "memory_stats": None,
         "identity_summary": None,
         "scored_pairs": [],
+        "review_pairs": [],
         "llm_cost": None,
         "throughput_posture": None,
         "golden_fused_used": golden_fused_used,

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1846,6 +1846,24 @@ def compute_thresholds(
     return 0.50, 0.35
 
 
+def resolve_thresholds(
+    mk: MatchkeyConfig, em_result: EMResult
+) -> tuple[float, float]:
+    """Resolve configured or calibrated ``(link, review)`` score cutoffs.
+
+    The review cutoff is clamped to the link cutoff so an explicit low link
+    threshold cannot accidentally turn linked pairs into review candidates.
+    """
+    computed_link, computed_review = compute_thresholds(em_result)
+    link = float(mk.link_threshold) if mk.link_threshold is not None else computed_link
+    review = (
+        float(mk.review_threshold)
+        if mk.review_threshold is not None
+        else computed_review
+    )
+    return link, min(review, link)
+
+
 def score_probabilistic(
     block_df: pl.DataFrame,
     mk: MatchkeyConfig,

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -984,6 +984,85 @@ class TestDedupeWithPersistedModel:
         assert _parts(second) == _parts(baseline)
 
 
+class TestProbabilisticReviewCandidates:
+    @staticmethod
+    def _config(*, link_threshold=None, review_threshold=None):
+        return GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="fs_review",
+                type="probabilistic",
+                fields=[MatchkeyField(
+                    field="name",
+                    scorer="jaro_winkler",
+                    levels=3,
+                    partial_threshold=0.8,
+                )],
+                link_threshold=link_threshold,
+                review_threshold=review_threshold,
+            )],
+            blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])]),
+        )
+
+    @staticmethod
+    def _rows():
+        return pl.DataFrame({
+            "name": ["John", "Jon", "John"],
+            "zip": ["x", "x", "x"],
+        })
+
+    def test_explicit_review_band_is_attached_without_merging(self):
+        from goldenmatch import dedupe_df
+
+        result = dedupe_df(
+            self._rows(),
+            config=self._config(link_threshold=0.9, review_threshold=0.4),
+        )
+
+        assert result.review_pairs
+        assert all(0.4 <= score < 0.9 for _, _, score in result.review_pairs)
+        assert all(score >= 0.9 for _, _, score in result.scored_pairs)
+
+    def test_absent_review_threshold_uses_calibrated_review_cut(self):
+        from goldenmatch import dedupe_df
+
+        result = dedupe_df(
+            self._rows(),
+            config=self._config(link_threshold=0.9),
+        )
+
+        assert result.review_pairs
+        assert all(0.35 <= score < 0.9 for _, _, score in result.review_pairs)
+
+    def test_absent_link_and_review_thresholds_use_calibration(self, monkeypatch):
+        from goldenmatch import dedupe_df
+        from goldenmatch.core import probabilistic
+
+        monkeypatch.setattr(
+            probabilistic,
+            "compute_thresholds",
+            lambda *_args, **_kwargs: (0.9, 0.4),
+        )
+        result = dedupe_df(self._rows(), config=self._config())
+
+        assert result.review_pairs
+        assert all(0.4 <= score < 0.9 for _, _, score in result.review_pairs)
+
+    def test_match_result_attaches_review_candidates_without_matching(self):
+        from goldenmatch import match_df
+
+        target = pl.DataFrame({"name": ["Jon"], "zip": ["x"]})
+        reference = pl.DataFrame({"name": ["John"], "zip": ["x"]})
+        result = match_df(
+            target,
+            reference,
+            config=self._config(link_threshold=0.9, review_threshold=0.4),
+        )
+
+        assert result.review_pairs
+        assert result.matched is None
+        assert result.unmatched.num_rows == 1
+
+
 class TestModelReuseSkipsBuildBlocks:
     """Issue #1798: preloaded FS model + bucket route must skip build_blocks.
 

--- a/packages/typescript/goldenmatch/src/core/pipeline.ts
+++ b/packages/typescript/goldenmatch/src/core/pipeline.ts
@@ -104,12 +104,14 @@ function scoreProbabilisticBlocks(
     readonly acrossFilesOnly: boolean;
     readonly sourceLookup: ReadonlyMap<number, string>;
   },
-): ScoredPair[] {
+): { linked: ScoredPair[]; review: ScoredPair[] } {
   const em = trainEM(rows, mk, {
     blockingFields: collectBlockingFields(blockingConfig),
   });
-  const threshold = mk.linkThreshold ?? mk.threshold ?? 0.5;
-  const allPairs: ScoredPair[] = [];
+  const linkThreshold = mk.linkThreshold ?? mk.threshold ?? 0.5;
+  const reviewThreshold = Math.min(mk.reviewThreshold ?? 0.35, linkThreshold);
+  const linked: ScoredPair[] = [];
+  const review: ScoredPair[] = [];
 
   for (const block of blocks) {
     if (options.acrossFilesOnly) {
@@ -124,7 +126,7 @@ function scoreProbabilisticBlocks(
 
     let pairs = scoreProbabilistic(block.rows, mk, em, {
       excludePairs: matchedPairs,
-      threshold,
+      threshold: reviewThreshold,
     });
     if (options.acrossFilesOnly) {
       pairs = pairs.filter(
@@ -136,11 +138,30 @@ function scoreProbabilisticBlocks(
     for (const pair of pairs) {
       const key = pairKey(pair.idA, pair.idB);
       if (matchedPairs.has(key)) continue;
-      matchedPairs.add(key);
-      allPairs.push(pair);
+      if (pair.score >= linkThreshold) {
+        matchedPairs.add(key);
+        linked.push(pair);
+      } else {
+        review.push(pair);
+      }
     }
   }
-  return allPairs;
+  return { linked, review };
+}
+
+function finalizeReviewCandidates(
+  review: readonly ScoredPair[],
+  linked: readonly ScoredPair[],
+): ScoredPair[] {
+  const linkedKeys = new Set(linked.map((pair) => pairKey(pair.idA, pair.idB)));
+  const best = new Map<PairKey, ScoredPair>();
+  for (const pair of review) {
+    const key = pairKey(pair.idA, pair.idB);
+    if (linkedKeys.has(key)) continue;
+    const previous = best.get(key);
+    if (previous === undefined || pair.score > previous.score) best.set(key, pair);
+  }
+  return [...best.values()].sort((a, b) => a.idA - b.idA || a.idB - b.idB);
 }
 
 /** Collect all row IDs from rows. */
@@ -399,6 +420,7 @@ export async function runDedupePipeline(
 
   // ---- Step 4 & 5: Score exact + fuzzy matchkeys ----
   const allPairs: ScoredPair[] = [];
+  const reviewCandidates: ScoredPair[] = [];
   const matchedPairKeys = new Set<PairKey>();
   const sourceLookup = buildSourceLookup(processed);
 
@@ -444,16 +466,16 @@ export async function runDedupePipeline(
     } else {
       // Phase 2b: genuine Fellegi-Sunter training + blocked scoring.
       const blocks = buildBlocks(processed, blockingConfig);
-      allPairs.push(
-        ...scoreProbabilisticBlocks(
-          processed,
-          blocks,
-          mk,
-          matchedPairKeys,
-          blockingConfig,
-          { acrossFilesOnly, sourceLookup },
-        ),
+      const probabilistic = scoreProbabilisticBlocks(
+        processed,
+        blocks,
+        mk,
+        matchedPairKeys,
+        blockingConfig,
+        { acrossFilesOnly, sourceLookup },
       );
+      allPairs.push(...probabilistic.linked);
+      reviewCandidates.push(...probabilistic.review);
     }
   }
 
@@ -560,6 +582,7 @@ export async function runDedupePipeline(
     unique,
     stats,
     scoredPairs: finalPairs,
+    reviewCandidates: finalizeReviewCandidates(reviewCandidates, finalPairs),
     config,
     ...(postflightReport !== undefined ? { postflightReport } : {}),
     memoryStats,
@@ -595,6 +618,7 @@ export async function runMatchPipeline(
         unmatchedCount: targetRows.length,
         matchRate: 0,
       },
+      reviewCandidates: [],
     };
   }
 
@@ -656,6 +680,7 @@ export async function runMatchPipeline(
       ? { postflightReport: result.postflightReport }
       : {}),
     memoryStats: result.memoryStats ?? null,
+    reviewCandidates: result.reviewCandidates ?? [],
   };
 }
 
@@ -677,6 +702,7 @@ function _emptyDedupeResult(config: GoldenMatchConfig): DedupeResult {
       uniqueRecords: 0,
     },
     scoredPairs: [],
+    reviewCandidates: [],
     config,
     suggestions: [],
   };

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -428,6 +428,8 @@ export interface DedupeResult {
   readonly unique: readonly Row[];
   readonly stats: DedupeStats;
   readonly scoredPairs: readonly ScoredPair[];
+  /** Probabilistic pairs in [reviewThreshold, linkThreshold); never clustered. */
+  readonly reviewCandidates?: readonly ScoredPair[];
   readonly config: GoldenMatchConfig;
   readonly postflightReport?: PostflightReport;
   /** Learning Memory outcome for this run. Null when memory was disabled
@@ -446,6 +448,7 @@ export interface MatchResult {
   readonly matched: readonly Row[];
   readonly unmatched: readonly Row[];
   readonly stats: Readonly<Record<string, unknown>>;
+  readonly reviewCandidates?: readonly ScoredPair[];
   readonly postflightReport?: PostflightReport;
   /** Learning Memory outcome for this run. See `DedupeResult.memoryStats`. */
   readonly memoryStats?: CorrectionStats | null;

--- a/packages/typescript/goldenmatch/tests/unit/pipeline.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/pipeline.test.ts
@@ -3,6 +3,52 @@ import { runDedupePipeline, runMatchPipeline, makeConfig, makeBlockingConfig } f
 import type { MatchkeyConfig, Row } from "../../src/core/index.js";
 
 describe("runDedupePipeline", () => {
+  it.each([
+    ["explicit", 0.9, 0.4],
+    ["absent review", 0.9, undefined],
+    ["calibrated defaults", undefined, undefined],
+  ])("attaches probabilistic review candidates with %s thresholds", async (
+    _case,
+    linkThreshold,
+    reviewThreshold,
+  ) => {
+    const rows: Row[] = [
+      { name: "John", zip: "x" },
+      { name: "Jon", zip: "x" },
+      { name: "John", zip: "x" },
+    ];
+    const mk: MatchkeyConfig = {
+      name: "fs_review",
+      type: "probabilistic",
+      fields: [{
+        field: "name",
+        transforms: [],
+        scorer: "jaro_winkler",
+        weight: 1,
+        levels: 3,
+        partialThreshold: 0.8,
+      }],
+      ...(linkThreshold === undefined ? {} : { linkThreshold }),
+      ...(reviewThreshold === undefined ? {} : { reviewThreshold }),
+    };
+    const config = makeConfig({
+      matchkeys: [mk],
+      blocking: makeBlockingConfig({
+        strategy: "static",
+        keys: [{ fields: ["zip"], transforms: [] }],
+      }),
+    });
+
+    const result = await runDedupePipeline(rows, config);
+
+    const reviewCandidates = result.reviewCandidates ?? [];
+    expect(result.reviewCandidates).toBeDefined();
+    if (linkThreshold === 0.9) {
+      expect(reviewCandidates.length).toBeGreaterThan(0);
+      expect(result.scoredPairs.every((pair) => pair.score >= 0.9)).toBe(true);
+    }
+  });
+
   it("with exact matchkey catches identical emails", async () => {
     const rows: Row[] = [
       { id: 1, email: "a@x.com", name: "Alice" },
@@ -79,6 +125,40 @@ describe("runDedupePipeline", () => {
 });
 
 describe("runMatchPipeline", () => {
+  it("attaches probabilistic review candidates without marking targets matched", async () => {
+    const mk: MatchkeyConfig = {
+      name: "fs_review",
+      type: "probabilistic",
+      fields: [{
+        field: "name",
+        transforms: [],
+        scorer: "jaro_winkler",
+        weight: 1,
+        levels: 3,
+        partialThreshold: 0.8,
+      }],
+      linkThreshold: 0.9,
+      reviewThreshold: 0.4,
+    };
+    const config = makeConfig({
+      matchkeys: [mk],
+      blocking: makeBlockingConfig({
+        strategy: "static",
+        keys: [{ fields: ["zip"], transforms: [] }],
+      }),
+    });
+
+    const result = await runMatchPipeline(
+      [{ name: "Jon", zip: "x" }],
+      [{ name: "John", zip: "x" }],
+      config,
+    );
+
+    expect(result.reviewCandidates?.length).toBeGreaterThan(0);
+    expect(result.matched).toHaveLength(0);
+    expect(result.unmatched).toHaveLength(1);
+  });
+
   it("finds cross-dataset matches", async () => {
     const target: Row[] = [{ id: 1, email: "a@x.com" }];
     const reference: Row[] = [


### PR DESCRIPTION
Closes #1818

## Summary
- score Fellegi-Sunter candidates once down to the configured or calibrated review threshold
- return review candidates separately without allowing them to affect clusters or match assignments
- de-duplicate review candidates and exclude pairs linked by another rule
- keep Python and TypeScript result semantics aligned

## Verification
- Python probabilistic/API suite: 190 passed
- Ruff: clean
- TypeScript pipeline/probabilistic/API suite: 34 passed
- TypeScript typecheck: passed
- TypeScript production build: passed
- git diff --check: clean