### PR TITLE
ci(docs): Mintlify render gate (mint validate + broken-links --check-anchors)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -740,10 +740,10 @@ readme_callouts:
   - 'packages/python/goldenmatch/CHANGELOG.md'
   - 'scripts/sync_readme_callouts.py'
 docs:
-  # Doc-lockstep gates (scripts/check_docs_*.py). Trigger whenever any
-  # tracked doc surface OR the gate scripts themselves change. The
-  # required `docs_consistency` job and the advisory `docs_staleness`
-  # job both gate on this.
+  # Doc-lockstep gates (scripts/check_docs_*.py) + the Mintlify render gate.
+  # Trigger whenever any tracked doc surface OR the gate scripts themselves
+  # change. The required `docs_consistency` and `docs_render` jobs and the
+  # advisory `docs_staleness` job all gate on this.
   - 'docs-site/**'
   - '**/README.md'
   - '**/CHANGELOG.md'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3231,6 +3231,34 @@ jobs:
       - name: Doc links + frontmatter (in-body cross-links resolve; MDX frontmatter valid)
         run: python scripts/check_docs_links.py
 
+  # Mintlify render gate (BLOCKING): the docs site's OWN parser/build, which the
+  # stdlib check_docs_links.py cannot replicate. `mint validate` builds the site in
+  # strict mode (any warning/error fails) -- it catches malformed MDX/JSX bodies
+  # (e.g. a bare `<->` that opens a JSX tag), invalid frontmatter, and docs.json
+  # schema errors. `mint broken-links --check-anchors` catches broken internal
+  # links AND anchor-slug mismatches (the anchor half is exactly what the Python
+  # check strips). Kept alongside docs_consistency so basic link/frontmatter
+  # coverage survives even if Mintlify's release CDN is unreachable.
+  docs_render:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || needs.changes.outputs.force_all == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    defaults:
+      run:
+        working-directory: docs-site
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 22
+      - name: Install Mintlify CLI
+        run: npm i -g mint
+      - name: Validate docs build (strict; MDX/JSX + frontmatter + docs.json)
+        run: mint validate --disable-openapi
+      - name: Broken internal links + anchors
+        run: mint broken-links --check-anchors
+
   # Config-matrix drift gate (BLOCKING), one leg per suite package. Each package's
   # config-matrix.mdx generated block is rendered from its live surface (pydantic
   # tree / constructor kwargs / vocab constants / <PREFIX>_* env scan) by the
@@ -3528,6 +3556,7 @@ jobs:
       - version_consistency
       - readme_callouts
       - docs_consistency
+      - docs_render
       - ts_parity_freshness
       # api_parity + native_symbols guard cross-surface invariants (Python<->TS
       # tool/CLI/skill/scorer/transform parity; native symbol registration) but

--- a/docs-site/goldenmatch/config-suggestions.mdx
+++ b/docs-site/goldenmatch/config-suggestions.mdx
@@ -27,7 +27,7 @@ GoldenMatch is built around one workflow, not a pile of knobs:
 **Zero-config gets you most of the way in one pass; the healing loop closes the gap to an expert-tuned config without you having to be the expert.** It is the user-facing expression of two project commitments: *zero-config should embarrass the alternatives*, and *out-of-the-box should approach the hand-tuned expert*.
 
 <Note>
-  The healer is **wired into the default pipeline**. Every `dedupe_df(df)` run now checks a free controller signal (RED/YELLOW health or a score dip) and, only when it fires, attaches cheap raw candidate suggestions to `result.suggestions` — no extra pipeline run on a healthy result. Opt into the expensive verified path with `dedupe_df(df, suggest=True)`, or run the full apply-and-re-run loop with `dedupe_df(df, heal=True)`. The same surface is on CLI (`--suggest` / `--heal`), MCP (`review_config`), A2A, REST, web, and the TUI (Suggestions tab). It requires `goldenmatch[native]` (the suggestion kernel is compiled); without the native wheel every surface **degrades gracefully** — it attaches no suggestions and never raises. Kill-switch: `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`. On the TypeScript surface the same healer is the opt-in `goldenmatch/core/suggest-wasm` subpath (see [TypeScript / WASM](#typescript--wasm) below); without the WASM kernel TS degrades gracefully to empty suggestions.
+  The healer is **wired into the default pipeline**. Every `dedupe_df(df)` run now checks a free controller signal (RED/YELLOW health or a score dip) and, only when it fires, attaches cheap raw candidate suggestions to `result.suggestions` — no extra pipeline run on a healthy result. Opt into the expensive verified path with `dedupe_df(df, suggest=True)`, or run the full apply-and-re-run loop with `dedupe_df(df, heal=True)`. The same surface is on CLI (`--suggest` / `--heal`), MCP (`review_config`), A2A, REST, web, and the TUI (Suggestions tab). It requires `goldenmatch[native]` (the suggestion kernel is compiled); without the native wheel every surface **degrades gracefully** — it attaches no suggestions and never raises. Kill-switch: `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`. On the TypeScript surface the same healer is the opt-in `goldenmatch/core/suggest-wasm` subpath (see [TypeScript and WASM](#typescript-and-wasm) below); without the WASM kernel TS degrades gracefully to empty suggestions.
 </Note>
 
 ## The loop in code
@@ -112,7 +112,7 @@ You can change or disable the gate:
 
 These are also in the full [tuning reference](/goldenmatch/tuning#config-suggestion-healer-knobs).
 
-## TypeScript / WASM
+## TypeScript and WASM
 
 The healer runs on the TS/JS surface too, via the `suggest-core` kernel compiled to
 WebAssembly (`suggest-wasm`). It is the same pyo3-free kernel

--- a/docs-site/goldenmatch/configuration.mdx
+++ b/docs-site/goldenmatch/configuration.mdx
@@ -572,7 +572,7 @@ for finding in cfg._preflight_report.findings:
     print(f"[{finding.severity}] {finding.check}: {finding.message}")
 ```
 
-See the [Verification section in the Python API docs](/goldenmatch/python-api#verification-v150) for the full `preflight` / `postflight` signatures and the `PostflightSignals` schema.
+See the [Verification section in the Python API docs](/goldenmatch/python-api#verification-v1-5-0) for the full `preflight` / `postflight` signatures and the `PostflightSignals` schema.
 
 ## Learning Memory (v1.6.0)
 

--- a/docs-site/goldenmatch/scoring.mdx
+++ b/docs-site/goldenmatch/scoring.mdx
@@ -24,7 +24,7 @@ GoldenMatch provides 10+ scoring methods for comparing record pairs. Scoring run
 | `name_freq_weighted_jw` | Jaro-Winkler modulated by US Census surname IDF | 0.0--1.0 | `last_name` / `surname` |
 | `given_name_aliased_jw` | Jaro-Winkler with alias-aware exact bonus | 0.0--1.0 | `first_name` / `given_name` |
 | `qgram` | Q-gram (n-gram) overlap similarity | 0.0--1.0 | General strings, typos |
-| `alias_match` | Matches known name aliases and nicknames (Bob <-> Robert) | 0 or 1 | Names with nicknames |
+| `alias_match` | Matches known name aliases and nicknames (e.g. Bob and Robert) | 0 or 1 | Names with nicknames |
 | `initialism_match` | Matches initials/acronyms against their expansions | 0 or 1 | Acronyms, initials |
 | `phash` | Perceptual-hash Hamming similarity | 0.0--1.0 | Images |
 | `radial` | Rotation/crop-invariant radial-variance similarity | 0.0--1.0 | Rotated/cropped images |

--- a/docs-site/goldenmatch/tuning.mdx
+++ b/docs-site/goldenmatch/tuning.mdx
@@ -563,7 +563,7 @@ Every `GOLDENMATCH_*` variable the package reads (plus the one `GOLDEN_*` except
 | `GOLDENMATCH_PREP_STAGED_COLLECT` | `0` | Staged prep collect (experimental, may slow). |
 | `GOLDENMATCH_STANDARDIZE_STAGED` | `0` | Staged standardization (experimental, may slow). |
 | `GOLDENMATCH_BUCKET_VEC_MIN` / `_MAX` | `32` / `2000` | Block-size band for the vectorized float64 NxN cdist path in bucket scoring. |
-| Fellegi-Sunter routing & scoring knobs (`GOLDENMATCH_FS_*`) | — | Have their own home: see [Probabilistic / Fellegi-Sunter](#probabilistic--fellegi-sunter-advanced) for the path-routing map + the complete `FS_*` table. |
+| Fellegi-Sunter routing & scoring knobs (`GOLDENMATCH_FS_*`) | — | Have their own home: see [Probabilistic / Fellegi-Sunter](#probabilistic-fellegi-sunter-advanced) for the path-routing map + the complete `FS_*` table. |
 | `GOLDENMATCH_BENCH_DUMP_PAIRS` | unset | Dump per-stage pairs for benchmarking. |
 | `GOLDENMATCH_SKIP_MATCH_LOG` / `GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS` | — | Streaming match-log controls. |
 
@@ -591,7 +591,7 @@ Every `GOLDENMATCH_*` variable the package reads (plus the one `GOLDEN_*` except
 | `GOLDENMATCH_FACILITY_NAME_NE` | `0` | On company/location-mode data (shared phone/address/company demoted because the sharers don't co-agree on the person name), add the person full name (first+last) as `token_sort` negative evidence so distinct colleagues at one facility don't fuse. Opt-in; only fires when facility mode is detected, so person datasets (e.g. Febrl) are unaffected even when set. |
 | `GOLDENMATCH_QUALITY_GATED_REVIEW` | `0` | Downgrade auto-merge on low-quality records. |
 
-### Probabilistic / Fellegi-Sunter (advanced)
+### Probabilistic Fellegi-Sunter (advanced)
 
 A `type: probabilistic` matchkey trains EM once, then its candidate pairs are scored by **one of four paths, chosen automatically** — you rarely set these by hand, but this is the map when you need to:
 


### PR DESCRIPTION
Adds a blocking `docs_render` CI job that runs the docs site's **own Mintlify parser/build** -- the thing the stdlib `check_docs_links.py` fundamentally can't replicate.

## What it runs (in `docs-site/`)
- **`mint validate --disable-openapi`** -- strict build; any warning/error fails. Catches malformed MDX/JSX bodies, invalid frontmatter, and `docs.json` schema errors.
- **`mint broken-links --check-anchors`** -- broken internal links **and** anchor-slug mismatches (the anchor half is exactly what the Python check strips off).

Kept alongside `docs_consistency` (defense in depth): the stdlib link/frontmatter floor still runs if Mintlify's release CDN is unreachable. Wired via the `docs` path filter and into `ci-required` (skipped == pass on non-doc PRs).

## It earned its keep on the first run
Caught 4 real defects the Python check missed:
- `scoring.mdx` -- a bare `(Bob <-> Robert)` opened a JSX tag and **broke the MDX parse** entirely.
- 3 broken same-page anchors (`config-suggestions`, `configuration`, `tuning`) where the heading slug didn't match the link -- including two headings whose ` / ` slugged unpredictably (removed the slash).

Both `mint validate` and `mint broken-links --check-anchors` are green locally after the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd