### PR TITLE
fix(deps): sail needs setuptools on py3.12 (pyspark 3.5 imports removed distutils)

### DIFF
--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -167,6 +167,13 @@ datafusion = [
 sail = [
     "pysail>=0.6",
     "pyspark[connect]>=3.5,<4",
+    # pyspark 3.5.x imports the stdlib `distutils`, which Python 3.12 REMOVED.
+    # setuptools ships the `distutils` shim (activated by its
+    # distutils-precedence .pth), so importing it restores `import distutils`
+    # on 3.12 -- the sail lane runs on 3.12 and otherwise dies at Spark Connect
+    # session setup with `ModuleNotFoundError: No module named 'distutils'`.
+    # Drop when pyspark >= 4 (Spark-4-Connect) is usable and no longer needs it.
+    "setuptools>=68; python_version >= '3.12'",
 ]
 agent = [
     "aiohttp>=3.14.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1343,6 +1343,7 @@ s3 = [
 sail = [
     { name = "pysail" },
     { name = "pyspark", extra = ["connect"] },
+    { name = "setuptools", marker = "python_full_version >= '3.12'" },
 ]
 salesforce = [
     { name = "simple-salesforce" },
@@ -1426,6 +1427,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
     { name = "sentence-transformers", marker = "extra == 'embeddings'", specifier = ">=2.2" },
+    { name = "setuptools", marker = "python_full_version >= '3.12' and extra == 'sail'", specifier = ">=68" },
     { name = "simple-salesforce", marker = "extra == 'salesforce'", specifier = ">=1.12" },
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.0" },
     { name = "soundfile", marker = "extra == 'audio'", specifier = ">=0.12" },


### PR DESCRIPTION
Second of a two-step sail repair. After #1862 pinned pyspark `<4`, the sail lane surfaced the **next** incompatibility:

```
ModuleNotFoundError: No module named 'distutils'
  test_sail_connectivity, at Spark Connect session setup
```

pyspark 3.5.x imports the stdlib `distutils`, which **Python 3.12 removed**. `setuptools` ships the `distutils` shim (its `distutils-precedence.pth` restores `import distutils` on 3.12).

## Fix

Add `setuptools>=68; python_version >= '3.12'` to the `sail` extra. The sail CI lane runs on 3.12.

## The two-step sail story

Both failures come from **pysail 0.6 targeting Spark 3.5 Connect**, exposed because #1847 (a CI-filter PR) forces the full job matrix:
1. #1862: pyspark 4's `int('3GB')` → pinned `<4`
2. **this**: pyspark 3.5 + py3.12's missing `distutils` → add setuptools

## Note on distributed_broad

The same matrix also shows `distributed_broad` failing, but it is **not** in `ci-required`'s `needs` — its step is literally `"(non-blocking)"` (a Ray-worker flake). So it does not gate the merge; `sail` was the only required blocker.

## Verification

- `uv lock` resolves with `setuptools` in the `sail` group (py>=3.12 marker)
- The sail lane needs pysail + a Spark server (CI-only). Like #1862, this PR's own `sail` run doesn't trigger (the sail filter watches `sail/**`, not dep files — a coverage gap worth its own fix). The end-to-end verifier is #1847's forced matrix once rebased onto this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0179KzseadM9N6we7bGHAWg9