### PR TITLE
docs(config): gate clustering-strategy + planning-effort vocab completeness

### DIFF
--- a/docs-site/goldenmatch/backends-and-scale.mdx
+++ b/docs-site/goldenmatch/backends-and-scale.mdx
@@ -95,6 +95,17 @@ The distributed connected-components algorithm is a randomized contraction (Bög
   Debug the prep-versus-kernel split for the bucket backend with `GOLDENMATCH_BUCKET_DEBUG=1`. It prints a per-bucket prep / kernel / post-filter timing breakdown. It is off by default, costs nothing, and does not change output.
 </Note>
 
+## Clustering strategies
+
+Once pairs are scored, GoldenMatch groups the surviving edges into entities. The planner picks a `clustering_strategy` to match the backend and scale; you can also set it explicitly in config.
+
+| Strategy | When it runs | How it works |
+|----------|--------------|--------------|
+| `in_memory` | Default, single machine | In-memory union-find over the full edge set. Fastest when the graph fits in RAM. |
+| `partitioned_union_find` | Large single-machine pair sets | Disk-partitioned union-find, so the edge set is not bounded by RAM. |
+| `streaming_cc` | Chunked / out-of-core runs | Streaming connected-components that consumes edges without materializing the whole graph. |
+| `distributed_wcc` | Ray cluster (100M+) | Distributed weakly-connected-components (randomized contraction) that resolves components spanning partitions, with no driver-side union-find. See the Distributed Phase 5 section above. |
+
 ## Native acceleration
 
 `pip install goldenmatch` ships the Rust kernel (`goldenmatch-native`) on common platforms. **Rust is the reference implementation** (2026-07 reference-mode change); the pure-Python paths are the lossy fallback used when the wheel is absent. The `GOLDENMATCH_NATIVE` environment variable has **three** modes:

--- a/scripts/config_matrix/registry.py
+++ b/scripts/config_matrix/registry.py
@@ -147,6 +147,8 @@ REGISTRY: dict[str, PackageSpec] = {
             ("configuration.mdx", "goldenmatch.config.schemas:VALID_STRATEGIES"),
             ("configuration.mdx", "goldenmatch.config.schemas:VALID_STANDARDIZERS"),
             ("backends-and-scale.mdx", "goldenmatch.core.execution_plan:BackendName"),
+            ("backends-and-scale.mdx", "goldenmatch.core.execution_plan:ClusteringStrategy"),
+            ("auto-config.mdx", "goldenmatch.core.autoconfig_controller:_PLANNING_EFFORTS"),
         ),
     ),
     "goldencheck": PackageSpec(


### PR DESCRIPTION
Follow-up to #1916/#1917. Folds the two remaining goldenmatch backend-family vocabs into the config-matrix `doc_coverage` completeness gate, so **every** goldenmatch vocab that renders into the matrix is also held to appearing in its topical prose page.

## What changed
- **`ClusteringStrategy` → `backends-and-scale.mdx`.** The four values (`in_memory`, `partitioned_union_find`, `streaming_cc`, `distributed_wcc`) previously lived **only** in the generated matrix block with no prose home. Added a "Clustering strategies" section documenting each value and when the planner picks it.
- **`_PLANNING_EFFORTS` → `auto-config.mdx`.** All four (`fast`, `normal`, `thinking`, `einstein`) were already documented there; the gate just locks it so a new effort tier can't be added without updating the page.

## Verification
Under the CI-matching `uv` env: config-matrix currency + topical-coverage + determinism tests pass. `mint validate` and `mint broken-links --check-anchors` green. (Dropped a fragile in-page anchor to the `Distributed Phase 5 (100M+)` heading — Mintlify's slug for the parenthetical `+` didn't match, and a plain-text "section above" pointer is robust.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd