### PR TITLE
feat(fused): fused FS covers multi-pass blocking (#1804 item 2)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Added
+
+- **Fused Fellegi-Sunter match now covers multi-pass blocking.** New
+  `match_fused_fs_multipass_ready` / `run_match_fused_fs_multipass_arrow`
+  (`core/fused_match.py`) expand the fused FS path from single-static-key
+  blocking to `multi_pass` / compound-union blocking (the shape that OOM'd in
+  the FS-at-scale reports) — mirroring the weighted `match_fused_multipass`
+  twin. No new native code: each pass runs the SAME single-key FS kernel and
+  the per-pass clusters are union-find-merged host-side, byte-identical to the
+  classic multi-pass FS pipeline (parity-tested). The fused FS path holds pairs
+  as a Rust `Vec` instead of a materialized Python pair list, so a covered FS
+  dedupe stays flat on peak RSS where the pair-list route scales with emitted
+  pairs (measured 2x leaner on realistic emission, up to ~19x on
+  high-candidate shapes). Coverage only for now; the pipeline wiring (routing a
+  covered FS run to the fused kernel under memory pressure) is a follow-up.
+
 ## [3.4.0] - 2026-07-16
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/core/fused_match.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_match.py
@@ -290,6 +290,17 @@ def match_fused_fs_ready(config: Any) -> bool:
     keys = getattr(b, "keys", None) or []
     if len(keys) != 1 or getattr(b, "ann_column", None):
         return False
+    return _fused_fs_matchkey_covered(config)
+
+
+def _fused_fs_matchkey_covered(config: Any) -> bool:
+    """Matchkey-coverage half of the fused FS gate (blocking-agnostic).
+
+    The single covered probabilistic matchkey must have every field named + on
+    an FS-native scorer, and the same NE / level_thresholds capability rules as
+    ``match_fused_fs_ready``. Extracted so the single-key AND multi-pass gates
+    share one coverage definition (the pass shape is the only thing that differs
+    -- both run the SAME per-block FS kernel)."""
     get_mks = getattr(config, "get_matchkeys", None)
     mks = get_mks() if callable(get_mks) else []
     if len(mks) != 1 or getattr(mks[0], "type", None) != "probabilistic" or not mks[0].fields:
@@ -329,6 +340,27 @@ def match_fused_fs_ready(config: Any) -> bool:
         ):
             return False
     return True
+
+
+def match_fused_fs_multipass_ready(config: Any) -> bool:
+    """Covered boundary for the fused FS MULTI-PASS blocking path.
+
+    Mirror of ``match_fused_multipass_ready`` (the weighted twin): ``multi_pass``
+    blocking with >=1 pass (each a real blocking key) + one covered probabilistic
+    matchkey. Each pass is run as a single-key fused FS match; their per-pass
+    clusters are union-find-merged (CC of the pass-pair union) -- so this covers
+    the compound-union blocking shape (#1798) that the single-key gate declines,
+    reusing the SAME single-key FS kernel with NO new native code.
+    """
+    b = getattr(config, "blocking", None)
+    if b is None or getattr(b, "strategy", None) != "multi_pass":
+        return False
+    if getattr(b, "ann_column", None):
+        return False
+    passes = getattr(b, "passes", None) or []
+    if not passes or any(not getattr(p, "fields", None) for p in passes):
+        return False
+    return _fused_fs_matchkey_covered(config)
 
 
 def _match_fused_fs_symbol() -> Any | None:
@@ -466,3 +498,65 @@ def run_match_fused_fs_arrow(
         **opt_kwargs,
     )
     return _clusters_to_table(clusters)
+
+
+def run_match_fused_fs_multipass_arrow(
+    columns: Mapping[str, Any],
+    config: Any,
+    em_result: Any,
+    n_rows: int | None = None,
+) -> Any | None:
+    """Fused FS multi-pass blocking: run each pass as a single-key fused FS match
+    (with the SAME pre-trained ``EMResult``), then union-find-merge the per-pass
+    clusters. Mirror of ``run_match_fused_multipass_arrow`` (the weighted twin).
+
+    Byte-parity with the pipeline's multi-pass FS path by the SAME argument the
+    weighted twin uses: the final partition is the connected components of the
+    union of all passes' emitted link-pairs, which equals merging each pass's
+    per-pass clusters. The FS score of a pair is pass-independent (one EM, same
+    fields), so a pair emitted in one pass would be emitted in any pass that
+    blocks it -- the CC of the union is invariant to which pass surfaced it.
+    Returns a ``(__row_id__, __cluster_id__)`` Table, or None if uncovered /
+    native absent.
+    """
+    from goldenmatch.config.schemas import BlockingConfig, GoldenMatchConfig
+
+    if _match_fused_fs_symbol() is None or not match_fused_fs_multipass_ready(config):
+        return None
+
+    n = n_rows if n_rows is not None else len(next(iter(columns.values())))
+    parent = list(range(n))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(a: int, b: int) -> None:
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+
+    mks = config.get_matchkeys()
+    for pass_cfg in config.blocking.passes:
+        single = GoldenMatchConfig(
+            blocking=BlockingConfig(strategy="static", keys=[pass_cfg]),
+            matchkeys=mks,
+        )
+        tbl = run_match_fused_fs_arrow(columns, single, em_result, n_rows=n)
+        if tbl is None:
+            continue
+        groups: dict[int, list[int]] = {}
+        for r, c in zip(
+            tbl.column("__row_id__").to_pylist(), tbl.column("__cluster_id__").to_pylist()
+        ):
+            groups.setdefault(c, []).append(r)
+        for members in groups.values():
+            for m in members[1:]:
+                union(members[0], m)
+
+    comps: dict[int, list[int]] = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+    return _clusters_to_table(list(comps.values()))

--- a/packages/python/goldenmatch/tests/test_fused_match.py
+++ b/packages/python/goldenmatch/tests/test_fused_match.py
@@ -742,3 +742,141 @@ def test_fused_arrow_backend_declines_uncovered(monkeypatch):
     c = _covered_config()
     c.matchkeys[0].fields[0].scorer = "soundex_match"
     assert fused_match.run_match_fused_arrow({"blk": pa.array(["a"]), "name": pa.array(["x"])}, c) is None
+
+
+# ---- Fellegi-Sunter fused path: MULTI-PASS blocking (#1804 item 2) --------
+#
+# Expands the fused FS coverage from single-static-key to the compound-union
+# blocking shape that OOM'd in #1798. No new native code: each pass runs the
+# SAME single-key FS kernel; per-pass clusters are union-find-merged host-side
+# (byte-parity with the classic multi-pass FS pipeline).
+
+def _fs_multipass_config():
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["blk1"])],
+            passes=[
+                BlockingKeyConfig(fields=["blk1"]),
+                BlockingKeyConfig(fields=["blk2"]),
+            ],
+        ),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk", type="probabilistic", link_threshold=0.5,
+                fields=[MatchkeyField(
+                    field="name", scorer="jaro_winkler", levels=3,
+                    partial_threshold=0.8,
+                )],
+            )
+        ],
+    )
+
+
+def test_fs_multipass_ready_true_false():
+    assert fused_match.match_fused_fs_multipass_ready(_fs_multipass_config()) is True
+    # static single-key FS config -> the single-key gate, not the multipass one.
+    assert fused_match.match_fused_fs_multipass_ready(_probabilistic_config()) is False
+    # weighted multipass -> the weighted twin, not this one (wrong matchkey type).
+    assert fused_match.match_fused_fs_multipass_ready(_multipass_config()) is False
+
+
+def test_fs_multipass_ready_declines_uncovered_matchkey():
+    # A non-FS-native scorer fails the shared _fused_fs_matchkey_covered check
+    # even with a valid multi_pass blocking shape.
+    cfg = _fs_multipass_config()
+    cfg.matchkeys[0].fields[0].scorer = "soundex_match"
+    assert fused_match.match_fused_fs_multipass_ready(cfg) is False
+    # empty passes -> declined.
+    cfg2 = _fs_multipass_config()
+    cfg2.blocking.passes = []
+    assert fused_match.match_fused_fs_multipass_ready(cfg2) is False
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused_fs not built")
+def test_fs_multipass_merges_across_passes():
+    import polars as pl
+
+    # pass1 blocks on blk1: {0,1}, {4,5}; pass2 on blk2: {0,2}, {3,4}. Identical
+    # names -> every intra-block pair scores above link_threshold; the union
+    # chains 0-1-2 (0-1 pass1, 0-2 pass2) and 3-4-5 (3-4 pass2, 4-5 pass1).
+    blk1 = ["a", "a", "x", "y", "z", "z"]
+    blk2 = ["p", "q", "p", "r", "r", "s"]
+    name = ["jonathan"] * 6
+    config = _fs_multipass_config()
+    em = _em()
+    columns = {"blk1": pa.array(blk1), "blk2": pa.array(blk2), "name": pa.array(name)}
+    tbl = fused_match.run_match_fused_fs_multipass_arrow(columns, config, em)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+    assert got == {frozenset({0, 1, 2}), frozenset({3, 4, 5})}
+
+    # Byte-parity with the classic multi-pass FS pipeline on the same data + EM.
+    df = (
+        pl.DataFrame({"blk1": blk1, "blk2": blk2, "name": name})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+    assert got == _classic_fs_clusters(df, config, em)
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused_fs not built")
+def test_fs_multipass_parity_partial_matches():
+    import polars as pl
+
+    # Realistic shape: near-dup names that only partially merge, spread across
+    # two orthogonal blocking keys -- exercises the union of link-pairs, not just
+    # all-identical blocks.
+    blk1 = ["a", "a", "a", "b", "b", "c"]
+    blk2 = ["p", "q", "p", "q", "q", "p"]
+    name = ["jonathan", "jonathon", "michael", "sarah", "sara", "solo"]
+    config = _fs_multipass_config()
+    em = _em()
+    columns = {"blk1": pa.array(blk1), "blk2": pa.array(blk2), "name": pa.array(name)}
+    tbl = fused_match.run_match_fused_fs_multipass_arrow(columns, config, em)
+    assert tbl is not None
+    got = _table_to_clusters(tbl)
+
+    df = (
+        pl.DataFrame({"blk1": blk1, "blk2": blk2, "name": name})
+        .with_row_index("__row_id__")
+        .with_columns(pl.col("__row_id__").cast(pl.Int64))
+    )
+    assert got == _classic_fs_clusters(df, config, em)
+
+
+@pytest.mark.skipif(not _HAS_FUSED, reason="goldenmatch-native match_fused_fs not built")
+def test_fs_multipass_equals_single_pass_when_one_pass():
+    # A one-pass multi_pass FS config must equal the single-key fused FS result.
+    blk = ["a", "a", "a", "b", "b", "c"]
+    name = ["jonathan", "jonathon", "michael", "sarah", "sara", "solo"]
+    em = _em()
+    columns = {"blk": pa.array(blk), "name": pa.array(name)}
+
+    single = _probabilistic_config()
+    mp = GoldenMatchConfig(
+        blocking=BlockingConfig(
+            strategy="multi_pass",
+            keys=[BlockingKeyConfig(fields=["blk"])],
+            passes=[BlockingKeyConfig(fields=["blk"])],
+        ),
+        matchkeys=single.matchkeys,
+    )
+    got_single = _table_to_clusters(
+        fused_match.run_match_fused_fs_arrow(columns, single, em)
+    )
+    got_mp = _table_to_clusters(
+        fused_match.run_match_fused_fs_multipass_arrow(columns, mp, em)
+    )
+    assert got_mp == got_single
+
+
+def test_fs_multipass_declines_uncovered_returns_none():
+    # Runner returns None (not raise) on an uncovered config -> caller falls back.
+    cfg = _fs_multipass_config()
+    cfg.matchkeys[0].fields[0].scorer = "soundex_match"
+    out = fused_match.run_match_fused_fs_multipass_arrow(
+        {"blk1": pa.array(["a"]), "blk2": pa.array(["p"]), "name": pa.array(["x"])},
+        cfg, _em(),
+    )
+    assert out is None


### PR DESCRIPTION
## What and why

Epic #1804 item 2 asked to **wire or delete the orphaned fused Fellegi-Sunter kernel**, re-evaluating the wall-clock-based dormancy verdict since the recent FS failures (#1792/#1798) were RSS failures and fused measured ~2x leaner RSS on the weighted path.

I measured it (single-static-key FS, 500K rows, native on, this box):

| shape | bucket peak RSS | fused peak RSS | ratio |
|---|---|---|---|
| realistic (sparse emission, 2.35M pairs) | 823 MB | 384 MB | **2.1× leaner** |
| dense (#1798-like candidate explosion, 22.5M pairs) | 7023 MB | 374 MB | **18.8× leaner** |

The win is real and scales with emission density (the bucket route materializes the full Python pair list; the fused kernel collapses pairs into cluster membership inside the FFI call). **But** the single-key gate would *decline* #1798's actual config — it used compound multi-pass union blocking (`npi`, `email`, `phone+last`, `last+first+zip5`). So the fused path only paid off on a shape that isn't the failure class.

This PR closes that gap: **expand the fused FS coverage from single-static-key to `multi_pass` / compound-union blocking**, so the fused path covers the shapes that actually OOM. It mirrors the existing weighted `match_fused_multipass` twin with **no new native code**.

This is the coverage half of item 2. The pipeline wiring (routing a covered FS run to the fused kernel under memory pressure) is a focused follow-up PR.

## Changes

- **`match_fused_fs_multipass_ready`** — `multi_pass` blocking + ≥1 real pass + the shared `_fused_fs_matchkey_covered` check (extracted from `match_fused_fs_ready` so the single-key and multipass gates share one coverage definition).
- **`run_match_fused_fs_multipass_arrow`** — runs each pass as a single-key fused FS match (`run_match_fused_fs_arrow` with the shared pre-trained `EMResult`) then union-find-merges the per-pass clusters. Byte-parity with the classic multi-pass FS pipeline by the same argument the weighted twin uses: the FS score of a pair is pass-independent, so the connected components of the union of all passes' link-pairs equal merging each pass's per-pass clusters.
- 6 tests: gate true/false, uncovered declines, cross-pass merge parity vs the classic pipeline (all-identical + partial-match shapes), one-pass == single-key, None-on-uncovered.
- CHANGELOG entry.

No new native symbol references (reuses the registered `match_fused_fs`), so no `native_symbols` / `api_parity` gate impact.

## Testing

- `uv run pytest tests/test_fused_match.py` — 38 passed (6 new multipass FS tests, all running not skipped; native built via `scripts/build_native.py`).
- `tests/test_fused_match.py tests/test_fused_routing.py tests/test_fs_ne_guards.py tests/test_pipeline_fused_match.py` — 85 passed, 2 skipped.
- `ruff check` clean on the changed files.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] No workflow/gotcha change needing a `CLAUDE.md` update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_