### PR TITLE
feat(scorer): date-aware `date` scorer across Rust/native/Python/TS/wasm (#1858)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -213,6 +213,14 @@ def _score_block_vec(
 # the Python per-pair loop for that bucket.
 _NATIVE_SCORER_IDS: dict[str, int] = {
     "jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3,
+    # id 4 = date (score-core score_one). Routing to native is GUARDED on the
+    # `date_similarity` capability symbol at the gating site below: a stale
+    # published wheel (pre-date) would hit score_one's catch-all and silently
+    # score every date pair 0.0, so absent the symbol, date declines to the
+    # pure-Python mirror. NOTE: distinct from _NATIVE_FIELD_SCORER_IDS (the
+    # score_field_matrix path), where id 4 is soundex_match -- different kernel,
+    # different namespace; date is not wired into that path.
+    "date": 4,
 }
 
 
@@ -274,6 +282,11 @@ def _resolve_score_pair_callable(
         # one call at a time instead of cdist-batched.
         import jellyfish as _jf
         return lambda a, b: 1.0 if _jf.soundex(a) == _jf.soundex(b) else 0.0
+    if scorer_name == "date":
+        # Date-aware scorer (#1858). Per-pair mirror of score-core::date_similarity
+        # (native id 4); byte-identical to the kernel (native-parity asserted).
+        from goldenmatch.core.scorer import _date_similarity_py
+        return _date_similarity_py
     if scorer_name == "dice":
         # Delegate to the existing per-pair implementation in core/scorer.py
         # (_dice_score_single, bigram set Dice coefficient). Matrix path is
@@ -945,7 +958,16 @@ def score_buckets(
         _, _, _field_specs, _ne_specs = fast_path_specs
         if not _ne_specs:
             ids = [_NATIVE_SCORER_IDS.get(spec[3]) for spec in _field_specs]
-            if all(i is not None for i in ids):
+            # Wheel-skew guard: the `date` scorer (id 4) exists only in kernels
+            # that also expose `date_similarity`. A stale published wheel would
+            # dispatch id 4 to score_one's catch-all and silently score every
+            # date pair 0.0 -- so if any field is `date` and the loaded kernel
+            # lacks the symbol, decline native entirely and let the pure-Python
+            # per-pair path (which mirrors the kernel) score the whole block.
+            _mod = native_module()
+            _date_ok = _mod is not None and hasattr(_mod, "date_similarity")
+            has_date = any(spec[3] == "date" for spec in _field_specs)
+            if all(i is not None for i in ids) and not (has_date and not _date_ok):
                 native_scorer_ids = ids  # type: ignore[assignment]
 
     # Track 1 Fix B: build the native ExcludeSet ONCE here, BEFORE the bucket

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -22,6 +22,12 @@ VALID_SCORERS = frozenset({
     "exact", "jaro_winkler", "levenshtein", "token_sort", "soundex_match",
     "embedding", "record_embedding", "ensemble",
     "dice", "jaccard", "qgram",
+    # Date-aware comparator (#1858): parses ISO YYYY-MM-DD and scores by
+    # Damerau-Levenshtein over the canonical digits, so a typo scores far above
+    # an unrelated date (jaro_winkler collapses both to 0.80+). Non-ISO input
+    # degrades to levenshtein. Use this for date columns instead of a name-
+    # oriented fuzzy scorer.
+    "date",
     # Hamming similarity over a hex perceptual hash (image pHash) -- the
     # multimodal-ER crawl-tier media-as-evidence comparator (ADR 0022).
     "phash",

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py
@@ -113,6 +113,7 @@ PreflightCheckName = Literal[
     "weight_confidence",
     "no_matchkeys_remain",
     "remote_asset_matchkey_empty",
+    "date_scorer_mismatch",
 ]
 
 
@@ -918,6 +919,54 @@ def _check_weight_confidence(
                 report.config_was_modified = True
 
 
+_NAME_ORIENTED_FUZZY_SCORERS: frozenset[str] = frozenset({
+    "jaro_winkler", "token_sort", "ensemble",
+    "given_name_aliased_jw", "name_freq_weighted_jw",
+})
+
+
+def _check_date_scorer(
+    config: GoldenMatchConfig,
+    profiles: list[ColumnProfile] | None,
+    report: PreflightReport,
+) -> None:
+    """Check 7 (#1858): WARN when a name-oriented fuzzy scorer sits on a date
+    field. jaro_winkler/token_sort/etc. score unrelated ISO dates 0.80+ (the
+    fixed YYYY-MM-DD shape + shared digits dominate), so a typo is
+    indistinguishable from a different person and precision craters. Recommend
+    scorer='date'. Warning only -- auto-config already skips date columns as fuzzy
+    fields, so this fires on hand-written / Splink-converted configs; it does not
+    rewrite the config (the user's dtype knowledge may differ from the heuristic).
+    """
+    from goldenmatch.core.autoconfig import _classify_by_name
+
+    col_type_by_col = {p.name: getattr(p, "col_type", None) for p in (profiles or [])}
+    for mk in config.get_matchkeys():
+        for f in mk.fields:
+            if f.field is None or f.scorer not in _NAME_ORIENTED_FUZZY_SCORERS:
+                continue
+            # Profile col_type is authoritative when present; else fall back to
+            # the name heuristic (dob / _date / birth... -- autoconfig._DATE_PATTERNS).
+            is_date = col_type_by_col.get(f.field) == "date" or _classify_by_name(f.field) == "date"
+            if not is_date:
+                continue
+            report.findings.append(
+                PreflightFinding(
+                    check="date_scorer_mismatch",
+                    severity="warning",
+                    subject=f"{mk.name}.{f.field}",
+                    message=(
+                        f"field '{f.field}' looks like a date but scores with "
+                        f"'{f.scorer}', a name-oriented fuzzy scorer that rates "
+                        f"unrelated ISO dates 0.80+ (a typo is indistinguishable "
+                        f"from a different person). Use scorer='date' instead."
+                    ),
+                    repaired=False,
+                    repair_note=None,
+                )
+            )
+
+
 # ── Postflight helpers ──────────────────────────────────────────────────
 
 
@@ -1290,4 +1339,7 @@ def preflight(
     _check_remote_assets(config, report, allow_remote_assets=allow_remote_assets)
     if profiles is not None:
         _check_weight_confidence(config, profiles, report)
+    # #1858: warn on a name-oriented fuzzy scorer over a date field. Runs even
+    # without profiles (falls back to the field-name date heuristic).
+    _check_date_scorer(config, profiles, report)
     return report

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import jellyfish
 import numpy as np
-from rapidfuzz.distance import JaroWinkler, Levenshtein
+from rapidfuzz.distance import DamerauLevenshtein, JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 from rapidfuzz.process import cdist
 
@@ -146,6 +146,31 @@ def _alias_match_single(val_a: str, val_b: str) -> float:
     return 0.0
 
 
+def _iso_date_digits(s: str) -> str | None:
+    """The 8 packed digits of an ISO-8601 ``YYYY-MM-DD`` string, or None if it
+    isn't that exact shape. Pure-Python mirror of score-core's ``iso_date_digits``
+    (strict: no locale parsing, month/day ranges not validated)."""
+    if len(s) != 10 or s[4] != "-" or s[7] != "-":
+        return None
+    digits = s[:4] + s[5:7] + s[8:10]
+    return digits if digits.isdigit() else None
+
+
+def _date_similarity_py(val_a: str, val_b: str) -> float:
+    """Pure-Python fallback mirror of score-core ``date_similarity`` (id 4).
+
+    Byte-identical to the Rust reference (asserted in the native-parity suite):
+    Damerau-Levenshtein over the 8 canonical ISO digits, mapped so a single-digit
+    typo stays above a typical 0.85 cutoff and an unrelated date cliffs to 0;
+    plain ``levenshtein`` fallback when either side isn't an ISO date. See #1858
+    (``jaro_winkler`` scores unrelated birthdays 0.80+)."""
+    da, db = _iso_date_digits(val_a), _iso_date_digits(val_b)
+    if da is not None and db is not None:
+        d = DamerauLevenshtein.distance(da, db)
+        return {0: 1.0, 1: 0.90, 2: 0.75}.get(d, 0.0)
+    return Levenshtein.normalized_similarity(val_a, val_b)
+
+
 def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | None:
     """Score two field values using the specified scorer.
 
@@ -156,6 +181,8 @@ def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | No
 
     if scorer == "exact":
         return 1.0 if val_a == val_b else 0.0
+    elif scorer == "date":
+        return _date_similarity_py(val_a, val_b)
     elif scorer == "jaro_winkler":
         return JaroWinkler.similarity(val_a, val_b)
     elif scorer == "levenshtein":
@@ -556,6 +583,19 @@ def _fuzzy_score_matrix(
             matrix = np.asarray(cdist(clean, clean, scorer=Levenshtein.normalized_similarity), dtype=np.float32)
         else:
             matrix = np.asarray(cdist(clean, clean, scorer=token_sort_ratio), dtype=np.float32) / 100.0
+    elif scorer_name == "date":
+        # Date-aware scorer (#1858). This find_fuzzy_matches / polars-direct path
+        # stays pure-Python: score_field_matrix's native id namespace already uses
+        # 4 for soundex_match, whereas the bucket path (score_one id 4) DOES route
+        # date through the kernel. Both agree by construction -- _date_similarity_py
+        # mirrors score-core::date_similarity (native-parity asserted). Dates land
+        # in small same-key blocks, so the O(n^2) Python loop is not a hot path.
+        n = len(clean)
+        matrix = np.zeros((n, n), dtype=np.float32)
+        for i in range(n):
+            for j in range(i + 1, n):
+                s = _date_similarity_py(clean[i], clean[j])
+                matrix[i, j] = matrix[j, i] = s
     elif scorer_name == "initialism_match":
         return _initialism_score_matrix(values)
     elif scorer_name == "alias_match":

--- a/packages/python/goldenmatch/tests/test_autoconfig_verify.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_verify.py
@@ -10,6 +10,48 @@ from goldenmatch.core.autoconfig_verify import (
 )
 
 
+def _date_lint_cfg(field: str, scorer: str):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="k", type="weighted", threshold=0.85,
+            fields=[MatchkeyField(field=field, scorer=scorer, weight=1.0)],
+        )],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["name"])]),
+    )
+
+
+class TestDateScorerLint:
+    """#1858: warn when a name-oriented fuzzy scorer sits on a date field."""
+
+    _df = pl.DataFrame({"dob": ["1980-01-01", "1975-11-30"], "name": ["a", "b"]})
+
+    def _warnings(self, config):
+        from goldenmatch.core.autoconfig_verify import preflight
+        return [f for f in preflight(self._df, config).findings if f.check == "date_scorer_mismatch"]
+
+    @pytest.mark.parametrize("scorer", ["jaro_winkler", "token_sort", "ensemble", "name_freq_weighted_jw"])
+    def test_name_scorer_on_date_field_warns(self, scorer):
+        w = self._warnings(_date_lint_cfg("dob", scorer))
+        assert len(w) == 1
+        assert w[0].severity == "warning"
+        assert not w[0].repaired  # advisory only, never rewrites the config
+        assert "date" in w[0].message and scorer in w[0].message
+
+    def test_date_scorer_on_date_field_is_clean(self):
+        assert self._warnings(_date_lint_cfg("dob", "date")) == []
+
+    def test_name_scorer_on_non_date_field_is_clean(self):
+        assert self._warnings(_date_lint_cfg("name", "jaro_winkler")) == []
+
+
 def test_postflight_report_dataclass_shape():
     adj = PostflightAdjustment(
         field="threshold", from_value=0.7, to_value=0.5,

--- a/packages/python/goldenmatch/tests/test_scorer.py
+++ b/packages/python/goldenmatch/tests/test_scorer.py
@@ -13,6 +13,66 @@ from goldenmatch.core.scorer import (
 )
 
 
+class TestDateScorer:
+    """The `date` scorer (#1858): jaro_winkler scores unrelated ISO dates 0.80+
+    and can't tell a typo from a different person; `date` uses Damerau-Levenshtein
+    over the canonical digits so a typo stays high and an unrelated date -> 0."""
+
+    def test_same_date(self):
+        assert score_field("1980-01-01", "1980-01-01", "date") == 1.0
+
+    def test_single_digit_typo_clears_a_typical_cutoff(self):
+        # jaro_winkler=0.96 here too, but see the unrelated case below.
+        assert score_field("1980-01-01", "1980-01-02", "date") == pytest.approx(0.90)
+        assert score_field("1980-01-01", "1980-01-02", "date") >= 0.85
+
+    def test_transposition_is_one_edit(self):
+        # Swapped adjacent digits = ONE Damerau edit -> still a typo.
+        assert score_field("1980-12-01", "1980-21-01", "date") == pytest.approx(0.90)
+
+    def test_two_edits_are_weak(self):
+        assert score_field("1980-01-01", "1975-01-01", "date") == pytest.approx(0.75)
+
+    def test_unrelated_date_is_zero_not_0_80(self):
+        # The whole point: jaro_winkler gives this 0.802; date gives 0.0.
+        assert score_field("1980-01-01", "1975-11-30", "date") == 0.0
+        assert score_field("1980-01-01", "1975-11-30", "jaro_winkler") > 0.80
+
+    def test_non_iso_falls_back_to_levenshtein(self):
+        from rapidfuzz.distance import Levenshtein
+        assert score_field("abc", "abc", "date") == 1.0
+        assert score_field("Jan 1 1980", "Jan 2 1980", "date") == pytest.approx(
+            Levenshtein.normalized_similarity("Jan 1 1980", "Jan 2 1980")
+        )
+
+    def test_null_short_circuits(self):
+        assert score_field(None, "1980-01-01", "date") is None
+
+    def test_schema_accepts_date_scorer(self):
+        mk = MatchkeyConfig(
+            name="k", type="weighted", threshold=0.85,
+            fields=[MatchkeyField(field="dob", scorer="date", weight=1.0)],
+        )
+        assert mk.fields[0].scorer == "date"
+
+    def test_native_matches_pure_python(self):
+        """When the native kernel is built, score-core::date_similarity (id 4)
+        must equal the pure-Python mirror bit-for-bit."""
+        from goldenmatch.core._native_loader import native_module
+        from goldenmatch.core.scorer import _date_similarity_py
+
+        native = native_module()
+        if native is None or not hasattr(native, "date_similarity"):
+            pytest.skip("native kernel with date scorer not built")
+        for a, b in [
+            ("1980-01-01", "1980-01-01"), ("1980-01-01", "1980-01-02"),
+            ("1980-01-01", "1975-01-01"), ("1980-01-01", "1975-11-30"),
+            ("1980-12-01", "1980-21-01"), ("2020-02-29", "2020-03-01"),
+            ("abc", "abd"), ("", ""),
+        ]:
+            assert native.date_similarity(a, b) == pytest.approx(_date_similarity_py(a, b), abs=1e-12)
+
+
 class TestScoreField:
     """Tests for score_field."""
 

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.17"
+version = "0.1.18"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.17"
+version = "0.1.18"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.17"
+    __version__ = "0.1.18"

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -92,6 +92,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::jaro_winkler_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::levenshtein_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::token_sort_ratio, m)?)?;
+    m.add_function(wrap_pyfunction!(score::date_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -224,6 +224,17 @@ pub fn levenshtein_similarity(a: &str, b: &str) -> f64 {
 }
 
 /// token_sort_ratio on the 0-100 scale (score_field divides by 100).
+/// Date-aware similarity (score-core id 4). Exposed as its own #[pyfunction] so
+/// the Python caller can `hasattr(_native, "date_similarity")` to detect whether
+/// the LOADED kernel understands the date scorer -- `score_one`/`score_block_*`
+/// dispatch id 4 too, but a stale published wheel (pre-date) would silently
+/// return 0.0 for id 4 (the catch-all), so the caller gates the native date
+/// route on this symbol and falls back to the pure-Python mirror otherwise.
+#[pyfunction]
+pub fn date_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::date_similarity(a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -8,7 +8,7 @@
 //! `#[pyfunction]` shims that delegate here; the FFI UDFs call these `pub fn`s
 //! directly. All functions operate on Unicode chars (codepoints), matching
 //! rapidfuzz.
-use rapidfuzz::distance::{jaro_winkler, levenshtein};
+use rapidfuzz::distance::{damerau_levenshtein, jaro_winkler, levenshtein};
 use rapidfuzz::fuzz;
 
 /// `rapidfuzz.fuzz.token_sort_ratio` preprocessing: split on whitespace, sort
@@ -71,9 +71,66 @@ pub fn token_sort_normalized_ratio(a: &str, b: &str) -> f64 {
     fuzz::ratio(normalize(a).chars(), normalize(b).chars())
 }
 
+/// Canonicalize an ISO-8601 `YYYY-MM-DD` date to its 8 packed digits
+/// (`YYYYMMDD`), or `None` if the string isn't that exact shape. Deliberately
+/// strict (no locale parsing, no `YYYY/MM/DD`): the point is to recognize a real
+/// ISO date so a typo can be told apart from a different date; anything else
+/// falls back to plain edit distance. Month/day RANGES are not validated -- a
+/// malformed-but-ISO-shaped value still scores structurally, which is fine for a
+/// similarity (and avoids dragging a calendar into the kernel).
+fn iso_date_digits(s: &str) -> Option<[u8; 8]> {
+    let b = s.as_bytes();
+    if b.len() != 10 || b[4] != b'-' || b[7] != b'-' {
+        return None;
+    }
+    let mut out = [0u8; 8];
+    let mut oi = 0;
+    for (i, &c) in b.iter().enumerate() {
+        if i == 4 || i == 7 {
+            continue;
+        }
+        if !c.is_ascii_digit() {
+            return None;
+        }
+        out[oi] = c;
+        oi += 1;
+    }
+    Some(out)
+}
+
+/// Date-aware similarity on [0, 1]. `jaro_winkler` on an ISO date scores
+/// unrelated birthdays 0.80+ (the fixed `YYYY-MM-DD` shape, shared digit
+/// alphabet, and common `19..`/`20..` prefix dominate) -- it cannot separate a
+/// typo from a different person (#1858). This parses both sides as ISO dates and
+/// uses the Damerau-Levenshtein edit distance over the 8 canonical digits
+/// (transposition-aware -- swapped digits are ONE edit), mapped so a single-digit
+/// typo stays above a typical 0.85 cutoff while an unrelated date cliffs to 0:
+///
+///   d == 0 -> 1.00 (same date)     d == 2 -> 0.75 (two edits -- weak)
+///   d == 1 -> 0.90 (one typo)      d >= 3 -> 0.00 (unrelated)
+///
+/// Mirrors Splink's `DamerauLevenshtein <= 2` date comparison. When EITHER side
+/// isn't an ISO date, degrades to `levenshtein` on the raw strings -- the
+/// like-for-like the issue recommends over `jaro_winkler`, never worse.
+pub fn date_similarity(a: &str, b: &str) -> f64 {
+    match (iso_date_digits(a), iso_date_digits(b)) {
+        (Some(da), Some(db)) => {
+            let d = damerau_levenshtein::distance(da.iter().copied(), db.iter().copied());
+            match d {
+                0 => 1.0,
+                1 => 0.90,
+                2 => 0.75,
+                _ => 0.0,
+            }
+        }
+        // Not both ISO dates: fall back to plain normalized edit distance.
+        _ => levenshtein::normalized_similarity(a.chars(), b.chars()),
+    }
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact.
+/// 2=token_sort, 3=exact, 4=date.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -93,6 +150,7 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         // (clippy::collapsible-match under CI's stable toolchain); scorer_id==3
         // with a!=b falls through to the catch-all 0.0, same as every other id.
         3 if a == b => 1.0,
+        4 => date_similarity(a, b),
         _ => 0.0,
     }
 }
@@ -117,6 +175,37 @@ mod tests {
     #[test]
     fn token_sort_is_order_invariant_on_0_100_scale() {
         assert_eq!(token_sort_ratio("a b", "b a"), 100.0);
+    }
+
+    #[test]
+    fn date_similarity_separates_typo_from_unrelated() {
+        // The #1858 cases: jaro_winkler scored the unrelated pair 0.80+; date must not.
+        assert_eq!(date_similarity("1980-01-01", "1980-01-01"), 1.0); // same
+        assert_eq!(date_similarity("1980-01-01", "1980-01-02"), 0.90); // 1-digit typo
+        assert_eq!(date_similarity("1980-01-01", "1975-11-30"), 0.0); // unrelated (>=3 edits)
+        // A single-digit typo must clear a typical 0.85 cutoff; unrelated must not.
+        assert!(date_similarity("1980-01-01", "1980-01-02") >= 0.85);
+        assert!(date_similarity("1980-01-01", "1975-01-01") < 0.85); // 2-edit year change
+    }
+
+    #[test]
+    fn date_similarity_transposition_is_one_edit() {
+        // Swapped adjacent digits = ONE Damerau edit (not two) -> stays a typo.
+        assert_eq!(date_similarity("1980-12-01", "1980-21-01"), 0.90);
+    }
+
+    #[test]
+    fn date_similarity_non_iso_falls_back_to_levenshtein() {
+        // Not both ISO -> plain normalized edit distance, never jaro_winkler.
+        assert_eq!(date_similarity("abc", "abc"), 1.0);
+        let s = date_similarity("1980-01-01", "Jan 1 1980");
+        assert!((s - levenshtein_similarity("1980-01-01", "Jan 1 1980")).abs() < 1e-12);
+    }
+
+    #[test]
+    fn score_one_id4_is_date() {
+        assert_eq!(score_one(4, "1980-01-01", "1980-01-01"), 1.0);
+        assert_eq!(score_one(4, "1980-01-01", "1975-11-30"), 0.0);
     }
 
     #[test]

--- a/packages/rust/extensions/score-wasm/src/lib.rs
+++ b/packages/rust/extensions/score-wasm/src/lib.rs
@@ -3,9 +3,10 @@
 //! are byte-identical across Python, the FFI UDFs, and TS WASM.
 //!
 //! Covered scorer ids (must match the TS backend): 0=jaro_winkler,
-//! 1=levenshtein, 2=token_sort, 3=exact. id=2 routes through score-core's
+//! 1=levenshtein, 2=token_sort, 3=exact, 4=date. id=2 routes through score-core's
 //! `token_sort_normalized_ratio` (the TS-parity lowercase+strip normalize), NOT
-//! the un-normalized `score_one(2)` (which the FFI/native path depends on).
+//! the un-normalized `score_one(2)` (which the FFI/native path depends on); every
+//! other id (incl. 4=date, the #1858 date-aware scorer) delegates to `score_one`.
 //!
 //! Boundary design: the batch `score_matrix` entry crosses the JS<->WASM boundary
 //! ONCE per NxN block (values arrive as one separator-joined string), never per
@@ -58,6 +59,16 @@ mod tests {
         let m = score_matrix_impl(&vals, 3);
         assert_eq!(m[1], 1.0); // (0,1) a==a
         assert_eq!(m[2], 0.0); // (0,2) a!=b
+    }
+
+    #[test]
+    fn date_id4_separates_typo_from_unrelated() {
+        // #1858: id=4 delegates to score_one -> date_similarity. Unrelated ISO
+        // dates -> 0.0 (jaro_winkler would give 0.80+); a 1-digit typo stays high.
+        let vals = ["1980-01-01", "1980-01-02", "1975-11-30"];
+        let m = score_matrix_impl(&vals, 4);
+        assert!((m[1] - 0.90).abs() < 1e-9); // (0,1) typo
+        assert_eq!(m[2], 0.0); // (0,2) unrelated
     }
 
     #[test]

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -239,6 +239,74 @@ export function levenshteinSimilarity(a: string, b: string): number {
 }
 
 /**
+ * Damerau-Levenshtein edit distance (adjacent-transposition / OSA). A swapped
+ * pair of adjacent chars costs ONE edit, not two -- the mirror of Python/Rust
+ * rapidfuzz `DamerauLevenshtein` for the short digit strings the `date` scorer
+ * compares (score-core `date_similarity`). Three-row DP for the transposition
+ * lookback.
+ */
+export function damerauLevenshteinDistance(a: string, b: string): number {
+  const ca = Array.from(a);
+  const cb = Array.from(b);
+  const lenA = ca.length;
+  const lenB = cb.length;
+  if (lenA === 0) return lenB;
+  if (lenB === 0) return lenA;
+
+  let prevPrev = new Uint32Array(lenB + 1);
+  let prev = new Uint32Array(lenB + 1);
+  let curr = new Uint32Array(lenB + 1);
+  for (let j = 0; j <= lenB; j++) prev[j] = j;
+
+  for (let i = 1; i <= lenA; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= lenB; j++) {
+      const cost = ca[i - 1] === cb[j - 1] ? 0 : 1;
+      let v = Math.min(
+        prev[j]! + 1, // deletion
+        curr[j - 1]! + 1, // insertion
+        prev[j - 1]! + cost, // substitution
+      );
+      // Adjacent transposition: ca[i-1]==cb[j-2] && ca[i-2]==cb[j-1].
+      if (i > 1 && j > 1 && ca[i - 1] === cb[j - 2] && ca[i - 2] === cb[j - 1]) {
+        v = Math.min(v, prevPrev[j - 2]! + 1);
+      }
+      curr[j] = v;
+    }
+    [prevPrev, prev, curr] = [prev, curr, prevPrev];
+  }
+  return prev[lenB]!;
+}
+
+/** The 8 packed digits of an ISO-8601 `YYYY-MM-DD` string, or null. Mirror of
+ * score-core `iso_date_digits` (strict; ranges not validated). */
+function isoDateDigits(s: string): string | null {
+  if (s.length !== 10 || s[4] !== "-" || s[7] !== "-") return null;
+  const digits = s.slice(0, 4) + s.slice(5, 7) + s.slice(8, 10);
+  return /^\d{8}$/.test(digits) ? digits : null;
+}
+
+/**
+ * Date-aware similarity (#1858). `jaro_winkler` scores unrelated ISO birthdays
+ * 0.80+; this parses `YYYY-MM-DD` and uses Damerau-Levenshtein over the canonical
+ * digits so a typo (0.90) is far above an unrelated date (0.00). Mirrors
+ * score-core `date_similarity` / the Python `_date_similarity_py`. Non-ISO input
+ * degrades to `levenshtein`.
+ */
+export function dateSimilarity(a: string, b: string): number {
+  const da = isoDateDigits(a);
+  const db = isoDateDigits(b);
+  if (da !== null && db !== null) {
+    const d = damerauLevenshteinDistance(da, db);
+    if (d === 0) return 1.0;
+    if (d === 1) return 0.9;
+    if (d === 2) return 0.75;
+    return 0.0;
+  }
+  return levenshteinSimilarity(a, b);
+}
+
+/**
  * Indel (insertion+deletion) edit distance.
  *
  * Like Levenshtein but without substitutions — a substitution costs 2
@@ -464,6 +532,8 @@ export function scoreField(
       return jaroWinkler(valA, valB);
     case "levenshtein":
       return levenshteinSimilarity(valA, valB);
+    case "date":
+      return dateSimilarity(valA, valB);
     case "token_sort":
       return tokenSortRatio(valA, valB);
     case "soundex_match":

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -488,6 +488,7 @@ export const VALID_SCORERS = new Set([
   "exact",
   "jaro_winkler",
   "levenshtein",
+  "date",
   "token_sort",
   "soundex_match",
   "embedding",

--- a/packages/typescript/goldenmatch/tests/parity/scorer-ground-truth.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/scorer-ground-truth.test.ts
@@ -90,6 +90,17 @@ const CASES: readonly Case[] = [
   ["name_freq_weighted_jw", "Taylor", "Tyler", 0.7111],  // borderline both-known -> reweighted
   ["name_freq_weighted_jw", "Moore", "More", 0.8484],    // borderline both-known -> reweighted
   ["name_freq_weighted_jw", "Taylor", "Tailor", 0.9111], // OOV gate (Tailor not in table) -> plain JW
+
+  // date (#1858) — Damerau-Levenshtein over the 8 canonical ISO digits, mapped
+  // d0->1.0 / d1->0.90 / d2->0.75 / d>=3->0.0. Mirror of score-core date_similarity
+  // and Python _date_similarity_py. The unrelated pair is the point: jaro_winkler
+  // scores it 0.80+, date gives 0.0.
+  ["date", "1980-01-01", "1980-01-01", 1.0], // same
+  ["date", "1980-01-01", "1980-01-02", 0.9], // 1-digit typo
+  ["date", "1980-01-01", "1975-01-01", 0.75], // 2 edits (year)
+  ["date", "1980-01-01", "1975-11-30", 0.0], // unrelated (>=3 edits)
+  ["date", "1980-12-01", "1980-21-01", 0.9], // adjacent transposition = 1 edit
+  ["date", "Jan 1 1980", "Jan 2 1980", 0.9], // non-ISO -> levenshtein fallback (1 - 1/10)
 ];
 
 describe("scorer Python parity (4-decimal tolerance)", () => {


### PR DESCRIPTION
## Why
`jaro_winkler` scores unrelated ISO birthdays **0.80+** — the fixed `YYYY-MM-DD` shape, shared digit alphabet, and common `19..`/`20..` prefix dominate the similarity, so it can't tell a typo from a different person. At any usable cutoff it's ~constant, cratering precision on date fields (bench `dob` precision 0.34 vs Splink's 0.9998). Not zero-config-reachable (auto-config skips date columns), but a live footgun for hand-written / Splink-converted configs.

## What
A `date` scorer whose **canonical logic lives in the Rust `score-core` kernel** (the reference) and funnels out to every surface:

| Surface | Change |
|---|---|
| **score-core** (Rust) | `date_similarity` + `score_one` id 4 — parse ISO, Damerau-Levenshtein over the 8 canonical digits, map `d0→1.0 / d1→0.90 / d2→0.75 / d≥3→0.0`; non-ISO → `levenshtein` |
| **native** (PyO3) | `date_similarity` shim (also the wheel-skew capability marker); bumped 0.1.17→0.1.18 |
| **Python** | pure-Python mirror wired into `score_field` / `_fuzzy_score_matrix` / bucket per-pair / `VALID_SCORERS`; bucket native route (id 4) guarded on the `date_similarity` symbol |
| **TS** | `damerauLevenshteinDistance` + `dateSimilarity` → `scoreField` + `VALID_SCORERS` + 6 parity rows |
| **wasm** | id 4 delegates to `score_one` (doc + matrix test) |
| **config-lint** | preflight **warning** when a name-oriented fuzzy scorer sits on a date field → recommends `scorer='date'` |

## Design chosen by measurement
Damerau-Levenshtein separates a typo (**0.90**) from an unrelated date (**0.00**); the issue's *suggested* component-compare does **not** (typo and diff-year both 0.667). A digit transposition (common date typo) is **one** edit, not two.

## Verified
- score-core + score-wasm Rust unit tests; **native == pure-Python byte-identical** (max diff 0.0).
- Bucket/native dedupe matches a typo-dob pair and **rejects** an unrelated-dob pair `jaro_winkler` would false-positive.
- Config-lint fires on `jaro_winkler`/`token_sort` over `dob`, silent on `scorer='date'` and non-date fields.
- 121 parity/config + 118 verify/scorer Python tests green; clippy + ruff clean. TS parity table extended (runs in CI).

Bench-config fix (`_person_gm_hand_built` dob scorer) stays a separate follow-up per the issue.

Closes #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd