### PR TITLE
feat(autoconfig-core): shared strong-identifier blocking union — increment 1 (#1207/#1317)

### DIFF
--- a/docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md
+++ b/docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md
@@ -1,0 +1,115 @@
+# Blocking-key selection in `autoconfig-core` (shared cross-surface)
+
+**Date:** 2026-07-19
+**Closes (via increment 2):** #1317 — TS `buildBlocking` missing the #1207 per-identifier union
+**Related:** `docs/superpowers/specs/2026-06-20-autoconfig-native-core-design.md` (the planner/classifier core this extends)
+
+## Problem
+
+Auto-config's **blocking-key selection** (`build_blocking` — which columns to
+block on, `static` vs `multi_pass`, the #1207 strong-identifier union) is the
+one remaining piece of the auto-config decision surface that is **hand-written
+twice**: `build_blocking` in Python `core/autoconfig.py`, and a separate
+hand-ported `buildBlocking` in TS `src/core/autoconfig.ts`. The planner and
+classifier were already unified into `autoconfig-core` (Rust → wasm for TS,
+native wheel for Python); blocking selection never was.
+
+The concrete cost: #1207 landed the strong-identifier blocking union in Python
+(`_build_strong_identifier_union`) but the TS twin was never updated, so TS
+zero-config on null-sparse multi-source strong-id data emits a name-only
+`multi_pass` and silently loses recall vs Python. That is exactly the
+parallel-logic drift the shared-core strategy exists to prevent.
+
+## The obstacle blocking selection posed, and the split that resolves it
+
+The planner/classifier are **pure functions of column profiles** (aggregates),
+so they moved into the core cleanly. Blocking selection is **data-dependent**:
+the union's gates need row-level signals the profile doesn't carry —
+- **OR-coverage** of a candidate pass set (fraction of rows non-null on ≥1
+  pass's fields; a multi-field pass needs ALL its fields non-null), and
+- **scale-safety** per pass (a strong-id singleton is gated on its NON-NULL
+  projected block size; name/geo passes on the standard bounded gate).
+
+Resolution — the **smart-core / dumb-measurement split** the codebase already
+uses for the planner (which consumes the host-measured `ComplexityProfile`):
+the **host measures** the row-level signals; the **core decides**. Measurement
+is inherently per-surface (polars in Python, JS loops in TS); the *decision*
+(assembly, transforms, every threshold and gate) lives once in Rust.
+
+Because coverage/scale-safety are measured over the passes the core assembles,
+the flow is naturally two-phase (mirroring Python's helper-then-call-site
+structure):
+
+```
+          ┌── core: assemble_strong_id_union(columns) ──► candidate passes | None
+host ─────┤   (pure: profiles + classify_by_name; ≥1 strong-id, ≥2 passes)
+          │
+          ├── host measures: OR-coverage(passes) + per-pass scale-safety bool
+          │
+          └── core: finalize_strong_id_union(passes, coverage, survives[], …) ──► BlockingConfig | None
+              (pure: coverage gate, survivor filter, re-gate, config emission)
+```
+
+## Core API (`autoconfig-core/src/select_blocking.rs`, serde JSON boundary)
+
+Faithful port of `_build_strong_identifier_union` (autoconfig.py:1583) + the
+`build_blocking` union call-site survivor filtering (autoconfig.py:3145). All
+thresholds/branch-orders reproduced from the Python source.
+
+```rust
+pub struct BlockingColumnInput { name, col_type: ColType, null_rate, cardinality_ratio }
+pub struct UnionPass { fields: Vec<String>, transforms: Vec<String>, is_strong_id: bool }
+
+/// Phase 1 — pure assembly from profiles. None unless ≥1 strong-id pass AND
+/// ≥2 distinct passes. (Coverage gate is applied in phase 2, once measured.)
+pub fn assemble_strong_id_union(cols: &[BlockingColumnInput]) -> Option<Vec<UnionPass>>
+
+pub struct UnionFinalizeInput { passes, coverage, pass_survives: Vec<bool>,
+                                coverage_target, max_safe_block }
+pub struct BlockingConfigOut { strategy, keys, passes, max_block_size, skip_oversized }
+
+/// Phase 2 — pure gates: coverage ≥ target, then survivor filter (host-measured
+/// `pass_survives`), then re-gate (≥1 surviving strong-id AND ≥2 survivors).
+pub fn finalize_strong_id_union(input: &UnionFinalizeInput) -> Option<BlockingConfigOut>
+```
+
+Ported constants (from autoconfig.py): `_STRONG_EXACT_TYPES = {identifier,
+email, phone}`, `_UNION_PASS_MIN_NONNULL = 0.02`, `_BLOCKING_UNION_COVERAGE_TARGET
+= 0.95`, `#876` surrogate guard `cardinality_ratio >= 1.0` excluded. name/geo
+passes: `[first,last]`, `[last,geo]` where first/last come from a name-classified
+column whose name contains `first` / `last|surname`, geo is a `zip`/`geo`
+col_type. Transforms: email → `[lowercase, strip]`, else `[strip]`.
+
+**Assembly detail — name classification:** the core reuses its own
+`classify::classify_by_name` for the name-column detection (Python uses
+`_classify_by_name(p.name) == "name"`), so the boundary stays `(name, col_type,
+null_rate, cardinality_ratio)` — no extra host input.
+
+## Increment plan
+
+1. **This PR — core only.** `select_blocking.rs` (both phases) + `lib.rs`
+   re-exports + Rust golden tests + a golden fixture JSON. Pure addition to
+   `autoconfig-core`; **no surface behavior changes**, so zero regression risk.
+   Fully built/tested with `cargo test` (no wasm/maturin needed).
+2. **TS reroute (closes #1317).** Rebuild the committed autoconfig wasm embed;
+   thread rows into `buildBlocking`; on the exact-pool-empty fall-through call
+   the core (assemble → measure coverage/block-size in JS → finalize) BEFORE the
+   name fallback. Keep a pure-TS fallback that matches the core (the established
+   opt-in-backend posture). TS parity test on the shared golden fixture.
+3. **Python reroute.** Route `_build_strong_identifier_union` + the call-site
+   survivor filtering through the core (native when the wheel carries the symbol,
+   pure-Python fallback matching the core otherwise). Equivalence test
+   Python == core golden. Wheel republish is CI's job.
+
+Later increments can migrate the rest of `build_blocking` (exact-pool pick,
+compound fallback, name fallback) into the core the same way; the union is first
+because it is where the surfaces have actually drifted (#1317).
+
+## Testing
+
+The Rust golden fixture (`autoconfig-core/tests/golden/select_blocking/*.json`)
+is the cross-surface oracle: increment-1 Rust `tests/golden.rs` reads it;
+increments 2/3 assert the wasm/TS and Python paths reproduce the SAME
+assemble/finalize outputs on the SAME inputs (the autoconfig-core parity-gate
+pattern). Fixtures use small datasets where Python's full-N block-size
+projection is a no-op, so the host-measured `pass_survives`/`coverage` are exact.

--- a/packages/rust/extensions/autoconfig-core/golden/select_blocking_vectors.json
+++ b/packages/rust/extensions/autoconfig-core/golden/select_blocking_vectors.json
@@ -1,0 +1,160 @@
+{
+  "_comment": "Cross-surface oracle for the #1207 strong-identifier blocking union (autoconfig-core::select_blocking). Hand-authored from the Python _build_strong_identifier_union (autoconfig.py:1583) + build_blocking call-site (:3145) semantics; the Python equivalence test (increment 3) and the TS parity test (increment 2) assert their paths reproduce these same outputs. Small datasets so Python's full-N block-size projection is a no-op and host-measured coverage/pass_survives are exact.",
+  "assemble": [
+    {
+      "name": "null_sparse_two_ids_plus_name_geo",
+      "input": [
+        {"name": "npi", "col_type": "identifier", "null_rate": 0.4, "cardinality_ratio": 0.9},
+        {"name": "email", "col_type": "email", "null_rate": 0.5, "cardinality_ratio": 0.8},
+        {"name": "first_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.3},
+        {"name": "last_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.4},
+        {"name": "zip", "col_type": "zip", "null_rate": 0.2, "cardinality_ratio": 0.1}
+      ],
+      "expected": [
+        {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+        {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true},
+        {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+        {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+      ]
+    },
+    {
+      "name": "no_strong_id_returns_none",
+      "input": [
+        {"name": "first_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.3},
+        {"name": "last_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.4},
+        {"name": "zip", "col_type": "zip", "null_rate": 0.2, "cardinality_ratio": 0.1}
+      ],
+      "expected": null
+    },
+    {
+      "name": "perfect_surrogate_id_excluded_876",
+      "input": [
+        {"name": "id", "col_type": "identifier", "null_rate": 0.0, "cardinality_ratio": 1.0},
+        {"name": "first_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.3},
+        {"name": "last_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.4}
+      ],
+      "expected": null
+    },
+    {
+      "name": "id_below_nonnull_floor_excluded",
+      "input": [
+        {"name": "rare_id", "col_type": "identifier", "null_rate": 0.99, "cardinality_ratio": 0.5},
+        {"name": "first_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.3},
+        {"name": "last_name", "col_type": "name", "null_rate": 0.1, "cardinality_ratio": 0.4}
+      ],
+      "expected": null
+    },
+    {
+      "name": "one_id_no_name_geo_under_two_passes_returns_none",
+      "input": [
+        {"name": "email", "col_type": "email", "null_rate": 0.5, "cardinality_ratio": 0.8}
+      ],
+      "expected": null
+    },
+    {
+      "name": "two_ids_no_name_geo_two_passes_ok",
+      "input": [
+        {"name": "npi", "col_type": "identifier", "null_rate": 0.3, "cardinality_ratio": 0.9},
+        {"name": "phone", "col_type": "phone", "null_rate": 0.4, "cardinality_ratio": 0.85}
+      ],
+      "expected": [
+        {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+        {"fields": ["phone"], "transforms": ["strip"], "is_strong_id": true}
+      ]
+    }
+  ],
+  "finalize": [
+    {
+      "name": "all_pass_coverage_ok_emits_union",
+      "input": {
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+          {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "coverage": 0.98,
+        "pass_survives": [true, true, true, true],
+        "max_safe_block": 1000
+      },
+      "expected": {
+        "strategy": "multi_pass",
+        "keys": [{"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true}],
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+          {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "max_block_size": 1000,
+        "skip_oversized": true
+      }
+    },
+    {
+      "name": "coverage_below_target_returns_none",
+      "input": {
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true}
+        ],
+        "coverage": 0.80,
+        "pass_survives": [true, true],
+        "max_safe_block": 1000
+      },
+      "expected": null
+    },
+    {
+      "name": "one_id_survives_but_under_two_survivors_returns_none",
+      "input": {
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+          {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "coverage": 0.98,
+        "pass_survives": [true, false, false, false],
+        "max_safe_block": 1000
+      },
+      "expected": null
+    },
+    {
+      "name": "two_survivors_but_no_strong_id_returns_none",
+      "input": {
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+          {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "coverage": 0.98,
+        "pass_survives": [false, true, true],
+        "max_safe_block": 1000
+      },
+      "expected": null
+    },
+    {
+      "name": "id_plus_one_name_survive_emits_two_pass_union",
+      "input": {
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["email"], "transforms": ["lowercase", "strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false},
+          {"fields": ["last_name", "zip"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "coverage": 0.96,
+        "pass_survives": [true, false, true, false],
+        "max_safe_block": 500
+      },
+      "expected": {
+        "strategy": "multi_pass",
+        "keys": [{"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true}],
+        "passes": [
+          {"fields": ["npi"], "transforms": ["strip"], "is_strong_id": true},
+          {"fields": ["first_name", "last_name"], "transforms": ["strip"], "is_strong_id": false}
+        ],
+        "max_block_size": 500,
+        "skip_oversized": true
+      }
+    }
+  ]
+}

--- a/packages/rust/extensions/autoconfig-core/src/lib.rs
+++ b/packages/rust/extensions/autoconfig-core/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod classify;
 pub mod extrapolate;
 pub mod planner;
+pub mod select_blocking;
 pub mod thresholds;
 #[cfg(feature = "arrow")]
 pub mod profile;
@@ -18,3 +19,8 @@ pub use classify::{classify_columns, ColType, ColumnProfile, ColumnStats};
 pub use extrapolate::{extrapolate_pair_count, ExtrapolationInput, ExtrapolationOutput};
 // S2b/S3 threshold kernel re-exports
 pub use thresholds::{exact_matchkey_floor, sparse_match_floor};
+// Blocking-selection kernel re-exports (#1207 strong-identifier union)
+pub use select_blocking::{
+    assemble_strong_id_union, finalize_strong_id_union, BlockingColumnInput, BlockingConfigOut,
+    UnionFinalizeInput, UnionPass, BLOCKING_UNION_COVERAGE_TARGET, STRONG_EXACT_TYPES,
+};

--- a/packages/rust/extensions/autoconfig-core/src/select_blocking.rs
+++ b/packages/rust/extensions/autoconfig-core/src/select_blocking.rs
@@ -1,0 +1,226 @@
+//! Blocking-key selection — the #1207 strong-identifier union decision, shared
+//! across surfaces (no pyo3).
+//!
+//! Parity port of:
+//!   - `packages/python/goldenmatch/goldenmatch/core/autoconfig.py`
+//!     `_build_strong_identifier_union` (~line 1583) — phase 1 (assembly), and
+//!   - the `build_blocking` union call-site survivor filtering (~line 3145) —
+//!     phase 2 (gates + config emission).
+//!
+//! Blocking selection is data-dependent (the gates need row-level OR-coverage +
+//! per-pass block-size), unlike the pure-profile planner/classifier. The split
+//! (see `docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md`):
+//! the **host measures** those signals; the **core decides**. So the flow is two
+//! phases mirroring Python's helper-then-call-site structure:
+//!
+//! 1. [`assemble_strong_id_union`] — pure assembly from column profiles.
+//! 2. host measures OR-coverage of the assembled passes + per-pass scale-safety.
+//! 3. [`finalize_strong_id_union`] — pure gates (coverage, survivor filter,
+//!    re-gate) → the emitted `multi_pass` config.
+//!
+//! All thresholds/branch-orders are reproduced from the Python source.
+
+use serde::{Deserialize, Serialize};
+
+use crate::classify::{classify_by_name, ColType};
+
+/// `autoconfig.py::_STRONG_EXACT_TYPES` — the strong-identifier col_types that
+/// back a per-id blocking pass.
+pub const STRONG_EXACT_TYPES: [ColType; 3] = [ColType::Identifier, ColType::Email, ColType::Phone];
+
+/// `_UNION_PASS_MIN_NONNULL` — a per-id pass must block more than a trivial
+/// handful of rows (non-null fraction floor).
+const UNION_PASS_MIN_NONNULL: f64 = 0.02;
+
+/// `_BLOCKING_UNION_COVERAGE_TARGET` — the assembled passes' OR-coverage must
+/// clear this for the union to be admitted. The threshold lives in the core; the
+/// host only supplies the *measured* coverage.
+pub const BLOCKING_UNION_COVERAGE_TARGET: f64 = 0.95;
+
+/// One column's profile signals the union decision needs. `col_type` is the full
+/// classifier's verdict (`classify_columns`); name-column detection for the
+/// name+geo passes is done in-core via [`classify_by_name`], so no extra host
+/// input is required.
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlockingColumnInput {
+    pub name: String,
+    pub col_type: ColType,
+    pub null_rate: f64,
+    pub cardinality_ratio: f64,
+}
+
+/// A blocking pass. `is_strong_id` marks the single-field strong-identifier
+/// singletons (the ones phase 2 gates on the NON-NULL block size); it is carried
+/// on the wire so the host can measure the right scale-safety signal per pass and
+/// so phase 2 can re-gate on "≥1 surviving strong-id".
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UnionPass {
+    pub fields: Vec<String>,
+    pub transforms: Vec<String>,
+    pub is_strong_id: bool,
+}
+
+fn is_strong(ct: ColType) -> bool {
+    STRONG_EXACT_TYPES.contains(&ct)
+}
+
+/// `_transforms_for(fields)` — email → `[lowercase, strip]`, else `[strip]`,
+/// keyed on the col_type of `fields[0]`.
+fn transforms_for_field(field: &str, cols: &[BlockingColumnInput]) -> Vec<String> {
+    let is_email = cols
+        .iter()
+        .find(|c| c.name == field)
+        .map(|c| c.col_type == ColType::Email)
+        .unwrap_or(false);
+    if is_email {
+        vec!["lowercase".to_string(), "strip".to_string()]
+    } else {
+        vec!["strip".to_string()]
+    }
+}
+
+/// Phase 1 — assemble the candidate union passes from column profiles (pure).
+///
+/// Returns `None` unless ≥1 strong-id pass is present AND ≥2 distinct passes
+/// survive assembly. The ≥1-strong-id requirement keeps this from emitting a
+/// name-only "strong-id union" (a name-only shape belongs to the name fallback).
+/// The OR-coverage gate is deferred to phase 2 (it needs the host measurement).
+///
+/// One pass per strong-identifier column above the non-null floor (excluding a
+/// #876 perfect-surrogate, `cardinality_ratio >= 1.0`, which makes singleton
+/// blocks), then `[first, last]` and `[last, geo]` for rows missing every strong
+/// id — matching `_build_strong_identifier_union`.
+pub fn assemble_strong_id_union(cols: &[BlockingColumnInput]) -> Option<Vec<UnionPass>> {
+    let mut passes: Vec<UnionPass> = Vec::new();
+    let mut strong_id_count = 0usize;
+
+    // one pass per strong-identifier field, above the non-null population floor.
+    for c in cols {
+        if !is_strong(c.col_type) {
+            continue;
+        }
+        let nonnull = 1.0 - c.null_rate;
+        if nonnull < UNION_PASS_MIN_NONNULL {
+            continue;
+        }
+        // #876 surrogate guard: a perfect-surrogate id (card_ratio >= 1.0) makes
+        // singleton blocks (0 pairs). NOTE: blocking_max_ratio is deliberately
+        // NOT applied — the union exists precisely to use near-unique-but-
+        // repeating ids the single-key gate rejects.
+        if c.cardinality_ratio >= 1.0 {
+            continue;
+        }
+        passes.push(UnionPass {
+            fields: vec![c.name.clone()],
+            transforms: transforms_for_field(&c.name, cols),
+            is_strong_id: true,
+        });
+        strong_id_count += 1;
+    }
+
+    // require ≥1 strong-id pass; a name-only shape belongs to the name fallback.
+    if strong_id_count < 1 {
+        return None;
+    }
+
+    // name+geo passes for rows missing every strong id. name columns are detected
+    // by the same name-classifier Python uses (`_classify_by_name(name) == name`).
+    let first: Option<String> = cols
+        .iter()
+        .filter(|c| classify_by_name(&c.name) == Some(ColType::Name))
+        .find(|c| c.name.to_lowercase().contains("first"))
+        .map(|c| c.name.clone());
+    let last: Option<String> = cols
+        .iter()
+        .filter(|c| classify_by_name(&c.name) == Some(ColType::Name))
+        .find(|c| {
+            let n = c.name.to_lowercase();
+            n.contains("last") || n.contains("surname")
+        })
+        .map(|c| c.name.clone());
+    let geo: Option<String> = cols
+        .iter()
+        .find(|c| matches!(c.col_type, ColType::Zip | ColType::Geo))
+        .map(|c| c.name.clone());
+
+    if let (Some(f), Some(l)) = (&first, &last) {
+        passes.push(UnionPass {
+            fields: vec![f.clone(), l.clone()],
+            transforms: transforms_for_field(f, cols),
+            is_strong_id: false,
+        });
+    }
+    if let (Some(l), Some(g)) = (&last, &geo) {
+        passes.push(UnionPass {
+            fields: vec![l.clone(), g.clone()],
+            transforms: transforms_for_field(l, cols),
+            is_strong_id: false,
+        });
+    }
+
+    if passes.len() < 2 {
+        return None;
+    }
+    Some(passes)
+}
+
+/// Phase 2 input: the assembled passes plus the host measurements. `coverage` is
+/// the OR-coverage of `passes` (a multi-field pass counts a row only when ALL its
+/// fields are non-null). `pass_survives[i]` is the per-pass scale-safety verdict
+/// the host measured — for a strong-id singleton, the NON-NULL projected block
+/// size ≤ `max_safe_block` (the runtime blocker drops null keys); for a name/geo
+/// pass, the standard bounded gate. `max_safe_block` is the host's scale budget.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UnionFinalizeInput {
+    pub passes: Vec<UnionPass>,
+    pub coverage: f64,
+    pub pass_survives: Vec<bool>,
+    pub max_safe_block: usize,
+}
+
+/// The emitted blocking config (the shape `build_blocking` returns for the
+/// union). `keys` is `[primary]` (the first surviving pass).
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct BlockingConfigOut {
+    pub strategy: String,
+    pub keys: Vec<UnionPass>,
+    pub passes: Vec<UnionPass>,
+    pub max_block_size: usize,
+    pub skip_oversized: bool,
+}
+
+/// Phase 2 — apply the gates and emit the `multi_pass` union config (pure).
+///
+/// `None` (fall through to the name/compound fallback) when the coverage target
+/// is not cleared, or fewer than 2 passes survive scale-safety, or no strong-id
+/// pass survives. Mirrors `_build_strong_identifier_union`'s coverage gate + the
+/// `build_blocking` call-site survivor filtering. Because the assembled order is
+/// already `[strong-id…, name/geo…]`, filtering it in place preserves Python's
+/// `surviving_ids + surviving_other` ordering.
+pub fn finalize_strong_id_union(input: &UnionFinalizeInput) -> Option<BlockingConfigOut> {
+    if input.coverage < BLOCKING_UNION_COVERAGE_TARGET {
+        return None;
+    }
+    // Defensive: a mismatched survives vector can't be trusted — fall through.
+    if input.pass_survives.len() != input.passes.len() {
+        return None;
+    }
+    let survivors: Vec<UnionPass> = input
+        .passes
+        .iter()
+        .zip(input.pass_survives.iter())
+        .filter(|(_, &survives)| survives)
+        .map(|(p, _)| p.clone())
+        .collect();
+    let any_strong_id = survivors.iter().any(|p| p.is_strong_id);
+    if !any_strong_id || survivors.len() < 2 {
+        return None;
+    }
+    Some(BlockingConfigOut {
+        strategy: "multi_pass".to_string(),
+        keys: vec![survivors[0].clone()],
+        passes: survivors,
+        max_block_size: input.max_safe_block,
+        skip_oversized: true,
+    })
+}

--- a/packages/rust/extensions/autoconfig-core/tests/golden.rs
+++ b/packages/rust/extensions/autoconfig-core/tests/golden.rs
@@ -22,8 +22,9 @@
 //!   and compare against Rust's before re-encoding to JSON.
 
 use goldenmatch_autoconfig_core::{
-    classify_columns, decide_plan, exact_matchkey_floor, extrapolate_pair_count,
-    sparse_match_floor, ColType, ColumnStats, ExtrapolationInput, PlannerInput,
+    assemble_strong_id_union, classify_columns, decide_plan, exact_matchkey_floor,
+    extrapolate_pair_count, finalize_strong_id_union, sparse_match_floor, BlockingColumnInput,
+    ColType, ColumnStats, ExtrapolationInput, PlannerInput, UnionFinalizeInput,
 };
 use serde_json::Value;
 
@@ -32,8 +33,7 @@ const PLANNER_JSON: &str = include_str!("../golden/planner_vectors.json");
 const CLASSIFIER_JSON: &str = include_str!("../golden/classifier_vectors.json");
 const EXTRAPOLATION_JSON: &str = include_str!("../golden/extrapolation_vectors.json");
 const SPARSE_MATCH_FLOOR_JSON: &str = include_str!("../golden/sparse_match_floor_vectors.json");
-const EXACT_MATCHKEY_FLOOR_JSON: &str =
-    include_str!("../golden/exact_matchkey_floor_vectors.json");
+const EXACT_MATCHKEY_FLOOR_JSON: &str = include_str!("../golden/exact_matchkey_floor_vectors.json");
 
 // ── Planner parity ────────────────────────────────────────────────────────────
 
@@ -80,8 +80,14 @@ fn planner_golden_parity() {
         };
 
         // Compare field by field (avoids f64 precision issues; no f64 in plan)
-        let fields = ["backend", "max_workers", "pair_spill_threshold",
-                      "clustering_strategy", "rule_name", "chunk_size"];
+        let fields = [
+            "backend",
+            "max_workers",
+            "pair_spill_threshold",
+            "clustering_strategy",
+            "rule_name",
+            "chunk_size",
+        ];
 
         for field in &fields {
             let got = &got_val[field];
@@ -186,9 +192,13 @@ fn sparse_match_floor_golden_parity() {
             .as_u64()
             .expect("estimated_pairs must be u64");
         let got = sparse_match_floor(estimated_pairs);
-        let exp = vec["expected"]["floor"].as_u64().expect("floor must be u64");
+        let exp = vec["expected"]["floor"]
+            .as_u64()
+            .expect("floor must be u64");
         if got != exp {
-            failures.push(format!("vec {idx}: estimated_pairs={estimated_pairs} got {got} exp {exp}"));
+            failures.push(format!(
+                "vec {idx}: estimated_pairs={estimated_pairs} got {got} exp {exp}"
+            ));
         }
     }
     assert!(
@@ -222,7 +232,9 @@ fn exact_matchkey_floor_golden_parity() {
             .as_f64()
             .expect("floor must be f64");
         if (got - exp).abs() >= 1e-9 {
-            failures.push(format!("vec {idx}: col_type={col_type} got {got} exp {exp}"));
+            failures.push(format!(
+                "vec {idx}: col_type={col_type} got {got} exp {exp}"
+            ));
         }
     }
     assert!(
@@ -440,7 +452,9 @@ fn serde_null_pair_spill_threshold() {
 #[test]
 fn serde_non_null_pair_spill_threshold() {
     // pair_spill_threshold=Some(Ram) must serialize to "ram" (not "Ram" or "RAM")
-    use goldenmatch_autoconfig_core::{BackendName, ClusteringStrategy, ExecutionPlan, SpillThreshold};
+    use goldenmatch_autoconfig_core::{
+        BackendName, ClusteringStrategy, ExecutionPlan, SpillThreshold,
+    };
     let plan = ExecutionPlan {
         backend: BackendName::Chunked,
         chunk_size: Some(100_000),
@@ -452,4 +466,71 @@ fn serde_non_null_pair_spill_threshold() {
     let v: Value = serde_json::to_value(&plan).unwrap();
     assert_eq!(v["pair_spill_threshold"], Value::String("ram".into()));
     assert_eq!(v["chunk_size"], Value::Number(100_000u64.into()));
+}
+
+// ── Blocking-selection parity (#1207 strong-identifier union) ─────────────────
+
+const SELECT_BLOCKING_JSON: &str = include_str!("../golden/select_blocking_vectors.json");
+
+#[test]
+fn select_blocking_golden_parity() {
+    let doc: Value = serde_json::from_str(SELECT_BLOCKING_JSON)
+        .expect("failed to parse select_blocking_vectors.json");
+    let mut failures: Vec<String> = Vec::new();
+
+    // Phase 1 — assemble
+    let assemble = doc["assemble"].as_array().expect("assemble array");
+    assert!(
+        assemble.len() >= 6,
+        "expected >= 6 assemble vectors, got {}",
+        assemble.len()
+    );
+    for case in assemble {
+        let name = case["name"].as_str().unwrap_or("?");
+        let cols: Vec<BlockingColumnInput> = match serde_json::from_value(case["input"].clone()) {
+            Ok(c) => c,
+            Err(e) => {
+                failures.push(format!("assemble[{name}]: bad input: {e}"));
+                continue;
+            }
+        };
+        let got: Value = serde_json::to_value(assemble_strong_id_union(&cols)).unwrap();
+        if got != case["expected"] {
+            failures.push(format!(
+                "assemble[{name}] mismatch:\n  expected={}\n  got={got}",
+                case["expected"]
+            ));
+        }
+    }
+
+    // Phase 2 — finalize
+    let finalize = doc["finalize"].as_array().expect("finalize array");
+    assert!(
+        finalize.len() >= 5,
+        "expected >= 5 finalize vectors, got {}",
+        finalize.len()
+    );
+    for case in finalize {
+        let name = case["name"].as_str().unwrap_or("?");
+        let input: UnionFinalizeInput = match serde_json::from_value(case["input"].clone()) {
+            Ok(i) => i,
+            Err(e) => {
+                failures.push(format!("finalize[{name}]: bad input: {e}"));
+                continue;
+            }
+        };
+        let got: Value = serde_json::to_value(finalize_strong_id_union(&input)).unwrap();
+        if got != case["expected"] {
+            failures.push(format!(
+                "finalize[{name}] mismatch:\n  expected={}\n  got={got}",
+                case["expected"]
+            ));
+        }
+    }
+
+    assert!(
+        failures.is_empty(),
+        "select_blocking golden failures:\n{}",
+        failures.join("\n")
+    );
 }


### PR DESCRIPTION
## Why

Blocking-key selection is the one piece of the auto-config decision surface still **hand-written twice** — Python `build_blocking` (`core/autoconfig.py`) and a separate hand-ported TS `buildBlocking` (`src/core/autoconfig.ts`). The planner and classifier were already unified into the shared `autoconfig-core` (Rust → wasm for TS, native wheel for Python); blocking selection never was. That duplication is exactly why **#1317** exists: #1207's strong-identifier blocking union landed in Python but the TS twin was never updated, silently costing TS zero-config recall on null-sparse strong-id data.

This is **increment 1 of moving blocking selection into the shared core** — the architecturally-correct fix for the whole drift class (per `docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md`).

## What

Blocking selection is **data-dependent** (unlike the pure-profile planner/classifier), so it uses the **smart-core / dumb-measurement split** the planner already uses (it consumes host-measured `ComplexityProfile` signals): the **host measures** the row-level signals (OR-coverage, per-pass block size), the **core decides**. Two phases mirroring Python's helper-then-call-site structure:

- **`assemble_strong_id_union(columns) -> passes | None`** — pure assembly from column profiles: one pass per strong-id (`identifier`/`email`/`phone`) above the non-null floor, the #876 perfect-surrogate guard, `[first,last]` / `[last,geo]` name+geo passes, per-field transforms. Reuses the core's own `classify_by_name` for name detection. Faithful port of `_build_strong_identifier_union` (`autoconfig.py:1583`).
- **`finalize_strong_id_union(passes, coverage, pass_survives, max_safe_block) -> BlockingConfig | None`** — pure gates: coverage ≥ 0.95, survivor filter (host-measured), re-gate on ≥1 surviving strong-id AND ≥2 survivors. Faithful port of the `build_blocking` union call-site (`autoconfig.py:3145`).

Every threshold, branch order, and transform is reproduced from the Python source.

## Scope / risk

**Pure addition to `autoconfig-core` — no surface behavior changes yet, so zero regression risk.** The cross-surface golden fixture (`golden/select_blocking_vectors.json`) is the oracle the follow-on reroutes assert against — the same "ship the shared kernel + parity fixture first" pattern used by fs-wasm / hnsw-wasm.

- **Increment 2** (follow-up): rebuild the autoconfig wasm embed; route TS `buildBlocking`'s fall-through through the core (assemble → measure coverage/block-size in JS → finalize) before the name fallback, pure-TS fallback matching the core, TS parity test on the shared fixture. **Closes #1317.**
- **Increment 3** (follow-up): route Python `_build_strong_identifier_union` + the call-site survivor filtering through the core (native when the wheel carries the symbol, pure-Python fallback otherwise); wheel republish is CI's job.

## Test plan

- `cargo test --manifest-path autoconfig-core/Cargo.toml` — **115 pass** (103 lib + 12 golden incl. the new `select_blocking_golden_parity`: 6 assemble + 5 finalize vectors).
- `cargo clippy --all-targets -- -D warnings` — clean.
- New files rustfmt-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_