### PR TITLE
feat(scale-lanes): FS matchkeys score in the distributed and chunked lanes

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/chunked.py
+++ b/packages/python/goldenmatch/goldenmatch/core/chunked.py
@@ -44,6 +44,11 @@ class ChunkedMatcher:
         # configured with `strategy="static"`. Lets cross-chunk matching
         # skip pure-index blocks and avoid joint-frame block building.
         self._index_by_block: list[dict[str, pl.DataFrame]] | None = None
+        # One shared EMResult per probabilistic matchkey, resolved on first
+        # use (loaded from mk.model_path, else trained ONCE on the first
+        # chunk) and reused for every chunk -- per-chunk retraining would
+        # fit a different model per slice.
+        self._fs_em_results: dict[str, Any] = {}
         self._row_offset = 0
         self._total_processed = 0
         self._chunk_count = 0
@@ -74,11 +79,6 @@ class ChunkedMatcher:
 
         file_path = Path(file_path)
         matchkeys = self.config.get_matchkeys()
-        # The within-chunk and cross-chunk loops handle only exact + weighted
-        # matchkeys; a probabilistic (FS) matchkey would be silently dropped
-        # (#1800). Fail loudly at lane entry -- run FS configs single-box.
-        from goldenmatch.core.pipeline import _reject_probabilistic_matchkeys
-        _reject_probabilistic_matchkeys(matchkeys, "chunked")
         t_start = time.perf_counter()
 
         # Determine reader
@@ -135,6 +135,25 @@ class ChunkedMatcher:
                         blocks = build_blocks(chunk_df.lazy(), self.config.blocking)
                         pairs = score_blocks_parallel(blocks, mk, matched_pairs)
                         chunk_pairs.extend(pairs)
+                    elif mk.type == "probabilistic":
+                        # FS: memory-bounded bucket scorer against the ONE
+                        # shared model (loaded/trained by _ensure_fs_model on
+                        # the first chunk). Mirrors the single-box FS route.
+                        from goldenmatch.backends.score_buckets import (
+                            score_buckets,
+                        )
+
+                        em_result = self._ensure_fs_model(mk, chunk_df)
+                        pairs = score_buckets(
+                            chunk_df,
+                            self.config.blocking,
+                            mk,
+                            matched_pairs,
+                            em_result=em_result,
+                        )
+                        chunk_pairs.extend(pairs)
+                        for a, b, _s in pairs:
+                            matched_pairs.add((min(a, b), max(a, b)))
 
             # Match against index (cross-chunk matching)
             if self._index_df is not None and self._index_df.height > 0:
@@ -332,6 +351,27 @@ class ChunkedMatcher:
                     )
                     for a, b, s in weighted_pairs:
                         cross_pairs.append((min(a, b), max(a, b), s))
+                elif mk.type == "probabilistic":
+                    # FS cross-chunk: score the joint frame via the bucket
+                    # scorer with target_ids=chunk ids -- its XOR filter
+                    # emits exactly the (chunk x index) cross pairs, so
+                    # within-chunk and within-index pairs (already scored
+                    # on their own chunks) are never re-emitted.
+                    from goldenmatch.backends.score_buckets import (
+                        score_buckets,
+                    )
+
+                    em_result = self._ensure_fs_model(mk, joint_df)
+                    fs_pairs = score_buckets(
+                        joint_df,
+                        self.config.blocking,
+                        mk,
+                        matched_pairs,
+                        target_ids=set(range(chunk_lo, chunk_hi)),
+                        em_result=em_result,
+                    )
+                    for a, b, s in fs_pairs:
+                        cross_pairs.append((min(a, b), max(a, b), s))
 
         return cross_pairs
 
@@ -428,6 +468,44 @@ class ChunkedMatcher:
         return list(score_blocks_parallel(
             synthetic_blocks, mk, matched_pairs, target_ids=chunk_ids,
         ))
+
+    def _ensure_fs_model(self, mk: Any, df: pl.DataFrame) -> Any:
+        """Resolve the shared EMResult for a probabilistic matchkey.
+
+        First call wins: load from ``mk.model_path`` when persisted, else
+        train ONCE on the given frame (the first chunk that reaches an FS
+        matchkey) and reuse for every subsequent chunk. Retraining per
+        chunk would fit a different model on each slice -- inconsistent
+        weights and nondeterministic scores across the file.
+        """
+        em = self._fs_em_results.get(mk.name)
+        if em is not None:
+            return em
+
+        from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+        from goldenmatch.core.probabilistic import (
+            fs_model_preloaded,
+            load_or_train_em,
+        )
+
+        blocks: list[Any] = []
+        blocking_fields: list[str] = []
+        if not fs_model_preloaded(mk):
+            logger.warning(
+                "FS matchkey %r: training EM once on the first chunk "
+                "(%d rows) and reusing the model for all chunks. For "
+                "explicit control over training data, train once on a "
+                "representative sample and set mk.model_path.",
+                mk.name, df.height,
+            )
+            if self.config.blocking is not None:
+                blocks = build_blocks(df.lazy(), self.config.blocking)
+                blocking_fields = collect_blocking_fields(self.config.blocking)
+        em = load_or_train_em(
+            df, mk, blocks=blocks, blocking_fields=blocking_fields,
+        )
+        self._fs_em_results[mk.name] = em
+        return em
 
     def _add_to_index(self, chunk_df: pl.DataFrame) -> None:
         """Append the chunk's slim slice to the persistent index frame.

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -4663,34 +4663,39 @@ def run_match_df(
 
 
 def _reject_probabilistic_matchkeys(matchkeys: list, lane: str) -> None:
-    """Fail loudly if any matchkey is probabilistic (Fellegi-Sunter).
+    """Fail loudly for probabilistic (Fellegi-Sunter) matchkeys that reach a
+    scale lane WITHOUT a trained model available.
 
-    The distributed and chunked lanes score only ``exact`` + ``weighted``
-    matchkeys per partition / chunk. A ``type="probabilistic"`` matchkey
-    routed through them contributes ZERO pairs with no error and no log,
-    silently losing its FS scoring the moment a config that works single-
-    box crosses into either lane (issue #1800). Raise instead -- matching
-    the DataFusion backend's ``NotImplementedError`` and Sail's documented
-    one-box fallback.
+    The distributed and chunked lanes score FS matchkeys per partition /
+    chunk against ONE shared ``EMResult`` (trained once on the driver, or
+    loaded from ``mk.model_path``). Training per partition would fit a
+    different model on each non-representative slice -- inconsistent weights,
+    nondeterministic scores -- and before #1800 the matchkey was silently
+    dropped instead. So callers reject exactly the FS matchkeys they could
+    not resolve a model for, and this raises for those -- matching the
+    DataFusion backend's ``NotImplementedError`` posture.
 
     ``lane`` names the offending lane for the error message. No-op when no
-    matchkey is probabilistic (so exact/weighted configs are unaffected).
+    matchkey in the given list is probabilistic.
     """
     fs = [mk.name for mk in matchkeys if getattr(mk, "type", None) == "probabilistic"]
     if fs:
         names = ", ".join(repr(n) for n in fs)
         raise NotImplementedError(
-            f"The {lane} lane does not support probabilistic "
-            f"(Fellegi-Sunter) matchkeys ({names}); routing them here "
-            f"silently drops their scoring. Run this config single-box "
-            f"(in-memory, backend='bucket'), or convert the matchkey to "
-            f"type='weighted'.",
+            f"The {lane} lane cannot score probabilistic (Fellegi-Sunter) "
+            f"matchkeys ({names}) without a trained model: per-partition EM "
+            f"training would fit inconsistent weights. Set mk.model_path to "
+            f"a persisted model (train once via load_or_train_em), route "
+            f"through score_blocks_distributed (which trains once on the "
+            f"driver), run single-box (in-memory, backend='bucket'), or "
+            f"convert the matchkey to type='weighted'.",
         )
 
 
 def _score_partition_with_config(  # pyright: ignore[reportUnusedFunction]
     df: pl.DataFrame,
     config: GoldenMatchConfig,
+    fs_em_results: dict[str, Any] | None = None,
 ) -> list[tuple[int, int, float]]:
     """Narrow scoring-only kernel for distributed per-partition execution.
 
@@ -4728,10 +4733,22 @@ def _score_partition_with_config(  # pyright: ignore[reportUnusedFunction]
     from goldenmatch.core.standardize import apply_standardization
 
     matchkeys = config.get_matchkeys()
-    # FS matchkeys are silently dropped by the weighted-only Phase 2 loop
-    # below (#1800). Fail loudly at kernel entry -- this also covers the
-    # db/sync streaming caller, which reuses this kernel.
-    _reject_probabilistic_matchkeys(matchkeys, "distributed")
+    # FS matchkeys score per partition against ONE shared EMResult: either
+    # supplied by the driver (``fs_em_results``, keyed by matchkey name --
+    # score_blocks_distributed trains once before dispatch) or loaded from
+    # ``mk.model_path``. Training inside a partition would fit a different
+    # model per slice, so FS matchkeys with NEITHER source still fail
+    # loudly (#1800) -- this also covers the db/sync streaming caller,
+    # which reuses this kernel without a driver-side training step.
+    from goldenmatch.core.probabilistic import fs_model_preloaded
+
+    _fs_unresolved = [
+        mk for mk in matchkeys
+        if getattr(mk, "type", None) == "probabilistic"
+        and not (fs_em_results and mk.name in fs_em_results)
+        and not fs_model_preloaded(mk)
+    ]
+    _reject_probabilistic_matchkeys(_fs_unresolved, "distributed")
     if not matchkeys or df.height < 2:
         return []
 
@@ -4794,6 +4811,31 @@ def _score_partition_with_config(  # pyright: ignore[reportUnusedFunction]
     # explicitly in case a caller skips that step.
     if config.blocking is not None:
         for mk in matchkeys:
+            if mk.type == "probabilistic":
+                # FS: score via the memory-bounded bucket scorer against the
+                # shared model. The entry guard above guarantees a model is
+                # available (driver-supplied or mk.model_path on disk --
+                # load_or_train_em takes the load path, never trains here).
+                from goldenmatch.backends.score_buckets import score_buckets
+                from goldenmatch.core.probabilistic import load_or_train_em
+
+                em_result = (fs_em_results or {}).get(mk.name)
+                if em_result is None:
+                    em_result = load_or_train_em(collected_df, mk)
+                pairs = score_buckets(
+                    collected_df,
+                    config.blocking,
+                    mk,
+                    matched_pairs,
+                    n_buckets=config.n_buckets,
+                    across_files_only=False,
+                    source_lookup=None,
+                    em_result=em_result,
+                )
+                all_pairs.extend(pairs)
+                for a, b, _s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+                continue
             if mk.type != "weighted":
                 continue
             if config.backend == "bucket":

--- a/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/scoring.py
@@ -214,21 +214,115 @@ def score_blocks_distributed(
         then needs a real distributed WCC rather than ``local_cc_assignments``
         (the WCC-at-scale question gates flipping the default).
     """
-    # Guard at driver entry, BEFORE dispatch: probabilistic (Fellegi-Sunter)
-    # matchkeys aren't scored by the per-partition kernel and would be
-    # silently dropped (#1800). Raising here (not inside the worker) avoids
-    # the ``_score_partition`` try/except swallowing the error per-partition.
-    from goldenmatch.core.pipeline import _reject_probabilistic_matchkeys
-    _reject_probabilistic_matchkeys(config.get_matchkeys(), "distributed")
+    # Resolve one shared EMResult per probabilistic (Fellegi-Sunter) matchkey
+    # BEFORE dispatch: load from mk.model_path when persisted, else train ONCE
+    # on a driver-side sample. Workers must never train -- per-partition EM
+    # would fit a different model on each slice (inconsistent weights,
+    # nondeterministic scores; pre-#1800 the matchkey was silently dropped
+    # instead). The dict ships to workers via the closure like the config.
+    fs_em_results = _prepare_fs_models(df_ds, config)
 
     if _block_shuffle_enabled() and _has_colocation_plan(config):
-        return _score_blocks_block_shuffle(df_ds, config)
-    return _score_blocks_legacy(df_ds, config)
+        return _score_blocks_block_shuffle(df_ds, config, fs_em_results)
+    return _score_blocks_legacy(df_ds, config, fs_em_results)
+
+
+def _fs_training_sample(df_ds: Dataset, config: GoldenMatchConfig) -> Any:
+    """Materialize a driver-side sample of ``df_ds`` prepared for EM training
+    (same standardize/matchkey shape the scoring kernel derives per
+    partition, so ``train_em`` sees the columns it expects).
+
+    Row budget via ``GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS`` (default 200k --
+    EM itself samples ~10k within-block pairs from this, so the budget only
+    needs to be representative, not exhaustive).
+    """
+    import polars as pl
+
+    from goldenmatch.core.matchkey import (
+        compute_matchkeys,
+        precompute_matchkey_transforms,
+    )
+    from goldenmatch.core.standardize import apply_standardization
+
+    n = int(os.environ.get("GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS", "200000"))
+    batch = df_ds.take_batch(n, batch_format="pyarrow")
+    df = pl.from_arrow(batch)
+    assert isinstance(df, pl.DataFrame)
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64),
+        )
+    lf = df.lazy()
+    if config.standardization and config.standardization.rules:
+        lf = apply_standardization(lf, config.standardization.rules)
+    matchkeys = config.get_matchkeys()
+    lf = compute_matchkeys(lf, matchkeys)
+    return precompute_matchkey_transforms(lf.collect(), matchkeys)
+
+
+def _prepare_fs_models(
+    df_ds: Dataset,
+    config: GoldenMatchConfig,
+) -> dict[str, Any] | None:
+    """Return ``{matchkey_name: EMResult}`` for every probabilistic matchkey,
+    or ``None`` when the config has none.
+
+    Per matchkey: a persisted ``mk.model_path`` is loaded and validated
+    (Splink-style train-once reuse -- the file only needs to exist on the
+    DRIVER; workers receive the loaded object, not the path). Otherwise EM
+    trains once on a driver-side sample (and persists to ``mk.model_path``
+    when the path is set but absent).
+    """
+    matchkeys = config.get_matchkeys()
+    fs_mks = [
+        mk for mk in matchkeys if getattr(mk, "type", None) == "probabilistic"
+    ]
+    if not fs_mks:
+        return None
+
+    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+    from goldenmatch.core.probabilistic import (
+        fs_model_preloaded,
+        load_or_train_em,
+    )
+
+    results: dict[str, Any] = {}
+    sample_df = None
+    sample_blocks: list[Any] = []
+    for mk in fs_mks:
+        if not fs_model_preloaded(mk):
+            if sample_df is None:
+                sample_df = _fs_training_sample(df_ds, config)
+                if config.blocking is not None:
+                    sample_blocks = build_blocks(
+                        sample_df.lazy(), config.blocking,
+                    )
+            logger.warning(
+                "FS matchkey %r: training EM once on a driver-side sample "
+                "of %d rows before distributed dispatch. For explicit "
+                "control over training data, train once and set "
+                "mk.model_path (load_or_train_em persists it).",
+                mk.name, sample_df.height,
+            )
+        # Loads mk.model_path when present (no training); else trains on the
+        # sample and saves to mk.model_path when set.
+        blocking_fields = (
+            collect_blocking_fields(config.blocking)
+            if config.blocking is not None
+            else []
+        )
+        results[mk.name] = load_or_train_em(
+            sample_df, mk,
+            blocks=sample_blocks,
+            blocking_fields=blocking_fields,
+        )
+    return results
 
 
 def _score_blocks_legacy(
     df_ds: Dataset,
     config: GoldenMatchConfig,
+    fs_em_results: dict[str, Any] | None = None,
 ) -> Dataset:
     """Per-partition fuzzy + exact scoring via the narrow scoring kernel.
 
@@ -270,7 +364,9 @@ def _score_blocks_legacy(
 
         _native_base = _native_worker_baseline()
         try:
-            pairs = _score_partition_with_config(df, local_cfg)
+            pairs = _score_partition_with_config(
+                df, local_cfg, fs_em_results=fs_em_results,
+            )
         except Exception as e:
             logger.warning("partition scoring failed: %s", e)
             return pa.table({"id_a": [], "id_b": [], "score": []})
@@ -378,6 +474,7 @@ def _attach_colocation_keys(df: Any, config: GoldenMatchConfig) -> Any:
 
 def _score_colocated_groups(
     df: Any, config: GoldenMatchConfig,
+    fs_em_results: dict[str, Any] | None = None,
 ) -> list[tuple[int, int, float]]:
     """Score the co-located records in this batch in a SINGLE vectorized pass.
     Returns ``list[(id_a, id_b, score)]``.
@@ -425,7 +522,9 @@ def _score_colocated_groups(
     if rec.height < 2:
         return []
     try:
-        return _score_partition_with_config(rec, local_cfg)
+        return _score_partition_with_config(
+            rec, local_cfg, fs_em_results=fs_em_results,
+        )
     except Exception as e:
         logger.warning("block-shuffle: partition scoring failed: %s", e)
         return []
@@ -434,6 +533,7 @@ def _score_colocated_groups(
 def _score_blocks_block_shuffle(
     df_ds: Dataset,
     config: GoldenMatchConfig,
+    fs_em_results: dict[str, Any] | None = None,
 ) -> Dataset:
     """Blocking-key-aware shuffle scoring (issue #844, opt-in).
 
@@ -501,7 +601,7 @@ def _score_blocks_block_shuffle(
         df = pl.from_arrow(batch)
         assert isinstance(df, pl.DataFrame)
         _native_base = _native_worker_baseline()
-        pairs = _score_colocated_groups(df, config)
+        pairs = _score_colocated_groups(df, config, fs_em_results)
         _warn_worker_slow_path(_native_base)
         if not pairs:
             return pa.table({"id_a": [], "id_b": [], "score": []})

--- a/packages/python/goldenmatch/tests/test_fs_lane_guards_1800.py
+++ b/packages/python/goldenmatch/tests/test_fs_lane_guards_1800.py
@@ -1,16 +1,18 @@
-"""Issue #1800 — FS (probabilistic) matchkeys must fail loudly in the
-distributed and chunked lanes, not silently contribute zero pairs.
+"""Issue #1800 / FS-in-scale-lanes — probabilistic matchkeys through the
+distributed and chunked lanes.
 
-Both lanes score only ``exact`` + ``weighted`` matchkeys per partition /
-chunk. A ``type="probabilistic"`` matchkey routed through them used to be
-skipped with no error and no log, so a config that works single-box lost
-its Fellegi-Sunter scoring the moment it crossed into either lane (silent
-wrong results). These tests assert the loud ``NotImplementedError`` guard,
-matching the DataFusion backend's posture and Sail's documented one-box
-fallback.
+History: both lanes used to score only ``exact`` + ``weighted`` matchkeys, so
+a ``type="probabilistic"`` matchkey contributed zero pairs with no error
+(#1800's silent drop), then failed loudly (the #1800 fix). They now SCORE FS
+matchkeys against one shared EMResult: the distributed driver trains once
+before dispatch (or loads ``mk.model_path``); the chunked lane trains once on
+the first chunk (or loads ``mk.model_path``). The loud guard remains for the
+one case that stays unsupported: the bare scoring kernel invoked with an FS
+matchkey and NO model source (per-partition EM training would fit
+inconsistent models).
 
-Deliberately NOT gated on ``ray`` — every guard fires on the driver before
-any Ray work, so the tests run in the default (ray-free) environment.
+Deliberately NOT gated on ``ray`` — the kernel and driver-side model prep run
+without touching Ray, so the tests run in the default (ray-free) environment.
 """
 
 from __future__ import annotations
@@ -29,7 +31,7 @@ from goldenmatch.config.schemas import (
 )
 
 
-def _fs_config() -> GoldenMatchConfig:
+def _fs_config(model_path: str | None = None) -> GoldenMatchConfig:
     """A config with a probabilistic (Fellegi-Sunter) matchkey + blocking."""
     return GoldenMatchConfig(
         matchkeys=[
@@ -37,6 +39,7 @@ def _fs_config() -> GoldenMatchConfig:
                 name="fs_name",
                 type="probabilistic",
                 fields=[MatchkeyField(field="name", scorer="jaro_winkler")],
+                model_path=model_path,
             ),
         ],
         blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])]),
@@ -69,28 +72,97 @@ def _person_df() -> pl.DataFrame:
     })
 
 
+_SURNAMES = [
+    "Garcia", "Kowalski", "Nguyen", "Okafor", "Petrov", "Sato",
+    "Muller", "Rossi", "Dubois", "Larsen", "Novak", "Silva",
+]
+
+
+def _dup_df() -> tuple[pl.DataFrame, set[tuple[int, int]]]:
+    """12 zip-blocks of 3 records: one exact-duplicate pair plus one
+    unrelated name per block. EM's within-block sample then sees both
+    agreements AND disagreements (a single-signal sample fits a
+    non-monotonic model where exact dups score below threshold), and the
+    expected FS output is exactly the 12 duplicate pairs.
+    """
+    names: list[str] = []
+    zips: list[str] = []
+    dup_pairs: set[tuple[int, int]] = set()
+    rid = 0
+    for i, nm in enumerate(_SURNAMES):
+        names += [f"{nm} Alpha", f"{nm} Alpha", f"Zed{i} Qrstuv"]
+        zips += [f"{40000 + i}"] * 3
+        dup_pairs.add((rid, rid + 1))
+        rid += 3
+    return pl.DataFrame({"name": names, "zip": zips}), dup_pairs
+
+
+def _trained_em(df: pl.DataFrame, cfg: GoldenMatchConfig):
+    from goldenmatch.core.probabilistic import load_or_train_em
+
+    if "__row_id__" not in df.columns:
+        df = df.with_row_index("__row_id__").with_columns(
+            pl.col("__row_id__").cast(pl.Int64),
+        )
+    return load_or_train_em(df, cfg.get_matchkeys()[0])
+
+
 # ── Distributed kernel (`_score_partition_with_config`) ────────────────
 
 
-def test_kernel_rejects_probabilistic_matchkey():
-    """The narrow scoring kernel must raise, not silently return []. This is
-    the cited buggy loop (``if mk.type != 'weighted': continue``)."""
+def test_kernel_rejects_probabilistic_without_model():
+    """No driver-supplied EMResult and no mk.model_path: the kernel must
+    raise, not train per-partition or silently return []."""
     from goldenmatch.core.pipeline import _score_partition_with_config
 
     with pytest.raises(NotImplementedError, match="probabilistic"):
         _score_partition_with_config(_person_df(), _fs_config())
 
 
-def test_kernel_error_names_the_matchkey_and_alternative():
-    """The message must name the offending matchkey and point at the
-    single-box alternative so a user can act on it."""
+def test_kernel_error_names_the_matchkey_and_alternatives():
+    """The message must name the offending matchkey and the ways out
+    (model_path, driver-side training, single-box, weighted)."""
     from goldenmatch.core.pipeline import _score_partition_with_config
 
     with pytest.raises(NotImplementedError) as exc:
         _score_partition_with_config(_person_df(), _fs_config())
     msg = str(exc.value)
     assert "fs_name" in msg
+    assert "model_path" in msg
     assert "weighted" in msg  # the conversion suggestion
+
+
+def test_kernel_scores_probabilistic_with_supplied_model():
+    """A driver-supplied EMResult unlocks FS scoring in the kernel: the
+    exact-duplicate pairs must come back."""
+    from goldenmatch.core.pipeline import _score_partition_with_config
+
+    cfg = _fs_config()
+    cfg.backend = "bucket"
+    df, dup_pairs = _dup_df()
+    em = _trained_em(df, cfg)
+    pairs = _score_partition_with_config(
+        df, cfg, fs_em_results={"fs_name": em},
+    )
+    got = {(min(a, b), max(a, b)) for a, b, _s in pairs}
+    assert dup_pairs <= got
+
+
+def test_kernel_scores_probabilistic_with_model_path(tmp_path):
+    """mk.model_path on disk unlocks FS scoring without a supplied dict
+    (the db/sync streaming caller's route)."""
+    from goldenmatch.core.pipeline import _score_partition_with_config
+
+    df, dup_pairs = _dup_df()
+    path = str(tmp_path / "fs_model.json")
+    train_cfg = _fs_config(model_path=path)
+    _trained_em(df, train_cfg)  # trains and persists to model_path
+
+    cfg = _fs_config(model_path=path)
+    cfg.backend = "bucket"
+    pairs = _score_partition_with_config(df, cfg)
+    got = {(min(a, b), max(a, b)) for a, b, _s in pairs}
+    assert dup_pairs <= got
 
 
 def test_kernel_still_accepts_weighted():
@@ -103,35 +175,106 @@ def test_kernel_still_accepts_weighted():
     assert isinstance(pairs, list)  # runs to completion, no raise
 
 
-# ── Distributed driver entry (`score_blocks_distributed`) ──────────────
+# ── Distributed driver model prep (`_prepare_fs_models`) ───────────────
 
 
-def test_score_blocks_distributed_rejects_probabilistic():
-    """Driver-side guard: must raise BEFORE dispatch (no Ray touched), so
-    the failure isn't swallowed by the per-partition try/except."""
-    from goldenmatch.distributed.scoring import score_blocks_distributed
+class _StubDataset:
+    """Duck-typed stand-in for ray.data.Dataset: only take_batch is used
+    by the driver-side FS model prep (no Ray in the test env)."""
 
-    # df_ds is never touched — the guard reads only the config.
-    with pytest.raises(NotImplementedError, match="probabilistic"):
-        score_blocks_distributed(None, _fs_config())
+    def __init__(self, df: pl.DataFrame):
+        self._df = df
+        self.take_batch_calls = 0
+
+    def take_batch(self, n: int, *, batch_format: str = "pyarrow"):
+        assert batch_format == "pyarrow"
+        self.take_batch_calls += 1
+        return self._df.head(n).to_arrow()
+
+
+def test_prepare_fs_models_trains_on_driver_sample():
+    from goldenmatch.distributed.scoring import _prepare_fs_models
+
+    ds = _StubDataset(_dup_df()[0])
+    models = _prepare_fs_models(ds, _fs_config())
+    assert models is not None and set(models) == {"fs_name"}
+    assert ds.take_batch_calls == 1
+    assert models["fs_name"].match_weights  # a real trained/fallback model
+
+
+def test_prepare_fs_models_loads_persisted_model_without_sampling(tmp_path):
+    """A preloaded mk.model_path must be loaded driver-side WITHOUT pulling
+    a sample from the dataset (the dataset may be expensive to touch)."""
+    from goldenmatch.distributed.scoring import _prepare_fs_models
+
+    df, _ = _dup_df()
+    path = str(tmp_path / "fs_model.json")
+    _trained_em(df, _fs_config(model_path=path))  # persist
+
+    ds = _StubDataset(df)
+    models = _prepare_fs_models(ds, _fs_config(model_path=path))
+    assert models is not None and "fs_name" in models
+    assert ds.take_batch_calls == 0
+
+
+def test_prepare_fs_models_none_without_fs_matchkeys():
+    from goldenmatch.distributed.scoring import _prepare_fs_models
+
+    assert _prepare_fs_models(None, _weighted_config()) is None
 
 
 # ── Chunked lane (`ChunkedMatcher.process_file`) ───────────────────────
 
 
-def test_chunked_process_file_rejects_probabilistic(tmp_path):
-    from goldenmatch.core.chunked import ChunkedMatcher
-
-    f = tmp_path / "data.csv"
-    with open(f, "w", newline="") as fp:
+def _write_csv(path, rows):
+    with open(path, "w", newline="") as fp:
         w = csv.writer(fp)
         w.writerow(["name", "zip"])
-        for i in range(10):
-            w.writerow([f"Person {i}", f"{10000 + i % 3}"])
+        w.writerows(rows)
 
-    matcher = ChunkedMatcher(config=_fs_config(), chunk_size=5)
-    with pytest.raises(NotImplementedError, match="probabilistic"):
-        matcher.process_file(str(f))
+
+def test_chunked_scores_probabilistic_within_and_across_chunks(tmp_path):
+    """FS through the chunked lane: exact duplicates inside one chunk AND
+    split across chunks must both surface as pairs. The model trains once
+    on the first chunk and is reused (see _ensure_fs_model)."""
+    from goldenmatch.core.chunked import ChunkedMatcher
+
+    rows = [[f"Person {chr(65 + i % 26)}{i}", f"{30000 + i}"] for i in range(40)]
+    rows[7] = ["Person Q7", "30003"]   # within-chunk dup of row 3 (chunk 1)...
+    rows[3] = ["Person Q7", "30003"]   # ...same name + zip
+    rows[31] = ["Person M12", "30012"]  # cross-chunk dup of row 12 (chunk 1 vs 2)
+    rows[12] = ["Person M12", "30012"]
+    f = tmp_path / "data.csv"
+    _write_csv(f, rows)
+
+    matcher = ChunkedMatcher(config=_fs_config(), chunk_size=20)
+    result = matcher.process_file(str(f))
+    assert result["chunks_processed"] == 2
+    got = {(min(a, b), max(a, b)) for a, b, _s in matcher._all_pairs}
+    assert (3, 7) in got     # within-chunk FS pair
+    assert (12, 31) in got   # cross-chunk FS pair
+    assert "fs_name" in matcher._fs_em_results  # trained once, cached
+
+
+def test_chunked_uses_persisted_model_when_set(tmp_path):
+    """mk.model_path short-circuits first-chunk training in the chunked
+    lane (Splink-style train-once reuse)."""
+    from goldenmatch.core.chunked import ChunkedMatcher
+
+    df, _ = _dup_df()
+    path = str(tmp_path / "fs_model.json")
+    _trained_em(df, _fs_config(model_path=path))  # persist
+
+    rows = [[f"Person {chr(65 + i % 26)}{i}", f"{30000 + i}"] for i in range(10)]
+    rows[6] = list(rows[1])  # one dup pair
+    f = tmp_path / "data.csv"
+    _write_csv(f, rows)
+
+    matcher = ChunkedMatcher(config=_fs_config(model_path=path), chunk_size=5)
+    result = matcher.process_file(str(f))
+    assert result["total_records"] == 10
+    got = {(min(a, b), max(a, b)) for a, b, _s in matcher._all_pairs}
+    assert (1, 6) in got
 
 
 def test_chunked_process_file_still_accepts_weighted(tmp_path):
@@ -139,11 +282,7 @@ def test_chunked_process_file_still_accepts_weighted(tmp_path):
     from goldenmatch.core.chunked import ChunkedMatcher
 
     f = tmp_path / "data.csv"
-    with open(f, "w", newline="") as fp:
-        w = csv.writer(fp)
-        w.writerow(["name", "zip"])
-        for i in range(10):
-            w.writerow([f"Person {i}", f"{10000 + i % 3}"])
+    _write_csv(f, [[f"Person {i}", f"{10000 + i % 3}"] for i in range(10)])
 
     matcher = ChunkedMatcher(config=_weighted_config(), chunk_size=5)
     result = matcher.process_file(str(f))  # no raise


### PR DESCRIPTION
Second PR of the "exclusions should not break the fast path" pass (follows #1842). The distributed and chunked lanes rejected FS matchkeys outright (#1800 turned the silent drop into a loud NotImplementedError). They now score them.

**The invariant: one shared EMResult per FS matchkey.** Per-partition/per-chunk EM training would fit a different model on each non-representative slice (inconsistent weights, nondeterministic scores), so both lanes resolve the model ONCE and reuse it everywhere:

- **Distributed:** `score_blocks_distributed` resolves models BEFORE dispatch (`_prepare_fs_models`). A persisted `mk.model_path` is loaded driver-side and validated (the file only needs to exist on the driver -- workers receive the loaded object through the task closure, same mechanism as the config). Without one, EM trains once on a driver-side sample (`GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS`, default 200k; EM itself samples ~10k within-block pairs from it) with a warning recommending `model_path`, and persists when the path is set. Both the legacy and block-shuffle paths thread the dict into `_score_partition_with_config`, which gains an FS branch scoring via the memory-bounded bucket scorer (`score_buckets(..., em_result=...)`).
- **Chunked:** `ChunkedMatcher._ensure_fs_model` loads `mk.model_path` or trains once on the first chunk, then reuses. Within-chunk FS scores via `score_buckets` over the chunk; cross-chunk scores the joint (chunk + index) frame with `target_ids=` the chunk's row ids -- the XOR filter emits exactly the (chunk x index) cross pairs, so nothing is re-scored.

**The loud guard survives** for the one case that stays unsupported: the bare kernel invoked with an FS matchkey and NO model source (db/sync streaming callers without `mk.model_path`). The message now names every way out.

Tests: `test_fs_lane_guards_1800.py` rewritten from reject-assertions to positive coverage -- kernel scores FS with a supplied model and with `model_path`; driver model prep trains on a stubbed dataset (no Ray needed) and skips sampling when a persisted model exists; chunked finds within-chunk AND cross-chunk FS duplicate pairs end-to-end, plus persisted-model reuse. The no-model reject and weighted negative controls remain. 22 passed locally across the lane suites.

Note: FS matchkeys still contribute no colocation key on the block-shuffle path (keys come from blocking passes + exact matchkeys); FS recall relies on the blocking passes, same as weighted. Non-static blocking strategies (lsh/ann/learned/canopy/sorted_neighborhood) get their memory-bounded FS path in the next PR.
