### PR TITLE
fix(test): pin run_name in test_frame_lane_file_outputs_and_lineage (timestamp flake)

### DIFF
--- a/packages/python/goldenmatch/tests/test_spine_dual_rep.py
+++ b/packages/python/goldenmatch/tests/test_spine_dual_rep.py
@@ -467,7 +467,16 @@ def test_frame_lane_file_outputs_and_lineage(tmp_path, monkeypatch):
     for lane, envval in (("frame", None), ("classic", "0")):
         d = tmp_path / lane
         cfg = GoldenMatchConfig(
-            **cfg_kw, output=OutputConfig(directory=str(d), format="csv")
+            # Pin run_name: without it the pipeline names outputs
+            # `datetime.now().strftime("%Y%m%d_%H%M%S")` (pipeline.py ~3723).
+            # This test runs the two lanes SEQUENTIALLY and then compares
+            # filenames -- so whenever the two runs straddle a second boundary
+            # the names differ and `set(outs["frame"]) == set(outs["classic"])`
+            # fails. A race against the wall clock, so it fires at a rate set by
+            # runner load (seen on CI; passes locally where both lanes land in
+            # the same second). run_name is the built-in override; the lanes
+            # write to separate directories so a shared name is unambiguous.
+            **cfg_kw, output=OutputConfig(directory=str(d), format="csv", run_name="lane")
         )
         if envval is not None:
             monkeypatch.setenv("GOLDENMATCH_FRAME_LANE", envval)


### PR DESCRIPTION
A test that races the wall clock. Fires at a rate set by runner load.

## The flake

`test_frame_lane_file_outputs_and_lineage` runs the frame and classic lanes **sequentially**, then asserts their output **filenames** match:

```python
for lane, envval in (("frame", None), ("classic", "0")):
    P.run_dedupe(...)
    outs[lane] = {f.name: f.read_bytes() for f in sorted(d.glob("*")) ...}
assert set(outs["frame"]) == set(outs["classic"])
```

Without an explicit `run_name`, the pipeline names outputs from the wall clock (`pipeline.py` ~3723):

```python
run_name = config.output.run_name or datetime.now().strftime("%Y%m%d_%H%M%S")
```

**Second resolution.** If the two runs straddle a second boundary, the names differ and the assert fails. Passes locally (both lanes land inside the same second); fails on a loaded runner.

Caught on #1851, whose diff (FS missing-value semantics) **cannot** touch this lane -- it never builds an FS matchkey. That is the cost of this flake: it makes an unrelated PR look broken, which is exactly the noise that makes a real red gate hard to trust.

## The fix

`run_name` is the built-in override; the test simply never set it. The lanes write to separate directories, so a shared name is unambiguous.

## Measured (not "passed on retry")

```
run_name='lane'  -> timestamped_names=0/3   e.g. lane_dupes.csv
run_name=None    -> timestamped_names=3/3   e.g. 20260717_011539_dupes.csv
```

The timestamp is gone entirely, so the test is boundary-immune **by construction**. `test_spine_dual_rep.py`: 31 passed.

## Scope

Only this test sets up the cross-lane filename comparison (it is the sole `OutputConfig(` site in the file), so this is the only instance of the pattern here. Test-only change; no production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9