### PR TITLE
feat(autoconfig): commit lowered multi_pass blocking, reclaiming the bucket scorer (#1839)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3515,7 +3515,8 @@ def _lower_learned_blocking(
     )
 
     try:
-        lf = df.lazy() if not hasattr(df, "collect") else df
+        # df is an eager DataFrame here; learn_rules_for_frame collects internally.
+        lf = df.lazy()
         rules = learn_rules_for_frame(lf, blocking)
         if not rules:
             logger.info("Learned-blocking lowering: no rules learned; keeping strategy='learned'.")
@@ -3538,11 +3539,11 @@ def _lower_learned_blocking(
         )
         return blocking
 
+    passes = lowered.passes or []
     logger.info(
         "Lowered learned blocking to multi_pass (%d rows, %d passes: %s) -- "
         "keeps the bucket scorer instead of forfeiting it to the legacy path.",
-        total_rows, len(lowered.passes),
-        [f"{p.fields}" for p in lowered.passes],
+        total_rows, len(passes), [f"{p.fields}" for p in passes],
     )
     return lowered
 

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3475,6 +3475,78 @@ def _maybe_promote_blocking_to_adaptive(
     return blocking.model_copy(update={"strategy": "adaptive"})
 
 
+def _lower_learned_blocking(
+    blocking: BlockingConfig,
+    df: pl.DataFrame,
+    total_rows: int,
+) -> BlockingConfig:
+    """Learn the blocking rules NOW and commit them as multi_pass passes (#1839).
+
+    ``strategy="learned"`` defers rule learning to runtime, inside build_blocks.
+    That forfeits the bucket scorer for EVERY zero-config run >= 50K rows:
+    ``_use_bucket_scorer`` refuses ``learned`` (bucket derives block keys from
+    ``passes``/``keys``, and a learned config carries neither), and the routing
+    decision is made BEFORE build_blocks runs -- so runtime-learned rules arrive
+    too late to matter. Learning at config time and lowering the rules into
+    multi_pass closes the gap using machinery that already exists (#1826
+    ``field_transforms``; score_buckets already honors it).
+
+    The learning pass is not new work -- it is the SAME sample-and-score pass
+    build_blocks would run at runtime, moved earlier. When the lowering succeeds,
+    build_blocks never runs the learned path at all.
+
+    Falls back to ``strategy="learned"`` (today's behavior, unchanged) whenever
+    the rules can't be learned or can't be lowered EXACTLY -- e.g. a same-field
+    conjunction, which ``field_transforms`` cannot express. Never lowers
+    approximately: that would silently change which pairs are generated
+    (precision stays 1.0, only recall moves -- the #1800 / #1837 / #1839 shape).
+
+    Kill-switch: ``GOLDENMATCH_LEARNED_LOWERING=0`` keeps the legacy path.
+    """
+    if os.environ.get("GOLDENMATCH_LEARNED_LOWERING", "1").strip().lower() in (
+        "0", "off", "false", "no",
+    ):
+        return blocking
+
+    from goldenmatch.core.blocker import learn_rules_for_frame
+    from goldenmatch.core.learned_blocking import (
+        LoweringUnsupportedError,
+        lower_rules_to_blocking_config,
+    )
+
+    try:
+        lf = df.lazy() if not hasattr(df, "collect") else df
+        rules = learn_rules_for_frame(lf, blocking)
+        if not rules:
+            logger.info("Learned-blocking lowering: no rules learned; keeping strategy='learned'.")
+            return blocking
+        lowered = lower_rules_to_blocking_config(
+            rules,
+            max_block_size=blocking.max_block_size,
+            skip_oversized=blocking.skip_oversized,
+        )
+    except LoweringUnsupportedError as e:
+        logger.info(
+            "Learned-blocking lowering not exact (%s); keeping strategy='learned' "
+            "(forfeits the bucket scorer, but preserves candidate pairs).", e,
+        )
+        return blocking
+    except Exception as e:  # noqa: BLE001 -- lowering is an optimization, never fatal
+        logger.warning(
+            "Learned-blocking lowering failed (%s: %s); keeping strategy='learned'.",
+            type(e).__name__, e,
+        )
+        return blocking
+
+    logger.info(
+        "Lowered learned blocking to multi_pass (%d rows, %d passes: %s) -- "
+        "keeps the bucket scorer instead of forfeiting it to the legacy path.",
+        total_rows, len(lowered.passes),
+        [f"{p.fields}" for p in lowered.passes],
+    )
+    return lowered
+
+
 def _maybe_prune_blocking_passes(
     blocking: BlockingConfig | None,
     df: pl.DataFrame,
@@ -4324,6 +4396,7 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
             "Upgraded to learned blocking (dataset has %d rows, sample_size=%d)",
             total_rows, blocking.learned_sample_size,
         )
+        blocking = _lower_learned_blocking(blocking, df, total_rows)
 
     # 2. Reranking for multi-field matchkeys
     for mk in matchkeys:

--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -1068,67 +1068,62 @@ def _build_ann_pair_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Blo
     )]
 
 
-def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
-    """Build blocks using learned predicates.
+def learn_rules_for_frame(lf: pl.LazyFrame, config: BlockingConfig) -> list:
+    """Learn blocking rules for a frame, or return [] if they can't be learned.
 
-    Two-pass approach:
-    1. If cached rules exist, load and apply them
-    2. Otherwise, run a fast sample with static blocking to generate training pairs,
-       then learn predicates from those pairs
+    Extracted from ``_build_learned_blocks`` (#1839) so auto-config can learn the
+    SAME rules at config time and lower them into a bucket-eligible multi_pass
+    config. Runtime learning cannot help bucket: the scorer routing decision
+    (``_use_bucket_scorer``) is made BEFORE ``build_blocks`` runs, and bucket
+    derives its own buckets from ``blocking.passes/keys`` rather than calling
+    build_blocks at all. So the rules have to exist by config time or not at all.
+
+    Returns [] (never raises) when learning isn't possible -- no columns, no
+    scored pairs from the sample. Callers fall back to their prior behavior.
     """
     from goldenmatch.core.learned_blocking import (
-        apply_learned_blocks,
         learn_blocking_rules,
         load_learned_rules,
         save_learned_rules,
     )
 
-    # Try loading cached rules
     if config.learned_cache_path:
         cached = load_learned_rules(config.learned_cache_path)
         if cached:
             logger.info("Using cached learned blocking rules from %s", config.learned_cache_path)
-            return apply_learned_blocks(lf, cached, config.max_block_size)
+            return cached
 
-    # Pass 1: fast static blocking on first key to generate training pairs
     df = lf.collect()
     sample_size = min(config.learned_sample_size, df.height)
-    if sample_size < df.height:
-        sample_df = df.sample(sample_size, seed=42)
-    else:
-        sample_df = df
+    sample_df = df.sample(sample_size, seed=42) if sample_size < df.height else df
 
-    # Use static blocking with the configured keys for the sample run
     sample_config = config.model_copy(update={"strategy": "static"})
     sample_blocks = _build_static_blocks(sample_df.lazy(), sample_config)
 
-    # Score sample blocks to get training pairs
     from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
     from goldenmatch.core.scorer import find_fuzzy_matches
 
-    # Build a simple weighted matchkey for scoring
     cols = [c for c in df.columns if not c.startswith("__")]
     if not cols:
-        return _build_static_blocks(lf, sample_config)
+        return []
 
-    # Use first few columns for a quick score
     score_fields = [
         MatchkeyField(field=c, scorer="token_sort", weight=1.0, transforms=["lowercase"])
         for c in cols[:3]
     ]
-    score_mk = MatchkeyConfig(name="_learned_score", type="weighted", threshold=0.5, fields=score_fields)
+    score_mk = MatchkeyConfig(
+        name="_learned_score", type="weighted", threshold=0.5, fields=score_fields
+    )
 
     scored_pairs = []
     for block in sample_blocks:
         block_df = block.materialize().native
-        pairs = find_fuzzy_matches(block_df, score_mk)
-        scored_pairs.extend(pairs)
+        scored_pairs.extend(find_fuzzy_matches(block_df, score_mk))
 
     if not scored_pairs:
-        logger.warning("No scored pairs from sample run. Falling back to static blocking.")
-        return _build_static_blocks(lf, sample_config)
+        logger.warning("No scored pairs from sample run; cannot learn blocking rules.")
+        return []
 
-    # Pass 2: learn rules from scored pairs
     rules = learn_blocking_rules(
         sample_df,
         scored_pairs,
@@ -1138,12 +1133,33 @@ def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[Bloc
         predicate_depth=config.learned_predicate_depth,
     )
 
-    # Cache rules
     if config.learned_cache_path and rules:
         save_learned_rules(rules, config.learned_cache_path)
         logger.info("Saved learned blocking rules to %s", config.learned_cache_path)
 
-    # Apply to full dataset
+    return rules or []
+
+
+def _build_learned_blocks(lf: pl.LazyFrame, config: BlockingConfig) -> list[BlockResult]:
+    """Build blocks using learned predicates.
+
+    Two-pass approach:
+    1. If cached rules exist, load and apply them
+    2. Otherwise, run a fast sample with static blocking to generate training pairs,
+       then learn predicates from those pairs
+
+    The learning itself lives in ``learn_rules_for_frame`` so auto-config can run
+    the same pass at config time (#1839); this stays the runtime application.
+    """
+    from goldenmatch.core.learned_blocking import apply_learned_blocks
+
+    rules = learn_rules_for_frame(lf, config)
+    if not rules:
+        # No columns, or no scored pairs from the sample -- same fallback the
+        # inline version had.
+        logger.warning("No learned rules available. Falling back to static blocking.")
+        return _build_static_blocks(lf, config.model_copy(update={"strategy": "static"}))
+
     return apply_learned_blocks(lf, rules, config.max_block_size)
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_learned_lowering_1839.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_learned_lowering_1839.py
@@ -1,0 +1,146 @@
+"""Issue #1839 -- auto-config commits LOWERED blocking instead of strategy="learned".
+
+``strategy="learned"`` defers rule learning to runtime inside build_blocks, which
+forfeits the bucket scorer for every zero-config run >= 50K rows: the routing
+decision (``_use_bucket_scorer``) happens BEFORE build_blocks, and bucket derives
+its own buckets from ``passes``/``keys`` rather than calling build_blocks at all.
+So runtime-learned rules arrive too late to matter -- the rules must be in the
+config by routing time.
+
+These tests pin the wiring AND its fallbacks. The fallbacks matter more than the
+happy path: a lowering that silently changed candidate pairs would be the exact
+failure mode (#1800 / #1837 / #1839) this work exists to remove.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import BlockingConfig, BlockingKeyConfig
+from goldenmatch.core.autoconfig import _lower_learned_blocking
+from goldenmatch.core.learned_blocking import (
+    BlockingPredicate,
+    BlockingRule,
+    LoweringUnsupportedError,
+)
+
+
+def _frame(n: int = 600) -> pl.DataFrame:
+    """Small but non-degenerate: real duplicate pairs so the learner finds
+    scored pairs, spread across soundex codes so nothing mega-blocks."""
+    firsts = ["John", "Jane", "Bob", "Mary", "Ann", "Paul", "Rita", "Sam"]
+    lasts = ["Smith", "Jones", "Brown", "Lee", "Clark", "Davis", "Evans", "Ford"]
+    cities = ["Boston", "Newark", "Chicago", "Denver", "Austin", "Fresno"]
+    rows = []
+    for i in range(n // 2):
+        f, s, c = firsts[i % 8], lasts[i % 8], cities[i % 6]
+        rows.append({"first": f, "last": f"{s}{i}", "city": c})
+        rows.append({"first": f, "last": f"{s}{i}", "city": c})  # its duplicate
+    return pl.DataFrame(rows).with_row_index("__row_id__")
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(
+        strategy="learned",
+        keys=[BlockingKeyConfig(fields=["last"], transforms=["lowercase"])],
+        learned_sample_size=200,
+        learned_min_recall=0.95,
+        skip_oversized=True,
+        max_block_size=5000,
+    )
+
+
+class TestLoweringWiring:
+    def test_lowers_to_multi_pass_when_it_can(self):
+        out = _lower_learned_blocking(_blocking(), _frame(), 100_000)
+        assert out.strategy == "multi_pass", "should not still be deferring to runtime"
+        assert out.passes, "multi_pass with no passes would fail validation downstream"
+
+    def test_preserves_the_caps_it_was_given(self):
+        blk = _blocking()
+        blk.max_block_size = 12_345
+        out = _lower_learned_blocking(blk, _frame(), 100_000)
+        if out.strategy == "multi_pass":  # only meaningful when lowering fired
+            assert out.max_block_size == 12_345
+            assert out.skip_oversized is True
+
+    def test_kill_switch_keeps_legacy_path(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_LEARNED_LOWERING", "0")
+        out = _lower_learned_blocking(_blocking(), _frame(), 100_000)
+        assert out.strategy == "learned"
+
+
+class TestFallsBackNeverRegresses:
+    """Every failure path must return strategy='learned' -- i.e. exactly today's
+    behavior. Forfeiting bucket is a perf cost; lowering wrong is a silent
+    correctness cost. Always take the former."""
+
+    def test_falls_back_when_no_rules_can_be_learned(self, monkeypatch):
+        monkeypatch.setattr(
+            "goldenmatch.core.blocker.learn_rules_for_frame", lambda lf, cfg: []
+        )
+        out = _lower_learned_blocking(_blocking(), _frame(), 100_000)
+        assert out.strategy == "learned"
+
+    def test_falls_back_on_unlowerable_rule(self, monkeypatch):
+        """A same-field conjunction (last:exact AND last:soundex) has no exact
+        multi_pass form -- field_transforms is keyed by field. learn_blocking_rules
+        CAN emit these, so this is a live path, not a hypothetical."""
+        rule = BlockingRule(predicates=[
+            BlockingPredicate("last", "exact"), BlockingPredicate("last", "soundex"),
+        ])
+        monkeypatch.setattr(
+            "goldenmatch.core.blocker.learn_rules_for_frame", lambda lf, cfg: [rule]
+        )
+        out = _lower_learned_blocking(_blocking(), _frame(), 100_000)
+        assert out.strategy == "learned"
+
+    def test_falls_back_on_unexpected_error(self, monkeypatch):
+        """Lowering is an optimization; it must never take down a config build."""
+        def boom(lf, cfg):
+            raise RuntimeError("learner exploded")
+        monkeypatch.setattr("goldenmatch.core.blocker.learn_rules_for_frame", boom)
+        out = _lower_learned_blocking(_blocking(), _frame(), 100_000)
+        assert out.strategy == "learned"
+
+    def test_lowering_error_is_not_swallowed_into_a_wrong_config(self, monkeypatch):
+        """Guard the shape of the fallback: on LoweringUnsupportedError we must
+        return the ORIGINAL learned config, not a half-built multi_pass."""
+        def boom(rules, **kw):
+            raise LoweringUnsupportedError("nope")
+        monkeypatch.setattr(
+            "goldenmatch.core.learned_blocking.lower_rules_to_blocking_config", boom
+        )
+        blk = _blocking()
+        out = _lower_learned_blocking(blk, _frame(), 100_000)
+        assert out.strategy == "learned"
+        assert out.keys == blk.keys
+
+
+class TestBucketPayoff:
+    """The point of the whole exercise."""
+
+    def test_lowered_config_reaches_the_bucket_scorer(self):
+        from goldenmatch.config.schemas import (
+            GoldenMatchConfig,
+            MatchkeyConfig,
+            MatchkeyField,
+        )
+        from goldenmatch.core.pipeline import _use_bucket_scorer
+
+        df = _frame()
+        lowered = _lower_learned_blocking(_blocking(), df, 100_000)
+        if lowered.strategy != "multi_pass":
+            pytest.skip("lowering did not fire on this fixture; covered elsewhere")
+
+        def cfg(blk):
+            return GoldenMatchConfig(
+                matchkeys=[MatchkeyConfig(
+                    name="mk", type="weighted", threshold=0.9,
+                    fields=[MatchkeyField(field="last", scorer="jaro_winkler", weight=1.0)],
+                )],
+                blocking=blk,
+            )
+
+        assert _use_bucket_scorer(cfg(_blocking()), df) is False  # before
+        assert _use_bucket_scorer(cfg(lowered), df) is True       # after


### PR DESCRIPTION
Follow-up to #1841 (compiler + harness, merged). This is the wiring that actually uses it.

> **This changes the default.** Every zero-config run `>= 50K` rows currently forfeits the bucket scorer; this stops that. Every failure path falls back to today's exact behavior, and there's a kill-switch. Details below.

## Why the wiring must live in auto-config

`strategy="learned"` defers rule learning to runtime inside `build_blocks`. That **cannot** be fixed at runtime:

```
pipeline.py:2420   if _use_bucket_scorer(config, df):   <- decides HERE
pipeline.py:2435       blocks = build_blocks(...)       <- learning happens HERE
```

Routing reads `config.blocking.strategy` **before** `build_blocks` runs, and when bucket wins it never calls `build_blocks` at all (it derives its own buckets from `passes`/`keys`). Runtime-learned rules arrive too late to matter. The rules must be in the config by routing time -- auto-config is the only seam that qualifies.

## What changed

- **`core/blocker.py`**: extract `learn_rules_for_frame()` out of `_build_learned_blocks` so config-time and runtime share **one** learner. `_build_learned_blocks` now only applies the rules; its fallbacks (no columns / no scored pairs -> static) are preserved.
- **`core/autoconfig.py`**: `_lower_learned_blocking()` learns at config time, lowers via `lower_rules_to_blocking_config` (#1841), commits `multi_pass`.

**Not new work.** This is the SAME sample-and-score pass `build_blocks` runs today, moved earlier. When lowering succeeds, `build_blocks` never runs the learned path at all.

## The payoff

```
learned strategy -> bucket?  False   # the bug
lowered strategy -> bucket?  True    # the fix
```

## Falls back, never regresses

Every failure path returns `strategy="learned"` -- today's behavior, unchanged:

- no rules learned
- **unlowerable rule**: a same-field conjunction (`last:exact AND last:soundex`). `field_transforms` is keyed by field and can't hold two chains for one field, and `learn_blocking_rules` **can** emit these (its guard is `p1.key() == p2.key()` -- field+transform, not field alone). Live path, not hypothetical.
- any unexpected exception (lowering is an optimization; it must never take down a config build)

The asymmetry is the design: **forfeiting bucket is a perf cost; lowering approximately is a silent correctness cost** (precision stays 1.0, only recall moves -- the #1800 / #1837 / #1839 shape). Always take the former.

Kill-switch: `GOLDENMATCH_LEARNED_LOWERING=0`.

## ORDERING HAZARD vs #1838 (read before rebasing either)

#1838 (#1837's fix) edits the **same six lines** of the learned upgrade. The order is load-bearing:

```python
blocking.max_block_size = _learned_block_cap(...)        # #1838: raise 5000 -> 25000
blocking = _lower_learned_blocking(blocking, df, ...)    # #1839: lowers, COPIES max_block_size
```

`_lower_learned_blocking` passes `max_block_size=blocking.max_block_size` into the lowered config, so **#1838's raise must come first** or the lowered config silently inherits the un-raised 5000 cap and #1837's regression returns -- recall-only, precision still 1.0, invisible.

#1838 is **not** superseded by this PR. Bucket honors the same drop cap (`score_buckets.py:1021`: `if skip_oversized and size > max_block_size` -> skipped entirely), so the cap problem follows the traffic onto the bucket path. Both fixes are needed, and they compose in this order.

## Verification

- new wiring tests: 8 passed (lowering fires; all fallbacks return `learned`; bucket payoff)
- with #1841's parity + #1840's dedup suites: 36 passed
- regression sweep (`learned or block or autoconfig or bucket`): **1456 passed**
- full-package `ruff check`: clean
- Pre-existing, NOT from this PR (each reproduced on trees without this change): `test_autoconfig_benchmarks.py` x3 (`FileNotFoundError` -- benchmark CSVs absent locally), `test_native_fs_ne.py::test_native_numpy_parity_ne`, `test_score_buckets_debug_mode.py::test_debug_flag_does_not_change_output`

## NOT verified: the wall

The routing flip is proven structurally and pairs are identical to the learned path on clean data (#1841's matrix). **The seconds are not measured** -- 1M zero-config OOMs the dev box. Per `feedback_verify_perf_not_just_ship`, shipping the symbol isn't the same as moving the wall. The CI quality gate is the right judge of both the wall and any quality delta, and I'd treat #1839 as open until it reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9