### PR TITLE
refactor(tui): route the TUI FS path through score_probabilistic_matchkey (#1804 item 3)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -286,15 +286,16 @@ def _score_probabilistic_matchkey(
     bench_candidate_pairs=None,
     bench_emitted_pairs=None,
     log_em: bool = False,
+    em_results=None,
 ) -> None:
     """Score one probabilistic (Fellegi-Sunter) matchkey, folding results into
     ``all_pairs`` / ``review_pairs`` and updating ``matched_pairs`` in place.
 
-    The single routing/scoring body shared by the dedupe pipeline and both match
-    lanes (``_run_match_pipeline`` / ``_run_match_scoring_and_output``) -- the
-    three were near-identical, so the #1798 bucket gate no longer has to be
-    maintained in three places (#1804 item 1). ``block_frame`` feeds
-    ``build_blocks``; ``score_frame`` feeds EM training + ``score_buckets``.
+    The single routing/scoring body shared by the dedupe pipeline, both match
+    lanes (``_run_match_pipeline`` / ``_run_match_scoring_and_output``) and the
+    TUI engine -- the four were near-identical, so the #1798 bucket gate no
+    longer has to be maintained in four places (#1804 items 1 + 3). ``block_frame``
+    feeds ``build_blocks``; ``score_frame`` feeds EM training + ``score_buckets``.
 
     Filtering is caller-shaped: the match lanes pass ``target_ids`` (each scorer
     filters internally); the dedupe across-files path passes ``across_files_only``
@@ -304,6 +305,8 @@ def _score_probabilistic_matchkey(
     ``bench_candidate_pairs`` / ``bench_emitted_pairs`` for exact candidate /
     emitted accounting; it is inert (no per-block work) when unset. ``log_em``
     emits the EM-convergence info line (dedupe only, preserving prior behavior).
+    ``em_results`` (the TUI engine's per-matchkey model waterfall) is populated
+    with the trained ``EMResult`` under ``mk.name`` when provided.
     """
     from goldenmatch.core.blocker import collect_blocking_fields
     from goldenmatch.core.probabilistic import (
@@ -346,6 +349,8 @@ def _score_probabilistic_matchkey(
     scoring_mk, link_threshold = _prepare_probabilistic_review_scoring(
         mk, em_result
     )
+    if em_results is not None:
+        em_results[mk.name] = em_result
     if log_em:
         logger.info(
             "F-S EM: converged=%s, iterations=%d, match_rate=%.4f",

--- a/packages/python/goldenmatch/goldenmatch/tui/engine.py
+++ b/packages/python/goldenmatch/goldenmatch/tui/engine.py
@@ -248,33 +248,26 @@ class MatchEngine:
             if mk.type == "probabilistic":
                 if config.blocking is None:
                     continue
-                from goldenmatch.core.probabilistic import (
-                    load_or_train_em,
-                    probabilistic_block_scorer,
+                from goldenmatch.core.pipeline import (
+                    _score_probabilistic_matchkey,
                 )
-                blocks = build_blocks(combined_lf, config.blocking)
-                blocking_fields = []
-                if config.blocking and config.blocking.keys:
-                    for bk in config.blocking.keys:
-                        blocking_fields.extend(bk.fields)
-                # Reuses mk.model_path when set (train-once), else trains.
-                em_result = load_or_train_em(
-                    collected_df, mk,
-                    blocks=blocks,
-                    blocking_fields=blocking_fields,
+                # Route through the ONE shared FS scorer the dedupe / match
+                # pipelines use (#1804 item 3): memory-bounded bucket routing,
+                # multi_pass-correct blocking-field collection, and the #1798
+                # build_blocks skip -- replacing the TUI's stale per-block loop
+                # (eager build_blocks + the `block.df` accessor + a keys-only
+                # blocking_fields that missed multi_pass `.passes`). The trained
+                # model is stored in `em_results` for the waterfall; review-band
+                # pairs are discarded (the TUI shows the >= link cut, unchanged).
+                _score_probabilistic_matchkey(
+                    mk, config,
+                    block_frame=combined_lf,
+                    score_frame=collected_df,
+                    matched_pairs=matched_pairs,
+                    all_pairs=all_pairs,
+                    review_pairs=[],
+                    em_results=em_results,
                 )
-                em_results[mk.name] = em_result
-                # Route through the block-scorer selector (native -> vectorized
-                # -> scalar) instead of calling the scalar scorer directly, so
-                # the TUI gets native/vectorized FS and model-backed scorers
-                # (embedding / record_embedding) work here too (#1806).
-                fs_scorer = probabilistic_block_scorer(mk, em_result)
-                for block in blocks:
-                    block_df = block.df.collect() if hasattr(block.df, 'collect') else block.df
-                    pairs = fs_scorer(block_df, exclude_pairs=matched_pairs)
-                    all_pairs.extend(pairs)
-                    for a, b, s in pairs:
-                        matched_pairs.add((min(a, b), max(a, b)))
 
         # ── Rerank (optional) ──
         for mk in matchkeys:


### PR DESCRIPTION
## What and why

Phase 2 of the FS pipeline audit (#1804), item 3: the TUI engine (`tui/engine.py`) carried the **oldest** Fellegi-Sunter scoring loop. Route it through the one `_score_probabilistic_matchkey` the dedupe / match pipelines now share (#1804 item 1), so **all four FS sites** use a single scoring body — a fix applied there lands everywhere. Builds on #1884.

## Changes

- **`tui/engine.py`** — the per-block FS loop is replaced by a call to `_score_probabilistic_matchkey`. This fixes three concrete issues the old loop had:
  - the stale `block.df` accessor → the shared function uses `.materialize().native`;
  - a **keys-only `blocking_fields`** build that missed multi_pass `.passes` (degrading FS recall on multi_pass configs) → `collect_blocking_fields`;
  - unconditional eager `build_blocks` → the #1798-aware memory-bounded routing.
- **`core/pipeline.py`** — `_score_probabilistic_matchkey` gains one optional `em_results` param: when provided it is populated with the trained `EMResult` under `mk.name` (the TUI's model waterfall, returned in `EngineResult.em_results`). All other callers pass nothing, so dedupe / match are unchanged.

## Behavior

Displayed pair-set is preserved. The shared function scores down to the review cut then splits at the link cut; the TUI's prior loop emitted exactly the `>= link` set — so `all_pairs` is unchanged. The new review-band pairs (below link) are discarded (the TUI has no review surface). The `blocking_fields` fix is a deliberate FS-recall improvement on multi_pass configs.

## Testing

`ARROW_DEFAULT_MEMORY_POOL=system` pytest — **165 passed** on the rebased branch across `test_tui`, `test_tui_wave2`, `test_tui_triage`, `test_router_preview_probabilistic` (runs `MatchEngine` FS end-to-end), and `test_probabilistic`. `ruff check` clean on both changed files.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (TUI + preview + probabilistic suites cover the routed path)
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal refactor; displayed pair-set preserved, multi_pass recall improved)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (no workflow/gotcha change)

With this, epic #1804's "one FS scoring function across every surface" goal is complete (items 1 + 3 + 4). Remaining tail: item 2 (wire-or-delete the orphaned fused FS kernel — a measurement/decision) and item 5 (document the ~20-knob inventory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_