### PR TITLE
docs(config): gate the hand-authored decision prose against dead env refs

### DIFF
--- a/scripts/config_matrix/crossref.py
+++ b/scripts/config_matrix/crossref.py
@@ -19,7 +19,7 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
-from .render import ROOT, _resolve_vocab, scan_env_vars
+from .render import MARKER_START, ROOT, _resolve_vocab, scan_env_vars
 
 # Pages whose whole job is to describe old/removed knobs.
 _EXCLUDE_STEMS = re.compile(
@@ -49,10 +49,23 @@ def _prose_pages(spec) -> list[Path]:
     doc_dir = (ROOT / spec.doc_path).parent
     pages = []
     for p in sorted(doc_dir.rglob("*.mdx")):
-        if p.name == "config-matrix.mdx" or _EXCLUDE_STEMS.search(p.stem):
+        if _EXCLUDE_STEMS.search(p.stem):
             continue
         pages.append(p)
     return pages
+
+
+def _scannable_text(page: Path) -> str:
+    """The prose region of a page to check for dead references. For the config
+    matrix, only the hand-authored region ABOVE the generated marker can rot --
+    the generated block is rendered from the source of truth, so scanning it would
+    be circular. Every other page is scanned whole."""
+    text = page.read_text(encoding="utf-8", errors="ignore")
+    if page.name == "config-matrix.mdx":
+        cut = text.find(MARKER_START)
+        if cut != -1:
+            text = text[:cut]
+    return text
 
 
 # Backticked value tokens in a doc. Includes `.`/`-` so dotted registry names
@@ -90,7 +103,7 @@ def stale_env_refs(spec) -> list[RefFinding]:
     rx = re.compile(re.escape(prefix) + r"_[A-Z0-9_]+")
     findings: list[RefFinding] = []
     for page in _prose_pages(spec):
-        for i, line in enumerate(page.read_text(encoding="utf-8", errors="ignore").splitlines(), 1):
+        for i, line in enumerate(_scannable_text(page).splitlines(), 1):
             if _REMOVAL_CTX.search(line):
                 continue
             for tok in set(rx.findall(line)):


### PR DESCRIPTION
First of three human-facing follow-ups. The insight: every gate so far protects the machine-generated, exhaustive matrix tables -- the easy-to-gate part. The richest **human** content, the hand-authored "Combinations & intended outcomes" decision layer in `config-matrix.mdx`, was completely exempt from drift checks. `_prose_pages` skipped `config-matrix.mdx` entirely, so a renamed/removed `GOLDENMATCH_*` knob would auto-update the generated tables while the human guidance silently kept pointing at the dead flag. The least-protected content was the part a person actually reads to decide.

## Change
- `stale_env_refs` now scans `config-matrix.mdx` too, but only the region **above** the generated marker (`_scannable_text`) -- the generated block is rendered from the source of truth, so scanning it would be circular.
- Scoped to env-var liveness. The namespaced `GOLDENMATCH_*` regex is robust; field-name / vocab-value liveness in free prose is deferred because common English words (`exact`, `fast`, `disagree`) would false-positive.

## Result
Passes clean on introduction: 0 dead refs, the decision layer's 5 env tokens are all live. Verified the gate genuinely scans the 8.6K-char hand-authored region (excludes the 95K generated block) and would flag a dead token. This locks the human guidance going forward -- turning the source-of-truth machinery toward protecting the human-facing prose, not just the generated tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd