### PR TITLE
chore(release): suite-wide minor version bumps (2026-07-16 train)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ pip install golden-suite    # the WHOLE suite (Check + Flow + Match + Analysis +
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **Unreleased** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
+> **v3.4.0** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
 `record_embedding` field scorers now train (EM) and score end-to-end on the
 probabilistic path via the vectorized matrix — previously they raised
 `Unknown scorer` on both training and scoring. They are matrix-only, so a

--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.0] - 2026-07-16
+
+- Suite minor train: floors raised to `goldenmatch[polars]>=3.4` (FS scoring in
+  the distributed/chunked lanes, memory-bounded strategy-blocking scorer,
+  columnar routing fix, missing-values-as-unobserved FS math),
+  `goldencheck[polars]>=3.2`, `goldenpipe[golden-suite]>=1.4` (compiler
+  SP1-SP3 + in-process moves), `infermap>=0.6` (Rust kernels on MCP servers +
+  pattern_type cutover), `goldenanalysis>=0.4`, `goldencheck-types>=0.2`
+  (16 domain packs), `goldenmatch-native>=0.1.17` (FS exclude-set Arc handle +
+  zero-copy arrow FS entry), `goldensuite-mcp>=0.5`.
+
 ## [0.2.5] - 2026-07-14
 
 - Floor bump: `goldenmatch[polars]>=3.3` (FS negative evidence on probabilistic

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.2.5"
+__version__ = "0.3.0"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.2.5"
+version = "0.3.0"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -36,15 +36,15 @@ classifiers = [
 # it; `golden-suite optimize` repairs it.
 dependencies = [
     # --- suite (floors track the current majors) ---
-    "goldenpipe[golden-suite]>=1.3",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.3",         # entity resolution: dedupe, match, golden records (>=3.3: FS negative evidence + Splink migration upgrade pass w/ fan-out lever; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
-    "goldencheck[polars]>=3.0.0",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
+    "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
+    "goldenmatch[polars]>=3.4",         # entity resolution: dedupe, match, golden records (>=3.4: FS in distributed/chunked lanes + bounded strategy-blocking scorer; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldencheck[polars]>=3.2",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
-    "infermap>=0.5.1",                  # GoldenSchema: inference-driven schema mapping
-    "goldenanalysis>=0.3",              # read-only cross-cutting metrics + reporting
-    "goldencheck-types>=0.1",           # shared canonical field-type contracts
+    "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping
+    "goldenanalysis>=0.4",              # read-only cross-cutting metrics + reporting
+    "goldencheck-types>=0.2",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.15",       # >=0.1.15 carries native FS negative evidence + fused N-level (FS_SUPPORTS_NE)
+    "goldenmatch-native>=0.1.17",       # >=0.1.17 carries the FS exclude-set Arc handle + zero-copy arrow FS entry + unobserved-evidence math
     "goldencheck-native>=0.1",
     "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
     "goldenanalysis-native>=0.1",
@@ -55,9 +55,9 @@ dependencies = [
 
 [project.optional-dependencies]
 # One MCP server exposing every tool — the agent front door.
-mcp = ["goldensuite-mcp>=0.3"]
+mcp = ["goldensuite-mcp>=0.5"]
 # GoldenPipe serving surfaces (A2A + async transports + TUI + REST).
-agent = ["goldenpipe[tui,api,agent]>=1.3"]
+agent = ["goldenpipe[tui,api,agent]>=1.4"]
 # Everything: full suite + native + MCP + serving.
 all = ["golden-suite[mcp,agent]"]
 dev = ["pytest>=8", "ruff>=0.6"]

--- a/packages/python/goldenanalysis/CHANGELOG.md
+++ b/packages/python/goldenanalysis/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to GoldenAnalysis are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.4.0] - 2026-07-16
+
+### Added
+
+- **Rust cutover Waves 2-3**: numeric reductions (mean/min/max) and the
+  cluster-size histogram run on the shared Rust core (anti-drift,
+  cross-surface parity fixtures for `quality_rollup`).
+- **Reference-mode gate** for the goldencheck + goldenanalysis native kernels.
+
+### Fixed
+
+- `_mean_pure` is Python-version-independent (naive sum).
+- Native `null_ratio` correct on all-null (Null dtype) columns.
+- TS frame kernels distinguish NaN from null (locked cross-surface).
+
 ## [0.3.0] - 2026-06-24
 
 The Rust accelerator goes live and GoldenAnalysis becomes an MCP server. (First published release since 0.1.0 — the 0.2.0 section below was staged but never tagged/published; its features ship here.)

--- a/packages/python/goldenanalysis/goldenanalysis/__init__.py
+++ b/packages/python/goldenanalysis/goldenanalysis/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "analyze",

--- a/packages/python/goldenanalysis/pyproject.toml
+++ b/packages/python/goldenanalysis/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenanalysis"
-version = "0.3.0"
+version = "0.4.0"
 description = "Read-only cross-cutting analysis, metrics, and reporting engine for the Golden Suite"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenanalysis/server.json
+++ b/packages/python/goldenanalysis/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenAnalysis",
   "description": "Read-only cross-cutting analysis, metrics, and reporting across the Golden Suite.",
   "websiteUrl": "https://github.com/benseverndev-oss/goldenmatch/tree/main/packages/python/goldenanalysis#readme",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenanalysis",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenanalysis/tests/test_smoke.py
+++ b/packages/python/goldenanalysis/tests/test_smoke.py
@@ -6,4 +6,4 @@ from __future__ import annotations
 def test_import_and_version() -> None:
     import goldenanalysis
 
-    assert goldenanalysis.__version__ == "0.3.0"
+    assert goldenanalysis.__version__ == "0.4.0"

--- a/packages/python/goldencheck-types/goldencheck_types/__init__.py
+++ b/packages/python/goldencheck-types/goldencheck_types/__init__.py
@@ -20,7 +20,7 @@ from goldencheck_types.types import (
     unmapped_cols,
 )
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = [
     "DetectionResult",
     "DomainPack",

--- a/packages/python/goldencheck-types/pyproject.toml
+++ b/packages/python/goldencheck-types/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldencheck-types"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared canonical field types for the Golden Suite"
 requires-python = ">=3.11"
 dependencies = ["pyyaml>=6.0"]

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to GoldenCheck will be documented in this file.
 
+## [3.2.0] - 2026-07-16
+
+### Fixed
+
+- **`EncodingDetectionProfiler` regex was silently dead on every column** (the
+  detection pattern never matched); mojibake/encoding-artifact detection now
+  fires.
+
+### Docs
+
+- 3.0.1-3.1.3 performance arc documented, `GOLDENCHECK_SCAN_THREADS` knob, and
+  the stale pure-Polars claim removed.
+
 ## [3.1.3] - 2026-07-12
 
 ### Performance

--- a/packages/python/goldencheck/goldencheck/__init__.py
+++ b/packages/python/goldencheck/goldencheck/__init__.py
@@ -1,7 +1,7 @@
 """GoldenCheck — data validation that discovers rules from your data."""
 from __future__ import annotations
 
-__version__ = "3.1.3"
+__version__ = "3.2.0"
 
 # Core: scanner + models
 from goldencheck.cell_quality import cell_quality

--- a/packages/python/goldencheck/pyproject.toml
+++ b/packages/python/goldencheck/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "goldencheck"
-version = "3.1.3"
+version = "3.2.0"
 description = "Data validation that discovers rules from your data so you don't have to write them"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldencheck/server.json
+++ b/packages/python/goldencheck/server.json
@@ -2,9 +2,9 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.benseverndev-oss/goldencheck",
   "title": "GoldenCheck",
-  "description": "Auto-discover validation rules from data — scan, profile, health-score. No rules to write.",
+  "description": "Auto-discover validation rules from data \u2014 scan, profile, health-score. No rules to write.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldencheck/",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldencheck",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldencheck",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-07-16
+
 <!-- README-callout
 **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
 `record_embedding` field scorers now train (EM) and score end-to-end on the
@@ -30,11 +32,35 @@ the same native/vectorized selector.
 - **Term-frequency (`tf_adjustment`) now applies on the scalar FS path**, matching
   the vectorized path — the same config no longer scores differently depending on
   route (a model-backed scorer or `GOLDENMATCH_FS_VECTORIZED=0` forces scalar).
-- **Distributed and chunked lanes fail loudly on probabilistic matchkeys.** An FS
-  matchkey routed through the distributed (`GOLDENMATCH_DISTRIBUTED_PIPELINE`) or
-  chunked lane previously contributed zero pairs silently; it now raises
-  `NotImplementedError` at lane entry. Run FS configs single-box (in-memory /
-  bucket backend).
+- **Distributed and chunked lanes score probabilistic matchkeys.** They
+  previously dropped FS pairs silently, then (mid-cycle) failed loudly. Both
+  lanes now score FS against ONE shared `EMResult`: the distributed driver
+  trains once before dispatch (or loads `mk.model_path` driver-side;
+  `GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS` bounds the training sample), and the
+  chunked lane trains once on the first chunk. The loud
+  `NotImplementedError` remains only for the bare scoring kernel invoked with
+  no model source.
+- **Memory-bounded FS scoring for strategy-generated blocks.** Probabilistic
+  matchkeys with `lsh` / `ann` / `learned` / `canopy` / `sorted_neighborhood`
+  blocking now score through `score_probabilistic_external_blocks` (one block
+  resident at a time, exclude-set Arc handle built once, oversized auto-split,
+  native/vectorized selection) instead of the batched scorer's all-units
+  accumulation. `GOLDENMATCH_FS_DEFAULT_BUCKET=0` still selects the legacy
+  batched scorer and now logs a warning (documented in tuning).
+- **The columnar opt-in no longer demotes FS to the batched path.** The
+  columnar branch is structurally weighted-only, so probabilistic matchkeys
+  keep the memory-bounded bucket route under `GOLDENMATCH_COLUMNAR_PIPELINE=1`.
+- **FS bucket lane auto-splits oversized blocks** (default
+  `skip_oversized=False` path) instead of scoring them whole, and the
+  vectorized scorer refuses impossible dense allocations with an actionable
+  error (`GOLDENMATCH_FS_VEC_MAX_ELEMS`).
+- **Missing values are unobserved evidence in FS scoring** (null field values
+  carry no likelihood contribution instead of folding into total disagreement);
+  persisted v1 models without a training manifest are rejected on reuse.
+- **Multi-pass EM conditions per pair and blocking fields keep the fixed
+  prior** (repairs a recall collapse on near-unique blocking fields).
+- **Per-field blocking transform chains** (`BlockingKeyConfig.field_transforms`);
+  the Splink converter maps mixed SUBSTR blocking rules exactly.
 
 ## [3.3.1] - 2026-07-15
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -57,7 +57,7 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
-> **Unreleased** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
+> **v3.4.0** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
 `record_embedding` field scorers now train (EM) and score end-to-end on the
 probabilistic path via the vectorized matrix — previously they raised
 `Unknown scorer` on both training and scoring. They are matrix-only, so a

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.3.1"
+__version__ = "3.4.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.3.1"
+version = "3.4.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.3.1",
+      "version": "3.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/CHANGELOG.md
+++ b/packages/python/goldenpipe/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## 1.4.0 (2026-07-16)
+
+### Added
+
+- **In-process moves**: pipeline stages scan the loaded frame and a one-run
+  `clean_and_dedupe` (no re-read of the source path mid-pipeline).
+- **Compiler SP1-SP3**: IR walking skeleton, field-level provenance from the
+  IR, and end-to-end field lineage.
+- **`run_pipeline` as an orchestration tool**: full result + inline input.
+- **`FusedDedupeStage`**: opt-in Arrow-native match stage (fused-match
+  increment 4).
+
 ### Fixed
 
 - **The `goldencheck.scan` stage now scans the in-memory frame** (`ctx.df` via

--- a/packages/python/goldenpipe/goldenpipe/__init__.py
+++ b/packages/python/goldenpipe/goldenpipe/__init__.py
@@ -1,5 +1,5 @@
 """GoldenPipe -- pluggable pipeline framework for data quality."""
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 
 from goldenpipe._api import run, run_df, run_stages
 from goldenpipe.config.loader import load_config

--- a/packages/python/goldenpipe/pyproject.toml
+++ b/packages/python/goldenpipe/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goldenpipe"
-version = "1.3.0"
+version = "1.4.0"
 description = "Pluggable pipeline framework for data quality workflows"
 readme = "README.md"
 license = {text = "MIT"}

--- a/packages/python/goldenpipe/server.json
+++ b/packages/python/goldenpipe/server.json
@@ -2,9 +2,9 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.benseverndev-oss/goldenpipe",
   "title": "GoldenPipe",
-  "description": "One command to validate, transform, and deduplicate — chain GoldenCheck + Flow + Match.",
+  "description": "One command to validate, transform, and deduplicate \u2014 chain GoldenCheck + Flow + Match.",
   "websiteUrl": "https://benseverndev-oss.github.io/goldenpipe/",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenpipe",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenpipe",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/python/goldenpipe/tests/test_pipeline.py
+++ b/packages/python/goldenpipe/tests/test_pipeline.py
@@ -56,4 +56,4 @@ class TestImports:
         assert hasattr(gp, "PipeResult")
         assert hasattr(gp, "stage")
         assert hasattr(gp, "__version__")
-        assert gp.__version__ == "1.3.0"
+        assert gp.__version__ == "1.4.0"

--- a/packages/python/infermap/CHANGELOG.md
+++ b/packages/python/infermap/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-16
+
 ### Added
 - **Compiled Rust scorer kernels** (`pip install infermap[native]`). The five scorers (exact, fuzzy-name, initialism, profile, pattern-type) and `detect_domain` now share a pyo3-free Rust core (`infermap-core`), wrapped by the abi3 `infermap-native` wheel. Under the default `INFERMAP_NATIVE=auto` the scorers auto-dispatch to the compiled kernels when the wheel is importable, else the pure-Python reference — byte-identical, CI parity-gated. `INFERMAP_NATIVE=1` requires native (raises if absent); `=0` forces pure Python.
 - **TypeScript WASM backend** — the same `infermap-core` kernels compiled to WASM (`infermap-wasm`), exposed as an opt-in backend via `enableInfermapWasm()`. Pure-TS stays the default + byte-identical fallback. The MCP servers enable it best-effort at startup and report the active backend through the `infermap://scorer-info` resource (Python: `native`/`pure-python`; TS: `wasm`/`pure-ts`).

--- a/packages/python/infermap/infermap/__init__.py
+++ b/packages/python/infermap/infermap/__init__.py
@@ -1,6 +1,6 @@
 """infermap — inference-driven schema mapping engine."""
 
-__version__ = "0.5.1"
+__version__ = "0.6.0"
 
 from infermap.config import from_config
 from infermap.detect import detect_domain, detect_domain_detailed

--- a/packages/python/infermap/pyproject.toml
+++ b/packages/python/infermap/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "infermap"
-version = "0.5.1"
+version = "0.6.0"
 description = "Inference-driven schema mapping engine"
 readme = "README.md"
 license = "MIT"

--- a/packages/python/infermap/server.json
+++ b/packages/python/infermap/server.json
@@ -2,9 +2,9 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.benseverndev-oss/infermap",
   "title": "InferMap",
-  "description": "Map messy columns to a known schema — 7 scorers, domain dictionaries, F1 0.84. Zero config.",
+  "description": "Map messy columns to a known schema \u2014 7 scorers, domain dictionaries, F1 0.84. Zero config.",
   "websiteUrl": "https://benseverndev-oss.github.io/infermap/",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/infermap",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "infermap",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"

--- a/packages/typescript/goldencheck-types/package.json
+++ b/packages/typescript/goldencheck-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck-types",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Shared TypeScript types and domain schemas for the goldencheck data-quality toolkit",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenpipe/package.json
+++ b/packages/typescript/goldenpipe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenpipe",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Golden Suite orchestrator — chains GoldenCheck, GoldenFlow, and GoldenMatch into one adaptive pipeline. TypeScript port of the goldenpipe Python library.",
   "keywords": [
     "pipeline",

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infermap",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Schema-to-schema field mapping engine. TypeScript port of the infermap Python library.",
   "keywords": [
     "schema",

--- a/uv.lock
+++ b/uv.lock
@@ -599,37 +599,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx" },
 ]
 
 [[package]]
@@ -908,7 +908,7 @@ wheels = [
 
 [[package]]
 name = "goldenanalysis"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/python/goldenanalysis" }
 dependencies = [
     { name = "polars" },
@@ -982,12 +982,12 @@ source = { directory = "packages/rust/extensions/analysis-native" }
 
 [[package]]
 name = "goldencheck"
-version = "1.4.1"
+version = "3.2.0"
 source = { editable = "packages/python/goldencheck" }
 dependencies = [
     { name = "goldencheck-types" },
     { name = "openpyxl" },
-    { name = "polars" },
+    { name = "pyarrow" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
@@ -1002,6 +1002,7 @@ agent = [
 ]
 baseline = [
     { name = "numpy" },
+    { name = "polars" },
     { name = "scipy" },
 ]
 db = [
@@ -1023,6 +1024,12 @@ native = [
     { name = "goldencheck-native" },
     { name = "pyarrow" },
 ]
+parquet = [
+    { name = "pyarrow" },
+]
+polars = [
+    { name = "polars" },
+]
 semantic = [
     { name = "sentence-transformers" },
 ]
@@ -1038,8 +1045,11 @@ requires-dist = [
     { name = "numpy", marker = "extra == 'baseline'", specifier = ">=1.26" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", specifier = ">=3.1" },
-    { name = "polars", specifier = ">=1.0" },
+    { name = "polars", marker = "extra == 'baseline'", specifier = ">=1.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0" },
+    { name = "pyarrow", specifier = ">=14" },
     { name = "pyarrow", marker = "extra == 'native'", specifier = ">=14" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=14" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -1052,7 +1062,7 @@ requires-dist = [
     { name = "textual", specifier = ">=1.0" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["dev", "llm", "db", "mcp", "agent", "baseline", "native", "semantic"]
+provides-extras = ["dev", "llm", "db", "mcp", "agent", "baseline", "native", "semantic", "parquet", "polars"]
 
 [[package]]
 name = "goldencheck-native"
@@ -1061,7 +1071,7 @@ source = { directory = "packages/rust/extensions/goldencheck-native" }
 
 [[package]]
 name = "goldencheck-types"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/python/goldencheck-types" }
 dependencies = [
     { name = "pyyaml" },
@@ -1081,12 +1091,12 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "goldenflow"
-version = "1.16.0"
+version = "2.1.0"
 source = { editable = "packages/python/goldenflow" }
 dependencies = [
     { name = "fastapi" },
+    { name = "goldenflow-native" },
     { name = "phonenumbers" },
-    { name = "polars" },
     { name = "pydantic" },
     { name = "python-dateutil" },
     { name = "python-multipart" },
@@ -1110,6 +1120,8 @@ all = [
     { name = "google-cloud-storage" },
     { name = "mcp" },
     { name = "openpyxl" },
+    { name = "polars" },
+    { name = "pyarrow" },
 ]
 check = [
     { name = "goldencheck" },
@@ -1138,8 +1150,13 @@ mcp = [
     { name = "mcp" },
 ]
 native = [
-    { name = "goldenflow-native" },
     { name = "pyarrow" },
+]
+parquet = [
+    { name = "pyarrow" },
+]
+polars = [
+    { name = "polars" },
 ]
 s3 = [
     { name = "boto3" },
@@ -1153,16 +1170,17 @@ requires-dist = [
     { name = "connectorx", marker = "extra == 'db'", specifier = ">=0.3" },
     { name = "fastapi", specifier = ">=0.110" },
     { name = "goldencheck", marker = "extra == 'check'", editable = "packages/python/goldencheck" },
-    { name = "goldenflow", extras = ["check", "excel", "db", "mcp", "agent", "s3", "gcs"], marker = "extra == 'all'", editable = "packages/python/goldenflow" },
-    { name = "goldenflow-native", marker = "extra == 'native'", directory = "packages/rust/extensions/native-flow" },
+    { name = "goldenflow", extras = ["check", "excel", "db", "mcp", "agent", "s3", "gcs", "polars", "parquet", "native"], marker = "extra == 'all'", editable = "packages/python/goldenflow" },
+    { name = "goldenflow-native", directory = "packages/rust/extensions/native-flow" },
     { name = "google-cloud-storage", marker = "extra == 'gcs'", specifier = ">=2.14" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.0" },
     { name = "openai", marker = "extra == 'llm'", specifier = ">=1.30" },
     { name = "openpyxl", marker = "extra == 'excel'", specifier = ">=3.1" },
     { name = "phonenumbers", specifier = ">=8.13" },
-    { name = "polars", specifier = ">=1.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0" },
     { name = "pyarrow", marker = "extra == 'native'", specifier = ">=10" },
+    { name = "pyarrow", marker = "extra == 'parquet'", specifier = ">=10" },
     { name = "pydantic", specifier = ">=2.7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -1177,11 +1195,11 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
-provides-extras = ["dev", "check", "excel", "db", "mcp", "llm", "s3", "gcs", "agent", "native", "all"]
+provides-extras = ["dev", "check", "polars", "excel", "parquet", "db", "mcp", "llm", "s3", "gcs", "agent", "native", "all"]
 
 [[package]]
 name = "goldenflow-native"
-version = "0.15.0"
+version = "0.27.0"
 source = { directory = "packages/rust/extensions/native-flow" }
 dependencies = [
     { name = "pyarrow" },
@@ -1192,7 +1210,7 @@ requires-dist = [{ name = "pyarrow", specifier = ">=10" }]
 
 [[package]]
 name = "goldenmatch"
-version = "2.8.0"
+version = "3.4.0"
 source = { editable = "packages/python/goldenmatch" }
 dependencies = [
     { name = "diptest" },
@@ -1201,7 +1219,6 @@ dependencies = [
     { name = "jellyfish" },
     { name = "numpy" },
     { name = "openpyxl" },
-    { name = "polars" },
     { name = "psutil" },
     { name = "pyarrow" },
     { name = "pydantic" },
@@ -1221,14 +1238,16 @@ all = [
     { name = "anthropic" },
     { name = "faiss-cpu" },
     { name = "fastapi" },
-    { name = "goldencheck" },
+    { name = "goldencheck", extra = ["polars"] },
     { name = "goldenflow" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "openai" },
     { name = "pillow" },
+    { name = "polars" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg-pool" },
+    { name = "python-multipart" },
     { name = "sentence-transformers" },
     { name = "soundfile" },
     { name = "uvicorn", extra = ["standard"] },
@@ -1301,13 +1320,16 @@ pgvector = [
     { name = "pgvector" },
     { name = "psycopg", extra = ["binary"] },
 ]
+polars = [
+    { name = "polars" },
+]
 postgres = [
     { name = "alembic" },
     { name = "psycopg", extra = ["binary"] },
     { name = "psycopg-pool" },
 ]
 quality = [
-    { name = "goldencheck" },
+    { name = "goldencheck", extra = ["polars"] },
 ]
 ray = [
     { name = "ray" },
@@ -1340,6 +1362,7 @@ vision = [
 web = [
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -1358,9 +1381,9 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'duckdb'", specifier = ">=0.9" },
     { name = "faiss-cpu", marker = "extra == 'embeddings'", specifier = ">=1.7" },
     { name = "fastapi", marker = "extra == 'web'", specifier = ">=0.110" },
-    { name = "goldencheck", marker = "extra == 'quality'", editable = "packages/python/goldencheck" },
+    { name = "goldencheck", extras = ["polars"], marker = "extra == 'quality'", editable = "packages/python/goldencheck" },
     { name = "goldenflow", marker = "extra == 'transform'", editable = "packages/python/goldenflow" },
-    { name = "goldenmatch", extras = ["embeddings", "llm", "postgres", "mcp", "quality", "transform", "web", "vision", "audio"], marker = "extra == 'all'", editable = "packages/python/goldenmatch" },
+    { name = "goldenmatch", extras = ["embeddings", "llm", "postgres", "mcp", "polars", "quality", "transform", "web", "vision", "audio"], marker = "extra == 'all'", editable = "packages/python/goldenmatch" },
     { name = "goldenmatch-native", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32') or sys_platform == 'darwin'", directory = "packages/rust/extensions/native" },
     { name = "goldenmatch-native", marker = "extra == 'native'", directory = "packages/rust/extensions/native" },
     { name = "google-cloud-bigquery", marker = "extra == 'bigquery'", specifier = ">=3.0" },
@@ -1378,7 +1401,7 @@ requires-dist = [
     { name = "pgvector", marker = "extra == 'pgvector'", specifier = ">=0.3" },
     { name = "pillow", marker = "extra == 'documents'", specifier = ">=10.0" },
     { name = "pillow", marker = "extra == 'vision'", specifier = ">=10.0" },
-    { name = "polars", specifier = ">=1.0" },
+    { name = "polars", marker = "extra == 'polars'", specifier = ">=1.0" },
     { name = "psutil", specifier = ">=5.9" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'pgvector'", specifier = ">=3.1" },
     { name = "psycopg", extras = ["binary"], marker = "extra == 'postgres'", specifier = ">=3.1" },
@@ -1395,6 +1418,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
+    { name = "python-multipart", marker = "extra == 'web'", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rapidfuzz", specifier = ">=3.0" },
     { name = "ray", marker = "extra == 'ray'", specifier = ">=2.0" },
@@ -1410,7 +1434,7 @@ requires-dist = [
     { name = "typer", specifier = ">=0.12" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'web'", specifier = ">=0.29" },
 ]
-provides-extras = ["dev", "embeddings", "vision", "documents", "audio", "inhouse-embeddings", "llm", "postgres", "mcp", "pprl", "snowflake", "bigquery", "databricks", "salesforce", "redshift", "s3", "gcs", "azure-blob", "sqlserver", "mysql", "duckdb", "pgvector", "ray", "datafusion", "sail", "agent", "quality", "transform", "native", "lance", "llama", "web", "bench", "all"]
+provides-extras = ["dev", "embeddings", "vision", "documents", "audio", "inhouse-embeddings", "llm", "postgres", "mcp", "pprl", "snowflake", "bigquery", "databricks", "salesforce", "redshift", "s3", "gcs", "azure-blob", "sqlserver", "mysql", "duckdb", "pgvector", "ray", "datafusion", "sail", "agent", "polars", "quality", "transform", "native", "lance", "llama", "web", "bench", "all"]
 
 [[package]]
 name = "goldenmatch-monorepo"
@@ -1447,12 +1471,12 @@ dev = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.12"
+version = "0.1.17"
 source = { directory = "packages/rust/extensions/native" }
 
 [[package]]
 name = "goldenpipe"
-version = "1.3.0"
+version = "1.4.0"
 source = { editable = "packages/python/goldenpipe" }
 dependencies = [
     { name = "goldencheck-types" },
@@ -1550,7 +1574,7 @@ provides-extras = ["check", "flow", "match", "analysis", "golden-suite", "tui", 
 
 [[package]]
 name = "goldensuite-mcp"
-version = "0.3.0"
+version = "0.5.0"
 source = { editable = "packages/python/goldensuite-mcp" }
 dependencies = [
     { name = "goldenanalysis", extra = ["mcp"] },
@@ -1972,7 +1996,7 @@ wheels = [
 
 [[package]]
 name = "infermap"
-version = "0.5.1"
+version = "0.6.0"
 source = { editable = "packages/python/infermap" }
 dependencies = [
     { name = "goldencheck-types" },


### PR DESCRIPTION
Release-prep for the 2026-07-16 suite minor train: every package with unreleased work gets a minor bump, all version-bearing files in lockstep (`scripts/check_version_consistency.py` green), `uv.lock` refreshed.

| package | from | to |
|---|---|---|
| goldenmatch (py) | 3.3.1 | 3.4.0 |
| goldenmatch-js | 1.3.0 | 1.4.0 |
| goldencheck (py) | 3.1.3 | 3.2.0 |
| goldencheck-js | 0.4.0 | 0.5.0 |
| goldenpipe (py) | 1.3.0 | 1.4.0 |
| goldenpipe-js | 0.2.0 | 0.3.0 |
| infermap (py) | 0.5.1 | 0.6.0 |
| infermap-js | 0.5.0 | 0.6.0 |
| goldenanalysis (py) | 0.3.0 | 0.4.0 |
| goldencheck-types (py + js) | 0.1.0 | 0.2.0 |
| golden-suite | 0.2.5 | 0.3.0 (floors raised) |

Not bumped here (already carry unreleased in-tree versions; they release at those versions once this lands): goldenmatch-native 0.1.17, goldensuite-mcp 0.5.0, goldenmatch-pg 0.13.0, goldenflow-native 0.27.0.

Skipped (no unreleased changes / dev-deps only): goldenflow py (0 commits since 2.1.0), goldenflow-js (one dev-deps bump).

Headline unreleased work riding this train: goldenmatch FS scale program (#1806/#1808/#1810/#1829/#1831 + the exclusions pass #1842/#1843/#1844, EM missing-evidence #1834, multi-pass EM #1835/#1836, learned-blocking compiler #1840/#1841), goldencheck-types 4->16 domain packs, goldencheck EncodingDetectionProfiler fix, goldensuite-mcp curated tool list.

Tags/releases are cut after this merges (bare v3.4.0 push for goldenmatch; -js tags pushed; gh-release-created for the release-triggered workflows).
