### PR TITLE
perf(learned-blocking): dedup on positions instead of collecting every block (#1839)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -288,6 +288,13 @@ def apply_learned_blocks(
 
     df = lf.collect()
     all_blocks: list = []
+    # Rules overlap, so the same member set can be produced by more than one rule.
+    # Dedup on the POSITIONS we already have rather than collecting each block to
+    # read back its __row_id__ values: __row_id__ is a with_row_index() column, so
+    # position <-> row_id is a bijection and frozenset(positions) is an equivalent
+    # set-identity key. Deduping here (not after the loop) also skips building the
+    # duplicate LazyFrame at all. Same blocks, same first-wins order, no collects.
+    seen: set[frozenset[int]] = set()
 
     for rule in rules[:3]:  # limit to top 3 rules
         rows = df.select(
@@ -309,6 +316,10 @@ def apply_learned_blocks(
                 continue
             if len(member_positions) > max_block_size:
                 continue
+            members = frozenset(member_positions)
+            if members in seen:
+                continue
+            seen.add(members)
             block_lf = df[sorted(member_positions)].lazy()
             all_blocks.append(BlockResult(
                 block_key=f"learned:{rule.key()}:{block_key}",
@@ -316,18 +327,8 @@ def apply_learned_blocks(
                 strategy="learned",
             ))
 
-    # Deduplicate blocks by member set
-    seen: set[frozenset[int]] = set()
-    deduped: list = []
-    for block in all_blocks:
-        block_df = block.materialize().native
-        members = frozenset(block_df["__row_id__"].to_list())
-        if members not in seen:
-            seen.add(members)
-            deduped.append(block)
-
-    logger.info("Learned blocking produced %d blocks from %d rules", len(deduped), min(len(rules), 3))
-    return deduped
+    logger.info("Learned blocking produced %d blocks from %d rules", len(all_blocks), min(len(rules), 3))
+    return all_blocks
 
 
 # ── Cache ─────────────────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_learned_dedup_1839.py
+++ b/packages/python/goldenmatch/tests/test_learned_dedup_1839.py
@@ -1,0 +1,128 @@
+"""Issue #1839 -- ``apply_learned_blocks`` must dedup overlapping rules WITHOUT
+collecting every block.
+
+The dedup loop used to materialize each candidate block just to read back its
+``__row_id__`` values and hash them. At 1M rows the learned path produces ~200K
+five-row blocks, so that was ~200K collects of pure overhead on top of the ~200K
+LazyFrames the loop above it had already built -- while the actual scoring work
+(5x5 matrices) is trivial. ``member_positions`` was already in hand, and
+``__row_id__`` is a ``with_row_index()`` column, so position <-> row_id is a
+bijection and ``frozenset(positions)`` is an equivalent set-identity key.
+
+These tests pin BOTH halves of that claim: the dedup must still happen (the
+cheap way to "speed this up" is to silently stop deduping), and it must happen
+without materializing.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.core.learned_blocking import (
+    BlockingPredicate,
+    BlockingRule,
+    apply_learned_blocks,
+)
+
+
+def _rule(field: str, transform: str = "exact") -> BlockingRule:
+    return BlockingRule(predicates=[BlockingPredicate(field=field, transform=transform)])
+
+
+def _frame() -> pl.LazyFrame:
+    # city and zone induce the SAME partition ({0,1}, {2,3}) via different fields,
+    # so two overlapping rules yield identical member sets -> dedup must collapse them.
+    return pl.DataFrame(
+        {
+            "__row_id__": [0, 1, 2, 3],
+            "city": ["nyc", "nyc", "sfo", "sfo"],
+            "zone": ["east", "east", "west", "west"],
+        }
+    ).lazy()
+
+
+def _members(block) -> frozenset[int]:
+    return frozenset(block.materialize().native["__row_id__"].to_list())
+
+
+class TestLearnedDedup:
+    def test_identical_member_sets_from_different_rules_are_deduped(self):
+        """The core behavior being preserved: two rules that partition the frame
+        the same way must not produce duplicate blocks."""
+        blocks = apply_learned_blocks(_frame(), [_rule("city"), _rule("zone")])
+
+        assert len(blocks) == 2, [b.block_key for b in blocks]
+        assert {_members(b) for b in blocks} == {frozenset({0, 1}), frozenset({2, 3})}
+
+    def test_first_rule_wins(self):
+        """Dedup keeps the FIRST occurrence -- moving dedup earlier must not flip
+        which rule's block_key survives."""
+        blocks = apply_learned_blocks(_frame(), [_rule("city"), _rule("zone")])
+
+        assert all(b.block_key.startswith("learned:city:") for b in blocks), [
+            b.block_key for b in blocks
+        ]
+
+    def test_distinct_member_sets_are_all_kept(self):
+        """Dedup must not over-collapse: genuinely different blocks all survive."""
+        lf = pl.DataFrame(
+            {
+                "__row_id__": [0, 1, 2, 3],
+                "city": ["nyc", "nyc", "sfo", "sfo"],   # {0,1}, {2,3}
+                "zone": ["east", "west", "east", "west"],  # {0,2}, {1,3}
+            }
+        ).lazy()
+
+        blocks = apply_learned_blocks(lf, [_rule("city"), _rule("zone")])
+
+        assert {_members(b) for b in blocks} == {
+            frozenset({0, 1}),
+            frozenset({2, 3}),
+            frozenset({0, 2}),
+            frozenset({1, 3}),
+        }
+
+    def test_collects_do_not_scale_with_block_count(self):
+        """The #1839 fix itself: collects must be CONSTANT in block count.
+
+        Not "zero collects" -- there's an irreducible floor of 1 (reading the
+        input frame) + 1 per rule (polars implements eager ``DataFrame.select``
+        as ``lazy().select().collect()``, which the ``.to_dicts()`` line pays).
+        The bug was the term that scaled: the old dedup loop collected every
+        candidate block, costing ``3 + 2*n_blocks`` here and ~400K collects at
+        the 1M / 200K-block shape. Measured on the pre-fix code: 7 / 103 / 1003
+        collects for 2 / 50 / 500 blocks vs a flat 3 now.
+
+        Asserting the SHAPE (flat vs linear) rather than a magic number keeps
+        this honest if polars changes its internal select strategy.
+        """
+        counts = {}
+        for n_blocks in (2, 50, 500):
+            collects = 0
+            original = pl.LazyFrame.collect
+
+            def counting_collect(self, *args, **kwargs):
+                nonlocal collects
+                collects += 1
+                return original(self, *args, **kwargs)
+
+            n = n_blocks * 2
+            lf = pl.DataFrame(
+                {
+                    "__row_id__": list(range(n)),
+                    "city": [f"c{i // 2}" for i in range(n)],
+                    "zone": [f"z{i // 2}" for i in range(n)],
+                }
+            ).lazy()
+
+            pl.LazyFrame.collect = counting_collect
+            try:
+                blocks = apply_learned_blocks(lf, [_rule("city"), _rule("zone")])
+            finally:
+                pl.LazyFrame.collect = original
+
+            assert len(blocks) == n_blocks  # dedup still collapsing the 2 rules
+            counts[n_blocks] = collects
+
+        assert len(set(counts.values())) == 1, (
+            f"collects must not scale with block count, got {counts}"
+        )


### PR DESCRIPTION
Fixes the contained half of #1839. **Throughput only** -- no semantics change.

## The bug

`apply_learned_blocks` deduped overlapping rules by materializing every candidate block just to read its `__row_id__` values back out and hash them:

```python
for block in all_blocks:
    block_df = block.materialize().native      # collects EVERY block
    members = frozenset(block_df["__row_id__"].to_list())
```

`member_positions` was already in hand a few lines above.

## The fix

`__row_id__` comes from `with_row_index()`, so position <-> row_id is a bijection and `frozenset(member_positions)` is an equivalent set-identity key. Dedup on that, **before** building the LazyFrame, so duplicates are never constructed at all.

## Measured (not theorized)

Collect counts, measured on the pre-fix code vs this branch:

| blocks | before | after |
|---|---|---|
| 2 | 7 | 3 |
| 50 | 103 | 3 |
| 500 | 1003 | 3 |

Before was `3 + 2*n_blocks` -- linear in *pre-dedup* blocks. After is flat. At the 1M zero-config shape (~200K five-row blocks) that's ~400K collects -> 3.

`blocks_out` is identical before and after at every size.

The remaining floor of 3 is irreducible: 1 to read the input frame, +1 per rule because polars implements eager `DataFrame.select` as `lazy().select().collect()`, which the `.to_dicts()` line pays.

Worth noting the loop directly above this was already tuned once for exactly this reason (the `cProfile Round 5` comment, O(N) `filter`+`is_in` -> O(K) positional indexing) -- the dedup loop below quietly undid it.

## Tests

`tests/test_learned_dedup_1839.py` pins both halves, since the cheap way to "speed this up" is to silently stop deduping:

- overlapping rules with identical member sets still collapse
- first rule still wins (dedup moved earlier must not flip which `block_key` survives)
- genuinely distinct member sets are all kept (no over-collapse)
- **collects do not scale with block count** -- asserts the *shape* (flat vs linear) across 2/50/500 blocks rather than a magic number, so it stays honest if polars changes its internal select strategy

## Scope / what this does NOT do

- Does **not** touch the #1839 gating question (zero-config `>=50K` sets `strategy="learned"`, which `_use_bucket_scorer` refuses -> forfeits the bucket scorer entirely). That needs measurement and a design call, not a patch.
- **Unrelated to the #1837 recall regression.** The `learned` upgrade fires at `>=50_000`, so this applies identically at 500K (green, F1 1.0) and 1M; a factor constant across both rungs can't explain a delta between them.

## Verification notes

- `tests/test_learned_dedup_1839.py` + `tests/test_learned_blocking.py`: 16 passed
- Full-package `ruff check`: clean
- Pre-existing on main, NOT introduced here (verified against untouched `origin/main`): `test_metrics_harness.py` collection error, `test_native_fs_ne.py::test_native_numpy_parity_ne` (6 failed), and `learned_blocking.py` failing `ruff format --check` (so this PR deliberately does not reformat the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9