### PR TITLE
fix(scorer): NE fast path declines non-direct scorers (bucket vs slow-path parity)

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -515,6 +515,24 @@ def _resolve_fast_path(
     if total_weight <= 0:
         _decline(f"total_weight={total_weight}")
         return None
+    # NE PARITY GUARD: the slow path (_apply_negative_evidence) applies a penalty
+    # for EVERY NE scorer `score_field` can score -- it only skips a scorer that
+    # RAISES (cached in _NE_BROKEN). But the fast path can faithfully reproduce a
+    # per-pair penalty only for scorers in _SCORE_FIELD_DIRECT_SCORERS;
+    # _resolve_ne_specs silently DROPS the rest (ensemble / qgram / date / phash /
+    # audio_fp / initialism_match / alias_match), zeroing a penalty the slow path
+    # applies -> the SAME pair scores differently on bucket vs polars-direct.
+    # Decline to the slow path whenever an NE scorer isn't fast-representable: for
+    # a genuinely-broken scorer the slow path also skips it (identical result), so
+    # declining is parity-correct either way. Parity over speed.
+    for _ne in (mk.negative_evidence or []):
+        _ne_scorer = getattr(_ne, "scorer", None)
+        if _ne_scorer is not None and _ne_scorer not in _SCORE_FIELD_DIRECT_SCORERS:
+            _decline(
+                f"NE scorer {_ne_scorer!r} not in _SCORE_FIELD_DIRECT_SCORERS "
+                f"(slow path would penalize; fast path can't) -> slow-path parity"
+            )
+            return None
     ne_specs = _resolve_ne_specs(mk, prepared_df)
     # Diagnostic on the success path: log matchkey shape so we can compare
     # what the controller commits at different row counts (rerank thresholds

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -1,19 +1,23 @@
-"""Unit tests for ``_ne_effectively_empty`` and the broader fast-path gate
-in ``score_buckets._resolve_fast_path``.
+"""Unit tests for ``_ne_effectively_empty`` and the fast-path gate in
+``score_buckets._resolve_fast_path``.
 
-Background: at auto-config time on the QIS realistic shape (10M rows),
-``promote_negative_evidence`` was adding an NE entry on the ``id`` column
-with scorer name ``ensemble``. ``score_field`` doesn't implement
-``ensemble`` and raises ``ValueError`` -- ``core/scorer.py::_NE_BROKEN``
-catches this once per (scorer, field) and silently skips it on subsequent
-calls. The NE contributes zero penalty at runtime.
+History (two layers):
+1. The gate once declined the fast path whenever ``mk.negative_evidence`` was
+   truthy -- too conservative, so the "smart gate" (PR #552) engaged when the NE
+   scorers were runtime no-ops. Back then ``ensemble`` RAISED in ``score_field``,
+   was cached in ``core/scorer.py::_NE_BROKEN``, and contributed zero penalty, so
+   engaging + dropping it matched the slow path.
+2. That premise is GONE: ``score_field`` later gained real handlers for
+   ``ensemble`` / ``qgram`` / ``date`` / ``phash`` / ``audio_fp`` /
+   ``initialism_match`` / ``alias_match``, so the SLOW path
+   (``_apply_negative_evidence``) now APPLIES their penalty. But those scorers are
+   still not in ``_SCORE_FIELD_DIRECT_SCORERS``, so the fast path dropped them ->
+   zero penalty -> the SAME pair scored differently on bucket vs polars-direct.
 
-But the old fast-path gate declined eligibility whenever
-``mk.negative_evidence`` was truthy, regardless of whether the entries were
-actually callable. That forced the entire workload onto the slow Python
-``find_fuzzy_matches`` path and blocked the native + ExcludeSet handle
-optimizations (PR #552). The smarter gate looks at the NE scorer names and
-only declines when at least one would actually fire at runtime.
+The parity guard in ``_resolve_fast_path`` now DECLINES to the slow path for any
+NE scorer outside ``_SCORE_FIELD_DIRECT_SCORERS`` (parity over speed; for a
+genuinely-``_NE_BROKEN`` scorer the slow path also skips it, so declining is
+correct either way). These tests pin that behavior.
 """
 from __future__ import annotations
 
@@ -113,20 +117,26 @@ class TestResolveFastPath:
             col_last: ["smith", "smith"],
         })
 
-    def test_fast_path_engaged_with_broken_ne(self):
+    @pytest.mark.parametrize("ne_scorer", ["ensemble", "qgram", "date"])
+    def test_fast_path_declines_score_field_handled_but_non_direct_ne(self, ne_scorer):
+        """PARITY GUARD: `score_field` gained handlers for ensemble/qgram/date/
+        phash/audio_fp/initialism_match/alias_match, so the SLOW path
+        (_apply_negative_evidence) applies their penalty -- but the fast path can
+        only reproduce a per-pair penalty for _SCORE_FIELD_DIRECT_SCORERS and would
+        silently DROP these (zero penalty). Same pair, different bucket-vs-polars
+        score. The fast path must DECLINE so the reference slow path scores it.
+        (Historically these RAISED -> _NE_BROKEN no-op -> engaging was safe; that
+        premise is gone.)"""
         mk = _mk_with_ne([
-            NegativeEvidenceField(field="id", scorer="ensemble", threshold=0.8, penalty=0.5),
+            NegativeEvidenceField(field="id", scorer=ne_scorer, threshold=0.8, penalty=0.5),
         ])
         result = _resolve_fast_path(
             mk, self._prepared_df(),
             across_files_only=False, source_lookup=None, target_ids=None,
         )
-        # _resolve_fast_path returns None when not eligible. With broken-NE
-        # only, we should get the spec back. It's None ONLY if some other
-        # prerequisite failed -- this fixture satisfies all of them, so a
-        # None here would mean the broken-NE gate logic didn't fire.
-        assert result is not None, (
-            "broken-NE matchkey should be fast-path eligible after the gate fix"
+        assert result is None, (
+            f"NE scorer {ne_scorer!r} is applied by the slow path but not fast-"
+            f"representable; the fast path must decline for parity, got engaged"
         )
 
     def test_fast_path_engaged_with_callable_ne_missing_xform(self):


### PR DESCRIPTION
## Why (real correctness bug, found in the cross-surface consistency audit)
Negative-evidence scoring **diverges between the bucket fast path and the slow path** for a class of NE scorers. Same pair, different final score depending on which path runs.

- Slow path (`_apply_negative_evidence`, `scorer.py:297`) calls `score_field` for **every** NE scorer and only skips one that **raises** (cached in `_NE_BROKEN`).
- `score_field` long ago gained real handlers for `ensemble` / `qgram` / `date` / `phash` / `audio_fp` / `initialism_match` / `alias_match` — so the slow path **applies** their penalty.
- But those aren't in `_SCORE_FIELD_DIRECT_SCORERS`, so the fast path's `_resolve_ne_specs` **silently drops** them → **zero** penalty.

Unit proof (`GOLDENMATCH_NATIVE=0`):
```
NE scorer=jaro_winkler  slow penalty=0.5  fast specs=1  -> agree
NE scorer=qgram         slow penalty=0.5  fast specs=0  -> DIVERGE
NE scorer=ensemble      slow penalty=0.5  fast specs=0  -> DIVERGE
NE scorer=date          slow penalty=0.5  fast specs=0  -> DIVERGE
```

**Root cause:** `score_field`'s handled-scorer set grew past `_SCORE_FIELD_DIRECT_SCORERS` without the fast-path NE classification following. The old "`ensemble` raises → `_NE_BROKEN` no-op → engaging is safe" premise (which the smart gate relied on) is gone.

## Fix
`_resolve_fast_path` now **declines** to the slow path when any NE scorer is outside `_SCORE_FIELD_DIRECT_SCORERS` — symmetric with the field-scorer decline one block up. Parity over speed; for a genuinely-`_NE_BROKEN` scorer the slow path also skips it, so declining is parity-correct either way.

## Verified
`_resolve_fast_path` now declines `ensemble`/`qgram`/`date` NE and still engages `jaro_winkler` NE; **62 NE tests green**; ruff clean. Updated the stale test + docstring that asserted the old "ensemble is broken → engage" behavior.

Part of the focused GoldenMatch consistency pass (item 1 of 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd