### PR TITLE
feat(fs): memory-bounded FS scoring for strategy-generated blocks

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -506,6 +506,142 @@ def _resolve_fast_path(
     return (float(mk.threshold), total_weight, field_specs, ne_specs)
 
 
+def score_probabilistic_external_blocks(
+    blocks: list,
+    blocking_config: BlockingConfig,
+    mk: MatchkeyConfig,
+    matched_pairs: set[tuple[int, int]],
+    em_result,
+    target_ids: set[int] | None = None,
+) -> list[tuple[int, int, float]]:
+    """Memory-bounded Fellegi-Sunter scoring over EXTERNALLY-GENERATED blocks.
+
+    ``score_buckets`` derives its own field-hash blocks, so candidate sets
+    from the non-field blocking strategies (lsh / ann / learned / canopy /
+    sorted_neighborhood) cannot route through it. This scorer consumes the
+    strategy's own ``BlockResult`` list ONE BLOCK AT A TIME with the bucket
+    lane's scale machinery: the frozen-exclude Arc handle built once
+    (#552/#688), oversized auto-split honoring ``skip_oversized``
+    (#1790/#1826), and the native (zero-copy arrow) / vectorized / scalar
+    per-block scorer selection -- replacing
+    ``score_probabilistic_blocks_batched``'s up-front all-units accumulation
+    for these strategies (whose whole-mega-block dense scoring is the #1826
+    OOM shape; a 388K-row canopy through the vectorized path is a 1.1 TiB
+    dense-matrix allocation).
+
+    Overlapping candidates (canopy membership, sorted-neighborhood windows)
+    can surface the same pair from two blocks; a canonical-key seen set
+    dedups in block order. Blocks carrying ``pre_scored_pairs`` (ann_pairs)
+    score their frames exactly like the batched scorer does -- FS weights
+    are not FAISS distances, so carried scores are ignored on this matchkey
+    type there too.
+    """
+    from goldenmatch.core.blocker import _auto_split_block
+    from goldenmatch.core.probabilistic import (
+        _fs_native_eligible,
+        probabilistic_block_scorer,
+        score_probabilistic_bucket_native,
+    )
+
+    if em_result is None:
+        raise ValueError(
+            "score_probabilistic_external_blocks requires em_result for "
+            "probabilistic scoring"
+        )
+
+    frozen_exclude = frozenset(matched_pairs)
+    max_block_size = blocking_config.max_block_size
+    skip_oversized = blocking_config.skip_oversized
+
+    use_native = _fs_bucket_native_enabled() and _fs_native_eligible(mk)
+    prob_scorer = None if use_native else probabilistic_block_scorer(mk, em_result)
+
+    # The #552/#688 fix, FS side: build the Rust exclude set ONCE, not per
+    # block call. Old wheels fall back to the Vec-per-call contract inside
+    # _score_fs_native_frame (byte-identical, just slower).
+    exclude_handle = None
+    if use_native and frozen_exclude:
+        try:
+            _mod = native_module()
+            _build = getattr(_mod, "build_exclude_set", None)
+            if _build is not None and (
+                getattr(_mod, "FS_SUPPORTS_ARROW", False)
+                or getattr(_mod, "FS_SUPPORTS_EXCLUDE_SET", False)
+            ):
+                exclude_handle = _build(list(frozen_exclude))
+            else:
+                _warn_stale_native_wheel_once(len(frozen_exclude))
+        except Exception:
+            exclude_handle = None
+
+    def _frames(block_df, n: int) -> list:
+        """Frames to score for one block: the block itself when within
+        bounds; auto-split sub-blocks when oversized (same semantics as the
+        bucket lane's _split_oversized: skip on skip_oversized=True, score
+        whole on split failure when skip_oversized=False)."""
+        if n <= max_block_size:
+            return [block_df]
+        if skip_oversized:
+            return []
+        try:
+            subs = _auto_split_block(
+                block_df, max_block_size, "__external_oversized__"
+            )
+        except Exception:
+            logger.error(
+                "external-blocks auto-split failed for an oversized block "
+                "(%d rows).", n, exc_info=True,
+            )
+            subs = []
+        useful = []
+        for b in subs:
+            try:
+                n_sub = b.n_rows()
+            except Exception:
+                n_sub = n + 1
+            if 2 <= n_sub < n:
+                useful.append(b.materialize().native)
+        if useful:
+            return useful
+        logger.error(
+            "Oversized external block (%d rows > max_block_size=%d, ~%s "
+            "pairs) could not be auto-split; scoring whole because "
+            "skip_oversized=False. See #1826.",
+            n, max_block_size, f"{n * (n - 1) // 2:,}",
+        )
+        return [block_df]
+
+    def _height(df) -> int:
+        return df.height if hasattr(df, "height") else df.num_rows
+
+    out: list[tuple[int, int, float]] = []
+    seen: set[tuple[int, int]] = set()
+    for block in blocks:
+        bdf = block.materialize().native
+        n = _height(bdf)
+        if n < 2:
+            continue
+        for frame in _frames(bdf, n):
+            if use_native:
+                pairs = score_probabilistic_bucket_native(
+                    frame, [_height(frame)], mk, em_result, frozen_exclude,
+                    exclude_handle=exclude_handle,
+                )
+            else:
+                pairs = prob_scorer(frame, frozen_exclude)
+            for a, b, s in pairs:
+                if target_ids is not None and (
+                    (a in target_ids) == (b in target_ids)
+                ):
+                    continue
+                key = (a, b) if a < b else (b, a)
+                if key in seen:
+                    continue
+                seen.add(key)
+                out.append((a, b, s))
+    return out
+
+
 def score_buckets(
     prepared_df: pl.DataFrame,
     blocking_config: BlockingConfig,

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -224,6 +224,40 @@ def _fs_use_bucket_route(config: GoldenMatchConfig, mk: Any) -> bool:
     return not has_active_emitter()
 
 
+def _fs_external_blocks_route(config: GoldenMatchConfig) -> bool:
+    """Whether a probabilistic matchkey that is NOT on the bucket route
+    (see ``_fs_use_bucket_route``) scores its strategy-generated blocks via
+    the memory-bounded external-blocks scorer
+    (``score_probabilistic_external_blocks``) instead of the legacy batched
+    scorer.
+
+    True exactly when the bucket exclusion was the blocking STRATEGY
+    (lsh / ann / learned / canopy / sorted_neighborhood -- candidates the
+    bucket scorer cannot re-derive from field hashes). Those blocks
+    previously fell to the batched scorer, whose up-front all-units
+    accumulation + whole-mega-block dense scoring is the #1826 OOM shape.
+    Every OTHER exclusion keeps legacy batched: the
+    ``GOLDENMATCH_FS_DEFAULT_BUCKET=0`` hatch means "legacy" literally,
+    active-emitter probe runs are calibrated against the legacy path (the
+    #1829 lesson), and explicit scale backends keep their own routing.
+    """
+    if getattr(config, "backend", None) not in (None, "polars-direct"):
+        return False
+    if (
+        os.environ.get("GOLDENMATCH_FS_DEFAULT_BUCKET", "1").strip().lower()
+        in _BUCKET_DEFAULT_OPT_OUT
+    ):
+        return False
+    _blk = getattr(config, "blocking", None)
+    if _blk is None or getattr(_blk, "strategy", None) in (
+        None, "static", "multi_pass",
+    ):
+        return False
+    from goldenmatch.core.profile_emitter import has_active_emitter
+
+    return not has_active_emitter()
+
+
 def _get_block_scorer(config: GoldenMatchConfig):
     """Return the block scoring function based on configured backend."""
     backend = getattr(config, "backend", None)
@@ -2712,6 +2746,35 @@ def _run_dedupe_pipeline(
                     for a, b, _s in pairs:
                         _bench_emitted_pairs.add((min(a, b), max(a, b)))
                 continue
+            # Strategy-generated candidates (lsh / ann / learned / canopy /
+            # sorted_neighborhood): score the strategy's own blocks one at a
+            # time through the bucket lane's scale machinery (exclude Arc
+            # handle, oversized auto-split, native/vectorized selection)
+            # instead of the batched scorer's all-units accumulation. The
+            # bench-dump path keeps the per-block loop below for exact
+            # candidate accounting.
+            if not _bench_dump_dir and _fs_external_blocks_route(config):
+                from goldenmatch.backends.score_buckets import (
+                    score_probabilistic_external_blocks,
+                )
+                pairs = score_probabilistic_external_blocks(
+                    blocks, config.blocking, scoring_mk, matched_pairs,
+                    em_result,
+                )
+                if across_files_only:
+                    pairs = [
+                        (a, b, s) for a, b, s in pairs
+                        if source_lookup.get(a) != source_lookup.get(b)
+                    ]
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
+                all_pairs.extend(pairs)
+                fuzzy_pair_count += len(pairs)
+                for a, b, _s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+                continue
             # Vectorized NxN-matrix block scorer: one rapidfuzz cdist per field
             # + numpy level/weight/normalize, replacing the per-pair Python
             # loop. This makes full-block scoring cheap enough that large
@@ -4203,6 +4266,24 @@ def _run_match_pipeline(
                 for a, b, _s in pairs:
                     matched_pairs.add((min(a, b), max(a, b)))
                 continue
+            # Strategy-generated candidates: memory-bounded external-blocks
+            # scorer (same refinement as the dedupe site).
+            if _fs_external_blocks_route(config):
+                from goldenmatch.backends.score_buckets import (
+                    score_probabilistic_external_blocks,
+                )
+                pairs = score_probabilistic_external_blocks(
+                    blocks, config.blocking, scoring_mk, matched_pairs,
+                    em_result, target_ids=target_ids,
+                )
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
+                all_pairs.extend(pairs)
+                for a, b, _s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+                continue
             # Blocks scored in parallel across cores (GIL-releasing FS kernels).
             # Does not mutate matched_pairs; fold the returned pairs in below.
             pairs = score_probabilistic_blocks_batched(
@@ -4446,6 +4527,24 @@ def _run_match_scoring_and_output(
                     n_buckets=config.n_buckets,
                     target_ids=target_ids,
                     em_result=em_result,
+                )
+                pairs, candidates = _split_probabilistic_pairs(
+                    pairs, link_threshold
+                )
+                review_pairs.extend(candidates)
+                all_pairs.extend(pairs)
+                for a, b, _s in pairs:
+                    matched_pairs.add((min(a, b), max(a, b)))
+                continue
+            # Strategy-generated candidates: memory-bounded external-blocks
+            # scorer (same refinement as the dedupe site).
+            if _fs_external_blocks_route(config):
+                from goldenmatch.backends.score_buckets import (
+                    score_probabilistic_external_blocks,
+                )
+                pairs = score_probabilistic_external_blocks(
+                    blocks, config.blocking, scoring_mk, matched_pairs,
+                    em_result, target_ids=target_ids,
                 )
                 pairs, candidates = _split_probabilistic_pairs(
                     pairs, link_threshold

--- a/packages/python/goldenmatch/tests/test_fs_bucket_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_bucket_native.py
@@ -544,3 +544,177 @@ def test_routing_fs_default_off_uses_batched(monkeypatch):
 
     assert calls["batched"] >= 1
     assert calls["bucket"] == 0
+
+
+# ── Strategy-generated FS candidates: external-blocks scorer ─────────────────
+
+
+def test_fs_external_blocks_route_decision(monkeypatch):
+    """The non-bucket FS refinement: strategy-generated candidates go to the
+    memory-bounded external-blocks scorer; the FS_DEFAULT_BUCKET=0 hatch,
+    explicit scale backends, and active-emitter probe runs keep legacy
+    batched."""
+    from goldenmatch.core.pipeline import _fs_external_blocks_route
+
+    monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
+
+    # static / multi_pass are the bucket route's job, not this one's.
+    assert _fs_external_blocks_route(_prob_config(backend=None)) is False
+
+    lsh_cfg = _prob_config(backend=None)
+    lsh_cfg.blocking.strategy = "lsh"
+    assert _fs_external_blocks_route(lsh_cfg) is True
+
+    # Hatch means "legacy batched" literally.
+    monkeypatch.setenv("GOLDENMATCH_FS_DEFAULT_BUCKET", "0")
+    assert _fs_external_blocks_route(lsh_cfg) is False
+    monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
+
+    # Explicit scale backends keep their own routing.
+    ray_cfg = _prob_config(backend="ray")
+    ray_cfg.blocking.strategy = "lsh"
+    assert _fs_external_blocks_route(ray_cfg) is False
+
+    # Emitter probe runs are calibrated against the legacy path (#1829).
+    from goldenmatch.core.profile_emitter import profile_capture
+
+    with profile_capture():
+        assert _fs_external_blocks_route(lsh_cfg) is False
+
+
+def _external_blocks(df: pl.DataFrame) -> list:
+    """Slice df into per-zip BlockResults tagged with a non-static strategy
+    (the shape lsh/canopy/sorted_neighborhood hand to the FS scorer)."""
+    from goldenmatch.core.blocker import BlockResult
+
+    return [
+        BlockResult(
+            block_key=str(z),
+            df=df.filter(pl.col("zip") == z).lazy(),
+            strategy="lsh",
+        )
+        for z in df["zip"].unique(maintain_order=True).to_list()
+    ]
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_fs_external_blocks_parity_with_batched(monkeypatch, native):
+    """Same blocks in -> same pair set + scores as the batched legacy scorer
+    (the path these strategies used before), on both scorer lanes."""
+    from goldenmatch.backends.score_buckets import (
+        score_probabilistic_external_blocks,
+    )
+    from goldenmatch.core.probabilistic import (
+        score_probabilistic_blocks_batched,
+    )
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", native)
+    df = _multiblock_df()
+    mk = _mk()
+    em = train_em(df, mk, n_sample_pairs=200)
+    blocking = BlockingConfig(
+        strategy="static", keys=[BlockingKeyConfig(fields=["zip"])]
+    )
+
+    got = score_probabilistic_external_blocks(
+        _external_blocks(df), blocking, mk, set(), em
+    )
+    ref = score_probabilistic_blocks_batched(_external_blocks(df), mk, em, set())
+    assert _pairset(got) == _pairset(ref)
+
+
+@pytest.mark.parametrize("native", ["1", "0"])
+def test_fs_external_blocks_oversized_semantics(monkeypatch, native):
+    """Oversized external blocks follow the bucket lane's semantics: SKIP on
+    skip_oversized=True; auto-split (never scored whole when splittable) on
+    the default skip_oversized=False."""
+    from goldenmatch.backends.score_buckets import (
+        score_probabilistic_external_blocks,
+    )
+    from goldenmatch.core.blocker import _auto_split_block
+    from goldenmatch.core.probabilistic import probabilistic_block_scorer
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", native)
+    df = _splittable_oversized_df()
+    mk = _mk()
+    em = train_em(df, mk, n_sample_pairs=200)
+
+    def blocking(skip):
+        return BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"])],
+            max_block_size=3,
+            skip_oversized=skip,
+        )
+
+    blocks = _external_blocks(df)  # zip A oversized (6 > 3), zip C control
+
+    # skip_oversized=True: oversized block contributes nothing; control kept.
+    skipped = _pairset(
+        score_probabilistic_external_blocks(blocks, blocking(True), mk, set(), em)
+    )
+    assert all(a > 6 or b > 6 for a, b in skipped)
+
+    # Default: auto-split. Expected = split sub-blocks + control block.
+    scorer = probabilistic_block_scorer(mk, em)
+    expected: list[tuple[int, int, float]] = []
+    big = df.filter(pl.col("zip") == "A")
+    for b in _auto_split_block(big, 3, "A"):
+        expected.extend(scorer(b.materialize().native, set()))
+    expected.extend(scorer(df.filter(pl.col("zip") == "C"), set()))
+    whole = _pairset(scorer(big, set()))
+    assert set(whole) - set(_pairset(expected)), "fixture no longer discriminates"
+
+    got = _pairset(
+        score_probabilistic_external_blocks(blocks, blocking(False), mk, set(), em)
+    )
+    assert got == _pairset(expected)
+
+
+def test_fs_external_blocks_dedupe_routing(monkeypatch):
+    """E2E: a sorted_neighborhood FS dedupe routes through the external-blocks
+    scorer (not score_buckets, not the batched scorer)."""
+    import goldenmatch as gm
+    import goldenmatch.backends.score_buckets as sb_mod
+    import goldenmatch.core.probabilistic as prob_mod
+    from goldenmatch.config.schemas import SortKeyField
+
+    monkeypatch.delenv("GOLDENMATCH_FS_DEFAULT_BUCKET", raising=False)
+
+    calls = {"external": 0, "bucket": 0, "batched": 0}
+    real_ext = sb_mod.score_probabilistic_external_blocks
+    real_sb = sb_mod.score_buckets
+    real_batched = prob_mod.score_probabilistic_blocks_batched
+
+    def spy_ext(*a, **k):
+        calls["external"] += 1
+        return real_ext(*a, **k)
+
+    def spy_sb(*a, **k):
+        calls["bucket"] += 1
+        return real_sb(*a, **k)
+
+    def spy_batched(*a, **k):
+        calls["batched"] += 1
+        return real_batched(*a, **k)
+
+    monkeypatch.setattr(
+        sb_mod, "score_probabilistic_external_blocks", spy_ext
+    )
+    monkeypatch.setattr(sb_mod, "score_buckets", spy_sb)
+    monkeypatch.setattr(
+        prob_mod, "score_probabilistic_blocks_batched", spy_batched
+    )
+
+    cfg = _prob_config(backend=None)
+    cfg.blocking = BlockingConfig(
+        strategy="sorted_neighborhood",
+        sort_key=[SortKeyField(column="last_name")],
+        window_size=4,
+    )
+    df = _multiblock_df().drop("__row_id__")
+    gm.dedupe_df(df, config=cfg)
+
+    assert calls["external"] >= 1
+    assert calls["bucket"] == 0
+    assert calls["batched"] == 0


### PR DESCRIPTION
Third PR of the "exclusions should not break the fast path" pass (follows #1842, #1843): probabilistic matchkeys with non-static blocking strategies (lsh / ann / learned / canopy / sorted_neighborhood) get a memory-bounded scoring path.

**The gap.** `_fs_use_bucket_route` correctly excludes these strategies -- their candidates come from signatures/embeddings/learned predicates the bucket scorer cannot re-derive from field hashes. But the fallback was `score_probabilistic_blocks_batched`: up-front all-units accumulation plus whole-mega-block dense scoring, the #1826 OOM shape (a 388K-row block through the vectorized path is a 1.1 TiB dense-matrix allocation).

**The fix.** New `score_probabilistic_external_blocks` in `score_buckets.py` consumes the strategy's own `BlockResult` list one block at a time with the bucket lane's scale machinery:

- frozen-exclude Arc handle built once (the #552/#688 fix; stale-wheel warning + byte-identical Vec fallback on old wheels)
- oversized auto-split honoring `skip_oversized` (#1790/#1826 semantics: skip on True, split on False, score-whole only when the split fails)
- native (zero-copy arrow) / vectorized / scalar per-block scorer selection; the dense-matrix guard still applies on the vectorized path
- canonical-key seen-set dedup for overlapping candidates (canopy membership, sorted-neighborhood windows)

**Routing.** `_fs_external_blocks_route` fires exactly when the bucket exclusion was the strategy. Everything else keeps its meaning: `GOLDENMATCH_FS_DEFAULT_BUCKET=0` still means legacy batched literally, active-emitter probe runs stay on the legacy path (the #1829 calibration lesson), explicit scale backends keep their own routing, and the bench-dump path keeps the per-block loop for exact candidate accounting. Wired at all three pipeline FS sites (dedupe + both match lanes, `target_ids` threaded on the match sides).

Tests: route decision, parity-with-batched on both scorer lanes (same blocks in, same pair set + scores out), oversized skip/auto-split semantics on the #1829 discriminating fixture, and an E2E `sorted_neighborhood` FS dedupe asserting the external scorer is the one that runs (bucket and batched spies at zero). 51 passed locally across the FS suites.
