### PR TITLE
release: goldenmatch 3.5.0 (full unreleased delta since v3.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ pip install golden-suite    # the WHOLE suite (Check + Flow + Match + Analysis +
 ```
 
 <!-- README-callouts:start  (auto-synced from packages/python/goldenmatch/CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
+> **v3.5.0** — **New `date` scorer for date fields (#1858).** `jaro_winkler` scores unrelated
+ISO birthdays 0.80+ (the fixed `YYYY-MM-DD` shape + shared digit alphabet
+dominate), so it can't tell a typo from a different person. The `date` scorer
+compares dates by Damerau-Levenshtein over the canonical digits — a typo scores
+0.90, an unrelated date 0.00 — with a `levenshtein` fallback for non-ISO input.
+Cross-surface (Python, native kernel, TypeScript), and a preflight check warns
+when a name-oriented scorer sits on a date field.
+>
 > **v3.4.0** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
 `record_embedding` field scorers now train (EM) and score end-to-end on the
 probabilistic path via the vectorized matrix — previously they raised
@@ -72,13 +80,6 @@ migration upgrade pass gains a **fan-out lever** — a risk-gated NE suggestion
 plus cluster-guard tuning from your reference clusters. `goldenmatch-native`
 0.1.15 scores NE in the Rust kernels (`FS_SUPPORTS_NE`; older wheels keep the
 pure-Python fallback automatically).
->
-> **v3.1.0** — **3.1.0 — polars is optional (and the polars-free install is the fast
-configuration).** The engine is Arrow-native end to end with the Rust fused
-kernels on the hot paths (a zero-polars CI gate proves a full dedupe with
-polars imports blocked); `pip install 'goldenmatch[polars]'` is a
-compatibility extra (classic lane, kernel-absent golden replay,
-cell-quality weighting), byte-identical to 3.0.x.
 <!-- README-callouts:end -->
 
 ---

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,6 +2,24 @@
 
 Newest first. One entry per meaningful change to the network.
 
+## 2026-07-18 -- goldenmatch 3.5.0: `date` scorer + cross-surface consistency hardening
+- Cut **goldenmatch 3.5.0** (docs sweep + release). Headline: the `date` scorer
+  (#1858) -- `jaro_winkler` scores unrelated ISO birthdays 0.80+, so `date`
+  compares by Damerau-Levenshtein over the canonical digits (typo 0.90 /
+  unrelated 0.00), canonical impl in the Rust `score-core` kernel funneled to
+  native + pure-Python + TypeScript (byte-identical). No new ADR: it is an
+  instance of the established "Rust is the reference, mirror cross-surface"
+  scorer pattern, not a new architectural decision. Documented in
+  `docs-site/goldenmatch/scoring.mdx` (scorer table + "Date fields" section).
+- Also in the release train: fused FS multi-pass + pipeline routing, Postgres
+  identity-resolution single-transaction fix (#1886).
+- Consistency-hardening wave (post-release, not gating 3.5.0): NE fast/slow-path
+  parity (#1888), api_parity/native_symbols made blocking + scorer/transform
+  surfaces added (#1889), BUCKET_HASH_SEED single-sourced + native scorer-id
+  cross-surface gate (#1890), and the version_consistency gate extended to
+  TypeScript (#1885). Same through-line: gates that guarded a cross-surface
+  invariant while watching only one surface.
+
 ## 2026-07-17 -- Context-network sweep: the FS scale + hardening wave (ADRs 0041-0045)
 - Swept the 2026-07-16..18 window (~40 PRs, shipped as **goldenmatch 3.4.0** +
   the suite minor train #1849) that the network had not yet captured. Five new

--- a/context-network/meta/updates.md
+++ b/context-network/meta/updates.md
@@ -2,23 +2,38 @@
 
 Newest first. One entry per meaningful change to the network.
 
-## 2026-07-18 -- goldenmatch 3.5.0: `date` scorer + cross-surface consistency hardening
-- Cut **goldenmatch 3.5.0** (docs sweep + release). Headline: the `date` scorer
-  (#1858) -- `jaro_winkler` scores unrelated ISO birthdays 0.80+, so `date`
-  compares by Damerau-Levenshtein over the canonical digits (typo 0.90 /
-  unrelated 0.00), canonical impl in the Rust `score-core` kernel funneled to
-  native + pure-Python + TypeScript (byte-identical). No new ADR: it is an
-  instance of the established "Rust is the reference, mirror cross-surface"
-  scorer pattern, not a new architectural decision. Documented in
-  `docs-site/goldenmatch/scoring.mdx` (scorer table + "Date fields" section).
-- Also in the release train: fused FS multi-pass + pipeline routing, Postgres
-  identity-resolution single-transaction fix (#1886).
-- Consistency-hardening wave (post-release, not gating 3.5.0): NE fast/slow-path
-  parity (#1888), api_parity/native_symbols made blocking + scorer/transform
-  surfaces added (#1889), BUCKET_HASH_SEED single-sourced + native scorer-id
-  cross-surface gate (#1890), and the version_consistency gate extended to
-  TypeScript (#1885). Same through-line: gates that guarded a cross-surface
-  invariant while watching only one surface.
+## 2026-07-18 -- goldenmatch 3.5.0: ships the FS correctness/coverage wave + `date` scorer
+- Cut **goldenmatch 3.5.0** (docs sweep + release). This release ships the whole
+  unreleased delta since 3.4.0 (~46 PRs) to PyPI, not one feature. The
+  architectural decisions were already captured in ADRs 0041-0045 (swept
+  2026-07-17, #1879); 3.5.0 is where they reach users. Four threads:
+  - **FS missing-value correctness (ADR 0041).** Restores `historical_50k`
+    probabilistic F1 0.33 -> 0.83: missing-value semantics are a per-matchkey
+    toggle auto-selected per dataset (#1851), the native kernel declines
+    `disagree`-mode matchkeys to numpy (#1872), null fields no longer cap a pair
+    below threshold (#1856), unobserved fields stop adding max evidence in
+    splink-upgrade calibration (#1861), and null block keys stop forming false
+    mega-blocks across bucket / sorted_neighborhood / learned blocking
+    (#1857/#1860).
+  - **100% native FS coverage (ADR 0042).** New pyo3-free `goldenmatch-fs-core`
+    crate shared by the native kernel + TS/WASM; kernel now owns every FS
+    comparison scorer incl. ensemble/TF (#1869) and embeddings (#1871). Fused FS
+    covers multi-pass blocking + pipeline routing.
+  - **The `date` scorer (#1858)** -- the one net-new user-facing capability.
+    `jaro_winkler` scores unrelated ISO birthdays 0.80+, so `date` compares by
+    Damerau-Levenshtein over the canonical digits (typo 0.90 / unrelated 0.00),
+    canonical impl in the Rust `score-core` kernel funneled to native +
+    pure-Python + TypeScript. Documented in `docs-site/goldenmatch/scoring.mdx`.
+  - **Correctness fixes + hardening:** `from_splink` discards the random-pair
+    prior (#1878), autoconfig compound blocking survives Arrow input (#1875),
+    bucket NE fast/slow-path parity (#1888), Postgres single-transaction resolve
+    (#1886) + `gm_run` batch writes (#1883), `sail` dep pins (#1862/#1866/#1873),
+    and cross-surface gates (version_consistency covers TS #1885; BUCKET_HASH_SEED
+    single-sourced + native scorer-id gate #1890; api_parity/native_symbols
+    blocking #1889).
+- Siblings (goldencheck/goldenflow/goldenpipe/infermap) had only the transitive
+  `mcp` bump; goldenanalysis had an internal byte-identical interner refactor
+  (#1880/#1881) -- none release-worthy, so this is a goldenmatch-only cut.
 
 ## 2026-07-17 -- Context-network sweep: the FS scale + hardening wave (ADRs 0041-0045)
 - Swept the 2026-07-16..18 window (~40 PRs, shipped as **goldenmatch 3.4.0** +

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -13,6 +13,7 @@ GoldenMatch provides 10+ scoring methods for comparing record pairs. Scoring run
 | `exact` | Binary 0/1 match | 0 or 1 | Email, phone, ID |
 | `jaro_winkler` | Edit distance with prefix bonus | 0.0--1.0 | Names |
 | `levenshtein` | Normalized Levenshtein distance | 0.0--1.0 | General strings |
+| `date` | Damerau-Levenshtein over canonical ISO digits | 0.0--1.0 | Dates (`dob`, `birth_date`) |
 | `token_sort` | Sort tokens, then ratio | 0.0--1.0 | Names, addresses |
 | `soundex_match` | Phonetic code comparison | 0 or 1 | Names |
 | `ensemble` | max(jaro_winkler, token_sort, soundex) | 0.0--1.0 | Names with reordering |
@@ -23,7 +24,32 @@ GoldenMatch provides 10+ scoring methods for comparing record pairs. Scoring run
 | `name_freq_weighted_jw` | Jaro-Winkler modulated by US Census surname IDF | 0.0--1.0 | `last_name` / `surname` |
 | `given_name_aliased_jw` | Jaro-Winkler with alias-aware exact bonus | 0.0--1.0 | `first_name` / `given_name` |
 
-The last two ship as part of the bundled reference-data packs and are picked automatically by auto-config when a column matches the relevant name pattern AND its profiled `col_type` agrees. See [Reference Data](/goldenmatch/reference-data) for the full pack overview, refinement rules, and the col_type gate.
+The `name_freq_weighted_jw` / `given_name_aliased_jw` scorers ship as part of the bundled reference-data packs and are picked automatically by auto-config when a column matches the relevant name pattern AND its profiled `col_type` agrees. See [Reference Data](/goldenmatch/reference-data) for the full pack overview, refinement rules, and the col_type gate.
+
+### Date fields
+
+Do **not** score an ISO date with `jaro_winkler`. The fixed `YYYY-MM-DD` shape, the shared digit alphabet, and the common `19..`/`20..` prefix push *unrelated* birthdays to 0.80+, so a threshold that admits a one-digit typo also admits a different person — precision collapses on any date column that blocking co-locates by birth year.
+
+The `date` scorer parses both sides as ISO dates and compares them by Damerau-Levenshtein edit distance over the eight canonical digits (a swapped-digit typo is one edit), mapped so a single-digit typo stays high while an unrelated date drops to 0:
+
+```
+1980-01-01 vs 1980-01-01  -> 1.00   (same)
+1980-01-01 vs 1980-01-02  -> 0.90   (one-digit typo)
+1980-01-01 vs 1975-01-01  -> 0.75   (two edits)
+1980-01-01 vs 1975-11-30  -> 0.00   (unrelated)   # jaro_winkler gives this 0.80
+```
+
+Non-ISO input falls back to `levenshtein`. Auto-config already skips date columns as fuzzy fields, so `date` is for hand-written / Splink-converted configs; a preflight check warns when a name-oriented scorer (`jaro_winkler` / `token_sort` / ...) is placed on a date field.
+
+```yaml
+matchkeys:
+  - name: person
+    type: weighted
+    fields:
+      - field: dob
+        scorer: date
+        weight: 0.3
+```
 
 ## Fuzzy scoring
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -32,6 +32,69 @@ when a name-oriented scorer sits on a date field.
   now wraps its whole write body in a single `IdentityStore.bulk_writes()`
   transaction -- N commits collapse to one and psycopg pipelines the statements.
   No-op for SQLite/Mongo; the resolve is now atomic per run.
+- **`historical_50k` probabilistic F1 restored 0.33 -> 0.83 (#1846, #1851, #1872).**
+  #1834 (from 3.4.0's train) made a missing FS field carry no evidence
+  (`unobserved` semantics) instead of counting as disagreement. Textbook
+  Fellegi-Sunter when data is missing-at-random, but wrong when missingness is
+  informative -- on null-heavy corpora a pair agreeing on its few populated
+  fields looked certain and the dataset mass-merged (F1 0.83 -> 0.33,
+  recall-only, no error or warning). Fixed in three parts: FS missing-value
+  semantics are now a per-matchkey toggle (`unobserved` vs `disagree`) and
+  auto-config picks the mode per dataset from its null profile (#1851); the
+  native FS kernel -- which only implements the neutral/`unobserved` mode --
+  now declines to `disagree`-mode matchkeys and routes them to the numpy path
+  that honors both (#1872); and a regression test pins the shape (#1867).
+- **Null fields no longer make a record unmatchable (#1856).** The live weighted
+  scorer accumulated `weight_sum` over the observed fields but then divided
+  `score_sum` by `total_weight`, so a pair with any null comparison field was
+  capped below the sum of the non-null weights -- e.g. a null `dob` capped the
+  pair at 0.70 under a 0.85 threshold, unmatchable however perfectly the names
+  agreed. The live path now renormalizes by the observed weight
+  (`score_sum / weight_sum`), matching what `core/scorer.py::score_pair` always
+  did.
+- **Null block keys no longer form a false mega-block (#1857, #1859, #1860).** A
+  null blocking key means "this row cannot be blocked", not "it blocks with
+  every other unblockable row". `build_blocks` filtered invalid keys but three
+  scoring/blocking paths did not: the bucket scorer (#1857 -- 9,846 null-postcode
+  rows collapsed into one 48.5M-comparison bucket at 1M rows, 8,571 of 8,682
+  false positives), `sorted_neighborhood` (a null sort key windowed adjacent
+  rows together), and `learned` multi-predicate blocking (an all-missing key
+  joined to a truthy `||` that leaked past the caller's guard) (#1860). All now
+  filter invalid keys the way `static`/`multi_pass` already did (keeping `""`
+  per #390). Bucket precision on the 1M person shape 0.96 -> 0.9995 at 0.04%
+  recall cost.
+- **Unobserved FS fields no longer add spurious match evidence in calibration
+  (#1859, #1861).** Two splink-upgrade calibration sites summed
+  `match_weights[name][vec[k]]` unguarded; for an unobserved field
+  `vec[k] == -1` indexed `weights[-1]`, the highest-agreement weight, so a null
+  field contributed the maximum evidence *for* a match (e.g. +6 bits for a null
+  `dob`) into the fan-out NE posteriors and the learned link/review thresholds.
+  Both now skip unobserved fields via a shared `fs_regular_weight_sum` helper,
+  matching every runtime FS scorer's existing `vec[k] < 0` guard.
+- **`auto_configure_df` no longer crashes on wide/sparse Arrow input (#1852,
+  #1875).** `_build_compound_blocking` still used three polars-only idioms
+  (`null_count()`, `n_unique()`, `group_by().len()`) that `AttributeError`'d on a
+  `pa.Table`; with Arrow-native auto-config default-on (2026-07-14) any input
+  reaching the compound-blocking fallback crashed (live on 3.3.1/3.4.0, hit by
+  the Golden Truth archive ingest). Routed through the backend-neutral `to_frame`
+  seam like its sibling helpers.
+- **`from_splink` import no longer collapses recall without `--upgrade` (#1802,
+  #1878).** `from_splink` imported Splink's random-pair
+  `probability_two_random_records_match` raw into `EMResult.proportion_matched`,
+  a field GoldenMatch's threshold/posterior math assumes is a within-block prior
+  (orders of magnitude higher). So a plain `from_splink()` pushed the link cut
+  into the extreme tail of the blocked-pair distribution (#1760 dogfood F1
+  0.482 -> 0.157). The random-pair prior is now discarded at import; the
+  within-block prior is estimated from the data (what `--upgrade` already did).
+- **Bucket fast path declines negative-evidence scorers it can't honor (#1888).**
+  The bucket scorer's fast path resolved negative-evidence specs to zero penalty
+  for scorers not in its direct set (ensemble, qgram, date), silently diverging
+  from the slow path's 0.5 penalty. It now declines the fast path when a
+  matchkey carries an NE scorer it can't score directly, so bucket and slow paths
+  agree.
+- **Postgres extension batches `gm_run` result writes (#1883).** The
+  `goldenmatch_pg` result-write path committed per row; it now batches the writes
+  and documents the JSON table handoff.
 
 ### Added
 
@@ -76,6 +139,45 @@ when a name-oriented scorer sits on a date field.
   through the pipeline: 4.5x leaner peak RSS + 5x faster on a 120K all-merge FS
   dedupe (442 MB vs 2004 MB). Off by default (fires only under memory pressure
   on an artifact-free config); `GOLDENMATCH_MATCH_FUSED=0` is the kill-switch.
+- **The native kernel now owns every Fellegi-Sunter comparison scorer (#1788,
+  #1869, #1871).** FS block scoring was the repo's parity orphan -- three
+  hand-synced implementations (Python numpy + scalar, the native pyo3 crate,
+  the TS port). The scoring math is extracted into a new pyo3-free
+  `goldenmatch-fs-core` crate consumed by both the native kernel and the TS/WASM
+  surface, so cross-surface parity is by construction. The kernel now covers
+  100% of FS comparison scorers -- the reference-data name scorers, the Winkler
+  TF adjustment, the ensemble scorer (#1869), and the model-backed `embedding` /
+  `record_embedding` scorers (#1871, scored as cosine over the L2-normalized
+  vectors, byte-comparable to the numpy reference). Previously any of these on a
+  matchkey forced the whole matchkey onto the numpy fallback; now the native
+  path is fully covered and numpy is the lossy fallback for the missing-value
+  modes it doesn't yet express.
+- **FS missing-value semantics are a per-matchkey toggle, auto-selected (#1846,
+  #1851).** A matchkey now carries whether a null field is `unobserved` (no
+  evidence, missing-at-random) or `disagree` (evidence against, informative
+  missingness); auto-config picks the mode per dataset from its null profile.
+  See the Fixed entry above for the `historical_50k` regression this closed.
+
+### Changed
+
+- **The three FS scoring sites are consolidated behind one entry point (#1804,
+  #1882, #1884, #1887).** The pipeline, the TUI, and the distributed path now all
+  score probabilistic matchkeys through `score_probabilistic_matchkey` instead of
+  three drifting copies -- no behavior change, but the FS routing/missing-value
+  fixes in this release land once instead of three times.
+- **Dependency pins for the `sail` extra (#1862, #1866, #1868, #1873).**
+  `pyspark[connect]` is pinned `>=3.5,<4` (pyspark 4's Spark Connect client
+  chokes on size-suffixed configs like `"3GB"`; pysail 0.6 targets the Spark 3.5
+  protocol), and `setuptools>=68` is required on Python 3.12 (pyspark 3.5 imports
+  the stdlib `distutils` that 3.12 removed). The `sail` and `inhouse-embeddings`
+  extras are declared mutually conflicting (#1868) so the resolver stops trying
+  to co-install their incompatible transitive pins.
+- Bumped `mcp` 1.27.0 -> 1.28.1 (#1850).
+- **Cross-surface consistency is now gated (#1885, #1888, #1890).**
+  `version_consistency` covers the TypeScript packages; the bucket-hash seed is
+  single-sourced and the native scorer-id maps are pinned canonically and
+  behaviorally, so a renumber or a value drift fails CI instead of silently
+  mis-dispatching.
 
 ## [3.4.0] - 2026-07-16
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.5.0] - 2026-07-18
+
+<!-- README-callout
+**New `date` scorer for date fields (#1858).** `jaro_winkler` scores unrelated
+ISO birthdays 0.80+ (the fixed `YYYY-MM-DD` shape + shared digit alphabet
+dominate), so it can't tell a typo from a different person. The `date` scorer
+compares dates by Damerau-Levenshtein over the canonical digits — a typo scores
+0.90, an unrelated date 0.00 — with a `levenshtein` fallback for non-ISO input.
+Cross-surface (Python, native kernel, TypeScript), and a preflight check warns
+when a name-oriented scorer sits on a date field.
+-->
+
 ### Fixed
 
 - **Postgres identity resolution no longer autocommits per record (#1886).** The
@@ -23,6 +35,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Added
 
+- **Date-aware `date` scorer (#1858).** A comparison scorer for date fields.
+  `jaro_winkler` on an ISO date scores unrelated birthdays 0.80+ (the fixed
+  `YYYY-MM-DD` shape, shared digit alphabet, and `19..`/`20..` prefix dominate),
+  so at any usable cutoff a typo is indistinguishable from a different person —
+  precision craters wherever blocking co-locates same-year records. `date`
+  parses both sides as ISO dates and scores by Damerau-Levenshtein over the eight
+  canonical digits (a swapped-digit typo is one edit): `d0→1.0 / d1→0.90 /
+  d2→0.75 / d≥3→0.0`, mirroring Splink's `DamerauLevenshtein<=2`. Non-ISO input
+  falls back to `levenshtein`. The canonical implementation lives in the Rust
+  `score-core` kernel and funnels to the native PyO3 extension, the pure-Python
+  fallback, and the TypeScript port (byte-identical, parity-tested). Not
+  auto-config-reachable (date columns are skipped as fuzzy fields), so it is for
+  hand-written / Splink-converted configs; a preflight check warns when a
+  name-oriented scorer (`jaro_winkler` / `token_sort` / ...) is placed on a date
+  field. Bumps `goldenmatch-native` to 0.1.18.
 - **Fused Fellegi-Sunter match now covers multi-pass blocking.** New
   `match_fused_fs_multipass_ready` / `run_match_fused_fs_multipass_arrow`
   (`core/fused_match.py`) expand the fused FS path from single-static-key

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -57,6 +57,14 @@ npm install goldenmatch
 > core parity. Version map + rationale: [`docs/versioning-policy.md`](docs/versioning-policy.md).
 
 <!-- README-callouts:start  (auto-synced from CHANGELOG.md by scripts/sync_readme_callouts.py — edit the CHANGELOG, not this block) -->
+> **v3.5.0** — **New `date` scorer for date fields (#1858).** `jaro_winkler` scores unrelated
+ISO birthdays 0.80+ (the fixed `YYYY-MM-DD` shape + shared digit alphabet
+dominate), so it can't tell a typo from a different person. The `date` scorer
+compares dates by Damerau-Levenshtein over the canonical digits — a typo scores
+0.90, an unrelated date 0.00 — with a `levenshtein` fallback for non-ISO input.
+Cross-surface (Python, native kernel, TypeScript), and a preflight check warns
+when a name-oriented scorer sits on a date field.
+>
 > **v3.4.0** — **Embeddings are first-class on Fellegi-Sunter matchkeys.** `embedding` and
 `record_embedding` field scorers now train (EM) and score end-to-end on the
 probabilistic path via the vectorized matrix — previously they raised
@@ -71,13 +79,6 @@ migration upgrade pass gains a **fan-out lever** — a risk-gated NE suggestion
 plus cluster-guard tuning from your reference clusters. `goldenmatch-native`
 0.1.15 scores NE in the Rust kernels (`FS_SUPPORTS_NE`; older wheels keep the
 pure-Python fallback automatically).
->
-> **v3.1.0** — **3.1.0 — polars is optional (and the polars-free install is the fast
-configuration).** The engine is Arrow-native end to end with the Rust fused
-kernels on the hot paths (a zero-polars CI gate proves a full dedupe with
-polars imports blocked); `pip install 'goldenmatch[polars]'` is a
-compatibility extra (classic lane, kernel-absent golden replay,
-cell-quality weighting), byte-identical to 3.0.x.
 <!-- README-callouts:end -->
 
 ---

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.4.0"
+version = "3.5.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## What
Docs sweep + version cut for **goldenmatch 3.5.0**. This ships the whole unreleased delta since v3.4.0 (~46 PRs), not one feature. The architecture was already ADR'd (0041-0045, #1879); 3.5.0 is where it reaches PyPI.

**Fixed (correctness)**
- `historical_50k` probabilistic F1 restored **0.33 → 0.83** — FS missing-value semantics are a per-matchkey toggle auto-selected per dataset (#1851), native kernel declines `disagree`-mode to numpy (#1872), regression pinned (#1867).
- Null fields no longer make a record unmatchable (#1856); null block keys no longer form false mega-blocks across bucket / sorted_neighborhood / learned (#1857, #1860); unobserved fields stop adding max evidence in splink-upgrade calibration (#1861).
- `auto_configure_df` survives wide/sparse Arrow input (#1875); `from_splink` discards the random-pair prior (#1878); bucket NE fast/slow-path parity (#1888); Postgres single-transaction resolve (#1886) + `gm_run` batch writes (#1883).

**Added**
- Date-aware **`date` scorer** (#1858) — the net-new capability (Damerau-Levenshtein over canonical ISO digits; Rust→native→Python→TS, parity-tested; preflight guard).
- **100% native FS coverage** via the pyo3-free `fs-core` crate (#1869, #1871); fused FS multi-pass + pipeline routing.

**Changed**
- FS-scoring-site consolidation (#1804/#1882/#1884/#1887); `sail` dep pins (#1862/#1866/#1873); `mcp` 1.27→1.28.1 (#1850); cross-surface gates — version_consistency covers TS (#1885), BUCKET_HASH_SEED single-sourced + native scorer-id gate (#1890).

Version lockstep → 3.5.0 (`pyproject` / `__init__` / `server.json`). Docs: `scoring.mdx` (date scorer), context-network log entry. Siblings had only the transitive `mcp` bump / an internal refactor → goldenmatch-only cut.

## Gates (local)
- `version_consistency`: 32 packages, lockstep ✅
- `sync_readme_callouts --check`: clean ✅
- `docs.json`: parses ✅

## Release
After merge: cut `v3.5.0` → fires `publish-goldenmatch.yml` (PyPI) + `publish-mcp.yml` (registry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd