### PR TITLE
fix: learned-blocking drop cap must not sit below the key-selection budget (#1837)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -2771,6 +2771,30 @@ def _compute_max_safe_block(height: int, native_scoring: bool) -> int:
     return max(1000, min(ceiling, height // 40))
 
 
+def _learned_block_cap(total_rows: int, current_cap: int, native_scoring: bool) -> int:
+    """Runtime oversized-DROP cap for learned blocking.
+
+    Learned blocking runs with ``skip_oversized=True``, and
+    ``apply_learned_blocks`` DROPS any block bigger than ``max_block_size``
+    outright (``continue``) -- the whole block, and every true pair in it.
+    So that cap must never sit BELOW the budget auto-config used to *select* the
+    blocking key (``_compute_max_safe_block``): otherwise the selector accepts a
+    key on the promise "blocks up to max_safe_block are fine" and the runtime
+    then silently throws those very blocks away. The loss is recall-only (a drop
+    never invents a merge), which is why it hides -- precision stays 1.0.
+
+    That gap is scale-dependent, so it reads as a scale-invariance regression:
+    a key whose blocks sit under the cap at 500K crosses it at 1M and is
+    discarded. #1784 widened the gap further (its native ceiling puts
+    max_safe_block at 25K on a 1M frame, against the default 5000 cap), which
+    collapsed 1M zero-config recall to 0.82 while <=500K stayed at 1.0 (#1837).
+
+    Raise-only: never tighten below the configured cap, so datasets under ~200K
+    rows (where ``height // 40`` < 5000) keep their existing cap byte-for-byte.
+    """
+    return max(current_cap, _compute_max_safe_block(total_rows, native_scoring))
+
+
 def build_blocking(
     profiles: list[ColumnProfile],
     df: pl.DataFrame,
@@ -4320,9 +4344,17 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
         blocking.learned_sample_size = min(total_rows // 4, 5000)
         blocking.learned_min_recall = 0.95
         blocking.skip_oversized = True
+        # skip_oversized DROPS whole blocks above max_block_size, so the cap must
+        # not sit below the budget that picked the key (see _learned_block_cap).
+        from goldenmatch.core._native_loader import native_enabled as _native_enabled
+
+        blocking.max_block_size = _learned_block_cap(
+            total_rows, blocking.max_block_size, _native_enabled("block_scoring"),
+        )
         logger.info(
-            "Upgraded to learned blocking (dataset has %d rows, sample_size=%d)",
-            total_rows, blocking.learned_sample_size,
+            "Upgraded to learned blocking (dataset has %d rows, sample_size=%d, "
+            "max_block_size=%d)",
+            total_rows, blocking.learned_sample_size, blocking.max_block_size,
         )
 
     # 2. Reranking for multi-field matchkeys

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -295,6 +295,8 @@ def apply_learned_blocks(
     # set-identity key. Deduping here (not after the loop) also skips building the
     # duplicate LazyFrame at all. Same blocks, same first-wins order, no collects.
     seen: set[frozenset[int]] = set()
+    dropped_blocks = 0
+    dropped_rows = 0
 
     for rule in rules[:3]:  # limit to top 3 rules
         rows = df.select(
@@ -315,6 +317,14 @@ def apply_learned_blocks(
             if len(member_positions) < 2:
                 continue
             if len(member_positions) > max_block_size:
+                # Dropping a block discards every candidate pair in it -- a
+                # RECALL-only loss (a drop never invents a merge, so precision
+                # stays 1.0 and the damage is invisible in every signal except
+                # recall). Count it and warn below rather than eating it
+                # silently: a silent instance of exactly this cost a full day of
+                # scale-regression bisection (#1837).
+                dropped_blocks += 1
+                dropped_rows += len(member_positions)
                 continue
             members = frozenset(member_positions)
             if members in seen:
@@ -328,6 +338,16 @@ def apply_learned_blocks(
             ))
 
     logger.info("Learned blocking produced %d blocks from %d rules", len(all_blocks), min(len(rules), 3))
+    if dropped_blocks:
+        logger.warning(
+            "Learned blocking DROPPED %d oversized block(s) covering %d row(s) "
+            "(max_block_size=%d, skip_oversized). Every candidate pair in a "
+            "dropped block is lost -- this costs RECALL only, so it will not "
+            "show up as a precision or over-merge signal. Raise "
+            "blocking.max_block_size (or tighten the blocking key) if recall "
+            "looks low at scale.",
+            dropped_blocks, dropped_rows, max_block_size,
+        )
     return all_blocks
 
 

--- a/packages/python/goldenmatch/tests/test_learned_block_cap_1837.py
+++ b/packages/python/goldenmatch/tests/test_learned_block_cap_1837.py
@@ -1,0 +1,44 @@
+"""Issue #1837 — the learned-blocking oversized-DROP cap must never sit below
+the budget auto-config used to SELECT the blocking key.
+
+Learned blocking runs with ``skip_oversized=True``, and ``apply_learned_blocks``
+drops any block larger than ``max_block_size`` outright. If that cap is below
+``_compute_max_safe_block`` (the budget the key was chosen against), the selector
+accepts a key whose blocks the runtime then silently discards — a RECALL-only
+loss (precision stays 1.0, so nothing else flags it).
+
+It surfaces as a SCALE-INVARIANCE regression: a key under the cap at 500K crosses
+it at 1M and gets discarded. Measured on the zero-config quality gate: 1M pairwise
+recall 0.82 / precision 1.0 / fp=0 while 50K-500K sat at ~1.0.
+"""
+
+from __future__ import annotations
+
+from goldenmatch.core.autoconfig import _compute_max_safe_block, _learned_block_cap
+
+
+class TestLearnedBlockCap:
+    def test_cap_never_below_selection_budget(self):
+        """The core invariant: whatever key-selection deemed safe must survive
+        the runtime drop guard."""
+        for n in (50_000, 100_000, 200_000, 500_000, 1_000_000, 5_000_000):
+            for native in (True, False):
+                cap = _learned_block_cap(n, 5000, native)
+                assert cap >= _compute_max_safe_block(n, native), (n, native, cap)
+
+    def test_raises_cap_at_1m_native(self):
+        """The #1837 case: native lifts max_safe_block to 25K on a 1M frame; the
+        default 5000 cap would drop those blocks (recall 0.82)."""
+        assert _compute_max_safe_block(1_000_000, True) == 25_000
+        assert _learned_block_cap(1_000_000, 5000, True) == 25_000
+
+    def test_raise_only_leaves_small_data_untouched(self):
+        """Below ~200K, height//40 < 5000 -- the cap must NOT tighten (that would
+        drop blocks that are kept today and regress recall the other way)."""
+        assert _compute_max_safe_block(100_000, True) == 2500  # < 5000
+        assert _learned_block_cap(100_000, 5000, True) == 5000  # unchanged
+        assert _learned_block_cap(50_000, 5000, True) == 5000
+
+    def test_never_lowers_an_explicit_cap(self):
+        """A caller-configured cap above the budget is preserved."""
+        assert _learned_block_cap(1_000_000, 40_000, True) == 40_000


### PR DESCRIPTION
Fixes #1837 (zero-config quality-at-scale gate red on `main`).

## Symptom

`historical`-style scale-invariance violation on **prefix-stable** data — same rows, same config, only `n` differs:

| rung | pairwise F1 | precision | recall | fp |
|---|---|---|---|---|
| 50k | 0.9986 | 0.9973 | 1.0 | 275 |
| 100k | 1.0 | 1.0 | 1.0 | 0 |
| 500k | 1.0 | 1.0 | 1.0 | 0 |
| **1M** | **0.9014** | **1.0** | **0.8206** | **0** |

358,860 true pairs lost, **zero** false merges, 216,086 clusters vs 200,000 expected.

## Root cause: two block-size numbers disagree

- auto-config **selects** a blocking key against `_compute_max_safe_block` → **25,000** on a 1M frame with native scoring (#1784 lifts the ceiling to 50K when native block-scoring is active);
- the learned-blocking upgrade sets **`skip_oversized=True`** but leaves **`max_block_size` at the schema default 5000**, and `apply_learned_blocks` **drops** any block above it outright (`continue`).

So the selector accepts a key on the promise *"blocks up to `max_safe_block` are fine"*, and the runtime then **silently discards those very blocks**. Dropping a block loses every true pair in it but **never invents a merge** — a recall-only loss, which is exactly why `precision=1.0`/`fp=0` and nothing else flagged it. It presents as a *scale* regression because a key whose blocks sit under 5000 at 500k crosses it at 1M.

## Evidence

Measured, not inferred:
- `max_safe_block(1M, native=True) = 25,000` vs `blocking.max_block_size = 5000`, `skip_oversized=True`.
- **Blocking recall is 1.0 at both 500k and 1M** on the pure-Python path (5-row blocks, `dropped_rows=0`) → blocking itself is sound.
- 40,000 true pairs scored under both the 500k- and 1M-derived configs: **0 fall below threshold** under either → the scorer (incl. the scale-varying `tf_freqs` table) is not the cause.
- Pure-Python end-to-end at 1M: **2,000,000 pairs → 200,000 clusters, all size 5 → F1 = 1.0.** The gate builds **native** (`max_safe_block` 25,000 vs 10,000), which is the deciding variable.

## Fix

1. `_learned_block_cap()` raises `max_block_size` to the same budget the key was selected against. **Raise-only**: below ~200k rows `height // 40 < 5000`, so tightening there would drop blocks kept today and regress recall the other way — those datasets stay byte-unchanged.
2. `apply_learned_blocks` no longer eats the drop silently: it counts dropped blocks/rows and **WARNs**, naming `max_block_size` and stating the loss is recall-only. The silence is what made this cost a day of bisection (same principle as #956/#957).

## Verification

The 1M rung only runs in CI (it OOMs a dev box), so **the quality gate is the end-to-end proof** — and the new WARNING makes the verdict self-evident either way: if drops are the cause, the gate log will now say so explicitly instead of hiding it.

`tests/test_learned_block_cap_1837.py` pins the invariant (cap ≥ selection budget at every scale, both scorer paths), the 1M native raise (5000 → 25,000), and raise-only at 50k/100k. 177 blocking/autoconfig tests green; full-package ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)