### PR TITLE
docs(config): generated full config matrix + CI drift gate

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -389,6 +389,20 @@ api_parity:
   - 'scripts/emit_python_surface.py'
   - 'scripts/emit_ts_surface.mjs'
   - 'scripts/check_api_parity.py'
+# Config-matrix drift gate (scripts/gen_config_matrix.py --check). The generated
+# block of config-matrix.mdx is rendered from the pydantic schema + VALID_*
+# vocabularies + the GOLDENMATCH_* env scan, so it must re-check whenever any of
+# those move. The env scan reads the whole goldenmatch python + rust source, so
+# any .py/.rs change there can add/remove a knob -> re-run the gate.
+config_matrix:
+  - 'docs-site/goldenmatch/config-matrix.mdx'
+  - 'packages/python/goldenmatch/goldenmatch/**/*.py'
+  - 'packages/python/goldenmatch/goldenmatch/core/config_matrix/**'
+  - 'packages/python/goldenmatch/scripts/gen_config_matrix.py'
+  - 'packages/python/goldenmatch/tests/test_config_matrix.py'
+  - 'packages/rust/extensions/**/*.rs'
+  - '.github/workflows/ci.yml'
+  - '.github/filters.yml'
 # Native-symbol reconciliation gate: the goldenmatch host's
 # native-kernel references must not drift from the kernel's exports.
 # Re-run the gate when the kernel crate, the host package, the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
       quality_gate: ${{ steps.filter.outputs.quality_gate }}
       api_parity: ${{ steps.filter.outputs.api_parity }}
       native_symbols: ${{ steps.filter.outputs.native_symbols }}
+      config_matrix: ${{ steps.filter.outputs.config_matrix }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
@@ -3228,6 +3229,31 @@ jobs:
       - name: Doc consistency (roster matrix + nav integrity + changelog/version)
         run: python scripts/check_docs_consistency.py
 
+  # Config-matrix drift gate (BLOCKING). The generated block of config-matrix.mdx
+  # is rendered from the pydantic GoldenMatchConfig tree + VALID_* vocabularies +
+  # the scanned GOLDENMATCH_* env set; this fails if the committed page is stale
+  # vs the live surface. Needs goldenmatch importable (pydantic introspection) +
+  # the source tree (env scan), so it uv-syncs like api_parity.
+  config_matrix:
+    needs: changes
+    if: needs.changes.outputs.config_matrix == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Sync goldenmatch (pure-Python; no native kernel needed for introspection)
+        run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
+      - name: Config-matrix drift check
+        run: uv run python packages/python/goldenmatch/scripts/gen_config_matrix.py --check
+        env:
+          POLARS_SKIP_CPU_CHECK: "1"
+          GOLDENMATCH_NATIVE: "0"
+          PYTHONPATH: packages/python/goldenmatch
+
   # Tier-2 doc-staleness ADVISORY. Diff-aware: flags a GOLDENMATCH_* env-flag
   # change with no tuning.mdx update (gating), and an __all__/re-export change
   # with no doc surface touched (warning). continue-on-error => never blocks
@@ -3475,6 +3501,7 @@ jobs:
       # were advisory -- a correct red couldn't block a merge. Now required.
       - api_parity
       - native_symbols
+      - config_matrix
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 1

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -90,6 +90,7 @@
                 "group": "API reference",
                 "pages": [
                   "goldenmatch/configuration",
+                  "goldenmatch/config-matrix",
                   "goldenmatch/tuning",
                   "goldenmatch/config-linter",
                   "goldenmatch/api-quick-reference"

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -1,0 +1,640 @@
+---
+title: "Config matrix"
+description: "The full matrix of GoldenMatch config knobs, their valid values, and how they combine -- generated from the schema so it never drifts."
+---
+
+This is the exhaustive reference for **every** GoldenMatch config knob: the
+declarative schema (`GoldenMatchConfig` and every nested object), the enumerated
+string vocabularies, and the `GOLDENMATCH_*` runtime environment knobs. It is
+built for both humans and AI agents that need a single, complete, always-current
+map of what is configurable.
+
+<Info>
+The **object reference**, **vocabularies**, and **env index** below the line are
+**generated from code** (`scripts/gen_config_matrix.py`) and verified in CI, so
+they can never silently drift from the engine. The **combinations & outcomes**
+section above the line is hand-authored guidance. For prose walkthroughs see
+[Configuration](/goldenmatch/configuration) (YAML fields), [Scoring](/goldenmatch/scoring),
+[Blocking](/goldenmatch/blocking), and [Tuning & opt-ins](/goldenmatch/tuning)
+(env-var semantics + defaults).
+</Info>
+
+## How to read this page
+
+- **Combinations & outcomes** (below) is the decision layer: which knob to reach
+  for, and what happens when knobs interact.
+- **Config object reference** is the structural layer: every field, its type, its
+  default, and its allowed Literal values, per config object.
+- **Enumerated vocabularies** lists the allowed values for the `str`-typed fields
+  (scorers, strategies, standardizers).
+- **Environment variables** indexes every `GOLDENMATCH_*` knob by area; defaults
+  and effects are in [Tuning & opt-ins](/goldenmatch/tuning).
+
+## Combinations & intended outcomes
+
+### Matchkey type: `exact` vs `weighted` vs `probabilistic`
+
+The single most consequential choice. Set per matchkey via `MatchkeyConfig.type`.
+
+| Type | You provide | Threshold | When to use | Outcome |
+|---|---|---|---|---|
+| `exact` | fields only | none | Deterministic keys (email, SSN, normalized phone). | Pair matches iff every field is identical after transforms. Fastest; no scoring. |
+| `weighted` | per-field `scorer` + `weight` + a `threshold` | required | You know the relative field importance and want an interpretable, training-free score. | Score = weighted mean over **observed** fields (a null field no longer caps the pair below threshold). |
+| `probabilistic` | fields + `scorer`; weights are EM-learned | `link_threshold` / `review_threshold` (auto if unset) | You have enough data to learn m/u weights and want best recall/precision without hand-tuning. | Fellegi-Sunter log-likelihood with EM-learned agreement/disagreement weights. Supports `levels`, `level_thresholds`, `negative_evidence`, `tf_adjustment`, and `missing` modes. Requires blocking. |
+
+### Missing values x scorer/type
+
+`MatchkeyConfig.missing` (`unobserved` vs `disagree`) is **probabilistic-only**.
+
+| Setting | Null field means | Use when | Failure mode if wrong |
+|---|---|---|---|
+| `unobserved` (default) | no evidence either way; field excluded, score renormalized over observed | missingness is at random | On null-heavy *informative*-missingness data, pairs agreeing on their few populated fields look certain -> mass over-merge (this is the `historical_50k` F1 0.83 -> 0.33 regression). |
+| `disagree` | evidence *against* a match (scored as level 0) | missingness is informative (a blank field is a real signal) | Slightly under-merges truly missing-at-random data. |
+
+- **Auto-config picks the mode** from profiled null rates (`disagree` when the worst comparison field is >= 20% null); override with `MatchkeyConfig.missing` or the global `GOLDENMATCH_FS_MISSING`.
+- **Native kernel caveat:** the native FS kernel implements only `unobserved`; a `disagree`-mode matchkey routes to the numpy path automatically (correctness over speed).
+- On **weighted** matchkeys there is no `missing` knob -- a null field is simply dropped from the weighted mean (renormalized by observed weight).
+
+### Blocking strategy x data scale
+
+`BlockingConfig.strategy` selects candidate generation. Any weighted/probabilistic
+matchkey **requires** a blocking config. A null block key means "cannot be
+blocked", never "blocks with every other null-key row" -- null keys are filtered
+across every strategy (no false mega-blocks).
+
+| Strategy | Needs | Best for | Notes |
+|---|---|---|---|
+| `static` | `keys` | Small/known equality keys | Simplest; one exact block key. |
+| `multi_pass` | `keys` or `passes` | Recall via several complementary keys | `union_mode` unions pairs across passes. |
+| `sorted_neighborhood` | `sort_key`, `window_size` | Fuzzy adjacency (typos in the key) | Sliding window over sorted rows. |
+| `learned` | recall/reduction targets | Auto-mined predicates | `learned_min_recall` / `learned_min_reduction` / `learned_predicate_depth`; cache with `learned_cache_path`. |
+| `lsh` / `simhash` / `perceptual` | the matching config block | Near-duplicate text / semantic / image | MinHash / semantic SimHash / perceptual-hash banding. |
+| `ann` | `ann_column`, `ann_model` | Embedding-neighbor recall | `ann_top_k` neighbors per row. |
+| `canopy` | `canopy` block | Cheap loose pre-grouping | Loose/tight thresholds. |
+
+Guardrails regardless of strategy: `max_block_size` + `skip_oversized`, `max_total_comparisons`, and `auto_suggest` / `auto_select` to let auto-config choose keys/strategy.
+
+### Execution routing: in-memory vs bucket vs distributed vs scale-mode
+
+Left mostly to the controller, but pinnable.
+
+| Knob | Values | Effect |
+|---|---|---|
+| `mode` | `standard` / `scale` | `scale` routes to the DataFusion out-of-core spine (handles data beyond RAM; **not** bit-identical to `standard`). |
+| `backend` | `None` (Polars) / `duckdb` / `ray` | Distributed/OOC compute backend. |
+| `distributed_routing` | per-stage `scoring` / `clustering` / `golden` = `auto` / `distributed*` / `in_process` | Pin an individual stage's route instead of letting the router decide. |
+| `n_buckets`, `prepared_record_store`, `partitioned_block_scoring` | int / bool / bool | Bucketed Parquet storage + on-disk block materialization for memory-bounded scale. |
+
+Env-level routing (see the env index): `GOLDENMATCH_BUCKET_DEFAULT` (the default in-memory bucket FS route up to ~750K rows), `GOLDENMATCH_MATCH_FUSED` (fused block->score->cluster kill-switch; fires under RSS pressure), `GOLDENMATCH_NATIVE` / `GOLDENMATCH_FRAME` (native kernel + arrow/polars frame seam). The controller **refuses** a low-confidence ("RED") auto-config at >= 100K rows unless `allow_red_config` is set.
+
+### Dedupe vs link
+
+Not an enum -- it is expressed by `InputConfig`: a single `files` list = **dedupe**
+(find duplicates within one dataset); `file_a` + `file_b` = **link** (match across
+two datasets, cross-source pairs only).
+
+### Survivorship: field rules, groups, conditional, correlated
+
+`golden_rules` decides the surviving value per field after clustering.
+
+- **`field_rules`** map a column to a `strategy` (see the survivorship vocabulary). List form = **conditional** rules (`when:` predicates over already-resolved fields, first match wins, one when-less default last).
+- **`field_groups`** pin >= 2 columns **lock-step** to one winning row (e.g. `city`/`state`/`zip` must come from the same record) via a group `strategy` (`most_complete` / `source_priority` / `most_recent` / `anchor`).
+- **Correlated / conditional / validated** survivorship runs **in-memory only** -- it is refused on the distributed/Sail paths.
+- `quality_weighting`, `weak_cluster_threshold`, `auto_split` + `max_cluster_size` control how weak/oversized clusters are downgraded or split before survivorship.
+
+### Multi-table / collective ER: `propagation_mode`
+
+For graph/relational ER across entity types (`graph.propagation_mode`):
+
+| Mode | Effect | Use when |
+|---|---|---|
+| `additive` (default) | Add a flat neighbor-evidence boost | Simple cross-entity reinforcement. |
+| `multiplicative` | Multiply by neighbor evidence | Stronger coupling. |
+| `relational` (collective) | Blend attribute + neighborhood similarity (`alpha`, `rel_threshold`, `rel_mode`) and iterate to fixpoint | Homonym-heavy data where shared neighbors disambiguate (largest F1 lift). |
+
+### Native / frame kill-switches
+
+Defaults are fast: arrow frames + native kernel where available. `GOLDENMATCH_NATIVE=auto`
+falls back to pure Python silently if the compiled wheel is absent; `=1` requires
+it (raises), `=0` forces Python. `GOLDENMATCH_FRAME=polars` restores the Polars
+frame seam (needs the `[polars]` extra). Reach for these only to reproduce a
+result across environments or to isolate a perf/parity question.
+
+{/* config-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_config_matrix.py --write */}
+
+## Config object reference
+
+Every config object in the pydantic `GoldenMatchConfig` tree, generated from `config/schemas.py`. Nested objects link by name.
+
+### `GoldenMatchConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `input` | InputConfig \| None | `None` | [`InputConfig`](#inputconfig) |
+| `output` | OutputConfig | _(default OutputConfig)_ | [`OutputConfig`](#outputconfig) |
+| `match_settings` | MatchSettingsConfig \| None | `None` | [`MatchSettingsConfig`](#matchsettingsconfig) |
+| `matchkeys` | list[MatchkeyConfig] \| None | `None` | [`MatchkeyConfig`](#matchkeyconfig) |
+| `blocking` | BlockingConfig \| None | `None` | [`BlockingConfig`](#blockingconfig) |
+| `golden_rules` | GoldenRulesConfig \| None | `None` | [`GoldenRulesConfig`](#goldenrulesconfig) |
+| `standardization` | StandardizationConfig \| None | `None` | [`StandardizationConfig`](#standardizationconfig) |
+| `validation` | ValidationConfig \| None | `None` | [`ValidationConfig`](#validationconfig) |
+| `quality` | QualityConfig \| None | `None` | [`QualityConfig`](#qualityconfig) |
+| `transform` | TransformConfig \| None | `None` | [`TransformConfig`](#transformconfig) |
+| `llm_boost` | bool | `False` |  |
+| `llm_scorer` | LLMScorerConfig \| None | `None` | [`LLMScorerConfig`](#llmscorerconfig) |
+| `llm_auto` | bool | `False` |  |
+| `domain` | DomainConfig \| None | `None` | [`DomainConfig`](#domainconfig) |
+| `backend` | str \| None | `None` |  |
+| `distributed_routing` | DistributedRoutingConfig \| None | `None` | [`DistributedRoutingConfig`](#distributedroutingconfig) |
+| `semantic_blocking` | SemanticBlockingConfig \| None | `None` | [`SemanticBlockingConfig`](#semanticblockingconfig) |
+| `allow_slow_path` | bool | `False` |  |
+| `mode` | Literal | `'standard'` | `standard`, `scale` |
+| `planning_effort` | Literal | `'normal'` | `fast`, `normal`, `thinking`, `einstein` -- Auto-config planning-effort tier (spec 2026-06-06 §Phase 0). Controls how hard the controller searches: 'fast' = a single cheap pass; 'normal' (default) = today's interactive budget; 'thinking'/'einstein' spend the freed engine cycles on a larger sample, more refit iterations, and — at thinking+ — measuring real blocking on the full frame instead of extrapolating. Overridable via the GOLDENMATCH_PLANNING_EFFORT env var. Default 'normal' is byte-for-byte the prior behavior. |
+| `throughput` | ThroughputConfig \| None | `None` | [`ThroughputConfig`](#throughputconfig) |
+| `memory` | MemoryConfig \| None | `None` | [`MemoryConfig`](#memoryconfig) |
+| `identity` | IdentityConfig \| None | `None` | [`IdentityConfig`](#identityconfig) |
+| `exclude_columns` | list[str] | `[]` | Column names to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking. GoldenFlow transforms skip them entirely (column passes through unchanged). Layered ADDITIVELY with GoldenCheck detector-derived exclusions (#404) -- the user list is OR'd with auto-detection, not a replacement. `QualityConfig.autoconfig_force_include` still wins on conflict (rescue beats every opt-out path). Column still appears in golden record output -- exclusion is about matching + transforming, not output. See spec docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md. |
+| `prepared_record_store` | bool | `False` | When True, the prep stage (quality scan + transform + auto-fix) writes its output to a DuckDB-backed disk store keyed by config signature. Subsequent calls with the same config + data shape read prepared records from disk instead of re-prepping. Path via GOLDENMATCH_PREPARED_RECORD_STORE_DIR env var; persistence via GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST=1. Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md §Component 1. |
+| `partitioned_block_scoring` | bool | `False` | When True AND prepared_record_store is True, the pipeline materializes blocks to the disk store as a side effect of build_blocks (Component 2 Phase 2 of Distributed Plan v1). Stages on-disk blocks for Component 3 (distributed scoring); no single-process win expected. Default off. |
+| `n_buckets` | int \| None | `None` | Number of hash buckets for Component 2 v2 bucketed Parquet storage. None means use the heuristic default max(cpu_count() * 4, 64). Hard-capped at 1024. Spec: docs/superpowers/specs/2026-05-17-distributed-plan-component-2-v2-bucketed-storage-design.md §Configuration. |
+
+### `InputConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `files` | list[InputFileConfig] | `[]` | [`InputFileConfig`](#inputfileconfig) |
+| `file_a` | InputFileConfig \| None | `None` | [`InputFileConfig`](#inputfileconfig) |
+| `file_b` | InputFileConfig \| None | `None` | [`InputFileConfig`](#inputfileconfig) |
+
+### `OutputConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `path` | str \| None | `None` |  |
+| `format` | str \| None | `None` |  |
+| `directory` | str \| None | `None` |  |
+| `run_name` | str \| None | `None` |  |
+| `lineage_provenance` | bool | `False` |  |
+
+### `MatchSettingsConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `matchkeys` | list[MatchkeyConfig] | **required** | [`MatchkeyConfig`](#matchkeyconfig) |
+
+### `MatchkeyConfig`
+_A matchkey: rule for declaring two records 'the same' on a field/field-set._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `name` | str | **required** |  |
+| `type` | Literal \| None | `None` | `exact`, `weighted`, `probabilistic` |
+| `comparison` | str \| None | `None` |  |
+| `fields` | list[MatchkeyField] | **required** | [`MatchkeyField`](#matchkeyfield) |
+| `threshold` | float \| None | `None` |  |
+| `auto_threshold` | bool | `False` |  |
+| `rerank` | bool | `False` |  |
+| `rerank_model` | str | `'cross-encoder/ms-marco-MiniLM-L-6-v2'` |  |
+| `rerank_band` | float | `0.1` |  |
+| `negative_evidence` | list[NegativeEvidenceField] \| None | `None` | [`NegativeEvidenceField`](#negativeevidencefield) |
+| `em_iterations` | int | `20` |  |
+| `convergence_threshold` | float | `0.001` |  |
+| `link_threshold` | float \| None | `None` |  |
+| `review_threshold` | float \| None | `None` |  |
+| `model_path` | str \| None | `None` |  |
+| `missing` | Literal \| None | `None` | `unobserved`, `disagree` |
+
+### `BlockingConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `keys` | list[BlockingKeyConfig] | `[]` | [`BlockingKeyConfig`](#blockingkeyconfig) |
+| `max_block_size` | int | `5000` |  |
+| `skip_oversized` | bool | `False` |  |
+| `strategy` | Literal | `'static'` | `static`, `adaptive`, `sorted_neighborhood`, `multi_pass`, `ann`, `canopy`, `ann_pairs`, `learned`, `lsh`, `simhash`, `perceptual` |
+| `learned_sample_size` | int | `5000` |  |
+| `learned_min_recall` | float | `0.95` |  |
+| `learned_min_reduction` | float | `0.9` |  |
+| `learned_predicate_depth` | int | `2` |  |
+| `learned_cache_path` | str \| None | `None` |  |
+| `auto_suggest` | bool | `False` |  |
+| `auto_select` | bool | `False` |  |
+| `sub_block_keys` | list[BlockingKeyConfig] \| None | `None` | [`BlockingKeyConfig`](#blockingkeyconfig) |
+| `window_size` | int | `20` |  |
+| `sort_key` | list[SortKeyField] \| None | `None` | [`SortKeyField`](#sortkeyfield) |
+| `passes` | list[BlockingKeyConfig] \| None | `None` | [`BlockingKeyConfig`](#blockingkeyconfig) |
+| `union_mode` | bool | `True` |  |
+| `max_total_comparisons` | int \| None | `None` |  |
+| `ann_column` | str \| None | `None` |  |
+| `ann_model` | str | `'all-MiniLM-L6-v2'` |  |
+| `ann_top_k` | int | `20` |  |
+| `canopy` | CanopyConfig \| None | `None` | [`CanopyConfig`](#canopyconfig) |
+| `lsh` | LSHKeyConfig \| None | `None` | [`LSHKeyConfig`](#lshkeyconfig) |
+| `simhash` | SimHashKeyConfig \| None | `None` | [`SimHashKeyConfig`](#simhashkeyconfig) |
+| `perceptual` | PerceptualKeyConfig \| None | `None` | [`PerceptualKeyConfig`](#perceptualkeyconfig) |
+
+### `GoldenRulesConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `default_strategy` | str \| None | `None` |  |
+| `default` | GoldenFieldRule \| None | `None` | [`GoldenFieldRule`](#goldenfieldrule) |
+| `field_rules` | dict[str, GoldenFieldRule \| list[GoldenFieldRule]] | `{}` | [`GoldenFieldRule`](#goldenfieldrule) |
+| `field_groups` | list[GoldenGroupRule] | `[]` | [`GoldenGroupRule`](#goldengrouprule) |
+| `field_group_detection` | bool | `False` |  |
+| `max_cluster_size` | int | `100` |  |
+| `auto_split` | bool | `True` |  |
+| `quality_weighting` | bool | `True` |  |
+| `weak_cluster_threshold` | float | `0.3` |  |
+| `split_edge_budget` | int \| None | `None` |  |
+| `adaptive` | bool | `False` |  |
+| `use_llm_for_ambiguous` | bool | `False` |  |
+| `cluster_overrides` | dict[int, dict[str, GoldenFieldRule]] \| None | `None` | [`GoldenFieldRule`](#goldenfieldrule) |
+
+### `StandardizationConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `rules` | dict[str, list[str]] | `{}` |  |
+
+### `ValidationConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `rules` | list[ValidationRuleConfig] | `[]` | [`ValidationRuleConfig`](#validationruleconfig) |
+| `auto_fix` | bool | `True` |  |
+
+### `QualityConfig`
+_GoldenCheck integration config for enhanced data quality._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `True` |  |
+| `mode` | str | `'announced'` |  |
+| `fix_mode` | str | `'safe'` |  |
+| `domain` | str \| None | `None` |  |
+| `autoconfig_force_exclude` | list[str] | `[]` |  |
+| `autoconfig_force_include` | list[str] | `[]` |  |
+
+### `TransformConfig`
+_GoldenFlow integration config for data transformation._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `True` |  |
+| `mode` | Literal | `'announced'` | `silent`, `announced`, `disabled` |
+
+### `LLMScorerConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `False` |  |
+| `provider` | str \| None | `None` |  |
+| `model` | str \| None | `None` |  |
+| `auto_threshold` | float | `0.95` |  |
+| `candidate_lo` | float | `0.75` |  |
+| `candidate_hi` | float | `0.95` |  |
+| `batch_size` | int | `75` |  |
+| `max_workers` | int | `5` |  |
+| `calibration_sample_size` | int | `100` |  |
+| `calibration_max_rounds` | int | `5` |  |
+| `calibration_convergence_delta` | float | `0.01` |  |
+| `budget` | BudgetConfig \| None | `None` | [`BudgetConfig`](#budgetconfig) |
+| `mode` | str | `'pairwise'` |  |
+| `cluster_max_size` | int | `100` |  |
+| `cluster_min_size` | int | `5` |  |
+
+### `DomainConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `False` |  |
+| `mode` | str \| None | `None` |  |
+| `confidence_threshold` | float | `0.3` |  |
+| `llm_validation` | bool | `True` |  |
+| `budget` | BudgetConfig \| None | `None` | [`BudgetConfig`](#budgetconfig) |
+
+### `DistributedRoutingConfig`
+_Per-stage distributed-routing pins. ``auto`` lets the planner decide;_
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `scoring` | Literal | `'auto'` | `auto`, `distributed`, `in_process` |
+| `clustering` | Literal | `'auto'` | `auto`, `distributed_wcc`, `in_memory_scipy` |
+| `golden` | Literal | `'auto'` | `auto`, `distributed`, `in_process` |
+
+### `SemanticBlockingConfig`
+_Opt-in semantic candidate-generation (recall-lever) config. Carries the_
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `keys` | list[Literal] | `['ann', 'initialism', 'alias']` | `ann`, `initialism`, `alias` -- Which semantic blocking keys to union into candidate generation: 'ann' (embedding nearest-neighbors), 'initialism' (initialism expansion), 'alias' (alias-table lookups). |
+| `ann_model` | str | `'inhouse'` | Embedding model id for the ANN key (e.g. 'inhouse'). |
+| `ann_top_k` | int | `20` | Number of ANN neighbors retrieved per record for candidate generation. |
+| `ann_threshold` | float | `0.5` | Minimum ANN similarity for a neighbor to become a candidate pair. |
+| `alias_tables` | list[Literal] | `['given_names', 'business']` | `given_names`, `business` -- Which alias tables the 'alias' key consults. |
+
+### `ThroughputConfig`
+_Opt-in sketch-then-verify throughput tier (#1083)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `False` |  |
+| `recall_target` | float | `0.95` |  |
+| `similarity_threshold` | float \| None | `None` |  |
+
+### `MemoryConfig`
+_Learning Memory configuration._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `True` |  |
+| `backend` | str | `'sqlite'` |  |
+| `path` | str | `'.goldenmatch/memory.db'` |  |
+| `connection` | str \| None | `None` |  |
+| `trust` | dict[str, float] | `{'human': 1.0, 'agent': 0.5}` |  |
+| `learning` | LearningConfig | _(default LearningConfig)_ | [`LearningConfig`](#learningconfig) |
+| `reanchor` | bool | `True` |  |
+| `dataset` | str \| None | `None` |  |
+| `table_prefix` | str | `''` |  |
+
+### `IdentityConfig`
+_Identity Graph configuration._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `False` |  |
+| `backend` | str | `'sqlite'` |  |
+| `path` | str | `'.goldenmatch/identity.db'` |  |
+| `connection` | str \| None | `None` |  |
+| `dataset` | str \| None | `None` |  |
+| `source_pk_column` | str \| None | `None` |  |
+| `emit_singletons` | bool | `True` |  |
+| `weak_confidence_threshold` | float | `0.6` |  |
+| `stitching` | ChannelStitchConfig \| None | `None` | [`ChannelStitchConfig`](#channelstitchconfig) |
+| `survivorship` | SurvivorshipConfig \| None | `None` | [`SurvivorshipConfig`](#survivorshipconfig) |
+| `stabilization` | StabilizationConfig \| None | `None` | [`StabilizationConfig`](#stabilizationconfig) |
+| `mediation` | MediationConfig \| None | `None` | [`MediationConfig`](#mediationconfig) |
+
+### `InputFileConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `path` | str | **required** |  |
+| `id_column` | str \| None | `None` |  |
+| `source_label` | str \| None | `None` |  |
+| `source_name` | str \| None | `None` |  |
+| `column_map` | dict[str, str] \| None | `None` |  |
+| `delimiter` | str | `','` |  |
+| `encoding` | str | `'utf8'` |  |
+| `sheet` | str \| None | `None` |  |
+| `parse_mode` | str | `'auto'` |  |
+| `header_row` | int \| None | `None` |  |
+| `has_header` | bool \| None | `None` |  |
+| `skip_rows` | list[int] \| None | `None` |  |
+
+### `MatchkeyField`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `field` | str \| None | `None` |  |
+| `column` | str \| None | `None` |  |
+| `transforms` | list[str] | `[]` |  |
+| `scorer` | str \| None | `None` |  |
+| `weight` | float \| None | `None` |  |
+| `model` | str \| None | `None` |  |
+| `columns` | list[str] \| None | `None` |  |
+| `column_weights` | dict[str, float] \| None | `None` |  |
+| `levels` | int | `2` |  |
+| `partial_threshold` | float | `0.8` |  |
+| `tf_adjustment` | bool | `False` |  |
+| `tf_freqs` | dict[str, float] \| None | `None` |  |
+| `type` | Literal \| None | `None` | `exact`, `weighted`, `probabilistic` |
+| `em_iterations` | int \| None | `None` |  |
+| `level_thresholds` | list[float] \| None | `None` |  |
+
+### `NegativeEvidenceField`
+_v1.11: a field whose disagreement subtracts from a weighted matchkey's_
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `field` | str | **required** |  |
+| `transforms` | list[str] | `[]` |  |
+| `scorer` | str | **required** |  |
+| `threshold` | float | **required** |  |
+| `penalty` | float \| None | `None` |  |
+| `penalty_bits` | float \| None | `None` |  |
+| `derive_from` | list[str] \| None | `None` |  |
+
+### `BlockingKeyConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `fields` | list[str] | **required** |  |
+| `transforms` | list[str] | `[]` |  |
+| `field_transforms` | dict[str, list[str]] | `{}` |  |
+
+### `SortKeyField`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `column` | str | **required** |  |
+| `transforms` | list[str] | `[]` |  |
+
+### `CanopyConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `fields` | list[str] | **required** |  |
+| `loose_threshold` | float | `0.3` |  |
+| `tight_threshold` | float | `0.7` |  |
+| `max_canopy_size` | int | `500` |  |
+
+### `LSHKeyConfig`
+_MinHash/LSH blocking on a text column (#1081)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `column` | str | **required** |  |
+| `mode` | Literal | `'char'` | `char`, `word` |
+| `k` | int | `3` |  |
+| `num_perms` | int | `128` |  |
+| `seed` | int | `0` |  |
+| `threshold` | float \| None | `None` |  |
+| `num_bands` | int \| None | `None` |  |
+
+### `SimHashKeyConfig`
+_SimHash/LSH blocking on a text column via dense embeddings (#1082)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `column` | str | **required** |  |
+| `num_planes` | int | `256` |  |
+| `seed` | int | `0` |  |
+| `threshold` | float \| None | `None` |  |
+| `num_bands` | int \| None | `None` |  |
+| `model` | str \| None | `None` |  |
+
+### `PerceptualKeyConfig`
+_Banded hamming-LSH blocking over a column of perceptual hashes (ADR 0022)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `column` | str | **required** |  |
+| `num_bands` | int | `16` |  |
+| `hash_bits` | int | `64` |  |
+
+### `GoldenFieldRule`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `strategy` | str | **required** |  |
+| `date_column` | str \| None | `None` |  |
+| `source_priority` | list[str] \| None | `None` |  |
+| `when` | str \| None | `None` |  |
+| `validate_with` _(alias `validate`)_ | str \| None | `None` |  |
+
+### `GoldenGroupRule`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `name` | str | **required** |  |
+| `columns` | list[str] | **required** |  |
+| `category` | str \| None | `None` |  |
+| `strategy` | str | `'most_complete'` |  |
+| `date_column` | str \| None | `None` |  |
+| `source_priority` | list[str] \| None | `None` |  |
+| `anchor` | str \| None | `None` |  |
+| `allow_fill` | bool | `False` |  |
+
+### `ValidationRuleConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `column` | str | **required** |  |
+| `rule_type` | Literal | **required** | `regex`, `min_length`, `max_length`, `not_null`, `in_set`, `format` |
+| `params` | dict | `{}` |  |
+| `action` | Literal | `'flag'` | `null`, `quarantine`, `flag` |
+
+### `BudgetConfig`
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `max_cost_usd` | float \| None | `None` |  |
+| `max_calls` | int \| None | `None` |  |
+| `escalation_model` | str \| None | `None` |  |
+| `escalation_band` | list[float] | `[0.8, 0.9]` |  |
+| `escalation_budget_pct` | float | `20` |  |
+| `warn_at_pct` | float | `80` |  |
+
+### `LearningConfig`
+_Learning Memory learning parameters._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `threshold_min_corrections` | int | `10` |  |
+| `weights_min_corrections` | int | `50` |  |
+
+### `ChannelStitchConfig`
+_Cross-device / channel stitching configuration (#1110, epic #1108)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `enabled` | bool | `False` |  |
+| `device_keys` | list[str] | `[]` |  |
+| `channel_column` | str | `'channel'` |  |
+| `channel_map` | dict[str, str] | `{}` |  |
+| `channel_trust` | dict[str, float] | `{}` |  |
+| `adjust_cross_channel` | bool | `True` |  |
+| `prob_threshold` | float | `0.0` |  |
+
+### `SurvivorshipConfig`
+_Golden-record survivorship configuration (#1111, epic #1108)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `field_strategies` | dict[str, str] | `{}` |  |
+| `default_strategy` | str | `'most_complete'` |  |
+| `timestamp_column` | str \| None | `None` |  |
+| `learn_from_corrections` | bool | `False` |  |
+
+### `StabilizationConfig`
+_Cross-run entity stabilization -- Identity v3 (#1112, epic #1108)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `min_runs` | int | `3` |  |
+| `winner_strategy` | str | `'most_records'` |  |
+| `min_score` | float | `0.0` |  |
+
+### `MediationConfig`
+_Conflict mediation workflow -- Identity v3 (#1113, epic #1108)._
+
+| Field | Type | Default | Choices / notes |
+|---|---|---|---|
+| `auto_apply` | bool | `True` |  |
+
+## Enumerated vocabularies
+
+The allowed string values for the `str`-typed fields above, from the frozensets in `config/schemas.py`.
+
+| Vocabulary | Constant | Applies to | Values |
+|---|---|---|---|
+| Scorers | `VALID_SCORERS` | `MatchkeyField.scorer` / `NegativeEvidenceField.scorer` | `alias_match`, `audio_fp`, `date`, `dice`, `embedding`, `ensemble`, `exact`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `record_embedding`, `soundex_match`, `token_sort` |
+| Simple transforms | `VALID_SIMPLE_TRANSFORMS` | `transforms` chains | `alpha_only`, `digits_only`, `first_token`, `last_token`, `lowercase`, `metaphone`, `normalize_whitespace`, `soundex`, `strip`, `strip_all`, `token_sort`, `uppercase` |
+| Survivorship strategies | `VALID_STRATEGIES` | `GoldenFieldRule.strategy` | `confidence_majority`, `first_non_null`, `longest_value`, `majority_vote`, `most_complete`, `most_recent`, `source_priority`, `unanimous_or_null` |
+| Group survivorship strategies | `_GROUP_STRATEGIES` | `GoldenGroupRule.strategy` | `anchor`, `most_complete`, `most_recent`, `source_priority` |
+| Standardizers | `VALID_STANDARDIZERS` | `StandardizationConfig.rules` | `address`, `email`, `name_lower`, `name_proper`, `name_upper`, `phone`, `state`, `strip`, `trim_whitespace`, `zip5` |
+| Matchkey types | `_VALID_MK_TYPES` | `MatchkeyConfig.type` | `exact`, `probabilistic`, `weighted` |
+
+Extended-grammar transforms (regex-validated, not in the set above): `substring:<start>:<end>`, `qgram:<n>`, `bloom_filter[:<a>:<b>:<c>]`. Custom survivorship: `custom:<snake_case>`. Plugin scorers/transforms resolve via the plugin registry.
+
+## Environment variables (index)
+
+147 `GOLDENMATCH_*` runtime knobs are read by the engine (Python + native kernel). This index is scanned from source so it is complete; **defaults, valid values, and effects live in [Tuning & opt-ins](/goldenmatch/tuning)**. Grouped by area:
+
+- **AGENT** (1): `GOLDENMATCH_AGENT_TOKEN`
+- **ALLOWED** (1): `GOLDENMATCH_ALLOWED_ROOT`
+- **ANALYTICS** (1): `GOLDENMATCH_ANALYTICS`
+- **API** (2): `GOLDENMATCH_API_CORS_ORIGINS`, `GOLDENMATCH_API_TOKEN`
+- **AUTOCONFIG** (10): `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE`, `GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE`, `GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE`, `GOLDENMATCH_AUTOCONFIG_INDICATOR_BUDGET`, `GOLDENMATCH_AUTOCONFIG_LLM`, `GOLDENMATCH_AUTOCONFIG_MEMORY`, `GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC`, `GOLDENMATCH_AUTOCONFIG_SAMPLE_STRATEGY`, `GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_COMMIT`, `GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_STABILITY`
+- **BENCH** (1): `GOLDENMATCH_BENCH_DUMP_PAIRS`
+- **BLOCKING** (8): `GOLDENMATCH_BLOCKING_CARDINALITY_SCALER`, `GOLDENMATCH_BLOCKING_DEGENERATE_MAX_AVG_BLOCK_SIZE`, `GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD`, `GOLDENMATCH_BLOCKING_MAX_RATIO`, `GOLDENMATCH_BLOCKING_MIN_RATIO`, `GOLDENMATCH_BLOCKING_PAIRS_PER_ROW`, `GOLDENMATCH_BLOCKING_PASS_MIN_WEAKPOS`, `GOLDENMATCH_BLOCKING_PRUNE_PASSES`
+- **BUCKET** (5): `GOLDENMATCH_BUCKET_DEBUG`, `GOLDENMATCH_BUCKET_DEFAULT`, `GOLDENMATCH_BUCKET_SLIM_PROJECTION`, `GOLDENMATCH_BUCKET_VEC_MAX`, `GOLDENMATCH_BUCKET_VEC_MIN`
+- **CLUSTER** (1): `GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET`
+- **COLUMNAR** (1): `GOLDENMATCH_COLUMNAR_PIPELINE`
+- **CONFIG** (1): `GOLDENMATCH_CONFIG_LINT`
+- **DATABASE** (1): `GOLDENMATCH_DATABASE_URL`
+- **DISTRIBUTED** (13): `GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE`, `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD`, `GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS`, `GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD`, `GOLDENMATCH_DISTRIBUTED_OP_RESERVATION`, `GOLDENMATCH_DISTRIBUTED_PIPELINE`, `GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY`, `GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS`, `GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT`, `GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS`, `GOLDENMATCH_DISTRIBUTED_WCC`, `GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH`, `GOLDENMATCH_DISTRIBUTED_WCC_SEED`
+- **EMBEDDING** (1): `GOLDENMATCH_EMBEDDING_PROVIDER`
+- **FRAME** (2): `GOLDENMATCH_FRAME`, `GOLDENMATCH_FRAME_LANE`
+- **FS** (11): `GOLDENMATCH_FS_AUTOCONFIG_V2`, `GOLDENMATCH_FS_BATCH_ROWS`, `GOLDENMATCH_FS_BUCKET_NATIVE`, `GOLDENMATCH_FS_CALIBRATED`, `GOLDENMATCH_FS_DEFAULT_BUCKET`, `GOLDENMATCH_FS_MISSING`, `GOLDENMATCH_FS_MONOTONIC`, `GOLDENMATCH_FS_NATIVE`, `GOLDENMATCH_FS_VECTORIZED`, `GOLDENMATCH_FS_VEC_MAX_ELEMS`, `GOLDENMATCH_FS_WORKERS`
+- **GOLDEN** (4): `GOLDENMATCH_GOLDEN_FUSED`, `GOLDENMATCH_GOLDEN_SLIM_MULTIDF`, `GOLDENMATCH_GOLDEN_STRATEGY_STRICT`, `GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS`
+- **GPU** (3): `GOLDENMATCH_GPU_API_KEY`, `GOLDENMATCH_GPU_ENDPOINT`, `GOLDENMATCH_GPU_MODE`
+- **HEAL** (2): `GOLDENMATCH_HEAL_MIN_HEALTH_GAIN`, `GOLDENMATCH_HEAL_STEP_CAP`
+- **IDENTITY** (2): `GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT`, `GOLDENMATCH_IDENTITY_DSN`
+- **INHOUSE** (1): `GOLDENMATCH_INHOUSE_MODEL`
+- **LLM** (2): `GOLDENMATCH_LLM_BASE_URL`, `GOLDENMATCH_LLM_MODEL`
+- **MATCH** (2): `GOLDENMATCH_MATCH_FUSED`, `GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS`
+- **MCP** (6): `GOLDENMATCH_MCP_ALLOW_PUBLIC`, `GOLDENMATCH_MCP_MAX_UPLOAD_BYTES`, `GOLDENMATCH_MCP_SESSION_MAX`, `GOLDENMATCH_MCP_SESSION_TTL`, `GOLDENMATCH_MCP_TOKEN`, `GOLDENMATCH_MCP_UPLOAD_TTL`
+- **NATIVE** (5): `GOLDENMATCH_NATIVE`, `GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE`, `GOLDENMATCH_NATIVE_RAYON_MIN_BLOOM_ROWS`, `GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS`, `GOLDENMATCH_NATIVE_SKETCH_RAYON_MIN_ROWS`
+- **NE** (1): `GOLDENMATCH_NE_TUNER_MIN_CORRECTIONS`
+- **OTHER** (37): `GOLDENMATCH_ANN_BACKEND`, `GOLDENMATCH_ANN_HNSW_EF_CONSTRUCTION`, `GOLDENMATCH_ANN_HNSW_EF_SEARCH`, `GOLDENMATCH_ANN_HNSW_M`, `GOLDENMATCH_ANN_HNSW_MAX_K`, `GOLDENMATCH_ANN_HNSW_MIN`, `GOLDENMATCH_ATTRIBUTE_DEMOTION`, `GOLDENMATCH_AUTO_SEMANTIC_BLOCKING`, `GOLDENMATCH_BASE_STORE`, `GOLDENMATCH_BRIDGE_REQUIRE_PY`, `GOLDENMATCH_DISCRIMINATIVE_TAU`, `GOLDENMATCH_DISCRIMINATIVE_VETO`, `GOLDENMATCH_DUCKDB_SCORE_DB`, `GOLDENMATCH_ENABLE_DISTRIBUTED_RAY`, `GOLDENMATCH_FACILITY_NAME_NE`, `GOLDENMATCH_FD_NEGATIVE_EVIDENCE`, `GOLDENMATCH_FIELD_GROUP_SURVIVORSHIP`, `GOLDENMATCH_FUSED_BLOCK_CONCURRENCY`, `GOLDENMATCH_FUSED_BYTES_PER_CELL`, `GOLDENMATCH_FUSED_BYTES_PER_PAIR`, `GOLDENMATCH_FUSED_PRESSURE_FRACTION`, `GOLDENMATCH_FUSED_RSS_SCALE`, `GOLDENMATCH_LLAMA_GGUF`, `GOLDENMATCH_MULTISOURCE_AUTOCONFIG`, `GOLDENMATCH_NOISE_AWARE_SCORERS`, `GOLDENMATCH_NOISE_AWARE_TARGET`, `GOLDENMATCH_PERCEPTUAL_AUTOCONFIG`, `GOLDENMATCH_QUALITY_AWARE_BLOCKING`, `GOLDENMATCH_QUALITY_GATED_REVIEW`, `GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD`, `GOLDENMATCH_SKIP_MATCH_LOG`, `GOLDENMATCH_STANDARDIZE_STAGED`, `GOLDENMATCH_STREAMING_BLOCK_WORKERS`, `GOLDENMATCH_TF_NAME_WEIGHTING`, `GOLDENMATCH_UDF_IMPORTS`, `GOLDENMATCH_WEAKNESS_LLM`, `GOLDENMATCH_WEAKNESS_LLM_MODEL`
+- **PLANNER** (1): `GOLDENMATCH_PLANNER_BUCKET`
+- **PLANNING** (1): `GOLDENMATCH_PLANNING_EFFORT`
+- **PREP** (3): `GOLDENMATCH_PREPARED_RECORD_STORE_DIR`, `GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST`, `GOLDENMATCH_PREP_STAGED_COLLECT`
+- **SAIL** (1): `GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME`
+- **SUGGEST** (10): `GOLDENMATCH_SUGGEST_COHESION`, `GOLDENMATCH_SUGGEST_COVERAGE_CAP`, `GOLDENMATCH_SUGGEST_FULL_DIST`, `GOLDENMATCH_SUGGEST_HEALTH`, `GOLDENMATCH_SUGGEST_MAX_VERIFY`, `GOLDENMATCH_SUGGEST_ON_DEDUPE`, `GOLDENMATCH_SUGGEST_RECALL_COH_ABS`, `GOLDENMATCH_SUGGEST_RECALL_MIN_SHED`, `GOLDENMATCH_SUGGEST_RECALL_RATIO`, `GOLDENMATCH_SUGGEST_VERIFY`
+- **SYNC** (1): `GOLDENMATCH_SYNC_STREAMING_THRESHOLD`
+- **THROUGHPUT** (3): `GOLDENMATCH_THROUGHPUT`, `GOLDENMATCH_THROUGHPUT_RECALL`, `GOLDENMATCH_THROUGHPUT_SIMILARITY`
+- **VECTOR** (1): `GOLDENMATCH_VECTOR_INDEX_DIR`
+- **WEB** (1): `GOLDENMATCH_WEB_TOKEN`
+
+{/* config-matrix:generated:end */}
+
+## See also
+
+- [Configuration](/goldenmatch/configuration) -- YAML field walkthroughs with examples.
+- [Tuning & opt-ins](/goldenmatch/tuning) -- `GOLDENMATCH_*` defaults, valid values, and effects.
+- [Scoring](/goldenmatch/scoring) and [Blocking](/goldenmatch/blocking) -- per-topic detail.
+- [Config linter](/goldenmatch/config-linter) -- the pre-flight rules that flag risky config.

--- a/packages/python/goldenmatch/goldenmatch/core/config_matrix/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_matrix/__init__.py
@@ -1,0 +1,38 @@
+"""Config-matrix doc generator: the config surface IS the documented surface.
+
+The full GoldenMatch config knob matrix (`docs-site/goldenmatch/config-matrix.mdx`)
+is generated from code so it cannot silently drift:
+
+- the pydantic `GoldenMatchConfig` tree (every config object, field, type, Literal
+  choice, and default) is introspected directly -- the schema is the source of
+  truth (unlike `configuration.mdx`, which is hand-maintained prose);
+- the enumerated string vocabularies (`VALID_SCORERS`, `VALID_STRATEGIES`, ...)
+  are rendered from the frozensets in `config/schemas.py`;
+- the `GOLDENMATCH_*` environment knobs are scanned out of the Python + Rust
+  source so the index is complete (semantics live in `tuning.mdx`).
+
+CI regenerates the block between the `config-matrix:generated` markers and diffs
+it against the committed page (`scripts/gen_config_matrix.py --check`), so adding
+or removing a knob without updating the matrix turns the merge queue red.
+"""
+from __future__ import annotations
+
+from .docgen import (
+    DOC_PATH,
+    MARKER_END,
+    MARKER_START,
+    docs_are_current,
+    render_generated_block,
+    scan_env_vars,
+    write_docs,
+)
+
+__all__ = [
+    "DOC_PATH",
+    "MARKER_START",
+    "MARKER_END",
+    "render_generated_block",
+    "scan_env_vars",
+    "docs_are_current",
+    "write_docs",
+]

--- a/packages/python/goldenmatch/goldenmatch/core/config_matrix/docgen.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_matrix/docgen.py
@@ -1,0 +1,310 @@
+"""Render (and diff) the generated block of ``config-matrix.mdx`` from code.
+
+Three generated parts, all sourced from the live code so they cannot drift:
+
+1. **Config object reference** -- the pydantic ``GoldenMatchConfig`` tree, walked
+   in field-declaration order. Every reachable config model gets a table of its
+   fields with type, default, and Literal choices / nested-model links.
+2. **Enumerated vocabularies** -- the ``VALID_*`` / group-strategy frozensets in
+   ``config/schemas.py`` (the allowed values for the ``str`` fields above).
+3. **Environment-variable index** -- every ``GOLDENMATCH_*`` name read anywhere
+   in the Python or Rust source (quoted string literals with that prefix are
+   env-var names and nothing else). Semantics live in ``tuning.mdx``; this index
+   only guarantees completeness.
+
+Only the text between the ``config-matrix:generated`` markers is owned by this
+generator; the prose around it (intro + the combinations/outcomes matrix) is
+hand-authored. ``docs_are_current()`` compares the committed marked block to a
+fresh render; CI runs ``scripts/gen_config_matrix.py --check``.
+"""
+from __future__ import annotations
+
+import re
+import types
+import typing
+from pathlib import Path
+
+from pydantic import BaseModel
+from pydantic_core import PydanticUndefined
+
+from goldenmatch.config import schemas as S
+
+# ROOT/packages/python/goldenmatch/goldenmatch/core/config_matrix/docgen.py
+ROOT = Path(__file__).resolve().parents[6]
+DOC_PATH = ROOT / "docs-site" / "goldenmatch" / "config-matrix.mdx"
+_PKG_DIR = Path(__file__).resolve().parents[2]  # .../goldenmatch/goldenmatch (inner package)
+_RUST_DIR = ROOT / "packages" / "rust" / "extensions"
+
+MARKER_START = "{/* config-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_config_matrix.py --write */}"
+MARKER_END = "{/* config-matrix:generated:end */}"
+
+_ROOT_MODEL = S.GoldenMatchConfig
+
+# ---------------------------------------------------------------------------
+# type rendering
+# ---------------------------------------------------------------------------
+
+
+def _is_model(tp: object) -> bool:
+    return isinstance(tp, type) and issubclass(tp, BaseModel)
+
+
+def _clean(text: str) -> str:
+    """Make generated text safe inside an MDX table cell: escape the table pipe
+    and the JSX-significant characters (`<`, `{`, `}`) so a description or type
+    string can never break the Mintlify build."""
+    return (
+        text.replace("|", r"\|")
+        .replace("<", "&lt;")
+        .replace("{", "&#123;")
+        .replace("}", "&#125;")
+    )
+
+
+def render_type(ann: object) -> tuple[str, list[str], list[str]]:
+    """Return ``(type_str, literal_choices, nested_model_names)`` for an annotation."""
+    origin = typing.get_origin(ann)
+    args = typing.get_args(ann)
+
+    # Optional / Union (both typing.Union and the X | Y form)
+    if origin is typing.Union or isinstance(ann, types.UnionType):
+        parts = [a for a in args if a is not type(None)]
+        has_none = len(parts) != len(args)
+        rendered, choices, nested = [], [], []
+        for part in parts:
+            t, c, n = render_type(part)
+            rendered.append(t)
+            choices += c
+            nested += n
+        text = " | ".join(rendered) if rendered else "None"
+        if has_none:
+            text += " | None"
+        return text, choices, nested
+
+    if origin is typing.Literal:
+        return "Literal", [str(a) for a in args], []
+
+    if origin in (list, set, frozenset):
+        inner, c, n = render_type(args[0]) if args else ("", [], [])
+        name = {list: "list", set: "set", frozenset: "frozenset"}[origin]
+        return f"{name}[{inner}]", c, n
+
+    if origin is dict:
+        k = render_type(args[0])[0] if args else ""
+        v, c, n = render_type(args[1]) if len(args) > 1 else ("", [], [])
+        return f"dict[{k}, {v}]", c, n
+
+    if _is_model(ann):
+        return ann.__name__, [], [ann.__name__]
+
+    if isinstance(ann, type):
+        return ann.__name__, [], []
+
+    # typing constructs we don't special-case (rare): fall back to a clean str
+    return _clean(str(ann).replace("typing.", "")), [], []
+
+
+def _default_repr(fi) -> str:
+    if fi.default is PydanticUndefined and fi.default_factory is None:
+        return "**required**"
+    if fi.default_factory is not None:
+        try:
+            val = fi.default_factory()
+        except Exception:
+            return "_(factory)_"
+        if isinstance(val, BaseModel):
+            return f"_(default {type(val).__name__})_"
+        return f"`{val!r}`"
+    if isinstance(fi.default, BaseModel):
+        return f"_(default {type(fi.default).__name__})_"
+    return f"`{fi.default!r}`"
+
+
+# ---------------------------------------------------------------------------
+# model traversal
+# ---------------------------------------------------------------------------
+
+
+def reachable_models() -> list[type[BaseModel]]:
+    """All config models reachable from GoldenMatchConfig, in BFS field order
+    (root first, then each nested model the first time it is referenced)."""
+    ordered: list[type[BaseModel]] = [_ROOT_MODEL]
+    seen: set[type[BaseModel]] = {_ROOT_MODEL}
+    queue: list[type[BaseModel]] = [_ROOT_MODEL]
+    while queue:
+        model = queue.pop(0)
+        for fi in model.model_fields.values():
+            _, _, nested = render_type(fi.annotation)
+            for name in nested:
+                tp = getattr(S, name, None)
+                if _is_model(tp) and tp not in seen:
+                    seen.add(tp)
+                    ordered.append(tp)
+                    queue.append(tp)
+    return ordered
+
+
+def render_schema_section() -> str:
+    lines = ["## Config object reference", "",
+             "Every config object in the pydantic `GoldenMatchConfig` tree, "
+             "generated from `config/schemas.py`. Nested objects link by name.",
+             ""]
+    for model in reachable_models():
+        lines.append(f"### `{model.__name__}`")
+        doc = (model.__doc__ or "").strip().splitlines()
+        if doc:
+            lines.append(f"_{doc[0].strip()}_")
+        lines.append("")
+        lines.append("| Field | Type | Default | Choices / notes |")
+        lines.append("|---|---|---|---|")
+        for fname, fi in model.model_fields.items():
+            type_str, choices, nested = render_type(fi.annotation)
+            notes = ""
+            if choices:
+                notes = ", ".join(f"`{c}`" for c in choices)
+            elif nested:
+                notes = ", ".join(f"[`{n}`](#{n.lower()})" for n in dict.fromkeys(nested))
+            if fi.description:
+                desc = _clean(fi.description.strip())
+                notes = f"{notes} -- {desc}" if notes else desc
+            alias = f" _(alias `{fi.alias}`)_" if getattr(fi, "alias", None) else ""
+            lines.append(
+                f"| `{fname}`{alias} | {_clean(type_str)} | {_default_repr(fi)} | {notes} |"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# enumerated vocabularies
+# ---------------------------------------------------------------------------
+
+_VOCABS = [
+    ("Scorers", "VALID_SCORERS", "`MatchkeyField.scorer` / `NegativeEvidenceField.scorer`"),
+    ("Simple transforms", "VALID_SIMPLE_TRANSFORMS", "`transforms` chains"),
+    ("Survivorship strategies", "VALID_STRATEGIES", "`GoldenFieldRule.strategy`"),
+    ("Group survivorship strategies", "_GROUP_STRATEGIES", "`GoldenGroupRule.strategy`"),
+    ("Standardizers", "VALID_STANDARDIZERS", "`StandardizationConfig.rules`"),
+    ("Matchkey types", "_VALID_MK_TYPES", "`MatchkeyConfig.type`"),
+]
+
+
+def render_vocab_section() -> str:
+    lines = ["## Enumerated vocabularies", "",
+             "The allowed string values for the `str`-typed fields above, from "
+             "the frozensets in `config/schemas.py`.", "",
+             "| Vocabulary | Constant | Applies to | Values |",
+             "|---|---|---|---|"]
+    for title, const, applies in _VOCABS:
+        values = getattr(S, const)
+        rendered = ", ".join(f"`{v}`" for v in sorted(values))
+        lines.append(f"| {title} | `{const}` | {applies} | {rendered} |")
+    lines.append("")
+    lines.append("Extended-grammar transforms (regex-validated, not in the set "
+                 "above): `substring:<start>:<end>`, `qgram:<n>`, `bloom_filter"
+                 "[:<a>:<b>:<c>]`. Custom survivorship: `custom:<snake_case>`. "
+                 "Plugin scorers/transforms resolve via the plugin registry.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# environment-variable index
+# ---------------------------------------------------------------------------
+
+_ENV_RE = re.compile(r"""["'](GOLDENMATCH_[A-Z0-9_]+)["']""")
+_ENV_PREFIX_ORDER = [
+    "NATIVE", "FRAME", "BUCKET", "COLUMNAR", "FS", "AUTOCONFIG", "PLANNER",
+    "PLANNING", "BLOCKING", "CLUSTER", "DISTRIBUTED", "WCC", "GOLDEN", "NE",
+    "SUGGEST", "HEAL", "THROUGHPUT", "RECALL", "SIMILARITY", "LLM", "GPU",
+    "EMBEDDING", "INHOUSE", "MCP", "API", "AGENT", "WEB", "ALLOWED",
+    "DATABASE", "IDENTITY", "SYNC", "VECTOR", "ANALYTICS", "SAIL", "SNOWFLAKE",
+    "PREP", "PREPARED", "MATCH", "GOLDEN_FUSED", "BENCH", "CONFIG",
+]
+
+
+def scan_env_vars() -> dict[str, list[str]]:
+    """Every ``GOLDENMATCH_*`` name that appears as a quoted string literal in
+    the non-test Python and Rust source, grouped by first token. That prefix is
+    only ever an env-var name, so quoted literals are a complete, precise scrape."""
+    names: set[str] = set()
+    roots = [(_PKG_DIR, "*.py"), (_RUST_DIR, "*.rs")]
+    for root, glob in roots:
+        if not root.exists():
+            continue
+        for path in root.rglob(glob):
+            parts = path.parts
+            if "tests" in parts or path.name.startswith("test_") or path.name.endswith("_test.py"):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            names.update(_ENV_RE.findall(text))
+
+    groups: dict[str, list[str]] = {}
+    for name in names:
+        body = name[len("GOLDENMATCH_"):]
+        token = next((p for p in _ENV_PREFIX_ORDER if body.startswith(p)), None)
+        key = token or "OTHER"
+        groups.setdefault(key, []).append(name)
+    return {k: sorted(v) for k, v in sorted(groups.items())}
+
+
+def render_env_section() -> str:
+    groups = scan_env_vars()
+    total = sum(len(v) for v in groups.values())
+    lines = ["## Environment variables (index)", "",
+             f"{total} `GOLDENMATCH_*` runtime knobs are read by the engine "
+             "(Python + native kernel). This index is scanned from source so it "
+             "is complete; **defaults, valid values, and effects live in "
+             "[Tuning & opt-ins](/goldenmatch/tuning)**. Grouped by area:", ""]
+    for group, envs in groups.items():
+        rendered = ", ".join(f"`{e}`" for e in envs)
+        lines.append(f"- **{group}** ({len(envs)}): {rendered}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# assembly + splice + diff
+# ---------------------------------------------------------------------------
+
+
+def render_generated_block() -> str:
+    body = "\n".join([
+        render_schema_section().rstrip(),
+        "",
+        render_vocab_section().rstrip(),
+        "",
+        render_env_section().rstrip(),
+    ])
+    return f"{MARKER_START}\n\n{body}\n\n{MARKER_END}"
+
+
+def _splice(existing: str, block: str) -> str:
+    """Replace the region between the markers (inclusive) with ``block``."""
+    start = existing.find(MARKER_START)
+    end = existing.find(MARKER_END)
+    if start == -1 or end == -1 or end < start:
+        raise ValueError(
+            f"{DOC_PATH} is missing the config-matrix generated markers; "
+            "the page must contain both MARKER_START and MARKER_END."
+        )
+    return existing[:start] + block + existing[end + len(MARKER_END):]
+
+
+def _rendered_full() -> str:
+    existing = DOC_PATH.read_text(encoding="utf-8")
+    return _splice(existing, render_generated_block())
+
+
+def docs_are_current() -> bool:
+    if not DOC_PATH.exists():
+        return False
+    return DOC_PATH.read_text(encoding="utf-8") == _rendered_full()
+
+
+def write_docs() -> Path:
+    DOC_PATH.write_text(_rendered_full(), encoding="utf-8", newline="\n")
+    return DOC_PATH

--- a/packages/python/goldenmatch/scripts/gen_config_matrix.py
+++ b/packages/python/goldenmatch/scripts/gen_config_matrix.py
@@ -1,0 +1,39 @@
+"""Generate (or check) the config-matrix doc from the live config surface.
+
+  python scripts/gen_config_matrix.py --write   # regenerate the .mdx block
+  python scripts/gen_config_matrix.py --check    # exit 1 if the committed .mdx is stale
+
+The pydantic `GoldenMatchConfig` tree + the `VALID_*` vocabularies + the scanned
+`GOLDENMATCH_*` env set are the source of truth; the committed page's generated
+block must match them. CI runs --check (mirroring gen_lint_docs.py), so adding or
+removing a config knob without regenerating the matrix turns the merge queue red.
+"""
+from __future__ import annotations
+
+import sys
+
+from goldenmatch.core.config_matrix import DOC_PATH, docs_are_current, write_docs
+
+
+def main(argv: list[str]) -> int:
+    if "--check" in argv:
+        if docs_are_current():
+            print(f"config matrix is current: {DOC_PATH}")
+            return 0
+        print(
+            f"::error::{DOC_PATH} is stale vs the config surface "
+            f"(schema / VALID_* / GOLDENMATCH_* env). "
+            f"Run: python scripts/gen_config_matrix.py --write",
+            file=sys.stderr,
+        )
+        return 1
+    if "--write" in argv:
+        p = write_docs()
+        print(f"wrote {p}")
+        return 0
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/packages/python/goldenmatch/tests/test_config_matrix.py
+++ b/packages/python/goldenmatch/tests/test_config_matrix.py
@@ -1,0 +1,41 @@
+"""The generated config-matrix page must stay in lockstep with the config surface.
+
+Mirrors tests/test_config_lint.py: the pydantic schema + VALID_* vocabularies +
+scanned GOLDENMATCH_* env set are the source of truth, and the committed
+`config-matrix.mdx` generated block must match a fresh render. Adding/removing a
+config knob without regenerating turns this test (and the merge queue) red.
+Regenerate with: python scripts/gen_config_matrix.py --write
+"""
+from __future__ import annotations
+
+from goldenmatch.config import schemas as S
+from goldenmatch.core.config_matrix import docgen
+
+
+def test_config_matrix_is_current():
+    assert docgen.docs_are_current(), (
+        f"{docgen.DOC_PATH} is stale vs the config surface. "
+        "Run: python scripts/gen_config_matrix.py --write"
+    )
+
+
+def test_generated_markers_present():
+    text = docgen.DOC_PATH.read_text(encoding="utf-8")
+    assert docgen.MARKER_START in text
+    assert docgen.MARKER_END in text
+
+
+def test_env_scan_finds_known_flags():
+    flat = {name for names in docgen.scan_env_vars().values() for name in names}
+    # A representative slice across native, FS, frame, and server areas.
+    for expected in ("GOLDENMATCH_NATIVE", "GOLDENMATCH_FS_MISSING",
+                     "GOLDENMATCH_FRAME", "GOLDENMATCH_MCP_TOKEN"):
+        assert expected in flat, f"env scan missed {expected}"
+
+
+def test_root_model_and_vocabs_rendered():
+    block = docgen.render_generated_block()
+    assert "### `GoldenMatchConfig`" in block
+    # Every enumerated scorer/strategy value must appear in the vocab tables.
+    for value in (*S.VALID_SCORERS, *S.VALID_STRATEGIES, *S.VALID_STANDARDIZERS):
+        assert f"`{value}`" in block, f"vocabulary value {value} not rendered"


### PR DESCRIPTION
## What
A single, exhaustive, **always-current** reference for every GoldenMatch config knob — built for humans and AI agents — plus a **blocking CI gate** so it can't drift.

### New page: `docs-site/goldenmatch/config-matrix.mdx`
- **Combinations & intended outcomes** (hand-authored): matchkey type (`exact`/`weighted`/`probabilistic`); missing-mode × scorer; blocking strategy × scale; execution routing (in-memory/bucket/distributed/scale-mode); dedupe vs link; survivorship (field rules/groups/conditional/correlated); `propagation_mode`; native/frame kill-switches.
- **Generated block** (from code, between markers): the full pydantic `GoldenMatchConfig` tree — every config object, field, type, `Literal` choice, and default — the `VALID_*` vocabularies, and a complete `GOLDENMATCH_*` env index (**147** knobs, scanned from Python + Rust source; semantics stay in `tuning.mdx`).

### Generator + gate
`goldenmatch/core/config_matrix/` + `scripts/gen_config_matrix.py`, mirroring the `config_lint` docgen pattern:
- `--write` regenerates the block; `--check` diffs the committed page vs a fresh render.
- Closes the real gap: `configuration.mdx` is hand-maintained and can silently drift from the schema; this is generated and gated.

### CI ("hate on CI if the matrix needs to change")
- Blocking **`config_matrix`** job (added to `ci-required`) runs `--check`, path-filtered on the schema + generator + doc + the whole goldenmatch py/rust source (the env-scan surface).
- Plus `tests/test_config_matrix.py` for local `pytest` coverage.
- Adding/removing any knob without regenerating the matrix turns the merge queue red.

## Verification
- `--check` catches an **injected** env var (exit 1) and clears on removal (exit 0).
- `ci.yml` + `filters.yml` parse (no startup-failure); `docs.json` parses; `check_docs_consistency` nav-integrity green; pytest 4/4.
- MDX-safety: generated cells escape `<`/`{`/`}`/`|`; the page never breaks the Mintlify build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd