### PR TITLE
release(golden-suite): 0.3.1 (floors to goldenmatch>=3.5 + native>=0.1.18)

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.1] - 2026-07-18
+
+- Floor bump: `goldenmatch[polars]>=3.5` (3.5.0: the date-aware `date` scorer;
+  the FS missing-value correctness wave that restored `historical_50k`
+  probabilistic F1 0.33 -> 0.83; 100% native Fellegi-Sunter coverage via the
+  shared `fs-core` crate; and the `from_splink` random-pair-prior fix) and
+  `goldenmatch-native>=0.1.18` (adds the native `date_similarity` kernel so the
+  `date` scorer runs on the native path, not just the pure-Python fallback).
+  Cut after goldenmatch 3.5.0 + goldenmatch-native 0.1.18 landed on PyPI
+  (member-on-PyPI-first lockstep).
+
 ## [0.3.0] - 2026-07-16
 
 - Suite minor train: floors raised to `goldenmatch[polars]>=3.4` (FS scoring in

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.0"
+version = "0.3.1"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,14 +37,14 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.4",         # entity resolution: dedupe, match, golden records (>=3.4: FS in distributed/chunked lanes + bounded strategy-blocking scorer; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.5",         # entity resolution: dedupe, match, golden records (>=3.5: date-aware `date` scorer + the FS missing-value correctness wave (historical_50k F1 restored) + 100% native FS coverage; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.2",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping
     "goldenanalysis>=0.4",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.2",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.17",       # >=0.1.17 carries the FS exclude-set Arc handle + zero-copy arrow FS entry + unobserved-evidence math
+    "goldenmatch-native>=0.1.18",       # >=0.1.18 adds the native `date_similarity` kernel (date scorer's native path); 0.1.17 carries the FS exclude-set Arc handle + zero-copy arrow FS entry + unobserved-evidence math
     "goldencheck-native>=0.1",
     "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
     "goldenanalysis-native>=0.1",


### PR DESCRIPTION
## What
Lockstep golden-suite bump after the goldenmatch 3.5.0 train.

- `goldenmatch[polars]>=3.4` → **`>=3.5`** — the date-aware `date` scorer, the FS missing-value correctness wave (`historical_50k` probabilistic F1 restored 0.33 → 0.83), 100% native FS coverage via the shared `fs-core` crate, and the `from_splink` random-pair-prior fix.
- `goldenmatch-native>=0.1.17` → **`>=0.1.18`** — adds the native `date_similarity` kernel so `goldenmatch[native]` runs the `date` scorer on the native path instead of the pure-Python fallback.
- version `0.3.0` → `0.3.1`; CHANGELOG entry.

## Lockstep ordering (member-on-PyPI-first)
- goldenmatch 3.5.0 → PyPI ✅
- goldenmatch-native 0.1.18 → cut via `cut-native-release.yml` (wheels building; `cut` job green, tag pushed). The `golden-suite-v0.3.1` release will be cut only **after** native 0.1.18 is confirmed on PyPI, so the `>=0.1.18` floor resolves.

Gate: `version_consistency` OK (32 packages, lockstep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd