### PR TITLE
refactor(probabilistic): consolidate shared FS scoring helpers (#1804 item 4)

### DIFF
--- a/.github/workflows/bench-fs-distributed.yml
+++ b/.github/workflows/bench-fs-distributed.yml
@@ -33,6 +33,10 @@ on:
         description: "Enable the opt-in native FS kernel (GOLDENMATCH_FS_NATIVE=1)"
         required: false
         default: "false"
+      fs_default_bucket:
+        description: "FS route: 'true' = memory-bounded bucket route (the #1803 default), 'false' = legacy batched route (GOLDENMATCH_FS_DEFAULT_BUCKET=0). Set false for the legacy leg of a parity A/B."
+        required: false
+        default: "true"
       build_native:
         description: "Build the native extension before running"
         required: false
@@ -50,6 +54,9 @@ jobs:
       # for determinism (mirrors the other bench lanes).
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
       GOLDENMATCH_FS_NATIVE: ${{ inputs.fs_native == 'true' && '1' || '0' }}
+      # Default backend (polars-direct/None) routes FS through the bucket scorer
+      # unless this is 0 -- the legacy batched leg of the item-3 parity A/B.
+      GOLDENMATCH_FS_DEFAULT_BUCKET: ${{ inputs.fs_default_bucket == 'false' && '0' || '1' }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
 

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -1935,22 +1935,7 @@ def score_probabilistic_continuous(
     with np.errstate(over="ignore"):
         normalized = 1.0 / (1.0 + np.exp(-np.clip(log_ratio, -700.0, 700.0)))
 
-    iu, ju = np.triu_indices(n, k=1)
-    keep = normalized[iu, ju] >= threshold
-    if not keep.any():
-        return []
-    ids = np.asarray(row_ids)
-    a_ids = ids[iu[keep]]
-    b_ids = ids[ju[keep]]
-    scores = normalized[iu, ju][keep]
-
-    results: list[tuple[int, int, float]] = []
-    for a, b, s in zip(a_ids.tolist(), b_ids.tolist(), scores.tolist()):
-        pair_key = (a, b) if a < b else (b, a)
-        if pair_key in exclude_pairs:
-            continue
-        results.append((a, b, round(float(s), 4)))
-    return results
+    return _emit_triu_pairs(normalized, row_ids, threshold, exclude_pairs)
 
 
 def _fallback_result(mk: MatchkeyConfig) -> EMResult:
@@ -2167,6 +2152,46 @@ def resolve_thresholds(
     return link, min(review, link)
 
 
+def _fs_link_threshold(
+    mk: MatchkeyConfig, em_result: EMResult, calibrated: bool
+) -> float:
+    """The FS link cutoff: configured ``mk.link_threshold`` when set, else the
+    calibration-aware value from ``compute_thresholds``. Extracted verbatim from
+    the scalar / vectorized / batched scorers (#1804 item 4) so they cannot
+    drift on how the cutoff is resolved."""
+    if mk.link_threshold is not None:
+        return mk.link_threshold
+    link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    return link_threshold
+
+
+def _emit_triu_pairs(
+    normalized: np.ndarray,
+    row_ids: list,
+    threshold: float,
+    exclude_pairs: set,
+) -> list[tuple[int, int, float]]:
+    """Emit upper-triangle (i<j) pairs whose ``normalized`` score is at/above
+    ``threshold``, dropping excluded pairs and rounding to 4 dp. Extracted
+    verbatim from the continuous / vectorized FS scorers (#1804 item 4)."""
+    n = len(row_ids)
+    iu, ju = np.triu_indices(n, k=1)
+    keep = normalized[iu, ju] >= threshold
+    if not keep.any():
+        return []
+    ids = np.asarray(row_ids)
+    a_ids = ids[iu[keep]]
+    b_ids = ids[ju[keep]]
+    scores = normalized[iu, ju][keep]
+    results: list[tuple[int, int, float]] = []
+    for a, b, s in zip(a_ids.tolist(), b_ids.tolist(), scores.tolist()):
+        pair_key = (a, b) if a < b else (b, a)
+        if pair_key in exclude_pairs:
+            continue
+        results.append((a, b, round(float(s), 4)))
+    return results
+
+
 def score_probabilistic(
     block_df: pl.DataFrame,
     mk: MatchkeyConfig,
@@ -2205,11 +2230,7 @@ def score_probabilistic(
     calibrated = _fs_calibration_mode() == "posterior"
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
 
-    # Determine threshold
-    if mk.link_threshold is not None:
-        link_threshold = mk.link_threshold
-    else:
-        link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    link_threshold = _fs_link_threshold(mk, em_result, calibrated)
 
     # Precompute per-row transformed values for TF-adjustment fields so the
     # per-pair loop can apply the same Winkler adjustment the vectorized path
@@ -2618,10 +2639,7 @@ def score_probabilistic_vectorized(
 
     ne_min_weight, ne_max_weight = _fs_ne_weight_range(em_result, mk)
 
-    if mk.link_threshold is not None:
-        link_threshold = mk.link_threshold
-    else:
-        link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    link_threshold = _fs_link_threshold(mk, em_result, calibrated)
 
     # Accumulate the total match-weight matrix field by field.
     total_weight = np.zeros((n, n), dtype=np.float64)
@@ -2696,22 +2714,7 @@ def score_probabilistic_vectorized(
         )
 
     # Emit upper-triangle pairs at/above threshold.
-    iu, ju = np.triu_indices(n, k=1)
-    keep = normalized[iu, ju] >= link_threshold
-    if not keep.any():
-        return []
-    ids = np.asarray(row_ids)
-    a_ids = ids[iu[keep]]
-    b_ids = ids[ju[keep]]
-    scores = normalized[iu, ju][keep]
-
-    results: list[tuple[int, int, float]] = []
-    for a, b, s in zip(a_ids.tolist(), b_ids.tolist(), scores.tolist()):
-        pair_key = (a, b) if a < b else (b, a)
-        if pair_key in exclude_pairs:
-            continue
-        results.append((a, b, round(float(s), 4)))
-    return results
+    return _emit_triu_pairs(normalized, row_ids, link_threshold, exclude_pairs)
 
 
 def _fs_batch_rows() -> int:
@@ -2773,10 +2776,7 @@ def score_probabilistic_vectorized_batch(
     _missing_mode = fs_missing_mode(mk)  # #1846
     prior_w = prior_weight(em_result.proportion_matched) if calibrated else 0.0
     ne_min_weight, ne_max_weight = _fs_ne_weight_range(em_result, mk)
-    if mk.link_threshold is not None:
-        link_threshold = mk.link_threshold
-    else:
-        link_threshold, _ = compute_thresholds(em_result, calibrated=calibrated)
+    link_threshold = _fs_link_threshold(mk, em_result, calibrated)
 
     total_weight = np.zeros((S, S), dtype=np.float64)
     has_regular_evidence = np.zeros((S, S), dtype=bool)

--- a/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
+++ b/packages/python/goldenmatch/goldenmatch/core/probabilistic.py
@@ -796,6 +796,28 @@ def _em_ne_fields(mk: MatchkeyConfig) -> list:
     return [ne for ne in (mk.negative_evidence or []) if ne.penalty_bits is None]
 
 
+def _fs_ne_extend_cols(cols: list, mk: MatchkeyConfig) -> None:
+    """Append each negative-evidence field name to ``cols`` in place when not
+    already present, so NE-only fields (e.g. the canonical phone example, absent
+    from ``mk.fields``) are projected into row_lookup for ``_ne_fired`` to read.
+    The single NE-projection source shared by the EM trainers and the scalar
+    scorer (#1804 item 4)."""
+    for ne in (mk.negative_evidence or []):
+        if ne.field not in cols:
+            cols.append(ne.field)
+
+
+def _fs_projection_cols(mk: MatchkeyConfig) -> list:
+    """The scoring/label projection columns: every non-record matchkey field
+    plus the negative-evidence fields. Used by ``estimate_m_from_labels`` and the
+    scalar scorer; ``train_em`` additionally projects record_embedding columns,
+    so it builds the base list itself and calls ``_fs_ne_extend_cols`` (#1804
+    item 4)."""
+    cols = [f.field for f in mk.fields if f.field != "__record__"]
+    _fs_ne_extend_cols(cols, mk)
+    return cols
+
+
 def _build_ne_matrix(
     pairs: list[tuple[int, int]],
     row_lookup: dict[int, dict],
@@ -1072,9 +1094,7 @@ def train_em(
     # else NE-only fields (the canonical phone example) are absent from
     # row_lookup, read as missing/null, and NE never fires during EM
     # (degenerate m/u estimate).
-    for ne in (mk.negative_evidence or []):
-        if ne.field not in cols:
-            cols.append(ne.field)
+    _fs_ne_extend_cols(cols, mk)
     # ── Step 1: Estimate u from RANDOM pairs (Splink approach) ──
     # Random pairs are overwhelmingly non-matches, so the observed
     # level distribution approximates u directly. No EM needed for u.
@@ -1483,10 +1503,7 @@ def estimate_m_from_labels(
     ne_fields_em = _em_ne_fields(mk)
     _warn_ne_blocking_overlap(ne_fields_em, blocking_fields)
 
-    cols = [f.field for f in mk.fields if f.field != "__record__"]
-    for ne in (mk.negative_evidence or []):
-        if ne.field not in cols:
-            cols.append(ne.field)
+    cols = _fs_projection_cols(mk)
     # Keep only labels whose ids are present and distinct; canonicalize + dedup.
     # Membership rides the (cheap, ints-only) id column — the row dicts are
     # materialized below for ONLY the sampled/labeled ids (#1803 item 4).
@@ -2211,10 +2228,7 @@ def score_probabilistic(
     # precompute_matchkey_transforms) so an NE-only field (the canonical
     # phone example -- not in mk.fields) is present for _ne_fired to read,
     # mirroring train_em's row_lookup projection.
-    cols = [f.field for f in mk.fields if f.field != "__record__"]
-    for ne in (mk.negative_evidence or []):
-        if ne.field not in cols:
-            cols.append(ne.field)
+    cols = _fs_projection_cols(mk)
     row_lookup: dict[int, dict] = {}
     from goldenmatch.core.frame import to_frame as _tf_d5c
 


### PR DESCRIPTION
## What and why

Phase 2 of the FS pipeline audit (#1804), item 4: kill the copy-pasted Fellegi-Sunter scoring blocks so the shared logic lives in one place. Bit-identical extractions only — this is the groundwork that de-risks the item-1 keystone (`score_probabilistic_matchkey`). Also carries the `fs_default_bucket` bench toggle used to validate #1803's route flip.

## Changes

- **`_emit_triu_pairs(normalized, row_ids, threshold, exclude_pairs)`** — the upper-triangle pair-emit + exclude-filter + 4dp-round block, was duplicated verbatim in `score_probabilistic_continuous` and `score_probabilistic_vectorized`. The span-offset + `seen`-dedup batched variant is intentionally left inline (it is a different block).
- **`_fs_link_threshold(mk, em_result, calibrated)`** — the "configured cutoff else calibration-aware `compute_thresholds`" block, duplicated in the scalar / vectorized / batched scorers. The native path's `float(mk.link_threshold)` cast differs, so that site is left untouched to stay strictly output-preserving.
- **`_fs_ne_extend_cols(cols, mk)` + `_fs_projection_cols(mk)`** — the negative-evidence column projection (the NE-only-field-must-reach-`row_lookup` contract), was copy-pasted across `train_em` / `estimate_m_from_labels` / the scalar scorer. Now one NE-projection source; `train_em` keeps its own base list (it also projects `record_embedding` columns) and calls the shared extender.
- **`ci(bench-fs-distributed)`** — adds an `fs_default_bucket` workflow_dispatch input (wired to `GOLDENMATCH_FS_DEFAULT_BUCKET`) so the FS bucket route and legacy batched route can be A/B'd on the default backend. workflow_dispatch-only lane, not in `ci-required`.

No behavior change: every extraction is verbatim, and the sites that were not identical (batched triu variant, native `float()` cast) were deliberately excluded.

## Testing

`ARROW_DEFAULT_MEMORY_POOL=system .venv/bin/python -m pytest` over the FS suite — **229 passed** across `test_probabilistic`, `test_probabilistic_vectorized`, `test_probabilistic_determinism`, `test_probabilistic_parallel`, `test_fs_ne_{em,scoring,e2e,guards,schema}`, `test_fs_tf_scalar_parity_1801`, `test_fs_missing_semantics_1846`, `test_fs_lane_guards_1800`, `test_probabilistic_bench_dump`, `test_fast_path_probabilistic`. `ruff check` clean on the changed file.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (existing FS suite covers the extractions; bit-identical, no new behavior to test)
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (no behavior change — internal refactor)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (no workflow/gotcha change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_