### PR TITLE
refactor(analysis-native): delegate intern_column to the shared core interner (#1788)

### DIFF
--- a/packages/python/goldenanalysis/tests/core/test_native_parity.py
+++ b/packages/python/goldenanalysis/tests/core/test_native_parity.py
@@ -361,3 +361,50 @@ def test_required_mode_implies_wheel_when_set() -> None:
     -- otherwise every native_only test would silently skip."""
     if os.environ.get("GOLDENANALYSIS_NATIVE") == "1":
         assert native_available()
+
+
+# ── #1788: native intern_column now delegates to the shared analysis-core ─────
+# interner. The frame-kernels adversarial fixture only exercises Float64 / Int64
+# / Utf8; these pin the dtypes it does NOT cover -- narrow signed/unsigned ints,
+# UInt64 above i64::MAX (the bit-reinterpret path), Float32 canonicalization, and
+# Boolean -- as native == pure (`_distinct_count_pure` / `_duplicate_row_ratio_pure`).
+
+_DTYPE_SERIES = {
+    "int8": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.Int8),
+    "int16": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.Int16),
+    "int32": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.Int32),
+    "int64": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.Int64),
+    "uint8": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.UInt8),
+    "uint16": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.UInt16),
+    "uint32": lambda pl: pl.Series("v", [5, 5, 3, None, 5], dtype=pl.UInt32),
+    # UInt64 values ABOVE i64::MAX: exercises the u64 -> i64 bit-reinterpret.
+    "uint64_high": lambda pl: pl.Series(
+        "v", [2**63 + 7, 2**63 + 7, 1, None, 2**63 + 7], dtype=pl.UInt64
+    ),
+    # Float32 with -0.0/+0.0 folding + NaN folding + null.
+    "float32": lambda pl: pl.Series(
+        "v", [-0.0, 0.0, float("nan"), float("nan"), None, 1.5], dtype=pl.Float32
+    ),
+    "bool": lambda pl: pl.Series("v", [True, False, True, None, False], dtype=pl.Boolean),
+}
+
+
+@native_only
+@pytest.mark.parametrize("dtype", sorted(_DTYPE_SERIES))
+def test_intern_column_distinct_count_parity_all_dtypes(dtype):
+    import polars as pl
+    from goldenanalysis.core import aggregate
+
+    s = _DTYPE_SERIES[dtype](pl)
+    assert native_module().distinct_count(s.to_arrow()) == aggregate._distinct_count_pure(s)
+
+
+@native_only
+@pytest.mark.parametrize("dtype", sorted(_DTYPE_SERIES))
+def test_intern_column_duplicate_row_ratio_parity_all_dtypes(dtype):
+    import polars as pl
+    from goldenanalysis.core import aggregate
+
+    df = pl.DataFrame([_DTYPE_SERIES[dtype](pl)])
+    native = native_module().duplicate_row_ratio([df[c].to_arrow() for c in df.columns])
+    assert native == aggregate._duplicate_row_ratio_pure(df)

--- a/packages/rust/extensions/analysis-native/src/lib.rs
+++ b/packages/rust/extensions/analysis-native/src/lib.rs
@@ -12,6 +12,7 @@
 //! (`PyArrowType<ArrayData>`), zero-copy, mirroring goldencheck-native. The shims
 //! never touch business logic -- they decode Arrow into a plain `&[f64]` (dropping
 //! null slots, whose backing value is undefined) and delegate to `analysis-core`.
+use analysis_core::{intern_f64, intern_i64, intern_str};
 use arrow::array::{
     make_array, Array, ArrayData, BooleanArray, Float32Array, Float64Array, Int16Array, Int32Array,
     Int64Array, Int8Array, LargeStringArray, StringArray, UInt16Array, UInt32Array, UInt64Array,
@@ -20,141 +21,80 @@ use arrow::array::{
 use arrow::datatypes::DataType;
 use arrow::pyarrow::PyArrowType;
 use pyo3::prelude::*;
-use rustc_hash::FxHashMap;
 
-/// Canonicalize an `f64` to a single `u64` bit-key matching Polars equality:
-/// all NaNs fold to one key, `-0.0` and `+0.0` fold together, everything else
-/// keys on its raw bit pattern. Keeps float interning behaviour-exact vs the
-/// pure-Python (Polars-backed) path.
-#[inline]
-fn canon_f64_bits(x: f64) -> u64 {
-    if x.is_nan() {
-        0x7ff8_0000_0000_0000 // one canonical NaN
-    } else if x == 0.0 {
-        0.0f64.to_bits() // -0.0 and +0.0 fold (x == 0.0 catches both)
-    } else {
-        x.to_bits()
-    }
-}
-
-/// Intern one Arrow column to dense `u64` value-ids. Null slots all share a
-/// single reserved id (0) distinct from every real value's id. Float columns
-/// canonicalize NaN / signed-zero to match Polars equality (see
-/// `canon_f64_bits`). Adapted from `goldencheck-native/src/keys.rs`.
+/// Intern one Arrow column to dense `u64` value-ids by extracting a typed buffer
+/// (+ byte-per-row validity) and delegating to the shared `analysis-core`
+/// interner (#1788) -- ONE arrow-free implementation shared with the wasm / SQL
+/// surfaces, so they cannot drift. Null slots share id 0; non-null get dense ids
+/// from 1; floats canonicalize NaN / signed-zero (`analysis_core::canon_f64_bits`)
+/// to match Polars equality. Every integer width, unsigned int, and bool reaches
+/// `intern_i64` by value promotion (`as i64` is bijective for all of them -- u64
+/// bit-reinterprets, bool -> 0/1), so the equality PARTITION the frame kernels
+/// depend on is preserved; the specific ids are never observed by a caller.
 fn intern_column(data: ArrayData) -> PyResult<Vec<u64>> {
-    macro_rules! intern_primitive {
-        ($arr:expr, $keyty:ty, $keyexpr:expr) => {{
-            let arr = $arr;
-            let mut map: FxHashMap<$keyty, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1; // 0 is reserved for null
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
+    let n = data.len();
+
+    // A byte-per-row validity buffer (0 = null) for any concrete Arrow array.
+    macro_rules! validity {
+        ($arr:expr) => {{
+            let a = &$arr;
+            (0..n)
+                .map(|i| if a.is_null(i) { 0u8 } else { 1u8 })
+                .collect::<Vec<u8>>()
+        }};
+    }
+    // Promote any int/uint/bool array to i64 + validity, then core-intern. `as i64`
+    // is bijective for every one of these (u64 bit-reinterprets, bool -> 0/1), so
+    // the equality partition is identical; the raw ids are unobservable.
+    macro_rules! intern_as_i64 {
+        ($arrty:ty) => {{
+            let arr = <$arrty>::from(data);
+            let valid = validity!(arr);
+            let vals: Vec<i64> = (0..n).map(|i| arr.value(i) as i64).collect();
+            Ok(intern_i64(&vals, &valid))
+        }};
+    }
+    macro_rules! intern_as_f64 {
+        ($arrty:ty) => {{
+            let arr = <$arrty>::from(data);
+            let valid = validity!(arr);
+            let vals: Vec<f64> = (0..n).map(|i| arr.value(i) as f64).collect();
+            Ok(intern_f64(&vals, &valid))
+        }};
+    }
+    macro_rules! intern_as_str {
+        ($arrty:ty) => {{
+            let arr = <$arrty>::from(data);
+            let valid = validity!(arr);
+            // Rebuild a contiguous utf8 offsets/bytes buffer; null rows get an empty
+            // span (validity marks them, so `intern_str` skips them regardless).
+            let mut bytes: Vec<u8> = Vec::new();
+            let mut offsets: Vec<u32> = Vec::with_capacity(n + 1);
+            offsets.push(0);
+            for i in 0..n {
+                if valid[i] != 0 {
+                    bytes.extend_from_slice(arr.value(i).as_bytes());
                 }
-                let key: $keyty = $keyexpr(&arr, i);
-                let id = *map.entry(key).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
+                offsets.push(bytes.len() as u32);
             }
-            Ok(ids)
+            Ok(intern_str(&offsets, &bytes, &valid))
         }};
     }
 
     match data.data_type() {
-        DataType::Utf8 => {
-            let arr = StringArray::from(data);
-            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
-                }
-                let id = *map.entry(arr.value(i)).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
-            }
-            Ok(ids)
-        }
-        DataType::LargeUtf8 => {
-            let arr = LargeStringArray::from(data);
-            let mut map: FxHashMap<&str, u64> = FxHashMap::default();
-            let mut ids = Vec::with_capacity(arr.len());
-            let mut next: u64 = 1;
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                    continue;
-                }
-                let id = *map.entry(arr.value(i)).or_insert_with(|| {
-                    let v = next;
-                    next += 1;
-                    v
-                });
-                ids.push(id);
-            }
-            Ok(ids)
-        }
-        DataType::Int8 => {
-            intern_primitive!(Int8Array::from(data), i8, |a: &Int8Array, i| a.value(i))
-        }
-        DataType::Int16 => {
-            intern_primitive!(Int16Array::from(data), i16, |a: &Int16Array, i| a.value(i))
-        }
-        DataType::Int32 => {
-            intern_primitive!(Int32Array::from(data), i32, |a: &Int32Array, i| a.value(i))
-        }
-        DataType::Int64 => {
-            intern_primitive!(Int64Array::from(data), i64, |a: &Int64Array, i| a.value(i))
-        }
-        DataType::UInt8 => {
-            intern_primitive!(UInt8Array::from(data), u8, |a: &UInt8Array, i| a.value(i))
-        }
-        DataType::UInt16 => {
-            intern_primitive!(UInt16Array::from(data), u16, |a: &UInt16Array, i| a
-                .value(i))
-        }
-        DataType::UInt32 => {
-            intern_primitive!(UInt32Array::from(data), u32, |a: &UInt32Array, i| a
-                .value(i))
-        }
-        DataType::UInt64 => {
-            intern_primitive!(UInt64Array::from(data), u64, |a: &UInt64Array, i| a
-                .value(i))
-        }
-        // Floats keyed by a canonicalized bit pattern so NaN / signed-zero fold
-        // exactly like Polars equality (see `canon_f64_bits`).
-        DataType::Float32 => {
-            intern_primitive!(Float32Array::from(data), u64, |a: &Float32Array, i| {
-                canon_f64_bits(a.value(i) as f64)
-            })
-        }
-        DataType::Float64 => {
-            intern_primitive!(Float64Array::from(data), u64, |a: &Float64Array, i| {
-                canon_f64_bits(a.value(i))
-            })
-        }
-        DataType::Boolean => {
-            let arr = BooleanArray::from(data);
-            let mut ids = Vec::with_capacity(arr.len());
-            for i in 0..arr.len() {
-                if arr.is_null(i) {
-                    ids.push(0);
-                } else {
-                    ids.push(if arr.value(i) { 1 } else { 2 });
-                }
-            }
-            Ok(ids)
-        }
+        DataType::Utf8 => intern_as_str!(StringArray),
+        DataType::LargeUtf8 => intern_as_str!(LargeStringArray),
+        DataType::Int8 => intern_as_i64!(Int8Array),
+        DataType::Int16 => intern_as_i64!(Int16Array),
+        DataType::Int32 => intern_as_i64!(Int32Array),
+        DataType::Int64 => intern_as_i64!(Int64Array),
+        DataType::UInt8 => intern_as_i64!(UInt8Array),
+        DataType::UInt16 => intern_as_i64!(UInt16Array),
+        DataType::UInt32 => intern_as_i64!(UInt32Array),
+        DataType::UInt64 => intern_as_i64!(UInt64Array),
+        DataType::Float32 => intern_as_f64!(Float32Array),
+        DataType::Float64 => intern_as_f64!(Float64Array),
+        DataType::Boolean => intern_as_i64!(BooleanArray),
         other => Err(pyo3::exceptions::PyTypeError::new_err(format!(
             "frame kernels do not support Arrow dtype {other:?}; \
              cast to a supported type (string/int/float/bool) first"


### PR DESCRIPTION
Part of #1788 — the native-delegation follow-up (checkbox 1) to the shared interner landed in #1880.

## What

`analysis-native::intern_column` had its own per-dtype Arrow interner (an `intern_primitive!` macro over ~12 dtypes + a private `canon_f64_bits`). #1880 landed the arrow-free interner in `analysis-core`. This PR **retires the native duplicate** and delegates: `intern_column` now extracts a typed buffer (+ byte-per-row validity) from each Arrow array and calls `analysis_core::intern_{f64,i64,str}`. **One interning implementation** shared across the native / (future) wasm / SQL surfaces — they cannot drift. Net **−60 lines** in the native crate.

**Value promotion is partition-preserving:** every integer width, unsigned int, and bool reaches `intern_i64` via `as i64`, which is bijective for all of them (u64 bit-reinterprets, bool → 0/1). The frame kernels (`distinct_count`, `duplicate_row_ratio`, `null_ratio_per_column`) only observe the equality **partition**, never the specific dense ids, so this is output-preserving by construction. Floats canonicalize NaN / signed-zero exactly as before (now via `analysis_core::canon_f64_bits`); strings rebuild a contiguous utf8 offsets/bytes buffer (null rows get an empty span, skipped via validity).

## Validation

- **Existing** frame-kernels adversarial parity (Float64 / Int64 / Utf8) passes unchanged end-to-end against the rebuilt wheel.
- **New** `tests/core/test_native_parity.py` dtype-coverage tests pin `native == pure` (`_distinct_count_pure` / `_duplicate_row_ratio_pure`) for the dtypes the fixture does **not** cover: Int8/16/32, UInt8/16/32, **UInt64 above `i64::MAX`** (the bit-reinterpret path), **Float32** canonicalization, and **Boolean** — 20 parametrized cases.
- `cargo clippy` + `cargo fmt --check` clean on `analysis-native`; broad `goldenanalysis` suite green (195 passed, 4 skipped).

Rust-level unit tests can't run in this crate (the pyo3 `extension-module` build won't link a standalone test binary — host Python provides the symbols at import time; `PyGILState_Ensure` etc. are undefined), so the coverage lives in the Python native-parity gate, which exercises the real wheel. The `goldenanalysis_native` CI lane builds the wheel and runs exactly these tests.

## Not in this PR

The wasm/TS surface (checkboxes 2–4 of #1788) stays deferred on its open go/no-go input — the unmeasured JS→wasm boundary cost — and the unresolved "is browser frame-dedup an established workload" question. With native now delegating, the shared `analysis-core` interner is the single implementation a wasm surface would reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_