### PR TITLE
fix(ci): quality_gate must watch the surfaces that move its own numbers (#1846)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -7,6 +7,13 @@
 # HERE + the matching `changes.outputs.*` line + the job's `if:` gate in ci.yml.
 ci_workflow:
   - '.github/workflows/ci.yml'
+  # #1846: workflow_lint validates path-filter COVERAGE, so an edit to the
+  # filters themselves (or to the checker) must run it. Without this, the one
+  # file the coverage check exists to validate was the one file that couldn't
+  # trigger it -- the same "a filter can't catch what it doesn't list" hole,
+  # one level up.
+  - '.github/filters.yml'
+  - 'scripts/check_filter_coverage.py'
 python_root:
   - 'pyproject.toml'
   - 'uv.lock'
@@ -307,6 +314,29 @@ benchmark_runner:
 # anchor_person_match F1 floor. Re-run whenever the decision kernel
 # (rust core or Python autoconfig/blocking surfaces) or the harness
 # itself changes, and on ci.yml edits (keeps the gate under test).
+#
+# #1846: this list used to cover only the CONFIG-DECISION surfaces, but the
+# scorecard also pins F1 and F1_PROBABILISTIC -- so every surface that moves
+# those numbers has to trigger it too. It didn't, and the gate went silent on
+# exactly the PRs most able to break quality:
+#
+#   #1829  backends/score_buckets.py + core/probabilistic.py  -> SKIPPED
+#   #1834  core/probabilistic.py + core/fused_match.py        -> SKIPPED
+#   #1836  core/probabilistic.py                              -> SKIPPED
+#   #1840  core/learned_blocking.py                           -> SKIPPED
+#
+# The gate MEASURED f1_probabilistic while not WATCHING probabilistic.py.
+# historical_50k f1_probabilistic then fell 0.83 -> 0.33 on the native path
+# and only surfaced later, on unrelated PRs that happened to touch a listed
+# path -- which reads as "those PRs broke it" and burns a day on attribution.
+#
+# This is the same failure #435 fixed for `benchmark_runner` above ("changes
+# to the library being benchmarked must also trigger the smoke"); the quality
+# gate never got the same treatment. Keep the two lists in sync.
+#
+# RULE: if a file can move a number the scorecard pins, it belongs here. A
+# quality gate that doesn't run is not a gate. Over-running costs ~22min of
+# CI; under-running costs a silent recall regression on the reference path.
 quality_gate:
   - 'scripts/autoconfig_quality/**'
   - 'packages/rust/extensions/autoconfig-core/**'
@@ -314,7 +344,30 @@ quality_gate:
   - 'packages/python/goldenmatch/goldenmatch/core/blocker.py'
   - 'packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py'
   - 'packages/python/goldenmatch/goldenmatch/core/matchkey.py'
+  # --- #1846: surfaces that move the scorecard's F1 / F1_PROBABILISTIC ---
+  # Fellegi-Sunter: f1_probabilistic is a pinned column.
+  - 'packages/python/goldenmatch/goldenmatch/core/probabilistic*.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/fused_match.py'
+  # Blocking: learned_blocking is a sibling of blocker.py, not covered by it.
+  - 'packages/python/goldenmatch/goldenmatch/core/learned_blocking.py'
+  # Scoring + clustering decide the pairs the F1 columns are computed from.
+  - 'packages/python/goldenmatch/goldenmatch/core/scorer*.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
+  # Routing: pipeline picks WHICH scorer runs (bucket vs legacy), so it can
+  # change the numbers without any kernel changing.
+  - 'packages/python/goldenmatch/goldenmatch/core/pipeline.py'
+  # The backends ARE the scorers the planner routes to. The gate runs native
+  # on purpose because native-on makes the planner pick `bucket` -- so a
+  # bucket-lane change moves the gate's own reference path (#1829).
+  - 'packages/python/goldenmatch/goldenmatch/backends/**'
+  # The gate builds the native ext and the baseline is blessed native-on, so
+  # the kernel is part of the measured path, not an implementation detail.
+  - 'packages/rust/extensions/native/**'
   - '.github/workflows/ci.yml'
+  # Self-test: an edit to THIS file must re-run the gate, same rule ci.yml
+  # already follows -- otherwise a filter change can't be validated by the
+  # thing it gates.
+  - '.github/filters.yml'
 # Cross-language API-parity gate: the goldenmatch MCP+CLI surface must
 # not drift between the Python and TypeScript ports. Re-run the gate
 # when either port, the parity manifest, or the emitter/checker tooling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,14 @@ jobs:
         run: |
           python3 -m pip install --quiet pyyaml
           python3 -c "import sys,glob,yaml; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('all workflow YAML parses')"
+      # #1846: parsing is not meaning. A path filter that lists too few paths
+      # makes its job go SILENT on exactly the changes it exists to catch --
+      # quality_gate pinned f1_probabilistic while not watching
+      # probabilistic.py, and a 0.83 -> 0.33 collapse landed unseen. This
+      # asserts each gated filter still covers the surfaces it claims to gate.
+      - name: Validate CI path-filter coverage
+        shell: bash
+        run: python3 scripts/check_filter_coverage.py
 
   python:
     needs: changes

--- a/scripts/check_filter_coverage.py
+++ b/scripts/check_filter_coverage.py
@@ -1,0 +1,116 @@
+"""Assert CI path filters cover the surfaces they claim to gate (#1846).
+
+A path-filtered job can only catch what its filter matches. When a filter
+lists fewer paths than the job actually gates, the job goes SILENT on exactly
+the changes it exists to catch -- and the failure surfaces later, on unrelated
+PRs that happen to touch a listed path, which reads as "that PR broke it".
+
+That happened: `quality_gate` pins f1 and f1_probabilistic in its scorecard but
+did not list `core/probabilistic.py`. It was skipped on #1829 / #1834 / #1836 /
+#1840 -- every recent PR able to move those numbers -- and historical_50k
+f1_probabilistic fell 0.83 -> 0.33 on the native path with nothing to catch it.
+
+`workflow_lint` only checks that the YAML parses. This checks that it MEANS
+something. Same spirit as #435 (benchmark_runner had the identical hole).
+
+Run: python scripts/check_filter_coverage.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+FILTERS = Path(__file__).resolve().parent.parent / ".github" / "filters.yml"
+
+GM = "packages/python/goldenmatch/goldenmatch"
+
+# filter name -> paths that MUST trigger it, with why. Each entry is a real
+# regression or a real near-miss, not a hypothetical.
+REQUIRED: dict[str, list[tuple[str, str]]] = {
+    "quality_gate": [
+        (f"{GM}/core/probabilistic.py", "scorecard pins f1_probabilistic (#1834, #1836)"),
+        (f"{GM}/core/fused_match.py", "FS scoring path (#1834)"),
+        (f"{GM}/backends/score_buckets.py", "native-on planner routes here (#1829)"),
+        (f"{GM}/core/learned_blocking.py", "blocking; sibling of blocker.py (#1840, #1841)"),
+        (f"{GM}/core/autoconfig.py", "the config decisions the scorecard pins"),
+        (f"{GM}/core/blocker.py", "blocking fields/cost signals"),
+        (f"{GM}/core/scorer.py", "scorecard pins f1"),
+        (f"{GM}/core/cluster.py", "clusters decide the measured pairs"),
+        (f"{GM}/core/pipeline.py", "routing picks WHICH scorer runs"),
+        ("packages/rust/extensions/native/src/lib.rs", "baseline is blessed native-on"),
+        ("scripts/autoconfig_quality/datasets.py", "the harness itself"),
+        (".github/filters.yml", "self-test: filter edits must re-run the gate"),
+    ],
+    "benchmark_runner": [
+        (f"{GM}/core/probabilistic.py", "#435: the library being benchmarked"),
+        (f"{GM}/core/scorer.py", "#435"),
+        (f"{GM}/core/pipeline.py", "#435"),
+    ],
+}
+
+# Paths that must NOT trigger these filters -- guards against "fix" by
+# over-matching, which turns a gate into a tax on every PR.
+FORBIDDEN: dict[str, list[str]] = {
+    "quality_gate": [
+        "README.md",
+        "docs/design/foo.md",
+        "packages/typescript/goldenmatch/src/cli.ts",
+    ],
+}
+
+
+def _matches(path: str, patterns: list[str]) -> str | None:
+    """Approximate dorny/paths-filter: globs are unanchored, ** spans dirs."""
+    for p in patterns:
+        if fnmatch.fnmatch(path, p) or fnmatch.fnmatch(path, p.replace("**", "*")):
+            return p
+    return None
+
+
+def main() -> int:
+    spec = yaml.safe_load(FILTERS.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    for name, cases in REQUIRED.items():
+        pats = spec.get(name)
+        if not pats:
+            failures.append(f"{name}: filter missing entirely")
+            continue
+        for path, why in cases:
+            if _matches(path, pats) is None:
+                failures.append(
+                    f"{name}: does NOT match {path}\n"
+                    f"      why it must: {why}\n"
+                    f"      -> add a pattern to `{name}:` in .github/filters.yml"
+                )
+
+    for name, paths in FORBIDDEN.items():
+        pats = spec.get(name) or []
+        for path in paths:
+            hit = _matches(path, pats)
+            if hit is not None:
+                failures.append(
+                    f"{name}: matches {path} via '{hit}' -- too broad; the gate "
+                    f"would run on unrelated PRs"
+                )
+
+    if failures:
+        print("CI filter coverage FAILED:\n")
+        for f in failures:
+            print(f"  - {f}")
+        print(
+            "\nA path-filtered job cannot catch what its filter does not match.\n"
+            "If a file can move a number a gate pins, the filter must list it."
+        )
+        return 1
+
+    total = sum(len(v) for v in REQUIRED.values())
+    print(f"CI filter coverage OK ({total} required paths across {len(REQUIRED)} filters)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The quality gate **measured** `f1_probabilistic` while not **watching** `probabilistic.py`.

A path-filtered job can only catch what its filter matches. So the gate went silent on exactly the PRs it exists to catch:

| PR | files touched | quality_gate |
|---|---|---|
| #1829 | `backends/score_buckets.py`, `core/probabilistic.py` | **SKIPPED** |
| #1834 | `core/probabilistic.py`, `core/fused_match.py` | **SKIPPED** |
| #1836 | `core/probabilistic.py` | **SKIPPED** |
| #1840 | `core/learned_blocking.py` | **SKIPPED** |

`historical_50k f1_probabilistic` then fell **0.83 -> 0.33** on the native path and landed on `main` unseen. It only surfaced later on #1838 / #1845 -- unrelated PRs that happened to touch a *listed* path -- which reads as "those PRs broke it" and cost a day of attribution. The loss is **recall-only** (precision stays 1.0), so nothing else flags it.

This is the same hole **#435** already fixed for `benchmark_runner` (*"changes to the library being benchmarked must also trigger the smoke"*). The quality gate never got the same treatment.

## 1. The filter

Added the surfaces that move the pinned numbers:

- `core/probabilistic*.py`, `core/fused_match.py` -- the scorecard pins `f1_probabilistic`
- `core/scorer*.py`, `core/cluster.py` -- it pins `f1`
- `core/pipeline.py` -- routing picks **which** scorer runs, so it moves the numbers with no kernel change
- `backends/**` -- the scorers themselves. The gate runs native **on purpose** because native-on makes the planner pick `bucket`, so the bucket lane **is** the gate's reference path (#1829)
- `core/learned_blocking.py` -- a sibling of `blocker.py`, not covered by it
- `packages/rust/extensions/native/**` -- the baseline is blessed native-on, so the kernel is part of the measured path
- `.github/filters.yml` -- self-test, same rule `ci.yml` already follows

## 2. The coverage check (the actual fix)

Adding paths fixes *today*. `scripts/check_filter_coverage.py` stops it recurring: it asserts each gated filter still matches the surfaces it claims to gate, and prints the reason + remediation on failure:

```
quality_gate: does NOT match .../core/probabilistic.py
      why it must: scorecard pins f1_probabilistic (#1834, #1836)
      -> add a pattern to `quality_gate:` in .github/filters.yml
```

**Verified it fails when the #1846 hole is reintroduced** (removed the probabilistic patterns -> exit 1 naming both), and that negative controls (docs-only, TS-only) still skip -- so this can't degrade into "run the 22min gate on every PR". Every `REQUIRED` entry is a real regression or near-miss, not a hypothetical.

Wired into `workflow_lint`, which until now only checked that the YAML parses. **Parsing is not meaning.**

## 3. The same bug, one level up

`ci_workflow` listed only `ci.yml`, **not** `filters.yml` -- so the one file the coverage check exists to validate was the one file that couldn't trigger it. Added `filters.yml` + the checker to `ci_workflow`.

## Scope

This does **not** fix the 0.83 -> 0.33 regression. **#1846 stays open** and needs a native bisect across #1836 -> #1834 -> #1829 (needs a native build, so it must run in CI).

**Expect `quality_gate` to go RED on PRs touching these paths until the regression itself is fixed.** That is the gate working -- it was always broken, we just couldn't see it. Note `quality_gate` is not a required check (only `ci-required` is), so a red gate shows as `UNSTABLE` and does not block merges.

## Verification

- `python scripts/check_filter_coverage.py` -> OK (15 required paths across 2 filters)
- reintroduced the hole -> exit 1, names both missing paths
- all workflow + filters YAML parses
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9