### PR TITLE
fix(fs): unobserved field must not index weights[-1] in splink-upgrade calibration (#1859)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py
@@ -504,6 +504,7 @@ def _lever_calibration(ctx: _LeverContext) -> None:
         _sample_blocked_pairs,
         comparison_vector,
         compute_thresholds,
+        fs_regular_weight_sum,
         fs_weight_range,
     )
 
@@ -621,7 +622,9 @@ def _lever_calibration(ctx: _LeverContext) -> None:
         row_b = row_lookup.get(b, {})
         vec = comparison_vector(row_a, row_b, mk)
         total_weights.append(
-            sum(em.match_weights[name][vec[k]] for k, name in indexed_fields)
+            # #1859: guard the unobserved (-1) sentinel -- a missing field must
+            # not index weights[-1] (the highest-agreement weight).
+            fs_regular_weight_sum(em.match_weights, vec, indexed_fields)
             # NE contributions: 0.0 unless the field FIRES (core scalar
             # helper -- penalty_bits override or the EM-learned `__ne__`
             # fired-weight), matching runtime FS scoring.

--- a/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
+++ b/packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py
@@ -155,6 +155,7 @@ def _suggest_negative_evidence(ctx: _LeverContext) -> None:
         _ne_fired,
         _sample_blocked_pairs,
         comparison_vector,
+        fs_regular_weight_sum,
         posterior_from_weight,
         prior_weight,
     )
@@ -266,8 +267,10 @@ def _suggest_negative_evidence(ctx: _LeverContext) -> None:
     total_weights: list[float] = []
     for a, b in pairs:
         vec = comparison_vector(row_lookup.get(a, {}), row_lookup.get(b, {}), mk)
+        # #1859: guard the unobserved (-1) sentinel -- a missing field must not
+        # index weights[-1] (the highest-agreement weight).
         total_weights.append(
-            sum(em.match_weights[name][vec[k]] for k, name in indexed_fields)
+            fs_regular_weight_sum(em.match_weights, vec, indexed_fields)
         )
 
     # Per-pair posterior under the shared within-block prior re-estimate.

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -496,6 +496,30 @@ def comparison_vector(
     return levels
 
 
+def fs_regular_weight_sum(
+    match_weights: dict[str, list[float]],
+    vec: list[int],
+    indexed_fields: list[tuple[int, str]],
+) -> float:
+    """Sum the FS match-weight bits for the OBSERVED regular fields of one pair.
+
+    ``comparison_vector`` returns ``-1`` for a field that is unobserved on either
+    side (the ``missing="unobserved"`` sentinel). Indexing ``weights[-1]`` picks
+    the LAST element -- the highest-agreement weight -- so a MISSING field would
+    contribute maximal positive evidence FOR a match. Guard it: an unobserved
+    field carries no evidence and is skipped, matching every runtime FS scorer
+    (``score_pair_probabilistic`` etc., which all ``continue`` on ``vec[k] < 0``).
+
+    ``indexed_fields`` is ``[(k, field_name), ...]`` for the regular comparison
+    fields (NE / record fields excluded by the caller).
+    """
+    return sum(
+        match_weights[name][vec[k]]
+        for k, name in indexed_fields
+        if vec[k] >= 0
+    )
+
+
 def continuous_scores(
     row_a: dict,
     row_b: dict,

--- a/packages/python/goldenmatch/tests/test_fs_unobserved_weight_index.py
+++ b/packages/python/goldenmatch/tests/test_fs_unobserved_weight_index.py
@@ -1,0 +1,81 @@
+"""An unobserved FS field must contribute NO weight, not weights[-1] (#1859).
+
+``comparison_vector`` returns ``-1`` for a field unobserved on either side (the
+``missing="unobserved"`` sentinel). The Splink-upgrade calibration paths summed
+``em.match_weights[name][vec[k]]`` unguarded -- and ``weights[-1]`` is the LAST
+element, i.e. the HIGHEST-agreement weight. So a MISSING field contributed the
+maximal positive match evidence, feeding the fan-out NE posteriors
+(``splink_upgrade_fanout``) and the learned link/review thresholds
+(``splink_upgrade``). ``fs_regular_weight_sum`` guards ``vec[k] >= 0``, matching
+every runtime FS scorer (which all ``continue`` on ``vec[k] < 0``).
+"""
+
+from __future__ import annotations
+
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core.probabilistic import comparison_vector, fs_regular_weight_sum
+
+# 3-level weights: [disagree, partial, agree]. weights[-1] == the agree weight.
+WEIGHTS = {"name": [-3.0, 0.0, 5.0], "dob": [-4.0, 0.0, 6.0]}
+INDEXED = [(0, "name"), (1, "dob")]
+
+
+class TestFsRegularWeightSum:
+    def test_unobserved_field_contributes_zero(self):
+        vec = [2, -1]  # name agrees; dob unobserved
+        got = fs_regular_weight_sum(WEIGHTS, vec, INDEXED)
+        assert got == 5.0, (
+            "the unobserved dob must add 0, not weights['dob'][-1]=+6 -- a missing "
+            "field is absence of evidence, not maximal agreement"
+        )
+
+    def test_matches_the_buggy_sum_when_all_observed(self):
+        """When nothing is unobserved the guard is a no-op -- no behavior change
+        for the common case."""
+        vec = [2, 0]  # name agrees, dob disagrees
+        assert fs_regular_weight_sum(WEIGHTS, vec, INDEXED) == 5.0 + (-4.0)
+
+    def test_all_unobserved_is_zero(self):
+        assert fs_regular_weight_sum(WEIGHTS, [-1, -1], INDEXED) == 0.0
+
+    def test_partial_and_agree_levels(self):
+        assert fs_regular_weight_sum(WEIGHTS, [1, 2], INDEXED) == 0.0 + 6.0
+
+
+class TestComparisonVectorEmitsUnobserved:
+    def test_missing_field_yields_minus_one(self):
+        """The upstream contract the guard depends on: a null field -> -1."""
+        mk = MatchkeyConfig(
+            name="m", type="probabilistic", threshold=0.9,
+            fields=[
+                MatchkeyField(field="name", scorer="jaro_winkler", levels=3),
+                MatchkeyField(field="dob", scorer="jaro_winkler", levels=3),
+            ],
+        )
+        vec = comparison_vector(
+            {"name": "john smith", "dob": "1980-01-01"},
+            {"name": "john smith", "dob": None},
+            mk,
+        )
+        assert vec[0] == 2  # name agrees exactly
+        assert vec[1] == -1  # dob unobserved
+
+    def test_end_to_end_missing_adds_no_spurious_evidence(self):
+        """The full bug: comparison_vector -> fs_regular_weight_sum. A missing dob
+        must not inflate the pair's total FS weight."""
+        mk = MatchkeyConfig(
+            name="m", type="probabilistic", threshold=0.9,
+            fields=[
+                MatchkeyField(field="name", scorer="jaro_winkler", levels=3),
+                MatchkeyField(field="dob", scorer="jaro_winkler", levels=3),
+            ],
+        )
+        vec_missing = comparison_vector(
+            {"name": "a b", "dob": "1980-01-01"}, {"name": "a b", "dob": None}, mk
+        )
+        assert vec_missing == [2, -1]  # name agrees exactly, dob unobserved
+        w_missing = fs_regular_weight_sum(WEIGHTS, vec_missing, INDEXED)
+        # The missing dob contributes 0: the pair scores the name weight alone.
+        # The bug added weights["dob"][-1]=+6 (the agree weight) on top.
+        assert w_missing == 5.0
+        assert w_missing < 5.0 + WEIGHTS["dob"][-1]  # never reaches the buggy +6


### PR DESCRIPTION
**A missing FS field contributed the MAXIMUM possible match evidence.**

`comparison_vector` returns `-1` for a field unobserved on either side (the `missing="unobserved"` sentinel). Two splink-upgrade calibration paths summed `em.match_weights[name][vec[k]]` **unguarded** — and `weights[-1]` is the last element, i.e. the **highest-agreement** weight:

```
weights["dob"] = [-4, 0, +6]     # [disagree, partial, agree]
missing dob -> vec[k] = -1 -> weights[-1] = +6   (the AGREE weight)
```

So a null `dob` added **+6 spurious bits of evidence FOR a match** (reproduced numerically). That fed:
- the fan-out NE posteriors (`splink_upgrade_fanout.py:270`)
- the learned link/review thresholds (`splink_upgrade.py:624`)

Every **runtime** FS scorer already guards this (`if vec[k] < 0: continue`); only these two **calibration** sites didn't.

## Fix

A shared `fs_regular_weight_sum(match_weights, vec, indexed_fields)` in `probabilistic.py` that skips `vec[k] < 0`, replacing both identical unguarded sums. One helper, both sites, no duplication.

## Scope

Blast radius is the **Splink conversion path only** (`upgrade_splink_conversion`'s fan-out NE suggestion + threshold calibration). The zero-config `auto_configure` path never reaches it, so the quality gate is byte-identical. Part of the #1859 "treats missing as a value" umbrella — the FS audit's confirmed `weights[-1]` finding.

## Verification

- new test **fails without the guard** (3 red incl. end-to-end + all-unobserved), passes with it (6 green) — validated by temporarily removing the guard
- `splink_upgrade` / `probabilistic` / `fanout` sweep: **487 passed**, nothing pinned the old behavior
- quality gate: **PASS**, every corpus byte-identical

Aside: my first test fixture tripped over #1858 — a "disagree" dob (`1975-11-30` vs `1980-01-01`) scores ~0.80 on jaro_winkler (**partial**, not disagree), so an over-specified assertion failed. Dropped it; the load-bearing assertions stand.

## #1859 progress

| slice | PR |
|---|---|
| weighted null normalization | #1856 |
| bucket null block key | #1857 |
| blocking strategies null keys | #1860 |
| **FS unobserved weights[-1]** | **this** |

Remaining in #1859: scoring `record_embedding` denominator (needs an embedding model to exercise), #1854 in the native FS kernel, and the `""`-vs-null policy decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9