### PR TITLE
perf(suggest): bound the config-healer loop cost with cache + tunable caps (#1404)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Changed
+
+- **Config-healer loop cost is now bounded and tunable (#1404).** `heal` (and
+  the `review_config` / `suggest_from_result` verify path it drives) could run up
+  to `step_cap × (1 + max_verify)` full pipeline passes per call — ~45 on the
+  defaults — plus a full goldencheck `blocking_risk` variant scan (O(distinct²)
+  per string column) re-run on the unchanged frame every iteration. Three cost
+  levers, all defaulting to byte-identical behavior:
+  - The goldencheck variant scan is **memoized for the whole heal loop** via a
+    new `variant_risk_cache()` scope (`core/suggest/adapter.py`) keyed on the
+    data-column set — it runs once over the frame instead of once per iteration.
+    Output is unchanged; only the cost moves.
+  - **Verify fan-out is tunable**: `review_config`/`suggest_from_result`/`heal`
+    take `max_verify`, and `GOLDENMATCH_SUGGEST_MAX_VERIFY` sets it globally
+    (default 8). Since the healer applies only the top surviving suggestion,
+    `max_verify=1` verifies just that candidate — the cheapest mode.
+  - **Marginal-gain early-stop**: `heal(min_health_gain=…)` /
+    `GOLDENMATCH_HEAL_MIN_HEALTH_GAIN` stops the loop once cluster-health gain
+    flattens (fail-open — a result without clusters never triggers a stop). Off
+    by default. `GOLDENMATCH_HEAL_STEP_CAP` also exposes the outer cap.
+
 ## [3.5.0] - 2026-07-18
 
 <!-- README-callout

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py
@@ -35,6 +35,8 @@ bench A/B) or with the environment variable ``GOLDENMATCH_SUGGEST_VERIFY=0``.
 """
 from __future__ import annotations
 
+import contextlib
+import contextvars
 import copy
 import json
 import logging
@@ -47,6 +49,59 @@ from goldenmatch._polars_lazy import pl
 from goldenmatch.core.suggest.types import Suggestion, SuggestionsNativeRequired
 
 logger = logging.getLogger(__name__)
+
+# Cache for the expensive goldencheck ``blocking_risk`` (variant-rate) scan,
+# scoped to a single frame (#1404). ``blocking_risk`` runs an O(distinct^2)
+# fuzzy-variant comparison per string column; the heal loop re-profiles the SAME
+# unchanged ``df`` on every iteration, so memoizing the scan for the loop's
+# lifetime turns N scans into 1. Keyed on the data-column set so a different
+# frame never reads a stale entry; a ContextVar so nested/concurrent scopes
+# don't collide. Empty (None) unless a ``variant_risk_cache()`` scope is active,
+# in which case the scan is byte-identical but computed once.
+_VARIANT_RISK_CACHE: contextvars.ContextVar[dict | None] = contextvars.ContextVar(
+    "goldenmatch_variant_risk_cache", default=None
+)
+
+
+@contextlib.contextmanager
+def variant_risk_cache():
+    """Scope a single-frame variant-risk cache across repeated suggest calls.
+
+    The healer re-runs ``suggest_from_result`` (→ ``_build_column_signals_batch``
+    → goldencheck ``blocking_risk``) once per iteration over an unchanged frame.
+    Wrapping the loop in this context memoizes that scan so it runs once instead
+    of once-per-iteration (#1404). Output is byte-identical; only the cost moves.
+
+    Re-entrant: a nested scope reuses the outer cache rather than shadowing it.
+    """
+    token = None
+    if _VARIANT_RISK_CACHE.get() is None:
+        token = _VARIANT_RISK_CACHE.set({})
+    try:
+        yield
+    finally:
+        if token is not None:
+            _VARIANT_RISK_CACHE.reset(token)
+
+
+def _cached_blocking_risk(df: pl.DataFrame, data_cols: list[str]) -> dict:
+    """``blocking_risk(df.select(data_cols))`` with the #1404 single-frame cache.
+
+    Reads/writes ``_VARIANT_RISK_CACHE`` when a ``variant_risk_cache()`` scope is
+    active (keyed on the data-column set), else computes directly. Fail-open: any
+    error → ``{}`` (the same value used when goldencheck is absent)."""
+    cache = _VARIANT_RISK_CACHE.get()
+    key = frozenset(data_cols)
+    if cache is not None and key in cache:
+        return cache[key]
+    from goldenmatch.core.quality import blocking_risk
+    try:
+        risk = blocking_risk(df.select(data_cols)) or {}
+    except Exception:
+        risk = {}
+    if cache is not None:
+        cache[key] = risk
+    return risk
 
 # ── Arrow schemas (frozen - must match the Rust kernel exactly) ────────────
 
@@ -286,7 +341,6 @@ def _build_column_signals_batch(
     - variant_rate: blocking_risk() -- defaults to 0.0 when goldencheck absent
     """
     from goldenmatch.core.indicators import compute_column_priors
-    from goldenmatch.core.quality import blocking_risk
 
     # -- Which columns to include (all non-internal data columns) --
     data_cols = [c for c in df.columns if not c.startswith("__")]
@@ -363,10 +417,9 @@ def _build_column_signals_batch(
     if cheap:
         variant_risk: dict = {}
     else:
-        try:
-            variant_risk = blocking_risk(df.select(data_cols)) or {}
-        except Exception:
-            variant_risk = {}
+        # #1404: memoized across a variant_risk_cache() scope (the heal loop);
+        # byte-identical to the direct scan, just computed once per frame.
+        variant_risk = _cached_blocking_risk(df, data_cols)
 
     # -- Assemble rows --
     rows_field: list[str] = []
@@ -469,6 +522,26 @@ def _diagnostic_scored_pairs(engine, df, config):
 # Maximum number of candidate suggestions to verify (avoids runaway cost
 # when the kernel returns an unusually large list).
 _MAX_VERIFY_CANDIDATES: int = 8
+
+
+def _resolve_max_verify(max_verify: int | None) -> int:
+    """Resolve the verify fan-out cap (#1404): explicit kwarg → env
+    ``GOLDENMATCH_SUGGEST_MAX_VERIFY`` → the ``_MAX_VERIFY_CANDIDATES`` default.
+
+    Each verified candidate costs one full pipeline re-run, so a consumer that
+    needs latency over thoroughness (e.g. the healer, which applies only the top
+    surviving suggestion) can lower it — ``=1`` verifies just the top candidate.
+    A value < 1 is clamped to 1 (verifying zero candidates would drop every
+    suggestion). Invalid env values fall back to the default."""
+    if max_verify is None:
+        raw = os.environ.get("GOLDENMATCH_SUGGEST_MAX_VERIFY", "").strip()
+        if not raw:
+            return _MAX_VERIFY_CANDIDATES
+        try:
+            max_verify = int(raw)
+        except ValueError:
+            return _MAX_VERIFY_CANDIDATES
+    return max(1, max_verify)
 
 # Epsilon: keep a suggestion if cand_health >= baseline_health - EPS.
 # Near-zero so we only suppress genuine health regressions.
@@ -605,11 +678,14 @@ def _kernel_suggest(
     return _parse_suggestions(raw_json)
 
 
-def _verify_suggestions(suggestions, df, config, clusters, engine) -> list[Suggestion]:
+def _verify_suggestions(
+    suggestions, df, config, clusters, engine, *, max_verify: int | None = None
+) -> list[Suggestion]:
     """Self-verification pass: re-run the pipeline per candidate suggestion and
     keep only the non-worsening ones (cand_health >= baseline_health - EPS).
-    Caps verification at ``_MAX_VERIFY_CANDIDATES``; the tail passes through
-    unverified.  Verification failures are conservative (keep the suggestion)."""
+    Caps verification at the resolved fan-out (``max_verify`` kwarg → env →
+    ``_MAX_VERIFY_CANDIDATES``); the tail passes through unverified.
+    Verification failures are conservative (keep the suggestion)."""
     # Compute baseline health from the baseline run's scored pairs + threshold.
     from goldenmatch.core.suggest.apply import apply_suggestion
     from goldenmatch.core.suggest.health import suggestion_health_from_clusters
@@ -624,9 +700,10 @@ def _verify_suggestions(suggestions, df, config, clusters, engine) -> list[Sugge
         baseline_health, n_records, len(clusters),
     )
 
-    # Cap verification at _MAX_VERIFY_CANDIDATES (cost guard)
-    candidates = suggestions[:_MAX_VERIFY_CANDIDATES]
-    tail = suggestions[_MAX_VERIFY_CANDIDATES:]  # pass through unverified if any
+    # Cap verification at the resolved fan-out (cost guard; #1404 makes it tunable)
+    cap = _resolve_max_verify(max_verify)
+    candidates = suggestions[:cap]
+    tail = suggestions[cap:]  # pass through unverified if any
 
     verified: list[Suggestion] = []
     for s in candidates:
@@ -693,6 +770,7 @@ def review_config(
     *,
     priors: dict | None = None,
     verify: bool = True,
+    max_verify: int | None = None,
 ) -> list[Suggestion]:
     """Analyze a dedupe run and return config improvement suggestions.
 
@@ -787,10 +865,14 @@ def review_config(
         return suggestions
 
     # -- Self-verification pass (verify=True) --
-    return _verify_suggestions(suggestions, df, _config, clusters, engine)
+    return _verify_suggestions(
+        suggestions, df, _config, clusters, engine, max_verify=max_verify
+    )
 
 
-def suggest_from_result(result, df, *, priors=None, verify=False) -> list[Suggestion]:
+def suggest_from_result(
+    result, df, *, priors=None, verify=False, max_verify: int | None = None
+) -> list[Suggestion]:
     """Artifacts-in suggestion: reuse result.scored_pairs/result.clusters (NO
     pipeline re-run for verify=False) and call the kernel directly. verify=True
     runs the per-candidate simulation loop (which DOES re-run). Returns [] when
@@ -830,4 +912,6 @@ def suggest_from_result(result, df, *, priors=None, verify=False) -> list[Sugges
         return suggestions
     from goldenmatch.tui.engine import MatchEngine
     engine = MatchEngine.from_dataframe(df)
-    return _verify_suggestions(suggestions, df, config, clusters, engine)
+    return _verify_suggestions(
+        suggestions, df, config, clusters, engine, max_verify=max_verify
+    )

--- a/packages/python/goldenmatch/goldenmatch/core/suggest/surface.py
+++ b/packages/python/goldenmatch/goldenmatch/core/suggest/surface.py
@@ -110,26 +110,114 @@ class HealOutcome:
 _HEAL_STEP_CAP = 5
 
 
-def heal(df, config, *, step_cap: int = _HEAL_STEP_CAP) -> HealOutcome:
+def _resolve_step_cap(step_cap: int | None) -> int:
+    """Resolve the heal iteration cap (#1404): explicit kwarg → env
+    ``GOLDENMATCH_HEAL_STEP_CAP`` → the ``_HEAL_STEP_CAP`` default. Each step is a
+    full dedupe plus up to ``max_verify`` verification re-runs, so this is the
+    coarsest cost lever. Clamped to >= 1; invalid env falls back to the default."""
+    if step_cap is None:
+        raw = os.environ.get("GOLDENMATCH_HEAL_STEP_CAP", "").strip()
+        if not raw:
+            return _HEAL_STEP_CAP
+        try:
+            step_cap = int(raw)
+        except ValueError:
+            return _HEAL_STEP_CAP
+    return max(1, step_cap)
+
+
+def _resolve_min_health_gain(min_health_gain: float | None) -> float | None:
+    """Resolve the marginal-gain early-stop threshold (#1404): explicit kwarg →
+    env ``GOLDENMATCH_HEAL_MIN_HEALTH_GAIN`` → ``None`` (disabled, the default).
+
+    When a float is resolved, the heal loop stops once an iteration's cluster
+    health fails to improve on the previous iteration's by at least this much --
+    i.e. the healer stops when it is no longer helping, instead of always
+    exhausting ``step_cap``. Left off by default so the shipped convergence is
+    byte-identical; a value of ``0.0`` stops on the first non-improving step."""
+    if min_health_gain is not None:
+        return min_health_gain
+    raw = os.environ.get("GOLDENMATCH_HEAL_MIN_HEALTH_GAIN", "").strip()
+    if not raw:
+        return None
+    try:
+        return float(raw)
+    except ValueError:
+        return None
+
+
+def _safe_cluster_health(result, df) -> float | None:
+    """Cluster-health proxy for the heal early-stop, fail-open. Returns ``None``
+    (never triggers a stop) when the result has no clusters or anything raises --
+    so callers/tests without a real DedupeResult keep the default convergence."""
+    try:
+        clusters = getattr(result, "clusters", None)
+        if not clusters:
+            return None
+        from goldenmatch.core.suggest.health import suggestion_health_from_clusters
+        return suggestion_health_from_clusters(clusters, df.height)
+    except Exception:
+        return None
+
+
+def heal(
+    df,
+    config,
+    *,
+    step_cap: int | None = None,
+    max_verify: int | None = None,
+    min_health_gain: float | None = None,
+) -> HealOutcome:
     """Bounded verified heal loop: re-run -> verified suggest -> apply top -> repeat
     until the healer goes quiet (or step_cap, or a repeated patch id). Returns the
-    healed config, the applied trail (auditable), and the last DedupeResult."""
+    healed config, the applied trail (auditable), and the last DedupeResult.
+
+    Cost bounds (#1404):
+    - ``step_cap`` (env ``GOLDENMATCH_HEAL_STEP_CAP``) caps the outer iterations.
+    - ``max_verify`` (env ``GOLDENMATCH_SUGGEST_MAX_VERIFY``) caps the per-step
+      verification fan-out. The healer applies only the TOP surviving suggestion,
+      so ``max_verify=1`` (verify just the top candidate) is the cheapest mode.
+    - ``min_health_gain`` (env ``GOLDENMATCH_HEAL_MIN_HEALTH_GAIN``) early-stops
+      when marginal cluster-health gain flattens; ``None`` (default) disables it.
+    - The expensive goldencheck variant scan is memoized for the whole loop via
+      ``variant_risk_cache()`` (runs once over the unchanged frame, not per step).
+    """
     from goldenmatch._api import dedupe_df  # deferred
-    from goldenmatch.core.suggest.adapter import suggest_from_result  # deferred
+    from goldenmatch.core.suggest.adapter import (  # deferred
+        suggest_from_result,
+        variant_risk_cache,
+    )
     from goldenmatch.core.suggest.apply import apply_suggestion  # deferred
+
+    step_cap = _resolve_step_cap(step_cap)
+    min_health_gain = _resolve_min_health_gain(min_health_gain)
 
     trail = []
     applied_ids = set()
     last_result = None
-    for _ in range(step_cap):
-        last_result = dedupe_df(df, config=config)
-        sugs = suggest_from_result(last_result, df, verify=True)
-        if not sugs:
-            break
-        top = sugs[0]
-        if top.id in applied_ids:
-            break
-        applied_ids.add(top.id)
-        config = apply_suggestion(config, top)
-        trail.append(top)
+    prev_health: float | None = None
+    with variant_risk_cache():
+        for _ in range(step_cap):
+            last_result = dedupe_df(df, config=config)
+            if min_health_gain is not None:
+                cur_health = _safe_cluster_health(last_result, df)
+                if (
+                    cur_health is not None
+                    and prev_health is not None
+                    and cur_health - prev_health < min_health_gain
+                ):
+                    break  # marginal cluster-health gain flattened -> stop early
+                if cur_health is not None:
+                    prev_health = cur_health
+            sugs = suggest_from_result(
+                last_result, df, verify=True, max_verify=max_verify
+            )
+            if not sugs:
+                break
+            top = sugs[0]
+            if top.id in applied_ids:
+                break
+            applied_ids.add(top.id)
+            config = apply_suggestion(config, top)
+            trail.append(top)
     return HealOutcome(config=config, trail=trail, result=last_result)

--- a/packages/python/goldenmatch/tests/test_suggest_surface.py
+++ b/packages/python/goldenmatch/tests/test_suggest_surface.py
@@ -182,7 +182,7 @@ def test_heal_applies_in_order_then_stops(monkeypatch):
     class _Res:  # stand-in DedupeResult
         config = "CFG0"
     monkeypatch.setattr("goldenmatch._api.dedupe_df", lambda df, *, config=None, **k: _Res())
-    def _sugg(res, df, *, verify=False):
+    def _sugg(res, df, *, verify=False, max_verify=None):
         i = calls["sugg"]; calls["sugg"] += 1
         return seq[i] if i < len(seq) else []
     monkeypatch.setattr("goldenmatch.core.suggest.adapter.suggest_from_result", _sugg)
@@ -205,7 +205,7 @@ def test_heal_cycle_guard_breaks_on_repeated_id(monkeypatch):
         config = "CFG"
     monkeypatch.setattr("goldenmatch._api.dedupe_df", lambda df, *, config=None, **k: _Res())
     monkeypatch.setattr("goldenmatch.core.suggest.adapter.suggest_from_result",
-                        lambda res, df, *, verify=False: [s1])   # ALWAYS returns s1
+                        lambda res, df, *, verify=False, max_verify=None: [s1])   # ALWAYS returns s1
     monkeypatch.setattr("goldenmatch.core.suggest.apply.apply_suggestion",
                         lambda cfg, s: cfg)
     out = surf.heal("DF", "CFG", step_cap=5)
@@ -216,7 +216,7 @@ def test_heal_step_cap(monkeypatch):
     import goldenmatch.core.suggest.surface as surf
     from goldenmatch.core.suggest.types import Suggestion
     n = {"i": 0}
-    def _sugg(res, df, *, verify=False):
+    def _sugg(res, df, *, verify=False, max_verify=None):
         n["i"] += 1
         return [Suggestion(id=f"s{n['i']}", kind="k", target="t", current_value=None,
                            proposed_value=None, rationale="", predicted_effect="",
@@ -228,6 +228,206 @@ def test_heal_step_cap(monkeypatch):
     monkeypatch.setattr("goldenmatch.core.suggest.apply.apply_suggestion", lambda cfg, s: cfg)
     out = surf.heal("DF", "CFG", step_cap=3)
     assert len(out.trail) == 3   # stops at the cap (unique ids each step)
+
+
+# --- #1404: bounded heal-loop cost (cache + tunable caps + early-stop) -------
+
+
+def test_variant_risk_cache_scopes_one_scan_across_calls(monkeypatch):
+    # blocking_risk is O(distinct^2) per column; the cache runs it once per frame
+    # across a variant_risk_cache() scope. Assert it fires once for repeated
+    # _cached_blocking_risk calls in-scope, and every call outside a scope.
+    import goldenmatch.core.suggest.adapter as ad
+
+    calls = {"n": 0}
+
+    def _fake_blocking_risk(frame):
+        calls["n"] += 1
+        return {"name": 0.1}
+
+    monkeypatch.setattr("goldenmatch.core.quality.blocking_risk", _fake_blocking_risk)
+
+    class _DF:  # only .select is exercised by _cached_blocking_risk
+        def select(self, cols):
+            return cols
+
+    df = _DF()
+    cols = ["name", "city"]
+
+    # Outside a scope: computed every call.
+    ad._cached_blocking_risk(df, cols)
+    ad._cached_blocking_risk(df, cols)
+    assert calls["n"] == 2
+
+    # Inside a scope: computed once, then served from cache.
+    calls["n"] = 0
+    with ad.variant_risk_cache():
+        r1 = ad._cached_blocking_risk(df, cols)
+        r2 = ad._cached_blocking_risk(df, cols)
+        assert calls["n"] == 1
+        assert r1 == r2 == {"name": 0.1}
+        # A different column set is a distinct key -> a second scan.
+        ad._cached_blocking_risk(df, ["name"])
+        assert calls["n"] == 2
+
+    # Cache is torn down on scope exit.
+    calls["n"] = 0
+    ad._cached_blocking_risk(df, cols)
+    assert calls["n"] == 1
+
+
+def test_cached_blocking_risk_fail_open(monkeypatch):
+    import goldenmatch.core.suggest.adapter as ad
+
+    def _boom(frame):
+        raise RuntimeError("goldencheck exploded")
+
+    monkeypatch.setattr("goldenmatch.core.quality.blocking_risk", _boom)
+
+    class _DF:
+        def select(self, cols):
+            return cols
+
+    with ad.variant_risk_cache():
+        assert ad._cached_blocking_risk(_DF(), ["name"]) == {}
+
+
+def test_resolve_max_verify_kwarg_env_default(monkeypatch):
+    import goldenmatch.core.suggest.adapter as ad
+
+    monkeypatch.delenv("GOLDENMATCH_SUGGEST_MAX_VERIFY", raising=False)
+    assert ad._resolve_max_verify(None) == ad._MAX_VERIFY_CANDIDATES
+    assert ad._resolve_max_verify(3) == 3
+    assert ad._resolve_max_verify(0) == 1  # clamped to >= 1
+    monkeypatch.setenv("GOLDENMATCH_SUGGEST_MAX_VERIFY", "2")
+    assert ad._resolve_max_verify(None) == 2
+    assert ad._resolve_max_verify(5) == 5  # explicit kwarg beats env
+    monkeypatch.setenv("GOLDENMATCH_SUGGEST_MAX_VERIFY", "garbage")
+    assert ad._resolve_max_verify(None) == ad._MAX_VERIFY_CANDIDATES
+
+
+def test_verify_suggestions_honors_max_verify(monkeypatch):
+    # _verify_suggestions caps the per-candidate pipeline re-runs at the resolved
+    # fan-out; the tail passes through unverified. Prove max_verify=1 re-runs once.
+    import goldenmatch.core.suggest.adapter as ad
+    from goldenmatch.core.suggest.types import Suggestion
+
+    def _mk(i):
+        return Suggestion(id=f"s{i}", kind="lower_threshold", target="t",
+                          current_value=None, proposed_value=None, rationale="",
+                          predicted_effect="", confidence=1.0, patch={}, evidence={})
+
+    sugs = [_mk(0), _mk(1), _mk(2)]
+    runs = {"n": 0}
+
+    class _Engine:
+        def _run_pipeline(self, df, cfg):
+            runs["n"] += 1
+            class _R:
+                clusters = {}
+            return _R()
+
+    class _DF:
+        height = 10
+
+    monkeypatch.setattr("goldenmatch.core.suggest.apply.apply_suggestion",
+                        lambda cfg, s: cfg)
+    monkeypatch.setattr(
+        "goldenmatch.core.suggest.health.suggestion_health_from_clusters",
+        lambda clusters, n: 1.0,
+    )
+
+    out = ad._verify_suggestions(sugs, _DF(), "CFG", {}, _Engine(), max_verify=1)
+    assert runs["n"] == 1              # only the top candidate was re-run
+    assert [s.id for s in out] == ["s0", "s1", "s2"]  # tail passes through
+
+
+def test_resolve_step_cap_and_min_health_gain(monkeypatch):
+    import goldenmatch.core.suggest.surface as surf
+
+    monkeypatch.delenv("GOLDENMATCH_HEAL_STEP_CAP", raising=False)
+    monkeypatch.delenv("GOLDENMATCH_HEAL_MIN_HEALTH_GAIN", raising=False)
+    assert surf._resolve_step_cap(None) == surf._HEAL_STEP_CAP
+    assert surf._resolve_step_cap(3) == 3
+    assert surf._resolve_step_cap(0) == 1
+    monkeypatch.setenv("GOLDENMATCH_HEAL_STEP_CAP", "2")
+    assert surf._resolve_step_cap(None) == 2
+
+    assert surf._resolve_min_health_gain(None) is None  # off by default
+    assert surf._resolve_min_health_gain(0.0) == 0.0
+    monkeypatch.setenv("GOLDENMATCH_HEAL_MIN_HEALTH_GAIN", "0.01")
+    assert surf._resolve_min_health_gain(None) == 0.01
+
+
+def test_heal_early_stop_disabled_by_default(monkeypatch):
+    # Without min_health_gain (default), the health path is inert: heal runs to
+    # step_cap even when clusters are present and health never improves.
+    import goldenmatch.core.suggest.surface as surf
+    from goldenmatch.core.suggest.types import Suggestion
+
+    monkeypatch.delenv("GOLDENMATCH_HEAL_MIN_HEALTH_GAIN", raising=False)
+
+    class _Res:
+        config = "CFG"
+        clusters = {"h": 0.5}  # constant health -> would stop early IF enabled
+
+    class _DF:
+        height = 100
+
+    monkeypatch.setattr("goldenmatch._api.dedupe_df",
+                        lambda df, *, config=None, **k: _Res())
+    monkeypatch.setattr(
+        "goldenmatch.core.suggest.health.suggestion_health_from_clusters",
+        lambda clusters, n: clusters["h"],
+    )
+    n = {"i": 0}
+    def _sugg(res, df, *, verify=False, max_verify=None):
+        n["i"] += 1
+        return [Suggestion(id=f"s{n['i']}", kind="k", target="t", current_value=None,
+                           proposed_value=None, rationale="", predicted_effect="",
+                           confidence=1.0, patch={}, evidence={})]
+    monkeypatch.setattr("goldenmatch.core.suggest.adapter.suggest_from_result", _sugg)
+    monkeypatch.setattr("goldenmatch.core.suggest.apply.apply_suggestion",
+                        lambda cfg, s: cfg)
+
+    out = surf.heal(_DF(), "CFG", step_cap=3)
+    assert len(out.trail) == 3  # ran the full cap; early-stop off by default
+
+
+def test_heal_early_stop_strictly_below_threshold(monkeypatch):
+    import goldenmatch.core.suggest.surface as surf
+    from goldenmatch.core.suggest.types import Suggestion
+
+    # health improves by 0.005 each step; min_health_gain=0.01 -> stop on step 2.
+    healths = iter([0.20, 0.205, 0.99, 0.99])
+
+    class _Res:
+        config = "CFG"
+        def __init__(self):
+            self.clusters = {"h": next(healths)}
+
+    class _DF:
+        height = 100
+
+    monkeypatch.setattr("goldenmatch._api.dedupe_df",
+                        lambda df, *, config=None, **k: _Res())
+    monkeypatch.setattr(
+        "goldenmatch.core.suggest.health.suggestion_health_from_clusters",
+        lambda clusters, n: clusters["h"],
+    )
+    n = {"i": 0}
+    def _sugg(res, df, *, verify=False, max_verify=None):
+        n["i"] += 1
+        return [Suggestion(id=f"s{n['i']}", kind="k", target="t", current_value=None,
+                           proposed_value=None, rationale="", predicted_effect="",
+                           confidence=1.0, patch={}, evidence={})]
+    monkeypatch.setattr("goldenmatch.core.suggest.adapter.suggest_from_result", _sugg)
+    monkeypatch.setattr("goldenmatch.core.suggest.apply.apply_suggestion",
+                        lambda cfg, s: cfg)
+
+    out = surf.heal(_DF(), "CFG", step_cap=10, min_health_gain=0.01)
+    # step0: health 0.20, apply s1. step1: health 0.205, gain 0.005 < 0.01 -> STOP.
+    assert [s.id for s in out.trail] == ["s1"]
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

Fixes #1404. The verified heal loop (`heal` → `suggest_from_result(verify=True)` → `_verify_suggestions`) ran up to `step_cap × (1 + max_verify)` full pipeline passes per call — ~45 on the defaults — **plus** a full goldencheck `blocking_risk` variant scan (O(distinct²) per string column) re-run on the *unchanged* frame every iteration. On a ~19k-row heal that OOMs a 1GB box and takes ~5 min.

This adds three cost levers, **all defaulting to byte-identical behavior** so the required `quality_gate` and existing convergence are untouched, and the free scan-cache win applies by default.

## Changes

- **Goldencheck variant scan memoized across the heal loop** — new `variant_risk_cache()` context (`core/suggest/adapter.py`), keyed on the data-column set, wraps the loop so the O(distinct²) scan runs **once over the frame instead of once per iteration**. Output byte-identical; only the cost moves. Fail-open (any error → `{}`, the goldencheck-absent value).
- **Verify fan-out tunable** — `review_config` / `suggest_from_result` / `heal` take `max_verify`; `GOLDENMATCH_SUGGEST_MAX_VERIFY` sets it globally (default 8, clamped ≥1). Since the healer applies only the *top surviving* suggestion, `max_verify=1` verifies just that candidate — the cheapest mode.
- **Marginal-gain early-stop** — `heal(min_health_gain=…)` / `GOLDENMATCH_HEAL_MIN_HEALTH_GAIN` stops the loop once cluster-health gain flattens, **fail-open** (a result without clusters never triggers a stop). Off by default. `GOLDENMATCH_HEAL_STEP_CAP` exposes the outer cap too.

## Design notes

- The cache is the one default-on change and it's output-preserving — it's the direct fix for "re-profiles the whole frame every iteration, uncached" (ask #1).
- The fan-out/step-cap/early-stop knobs are ask #2/#3/#4: they let a consumer (the reporter is moving heal onto async jobs) trade thoroughness for latency. Defaults preserve today's convergence exactly, so nothing regresses unmeasured — a smaller default `max_verify` was left as a caller/env choice rather than hard-coded without a convergence measurement.

## Test plan

- `tests/test_suggest_surface.py` — 23 pass (7 new: cache scoping + fail-open, `max_verify` resolver + threading through `_verify_suggestions`, `step_cap`/`min_health_gain` resolvers, early-stop strict-threshold + default-off). Existing heal tests unchanged (mocks updated only for the new optional `max_verify` kwarg).
- `tests/test_suggest_adapter.py` — pass.
- `ruff check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_