### PR TITLE
FS increment 7: embedding + record_embedding on the native kernel (100% FS coverage)

### DIFF
--- a/docs/superpowers/specs/2026-07-17-fs-core-cross-surface-extraction-design.md
+++ b/docs/superpowers/specs/2026-07-17-fs-core-cross-surface-extraction-design.md
@@ -15,7 +15,22 @@ subpath `goldenmatch/core/fs-wasm`, and `tests/parity/fs-wasm.parity.test.ts`
 asserts fs-wasm reproduces the Python-native `score_block_pairs_fs` oracle
 (fixture authored by `scripts/emit_fs_wasm_fixture.py`) — the TS scoring-path
 reroute stays a deliberate follow-up (kernel + parity shipped first, like
-hnsw-wasm). Remaining: 7 (delete the numpy/scalar production paths).
+hnsw-wasm). **7a (embedding → native) landed**: `embedding` AND `record_embedding`
+now score on the native kernel (scorer id 7 = cosine/dot of host-precomputed
+L2-normalized vectors), so the native kernel covers **100 % of FS comparison
+scorers** — the last two that forced the whole matchkey onto numpy. `fs-core`
+gained `FS_SCORER_EMBEDDING_COSINE` + `embedding_cosine` + `FsPairParams.emb_*`;
+native marshals per-field vectors (`emb_vectors`/`emb_dims`, `FS_SUPPORTS_EMBEDDING`);
+`probabilistic.py` embeds host-side (same embedder + values as the numpy path) and
+admits both scorers. New native == numpy parity tests (`test_fs_embedding_native.py`).
+**7b (native-required deletion) RECONCILED with the 2026-07-01 reference-mode
+roadmap:** native is the AUTHORITATIVE FS path (default-on, and now 100 % capable),
+but the pure-Python numpy/scalar path is RETAINED as the documented *lossy fallback*
+(`GOLDENMATCH_FS_NATIVE=0` / no-native install), matching how every other kernel in
+the repo degrades — the original note's "delete numpy + raise when native absent"
+would remove FS from `pip install goldenmatch` (no `[native]`), a base-install
+capability, so that irreversible deletion is deferred pending explicit product
+sign-off.
 **Owner:** benchmark-failure follow-up (`claude/benchmark-failure-gh-vbtusq`)
 
 ## Problem: Fellegi-Sunter is the repo's parity orphan
@@ -169,10 +184,25 @@ scorers, so this is explicit-config only.
 5. **Port `tf_adjustment`** (EM freq/collision tables across the seam).
 6. **Port `ensemble` NE** (explicit-config only; probabilistic auto-config emits
    no NE).
-7. **Delete the Python numpy + scalar *production* paths, the `_fs_vec_guard`,
-   and the `GOLDENMATCH_FS_NATIVE` / `GOLDENMATCH_FS_VECTORIZED` knobs.** Keep a
-   minimal scalar reference in **test scope** as the parity oracle. Bump the
-   `goldenmatch-native` floor and delete the `FS_SUPPORTS_*` old-wheel branches.
+7. **7a — Port `embedding` / `record_embedding` to native (LANDED).** The last
+   two FS scorers with no native id: the host embeds the field (per-field column
+   for `embedding`; the record-concat for `record_embedding`, byte-for-byte the
+   `_record_embedding_score_matrix` join) with the SAME embedder the numpy path
+   uses, and marshals the L2-normalized vectors; `fs-core::score_fs_pair` scores
+   an id-7 field as `dot(row_i, row_j)` (= cosine), gated by `FS_SUPPORTS_EMBEDDING`.
+   Native now covers 100 % of FS scorers, `native == numpy` (abs 1e-6) proven.
+7. **7b — "make native required": RECONCILED, aggressive deletion DEFERRED.**
+   The original plan (delete the numpy/scalar *production* paths + the
+   `GOLDENMATCH_FS_NATIVE` / `GOLDENMATCH_FS_VECTORIZED` knobs + `_fs_vec_guard`,
+   raise when native is absent) conflicts with the 2026-07-01 reference-mode
+   roadmap, which keeps the pure-Python path as a *lossy fallback* (`=0` forces it;
+   no-`[native]` installs still run). Deleting it removes probabilistic FS from the
+   base `pip install goldenmatch`. So: native is the authoritative + default path
+   (already true, now 100 %-capable), the numpy/scalar path STAYS as the documented
+   reference-mode fallback + parity oracle, and the base-install-breaking deletion
+   is deferred pending explicit product sign-off. (The `FS_SUPPORTS_*` capability
+   consts also stay — they are exactly the graceful-degradation gate the roadmap
+   wants, not old-wheel cruft to delete while a fallback exists.)
 
 ## Notes
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3004,7 +3004,18 @@ def _fs_vectorized_enabled() -> bool:
 _NATIVE_FS_SCORER_IDS: dict[str, int] = {
     "jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3,
     "name_freq_weighted_jw": 4, "given_name_aliased_jw": 5, "ensemble": 6,
+    # Model-backed embedding scorers (kernel id 7). The field's value is a dense
+    # vector, not a string: the host embeds the column and marshals the
+    # already-L2-normalized vectors; the kernel scores the pair as their cosine
+    # (dot). Native only when the wheel advertises FS_SUPPORTS_EMBEDDING. NOT a
+    # valid NE scorer (the kernel's NE path is score_one 0..=3 + ensemble only).
+    "embedding": 7, "record_embedding": 7,
 }
+# The model-backed embedding scorers (kernel id 7). A field carrying one is native
+# only when the wheel advertises FS_SUPPORTS_EMBEDDING; the host marshals the
+# precomputed vectors. Same members as `_MODEL_BACKED_SCORERS` (the numpy-path
+# name), kept here as a frozenset for the eligibility gates.
+_EMBEDDING_SCORER_IDS: frozenset[str] = frozenset({"embedding", "record_embedding"})
 # The reference-data name scorers (kernel ids 4/5). A field carrying one is
 # native only when the wheel advertises FS_SUPPORTS_NAME_SCORERS AND the relevant
 # refdata pack is loaded (so the injected table matches the numpy path). NE fields
@@ -3119,16 +3130,27 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
     ne_fields = mk.negative_evidence or []
     for ne in ne_fields:
         # NE goes through field_similarity (score_one 0..=3 + ensemble id 6); the
-        # reference-data name scorers (4/5) are NOT valid NE scorers.
-        if ne.scorer not in _NATIVE_FS_SCORER_IDS or ne.scorer in _NAME_SCORER_IDS:
+        # reference-data name scorers (4/5) and embedding (7) are NOT valid NE
+        # scorers (the kernel's NE path has no vector access).
+        if (
+            ne.scorer not in _NATIVE_FS_SCORER_IDS
+            or ne.scorer in _NAME_SCORER_IDS
+            or ne.scorer in _EMBEDDING_SCORER_IDS
+        ):
             return False
         if ne.scorer == "ensemble":
             needs_ensemble = True
     needs_level_thresholds = False
     needs_tf = False
+    needs_embedding = False
     name_scorers_needed: set[str] = set()
     for f in mk.fields:
         if f.scorer not in _NATIVE_FS_SCORER_IDS:
+            return False
+        if f.scorer == "record_embedding":
+            # Record-level embedding concatenates multiple columns host-side
+            # before embedding; marshaling that synthetic never-null column is a
+            # follow-up. Per-field `embedding` is native (id 7); record stays numpy.
             return False
         if getattr(f, "tf_adjustment", False):
             needs_tf = True
@@ -3138,6 +3160,8 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
             name_scorers_needed.add(f.scorer)
         if f.scorer == "ensemble":
             needs_ensemble = True
+        if f.scorer in _EMBEDDING_SCORER_IDS:
+            needs_embedding = True
     if name_scorers_needed and not _fs_name_refdata_available(name_scorers_needed):
         # The pack that would supply the injected table isn't loaded, so the
         # kernel would degrade to plain JW — diverging from the numpy path (which
@@ -3164,6 +3188,8 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
             return False  # old wheel: tf_freqs/tf_collision never cross their FFI
         if needs_ensemble and not getattr(mod, "FS_SUPPORTS_ENSEMBLE", False):
             return False  # old wheel: scores ensemble (id 6) as 0.0 (catch-all)
+        if needs_embedding and not getattr(mod, "FS_SUPPORTS_EMBEDDING", False):
+            return False  # old wheel: no emb_vectors kwarg / scores id 7 as 0.0
         return True
     except Exception:
         return False
@@ -3198,6 +3224,42 @@ def _fs_arrow_column(native_df, f, n: int):
         return arr
     vals = _field_values_from_list(_bf.column(f.field).to_list(), f, n)
     return _pa.array(vals, type=_pa.large_string())
+
+
+def _fs_embedding_vectors(frame, mk: MatchkeyConfig, n: int):
+    """Per-field embedding vectors for the native FS kernel (scorer id 7).
+
+    Returns ``(emb_vectors, emb_dims)`` — lists indexed like ``mk.fields``:
+    ``None``/``0`` for a non-embedding field, else the ROW-MAJOR ``n*dim`` f64
+    buffer + its ``dim``. Each ``embedding`` field is embedded with the SAME
+    embedder + SAME transformed values (``_field_values_for_block``) the numpy
+    path feeds ``_fuzzy_score_matrix(vals, "embedding")``, so native's per-pair
+    ``dot(row_i, row_j)`` equals the numpy ``embeddings @ embeddings.T`` cosine
+    within f64 tolerance (embeddings are L2-normalized). Null rows are embedded as
+    ``""`` exactly like the numpy path; their observed-ness is still carried by
+    the value column, so the missing-mode machinery is unchanged.
+    """
+    import numpy as _np
+
+    from goldenmatch.core.embedder import get_embedder
+
+    emb_vectors: list[list[float] | None] = []
+    emb_dims: list[int] = []
+    for f in mk.fields:
+        if f.scorer != "embedding":
+            emb_vectors.append(None)
+            emb_dims.append(0)
+            continue
+        vals = _field_values_for_block(frame, f, n)
+        embedder = get_embedder(f.model or "all-MiniLM-L6-v2")
+        vecs = _np.asarray(
+            embedder.embed_column(vals, cache_key=f"_fsnat_{id(vals)}"),
+            dtype=_np.float64,
+        )
+        dim = int(vecs.shape[1]) if vecs.ndim == 2 and vecs.shape[0] == n else 0
+        emb_vectors.append([float(x) for x in vecs.reshape(-1)] if dim else None)
+        emb_dims.append(dim)
+    return emb_vectors, emb_dims
 
 
 def _score_fs_native_frame(
@@ -3341,6 +3403,17 @@ def _score_fs_native_frame(
                 tf_collision_list.append(None)
         opt_kwargs["tf_freqs"] = tf_freqs_list
         opt_kwargs["tf_collision"] = tf_collision_list
+
+    # Embedding scorers (goldenmatch-native FS_SUPPORTS_EMBEDDING). The host
+    # embeds each `embedding` field's transformed column and marshals the
+    # L2-normalized vectors; the kernel scores the pair as their cosine (dot).
+    # Sent only when the matchkey actually carries an embedding field (an old
+    # wheel must never see the kwarg — `_fs_native_eligible` already gated on the
+    # capability). record_embedding stays on numpy (declined upstream).
+    if any(f.scorer == "embedding" for f in mk.fields):
+        emb_vectors, emb_dims = _fs_embedding_vectors(frame, mk, n)
+        opt_kwargs["emb_vectors"] = emb_vectors
+        opt_kwargs["emb_dims"] = emb_dims
 
     if use_arrow:
         import pyarrow as _pa

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3147,11 +3147,6 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
     for f in mk.fields:
         if f.scorer not in _NATIVE_FS_SCORER_IDS:
             return False
-        if f.scorer == "record_embedding":
-            # Record-level embedding concatenates multiple columns host-side
-            # before embedding; marshaling that synthetic never-null column is a
-            # follow-up. Per-field `embedding` is native (id 7); record stays numpy.
-            return False
         if getattr(f, "tf_adjustment", False):
             needs_tf = True
         if getattr(f, "level_thresholds", None) is not None:
@@ -3226,18 +3221,51 @@ def _fs_arrow_column(native_df, f, n: int):
     return _pa.array(vals, type=_pa.large_string())
 
 
+def _record_concat_values(frame, f, n: int) -> list[str]:
+    """Per-row concatenated text for a ``record_embedding`` field — a byte-for-byte
+    copy of the concat in ``core/scorer._record_embedding_score_matrix`` (``col:
+    val`` parts joined by `` | ``, ``column_weights`` repeats, ``""`` when empty),
+    so native embeds the SAME strings the numpy path does. Built via column lists
+    (works for both polars + arrow frames), never ``iter_rows``."""
+    from goldenmatch.core.frame import to_frame as _tf_rc
+
+    bf = _tf_rc(frame)
+    cols = list(f.columns or [])
+    weights = f.column_weights
+    data: dict[str, list] = {
+        c: bf.column(c).to_list() for c in cols if c in bf.columns
+    }
+    out: list[str] = []
+    for r in range(n):
+        parts: list[str] = []
+        for c in cols:
+            val = data.get(c, [None] * n)[r]
+            if weights is not None:
+                w = weights.get(c, 1.0)
+                if w <= 0:
+                    continue
+                if val is not None:
+                    part = f"{c}: {val}"
+                    repeats = round(w) if w > 1.0 else 1
+                    parts.extend([part] * repeats)
+            elif val is not None:
+                parts.append(f"{c}: {val}")
+        out.append(" | ".join(parts) if parts else "")
+    return out
+
+
 def _fs_embedding_vectors(frame, mk: MatchkeyConfig, n: int):
     """Per-field embedding vectors for the native FS kernel (scorer id 7).
 
     Returns ``(emb_vectors, emb_dims)`` — lists indexed like ``mk.fields``:
     ``None``/``0`` for a non-embedding field, else the ROW-MAJOR ``n*dim`` f64
-    buffer + its ``dim``. Each ``embedding`` field is embedded with the SAME
-    embedder + SAME transformed values (``_field_values_for_block``) the numpy
-    path feeds ``_fuzzy_score_matrix(vals, "embedding")``, so native's per-pair
-    ``dot(row_i, row_j)`` equals the numpy ``embeddings @ embeddings.T`` cosine
-    within f64 tolerance (embeddings are L2-normalized). Null rows are embedded as
-    ``""`` exactly like the numpy path; their observed-ness is still carried by
-    the value column, so the missing-mode machinery is unchanged.
+    buffer + its ``dim``. Each field is embedded with the SAME embedder + SAME
+    values the numpy path feeds: an ``embedding`` field uses the transformed
+    column (``_field_values_for_block`` -> ``_fuzzy_score_matrix(vals,
+    "embedding")``); a ``record_embedding`` field uses the concatenated record
+    text (``_record_concat_values`` -> ``_record_embedding_score_matrix``). So
+    native's per-pair ``dot(row_i, row_j)`` equals the numpy ``embeddings @
+    embeddings.T`` cosine within f64 tolerance (embeddings are L2-normalized).
     """
     import numpy as _np
 
@@ -3246,11 +3274,14 @@ def _fs_embedding_vectors(frame, mk: MatchkeyConfig, n: int):
     emb_vectors: list[list[float] | None] = []
     emb_dims: list[int] = []
     for f in mk.fields:
-        if f.scorer != "embedding":
+        if f.scorer not in _EMBEDDING_SCORER_IDS:
             emb_vectors.append(None)
             emb_dims.append(0)
             continue
-        vals = _field_values_for_block(frame, f, n)
+        if f.scorer == "record_embedding":
+            vals: list = _record_concat_values(frame, f, n)
+        else:
+            vals = _field_values_for_block(frame, f, n)
         embedder = get_embedder(f.model or "all-MiniLM-L6-v2")
         vecs = _np.asarray(
             embedder.embed_column(vals, cache_key=f"_fsnat_{id(vals)}"),
@@ -3405,12 +3436,12 @@ def _score_fs_native_frame(
         opt_kwargs["tf_collision"] = tf_collision_list
 
     # Embedding scorers (goldenmatch-native FS_SUPPORTS_EMBEDDING). The host
-    # embeds each `embedding` field's transformed column and marshals the
+    # embeds each `embedding` / `record_embedding` field and marshals the
     # L2-normalized vectors; the kernel scores the pair as their cosine (dot).
-    # Sent only when the matchkey actually carries an embedding field (an old
-    # wheel must never see the kwarg — `_fs_native_eligible` already gated on the
-    # capability). record_embedding stays on numpy (declined upstream).
-    if any(f.scorer == "embedding" for f in mk.fields):
+    # Sent only when the matchkey carries an embedding field (an old wheel must
+    # never see the kwarg — `_fs_native_eligible` already gated on the capability).
+    has_embedding = any(f.scorer in _EMBEDDING_SCORER_IDS for f in mk.fields)
+    if has_embedding:
         emb_vectors, emb_dims = _fs_embedding_vectors(frame, mk, n)
         opt_kwargs["emb_vectors"] = emb_vectors
         opt_kwargs["emb_dims"] = emb_dims
@@ -3430,6 +3461,14 @@ def _score_fs_native_frame(
                 native_df.column("__row_id__").combine_chunks(), _pa.int64()
             )
         field_arrays = [_fs_arrow_column(frame, f, n) for f in mk.fields]
+        # record_embedding has no single value column (`f.field` isn't in the
+        # frame), so _fs_arrow_column returns all-null -> the kernel would treat it
+        # as unobserved. A record embedding is ALWAYS observed (the concat is ""
+        # for empty, never null), so pin its value column to a never-null sentinel;
+        # the actual similarity rides in emb_vectors.
+        for _i, _f in enumerate(mk.fields):
+            if _f.scorer == "record_embedding":
+                field_arrays[_i] = _pa.array([""] * n, type=_pa.large_string())
         if use_handle:
             opt_kwargs["exclude_set"] = exclude_handle
         pairs = mod.score_block_pairs_fs_arrow(
@@ -3442,6 +3481,11 @@ def _score_fs_native_frame(
         return [(a, b, round(float(s), 4)) for a, b, s in pairs]
 
     field_values = [_field_values_for_block(frame, f, n) for f in mk.fields]
+    # record_embedding is always observed (see the arrow branch above) — pin its
+    # value column to a never-null sentinel so the kernel scores it, not skips it.
+    for _i, _f in enumerate(mk.fields):
+        if _f.scorer == "record_embedding":
+            field_values[_i] = [""] * n
     if use_handle:
         opt_kwargs["exclude_set"] = exclude_handle
     pairs = mod.score_block_pairs_fs(

--- a/packages/python/goldenmatch/tests/test_fs_embedding_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_embedding_native.py
@@ -63,20 +63,20 @@ def test_embedding_eligible_only_with_capability(fake_embedder):
 
     fE = MatchkeyField(field="name", scorer="embedding", levels=2, partial_threshold=0.9)
     mk = MatchkeyConfig(name="m", type="probabilistic", fields=[fE], link_threshold=0.0)
-    # record_embedding stays on numpy (declined).
     fR = MatchkeyField(field="name", scorer="record_embedding", levels=2,
                        partial_threshold=0.9, columns=["name"])
     mk_rec = MatchkeyConfig(name="r", type="probabilistic", fields=[fR],
                             link_threshold=0.0)
     assert P._NATIVE_FS_SCORER_IDS["embedding"] == 7
+    assert P._NATIVE_FS_SCORER_IDS["record_embedding"] == 7
     if _new_kernel_available():
-        # embedding admitted; record_embedding declined by design.
+        # Both embedding + record_embedding admitted (native id 7).
         import os
 
         os.environ["GOLDENMATCH_FS_NATIVE"] = "1"
         try:
             assert P._fs_native_eligible(mk) is True
-            assert P._fs_native_eligible(mk_rec) is False
+            assert P._fs_native_eligible(mk_rec) is True
         finally:
             os.environ.pop("GOLDENMATCH_FS_NATIVE", None)
 
@@ -100,6 +100,44 @@ def test_native_numpy_parity_embedding(monkeypatch, fake_embedder):
     df = pl.DataFrame({
         "__row_id__": list(range(len(name))),
         "name": name, "zip": zipc,
+    })
+    em = P.train_em(df, mk, n_sample_pairs=2000)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+    assert P._fs_native_eligible(mk) is False
+    numpy_pairs = P.score_probabilistic_vectorized(df, mk, em)
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    assert P._fs_native_eligible(mk) is True
+    native_pairs = P.score_probabilistic_native(df, mk, em)
+
+    n0 = {(a, b): s for a, b, s in numpy_pairs}
+    n1 = {(a, b): s for a, b, s in native_pairs}
+    assert n0.keys() == n1.keys() and len(n0) > 0
+    for pair, s in n0.items():
+        assert n1[pair] == pytest.approx(s, abs=1e-6)
+
+
+@pytest.mark.skipif(
+    not _new_kernel_available(),
+    reason="native kernel without FS_SUPPORTS_EMBEDDING",
+)
+def test_native_numpy_parity_record_embedding(monkeypatch, fake_embedder):
+    """record_embedding (record-level concat) scores IDENTICALLY on native and
+    numpy: the host concatenates + embeds the SAME string both paths use, and the
+    kernel scores its cosine (record fields are always observed)."""
+    from goldenmatch.core import probabilistic as P
+
+    first = ["alpha", "alpha", "bravo", "bravo", "carol", "zzzz"]
+    last = ["one", "one", "two", "two", "three", "nine"]
+    fR = MatchkeyField(field="__record__", scorer="record_embedding", levels=2,
+                       partial_threshold=0.9, columns=["first", "last"])
+    fZ = MatchkeyField(field="zip", scorer="exact", levels=2, partial_threshold=0.9)
+    mk = MatchkeyConfig(name="m", type="probabilistic", fields=[fR, fZ],
+                        link_threshold=0.0)
+    df = pl.DataFrame({
+        "__row_id__": list(range(len(first))),
+        "first": first, "last": last,
+        "zip": ["1", "1", "2", "2", "3", "9"],
     })
     em = P.train_em(df, mk, n_sample_pairs=2000)
 

--- a/packages/python/goldenmatch/tests/test_fs_embedding_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_embedding_native.py
@@ -1,0 +1,117 @@
+"""Embedding FS scorer on the native Rust kernel (increment 7a).
+
+`embedding` fields used to force the WHOLE probabilistic matchkey onto the numpy
+vectorized path (no native kernel id). The native kernel now scores an embedding
+field (id 7) as the cosine (dot) of the two rows' host-precomputed L2-normalized
+vectors, so a mixed string+embedding matchkey runs natively. This pins native ==
+numpy on the embedding path, using a deterministic fake embedder (torch-free).
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+import numpy as np
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+
+class _FakeEmbedder:
+    """Deterministic, L2-normalized, hash-based embeddings. Identical strings map
+    to identical vectors (cosine 1.0); different strings ~orthogonal. Mirrors the
+    real embedder's null coercion (None/empty -> "")."""
+
+    dim = 8
+
+    def embed_column(self, values, cache_key=None):
+        clean = [str(v) if v is not None and str(v).strip() else "" for v in values]
+        out = np.zeros((len(clean), self.dim), dtype=np.float64)
+        for i, s in enumerate(clean):
+            h = hashlib.sha256(s.encode("utf-8")).digest()
+            v = np.frombuffer(h[: self.dim], dtype=np.uint8).astype(np.float64)
+            v = v - v.mean()
+            norm = np.linalg.norm(v)
+            out[i] = v / norm if norm > 0 else v
+        return out
+
+    def cosine_similarity_matrix(self, embeddings):
+        return embeddings @ embeddings.T
+
+
+def _new_kernel_available() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module
+
+        mod = native_module()
+        return bool(mod) and bool(getattr(mod, "FS_SUPPORTS_EMBEDDING", False))
+    except Exception:
+        return False
+
+
+@pytest.fixture
+def fake_embedder(monkeypatch):
+    emb = _FakeEmbedder()
+    monkeypatch.setattr(
+        "goldenmatch.core.embedder.get_embedder", lambda *a, **k: emb
+    )
+    return emb
+
+
+def test_embedding_eligible_only_with_capability(fake_embedder):
+    from goldenmatch.core import probabilistic as P
+
+    fE = MatchkeyField(field="name", scorer="embedding", levels=2, partial_threshold=0.9)
+    mk = MatchkeyConfig(name="m", type="probabilistic", fields=[fE], link_threshold=0.0)
+    # record_embedding stays on numpy (declined).
+    fR = MatchkeyField(field="name", scorer="record_embedding", levels=2,
+                       partial_threshold=0.9, columns=["name"])
+    mk_rec = MatchkeyConfig(name="r", type="probabilistic", fields=[fR],
+                            link_threshold=0.0)
+    assert P._NATIVE_FS_SCORER_IDS["embedding"] == 7
+    if _new_kernel_available():
+        # embedding admitted; record_embedding declined by design.
+        import os
+
+        os.environ["GOLDENMATCH_FS_NATIVE"] = "1"
+        try:
+            assert P._fs_native_eligible(mk) is True
+            assert P._fs_native_eligible(mk_rec) is False
+        finally:
+            os.environ.pop("GOLDENMATCH_FS_NATIVE", None)
+
+
+@pytest.mark.skipif(
+    not _new_kernel_available(),
+    reason="native kernel without FS_SUPPORTS_EMBEDDING",
+)
+def test_native_numpy_parity_embedding(monkeypatch, fake_embedder):
+    """A probabilistic matchkey with an `embedding` field + an `exact` field
+    scores IDENTICALLY on the native kernel and the numpy path, on clean data
+    (identical vs very-different values, so no pair sits at a level boundary)."""
+    from goldenmatch.core import probabilistic as P
+
+    name = ["alpha", "alpha", "bravo", "bravo", "charlie", "zzzzz"]
+    zipc = ["10001", "10001", "20002", "20002", "30003", "99999"]
+    fN = MatchkeyField(field="name", scorer="embedding", levels=2, partial_threshold=0.9)
+    fZ = MatchkeyField(field="zip", scorer="exact", levels=2, partial_threshold=0.9)
+    mk = MatchkeyConfig(name="m", type="probabilistic", fields=[fN, fZ],
+                        link_threshold=0.0)
+    df = pl.DataFrame({
+        "__row_id__": list(range(len(name))),
+        "name": name, "zip": zipc,
+    })
+    em = P.train_em(df, mk, n_sample_pairs=2000)
+
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+    assert P._fs_native_eligible(mk) is False
+    numpy_pairs = P.score_probabilistic_vectorized(df, mk, em)
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    assert P._fs_native_eligible(mk) is True
+    native_pairs = P.score_probabilistic_native(df, mk, em)
+
+    n0 = {(a, b): s for a, b, s in numpy_pairs}
+    n1 = {(a, b): s for a, b, s in native_pairs}
+    assert n0.keys() == n1.keys() and len(n0) > 0
+    for pair, s in n0.items():
+        assert n1[pair] == pytest.approx(s, abs=1e-6)

--- a/packages/rust/extensions/fs-core/src/lib.rs
+++ b/packages/rust/extensions/fs-core/src/lib.rs
@@ -956,10 +956,16 @@ mod tests {
         let noop_ne = |_: usize, _: usize| None;
         // Identical vectors -> cosine 1.0 >= 0.9 -> agree (weight 3) -> normalized 1.0.
         let s_same = score_fs_pair(0, 1, &p, get, noop_ne);
-        assert!((s_same - 1.0).abs() < 1e-9, "cosine 1.0 -> top -> 1.0, got {s_same}");
+        assert!(
+            (s_same - 1.0).abs() < 1e-9,
+            "cosine 1.0 -> top -> 1.0, got {s_same}"
+        );
         // Orthogonal vectors -> cosine 0.0 < 0.9 -> disagree (weight -2) -> 0.0.
         let s_orth = score_fs_pair(0, 2, &p, get, noop_ne);
-        assert!((s_orth - 0.0).abs() < 1e-9, "cosine 0.0 -> disagree -> 0.0, got {s_orth}");
+        assert!(
+            (s_orth - 0.0).abs() < 1e-9,
+            "cosine 0.0 -> disagree -> 0.0, got {s_orth}"
+        );
         assert!(s_orth < s_same);
     }
 

--- a/packages/rust/extensions/fs-core/src/lib.rs
+++ b/packages/rust/extensions/fs-core/src/lib.rs
@@ -344,6 +344,32 @@ pub struct FsPairParams<'a> {
     /// [`TfTable`] and the field loop in [`score_fs_pair`]. Indexed like
     /// `scorer_ids`; a shorter/empty slice means "no TF for any field".
     pub tf_tables: &'a [Option<TfTable>],
+    /// Per-field embedding vectors for `embedding` / `record_embedding`
+    /// (scorer id [`FS_SCORER_EMBEDDING_COSINE`]) fields. `emb_vectors[f]` is
+    /// `Some(flat)` — the ROW-MAJOR `n_rows * dim` already-L2-normalized vectors
+    /// the host computed (the model stays host-side) — only for an embedding
+    /// field; `None` for every string-scorer field. Row `r`'s vector is
+    /// `flat[r*dim .. (r+1)*dim]` with `dim = emb_dims[f]`. Cosine of two
+    /// L2-normalized vectors IS their dot product, so [`score_fs_pair`] scores an
+    /// embedding field as `dot(row_i, row_j)` — byte-comparable to the numpy
+    /// `vecs @ vecs.T` reference within f64 tolerance. Null-ness is still carried
+    /// by `get_field` (the host passes the raw value column, or a never-null
+    /// synthetic column for `record_embedding`), so the existing observed / TF /
+    /// missing-mode machinery is unchanged. `[]` / all-`None` = no embedding.
+    pub emb_vectors: &'a [Option<&'a [f64]>],
+    /// Per-field embedding dimensionality, indexed like `scorer_ids`. Read only
+    /// where `emb_vectors[f]` is `Some`; `0` elsewhere.
+    pub emb_dims: &'a [usize],
+}
+
+/// Dot product of two equal-length f64 slices — the cosine of two L2-normalized
+/// embedding vectors (the `embedding` / `record_embedding` FS scorer). Naive
+/// summation mirrors the numpy reference closely enough for the FS f64 tolerance
+/// (embedding parity is cosine-tolerance, never byte-exact — f32/BLAS reorder the
+/// same accumulation on the numpy side too).
+#[inline]
+pub fn embedding_cosine(a: &[f64], b: &[f64]) -> f64 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
 /// Winkler term-frequency adjustment table for one field (EM-trained; the host
@@ -390,6 +416,11 @@ pub const FS_SCORER_GIVEN_NAME_ALIASED: u8 = 5;
 /// packs aren't installed, so this is a regular-field scorer (and a valid NE
 /// scorer), not name-specific.
 pub const FS_SCORER_ENSEMBLE: u8 = 6;
+/// Reserved FS-kernel scorer id for `embedding` / `record_embedding`. The field's
+/// value is a dense vector (not a string); [`score_fs_pair`] reads the row vectors
+/// from [`FsPairParams::emb_vectors`] and scores the pair as their cosine
+/// ([`embedding_cosine`]). `score_one` does NOT implement it.
+pub const FS_SCORER_EMBEDDING_COSINE: u8 = 7;
 
 /// American Soundex, byte-compatible with `jellyfish.soundex` on ASCII input.
 ///
@@ -525,7 +556,26 @@ where
     for f in 0..p.scorer_ids.len() {
         if let (Some(a), Some(b)) = (get_field(f, i), get_field(f, j)) {
             has_regular_evidence = true;
-            let sim = field_similarity(p.scorer_ids[f], a, b, p.surname_freq, p.name_aliases);
+            // An `embedding` / `record_embedding` field carries its similarity in
+            // the row vectors, not the string value — `get_field` above still
+            // gates observed-ness (raw value column, or a never-null synthetic
+            // column for record_embedding), so nulls flow through the SAME path.
+            let sim = if p.scorer_ids[f] == FS_SCORER_EMBEDDING_COSINE {
+                match p.emb_vectors.get(f).copied().flatten() {
+                    Some(flat) => {
+                        let dim = p.emb_dims[f];
+                        embedding_cosine(
+                            &flat[i * dim..i * dim + dim],
+                            &flat[j * dim..j * dim + dim],
+                        )
+                    }
+                    // No vectors supplied for an id-7 field is a caller bug; degrade
+                    // to "fully disagree" rather than panic in the hot loop.
+                    None => 0.0,
+                }
+            } else {
+                field_similarity(p.scorer_ids[f], a, b, p.surname_freq, p.name_aliases)
+            };
             let level = fs_level_from_sim(
                 sim,
                 p.levels[f],
@@ -538,10 +588,13 @@ where
             // Winkler TF adjustment: on an exact-equal TOP-level agreement, bump
             // the weight by the value's rarity. `a == b` mirrors the numpy
             // `equal & (lvl == top)` mask (equal transformed values → top level).
-            if let Some(Some(tf)) = p.tf_tables.get(f) {
-                let top = (p.levels[f] as usize).saturating_sub(1);
-                if level == top && a == b {
-                    total_weight += tf.adjustment(a);
+            // Embedding fields never carry a TF table (no exact-value semantics).
+            if p.scorer_ids[f] != FS_SCORER_EMBEDDING_COSINE {
+                if let Some(Some(tf)) = p.tf_tables.get(f) {
+                    let top = (p.levels[f] as usize).saturating_sub(1);
+                    if level == top && a == b {
+                        total_weight += tf.adjustment(a);
+                    }
                 }
             }
         }
@@ -631,6 +684,8 @@ mod tests {
             surname_freq: None,
             name_aliases: None,
             tf_tables: &[],
+            emb_vectors: &[],
+            emb_dims: &[],
         };
         let rows = [["alice", "smith"], ["alice", "jones"], ["bob", "brown"]];
         let get = |f: usize, r: usize| Some(rows[r][f]);
@@ -680,6 +735,8 @@ mod tests {
             surname_freq: None,
             name_aliases: None,
             tf_tables: &[],
+            emb_vectors: &[],
+            emb_dims: &[],
         };
         // field 1 is null for row 1 -> only field 0 observed; agree -> 1.0 of the
         // single-field observed range.
@@ -732,6 +789,8 @@ mod tests {
             surname_freq: None,
             name_aliases: Some(&aliases),
             tf_tables: &[],
+            emb_vectors: &[],
+            emb_dims: &[],
         };
         let rows = ["William", "Bill"];
         let get = |_f: usize, r: usize| Some(rows[r]);
@@ -841,6 +900,8 @@ mod tests {
             surname_freq: None,
             name_aliases: None,
             tf_tables: &[],
+            emb_vectors: &[],
+            emb_dims: &[],
         };
         let rows = ["Robert", "Rupert"];
         let get = |_f: usize, r: usize| Some(rows[r]);
@@ -851,6 +912,63 @@ mod tests {
             s > 0.5,
             "phonetic agreement clears the partial threshold, got {s}"
         );
+    }
+
+    #[test]
+    fn score_fs_pair_embedding_cosine_bands_by_dot_product() {
+        // A single embedding-cosine field (id 7). Row vectors are L2-normalized;
+        // the pair score is their dot product = cosine, banded by the level
+        // thresholds. get_field carries only null-ness (raw value column), the
+        // vectors carry the similarity — the numpy `vecs @ vecs.T` reference.
+        let mw = vec![vec![-2.0_f64, 3.0]];
+        let field_mins = [-2.0_f64];
+        let field_maxs = [3.0_f64];
+        let regular_min = -2.0;
+        let regular_max = 3.0;
+        // 3 rows, dim 2: r0=r1=[1,0] (identical), r2=[0,1] (orthogonal to r0).
+        let flat: Vec<f64> = vec![1.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let emb_vectors: Vec<Option<&[f64]>> = vec![Some(flat.as_slice())];
+        let emb_dims = [2usize];
+        let p = FsPairParams {
+            scorer_ids: &[FS_SCORER_EMBEDDING_COSINE],
+            levels: &[2],
+            partial_thresholds: &[0.9],
+            field_thresholds: &[None],
+            match_weights: &mw,
+            field_mins: &field_mins,
+            field_maxs: &field_maxs,
+            base_min: regular_min - regular_min, // min_weight = regular_min
+            base_max: regular_min + (regular_max - regular_min) - regular_max,
+            ne_scorer_ids: &[],
+            ne_thresholds: &[],
+            ne_weights: &[],
+            calibrated: false,
+            prior_w: 0.0,
+            surname_freq: None,
+            name_aliases: None,
+            tf_tables: &[],
+            emb_vectors: &emb_vectors,
+            emb_dims: &emb_dims,
+        };
+        // All rows present (non-null) — a synthetic never-null value column.
+        let rows = ["x", "x", "x"];
+        let get = |_f: usize, r: usize| Some(rows[r]);
+        let noop_ne = |_: usize, _: usize| None;
+        // Identical vectors -> cosine 1.0 >= 0.9 -> agree (weight 3) -> normalized 1.0.
+        let s_same = score_fs_pair(0, 1, &p, get, noop_ne);
+        assert!((s_same - 1.0).abs() < 1e-9, "cosine 1.0 -> top -> 1.0, got {s_same}");
+        // Orthogonal vectors -> cosine 0.0 < 0.9 -> disagree (weight -2) -> 0.0.
+        let s_orth = score_fs_pair(0, 2, &p, get, noop_ne);
+        assert!((s_orth - 0.0).abs() < 1e-9, "cosine 0.0 -> disagree -> 0.0, got {s_orth}");
+        assert!(s_orth < s_same);
+    }
+
+    #[test]
+    fn embedding_cosine_matches_manual_dot() {
+        let a = [0.6_f64, 0.8];
+        let b = [0.8_f64, 0.6];
+        // 0.6*0.8 + 0.8*0.6 = 0.96
+        assert!((embedding_cosine(&a, &b) - 0.96).abs() < 1e-12);
     }
 
     #[test]
@@ -906,6 +1024,8 @@ mod tests {
             surname_freq: None,
             name_aliases: None,
             tf_tables: &tf_tables,
+            emb_vectors: &[],
+            emb_dims: &[],
         };
         let rows = ["smith", "smith", "rare", "rare", "jones"];
         let get = |_f: usize, r: usize| Some(rows[r]);

--- a/packages/rust/extensions/fs-wasm/src/lib.rs
+++ b/packages/rust/extensions/fs-wasm/src/lib.rs
@@ -90,6 +90,11 @@ pub fn score_block_pairs_fs_impl(
         surname_freq: None,
         name_aliases: None,
         tf_tables: &[],
+        // Embedding scorers marshal precomputed vectors from the host — a later
+        // TS increment (the native pyo3 side lands first). None here degrades an
+        // id-7 field to "fully disagree", but the wasm entry never emits id 7.
+        emb_vectors: &[],
+        emb_dims: &[],
     };
 
     let mut out: Vec<(i64, i64, f64)> = Vec::new();

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -65,6 +65,12 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // only when this flag is present; old wheels score id 6 as 0.0 (score_one's
     // catch-all), so they must keep the numpy path for ensemble matchkeys.
     m.add("FS_SUPPORTS_ENSEMBLE", true)?;
+    // Wheel-skew capability flag: both FS entries accept the per-field
+    // `emb_vectors`/`emb_dims` kwargs and score an `embedding` / `record_embedding`
+    // field (id 7) as the cosine (dot) of the two rows' host-precomputed
+    // L2-normalized vectors. Python's `_fs_native_eligible` admits an embedding
+    // field only when this flag is present; old wheels keep the numpy path.
+    m.add("FS_SUPPORTS_EMBEDDING", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -112,6 +112,10 @@ fn build_tf_tables(
 /// does no embedding work. Every id-7 field MUST carry a correctly-sized vector
 /// block (a caller bug otherwise, surfaced as a `ValueError`, never a hot-loop
 /// panic).
+// The `(Vec<Option<Vec<f64>>>, Vec<usize>)` return mirrors the pyo3 kwarg shapes
+// (per-field optional flat vectors + per-field dims); a type alias would obscure
+// more than it clarifies here.
+#[allow(clippy::type_complexity)]
 fn build_emb_vectors(
     emb_vectors: Option<Vec<Option<Vec<f64>>>>,
     emb_dims: Option<Vec<usize>>,

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -126,10 +126,7 @@ fn build_emb_vectors(
     for f in 0..n_fields {
         if scorer_ids[f] == goldenmatch_fs_core::FS_SCORER_EMBEDDING_COSINE {
             let dim = dims[f];
-            let ok = dim > 0
-                && owned[f]
-                    .as_ref()
-                    .is_some_and(|v| v.len() == n_rows * dim);
+            let ok = dim > 0 && owned[f].as_ref().is_some_and(|v| v.len() == n_rows * dim);
             if !ok {
                 return Err(PyValueError::new_err(format!(
                     "score_block_pairs_fs: field {f} is embedding-cosine (id 7) but \
@@ -528,8 +525,7 @@ pub fn score_block_pairs_fs(
     // Embedding vectors for FS_SCORER_EMBEDDING_COSINE fields: row-major
     // n_rows*dim, already L2-normalized host-side (the model stays host-side).
     // `emb_owned` keeps the buffers alive; `emb_vectors` borrows into it.
-    let (emb_owned, emb_dims) =
-        build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
+    let (emb_owned, emb_dims) = build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
     let emb_vectors: Vec<Option<&[f64]>> = emb_owned.iter().map(|o| o.as_deref()).collect();
 
     // Per-matchkey scoring constants, borrowed once and reused per pair. The
@@ -989,8 +985,7 @@ pub fn score_block_pairs_fs_arrow(
     let (surname_freq, name_aliases) = name_providers(&name_refdata);
 
     // Embedding vectors (id 7) — same host-marshaled buffers as the Vec entry.
-    let (emb_owned, emb_dims) =
-        build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
+    let (emb_owned, emb_dims) = build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
     let emb_vectors: Vec<Option<&[f64]>> = emb_owned.iter().map(|o| o.as_deref()).collect();
 
     // Per-matchkey scoring constants, borrowed once and reused per pair. The

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -103,6 +103,44 @@ fn build_tf_tables(
     out
 }
 
+/// Validate + own the per-field embedding vectors for `FS_SCORER_EMBEDDING_COSINE`
+/// (id 7) fields. `emb_vectors[f]` (when the host supplies it) is the ROW-MAJOR
+/// `n_rows * emb_dims[f]` already-L2-normalized buffer for field `f`; `None` for
+/// every non-embedding field. Returns owned buffers (kept alive by the caller,
+/// which then hands `score_fs_pair` a borrowed `Vec<Option<&[f64]>>`) plus an
+/// `emb_dims` padded to `n_fields`. Absent everywhere -> empty Vecs, so the kernel
+/// does no embedding work. Every id-7 field MUST carry a correctly-sized vector
+/// block (a caller bug otherwise, surfaced as a `ValueError`, never a hot-loop
+/// panic).
+fn build_emb_vectors(
+    emb_vectors: Option<Vec<Option<Vec<f64>>>>,
+    emb_dims: Option<Vec<usize>>,
+    scorer_ids: &[u8],
+    n_rows: usize,
+) -> PyResult<(Vec<Option<Vec<f64>>>, Vec<usize>)> {
+    let n_fields = scorer_ids.len();
+    let mut owned = emb_vectors.unwrap_or_default();
+    let mut dims = emb_dims.unwrap_or_default();
+    owned.resize_with(n_fields, || None);
+    dims.resize(n_fields, 0);
+    for f in 0..n_fields {
+        if scorer_ids[f] == goldenmatch_fs_core::FS_SCORER_EMBEDDING_COSINE {
+            let dim = dims[f];
+            let ok = dim > 0
+                && owned[f]
+                    .as_ref()
+                    .is_some_and(|v| v.len() == n_rows * dim);
+            if !ok {
+                return Err(PyValueError::new_err(format!(
+                    "score_block_pairs_fs: field {f} is embedding-cosine (id 7) but \
+                     emb_vectors[{f}] is missing or not n_rows*dim ({n_rows}*{dim})"
+                )));
+            }
+        }
+    }
+    Ok((owned, dims))
+}
+
 /// Resolve the injected provider handles for a scoring call. Borrows live as
 /// long as the caller keeps the returned `Arc` alive.
 #[inline]
@@ -336,6 +374,7 @@ pub(crate) use goldenmatch_fs_core::{fs_level_from_sim, fs_normalize};
     ne_values=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
     exclude_set=None,
     tf_freqs=None, tf_collision=None,
+    emb_vectors=None, emb_dims=None,
 ))]
 pub fn score_block_pairs_fs(
     py: Python<'_>,
@@ -360,6 +399,8 @@ pub fn score_block_pairs_fs(
     exclude_set: Option<PyRef<'_, ExcludeSet>>,
     tf_freqs: Option<Vec<Option<std::collections::HashMap<String, f64>>>>,
     tf_collision: Option<Vec<Option<f64>>>,
+    emb_vectors: Option<Vec<Option<Vec<f64>>>>,
+    emb_dims: Option<Vec<usize>>,
 ) -> PyResult<Vec<(i64, i64, f64)>> {
     // FS_SUPPORTS_EXCLUDE_SET: prefer the shared Arc handle (built once per
     // score_buckets call via `build_exclude_set`), fall back to the legacy
@@ -484,6 +525,13 @@ pub fn score_block_pairs_fs(
     let name_refdata = current_name_refdata();
     let (surname_freq, name_aliases) = name_providers(&name_refdata);
 
+    // Embedding vectors for FS_SCORER_EMBEDDING_COSINE fields: row-major
+    // n_rows*dim, already L2-normalized host-side (the model stays host-side).
+    // `emb_owned` keeps the buffers alive; `emb_vectors` borrows into it.
+    let (emb_owned, emb_dims) =
+        build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
+    let emb_vectors: Vec<Option<&[f64]>> = emb_owned.iter().map(|o| o.as_deref()).collect();
+
     // Per-matchkey scoring constants, borrowed once and reused per pair. The
     // per-pair FS math itself lives in `goldenmatch-fs-core::score_fs_pair` (the
     // single cross-surface source of truth); this entry point owns only the
@@ -506,6 +554,8 @@ pub fn score_block_pairs_fs(
         surname_freq,
         name_aliases,
         tf_tables: &tf_tables,
+        emb_vectors: &emb_vectors,
+        emb_dims: &emb_dims,
     };
 
     let result = py.detach(|| {
@@ -765,6 +815,7 @@ pub fn score_block_pairs_arrow(
     exclude=None, exclude_set=None, level_thresholds=None,
     ne_arrays=None, ne_scorer_ids=None, ne_thresholds=None, ne_weights=None,
     tf_freqs=None, tf_collision=None,
+    emb_vectors=None, emb_dims=None,
 ))]
 pub fn score_block_pairs_fs_arrow(
     py: Python<'_>,
@@ -789,6 +840,8 @@ pub fn score_block_pairs_fs_arrow(
     ne_weights: Option<Vec<f64>>,
     tf_freqs: Option<Vec<Option<std::collections::HashMap<String, f64>>>>,
     tf_collision: Option<Vec<Option<f64>>>,
+    emb_vectors: Option<Vec<Option<Vec<f64>>>>,
+    emb_dims: Option<Vec<usize>>,
 ) -> PyResult<Vec<(i64, i64, f64)>> {
     let row_data = row_ids.0;
     if row_data.data_type() != &DataType::Int64 {
@@ -935,6 +988,11 @@ pub fn score_block_pairs_fs_arrow(
     let name_refdata = current_name_refdata();
     let (surname_freq, name_aliases) = name_providers(&name_refdata);
 
+    // Embedding vectors (id 7) — same host-marshaled buffers as the Vec entry.
+    let (emb_owned, emb_dims) =
+        build_emb_vectors(emb_vectors, emb_dims, &scorer_ids, n_rows)?;
+    let emb_vectors: Vec<Option<&[f64]>> = emb_owned.iter().map(|o| o.as_deref()).collect();
+
     // Per-matchkey scoring constants, borrowed once and reused per pair. The
     // per-pair FS math is `goldenmatch-fs-core::score_fs_pair` — identical to the
     // Vec entry point; this arrow entry differs only in the zero-copy field
@@ -957,6 +1015,8 @@ pub fn score_block_pairs_fs_arrow(
         surname_freq,
         name_aliases,
         tf_tables: &tf_tables,
+        emb_vectors: &emb_vectors,
+        emb_dims: &emb_dims,
     };
 
     // Per-block FS scorer shared by the sequential and rayon paths (mirrors


### PR DESCRIPTION
## What and why

Follow-up to #1869 (the `fs-core` cross-surface extraction). This ports the last
two Fellegi-Sunter comparison scorers that had **no native kernel id** — the
model-backed `embedding` and `record_embedding` scorers — onto the shared
`goldenmatch-fs-core` kernel. Before this, a probabilistic matchkey carrying an
embedding field forced the WHOLE matchkey onto the numpy path. After this, the
**native kernel covers 100% of FS comparison scorers**.

The model stays host-side (torch / Vertex / goldenembed); only the already-
L2-normalized vectors cross the pyo3 boundary. The kernel scores an embedding
field as the cosine — i.e. the dot product — of the two rows' vectors, which is
byte-comparable (f64 tolerance) to the numpy `embeddings @ embeddings.T`
reference.

## Changes (increment 7a)

- **fs-core**: `FS_SCORER_EMBEDDING_COSINE = 7` + `embedding_cosine(a, b)` (naive
  f64 dot); `FsPairParams` gains `emb_vectors` (row-major `n_rows*dim` per field)
  + `emb_dims`; `score_fs_pair` reads the row vectors for an id-7 field while
  null-ness still flows through `get_field`, so the observed / missing-mode /
  TF machinery is unchanged. 2 new unit tests.
- **native**: `emb_vectors`/`emb_dims` kwargs on both FS entry points +
  `build_emb_vectors` (validates every id-7 field carries an `n_rows*dim` block);
  `FS_SUPPORTS_EMBEDDING` capability const.
- **fs-wasm**: passes empty embedding slices (the wasm entry never emits id 7 yet).
- **probabilistic.py**: `embedding`/`record_embedding` -> id 7 in
  `_NATIVE_FS_SCORER_IDS`; `_fs_native_eligible` admits both behind the
  `FS_SUPPORTS_EMBEDDING` gate (and rejects them as NE scorers);
  `_fs_embedding_vectors` embeds each field with the SAME embedder + values the
  numpy path uses (`_record_concat_values` is a byte-for-byte copy of
  `_record_embedding_score_matrix`'s concat); `_score_fs_native_frame` marshals
  the vectors and pins the `record_embedding` value column to a never-null
  sentinel (record fields are always observed).

## Increment 7b (native-required deletion): reconciled, aggressive delete deferred

The design note's original 7b was "make native required + delete the numpy/scalar
production paths + the `GOLDENMATCH_FS_NATIVE`/`_FS_VECTORIZED` knobs, raise when
native is absent." That conflicts with the shipped 2026-07-01 reference-mode
roadmap, which keeps the pure-Python path as a *lossy fallback* (`=0` forces it;
`pip install goldenmatch` without `[native]` still runs FS). Deleting it removes a
base-install capability. So native is the authoritative + default path (already
true, now 100%-capable) and the numpy/scalar path is **retained** as the
reference-mode fallback + parity oracle; the base-install-breaking deletion is
deferred pending explicit product sign-off. Design note updated accordingly.

## Testing

- `cargo test` fs-core (19, incl. 2 new embedding tests); `cargo fmt --check`
  clean on fs-core / native / fs-wasm.
- Rebuilt the native ext and ran the FS suite against the real `.so`:
  `test_fs_embedding_native.py` (native == numpy, abs 1e-6, for BOTH `embedding`
  and `record_embedding`) + `test_fs_embedding_firstclass` /
  `test_fs_name_scorers_native` / `test_native_fs_ne` / `test_probabilistic` /
  `test_probabilistic_vectorized` / `test_fs_bucket_native` -> **223 passed**,
  including the existing embedding-firstclass suite now routing through native.
- `ruff check` clean on the changed Python.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff` / `cargo fmt` / `clippy` clean
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Design note updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_