### PR TITLE
chore(native): bump goldenmatch-native 0.1.18 → 0.1.19 (ship the FS positive-evidence symbol)

### DIFF
--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -572,7 +572,7 @@ dependencies = [
 
 [[package]]
 name = "goldenmatch-native"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "arrow",
  "blake2",

--- a/packages/rust/extensions/native/Cargo.toml
+++ b/packages/rust/extensions/native/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "goldenmatch-native"
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/native/pyproject.toml
+++ b/packages/rust/extensions/native/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "maturin"
 
 [project]
 name = "goldenmatch-native"
-version = "0.1.18"
+version = "0.1.19"
 description = "Optional native (Rust/PyO3) acceleration kernels for goldenmatch"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
+++ b/packages/rust/extensions/native/python/goldenmatch_native/__init__.py
@@ -20,4 +20,4 @@ from importlib.metadata import PackageNotFoundError, version as _pkg_version
 try:
     __version__ = _pkg_version("goldenmatch-native")
 except PackageNotFoundError:  # source checkout without installed dist metadata
-    __version__ = "0.1.18"
+    __version__ = "0.1.19"


### PR DESCRIPTION
## What

Bumps `goldenmatch-native` `0.1.18` → `0.1.19` (pyproject + Cargo + Cargo.lock in lockstep). Version-only; **no code change**.

## Why

#1899 added the `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability const to the native kernel (`native/src/lib.rs`) but did not bump the version. The published `goldenmatch-native 0.1.18` wheel (tag commit `070a3ae9`, cut ~12h before #1899 merged) predates the symbol, so:

- `goldenmatch[native]` installs see a wheel **without** the symbol → the host's `hasattr`-guarded check declines to pass `require_positive_evidence`, and the native FS kernel silently runs the **legacy emit-at-neutral** path. The default-ON net-zero-evidence link filter is therefore a **no-op on native-wheel installs** until the wheel is republished.
- Republishing `0.1.18` is a no-op (`skip-existing` on an immutable PyPI version), so a bump is required.

## Release flow (after merge)

Dispatch `cut-native-release.yml` with `version=0.1.19` — it validates the tree version, pushes the `goldenmatch-native-v0.1.19` tag, and calls `publish-goldenmatch-native.yml` to build every platform wheel + upload to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_