### PR TITLE
diag(#1846): CI-vs-local fact dump for the historical_50k native collapse [DO NOT MERGE]

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -7,6 +7,13 @@
 # HERE + the matching `changes.outputs.*` line + the job's `if:` gate in ci.yml.
 ci_workflow:
   - '.github/workflows/ci.yml'
+  # #1846: workflow_lint validates path-filter COVERAGE, so an edit to the
+  # filters themselves (or to the checker) must run it. Without this, the one
+  # file the coverage check exists to validate was the one file that couldn't
+  # trigger it -- the same "a filter can't catch what it doesn't list" hole,
+  # one level up.
+  - '.github/filters.yml'
+  - 'scripts/check_filter_coverage.py'
 python_root:
   - 'pyproject.toml'
   - 'uv.lock'
@@ -307,6 +314,29 @@ benchmark_runner:
 # anchor_person_match F1 floor. Re-run whenever the decision kernel
 # (rust core or Python autoconfig/blocking surfaces) or the harness
 # itself changes, and on ci.yml edits (keeps the gate under test).
+#
+# #1846: this list used to cover only the CONFIG-DECISION surfaces, but the
+# scorecard also pins F1 and F1_PROBABILISTIC -- so every surface that moves
+# those numbers has to trigger it too. It didn't, and the gate went silent on
+# exactly the PRs most able to break quality:
+#
+#   #1829  backends/score_buckets.py + core/probabilistic.py  -> SKIPPED
+#   #1834  core/probabilistic.py + core/fused_match.py        -> SKIPPED
+#   #1836  core/probabilistic.py                              -> SKIPPED
+#   #1840  core/learned_blocking.py                           -> SKIPPED
+#
+# The gate MEASURED f1_probabilistic while not WATCHING probabilistic.py.
+# historical_50k f1_probabilistic then fell 0.83 -> 0.33 on the native path
+# and only surfaced later, on unrelated PRs that happened to touch a listed
+# path -- which reads as "those PRs broke it" and burns a day on attribution.
+#
+# This is the same failure #435 fixed for `benchmark_runner` above ("changes
+# to the library being benchmarked must also trigger the smoke"); the quality
+# gate never got the same treatment. Keep the two lists in sync.
+#
+# RULE: if a file can move a number the scorecard pins, it belongs here. A
+# quality gate that doesn't run is not a gate. Over-running costs ~22min of
+# CI; under-running costs a silent recall regression on the reference path.
 quality_gate:
   - 'scripts/autoconfig_quality/**'
   - 'packages/rust/extensions/autoconfig-core/**'
@@ -314,7 +344,30 @@ quality_gate:
   - 'packages/python/goldenmatch/goldenmatch/core/blocker.py'
   - 'packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py'
   - 'packages/python/goldenmatch/goldenmatch/core/matchkey.py'
+  # --- #1846: surfaces that move the scorecard's F1 / F1_PROBABILISTIC ---
+  # Fellegi-Sunter: f1_probabilistic is a pinned column.
+  - 'packages/python/goldenmatch/goldenmatch/core/probabilistic*.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/fused_match.py'
+  # Blocking: learned_blocking is a sibling of blocker.py, not covered by it.
+  - 'packages/python/goldenmatch/goldenmatch/core/learned_blocking.py'
+  # Scoring + clustering decide the pairs the F1 columns are computed from.
+  - 'packages/python/goldenmatch/goldenmatch/core/scorer*.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
+  # Routing: pipeline picks WHICH scorer runs (bucket vs legacy), so it can
+  # change the numbers without any kernel changing.
+  - 'packages/python/goldenmatch/goldenmatch/core/pipeline.py'
+  # The backends ARE the scorers the planner routes to. The gate runs native
+  # on purpose because native-on makes the planner pick `bucket` -- so a
+  # bucket-lane change moves the gate's own reference path (#1829).
+  - 'packages/python/goldenmatch/goldenmatch/backends/**'
+  # The gate builds the native ext and the baseline is blessed native-on, so
+  # the kernel is part of the measured path, not an implementation detail.
+  - 'packages/rust/extensions/native/**'
   - '.github/workflows/ci.yml'
+  # Self-test: an edit to THIS file must re-run the gate, same rule ci.yml
+  # already follows -- otherwise a filter change can't be validated by the
+  # thing it gates.
+  - '.github/filters.yml'
 # Cross-language API-parity gate: the goldenmatch MCP+CLI surface must
 # not drift between the Python and TypeScript ports. Re-run the gate
 # when either port, the parity manifest, or the emitter/checker tooling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,14 @@ jobs:
         run: |
           python3 -m pip install --quiet pyyaml
           python3 -c "import sys,glob,yaml; [yaml.safe_load(open(f)) for f in glob.glob('.github/workflows/*.yml')]; print('all workflow YAML parses')"
+      # #1846: parsing is not meaning. A path filter that lists too few paths
+      # makes its job go SILENT on exactly the changes it exists to catch --
+      # quality_gate pinned f1_probabilistic while not watching
+      # probabilistic.py, and a 0.83 -> 0.33 collapse landed unseen. This
+      # asserts each gated filter still covers the surfaces it claims to gate.
+      - name: Validate CI path-filter coverage
+        shell: bash
+        run: python3 scripts/check_filter_coverage.py
 
   python:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,6 +878,17 @@ jobs:
           workspaces: packages/rust/extensions/native
       - name: Build native ext (reference mode -> gate runs on the native path)
         run: uv run python scripts/build_native.py
+      # TEMPORARY (#1846 diagnostic -- revert before merge). historical_50k
+      # f1_probabilistic is 0.82 on Windows and 0.33 here, on the same commit
+      # with the same flags, and #1847 shows it needs no code change at all.
+      # Local cannot reproduce it, so dump the same facts here that the local
+      # run dumps and diff them.
+      - name: "#1846 diagnostic (temporary)"
+        if: always()
+        shell: bash
+        env:
+          GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+        run: uv run python scripts/diag_1846.py || true
       - name: Run auto-config quality gate
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,7 +888,9 @@ jobs:
         shell: bash
         env:
           GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
-        run: uv run python scripts/diag_1846.py || true
+        run: |
+          uv run python scripts/diag_1846.py || true
+          uv run python scripts/diag_1846_em.py || true
       - name: Run auto-config quality gate
         shell: bash
         env:

--- a/scripts/check_filter_coverage.py
+++ b/scripts/check_filter_coverage.py
@@ -1,0 +1,116 @@
+"""Assert CI path filters cover the surfaces they claim to gate (#1846).
+
+A path-filtered job can only catch what its filter matches. When a filter
+lists fewer paths than the job actually gates, the job goes SILENT on exactly
+the changes it exists to catch -- and the failure surfaces later, on unrelated
+PRs that happen to touch a listed path, which reads as "that PR broke it".
+
+That happened: `quality_gate` pins f1 and f1_probabilistic in its scorecard but
+did not list `core/probabilistic.py`. It was skipped on #1829 / #1834 / #1836 /
+#1840 -- every recent PR able to move those numbers -- and historical_50k
+f1_probabilistic fell 0.83 -> 0.33 on the native path with nothing to catch it.
+
+`workflow_lint` only checks that the YAML parses. This checks that it MEANS
+something. Same spirit as #435 (benchmark_runner had the identical hole).
+
+Run: python scripts/check_filter_coverage.py
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+import yaml
+
+FILTERS = Path(__file__).resolve().parent.parent / ".github" / "filters.yml"
+
+GM = "packages/python/goldenmatch/goldenmatch"
+
+# filter name -> paths that MUST trigger it, with why. Each entry is a real
+# regression or a real near-miss, not a hypothetical.
+REQUIRED: dict[str, list[tuple[str, str]]] = {
+    "quality_gate": [
+        (f"{GM}/core/probabilistic.py", "scorecard pins f1_probabilistic (#1834, #1836)"),
+        (f"{GM}/core/fused_match.py", "FS scoring path (#1834)"),
+        (f"{GM}/backends/score_buckets.py", "native-on planner routes here (#1829)"),
+        (f"{GM}/core/learned_blocking.py", "blocking; sibling of blocker.py (#1840, #1841)"),
+        (f"{GM}/core/autoconfig.py", "the config decisions the scorecard pins"),
+        (f"{GM}/core/blocker.py", "blocking fields/cost signals"),
+        (f"{GM}/core/scorer.py", "scorecard pins f1"),
+        (f"{GM}/core/cluster.py", "clusters decide the measured pairs"),
+        (f"{GM}/core/pipeline.py", "routing picks WHICH scorer runs"),
+        ("packages/rust/extensions/native/src/lib.rs", "baseline is blessed native-on"),
+        ("scripts/autoconfig_quality/datasets.py", "the harness itself"),
+        (".github/filters.yml", "self-test: filter edits must re-run the gate"),
+    ],
+    "benchmark_runner": [
+        (f"{GM}/core/probabilistic.py", "#435: the library being benchmarked"),
+        (f"{GM}/core/scorer.py", "#435"),
+        (f"{GM}/core/pipeline.py", "#435"),
+    ],
+}
+
+# Paths that must NOT trigger these filters -- guards against "fix" by
+# over-matching, which turns a gate into a tax on every PR.
+FORBIDDEN: dict[str, list[str]] = {
+    "quality_gate": [
+        "README.md",
+        "docs/design/foo.md",
+        "packages/typescript/goldenmatch/src/cli.ts",
+    ],
+}
+
+
+def _matches(path: str, patterns: list[str]) -> str | None:
+    """Approximate dorny/paths-filter: globs are unanchored, ** spans dirs."""
+    for p in patterns:
+        if fnmatch.fnmatch(path, p) or fnmatch.fnmatch(path, p.replace("**", "*")):
+            return p
+    return None
+
+
+def main() -> int:
+    spec = yaml.safe_load(FILTERS.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    for name, cases in REQUIRED.items():
+        pats = spec.get(name)
+        if not pats:
+            failures.append(f"{name}: filter missing entirely")
+            continue
+        for path, why in cases:
+            if _matches(path, pats) is None:
+                failures.append(
+                    f"{name}: does NOT match {path}\n"
+                    f"      why it must: {why}\n"
+                    f"      -> add a pattern to `{name}:` in .github/filters.yml"
+                )
+
+    for name, paths in FORBIDDEN.items():
+        pats = spec.get(name) or []
+        for path in paths:
+            hit = _matches(path, pats)
+            if hit is not None:
+                failures.append(
+                    f"{name}: matches {path} via '{hit}' -- too broad; the gate "
+                    f"would run on unrelated PRs"
+                )
+
+    if failures:
+        print("CI filter coverage FAILED:\n")
+        for f in failures:
+            print(f"  - {f}")
+        print(
+            "\nA path-filtered job cannot catch what its filter does not match.\n"
+            "If a file can move a number a gate pins, the filter must list it."
+        )
+        return 1
+
+    total = sum(len(v) for v in REQUIRED.values())
+    print(f"CI filter coverage OK ({total} required paths across {len(REQUIRED)} filters)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag_1846.py
+++ b/scripts/diag_1846.py
@@ -1,0 +1,131 @@
+"""#1846 diagnostic: why does historical_50k f1_probabilistic collapse on CI/Linux?
+
+Measured so far -- every one of these PASSES (~0.82):
+
+  * local Windows, native=0 / native=1 / auto, memory=0 / memory=1  (4 combos)
+  * local Windows, main HEAD and every commit back through #1826      (5 rungs)
+
+CI/Linux on the SAME commit with the SAME flags: 0.3335. #1847 proves it needs
+no code change at all -- it changes only ci.yml/filters.yml and still fails --
+so this is main + Linux, not any PR and not any of the commits bisected.
+
+historical_50k is the ONLY dataset >= 50,000 rows, so it is the only one that
+trips the learned-blocking upgrade. Every smaller dataset is clean on both
+platforms. That is the sharpest clue we have.
+
+This dumps the same facts on both platforms so the DIFF names the cause instead
+of another hypothesis. Prefix every line with DIAG1846 so it greps cleanly out
+of a CI log.
+
+Run: python scripts/diag_1846.py
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "packages" / "python" / "goldenmatch"))
+sys.path.insert(0, str(ROOT))
+
+P = "DIAG1846"
+
+
+def out(k: str, v: object) -> None:
+    print(f"{P} {k}={v}", flush=True)
+
+
+def main() -> int:
+    # ---- host / deps -------------------------------------------------------
+    out("os", platform.system())
+    out("machine", platform.machine())
+    out("python", platform.python_version())
+    out("cpu_count", os.cpu_count())
+    out("env.GOLDENMATCH_NATIVE", os.environ.get("GOLDENMATCH_NATIVE", "<unset>"))
+    out("env.GOLDENMATCH_AUTOCONFIG_MEMORY",
+        os.environ.get("GOLDENMATCH_AUTOCONFIG_MEMORY", "<unset>"))
+
+    for mod in ("polars", "numpy", "pyarrow", "jellyfish", "recordlinkage"):
+        try:
+            m = __import__(mod)
+            out(f"dep.{mod}", getattr(m, "__version__", "?"))
+        except Exception as e:
+            out(f"dep.{mod}", f"MISSING ({type(e).__name__})")
+
+    # jellyfish drives _safe_soundex; without it every soundex blocking key
+    # silently degrades to val[:4].upper() -> different blocks -> different recall.
+    try:
+        import jellyfish
+        out("soundex.jellyfish('Smith')", jellyfish.soundex("Smith"))
+    except Exception:
+        out("soundex.jellyfish", "UNAVAILABLE -> _safe_soundex falls back to val[:4].upper()")
+    from goldenmatch.core.learned_blocking import _safe_soundex
+    out("soundex.effective('Smith')", _safe_soundex("Smith"))
+
+    # ---- native ------------------------------------------------------------
+    from goldenmatch.core._native_loader import native_enabled, native_module
+    try:
+        out("native.module", getattr(native_module(), "__file__", "<none>"))
+    except Exception as e:
+        out("native.module", f"UNAVAILABLE ({type(e).__name__}: {e})")
+    for cap in ("block_scoring", "fs_bucket", "autoconfig", "scoring"):
+        try:
+            out(f"native.{cap}", native_enabled(cap))
+        except Exception as e:
+            out(f"native.{cap}", f"ERR {type(e).__name__}")
+
+    # ---- the committed config for historical_50k ---------------------------
+    import polars as pl
+    p = ROOT / "scripts" / "autoconfig_quality" / "vendored" / "historical_50k.parquet"
+    if not p.exists():
+        out("dataset", "ABSENT -- cannot diagnose")
+        return 0
+    df = pl.read_parquet(p)
+    df = df.drop([c for c in ("cluster", "unique_id") if c in df.columns])
+    out("rows", df.height)
+    out("cols", df.columns)
+
+    from goldenmatch.core.autoconfig import auto_configure_df
+    cfg = auto_configure_df(df)
+    blk = cfg.blocking
+    out("cfg.backend", getattr(cfg, "backend", None))
+    out("cfg.blocking.strategy", getattr(blk, "strategy", None))
+    out("cfg.blocking.keys", [k.fields for k in (getattr(blk, "keys", None) or [])])
+    out("cfg.blocking.passes", [p_.fields for p_ in (getattr(blk, "passes", None) or [])])
+    out("cfg.blocking.max_block_size", getattr(blk, "max_block_size", None))
+    out("cfg.blocking.skip_oversized", getattr(blk, "skip_oversized", None))
+    out("cfg.matchkeys", [(m.name, m.type, [f.field for f in m.fields]) for m in cfg.matchkeys])
+
+    from goldenmatch.core.blocker import collect_blocking_fields
+    out("cfg.em_blocking_fields", collect_blocking_fields(blk))
+
+    # Which scorer will actually run -- the routing decision the gate depends on.
+    try:
+        from goldenmatch.core.pipeline import _use_bucket_scorer
+        out("routing.use_bucket_scorer", _use_bucket_scorer(cfg, df.head(1000)))
+    except Exception as e:
+        out("routing.use_bucket_scorer", f"ERR {type(e).__name__}: {e}")
+
+    # ---- blocking outcome --------------------------------------------------
+    from goldenmatch.core.blocker import build_blocks
+    lf = df.with_row_index("__row_id__").lazy()
+    try:
+        blocks = build_blocks(lf, blk)
+        sizes = [b.n_rows() for b in blocks]
+        out("blocks.count", len(blocks))
+        out("blocks.total_rows", sum(sizes))
+        out("blocks.max_size", max(sizes) if sizes else 0)
+        out("blocks.pairs", sum(s * (s - 1) // 2 for s in sizes))
+        cap = getattr(blk, "max_block_size", 0) or 0
+        out("blocks.over_cap", sum(1 for s in sizes if s > cap))
+    except Exception as e:
+        out("blocks", f"ERR {type(e).__name__}: {e}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/diag_1846_em.py
+++ b/scripts/diag_1846_em.py
@@ -1,0 +1,90 @@
+"""#1846 probe 2: dump the EM result for historical_50k (DIAG1846EM lines).
+
+Probe 1 proved config, blocking and the 12,608,858 candidate pairs are
+BYTE-IDENTICAL on Windows (0.82) and Linux CI (0.33). Same input, different
+answer -> the divergence is inside FS/EM, not upstream.
+
+Ruled out since:
+  * cpu_count (n_buckets 48 vs 16, FS workers 12 vs 4): forcing cpu_count=4
+    locally still PASSES at 0.8236. The "output pairs are invariant to bucket
+    count" docstring holds.
+
+Weighted f1 is fine on BOTH hosts (0.3409 -> 0.3421); only f1_probabilistic
+collapses. So the similarity scorers agree -- it is the FS layer on top.
+
+train_em is seeded (seed=42) and samples within-block pairs, and the blocks are
+identical, so the sample should be identical too. If m/u or match_weights
+differ, EM diverged; if `converged` is False on Linux, it hit max_iterations
+and the weights are unconverged garbage. Either way THIS names it.
+
+Run: python scripts/diag_1846_em.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "packages" / "python" / "goldenmatch"))
+sys.path.insert(0, str(ROOT))
+
+P = "DIAG1846EM"
+
+
+def _fmt(xs, n=4):
+    if xs is None:
+        return None
+    return [round(float(x), n) for x in xs]
+
+
+def main() -> int:
+    import goldenmatch.core.probabilistic as prob
+
+    real_train_em = prob.train_em
+    calls: list = []
+
+    def traced(*a, **kw):
+        res = real_train_em(*a, **kw)
+        calls.append(res)
+        i = len(calls)
+        print(f"{P} call={i} converged={res.converged} iterations={res.iterations} "
+              f"proportion_matched={round(float(res.proportion_matched), 6)}", flush=True)
+        for field in sorted(res.match_weights):
+            print(f"{P} call={i} field={field} "
+                  f"m={_fmt(res.m_probs.get(field))} "
+                  f"u={_fmt(res.u_probs.get(field))} "
+                  f"w={_fmt(res.match_weights.get(field))}", flush=True)
+        tf = res.tf_freqs
+        print(f"{P} call={i} tf_fields={sorted(tf) if tf else None} "
+              f"tf_collision={ {k: round(v,6) for k,v in (res.tf_collision or {}).items()} }",
+              flush=True)
+        return res
+
+    prob.train_em = traced
+    # The FS pipeline may hold its own reference; patch the common re-exports too.
+    for modname in ("goldenmatch.core.probabilistic_fast", "goldenmatch.core.pipeline"):
+        try:
+            m = __import__(modname, fromlist=["*"])
+            if hasattr(m, "train_em"):
+                m.train_em = traced
+        except Exception:
+            pass
+
+    import polars as pl
+    p = ROOT / "scripts" / "autoconfig_quality" / "vendored" / "historical_50k.parquet"
+    if not p.exists():
+        print(f"{P} dataset=ABSENT", flush=True)
+        return 0
+
+    # Drive the SAME path the gate drives, so the EM we trace is the gate's EM.
+    sys.argv = ["autoconfig_quality", "report", "--datasets", "historical_50k"]
+    from scripts.autoconfig_quality.__main__ import main as harness
+
+    rc = harness()
+    print(f"{P} train_em_calls={len(calls)}", flush=True)
+    return rc if isinstance(rc, int) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**DIAGNOSTIC ONLY. DO NOT MERGE.** The `ci.yml` step here is temporary.

`historical_50k f1_probabilistic` is **0.82 on local Windows** and **0.3335 on CI/Linux** -- same commit, same flags. Everything reasoned about this has been wrong, so this stops reasoning and diffs the two hosts.

## Ruled out BY MEASUREMENT (not argument)

| hypothesis | how it died |
|---|---|
| a bad commit (#1836 / #1834 / #1829) | all 5 rungs back through #1826 **PASS** locally, incl. main HEAD (0.8298) |
| the env knobs | `native=auto/1/0` x `memory=0/1` -- all 4 **PASS** locally, incl. CI-exact (0.8237) |
| any open PR | **#1847** changes only `ci.yml`/`filters.yml` + a new script and still **FAILS 0.3335** |

So: **main + Linux.** Not a PR, not a commit, not a flag.

`historical_50k` is the **only** dataset >= 50,000 rows -- the only one that trips the learned-blocking upgrade. Every smaller dataset (febrl3, ncvr_synthetic, anchor_person_match) is clean on **both** hosts, including their `f1_probabilistic`. That is the sharpest clue available.

## What this adds

`scripts/diag_1846.py` -- same script, both hosts, `DIAG1846`-prefixed lines so it greps out of a CI log. Dumps host/deps, native capability flags, the committed config, EM blocking fields, the routing decision, and the blocking outcome (counts, pairs, over-cap).

## Local Windows baseline (for the diff)

```
os=Windows  cpu_count=12  python=3.13.12
polars=1.40.1  numpy=2.4.4  pyarrow=24.0.0  jellyfish present (soundex Smith=S530)
native: block_scoring=True  fs_bucket=False  autoconfig=True  scoring=False
cfg.backend=bucket  strategy=learned  max_block_size=1264  skip_oversized=True
keys=[[full_name]]  passes=[full_name x3, first_and_surname x2]
em_blocking_fields=[full_name, first_and_surname]
routing.use_bucket_scorer=True
blocks=3359  total_rows=83208  max_size=1262  pairs=12608858  over_cap=0
```

## Two claims of mine this ALREADY corrected

1. **`max_block_size=1264`, not 5000.** So #1838's `_learned_block_cap` **is live** at 50,578 rows -- it raised the cap. I had called it a no-op there, assuming the incoming cap was 5000. It wasn't.
2. **`use_bucket_scorer=True` despite `strategy=learned`.** The planner sets `backend=bucket`, and `_use_bucket_scorer`'s first branch (`if backend == "bucket": return True`) fires **before** the strategy check. So this dataset **already uses the bucket scorer** -- which undercuts #1839's "zero-config >=50K forfeits bucket" premise for exactly the dataset that is failing.

## Next

Read `DIAG1846` off the runner, diff against the block above, and let the delta name the cause. Then revert the `ci.yml` step and fold the finding into #1846 (whose current "suspects + bisect" plan is refuted and needs rewriting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9