### PR TITLE
chore: harden repo hygiene for agent navigation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,11 @@
 /tests/fixtures/synthetic_1m.csv filter=lfs diff=lfs merge=lfs -text
 /packages/python/goldenmatch/tests/fixtures/synthetic_1m.csv filter=lfs diff=lfs merge=lfs -text
+
+# Generated / machine-authored files. `linguist-generated` collapses them in
+# PR diffs and drops them from GitHub language stats; `-diff` stops git from
+# emitting a (useless, huge) textual diff. These are outputs, not source an
+# agent or reviewer should read line-by-line.
+**/llms.txt        linguist-generated=true -diff
+**/llms-full.txt   linguist-generated=true -diff
+uv.lock            linguist-generated=true -diff
+pnpm-lock.yaml     linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,17 @@ packages/python/goldengraph/goldengraph/_native*.so
 
 # scratch Modal run logs (transient)
 modal_*.log
+
+# --- Agent/session hygiene (keep the repo root readable to crawlers) ---
+# Secrets: MCP registry bearer tokens written to the repo root by local tooling.
+# These must NEVER be committed. Pattern-ignored so `git add -A` can't leak them.
+.mcpregistry_*token
+# Session build logs dropped at the root (_cargobuild.log, _pnpm.log, _uvsync.log …).
+_*.log
+# Session handoff / working-notes dumps. Point-in-time snapshots an agent can't
+# tell are stale — keep them out of the tree an agent crawls first.
+HANDOFF-*.md
+# Stray npm lockfiles. This is a pnpm workspace (pnpm-lock.yaml is authoritative);
+# a package-lock.json is drift that confuses both tooling and agents.
+package-lock.json
+**/package-lock.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Golden Suite monorepo — agent guide
+
+Fast navigational map for any coding agent. This is the **entry point**; the
+deep operational lore (CI internals, incident post-mortems, release/publish
+mechanics, native-kernel gotchas) lives in `CLAUDE.md` and the per-package
+files listed below. Read those before doing package-specific work.
+
+## What this is
+
+A polyglot monorepo for **entity resolution and data-quality tooling**. Six
+core products, each shipped across multiple language surfaces (Python, a
+TypeScript port, and pyo3-free Rust `-core` kernels with optional compiled
+accelerators). North Star: be the tool a developer reaches for *by default* for
+entity resolution — defaults are re-earned every release
+(`context-network/foundation/project-definition.md`).
+
+## Layout
+
+```
+packages/
+  python/        uv workspace — members: packages/python/*
+                 (excluded standalone: goldenmatch-kg, goldengraph, golden-suite)
+  typescript/    pnpm + Turborepo workspace (TS ports + wasm runtime)
+  rust/extensions/  cargo workspace — pyo3-free *-core kernels + *-native accelerators
+  actions/       reusable GitHub Actions
+  dbt/           dbt models
+docs/            design docs, ADRs, specs (docs/superpowers/{specs,plans})
+docs-site/       the published docs site (Mintlify)
+context-network/ project foundation, decisions, discovery — read for "why"
+scripts/         benches, gates, release tooling
+```
+
+Products: **goldenmatch** (ER core), **goldencheck** (data-quality scan),
+**goldenflow** (transforms), **goldenpipe** (pipeline compiler), **infermap**
+(schema/column mapping), **goldenanalysis** (cluster/quality analysis). Plus
+**goldengraph** (KG engine, standalone) and **golden-suite** (meta-package).
+
+## Build & test
+
+Canonical recipes are in the `justfile`:
+
+| Task    | Command      | Under the hood                                                    |
+| ------- | ------------ | ---------------------------------------------------------------- |
+| install | `just install` | `uv sync`; `npm install` per TS pkg; `cargo fetch`             |
+| test    | `just test`    | `uv run pytest packages/python`; `npm test` per TS pkg; `cargo test --workspace` |
+| lint    | `just lint`    | `ruff check`; TS lint; `cargo clippy --workspace -- -D warnings` |
+| build   | `just build`   | `uv build`; TS build; `cargo build --workspace --release`       |
+
+Scope work to one package where possible: `uv run pytest packages/python/<pkg>`.
+
+## Landmines to know before you touch anything
+
+- **Do NOT run the full pytest suite locally** — xdist OOMs a dev box. Run
+  per-package, or let CI run the full matrix. (`feedback_avoid_full_suite_oom`.)
+- **GitHub auth:** `benseverndev-oss/*` and `benzsevern/*` repos use the personal
+  `benzsevern` account, not the work account. `gh auth switch --user benzsevern`
+  before any push. See `CLAUDE.md` › "GitHub auth".
+- **Rust is the reference implementation; pure-Python is the lossy fallback.**
+  `GOLDENMATCH_NATIVE=auto` runs native wherever a kernel symbol exists. Set
+  `=0` to force pure-Python (and `POLARS_SKIP_CPU_CHECK=1` on Windows). See
+  `CLAUDE.md` › "goldenmatch-native".
+- **Branch + squash-merge via PR;** `main` is a native FIFO merge queue —
+  `gh pr merge <N> --auto --squash` then stop. Never commit direct to `main`.
+- **Only `.github/workflows/` at the repo root runs.** Workflow files left under
+  `packages/*/.github/` are orphaned and silently ignored.
+
+## Where the deep context lives
+
+- `CLAUDE.md` (repo root) — CI structure, path filters, merge queue, release &
+  publish mechanics, native-kernel incident lore (#688 etc.). The source of
+  truth for operational gotchas.
+- `packages/python/<pkg>/CLAUDE.md` and `.../AGENTS.md` — package-specific test
+  tuning, `--ignore` lists, and quirks.
+- `context-network/` — decisions (ADRs), foundation, and the "why" behind the
+  architecture. Search here before assuming something is undesigned.
+- `_archive/goldenmatch-pre-fold/` — the standalone repo's history; old specs
+  are sometimes the foundation for current work.


### PR DESCRIPTION
## What

Three low-risk changes to make the repo easier and cheaper for coding agents (and humans) to ingest. Grew out of an audit of the repo's agent-facing scaffolding.

- **`.gitignore`** — pattern-ignore:
  - `.mcpregistry_*token` — **untracked MCP registry bearer tokens sitting at the repo root**, one `git add -A` from being committed. This is the important one.
  - `_*.log` — session build logs dropped at root (`_cargobuild.log`, `_pnpm.log`, `_uvsync.log`, …).
  - `HANDOFF-*.md` — point-in-time working-notes dumps an agent can't tell are stale.
  - `package-lock.json` — stray npm lockfiles (this is a pnpm workspace).
- **`.gitattributes`** — mark generated files (`llms.txt`/`llms-full.txt`, `uv.lock`, `pnpm-lock.yaml`) `linguist-generated` + `-diff` so PR diffs collapse them and agents deprioritize them.
- **`AGENTS.md`** (new, root) — lean navigational map for non-Claude agents: layout, build/test via the `justfile`, top landmines, with pointers to `CLAUDE.md` + per-package files for deep lore. The root had **no** `AGENTS.md`, so AGENTS-standard tools (Cursor/Codex) got nothing at the entry point.

## Deliberately not done

- **No `CLAUDE.md` split.** Its incident lore (#688 rayon park, `[skip ci]` self-skip, immutable-releases tombstoning) is load-bearing repeat-mistake prevention; the token cost buys guardrails. The new lean `AGENTS.md` provides the token-cheap entry point without stripping that.
- **Per-package `CLAUDE.md` ↔ `AGENTS.md` drift** (e.g. goldenmatch's are 412 vs 370 lines and diverged) is a separate, larger content-reconciliation task — flagged, not touched here.

## Test plan

- `git check-ignore` confirms every junk filename matches and no tracked file is caught.
- Docs/config-only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)