### PR TITLE
feat(learned-blocking): compiler + differential harness for lowering to multi_pass (#1839)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -22,8 +22,12 @@ import logging
 from dataclasses import dataclass
 from itertools import combinations
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from goldenmatch._polars_lazy import pl
+
+if TYPE_CHECKING:
+    from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
 
 logger = logging.getLogger(__name__)
 
@@ -328,6 +332,105 @@ def apply_learned_blocks(
 
     logger.info("Learned blocking produced %d blocks from %d rules", len(deduped), min(len(rules), 3))
     return deduped
+
+
+# ── Lowering to a bucket-eligible config (#1839) ──────────────────────────
+#
+# WHY: `_use_bucket_scorer` refuses `strategy="learned"`, so every zero-config
+# run >= 50K rows forfeits the bucket scorer and pays the legacy per-block path.
+# That is NOT a semantic parity gap -- it is a REPRESENTATION gap. Bucket derives
+# block keys from `blocking.passes/keys`, and a learned config carries neither,
+# so bucket has nothing to bucket on. (Which is also why "just relax the gate"
+# is not a fix: bucket would have no keys at all.)
+#
+# A learned rule is a conjunction of (field, transform) predicates -- exactly the
+# shape `BlockingKeyConfig.field_transforms` expresses (#1826, built to map mixed
+# Splink rules per-field instead of widening every field). Lowering learned rules
+# into multi_pass passes closes the gap using machinery that already exists;
+# `score_buckets.py` already honors `field_transforms`.
+#
+# NOTHING HERE IS WIRED UP YET. This is the compiler + a differential harness to
+# ANSWER the gating question with data, not to flip any default. See
+# `scripts/learned_lowering_diff.py`.
+
+# Each learned transform -> a registry chain that is value-identical to the
+# learned lambda (pinned across edge cases in test_learned_lowering_parity.py).
+# 4 of 6 are natively vectorizable, so a lowered config additionally escapes
+# map_elements for those -- a second, independent win.
+_LOWERED_CHAIN: dict[str, list[str]] = {
+    "exact": ["strip", "lowercase"],
+    "first_3": ["strip", "lowercase", "substring:0:3"],
+    "first_5": ["strip", "lowercase", "substring:0:5"],
+    "first_token": ["strip", "lowercase", "first_token"],
+    "soundex": ["soundex"],
+    "digits_only": ["digits_only"],
+}
+
+
+class LoweringUnsupportedError(ValueError):
+    """A learned rule has no exact multi_pass equivalent.
+
+    Raised rather than lowering approximately. An approximate lowering would
+    silently change which pairs are generated -- the exact failure mode (silent,
+    recall-only, precision stays 1.0) that #1800 / #1837 / #1839 all were.
+    """
+
+
+def lower_rule_to_key(rule: BlockingRule) -> BlockingKeyConfig:
+    """Lower ONE learned rule to a BlockingKeyConfig pass.
+
+    Raises LoweringUnsupportedError when the rule cannot be expressed exactly:
+
+    * an unknown transform (no registry chain), or
+    * two predicates on the SAME field (e.g. ``last:exact AND last:soundex``).
+      ``field_transforms`` is keyed by field, so it cannot hold two chains for
+      one field. `learn_blocking_rules` CAN generate these: its dedup guard is
+      ``p1.key() == p2.key()``, which compares field+transform, not field alone.
+      Collapsing them would widen the key and mega-block it (the #1826 footgun).
+    """
+    from goldenmatch.config.schemas import BlockingKeyConfig
+
+    fields = [p.field for p in rule.predicates]
+    dupes = {f for f in fields if fields.count(f) > 1}
+    if dupes:
+        raise LoweringUnsupportedError(
+            f"rule {rule.key()!r} has multiple predicates on field(s) {sorted(dupes)}; "
+            f"field_transforms cannot express two chains for one field"
+        )
+    unknown = [p.transform for p in rule.predicates if p.transform not in _LOWERED_CHAIN]
+    if unknown:
+        raise LoweringUnsupportedError(
+            f"rule {rule.key()!r} uses transform(s) {unknown} with no registry chain"
+        )
+    return BlockingKeyConfig(
+        fields=fields,
+        field_transforms={p.field: list(_LOWERED_CHAIN[p.transform]) for p in rule.predicates},
+    )
+
+
+def lower_rules_to_blocking_config(
+    rules: list[BlockingRule],
+    *,
+    max_block_size: int = 5000,
+    skip_oversized: bool = True,
+) -> BlockingConfig:
+    """Lower learned rules to a multi_pass BlockingConfig that bucket accepts.
+
+    Mirrors ``apply_learned_blocks``: same ``rules[:3]`` cap, union semantics.
+    Raises LoweringUnsupportedError if ANY of those rules cannot be lowered
+    exactly -- a partial lowering would silently drop that rule's candidates.
+    """
+    from goldenmatch.config.schemas import BlockingConfig
+
+    if not rules:
+        raise LoweringUnsupportedError("no rules to lower")
+    return BlockingConfig(
+        strategy="multi_pass",
+        passes=[lower_rule_to_key(r) for r in rules[:3]],
+        union_mode=True,
+        max_block_size=max_block_size,
+        skip_oversized=skip_oversized,
+    )
 
 
 # ── Cache ─────────────────────────────────────────────────────────────────

--- a/packages/python/goldenmatch/tests/test_learned_lowering_parity.py
+++ b/packages/python/goldenmatch/tests/test_learned_lowering_parity.py
@@ -1,0 +1,261 @@
+"""Issue #1839 -- lowering learned rules into a bucket-eligible multi_pass config.
+
+Zero-config runs >= 50K rows set ``strategy="learned"``; ``_use_bucket_scorer``
+refuses ``learned``, so the DEFAULT path at scale forfeits the bucket scorer and
+pays the legacy per-block path. That is a REPRESENTATION gap, not a semantic one:
+bucket derives keys from ``blocking.passes/keys`` and a learned config carries
+neither. Lowering the rules into ``multi_pass`` + ``field_transforms`` (#1826)
+closes it.
+
+Nothing here is wired up -- no default changes. These tests answer the gating
+question with data. See also ``scripts/learned_lowering_diff.py``.
+
+The tests split deliberately into two kinds:
+
+* PARITY tests assert the lowering is exact where it must be.
+* CHARACTERIZATION tests pin the two known divergences WITHOUT asserting either
+  side is correct. Each is a recall/cost tradeoff previously settled by
+  measurement (PR #390: dropping empty keys "lost 3 records on the cross-file
+  dedupe regression suite"), and they must be settled the same way -- not by
+  argument. They are recorded here so a future change can't move them silently.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.learned_blocking import (
+    _LOWERED_CHAIN,
+    _TRANSFORM_MAP,
+    BlockingPredicate,
+    BlockingRule,
+    LoweringUnsupportedError,
+    apply_learned_blocks,
+    lower_rule_to_key,
+    lower_rules_to_blocking_config,
+)
+from goldenmatch.core.matchkey import _try_native_chain
+from goldenmatch.core.pipeline import _use_bucket_scorer
+from goldenmatch.utils.transforms import apply_transforms
+
+BIG = 10**9  # take max_block_size out of the picture; we compare semantics
+
+
+def _p(field: str, transform: str) -> BlockingPredicate:
+    return BlockingPredicate(field=field, transform=transform)
+
+
+def _rule(*preds: BlockingPredicate) -> BlockingRule:
+    return BlockingRule(predicates=list(preds))
+
+
+def _pairs(blocks) -> set[tuple[int, int]]:
+    """Candidate pairs implied by a block list. Pairs -- not block identity --
+    are what decide recall: two paths can disagree on block SHAPE yet generate
+    identical pairs."""
+    out: set[tuple[int, int]] = set()
+    for b in blocks:
+        ids = sorted(b.materialize().native["__row_id__"].to_list())
+        for i, a in enumerate(ids):
+            for c in ids[i + 1:]:
+                out.add((a, c))
+    return out
+
+
+def _both(df: pl.DataFrame, rules: list[BlockingRule]) -> tuple[set, set]:
+    learned = _pairs(apply_learned_blocks(df.lazy(), rules, max_block_size=BIG))
+    cfg = lower_rules_to_blocking_config(rules, max_block_size=BIG, skip_oversized=False)
+    lowered = _pairs(build_blocks(df.lazy(), cfg))
+    return learned, lowered
+
+
+CLEAN = pl.DataFrame({
+    "__row_id__": [0, 1, 2, 3, 4, 5],
+    "last": ["Smith", "Smyth", "Jones", "Jones", "Brown", "Brown"],
+    "city": ["Boston", "Boston", "Newark", "New York", "Chicago", "Chicago"],
+})
+
+
+class TestTransformMapping:
+    """Every learned transform must have a value-identical registry chain."""
+
+    SAMPLES = ["Smith Jones 123", "  Padded  Name ", "O'Brien", "de la Cruz",
+               "X", "", "12345", "ABC-123-XYZ", "Ünicode Näme", "Mc Donald  Jr"]
+
+    def test_every_learned_transform_is_lowerable(self):
+        assert set(_LOWERED_CHAIN) == set(_TRANSFORM_MAP), (
+            "a learned transform with no chain would make its rules unlowerable"
+        )
+
+    @pytest.mark.parametrize("transform", sorted(_TRANSFORM_MAP))
+    def test_chain_is_value_identical(self, transform):
+        chain = _LOWERED_CHAIN[transform]
+        for s in self.SAMPLES:
+            assert apply_transforms(s, chain) == _TRANSFORM_MAP[transform](s), (
+                f"{transform} diverges on {s!r}"
+            )
+
+    def test_majority_of_chains_are_natively_vectorizable(self):
+        """Not a requirement -- a recorded bonus. The lowered config escapes
+        map_elements for these, which is a second win on top of reclaiming
+        bucket. If this regresses, the lowering got slower, not wronger."""
+        native = {t for t, c in _LOWERED_CHAIN.items() if _try_native_chain("f", c) is not None}
+        assert native == {"exact", "first_3", "first_5", "digits_only"}
+
+
+class TestBucketEligibility:
+    """The whole point: the lowered config must clear the gate learned fails."""
+
+    @staticmethod
+    def _cfg(blocking: BlockingConfig) -> GoldenMatchConfig:
+        return GoldenMatchConfig(
+            matchkeys=[MatchkeyConfig(
+                name="mk", type="weighted", threshold=0.9,
+                fields=[MatchkeyField(field="last", scorer="jaro_winkler", weight=1.0)],
+            )],
+            blocking=blocking,
+        )
+
+    def test_learned_is_refused_but_lowered_is_accepted(self):
+        df = pl.DataFrame({"__row_id__": [0, 1], "last": ["Smith", "Smyth"],
+                           "city": ["Boston", "Boston"]})
+        learned = self._cfg(BlockingConfig(strategy="learned", skip_oversized=True))
+        lowered = self._cfg(lower_rules_to_blocking_config(
+            [_rule(_p("last", "soundex"), _p("city", "first_3"))]))
+
+        assert _use_bucket_scorer(learned, df) is False  # the bug
+        assert _use_bucket_scorer(lowered, df) is True   # the fix
+
+
+class TestLoweringParity:
+    """On clean data the lowering must be pair-identical to learned."""
+
+    @pytest.mark.parametrize("label,rules", [
+        ("depth-1", [_rule(_p("last", "soundex"))]),
+        ("depth-2", [_rule(_p("last", "soundex"), _p("city", "first_3"))]),
+        ("multi-rule union", [_rule(_p("last", "soundex")), _rule(_p("city", "first_3"))]),
+        ("every transform", [_rule(_p("last", "exact")), _rule(_p("city", "first_3")),
+                             _rule(_p("last", "first_5")), _rule(_p("city", "first_token"))]),
+    ])
+    def test_pairs_identical_on_clean_data(self, label, rules):
+        learned, lowered = _both(CLEAN, rules)
+        assert learned == lowered, f"{label}: -{learned - lowered} +{lowered - learned}"
+
+    def test_respects_the_same_three_rule_cap_as_apply_learned_blocks(self):
+        """apply_learned_blocks uses rules[:3]; a lowering that kept more (or
+        fewer) would generate different candidates."""
+        rules = [_rule(_p("last", "exact")), _rule(_p("city", "exact")),
+                 _rule(_p("last", "soundex")), _rule(_p("city", "first_3"))]
+        cfg = lower_rules_to_blocking_config(rules)
+        assert len(cfg.passes) == 3
+        learned, lowered = _both(CLEAN, rules)
+        assert learned == lowered
+
+    def test_emits_multi_pass_union(self):
+        cfg = lower_rules_to_blocking_config([_rule(_p("last", "soundex"))])
+        assert cfg.strategy == "multi_pass"
+        assert cfg.union_mode is True
+
+    def test_carries_per_field_chains_not_a_widened_key(self):
+        """The #1826 footgun: collapsing per-field chains into one key-level
+        chain widens every field and mega-blocks."""
+        key = lower_rule_to_key(_rule(_p("last", "soundex"), _p("city", "first_3")))
+        assert key.fields == ["last", "city"]
+        assert key.field_transforms == {
+            "last": ["soundex"],
+            "city": ["strip", "lowercase", "substring:0:3"],
+        }
+
+
+class TestRefusesInexactLowering:
+    """Refuse rather than lower approximately. An approximate lowering changes
+    which pairs are generated SILENTLY -- precision stays 1.0 and only recall
+    moves, the exact shape of #1800 / #1837 / #1839."""
+
+    def test_same_field_conjunction_is_refused(self):
+        """field_transforms is keyed by field, so it cannot hold two chains for
+        one field. learn_blocking_rules CAN emit these: its guard is
+        `p1.key() == p2.key()` (field+transform), not field alone."""
+        with pytest.raises(LoweringUnsupportedError, match="multiple predicates on field"):
+            lower_rule_to_key(_rule(_p("last", "exact"), _p("last", "soundex")))
+
+    def test_unknown_transform_is_refused(self):
+        with pytest.raises(LoweringUnsupportedError, match="no registry chain"):
+            lower_rule_to_key(_rule(_p("last", "metaphone")))
+
+    def test_one_bad_rule_refuses_the_whole_config(self):
+        """A partial lowering would silently drop that rule's candidate pairs."""
+        with pytest.raises(LoweringUnsupportedError):
+            lower_rules_to_blocking_config([
+                _rule(_p("last", "soundex")),
+                _rule(_p("city", "exact"), _p("city", "first_3")),
+            ])
+
+    def test_empty_rules_refused(self):
+        with pytest.raises(LoweringUnsupportedError):
+            lower_rules_to_blocking_config([])
+
+
+class TestKnownDivergences:
+    """CHARACTERIZATION -- not correctness.
+
+    These pin the two edge cases where learned and static disagree. Neither side
+    is asserted correct: both are recall/cost tradeoffs that must be settled by
+    measurement on real corpora (PR #390 is the precedent), not by argument.
+    Recorded so the behavior can't shift silently while we decide.
+    """
+
+    EMPTIES = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4],
+        "last": ["", "", "", "Smith", "Smith"],
+        "city": ["", "", "", "Boston", "Boston"],
+    })
+
+    def test_empty_key_depth1_lowered_adds_the_zero_information_block(self):
+        """learned drops it ("" is falsy); static keeps it. At 1M this is every
+        missing value in one O(n^2) block -- but #390 measured that dropping it
+        loses REAL matches, because scoring still compares those rows on their
+        other fields."""
+        learned, lowered = _both(self.EMPTIES, [_rule(_p("last", "exact"))])
+        assert learned == {(3, 4)}
+        assert lowered == {(0, 1), (0, 2), (1, 2), (3, 4)}
+
+    def test_empty_key_depth2_both_keep_it(self):
+        """The truthiness accident: at depth 2 an all-empty key is "||", which is
+        truthy, so learned keeps the same block it drops at depth 1.
+        learned_predicate_depth DEFAULTS to 2, so the default path keeps it."""
+        learned, lowered = _both(self.EMPTIES, [_rule(_p("last", "exact"), _p("city", "exact"))])
+        assert learned == lowered
+        assert (0, 1) in learned
+
+    def test_nulls_agree_by_coincidence(self):
+        """Both paths drop NULLs, via DIFFERENT mechanisms: static filters
+        is_not_null; learned maps None -> "" which is falsy. Same outcome at
+        depth 1 -- but it is a coincidence, not a shared rule."""
+        nulls = pl.DataFrame({
+            "__row_id__": [0, 1, 2, 3],
+            "last": [None, None, "Smith", "Smith"],
+            "city": [None, None, "Boston", "Boston"],
+        })
+        learned, lowered = _both(nulls, [_rule(_p("last", "exact"))])
+        assert learned == lowered == {(2, 3)}
+
+    def test_sentinel_strings_diverge(self):
+        """static filters "nan"/"null"/"none" as stringified-NULL artifacts;
+        learned keeps them as literals. If a user genuinely has the string
+        "null", static silently drops that pair."""
+        sentinels = pl.DataFrame({
+            "__row_id__": [0, 1, 2, 3],
+            "last": ["null", "null", "Smith", "Smith"],
+            "city": ["nan", "nan", "Boston", "Boston"],
+        })
+        learned, lowered = _both(sentinels, [_rule(_p("last", "exact"))])
+        assert (0, 1) in learned
+        assert (0, 1) not in lowered

--- a/scripts/learned_lowering_diff.py
+++ b/scripts/learned_lowering_diff.py
@@ -1,0 +1,235 @@
+"""Differential harness: learned blocking vs its lowered multi_pass equivalent (#1839).
+
+WHY THIS EXISTS
+---------------
+Zero-config runs >= 50K rows set ``strategy="learned"``, which
+``_use_bucket_scorer`` refuses -- so the default path at scale forfeits the
+bucket scorer and pays the legacy per-block path. Lowering learned rules into
+``multi_pass`` + ``field_transforms`` closes that gap (see
+``learned_blocking.lower_rules_to_blocking_config``).
+
+The transforms lower exactly, and on CLEAN data the two paths generate identical
+pairs. Divergence is confined to two edge cases (measured by this harness -- an
+earlier hand-written version of this table got the NULL row wrong, which is the
+whole argument for having the harness):
+
+    | case                    | learned               | static/multi_pass  | same? |
+    |-------------------------|-----------------------|--------------------|-------|
+    | all-empty key, depth 1  | dropped ("" is falsy) | kept               | NO    |
+    | all-empty key, depth 2  | KEPT ("||" is truthy) | kept               | yes   |
+    | NULL                    | -> "" -> falsy -> dropped | filtered out   | yes   |
+    | "nan"/"null"/"none"     | kept as literal       | filtered sentinels | NO    |
+
+Two things worth naming:
+
+* The depth-1 vs depth-2 split is a string-truthiness accident, not a rule --
+  and ``learned_predicate_depth`` DEFAULTS to 2, so the default path keeps the
+  zero-information block that depth 1 drops.
+* NULLs agree by COINCIDENCE, not by a shared rule: static filters is_not_null,
+  while learned maps None -> "" and drops it for being falsy. Same outcome at
+  depth 1; at depth 2 learned's "||" would be truthy again.
+
+These cannot be resolved by argument -- each is a recall/cost tradeoff. PR #390
+recorded the only hard evidence: dropping empty keys "lost 3 records on the
+cross-file dedupe regression suite". This harness produces that same class of
+evidence on demand: it reports not just THAT the block sets differ, but WHICH
+records are at stake, so the divergences adjudicate themselves.
+
+USAGE
+-----
+    # built-in synthetic probes (each isolates one divergence)
+    python scripts/learned_lowering_diff.py
+
+    # against a real corpus
+    python scripts/learned_lowering_diff.py --csv path/to/data.csv \\
+        --rule last:soundex+city:first_3 --rule first:first_token
+
+Exit code is 0 always: this is an evidence tool, not a gate. Nothing here is
+wired into the pipeline and no default changes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PKG = REPO_ROOT / "packages" / "python" / "goldenmatch"
+if str(PKG) not in sys.path:
+    sys.path.insert(0, str(PKG))
+
+import polars as pl  # noqa: E402
+from goldenmatch.core.blocker import build_blocks  # noqa: E402
+from goldenmatch.core.learned_blocking import (  # noqa: E402
+    BlockingPredicate,
+    BlockingRule,
+    LoweringUnsupportedError,
+    apply_learned_blocks,
+    lower_rules_to_blocking_config,
+)
+
+BIG = 10**9  # take max_block_size out of the picture; we compare semantics
+
+
+def _member_sets(blocks) -> set[frozenset[int]]:
+    """Block member sets, keyed by __row_id__. Singletons are dropped -- they
+    generate no pairs, so they cannot account for a recall difference."""
+    out = set()
+    for b in blocks:
+        ids = frozenset(b.materialize().native["__row_id__"].to_list())
+        if len(ids) >= 2:
+            out.add(ids)
+    return out
+
+
+def _pairs(member_sets: set[frozenset[int]]) -> set[tuple[int, int]]:
+    """Candidate pairs implied by a block set. This -- not block identity -- is
+    what actually decides recall: two paths can disagree on block SHAPE while
+    generating the same pairs."""
+    out: set[tuple[int, int]] = set()
+    for s in member_sets:
+        ids = sorted(s)
+        for i, a in enumerate(ids):
+            for b in ids[i + 1:]:
+                out.add((a, b))
+    return out
+
+
+def diff(df: pl.DataFrame, rules: list[BlockingRule], label: str) -> dict:
+    """Compare learned blocks against lowered multi_pass blocks on one frame."""
+    print(f"\n=== {label} ===")
+    print(f"    rows={df.height}  rules={[r.key() for r in rules]}")
+
+    learned_blocks = apply_learned_blocks(df.lazy(), rules, max_block_size=BIG)
+    learned_sets = _member_sets(learned_blocks)
+
+    try:
+        cfg = lower_rules_to_blocking_config(rules, max_block_size=BIG, skip_oversized=False)
+    except LoweringUnsupportedError as e:
+        print(f"    NOT LOWERABLE: {e}")
+        return {"label": label, "lowerable": False, "reason": str(e)}
+
+    lowered_sets = _member_sets(build_blocks(df.lazy(), cfg))
+
+    lp, bp = _pairs(learned_sets), _pairs(lowered_sets)
+    only_learned, only_lowered = lp - bp, bp - lp
+
+    print(f"    blocks:  learned={len(learned_sets):5d}  lowered={len(lowered_sets):5d}")
+    print(f"    pairs:   learned={len(lp):5d}  lowered={len(bp):5d}")
+
+    if not only_learned and not only_lowered:
+        print("    PAIRS IDENTICAL")
+    else:
+        print(f"    DIVERGE: only-learned={len(only_learned)}  only-lowered={len(only_lowered)}")
+        for tag, pairs in (("only-learned", only_learned), ("only-lowered", only_lowered)):
+            for a, b in sorted(pairs)[:4]:
+                ra = df.filter(pl.col("__row_id__") == a).to_dicts()[0]
+                rb = df.filter(pl.col("__row_id__") == b).to_dicts()[0]
+                ra.pop("__row_id__", None)
+                rb.pop("__row_id__", None)
+                print(f"      {tag}: {a} {ra}")
+                print(f"      {' ' * len(tag)}  {b} {rb}")
+            if len(pairs) > 4:
+                print(f"      {tag}: ... and {len(pairs) - 4} more")
+
+    return {
+        "label": label,
+        "lowerable": True,
+        "identical": not only_learned and not only_lowered,
+        "only_learned": len(only_learned),
+        "only_lowered": len(only_lowered),
+    }
+
+
+def _p(field: str, transform: str) -> BlockingPredicate:
+    return BlockingPredicate(field=field, transform=transform)
+
+
+def _probes() -> list[tuple[str, pl.DataFrame, list[BlockingRule]]]:
+    """Synthetic frames, each isolating ONE divergence from the table above."""
+    clean = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "last": ["Smith", "Smyth", "Jones", "Jones", "Brown", "Brown"],
+        "city": ["Boston", "Boston", "Newark", "New York", "Chicago", "Chicago"],
+    })
+    empties = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "last": ["", "", "", "Smith", "Smith", "Jones"],
+        "city": ["", "", "", "Boston", "Boston", "Newark"],
+    })
+    nulls = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3, 4, 5],
+        "last": [None, None, None, "Smith", "Smith", "Jones"],
+        "city": [None, None, None, "Boston", "Boston", "Newark"],
+    })
+    sentinels = pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        "last": ["null", "null", "Smith", "Smith"],
+        "city": ["nan", "nan", "Boston", "Boston"],
+    })
+    return [
+        ("clean / depth-1", clean, [BlockingRule(predicates=[_p("last", "soundex")])]),
+        ("clean / depth-2", clean, [BlockingRule(predicates=[_p("last", "soundex"), _p("city", "first_3")])]),
+        ("clean / multi-rule union", clean, [
+            BlockingRule(predicates=[_p("last", "soundex")]),
+            BlockingRule(predicates=[_p("city", "first_3")]),
+        ]),
+        ("EMPTY strings / depth-1  (learned drops, static keeps)", empties,
+         [BlockingRule(predicates=[_p("last", "exact")])]),
+        ("EMPTY strings / depth-2  (truthiness accident: both keep)", empties,
+         [BlockingRule(predicates=[_p("last", "exact"), _p("city", "exact")])]),
+        ("NULLs / depth-1  (agree, but by coincidence)", nulls,
+         [BlockingRule(predicates=[_p("last", "exact")])]),
+        ("SENTINELS 'null'/'nan'  (static filters, learned keeps literal)", sentinels,
+         [BlockingRule(predicates=[_p("last", "exact")])]),
+        ("SAME-FIELD conjunction  (not lowerable by construction)", clean,
+         [BlockingRule(predicates=[_p("last", "exact"), _p("last", "soundex")])]),
+    ]
+
+
+def _parse_rule(spec: str) -> BlockingRule:
+    preds = []
+    for part in spec.split("+"):
+        field, _, transform = part.partition(":")
+        if not transform:
+            raise ValueError(f"bad rule spec {spec!r}; want field:transform[+field:transform]")
+        preds.append(_p(field, transform))
+    return BlockingRule(predicates=preds)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--csv", type=Path, help="corpus to diff against (else: synthetic probes)")
+    ap.add_argument("--rule", action="append", default=[],
+                    help="field:transform[+field:transform], repeatable")
+    args = ap.parse_args()
+
+    if args.csv:
+        df = pl.read_csv(args.csv)
+        if "__row_id__" not in df.columns:
+            df = df.with_row_index("__row_id__")
+        if not args.rule:
+            print("--csv requires at least one --rule", file=sys.stderr)
+            return 2
+        results = [diff(df, [_parse_rule(r) for r in args.rule], str(args.csv))]
+    else:
+        results = [diff(df, rules, label) for label, df, rules in _probes()]
+
+    print("\n" + "=" * 72)
+    print("SUMMARY")
+    for r in results:
+        if not r["lowerable"]:
+            verdict = "NOT LOWERABLE"
+        elif r["identical"]:
+            verdict = "pairs identical"
+        else:
+            verdict = f"DIVERGE (-{r['only_learned']} / +{r['only_lowered']} pairs)"
+        print(f"  {r['label']:58} {verdict}")
+    print("\nDivergences are evidence, not failures: each names the records a")
+    print("semantics decision would gain or lose. Nothing here changes a default.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Answers the gating question in #1839 **with data**. Wired to nothing: no default changes, no routing flips.

> The auto-config wiring that USES this compiler is a separate follow-up PR. This PR is the compiler + evidence only.

## The finding

`_use_bucket_scorer` refuses `strategy="learned"`, and the auto-config learned upgrade sets that strategy unconditionally for `total_rows >= 50_000`. So **every zero-config run at or above 50K rows forfeits the bucket scorer** and pays the legacy per-block path.

That is a **representation** gap, not a semantic one. Bucket derives block keys from `blocking.passes/keys`; a learned config carries neither, so bucket has nothing to bucket on. This also rules out the obvious shortcut: *relaxing the gate would not work*, because bucket would still have no keys.

A learned rule is a conjunction of `(field, transform)` predicates -- which is exactly what `BlockingKeyConfig.field_transforms` expresses (#1826, built to map mixed Splink rules per-field instead of widening). `score_buckets.py:1318` already honors `field_transforms`, so the bucket side needs no work at all.

## The payoff, proven

```
learned strategy -> bucket?  False   # the bug
lowered strategy -> bucket?  True    # the fix
```

## Measured

- **All 6 learned transforms** map to a value-identical registry chain across 10 edge cases (empty, unicode, apostrophes, multi-token, single char).
- **4 of 6 are natively vectorizable** (`exact`, `first_3`, `first_5`, `digits_only`) -- so a lowered config additionally escapes `map_elements`. A second, independent win.
- **On clean data the two paths generate identical pairs**: depth-1, depth-2, multi-rule union, and all-transforms.

## What's added

| file | what |
|---|---|
| `core/learned_blocking.py` | `lower_rule_to_key`, `lower_rules_to_blocking_config`, `LoweringUnsupportedError` |
| `scripts/learned_lowering_diff.py` | differential harness -- reports *which records* are at stake, not just that sets differ |
| `tests/test_learned_lowering_parity.py` | 24 tests, split PARITY vs CHARACTERIZATION |

The compiler **refuses rather than lowering approximately**. An approximate lowering changes which pairs are generated *silently* -- precision stays 1.0 and only recall moves, the exact shape of #1800 / #1837 / #1839. Two refusals:

- **same-field conjunctions** (`last:exact AND last:soundex`): `field_transforms` is keyed by field and cannot hold two chains for one field. `learn_blocking_rules` **can** emit these -- its guard is `p1.key() == p2.key()`, comparing field+transform, not field alone. Collapsing them would widen the key and mega-block it (the #1826 footgun).
- **unknown transforms**.

## Divergences: recorded, NOT resolved

Divergence is confined to two edge cases: empty-string cells and sentinel strings. On those, the lowered config behaves like `static`/`multi_pass` -- i.e. like every other blocking config in the product.

| case | learned | static/multi_pass | same? |
|---|---|---|---|
| all-empty key, depth 1 | dropped (`""` falsy) | kept | **NO** |
| all-empty key, depth 2 | KEPT (`"\|\|"` truthy) | kept | yes |
| NULL | `-> ""` -> falsy -> dropped | filtered out | yes |
| `"nan"/"null"/"none"` | kept as literal | filtered as sentinels | **NO** |

Two things worth naming:

- The depth-1/depth-2 split is a **string-truthiness accident**, not a rule -- an all-empty key is `""` (falsy) at depth 1 but `"||"` (truthy) at depth 2. And `learned_predicate_depth` **defaults to 2**, so the default path already keeps the zero-information block that depth 1 drops. Worth its own issue regardless of this PR.
- **NULLs agree by coincidence**, not by a shared rule: static filters `is_not_null`; learned maps `None -> ""` and drops it for being falsy.

That last row is the case for the harness: a hand-written version of this table **got it wrong**, predicting a divergence that doesn't exist. The harness corrected it.

The CHARACTERIZATION tests pin these without asserting either side correct.

## Verification notes

- `test_learned_lowering_parity.py` + `test_learned_blocking.py`: 36 passed
- blocking/bucket/learned sweep: 744 passed
- full-package `ruff check`: clean
- **Not measured**: the actual wall-clock win. 1M zero-config OOMs my box, so the payoff is proven structurally (`_use_bucket_scorer -> True`) but the wall needs CI.
- Pre-existing on main, NOT from this PR (each reproduced in a tree without this code): `test_native_fs_ne.py::test_native_numpy_parity_ne`, `test_score_buckets_debug_mode.py::test_debug_flag_does_not_change_output`, `test_metrics_harness.py` collection error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9