### PR TITLE
feat(fused): wire fused FS into the pipeline + controller routing (#1804 item 2)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -19,8 +19,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   as a Rust `Vec` instead of a materialized Python pair list, so a covered FS
   dedupe stays flat on peak RSS where the pair-list route scales with emitted
   pairs (measured 2x leaner on realistic emission, up to ~19x on
-  high-candidate shapes). Coverage only for now; the pipeline wiring (routing a
-  covered FS run to the fused kernel under memory pressure) is a follow-up.
+  high-candidate shapes).
+- **Fused Fellegi-Sunter match is now wired into the pipeline.** The controller
+  fused-routing post-step (`maybe_route_fused_match`) routes a covered FS run
+  (single-key OR multi-pass) to the fused kernel under estimated-RSS pressure,
+  exactly like the weighted twin — the routing decision is config-only + RSS
+  estimate (both available at controller time), and the new
+  `_run_fused_fs_match_short_circuit` does the O(n) EM fit before the kernel
+  call (the piece a controller-time flag can't carry). Same capacity-survival
+  contract as the weighted path: `scored_pairs`/`review_pairs` + per-cluster
+  confidence are shed, but cluster membership + golden are byte-identical to the
+  classic FS path (same seeded EM → same kernel math → same connected
+  components; parity-tested single-key + multi-pass). Measured end-to-end
+  through the pipeline: 4.5x leaner peak RSS + 5x faster on a 120K all-merge FS
+  dedupe (442 MB vs 2004 MB). Off by default (fires only under memory pressure
+  on an artifact-free config); `GOLDENMATCH_MATCH_FUSED=0` is the kill-switch.
 
 ## [3.4.0] - 2026-07-16
 

--- a/packages/python/goldenmatch/goldenmatch/core/fused_routing.py
+++ b/packages/python/goldenmatch/goldenmatch/core/fused_routing.py
@@ -167,20 +167,30 @@ _DEFAULT_PRESSURE_FRACTION = 0.65
 
 
 def _count_score_cols(config) -> int:
-    """Number of matchkey comparison fields in the covered weighted matchkey.
+    """Number of matchkey comparison fields in the covered matchkey.
 
     Reads the SINGLE covered ``weighted`` matchkey via
     ``fused_match._covered_weighted_matchkey`` (the same gate the single-key and
     multi-pass fused entries use) and counts its comparison fields -- the columns
-    the classic scorer materializes. Floors to 1 (a matchkey always materializes
-    >=1 score column); callers only reach this after confirming coverage, so the
-    None branch is defensive.
+    the classic scorer materializes. For a covered Fellegi-Sunter run the weighted
+    lookup returns None, so fall back to the sole probabilistic matchkey's field
+    count. Floors to 1 (a matchkey always materializes >=1 score column); callers
+    only reach this after confirming coverage, so the None branch is defensive.
     """
     from goldenmatch.core.fused_match import _covered_weighted_matchkey
 
     mk = _covered_weighted_matchkey(config)
     fields = getattr(mk, "fields", None) if mk is not None else None
-    return len(fields) if fields else 1
+    if fields:
+        return len(fields)
+    # FS-covered: the weighted lookup declines a probabilistic matchkey.
+    get_mks = getattr(config, "get_matchkeys", None)
+    mks = get_mks() if callable(get_mks) else []
+    if len(mks) == 1:
+        fs_fields = getattr(mks[0], "fields", None)
+        if fs_fields:
+            return len(fs_fields)
+    return 1
 
 
 def maybe_route_fused_match(
@@ -198,10 +208,14 @@ def maybe_route_fused_match(
     - ``GOLDENMATCH_MATCH_FUSED`` is not the kill-switch (``0``/``false``/``off``);
     - ``needs_artifacts`` is False (no caller-intent / config-driven divergence --
       the controller folds the caller hint + ``config_needs_artifacts`` into it);
-    - the config is COVERED by the fused single-key OR multi-pass entry
-      (``match_fused_ready`` / ``match_fused_multipass_ready``). The
-      Fellegi-Sunter branch is deliberately OUT of v1 -- no trained ``EMResult``
-      exists at decision time -- so a probabilistic config is not covered here;
+    - the config is COVERED by a fused entry -- weighted single-key/multi-pass
+      (``match_fused_ready`` / ``match_fused_multipass_ready``) OR Fellegi-Sunter
+      single-key/multi-pass (``match_fused_fs_ready`` /
+      ``match_fused_fs_multipass_ready``). The routing DECISION is config-only +
+      RSS-only (both available here); the FS kernel additionally needs a trained
+      ``EMResult``, but that is fit inside the pipeline short-circuit at run time,
+      NOT at this decision point -- so a covered probabilistic config routes here
+      just like a weighted one;
     - the estimated CLASSIC peak RSS exceeds ``available_ram_gb * frac`` (memory
       pressure). Match routing is a capacity-survival escape hatch, not a broad
       default; below the pressure line the classic path runs unchanged.
@@ -216,10 +230,20 @@ def maybe_route_fused_match(
     if needs_artifacts:
         return False
 
-    from goldenmatch.core.fused_match import match_fused_multipass_ready, match_fused_ready
+    from goldenmatch.core.fused_match import (
+        match_fused_fs_multipass_ready,
+        match_fused_fs_ready,
+        match_fused_multipass_ready,
+        match_fused_ready,
+    )
 
-    if not (match_fused_ready(config) or match_fused_multipass_ready(config)):
-        return False  # FS branch out of v1 (no EMResult at decision time).
+    if not (
+        match_fused_ready(config)
+        or match_fused_multipass_ready(config)
+        or match_fused_fs_ready(config)
+        or match_fused_fs_multipass_ready(config)
+    ):
+        return False  # not covered by any fused entry (weighted or FS).
 
     frac = float(
         os.environ.get(

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -1847,9 +1847,16 @@ def _golden_from_multi_df(
 
 def _fused_needed_src_cols(config: GoldenMatchConfig) -> list[str]:
     """Source columns the fused match kernel needs as Arrow arrays: the blocking
-    key field(s) (single-key or every multi-pass field) + the covered weighted
-    matchkey's comparison fields. Deduped, source-order preserved (mirrors
-    ``fused_match.run_match_fused_arrow``'s own ``src_cols`` derivation)."""
+    key field(s) (single-key or every multi-pass field) + the covered matchkey's
+    comparison fields + (FS only) its negative-evidence fields. Deduped,
+    source-order preserved (mirrors ``fused_match.run_match_fused_arrow`` /
+    ``run_match_fused_fs_arrow``'s own ``src_cols`` derivation).
+
+    NE fields matter only for the FS path -- a weighted-covered matchkey never
+    carries NE (``_covered_weighted_matchkey`` declines it), so collecting them
+    is a no-op there; for FS, omitting an NE column would leave it out of the
+    kernel's ``columns`` mapping and NE would silently never fire (divergence
+    from the classic FS path)."""
     fields: list[str] = []
     b = config.blocking
     if b is not None and getattr(b, "strategy", None) == "multi_pass":
@@ -1861,6 +1868,10 @@ def _fused_needed_src_cols(config: GoldenMatchConfig) -> list[str]:
             fields.extend(keys[0].fields)
     mk = config.get_matchkeys()[0]
     fields.extend(f.field for f in mk.fields if f.field is not None)
+    fields.extend(
+        ne.field for ne in (getattr(mk, "negative_evidence", None) or [])
+        if ne.field is not None
+    )
     return list(dict.fromkeys(fields))
 
 
@@ -1930,7 +1941,29 @@ def _run_fused_match_short_circuit(
     ) or run_match_fused_multipass_arrow(columns, config, n_rows=n_rows)
     if fused_tbl is None:
         return None
+    return _fused_result_from_clusters(
+        fused_tbl, collected_df, config,
+        quarantine_df=quarantine_df, output_report=output_report,
+    )
 
+
+def _fused_result_from_clusters(
+    fused_tbl: Any,
+    collected_df: pl.DataFrame,
+    config: GoldenMatchConfig,
+    *,
+    quarantine_df: pl.DataFrame | None,
+    output_report: bool,
+) -> dict:
+    """Assemble the fused-match result dict from a ``(__row_id__, __cluster_id__)``
+    kernel Table.
+
+    Shared by the weighted (``_run_fused_match_short_circuit``) and Fellegi-Sunter
+    (``_run_fused_fs_match_short_circuit``) fused short-circuits -- both kernels
+    emit the SAME connected-component Table shape, so the dupes/unique/golden/
+    clusters derivation + capacity-mode result dict is identical (only the way the
+    Table is PRODUCED -- weighted scorer vs FS EM kernel -- differs upstream).
+    """
     # (__row_id__, __cluster_id__), one row per input record. match_fused emits
     # every record incl singletons (own component). auto_split is excluded by
     # config_needs_artifacts, so oversized clusters are never SPLIT -- but the
@@ -2063,6 +2096,98 @@ def _run_fused_match_short_circuit(
         "golden_fused_used": golden_fused_used,
         "match_fused_capacity_mode": True,
     }
+
+
+def _run_fused_fs_match_short_circuit(
+    collected_df: pl.DataFrame,
+    config: GoldenMatchConfig,
+    *,
+    quarantine_df: pl.DataFrame | None,
+    output_report: bool,
+    across_files_only: bool,
+) -> dict | None:
+    """Fused Fellegi-Sunter whole-stage short-circuit -- the FS twin of
+    ``_run_fused_match_short_circuit``.
+
+    Trains EM (the caller's O(n) model fit, unchanged), then runs block + score +
+    dedup + cluster in ONE ``match_fused_fs`` FFI call (single-key OR multi-pass),
+    routing the connected components DIRECTLY to golden via the shared
+    ``_fused_result_from_clusters`` assembler. Returns a full result dict on
+    success, or None to fall through to the classic FS path (kill-switch /
+    uncovered / native absent / across-files / non-strict postflight).
+
+    Same capacity-survival contract + divergence guards as the weighted twin:
+    ``scored_pairs`` / ``review_pairs`` and per-cluster confidence/bottleneck are
+    shed, but cluster MEMBERSHIP + GOLDEN are byte-identical to the classic FS
+    path -- same EM -> same kernel FS math -> same link-threshold pairs -> same
+    connected components (FS review candidates never cluster, so shedding them
+    does not move membership). ``config_needs_artifacts`` (auto_split=False, no
+    identity/memory/llm_boost/confidence_majority/lineage) is re-checked by the
+    caller before entry.
+
+    Why the EM is trained HERE and not folded into the controller flag (unlike
+    the weighted path): the fused-routing DECISION is config-only + RSS-only (both
+    available at controller time), but the fused FS EXECUTION needs a trained
+    ``EMResult`` that only exists once the pipeline runs -- so the controller sets
+    the flag, and this short-circuit does the O(n) fit before the kernel call.
+    """
+    if os.environ.get("GOLDENMATCH_MATCH_FUSED", "").lower() in {"0", "false", "off"}:
+        return None
+    if across_files_only:
+        return None
+    _preflight = getattr(config, "_preflight_report", None)
+    if _preflight is not None and not getattr(config, "_strict_autoconfig", False):
+        return None
+
+    from goldenmatch.core.fused_match import (
+        match_fused_fs_multipass_ready,
+        match_fused_fs_ready,
+        run_match_fused_fs_arrow,
+        run_match_fused_fs_multipass_arrow,
+    )
+
+    if not (match_fused_fs_ready(config) or match_fused_fs_multipass_ready(config)):
+        return None
+
+    from goldenmatch.core.blocker import build_blocks, collect_blocking_fields
+    from goldenmatch.core.frame import to_frame as _tf_entry
+    from goldenmatch.core.probabilistic import fs_model_preloaded, load_or_train_em
+
+    mk = config.get_matchkeys()[0]
+    _cf_entry = _tf_entry(collected_df)
+    n_rows = _cf_entry.height
+
+    # EM training mirrors _score_probabilistic_matchkey's preamble. Blocks feed
+    # ONLY the EM sample fit (skipped when a from_splink model is preloaded), then
+    # are freed before the fused kernel does its OWN Rust-internal blocking -- so
+    # the Python candidate-pair list is never materialized (the RSS win the whole
+    # short-circuit exists for).
+    _need_blocks = not fs_model_preloaded(mk)
+    blocks = (
+        list(build_blocks(collected_df.lazy(), config.blocking)) if _need_blocks else []
+    )
+    blocking_fields = (
+        collect_blocking_fields(config.blocking) if config.blocking else []
+    )
+    em_result = load_or_train_em(
+        collected_df, mk, blocks=blocks, blocking_fields=blocking_fields,
+    )
+    blocks = []  # free training blocks before the kernel allocates
+
+    columns = {
+        c: _cf_entry.column(c).to_arrow() for c in _fused_needed_src_cols(config)
+    }
+    fused_tbl = run_match_fused_fs_arrow(
+        columns, config, em_result, n_rows=n_rows
+    ) or run_match_fused_fs_multipass_arrow(
+        columns, config, em_result, n_rows=n_rows
+    )
+    if fused_tbl is None:
+        return None
+    return _fused_result_from_clusters(
+        fused_tbl, collected_df, config,
+        quarantine_df=quarantine_df, output_report=output_report,
+    )
 
 
 def _run_dedupe_pipeline(
@@ -2484,7 +2609,19 @@ def _run_dedupe_pipeline(
     # the flag via the _api.py hint (Task D.3), so they are not re-checked here
     # (out of pipeline scope). On decline (kill-switch / uncovered / native
     # absent) the helper returns None and the classic path runs unchanged.
+    #
+    # DISPATCH: the WEIGHTED twin (match_fused / _multipass) decides + runs from
+    # the config alone; the FELLEGI-SUNTER twin needs a trained EMResult, so its
+    # short-circuit does the O(n) fit before the kernel call (see
+    # _run_fused_fs_match_short_circuit). The controller flag + config_needs_
+    # artifacts gate both, but a run is covered by exactly one family, so we try
+    # weighted first then FS (each returns None when its family is uncovered).
     if getattr(config, "_use_fused_match", False) and not config_needs_artifacts(config):
+        from goldenmatch.core.fused_match import (
+            match_fused_fs_multipass_ready,
+            match_fused_fs_ready,
+        )
+
         _fused_result = _run_fused_match_short_circuit(
             collected_df,
             config,
@@ -2492,6 +2629,16 @@ def _run_dedupe_pipeline(
             output_report=output_report,
             across_files_only=across_files_only,
         )
+        if _fused_result is None and (
+            match_fused_fs_ready(config) or match_fused_fs_multipass_ready(config)
+        ):
+            _fused_result = _run_fused_fs_match_short_circuit(
+                collected_df,
+                config,
+                quarantine_df=quarantine_df,
+                output_report=output_report,
+                across_files_only=across_files_only,
+            )
         if _fused_result is not None:
             if memory_store is not None:
                 memory_store.close()

--- a/packages/python/goldenmatch/tests/test_fused_routing.py
+++ b/packages/python/goldenmatch/tests/test_fused_routing.py
@@ -283,9 +283,11 @@ def _covered_match_config(n_fields: int = 1, threshold: float = 0.85) -> GoldenM
     )
 
 
-def _uncovered_match_config() -> GoldenMatchConfig:
-    """A probabilistic config -- OUT of the fused v1 boundary (no EMResult at
-    decision time), so not covered by match_fused_ready / _multipass_ready."""
+def _fs_covered_match_config() -> GoldenMatchConfig:
+    """A probabilistic config COVERED by the fused FS entry (static single-key +
+    one probabilistic matchkey with an FS-native scorer). The routing decision is
+    config-only + RSS-only here; the EM is fit inside the pipeline short-circuit
+    at run time, so a covered FS config routes just like a weighted one."""
     return GoldenMatchConfig(
         blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])]),
         matchkeys=[
@@ -293,6 +295,22 @@ def _uncovered_match_config() -> GoldenMatchConfig:
                 name="mk",
                 type="probabilistic",
                 fields=[MatchkeyField(field="c0", scorer="jaro_winkler")],
+            )
+        ],
+    )
+
+
+def _uncovered_match_config() -> GoldenMatchConfig:
+    """A probabilistic config OUTSIDE every fused entry: its scorer (`qgram`) is a
+    valid classic FS scorer but is NOT in the fused-FS scorer set, so neither the
+    weighted nor the FS gate covers it."""
+    return GoldenMatchConfig(
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["blk"])]),
+        matchkeys=[
+            MatchkeyConfig(
+                name="mk",
+                type="probabilistic",
+                fields=[MatchkeyField(field="c0", scorer="qgram")],
             )
         ],
     )
@@ -322,9 +340,24 @@ def test_routes_when_covered_pressure_safe():
     )
 
 
+def test_routes_when_fs_covered_pressure():
+    # A covered Fellegi-Sunter config routes under pressure just like a weighted
+    # one -- the decision is config-only + RSS-only; the EM is fit at run time.
+    assert (
+        maybe_route_fused_match(
+            config=_fs_covered_match_config(),
+            profile=_profile(),
+            runtime=_runtime(1.0),
+            n_rows=10_000_000,
+            needs_artifacts=False,
+        )
+        is True
+    )
+
+
 def test_not_covered_declines():
-    # Probabilistic config -> not covered by the fused single/multi-pass entry ->
-    # declines even under extreme pressure.
+    # A probabilistic config on a non-fused-FS scorer (qgram) -> not covered by
+    # any fused entry -> declines even under extreme pressure.
     assert (
         maybe_route_fused_match(
             config=_uncovered_match_config(),

--- a/packages/python/goldenmatch/tests/test_pipeline_fused_fs_match.py
+++ b/packages/python/goldenmatch/tests/test_pipeline_fused_fs_match.py
@@ -1,0 +1,229 @@
+"""Parity: the pipeline short-circuits a covered Fellegi-Sunter dedupe to the
+fused ``match_fused_fs`` kernel when the controller flagged the run
+(``config._use_fused_match``) AND the config-driven divergence gate is clear
+(#1804 item 2, the FS twin of ``test_pipeline_fused_match.py``).
+
+Capacity-survival mode: the fused-routed FS run sheds ``scored_pairs`` /
+``review_pairs`` + per-cluster confidence, but CLUSTER MEMBERSHIP + GOLDEN are
+byte-identical to the classic block->score->cluster FS path -- both train the
+SAME (seeded) EM and run the SAME kernel FS math, so the link-threshold pairs
+and their connected components match. ``match_fused_capacity_mode=True`` marks
+the shed so it is never silent.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    GoldenMatchConfig,
+    GoldenRulesConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.fused_match import (
+    match_fused_fs_multipass_ready,
+    match_fused_fs_ready,
+)
+from goldenmatch.core.fused_routing import config_needs_artifacts
+from goldenmatch.core.pipeline import run_dedupe_df
+from polars.testing import assert_frame_equal
+
+
+def _kernel_present() -> bool:
+    try:
+        from goldenmatch.core._native_loader import native_module
+
+        return hasattr(native_module(), "match_fused_fs")
+    except Exception:
+        return False
+
+
+requires_kernel = pytest.mark.skipif(
+    not _kernel_present(),
+    reason="match_fused_fs native kernel not built (build_native.py); CI builds it",
+)
+
+
+def _people_df(n_clusters: int = 8, members: int = 3, n_singletons: int = 5) -> pl.DataFrame:
+    """Personlike frame: ``n_clusters`` groups sharing a zip block + an identical
+    name (FS exact-agreement -> high weight -> link), plus ``n_singletons`` rows
+    on their own unique zip block. A second orthogonal ``city`` block key gives
+    the multi-pass config something real to union on."""
+    rows: list[dict] = []
+    for c in range(n_clusters):
+        for _m in range(members):
+            rows.append(
+                {"name": f"Cluster Person {c}", "zip": f"200{c:02d}", "city": f"town{c % 4}"}
+            )
+    for s in range(n_singletons):
+        rows.append(
+            {"name": f"Solo Human {s}", "zip": f"900{s:02d}", "city": f"solo{s}"}
+        )
+    return pl.DataFrame(rows)
+
+
+def _fs_config(scorer: str = "jaro_winkler") -> GoldenMatchConfig:
+    """Static single-key blocking (zip) + one probabilistic matchkey (name) --
+    the match_fused_fs-covered shape. auto_split off + quality_weighting off + no
+    identity/lineage -> config_needs_artifacts False, so the short-circuit is
+    allowed when the flag is set."""
+    return GoldenMatchConfig(
+        matchkeys=[
+            MatchkeyConfig(
+                name="name_fs",
+                type="probabilistic",
+                link_threshold=0.5,
+                fields=[MatchkeyField(
+                    field="name", scorer=scorer, levels=3, partial_threshold=0.8,
+                )],
+            ),
+        ],
+        blocking=BlockingConfig(
+            strategy="static",
+            keys=[BlockingKeyConfig(fields=["zip"])],
+            max_block_size=1000,
+            skip_oversized=False,
+        ),
+        golden_rules=GoldenRulesConfig(
+            default_strategy="most_complete",
+            auto_split=False,
+            quality_weighting=False,
+        ),
+    )
+
+
+def _fs_multipass_config(scorer: str = "jaro_winkler") -> GoldenMatchConfig:
+    """multi_pass blocking (zip + city, orthogonal) + one probabilistic matchkey
+    -- the compound-union shape the single-key gate declines (#1798)."""
+    cfg = _fs_config(scorer)
+    cfg.blocking = BlockingConfig(
+        strategy="multi_pass",
+        keys=[BlockingKeyConfig(fields=["zip"])],
+        passes=[BlockingKeyConfig(fields=["zip"]), BlockingKeyConfig(fields=["city"])],
+        max_block_size=1000,
+        skip_oversized=False,
+    )
+    return cfg
+
+
+def _flag(cfg: GoldenMatchConfig) -> GoldenMatchConfig:
+    """Simulate the controller post-step setting ExecutionPlan.use_fused_match."""
+    cfg._use_fused_match = True
+    return cfg
+
+
+def _multi_partition(clusters: dict) -> set[frozenset[int]]:
+    return {frozenset(c["members"]) for c in clusters.values() if c["size"] > 1}
+
+
+def _golden_content(g) -> pl.DataFrame:
+    if not isinstance(g, pl.DataFrame):
+        g = pl.from_arrow(g)
+    cols = [c for c in g.columns if c not in ("__cluster_id__", "__golden_confidence__")]
+    return g.select(sorted(cols)).sort(sorted(cols))
+
+
+def test_fs_config_covered_and_artifact_free():
+    assert match_fused_fs_ready(_fs_config()) is True
+    assert config_needs_artifacts(_fs_config()) is False
+    assert match_fused_fs_multipass_ready(_fs_multipass_config()) is True
+    assert config_needs_artifacts(_fs_multipass_config()) is False
+
+
+@requires_kernel
+def test_fs_fused_parity_single_key(monkeypatch):
+    """Flag set + FS-covered + artifact-free -> short-circuit to match_fused_fs;
+    membership + golden byte-identical to classic FS, empty scored_pairs +
+    capacity marker."""
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    df = _people_df()
+
+    classic = run_dedupe_df(df, _fs_config())
+    assert classic.get("match_fused_capacity_mode") is not True
+
+    fused = run_dedupe_df(df, _flag(_fs_config()))
+    assert fused["match_fused_capacity_mode"] is True
+    assert fused["scored_pairs"] == []
+    assert fused["review_pairs"] == []
+
+    assert _multi_partition(fused["clusters"]) == _multi_partition(classic["clusters"])
+    assert set(fused["dupes"]["__row_id__"].to_pylist()) == set(
+        classic["dupes"]["__row_id__"].to_pylist()
+    )
+    assert set(fused["unique"]["__row_id__"].to_pylist()) == set(
+        classic["unique"]["__row_id__"].to_pylist()
+    )
+    assert fused["golden"] is not None and classic["golden"] is not None
+    assert_frame_equal(
+        _golden_content(fused["golden"]), _golden_content(classic["golden"])
+    )
+
+
+@requires_kernel
+def test_fs_fused_parity_multipass(monkeypatch):
+    """The multi-pass FS fused path (compound-union blocking, the #1798 shape) is
+    byte-identical to the classic multi-pass FS dedupe."""
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    df = _people_df()
+
+    classic = run_dedupe_df(df, _fs_multipass_config())
+    fused = run_dedupe_df(df, _flag(_fs_multipass_config()))
+    assert fused["match_fused_capacity_mode"] is True
+
+    assert _multi_partition(fused["clusters"]) == _multi_partition(classic["clusters"])
+    assert set(fused["dupes"]["__row_id__"].to_pylist()) == set(
+        classic["dupes"]["__row_id__"].to_pylist()
+    )
+    assert fused["golden"] is not None and classic["golden"] is not None
+    assert_frame_equal(
+        _golden_content(fused["golden"]), _golden_content(classic["golden"])
+    )
+
+
+@requires_kernel
+def test_fs_kill_switch_uses_classic(monkeypatch):
+    """GOLDENMATCH_MATCH_FUSED=0 -> the FS short-circuit declines even with the
+    flag set; classic FS runs byte-identical."""
+    df = _people_df()
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    classic = run_dedupe_df(df, _fs_config())
+
+    monkeypatch.setenv("GOLDENMATCH_MATCH_FUSED", "0")
+    killed = run_dedupe_df(df, _flag(_fs_config()))
+    assert killed.get("match_fused_capacity_mode") is not True
+    assert _multi_partition(killed["clusters"]) == _multi_partition(classic["clusters"])
+    assert_frame_equal(
+        _golden_content(killed["golden"]), _golden_content(classic["golden"])
+    )
+
+
+@requires_kernel
+def test_fs_fused_declines_uncovered_falls_through(monkeypatch):
+    """Flag set but the FS config is NOT covered (a valid classic FS scorer that
+    is outside the fused-FS scorer set) -> both the weighted and FS
+    short-circuits decline and classic FS runs unchanged."""
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    df = _people_df()
+    # qgram is a valid FS block scorer but NOT in _FUSED_FS_SCORER_IDS.
+    assert match_fused_fs_ready(_fs_config(scorer="qgram")) is False
+
+    plain = run_dedupe_df(df, _fs_config(scorer="qgram"))
+    flagged = run_dedupe_df(df, _flag(_fs_config(scorer="qgram")))
+    assert flagged.get("match_fused_capacity_mode") is not True
+    assert _multi_partition(flagged["clusters"]) == _multi_partition(plain["clusters"])
+    assert_frame_equal(
+        _golden_content(flagged["golden"]), _golden_content(plain["golden"])
+    )
+
+
+def test_fs_no_flag_uses_classic(monkeypatch):
+    """No _use_fused_match flag (no est-RSS pressure) -> classic FS, no capacity
+    marker. Runs without the kernel (classic path only)."""
+    monkeypatch.delenv("GOLDENMATCH_MATCH_FUSED", raising=False)
+    df = _people_df()
+    result = run_dedupe_df(df, _fs_config())
+    assert result.get("match_fused_capacity_mode") is not True
+    assert result["scored_pairs"] is not None


### PR DESCRIPTION
## What and why

Part B of epic #1804 item 2 (follow-up to #1891, which expanded fused-FS *coverage* to multi-pass blocking). This **wires** the fused Fellegi-Sunter kernel into the pipeline so a covered FS dedupe actually routes to it under memory pressure — the piece that makes item 2 non-dead.

**Measured end-to-end through the pipeline** (120K all-merge FS dedupe, native on):

| arm | peak RSS | wall | dupes |
|---|---|---|---|
| classic FS | 2004 MB | 10.9s | 120000 |
| fused FS (flag set) | **442 MB** | **2.1s** | 120000 |

Same dupes (parity) — **4.5× leaner peak RSS, 5× faster**. The bucket route materializes the full Python candidate-pair list; the fused kernel collapses pairs into cluster membership inside the FFI call and never returns them.

**The key realization that unblocked wiring:** the "no trained `EMResult` at controller decision time" carve-out (`fused_routing.py`) was narrower than the flag needs. The routing *decision* is config-only + RSS-estimate (both available at controller time); only the kernel *execution* needs the EM. So the controller sets `_use_fused_match` for covered FS configs exactly like weighted, and the new pipeline short-circuit does the O(n) EM fit before the kernel call.

## Changes

- **`maybe_route_fused_match`** now covers FS configs (single-key + multi-pass), and **`_count_score_cols`** reads the probabilistic matchkey's fields for the RSS estimate. Docstring updated (the FS branch is no longer "out of v1").
- **`_run_fused_fs_match_short_circuit`** (pipeline): trains EM (mirrors `_score_probabilistic_matchkey`'s preamble; training blocks freed before the kernel allocates), runs `run_match_fused_fs_arrow` / `_multipass_arrow`, and routes the connected components to golden via the new shared **`_fused_result_from_clusters`** — extracted from the weighted short-circuit since both kernels emit the same `(__row_id__, __cluster_id__)` Table shape.
- **Pipeline dispatch**: weighted short-circuit first, then FS (each declines when its family is uncovered). **`_fused_needed_src_cols`** now also collects NE fields (weighted-covered matchkeys never carry NE, so it's a no-op there; for FS, omitting an NE column would silently disable NE → divergence from the classic path).
- 6 pipeline parity tests (`test_pipeline_fused_fs_match.py`): single-key + multi-pass membership/dupes/golden byte-identical to classic FS, capacity-mode marker + empty scored/review pairs, kill-switch, uncovered-falls-through, no-flag-uses-classic. Repurposed the now-obsolete `test_not_covered_declines` fixture (FS is covered now) and added `test_routes_when_fs_covered_pressure`.

**Capacity-survival contract** identical to the weighted twin: `scored_pairs`/`review_pairs` + per-cluster confidence are shed, but cluster membership + golden are byte-identical to classic FS — same seeded EM (`seed=42`) → same kernel math → same link-threshold pairs → same connected components (FS review candidates never cluster). Off by default (fires only under est-RSS pressure on an artifact-free config, i.e. `auto_split=False` + no identity/memory/llm_boost/confidence_majority/lineage); `GOLDENMATCH_MATCH_FUSED=0` kill-switch.

## Testing

- `uv run pytest tests/test_pipeline_fused_fs_match.py tests/test_fused_routing.py tests/test_fused_match.py tests/test_pipeline_fused_match.py` — 80 passed, 2 skipped.
- Broader sweep (api/probabilistic/fs-guards/execution-plan/telemetry) — 281 passed locally on the pre-cherry-pick branch.
- `ruff check` clean on the changed files.
- End-to-end RSS validated via `run_dedupe_df` (numbers above).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed
- [x] No workflow/gotcha change needing a `CLAUDE.md` update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_