### PR TITLE
fix(autoconfig): route _build_compound_blocking through the Frame seam (#1852)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1660,7 +1660,7 @@ def _build_strong_identifier_union(
 
 def _build_compound_blocking(
     profiles: list[ColumnProfile],
-    df: pl.DataFrame,
+    df: pl.DataFrame | Any,  # #1852: also accepts pa.Table (routed via to_frame)
     max_safe_block: int,
     max_null_rate: float,
 ) -> BlockingConfig | None:
@@ -1672,23 +1672,29 @@ def _build_compound_blocking(
 
     Returns None if no compound pair brings blocks below max_safe_block.
     """
+    # #1852: route every column/group op through the backend-neutral Frame
+    # seam so this helper works on BOTH a polars ``pl.DataFrame`` and an Arrow
+    # ``pa.Table`` (the latter is the default input since the arrow-native
+    # autoconfig path, `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1`). The raw
+    # `df[col].null_count()` / `df.height` / `df.group_by(...)` polars idioms
+    # AttributeError'd on a `pa.Table`.
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+
     def _null_rate(col_name: str) -> float:
-        return df[col_name].null_count() / df.height if df.height > 0 else 0.0
+        return frame.column(col_name).null_count() / frame.height if frame.height > 0 else 0.0
 
     def _max_block_size(col_name: str) -> int:
         """Largest group size when blocking on this column (W3d: seam)."""
-        from goldenmatch.core.frame import to_frame
-
-        return int(to_frame(df).group_len([col_name]).column("len").max() or 0)
+        return int(frame.group_len([col_name]).column("len").max() or 0)
 
     def _nonnull_ratio(col_name: str) -> float:
         """Distinct/non-null ratio -- the TRUE per-record uniqueness, not the
         null-deflated ColumnProfile.cardinality_ratio. A near-1.0 value means a
         surrogate-key-like column (npi/phone/email) whose only big "block" is
         its null bucket -- useless as a blocking component."""
-        from goldenmatch.core.frame import to_frame
-
-        nn = to_frame(df).column(col_name).drop_nulls()
+        nn = frame.column(col_name).drop_nulls()
         n = len(nn)
         return (nn.n_unique() / n) if n > 0 else 1.0
 
@@ -1752,14 +1758,14 @@ def _build_compound_blocking(
         return None
 
     # Sort by cardinality descending — best single column first
-    candidates.sort(key=lambda p: df[p.name].n_unique(), reverse=True)
+    candidates.sort(key=lambda p: frame.column(p.name).n_unique(), reverse=True)
     best = candidates[0]
 
     # Test compound pairs: best + each other candidate (up to 5)
     pair_results: list[tuple[ColumnProfile, int]] = []
     for other in candidates[1:6]:
         try:
-            max_block = int(df.group_by([best.name, other.name]).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" column is int64 at runtime
+            max_block = int(frame.group_len([best.name, other.name]).column("len").max() or 0)
             pair_results.append((other, max_block))
             logger.debug(
                 "Compound pair [%s, %s]: max_block=%d",

--- a/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
@@ -156,6 +156,47 @@ def test_arrow_native_is_the_default():
     assert _dupe_count(res_default) == _dupe_count(res_pl)
 
 
+def _compound_shape():
+    """400 rows where every SINGLE column is oversized (4 blocks of 100) but the
+    compound (first, last) pair is bounded (16 blocks of 25) -- the shape that
+    routes ``build_blocking`` into ``_build_compound_blocking``."""
+    return {
+        "first": [f"n{i % 4}" for i in range(400)],
+        "last": [f"s{(i // 4) % 4}" for i in range(400)],
+    }
+
+
+def test_build_compound_blocking_accepts_arrow_table():
+    """#1852: ``_build_compound_blocking`` AttributeError'd on a ``pa.Table``
+    (``df[col].null_count()`` / ``df.height`` / ``df.group_by`` are polars-only)
+    -- live on 3.3.1/3.4.0 with GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE default-on.
+    It must now run on Arrow via the Frame seam and return the SAME config the
+    polars input yields (byte-value-equivalent on this deterministic shape)."""
+    from goldenmatch.core.autoconfig import ColumnProfile, _build_compound_blocking
+
+    data = _compound_shape()
+    profiles = [
+        ColumnProfile(name="first", dtype="str", col_type="string", confidence=1.0,
+                      cardinality_ratio=4 / 400),
+        ColumnProfile(name="last", dtype="str", col_type="string", confidence=1.0,
+                      cardinality_ratio=4 / 400),
+    ]
+
+    cfg_pa = _build_compound_blocking(profiles, pa.table(data), max_safe_block=50, max_null_rate=0.2)
+    cfg_pl = _build_compound_blocking(
+        profiles, pl.DataFrame(data), max_safe_block=50, max_null_rate=0.2
+    )
+
+    # Arrow no longer raises AttributeError and finds a bounded compound.
+    assert cfg_pa is not None
+    assert cfg_pa.strategy == "multi_pass"
+    # Cross-backend equivalence: same passes selected on the deterministic shape.
+    assert cfg_pl is not None
+    assert [(list(p.fields), list(p.transforms)) for p in cfg_pa.passes] == [
+        (list(p.fields), list(p.transforms)) for p in cfg_pl.passes
+    ]
+
+
 @pytest.mark.parametrize("shape", ["exact-id-plus-names", "shared-email-switchboard"])
 def test_arrow_native_config_matchkey_equivalence(shape):
     """On shapes without a near-tie blocking choice, the arrow-native config's


### PR DESCRIPTION
Fixes #1852.

## Summary

`_build_compound_blocking` was still polars-typed and `AttributeError`'d on a `pa.Table`:
- `_null_rate`: `df[col_name].null_count() / df.height`
- the cardinality sort: `df[p.name].n_unique()`
- the compound-pair probe: `df.group_by([...]).len().get_column("len").max()`

Since `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE` defaults **ON** (2026-07-14), any wide/sparse Arrow input that reached the compound-blocking fallback crashed `auto_configure_df` — **live in production on 3.3.1, and the offending line was still on `main`, so 3.4.0 shipped it too** (Golden Truth archive ingest hit it).

## Fix

The two sibling helpers in the same function (`_max_block_size` / `_nonnull_ratio`) and `_check_source_overlap` already route through the backend-neutral `to_frame` seam. This extends the same treatment to the three remaining polars-only idioms, so the whole helper is dtype-agnostic and works on both a `pl.DataFrame` and a `pa.Table`. One shared `frame = to_frame(df)` replaces the per-helper re-imports. Byte-value-equivalent on the polars path (the seam delegates to the exact same polars calls).

## Test plan

`tests/test_autoconfig_arrow_native_parity.py::test_build_compound_blocking_accepts_arrow_table` (new):
- drives the crash shape on a `pa.Table` — 400 rows where every single column is oversized (4 blocks of 100) but the compound `(first, last)` pair is bounded (16 blocks of 25), the shape that routes into `_build_compound_blocking`;
- asserts Arrow no longer raises and returns a `multi_pass` config;
- pins Arrow == polars pass selection cross-backend.

Verified the test fails with `AttributeError: 'pyarrow.lib.Table' object has no attribute 'height'` before the fix and passes after. Full `test_autoconfig_arrow_native_parity.py` (11) + `test_zero_config_no_polars.py` + `test_autoconfig_facade.py` + `test_coreapi_aux_no_polars.py` green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_