### PR TITLE
chore(golden-suite): 0.3.2 — floor goldenmatch-native>=0.1.19

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.2] - 2026-07-19
+
+- Floor bump: `goldenmatch-native>=0.1.19`. 0.1.19 adds the
+  `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability flag, so the net-zero-evidence
+  Fellegi-Sunter link filter (default-on; requires strictly positive summed match
+  weight `W > 0` to link, killing the precision collapse that grew with row count)
+  actually runs on the native kernel instead of silently degrading to the legacy
+  emit-at-neutral path. Cut after goldenmatch-native 0.1.19 landed on PyPI
+  (member-on-PyPI-first lockstep).
+
 ## [0.3.1] - 2026-07-18
 
 - Floor bump: `goldenmatch[polars]>=3.5` (3.5.0: the date-aware `date` scorer;

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.1"
+version = "0.3.2"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -44,7 +44,7 @@ dependencies = [
     "goldenanalysis>=0.4",              # read-only cross-cutting metrics + reporting
     "goldencheck-types>=0.2",           # shared canonical field-type contracts
     # --- native acceleration (on by default; see note above) ---
-    "goldenmatch-native>=0.1.18",       # >=0.1.18 adds the native `date_similarity` kernel (date scorer's native path); 0.1.17 carries the FS exclude-set Arc handle + zero-copy arrow FS entry + unobserved-evidence math
+    "goldenmatch-native>=0.1.19",       # >=0.1.19 adds the `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability so the net-zero-evidence FS link filter (default-on, kills the scale-growing over-merge) actually runs on the native kernel; 0.1.18 added the native `date_similarity` kernel
     "goldencheck-native>=0.1",
     "goldenflow-native>=0.26.0",        # >=0.26.0 = the full columnar surface (format_f64 + AsFloat numeric-input); now a BASE dep of goldenflow 2.0
     "goldenanalysis-native>=0.1",


### PR DESCRIPTION
## What

Bumps `golden-suite` `0.3.1` → `0.3.2` and raises its `goldenmatch-native` floor `>=0.1.18` → `>=0.1.19`. Deps-only meta-package; **no code**.

## Why

Golden-suite lockstep: `goldenmatch-native 0.1.19` landed on PyPI, so the suite meta-package moves to mandate it. 0.1.19 carries the `FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE` capability flag — without it, the default-on net-zero-evidence Fellegi-Sunter link filter (requires `W > 0` to link, killing the precision collapse that grew with row count) silently degrades to the legacy emit-at-neutral path on native installs. Bumping the floor mandates the fixed baseline for suite installs.

Sequencing honored: member (`goldenmatch-native 0.1.19`) is live on PyPI and its version bump (#1915) is merged, so the raised floor is satisfiable and the uv workspace carries the new member version.

## Release (after merge)

Tag `golden-suite-v0.3.2` → `publish-golden-suite.yml` → PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_