### PR TITLE
fix(identity): batch resolve_clusters writes in one transaction on postgres (#1886)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **Postgres identity resolution no longer autocommits per record (#1886).** The
+  Postgres `IdentityStore` connects with `autocommit=True`, so `resolve_clusters`'
+  per-record write path (absorbing/merging into existing identities, and weak
+  multi-member clusters) committed every `upsert_identity`/`emit_event`/
+  `upsert_record`/`add_edge` on its own -- one COMMIT + network round-trip per
+  write. Against a remote DB (e.g. Cloud SQL) that turned a ~20k-record resolve
+  into minutes of latency even though the compute is milliseconds; a re-resolve
+  or incremental load against a populated store (where nothing is brand-new, so
+  the bulk COPY fast-path never engages) was the worst case. `resolve_clusters`
+  now wraps its whole write body in a single `IdentityStore.bulk_writes()`
+  transaction -- N commits collapse to one and psycopg pipelines the statements.
+  No-op for SQLite/Mongo; the resolve is now atomic per run.
+
 ### Added
 
 - **Fused Fellegi-Sunter match now covers multi-pass blocking.** New

--- a/packages/python/goldenmatch/goldenmatch/identity/resolve.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/resolve.py
@@ -436,70 +436,242 @@ def resolve_clusters(
     bulk_event_rows: list[dict[str, Any]] = []
     bulk_cluster_ids: set = set()
 
-    # 3. Iterate clusters.
-    for cluster_id, info in cluster_items:
-        members: list[int] = list(info.get("members") or [])
-        if not members:
-            continue
-        size = len(members)
-        if size == 1 and not emit_singletons:
-            continue
+    with store.bulk_writes():
+        # 3. Iterate clusters.
+        for cluster_id, info in cluster_items:
+            members: list[int] = list(info.get("members") or [])
+            if not members:
+                continue
+            size = len(members)
+            if size == 1 and not emit_singletons:
+                continue
 
-        record_ids = [rowid_to_recid[m] for m in members if m in rowid_to_recid]
-        if not record_ids:
-            continue
+            record_ids = [rowid_to_recid[m] for m in members if m in rowid_to_recid]
+            if not record_ids:
+                continue
 
-        # 3a. Look up existing identities for these records.
-        # Use the pre-flight dict instead of per-cluster SELECT.
-        existing = {
-            rid: preflight_existing[rid]
-            for rid in record_ids if rid in preflight_existing
-        }
-        unique_entities = list(set(existing.values()))
+            # 3a. Look up existing identities for these records.
+            # Use the pre-flight dict instead of per-cluster SELECT.
+            existing = {
+                rid: preflight_existing[rid]
+                for rid in record_ids if rid in preflight_existing
+            }
+            unique_entities = list(set(existing.values()))
 
-        # 3a'. Bulk fast-path: brand-new cluster on postgres, no weak
-        # conflict edge -> accumulate rows for bulk flush, skip the
-        # per-row writes for this cluster.
-        cluster_conf_check = _cluster_confidence(info)
-        is_weak = (
-            weak_confidence_threshold > 0
-            and cluster_conf_check is not None
-            and cluster_conf_check < weak_confidence_threshold
-            and info.get("bottleneck_pair") is not None
-        )
-        if (
-            use_bulk_fast_path
-            and not unique_entities
-            and not is_weak
-        ):
-            entity_id = new_entity_id()
-            now = datetime.now()
-            golden = _golden_record_from_payloads(rowid_to_payload, members)
-            bulk_node_rows.append({
-                "entity_id": entity_id,
-                "status": IdentityStatus.ACTIVE.value,
-                "merged_into": None,
-                "golden_record": json.dumps(golden, default=str) if golden else None,
-                "confidence": cluster_conf_check,
-                "dataset": dataset,
-                "created_at": now,
-                "updated_at": now,
-            })
+            # 3a'. Bulk fast-path: brand-new cluster on postgres, no weak
+            # conflict edge -> accumulate rows for bulk flush, skip the
+            # per-row writes for this cluster.
+            cluster_conf_check = _cluster_confidence(info)
+            is_weak = (
+                weak_confidence_threshold > 0
+                and cluster_conf_check is not None
+                and cluster_conf_check < weak_confidence_threshold
+                and info.get("bottleneck_pair") is not None
+            )
+            if (
+                use_bulk_fast_path
+                and not unique_entities
+                and not is_weak
+            ):
+                entity_id = new_entity_id()
+                now = datetime.now()
+                golden = _golden_record_from_payloads(rowid_to_payload, members)
+                bulk_node_rows.append({
+                    "entity_id": entity_id,
+                    "status": IdentityStatus.ACTIVE.value,
+                    "merged_into": None,
+                    "golden_record": json.dumps(golden, default=str) if golden else None,
+                    "confidence": cluster_conf_check,
+                    "dataset": dataset,
+                    "created_at": now,
+                    "updated_at": now,
+                })
+                for member in members:
+                    rid = rowid_to_recid.get(member)
+                    if rid is None:
+                        continue
+                    bulk_record_rows.append({
+                        "record_id": rid,
+                        "source": rowid_to_source[member],
+                        "source_pk": rowid_to_pk[member],
+                        "record_hash": rowid_to_hash[member],
+                        "entity_id": entity_id,
+                        "dataset": dataset,
+                        "first_seen_at": now,
+                        "last_seen_at": now,
+                    })
+                    summary.records_upserted += 1
+                pair_scores = (
+                    pair_score_view.for_cluster(cluster_id)
+                    if pair_score_view is not None
+                    else (info.get("pair_scores") or {})
+                )
+                for pair_key, score in pair_scores.items():
+                    if isinstance(pair_key, tuple) and len(pair_key) == 2:
+                        a, b = pair_key
+                    else:
+                        continue
+                    ra = rowid_to_recid.get(int(a))
+                    rb = rowid_to_recid.get(int(b))
+                    if not ra or not rb:
+                        continue
+                    bulk_edge_rows.append({
+                        "entity_id": entity_id,
+                        "record_a_id": ra,
+                        "record_b_id": rb,
+                        "kind": EdgeKind.SAME_AS.value,
+                        "score": float(score),
+                        "matchkey_name": matchkey_name,
+                        "run_name": run_name,
+                        "dataset": dataset,
+                        "recorded_at": now,
+                    })
+                    summary.edges_added += 1
+                bulk_event_rows.append({
+                    "entity_id": entity_id,
+                    "kind": EventKind.CREATED.value,
+                    "run_name": run_name,
+                    "dataset": dataset,
+                    "recorded_at": now,
+                })
+                summary.events_emitted += 1
+                summary.created += 1
+                bulk_cluster_ids.add(cluster_id)
+                continue
+
+
+            if not unique_entities:
+                # Brand-new identity.
+                entity_id = new_entity_id()
+                now = datetime.now()
+                store.upsert_identity(IdentityNode(
+                    entity_id=entity_id,
+                    status=IdentityStatus.ACTIVE.value,
+                    golden_record=_golden_record_from_payloads(rowid_to_payload, members),
+                    confidence=_cluster_confidence(info),
+                    dataset=dataset,
+                    created_at=now,
+                    updated_at=now,
+                ))
+                if not store.has_run_event(entity_id, run_name, EventKind.CREATED.value):
+                    store.emit_event(IdentityEvent(
+                        entity_id=entity_id,
+                        kind=EventKind.CREATED.value,
+                        payload={
+                            "cluster_id": cluster_id,
+                            "member_count": size,
+                            "record_ids": record_ids,
+                        },
+                        run_name=run_name, dataset=dataset, recorded_at=now,
+                        actor=actor, trust=_cluster_confidence(info),
+                    ))
+                    summary.events_emitted += 1
+                summary.created += 1
+            elif len(unique_entities) == 1:
+                # Absorb new records into existing identity.
+                entity_id = unique_entities[0]
+                existing_node = store.get_identity(entity_id)
+                now = datetime.now()
+                store.upsert_identity(IdentityNode(
+                    entity_id=entity_id,
+                    status=existing_node.status if existing_node else IdentityStatus.ACTIVE.value,
+                    merged_into=existing_node.merged_into if existing_node else None,
+                    golden_record=_golden_record_from_payloads(rowid_to_payload, members),
+                    confidence=_cluster_confidence(info),
+                    dataset=dataset,
+                    created_at=existing_node.created_at if existing_node else now,
+                    updated_at=now,
+                ))
+                newly_added = [rid for rid in record_ids if rid not in existing]
+                for rid in newly_added:
+                    store.emit_event(IdentityEvent(
+                        entity_id=entity_id,
+                        kind=EventKind.ABSORBED_RECORD.value,
+                        payload={"record_id": rid, "cluster_id": cluster_id},
+                        run_name=run_name, dataset=dataset, recorded_at=now,
+                        actor=actor, trust=_cluster_confidence(info),
+                    ))
+                    summary.events_emitted += 1
+                    summary.absorbed_records += 1
+            else:
+                # Multi-entity overlap -> merge into the one with most members
+                # (tie-break: oldest created_at).
+                counts = Counter(existing.values())
+                ranked = sorted(
+                    counts.items(),
+                    key=lambda kv: (-kv[1], _node_age(store, kv[0])),
+                )
+                winner = ranked[0][0]
+                losers = [eid for eid, _ in ranked[1:]]
+                now = datetime.now()
+                winner_node = store.get_identity(winner)
+                store.upsert_identity(IdentityNode(
+                    entity_id=winner,
+                    status=IdentityStatus.ACTIVE.value,
+                    merged_into=None,
+                    golden_record=_golden_record_from_payloads(rowid_to_payload, members),
+                    confidence=_cluster_confidence(info),
+                    dataset=dataset,
+                    created_at=winner_node.created_at if winner_node else now,
+                    updated_at=now,
+                ))
+                store.emit_event(IdentityEvent(
+                    entity_id=winner,
+                    kind=EventKind.MERGED_WITH.value,
+                    payload={
+                        "absorbed": losers,
+                        "cluster_id": cluster_id,
+                        "member_count": size,
+                    },
+                    run_name=run_name, dataset=dataset, recorded_at=now,
+                    actor=actor, trust=_cluster_confidence(info),
+                ))
+                summary.events_emitted += 1
+                for loser in losers:
+                    store.retire_identity(loser, merged_into=winner)
+                    store.emit_event(IdentityEvent(
+                        entity_id=loser,
+                        kind=EventKind.MERGED_WITH.value,
+                        payload={"merged_into": winner},
+                        run_name=run_name, dataset=dataset, recorded_at=now,
+                        actor=actor, trust=_cluster_confidence(info),
+                    ))
+                    summary.events_emitted += 1
+                entity_id = winner
+                summary.merged += 1
+
+            # 3b. Reassign losers' records to winner BEFORE upserting cluster records,
+            # so an absorb branch on the next iteration sees them already migrated.
+            # In merge branch above, loser records are reassigned here:
+            if len(unique_entities) > 1:
+                # Migrate records that previously pointed at losers.
+                losers_set = {eid for eid in unique_entities if eid != entity_id}
+                for rid, old_eid in existing.items():
+                    if old_eid in losers_set:
+                        rec = store.get_record(rid)
+                        if rec is not None:
+                            rec.entity_id = entity_id
+                            rec.last_seen_at = datetime.now()
+                            store.upsert_record(rec)
+
+            # 3c. Upsert all cluster records under the chosen entity_id.
             for member in members:
                 rid = rowid_to_recid.get(member)
                 if rid is None:
                     continue
-                bulk_record_rows.append({
-                    "record_id": rid,
-                    "source": rowid_to_source[member],
-                    "source_pk": rowid_to_pk[member],
-                    "record_hash": rowid_to_hash[member],
-                    "entity_id": entity_id,
-                    "dataset": dataset,
-                    "first_seen_at": now,
-                    "last_seen_at": now,
-                })
+                store.upsert_record(SourceRecord(
+                    record_id=rid,
+                    source=rowid_to_source[member],
+                    source_pk=rowid_to_pk[member],
+                    record_hash=rowid_to_hash[member],
+                    entity_id=entity_id,
+                    payload=rowid_to_payload[member],
+                    dataset=dataset,
+                    last_seen_at=datetime.now(),
+                ))
                 summary.records_upserted += 1
+
+            # 3d. Record evidence edges for every scored within-cluster pair.
             pair_scores = (
                 pair_score_view.for_cluster(cluster_id)
                 if pair_score_view is not None
@@ -514,345 +686,174 @@ def resolve_clusters(
                 rb = rowid_to_recid.get(int(b))
                 if not ra or not rb:
                     continue
-                bulk_edge_rows.append({
-                    "entity_id": entity_id,
-                    "record_a_id": ra,
-                    "record_b_id": rb,
-                    "kind": EdgeKind.SAME_AS.value,
-                    "score": float(score),
-                    "matchkey_name": matchkey_name,
-                    "run_name": run_name,
-                    "dataset": dataset,
-                    "recorded_at": now,
-                })
-                summary.edges_added += 1
-            bulk_event_rows.append({
-                "entity_id": entity_id,
-                "kind": EventKind.CREATED.value,
-                "run_name": run_name,
-                "dataset": dataset,
-                "recorded_at": now,
-            })
-            summary.events_emitted += 1
-            summary.created += 1
-            bulk_cluster_ids.add(cluster_id)
-            continue
-
-
-        if not unique_entities:
-            # Brand-new identity.
-            entity_id = new_entity_id()
-            now = datetime.now()
-            store.upsert_identity(IdentityNode(
-                entity_id=entity_id,
-                status=IdentityStatus.ACTIVE.value,
-                golden_record=_golden_record_from_payloads(rowid_to_payload, members),
-                confidence=_cluster_confidence(info),
-                dataset=dataset,
-                created_at=now,
-                updated_at=now,
-            ))
-            if not store.has_run_event(entity_id, run_name, EventKind.CREATED.value):
-                store.emit_event(IdentityEvent(
-                    entity_id=entity_id,
-                    kind=EventKind.CREATED.value,
-                    payload={
-                        "cluster_id": cluster_id,
-                        "member_count": size,
-                        "record_ids": record_ids,
-                    },
-                    run_name=run_name, dataset=dataset, recorded_at=now,
-                    actor=actor, trust=_cluster_confidence(info),
-                ))
-                summary.events_emitted += 1
-            summary.created += 1
-        elif len(unique_entities) == 1:
-            # Absorb new records into existing identity.
-            entity_id = unique_entities[0]
-            existing_node = store.get_identity(entity_id)
-            now = datetime.now()
-            store.upsert_identity(IdentityNode(
-                entity_id=entity_id,
-                status=existing_node.status if existing_node else IdentityStatus.ACTIVE.value,
-                merged_into=existing_node.merged_into if existing_node else None,
-                golden_record=_golden_record_from_payloads(rowid_to_payload, members),
-                confidence=_cluster_confidence(info),
-                dataset=dataset,
-                created_at=existing_node.created_at if existing_node else now,
-                updated_at=now,
-            ))
-            newly_added = [rid for rid in record_ids if rid not in existing]
-            for rid in newly_added:
-                store.emit_event(IdentityEvent(
-                    entity_id=entity_id,
-                    kind=EventKind.ABSORBED_RECORD.value,
-                    payload={"record_id": rid, "cluster_id": cluster_id},
-                    run_name=run_name, dataset=dataset, recorded_at=now,
-                    actor=actor, trust=_cluster_confidence(info),
-                ))
-                summary.events_emitted += 1
-                summary.absorbed_records += 1
-        else:
-            # Multi-entity overlap -> merge into the one with most members
-            # (tie-break: oldest created_at).
-            counts = Counter(existing.values())
-            ranked = sorted(
-                counts.items(),
-                key=lambda kv: (-kv[1], _node_age(store, kv[0])),
-            )
-            winner = ranked[0][0]
-            losers = [eid for eid, _ in ranked[1:]]
-            now = datetime.now()
-            winner_node = store.get_identity(winner)
-            store.upsert_identity(IdentityNode(
-                entity_id=winner,
-                status=IdentityStatus.ACTIVE.value,
-                merged_into=None,
-                golden_record=_golden_record_from_payloads(rowid_to_payload, members),
-                confidence=_cluster_confidence(info),
-                dataset=dataset,
-                created_at=winner_node.created_at if winner_node else now,
-                updated_at=now,
-            ))
-            store.emit_event(IdentityEvent(
-                entity_id=winner,
-                kind=EventKind.MERGED_WITH.value,
-                payload={
-                    "absorbed": losers,
-                    "cluster_id": cluster_id,
-                    "member_count": size,
-                },
-                run_name=run_name, dataset=dataset, recorded_at=now,
-                actor=actor, trust=_cluster_confidence(info),
-            ))
-            summary.events_emitted += 1
-            for loser in losers:
-                store.retire_identity(loser, merged_into=winner)
-                store.emit_event(IdentityEvent(
-                    entity_id=loser,
-                    kind=EventKind.MERGED_WITH.value,
-                    payload={"merged_into": winner},
-                    run_name=run_name, dataset=dataset, recorded_at=now,
-                    actor=actor, trust=_cluster_confidence(info),
-                ))
-                summary.events_emitted += 1
-            entity_id = winner
-            summary.merged += 1
-
-        # 3b. Reassign losers' records to winner BEFORE upserting cluster records,
-        # so an absorb branch on the next iteration sees them already migrated.
-        # In merge branch above, loser records are reassigned here:
-        if len(unique_entities) > 1:
-            # Migrate records that previously pointed at losers.
-            losers_set = {eid for eid in unique_entities if eid != entity_id}
-            for rid, old_eid in existing.items():
-                if old_eid in losers_set:
-                    rec = store.get_record(rid)
-                    if rec is not None:
-                        rec.entity_id = entity_id
-                        rec.last_seen_at = datetime.now()
-                        store.upsert_record(rec)
-
-        # 3c. Upsert all cluster records under the chosen entity_id.
-        for member in members:
-            rid = rowid_to_recid.get(member)
-            if rid is None:
-                continue
-            store.upsert_record(SourceRecord(
-                record_id=rid,
-                source=rowid_to_source[member],
-                source_pk=rowid_to_pk[member],
-                record_hash=rowid_to_hash[member],
-                entity_id=entity_id,
-                payload=rowid_to_payload[member],
-                dataset=dataset,
-                last_seen_at=datetime.now(),
-            ))
-            summary.records_upserted += 1
-
-        # 3d. Record evidence edges for every scored within-cluster pair.
-        pair_scores = (
-            pair_score_view.for_cluster(cluster_id)
-            if pair_score_view is not None
-            else (info.get("pair_scores") or {})
-        )
-        for pair_key, score in pair_scores.items():
-            if isinstance(pair_key, tuple) and len(pair_key) == 2:
-                a, b = pair_key
-            else:
-                continue
-            ra = rowid_to_recid.get(int(a))
-            rb = rowid_to_recid.get(int(b))
-            if not ra or not rb:
-                continue
-            store.add_edge(EvidenceEdge(
-                entity_id=entity_id,
-                record_a_id=ra,
-                record_b_id=rb,
-                kind=EdgeKind.SAME_AS.value,
-                score=float(score),
-                matchkey_name=matchkey_name,
-                controller_snapshot=controller_snapshot,
-                run_name=run_name,
-                dataset=dataset,
-                actor=actor, trust=float(score),
-            ))
-            summary.edges_added += 1
-
-        # 3e. v2.1 conflict detection -- weak bottleneck.
-        # When the cluster confidence dropped low enough that the cluster
-        # quality engine flagged it weak, surface the bottleneck pair as a
-        # `conflicts_with` edge so a steward sees it in the conflicts feed.
-        # Same-source identical row pairs (score 1.0 exact dupes) are
-        # excluded so the conflicts feed stays signal-rich.
-        cluster_conf = _cluster_confidence(info)
-        bottleneck = info.get("bottleneck_pair")
-        if (
-            weak_confidence_threshold > 0
-            and cluster_conf is not None
-            and cluster_conf < weak_confidence_threshold
-            and bottleneck is not None
-            and isinstance(bottleneck, tuple)
-            and len(bottleneck) == 2
-        ):
-            ba, bb = bottleneck
-            ra = rowid_to_recid.get(int(ba))
-            rb = rowid_to_recid.get(int(bb))
-            bottleneck_score = (
-                pair_score_view.score_for(cluster_id, int(ba), int(bb))
-                if pair_score_view is not None
-                else info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
-            )
-            if ra and rb:
                 store.add_edge(EvidenceEdge(
                     entity_id=entity_id,
                     record_a_id=ra,
                     record_b_id=rb,
-                    kind=EdgeKind.CONFLICTS_WITH.value,
-                    score=float(bottleneck_score) if bottleneck_score is not None else None,
+                    kind=EdgeKind.SAME_AS.value,
+                    score=float(score),
                     matchkey_name=matchkey_name,
-                    negative_evidence={
-                        "reason": "weak_cluster_bottleneck",
-                        "cluster_confidence": cluster_conf,
-                        "threshold": weak_confidence_threshold,
-                    },
                     controller_snapshot=controller_snapshot,
                     run_name=run_name,
                     dataset=dataset,
-                    actor=actor,
-                    trust=float(bottleneck_score) if bottleneck_score is not None else None,
+                    actor=actor, trust=float(score),
                 ))
-                summary.conflicts_flagged += 1
+                summary.edges_added += 1
 
-        # 3f. v2.1 conflict detection -- carry forward prior conflicts on merge.
-        # If we just merged two identities and either side previously had a
-        # `conflicts_with` edge between *their* members, surface a fresh
-        # `conflicts_with` on the winner so a steward can re-verify post-merge.
-        if len(unique_entities) > 1:
-            prior_losers = [eid for eid in unique_entities if eid != entity_id]
-            for loser in prior_losers:
-                # Lightweight inspection: scan the loser's recent edges for
-                # any explicit conflicts_with. (For very high-volume graphs a
-                # dedicated query would be cheaper; this is fine for the
-                # cluster-counts we see in practice.)
-                for prior_edge in store.edges_for_entity(loser):
-                    if prior_edge.kind != EdgeKind.CONFLICTS_WITH.value:
-                        continue
+            # 3e. v2.1 conflict detection -- weak bottleneck.
+            # When the cluster confidence dropped low enough that the cluster
+            # quality engine flagged it weak, surface the bottleneck pair as a
+            # `conflicts_with` edge so a steward sees it in the conflicts feed.
+            # Same-source identical row pairs (score 1.0 exact dupes) are
+            # excluded so the conflicts feed stays signal-rich.
+            cluster_conf = _cluster_confidence(info)
+            bottleneck = info.get("bottleneck_pair")
+            if (
+                weak_confidence_threshold > 0
+                and cluster_conf is not None
+                and cluster_conf < weak_confidence_threshold
+                and bottleneck is not None
+                and isinstance(bottleneck, tuple)
+                and len(bottleneck) == 2
+            ):
+                ba, bb = bottleneck
+                ra = rowid_to_recid.get(int(ba))
+                rb = rowid_to_recid.get(int(bb))
+                bottleneck_score = (
+                    pair_score_view.score_for(cluster_id, int(ba), int(bb))
+                    if pair_score_view is not None
+                    else info.get("pair_scores", {}).get((min(int(ba), int(bb)), max(int(ba), int(bb))))
+                )
+                if ra and rb:
                     store.add_edge(EvidenceEdge(
                         entity_id=entity_id,
-                        record_a_id=prior_edge.record_a_id,
-                        record_b_id=prior_edge.record_b_id,
+                        record_a_id=ra,
+                        record_b_id=rb,
                         kind=EdgeKind.CONFLICTS_WITH.value,
-                        score=prior_edge.score,
-                        matchkey_name=prior_edge.matchkey_name,
+                        score=float(bottleneck_score) if bottleneck_score is not None else None,
+                        matchkey_name=matchkey_name,
                         negative_evidence={
-                            "reason": "carried_forward_from_merge",
-                            "from_entity": loser,
-                            "original_run": prior_edge.run_name,
+                            "reason": "weak_cluster_bottleneck",
+                            "cluster_confidence": cluster_conf,
+                            "threshold": weak_confidence_threshold,
                         },
                         controller_snapshot=controller_snapshot,
                         run_name=run_name,
                         dataset=dataset,
                         actor=actor,
-                        trust=prior_edge.score,
+                        trust=float(bottleneck_score) if bottleneck_score is not None else None,
                     ))
                     summary.conflicts_flagged += 1
 
-    # 3z. Flush bulk-fast-path accumulators in one COPY each. Order
-    # matters: identities first (so the source_records FK is valid),
-    # then records, then edges, then events.
-    if use_bulk_fast_path and bulk_node_rows:
-        from goldenmatch.core.frame import frame_from_rows
+            # 3f. v2.1 conflict detection -- carry forward prior conflicts on merge.
+            # If we just merged two identities and either side previously had a
+            # `conflicts_with` edge between *their* members, surface a fresh
+            # `conflicts_with` on the winner so a steward can re-verify post-merge.
+            if len(unique_entities) > 1:
+                prior_losers = [eid for eid in unique_entities if eid != entity_id]
+                for loser in prior_losers:
+                    # Lightweight inspection: scan the loser's recent edges for
+                    # any explicit conflicts_with. (For very high-volume graphs a
+                    # dedicated query would be cheaper; this is fine for the
+                    # cluster-counts we see in practice.)
+                    for prior_edge in store.edges_for_entity(loser):
+                        if prior_edge.kind != EdgeKind.CONFLICTS_WITH.value:
+                            continue
+                        store.add_edge(EvidenceEdge(
+                            entity_id=entity_id,
+                            record_a_id=prior_edge.record_a_id,
+                            record_b_id=prior_edge.record_b_id,
+                            kind=EdgeKind.CONFLICTS_WITH.value,
+                            score=prior_edge.score,
+                            matchkey_name=prior_edge.matchkey_name,
+                            negative_evidence={
+                                "reason": "carried_forward_from_merge",
+                                "from_entity": loser,
+                                "original_run": prior_edge.run_name,
+                            },
+                            controller_snapshot=controller_snapshot,
+                            run_name=run_name,
+                            dataset=dataset,
+                            actor=actor,
+                            trust=prior_edge.score,
+                        ))
+                        summary.conflicts_flagged += 1
 
-        # W4b: seam constructor (datetime_us == bare pl.Datetime). The store
-        # COPY contract stays polars-typed until W5.
-        nodes_df = frame_from_rows(
-            bulk_node_rows,
-            {
-                "entity_id": "utf8",
-                "status": "utf8",
-                "merged_into": "utf8",
-                "golden_record": "utf8",
-                "confidence": "float64",
-                "dataset": "utf8",
-                "created_at": "datetime_us",
-                "updated_at": "datetime_us",
-            },
-            backend="polars",
-        ).native
-        store.bulk_upsert_identities(nodes_df)
-        if bulk_record_rows:
-            records_df = frame_from_rows(
-                bulk_record_rows,
+        # 3z. Flush bulk-fast-path accumulators in one COPY each. Order
+        # matters: identities first (so the source_records FK is valid),
+        # then records, then edges, then events.
+        if use_bulk_fast_path and bulk_node_rows:
+            from goldenmatch.core.frame import frame_from_rows
+
+            # W4b: seam constructor (datetime_us == bare pl.Datetime). The store
+            # COPY contract stays polars-typed until W5.
+            nodes_df = frame_from_rows(
+                bulk_node_rows,
                 {
-                    "record_id": "utf8",
-                    "source": "utf8",
-                    "source_pk": "utf8",
-                    "record_hash": "utf8",
                     "entity_id": "utf8",
+                    "status": "utf8",
+                    "merged_into": "utf8",
+                    "golden_record": "utf8",
+                    "confidence": "float64",
                     "dataset": "utf8",
-                    "first_seen_at": "datetime_us",
-                    "last_seen_at": "datetime_us",
+                    "created_at": "datetime_us",
+                    "updated_at": "datetime_us",
                 },
                 backend="polars",
             ).native
-            store.bulk_upsert_records(records_df)
-        if bulk_edge_rows:
-            edges_df = frame_from_rows(
-                bulk_edge_rows,
-                {
-                    "entity_id": "utf8",
-                    "record_a_id": "utf8",
-                    "record_b_id": "utf8",
-                    "kind": "utf8",
-                    "score": "float64",
-                    "matchkey_name": "utf8",
-                    "run_name": "utf8",
-                    "dataset": "utf8",
-                    "recorded_at": "datetime_us",
-                },
-                backend="polars",
-            ).native
-            store.bulk_add_edges(edges_df)
-        if bulk_event_rows:
-            events_df = frame_from_rows(
-                bulk_event_rows,
-                {
-                    "entity_id": "utf8",
-                    "kind": "utf8",
-                    "run_name": "utf8",
-                    "dataset": "utf8",
-                    "recorded_at": "datetime_us",
-                },
-                backend="polars",
-            ).native
-            store.bulk_emit_events(events_df)
-        log.info(
-            "resolve_clusters bulk fast-path: %d clusters / %d nodes / "
-            "%d records / %d edges / %d events flushed in 4 COPY batches",
-            len(bulk_cluster_ids), len(bulk_node_rows), len(bulk_record_rows),
-            len(bulk_edge_rows), len(bulk_event_rows),
-        )
+            store.bulk_upsert_identities(nodes_df)
+            if bulk_record_rows:
+                records_df = frame_from_rows(
+                    bulk_record_rows,
+                    {
+                        "record_id": "utf8",
+                        "source": "utf8",
+                        "source_pk": "utf8",
+                        "record_hash": "utf8",
+                        "entity_id": "utf8",
+                        "dataset": "utf8",
+                        "first_seen_at": "datetime_us",
+                        "last_seen_at": "datetime_us",
+                    },
+                    backend="polars",
+                ).native
+                store.bulk_upsert_records(records_df)
+            if bulk_edge_rows:
+                edges_df = frame_from_rows(
+                    bulk_edge_rows,
+                    {
+                        "entity_id": "utf8",
+                        "record_a_id": "utf8",
+                        "record_b_id": "utf8",
+                        "kind": "utf8",
+                        "score": "float64",
+                        "matchkey_name": "utf8",
+                        "run_name": "utf8",
+                        "dataset": "utf8",
+                        "recorded_at": "datetime_us",
+                    },
+                    backend="polars",
+                ).native
+                store.bulk_add_edges(edges_df)
+            if bulk_event_rows:
+                events_df = frame_from_rows(
+                    bulk_event_rows,
+                    {
+                        "entity_id": "utf8",
+                        "kind": "utf8",
+                        "run_name": "utf8",
+                        "dataset": "utf8",
+                        "recorded_at": "datetime_us",
+                    },
+                    backend="polars",
+                ).native
+                store.bulk_emit_events(events_df)
+            log.info(
+                "resolve_clusters bulk fast-path: %d clusters / %d nodes / "
+                "%d records / %d edges / %d events flushed in 4 COPY batches",
+                len(bulk_cluster_ids), len(bulk_node_rows), len(bulk_record_rows),
+                len(bulk_edge_rows), len(bulk_event_rows),
+            )
 
     # 4. Split detection: records that previously had an entity_id but did
     # NOT appear in any cluster this run should not be retired here -- they

--- a/packages/python/goldenmatch/goldenmatch/identity/store.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/store.py
@@ -6,12 +6,13 @@ multi-process safety. Schema versioned via ``PRAGMA user_version``.
 """
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import time
 import uuid
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime
 from typing import Any
 
@@ -465,6 +466,33 @@ class IdentityStore:
     # Single transaction per call. SQLite raises NotImplementedError -- the
     # SQLite path is single-process and the row-by-row upsert_* methods are
     # plenty fast for that scale.
+
+    @contextlib.contextmanager
+    def bulk_writes(self) -> Iterator[None]:
+        """Run a batch of writes inside ONE transaction (Postgres).
+
+        The Postgres connection is opened ``autocommit=True``, so on the
+        per-record resolve path every ``upsert_identity`` / ``emit_event`` /
+        ``upsert_record`` / ``add_edge`` commits on its own -- one COMMIT + a
+        network round-trip PER write. Against a remote DB (e.g. Cloud SQL) that
+        turns a ~20k-record resolve into minutes of latency even though the
+        compute is milliseconds (#1886). Wrapping the whole write body in a
+        single ``conn.transaction()`` collapses those N commits into one and lets
+        psycopg pipeline the statements.
+
+        No-op for SQLite (already local + WAL) and Mongo, so callers can wrap
+        unconditionally. Nesting is safe: the bulk COPY helpers open their own
+        ``conn.transaction()`` which becomes a savepoint under this outer one.
+        Errors roll the batch back (atomic per resolve run) instead of leaving a
+        partially-committed graph -- an improvement over the autocommit path,
+        which the caller already treats as all-or-nothing (it has no per-cluster
+        recovery).
+        """
+        if self._backend == "postgres":
+            with self._conn.transaction():
+                yield
+        else:
+            yield
 
     def bulk_upsert_identities(self, df: Any) -> None:
         if self._backend != "postgres":

--- a/packages/python/goldenmatch/tests/identity/test_resolve_bulk_writes_1886.py
+++ b/packages/python/goldenmatch/tests/identity/test_resolve_bulk_writes_1886.py
@@ -1,0 +1,172 @@
+"""#1886: resolve_clusters must run its writes inside ONE transaction.
+
+The Postgres IdentityStore connects with ``autocommit=True``. The bulk fast-path
+already batches brand-new clusters into 4 COPY transactions, but the per-record
+path (absorb/merge into existing identities, weak multi-member clusters) issued
+every write on its own autocommit -- one COMMIT + network round-trip per write,
+which is minutes of latency against a remote DB for ~20k records.
+
+These tests use a fake ``_backend="postgres"`` store whose ``bulk_writes()``
+records enter/exit and every write records its call order, then assert that
+EVERY write on both the per-record and the bulk path falls inside a single
+``bulk_writes()`` scope.
+"""
+from __future__ import annotations
+
+import contextlib
+
+import polars as pl
+from goldenmatch.identity.resolve import resolve_clusters
+
+_PER_RECORD_WRITES = {
+    "upsert_identity", "upsert_record", "emit_event", "add_edge",
+}
+_BULK_WRITES = {
+    "bulk_upsert_identities", "bulk_upsert_records",
+    "bulk_add_edges", "bulk_emit_events",
+}
+
+
+class _TxnRecordingStore:
+    """Fake postgres-backed store. Records the order of bulk_writes enter/exit
+    and every write call so a test can assert writes are transaction-scoped."""
+
+    _backend = "postgres"
+
+    def __init__(self, preexisting: dict[str, str] | None = None):
+        self.events: list[str] = []
+        self._preexisting = preexisting or {}
+        self._identity_nodes: dict[str, object] = {}
+
+    @contextlib.contextmanager
+    def bulk_writes(self):
+        self.events.append("ENTER")
+        try:
+            yield
+        finally:
+            self.events.append("EXIT")
+
+    # --- reads ---
+    def lookup_entity_ids(self, ids):
+        return {i: self._preexisting[i] for i in ids if i in self._preexisting}
+
+    def get_identity(self, eid):
+        return self._identity_nodes.get(eid)
+
+    def has_run_event(self, *a):
+        return False
+
+    # --- per-record writes ---
+    def upsert_identity(self, node):
+        self.events.append("upsert_identity")
+        self._identity_nodes[node.entity_id] = node
+
+    def upsert_record(self, rec):
+        self.events.append("upsert_record")
+
+    def emit_event(self, ev):
+        self.events.append("emit_event")
+
+    def add_edge(self, edge):
+        self.events.append("add_edge")
+
+    # --- bulk writes ---
+    def bulk_upsert_identities(self, df):
+        self.events.append("bulk_upsert_identities")
+
+    def bulk_upsert_records(self, df):
+        self.events.append("bulk_upsert_records")
+
+    def bulk_add_edges(self, df):
+        self.events.append("bulk_add_edges")
+
+    def bulk_emit_events(self, df):
+        self.events.append("bulk_emit_events")
+
+    def close(self):
+        pass
+
+
+def _assert_writes_transaction_scoped(events: list[str]) -> None:
+    assert events.count("ENTER") == 1, f"expected 1 bulk_writes scope, got {events}"
+    lo, hi = events.index("ENTER"), events.index("EXIT")
+    writes = _PER_RECORD_WRITES | _BULK_WRITES
+    for i, ev in enumerate(events):
+        if ev in writes:
+            assert lo < i < hi, f"write {ev!r} at {i} outside bulk_writes {events}"
+
+
+def _singleton_df(n: int) -> pl.DataFrame:
+    return pl.DataFrame({
+        "__row_id__": list(range(n)),
+        "__source__": ["crm"] * n,
+        "raw_id": [f"r{i}" for i in range(n)],
+        "name": [f"person {i}" for i in range(n)],
+    })
+
+
+def _singleton_clusters(n: int) -> dict[int, dict]:
+    return {
+        i: {"members": [i], "size": 1, "pair_scores": {},
+            "confidence": 1.0, "bottleneck_pair": None, "oversized": False}
+        for i in range(n)
+    }
+
+
+def test_bulk_path_writes_inside_one_transaction():
+    # Brand-new singletons -> bulk fast-path. The 4 COPY calls must be inside
+    # the single bulk_writes() scope.
+    store = _TxnRecordingStore()
+    resolve_clusters(
+        clusters=_singleton_clusters(5), df=_singleton_df(5), scored_pairs=[],
+        store=store, run_name="run1", dataset="crm", source_pk_col="raw_id",
+    )
+    _assert_writes_transaction_scoped(store.events)
+    assert any(e in _BULK_WRITES for e in store.events)
+
+
+def test_bulk_writes_dispatch_postgres_uses_conn_transaction():
+    # The store's bulk_writes() must open a real conn.transaction() on postgres
+    # and be a no-op elsewhere. Build stores via __new__ to skip DB connect.
+    from goldenmatch.identity.store import IdentityStore
+
+    class _FakeTxn:
+        def __init__(self, log): self.log = log
+        def __enter__(self): self.log.append("txn-enter")
+        def __exit__(self, *a): self.log.append("txn-exit")
+
+    class _FakeConn:
+        def __init__(self): self.log = []
+        def transaction(self): return _FakeTxn(self.log)
+
+    pg = IdentityStore.__new__(IdentityStore)
+    pg._backend = "postgres"
+    pg._conn = _FakeConn()
+    with pg.bulk_writes():
+        pg._conn.log.append("body")
+    assert pg._conn.log == ["txn-enter", "body", "txn-exit"]
+
+    # sqlite: no transaction object touched, still yields.
+    lite = IdentityStore.__new__(IdentityStore)
+    lite._backend = "sqlite"
+    ran = []
+    with lite.bulk_writes():
+        ran.append("body")
+    assert ran == ["body"]
+
+
+def test_per_record_absorb_writes_inside_one_transaction():
+    # Every record already maps to an existing entity -> the per-record ABSORB
+    # path (not the bulk fast-path). This is the #1886 re-resolve shape: without
+    # the fix each of these writes autocommits on its own round-trip.
+    n = 5
+    preexisting = {f"crm:r{i}": f"ent-{i}" for i in range(n)}
+    store = _TxnRecordingStore(preexisting=preexisting)
+    resolve_clusters(
+        clusters=_singleton_clusters(n), df=_singleton_df(n), scored_pairs=[],
+        store=store, run_name="run2", dataset="crm", source_pk_col="raw_id",
+    )
+    # The per-record path was exercised...
+    assert any(e in _PER_RECORD_WRITES for e in store.events), store.events
+    # ...and all of it inside the single transaction.
+    _assert_writes_transaction_scoped(store.events)


### PR DESCRIPTION
## What and why

Fixes #1886 — postgres `IdentityStore.resolve_clusters` taking >12 min for ~20k records while matching is ~2s.

**Root cause (confirms the reporter's autocommit hypothesis).** The Postgres `IdentityStore` connects with `autocommit=True` (`store.py:215`). `resolve_clusters` has a bulk COPY fast-path that already batches **brand-new** clusters into 4 transactions — but the **per-record path** (absorbing/merging records into existing identities, and weak multi-member clusters) issued every `upsert_identity`/`emit_event`/`upsert_record`/`add_edge` on its own autocommit: **one COMMIT + network round-trip per write**. Against Cloud SQL that's minutes for ~20k records even though the compute is milliseconds.

The worst case — and the reporter's — is a **re-resolve / incremental load against a populated store**: every record already maps to an existing entity, so the bulk fast-path (which requires `not unique_entities`) never engages and *all* records go per-record under autocommit.

**How I confirmed it.** I instrumented `resolve_clusters` with a fake postgres-backed store (counting bulk vs per-record calls) on 20k singletons: the bulk fast-path *is* taken for brand-new clusters, and pure-Python resolve is ~3s/20k (strictly linear, no O(n²)) with an instant store. So the DB round-trips on the per-record path were the entire cost — not Python, not the bulk COPYs.

## Changes

- **`IdentityStore.bulk_writes()`** — a context manager that opens **one** `conn.transaction()` on postgres (a no-op for SQLite/Mongo, so callers wrap unconditionally). Nesting is safe: the existing bulk COPY helpers' own `conn.transaction()` become savepoints under it.
- **`resolve_clusters`** wraps its whole write body (the per-record cluster loop **and** the bulk COPY flush) in `with store.bulk_writes():`. N commits collapse to one; psycopg pipelines the statements. The resolve is now **atomic per run** — an error rolls back instead of leaving a half-resolved graph (the caller already treats a failure as all-or-nothing; it has no per-cluster recovery).

No behavior change to cluster membership / golden records / event content — only when the writes commit.

## Testing

- `tests/identity/test_resolve_bulk_writes_1886.py` (3 tests): a fake postgres store asserts every write on **both** the bulk and per-record (absorb) paths falls inside a single `bulk_writes()` scope; plus a dispatch test that `bulk_writes()` opens a real `conn.transaction()` on postgres and is a no-op on sqlite.
- `uv run pytest tests/identity/` — 216 passed, 6 skipped (one module skipped locally: needs `fastapi`, not installed here). The sqlite-backed suite exercises `resolve_clusters` through the new no-op wrapper unchanged.
- `ruff check` clean.

## Notes

The absorb/merge path still issues per-record *statements* (now within one transaction, so one commit + pipelined round-trips). A fuller follow-up could extend the bulk COPY accumulation to the absorb/merge branches, but the single-transaction fix is the reporter's suggested change and removes the per-write commit latency that dominates.

## Checklist

- [x] Tests added/updated and passing locally
- [x] `ruff check` clean
- [x] `CHANGELOG.md` updated
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_