### PR TITLE
fix(bucket): filter invalid block keys, like the blocker already does (null mega-block)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -1447,13 +1447,41 @@ def score_buckets(
             from goldenmatch.core.frame import to_frame as _tf
 
             _slim_frame = _tf(slim_df)
-            keyed = _slim_frame.with_column(
-                "__block_key__",
-                _slim_frame.derive_block_key(
-                    key.fields, key.transforms or [],
-                    field_transforms=getattr(key, "field_transforms", None),
-                ),
-            ).native
+            keyed = (
+                _slim_frame.with_column(
+                    "__block_key__",
+                    _slim_frame.derive_block_key(
+                        key.fields, key.transforms or [],
+                        field_transforms=getattr(key, "field_transforms", None),
+                    ),
+                )
+                # A null block key means "this row CANNOT be blocked" -- NOT "this
+                # row blocks with every other unblockable row". Without this, every
+                # null-key row hashes into ONE bucket and is scored against every
+                # other: on the ER person shape at 1M that is 9,846 rows -> 48.5M
+                # comparisons, while the largest LEGITIMATE postcode block is 25.
+                #
+                # Measured cost of NOT filtering (1M person):
+                #   wall 31.81s -> 21.44s; FP 8,682 -> 111 (precision .9626 -> .9995)
+                #   recall .9319 -> .9315 (the null block gave +81 TP / +8,571 FP)
+                # One kernel call took 20.482s of 22.669s: 256 buckets across 12
+                # workers all serialized behind that single straggler.
+                #
+                # This is build_blocks' own guard -- it filters the derived key the
+                # same way: drop null + the nan/null/none stringified-missing
+                # sentinels, keep "" (#390).
+                #
+                # KNOWN GAP (pre-existing, not introduced here): an empty-string key
+                # arrives here ALREADY NULL (something upstream in prepare nulls
+                # ""), so filter_valid_key's keep-"" branch is unreachable on this
+                # path and ""-keyed rows drop with the true nulls. Before this filter
+                # they matched via the null mega-block -- #390's intent met by
+                # accident, at the cost of the FP/perf blowup above. Preserving
+                # ""-vs-null through prepare is a separate fix; pinned as an
+                # xfail(strict) in tests/test_bucket_null_block_key.py.
+                .filter_valid_key("__block_key__")
+                .native
+            )
             if _bkt_debug_on():
                 print(f"[score_buckets] t={time.perf_counter()-_t0:.2f}s: keyed (with_columns key_expr) in {time.perf_counter()-_ta:.2f}s", flush=True)
 

--- a/packages/python/goldenmatch/tests/test_bucket_null_block_key.py
+++ b/packages/python/goldenmatch/tests/test_bucket_null_block_key.py
@@ -1,0 +1,138 @@
+"""The bucket scorer must filter invalid block keys, like the blocker does.
+
+``build_blocks`` derives ``__block_key__`` and then filters it
+(``is_not_null`` + the ``nan``/``null``/``none`` stringified-missing sentinels,
+keeping ``""`` -- the #390 semantics). ``score_buckets`` derived the key and
+NEVER filtered, so every row with a NULL blocking key collapsed into one hash
+bucket and was compared against every other such row.
+
+Measured on the ER head-to-head person shape at 1M (9,846 rows carry a null
+postcode; the largest LEGITIMATE postcode block is 25 rows):
+
+    without the filter:  wall 31.81s  TP 223,575  FP 8,682  precision 0.9626
+    with the filter:     wall 21.44s  TP 223,494  FP   111  precision 0.9995
+
+The null block contributed +81 TP and +8,571 FP -- its output was 99% false. It
+also cost ~20s of the ~40s dedupe: one 9,846-row block is 48.5M comparisons, and
+with 256 buckets over 12 workers the whole scoring stage serialized behind that
+single straggler (slowest kernel call 20.482s of 22.669s total).
+
+A null blocking key means "this row cannot be blocked", not "this row belongs
+with every other unblockable row".
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.blocker import build_blocks
+
+
+def _cfg(backend: str) -> GoldenMatchConfig:
+    cfg = GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="person",
+                type="weighted",
+                threshold=0.85,
+                fields=[
+                    MatchkeyField(field="first_name", scorer="jaro_winkler", weight=0.5),
+                    MatchkeyField(field="surname", scorer="jaro_winkler", weight=0.5),
+                ],
+            )
+        ],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["postcode"])]),
+    )
+    object.__setattr__(cfg, "backend", backend)
+    return cfg
+
+
+def _pairs(df: pl.DataFrame, backend: str) -> set[tuple[int, int]]:
+    import goldenmatch
+
+    res = goldenmatch.dedupe_df(df, config=_cfg(backend))
+    clusters = res.clusters if hasattr(res, "clusters") else res
+    out: set[tuple[int, int]] = set()
+    for _cid, c in clusters.items():
+        members = c["members"] if isinstance(c, dict) else c.members
+        for pr in itertools.combinations(sorted(members), 2):
+            out.add(pr)
+    return out
+
+
+# Rows 0,1: identical names, BOTH postcodes NULL -> unblockable, must not pair.
+# Rows 2,3: identical names AND a shared real postcode -> must pair (control).
+NULLKEY_DF = pl.DataFrame(
+    [
+        {"record_id": 0, "first_name": "john", "surname": "smith", "postcode": None},
+        {"record_id": 1, "first_name": "john", "surname": "smith", "postcode": None},
+        {"record_id": 2, "first_name": "mary", "surname": "jones", "postcode": "AB1 2CD"},
+        {"record_id": 3, "first_name": "mary", "surname": "jones", "postcode": "AB1 2CD"},
+    ]
+)
+
+
+class TestBlockerIsTheContract:
+    """build_blocks already filters invalid keys; that defines the behavior."""
+
+    def test_blocker_drops_null_key_rows(self):
+        blocks = build_blocks(
+            NULLKEY_DF.with_row_index("__row_id__").lazy(),
+            _cfg("bucket").blocking,
+        )
+        members = {
+            tuple(sorted(b.materialize().native["__row_id__"].to_list())) for b in blocks
+        }
+        assert members == {(2, 3)}, (
+            "the null-postcode rows must not form a block; only the real key does"
+        )
+
+
+class TestBucketScorerMatchesTheBlocker:
+    @pytest.mark.parametrize("backend", ["bucket", "polars-direct"])
+    def test_null_key_rows_are_not_compared(self, backend):
+        """The regression: rows with a NULL block key collapsed into one bucket
+        and were scored against each other. At 1M that was 9,846 rows -> 48.5M
+        comparisons -> 8,571 false positives and ~20s."""
+        pairs = _pairs(NULLKEY_DF, backend)
+        assert (0, 1) not in pairs, (
+            f"{backend}: rows with a NULL blocking key were compared to each other -- "
+            f"a null key means 'cannot be blocked', not 'blocks with every other null'"
+        )
+
+    @pytest.mark.parametrize("backend", ["bucket", "polars-direct"])
+    def test_real_key_rows_still_match(self, backend):
+        """Guard the other side: filtering null keys must not drop real blocks."""
+        assert (2, 3) in _pairs(NULLKEY_DF, backend)
+
+    @pytest.mark.xfail(
+        reason="KNOWN GAP (pre-existing): an empty-string key reaches the bucket "
+               "scorer ALREADY NULL -- something upstream in prepare nulls \"\" -- so "
+               "it cannot be told apart from a real null here and is dropped with "
+               "them. Before the null filter these rows matched via the null "
+               "mega-block, i.e. #390's intent was met by accident at the cost of "
+               "8,571 FPs and ~20s. Preserving \"\"-vs-null through prepare is a "
+               "separate fix; pinned here so it is not forgotten.",
+        strict=True,
+    )
+    @pytest.mark.parametrize("backend", ["bucket", "polars-direct"])
+    def test_empty_string_key_is_kept(self, backend):
+        """#390: "" is a REAL value (an explicit empty cell), NOT missing."""
+        df = pl.DataFrame(
+            [
+                {"record_id": 0, "first_name": "ann", "surname": "brown", "postcode": ""},
+                {"record_id": 1, "first_name": "ann", "surname": "brown", "postcode": ""},
+            ]
+        )
+        assert (0, 1) in _pairs(df, backend), (
+            f"{backend}: an explicit empty-string key must still block (#390)"
+        )


### PR DESCRIPTION
**A null block key means "this row cannot be blocked" — not "this row blocks with every other unblockable row."**

`build_blocks` derives `__block_key__` and then **filters** it. `score_buckets` derived the key and **never filtered** — so every null-key row hashed into **one** bucket and was scored against every other one.

On the ER head-to-head person shape at 1M: **9,846 rows** carry a null postcode. The largest **legitimate** postcode block is **25 rows**. That one null block is **48.5M comparisons**.

## Measured (1M person; one variable: the filter)

| | wall | TP | FP | recall | precision |
|---|---|---|---|---|---|
| **without** filter | 31.81s | 223,575 | **8,682** | 0.9319 | 0.9626 |
| **with** filter | **21.44s** | 223,494 | **111** | 0.9315 | **0.9995** |

The null block's entire contribution: **+81 TP and +8,571 FP — 99% false.**

Filtering costs **0.04% recall** and buys **78× fewer false positives** plus **33% wall**. It wins on precision, wall, and (trivially) loses on recall.

The wall is not incidental: **one kernel call took 20.482s of 22.669s total**. With 256 buckets across 12 workers, the entire scoring stage serialized behind that single straggler — **~20s of a ~40s dedupe spent comparing rows whose postcodes are merely absent**.

## The fix

Call `filter_valid_key` — the seam function whose own docstring calls it *"the blocker sentinel guard VERBATIM"*. Drops null + the `nan`/`null`/`none` stringified-missing sentinels; keeps `""` (#390).

**No new semantics.** This makes the bucket path agree with the blocker.

## Known gap (pre-existing, NOT introduced here)

An empty-string key reaches the bucket scorer **already null** — something upstream in prepare nulls `""` — so `filter_valid_key`'s keep-`""` branch is unreachable on this path, and `""`-keyed rows drop with the true nulls.

Before this filter, those rows matched **via the null mega-block**: #390's intent was being met **by accident**, at the cost of the 8,571 FPs and ~20s above. Preserving `""`-vs-null through prepare is a separate fix.

Pinned as **`xfail(strict)`** so it fails loudly the moment someone fixes the upstream nulling, rather than being silently forgotten.

## Tests

`tests/test_bucket_null_block_key.py` — 5 passed + 2 xfail(strict). The **blocker's** behavior is asserted first as the contract, then the bucket scorer is held to it. Controls: real-key rows must still match; the `""` gap is pinned, not hidden.

## Verification

- **Quality gate: PASS**, every corpus byte-identical (anchor 1.0 / febrl3 0.9912, 0.9883 / ncvr 0.9649, 0.9899 / hist50k 0.3421, 0.8284)
- **The 12 suite failures in this area are PRE-EXISTING**, confirmed by control: **14 fail with this reverted, 12 with it applied** — the delta is this PR's own two tests. They pass in isolation; it's the known cross-file state leak.
- ruff clean

## Context

Third null-handling bug in this family: #1851 (FS missing semantics), #1856 (weighted null renormalization), and this. Same root — **GM treats a missing value as a value**. Worth a design note rather than a fourth point fix.

Combined with #1856, GM at 1M on the ER person shape goes **45.44s → 21.44s** (Splink: 21.28s) and **precision 0.9862 → 0.9995** (Splink: 0.9998). The residual recall gap (0.9315 vs 0.9904) is the bench config giving GM **one** blocking pass vs Splink's **three** — separate, and not a GM defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9