### PR TITLE
fix(ci): extend version_consistency to TypeScript + sync drifted TS versions

### DIFF
--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -19,7 +19,7 @@ export const program = new Command();
 program
   .name("goldencheck-js")
   .description("Data validation that discovers rules from your data")
-  .version("0.1.0");
+  .version("0.5.0");
 
 // --- scan ---
 program

--- a/packages/typescript/goldencheck/src/core/engine/notifier.ts
+++ b/packages/typescript/goldencheck/src/core/engine/notifier.ts
@@ -91,7 +91,7 @@ export async function sendWebhook(
 
   const payload = {
     tool: "goldencheck-js",
-    version: "0.1.0",
+    version: "0.5.0",
     trigger,
     file,
     health_grade: grade,

--- a/packages/typescript/goldencheck/src/node/a2a/server.ts
+++ b/packages/typescript/goldencheck/src/node/a2a/server.ts
@@ -29,7 +29,7 @@ import { ReviewQueue, type ReviewItem } from "../../core/agent/review-queue.js";
 
 export const AGENT_CARD = {
   name: "goldencheck-agent",
-  version: "1.0.0",
+  version: "0.5.0",
   description: "Data validation agent that discovers rules from your data.",
   skills: [
     { id: "scan", description: "Scan a data file for quality issues" },

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -375,7 +375,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldencheck", version: "0.3.0" },
+            serverInfo: { name: "goldencheck", version: "0.5.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenflow/src/cli.ts
+++ b/packages/typescript/goldenflow/src/cli.ts
@@ -20,7 +20,7 @@ import { listRuns } from "./node/history.js";
 // Ensure all transforms are registered
 import "./core/transforms/index.js";
 
-const VERSION = "0.1.0";
+const VERSION = "0.16.0";
 
 export const program = new Command()
   .name("goldenflow-js")

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -46,7 +46,7 @@ export const AGENT_CARD: {
   name: "GoldenFlow",
   description:
     "Data transformation -- standardize, clean, and normalize data with auto-detection and domain-aware transforms",
-  version: "1.0.0",
+  version: "0.16.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8150",
   skills: [

--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -14,7 +14,7 @@ function sanitizePath(raw: string): string {
   return resolved;
 }
 
-const VERSION = "0.1.0";
+const VERSION = "0.16.0";
 
 /** Strip stack / errno / syscall fields from objects + Error instances so
  *  unauthenticated callers don't see internal paths / library versions. */

--- a/packages/typescript/goldenflow/src/node/mcp/server.ts
+++ b/packages/typescript/goldenflow/src/node/mcp/server.ts
@@ -348,7 +348,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenflow", version: "0.3.0" },
+            serverInfo: { name: "goldenflow", version: "0.16.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "0.1.0",
+  version: "1.4.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -892,7 +892,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "0.1.0",
+          version: "1.4.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1035,7 +1035,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "0.1.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.4.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenpipe/src/cli.ts
+++ b/packages/typescript/goldenpipe/src/cli.ts
@@ -22,7 +22,7 @@ import { startMcpServer } from "./node/mcp/server.js";
 import { startA2aServer } from "./node/a2a/server.js";
 import { runServer as runApiServer } from "./node/api/server.js";
 
-const VERSION = "0.2.0";
+const VERSION = "0.3.0";
 
 function printResult(result: PipeResult, verbose: boolean): void {
   process.stdout.write(`GoldenPipe: ${result.source}\n`);

--- a/packages/typescript/goldenpipe/src/node/a2a/server.ts
+++ b/packages/typescript/goldenpipe/src/node/a2a/server.ts
@@ -45,7 +45,7 @@ export const AGENT_CARD: {
 } = {
   name: "GoldenPipe",
   description: "Pluggable pipeline framework for data quality workflows",
-  version: "1.0.0",
+  version: "0.3.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8250",
   skills: [

--- a/packages/typescript/goldenpipe/src/node/api/server.ts
+++ b/packages/typescript/goldenpipe/src/node/api/server.ts
@@ -24,7 +24,7 @@ import { resolve, isAbsolute } from "node:path";
 import { handleTool } from "../mcp/server.js";
 import { run } from "../run.js";
 
-const VERSION = "1.0.0";
+const VERSION = "0.3.0";
 
 /** Resolve a path relative to cwd and reject traversal outside it. */
 function sanitizePath(raw: string): string {

--- a/packages/typescript/goldenpipe/src/node/mcp/server.ts
+++ b/packages/typescript/goldenpipe/src/node/mcp/server.ts
@@ -214,7 +214,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenpipe", version: "0.2.0" },
+              serverInfo: { name: "goldenpipe", version: "0.3.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });

--- a/packages/typescript/infermap/src/node/mcp/server.ts
+++ b/packages/typescript/infermap/src/node/mcp/server.ts
@@ -573,7 +573,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "infermap", version: "0.5.0" },
+              serverInfo: { name: "infermap", version: "0.6.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });

--- a/scripts/check_version_consistency.py
+++ b/scripts/check_version_consistency.py
@@ -44,6 +44,35 @@ def _init_version(path: Path) -> str | None:
     return m.group(1) if m else None
 
 
+# TS package-version declarations we enforce against package.json:
+#   const VERSION = "x.y.z" / export const VERSION = ... (cli + api-server banners)
+#   .version("x.y.z")                                    (commander CLI)
+#   version: "x.y.z"                                     (A2A AgentCard + MCP serverInfo)
+# Restricted to THREE-part semver so it never matches MCP `protocolVersion`
+# ("2024-11-05"), two-part schema tags, or numeric wire-format versions.
+_TS_VERSION_RE = re.compile(
+    r"""(?:(?:export\s+)?const\s+VERSION\s*=\s*|\.version\(\s*|\bversion:\s*)["'](\d+\.\d+\.\d+)["']"""
+)
+
+
+def _package_json_version(path: Path) -> str | None:
+    return json.loads(path.read_text(encoding="utf-8")).get("version")
+
+
+def _ts_src_versions(src_dir: Path) -> list[tuple[str, str]]:
+    """Every enforced version literal under a TS package's src/, labelled by
+    file:line so a drift points at the exact spot to fix."""
+    found: list[tuple[str, str]] = []
+    for ts in sorted(src_dir.rglob("*.ts")):
+        if ts.name.endswith((".test.ts", ".spec.ts", ".d.ts")):
+            continue
+        for i, line in enumerate(ts.read_text(encoding="utf-8").splitlines(), 1):
+            m = _TS_VERSION_RE.search(line)
+            if m is not None:
+                found.append((f"{ts.relative_to(src_dir.parent)}:{i}", m.group(1)))
+    return found
+
+
 def _check(name: str, sources: list[tuple[str, str | None]], errors: list[str]) -> None:
     present = [(label, v) for label, v in sources if v is not None]
     distinct = {v for _, v in present}
@@ -91,6 +120,21 @@ def main() -> int:
             if v is not None:
                 sources.append((str(init.relative_to(crate_dir)), v))
         _check(f"native/{crate_dir.name}", sources, errors)
+        checked += 1
+
+    # --- TypeScript packages (package.json + src version literals) ---
+    # The Python/Rust gates above never saw TS, so cli.ts / api-server / A2A
+    # AgentCard / MCP serverInfo versions drifted from package.json unnoticed.
+    for pkgjson in sorted((ROOT / "packages" / "typescript").glob("*/package.json")):
+        pkg_dir = pkgjson.parent
+        pkg_v = _package_json_version(pkgjson)
+        if pkg_v is None:
+            continue
+        sources = [("package.json", pkg_v)]
+        src = pkg_dir / "src"
+        if src.is_dir():
+            sources.extend(_ts_src_versions(src))
+        _check(f"ts/{pkg_dir.name}", sources, errors)
         checked += 1
 
     if errors:


### PR DESCRIPTION
## Why
The `version_consistency` gate (`scripts/check_version_consistency.py`) walked **Python + Rust only** — it never saw TypeScript. So TS versions declared anywhere other than `package.json` drifted silently. Found while confirming the #1858 lockstep miss wasn't unique (thanks for the nudge). Live on `main`: `goldenflow --version` reported `0.1.0` for a `0.16.0` package, and the MCP/A2A handshakes advertised stale versions.

## What
**1. Extend the gate to TypeScript.** For every `packages/typescript/*`, assert `package.json` version == each enforced `src` literal:
- `const VERSION = "x.y.z"` / `export const VERSION` (cli + api-server banners)
- `.version("x.y.z")` (commander)
- `version: "x.y.z"` (A2A `AgentCard.version` + MCP `serverInfo.version`)

Restricted to **3-part semver**, so it never matches MCP `protocolVersion` (`"2024-11-05"`), two-part tags, or numeric wire-format versions. Verified **zero false positives** across the repo — every flag was a real drift.

**2. Sync the drifts the lane surfaced** (all → their `package.json` version):

| Package | `package.json` | Fixed |
|---|---|---|
| goldencheck | 0.5.0 | cli `.version`, notifier payload, A2A card, MCP serverInfo |
| goldenflow | 0.16.0 | cli, api server, A2A card, MCP serverInfo |
| goldenmatch | 1.4.0 | A2A card + two MCP serverInfo |
| goldenpipe | 0.3.0 | cli, api server, A2A card, MCP serverInfo |
| infermap | 0.6.0 | MCP serverInfo |

## Verified
Check now green: **32 packages (10 TS added), all in lockstep**. No test breakage — the a2a/server tests assert `typeof version === "string"` (and `goldenmatch cli-evaluate.test.ts` already asserts `pkg.version !== "0.1.0"`, i.e. it was watching for exactly this). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd