### PR TITLE
fix(ci): api_parity/native_symbols blocking + gate scorer/transform parity

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -380,6 +380,11 @@ api_parity:
   - 'packages/typescript/*/src/node/mcp/**'
   - 'packages/typescript/*/src/node/a2a/**'
   - 'packages/typescript/*/src/cli.ts'
+  # scorers/transforms surfaces: the VALID_SCORERS / VALID_SIMPLE_TRANSFORMS
+  # (Python) and VALID_SCORERS / VALID_TRANSFORMS (TS) declarations. Without
+  # these the gate can't see a scorer/transform added on one side only.
+  - 'packages/python/*/*/config/schemas.py'
+  - 'packages/typescript/*/src/core/types.ts'
   - 'parity/**'
   - 'scripts/emit_python_surface.py'
   - 'scripts/emit_ts_surface.mjs'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3470,6 +3470,11 @@ jobs:
       - readme_callouts
       - docs_consistency
       - ts_parity_freshness
+      # api_parity + native_symbols guard cross-surface invariants (Python<->TS
+      # tool/CLI/skill/scorer/transform parity; native symbol registration) but
+      # were advisory -- a correct red couldn't block a merge. Now required.
+      - api_parity
+      - native_symbols
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -237,3 +237,49 @@ a2a_skills:
   - score
   - suggest_config
   - suggest_pprl
+
+# scorers surface (config.schemas.VALID_SCORERS <-> types.ts VALID_SCORERS).
+# python_only: multimodal media comparators (ADR 0022) with no TS port yet.
+# ts_only: census/alias name-scorer plugins (Python accepts them via the
+# PluginRegistry validator fallback, so they're NOT in Python VALID_SCORERS).
+scorers:
+  shared:
+  - date
+  - dice
+  - embedding
+  - ensemble
+  - exact
+  - jaccard
+  - jaro_winkler
+  - levenshtein
+  - qgram
+  - record_embedding
+  - soundex_match
+  - token_sort
+  python_only:
+  - alias_match
+  - audio_fp
+  - initialism_match
+  - phash
+  - radial
+  ts_only:
+  - given_name_aliased_jw
+  - name_freq_weighted_jw
+# transforms surface (config.schemas.VALID_SIMPLE_TRANSFORMS <-> types.ts
+# VALID_TRANSFORMS). Currently in exact parity -- no declared deltas.
+transforms:
+  shared:
+  - alpha_only
+  - digits_only
+  - first_token
+  - last_token
+  - lowercase
+  - metaphone
+  - normalize_whitespace
+  - soundex
+  - strip
+  - strip_all
+  - token_sort
+  - uppercase
+  python_only: []
+  ts_only: []

--- a/scripts/check_api_parity.py
+++ b/scripts/check_api_parity.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-SURFACES = ("mcp_tools", "cli_commands", "a2a_skills")
+SURFACES = ("mcp_tools", "cli_commands", "a2a_skills", "scorers", "transforms")
 
 
 class ParityFailure(NamedTuple):

--- a/scripts/emit_python_surface.py
+++ b/scripts/emit_python_surface.py
@@ -52,6 +52,19 @@ def _cli(cli_module: str):
     return fn
 
 
+def _scorers() -> list[str]:
+    # goldenmatch config surface: the accepted comparison-scorer names. Mirrors
+    # TS `VALID_SCORERS` (types.ts); intended cross-language deltas are declared
+    # in parity/goldenmatch.yaml (e.g. audio_fp/phash/radial are Python-only).
+    from goldenmatch.config.schemas import VALID_SCORERS
+    return sorted(VALID_SCORERS)
+
+
+def _transforms() -> list[str]:
+    from goldenmatch.config.schemas import VALID_SIMPLE_TRANSFORMS
+    return sorted(VALID_SIMPLE_TRANSFORMS)
+
+
 # The only per-package variance on the Python side is the CLI module path.
 _CLI_MODULE = {
     "goldenmatch": "goldenmatch.cli.main",
@@ -65,7 +78,12 @@ _CLI_MODULE = {
 # Each surface -> (callable returning list[str], extra-name for the env-gap message).
 REGISTRY = {
     pkg: {"mcp_tools": (_mcp(pkg), "mcp"), "cli_commands": (_cli(mod), None),
-          **({"a2a_skills": (_a2a(pkg), "a2a")} if pkg in _A2A_PACKAGES else {})}
+          **({"a2a_skills": (_a2a(pkg), "a2a")} if pkg in _A2A_PACKAGES else {}),
+          # Scorer/transform config surfaces are goldenmatch-only (no extra needed:
+          # config.schemas imports without the mcp/a2a stacks). Other packages
+          # never declare these surfaces, so they're skipped for them.
+          **({"scorers": (_scorers, None), "transforms": (_transforms, None)}
+             if pkg == "goldenmatch" else {})}
     for pkg, mod in _CLI_MODULE.items()
 }
 

--- a/scripts/emit_ts_surface.mjs
+++ b/scripts/emit_ts_surface.mjs
@@ -58,6 +58,16 @@ async function emit(pkg) {
     descriptor.a2a_skills = a.AGENT_CARD.skills.map((s) => s.id).sort();
   }
 
+  // goldenmatch config surfaces: the scorer/transform name sets. Mirrors the
+  // Python emitter; intended cross-language deltas live in parity/goldenmatch.yaml.
+  if (pkg === "goldenmatch") {
+    const t = await load("dist/core/types.js");
+    if (!t.VALID_SCORERS || !t.VALID_TRANSFORMS)
+      throw new Error(`${pkg}: expected VALID_SCORERS + VALID_TRANSFORMS in dist/core/types.js`);
+    descriptor.scorers = [...t.VALID_SCORERS].sort();
+    descriptor.transforms = [...t.VALID_TRANSFORMS].sort();
+  }
+
   return descriptor;
 }
 

--- a/scripts/emit_ts_surface.mjs
+++ b/scripts/emit_ts_surface.mjs
@@ -61,9 +61,11 @@ async function emit(pkg) {
   // goldenmatch config surfaces: the scorer/transform name sets. Mirrors the
   // Python emitter; intended cross-language deltas live in parity/goldenmatch.yaml.
   if (pkg === "goldenmatch") {
-    const t = await load("dist/core/types.js");
+    // types.ts is bundled (not its own tsup entry) -> dist/core/types.js does
+    // not exist. The `./core` export entry (dist/core/index.js) re-exports both.
+    const t = await load("dist/core/index.js");
     if (!t.VALID_SCORERS || !t.VALID_TRANSFORMS)
-      throw new Error(`${pkg}: expected VALID_SCORERS + VALID_TRANSFORMS in dist/core/types.js`);
+      throw new Error(`${pkg}: expected VALID_SCORERS + VALID_TRANSFORMS in dist/core/index.js`);
     descriptor.scorers = [...t.VALID_SCORERS].sort();
     descriptor.transforms = [...t.VALID_TRANSFORMS].sort();
   }


### PR DESCRIPTION
## Why
From the focused consistency audit: two cross-surface gates guarded real invariants but were **advisory** (absent from `ci-required`), so a correct red couldn't block a merge — the same shape as the `version_consistency`-skips-TS blind spot. And `api_parity`'s `SURFACES` only covered `mcp_tools`/`cli_commands`/`a2a_skills`, so a scorer/transform added on one language slipped through. Confirmed: **`audio_fp`/`phash`/`radial`/`alias_match`/`initialism_match` are Python-only scorers with no TS mirror and nothing flagging it.**

## What
- **Widen `api_parity`** to `scorers` + `transforms`: both emitters emit goldenmatch's `VALID_SCORERS` / `VALID_(SIMPLE_)TRANSFORMS`; `SURFACES` extended; `parity/goldenmatch.yaml` declares the intended deltas — 5 Python-only scorers, 2 TS-only name-plugin scorers (`given_name_aliased_jw`, `name_freq_weighted_jw`, accepted in Python via the PluginRegistry validator); transforms in exact parity.
- **Extend the filter** (`config/schemas.py` + `core/types.ts`) so a `VALID_SCORERS` edit actually fires the gate — otherwise the gate is itself blind.
- **`api_parity` + `native_symbols` → `ci-required`**.

## Verified
Validated locally against authoritative Python (import) + TS (`types.ts` source) ground truth via the *real* `check_partition`/`check_structure`: **PARITY OK**. The local check even caught two scorers my first pass missed (`alias_match`/`initialism_match`). 22 api_parity gate tests green; `ci.yml` + `filters.yml` valid. The TS emitter side (loading `dist/core/types.js`) runs in CI's built environment.

Part 2 of the focused GoldenMatch consistency pass (#1888 was part 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd