### PR TITLE
fix(scorer): mask unobserved record_embedding out of the weighted score (#1859)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -748,4 +748,17 @@ pyright_slice:
   - 'packages/python/goldenmatch/goldenmatch/core/indicators.py'
   - 'packages/python/goldenmatch/goldenmatch/core/complexity_profile.py'
   - 'packages/python/goldenmatch/goldenmatch/core/scorer.py'
+  # The trigger filter must mirror pyrightconfig.json's `include` -- a file that
+  # is type-checked but NOT a trigger lets a strict-type regression land
+  # undetected (a pipeline.py-only change did exactly that; the errors only
+  # surfaced when an unrelated PR touched scorer.py). Keep these in lockstep.
+  - 'packages/python/goldenmatch/goldenmatch/core/pipeline.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/blocker.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/cluster.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/profiler.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/learned_blocking.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/profile_emitter.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py'
+  - 'packages/python/goldenmatch/goldenmatch/_api.py'
+  - 'packages/python/goldenmatch/goldenmatch/utils/transforms.py'
   - 'packages/python/goldenmatch/goldenmatch/config/**'

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -20,6 +20,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   now wraps its whole write body in a single `IdentityStore.bulk_writes()`
   transaction -- N commits collapse to one and psycopg pipelines the statements.
   No-op for SQLite/Mongo; the resolve is now atomic per run.
+- **Unobserved `record_embedding` field no longer dilutes the weighted score
+  (#1859).** In the vectorized weighted scorer (`find_fuzzy_matches`), a
+  `record_embedding` field added its full weight to the score DENOMINATOR
+  unconditionally, while every other field type multiplied by an observed-value
+  mask -- so a row missing all its embedding columns still counted the field's
+  weight, diluting the pair score (the #1856 shape on a first-class weighted
+  scorer). It now masks the contribution out of both numerator and denominator
+  when a row is unobserved (all embedding columns null), pair-wise like every
+  other field. Clean data (no all-null embedding rows) is byte-identical.
 
 ### Added
 

--- a/packages/python/goldenmatch/goldenmatch/core/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/core/pipeline.py
@@ -274,19 +274,19 @@ def _score_probabilistic_matchkey(
     mk: Any,
     config: GoldenMatchConfig,
     *,
-    block_frame,
-    score_frame,
+    block_frame: Any,
+    score_frame: Any,
     matched_pairs: set,
     all_pairs: list,
     review_pairs: list,
-    target_ids=None,
+    target_ids: set[int] | None = None,
     across_files_only: bool = False,
-    source_lookup=None,
-    bench_dump_dir=None,
-    bench_candidate_pairs=None,
-    bench_emitted_pairs=None,
+    source_lookup: dict[int, str] | None = None,
+    bench_dump_dir: str | None = None,
+    bench_candidate_pairs: set[tuple[int, int]] | None = None,
+    bench_emitted_pairs: set[tuple[int, int]] | None = None,
     log_em: bool = False,
-    em_results=None,
+    em_results: dict | None = None,
 ) -> None:
     """Score one probabilistic (Fellegi-Sunter) matchkey, folding results into
     ``all_pairs`` / ``review_pairs`` and updating ``matched_pairs`` in place.
@@ -316,13 +316,20 @@ def _score_probabilistic_matchkey(
         score_probabilistic_blocks_batched,
     )
 
-    def _across_files_filter(pairs):
+    def _across_files_filter(pairs: list) -> list:
         if not across_files_only:
             return pairs
+        _sl = source_lookup or {}
         return [
             (a, b, s) for a, b, s in pairs
-            if source_lookup.get(a) != source_lookup.get(b)
+            if _sl.get(a) != _sl.get(b)
         ]
+
+    # The probabilistic scoring body always runs with blocking configured (FS
+    # without blocking is full O(n^2), which the pipeline never routes here);
+    # narrow the Optional for the build_blocks / score_buckets / external-blocks
+    # calls below.
+    assert config.blocking is not None, "probabilistic scoring requires blocking"
 
     # Resolve the bucket route BEFORE building blocks: skip build_blocks entirely
     # when the blocks feed nothing (bucket route + preloaded model + no bench
@@ -383,6 +390,9 @@ def _score_probabilistic_matchkey(
         for a, b, _s in pairs:
             matched_pairs.add((min(a, b), max(a, b)))
         if bench_dump_dir:
+            # bench_dump_dir set => the caller always supplies both bench sets.
+            assert bench_candidate_pairs is not None
+            assert bench_emitted_pairs is not None
             # Candidate ceiling: enumerate within-block pairs from the SAME
             # blocks score_buckets consumes (blocking is backend-independent);
             # `pairs` is already the emitted set.
@@ -413,6 +423,9 @@ def _score_probabilistic_matchkey(
     # Bench-dump path: per-block scoring for exact candidate/emitted accounting
     # (the batched path doesn't expose per-block candidates).
     if bench_dump_dir:
+        # bench_dump_dir set => the caller always supplies both bench sets.
+        assert bench_candidate_pairs is not None
+        assert bench_emitted_pairs is not None
         block_scorer = probabilistic_block_scorer(scoring_mk, em_result)
         for block in blocks:
             block_df = block.materialize().native
@@ -2164,7 +2177,9 @@ def _run_fused_fs_match_short_circuit(
     # short-circuit exists for).
     _need_blocks = not fs_model_preloaded(mk)
     blocks = (
-        list(build_blocks(collected_df.lazy(), config.blocking)) if _need_blocks else []
+        list(build_blocks(collected_df.lazy(), config.blocking))
+        if _need_blocks and config.blocking is not None
+        else []
     )
     blocking_fields = (
         collect_blocking_fields(config.blocking) if config.blocking else []

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1263,8 +1263,23 @@ def find_fuzzy_matches(
                         parts = [str(row.get(c, "") or "") for c in (f.columns or [])]
                         concat_values.append(" ".join(parts))
                     scores = _fuzzy_score_matrix(concat_values, "token_sort")
-                fuzzy_numerator += scores * _w(f)
-                fuzzy_denominator += _w(f)
+                # #1859: mask the record_embedding contribution like every other
+                # field. A row is unobserved on this field iff ALL its columns
+                # are null; a pair counts the field only when BOTH sides are
+                # observed. Without this, an unobserved record_embedding always
+                # added its full weight to the DENOMINATOR (diluting the score)
+                # -- the #1856 shape on a first-class weighted scorer. Clean data
+                # (no all-null emb rows) is unaffected: valid is then all-True.
+                emb_cols = f.columns or []
+                emb_row_null = np.ones(n, dtype=bool)
+                for c in emb_cols:
+                    col_vals = (
+                        block_df[c].to_list() if c in block_df.columns else [None] * n
+                    )
+                    emb_row_null &= np.array([v is None for v in col_vals])
+                emb_valid = ~(emb_row_null[:, None] | emb_row_null[None, :])
+                fuzzy_numerator += scores * _w(f) * emb_valid
+                fuzzy_denominator += _w(f) * emb_valid
             else:
                 values = _get_transformed_values(block_df, f)
                 null_mask = _build_null_mask(values)

--- a/packages/python/goldenmatch/tests/test_record_embedding_null_mask_1859.py
+++ b/packages/python/goldenmatch/tests/test_record_embedding_null_mask_1859.py
@@ -1,0 +1,82 @@
+"""#1859: the vectorized weighted scorer must mask an unobserved
+``record_embedding`` field out of BOTH the numerator and the denominator, like
+every other field type -- otherwise a row missing all its embedding columns
+still contributes the field's full weight to the denominator, diluting the score
+(the #1856 shape on a first-class weighted scorer).
+
+The real ``record_embedding`` scorer needs an embedding model (torch/HF), which
+hangs in CI here, so these tests stub ``_record_embedding_score_matrix`` with a
+fixed matrix and check the masking arithmetic at the ``find_fuzzy_matches`` level.
+"""
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+from goldenmatch.config.schemas import MatchkeyConfig, MatchkeyField
+from goldenmatch.core import scorer as scorer_mod
+from goldenmatch.core.scorer import find_fuzzy_matches
+
+
+def _mk() -> MatchkeyConfig:
+    # exact name (cheap field, always agrees below) + a record_embedding field.
+    return MatchkeyConfig(
+        name="mk",
+        type="weighted",
+        threshold=0.4,
+        fields=[
+            MatchkeyField(field="name", scorer="exact", weight=1.0),
+            MatchkeyField(scorer="record_embedding", columns=["bio"], weight=1.0),
+        ],
+    )
+
+
+def _df() -> pl.DataFrame:
+    # All names agree (exact -> 1.0). row2 has a NULL bio (unobserved on the
+    # record_embedding field); rows 0/1 both have a bio.
+    return pl.DataFrame(
+        {
+            "__row_id__": [0, 1, 2],
+            "name": ["alice", "alice", "alice"],
+            "bio": ["x", "y", None],
+        }
+    )
+
+
+def test_null_record_embedding_is_masked_out(monkeypatch):
+    # Stub the embedding similarity to a constant 0.0 (the model says "no
+    # similarity") so the arithmetic is unambiguous.
+    monkeypatch.setattr(
+        scorer_mod,
+        "_record_embedding_score_matrix",
+        lambda block_df, cols, **kw: np.zeros((block_df.height, block_df.height), dtype=np.float32),
+    )
+    pairs = find_fuzzy_matches(_df(), _mk())
+    scores = {(min(a, b), max(a, b)): s for a, b, s in pairs}
+
+    # Pair (0,1): both bio present -> emb (0.0) counts. score = (1*1 + 0*1)/(1+1) = 0.5.
+    assert (0, 1) in scores
+    assert abs(scores[(0, 1)] - 0.5) < 1e-6, scores
+
+    # Pairs with row2 (NULL bio): emb masked out. score = name only = 1/1 = 1.0.
+    # Without the fix these would dilute to 0.5 (emb wrongly in the denominator).
+    assert abs(scores[(0, 2)] - 1.0) < 1e-6, scores
+    assert abs(scores[(1, 2)] - 1.0) < 1e-6, scores
+
+
+def test_clean_data_unchanged(monkeypatch):
+    # No all-null embedding rows -> the mask is all-True, so behavior is
+    # byte-identical to before the fix (a pure correctness guard, no regression).
+    monkeypatch.setattr(
+        scorer_mod,
+        "_record_embedding_score_matrix",
+        lambda block_df, cols, **kw: np.full(
+            (block_df.height, block_df.height), 0.6, dtype=np.float32
+        ),
+    )
+    df = pl.DataFrame(
+        {"__row_id__": [0, 1], "name": ["alice", "alice"], "bio": ["x", "y"]}
+    )
+    pairs = find_fuzzy_matches(df, _mk())
+    scores = {(min(a, b), max(a, b)): s for a, b, s in pairs}
+    # (1*1 + 0.6*1) / (1 + 1) = 0.8
+    assert abs(scores[(0, 1)] - 0.8) < 1e-6, scores


### PR DESCRIPTION
## Summary

Fixes #1859. In the vectorized weighted scorer (`find_fuzzy_matches`), a `record_embedding` field added its full weight to the score **denominator unconditionally**, while every other field type multiplies its weight by a per-pair observed-value mask. The result: a row missing all of its embedding columns still counted the field's weight in the denominator, diluting the pair score toward 0.5 rather than letting the observed fields carry the decision. This is the #1856 dilution shape, but on a first-class weighted scorer path.

The fix masks the `record_embedding` contribution out of **both** the numerator and the denominator when a row is unobserved on that field — where "unobserved" means *all* of the field's embedding columns are null for that row — pair-wise, exactly like every other field type. Clean data (no all-null embedding rows) is byte-identical: the mask is then all-`True`, so numerator and denominator are unchanged.

## Changes

- `goldenmatch/core/scorer.py` — build a per-row null mask over the `record_embedding` field's columns, expand it to the NxN pair mask (`emb_row_null[:, None] | emb_row_null[None, :]`), and multiply both the numerator (`scores * _w(f)`) and denominator (`_w(f)`) contributions by `~mask`.
- `tests/test_record_embedding_null_mask_1859.py` — 2 tests: a pair whose rows are both unobserved on the embedding field scores from the *other* observed fields (not diluted to 0.5), and a clean-data case scores byte-identically to the pre-fix path.
- `CHANGELOG.md` — `### Fixed` entry under `[Unreleased]`.

## Bundled: clear latent pyright-strict errors that this PR surfaced

This PR's `scorer.py` change triggers the path-filtered `pyright` lane, which type-checks the whole `pyrightconfig.json` `include` in strict mode. That surfaced **19 pre-existing strict-type errors in `pipeline.py`** — landed by the fused-FS refactor (#1804 items 1+3 / #1892) and latent on `main` because `pipeline.py` was type-checked but **not** in the `pyright_slice` *trigger* filter, so its own PRs never ran the lane. `ci-required` was red on those, not on the `record_embedding` change.

Second commit fixes them:
- Resolve all 19 `pipeline.py` errors — annotate `_score_probabilistic_matchkey`'s keyword params; narrow the `config.blocking` Optional on the FS scoring path (an assert on an already-true invariant + a guard at the fused short-circuit's `build_blocks`); narrow the bench-dump sets inside their `if bench_dump_dir:` blocks; guard `_across_files_filter`'s null lookup. No behavior change (150 probabilistic/FS-bucket tests pass).
- Sync `.github/filters.yml::pyright_slice` to `pyrightconfig.json::include` (add pipeline/blocker/cluster/profiler/learned_blocking/profile_emitter/_profile_helpers/_api/utils.transforms) so a type-checked file is always also a trigger — closes the latent-regression hole. No new errors surface (the lane already checked these on every run).

## Test plan

- `pytest tests/test_record_embedding_null_mask_1859.py` — 2 passed.
- `pytest tests/test_probabilistic.py tests/test_fs_bucket_native.py` — 150 passed (the pipeline.py narrowing asserts never fire on a legitimate FS path).
- `pyright` (full slice) — 0 errors.
- `ruff check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf