### PR TITLE
fix: repair #1835 multi-pass EM regression (main is red on quality_gate)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1062,6 +1062,16 @@ def train_em(
         for j, field in enumerate(mk.fields)
         if len(conditioned_mask) and bool(conditioned_mask[:, j].all())
     }
+    # A configured blocking field carries a deliberate fixed prior that EM
+    # cannot recover from random pairs: a disagreement PENALTY (drives
+    # precision) and a BOUNDED agreement weight (preserves recall). Learning it
+    # per-pass (#1835) loses both -- a near-unique key's `u` collapses to the
+    # smoothing floor, exploding the agreement weight (e.g. 28 bits on
+    # historical_50k) and dominating the score, which collapsed recall
+    # (F1 0.83 -> 0.57). So blocking fields always take the fixed-weight prior.
+    # The per-pass conditioning of the E/M sample still applies to non-blocking
+    # fields; only the final weight/skip treatment is forced here.
+    always_conditioned |= set(blocking_fields or [])
     ne_conditioned_mask = np.zeros(
         (len(pair_conditioning), len(ne_fields_em)), dtype=bool
     )
@@ -1676,6 +1686,9 @@ def train_em_continuous(
         for j, field in enumerate(mk.fields)
         if bool(conditioned_mask[:, j].all())
     }
+    # Blocking fields take the fixed prior, same as the discrete path -- learning
+    # them per-pass regresses recall on near-unique keys (see train_em).
+    always_conditioned |= set(blocking_fields or [])
 
     # Initialize with strong priors — matches score high, non-matches score low.
     # Use the actual score distribution to set non-match priors at the median.

--- a/packages/python/goldenmatch/tests/test_probabilistic.py
+++ b/packages/python/goldenmatch/tests/test_probabilistic.py
@@ -782,8 +782,20 @@ class TestEMWithBlockingFields:
         result = train_em(df, mk, n_sample_pairs=100, blocking_fields=["zip"])
         assert result.u_probs["zip"] == [0.50, 0.50]
 
-    def test_multi_pass_conditions_fields_per_pass_and_is_order_stable(self):
-        """A field used by one pass remains evidence in another pass."""
+    def test_multi_pass_blocking_fields_fixed_and_order_stable(self):
+        """Configured blocking fields take the fixed-weight prior and the result
+        is stable under pass order.
+
+        #1835 tried to LEARN blocking-field weights per pass, but that regressed
+        real corrupted-PII data badly (historical_50k quality gate F1 0.83 ->
+        0.57): a near-unique blocking key's ``u`` collapses to the smoothing
+        floor and its agreement weight explodes (~28 bits), dominating the score
+        and collapsing recall. The disagreement penalty + bounded agreement of
+        the fixed prior are what EM cannot recover from random pairs, so blocking
+        fields keep the fixed prior. The per-pass conditioning scaffolding still
+        governs the training sample (order stability below), just not the
+        blocking-field weights.
+        """
         from goldenmatch.core.blocker import build_blocks
 
         df = pl.DataFrame({
@@ -823,10 +835,11 @@ class TestEMWithBlockingFields:
         forward = train([zip_pass, name_pass])
         reversed_plan = train([name_pass, zip_pass])
 
-        # The old global-union behavior fixed both fields to [-3, 3]. Each is
-        # now learned from candidate pairs emitted by the other pass.
-        assert forward.match_weights["zip"] != [-3.0, 3.0]
-        assert forward.match_weights["last_name"] != [-3.0, 3.0]
+        # Blocking fields take the fixed prior [-3, 3] (recall/precision-safe;
+        # EM cannot recover the disagreement penalty from random pairs).
+        assert forward.match_weights["zip"] == [-3.0, 3.0]
+        assert forward.match_weights["last_name"] == [-3.0, 3.0]
+        # Still order-stable regardless of pass order.
         assert reversed_plan.m_probs == forward.m_probs
         assert reversed_plan.match_weights == forward.match_weights
 
@@ -842,6 +855,48 @@ class TestEMWithBlockingFields:
             for j in range(i + 1, len(rows))
         ]
         assert reversed_scores == forward_scores
+
+    def test_near_unique_blocking_field_does_not_explode(self):
+        """Regression for the #1835 -> historical_50k quality-gate collapse.
+
+        A near-unique blocking key (like historical_50k's ``postcode_fake``)
+        never agrees among random pairs, so its ``u`` hits the smoothing floor
+        and a learned ``log2(m/u)`` explodes (~28 bits), dominating the score
+        and collapsing recall (F1 0.83 -> 0.57). It must take the bounded fixed
+        prior instead.
+        """
+        from goldenmatch.core.blocker import build_blocks
+
+        # postcode near-unique (two dup pairs so the postcode pass emits pairs);
+        # name moderate so the name pass carries the training sample.
+        codes = [f"P{i}" for i in range(30)]
+        codes[1], codes[3] = codes[0], codes[2]
+        df = pl.DataFrame({
+            "__row_id__": list(range(30)),
+            "postcode": codes,
+            "name": [f"N{i % 5}" for i in range(30)],
+        })
+        mk = MatchkeyConfig(
+            name="fs", type="probabilistic",
+            fields=[
+                MatchkeyField(field="postcode", scorer="exact", levels=2),
+                MatchkeyField(field="name", scorer="exact", levels=2),
+            ],
+        )
+        blocks = build_blocks(
+            df.lazy(),
+            BlockingConfig(strategy="multi_pass", passes=[
+                BlockingKeyConfig(fields=["postcode"]),
+                BlockingKeyConfig(fields=["name"]),
+            ]),
+        )
+        em = train_em(
+            df, mk, n_sample_pairs=200, max_iterations=10,
+            blocks=blocks, blocking_fields=["postcode", "name"],
+        )
+        # Bounded fixed prior, not an exploded learned weight.
+        assert em.match_weights["postcode"] == [-3.0, 3.0]
+        assert max(abs(w) for w in em.match_weights["postcode"]) <= 3.0
 
     def test_continuous_multi_pass_conditions_fields_per_pass(self):
         from goldenmatch.core.blocker import build_blocks
@@ -878,8 +933,11 @@ class TestEMWithBlockingFields:
             blocking_fields=["zip", "last_name"],
         )
 
-        assert result.m_mean["zip"] != 0.99
-        assert result.m_mean["last_name"] != 0.99
+        # Blocking fields take the fixed prior (m_mean 0.99), same as the
+        # discrete path -- learning them per-pass regressed real data (see
+        # train_em / test_multi_pass_blocking_fields_fixed_and_order_stable).
+        assert result.m_mean["zip"] == 0.99
+        assert result.m_mean["last_name"] == 0.99
 
 
 # ── Weight monotonicity guard (Phase 0) ────────────────────────────────────


### PR DESCRIPTION
**Fixes main red on `quality_gate`.** #1835 ("condition multi-pass EM per pair") regressed the auto-config quality gate — `historical_50k f1_probabilistic` dropped **0.8279 → 0.5652** — and merged red because that job is non-blocking.

## Root cause (reproduced locally, exact 0.5652)

#1835 switched the fixed-weight guard from `f.field in blocking_fields` to `f.field in always_conditioned`. In a multi-pass config **no field conditions every sampled pair**, so `always_conditioned` is empty and configured blocking fields become EM-learned. A near-unique blocking key (historical_50k's `postcode_fake`) never agrees among random pairs → its `u` collapses to the smoothing floor → `log2(m/u)` explodes to **~28 bits**, dominating the score and pushing true matches that disagree on it below threshold. Recall **0.75 → 0.40**, F1 0.5652.

I proved the mechanism by capturing the trained weights (`postcode_fake: [-0.111, 28.47]`) and bisecting fixes:
- fixed prior `[-3,0,+3]` → 0.8284 (best)
- clamp to ±3 (learned neutral disagreement) → over-merges, P 0.79
- fixed disagreement + high learned agreement → recall 0.63

The fixed prior encodes two things **EM cannot recover from random pairs**: a disagreement *penalty* (precision) and a *bounded* agreement weight (recall). Both are needed.

## Fix

Fold `blocking_fields` back into `always_conditioned` in `train_em` and `train_em_continuous`, so configured blocking fields always take the fixed prior. #1835's per-pass sample-conditioning scaffolding — and its `PYTHONHASHSEED` determinism fix (`sorted(unique_pairs)`) — is **retained** for non-blocking fields.

## Verification

Full auto-config quality gate **PASSES** (native path, as CI runs it):

| dataset | metric | result |
|---|---|---|
| historical_50k | f1_probabilistic | 0.8279 → **0.8284** ✓ |
| anchor_person_match | f1 | → 1.0 ✓ |
| ncvr_synthetic | f1_probabilistic | → 0.9894 (= baseline) ✓ |
| febrl3 | f1_probabilistic | → 0.9839 (within tol) ✓ |

**verdict: PASS.** Probabilistic test suites: 172 passed.

## Tests

Repurposed #1835's two multi-pass tests to assert the fixed-weight posture + order stability (discrete + continuous), and added `test_near_unique_blocking_field_does_not_explode` pinning the no-explosion invariant.

Note: this supersedes #1835's blocking-field *weight learning*, which measurably regresses real corrupted-PII data (its benefit was only shown on a clean synthetic unit test). The order-stability and determinism improvements are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)