### PR TITLE
fix(blocking): sorted_neighborhood + learned filter missing keys (#1859)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -910,8 +910,18 @@ def _build_sorted_neighborhood_blocks(
     else:
         sort_key_expr = pl.concat_str(sort_field_exprs, separator="||").alias("__sort_key__")
 
-    # Collect and sort
-    df = lf.with_columns(sort_key_expr).collect().sort("__sort_key__")
+    # Collect and sort. Drop rows whose sort key is missing FIRST: a null (or
+    # nan/null/none sentinel) sort key means "this row cannot be ordered", not
+    # "it neighbors every other unorderable row". Without this, null-key rows
+    # sort adjacent and window together into spurious candidate blocks (#1859).
+    # filter_valid_key is the blocker's guard verbatim -- it keeps "" (#390).
+    from goldenmatch.core.frame import to_frame as _tf
+
+    df = (
+        _tf(lf.with_columns(sort_key_expr).collect())
+        .filter_valid_key("__sort_key__")
+        .native.sort("__sort_key__")
+    )
     n = len(df)
     window_size = config.window_size
 

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -92,11 +92,19 @@ def _apply_predicate(value: object, predicate: BlockingPredicate) -> str:
 
 
 def _compute_block_key(row: dict, predicates: list[BlockingPredicate]) -> str:
-    """Compute a block key from multiple predicates (conjunction)."""
-    parts = []
-    for p in predicates:
-        val = row.get(p.field)
-        parts.append(_apply_predicate(val, p))
+    """Compute a block key from multiple predicates (conjunction).
+
+    Returns "" (a falsy, dropped-by-the-caller key) when EVERY predicate is
+    missing. A missing conjunction is "this row cannot be blocked", not "this row
+    blocks with every other all-missing row". The caller's ``if key:`` guard
+    already drops the single-predicate case (an empty part IS ""), but a 2+
+    predicate all-missing row produced "||" -- truthy -- so those rows collapsed
+    into one shared block (#1859). A PARTIALLY populated key ("smith||") stays
+    truthy and is kept: its real parts still carry blocking signal (#390).
+    """
+    parts = [_apply_predicate(row.get(p.field), p) for p in predicates]
+    if not any(parts):
+        return ""
     return "||".join(parts)
 
 

--- a/packages/python/goldenmatch/tests/test_blocking_null_key_strategies.py
+++ b/packages/python/goldenmatch/tests/test_blocking_null_key_strategies.py
@@ -1,0 +1,104 @@
+"""Every blocking strategy must treat a MISSING key as "cannot be blocked",
+not "blocks with every other missing-key row".
+
+`static`/`multi_pass` already filter invalid keys (via `build_blocks` +
+`filter_valid_key`, keeping "" per #390), and the bucket scorer got the same
+guard in #1857. This pins the two remaining exact-order/exact-equality
+strategies that grouped missing-key rows together (part of the #1859 audit):
+
+* sorted_neighborhood: a null `__sort_key__` used to sort adjacent and window
+  together.
+* learned (multi-predicate): `_compute_block_key` joined predicate parts with
+  "||", so an all-missing 2+ predicate row produced "||" -- TRUTHY -- and the
+  caller's `if key:` guard (which correctly drops the "" of a single missing
+  predicate) leaked. All-missing rows collapsed into one shared block.
+
+`adaptive` is intentionally NOT covered: its `_sub_block` already drops a null
+sub-key (`if key_str is None: continue`), verified by reproduction.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+from goldenmatch.config.schemas import BlockingConfig, SortKeyField
+from goldenmatch.core.blocker import build_blocks
+from goldenmatch.core.learned_blocking import (
+    BlockingPredicate,
+    BlockingRule,
+    _compute_block_key,
+    apply_learned_blocks,
+)
+
+# rows 0,1,2 have a NULL city (the block/sort key); 3,4 share a real city.
+DF = pl.DataFrame(
+    {
+        "__row_id__": [0, 1, 2, 3, 4],
+        "name": ["a", "b", "c", "d", "e"],
+        "city": [None, None, None, "boston", "boston"],
+    }
+)
+NULL_ROWS = {0, 1, 2}
+
+
+def _groups_null_rows(blocks) -> bool:
+    for b in blocks:
+        ids = set(b.materialize().native["__row_id__"].to_list())
+        if len(ids & NULL_ROWS) >= 2:
+            return True
+    return False
+
+
+def _real_rows_still_block(blocks) -> bool:
+    for b in blocks:
+        ids = set(b.materialize().native["__row_id__"].to_list())
+        if {3, 4} <= ids:
+            return True
+    return False
+
+
+class TestSortedNeighborhood:
+    def test_null_sort_key_rows_are_not_windowed_together(self):
+        blocks = build_blocks(
+            DF.lazy(),
+            BlockingConfig(
+                strategy="sorted_neighborhood",
+                sort_key=[SortKeyField(column="city")],
+                window_size=3,
+            ),
+        )
+        assert not _groups_null_rows(blocks), (
+            "null-sort-key rows were placed in a shared window -- a null key "
+            "means the row cannot be ordered, not that it neighbors every other "
+            "unorderable row"
+        )
+        assert _real_rows_still_block(blocks), "the real-city rows must still window together"
+
+
+class TestLearnedMultiPredicate:
+    def test_all_missing_multi_predicate_key_is_dropped(self):
+        """The "||" truthiness leak, at its source: an all-missing conjunction
+        must yield an empty (falsy) key so the caller drops it."""
+        preds = [BlockingPredicate("city", "exact"), BlockingPredicate("name", "digits_only")]
+        # both parts empty (city null -> "", name has no digits -> "")
+        assert _compute_block_key({"city": None, "name": "abc"}, preds) == ""
+        # a partially-populated key is still real and kept
+        assert _compute_block_key({"city": "boston", "name": "abc"}, preds) != ""
+
+    def test_all_missing_rows_do_not_share_a_block(self):
+        rules = [
+            BlockingRule(
+                predicates=[
+                    BlockingPredicate("city", "exact"),
+                    BlockingPredicate("name", "digits_only"),
+                ]
+            )
+        ]
+        blocks = apply_learned_blocks(DF.lazy(), rules, max_block_size=10**9)
+        assert not _groups_null_rows(blocks), (
+            "all-missing rows collapsed into one learned block via the '||' key"
+        )
+
+    def test_single_predicate_all_missing_still_dropped(self):
+        """Regression guard: the single-predicate case already worked ("" falsy);
+        the fix must not break it."""
+        assert _compute_block_key({"city": None}, [BlockingPredicate("city", "exact")]) == ""

--- a/packages/python/goldenmatch/tests/test_learned_lowering_parity.py
+++ b/packages/python/goldenmatch/tests/test_learned_lowering_parity.py
@@ -227,13 +227,24 @@ class TestKnownDivergences:
         assert learned == {(3, 4)}
         assert lowered == {(0, 1), (0, 2), (1, 2), (3, 4)}
 
-    def test_empty_key_depth2_both_keep_it(self):
-        """The truthiness accident: at depth 2 an all-empty key is "||", which is
-        truthy, so learned keeps the same block it drops at depth 1.
-        learned_predicate_depth DEFAULTS to 2, so the default path keeps it."""
+    def test_empty_key_depth2_learned_drops_lowered_keeps(self):
+        """UPDATED (fix/blocking-null-key-filter, #1859): the depth-2 "||"
+        truthiness leak is fixed at the source -- ``_compute_block_key`` now
+        returns "" when every predicate is empty, so learned DROPS the all-empty
+        block at depth 2, matching depth 1.
+
+        This creates a divergence with the LOWERED path: ``filter_valid_key``
+        keeps "" (the explicit-empty-cell value, #390), so lowered still blocks
+        the all-empty rows. learned cannot tell "" from null (its transforms map
+        both to ""), the lowered path can -- so on genuinely-"" data they now
+        differ. Recorded, not resolved: settling the ""-vs-null policy uniformly
+        is the #1859 umbrella item. The lowering compiler is currently inert
+        (its auto-config wiring #1845 was closed as invalid), so no live path
+        depends on this equivalence."""
         learned, lowered = _both(self.EMPTIES, [_rule(_p("last", "exact"), _p("city", "exact"))])
-        assert learned == lowered
-        assert (0, 1) in learned
+        assert learned == {(3, 4)}  # all-empty rows 0,1,2 dropped
+        assert (0, 1) in lowered    # lowered keeps "" per #390
+        assert learned != lowered   # the new, tracked divergence
 
     def test_nulls_agree_by_coincidence(self):
         """Both paths drop NULLs, via DIFFERENT mechanisms: static filters


### PR DESCRIPTION
First slice of the #1859 audit: **a missing block key means "this row cannot be blocked", not "it blocks with every other missing-key row."**

`static`/`multi_pass` already filter invalid keys (`build_blocks` + `filter_valid_key`, keeping `""` per #390), and the bucket scorer got the same guard in #1857. Two exact-order/exact-equality strategies still grouped missing keys:

| strategy | bug | fix |
|---|---|---|
| `sorted_neighborhood` | a null `__sort_key__` sorted adjacent and windowed together into spurious blocks | `filter_valid_key` on `__sort_key__` before the window slide (keeps `""`) |
| `learned` (multi-predicate) | `_compute_block_key` joined parts with `\|\|`, so an all-missing 2+ predicate row produced `\|\|` (**truthy**), leaking past the caller's `if key:` guard | return `""` when every part is empty, uniform with the single-predicate case |

A **partial** key (`smith\|\|`) stays truthy and is kept — its real parts carry signal (#390).

## Scope discipline

**Reproduction, not the audit's say-so, set the scope.** The audit line-referenced three strategies; a probe confirmed these two and **cleared `adaptive`** — its `_sub_block` already drops a null sub-key (`if key_str is None: continue`). `lsh`/`simhash` (`fill_null("")`) are left to the #1859 umbrella because they depend on settling the `""`-vs-null policy first.

## One consequence, recorded not hidden

The learned fix drops all-empty depth-2 keys, which **diverges** from the lowered (`multi_pass`) path: `filter_valid_key` keeps `""` (an explicit empty cell) while `learned` cannot tell `""` from null (its transforms map both to `""`). So on genuinely-`""` data they now differ.

This only affects the parity tests of the lowering compiler, which is **inert** — its auto-config wiring (#1845) was closed as invalid, so no live path depends on the equivalence. `test_learned_lowering_parity`'s characterization test is **updated to record the divergence explicitly**, not silently re-greened. Resolving `""`-vs-null uniformly is the #1859 umbrella item.

## Verification

- new tests **fail without the fix** (3 red), pass with it; regression guards that single-predicate and partial keys are unchanged
- blocking sweep: 406 passed, 1 updated (the characterization test above)
- **autoconfig quality gate: PASS, every corpus byte-identical** (anchor 1.0 / febrl3 0.9912, 0.9885 / ncvr 0.9649, 0.9899 / hist50k 0.3421, 0.8284) — the fix only touches missing-key rows
- ruff clean

## Context

Part of the #1859 "GoldenMatch treats missing as a value" umbrella. Siblings: #1856 (weighted normalization), #1857 (bucket null block key), #1851 (FS semantics). This is the blocking-surface slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9