### PR TITLE
fix(from_splink): discard the random-pair prior at import (#1802)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/config/from_splink.py
+++ b/packages/python/goldenmatch/goldenmatch/config/from_splink.py
@@ -824,14 +824,40 @@ def import_em(
         for f in m_probs
     }
 
-    if "probability_two_random_records_match" in settings:
-        proportion_matched = settings["probability_two_random_records_match"]
+    # #1802: Splink's `probability_two_random_records_match` is a RANDOM-PAIR
+    # prior -- P(match | two records drawn at random) -- orders of magnitude
+    # below the WITHIN-BLOCK match rate that `EMResult.proportion_matched`
+    # means and that `prior_weight` / `compute_thresholds` / posterior scoring
+    # all assume. GoldenMatch's own `train_em` estimates the within-block rate
+    # from blocked pairs; feeding the raw random-pair prior into the percentile
+    # cut pushes the link threshold into the extreme top of the blocked-pair
+    # distribution and collapses recall (#1760 dogfood: F1 0.482 -> 0.157).
+    # A DATA-FREE model import cannot re-estimate the within-block rate (that
+    # needs scored candidate pairs -- what `import-splink --upgrade` does via
+    # splink_upgrade._estimate_within_block_prior). So discard the mis-scaled
+    # random-pair prior and fall back to the same within-block default an
+    # ABSENT setting uses: a present-but-random-pair prior then behaves
+    # identically to no prior (the safe regime), while `--upgrade` still
+    # refines it from the user's data.
+    _WITHIN_BLOCK_PRIOR_DEFAULT = 0.05
+    raw_prior = settings.get("probability_two_random_records_match")
+    proportion_matched = _WITHIN_BLOCK_PRIOR_DEFAULT
+    if raw_prior is not None:
+        report.warn(
+            "probability_two_random_records_match",
+            f"probability_two_random_records_match={raw_prior} is a random-pair "
+            "prior, but GoldenMatch's proportion_matched is a WITHIN-BLOCK match "
+            f"rate; the raw value is discarded and defaulted to "
+            f"{_WITHIN_BLOCK_PRIOR_DEFAULT} to avoid a recall collapse "
+            "(#1802/#1760). Run `import-splink --upgrade` to re-estimate the "
+            "within-block prior from your data.",
+            mapped_to="em.proportion_matched",
+        )
     else:
-        proportion_matched = 0.05
         report.info(
             "probability_two_random_records_match",
             "probability_two_random_records_match absent from trained settings; "
-            "assumed default 0.05",
+            f"assumed within-block default {_WITHIN_BLOCK_PRIOR_DEFAULT}",
             mapped_to="em.proportion_matched",
         )
 

--- a/packages/python/goldenmatch/tests/test_from_splink_model_import.py
+++ b/packages/python/goldenmatch/tests/test_from_splink_model_import.py
@@ -97,14 +97,42 @@ def test_match_weights_are_log2_m_over_u():
         assert w[i] == pytest.approx(math.log2(m[i] / u[i]), abs=1e-9)
 
 
-def test_proportion_matched_from_settings():
+def test_random_pair_prior_discarded_for_within_block_default():
+    """#1802: Splink's `probability_two_random_records_match` is a RANDOM-PAIR
+    prior, orders of magnitude below the WITHIN-BLOCK match rate that
+    `EMResult.proportion_matched` (and prior_weight/compute_thresholds) assume.
+    Importing it raw collapsed recall (#1760: F1 0.482 -> 0.157). A data-free
+    import discards the mis-scaled value for the within-block default (0.05, the
+    same one an ABSENT setting uses) and warns; `import-splink --upgrade`
+    re-estimates it from data separately."""
     comp = _trained_jw_comparison()
-    settings = _trained_settings([comp])
+    settings = _trained_settings([comp])  # carries probability_two_random_records_match=0.0002
     report = ConversionReport()
     field = convert_comparison(comp, 0, report)
     em = import_em([(comp, 0, field)], settings, report)
 
-    assert em.proportion_matched == pytest.approx(0.0002)
+    # The tiny random-pair prior is NOT stored as the within-block rate.
+    assert em.proportion_matched == pytest.approx(0.05)
+    # And the discard is surfaced loudly (a warning, not silent).
+    assert any(
+        f.severity == "warning"
+        and f.splink_path == "probability_two_random_records_match"
+        and "random-pair prior" in f.message
+        for f in report.findings
+    ), "expected a warning that the random-pair prior was discarded"
+
+
+def test_absent_prior_uses_within_block_default():
+    """No `probability_two_random_records_match` -> the same within-block
+    default (0.05), so a present-but-random-pair prior behaves identically to
+    an absent one (#1802)."""
+    comp = _trained_jw_comparison()
+    settings = {"comparisons": [comp]}  # no probability_two_random_records_match
+    report = ConversionReport()
+    field = convert_comparison(comp, 0, report)
+    em = import_em([(comp, 0, field)], settings, report)
+
+    assert em.proportion_matched == pytest.approx(0.05)
 
 
 def test_import_marks_converged_zero_iterations_no_tf():

--- a/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
+++ b/packages/python/goldenmatch/tests/test_splink_upgrade_levers.py
@@ -1045,15 +1045,20 @@ def test_calibration_lever_reestimates_within_block_rate_from_tiny_prior():
 
     upgraded_mk = result.upgraded_config.get_matchkeys()[0]
     assert upgraded_mk.link_threshold is not None
-    # Raw 0.001 prior -> link_idx at the 99.8th percentile of 115 pairs, deep
-    # in the saturated exact-dupe top (normalized 1.0, clamped to 0.95). The
-    # E-step estimate (~0.5) pulls the cut down into the distribution body.
+    # The lever re-estimates the within-block rate (~0.5) from the model's own
+    # likelihood ratios and cuts in the distribution body, not at the saturated
+    # exact-dupe top. (#1802 now ALSO discards the raw random-pair prior at
+    # IMPORT, but the lever's scratch re-estimate is what's under test here and
+    # is computed independently of the stored proportion_matched.)
     assert upgraded_mk.link_threshold <= 0.5
-    # Copy-on-write: the shipped upgraded model keeps the imported prior.
+    # Copy-on-write: the lever does not mutate the shipped model's
+    # proportion_matched. #1802 makes import store the within-block default
+    # (0.05) rather than the raw 0.001 random-pair prior, and the lever leaves
+    # that untouched (it re-estimates into a scratch copy).
     assert result.em_model is not None
-    assert result.em_model.proportion_matched == pytest.approx(0.001)
+    assert result.em_model.proportion_matched == pytest.approx(0.05)
     assert conversion.em_model is not None
-    assert conversion.em_model.proportion_matched == pytest.approx(0.001)
+    assert conversion.em_model.proportion_matched == pytest.approx(0.05)
 
     findings = [
         f for f in result.report.findings


### PR DESCRIPTION
Fixes #1802.

## Problem

`EMResult.proportion_matched` carries **two incompatible semantics** depending on producer:
- GoldenMatch's `train_em` estimates it on **within-block** candidate pairs — what `prior_weight`, `compute_thresholds`' percentile math, and the 5 posterior scoring sites all assume.
- `from_splink` imported Splink's `probability_two_random_records_match` **raw** into the same field — a **random-pair** prior, orders of magnitude lower.

So plain `from_splink()` / `import-splink` **without `--upgrade`** carried the random-pair prior straight into threshold/posterior math, pushing the link cut into the extreme top of the blocked-pair distribution and collapsing recall (#1760 dogfood: F1 **0.482 → 0.157**). Only the `--upgrade` lever (`_estimate_within_block_prior`) corrected it; nothing at the `EMResult` level encoded which semantics you held.

## Fix (issue option 1 — normalize at import)

A **data-free** model import cannot re-estimate the within-block rate (that needs scored candidate pairs — exactly what `--upgrade` does). So `import_em` now **discards** the mis-scaled `probability_two_random_records_match` and falls back to the same within-block default (`0.05`) an **absent** setting already uses, emitting a warning that points at `--upgrade` for a data-driven estimate. Net effect: a present-but-random-pair prior behaves identically to no prior (the safe regime), which is exactly the #1760 precedent (discard the mis-scaled prior rather than trust it).

**The `--upgrade` path is unaffected**: `_lever_calibration` re-estimates the within-block rate into a *scratch* `EMResult` copy from `total_weights` and never reads the stored `proportion_matched` for the computation — so upgraded thresholds are byte-identical to before.

Chose option 1 over option 2 (encode `prior_kind` on the schema + convert/refuse in consumers): option 1 is a single contained change that fixes every downstream consumer uniformly with no schema bump / TS round-trip, and it matches the existing #1760 precedent. `estimate_m_from_labels`' `0.02` default is a within-block-semantics default (not a random-pair prior), so it's not part of this mismatch.

## Test plan

- `test_from_splink_model_import.py::test_random_pair_prior_discarded_for_within_block_default` — a Splink model with a tiny random-pair prior (`0.0002`) imports to `proportion_matched == 0.05`, and the discard is surfaced as a **warning** (not silent).
- `test_from_splink_model_import.py::test_absent_prior_uses_within_block_default` — the absent case still defaults to `0.05`, so present-but-random-pair == absent.
- Updated `test_splink_upgrade_levers.py::test_calibration_lever_reestimates_within_block_rate_from_tiny_prior` — the lever's copy-on-write assertion now expects the imported prior at the `0.05` default (still not mutated by the lever); the data-driven `link_threshold <= 0.5` re-estimation is unchanged.
- Full `from_splink` + `splink_upgrade` suites green (100 passed); ruff clean. (Pre-existing, unrelated local failures in `test_cli_import_splink*` and `test_mcp_splink_convert` come from newer local click's dropped `CliRunner.isolated_filesystem` and a missing local `mcp` import respectively — both fail identically on `main` with this change stashed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_