### PR TITLE
perf(ci): skip the redundant native compile in uv sync (~200s/job)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # GoldenAnalysis's suite adapters consume goldenmatch/goldencheck/goldenflow/
       # goldenpipe outputs. uv sync --all-packages installs those workspace members,
       # but install the [match,check,flow,pipe] extras explicitly so the real-producer
@@ -329,7 +329,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # Scale-mode DataFusion edge stream (cluster_edges_df.py) lives behind the
       # optional `datafusion` extra; install it so the parity tests RUN rather
       # than importorskip-SKIP (a false green). Cheap (wheel download).
@@ -462,7 +462,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: pytest (heavy, serial)
         env:
           COVERAGE_FILE: coverage_heavy.dat
@@ -495,7 +495,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: gm-cov-*
@@ -528,7 +528,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: pytest (pure-Python fallback -- core behavior slice, GOLDENMATCH_NATIVE=0)
         # -k excludes tests that ASSERT native dispatch (e.g. TestNativeFSParity's
         # opt-in-picks-native): the job-level GOLDENMATCH_NATIVE=0 force-disables
@@ -568,7 +568,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: pytest (pure-Python fallback -- transform slice, GOLDENFLOW_NATIVE=0)
         # -k excludes tests that ASSERT native dispatch: the job-level
         # GOLDENFLOW_NATIVE=0 force-disables native, so those tests can't hold
@@ -611,7 +611,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Run ${{ matrix.lane.name }} lane
         shell: bash
         env:
@@ -704,7 +704,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Run Postgres-backed tests
         shell: bash
         run: |
@@ -733,7 +733,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Run synthetic benchmarks
         shell: bash
         run: |
@@ -780,7 +780,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # `recordlinkage` ships the Febrl3 dataset bundled — installing it
       # lets the smoke run actually exercise the febrl3 helper end-to-end
       # without needing any gitignored dataset. The other three datasets
@@ -854,7 +854,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # FEBRL3's loader needs recordlinkage (ships the dataset bundled); it is not
       # a declared dep. pyarrow backs pl.from_pandas in the febrl3/ncvr loaders
       # (mirrors the benchmark_runner_smoke precedent). synthetic-NCVR +
@@ -935,7 +935,7 @@ jobs:
         # Every package's [mcp] extra is just the shared `mcp` SDK, so one install provisions
         # the Python MCP surface for all six packages.
         run: |
-          uv sync --all-packages
+          uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
           # mcp: the MCP-tool surface; aiohttp: the a2a servers (the a2a_skills
           # emitter imports <pkg>.a2a.server, which needs the [a2a] extra). Without
           # aiohttp the a2a emitter exits 3 (env-gap) and the a2a surface is silently
@@ -1830,7 +1830,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Diagnostics (toolchain + dep versions)
         run: |
           (cd packages/rust/extensions/native && rustc --version && cargo clippy --version)
@@ -1932,7 +1932,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: clippy + test (goldencheck-core, pyo3-free kernels)
         working-directory: packages/rust/extensions/goldencheck-core
         run: |
@@ -1987,7 +1987,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: clippy + test (analysis-core, pyo3-free kernels)
         working-directory: packages/rust/extensions/analysis-core
         run: |
@@ -2026,7 +2026,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: clippy + test (infermap-core, pyo3-free kernels)
         working-directory: packages/rust/extensions/infermap-core
         run: |
@@ -2072,7 +2072,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: clippy + test (goldengraph-core, pyo3-free kernels)
         working-directory: packages/rust/extensions/goldengraph-core
         run: |
@@ -2112,7 +2112,7 @@ jobs:
           cache-dependency-glob: uv.lock
       # Frontend only (pure-Python goldenmatch); NO build_native.py, so
       # `goldenmatch._native` is absent and the loader must use the wheel.
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build the goldenmatch-native wheel (maturin, abi3)
         run: uv run --with maturin maturin build --release --manifest-path packages/rust/extensions/native/Cargo.toml --out dist
       - name: Install the wheel + smoke-test the split
@@ -2154,7 +2154,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: clippy + fmt (native-flow crate)
         working-directory: packages/rust/extensions/native-flow
         run: |
@@ -2215,7 +2215,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build native in-memory core into the package
         run: uv run python packages/python/goldenflow/scripts/build_native.py
       - name: Uninstall polars (simulate the 2.0 base-deps flip)
@@ -2252,7 +2252,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build goldencheck native (regex kernel, so hard-op checks run covered not skipped)
         # No --offline: same idiom as the goldencheck_native lane. Mirrors goldenflow_nopolars'
         # build-before-uninstall ordering. If this ever fails, the nopolars tests still pass --
@@ -2290,7 +2290,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Frame-backend differential (polars vs arrow)
         run: uv run python scripts/diff_frame_backends.py
 
@@ -2318,7 +2318,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: fmt + clippy (goldenpipe-core + goldenpipe-native)
         run: |
           cargo fmt --check --manifest-path packages/rust/extensions/goldenpipe-core/Cargo.toml
@@ -2357,7 +2357,7 @@ jobs:
           cache-dependency-glob: uv.lock
       # Frontend only (pure-Python goldenflow); NO build_native.py, so
       # `goldenflow._native` is absent and the loader must use the wheel.
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build the goldenflow-native wheel (maturin, abi3)
         run: uv run --with maturin maturin build --release --manifest-path packages/rust/extensions/native-flow/Cargo.toml --out dist
       - name: Install the wheel + smoke-test the split
@@ -2441,7 +2441,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build the goldenmatch-embed wheel (maturin, pyo3)
         run: uv run --with maturin maturin build --release --manifest-path packages/rust/extensions/embed-py/Cargo.toml --out dist
       - name: Install the wheel + smoke-test load/embed
@@ -2514,7 +2514,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Build the goldenmatch-hnsw wheel (maturin, pyo3)
         run: uv run --with maturin maturin build --release --manifest-path packages/rust/extensions/hnsw-py/Cargo.toml --out dist
       - name: Install the wheel + standalone smoke
@@ -2573,7 +2573,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # ray is an optional extra; install it into the uv venv so the ray-gated
       # tests/test_distributed_*.py actually run (they skip everywhere else via
       # pytest.importorskip). pandas<3 because ray pins pandas<3.
@@ -2617,7 +2617,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Install ray extra
         run: uv pip install 'ray[default]>=2.0' 'pandas<3'
       - name: Randomized-contraction WCC ray gate (blocking)
@@ -2649,7 +2649,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Install ray extra
         run: uv pip install 'ray[default]>=2.0' 'pandas<3'
       - name: Distributed broad coverage (non-blocking)
@@ -2676,7 +2676,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # Sail (Spark Connect) optional stack. NO Java: pyspark[connect] is a
       # pure-gRPC client (no py4j/JVM launch) and the Sail server is Rust.
       # Install VIA THE EXTRA so the pyproject [sail] entry is exercised.
@@ -3169,7 +3169,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - run: uv run pyright
 
   # Enforce per-package version lockstep across every file that declares it
@@ -3251,7 +3251,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       # Regenerate every committed TS parity fixture from the Python emitters,
       # then assert the working tree still matches HEAD within a 4-decimal float
       # tolerance. Closes the silent-drift hole (#856): a pure-Python behaviour
@@ -3306,7 +3306,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages
+      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - run: uv pip install -e packages/python/goldenmatch
       - run: uv pip install duckdb
       - name: Bench harness unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - run: uv sync --all-packages ${{ matrix.pkg != 'goldenpipe' && '--no-install-package goldenmatch-native --no-install-package goldenflow-native' || '' }}
       # GoldenAnalysis's suite adapters consume goldenmatch/goldencheck/goldenflow/
       # goldenpipe outputs. uv sync --all-packages installs those workspace members,
       # but install the [match,check,flow,pipe] extras explicitly so the real-producer
@@ -2290,7 +2290,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
-      - run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - run: uv sync --all-packages
       - name: Frame-backend differential (polars vs arrow)
         run: uv run python scripts/diff_frame_backends.py
 


### PR DESCRIPTION
## Why
`uv sync --all-packages` spends ~200s per job **compiling the local Rust workspace deps** — `goldenmatch-native` (a platform-marked base dep of goldenmatch on linux-x64) and `goldenflow-native` (a base dep of goldenflow) build from path via maturin/cargo. This is the real reason `uv sync` is slow; the download cache can't touch a source build (a setup-uv v8 / prune-cache experiment confirmed a warm cache still took 195s — the wheels were never the bottleneck).

No job needs the uv-sync-built native: the loaders import `goldenmatch_native` / `goldenflow_native` only as the **second** fallback, after the in-tree `goldenmatch._native` that the native/shard lanes build explicitly via `build_native.py`; `native_wheel` builds + installs the wheel itself.

## What
`--no-install-package goldenmatch-native --no-install-package goldenflow-native` on the `uv sync` calls (31 sites), which skips the compile while still resolving the metadata.

Two lanes genuinely exercise the native `match_fused` kernel without building it, so they keep the install:
- `goldenmatch_frame_diff` (the fused differential dataset) → plain `uv sync`.
- `python (goldenpipe)` (`test_fused_dedupe_stage.py`) → the shared python-matrix sync skips native for every pkg **except** `goldenpipe`.

## Measured (run_all validation, all lanes green)
- **uv sync: ~205s → 4s** on the affected jobs (`Prepared 81 packages in 3.71s`, no `Building …-native`).
- **Slowest goldenmatch shard: 9m24s → ~7.9m** (stacks on the merged rebalance #1865; the shards build native via `build_native.py` and passed).
- All native lanes (`native`, `native_flow`, `native_wheel`, `goldencheck_native`, …) stay green — they build their own extension.

Full-matrix `workflow_dispatch run_all=true`: **success, zero failures.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd