### PR TITLE
fix(consistency): single-source BUCKET_HASH_SEED + gate native scorer-id maps

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -224,9 +224,11 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
 }
 
 
-BUCKET_HASH_SEED = 0xC2B5C0BBE7ED5E5D
-"""Same constant as goldenmatch.distributed.record_store. Deterministic
-xxHash seed so block_key -> bucket assignment is stable across runs."""
+# Single source in core._hashing (re-exported here for back-compat). The
+# distributed record store imports the SAME constant, so bucket assignment is
+# identical across the two surfaces. Was a duplicated literal; drift is now
+# gated by test_cross_surface_consistency.
+from goldenmatch.core._hashing import BUCKET_HASH_SEED  # noqa: E402
 
 
 def _default_n_buckets(height: int | None = None) -> int:

--- a/packages/python/goldenmatch/goldenmatch/core/_hashing.py
+++ b/packages/python/goldenmatch/goldenmatch/core/_hashing.py
@@ -29,6 +29,15 @@ from goldenmatch.core._native_loader import native_enabled, native_module
 _US = b"\x1f"  # unit separator: between a field name and its value
 _RS = b"\x1e"  # record separator: end of one field
 
+# Deterministic xxHash seed for block_key -> bucket assignment. SINGLE SOURCE:
+# the bucket scorer (backends.score_buckets) and the distributed record store
+# (distributed.record_store) both hash `__block_key__ % n_buckets` with THIS
+# seed, so a record's bucket must be identical across the two surfaces -- a drift
+# would silently misroute rows. Kept here (a low-level, dependency-light module
+# both import) instead of re-declared in each; test_cross_surface_consistency
+# pins that the importers agree.
+BUCKET_HASH_SEED = 0xC2B5C0BBE7ED5E5D
+
 
 def _value_bytes(name: str, value: Any) -> bytes:
     """TAG + value bytes for one value. Type-tagged so int ``1`` != str ``"1"``

--- a/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/record_store.py
@@ -37,10 +37,10 @@ from goldenmatch._polars_lazy import pl
 
 _TABLE_PREFIX = "prepared_"
 
-BUCKET_HASH_SEED = 0xC2B5C0BBE7ED5E5D
-"""Deterministic seed for Polars' xxHash-based bucket assignment.
-Changing this value reshuffles every bucket assignment; treat as a
-constant. See spec §Decisions log."""
+# Single source in core._hashing (re-exported here for back-compat). The bucket
+# scorer (backends.score_buckets) imports the SAME constant; changing it
+# reshuffles every bucket assignment on BOTH surfaces. See spec §Decisions log.
+from goldenmatch.core._hashing import BUCKET_HASH_SEED
 
 
 def _sanitize_signature(signature: str) -> str:

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -1,0 +1,78 @@
+"""Gates for values that MUST agree across surfaces but are hand-maintained in
+several places -- the drift class the focused consistency audit surfaced.
+
+1. BUCKET_HASH_SEED: the bucket scorer and the distributed record store hash
+   `__block_key__ % n_buckets` with the same seed, so a record's bucket is
+   identical across surfaces. It was a duplicated literal; now a single source in
+   core._hashing, pinned here.
+2. Native scorer-id maps: the integer ids in _NATIVE_SCORER_IDS (score_buckets,
+   the score_block_pairs/score_one namespace) and _NATIVE_FIELD_SCORER_IDS
+   (scorer.py, the score_field_matrix namespace) are hand-maintained mirrors of
+   the Rust score-core dispatch. Nothing asserted they match the kernel; a
+   renumber would silently mis-dispatch. Pinned canonically + behaviorally.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from goldenmatch.backends.score_buckets import _NATIVE_SCORER_IDS
+from goldenmatch.core import _hashing
+from goldenmatch.core.scorer import _NATIVE_FIELD_SCORER_IDS, _native_field_matrix, score_field
+
+
+class TestBucketHashSeedSingleSource:
+    def test_score_buckets_uses_the_hashing_seed_object(self):
+        from goldenmatch.backends import score_buckets
+        assert score_buckets.BUCKET_HASH_SEED is _hashing.BUCKET_HASH_SEED
+
+    def test_record_store_uses_the_hashing_seed_object(self):
+        pytest.importorskip("duckdb")  # record_store imports duckdb at module load
+        from goldenmatch.distributed import record_store
+        assert record_store.BUCKET_HASH_SEED is _hashing.BUCKET_HASH_SEED
+
+    def test_seed_value_is_pinned(self):
+        # A change here reshuffles every bucket assignment on BOTH surfaces.
+        assert _hashing.BUCKET_HASH_SEED == 0xC2B5C0BBE7ED5E5D
+
+
+class TestNativeScorerIdMaps:
+    # The canonical Rust score-core `score_one` dispatch (lib.rs): the block-pair
+    # kernel. `score_field_matrix` shares 0-3 (it delegates to score_one) but its
+    # id 4 is soundex_match, a DIFFERENT namespace -- pinned separately so the two
+    # can't silently collide.
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4}
+    _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
+
+    def test_native_scorer_ids_match_score_one_ordering(self):
+        assert _NATIVE_SCORER_IDS == self._SCORE_ONE_IDS
+
+    def test_native_field_scorer_ids_match_score_field_matrix_ordering(self):
+        assert _NATIVE_FIELD_SCORER_IDS == self._FIELD_MATRIX_IDS
+
+    def test_shared_ids_agree_across_the_two_namespaces(self):
+        # 0-3 are delegated by score_field_matrix to score_one, so they MUST be
+        # identical in both Python dicts; only id 4 diverges (date vs soundex).
+        for name in ("jaro_winkler", "levenshtein", "token_sort", "exact"):
+            assert _NATIVE_SCORER_IDS[name] == _NATIVE_FIELD_SCORER_IDS[name]
+
+    def test_field_matrix_ids_bind_to_the_right_scorer_in_the_kernel(self):
+        """Behavioral: for each (name, id), the native score_field_matrix kernel
+        dispatched by that id must produce the SAME score as the pure-Python
+        score_field(name) -- proving the Python id->scorer binding agrees with the
+        Rust arms. Catches a renumber of either the dict OR the kernel."""
+        a, b = "smith", "smyth"  # alpha: valid for soundex + distinct across scorers
+        # Skip unless the native field-matrix path is actually active (needs the
+        # kernel built AND GOLDENMATCH_NATIVE != 0); _native_field_matrix returns
+        # None otherwise. This is a native<->python parity check, not a "is native
+        # on" check, so it only runs where native runs (the CI `native` lane).
+        if _native_field_matrix([a, b], "jaro_winkler") is None:
+            pytest.skip("native field-matrix path not active (unbuilt or GOLDENMATCH_NATIVE=0)")
+        for name in _NATIVE_FIELD_SCORER_IDS:
+            m = _native_field_matrix([a, b], name)  # routes name -> id -> kernel
+            assert m is not None, f"native path unexpectedly declined for {name}"
+            py = score_field(a, b, name)
+            assert py is not None
+            assert np.isclose(m[0, 1], py, atol=1e-6), (
+                f"native id {_NATIVE_FIELD_SCORER_IDS[name]} for {name!r} scored "
+                f"{m[0, 1]} but pure-Python score_field gave {py} -- id<->scorer drift"
+            )


### PR DESCRIPTION
## Why
Two values the focused audit flagged as hand-maintained across surfaces with no gate.

**1. `BUCKET_HASH_SEED` duplicated.** Independent literals in `backends/score_buckets.py` and `distributed/record_store.py` (the latter didn't import it). Both hash `__block_key__ % n_buckets` with it, so a drift would silently misroute a record's bucket between the scorer backend and the distributed store.

**2. Native scorer-id maps ungated.** `_NATIVE_SCORER_IDS` (the `score_one`/block-pair namespace) and `_NATIVE_FIELD_SCORER_IDS` (the `score_field_matrix` namespace, where id 4 = `soundex_match`, not `date`) mirror the Rust `score-core` dispatch with nothing asserting they match the kernel. A renumber would silently mis-dispatch.

## What
- Move `BUCKET_HASH_SEED` to the low-level `core/_hashing.py`; both surfaces import it (re-exported for back-compat — `record_store` pulls `duckdb`, so it can't be the source for the hot scoring path).
- Add `test_cross_surface_consistency.py`: pins both id dicts to the canonical ordering, asserts the shared 0-3 agree across the two namespaces, and a **native behavioral check** that each id dispatches to the right scorer in `score_field_matrix` (native == pure-Python) — catches a renumber of the dict *or* the kernel.

## Verified
**7/7 new tests** (incl. the native behavioral check with the kernel built + `record_store` seed via duckdb); `score_buckets` + `bucketed_store` suites green; ruff clean.

Part 3 of the focused GoldenMatch consistency pass (#1888, #1889 were parts 1-2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd