### PR TITLE
feat(goldenmatch): route the #1207 blocking union through the shared native core (#1317 increment 3)

### DIFF
--- a/docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md
+++ b/docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md
@@ -119,10 +119,20 @@ null_rate, cardinality_ratio)` — no extra host input.
      `blocking-union.parity.test.ts` (Python-oracle fixture): TS emits the SAME
      union as Python on the null-sparse multi-source case, and the SAME name
      fallback on the bare-`first`/`last` case. **#1317 closed.**
-3. **Python reroute.** Route `_build_strong_identifier_union` + the call-site
-   survivor filtering through the core (native when the wheel carries the symbol,
-   pure-Python fallback matching the core otherwise). Equivalence test
-   Python == core golden. Wheel republish is CI's job.
+3. **Python reroute (SHIPPED).** `build_blocking` routes the #1207 union DECISION
+   through the shared core when the `goldenmatch-native` wheel carries the symbol
+   (`autoconfig_assemble_/finalize_strong_id_union` pyo3 shims + the
+   `native_enabled("autoconfig")` + `hasattr` gate, mirroring the planner), else
+   the legacy `_build_strong_identifier_union` + call-site survivor filter (kept
+   BYTE-UNCHANGED — its direct unit tests still pass verbatim). The host still
+   MEASURES OR-coverage + per-pass scale-safety; the core ASSEMBLES + gates. A
+   pyo3-free pure-Python mirror (`blocking_union_core.py`,
+   `assemble_/finalize_strong_id_union_pure`) is the symbol-less-wheel fallback.
+   Proven three ways: (a) the pure mirror reproduces `select_blocking_vectors.json`
+   (Python == Rust == TS); (b) native IS the Rust core, exercised by the `native`
+   CI lane; (c) an equivalence test that the core path == the legacy path on both
+   a union-firing and a decline dataset. Wheel republish is CI's job. Default
+   users (no wheel) are byte-unchanged.
 
 Later increments can migrate the rest of `build_blocking` (exact-pool pick,
 compound fallback, name fallback) into the core the same way; the union is first

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -36,6 +36,11 @@ from goldenmatch.core.autoconfig_discriminative import (
     should_demote_attribute_field,
     should_veto_exact,
 )
+from goldenmatch.core.blocking_union_core import (
+    assemble_union,
+    finalize_union,
+    union_via_core_enabled,
+)
 from goldenmatch.core.complexity_profile import DataProfile
 from goldenmatch.core.profile_emitter import _emitter_stack, current_emitter
 from goldenmatch.core.profiler import _guess_type
@@ -3173,37 +3178,89 @@ def build_blocking(
             return _project_pairs_per_row(pb) <= _blocking_pairs_per_row_budget()
         return True
 
-    union_cfg = _build_strong_identifier_union(profiles, df, n_rows_full=n_rows_full)
-    if union_cfg is not None:
-        id_passes: list[BlockingKeyConfig] = []
-        other_passes: list[BlockingKeyConfig] = []
-        for p in union_cfg.passes or []:
-            if len(p.fields) == 1 and _col_types.get(p.fields[0]) in _STRONG_EXACT_TYPES:
-                id_passes.append(p)
-            else:
-                other_passes.append(p)
-        # Strong-id singletons: gate on the NON-NULL projected block (the static
-        # blocker drops null keys). Name/geo passes: standard #715/#876 gate.
-        surviving_ids = [p for p in id_passes if _id_pass_scale_safe_nonnull(p.fields[0])]
-        surviving_other = [p for p in other_passes if _pass_is_bounded(p)]
-        survivors = surviving_ids + surviving_other
-        if surviving_ids and len(survivors) >= 2:
-            primary = survivors[0]
-            logger.info(
-                "Auto-selecting strong-identifier blocking UNION (%d passes, "
-                "%d strong-id) on null-sparse data: no single exact key cleared "
-                "the 0.20 null ceiling; union OR-coverage restores the dropped "
-                "population. Strong-id passes gated on non-null block size "
-                "(null keys are dropped at runtime). See #1207.",
-                len(survivors), len(surviving_ids),
-            )
-            return BlockingConfig(
-                keys=[primary],
-                strategy="multi_pass",
-                passes=survivors,
-                max_block_size=max_safe_block,
-                skip_oversized=True,
-            )
+    if union_via_core_enabled():
+        # #1317 increment 3: route the #1207 union DECISION through the shared
+        # native ``autoconfig-core`` kernel (byte-identical to the pure-Python
+        # path below; see ``blocking_union_core``). The host still MEASURES the
+        # two row-level signals (OR-coverage + per-pass scale-safety); the core
+        # ASSEMBLES the candidate passes and applies the coverage/survivor gates.
+        _union_cols = [
+            {
+                "name": p.name,
+                "col_type": p.col_type,
+                "null_rate": _null_rate(p.name),
+                "cardinality_ratio": float(p.cardinality_ratio or 0.0),
+            }
+            for p in profiles
+        ]
+        _cand = assemble_union(_union_cols)
+        if _cand is not None:
+            _cov = _union_coverage(df, [list(p["fields"]) for p in _cand])
+            _survives = [
+                _id_pass_scale_safe_nonnull(p["fields"][0])
+                if p["is_strong_id"]
+                else _pass_is_bounded(
+                    BlockingKeyConfig(fields=list(p["fields"]), transforms=list(p["transforms"]))
+                )
+                for p in _cand
+            ]
+            _out = finalize_union(_cand, _cov, _survives, max_safe_block)
+            if _out is not None:
+                logger.info(
+                    "Auto-selecting strong-identifier blocking UNION via the shared "
+                    "native core (%d passes) on null-sparse data. See #1207/#1317.",
+                    len(_out["passes"]),
+                )
+                return BlockingConfig(
+                    keys=[
+                        BlockingKeyConfig(
+                            fields=list(k["fields"]), transforms=list(k["transforms"])
+                        )
+                        for k in _out["keys"]
+                    ],
+                    strategy="multi_pass",
+                    passes=[
+                        BlockingKeyConfig(
+                            fields=list(p["fields"]), transforms=list(p["transforms"])
+                        )
+                        for p in _out["passes"]
+                    ],
+                    max_block_size=int(_out["max_block_size"]),
+                    skip_oversized=True,
+                )
+        # The core declined the union -> fall through to the name fallback below.
+    else:
+        union_cfg = _build_strong_identifier_union(profiles, df, n_rows_full=n_rows_full)
+        if union_cfg is not None:
+            id_passes: list[BlockingKeyConfig] = []
+            other_passes: list[BlockingKeyConfig] = []
+            for p in union_cfg.passes or []:
+                if len(p.fields) == 1 and _col_types.get(p.fields[0]) in _STRONG_EXACT_TYPES:
+                    id_passes.append(p)
+                else:
+                    other_passes.append(p)
+            # Strong-id singletons: gate on the NON-NULL projected block (the static
+            # blocker drops null keys). Name/geo passes: standard #715/#876 gate.
+            surviving_ids = [p for p in id_passes if _id_pass_scale_safe_nonnull(p.fields[0])]
+            surviving_other = [p for p in other_passes if _pass_is_bounded(p)]
+            survivors = surviving_ids + surviving_other
+            if surviving_ids and len(survivors) >= 2:
+                primary = survivors[0]
+                logger.info(
+                    "Auto-selecting strong-identifier blocking UNION (%d passes, "
+                    "%d strong-id) on null-sparse data: no single exact key cleared "
+                    "the 0.20 null ceiling; union OR-coverage restores the dropped "
+                    "population. Strong-id passes gated on non-null block size "
+                    "(null keys are dropped at runtime). See #1207.",
+                    len(survivors), len(surviving_ids),
+                )
+                return BlockingConfig(
+                    keys=[primary],
+                    strategy="multi_pass",
+                    passes=survivors,
+                    max_block_size=max_safe_block,
+                    skip_oversized=True,
+                )
 
     # ── Check if name-based fallback would also be oversized ──
     # #715: the name path picks ONE primary name column (pattern_names[0], else

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_union_core.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_union_core.py
@@ -1,0 +1,199 @@
+"""Shared decision core for the #1207 strong-identifier blocking union.
+
+This is the Python side of the cross-surface ``autoconfig-core`` blocking-union
+kernel (Rust ``select_blocking.rs`` → the ``goldenmatch-native`` wheel + the
+TS-wasm surface). The DECISION (assembly + the coverage/survivor/re-gate)
+lives once in Rust; this module either delegates to that native kernel (when the
+wheel carries the symbol) or runs a **byte-identical pure-Python mirror** as the
+fallback — the reference-mode posture (`docs/design/2026-07-01-rust-is-the-
+reference-roadmap.md`).
+
+Two phases, over the same JSON-boundary shapes the native/wasm shims use:
+
+  * ``assemble_union(cols)`` — phase 1, pure assembly from column profiles
+    (``{name, col_type, null_rate, cardinality_ratio}``). Returns candidate
+    passes (``{fields, transforms, is_strong_id}``) or ``None`` (needs ≥1
+    strong-id AND ≥2 passes). Name-column detection uses ``_classify_by_name``
+    (the name-*pattern* classifier), exactly as the Rust core does.
+  * ``finalize_union(passes, coverage, pass_survives, max_safe_block)`` — phase
+    2, pure gates: coverage ≥ target, survivor filter (host-measured), re-gate
+    (≥1 surviving strong-id AND ≥2 survivors). Returns the emitted config
+    (``{strategy, keys, passes, max_block_size, skip_oversized}``) or ``None``.
+
+The HOST (``build_blocking`` in ``autoconfig.py``) measures the two row-level
+signals between the phases — OR-coverage and per-pass scale-safety — because
+those need polars, not a profile aggregate (the smart-core / dumb-measurement
+split the planner already uses).
+
+Pinned byte-for-byte to the Rust core by ``select_blocking_vectors.json`` (the
+same golden fixture the Rust ``tests/golden.rs`` and the TS parity test read),
+so native == pure-Python == Rust == TS.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Mirror of the union constants in ``autoconfig.py`` (kept in lockstep with the
+# Rust ``select_blocking.rs`` constants).
+_STRONG_EXACT_TYPES = ("identifier", "email", "phone")
+_UNION_PASS_MIN_NONNULL = 0.02
+_BLOCKING_UNION_COVERAGE_TARGET = 0.95
+
+
+def _transforms_for(field: str, cols: list[dict[str, Any]]) -> list[str]:
+    """``email`` → ``[lowercase, strip]``, else ``[strip]`` (keyed on the FIRST
+    field's col_type, matching the Rust core + ``_build_strong_identifier_union``)."""
+    for c in cols:
+        if c["name"] == field:
+            if c.get("col_type") == "email":
+                return ["lowercase", "strip"]
+            break
+    return ["strip"]
+
+
+def assemble_strong_id_union_pure(cols: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+    """Pure-Python mirror of ``assemble_strong_id_union`` (phase 1).
+
+    ``None`` unless ≥1 strong-id pass AND ≥2 distinct passes. NO coverage check
+    (that is phase 2, once the host has measured it).
+    """
+    from goldenmatch.core.autoconfig import _classify_by_name  # noqa: PLC0415
+
+    passes: list[dict[str, Any]] = []
+    strong_id_count = 0
+    for c in cols:
+        if c.get("col_type") not in _STRONG_EXACT_TYPES:
+            continue
+        nonnull = 1.0 - float(c.get("null_rate", 0.0))
+        if nonnull < _UNION_PASS_MIN_NONNULL:
+            continue
+        # #876 surrogate guard: a perfect-surrogate id (card_ratio >= 1.0) makes
+        # singleton blocks. blocking_max_ratio is deliberately NOT applied here.
+        if float(c.get("cardinality_ratio") or 0.0) >= 1.0:
+            continue
+        passes.append({
+            "fields": [c["name"]],
+            "transforms": _transforms_for(c["name"], cols),
+            "is_strong_id": True,
+        })
+        strong_id_count += 1
+
+    if strong_id_count < 1:
+        return None
+
+    # name+geo passes for rows missing every strong id.
+    name_cols = [c for c in cols if _classify_by_name(c["name"]) == "name"]
+    first = next((c["name"] for c in name_cols if "first" in c["name"].lower()), None)
+    last = next(
+        (c["name"] for c in name_cols
+         if "last" in c["name"].lower() or "surname" in c["name"].lower()),
+        None,
+    )
+    geo = next((c["name"] for c in cols if c.get("col_type") in ("zip", "geo")), None)
+
+    if first is not None and last is not None:
+        passes.append({
+            "fields": [first, last],
+            "transforms": _transforms_for(first, cols),
+            "is_strong_id": False,
+        })
+    if last is not None and geo is not None:
+        passes.append({
+            "fields": [last, geo],
+            "transforms": _transforms_for(last, cols),
+            "is_strong_id": False,
+        })
+
+    if len(passes) < 2:
+        return None
+    return passes
+
+
+def finalize_strong_id_union_pure(
+    passes: list[dict[str, Any]],
+    coverage: float,
+    pass_survives: list[bool],
+    max_safe_block: int,
+) -> dict[str, Any] | None:
+    """Pure-Python mirror of ``finalize_strong_id_union`` (phase 2).
+
+    ``None`` (fall through) when the coverage target is not cleared, or < 2
+    passes survive, or no strong-id survives. ``pass_survives[i]`` is the host's
+    scale-safety verdict for ``passes[i]``.
+    """
+    if coverage < _BLOCKING_UNION_COVERAGE_TARGET:
+        return None
+    if len(pass_survives) != len(passes):
+        return None
+    survivors = [p for p, ok in zip(passes, pass_survives) if ok]
+    any_strong_id = any(p["is_strong_id"] for p in survivors)
+    if not any_strong_id or len(survivors) < 2:
+        return None
+    return {
+        "strategy": "multi_pass",
+        "keys": [survivors[0]],
+        "passes": survivors,
+        "max_block_size": max_safe_block,
+        "skip_oversized": True,
+    }
+
+
+# ── Native-routing wrappers ────────────────────────────────────────────────
+#
+# When the ``autoconfig`` component is native-enabled AND the wheel carries the
+# symbol, delegate to the Rust kernel (byte-identical by construction); else run
+# the pure-Python mirror. The ``hasattr`` guard keeps a wheel that predates these
+# symbols (but has the Phase-1 ``autoconfig_decide_plan``) on the pure path.
+
+
+def _native():
+    """Return the native module iff the autoconfig union kernel is usable, else None."""
+    from goldenmatch.core._native_loader import native_enabled, native_module  # noqa: PLC0415
+
+    if not native_enabled("autoconfig"):
+        return None
+    nm = native_module()
+    if nm is None or not hasattr(nm, "autoconfig_assemble_strong_id_union"):
+        return None
+    if not hasattr(nm, "autoconfig_finalize_strong_id_union"):
+        return None
+    return nm
+
+
+def assemble_union(cols: list[dict[str, Any]]) -> list[dict[str, Any]] | None:
+    """Phase 1 — native when available, else the pure-Python mirror."""
+    import json  # noqa: PLC0415
+
+    nm = _native()
+    if nm is not None:
+        out = nm.autoconfig_assemble_strong_id_union(json.dumps(cols))
+        return json.loads(out)
+    return assemble_strong_id_union_pure(cols)
+
+
+def finalize_union(
+    passes: list[dict[str, Any]],
+    coverage: float,
+    pass_survives: list[bool],
+    max_safe_block: int,
+) -> dict[str, Any] | None:
+    """Phase 2 — native when available, else the pure-Python mirror."""
+    import json  # noqa: PLC0415
+
+    nm = _native()
+    if nm is not None:
+        payload = json.dumps({
+            "passes": passes,
+            "coverage": coverage,
+            "pass_survives": pass_survives,
+            "max_safe_block": int(max_safe_block),
+        })
+        out = nm.autoconfig_finalize_strong_id_union(payload)
+        return json.loads(out)
+    return finalize_strong_id_union_pure(passes, coverage, pass_survives, max_safe_block)
+
+
+def union_via_core_enabled() -> bool:
+    """True when the native union kernel should drive ``build_blocking`` (the
+    wheel carries the symbol AND autoconfig is native-enabled)."""
+    return _native() is not None

--- a/packages/python/goldenmatch/tests/test_blocking_union_core_parity.py
+++ b/packages/python/goldenmatch/tests/test_blocking_union_core_parity.py
@@ -1,0 +1,132 @@
+"""Cross-surface parity for the #1207 strong-identifier blocking union core
+(increment 3 — the Python reroute through the shared ``autoconfig-core`` kernel).
+
+Two guarantees:
+
+1. **Golden parity** — the pure-Python mirror (`assemble_strong_id_union_pure` /
+   `finalize_strong_id_union_pure`) reproduces the SAME
+   ``select_blocking_vectors.json`` the Rust ``tests/golden.rs`` and the TS parity
+   test read. So Python == Rust == TS by construction; the native pyo3 shim IS
+   the Rust core, so native == Rust too (its own path is exercised by the
+   ``native`` CI lane).
+
+2. **Core-path == legacy-path equivalence** — with the core path forced on (via
+   the pure mirror; no wheel needed), ``build_blocking`` emits the SAME
+   ``BlockingConfig`` as the legacy ``_build_strong_identifier_union`` +
+   call-site survivor filter, both on a union-firing dataset and on a dataset
+   where the union declines. This proves the reroute is output-identical to the
+   path it replaces when the wheel is present.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import polars as pl
+import pytest
+from goldenmatch.core import autoconfig
+from goldenmatch.core.autoconfig import build_blocking, profile_columns
+from goldenmatch.core.blocking_union_core import (
+    assemble_strong_id_union_pure,
+    finalize_strong_id_union_pure,
+)
+
+_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "rust"
+    / "extensions"
+    / "autoconfig-core"
+    / "golden"
+    / "select_blocking_vectors.json"
+)
+
+
+def _load_fixture() -> dict:
+    return json.loads(_FIXTURE.read_text())
+
+
+@pytest.mark.skipif(not _FIXTURE.exists(), reason="autoconfig-core golden fixture not present")
+def test_pure_mirror_reproduces_golden_assemble():
+    fx = _load_fixture()
+    assert len(fx["assemble"]) >= 6
+    for case in fx["assemble"]:
+        got = assemble_strong_id_union_pure(case["input"])
+        assert got == case["expected"], f"assemble[{case['name']}]"
+
+
+@pytest.mark.skipif(not _FIXTURE.exists(), reason="autoconfig-core golden fixture not present")
+def test_pure_mirror_reproduces_golden_finalize():
+    fx = _load_fixture()
+    assert len(fx["finalize"]) >= 5
+    for case in fx["finalize"]:
+        i = case["input"]
+        got = finalize_strong_id_union_pure(
+            i["passes"], i["coverage"], i["pass_survives"], i["max_safe_block"]
+        )
+        assert got == case["expected"], f"finalize[{case['name']}]"
+
+
+def _union_dataset() -> pl.DataFrame:
+    """Null-sparse multi-source strong-id shape — no single exact key clears the
+    0.20 null ceiling, so ``build_blocking`` reaches the union path."""
+    rows = []
+    for i in range(12):
+        rows.append({
+            "first_name": f"First{i}", "last_name": f"Last{i}",
+            "member_id": f"MID{i:04d}", "email": None, "city": f"City{i % 5}",
+        })
+        rows.append({
+            "first_name": f"First{i}", "last_name": f"Last{i}",
+            "member_id": None, "email": f"user{i}@ex.com", "city": f"City{i % 5}",
+        })
+    return pl.DataFrame(rows)
+
+
+def _decline_dataset() -> pl.DataFrame:
+    """Bare first/last (classify_by_name -> None) -> the union declines and the
+    name fallback is emitted."""
+    return pl.DataFrame([
+        {"first": "Alice", "last": "Smith", "phone": "5551234", "zip": "10001"},
+        {"first": "Alice", "last": "Smyth", "phone": "5551234", "zip": "10001"},
+        {"first": "Bob", "last": "Jones", "phone": "5552222", "zip": "10002"},
+        {"first": "Bob", "last": "Jones", "phone": "5552222", "zip": "10002"},
+        {"first": "Carol", "last": "White", "phone": "5553333", "zip": "10003"},
+        {"first": "Dan", "last": "Brown", "phone": "5554444", "zip": "10004"},
+        {"first": "Eve", "last": "Green", "phone": "5555555", "zip": "10005"},
+    ])
+
+
+def _blocking_shape(cfg) -> dict:
+    """Normalize a BlockingConfig to its union-determining structure."""
+    return {
+        "strategy": cfg.strategy,
+        "keys": [(list(k.fields), list(k.transforms)) for k in (cfg.keys or [])],
+        "passes": [(list(p.fields), list(p.transforms)) for p in (cfg.passes or [])],
+    }
+
+
+@pytest.mark.parametrize("make_df", [_union_dataset, _decline_dataset])
+def test_core_path_equals_legacy_path(monkeypatch, make_df):
+    df = make_df()
+    profiles = profile_columns(df)
+
+    # Legacy path (default: no wheel -> union_via_core_enabled() is False).
+    legacy = build_blocking(profiles, df, n_rows_full=df.height)
+
+    # Core path forced on. No wheel is present, so assemble_union/finalize_union
+    # run the pure-Python mirror — the exact fallback a symbol-less wheel uses.
+    monkeypatch.setattr(autoconfig, "union_via_core_enabled", lambda: True)
+    core = build_blocking(profiles, df, n_rows_full=df.height)
+
+    assert _blocking_shape(core) == _blocking_shape(legacy)
+
+
+def test_union_dataset_actually_emits_union():
+    """Guard: the union dataset really exercises the union (not some other path),
+    so the equivalence test above is meaningful."""
+    df = _union_dataset()
+    cfg = build_blocking(profile_columns(df), df, n_rows_full=df.height)
+    assert cfg.strategy == "multi_pass"
+    pass_fields = [list(p.fields) for p in (cfg.passes or [])]
+    assert ["member_id"] in pass_fields
+    assert ["email"] in pass_fields

--- a/packages/rust/extensions/native/src/autoconfig.rs
+++ b/packages/rust/extensions/native/src/autoconfig.rs
@@ -2,8 +2,9 @@
 //! The structured contract lives in the core crate; Python serializes the
 //! input dict to JSON, this deserializes -> calls the core -> serializes back.
 use goldenmatch_autoconfig_core::{
-    classify_columns, decide_plan, exact_matchkey_floor, extrapolate_pair_count,
-    sparse_match_floor, ColumnStats, ExtrapolationInput, PlannerInput,
+    assemble_strong_id_union, classify_columns, decide_plan, exact_matchkey_floor,
+    extrapolate_pair_count, finalize_strong_id_union, sparse_match_floor, BlockingColumnInput,
+    ColumnStats, ExtrapolationInput, PlannerInput, UnionFinalizeInput,
 };
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -56,4 +57,25 @@ pub fn autoconfig_exact_matchkey_floor(input_json: &str) -> PyResult<String> {
         .ok_or_else(|| PyValueError::new_err("missing/invalid col_type"))?;
     let floor = exact_matchkey_floor(col_type);
     Ok(serde_json::json!({ "floor": floor }).to_string())
+}
+
+/// Blocking selection, phase 1 (#1207 strong-identifier union): a JSON array of
+/// `BlockingColumnInput` -> a JSON array of `UnionPass` (candidate passes) or `null`.
+#[pyfunction]
+pub fn autoconfig_assemble_strong_id_union(cols_json: &str) -> PyResult<String> {
+    let cols: Vec<BlockingColumnInput> = serde_json::from_str(cols_json)
+        .map_err(|e| PyValueError::new_err(format!("bad BlockingColumnInput json: {e}")))?;
+    let out = assemble_strong_id_union(&cols);
+    serde_json::to_string(&out).map_err(|e| PyValueError::new_err(e.to_string()))
+}
+
+/// Blocking selection, phase 2 (#1207 strong-identifier union): a JSON
+/// `UnionFinalizeInput` -> a JSON `BlockingConfigOut` (the emitted `multi_pass`
+/// union) or `null`.
+#[pyfunction]
+pub fn autoconfig_finalize_strong_id_union(input_json: &str) -> PyResult<String> {
+    let input: UnionFinalizeInput = serde_json::from_str(input_json)
+        .map_err(|e| PyValueError::new_err(format!("bad UnionFinalizeInput json: {e}")))?;
+    let out = finalize_strong_id_union(&input);
+    serde_json::to_string(&out).map_err(|e| PyValueError::new_err(e.to_string()))
 }

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -137,6 +137,14 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
         autoconfig::autoconfig_exact_matchkey_floor,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(
+        autoconfig::autoconfig_assemble_strong_id_union,
+        m
+    )?)?;
+    m.add_function(wrap_pyfunction!(
+        autoconfig::autoconfig_finalize_strong_id_union,
+        m
+    )?)?;
     m.add_function(wrap_pyfunction!(suggest::suggest_config, m)?)?;
     m.add_function(wrap_pyfunction!(documents::documents_schema_validate, m)?)?;
     m.add_function(wrap_pyfunction!(


### PR DESCRIPTION
## What

Increment 3 completes the shared-core migration of blocking-key selection
(design: `docs/superpowers/specs/2026-07-19-blocking-selection-native-core-design.md`).
`build_blocking` now routes the #1207 strong-identifier union **decision** through the
same `autoconfig-core` kernel the TS surface uses — so the union decision has ONE source of
truth (Rust), with Python == Rust == TS, no hand-maintained parallel logic. (Increment 1
landed the Rust core; 2a/2b brought it to TS and closed #1317.)

- **native pyo3 shims** (`native/src/autoconfig.rs` + `lib.rs`):
  `autoconfig_assemble_strong_id_union` / `autoconfig_finalize_strong_id_union`, the same
  serde-JSON boundary the wasm shims use.
- **`blocking_union_core.py`** — the pyo3-free pure-Python mirror
  (`assemble_/finalize_strong_id_union_pure`, byte-identical to the Rust core) + the
  native-routing wrappers (`assemble_union` / `finalize_union`), gated on
  `native_enabled("autoconfig")` + `hasattr` (wheel-skew safe, mirroring the planner reroute).
- **`build_blocking` call-site**: when the core is enabled (wheel carries the symbol), the
  host MEASURES OR-coverage + per-pass scale-safety and the core ASSEMBLES + applies the
  gates; otherwise the legacy `_build_strong_identifier_union` + call-site survivor filter
  runs **byte-unchanged** (its direct unit tests still pass verbatim). **Default users
  (no wheel) are byte-unchanged.**

## Why safe (proven three ways)

`tests/test_blocking_union_core_parity.py`:
1. the pure-Python mirror reproduces `select_blocking_vectors.json` — the SAME golden fixture
   the Rust `tests/golden.rs` and the TS parity test read (Python == Rust == TS);
2. the native pyo3 shim **is** the Rust core, exercised by the `native` CI lane;
3. an equivalence test that the core path emits the SAME `BlockingConfig` as the legacy path
   on both a union-firing dataset and a decline dataset.

## Validation

- `test_blocking_union_core_parity.py` (5) + the existing #1207 union tests (9) green.
- 204 build_blocking-touching tests green; broad autoconfig sweep 1090 passed (the only
  failures are the DBLP-ACM benchmark tests whose gitignored datasets aren't present locally).
- `cargo check` + `cargo fmt --check` clean on `goldenmatch-native`; `ruff` + `pyright` clean;
  `check_native_symbols.py goldenmatch` → reconciliation OK (both new symbols registered +
  referenced).

Wheel republish is CI's job (the native-wheel-drift advisory covers the lag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_