### PR TITLE
fix(fs): decline the native kernel for disagree-missing-mode matchkeys

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -3126,6 +3126,14 @@ def _fs_native_eligible(mk: MatchkeyConfig) -> bool:
         return False
     if not mk.fields:
         return False
+    # The native kernel implements ONLY the "unobserved"/neutral missing semantics
+    # (a null field is skipped; FS_SUPPORTS_MISSING_NEUTRAL). Under the "disagree"
+    # mode (#1834/#1851: auto-config picks it per-dataset for null-heavy data like
+    # historical_50k) a null field must instead score as level 0 (evidence AGAINST),
+    # which the kernel cannot express -- scoring nulls as neutral over-matches and
+    # collapses precision. Decline to the numpy path, which honors both modes.
+    if fs_missing_mode(mk) == "disagree":
+        return False
     needs_ensemble = False
     ne_fields = mk.negative_evidence or []
     for ne in ne_fields:

--- a/packages/python/goldenmatch/tests/test_fs_native_missing_mode.py
+++ b/packages/python/goldenmatch/tests/test_fs_native_missing_mode.py
@@ -1,0 +1,66 @@
+"""The native FS kernel only implements the "unobserved"/neutral missing
+semantics. A matchkey whose auto-config picked `missing="disagree"` (#1834/#1851,
+e.g. null-heavy historical_50k) must DECLINE the native path and score on numpy,
+which honors both modes -- otherwise native scores nulls as neutral instead of
+level-0-disagree and precision collapses (the #1869 regression on historical_50k
+f1_probabilistic 0.83 -> 0.33)."""
+
+from __future__ import annotations
+
+import os
+
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+
+
+def _mk(missing: str) -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="p", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.8),
+            MatchkeyField(field="surname", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.8),
+        ],
+        missing=missing, link_threshold=0.0,
+    )
+
+
+def _native_ready() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module
+        mod = native_module()
+        return bool(mod) and hasattr(mod, "score_block_pairs_fs")
+    except Exception:
+        return False
+
+
+def test_disagree_mode_declines_native(monkeypatch):
+    """`missing="disagree"` is not expressible by the kernel -> decline to numpy."""
+    from goldenmatch.core import probabilistic as P
+
+    assert P.fs_missing_mode(_mk("disagree")) == "disagree"
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    # Declined regardless of whether the native ext is present.
+    assert P._fs_native_eligible(_mk("disagree")) is False
+
+
+def test_unobserved_mode_stays_native_eligible(monkeypatch):
+    """The default `unobserved`/neutral mode IS what the kernel implements."""
+    from goldenmatch.core import probabilistic as P
+
+    assert P.fs_missing_mode(_mk("unobserved")) == "unobserved"
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    if _native_ready():
+        assert P._fs_native_eligible(_mk("unobserved")) is True
+
+
+def test_env_disagree_override_also_declines(monkeypatch):
+    """`GOLDENMATCH_FS_MISSING=disagree` (env override) also declines native."""
+    from goldenmatch.core import probabilistic as P
+
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "1")
+    monkeypatch.setenv("GOLDENMATCH_FS_MISSING", "disagree")
+    try:
+        assert P._fs_native_eligible(_mk("unobserved")) is False
+    finally:
+        os.environ.pop("GOLDENMATCH_FS_MISSING", None)


### PR DESCRIPTION
## Summary

Fixes the `quality_gate` main-red regression on `historical_50k` (`f1_probabilistic` collapsed from ~0.83 to ~0.33).

**Root cause:** the native FS block-scoring kernel implements ONLY the `unobserved`/neutral missing-value semantics (a null field is skipped; `FS_SUPPORTS_MISSING_NEUTRAL`). Under the `disagree` mode (#1834/#1851 — auto-config picks it per-dataset for null-heavy data like `historical_50k`) a null field must instead score as level 0 (evidence AGAINST). The kernel cannot express this, so it scored nulls as neutral, over-matched, and collapsed precision (P 0.94 → 0.24).

**Fix:** `_fs_native_eligible` now declines the native path (routing to numpy, which honors both modes) whenever `fs_missing_mode(mk) == "disagree"`. This is the reference-mode fallback posture: numpy is the lossy fallback that covers the semantics the kernel doesn't yet implement.

Verified locally: `historical_50k` `f1_probabilistic` restored to `0.8515` (P=0.9420, R=0.7768) under `GOLDENMATCH_FS_NATIVE=auto`, byte-matching the numpy path.

## Test plan

- `tests/test_fs_native_missing_mode.py` (new regression test):
  - `test_disagree_mode_declines_native` — `missing="disagree"` declines regardless of native availability
  - `test_unobserved_mode_stays_native_eligible` — the default neutral mode stays native-eligible
  - `test_env_disagree_override_also_declines` — `GOLDENMATCH_FS_MISSING=disagree` env override also declines
- Existing FS native parity + missing-mode suites pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_