### PR TITLE
fix(#1846): FS missing-value semantics are toggleable; auto-config picks per-dataset

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -360,6 +360,25 @@ class MatchkeyConfig(BaseModel):
     # Ignored for non-probabilistic matchkeys. See core/probabilistic.py
     # load_or_train_em.
     model_path: str | None = None
+    # Probabilistic-only: how a missing value on either side of a comparison is
+    # treated (#1846).
+    #
+    #   "unobserved" (default, #1819/#1834) -- textbook Fellegi-Sunter: a missing
+    #       value is absence of evidence and contributes nothing either way.
+    #   "disagree" -- a missing value is evidence AGAINST a match (level 0), the
+    #       pre-#1834 behavior.
+    #
+    # Neither is universally right; it depends on whether missingness is
+    # INFORMATIVE in the data. When missing-not-at-random (a record lacking a DOB
+    # is systematically unlike one that has it), "disagree" is the better model
+    # and "unobserved" over-merges: measured on historical_50k (8.9-50% nulls
+    # across FS fields), "unobserved" costs f1_probabilistic 0.83 -> 0.33.
+    # On clean data (febrl3, ncvr_synthetic) the two are indistinguishable.
+    #
+    # auto_configure_probabilistic_df picks this from the profiled null rates;
+    # GOLDENMATCH_FS_MISSING overrides globally. Ignored for non-probabilistic
+    # matchkeys.
+    missing: Literal["unobserved", "disagree"] | None = None
 
     @model_validator(mode="after")
     def _validate_weighted(self) -> MatchkeyConfig:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -11,7 +11,7 @@ from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from goldenmatch._polars_lazy import pl
 
@@ -4731,7 +4731,7 @@ _FS_MISSING_DISAGREE_NULL_RATE = 0.20
 
 def _pick_missing_semantics(
     profiles: list[ColumnProfile], fields: list[MatchkeyField]
-) -> str:
+) -> Literal["unobserved", "disagree"]:
     """Choose FS missing-value semantics from the profiled null rates (#1846).
 
     Textbook Fellegi-Sunter treats a missing value as UNOBSERVED -- absence of
@@ -4756,7 +4756,9 @@ def _pick_missing_semantics(
     if not rates:
         return "unobserved"
     worst = max(rates)
-    mode = "disagree" if worst >= _FS_MISSING_DISAGREE_NULL_RATE else "unobserved"
+    mode: Literal["unobserved", "disagree"] = (
+        "disagree" if worst >= _FS_MISSING_DISAGREE_NULL_RATE else "unobserved"
+    )
     logger.info(
         "FS missing-value semantics: %s (max comparison-field null rate %.1f%%, "
         "cut %.0f%%)", mode, worst * 100, _FS_MISSING_DISAGREE_NULL_RATE * 100,

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4716,7 +4716,52 @@ def build_probabilistic_matchkeys(profiles: list[ColumnProfile]) -> list[Matchke
         name="probabilistic_auto",
         type="probabilistic",
         fields=fields,
+        missing=_pick_missing_semantics(profiles, fields),
     )]
+
+
+#: A comparison field at or above this null rate makes missingness a strong
+#: enough signal to model as disagreement rather than absence of evidence.
+#: Calibrated against the quality corpora, not derived: historical_50k's FS
+#: fields run 8.9-50% null and need "disagree" (0.83 vs 0.33 f1_probabilistic);
+#: febrl3 / ncvr_synthetic are near-complete and score the same either way, so
+#: the cut only has to separate those two populations. 0.20 sits in the gap.
+_FS_MISSING_DISAGREE_NULL_RATE = 0.20
+
+
+def _pick_missing_semantics(
+    profiles: list[ColumnProfile], fields: list[MatchkeyField]
+) -> str:
+    """Choose FS missing-value semantics from the profiled null rates (#1846).
+
+    Textbook Fellegi-Sunter treats a missing value as UNOBSERVED -- absence of
+    evidence, contributing nothing (#1819/#1834). That is correct when data is
+    missing at random. It is wrong when missingness is INFORMATIVE: if records
+    lacking a DOB are systematically unlike records that have one, "no evidence"
+    lets a pair agreeing on its one populated field look like a certain match,
+    and null-heavy data mass-merges (historical_50k: 0.83 -> 0.33).
+
+    We cannot test informativeness directly -- that needs labels auto-config does
+    not have. Null rate is a PROXY: heavily-null columns in real-world PII are
+    usually missing-not-at-random. This can therefore pick wrong on a null-heavy
+    but genuinely-random dataset; ``GOLDENMATCH_FS_MISSING`` and the explicit
+    ``MatchkeyConfig.missing`` are the escape hatches.
+    """
+    by_name = {p.name: p for p in profiles}
+    rates = [
+        by_name[f.field].null_rate
+        for f in fields
+        if f.field in by_name and by_name[f.field].null_rate is not None
+    ]
+    if not rates:
+        return "unobserved"
+    worst = max(rates)
+    mode = "disagree" if worst >= _FS_MISSING_DISAGREE_NULL_RATE else "unobserved"
+    logger.info(
+        "FS missing-value semantics: %s (max comparison-field null rate %.1f%%, "
+        "cut %.0f%%)", mode, worst * 100, _FS_MISSING_DISAGREE_NULL_RATE * 100,
+    )
+    return mode
 
 
 def auto_configure_probabilistic_df(

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -75,6 +75,33 @@ def _fs_calibration_mode() -> str:
     return _FS_CALIBRATION_DEFAULT
 
 
+_FS_MISSING_DEFAULT = "unobserved"
+
+
+def fs_missing_mode(mk: MatchkeyConfig | None = None) -> str:
+    """Resolve missing-value semantics: 'unobserved' or 'disagree' (#1846).
+
+    Precedence: GOLDENMATCH_FS_MISSING env > mk.missing > default.
+
+    'unobserved' (#1819/#1834) is textbook Fellegi-Sunter -- a missing value is
+    absence of evidence. 'disagree' (pre-#1834) treats it as evidence against a
+    match. Which is correct depends on whether missingness is INFORMATIVE in the
+    data, so auto-config picks per-dataset from the profiled null rates rather
+    than the library imposing one globally. See MatchkeyConfig.missing.
+    """
+    val = os.environ.get("GOLDENMATCH_FS_MISSING")
+    if val is not None:
+        v = val.strip().lower()
+        if v in ("disagree", "level0", "0"):
+            return "disagree"
+        if v in ("unobserved", "skip", "1"):
+            return "unobserved"
+    cfg = getattr(mk, "missing", None) if mk is not None else None
+    if cfg in ("unobserved", "disagree"):
+        return cfg
+    return _FS_MISSING_DEFAULT
+
+
 def prior_weight(proportion_matched: float) -> float:
     """log2 prior odds of a match: log2(λ / (1-λ)).
 
@@ -439,7 +466,8 @@ def comparison_vector(
             s = score_field(val_a, val_b, f.scorer)
 
         if s is None:
-            levels.append(-1)
+            # #1846: -1 (unobserved, no evidence) or 0 (disagree) per mk.missing.
+            levels.append(-1 if fs_missing_mode(mk) == "unobserved" else 0)
         elif f.level_thresholds is not None:
             level = 0
             for t in f.level_thresholds:
@@ -2551,6 +2579,7 @@ def score_probabilistic_vectorized(
     _fs_vec_guard(n, "score_probabilistic_vectorized")
 
     calibrated = _fs_calibration_mode() == "posterior"
+    _missing_mode = fs_missing_mode(mk)  # #1846
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
 
     ne_min_weight, ne_max_weight = _fs_ne_weight_range(em_result, mk)
@@ -2595,7 +2624,13 @@ def score_probabilistic_vectorized(
             sim, int(f.levels), float(f.partial_threshold), level_thresholds=f.level_thresholds
         )
         null_mask = np.array([v is None for v in vals], dtype=bool)
+        # #1846: under "disagree", a missing value is evidence AGAINST a match
+        # (level 0) rather than absence of evidence, so it stays "observed" and
+        # `lvl` is forced to 0 -- the pre-#1834 semantics, selected per-dataset.
         observed = ~(null_mask[:, None] | null_mask[None, :])
+        if _missing_mode == "disagree":
+            lvl = np.where(observed, lvl, 0)
+            observed = np.ones_like(observed, dtype=bool)
         has_regular_evidence |= observed
         total_weight += np.where(observed, weights[lvl], 0.0)
         pair_min_weight += np.where(observed, float(weights.min()), 0.0)
@@ -2701,6 +2736,7 @@ def score_probabilistic_vectorized_batch(
     _fs_vec_guard(S, "score_probabilistic_vectorized_batch")
 
     calibrated = _fs_calibration_mode() == "posterior"
+    _missing_mode = fs_missing_mode(mk)  # #1846
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
     ne_min_weight, ne_max_weight = _fs_ne_weight_range(em_result, mk)
     if mk.link_threshold is not None:
@@ -2722,7 +2758,13 @@ def score_probabilistic_vectorized_batch(
             sim, int(f.levels), float(f.partial_threshold), level_thresholds=f.level_thresholds
         )
         null_mask = np.array([v is None for v in vals], dtype=bool)
+        # #1846: under "disagree", a missing value is evidence AGAINST a match
+        # (level 0) rather than absence of evidence, so it stays "observed" and
+        # `lvl` is forced to 0 -- the pre-#1834 semantics, selected per-dataset.
         observed = ~(null_mask[:, None] | null_mask[None, :])
+        if _missing_mode == "disagree":
+            lvl = np.where(observed, lvl, 0)
+            observed = np.ones_like(observed, dtype=bool)
         has_regular_evidence |= observed
         total_weight += np.where(observed, weights[lvl], 0.0)
         pair_min_weight += np.where(observed, float(weights.min()), 0.0)

--- a/packages/python/goldenmatch/tests/test_fs_missing_semantics_1846.py
+++ b/packages/python/goldenmatch/tests/test_fs_missing_semantics_1846.py
@@ -1,0 +1,137 @@
+"""Issue #1846 -- FS missing-value semantics are toggleable and auto-config picks.
+
+#1819/#1834 made a missing value UNOBSERVED (absence of evidence) rather than
+disagreement. That is textbook Fellegi-Sunter and correct when data is missing
+at random -- but wrong when missingness is INFORMATIVE. On historical_50k
+(8.9-50% null across comparison fields) it let pairs agreeing on their few
+populated fields look certain, and f1_probabilistic collapsed 0.83 -> 0.33.
+
+Neither semantics is universally right, so the library stops imposing one:
+``MatchkeyConfig.missing`` selects, ``GOLDENMATCH_FS_MISSING`` overrides, and
+auto-config picks per-dataset from the profiled null rates.
+
+Measured on the quality corpora (scripts/autoconfig_quality):
+  historical_50k  f1_probabilistic  0.3335 -> 0.8284  (== the pre-#1834 value)
+  febrl3 / ncvr_synthetic           unchanged (clean data -> picks "unobserved")
+"""
+
+from __future__ import annotations
+
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.probabilistic import comparison_vector, fs_missing_mode
+
+
+def _mk(missing=None) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="a", scorer="jaro_winkler", levels=3),
+            MatchkeyField(field="b", scorer="jaro_winkler", levels=3),
+        ],
+        missing=missing,
+    )
+
+
+class TestModeResolution:
+    def test_defaults_to_unobserved(self):
+        """#1819/#1834's semantics stay the default -- existing configs unchanged."""
+        assert fs_missing_mode(_mk()) == "unobserved"
+        assert fs_missing_mode(None) == "unobserved"
+
+    def test_config_selects(self):
+        assert fs_missing_mode(_mk("disagree")) == "disagree"
+        assert fs_missing_mode(_mk("unobserved")) == "unobserved"
+
+    @pytest.mark.parametrize("val,want", [
+        ("disagree", "disagree"), ("level0", "disagree"), ("0", "disagree"),
+        ("unobserved", "unobserved"), ("skip", "unobserved"), ("1", "unobserved"),
+        ("DISAGREE", "disagree"), ("  disagree  ", "disagree"),
+    ])
+    def test_env_override(self, monkeypatch, val, want):
+        monkeypatch.setenv("GOLDENMATCH_FS_MISSING", val)
+        assert fs_missing_mode(_mk("unobserved")) == want  # env beats config
+
+    def test_unknown_env_falls_back_to_config(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "banana")
+        assert fs_missing_mode(_mk("disagree")) == "disagree"
+
+
+class TestComparisonVector:
+    """The semantics difference, at the one place it originates."""
+
+    A = {"a": "smith", "b": None}   # b missing on one side
+    B = {"a": "smith", "b": "x"}
+
+    def test_unobserved_emits_minus_one(self):
+        vec = comparison_vector(self.A, self.B, _mk("unobserved"))
+        assert vec[0] == 2, "a agrees exactly"
+        assert vec[1] == -1, "b unobserved: carries no evidence (#1819)"
+
+    def test_disagree_emits_level_zero(self):
+        vec = comparison_vector(self.A, self.B, _mk("disagree"))
+        assert vec[0] == 2
+        assert vec[1] == 0, "b missing: evidence AGAINST a match (pre-#1834)"
+
+    def test_both_present_is_identical_under_both(self):
+        """The toggle must ONLY affect missing comparisons -- observed pairs are
+        untouched, which is why clean corpora (febrl3/ncvr) don't move."""
+        a, b = {"a": "smith", "b": "x"}, {"a": "smith", "b": "y"}
+        assert comparison_vector(a, b, _mk("unobserved")) == \
+               comparison_vector(a, b, _mk("disagree"))
+
+    def test_env_reaches_the_vector(self, monkeypatch):
+        monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "disagree")
+        assert comparison_vector(self.A, self.B, _mk("unobserved"))[1] == 0
+
+
+class TestAutoConfigPicks:
+    """auto-config chooses from the profiled null rates. The cut is calibrated
+    against the corpora, not derived -- see _pick_missing_semantics."""
+
+    @staticmethod
+    def _profiles(rates: dict[str, float]):
+        from goldenmatch.core.autoconfig import ColumnProfile
+        return [
+            ColumnProfile(
+                name=n, dtype="str", col_type="name", confidence=0.9,
+                null_rate=r, cardinality_ratio=0.9,
+            )
+            for n, r in rates.items()
+        ]
+
+    @staticmethod
+    def _fields(names):
+        return [MatchkeyField(field=n, scorer="jaro_winkler") for n in names]
+
+    def test_null_heavy_picks_disagree(self):
+        """historical_50k's shape: occupation 50% null, dob 22.5%."""
+        from goldenmatch.core.autoconfig import _pick_missing_semantics
+        got = _pick_missing_semantics(
+            self._profiles({"first_name": 0.001, "dob": 0.225, "occupation": 0.50}),
+            self._fields(["first_name", "dob", "occupation"]),
+        )
+        assert got == "disagree"
+
+    def test_clean_data_keeps_unobserved(self):
+        """febrl3 / ncvr_synthetic: near-complete -> textbook FS semantics."""
+        from goldenmatch.core.autoconfig import _pick_missing_semantics
+        got = _pick_missing_semantics(
+            self._profiles({"first_name": 0.001, "surname": 0.01, "dob": 0.02}),
+            self._fields(["first_name", "surname", "dob"]),
+        )
+        assert got == "unobserved"
+
+    def test_worst_field_decides_not_the_mean(self):
+        """One heavily-null comparison field is enough to make missingness
+        informative; averaging would let clean fields mask it."""
+        from goldenmatch.core.autoconfig import _pick_missing_semantics
+        got = _pick_missing_semantics(
+            self._profiles({"a": 0.0, "b": 0.0, "c": 0.0, "d": 0.45}),
+            self._fields(["a", "b", "c", "d"]),
+        )
+        assert got == "disagree"
+
+    def test_no_profile_match_is_safe(self):
+        from goldenmatch.core.autoconfig import _pick_missing_semantics
+        assert _pick_missing_semantics([], self._fields(["x"])) == "unobserved"


### PR DESCRIPTION
Fixes #1846. `historical_50k f1_probabilistic` **0.3335 -> 0.8284** (the pre-#1834 value). Clean corpora unchanged. **The full quality gate goes PASS.**

## What broke

#1834 (*"treat missing values as unobserved"*, completing #1819) made a missing value carry **no evidence** instead of counting as disagreement. That is textbook Fellegi-Sunter, and correct when data is missing at random.

It is wrong when missingness is **informative**. On `historical_50k` (8.9-50% null across comparison fields), a pair agreeing on its few populated fields looks certain -> the dataset mass-merges -> 0.83 -> 0.33. Recall-only in character: nothing else moves, no error, no warning.

Bisected to `ec6ea0e48` (#1834). `db6b7f367` (#1836) immediately before it scores **0.8284**.

**EM is not implicated.** Weights and lambda are near-identical either side of the commit — lambda was *already* 0.867 pre-#1834, at F1 0.8284. The entire delta is the scoring treatment of missing values.

## The fix

Neither semantics is universally right, so the library stops imposing one.

| | |
|---|---|
| `MatchkeyConfig.missing` | `"unobserved"` \| `"disagree"` \| `None` — default `None` -> `"unobserved"`, so **existing configs are byte-unchanged** |
| `GOLDENMATCH_FS_MISSING` | global override — same shape as the existing `GOLDENMATCH_FS_CALIBRATED` / `FS_MONOTONIC` knobs |
| both scoring paths | scalar `comparison_vector` (`-1` vs `0`) and the two vectorized sites (force `lvl=0`, keep the pair `observed` == pre-#1834) |
| `_pick_missing_semantics` | auto-config reads the profiled `null_rate` of the **comparison** fields, picks `disagree` at >= 20% |

## Measured (full gate)

```
historical_50k  f1_probabilistic  0.3335 -> 0.8284   PASS   (auto-picked "disagree")
febrl3          f1_probabilistic  0.9885 -> 0.9885   unchanged
ncvr_synthetic  f1_probabilistic  0.9899 -> 0.9899   unchanged
anchor / f1                                          unchanged
verdict: PASS  (was FAIL)
```

Clean corpora are untouched **by construction**: the toggle only affects *missing* comparisons — observed pairs score identically under both modes (pinned by `test_both_present_is_identical_under_both`).

## Honest limits

- **The 20% cut is calibrated, not derived.** It only has to separate `historical_50k` (needs `disagree`) from febrl3/ncvr (indifferent). 0.20 sits in the gap.
- **Null rate is a proxy for informativeness.** The real condition is missing-not-at-random, which needs labels auto-config doesn't have. A null-heavy but genuinely-random dataset would be picked wrong — hence two escape hatches. Documented at the constant, the function, and the tests.
- **Uses `max`, not `mean`.** One heavily-null comparison field is enough to make missingness informative; averaging lets clean fields mask it. Debatable — stated so it can be argued with.

## Tests

`tests/test_fs_missing_semantics_1846.py` — 19 tests: default unchanged, env-beats-config precedence, both `comparison_vector` branches, observed-pairs-identical-under-both, and auto-config picking correctly at both ends of the null-rate range.

## Not included (deliberately)

A **separate real bug** found en route: under `"unobserved"`, the score is min-max normalized over the **observed fields only**, so a pair agreeing on its single observed field normalizes to **1.0** — maximal confidence from minimal evidence. Fixing that alone moves `historical_50k` 0.33 -> 0.59, but it costs febrl3 0.9885 -> 0.9868 and is **inert** once auto-config routes null-heavy data to `disagree`. Parked on `fix/1846-normalization-range`; it deserves its own issue and evidence rather than riding in on a regression fix.

## Verification

- new tests: 19 passed
- FS/probabilistic/autoconfig sweep: **1321 passed**
- full-package `ruff check`: clean
- 3 sweep failures are pre-existing (`test_autoconfig_benchmarks.py`, `FileNotFoundError` — benchmark CSVs absent locally); reproduced on trees without this change

> Note: #1834's `quality_gate` never ran (the filter didn't list `probabilistic.py`) — #1847 fixes that class of hole and is what surfaced this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9