### PR TITLE
ci: make quality_gate a required check via ci-required (#1855)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3434,6 +3434,12 @@ jobs:
       - python_postgres
       - synthetic_benchmarks
       - benchmark_runner_smoke
+      # #1855: quality_gate is BLOCKING via ci-required (not just its own job).
+      # It is path-filtered (skipped -> counts as pass here) and its gate step is
+      # not continue-on-error, so a real red blocks the merge queue instead of
+      # surfacing as a mergeable UNSTABLE. #1834 (historical_50k f1_probabilistic
+      # 0.83 -> 0.33) merged precisely because this was absent.
+      - quality_gate
       - typescript
       - wasm_flow
       - web_ui_e2e


### PR DESCRIPTION
Fixes #1855.

## Problem

`quality_gate` ran as its own job but was **not** in `ci-required`'s `needs` list — and `ci-required` is the only required status check. So a red `quality_gate` surfaced as a mergeable `UNSTABLE` and **merged anyway**. That is exactly how #1834 landed: `historical_50k f1_probabilistic` dropped **0.83 → 0.33** (half the true matches on the only real-world corpus in the gate) and merged. #1847 fixed the path filter so the gate *sees* `core/probabilistic.py` changes; this PR makes it *block*.

## Fix

Add `quality_gate` to the `ci-required` job's `needs`. This is the repo's established mechanism for "required check" — `ci-required` fails on any upstream `result` that is not `success`/`skipped`.

Why this is safe and correct:
- **Skipped counts as pass.** `quality_gate` is path-filtered (`if: needs.changes.outputs.quality_gate == 'true' || force_all`), so a PR that doesn't touch its paths skips the job → `result: skipped` → `ci-required` still passes. It only gates PRs that can actually move the number it pins.
- **A real red blocks.** The gate step (`python -m scripts.autoconfig_quality gate`) is **not** `continue-on-error`, so an actual regression sets `result: failure` → `ci-required` fails → the merge queue is blocked instead of merging an `UNSTABLE` PR.
- **No branch-protection ruleset edit.** Branch protection still requires only `ci-required`, so this lands through normal PR review rather than a unilateral ruleset change — which is precisely the concern the issue author raised.
- Works identically in the **merge queue**: the `changes` filter runs on `merge_group` too, so a queued entry runs `quality_gate` only when its paths were touched, and `ci-required` aggregates it there as well.

Editing `ci.yml` forces the full matrix to re-run, so this PR's own run re-validates the wiring.

## Test plan

- `python -c "import yaml; ..."` confirms the workflow parses and `quality_gate` is in `ci-required.needs` (44 entries) and remains a defined job with its path-filter `if:` intact.
- `workflow_lint` + the forced full-matrix re-run on this PR exercise the change end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_