### PR TITLE
fix(routing): FS keeps the bucket route under the columnar opt-in; loud FS_DEFAULT_BUCKET=0 hatch

### DIFF
--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -558,6 +558,7 @@ Every `GOLDENMATCH_*` variable the package reads (plus the one `GOLDEN_*` except
 | `GOLDENMATCH_STANDARDIZE_STAGED` | `0` | Staged standardization (experimental, may slow). |
 | `GOLDENMATCH_BUCKET_VEC_MIN` / `_MAX` | `32` / `2000` | Block-size band for the vectorized float64 NxN cdist path in bucket scoring. |
 | `GOLDENMATCH_FS_BATCH_ROWS` | `256` | Row cap per batched Fellegi-Sunter block-scoring call. |
+| `GOLDENMATCH_FS_DEFAULT_BUCKET` | `1` (on) | Probabilistic matchkeys score via the memory-bounded bucket route by default. `0` = legacy batched scorer (eager `build_blocks` -- memory grows with dataset size; logs a warning). Escape hatch only. |
 | `GOLDENMATCH_BENCH_DUMP_PAIRS` | unset | Dump per-stage pairs for benchmarking. |
 | `GOLDENMATCH_SKIP_MATCH_LOG` / `GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS` | — | Streaming match-log controls. |
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -194,10 +194,12 @@ def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
       - an EXPLICIT scale backend (ray / duckdb / datafusion / chunked) keeps
         its own routing; ``polars-direct`` is the planner's in-band choice and
         keeps the default (same band semantics as ``_use_bucket_scorer``);
-      - ``GOLDENMATCH_FS_DEFAULT_BUCKET=0`` escape hatch (legacy batched);
-      - ``GOLDENMATCH_COLUMNAR_PIPELINE`` opt-in wins;
+      - ``GOLDENMATCH_FS_DEFAULT_BUCKET=0`` escape hatch (legacy batched --
+        memory-unbounded; a warning is logged when it fires);
       - active profile emitter: auto-config reads the legacy block-size
-        signals during sample runs (the final committed dedupe gets bucket);
+        signals during sample runs ONLY -- emitters are opened exclusively by
+        the controller/optimizer around sample probes, so a user's committed
+        dedupe/match run always gets bucket;
       - blocking strategies bucket cannot replicate (non static/multi_pass --
         lsh / ann / learned / canopy / sorted_neighborhood candidates are not
         field-hash reproducible).
@@ -211,9 +213,19 @@ def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
         os.environ.get("GOLDENMATCH_FS_DEFAULT_BUCKET", "1").strip().lower()
         in _BUCKET_DEFAULT_OPT_OUT
     ):
+        logger.warning(
+            "GOLDENMATCH_FS_DEFAULT_BUCKET=0: probabilistic matchkey %r routed "
+            "to the legacy batched scorer (eager build_blocks -- memory grows "
+            "with dataset size). Unset the variable to restore the "
+            "memory-bounded bucket route.",
+            getattr(mk, "name", mk),
+        )
         return False
-    if _columnar_pipeline_enabled():
-        return False
+    # NOTE: GOLDENMATCH_COLUMNAR_PIPELINE deliberately does NOT exclude FS.
+    # The columnar branch is structurally weighted-only (_is_columnar_eligible
+    # requires a single weighted matchkey), so a probabilistic matchkey never
+    # enters it -- excluding FS here only demoted FS to the batched path for
+    # users who happened to have the columnar opt-in set.
     _blk = getattr(config, "blocking", None)
     if _blk is not None and getattr(_blk, "strategy", None) not in (
         None, "static", "multi_pass",

--- a/packages/python/goldenmatch/tests/test_fs_bucket_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_native.py
@@ -231,10 +231,12 @@ def _prob_config(backend=None) -> GoldenMatchConfig:
     )
 
 
-def test_fs_bucket_route_decision(monkeypatch):
+def test_fs_bucket_route_decision(monkeypatch, caplog):
     """#1803 item 3: bucket is the FS route by default -- NO native-kernel
     requirement, NO row cap. Exclusions: explicit scale backends, the
     escape hatch, non-field blocking strategies, active profile emitter."""
+    import logging
+
     from goldenmatch.core.pipeline import _fs_use_bucket_route
 
     mk = _mk()
@@ -257,10 +259,22 @@ def test_fs_bucket_route_decision(monkeypatch):
     for be in ("ray", "duckdb", "datafusion"):
         assert _fs_use_bucket_route(_prob_config(backend=be), mk) is False
 
-    # Escape hatch always wins.
+    # Escape hatch always wins -- and warns (the batched fallback is the
+    # memory-unbounded #1798 path; opting out should be loud).
     monkeypatch.setenv("GOLDENMATCH_FS_DEFAULT_BUCKET", "0")
-    assert _fs_use_bucket_route(cfg, mk) is False
+    with caplog.at_level(logging.WARNING, logger="goldenmatch.core.pipeline"):
+        assert _fs_use_bucket_route(cfg, mk) is False
+    assert any(
+        "GOLDENMATCH_FS_DEFAULT_BUCKET=0" in r.getMessage() for r in caplog.records
+    )
     monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
+
+    # The columnar opt-in does NOT demote FS: the columnar branch is
+    # structurally weighted-only (_is_columnar_eligible), so a probabilistic
+    # matchkey keeps the bucket route even with the experiment enabled.
+    monkeypatch.setenv("GOLDENMATCH_COLUMNAR_PIPELINE", "1")
+    assert _fs_use_bucket_route(cfg, mk) is True
+    monkeypatch.delenv("GOLDENMATCH_COLUMNAR_PIPELINE", raising=False)
 
     # Blocking strategies bucket can't replicate stay legacy.
     lsh_cfg = _prob_config(backend=None)


### PR DESCRIPTION
Follow-up to #1803/#1810: two of the `_fs_use_bucket_route` exclusions demoted FS to the memory-unbounded batched path without a real reason.

**Columnar opt-in no longer excludes FS.** The columnar branch is structurally weighted-only: `_is_columnar_eligible` requires exactly one matchkey of type `weighted`, so a probabilistic matchkey can never enter it. The exclusion was defensive coupling that punished FS users who happened to have `GOLDENMATCH_COLUMNAR_PIPELINE=1` set. Removed; FS keeps the bucket route.

**`GOLDENMATCH_FS_DEFAULT_BUCKET=0` is now loud and documented.** The hatch stays honored (legacy batched), but it now logs a warning naming the matchkey and the memory consequence (eager `build_blocks`, the #1798 OOM shape), and gets a tuning.mdx entry (it was code-only before).

**Emitter exclusion unchanged, now documented.** Emitters are only active during autoconfig/optimizer sample probes (calibrated against legacy block-size signals -- see the #1829 lesson); a committed user run never has an active emitter, so this exclusion never demotes a real run. Docstring states that explicitly.

Tests: `test_fs_bucket_route_decision` extended (columnar keeps bucket; hatch warns). Full `test_fs_bucket_native.py` + `test_columnar_pipeline_parity.py` green locally (24 passed).

Part of the "exclusions should not break the fast path" pass; distributed/chunked FS support and non-static-strategy bounded scoring follow in separate PRs.
