### PR TITLE
feat(agent-nav): gated agent-navigation manifest from the config-matrix registry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,7 @@
 **/llms-full.txt   linguist-generated=true -diff
 uv.lock            linguist-generated=true -diff
 pnpm-lock.yaml     linguist-generated=true -diff
+# Agent-navigation manifest: generated from scripts/config_matrix, gated by
+# scripts/test_config_matrix.py. Force LF so the byte-for-byte drift gate can't
+# trip on a CRLF checkout (Windows dev vs Linux CI).
+docs/agent-manifest.json  linguist-generated=true -diff eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,4 @@ pnpm-lock.yaml     linguist-generated=true -diff
 # scripts/test_config_matrix.py. Force LF so the byte-for-byte drift gate can't
 # trip on a CRLF checkout (Windows dev vs Linux CI).
 docs/agent-manifest.json  linguist-generated=true -diff eol=lf
+packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json  linguist-generated=true -diff eol=lf

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -403,6 +403,9 @@ config_matrix:
   - 'packages/rust/extensions/**/*.rs'
   - 'scripts/config_matrix/**'
   - 'scripts/gen_config_matrix.py'
+  # The agent-navigation manifest is rendered from the same registry; a hand-edit
+  # of the committed JSON must re-run the gate so it can't be tampered out of sync.
+  - 'docs/agent-manifest.json'
   - 'scripts/test_config_matrix.py'
   - '.github/workflows/ci.yml'
   - '.github/filters.yml'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,21 @@ Scope work to one package where possible: `uv run pytest packages/python/<pkg>`.
 - **Only `.github/workflows/` at the repo root runs.** Workflow files left under
   `packages/*/.github/` are orphaned and silently ignored.
 
+## Look it up instead of grepping: `docs/agent-manifest.json`
+
+`docs/agent-manifest.json` is a generated, machine-readable index of every
+package's **config schema, CLI commands, MCP tools, enumerated vocabularies
+(with `best_for` decision hints), and `<PREFIX>_*` env knobs** — for all six
+packages. Query it to answer "what scorers exist and which suits names", "what
+MCP tools does goldenpipe expose", "what's the type/default of
+`GoldenMatchConfig.threshold`", or "which env vars tune goldenmatch" without
+searching the tree.
+
+It is generated from the same registry as the CI-gated config-matrix docs
+(`scripts/config_matrix/`) and gated for drift by `scripts/test_config_matrix.py`,
+so it can't silently fall out of sync with the code. Never hand-edit it;
+regenerate with `python scripts/gen_config_matrix.py --manifest`.
+
 ## Where the deep context lives
 
 - `CLAUDE.md` (repo root) — CI structure, path filters, merge queue, release &

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,16 +68,22 @@ Scope work to one package where possible: `uv run pytest packages/python/<pkg>`.
 
 `docs/agent-manifest.json` is a generated, machine-readable index of every
 package's **config schema, CLI commands, MCP tools, enumerated vocabularies
-(with `best_for` decision hints), and `<PREFIX>_*` env knobs** — for all six
-packages. Query it to answer "what scorers exist and which suits names", "what
-MCP tools does goldenpipe expose", "what's the type/default of
-`GoldenMatchConfig.threshold`", or "which env vars tune goldenmatch" without
-searching the tree.
+(with `best_for` decision hints), `<PREFIX>_*` env knobs, source-file locations
+(where the config schema / CLI / MCP server live + pyproject entry points), and
+the repo's Rust crate map** — for all six packages. Query it to answer "what
+scorers exist and which suits names", "what MCP tools does goldenpipe expose",
+"the type/default of `GoldenMatchConfig.threshold`", "which env vars tune
+goldenmatch", "where does goldenpipe's MCP server live", or "which crate is
+`goldenmatch-fs-core`" — without searching the tree.
 
 It is generated from the same registry as the CI-gated config-matrix docs
 (`scripts/config_matrix/`) and gated for drift by `scripts/test_config_matrix.py`,
 so it can't silently fall out of sync with the code. Never hand-edit it;
 regenerate with `python scripts/gen_config_matrix.py --manifest`.
+
+**Via MCP:** the `goldensuite-mcp` server exposes a `suite_manifest` tool that
+serves slices of this file (overview / one package / one section / keyword
+search) so you don't pull the whole 300 KB for one lookup.
 
 ## Where the deep context lives
 

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -6,6 +6,15 @@
       "nav_group": "GoldenMatch",
       "env_prefix": "GOLDENMATCH_",
       "doc_path": "docs-site/goldenmatch/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenmatch",
+        "root": "packages/python/goldenmatch/goldenmatch",
+        "modules": {
+          "config_schema": "packages/python/goldenmatch/goldenmatch/config/schemas.py",
+          "cli": "packages/python/goldenmatch/goldenmatch/cli/main.py",
+          "mcp_server": "packages/python/goldenmatch/goldenmatch/mcp/server.py"
+        }
+      },
       "config_models": [
         {
           "name": "GoldenMatchConfig",
@@ -5370,6 +5379,15 @@
       "nav_group": "GoldenCheck",
       "env_prefix": "GOLDENCHECK_",
       "doc_path": "docs-site/goldencheck/config-matrix.mdx",
+      "source": {
+        "import_name": "goldencheck",
+        "root": "packages/python/goldencheck/goldencheck",
+        "modules": {
+          "config_schema": "packages/python/goldencheck/goldencheck/config/schema.py",
+          "cli": "packages/python/goldencheck/goldencheck/cli/main.py",
+          "mcp_server": "packages/python/goldencheck/goldencheck/mcp/server.py"
+        }
+      },
       "config_models": [
         {
           "name": "GoldenCheckConfig",
@@ -6562,6 +6580,15 @@
       "nav_group": "GoldenFlow",
       "env_prefix": "GOLDENFLOW_",
       "doc_path": "docs-site/goldenflow/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenflow",
+        "root": "packages/python/goldenflow/goldenflow",
+        "modules": {
+          "config_schema": "packages/python/goldenflow/goldenflow/config/schema.py",
+          "cli": "packages/python/goldenflow/goldenflow/cli/main.py",
+          "mcp_server": "packages/python/goldenflow/goldenflow/mcp/server.py"
+        }
+      },
       "config_models": [
         {
           "name": "GoldenFlowConfig",
@@ -7730,6 +7757,26 @@
       "nav_group": "GoldenPipe",
       "env_prefix": "GOLDENPIPE_",
       "doc_path": "docs-site/goldenpipe/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenpipe",
+        "root": "packages/python/goldenpipe/goldenpipe",
+        "modules": {
+          "config_schema": "packages/python/goldenpipe/goldenpipe/models/config.py",
+          "cli": "packages/python/goldenpipe/goldenpipe/cli/main.py",
+          "mcp_server": "packages/python/goldenpipe/goldenpipe/mcp/server.py"
+        },
+        "entry_points": {
+          "goldenpipe.stages": {
+            "goldenanalysis.report": "goldenpipe.adapters.analysis:AnalysisReportStage",
+            "goldencheck.scan": "goldenpipe.adapters.check:ScanStage",
+            "goldenflow.transform": "goldenpipe.adapters.flow:TransformStage",
+            "goldenmatch.dedupe": "goldenpipe.adapters.match:DedupeStage",
+            "goldenmatch.dedupe_fused": "goldenpipe.adapters.match:FusedDedupeStage",
+            "goldenmatch.identity_resolve": "goldenpipe.adapters.identity:IdentityResolveStage",
+            "infer_schema": "goldenpipe.stages.infer_schema:infer_schema_stage"
+          }
+        }
+      },
       "config_models": [
         {
           "name": "PipelineConfig",
@@ -8207,6 +8254,15 @@
       "nav_group": "InferMap",
       "env_prefix": "INFERMAP_",
       "doc_path": "docs-site/infermap/config-matrix.mdx",
+      "source": {
+        "import_name": "infermap",
+        "root": "packages/python/infermap/infermap",
+        "modules": {
+          "constructor": "packages/python/infermap/infermap/engine.py",
+          "cli": "packages/python/infermap/infermap/cli.py",
+          "mcp_server": "packages/python/infermap/infermap/mcp/server.py"
+        }
+      },
       "constructors": [
         {
           "name": "MapEngine",
@@ -8550,6 +8606,23 @@
       "nav_group": "GoldenAnalysis",
       "env_prefix": "GOLDENANALYSIS_",
       "doc_path": "docs-site/goldenanalysis/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenanalysis",
+        "root": "packages/python/goldenanalysis/goldenanalysis",
+        "modules": {
+          "config_schema": "packages/python/goldenanalysis/goldenanalysis/models/policy.py",
+          "constructor": "packages/python/goldenanalysis/goldenanalysis/_api.py",
+          "cli": "packages/python/goldenanalysis/goldenanalysis/cli/main.py"
+        },
+        "entry_points": {
+          "goldenanalysis.analyzers": {
+            "cluster.distribution": "goldenanalysis.analyzers.cluster_dist:ClusterDistributionAnalyzer",
+            "frame.summary": "goldenanalysis.analyzers.frame_summary:FrameSummaryAnalyzer",
+            "match.rates": "goldenanalysis.analyzers.match_rates:MatchRatesAnalyzer",
+            "quality.rollup": "goldenanalysis.analyzers.quality_rollup:QualityRollupAnalyzer"
+          }
+        }
+      },
       "config_models": [
         {
           "name": "RegressionPolicy",
@@ -8812,5 +8885,223 @@
         ]
       }
     }
-  }
+  },
+  "rust_crates": [
+    {
+      "name": "analysis-core",
+      "path": "packages/rust/extensions/analysis-core"
+    },
+    {
+      "name": "analysis-native",
+      "path": "packages/rust/extensions/analysis-native"
+    },
+    {
+      "name": "fingerprint-wasm",
+      "path": "packages/rust/extensions/fingerprint-wasm"
+    },
+    {
+      "name": "goldencheck-core",
+      "path": "packages/rust/extensions/goldencheck-core"
+    },
+    {
+      "name": "goldencheck-native",
+      "path": "packages/rust/extensions/goldencheck-native"
+    },
+    {
+      "name": "goldencheck-wasm",
+      "path": "packages/rust/extensions/goldencheck-wasm"
+    },
+    {
+      "name": "goldenembed",
+      "path": "packages/rust/extensions/goldenembed"
+    },
+    {
+      "name": "goldenembed-core",
+      "path": "packages/rust/extensions/goldenembed-core"
+    },
+    {
+      "name": "goldenembed-wasm",
+      "path": "packages/rust/extensions/goldenembed-wasm"
+    },
+    {
+      "name": "goldenflow-core",
+      "path": "packages/rust/extensions/goldenflow-core"
+    },
+    {
+      "name": "goldenflow-native",
+      "path": "packages/rust/extensions/native-flow"
+    },
+    {
+      "name": "goldenflow-wasm",
+      "path": "packages/rust/extensions/goldenflow-wasm"
+    },
+    {
+      "name": "goldenflow_duckdb",
+      "path": "packages/rust/extensions/goldenflow-duckdb"
+    },
+    {
+      "name": "goldengraph-cabi",
+      "path": "packages/rust/extensions/goldengraph-cabi"
+    },
+    {
+      "name": "goldengraph-core",
+      "path": "packages/rust/extensions/goldengraph-core"
+    },
+    {
+      "name": "goldengraph-native",
+      "path": "packages/rust/extensions/goldengraph-native"
+    },
+    {
+      "name": "goldengraph-wasm",
+      "path": "packages/rust/extensions/goldengraph-wasm"
+    },
+    {
+      "name": "goldenhnsw",
+      "path": "packages/rust/extensions/goldenhnsw"
+    },
+    {
+      "name": "goldenhnsw-wasm",
+      "path": "packages/rust/extensions/goldenhnsw-wasm"
+    },
+    {
+      "name": "goldenmatch-analysis-wasm",
+      "path": "packages/rust/extensions/analysis-wasm"
+    },
+    {
+      "name": "goldenmatch-autoconfig-core",
+      "path": "packages/rust/extensions/autoconfig-core"
+    },
+    {
+      "name": "goldenmatch-autoconfig-wasm",
+      "path": "packages/rust/extensions/autoconfig-wasm"
+    },
+    {
+      "name": "goldenmatch-bridge",
+      "path": "packages/rust/extensions/bridge"
+    },
+    {
+      "name": "goldenmatch-datafusion-udf",
+      "path": "packages/rust/extensions/datafusion-udf"
+    },
+    {
+      "name": "goldenmatch-documents-core",
+      "path": "packages/rust/extensions/documents-core"
+    },
+    {
+      "name": "goldenmatch-documents-wasm",
+      "path": "packages/rust/extensions/documents-wasm"
+    },
+    {
+      "name": "goldenmatch-embed-py",
+      "path": "packages/rust/extensions/embed-py"
+    },
+    {
+      "name": "goldenmatch-fingerprint-core",
+      "path": "packages/rust/extensions/fingerprint-core"
+    },
+    {
+      "name": "goldenmatch-fs-core",
+      "path": "packages/rust/extensions/fs-core"
+    },
+    {
+      "name": "goldenmatch-fs-wasm",
+      "path": "packages/rust/extensions/fs-wasm"
+    },
+    {
+      "name": "goldenmatch-graph-core",
+      "path": "packages/rust/extensions/graph-core"
+    },
+    {
+      "name": "goldenmatch-graph-layout",
+      "path": "packages/rust/extensions/graph-layout"
+    },
+    {
+      "name": "goldenmatch-hnsw-py",
+      "path": "packages/rust/extensions/hnsw-py"
+    },
+    {
+      "name": "goldenmatch-native",
+      "path": "packages/rust/extensions/native"
+    },
+    {
+      "name": "goldenmatch-perceptual-core",
+      "path": "packages/rust/extensions/perceptual-core"
+    },
+    {
+      "name": "goldenmatch-perceptual-wasm",
+      "path": "packages/rust/extensions/perceptual-wasm"
+    },
+    {
+      "name": "goldenmatch-score-core",
+      "path": "packages/rust/extensions/score-core"
+    },
+    {
+      "name": "goldenmatch-score-wasm",
+      "path": "packages/rust/extensions/score-wasm"
+    },
+    {
+      "name": "goldenmatch-sketch-core",
+      "path": "packages/rust/extensions/sketch-core"
+    },
+    {
+      "name": "goldenmatch-suggest-core",
+      "path": "packages/rust/extensions/suggest-core"
+    },
+    {
+      "name": "goldenmatch-suggest-wasm",
+      "path": "packages/rust/extensions/suggest-wasm"
+    },
+    {
+      "name": "goldenmatch_pg",
+      "path": "packages/rust/extensions/postgres"
+    },
+    {
+      "name": "goldenpipe-core",
+      "path": "packages/rust/extensions/goldenpipe-core"
+    },
+    {
+      "name": "goldenpipe-native",
+      "path": "packages/rust/extensions/goldenpipe-native"
+    },
+    {
+      "name": "goldenpipe-wasm",
+      "path": "packages/rust/extensions/goldenpipe-wasm"
+    },
+    {
+      "name": "goldenprofile-cabi",
+      "path": "packages/rust/extensions/goldenprofile-cabi"
+    },
+    {
+      "name": "goldenprofile-core",
+      "path": "packages/rust/extensions/goldenprofile-core"
+    },
+    {
+      "name": "goldenprofile-native",
+      "path": "packages/rust/extensions/goldenprofile-native"
+    },
+    {
+      "name": "goldenprofile-wasm",
+      "path": "packages/rust/extensions/goldenprofile-wasm"
+    },
+    {
+      "name": "graph-wasm",
+      "path": "packages/rust/extensions/graph-wasm"
+    },
+    {
+      "name": "infermap-core",
+      "path": "packages/rust/extensions/infermap-core"
+    },
+    {
+      "name": "infermap-native",
+      "path": "packages/rust/extensions/infermap-native"
+    },
+    {
+      "name": "infermap-wasm",
+      "path": "packages/rust/extensions/infermap-wasm"
+    },
+    {
+      "name": "sketch-wasm",
+      "path": "packages/rust/extensions/sketch-wasm"
+    }
+  ]
 }

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -1,0 +1,8816 @@
+{
+  "schema": "goldenmatch.agent-manifest/v1",
+  "note": "Generated from scripts/config_matrix (same registry + resolvers as the CI-gated config-matrix docs). DO NOT EDIT. Regenerate: python scripts/gen_config_matrix.py --manifest",
+  "packages": {
+    "goldenmatch": {
+      "nav_group": "GoldenMatch",
+      "env_prefix": "GOLDENMATCH_",
+      "doc_path": "docs-site/goldenmatch/config-matrix.mdx",
+      "config_models": [
+        {
+          "name": "GoldenMatchConfig",
+          "fields": [
+            {
+              "name": "input",
+              "type": "InputConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputConfig"
+              ],
+              "description": "Input files to load; omit when passing a DataFrame directly to the API."
+            },
+            {
+              "name": "output",
+              "type": "OutputConfig",
+              "required": false,
+              "default": "OutputConfig(path=None, format=None, directory=None, run_name=None, lineage_provenance=False)",
+              "nested": [
+                "OutputConfig"
+              ],
+              "description": "Where and how results are written."
+            },
+            {
+              "name": "match_settings",
+              "type": "MatchSettingsConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MatchSettingsConfig"
+              ],
+              "description": "Nested matchkeys container; an alternative to the top-level matchkeys field."
+            },
+            {
+              "name": "matchkeys",
+              "type": "list[MatchkeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MatchkeyConfig"
+              ],
+              "description": "Matchkeys defining how records are compared; takes precedence over match_settings."
+            },
+            {
+              "name": "blocking",
+              "type": "BlockingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingConfig"
+              ],
+              "description": "Candidate-generation configuration; required when any matchkey is weighted or probabilistic."
+            },
+            {
+              "name": "golden_rules",
+              "type": "GoldenRulesConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenRulesConfig"
+              ],
+              "description": "Survivorship rules for building one golden record per cluster."
+            },
+            {
+              "name": "standardization",
+              "type": "StandardizationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "StandardizationConfig"
+              ],
+              "description": "Per-column standardizers applied before matching."
+            },
+            {
+              "name": "validation",
+              "type": "ValidationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ValidationConfig"
+              ],
+              "description": "Validation rules and auto-fix settings applied to the input."
+            },
+            {
+              "name": "quality",
+              "type": "QualityConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "QualityConfig"
+              ],
+              "description": "GoldenCheck data-quality integration settings."
+            },
+            {
+              "name": "transform",
+              "type": "TransformConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "TransformConfig"
+              ],
+              "description": "GoldenFlow data-transformation integration settings."
+            },
+            {
+              "name": "llm_boost",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables active-learning LLM boosting of borderline matches."
+            },
+            {
+              "name": "llm_scorer",
+              "type": "LLMScorerConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "LLMScorerConfig"
+              ],
+              "description": "LLM pair-scoring configuration for borderline candidates."
+            },
+            {
+              "name": "llm_auto",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets auto-config enable and configure the LLM scorer automatically."
+            },
+            {
+              "name": "domain",
+              "type": "DomainConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DomainConfig"
+              ],
+              "description": "Domain feature-extraction configuration used before matchkeys."
+            },
+            {
+              "name": "backend",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Execution backend: None (default Polars in-memory), 'ray', 'duckdb', 'chunked', or 'bucket'."
+            },
+            {
+              "name": "distributed_routing",
+              "type": "DistributedRoutingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DistributedRoutingConfig"
+              ],
+              "description": "Per-stage distributed-routing pins; None lets the planner decide every stage."
+            },
+            {
+              "name": "semantic_blocking",
+              "type": "SemanticBlockingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SemanticBlockingConfig"
+              ],
+              "description": "Opt-in semantic candidate-generation keys (ANN, initialism, alias) unioned into blocking."
+            },
+            {
+              "name": "allow_slow_path",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Permits falling back to a slower non-fused execution path when the fast path is ineligible."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'standard'",
+              "choices": [
+                "standard",
+                "scale"
+              ],
+              "description": "Execution mode: 'standard' in-memory/Ray (bit-identical) or 'scale' DataFusion spine (out-of-core, reduced features)."
+            },
+            {
+              "name": "planning_effort",
+              "type": "Literal",
+              "required": false,
+              "default": "'normal'",
+              "choices": [
+                "fast",
+                "normal",
+                "thinking",
+                "einstein"
+              ],
+              "description": "Auto-config planning-effort tier (spec 2026-06-06 §Phase 0). Controls how hard the controller searches: 'fast' = a single cheap pass; 'normal' (default) = today's interactive budget; 'thinking'/'einstein' spend the freed engine cycles on a larger sample, more refit iterations, and — at thinking+ — measuring real blocking on the full frame instead of extrapolating. Overridable via the GOLDENMATCH_PLANNING_EFFORT env var. Default 'normal' is byte-for-byte the prior behavior."
+            },
+            {
+              "name": "throughput",
+              "type": "ThroughputConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ThroughputConfig"
+              ],
+              "description": "Opt-in sketch-then-verify throughput tier for high-recall, low-cost dedup."
+            },
+            {
+              "name": "memory",
+              "type": "MemoryConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MemoryConfig"
+              ],
+              "description": "Learning Memory configuration for persisting corrections and learned thresholds."
+            },
+            {
+              "name": "identity",
+              "type": "IdentityConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "IdentityConfig"
+              ],
+              "description": "Identity Graph configuration for stable cross-run entity ids."
+            },
+            {
+              "name": "exclude_columns",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Column names to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking. GoldenFlow transforms skip them entirely (column passes through unchanged). Layered ADDITIVELY with GoldenCheck detector-derived exclusions (#404) -- the user list is OR'd with auto-detection, not a replacement. `QualityConfig.autoconfig_force_include` still wins on conflict (rescue beats every opt-out path). Column still appears in golden record output -- exclusion is about matching + transforming, not output. See spec docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md."
+            },
+            {
+              "name": "prepared_record_store",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When True, the prep stage (quality scan + transform + auto-fix) writes its output to a DuckDB-backed disk store keyed by config signature. Subsequent calls with the same config + data shape read prepared records from disk instead of re-prepping. Path via GOLDENMATCH_PREPARED_RECORD_STORE_DIR env var; persistence via GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST=1. Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md §Component 1."
+            },
+            {
+              "name": "partitioned_block_scoring",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When True AND prepared_record_store is True, the pipeline materializes blocks to the disk store as a side effect of build_blocks (Component 2 Phase 2 of Distributed Plan v1). Stages on-disk blocks for Component 3 (distributed scoring); no single-process win expected. Default off."
+            },
+            {
+              "name": "n_buckets",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Number of hash buckets for Component 2 v2 bucketed Parquet storage. None means use the heuristic default max(cpu_count() * 4, 64). Hard-capped at 1024. Spec: docs/superpowers/specs/2026-05-17-distributed-plan-component-2-v2-bucketed-storage-design.md §Configuration."
+            }
+          ]
+        },
+        {
+          "name": "InputConfig",
+          "fields": [
+            {
+              "name": "files",
+              "type": "list[InputFileConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "Input files to load and combine, used for deduplication across one or more sources."
+            },
+            {
+              "name": "file_a",
+              "type": "InputFileConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "First file in a two-source record-linkage (match) run."
+            },
+            {
+              "name": "file_b",
+              "type": "InputFileConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "Second file matched against file_a in a two-source record-linkage run."
+            }
+          ]
+        },
+        {
+          "name": "OutputConfig",
+          "fields": [
+            {
+              "name": "path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Destination file path for the primary results output."
+            },
+            {
+              "name": "format",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Output file format (e.g. csv or parquet); inferred from the path when unset."
+            },
+            {
+              "name": "directory",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Directory the run's output artifacts are written into."
+            },
+            {
+              "name": "run_name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Name identifying this run, used to key output subdirectories and lineage."
+            },
+            {
+              "name": "lineage_provenance",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Adds per-field golden-record provenance (winning value plus source row id) to the lineage sidecar."
+            }
+          ]
+        },
+        {
+          "name": "MatchSettingsConfig",
+          "fields": [
+            {
+              "name": "matchkeys",
+              "type": "list[MatchkeyConfig]",
+              "required": true,
+              "nested": [
+                "MatchkeyConfig"
+              ],
+              "description": "Matchkeys defining how records are compared and declared the same."
+            }
+          ]
+        },
+        {
+          "name": "MatchkeyConfig",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str",
+              "required": true,
+              "description": "Identifier for this matchkey, used in output and logs."
+            },
+            {
+              "name": "type",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "exact",
+                "weighted",
+                "probabilistic"
+              ],
+              "description": "Matching mode: exact equality, weighted per-field scoring, or probabilistic Fellegi-Sunter."
+            },
+            {
+              "name": "comparison",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Alias for 'type' accepting the same exact/weighted/probabilistic values."
+            },
+            {
+              "name": "fields",
+              "type": "list[MatchkeyField]",
+              "required": true,
+              "nested": [
+                "MatchkeyField"
+              ],
+              "description": "Fields compared to decide whether two records match under this matchkey."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Score at or above which a pair is accepted as a match; required for weighted matchkeys."
+            },
+            {
+              "name": "auto_threshold",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables automatic Otsu-style tuning of the accept threshold from the score distribution."
+            },
+            {
+              "name": "rerank",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables cross-encoder reranking of borderline pairs near the threshold."
+            },
+            {
+              "name": "rerank_model",
+              "type": "str",
+              "required": false,
+              "default": "'cross-encoder/ms-marco-MiniLM-L-6-v2'",
+              "description": "Cross-encoder model used to rerank borderline pairs when rerank is on."
+            },
+            {
+              "name": "rerank_band",
+              "type": "float",
+              "required": false,
+              "default": "0.1",
+              "description": "Half-width of the score band around the threshold within which pairs are reranked."
+            },
+            {
+              "name": "negative_evidence",
+              "type": "list[NegativeEvidenceField] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "NegativeEvidenceField"
+              ],
+              "description": "Fields whose disagreement penalizes the match score, catching false positives that agree on other fields."
+            },
+            {
+              "name": "em_iterations",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Maximum EM iterations when training probabilistic weights."
+            },
+            {
+              "name": "convergence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.001",
+              "description": "EM stops early once parameter change between iterations falls below this value."
+            },
+            {
+              "name": "link_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Probabilistic match probability at or above which a pair is auto-linked."
+            },
+            {
+              "name": "review_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Probabilistic match probability at or above which a pair is sent for manual review; must not exceed link_threshold."
+            },
+            {
+              "name": "model_path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "File where the trained probabilistic model is loaded from if present, or saved to after training."
+            },
+            {
+              "name": "missing",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "unobserved",
+                "disagree"
+              ],
+              "description": "How a missing value is treated probabilistically: 'unobserved' contributes nothing, 'disagree' counts against a match."
+            }
+          ],
+          "doc": "A matchkey: rule for declaring two records 'the same' on a field/field-set."
+        },
+        {
+          "name": "BlockingConfig",
+          "fields": [
+            {
+              "name": "keys",
+              "type": "list[BlockingKeyConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Blocking keys that generate candidate pairs; records sharing any key are compared."
+            },
+            {
+              "name": "max_block_size",
+              "type": "int",
+              "required": false,
+              "default": "5000",
+              "description": "Ceiling on how many records one block may hold before it is treated as oversized."
+            },
+            {
+              "name": "skip_oversized",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When true, blocks exceeding max_block_size are dropped rather than scored, guarding against mega-block blowups."
+            },
+            {
+              "name": "strategy",
+              "type": "Literal",
+              "required": false,
+              "default": "'static'",
+              "choices": [
+                "static",
+                "adaptive",
+                "sorted_neighborhood",
+                "multi_pass",
+                "ann",
+                "canopy",
+                "ann_pairs",
+                "learned",
+                "lsh",
+                "simhash",
+                "perceptual"
+              ],
+              "description": "Candidate-generation method that selects how pairs are proposed for scoring."
+            },
+            {
+              "name": "learned_sample_size",
+              "type": "int",
+              "required": false,
+              "default": "5000",
+              "description": "Number of sampled records the learned-predicate miner trains its blocking rules on."
+            },
+            {
+              "name": "learned_min_recall",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Minimum pair recall a learned predicate must retain to be accepted."
+            },
+            {
+              "name": "learned_min_reduction",
+              "type": "float",
+              "required": false,
+              "default": "0.9",
+              "description": "Minimum fraction of the full comparison space a learned predicate must eliminate."
+            },
+            {
+              "name": "learned_predicate_depth",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "Maximum number of conjoined conditions in a mined blocking predicate."
+            },
+            {
+              "name": "learned_cache_path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "File where learned blocking predicates are persisted for reuse across runs."
+            },
+            {
+              "name": "auto_suggest",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets the engine discover blocking keys at runtime instead of using the static keys."
+            },
+            {
+              "name": "auto_select",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets the engine pick the best blocking strategy automatically."
+            },
+            {
+              "name": "sub_block_keys",
+              "type": "list[BlockingKeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Secondary keys used to split oversized blocks into smaller candidate sets."
+            },
+            {
+              "name": "window_size",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Sliding-window width, in sorted records, for sorted-neighborhood blocking."
+            },
+            {
+              "name": "sort_key",
+              "type": "list[SortKeyField] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SortKeyField"
+              ],
+              "description": "Ordered columns records are sorted on for sorted-neighborhood blocking."
+            },
+            {
+              "name": "passes",
+              "type": "list[BlockingKeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Sequence of blocking key sets applied in separate passes for multi_pass blocking."
+            },
+            {
+              "name": "union_mode",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "When true, candidate pairs from all passes are unioned rather than intersected."
+            },
+            {
+              "name": "max_total_comparisons",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Global cap on the number of candidate pairs generated across all blocks."
+            },
+            {
+              "name": "ann_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Text column embedded for approximate-nearest-neighbor blocking."
+            },
+            {
+              "name": "ann_model",
+              "type": "str",
+              "required": false,
+              "default": "'all-MiniLM-L6-v2'",
+              "description": "Embedding model used to vectorize records for ANN blocking."
+            },
+            {
+              "name": "ann_top_k",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Number of nearest neighbors retrieved per record in ANN blocking."
+            },
+            {
+              "name": "canopy",
+              "type": "CanopyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "CanopyConfig"
+              ],
+              "description": "Configuration for canopy clustering when the strategy is 'canopy'."
+            },
+            {
+              "name": "lsh",
+              "type": "LSHKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "LSHKeyConfig"
+              ],
+              "description": "MinHash/LSH configuration required when the strategy is 'lsh'."
+            },
+            {
+              "name": "simhash",
+              "type": "SimHashKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SimHashKeyConfig"
+              ],
+              "description": "SimHash/LSH configuration required when the strategy is 'simhash'."
+            },
+            {
+              "name": "perceptual",
+              "type": "PerceptualKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "PerceptualKeyConfig"
+              ],
+              "description": "Perceptual-hash LSH configuration used when the strategy is 'perceptual'."
+            }
+          ]
+        },
+        {
+          "name": "GoldenRulesConfig",
+          "fields": [
+            {
+              "name": "default_strategy",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Survivorship strategy applied to any field without its own rule; required unless 'default' is set."
+            },
+            {
+              "name": "default",
+              "type": "GoldenFieldRule | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Full default rule whose strategy backfills default_strategy when the latter is unset."
+            },
+            {
+              "name": "field_rules",
+              "type": "dict[str, GoldenFieldRule | list[GoldenFieldRule]]",
+              "required": false,
+              "default": "{}",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Per-column survivorship rules, or an ordered list of conditional rules ending in a default clause."
+            },
+            {
+              "name": "field_groups",
+              "type": "list[GoldenGroupRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "GoldenGroupRule"
+              ],
+              "description": "Groups of columns resolved together so their values stay mutually consistent."
+            },
+            {
+              "name": "field_group_detection",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables automatic discovery of related column groups to resolve as units."
+            },
+            {
+              "name": "max_cluster_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Cluster size above which auto-split intervenes to break up likely over-merged clusters."
+            },
+            {
+              "name": "auto_split",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables splitting oversized clusters into tighter subclusters before building golden records."
+            },
+            {
+              "name": "quality_weighting",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Weights survivorship choices by per-source completeness and quality signals."
+            },
+            {
+              "name": "weak_cluster_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Cohesion score below which a cluster is flagged as weak and handled more conservatively."
+            },
+            {
+              "name": "split_edge_budget",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Cap on cumulative edge work spent auto-splitting clusters; None auto-scales from the row count."
+            },
+            {
+              "name": "adaptive",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables post-cluster refinement that re-picks per-field strategies from cluster health and profiles."
+            },
+            {
+              "name": "use_llm_for_ambiguous",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Falls back to one cached LLM call per field to pick a strategy when the heuristic refiner is undecided."
+            },
+            {
+              "name": "cluster_overrides",
+              "type": "dict[int, dict[str, GoldenFieldRule]] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Per-cluster field rules that supersede the top-level rules for the named clusters only."
+            }
+          ]
+        },
+        {
+          "name": "StandardizationConfig",
+          "fields": [
+            {
+              "name": "rules",
+              "type": "dict[str, list[str]]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-column ordered standardizer names applied before matching."
+            }
+          ]
+        },
+        {
+          "name": "ValidationConfig",
+          "fields": [
+            {
+              "name": "rules",
+              "type": "list[ValidationRuleConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "ValidationRuleConfig"
+              ],
+              "description": "Per-column validation rules run against the input before matching."
+            },
+            {
+              "name": "auto_fix",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Runs GoldenFlow auto-fix on the data before validation executes."
+            }
+          ]
+        },
+        {
+          "name": "QualityConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables GoldenCheck quality scanning and fixes; auto-detected true when goldencheck is installed."
+            },
+            {
+              "name": "mode",
+              "type": "str",
+              "required": false,
+              "default": "'announced'",
+              "description": "How quality findings are surfaced: 'silent', 'announced', or 'disabled'."
+            },
+            {
+              "name": "fix_mode",
+              "type": "str",
+              "required": false,
+              "default": "'safe'",
+              "description": "How aggressively quality fixes are applied: 'safe', 'moderate', or 'none'."
+            },
+            {
+              "name": "domain",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Domain pack tuning the quality checks, such as 'healthcare', 'finance', or 'ecommerce'."
+            },
+            {
+              "name": "autoconfig_force_exclude",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns always excluded from matching regardless of auto-detection."
+            },
+            {
+              "name": "autoconfig_force_include",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns rescued from any auto-exclusion; wins on conflict with force_exclude."
+            }
+          ],
+          "doc": "GoldenCheck integration config for enhanced data quality."
+        },
+        {
+          "name": "TransformConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables GoldenFlow data transformation; auto-detected true when goldenflow is installed."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'announced'",
+              "choices": [
+                "silent",
+                "announced",
+                "disabled"
+              ],
+              "description": "How applied transforms are surfaced: 'silent', 'announced', or 'disabled'."
+            }
+          ],
+          "doc": "GoldenFlow integration config for data transformation."
+        },
+        {
+          "name": "LLMScorerConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on LLM scoring of borderline candidate pairs."
+            },
+            {
+              "name": "provider",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "LLM provider ('openai' or 'anthropic'); auto-detected from credentials when None."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "LLM model name (e.g. 'gpt-4o-mini'); auto-detected when None."
+            },
+            {
+              "name": "auto_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Score above which pairs are auto-accepted without an LLM call."
+            },
+            {
+              "name": "candidate_lo",
+              "type": "float",
+              "required": false,
+              "default": "0.75",
+              "description": "Lower bound of the score band whose pairs are sent to the LLM."
+            },
+            {
+              "name": "candidate_hi",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Upper bound of the score band whose pairs are sent to the LLM."
+            },
+            {
+              "name": "batch_size",
+              "type": "int",
+              "required": false,
+              "default": "75",
+              "description": "Number of pairs packed into a single LLM request."
+            },
+            {
+              "name": "max_workers",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Number of concurrent LLM requests."
+            },
+            {
+              "name": "calibration_sample_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Pairs sampled per calibration round to tune the accept threshold."
+            },
+            {
+              "name": "calibration_max_rounds",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Maximum threshold-calibration rounds before stopping."
+            },
+            {
+              "name": "calibration_convergence_delta",
+              "type": "float",
+              "required": false,
+              "default": "0.01",
+              "description": "Calibration stops once the threshold shift between rounds falls below this."
+            },
+            {
+              "name": "budget",
+              "type": "BudgetConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BudgetConfig"
+              ],
+              "description": "Cost and call limits governing LLM usage; None means unbounded."
+            },
+            {
+              "name": "mode",
+              "type": "str",
+              "required": false,
+              "default": "'pairwise'",
+              "description": "LLM scoring mode: 'pairwise' per-pair scoring or 'cluster' in-context block clustering."
+            },
+            {
+              "name": "cluster_max_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Maximum records per LLM cluster block in cluster mode."
+            },
+            {
+              "name": "cluster_min_size",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Block size below which cluster mode falls back to pairwise scoring."
+            }
+          ]
+        },
+        {
+          "name": "DomainConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on domain feature extraction as a pipeline step before matchkeys."
+            },
+            {
+              "name": "mode",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Domain to extract for ('product', 'person', 'bibliographic', 'company', or 'auto' to detect)."
+            },
+            {
+              "name": "confidence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Extraction confidence below which a record is routed to the LLM instead."
+            },
+            {
+              "name": "llm_validation",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Uses the LLM to validate low-confidence extractions."
+            },
+            {
+              "name": "budget",
+              "type": "BudgetConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BudgetConfig"
+              ],
+              "description": "Cost and call limits for the domain-extraction LLM calls."
+            }
+          ]
+        },
+        {
+          "name": "DistributedRoutingConfig",
+          "fields": [
+            {
+              "name": "scoring",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed",
+                "in_process"
+              ],
+              "description": "Pins where pair scoring runs; 'auto' lets the planner choose distributed vs in-process."
+            },
+            {
+              "name": "clustering",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed_wcc",
+                "in_memory_scipy"
+              ],
+              "description": "Pins the clustering engine; 'auto' lets the planner choose distributed WCC vs in-memory scipy."
+            },
+            {
+              "name": "golden",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed",
+                "in_process"
+              ],
+              "description": "Pins where golden-record building runs; 'auto' lets the planner choose distributed vs in-process."
+            }
+          ],
+          "doc": "Per-stage distributed-routing pins. ``auto`` lets the planner decide;"
+        },
+        {
+          "name": "SemanticBlockingConfig",
+          "fields": [
+            {
+              "name": "keys",
+              "type": "list[Literal]",
+              "required": false,
+              "default": "['ann', 'initialism', 'alias']",
+              "choices": [
+                "ann",
+                "initialism",
+                "alias"
+              ],
+              "description": "Which semantic blocking keys to union into candidate generation: 'ann' (embedding nearest-neighbors), 'initialism' (initialism expansion), 'alias' (alias-table lookups)."
+            },
+            {
+              "name": "ann_model",
+              "type": "str",
+              "required": false,
+              "default": "'inhouse'",
+              "description": "Embedding model id for the ANN key (e.g. 'inhouse')."
+            },
+            {
+              "name": "ann_top_k",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Number of ANN neighbors retrieved per record for candidate generation."
+            },
+            {
+              "name": "ann_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "description": "Minimum ANN similarity for a neighbor to become a candidate pair."
+            },
+            {
+              "name": "alias_tables",
+              "type": "list[Literal]",
+              "required": false,
+              "default": "['given_names', 'business']",
+              "choices": [
+                "given_names",
+                "business"
+              ],
+              "description": "Which alias tables the 'alias' key consults."
+            }
+          ],
+          "doc": "Opt-in semantic candidate-generation (recall-lever) config. Carries the"
+        },
+        {
+          "name": "ThroughputConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on the sketch-then-verify throughput tier in place of per-field fuzzy/FS scoring."
+            },
+            {
+              "name": "recall_target",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Desired blocking recall the sketch tier tunes its band count toward."
+            },
+            {
+              "name": "similarity_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Overrides the default near-duplicate similarity cutoff; None uses the metric-specific default."
+            }
+          ],
+          "doc": "Opt-in sketch-then-verify throughput tier (#1083)."
+        },
+        {
+          "name": "MemoryConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Turns on Learning Memory so stored corrections and learned thresholds feed back into runs."
+            },
+            {
+              "name": "backend",
+              "type": "str",
+              "required": false,
+              "default": "'sqlite'",
+              "description": "Storage backend for the memory store ('sqlite' or 'postgres')."
+            },
+            {
+              "name": "path",
+              "type": "str",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "description": "SQLite file path for the memory store when the backend is sqlite."
+            },
+            {
+              "name": "connection",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Database connection string used when the backend is postgres."
+            },
+            {
+              "name": "trust",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{'human': 1.0, 'agent': 0.5}",
+              "description": "Per-source trust weights that scale how strongly a correction's origin influences learning."
+            },
+            {
+              "name": "learning",
+              "type": "LearningConfig",
+              "required": false,
+              "default": "LearningConfig(threshold_min_corrections=10, weights_min_corrections=50)",
+              "nested": [
+                "LearningConfig"
+              ],
+              "description": "Thresholds governing how many corrections are needed before rules are learned."
+            },
+            {
+              "name": "reanchor",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Re-anchors stored corrections to current rows by record hash so they survive row reordering."
+            },
+            {
+              "name": "dataset",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Dataset name scoping corrections so unrelated datasets do not share memory."
+            },
+            {
+              "name": "table_prefix",
+              "type": "str",
+              "required": false,
+              "default": "''",
+              "description": "Prefix applied to memory table names, letting multiple stores share one database."
+            }
+          ],
+          "doc": "Learning Memory configuration."
+        },
+        {
+          "name": "IdentityConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on the durable identity graph that assigns stable entity ids across runs after clustering."
+            },
+            {
+              "name": "backend",
+              "type": "str",
+              "required": false,
+              "default": "'sqlite'",
+              "description": "Storage backend for the identity graph ('sqlite' or 'postgres')."
+            },
+            {
+              "name": "path",
+              "type": "str",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "description": "SQLite file path for the identity graph when the backend is sqlite."
+            },
+            {
+              "name": "connection",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Database connection string used when the backend is postgres."
+            },
+            {
+              "name": "dataset",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Dataset name scoping identities so unrelated datasets do not share entity ids."
+            },
+            {
+              "name": "source_pk_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying each record's source primary key for stable record ids; a payload hash is used when unset."
+            },
+            {
+              "name": "emit_singletons",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Whether single-record clusters also get a durable entity id."
+            },
+            {
+              "name": "weak_confidence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.6",
+              "description": "Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it."
+            },
+            {
+              "name": "stitching",
+              "type": "ChannelStitchConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ChannelStitchConfig"
+              ],
+              "description": "Cross-device/channel stitching configuration; None leaves identity resolution unchanged."
+            },
+            {
+              "name": "survivorship",
+              "type": "SurvivorshipConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SurvivorshipConfig"
+              ],
+              "description": "Identity golden-record survivorship configuration; None keeps the default flat golden record."
+            },
+            {
+              "name": "stabilization",
+              "type": "StabilizationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "StabilizationConfig"
+              ],
+              "description": "Cross-run entity stabilization configuration; None runs no stabilize pass."
+            },
+            {
+              "name": "mediation",
+              "type": "MediationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MediationConfig"
+              ],
+              "description": "Conflict mediation workflow configuration; None leaves mediation unconfigured."
+            }
+          ],
+          "doc": "Identity Graph configuration."
+        },
+        {
+          "name": "InputFileConfig",
+          "fields": [
+            {
+              "name": "path",
+              "type": "str",
+              "required": true,
+              "description": "Filesystem path to the input data file."
+            },
+            {
+              "name": "id_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column holding a stable record identifier; a row index is used when unset."
+            },
+            {
+              "name": "source_label",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Human-readable label attached to records from this file."
+            },
+            {
+              "name": "source_name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Source name recorded on each record for provenance and source-priority survivorship."
+            },
+            {
+              "name": "column_map",
+              "type": "dict[str, str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Renames raw file columns to canonical names before matching."
+            },
+            {
+              "name": "delimiter",
+              "type": "str",
+              "required": false,
+              "default": "','",
+              "description": "Field delimiter for delimited text files."
+            },
+            {
+              "name": "encoding",
+              "type": "str",
+              "required": false,
+              "default": "'utf8'",
+              "description": "Character encoding used to decode the file."
+            },
+            {
+              "name": "sheet",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Worksheet name to read from an Excel workbook."
+            },
+            {
+              "name": "parse_mode",
+              "type": "str",
+              "required": false,
+              "default": "'auto'",
+              "description": "How the file is parsed: auto, delimited, fixed_width, key_value, block, or entity_extract."
+            },
+            {
+              "name": "header_row",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Zero-based row index that holds column headers."
+            },
+            {
+              "name": "has_header",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether the file has a header row; None lets the parser infer it."
+            },
+            {
+              "name": "skip_rows",
+              "type": "list[int] | None",
+              "required": false,
+              "default": "None",
+              "description": "Row indices to skip while reading, such as banner or junk lines."
+            }
+          ]
+        },
+        {
+          "name": "MatchkeyField",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Source column this field compares on; may be given as 'column' instead."
+            },
+            {
+              "name": "column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Alias for 'field' naming the source column to compare."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before scoring, in order."
+            },
+            {
+              "name": "scorer",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Similarity comparator used to score agreement between the two values."
+            },
+            {
+              "name": "weight",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Relative importance of this field's agreement within a weighted matchkey."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Embedding model name used when the scorer is 'embedding'."
+            },
+            {
+              "name": "columns",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Set of source columns fused into one vector when the scorer is 'record_embedding'."
+            },
+            {
+              "name": "column_weights",
+              "type": "dict[str, float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Per-column weights blending the inputs for the 'record_embedding' scorer."
+            },
+            {
+              "name": "levels",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "Number of probabilistic agreement bands (2=agree/disagree, 3=agree/partial/disagree)."
+            },
+            {
+              "name": "partial_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.8",
+              "description": "Similarity at or above which a 3-level comparison counts as a partial agreement."
+            },
+            {
+              "name": "tf_adjustment",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables Winkler term-frequency weighting so agreement on a rare value counts more than on a common one."
+            },
+            {
+              "name": "tf_freqs",
+              "type": "dict[str, float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Precomputed value-to-frequency table that drives data-driven downweighting of common values."
+            },
+            {
+              "name": "type",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "exact",
+                "weighted",
+                "probabilistic"
+              ],
+              "description": "Workbench hint for which matchkey kind to wrap this field in when translating a flat field list."
+            },
+            {
+              "name": "em_iterations",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Per-field cap on EM training iterations for a probabilistic comparison."
+            },
+            {
+              "name": "level_thresholds",
+              "type": "list[float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries."
+            }
+          ]
+        },
+        {
+          "name": "NegativeEvidenceField",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str",
+              "required": true,
+              "description": "Column whose disagreement between two records counts as evidence against a match."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before the disagreement check."
+            },
+            {
+              "name": "scorer",
+              "type": "str",
+              "required": true,
+              "description": "Similarity comparator used to decide whether the two values disagree."
+            },
+            {
+              "name": "threshold",
+              "type": "float",
+              "required": true,
+              "description": "Similarity below which the two values are treated as disagreeing and the penalty fires."
+            },
+            {
+              "name": "penalty",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Flat 0-1 amount subtracted from a weighted/exact score on disagreement."
+            },
+            {
+              "name": "penalty_bits",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Fixed log-likelihood-ratio penalty in bits applied on disagreement for probabilistic matchkeys, overriding EM."
+            },
+            {
+              "name": "derive_from",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Source columns space-joined to synthesize the compared field when it is not present in the raw frame."
+            }
+          ],
+          "doc": "v1.11: a field whose disagreement subtracts from a weighted matchkey's"
+        },
+        {
+          "name": "BlockingKeyConfig",
+          "fields": [
+            {
+              "name": "fields",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns whose combined values form the blocking key; records sharing a key become candidate pairs."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to every field before deriving the block key."
+            },
+            {
+              "name": "field_transforms",
+              "type": "dict[str, list[str]]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-field transform chains overriding the key-level transforms for the named fields only."
+            }
+          ]
+        },
+        {
+          "name": "SortKeyField",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column records are sorted on for sorted-neighborhood blocking."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before sorting."
+            }
+          ]
+        },
+        {
+          "name": "CanopyConfig",
+          "fields": [
+            {
+              "name": "fields",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns used to compute cheap similarity when forming canopies."
+            },
+            {
+              "name": "loose_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Loose similarity at or above which a record joins a canopy as a candidate."
+            },
+            {
+              "name": "tight_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.7",
+              "description": "Tight similarity at or above which a record is removed from the pool so it seeds no new canopy."
+            },
+            {
+              "name": "max_canopy_size",
+              "type": "int",
+              "required": false,
+              "default": "500",
+              "description": "Ceiling on records in one canopy, capping the candidate pairs it can generate."
+            }
+          ]
+        },
+        {
+          "name": "LSHKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Text column MinHash/LSH blocks on to group near-duplicate strings."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'char'",
+              "choices": [
+                "char",
+                "word"
+              ],
+              "description": "Whether shingles are character-grams or word-grams before hashing."
+            },
+            {
+              "name": "k",
+              "type": "int",
+              "required": false,
+              "default": "3",
+              "description": "Shingle size (number of chars or words per gram)."
+            },
+            {
+              "name": "num_perms",
+              "type": "int",
+              "required": false,
+              "default": "128",
+              "description": "Number of MinHash permutations; more permutations sharpen the similarity estimate at higher cost."
+            },
+            {
+              "name": "seed",
+              "type": "int",
+              "required": false,
+              "default": "0",
+              "description": "Random seed making the MinHash permutations reproducible."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Target Jaccard similarity from which the band/row split is derived when num_bands is unset."
+            },
+            {
+              "name": "num_bands",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Explicit LSH band count (must divide num_perms); overrides threshold when set."
+            }
+          ],
+          "doc": "MinHash/LSH blocking on a text column (#1081)."
+        },
+        {
+          "name": "SimHashKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Text column embedded then SimHash-blocked to group semantically near records."
+            },
+            {
+              "name": "num_planes",
+              "type": "int",
+              "required": false,
+              "default": "256",
+              "description": "Number of random hyperplanes the embedding is projected through to form the SimHash signature."
+            },
+            {
+              "name": "seed",
+              "type": "int",
+              "required": false,
+              "default": "0",
+              "description": "Random seed making the SimHash hyperplanes reproducible."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Target cosine similarity from which the band/row split is derived when num_bands is unset."
+            },
+            {
+              "name": "num_bands",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Explicit LSH band count (must divide num_planes); overrides threshold when set."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Embedding model used to vectorize the column; None uses the in-house ER embedder."
+            }
+          ],
+          "doc": "SimHash/LSH blocking on a text column via dense embeddings (#1082)."
+        },
+        {
+          "name": "PerceptualKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column holding fixed-width hex perceptual hashes to block media near-duplicates on."
+            },
+            {
+              "name": "num_bands",
+              "type": "int",
+              "required": false,
+              "default": "16",
+              "description": "Number of contiguous bit-bands the hash is split into; more bands raise recall and candidate pairs."
+            },
+            {
+              "name": "hash_bits",
+              "type": "int",
+              "required": false,
+              "default": "64",
+              "description": "Total bit width of the perceptual hash; must be a positive multiple of num_bands."
+            }
+          ],
+          "doc": "Banded hamming-LSH blocking over a column of perceptual hashes (ADR 0022)."
+        },
+        {
+          "name": "GoldenFieldRule",
+          "fields": [
+            {
+              "name": "strategy",
+              "type": "str",
+              "required": true,
+              "description": "Survivorship strategy that picks the winning value for a field across a cluster's records."
+            },
+            {
+              "name": "date_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying recency, required by the 'most_recent' strategy."
+            },
+            {
+              "name": "source_priority",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Ordered source names preferred first, required by the 'source_priority' strategy."
+            },
+            {
+              "name": "when",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Predicate over already-resolved fields gating whether this rule applies."
+            },
+            {
+              "name": "validate_with",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Name of a goldenflow validator that filters candidate values before survivorship.",
+              "alias": "validate"
+            }
+          ]
+        },
+        {
+          "name": "GoldenGroupRule",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str",
+              "required": true,
+              "description": "Identifier for this group of columns that must survive together."
+            },
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Related columns resolved as a unit so their values stay from a single source record."
+            },
+            {
+              "name": "category",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional label categorizing the group for reporting."
+            },
+            {
+              "name": "strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_complete'",
+              "description": "Survivorship strategy applied to the group as a whole when choosing the winning record."
+            },
+            {
+              "name": "date_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying recency, required by the group's 'most_recent' strategy."
+            },
+            {
+              "name": "source_priority",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Ordered source names preferred first, required by the group's 'source_priority' strategy."
+            },
+            {
+              "name": "anchor",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column whose non-null presence selects the source record, required by and only valid with the 'anchor' strategy."
+            },
+            {
+              "name": "allow_fill",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When true, individually missing values in the winning record may be filled from other records."
+            }
+          ]
+        },
+        {
+          "name": "ValidationRuleConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column the validation rule is checked against."
+            },
+            {
+              "name": "rule_type",
+              "type": "Literal",
+              "required": true,
+              "choices": [
+                "regex",
+                "min_length",
+                "max_length",
+                "not_null",
+                "in_set",
+                "format"
+              ],
+              "description": "Kind of check applied to the column's values."
+            },
+            {
+              "name": "params",
+              "type": "dict",
+              "required": false,
+              "default": "{}",
+              "description": "Rule-specific parameters, such as the pattern, length bound, or allowed set."
+            },
+            {
+              "name": "action",
+              "type": "Literal",
+              "required": false,
+              "default": "'flag'",
+              "choices": [
+                "null",
+                "quarantine",
+                "flag"
+              ],
+              "description": "What happens to a failing value: null it out, quarantine the row, or just flag it."
+            }
+          ]
+        },
+        {
+          "name": "BudgetConfig",
+          "fields": [
+            {
+              "name": "max_cost_usd",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Hard cap on total LLM spend for the run; calls stop once it is reached."
+            },
+            {
+              "name": "max_calls",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Hard cap on the number of LLM requests for the run."
+            },
+            {
+              "name": "escalation_model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Pricier model borderline pairs are escalated to for a second opinion."
+            },
+            {
+              "name": "escalation_band",
+              "type": "list[float]",
+              "required": false,
+              "default": "[0.8, 0.9]",
+              "description": "Score band [low, high] whose pairs are escalated to the pricier model."
+            },
+            {
+              "name": "escalation_budget_pct",
+              "type": "float",
+              "required": false,
+              "default": "20",
+              "description": "Percentage of the budget reserved for escalation to the pricier model."
+            },
+            {
+              "name": "warn_at_pct",
+              "type": "float",
+              "required": false,
+              "default": "80",
+              "description": "Percentage of the budget spent at which a warning is emitted."
+            }
+          ]
+        },
+        {
+          "name": "LearningConfig",
+          "fields": [
+            {
+              "name": "threshold_min_corrections",
+              "type": "int",
+              "required": false,
+              "default": "10",
+              "description": "Minimum stored corrections before learned thresholds are tuned from them."
+            },
+            {
+              "name": "weights_min_corrections",
+              "type": "int",
+              "required": false,
+              "default": "50",
+              "description": "Minimum stored corrections before learned field weights are tuned from them."
+            }
+          ],
+          "doc": "Learning Memory learning parameters."
+        },
+        {
+          "name": "ChannelStitchConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on cross-device/channel stitching so a caller can join a person's records across channels."
+            },
+            {
+              "name": "device_keys",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns whose shared non-null value is a near-certain same-person signal; empty uses the defaults."
+            },
+            {
+              "name": "channel_column",
+              "type": "str",
+              "required": false,
+              "default": "'channel'",
+              "description": "Column carrying an explicit channel label per record."
+            },
+            {
+              "name": "channel_map",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Exact source-name to channel overrides that beat substring channel inference."
+            },
+            {
+              "name": "channel_trust",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-channel trust weight in (0, 1] used to downweight cross-channel matches; empty uses the defaults."
+            },
+            {
+              "name": "adjust_cross_channel",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Scales probabilistic match scores by the two channels' trust factor."
+            },
+            {
+              "name": "prob_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "description": "Drops probabilistic stitch edges whose post-adjustment weight falls below this."
+            }
+          ],
+          "doc": "Cross-device / channel stitching configuration (#1110, epic #1108)."
+        },
+        {
+          "name": "SurvivorshipConfig",
+          "fields": [
+            {
+              "name": "field_strategies",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-column survivorship strategy overrides; unlisted columns fall back to default_strategy."
+            },
+            {
+              "name": "default_strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_complete'",
+              "description": "Survivorship strategy applied to any column without its own override."
+            },
+            {
+              "name": "timestamp_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column with a per-record timestamp enabling most_recent survivorship and per-cell provenance."
+            },
+            {
+              "name": "learn_from_corrections",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Folds per-field strategies learned from steward corrections into field_strategies."
+            }
+          ],
+          "doc": "Golden-record survivorship configuration (#1111, epic #1108)."
+        },
+        {
+          "name": "StabilizationConfig",
+          "fields": [
+            {
+              "name": "min_runs",
+              "type": "int",
+              "required": false,
+              "default": "3",
+              "description": "Distinct runs of cross-entity overlap evidence required before two entities auto-consolidate."
+            },
+            {
+              "name": "winner_strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_records'",
+              "description": "Which entity survives a consolidation: most_records, oldest, newest, or lowest_id."
+            },
+            {
+              "name": "min_score",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "description": "Minimum max-edge score for a cross-entity pair to count as overlap evidence."
+            }
+          ],
+          "doc": "Cross-run entity stabilization -- Identity v3 (#1112, epic #1108)."
+        },
+        {
+          "name": "MediationConfig",
+          "fields": [
+            {
+              "name": "auto_apply",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Whether a 'distinct' mediation verdict actually splits the record out or is only recorded."
+            }
+          ],
+          "doc": "Conflict mediation workflow -- Identity v3 (#1113, epic #1108)."
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8200",
+              "help": "Port for the A2A server"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host to bind to"
+            }
+          ]
+        },
+        {
+          "command": "analyze-blocking",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to analyze"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Config file with matchkeys"
+            }
+          ]
+        },
+        {
+          "command": "anomalies",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--sensitivity",
+              "type": "text",
+              "required": false,
+              "default": "'medium'",
+              "help": "low, medium, or high"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write anomalies to a CSV instead of printing"
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Max rows to print"
+            }
+          ]
+        },
+        {
+          "command": "autoconfig",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files as path or path:source_name"
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write committed config to this path instead of stdout."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
+            },
+            {
+              "name": "--show-controller",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Render the controller telemetry panel on stderr."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Include indicator priors + decision trace in the panel."
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress all stderr output (panel + status messages)."
+            }
+          ]
+        },
+        {
+          "command": "compare-clusters",
+          "options": [
+            {
+              "name": "file_a",
+              "type": "text",
+              "required": true,
+              "help": "First cluster JSON file (baseline / ER1)"
+            },
+            {
+              "name": "file_b",
+              "type": "text",
+              "required": true,
+              "help": "Second cluster JSON file (comparison / ER2)"
+            },
+            {
+              "name": "--details",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show per-cluster transformation details"
+            },
+            {
+              "name": "--case-type",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            }
+          ]
+        },
+        {
+          "command": "config delete",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to delete"
+            }
+          ]
+        },
+        {
+          "command": "config list",
+          "options": []
+        },
+        {
+          "command": "config load",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to load"
+            },
+            {
+              "name": "--dest",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Destination path"
+            }
+          ]
+        },
+        {
+          "command": "config save",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name"
+            },
+            {
+              "name": "config_path",
+              "type": "text",
+              "required": true,
+              "help": "Path to config YAML file"
+            }
+          ]
+        },
+        {
+          "command": "config show",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to display"
+            }
+          ]
+        },
+        {
+          "command": "dedupe",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files as path or path:source_name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to YAML config file (optional - auto-detects if omitted)"
+            },
+            {
+              "name": "--tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Open the interactive review TUI instead of running directly (auto-config path only)."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Deprecated: non-interactive is now the default. Accepted for back-compat (no-op)."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Override embedding model selection"
+            },
+            {
+              "name": "--preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Preview results without writing files"
+            },
+            {
+              "name": "--preview-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Number of records for preview sample"
+            },
+            {
+              "name": "--preview-random",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Random sample instead of first N"
+            },
+            {
+              "name": "--output-golden",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output golden records"
+            },
+            {
+              "name": "--output-clusters",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output cluster info"
+            },
+            {
+              "name": "--output-dupes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output duplicate records"
+            },
+            {
+              "name": "--output-unique",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output unique records"
+            },
+            {
+              "name": "--output-all",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output all result types"
+            },
+            {
+              "name": "--output-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate summary report"
+            },
+            {
+              "name": "--html-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate standalone HTML report"
+            },
+            {
+              "name": "--dashboard",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after data quality dashboard"
+            },
+            {
+              "name": "--across-files-only",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Only match across different sources"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output format (csv, parquet)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run name for output files"
+            },
+            {
+              "name": "--auto-fix",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Run auto-fix before matching"
+            },
+            {
+              "name": "--auto-block",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-suggest blocking keys"
+            },
+            {
+              "name": "--chunked",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Large dataset mode - process in chunks for files >1M records"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Records per chunk in chunked mode"
+            },
+            {
+              "name": "--diff",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after CSV diff"
+            },
+            {
+              "name": "--diff-html",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after HTML diff with highlighting"
+            },
+            {
+              "name": "--merge-preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show merge preview (what will change) without writing"
+            },
+            {
+              "name": "--anomalies",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Detect suspicious/fake records"
+            },
+            {
+              "name": "--anomaly-sensitivity",
+              "type": "text",
+              "required": false,
+              "default": "'medium'",
+              "help": "low, medium, or high"
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Boost accuracy with LLM-labeled training data"
+            },
+            {
+              "name": "--llm-retrain",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Force re-labeling (ignore saved model)"
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "LLM provider: auto, anthropic, or openai"
+            },
+            {
+              "name": "--llm-max-labels",
+              "type": "integer",
+              "required": false,
+              "default": "500",
+              "help": "Max pairs to label with LLM"
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Processing backend: default, bucket, chunked, ray, duckdb"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
+            },
+            {
+              "name": "--show-controller",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Render AutoConfigController telemetry (stop_reason, decisions, Path Y) when auto-config ran. No-op for runs with an explicit --config."
+            },
+            {
+              "name": "--suggest",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show verified config-improvement suggestions for this run."
+            },
+            {
+              "name": "--heal",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Apply the suggestion heal loop and print the applied trail."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Verbose output"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress output"
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Launch interactive TUI with demo data"
+            },
+            {
+              "name": "--report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate HTML report"
+            },
+            {
+              "name": "--dashboard",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after dashboard"
+            },
+            {
+              "name": "--graph",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate cluster graph"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress animated output"
+            }
+          ]
+        },
+        {
+          "command": "evaluate",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--ground-truth",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Ground truth CSV path (required unless --certify)"
+            },
+            {
+              "name": "--col-a",
+              "type": "text",
+              "required": false,
+              "default": "'id_a'",
+              "help": "Ground truth column A"
+            },
+            {
+              "name": "--col-b",
+              "type": "text",
+              "required": false,
+              "default": "'id_b'",
+              "help": "Ground truth column B"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Override match threshold"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            },
+            {
+              "name": "--min-f1",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum F1 score (exit code 1 if below). For CI/CD quality gates."
+            },
+            {
+              "name": "--min-precision",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum precision (exit code 1 if below)"
+            },
+            {
+              "name": "--min-recall",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum recall (exit code 1 if below)"
+            },
+            {
+              "name": "--certify",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Estimate recall WITHOUT ground truth (unsupervised, via capture-recapture over the config's matchkeys/passes; needs >=3)."
+            },
+            {
+              "name": "--audit-out",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "With --certify: emit a stratified audit sample CSV to label for a SAFE recall lower bound."
+            },
+            {
+              "name": "--audit-in",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "With --certify: read a labelled audit sample and print the audit-calibrated SAFE lower bound."
+            },
+            {
+              "name": "--audit-n",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Audit samples per stratum (default 50)."
+            },
+            {
+              "name": "--threshold-sweep",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Sweep the link threshold over scored pairs: P/R/F1 table + recommended cut (+ Fellegi-Sunter m/u model report when a probabilistic matchkey ran)."
+            }
+          ]
+        },
+        {
+          "command": "explain",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--pair",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Explain a pair: 'id_a,id_b'"
+            },
+            {
+              "name": "--cluster",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Explain a cluster by id"
+            }
+          ]
+        },
+        {
+          "command": "identity conflicts",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities in this dataset."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity history",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Maximum number of events to return."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity list",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities in this dataset."
+            },
+            {
+              "name": "--status",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities with this status."
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Maximum number of identities to return."
+            },
+            {
+              "name": "--offset",
+              "type": "integer",
+              "required": false,
+              "default": "0",
+              "help": "Number of identities to skip for pagination."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity merge",
+          "options": [
+            {
+              "name": "keep",
+              "type": "text",
+              "required": true,
+              "help": "entity_id to keep"
+            },
+            {
+              "name": "absorb",
+              "type": "text",
+              "required": true,
+              "help": "entity_id to absorb"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason recorded in the event log."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            }
+          ]
+        },
+        {
+          "command": "identity migrate",
+          "options": [
+            {
+              "name": "--dsn",
+              "type": "text",
+              "required": true,
+              "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
+            },
+            {
+              "name": "--stamp-existing",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Stamp an existing v1 schema at revision 0001 without re-creating tables."
+            },
+            {
+              "name": "--revision",
+              "type": "text",
+              "required": false,
+              "default": "'head'",
+              "help": "Target revision (default: head)."
+            }
+          ]
+        },
+        {
+          "command": "identity migrate-ids",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dsn",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database connection string for the identity store."
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Report what would change; mutate nothing."
+            }
+          ]
+        },
+        {
+          "command": "identity resolve",
+          "options": [
+            {
+              "name": "record_id",
+              "type": "text",
+              "required": true,
+              "help": "`{source}:{pk}` to look up"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity show",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity split",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "record_ids",
+              "type": "text",
+              "required": true,
+              "help": "record_ids to move to a new identity"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason recorded in the event log."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            }
+          ]
+        },
+        {
+          "command": "import-splink",
+          "options": [
+            {
+              "name": "input_path",
+              "type": "text",
+              "required": true,
+              "help": "Splink settings or trained-model JSON file"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Output YAML config path"
+            },
+            {
+              "name": "--model-out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail on any lossy mapping (warnings), not just errors"
+            },
+            {
+              "name": "--upgrade",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
+            },
+            {
+              "name": "--splink-clusters",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
+            },
+            {
+              "name": "--labels",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
+            },
+            {
+              "name": "--sample-cap",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
+            },
+            {
+              "name": "--no-measure",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Skip the baseline-vs-upgraded measurement pass"
+            },
+            {
+              "name": "--id-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
+            }
+          ]
+        },
+        {
+          "command": "incremental",
+          "options": [
+            {
+              "name": "base_file",
+              "type": "text",
+              "required": true,
+              "help": "Base dataset file path"
+            },
+            {
+              "name": "--new-records",
+              "type": "path",
+              "required": true,
+              "help": "New records CSV to match"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output CSV path"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Override threshold"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
+            }
+          ]
+        },
+        {
+          "command": "ingest-docs run",
+          "options": [
+            {
+              "name": "docs",
+              "type": "text",
+              "required": true,
+              "help": "Document paths (PDF/image)."
+            },
+            {
+              "name": "--schema",
+              "type": "text",
+              "required": true,
+              "help": "Target schema JSON file."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": true,
+              "help": "Write records here (.csv or .parquet)."
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "'vlm'",
+              "help": "Extraction backend."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "'gpt-4o'",
+              "help": "Vision model."
+            }
+          ]
+        },
+        {
+          "command": "ingest-docs suggest-schema",
+          "options": [
+            {
+              "name": "sample",
+              "type": "text",
+              "required": true,
+              "help": "A representative document (PDF/image)."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": true,
+              "help": "Write the proposed schema JSON here."
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "'vlm'",
+              "help": "Extraction backend."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "'gpt-4o'",
+              "help": "Vision model."
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output path for generated config"
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to load"
+            }
+          ]
+        },
+        {
+          "command": "label",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'ground_truth.csv'",
+              "help": "Output ground truth CSV"
+            },
+            {
+              "name": "--n",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Number of pairs to label"
+            },
+            {
+              "name": "--strategy",
+              "type": "text",
+              "required": false,
+              "default": "'borderline'",
+              "help": "Pair selection: borderline, random, or hardest"
+            },
+            {
+              "name": "--append",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Append to existing ground truth file"
+            }
+          ]
+        },
+        {
+          "command": "lineage",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write lineage.json here (default: print a summary)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "'lineage'",
+              "help": "Run name for the lineage file"
+            },
+            {
+              "name": "--max-pairs",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Cap on lineage records (0 = no cap)"
+            },
+            {
+              "name": "--nl",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Include natural-language explanations"
+            }
+          ]
+        },
+        {
+          "command": "match",
+          "options": [
+            {
+              "name": "target",
+              "type": "text",
+              "required": true,
+              "help": "Target file as path or path:source_name"
+            },
+            {
+              "name": "--against",
+              "type": "text",
+              "required": true,
+              "help": "Reference files as path or path:source_name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to YAML config file (optional - auto-detects if omitted)"
+            },
+            {
+              "name": "--preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Preview results without writing files"
+            },
+            {
+              "name": "--preview-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Number of records for preview sample"
+            },
+            {
+              "name": "--preview-random",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Random sample instead of first N"
+            },
+            {
+              "name": "--output-matched",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output matched records"
+            },
+            {
+              "name": "--output-unmatched",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output unmatched records"
+            },
+            {
+              "name": "--output-scores",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output score details"
+            },
+            {
+              "name": "--output-all",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output all result types"
+            },
+            {
+              "name": "--output-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate summary report"
+            },
+            {
+              "name": "--match-mode",
+              "type": "text",
+              "required": false,
+              "default": "'best'",
+              "help": "Match mode: best or all"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output format (csv, parquet)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run name for output files"
+            },
+            {
+              "name": "--auto-fix",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Run auto-fix before matching"
+            },
+            {
+              "name": "--auto-block",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-suggest blocking keys"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Verbose output"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress output"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Data files to load"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "HTTP host (only for http transport)"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8200",
+              "help": "HTTP port (only for http transport)"
+            }
+          ]
+        },
+        {
+          "command": "memory add",
+          "options": [
+            {
+              "name": "--decision",
+              "type": "text",
+              "required": true,
+              "help": "approve | reject | field_correct"
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset key (required)"
+            },
+            {
+              "name": "--id-a",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Pair-level: first row id"
+            },
+            {
+              "name": "--id-b",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Pair-level: second row id"
+            },
+            {
+              "name": "--cluster-id",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: cluster id the correction targets"
+            },
+            {
+              "name": "--field-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: column being corrected"
+            },
+            {
+              "name": "--original-value",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: original chosen value"
+            },
+            {
+              "name": "--corrected-value",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: the value the reviewer changed it to"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason"
+            },
+            {
+              "name": "--matchkey-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional matchkey scope"
+            },
+            {
+              "name": "--source",
+              "type": "text",
+              "required": false,
+              "default": "'steward'",
+              "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory export",
+          "options": [
+            {
+              "name": "out",
+              "type": "text",
+              "required": true,
+              "help": "Output CSV path"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory import",
+          "options": [
+            {
+              "name": "src",
+              "type": "text",
+              "required": true,
+              "help": "Source CSV path"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory learn",
+          "options": [
+            {
+              "name": "--matchkey-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Limit learning to this matchkey"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory show",
+          "options": [
+            {
+              "name": "id_a",
+              "type": "integer",
+              "required": true,
+              "help": "First record ID"
+            },
+            {
+              "name": "id_b",
+              "type": "integer",
+              "required": true,
+              "help": "Second record ID"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory stats",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "pprl auto-config",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to analyze (CSV)"
+            },
+            {
+              "name": "--security",
+              "type": "text",
+              "required": false,
+              "default": "'high'",
+              "help": "Security level: standard, high, paranoid"
+            },
+            {
+              "name": "--llm",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Use LLM for enhanced recommendations"
+            }
+          ]
+        },
+        {
+          "command": "pprl link",
+          "options": [
+            {
+              "name": "--file-a",
+              "type": "path",
+              "required": true,
+              "help": "Party A data file (CSV)"
+            },
+            {
+              "name": "--file-b",
+              "type": "path",
+              "required": true,
+              "help": "Party B data file (CSV)"
+            },
+            {
+              "name": "--fields",
+              "type": "text",
+              "required": true,
+              "help": "Comma-separated field names to match on"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.85",
+              "help": "Match threshold"
+            },
+            {
+              "name": "--security",
+              "type": "text",
+              "required": false,
+              "default": "'high'",
+              "help": "Security level: standard, high, paranoid"
+            },
+            {
+              "name": "--protocol",
+              "type": "text",
+              "required": false,
+              "default": "'trusted_third_party'",
+              "help": "Protocol: trusted_third_party or smc"
+            },
+            {
+              "name": "--scorer",
+              "type": "text",
+              "required": false,
+              "default": "'dice'",
+              "help": "Similarity scorer: dice or jaccard"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output CSV path for cluster assignments"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
+            }
+          ]
+        },
+        {
+          "command": "profile",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to profile"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show detailed per-column info"
+            },
+            {
+              "name": "--suggest-fixes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show what auto-fix would do (dry run)"
+            },
+            {
+              "name": "--exclusions",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show GoldenCheck auto-config column exclusions (#404). Lists columns auto-config will skip (audit timestamps, foreign IDs, sentinel values, etc) and why."
+            }
+          ]
+        },
+        {
+          "command": "review",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Input files (path or path:source_name). Omit to review only the pending queue."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--job",
+              "type": "text",
+              "required": false,
+              "default": "'review'",
+              "help": "Review-queue job name for freshly-gated pairs"
+            },
+            {
+              "name": "--queue-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
+            },
+            {
+              "name": "--memory-path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Learning Memory SQLite path"
+            },
+            {
+              "name": "--merge-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "help": "Scores above this auto-merge (skip review)"
+            },
+            {
+              "name": "--review-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.75",
+              "help": "Scores >= this go to review"
+            },
+            {
+              "name": "--decided-by",
+              "type": "text",
+              "required": false,
+              "default": "'cli'",
+              "help": "Steward identifier recorded on each decision"
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Max pairs to review this session"
+            }
+          ]
+        },
+        {
+          "command": "rollback",
+          "options": [
+            {
+              "name": "run_id",
+              "type": "text",
+              "required": true,
+              "help": "Run ID to rollback"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory containing run log"
+            }
+          ]
+        },
+        {
+          "command": "runs",
+          "options": [
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory containing run log"
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Data files to process"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--every",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
+            },
+            {
+              "name": "--cron",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Cron schedule (e.g. '0 6 * * *')"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Output directory"
+            }
+          ]
+        },
+        {
+          "command": "sensitivity",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--sweep",
+              "type": "text",
+              "required": true,
+              "help": "Sweep spec: field:start:stop:step (repeatable)"
+            },
+            {
+              "name": "--sample",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Random sample size for speed"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Data files to load"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Server host"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8080",
+              "help": "Server port"
+            }
+          ]
+        },
+        {
+          "command": "serve-ui",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Optional run dir or project dir."
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Host to bind."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "5050",
+              "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
+            },
+            {
+              "name": "--dev",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Skip static; expect Vite at :5173."
+            },
+            {
+              "name": "--open",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Open the UI in a browser once the server starts."
+            }
+          ]
+        },
+        {
+          "command": "setup",
+          "options": []
+        },
+        {
+          "command": "sync",
+          "options": [
+            {
+              "name": "--source-type",
+              "type": "text",
+              "required": false,
+              "default": "'postgres'",
+              "help": "Database type"
+            },
+            {
+              "name": "--connection-string",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database URL"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": true,
+              "help": "Source table name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--output-mode",
+              "type": "text",
+              "required": false,
+              "default": "'separate'",
+              "help": "separate or in_place"
+            },
+            {
+              "name": "--full-rescan",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Force full rescan"
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Match without writing results"
+            },
+            {
+              "name": "--incremental-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column for incremental detection"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Records per chunk"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable debug-level logging output."
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress informational output."
+            }
+          ]
+        },
+        {
+          "command": "unmerge",
+          "options": [
+            {
+              "name": "record_id",
+              "type": "integer",
+              "required": true,
+              "help": "Record row ID to unmerge from its cluster"
+            },
+            {
+              "name": "--clusters",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to clusters CSV from a previous run"
+            },
+            {
+              "name": "--pairs",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to scored pairs CSV (id_a,id_b,score)"
+            },
+            {
+              "name": "--shatter",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Shatter the entire cluster into singletons"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "help": "Min score threshold for re-clustering"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "--source-type",
+              "type": "text",
+              "required": false,
+              "default": "'postgres'",
+              "help": "Database type"
+            },
+            {
+              "name": "--connection-string",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database URL"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": true,
+              "help": "Table to watch"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--interval",
+              "type": "integer",
+              "required": false,
+              "default": "30",
+              "help": "Seconds between polls"
+            },
+            {
+              "name": "--output-mode",
+              "type": "text",
+              "required": false,
+              "default": "'separate'",
+              "help": "separate or in_place"
+            },
+            {
+              "name": "--incremental-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column for change detection"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "add_correction",
+          "description": "Add a Learning Memory correction. Two shapes:"
+        },
+        {
+          "name": "agent_approve_reject",
+          "description": "Approve or reject a review queue pair"
+        },
+        {
+          "name": "agent_compare_strategies",
+          "description": "Compare ER strategies on your data"
+        },
+        {
+          "name": "agent_deduplicate",
+          "description": "Deduplicate ONE dataset: auto-configures matching, runs the full entity-resolution pipeline, and returns the duplicate clusters with confidence gating (auto-merge / needs-review / reject) plus per-decision reasoning. Takes a file path or an uploaded dataset; pass output_path to also write the golden (deduplicated) records to CSV. Operates on a single source -- to link records across TWO datasets use agent_match_sources instead."
+        },
+        {
+          "name": "agent_explain_cluster",
+          "description": "Explain why records are in the same cluster"
+        },
+        {
+          "name": "agent_explain_pair",
+          "description": "Natural language explanation for a record pair"
+        },
+        {
+          "name": "agent_match_sources",
+          "description": "Link records across TWO datasets (not dedupe one): auto-selects a matching strategy, scores cross-source pairs, and returns the matched pairs with confidence. Takes two file paths or uploaded datasets (file_a / file_b); pass output_path to also write the matched pairs to CSV. To find duplicates WITHIN a single dataset use agent_deduplicate instead."
+        },
+        {
+          "name": "agent_review_queue",
+          "description": "Get borderline pairs awaiting approval"
+        },
+        {
+          "name": "analyze_blocking",
+          "description": "Diagnose blocking on the loaded dataset: returns ranked blocking key candidates with block counts, max block size, total candidate comparisons, and estimated recall. Use it to explain why matching is slow or produces too many candidate pairs."
+        },
+        {
+          "name": "analyze_data",
+          "description": "Profile a dataset (read-only, runs no matching and writes nothing): column stats, the detected domain/entity type, data-quality signals, and a recommended entity-resolution strategy. Takes a file path or an uploaded dataset. Use it before deduplicating to understand the data and preview the strategy the auto-config would pick."
+        },
+        {
+          "name": "auto_configure",
+          "description": "Run AutoConfigController on a CSV; return the committed GoldenMatchConfig (incl. negative_evidence / Path Y when chosen) plus telemetry — stop_reason, health, decision trace, indicator column priors. Programmatic equivalent of `goldenmatch autoconfig`."
+        },
+        {
+          "name": "certify_recall",
+          "description": "Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems."
+        },
+        {
+          "name": "compare_clusters",
+          "description": "Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output)."
+        },
+        {
+          "name": "config_weaknesses",
+          "description": "Diagnose weaknesses in the loaded run's auto-config: columns admitted that shouldn't be (source/provenance labels, per-row IDs), oversized or shared-value blocks, null sinks, low-signal matchkeys, and over-merging. Returns ranked findings, each with a plain-English explanation + a concrete fix, plus a one-paragraph summary."
+        },
+        {
+          "name": "controller_telemetry",
+          "description": "Return the AutoConfigController telemetry from the most recent `auto_configure` or `agent_deduplicate` call in this MCP session. Same JSON shape as the web /api/v1/controller/telemetry endpoint."
+        },
+        {
+          "name": "convert_splink_config",
+          "description": "Convert a Splink settings JSON (bare or trained) into a GoldenMatch config. Pass the settings as an inline JSON string -- no filesystem access needed. Returns the config as YAML, a findings report (severity/splink_path/message/mapped_to per finding), a summary, and -- when the Splink input carried trained m/u probabilities -- the imported EM model as a dict you can persist yourself. strict=True fails on ANY lossy mapping (not just hard errors)."
+        },
+        {
+          "name": "create_domain",
+          "description": "Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.)."
+        },
+        {
+          "name": "dedupe",
+          "description": "Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset."
+        },
+        {
+          "name": "documents_ingest",
+          "description": "Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report."
+        },
+        {
+          "name": "documents_suggest_schema",
+          "description": "Propose a target extraction schema (JSON) from a sample document image/PDF."
+        },
+        {
+          "name": "evaluate",
+          "description": "Score the loaded run against ground-truth pairs. Loads a ground-truth CSV (id_a,id_b columns) and returns precision, recall, and F1 for the current clustering."
+        },
+        {
+          "name": "explain_cluster",
+          "description": "Alias for `agent_explain_cluster`. Explain why records are in the same cluster"
+        },
+        {
+          "name": "explain_match",
+          "description": "Explain why two records match or don't match. Shows per-field score breakdown."
+        },
+        {
+          "name": "explain_pair",
+          "description": "Alias for `explain_match`. Explain why two records match or don't match. Shows per-field score breakdown."
+        },
+        {
+          "name": "explain_routing",
+          "description": "Human-readable explanation of why each stage is routed the way it is, with the driver-RAM projection that drove it."
+        },
+        {
+          "name": "export_results",
+          "description": "Export matching results to a file (CSV or JSON)."
+        },
+        {
+          "name": "find_duplicates",
+          "description": "Find duplicate matches for a record. Provide field values to search against the loaded dataset."
+        },
+        {
+          "name": "fix_quality",
+          "description": "Run GoldenCheck scan and apply fixes to a CSV file. Returns the fixed data summary and a manifest of all fixes applied. Requires goldencheck: pip install goldenmatch[quality]"
+        },
+        {
+          "name": "get_cluster",
+          "description": "Get details of a specific cluster: all member records and their field values."
+        },
+        {
+          "name": "get_golden_record",
+          "description": "Get the merged golden (canonical) record for a cluster."
+        },
+        {
+          "name": "get_stats",
+          "description": "Get dataset statistics: record count, cluster count, match rate, cluster sizes."
+        },
+        {
+          "name": "identity_audit",
+          "description": "Export the append-only identity audit log in commit order: every event with actor / trust / timestamp / reason, so a reviewer can reconstruct exactly which actor changed what, when, and why. Optionally filtered by dataset / actor."
+        },
+        {
+          "name": "identity_audit_seal",
+          "description": "Anchor the append-only audit log with a tamper-evidence seal: a chained sha256 root over every event since the last seal. Cheap and idempotent (a no-op when nothing new has been logged). Run it periodically (or after a batch of stewardship actions) so the history becomes provably untampered. Optionally scoped to a dataset. Publish/mirror the returned root_hash to make tampering detectable by an external party."
+        },
+        {
+          "name": "identity_audit_verify",
+          "description": "Verify the append-only audit log against its seal chain. Replays the per-event content hashes and the seal roots to detect content edits, deletion, reordering, and insertion of any sealed event. Returns {ok, events_checked, seals_checked} plus the ids of any content mismatches / broken seals / missing sealed events. Optionally scoped to a dataset."
+        },
+        {
+          "name": "identity_claim",
+          "description": "Claim a record into an identity, moving it out of any prior entity ('this record belongs to that identity'). Emits a provenance-stamped `claimed` event on both the gaining and losing entities."
+        },
+        {
+          "name": "identity_conflicts",
+          "description": "List evidence edges marked `conflicts_with`."
+        },
+        {
+          "name": "identity_history",
+          "description": "Return the temporal event log for an identity."
+        },
+        {
+          "name": "identity_list",
+          "description": "List identities, optionally filtered by dataset/status."
+        },
+        {
+          "name": "identity_merge",
+          "description": "Manually merge two identities. All records from `absorb_entity_id` are reassigned to `keep_entity_id`. The merge events are stamped with `actor`/`trust` provenance so the audit log records who merged these and on what authority."
+        },
+        {
+          "name": "identity_profile",
+          "description": "MDM profile of one entity: record count + per-source breakdown, golden record, confidence, conflict count, canonical version (structural-event count), and first/last activity. Returns {found: false} when no such entity exists."
+        },
+        {
+          "name": "identity_resolve",
+          "description": "Resolve a record_id to its durable identity. Returns the full identity view (members, evidence edges, recent events) or null when no identity exists for that record."
+        },
+        {
+          "name": "identity_resolve_conflict",
+          "description": "Adjudicate a `conflicts_with` pair: 'same' keeps the entity intact, 'distinct' splits the second record out into a new identity, 'defer' only logs. Records a durable mediation verdict + event with actor/trust provenance, and stops the conflict re-surfacing in the open-conflicts queue."
+        },
+        {
+          "name": "identity_show",
+          "description": "Fetch the full detail of one identity by entity_id: its member records, evidence edges, and recent event log. Returns {found: false} when no such entity exists."
+        },
+        {
+          "name": "identity_split",
+          "description": "Split a subset of records off an identity into a brand-new identity. The original keeps the remaining records. The split events carry `actor`/`trust` provenance."
+        },
+        {
+          "name": "identity_stats",
+          "description": "Graph-level summary / health stats: entities by status, total records, records-per-entity distribution, conflict total, source mix, and the largest entities. Optionally scoped to a dataset."
+        },
+        {
+          "name": "identity_worklist",
+          "description": "Prioritized steward worklist: active entities needing attention (open conflicts and/or confidence below weak_confidence), highest conflict count first."
+        },
+        {
+          "name": "incremental",
+          "description": "Match a batch of new records against an existing base dataset (without re-running the whole base). Returns matched (new_row_id, base_row_id, score) pairs plus counts. Auto-configures from the base file if no config is given."
+        },
+        {
+          "name": "learn_thresholds",
+          "description": "Force a MemoryLearner pass over accumulated corrections. Returns the list of LearnedAdjustments produced (matchkey_name, threshold, sample_size, learned_at). Requires >= 10 corrections per matchkey before threshold tuning fires; otherwise returns an empty list."
+        },
+        {
+          "name": "lineage",
+          "description": "Field-level provenance for the loaded run: for each scored pair, the per-field scores that produced the match, plus cluster id. Optionally write a lineage JSON to a directory."
+        },
+        {
+          "name": "lint_routing",
+          "description": "Flag config/env overrides that force a slow path (e.g. CLUSTERING_THRESHOLD=0 when the edge set fits driver RAM). ERROR at scale; would_refuse mirrors the runtime guard."
+        },
+        {
+          "name": "list_clusters",
+          "description": "List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts."
+        },
+        {
+          "name": "list_corrections",
+          "description": "List stored Learning Memory corrections, optionally filtered by dataset. Returns id_a, id_b, decision, source, trust, reason, matchkey_name, dataset, original_score, created_at."
+        },
+        {
+          "name": "list_domains",
+          "description": "List available domain extraction rulebooks (built-in + user-defined)."
+        },
+        {
+          "name": "list_plugins",
+          "description": "List all registered goldenmatch plugins by category. Includes the 22 v1.18.2 predefined plugins (numeric/format/business/aggregation) plus any user-registered plugins via entry-points or PluginRegistry.register_*(). Each entry includes name, source (builtin or user), category, and the first line of the merge docstring."
+        },
+        {
+          "name": "list_runs",
+          "description": "List previous dedupe/match runs (for rollback) from the run log."
+        },
+        {
+          "name": "match",
+          "description": "Alias for `match_record`. Match a single record against the loaded dataset in real-time. Paste a record's fields and instantly see if it matches any existing record. Uses the configured matchkeys, scorers, and thresholds. Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
+        },
+        {
+          "name": "match_record",
+          "description": "Match a single record against the loaded dataset in real-time. Paste a record's fields and instantly see if it matches any existing record. Uses the configured matchkeys, scorers, and thresholds. Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
+        },
+        {
+          "name": "memory_export",
+          "description": "Return all corrections as a list of dicts (CSV-shaped). Caller is responsible for writing the file. Optionally filter by dataset."
+        },
+        {
+          "name": "memory_import",
+          "description": "Import corrections from a list of dicts (the exact shape memory_export returns). Upserts into the store: higher trust wins, same trust = latest wins. Returns the count imported."
+        },
+        {
+          "name": "memory_stats",
+          "description": "Return Learning Memory status: total correction count, last learn time, and current learned adjustments. Cheap; safe for status checks."
+        },
+        {
+          "name": "plan_routing",
+          "description": "Project per-stage distributed routing (scoring/clustering/golden) for a given data shape + cluster. Pure; no controller run."
+        },
+        {
+          "name": "pprl_auto_config",
+          "description": "Analyze the loaded dataset and recommend optimal PPRL (privacy-preserving record linkage) configuration. Returns recommended fields, bloom filter parameters, threshold, and explanation."
+        },
+        {
+          "name": "pprl_link",
+          "description": "Run privacy-preserving record linkage between two parties' data. Computes bloom filters, matches records without sharing raw data. Specify fields, threshold, and security level."
+        },
+        {
+          "name": "profile",
+          "description": "Alias for `profile_data`. Get data quality profile: column types, null rates, unique counts, sample values."
+        },
+        {
+          "name": "profile_data",
+          "description": "Get data quality profile: column types, null rates, unique counts, sample values."
+        },
+        {
+          "name": "retrieve_similar",
+          "description": "Semantic retrieval (#1089): return the records in a CSV most similar to a free-text query, ranked by cosine similarity. Embeds the chosen column and the query with the zero-config in-house embedder (no cloud/torch by default) and runs ANN search. The read side of the RAG entity-canonicalization epic -- fetch candidate records by query without running a full dedupe."
+        },
+        {
+          "name": "review_config",
+          "description": "Run the config healer over the loaded dataset: analyze the dedupe run and return ranked, self-verified suggestions for improving the matching config (thresholds, scorers, negative evidence, blocking). Each suggestion carries an id, kind, target, rationale, and a machine-applicable patch. Requires the native kernel (pip install goldenmatch[native]); returns an empty list otherwise."
+        },
+        {
+          "name": "rollback",
+          "description": "Undo a previous run by DELETING its output files (looked up by run_id in the run log). Destructive: removes the files that run wrote. Use list_runs first to find the run_id."
+        },
+        {
+          "name": "run_transforms",
+          "description": "Run GoldenFlow data transforms on a CSV file. Normalizes phone numbers (E.164), dates (ISO), categorical spelling, and Unicode issues. Returns a manifest of transforms applied. Requires goldenflow: pip install goldenmatch[transform]"
+        },
+        {
+          "name": "scan_quality",
+          "description": "Run GoldenCheck data quality scan on a CSV file. Returns issues found (encoding errors, Unicode problems, format violations) without applying fixes. Requires goldencheck: pip install goldenmatch[quality]"
+        },
+        {
+          "name": "schema_match",
+          "description": "Auto-map columns between two files with different schemas. Returns proposed (col_a, col_b) mappings with a confidence score and method (synonym / name_sim / composite). Useful before matching two sources."
+        },
+        {
+          "name": "sensitivity",
+          "description": "Parameter-sensitivity analysis: sweep one or more config parameters across a range and report how stable the clustering is at each value (CCMS unchanged %). Use it to find robust thresholds. Auto-configures the file if no config is given."
+        },
+        {
+          "name": "shatter_cluster",
+          "description": "Break an entire cluster into individual records. All members become singletons. Use when a cluster is completely wrong."
+        },
+        {
+          "name": "suggest_config",
+          "description": "Analyze bad merges and suggest config changes. Provide examples of incorrect merges (pairs that should NOT have matched) and GoldenMatch will identify which fields/thresholds to tighten. Example: [{\"record_a\": {...}, \"record_b\": {...}, \"reason\": \"different people\"}]"
+        },
+        {
+          "name": "suggest_pprl",
+          "description": "Check if data needs privacy-preserving matching"
+        },
+        {
+          "name": "test_domain",
+          "description": "Test a domain extraction rulebook against sample records. Shows what features would be extracted from the loaded data."
+        },
+        {
+          "name": "unmerge_record",
+          "description": "Remove a record from its cluster. The record becomes a singleton. Remaining cluster members are re-clustered using stored pair scores. Use this to fix bad merges."
+        },
+        {
+          "name": "upload_dataset",
+          "description": "Upload a local file's bytes to the server and get back a server-side path to reuse across other tools (analyze_data, auto_configure, agent_deduplicate, ...). No hosting needed. Send base64 (default) or raw text via `encoding`. Uploaded files are ephemeral scratch, reaped after GOLDENMATCH_MCP_UPLOAD_TTL (default 24h); re-upload if you need a path older than that. Max size GOLDENMATCH_MCP_MAX_UPLOAD_BYTES (default 64MB) -- above it, pass a public http(s) URL as file_path instead."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Scorers",
+          "target": "goldenmatch.config.schemas:VALID_SCORERS",
+          "applies": "`MatchkeyField.scorer` / `NegativeEvidenceField.scorer`",
+          "values": [
+            {
+              "value": "alias_match",
+              "meaning": "Matches known name aliases and nicknames (Bob <-> Robert).",
+              "best_for": "Names with nicknames",
+              "range": "0 or 1"
+            },
+            {
+              "value": "audio_fp",
+              "meaning": "Audio-fingerprint similarity.",
+              "best_for": "Audio clips",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "date",
+              "meaning": "Damerau-Levenshtein over canonical ISO date digits; typo-tolerant.",
+              "best_for": "Dates (dob, birth_date)",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "dice",
+              "meaning": "Dice coefficient over character bigrams / bloom filters.",
+              "best_for": "PPRL",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "embedding",
+              "meaning": "Cosine similarity of a model embedding of the field.",
+              "best_for": "Semantic matching",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "ensemble",
+              "meaning": "Best of several sub-scorers (max of jaro_winkler / token_sort / soundex).",
+              "best_for": "Names with reordering",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "exact",
+              "meaning": "Exact string equality after transforms.",
+              "best_for": "Email, phone, ID",
+              "range": "0 or 1"
+            },
+            {
+              "value": "initialism_match",
+              "meaning": "Matches initials/acronyms against their expansions.",
+              "best_for": "Acronyms, initials",
+              "range": "0 or 1"
+            },
+            {
+              "value": "jaccard",
+              "meaning": "Jaccard overlap of token/character sets or bloom filters.",
+              "best_for": "PPRL",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "jaro_winkler",
+              "meaning": "Jaro-Winkler edit distance with a shared-prefix bonus.",
+              "best_for": "Names",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "levenshtein",
+              "meaning": "Normalized Levenshtein edit distance.",
+              "best_for": "General strings",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "phash",
+              "meaning": "Perceptual-hash Hamming similarity.",
+              "best_for": "Images",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "qgram",
+              "meaning": "Q-gram (n-gram) overlap similarity.",
+              "best_for": "General strings, typos",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "radial",
+              "meaning": "Rotation/crop-invariant radial-variance similarity.",
+              "best_for": "Rotated/cropped images",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "record_embedding",
+              "meaning": "Cosine similarity of an embedding over several columns.",
+              "best_for": "Cross-field semantic",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "soundex_match",
+              "meaning": "Phonetic Soundex-code equality.",
+              "best_for": "Names",
+              "range": "0 or 1"
+            },
+            {
+              "value": "token_sort",
+              "meaning": "Sort the tokens, then ratio; order-insensitive.",
+              "best_for": "Names, addresses",
+              "range": "0.0-1.0"
+            }
+          ]
+        },
+        {
+          "title": "Blocking strategies",
+          "target": "goldenmatch.config.schemas:BlockingConfig.strategy",
+          "applies": "`BlockingConfig.strategy`",
+          "values": [
+            {
+              "value": "adaptive",
+              "meaning": "Static plus recursive sub-blocking of oversized blocks.",
+              "best_for": "Default choice"
+            },
+            {
+              "value": "ann",
+              "meaning": "Approximate nearest-neighbor over embeddings.",
+              "best_for": "Semantic matching"
+            },
+            {
+              "value": "ann_pairs",
+              "meaning": "Direct-pair ANN scoring (skips block materialization).",
+              "best_for": "Faster ANN"
+            },
+            {
+              "value": "canopy",
+              "meaning": "Cheap loose canopy pre-grouping.",
+              "best_for": "Text-heavy data"
+            },
+            {
+              "value": "learned",
+              "meaning": "Data-driven mined blocking predicates.",
+              "best_for": "Auto-discovered rules"
+            },
+            {
+              "value": "lsh",
+              "meaning": "MinHash / LSH sketching on a text column.",
+              "best_for": "Near-duplicate text"
+            },
+            {
+              "value": "multi_pass",
+              "meaning": "Union candidate pairs from several blocking passes.",
+              "best_for": "Noisy data, best recall"
+            },
+            {
+              "value": "perceptual",
+              "meaning": "Banded-Hamming LSH over perceptual image hashes.",
+              "best_for": "Near-duplicate images"
+            },
+            {
+              "value": "simhash",
+              "meaning": "SimHash LSH over embeddings.",
+              "best_for": "Semantic near-duplicate text"
+            },
+            {
+              "value": "sorted_neighborhood",
+              "meaning": "Slide a window over sorted records.",
+              "best_for": "Typos in the blocking key"
+            },
+            {
+              "value": "static",
+              "meaning": "Group records by an exact blocking key.",
+              "best_for": "Clean data with reliable keys"
+            }
+          ]
+        },
+        {
+          "title": "Simple transforms",
+          "target": "goldenmatch.config.schemas:VALID_SIMPLE_TRANSFORMS",
+          "applies": "`transforms` chains",
+          "values": [
+            {
+              "value": "alpha_only",
+              "meaning": "Keep only alphabetic characters."
+            },
+            {
+              "value": "digits_only",
+              "meaning": "Keep only digits."
+            },
+            {
+              "value": "first_token",
+              "meaning": "Keep the first whitespace token."
+            },
+            {
+              "value": "last_token",
+              "meaning": "Keep the last whitespace token."
+            },
+            {
+              "value": "lowercase",
+              "meaning": "Lowercase the value."
+            },
+            {
+              "value": "metaphone",
+              "meaning": "Metaphone phonetic encoding."
+            },
+            {
+              "value": "normalize_whitespace",
+              "meaning": "Collapse runs of whitespace to single spaces."
+            },
+            {
+              "value": "soundex",
+              "meaning": "Soundex phonetic encoding."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim leading/trailing whitespace."
+            },
+            {
+              "value": "strip_all",
+              "meaning": "Remove all whitespace."
+            },
+            {
+              "value": "token_sort",
+              "meaning": "Sort the whitespace tokens alphabetically."
+            },
+            {
+              "value": "uppercase",
+              "meaning": "Uppercase the value."
+            }
+          ]
+        },
+        {
+          "title": "Survivorship strategies",
+          "target": "goldenmatch.config.schemas:VALID_STRATEGIES",
+          "applies": "`GoldenFieldRule.strategy`",
+          "values": [
+            {
+              "value": "confidence_majority",
+              "meaning": "Value backed by the highest total match confidence.",
+              "best_for": "Weighting by match quality"
+            },
+            {
+              "value": "first_non_null",
+              "meaning": "First non-null value in row order.",
+              "best_for": "Pre-ordered inputs"
+            },
+            {
+              "value": "longest_value",
+              "meaning": "The longest, most detailed value.",
+              "best_for": "Truncated/abbreviated values"
+            },
+            {
+              "value": "majority_vote",
+              "meaning": "Most frequent value across the cluster.",
+              "best_for": "Many redundant sources"
+            },
+            {
+              "value": "most_complete",
+              "meaning": "Value from the record with the fewest nulls.",
+              "best_for": "Default; sparse records"
+            },
+            {
+              "value": "most_recent",
+              "meaning": "Value from the newest record (needs date_column).",
+              "best_for": "Time-stamped sources"
+            },
+            {
+              "value": "source_priority",
+              "meaning": "Value from the highest-priority source (needs source_priority).",
+              "best_for": "A trusted source ranking"
+            },
+            {
+              "value": "unanimous_or_null",
+              "meaning": "The value only if every record agrees, else null.",
+              "best_for": "Zero-tolerance fields"
+            }
+          ]
+        },
+        {
+          "title": "Group survivorship strategies",
+          "target": "goldenmatch.config.schemas:_GROUP_STRATEGIES",
+          "applies": "`GoldenGroupRule.strategy`",
+          "values": [
+            {
+              "value": "anchor",
+              "meaning": "Take all group columns from the anchor column's winning row.",
+              "best_for": "Tying the group to one key field"
+            },
+            {
+              "value": "most_complete",
+              "meaning": "Take all group columns from the most-complete row.",
+              "best_for": "Default; a coherent row"
+            },
+            {
+              "value": "most_recent",
+              "meaning": "Take the group from the newest row.",
+              "best_for": "Time-stamped groups"
+            },
+            {
+              "value": "source_priority",
+              "meaning": "Take the group from the highest-priority source.",
+              "best_for": "A trusted source ranking"
+            }
+          ]
+        },
+        {
+          "title": "Standardizers",
+          "target": "goldenmatch.config.schemas:VALID_STANDARDIZERS",
+          "applies": "`StandardizationConfig.rules`",
+          "values": [
+            {
+              "value": "address",
+              "meaning": "Normalize a postal address."
+            },
+            {
+              "value": "email",
+              "meaning": "Lowercase and canonicalize an email address."
+            },
+            {
+              "value": "name_lower",
+              "meaning": "Lowercase a name."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name."
+            },
+            {
+              "value": "name_upper",
+              "meaning": "Uppercase a name."
+            },
+            {
+              "value": "phone",
+              "meaning": "Normalize a phone number."
+            },
+            {
+              "value": "state",
+              "meaning": "Normalize a US state to its 2-letter code."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim whitespace."
+            },
+            {
+              "value": "trim_whitespace",
+              "meaning": "Collapse and trim whitespace."
+            },
+            {
+              "value": "zip5",
+              "meaning": "Normalize a US ZIP to 5 digits."
+            }
+          ]
+        },
+        {
+          "title": "Matchkey types",
+          "target": "goldenmatch.config.schemas:_VALID_MK_TYPES",
+          "applies": "`MatchkeyConfig.type`",
+          "values": [
+            {
+              "value": "exact",
+              "meaning": "All fields must match exactly; fastest, no scoring.",
+              "best_for": "Reliable keys, max speed"
+            },
+            {
+              "value": "probabilistic",
+              "meaning": "Fellegi-Sunter scoring with EM-learned agreement weights.",
+              "best_for": "Unknown field reliability, best recall"
+            },
+            {
+              "value": "weighted",
+              "meaning": "Weighted mean of per-field scores compared to a threshold.",
+              "best_for": "Tunable fuzzy matching"
+            }
+          ]
+        },
+        {
+          "title": "Backends",
+          "target": "goldenmatch.core.execution_plan:BackendName",
+          "applies": "`GoldenMatchConfig.backend` / `--backend`",
+          "values": [
+            {
+              "value": "bucket",
+              "meaning": "Memory-bounded field-hash bucket scorer (the in-memory default route).",
+              "best_for": "< 500K, default (native on)"
+            },
+            {
+              "value": "chunked",
+              "meaning": "Chunked in-memory execution to cap peak memory.",
+              "best_for": "5M+ on one machine"
+            },
+            {
+              "value": "duckdb",
+              "meaning": "DuckDB-backed out-of-core execution.",
+              "best_for": "500K-50M, out-of-core"
+            },
+            {
+              "value": "polars-direct",
+              "meaning": "Straight in-memory Polars execution.",
+              "best_for": "< 500K, native kernel absent"
+            },
+            {
+              "value": "ray",
+              "meaning": "Distributed execution on a Ray cluster.",
+              "best_for": "50M+, distributed"
+            }
+          ]
+        },
+        {
+          "title": "Clustering strategies",
+          "target": "goldenmatch.core.execution_plan:ClusteringStrategy",
+          "applies": "planner cluster route",
+          "values": [
+            {
+              "value": "distributed_wcc",
+              "meaning": "Distributed weakly-connected-components on a cluster.",
+              "best_for": "Ray cluster, 100M+"
+            },
+            {
+              "value": "in_memory",
+              "meaning": "In-memory union-find clustering.",
+              "best_for": "Default; graph fits in RAM"
+            },
+            {
+              "value": "partitioned_union_find",
+              "meaning": "Disk-partitioned union-find for large pair sets.",
+              "best_for": "Huge single-box pair sets"
+            },
+            {
+              "value": "streaming_cc",
+              "meaning": "Streaming connected-components.",
+              "best_for": "Chunked / out-of-core runs"
+            }
+          ]
+        },
+        {
+          "title": "Planning efforts",
+          "target": "goldenmatch.core.autoconfig_controller:_PLANNING_EFFORTS",
+          "applies": "`planning_effort`",
+          "values": [
+            {
+              "value": "einstein",
+              "meaning": "Maximum auto-config search; slowest and most thorough.",
+              "best_for": "Max quality, cost no object"
+            },
+            {
+              "value": "fast",
+              "meaning": "Single cheap auto-config pass.",
+              "best_for": "Quick iteration"
+            },
+            {
+              "value": "normal",
+              "meaning": "Default interactive auto-config budget (byte-identical to historical).",
+              "best_for": "Default balance"
+            },
+            {
+              "value": "thinking",
+              "meaning": "Extra refit iterations plus full-frame blocking measurement.",
+              "best_for": "Harder datasets"
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "AGENT": [
+          "GOLDENMATCH_AGENT_TOKEN"
+        ],
+        "ALLOWED": [
+          "GOLDENMATCH_ALLOWED_ROOT"
+        ],
+        "ANALYTICS": [
+          "GOLDENMATCH_ANALYTICS"
+        ],
+        "ANN": [
+          "GOLDENMATCH_ANN_BACKEND",
+          "GOLDENMATCH_ANN_HNSW_EF_CONSTRUCTION",
+          "GOLDENMATCH_ANN_HNSW_EF_SEARCH",
+          "GOLDENMATCH_ANN_HNSW_M",
+          "GOLDENMATCH_ANN_HNSW_MAX_K",
+          "GOLDENMATCH_ANN_HNSW_MIN"
+        ],
+        "API": [
+          "GOLDENMATCH_API_CORS_ORIGINS",
+          "GOLDENMATCH_API_TOKEN"
+        ],
+        "ATTRIBUTE": [
+          "GOLDENMATCH_ATTRIBUTE_DEMOTION"
+        ],
+        "AUTO": [
+          "GOLDENMATCH_AUTO_SEMANTIC_BLOCKING"
+        ],
+        "AUTOCONFIG": [
+          "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE",
+          "GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE",
+          "GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE",
+          "GOLDENMATCH_AUTOCONFIG_INDICATOR_BUDGET",
+          "GOLDENMATCH_AUTOCONFIG_LLM",
+          "GOLDENMATCH_AUTOCONFIG_MEMORY",
+          "GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC",
+          "GOLDENMATCH_AUTOCONFIG_SAMPLE_STRATEGY",
+          "GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_COMMIT",
+          "GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_STABILITY"
+        ],
+        "BASE": [
+          "GOLDENMATCH_BASE_STORE"
+        ],
+        "BENCH": [
+          "GOLDENMATCH_BENCH_DUMP_PAIRS"
+        ],
+        "BLOCKING": [
+          "GOLDENMATCH_BLOCKING_CARDINALITY_SCALER",
+          "GOLDENMATCH_BLOCKING_DEGENERATE_MAX_AVG_BLOCK_SIZE",
+          "GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD",
+          "GOLDENMATCH_BLOCKING_MAX_RATIO",
+          "GOLDENMATCH_BLOCKING_MIN_RATIO",
+          "GOLDENMATCH_BLOCKING_PAIRS_PER_ROW",
+          "GOLDENMATCH_BLOCKING_PASS_MIN_WEAKPOS",
+          "GOLDENMATCH_BLOCKING_PRUNE_PASSES"
+        ],
+        "BRIDGE": [
+          "GOLDENMATCH_BRIDGE_REQUIRE_PY"
+        ],
+        "BUCKET": [
+          "GOLDENMATCH_BUCKET_DEBUG",
+          "GOLDENMATCH_BUCKET_DEFAULT",
+          "GOLDENMATCH_BUCKET_SLIM_PROJECTION",
+          "GOLDENMATCH_BUCKET_VEC_MAX",
+          "GOLDENMATCH_BUCKET_VEC_MIN"
+        ],
+        "CLUSTER": [
+          "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET"
+        ],
+        "COLUMNAR": [
+          "GOLDENMATCH_COLUMNAR_PIPELINE"
+        ],
+        "CONFIG": [
+          "GOLDENMATCH_CONFIG_LINT"
+        ],
+        "DATABASE": [
+          "GOLDENMATCH_DATABASE_URL"
+        ],
+        "DISCRIMINATIVE": [
+          "GOLDENMATCH_DISCRIMINATIVE_TAU",
+          "GOLDENMATCH_DISCRIMINATIVE_VETO"
+        ],
+        "DISTRIBUTED": [
+          "GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE",
+          "GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD",
+          "GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS",
+          "GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD",
+          "GOLDENMATCH_DISTRIBUTED_OP_RESERVATION",
+          "GOLDENMATCH_DISTRIBUTED_PIPELINE",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT",
+          "GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS",
+          "GOLDENMATCH_DISTRIBUTED_WCC",
+          "GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH",
+          "GOLDENMATCH_DISTRIBUTED_WCC_SEED"
+        ],
+        "DUCKDB": [
+          "GOLDENMATCH_DUCKDB_SCORE_DB"
+        ],
+        "EMBEDDING": [
+          "GOLDENMATCH_EMBEDDING_PROVIDER"
+        ],
+        "ENABLE": [
+          "GOLDENMATCH_ENABLE_DISTRIBUTED_RAY"
+        ],
+        "FACILITY": [
+          "GOLDENMATCH_FACILITY_NAME_NE"
+        ],
+        "FD": [
+          "GOLDENMATCH_FD_NEGATIVE_EVIDENCE"
+        ],
+        "FIELD": [
+          "GOLDENMATCH_FIELD_GROUP_SURVIVORSHIP"
+        ],
+        "FRAME": [
+          "GOLDENMATCH_FRAME",
+          "GOLDENMATCH_FRAME_LANE"
+        ],
+        "FS": [
+          "GOLDENMATCH_FS_ARROW_STREAM",
+          "GOLDENMATCH_FS_AUTOCONFIG_V2",
+          "GOLDENMATCH_FS_BATCH_ROWS",
+          "GOLDENMATCH_FS_BUCKET_NATIVE",
+          "GOLDENMATCH_FS_CALIBRATED",
+          "GOLDENMATCH_FS_DEFAULT_BUCKET",
+          "GOLDENMATCH_FS_EM_SAMPLE_ROWS",
+          "GOLDENMATCH_FS_MAX_PASS_PAIRS",
+          "GOLDENMATCH_FS_MISSING",
+          "GOLDENMATCH_FS_MONOTONIC",
+          "GOLDENMATCH_FS_NATIVE",
+          "GOLDENMATCH_FS_REQUIRE_POSITIVE_EVIDENCE",
+          "GOLDENMATCH_FS_VECTORIZED",
+          "GOLDENMATCH_FS_VEC_MAX_ELEMS",
+          "GOLDENMATCH_FS_WORKERS"
+        ],
+        "FUSED": [
+          "GOLDENMATCH_FUSED_BLOCK_CONCURRENCY",
+          "GOLDENMATCH_FUSED_BYTES_PER_CELL",
+          "GOLDENMATCH_FUSED_BYTES_PER_PAIR",
+          "GOLDENMATCH_FUSED_PRESSURE_FRACTION",
+          "GOLDENMATCH_FUSED_RSS_SCALE"
+        ],
+        "GOLDEN": [
+          "GOLDENMATCH_GOLDEN_FUSED",
+          "GOLDENMATCH_GOLDEN_SLIM_MULTIDF",
+          "GOLDENMATCH_GOLDEN_STRATEGY_STRICT",
+          "GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS"
+        ],
+        "GPU": [
+          "GOLDENMATCH_GPU_API_KEY",
+          "GOLDENMATCH_GPU_ENDPOINT",
+          "GOLDENMATCH_GPU_MODE"
+        ],
+        "HEAL": [
+          "GOLDENMATCH_HEAL_MIN_HEALTH_GAIN",
+          "GOLDENMATCH_HEAL_STEP_CAP"
+        ],
+        "IDENTITY": [
+          "GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT",
+          "GOLDENMATCH_IDENTITY_DSN"
+        ],
+        "INHOUSE": [
+          "GOLDENMATCH_INHOUSE_MODEL"
+        ],
+        "LLAMA": [
+          "GOLDENMATCH_LLAMA_GGUF"
+        ],
+        "LLM": [
+          "GOLDENMATCH_LLM_BASE_URL",
+          "GOLDENMATCH_LLM_MODEL"
+        ],
+        "MATCH": [
+          "GOLDENMATCH_MATCH_FUSED",
+          "GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS"
+        ],
+        "MCP": [
+          "GOLDENMATCH_MCP_ALLOW_PUBLIC",
+          "GOLDENMATCH_MCP_MAX_UPLOAD_BYTES",
+          "GOLDENMATCH_MCP_SESSION_MAX",
+          "GOLDENMATCH_MCP_SESSION_TTL",
+          "GOLDENMATCH_MCP_TOKEN",
+          "GOLDENMATCH_MCP_UPLOAD_TTL"
+        ],
+        "MULTISOURCE": [
+          "GOLDENMATCH_MULTISOURCE_AUTOCONFIG"
+        ],
+        "NATIVE": [
+          "GOLDENMATCH_NATIVE",
+          "GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE",
+          "GOLDENMATCH_NATIVE_RAYON_MIN_BLOOM_ROWS",
+          "GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS",
+          "GOLDENMATCH_NATIVE_SKETCH_RAYON_MIN_ROWS"
+        ],
+        "NE": [
+          "GOLDENMATCH_NE_TUNER_MIN_CORRECTIONS"
+        ],
+        "NOISE": [
+          "GOLDENMATCH_NOISE_AWARE_SCORERS",
+          "GOLDENMATCH_NOISE_AWARE_TARGET"
+        ],
+        "PERCEPTUAL": [
+          "GOLDENMATCH_PERCEPTUAL_AUTOCONFIG"
+        ],
+        "PLANNER": [
+          "GOLDENMATCH_PLANNER_BUCKET"
+        ],
+        "PLANNING": [
+          "GOLDENMATCH_PLANNING_EFFORT"
+        ],
+        "PREP": [
+          "GOLDENMATCH_PREP_STAGED_COLLECT"
+        ],
+        "PREPARED": [
+          "GOLDENMATCH_PREPARED_RECORD_STORE_DIR",
+          "GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST"
+        ],
+        "QUALITY": [
+          "GOLDENMATCH_QUALITY_AWARE_BLOCKING",
+          "GOLDENMATCH_QUALITY_GATED_REVIEW"
+        ],
+        "SAIL": [
+          "GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME"
+        ],
+        "SEMANTIC": [
+          "GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD"
+        ],
+        "SKIP": [
+          "GOLDENMATCH_SKIP_MATCH_LOG"
+        ],
+        "STANDARDIZE": [
+          "GOLDENMATCH_STANDARDIZE_STAGED"
+        ],
+        "STREAMING": [
+          "GOLDENMATCH_STREAMING_BLOCK_WORKERS"
+        ],
+        "SUGGEST": [
+          "GOLDENMATCH_SUGGEST_COHESION",
+          "GOLDENMATCH_SUGGEST_COVERAGE_CAP",
+          "GOLDENMATCH_SUGGEST_FULL_DIST",
+          "GOLDENMATCH_SUGGEST_HEALTH",
+          "GOLDENMATCH_SUGGEST_MAX_VERIFY",
+          "GOLDENMATCH_SUGGEST_ON_DEDUPE",
+          "GOLDENMATCH_SUGGEST_RECALL_COH_ABS",
+          "GOLDENMATCH_SUGGEST_RECALL_MIN_SHED",
+          "GOLDENMATCH_SUGGEST_RECALL_RATIO",
+          "GOLDENMATCH_SUGGEST_VERIFY"
+        ],
+        "SYNC": [
+          "GOLDENMATCH_SYNC_STREAMING_THRESHOLD"
+        ],
+        "TF": [
+          "GOLDENMATCH_TF_NAME_WEIGHTING"
+        ],
+        "THROUGHPUT": [
+          "GOLDENMATCH_THROUGHPUT",
+          "GOLDENMATCH_THROUGHPUT_RECALL",
+          "GOLDENMATCH_THROUGHPUT_SIMILARITY"
+        ],
+        "UDF": [
+          "GOLDENMATCH_UDF_IMPORTS"
+        ],
+        "VECTOR": [
+          "GOLDENMATCH_VECTOR_INDEX_DIR"
+        ],
+        "WEAKNESS": [
+          "GOLDENMATCH_WEAKNESS_LLM",
+          "GOLDENMATCH_WEAKNESS_LLM_MODEL"
+        ],
+        "WEB": [
+          "GOLDENMATCH_WEB_TOKEN"
+        ]
+      }
+    },
+    "goldencheck": {
+      "nav_group": "GoldenCheck",
+      "env_prefix": "GOLDENCHECK_",
+      "doc_path": "docs-site/goldencheck/config-matrix.mdx",
+      "config_models": [
+        {
+          "name": "GoldenCheckConfig",
+          "fields": [
+            {
+              "name": "version",
+              "type": "int",
+              "required": false,
+              "default": "1",
+              "description": "Schema version of this configuration file, used to handle format changes across releases."
+            },
+            {
+              "name": "settings",
+              "type": "Settings",
+              "required": false,
+              "default": "Settings(sample_size=100000, severity_threshold='warning', fail_on='error')",
+              "nested": [
+                "Settings"
+              ],
+              "description": "Global run settings such as sampling size and severity handling that apply to the whole check."
+            },
+            {
+              "name": "columns",
+              "type": "dict[str, ColumnRule]",
+              "required": false,
+              "default": "{}",
+              "nested": [
+                "ColumnRule"
+              ],
+              "description": "Per-column validation rules keyed by column name."
+            },
+            {
+              "name": "relations",
+              "type": "list[RelationRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "RelationRule"
+              ],
+              "description": "Cross-column relationship rules applied across multiple columns."
+            },
+            {
+              "name": "ignore",
+              "type": "list[IgnoreEntry]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "IgnoreEntry"
+              ],
+              "description": "List of column and check pairs whose findings should be excluded from results."
+            }
+          ]
+        },
+        {
+          "name": "Settings",
+          "fields": [
+            {
+              "name": "sample_size",
+              "type": "int",
+              "required": false,
+              "default": "100000",
+              "description": "Maximum number of rows sampled from the dataset when running checks, capping work on large tables."
+            },
+            {
+              "name": "severity_threshold",
+              "type": "str",
+              "required": false,
+              "default": "'warning'",
+              "description": "Minimum severity level at which a finding is reported, so anything below this floor is suppressed from results."
+            },
+            {
+              "name": "fail_on",
+              "type": "str",
+              "required": false,
+              "default": "'error'",
+              "description": "Severity level that causes the overall run to fail once a finding at or above it is produced."
+            }
+          ]
+        },
+        {
+          "name": "ColumnRule",
+          "fields": [
+            {
+              "name": "type",
+              "type": "str",
+              "required": true,
+              "description": "Expected data type for the column, used to flag values that do not conform to it."
+            },
+            {
+              "name": "required",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether the column must be present in the dataset, failing the check when it is missing."
+            },
+            {
+              "name": "nullable",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether null values are permitted in the column, flagging nulls when set to false."
+            },
+            {
+              "name": "format",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Named format the column values must match, such as an email or date pattern, for validating string shape."
+            },
+            {
+              "name": "unique",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether every value in the column must be distinct, flagging duplicate values when set to true."
+            },
+            {
+              "name": "range",
+              "type": "list[float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Inclusive lower and upper numeric bounds that column values must fall within."
+            },
+            {
+              "name": "enum",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Closed set of allowed values for the column, flagging any value outside this list."
+            },
+            {
+              "name": "outlier_stddev",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Number of standard deviations from the mean beyond which a numeric value is flagged as an outlier."
+            }
+          ]
+        },
+        {
+          "name": "RelationRule",
+          "fields": [
+            {
+              "name": "type",
+              "type": "str",
+              "required": true,
+              "description": "Kind of cross-column relationship to enforce, for example a uniqueness or foreign-key style constraint."
+            },
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns that participate in the relationship, evaluated together as a group."
+            }
+          ]
+        },
+        {
+          "name": "IgnoreEntry",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column whose check results should be suppressed from the report."
+            },
+            {
+              "name": "check",
+              "type": "str",
+              "required": true,
+              "description": "Specific check on that column to skip, silencing its findings for that column."
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for the A2A server"
+            }
+          ]
+        },
+        {
+          "command": "baseline",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "CSV/Parquet/Excel file to profile"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output YAML path"
+            },
+            {
+              "name": "--skip",
+              "type": "text",
+              "required": false,
+              "default": "[]",
+              "help": "Techniques to skip"
+            },
+            {
+              "name": "--update",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Update existing baseline"
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Print results to stdout."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack to apply."
+            }
+          ]
+        },
+        {
+          "command": "denial-constraints",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to mine for denial constraints."
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Fraction of rows/pairs a DC must hold for (default: engine default)."
+            },
+            {
+              "name": "--sample-size",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Bound the cross-tuple (pairwise) pass."
+            },
+            {
+              "name": "--max-constraints",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Cap the ranked number of DCs reported."
+            }
+          ]
+        },
+        {
+          "command": "diff",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to compare."
+            },
+            {
+              "name": "file2",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Second file (omit to compare against git)."
+            },
+            {
+              "name": "--ref",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Git ref to compare against (default: HEAD)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            }
+          ]
+        },
+        {
+          "command": "evaluate",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to scan."
+            },
+            {
+              "name": "--ground-truth",
+              "type": "path",
+              "required": true,
+              "help": "JSON file with expected findings."
+            },
+            {
+              "name": "--min-f1",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "help": "Minimum F1 score; exit 1 if below."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            }
+          ]
+        },
+        {
+          "command": "fix",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to fix."
+            },
+            {
+              "name": "--mode",
+              "type": "text",
+              "required": false,
+              "default": "'safe'",
+              "help": "Fix mode: safe, moderate, or aggressive."
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output file path."
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show fixes without writing."
+            },
+            {
+              "name": "--force",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Required for aggressive mode."
+            }
+          ]
+        },
+        {
+          "command": "history",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Filter history by file."
+            },
+            {
+              "name": "--last",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Show last N scans."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to scan for initial rules."
+            },
+            {
+              "name": "--yes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Accept defaults, skip interactive prompts."
+            }
+          ]
+        },
+        {
+          "command": "learn",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to analyze."
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output path for rules (default: goldencheck_rules.json)."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: 'stdio' or 'http'"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "refs",
+          "options": [
+            {
+              "name": "child",
+              "type": "path",
+              "required": true,
+              "help": "Child/fact file holding the foreign key(s)."
+            },
+            {
+              "name": "parent",
+              "type": "path",
+              "required": true,
+              "help": "Parent/dimension file holding the key(s)."
+            },
+            {
+              "name": "--on",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--fail-on",
+              "type": "text",
+              "required": false,
+              "default": "'error'",
+              "help": "CI exit threshold: error/warning/info."
+            }
+          ]
+        },
+        {
+          "command": "review",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to profile and validate."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to goldencheck.yml."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM enhancement pass."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack: healthcare, finance, ecommerce."
+            }
+          ]
+        },
+        {
+          "command": "scan",
+          "options": [
+            {
+              "name": "files",
+              "type": "path",
+              "required": true,
+              "help": "Data file(s) to profile."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM enhancement pass."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack: healthcare, finance, ecommerce."
+            },
+            {
+              "name": "--smart",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-triage: pin high-confidence, dismiss low."
+            },
+            {
+              "name": "--guided",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Walk through findings one at a time."
+            },
+            {
+              "name": "--no-history",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Don't record this scan in history."
+            },
+            {
+              "name": "--webhook",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "URL to POST findings to."
+            },
+            {
+              "name": "--notify-on",
+              "type": "text",
+              "required": false,
+              "default": "'grade-drop'",
+              "help": "Trigger: grade-drop, any-error, any-warning."
+            },
+            {
+              "name": "--html",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Generate HTML report at this path."
+            },
+            {
+              "name": "--baseline",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to baseline YAML"
+            },
+            {
+              "name": "--no-baseline",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Ignore baseline files"
+            },
+            {
+              "name": "--deep",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Profile the full dataset (skip the 100K sample cap)."
+            },
+            {
+              "name": "--denial",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also mine denial constraints (opt-in; slower)."
+            }
+          ]
+        },
+        {
+          "command": "scan-db",
+          "options": [
+            {
+              "name": "connection",
+              "type": "text",
+              "required": true,
+              "help": "Database connection string (postgres://, snowflake://, etc.)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Table name to scan."
+            },
+            {
+              "name": "--query",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Custom SQL query."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            },
+            {
+              "name": "--html",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Generate HTML report."
+            },
+            {
+              "name": "--sample-size",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Max rows to fetch."
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "files",
+              "type": "path",
+              "required": true,
+              "help": "Data files to scan on schedule."
+            },
+            {
+              "name": "--interval",
+              "type": "text",
+              "required": false,
+              "default": "'daily'",
+              "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack."
+            },
+            {
+              "name": "--webhook",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Webhook URL for notifications."
+            },
+            {
+              "name": "--notify-on",
+              "type": "text",
+              "required": false,
+              "default": "'grade-drop'",
+              "help": "Trigger: grade-drop, any-error, any-warning."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "JSON output per scan."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host to bind to."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port to listen on."
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to validate."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to goldencheck.yml."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "directory",
+              "type": "path",
+              "required": true,
+              "help": "Directory to watch."
+            },
+            {
+              "name": "--interval",
+              "type": "integer",
+              "required": false,
+              "default": "60",
+              "help": "Poll interval in seconds."
+            },
+            {
+              "name": "--pattern",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Glob pattern (e.g., '*.csv')."
+            },
+            {
+              "name": "--exit-on",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Exit on severity: error or warning."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "JSON output per scan."
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "analyze_data",
+          "description": "Analyze a data file to detect its domain, profile columns, and recommend a scanning strategy. Returns domain detection, column count, row count, strategy decisions, and alternative approaches."
+        },
+        {
+          "name": "approve_reject",
+          "description": "Approve (pin) or reject (dismiss) a review queue item. Decision must be 'pin' or 'dismiss'."
+        },
+        {
+          "name": "auto_configure",
+          "description": "Scan a data file, triage findings by confidence, and generate goldencheck.yml content from the pinned findings. Optionally accepts constraints to filter or adjust the generated config."
+        },
+        {
+          "name": "compare_domains",
+          "description": "Scan a file with every available domain pack (plus base/no-domain) and compare health scores. Recommends the best-fitting domain."
+        },
+        {
+          "name": "explain_column",
+          "description": "Get a natural-language health narrative for a specific column. Scans the file, profiles the column, and explains all findings."
+        },
+        {
+          "name": "explain_finding",
+          "description": "Explain a single finding in natural language. Requires the finding as a JSON dict and the file_path to load a profile for context."
+        },
+        {
+          "name": "get_column_detail",
+          "description": "Get detailed profile and findings for a specific column."
+        },
+        {
+          "name": "get_domain_info",
+          "description": "Get detailed info about a specific domain pack — lists all semantic types, their name hints, and suppression rules."
+        },
+        {
+          "name": "health_score",
+          "description": "Get the health score (A-F, 0-100) for a data file. Quick summary of overall data quality."
+        },
+        {
+          "name": "install_domain",
+          "description": "Download a community domain pack from the goldencheck-types repository and save it for use in future scans."
+        },
+        {
+          "name": "list_checks",
+          "description": "List all available profiler checks and what they detect. No arguments needed."
+        },
+        {
+          "name": "list_domains",
+          "description": "List all available domain packs (healthcare, finance, ecommerce, etc.). Domain packs provide specialized semantic type definitions for specific data domains."
+        },
+        {
+          "name": "pipeline_handoff",
+          "description": "Generate a structured quality attestation JSON for a data file. Includes health score, findings summary, pinned rules, and attestation status (PASS, PASS_WITH_WARNINGS, REVIEW_REQUIRED, FAIL)."
+        },
+        {
+          "name": "profile",
+          "description": "Profile a data file and return column-level statistics: type, null%, unique%, min/max, top values, detected formats. Also returns a health score (A-F) based on finding severity."
+        },
+        {
+          "name": "review_queue",
+          "description": "List all pending review items for a given job. Returns items that need human decision (medium-confidence findings)."
+        },
+        {
+          "name": "review_stats",
+          "description": "Get review queue statistics for a job — counts of pending, pinned, and dismissed items."
+        },
+        {
+          "name": "scan",
+          "description": "Scan a data file (CSV, Parquet, Excel) for data quality issues. Returns findings with severity, confidence, affected rows, and sample values. No configuration needed — rules are discovered from the data."
+        },
+        {
+          "name": "suggest_fix",
+          "description": "Preview fixes for a data file without applying them. Shows what would change (columns, fix types, rows affected, before/after samples)."
+        },
+        {
+          "name": "validate",
+          "description": "Validate a data file against pinned rules in goldencheck.yml. Returns validation findings (existence, required, unique, enum, range checks)."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Finding severity",
+          "target": "goldencheck.models.finding:Severity",
+          "applies": "`Settings.severity_threshold` / `fail_on`",
+          "values": [
+            {
+              "value": "ERROR",
+              "meaning": "Highest severity; fails the run at the default fail_on=error."
+            },
+            {
+              "value": "INFO",
+              "meaning": "Informational finding; never fails the run."
+            },
+            {
+              "value": "WARNING",
+              "meaning": "Advisory finding; fails only when fail_on=warning."
+            }
+          ]
+        },
+        {
+          "title": "Denial-constraint operators",
+          "target": "goldencheck.denial.models:Op",
+          "applies": "mined denial constraints",
+          "values": [
+            {
+              "value": "<",
+              "meaning": "Less than."
+            },
+            {
+              "value": "=",
+              "meaning": "Equal."
+            },
+            {
+              "value": ">",
+              "meaning": "Greater than."
+            },
+            {
+              "value": "≠",
+              "meaning": "Not equal."
+            },
+            {
+              "value": "≤",
+              "meaning": "Less than or equal."
+            },
+            {
+              "value": "≥",
+              "meaning": "Greater than or equal."
+            }
+          ]
+        },
+        {
+          "title": "Check types",
+          "target": "goldencheck.models.finding:CHECK_TYPES",
+          "applies": "`Finding.check`",
+          "values": [
+            {
+              "value": "benford_drift",
+              "meaning": "Leading-digit (Benford) distribution drifted."
+            },
+            {
+              "value": "bound_violation",
+              "meaning": "A value crossed a learned baseline bound."
+            },
+            {
+              "value": "cardinality",
+              "meaning": "A column's distinct-value count / ratio."
+            },
+            {
+              "value": "composite_key",
+              "meaning": "A candidate multi-column key."
+            },
+            {
+              "value": "correlation_break",
+              "meaning": "A previously strong correlation weakened."
+            },
+            {
+              "value": "cross_column",
+              "meaning": "A cross-column relationship finding."
+            },
+            {
+              "value": "cross_column_validation",
+              "meaning": "A cross-column validation rule failed."
+            },
+            {
+              "value": "denial_constraint",
+              "meaning": "A mined denial constraint is violated."
+            },
+            {
+              "value": "distribution_drift",
+              "meaning": "A column's value distribution drifted."
+            },
+            {
+              "value": "drift_detection",
+              "meaning": "General distribution drift versus the baseline."
+            },
+            {
+              "value": "duplicate_rows",
+              "meaning": "Fully duplicated rows."
+            },
+            {
+              "value": "encoding_detection",
+              "meaning": "Suspect character encoding / mojibake."
+            },
+            {
+              "value": "entropy_drift",
+              "meaning": "A column's entropy drifted."
+            },
+            {
+              "value": "enum",
+              "meaning": "A value is outside the allowed enum set."
+            },
+            {
+              "value": "existence",
+              "meaning": "A column the config expects is present."
+            },
+            {
+              "value": "fd_violation",
+              "meaning": "Rows violate a functional dependency."
+            },
+            {
+              "value": "format_detection",
+              "meaning": "The detected value format (email, phone, ...)."
+            },
+            {
+              "value": "functional_dependency",
+              "meaning": "A discovered functional dependency."
+            },
+            {
+              "value": "future_dated",
+              "meaning": "A date is in the future."
+            },
+            {
+              "value": "fuzzy_duplicate_values",
+              "meaning": "Near-duplicate values within a column."
+            },
+            {
+              "value": "identity_safe_pk",
+              "meaning": "A column is a safe, stable primary key."
+            },
+            {
+              "value": "key_uniqueness_loss",
+              "meaning": "A key lost uniqueness versus the baseline."
+            },
+            {
+              "value": "near_duplicate_rows",
+              "meaning": "Near-duplicate rows (fuzzy)."
+            },
+            {
+              "value": "new_correlation",
+              "meaning": "A new column correlation appeared."
+            },
+            {
+              "value": "new_pattern",
+              "meaning": "A new value pattern appeared."
+            },
+            {
+              "value": "null_correlation",
+              "meaning": "Nulls in two columns co-occur suspiciously."
+            },
+            {
+              "value": "nullability",
+              "meaning": "A column's null rate exceeds the allowed bound."
+            },
+            {
+              "value": "pattern_consistency",
+              "meaning": "Values deviate from the column's dominant pattern."
+            },
+            {
+              "value": "pattern_drift",
+              "meaning": "A column's dominant pattern changed."
+            },
+            {
+              "value": "range",
+              "meaning": "A value falls outside the allowed range."
+            },
+            {
+              "value": "range_distribution",
+              "meaning": "Value distribution versus the expected range."
+            },
+            {
+              "value": "referential_integrity",
+              "meaning": "A foreign-key reference is unmatched."
+            },
+            {
+              "value": "required",
+              "meaning": "A required column contains no nulls."
+            },
+            {
+              "value": "sequence_detection",
+              "meaning": "A column is a monotonic sequence / counter."
+            },
+            {
+              "value": "stale_data",
+              "meaning": "Data is older than the freshness bound."
+            },
+            {
+              "value": "temporal_order",
+              "meaning": "Dates violate an expected ordering."
+            },
+            {
+              "value": "temporal_order_drift",
+              "meaning": "Temporal ordering changed versus the baseline."
+            },
+            {
+              "value": "type_drift",
+              "meaning": "A column's inferred type changed."
+            },
+            {
+              "value": "type_inference",
+              "meaning": "The inferred data type for a column."
+            },
+            {
+              "value": "unique",
+              "meaning": "A column declared unique has duplicates."
+            },
+            {
+              "value": "uniqueness",
+              "meaning": "The observed uniqueness of a column."
+            },
+            {
+              "value": "unmapped_column",
+              "meaning": "A column has no rule and no inferred type."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "AGENT": [
+          "GOLDENCHECK_AGENT_TOKEN"
+        ],
+        "FORCE": [
+          "GOLDENCHECK_FORCE_TUI"
+        ],
+        "LLM": [
+          "GOLDENCHECK_LLM_BUDGET",
+          "GOLDENCHECK_LLM_MODEL"
+        ],
+        "NATIVE": [
+          "GOLDENCHECK_NATIVE"
+        ],
+        "SCAN": [
+          "GOLDENCHECK_SCAN_THREADS"
+        ]
+      }
+    },
+    "goldenflow": {
+      "nav_group": "GoldenFlow",
+      "env_prefix": "GOLDENFLOW_",
+      "doc_path": "docs-site/goldenflow/config-matrix.mdx",
+      "config_models": [
+        {
+          "name": "GoldenFlowConfig",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Path or identifier of the input dataset to read records from."
+            },
+            {
+              "name": "output",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Path or identifier where the transformed dataset is written."
+            },
+            {
+              "name": "transforms",
+              "type": "list[TransformSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "TransformSpec"
+              ],
+              "description": "Per-column transform specs that standardize values by applying ordered ops."
+            },
+            {
+              "name": "splits",
+              "type": "list[SplitSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "SplitSpec"
+              ],
+              "description": "Split specs that break one column into several target columns."
+            },
+            {
+              "name": "renames",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Mapping of existing column names to new names to rename them to."
+            },
+            {
+              "name": "drop",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Names of columns to remove from the output."
+            },
+            {
+              "name": "filters",
+              "type": "list[FilterSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "FilterSpec"
+              ],
+              "description": "Filter specs that keep only rows satisfying each condition."
+            },
+            {
+              "name": "dedup",
+              "type": "DedupSpec | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DedupSpec"
+              ],
+              "description": "Optional deduplication spec that collapses duplicate rows by key columns."
+            },
+            {
+              "name": "mappings",
+              "type": "list[MappingSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "MappingSpec"
+              ],
+              "description": "Mapping specs that copy source columns to targets with optional transforms."
+            }
+          ]
+        },
+        {
+          "name": "TransformSpec",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column the transform operations are applied to."
+            },
+            {
+              "name": "ops",
+              "type": "list[str]",
+              "required": true,
+              "description": "Ordered list of transform-op names applied in sequence to the column."
+            }
+          ]
+        },
+        {
+          "name": "SplitSpec",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column whose values are split into multiple columns."
+            },
+            {
+              "name": "target",
+              "type": "list[str]",
+              "required": true,
+              "description": "Names of the output columns produced by the split."
+            },
+            {
+              "name": "method",
+              "type": "str",
+              "required": true,
+              "description": "Splitting method that determines how the source value is divided."
+            }
+          ]
+        },
+        {
+          "name": "FilterSpec",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column the filter condition is evaluated against."
+            },
+            {
+              "name": "condition",
+              "type": "str",
+              "required": true,
+              "description": "Predicate expression that rows must satisfy to be kept."
+            }
+          ]
+        },
+        {
+          "name": "DedupSpec",
+          "fields": [
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns whose combined values define what counts as a duplicate row."
+            },
+            {
+              "name": "keep",
+              "type": "Literal",
+              "required": false,
+              "default": "'first'",
+              "choices": [
+                "first",
+                "last"
+              ],
+              "description": "Which duplicate to retain within each group, either the first or last occurrence."
+            }
+          ]
+        },
+        {
+          "name": "MappingSpec",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str",
+              "required": true,
+              "description": "Name of the source column to read values from."
+            },
+            {
+              "name": "target",
+              "type": "str | list[str]",
+              "required": true,
+              "description": "Name or names of the target column(s) the source values are written to."
+            },
+            {
+              "name": "transform",
+              "type": "str | list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional transform op or ordered list of ops applied while mapping source to target."
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8150",
+              "help": "Port the A2A agent server listens on."
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "Path('.')",
+              "help": "Directory where the sample data and config files are written."
+            }
+          ]
+        },
+        {
+          "command": "diff",
+          "options": [
+            {
+              "name": "before",
+              "type": "path",
+              "required": true,
+              "help": "Before file"
+            },
+            {
+              "name": "after",
+              "type": "path",
+              "required": true,
+              "help": "After file"
+            }
+          ]
+        },
+        {
+          "command": "history",
+          "options": [
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "20",
+              "help": "Number of recent runs to show"
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "data",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Data file to profile"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'goldenflow.yaml'",
+              "help": "Path where the generated config file is written."
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Input data file"
+            }
+          ]
+        },
+        {
+          "command": "learn",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'goldenflow.yaml'",
+              "help": "Output config path"
+            }
+          ]
+        },
+        {
+          "command": "map",
+          "options": [
+            {
+              "name": "--source",
+              "type": "path",
+              "required": true,
+              "help": "Source data file"
+            },
+            {
+              "name": "--target",
+              "type": "path",
+              "required": true,
+              "help": "Target data file or schema"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Mapping config"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save mapping config"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8150",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "profile",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Data file to transform"
+            },
+            {
+              "name": "--every",
+              "type": "text",
+              "required": false,
+              "default": "'1h'",
+              "help": "Interval (e.g., 5m, 1h, 30s)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied on each scheduled run."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where transformed files are written."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Network interface the REST API server binds to."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port the REST API server listens on."
+            }
+          ]
+        },
+        {
+          "command": "stream",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Rows per batch"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied to each streamed batch."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where the combined transformed file is written."
+            }
+          ]
+        },
+        {
+          "command": "transform",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config file"
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack to use"
+            },
+            {
+              "name": "--from-findings",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Read findings from stdin"
+            },
+            {
+              "name": "--llm",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM-enhanced transforms"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail if any transform errors occur"
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config file describing which transforms to apply."
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory to watch"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied to each new or changed file."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where transformed files are written."
+            },
+            {
+              "name": "--interval",
+              "type": "float",
+              "required": false,
+              "default": "2.0",
+              "help": "Poll interval in seconds"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "diff",
+          "description": "Compare two data files and show what changed (added, removed, modified rows)."
+        },
+        {
+          "name": "explain_transform",
+          "description": "Describe what a specific transform does, its mode, and input types."
+        },
+        {
+          "name": "learn",
+          "description": "Generate a YAML config from data patterns."
+        },
+        {
+          "name": "list_domains",
+          "description": "List available domain packs (e.g., people_hr, ecommerce, finance)."
+        },
+        {
+          "name": "list_transforms",
+          "description": "List all registered transforms with their modes, input types, and auto-apply status."
+        },
+        {
+          "name": "map",
+          "description": "Auto-map schemas between source and target files."
+        },
+        {
+          "name": "profile",
+          "description": "Profile a data file showing column types, nulls, and patterns."
+        },
+        {
+          "name": "select_from_findings",
+          "description": "Map GoldenCheck findings to recommended GoldenFlow transforms. Bridge tool for Check-to-Flow handoff."
+        },
+        {
+          "name": "transform",
+          "description": "Clean / normalize a data file with GoldenFlow transforms (phone, date, unicode, casing, categorical, and more) and write the transformed file. Zero-config auto-detects and applies transforms; pass a config to control them. See list_transforms for what's available. Does not deduplicate or match -- it only reshapes column values."
+        },
+        {
+          "name": "validate",
+          "description": "Dry-run transform on a file. Shows what would change without writing output."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Transform ops",
+          "target": "goldenflow.transforms:list_transforms",
+          "applies": "`TransformSpec.ops`",
+          "values": [
+            {
+              "value": "aba_validate",
+              "meaning": "Validate a US ABA bank routing number: exactly 9 digits plus the"
+            },
+            {
+              "value": "abs_value",
+              "meaning": "Return the absolute value."
+            },
+            {
+              "value": "account_mask",
+              "meaning": "Mask account numbers showing only last 4 digits."
+            },
+            {
+              "value": "address_expand",
+              "meaning": "Replace street abbreviations (St, Ave...) with full forms."
+            },
+            {
+              "value": "address_standardize",
+              "meaning": "Replace full street suffixes (Street, Avenue...) with abbreviations."
+            },
+            {
+              "value": "age_from_dob",
+              "meaning": "Compute age in years from a date of birth."
+            },
+            {
+              "value": "boolean_normalize",
+              "meaning": "Parse loose boolean-ish strings (yes/no/y/n/1/0/true/false/t/f)."
+            },
+            {
+              "value": "carceral_abbreviate",
+              "meaning": "Expand carceral facility-type abbreviations and state-complex aliases."
+            },
+            {
+              "value": "carceral_name_normalize",
+              "meaning": "Full carceral name pipeline: org-strip + uppercase + punctuation strip"
+            },
+            {
+              "value": "carceral_org_strip",
+              "meaning": "Strip leading operator-org prefix from a carceral facility name."
+            },
+            {
+              "value": "category_auto_correct",
+              "meaning": "Auto-correct categorical misspellings and case variants."
+            },
+            {
+              "value": "category_from_file",
+              "meaning": "Load mapping from a CSV/YAML file and standardize values."
+            },
+            {
+              "value": "category_llm_correct",
+              "meaning": "LLM-enhanced categorical correction."
+            },
+            {
+              "value": "category_standardize",
+              "meaning": "Map variant values to canonical values. mapping: {canonical: [variant1, variant2, ...]}"
+            },
+            {
+              "value": "cc_brand",
+              "meaning": "Detect the card brand (visa/mastercard/amex/...) or null. Native-first."
+            },
+            {
+              "value": "cc_format",
+              "meaning": "Group a valid payment-card number (Amex 4-6-5, else 4-4-4-4...);"
+            },
+            {
+              "value": "cc_mask",
+              "meaning": "Mask a payment-card number to stars + last 4 digits."
+            },
+            {
+              "value": "cc_validate",
+              "meaning": "Validate a payment-card number via the Luhn checksum."
+            },
+            {
+              "value": "clamp",
+              "meaning": "Clip values into [min_val, max_val]."
+            },
+            {
+              "value": "collapse_whitespace",
+              "meaning": "Collapse runs of whitespace to single spaces."
+            },
+            {
+              "value": "comma_decimal",
+              "meaning": "Convert European decimal format (1.234,56) to float (1234.56)."
+            },
+            {
+              "value": "company_extract_legal",
+              "meaning": "Extract the canonical legal-form token (``inc``/``llc``/...) or null."
+            },
+            {
+              "value": "company_normalize",
+              "meaning": "Composite company dedup key: lowercase, drop leading 'the', strip legal"
+            },
+            {
+              "value": "company_strip_legal",
+              "meaning": "Strip trailing legal-form suffixes, preserving the core name's case."
+            },
+            {
+              "value": "country_standardize",
+              "meaning": "Normalize country names to ISO 3166-1 alpha-2 codes."
+            },
+            {
+              "value": "currency_strip",
+              "meaning": "Strip currency symbols and thousand separators, return numeric."
+            },
+            {
+              "value": "cusip_format",
+              "meaning": "Standardize CUSIP identifiers (9 chars, uppercase)."
+            },
+            {
+              "value": "cusip_validate",
+              "meaning": "Validate a CUSIP. Native-first over goldenflow-core."
+            },
+            {
+              "value": "date_eu",
+              "meaning": "Parse a European (DD/MM/YYYY) date."
+            },
+            {
+              "value": "date_iso8601",
+              "meaning": "Parse/format a date as ISO-8601."
+            },
+            {
+              "value": "date_parse",
+              "meaning": "Auto-detect format and normalize to ISO 8601."
+            },
+            {
+              "value": "date_shift",
+              "meaning": "Shift dates by a number of days (positive = forward, negative = backward)."
+            },
+            {
+              "value": "date_us",
+              "meaning": "Parse a US (MM/DD/YYYY) date."
+            },
+            {
+              "value": "date_validate",
+              "meaning": "Validate if value is a parseable date. Returns True/False/None."
+            },
+            {
+              "value": "datetime_iso8601",
+              "meaning": "Parse to ISO 8601 datetime (with time component)."
+            },
+            {
+              "value": "double_metaphone_alt",
+              "meaning": "Alternate Double Metaphone code. Native-first."
+            },
+            {
+              "value": "double_metaphone_primary",
+              "meaning": "Primary Double Metaphone code (blocking key). Native-first."
+            },
+            {
+              "value": "ean_validate",
+              "meaning": "Validate an EAN-8, UPC-A, or EAN-13 via its GTIN mod-10 checksum."
+            },
+            {
+              "value": "ein_format",
+              "meaning": "Normalize EIN to XX-XXXXXXX format. Native-first."
+            },
+            {
+              "value": "email_canonical",
+              "meaning": "Full dedup key: email_normalize + alias googlemail.com -> gmail.com so"
+            },
+            {
+              "value": "email_extract_domain",
+              "meaning": "Extract the lowercased domain from an email address."
+            },
+            {
+              "value": "email_lowercase",
+              "meaning": "Lowercase the entire email address (trim + lowercase)."
+            },
+            {
+              "value": "email_mask",
+              "meaning": "PII mask: keep the first local char, star the rest, keep @domain"
+            },
+            {
+              "value": "email_normalize",
+              "meaning": "Normalize email: lowercase, strip +tags, strip dots from Gmail local part."
+            },
+            {
+              "value": "email_validate",
+              "meaning": "Validate email format. Returns True/False/None."
+            },
+            {
+              "value": "extract_day",
+              "meaning": "Extract the day of month as an integer (1-31)."
+            },
+            {
+              "value": "extract_day_of_week",
+              "meaning": "Extract the day of week name (Monday, Tuesday, etc.)."
+            },
+            {
+              "value": "extract_month",
+              "meaning": "Extract the month as an integer (1-12)."
+            },
+            {
+              "value": "extract_numbers",
+              "meaning": "Extract all numbers from text, joined by spaces."
+            },
+            {
+              "value": "extract_quarter",
+              "meaning": "Extract the quarter (1-4) from a date."
+            },
+            {
+              "value": "extract_year",
+              "meaning": "Extract the year as an integer."
+            },
+            {
+              "value": "fill_zero",
+              "meaning": "Replace null values with 0."
+            },
+            {
+              "value": "fix_mojibake",
+              "meaning": "Fix common UTF-8/Latin-1 mojibake by re-encoding."
+            },
+            {
+              "value": "fraction_to_decimal",
+              "meaning": "Parse a fraction or mixed number (1/2, 3 3/4) to a float. Native-first."
+            },
+            {
+              "value": "gender_standardize",
+              "meaning": "Standardize gender strings to ``M``/``F``; anything else passes"
+            },
+            {
+              "value": "iban_format",
+              "meaning": "Group a valid IBAN into 4-char blocks; ``null`` for invalid input."
+            },
+            {
+              "value": "iban_validate",
+              "meaning": "Validate an IBAN via structural checks + the ISO 7064 mod-97 check."
+            },
+            {
+              "value": "icd10_format",
+              "meaning": "Standardize ICD-10 codes (uppercase, insert dot after 3rd char)."
+            },
+            {
+              "value": "imei_validate",
+              "meaning": "Validate an IMEI: exactly 15 digits plus the Luhn checksum."
+            },
+            {
+              "value": "initial_expand",
+              "meaning": "Returns (series, flagged_rows). Values with initials are unchanged but flagged."
+            },
+            {
+              "value": "isbn_normalize",
+              "meaning": "Canonicalize a valid ISBN-10/13 to its 13-digit form; ``null`` for"
+            },
+            {
+              "value": "isbn_validate",
+              "meaning": "Validate an ISBN-10 or ISBN-13 via its checksum."
+            },
+            {
+              "value": "isin_validate",
+              "meaning": "Validate an ISIN (ISO 6166). Native-first over goldenflow-core."
+            },
+            {
+              "value": "latlng_pack",
+              "meaning": "Pack ``lat`` + ``lng`` into a single ``latlng`` column shaped"
+            },
+            {
+              "value": "lowercase",
+              "meaning": "Lowercase the value."
+            },
+            {
+              "value": "luhn_validate",
+              "meaning": "Generic Luhn check-digit validation. Native-first over goldenflow-core."
+            },
+            {
+              "value": "merge_name",
+              "meaning": "Merge first_name and last_name columns into a full_name column."
+            },
+            {
+              "value": "mls_normalize",
+              "meaning": "Normalize MLS listing IDs (uppercase, strip whitespace)."
+            },
+            {
+              "value": "name_initials",
+              "meaning": "Initials of each whitespace token (letter-leading tokens only)."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name (title-case + Mc/O' fixups)."
+            },
+            {
+              "value": "name_script",
+              "meaning": "Detect the dominant Unicode script in a name: ``Unknown`` for empty"
+            },
+            {
+              "value": "name_transliterate",
+              "meaning": "ASCII-fold a name via an explicit curated diacritic map. Non-ASCII"
+            },
+            {
+              "value": "nickname_standardize",
+              "meaning": "Map common nicknames to formal first names."
+            },
+            {
+              "value": "normalize_line_endings",
+              "meaning": "Normalize \\r\\n and \\r to \\n."
+            },
+            {
+              "value": "normalize_quotes",
+              "meaning": "Replace smart/curly quotes with straight quotes."
+            },
+            {
+              "value": "normalize_unicode",
+              "meaning": "Normalize to Unicode NFC form."
+            },
+            {
+              "value": "npi_validate",
+              "meaning": "Validate a US NPI. Native-first over goldenflow-core."
+            },
+            {
+              "value": "null_standardize",
+              "meaning": "Map null-sentinel strings (n/a, null, none, na, nil, nan, -, empty) to"
+            },
+            {
+              "value": "ordinal_to_int",
+              "meaning": "Parse an English ordinal (1st/2nd/3rd) to its integer. Native-first."
+            },
+            {
+              "value": "pad_left",
+              "meaning": "Left-pad strings to a fixed width."
+            },
+            {
+              "value": "pad_right",
+              "meaning": "Right-pad strings to a fixed width."
+            },
+            {
+              "value": "percentage_normalize",
+              "meaning": "Strip trailing %, parse to float, divide by 100."
+            },
+            {
+              "value": "phone_country_code",
+              "meaning": "Extract the country calling code as an integer."
+            },
+            {
+              "value": "phone_digits",
+              "meaning": "Keep only the phone number's digits."
+            },
+            {
+              "value": "phone_e164",
+              "meaning": "Format a phone number as E.164."
+            },
+            {
+              "value": "phone_national",
+              "meaning": "Format a phone number in national format."
+            },
+            {
+              "value": "phone_validate",
+              "meaning": "Flag whether the phone number is valid."
+            },
+            {
+              "value": "remove_digits",
+              "meaning": "Remove all digit characters from text."
+            },
+            {
+              "value": "remove_emojis",
+              "meaning": "Remove emoji characters from text."
+            },
+            {
+              "value": "remove_html_tags",
+              "meaning": "Strip HTML tags from text."
+            },
+            {
+              "value": "remove_punctuation",
+              "meaning": "Strip punctuation characters."
+            },
+            {
+              "value": "remove_urls",
+              "meaning": "Strip URLs (http/https) from text."
+            },
+            {
+              "value": "roman_to_int",
+              "meaning": "Parse a Roman numeral to its integer (canonical forms only, 1..=3999)."
+            },
+            {
+              "value": "round",
+              "meaning": "Round to n decimal places (round-half-away-from-zero, see the"
+            },
+            {
+              "value": "scientific_to_decimal",
+              "meaning": "Convert scientific notation (1.5e3) to decimal (1500.0)."
+            },
+            {
+              "value": "sku_normalize",
+              "meaning": "Normalize SKU identifiers (uppercase, strip whitespace, remove special chars)."
+            },
+            {
+              "value": "soundex",
+              "meaning": "Soundex phonetic key. Native-first over goldenflow-core."
+            },
+            {
+              "value": "split_address",
+              "meaning": "Parse 'street, city, state zip' into separate columns."
+            },
+            {
+              "value": "split_name",
+              "meaning": "Split 'First Last' into first_name and last_name columns."
+            },
+            {
+              "value": "split_name_reverse",
+              "meaning": "Split 'Last, First' into first_name and last_name columns."
+            },
+            {
+              "value": "ssn_format",
+              "meaning": "Normalize SSN to XXX-XX-XXXX format. Native-first over goldenflow-core."
+            },
+            {
+              "value": "ssn_mask",
+              "meaning": "Mask SSN to ***-**-XXXX (last 4 visible). Native-first."
+            },
+            {
+              "value": "ssn_validate",
+              "meaning": "Flag whether the value is a valid US Social Security Number."
+            },
+            {
+              "value": "state_abbreviate",
+              "meaning": "Normalize state name to a 2-letter abbreviation (unmatched -> original)."
+            },
+            {
+              "value": "state_expand",
+              "meaning": "Expand a 2-letter state abbreviation to its full name (unmatched -> original)."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim leading/trailing whitespace."
+            },
+            {
+              "value": "strip_middle",
+              "meaning": "Keep only the first and last whitespace tokens (drop the middle)."
+            },
+            {
+              "value": "strip_suffixes",
+              "meaning": "Strip trailing professional suffixes (Jr/Sr/II/MD/PhD/etc.) from names."
+            },
+            {
+              "value": "strip_titles",
+              "meaning": "Strip leading personal titles (Mr/Mrs/Ms/Dr/Prof/etc.) from names."
+            },
+            {
+              "value": "swift_format",
+              "meaning": "Normalize a valid SWIFT/BIC code to uppercase (spaces stripped);"
+            },
+            {
+              "value": "swift_validate",
+              "meaning": "Validate a SWIFT/BIC code via structural checks (length 8/11 +"
+            },
+            {
+              "value": "title_case",
+              "meaning": "Title-case the value."
+            },
+            {
+              "value": "to_integer",
+              "meaning": "Parse string to integer, truncating any decimal part."
+            },
+            {
+              "value": "truncate",
+              "meaning": "Truncate string to the first n characters."
+            },
+            {
+              "value": "unit_normalize",
+              "meaning": "Normalize unit/apartment/suite designations."
+            },
+            {
+              "value": "uppercase",
+              "meaning": "Uppercase the value."
+            },
+            {
+              "value": "url_canonical",
+              "meaning": "Composite dedup key: ensure scheme, lowercase scheme+host, strip www.,"
+            },
+            {
+              "value": "url_extract_domain",
+              "meaning": "Extract domain from a URL."
+            },
+            {
+              "value": "url_normalize",
+              "meaning": "Normalize URLs: ensure scheme, lowercase domain, strip trailing slash."
+            },
+            {
+              "value": "url_strip_tracking",
+              "meaning": "Remove tracking query params (utm_*, gclid, fbclid, ...), preserving the"
+            },
+            {
+              "value": "url_strip_www",
+              "meaning": "Strip a leading ``www.`` label from the host, preserving scheme, path,"
+            },
+            {
+              "value": "vat_format",
+              "meaning": "Normalize a valid EU VAT number to its compact uppercase form (prefix"
+            },
+            {
+              "value": "vat_validate",
+              "meaning": "Validate an EU VAT number: structural check (country prefix + length +"
+            },
+            {
+              "value": "zip_normalize",
+              "meaning": "Normalize a US ZIP to 5-digit form (strip +4, zero-pad all-digit, preserve"
+            }
+          ]
+        },
+        {
+          "title": "Domain packs",
+          "target": "goldenflow.domains:_DOMAINS",
+          "applies": "`learn_config(domain=...)`",
+          "values": [
+            {
+              "value": "carceral",
+              "meaning": "Corrections / justice field pack."
+            },
+            {
+              "value": "ecommerce",
+              "meaning": "E-commerce / retail field pack."
+            },
+            {
+              "value": "finance",
+              "meaning": "Financial-services field pack."
+            },
+            {
+              "value": "healthcare",
+              "meaning": "Healthcare field pack."
+            },
+            {
+              "value": "people_hr",
+              "meaning": "People / HR field pack."
+            },
+            {
+              "value": "real_estate",
+              "meaning": "Real-estate field pack."
+            }
+          ]
+        },
+        {
+          "title": "Canonicalize kinds",
+          "target": "goldenflow.canonicalize:CanonicalizeKind",
+          "applies": "`canonicalize` op",
+          "values": [
+            {
+              "value": "email",
+              "meaning": "Canonical email form."
+            },
+            {
+              "value": "name",
+              "meaning": "Canonical person-name form."
+            },
+            {
+              "value": "phone",
+              "meaning": "Canonical phone form."
+            },
+            {
+              "value": "postal",
+              "meaning": "Canonical postal-address form."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "ENGINE": [
+          "GOLDENFLOW_ENGINE"
+        ],
+        "FUSED": [
+          "GOLDENFLOW_FUSED_APPLY"
+        ],
+        "LLM": [
+          "GOLDENFLOW_LLM"
+        ],
+        "NATIVE": [
+          "GOLDENFLOW_NATIVE",
+          "GOLDENFLOW_NATIVE_CSV_PARALLEL_MIN_BYTES"
+        ]
+      }
+    },
+    "goldenpipe": {
+      "nav_group": "GoldenPipe",
+      "env_prefix": "GOLDENPIPE_",
+      "doc_path": "docs-site/goldenpipe/config-matrix.mdx",
+      "config_models": [
+        {
+          "name": "PipelineConfig",
+          "fields": [
+            {
+              "name": "pipeline",
+              "type": "str",
+              "required": true,
+              "description": "Name of the pipeline, identifying this end-to-end configuration in runs and logs."
+            },
+            {
+              "name": "source",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional default input location that stages read from when they do not specify their own source."
+            },
+            {
+              "name": "output",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional default destination where the pipeline writes its final results."
+            },
+            {
+              "name": "stages",
+              "type": "list[StageSpec | str]",
+              "required": true,
+              "nested": [
+                "StageSpec"
+              ],
+              "description": "Ordered list of stages to run, each given as a full StageSpec or a shorthand string naming the adapter to use."
+            },
+            {
+              "name": "decisions",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Recorded pipeline decision entries that capture the choices and rationale behind this configuration."
+            }
+          ],
+          "doc": "Top-level pipeline configuration."
+        },
+        {
+          "name": "StageSpec",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional human-readable label for this stage, used in logs and as the key other stages reference in their needs list."
+            },
+            {
+              "name": "use",
+              "type": "str",
+              "required": true,
+              "description": "Identifier of the adapter that runs this stage, such as goldenmatch.dedupe, naming which suite tool to invoke."
+            },
+            {
+              "name": "needs",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Names of stages that must finish before this one runs, defining the dependency order in the pipeline graph."
+            },
+            {
+              "name": "skip_if",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Condition expression that, when it evaluates true at runtime, causes this stage to be skipped rather than executed."
+            },
+            {
+              "name": "on_error",
+              "type": "Literal",
+              "required": false,
+              "default": "'continue'",
+              "choices": [
+                "continue",
+                "abort"
+              ],
+              "description": "What to do when this stage raises an error: continue on to later stages or abort the whole pipeline."
+            },
+            {
+              "name": "config",
+              "type": "dict[str, Any]",
+              "required": false,
+              "default": "{}",
+              "description": "Free-form settings dictionary passed straight through to the named adapter to configure how the tool runs."
+            }
+          ],
+          "doc": "Configuration for a single pipeline stage."
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8250",
+              "help": "Port for A2A server"
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "--dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory to create config in"
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional data file to load (press 'r' to run)."
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional pipeline YAML config."
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport type: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8250",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "run",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Input file path"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Pipeline YAML config"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output file path"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show reasoning and timing"
+            },
+            {
+              "name": "--identity-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Enable Identity Graph; persist to this SQLite path"
+            },
+            {
+              "name": "--identity-dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Identity Graph dataset namespace"
+            },
+            {
+              "name": "--identity-source-pk",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column to derive `{source}:{source_pk}` record_id from"
+            },
+            {
+              "name": "--identity-weak-threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Auto-flag bottleneck pair as conflicts_with when cluster confidence < this. Defaults to 0.6 (per IdentityConfig)."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port for REST API"
+            }
+          ]
+        },
+        {
+          "command": "stages",
+          "options": []
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Pipeline YAML config"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "explain_pipeline",
+          "description": "Explain what a pipeline config does"
+        },
+        {
+          "name": "list_stages",
+          "description": "List all discovered pipeline stages"
+        },
+        {
+          "name": "run_pipeline",
+          "description": "Run a pipeline on a file OR inline data (records / csv_text) and return per-stage status, reasoning and timing PLUS the deduped output (golden-record count + preview, unique/duplicate counts, cluster count, match stats). Give a `stages` list or `config_path` to control the chain, or omit both for zero-config auto."
+        },
+        {
+          "name": "validate_pipeline",
+          "description": "Validate pipeline wiring"
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Stage status",
+          "target": "goldenpipe.models.context:StageStatus",
+          "applies": "per-stage result status",
+          "values": [
+            {
+              "value": "failed",
+              "meaning": "Stage raised an error."
+            },
+            {
+              "value": "skipped",
+              "meaning": "Stage skipped by its skip_if condition."
+            },
+            {
+              "value": "success",
+              "meaning": "Stage completed successfully."
+            }
+          ]
+        },
+        {
+          "title": "Pipeline status",
+          "target": "goldenpipe.models.context:PipeStatus",
+          "applies": "run result status",
+          "values": [
+            {
+              "value": "failed",
+              "meaning": "One or more stages failed the run."
+            },
+            {
+              "value": "partial",
+              "meaning": "Some stages succeeded and some failed."
+            },
+            {
+              "value": "success",
+              "meaning": "Every stage succeeded."
+            }
+          ]
+        },
+        {
+          "title": "Column types",
+          "target": "goldenpipe.models.column_context:ColumnType",
+          "applies": "column classification",
+          "values": [
+            {
+              "value": "address",
+              "meaning": "Postal address."
+            },
+            {
+              "value": "date",
+              "meaning": "Date/time value."
+            },
+            {
+              "value": "description",
+              "meaning": "Long free text."
+            },
+            {
+              "value": "email",
+              "meaning": "Email address."
+            },
+            {
+              "value": "geo",
+              "meaning": "Geographic coordinate."
+            },
+            {
+              "value": "identifier",
+              "meaning": "Unique identifier / key."
+            },
+            {
+              "value": "name",
+              "meaning": "Person or entity name."
+            },
+            {
+              "value": "numeric",
+              "meaning": "Numeric measure."
+            },
+            {
+              "value": "phone",
+              "meaning": "Phone number."
+            },
+            {
+              "value": "string",
+              "meaning": "Free-form string."
+            },
+            {
+              "value": "zip",
+              "meaning": "Postal/ZIP code."
+            }
+          ]
+        },
+        {
+          "title": "Cardinality bands",
+          "target": "goldenpipe.models.column_context:CardinalityBand",
+          "applies": "column cardinality band",
+          "values": [
+            {
+              "value": "",
+              "meaning": "Unset / unknown."
+            },
+            {
+              "value": "high",
+              "meaning": "Many distinct values (near-unique)."
+            },
+            {
+              "value": "low",
+              "meaning": "Few distinct values."
+            },
+            {
+              "value": "mid",
+              "meaning": "Moderate distinct values."
+            },
+            {
+              "value": "skip",
+              "meaning": "Excluded from cardinality analysis."
+            }
+          ]
+        },
+        {
+          "title": "Repair fixers",
+          "target": "goldenpipe.repair_host:FIXERS",
+          "applies": "repair-op allowlist",
+          "values": [
+            {
+              "value": "date_parse",
+              "meaning": "Parse a date into ISO form."
+            },
+            {
+              "value": "email_canonical",
+              "meaning": "Canonicalize an email (dedupe dots/plus)."
+            },
+            {
+              "value": "email_normalize",
+              "meaning": "Lowercase/normalize an email."
+            },
+            {
+              "value": "fix_mojibake",
+              "meaning": "Repair UTF-8/Latin-1 mojibake."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name."
+            },
+            {
+              "value": "normalize_unicode",
+              "meaning": "Normalize to Unicode NFC."
+            },
+            {
+              "value": "phone_national",
+              "meaning": "Normalize a phone to national format."
+            },
+            {
+              "value": "zip_normalize",
+              "meaning": "Normalize a ZIP code."
+            }
+          ]
+        },
+        {
+          "title": "Stages",
+          "target": "goldenpipe.engine.registry:BUILTIN_STAGES",
+          "applies": "`StageSpec.use`",
+          "values": [
+            {
+              "value": "goldenanalysis.report",
+              "meaning": "Run GoldenAnalysis metrics + reporting."
+            },
+            {
+              "value": "goldencheck.scan",
+              "meaning": "Run a GoldenCheck data-quality scan."
+            },
+            {
+              "value": "goldenflow.transform",
+              "meaning": "Run GoldenFlow transforms / standardization."
+            },
+            {
+              "value": "goldenmatch.dedupe",
+              "meaning": "Run GoldenMatch dedupe / entity resolution."
+            },
+            {
+              "value": "goldenmatch.dedupe_fused",
+              "meaning": "Run the fused GoldenMatch dedupe kernel."
+            },
+            {
+              "value": "goldenmatch.identity_resolve",
+              "meaning": "Resolve records against the identity graph."
+            },
+            {
+              "value": "infer_schema",
+              "meaning": "Infer the source schema (via infermap)."
+            },
+            {
+              "value": "load",
+              "meaning": "Load a source file into the pipeline frame."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "GOLDENPIPE_NATIVE"
+        ]
+      }
+    },
+    "infermap": {
+      "nav_group": "InferMap",
+      "env_prefix": "INFERMAP_",
+      "doc_path": "docs-site/infermap/config-matrix.mdx",
+      "constructors": [
+        {
+          "name": "MapEngine",
+          "fields": [
+            {
+              "name": "min_confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.2"
+            },
+            {
+              "name": "sample_size",
+              "type": "int",
+              "required": false,
+              "default": "500"
+            },
+            {
+              "name": "scorers",
+              "type": "any",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "config_path",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "return_score_matrix",
+              "type": "bool",
+              "required": false,
+              "default": "False"
+            },
+            {
+              "name": "calibrator",
+              "type": "Calibrator \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "domains",
+              "type": "list[str] \\| None",
+              "required": false,
+              "default": "None"
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "apply",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source CSV file to apply mapping to"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Path to mapping config YAML (required)"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": true,
+              "help": "Output CSV path (required)"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        },
+        {
+          "command": "inspect",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data to inspect (CSV path, schema YAML, etc.)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Table name for DB sources"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        },
+        {
+          "command": "map",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
+            },
+            {
+              "name": "target",
+              "type": "text",
+              "required": true,
+              "help": "Target data (same variety of inputs)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional table name for DB sources"
+            },
+            {
+              "name": "--required",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated required target field names"
+            },
+            {
+              "name": "--schema-file",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to schema YAML file"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "'table'",
+              "help": "Output format: table, json, or yaml"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Save mapping config to this YAML file"
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.2",
+              "help": "Minimum confidence threshold (default 0.2, was 0.3 before v0.3)"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            },
+            {
+              "name": "--debug",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable debug logging"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: 'stdio' or 'http'"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data to validate (CSV path, etc.)"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Path to mapping config YAML (required)"
+            },
+            {
+              "name": "--required",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated required field names"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit code 1 if required fields unmapped"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "apply",
+          "description": "Apply a saved mapping config to a source CSV, renaming columns according to the mapping and writing the result to an output file."
+        },
+        {
+          "name": "inspect",
+          "description": "Inspect a data source — show fields, types, sample values, null rates, unique rates, and statistics."
+        },
+        {
+          "name": "map",
+          "description": "Map source columns to target schema using a weighted scorer pipeline with optimal 1:1 assignment. Returns mappings with confidence scores and human-readable reasoning."
+        },
+        {
+          "name": "validate",
+          "description": "Validate that a source file's columns satisfy a saved mapping config. Reports missing source columns and unmapped required fields."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Data types",
+          "target": "infermap.types:VALID_DTYPES",
+          "applies": "`FieldInfo.dtype`",
+          "values": [
+            {
+              "value": "boolean",
+              "meaning": "True/false."
+            },
+            {
+              "value": "date",
+              "meaning": "Calendar date."
+            },
+            {
+              "value": "datetime",
+              "meaning": "Date and time."
+            },
+            {
+              "value": "float",
+              "meaning": "Decimal number."
+            },
+            {
+              "value": "integer",
+              "meaning": "Whole number."
+            },
+            {
+              "value": "string",
+              "meaning": "Text."
+            }
+          ]
+        },
+        {
+          "title": "Semantic pattern types",
+          "target": "infermap.scorers.pattern_type:SEMANTIC_TYPES",
+          "applies": "pattern-type detection",
+          "values": [
+            {
+              "value": "currency",
+              "meaning": "Currency amount."
+            },
+            {
+              "value": "date_iso",
+              "meaning": "ISO-8601 date."
+            },
+            {
+              "value": "email",
+              "meaning": "Email address."
+            },
+            {
+              "value": "ip_v4",
+              "meaning": "IPv4 address."
+            },
+            {
+              "value": "phone",
+              "meaning": "Phone number."
+            },
+            {
+              "value": "url",
+              "meaning": "Web URL."
+            },
+            {
+              "value": "uuid",
+              "meaning": "UUID."
+            },
+            {
+              "value": "zip_us",
+              "meaning": "US ZIP code."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "INFERMAP_NATIVE"
+        ]
+      }
+    },
+    "goldenanalysis": {
+      "nav_group": "GoldenAnalysis",
+      "env_prefix": "GOLDENANALYSIS_",
+      "doc_path": "docs-site/goldenanalysis/config-matrix.mdx",
+      "config_models": [
+        {
+          "name": "RegressionPolicy",
+          "fields": [
+            {
+              "name": "default_pct",
+              "type": "float",
+              "required": false,
+              "default": "10.0",
+              "description": "Percent change from the baseline that counts as a regression for any metric without a per-metric override."
+            },
+            {
+              "name": "per_metric",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-metric percent thresholds keyed by metric name, overriding default_pct for those metrics."
+            }
+          ],
+          "doc": "Per-metric regression thresholds (percent). Falls back to ``default_pct``."
+        }
+      ],
+      "constructors": [
+        {
+          "name": "analyze",
+          "fields": [
+            {
+              "name": "df",
+              "type": "pl.DataFrame",
+              "required": true
+            },
+            {
+              "name": "analyzers",
+              "type": "Sequence[str] \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "dataset",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "run_id",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "generated_at",
+              "type": "datetime \\| None",
+              "required": false,
+              "default": "None"
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "stdio | http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host interface to bind when transport is http."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8300",
+              "help": "HTTP port (A2A convention: Analysis = 8300)."
+            }
+          ]
+        },
+        {
+          "command": "regressions",
+          "options": [
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset name whose run history to check."
+            },
+            {
+              "name": "--history",
+              "type": "path",
+              "required": true,
+              "help": "ReportHistory path (.jsonl or .db)."
+            },
+            {
+              "name": "--baseline",
+              "type": "text",
+              "required": false,
+              "default": "'rolling_median'",
+              "help": "Baseline strategy to compare against, e.g. rolling_median."
+            },
+            {
+              "name": "--window",
+              "type": "integer",
+              "required": false,
+              "default": "7",
+              "help": "Number of prior runs the baseline is computed over."
+            },
+            {
+              "name": "--policy",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
+            },
+            {
+              "name": "--fail-on-regression",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit 1 if any regression is flagged (CI gate)."
+            }
+          ]
+        },
+        {
+          "command": "report",
+          "options": [
+            {
+              "name": "input",
+              "type": "path",
+              "required": true,
+              "help": "A .parquet/.csv frame, or a .json AnalysisReport to re-render."
+            },
+            {
+              "name": "--analyzers",
+              "type": "text",
+              "required": false,
+              "default": "'all'",
+              "help": "Comma-separated analyzer names, or 'all'."
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "'markdown'",
+              "help": "markdown | json"
+            },
+            {
+              "name": "--out",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Write the report here instead of (also) printing."
+            }
+          ]
+        },
+        {
+          "command": "trend",
+          "options": [
+            {
+              "name": "--metric",
+              "type": "text",
+              "required": true,
+              "help": "Metric key to trend, e.g. cluster.singleton_ratio."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset name whose run history to read."
+            },
+            {
+              "name": "--history",
+              "type": "path",
+              "required": true,
+              "help": "ReportHistory path (.jsonl or .db)."
+            },
+            {
+              "name": "--last",
+              "type": "integer",
+              "required": false,
+              "default": "30",
+              "help": "Number of most recent runs to include in the trend."
+            }
+          ]
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Metric direction",
+          "target": "goldenanalysis.models.report:Direction",
+          "applies": "`Metric.direction`",
+          "values": [
+            {
+              "value": "higher_better",
+              "meaning": "A higher value is better; flag a regression on a decrease."
+            },
+            {
+              "value": "lower_better",
+              "meaning": "A lower value is better; flag a regression on an increase."
+            },
+            {
+              "value": "neutral",
+              "meaning": "No preferred direction; never flags a regression."
+            }
+          ]
+        },
+        {
+          "title": "Regression baseline",
+          "target": "goldenanalysis.models.policy:Baseline",
+          "applies": "`--baseline`",
+          "values": [
+            {
+              "value": "last_known_good",
+              "meaning": "Compare against the last run marked good."
+            },
+            {
+              "value": "previous",
+              "meaning": "Compare against the immediately prior run."
+            },
+            {
+              "value": "rolling_median",
+              "meaning": "Compare against the rolling median of recent runs."
+            }
+          ]
+        },
+        {
+          "title": "Analyzers",
+          "target": "goldenanalysis.registry:_FALLBACK",
+          "applies": "`analyze(analyzers=...)`",
+          "values": [
+            {
+              "value": "cluster.distribution",
+              "meaning": "GoldenMatch clusters: count, singletons, size percentiles, reduction ratio."
+            },
+            {
+              "value": "frame.summary",
+              "meaning": "Generic frame stats: row/column counts, null ratio, duplicate ratio, memory."
+            },
+            {
+              "value": "match.rates",
+              "meaning": "GoldenMatch results: pair count, match rate, threshold, recall estimate, score histogram."
+            },
+            {
+              "value": "quality.rollup",
+              "meaning": "GoldenCheck / GoldenFlow rollup: findings, health score, rows changed, rules fired."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "GOLDENANALYSIS_NATIVE"
+        ]
+      }
+    }
+  }
+}

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -1,0 +1,9107 @@
+{
+  "schema": "goldenmatch.agent-manifest/v1",
+  "note": "Generated from scripts/config_matrix (same registry + resolvers as the CI-gated config-matrix docs). DO NOT EDIT. Regenerate: python scripts/gen_config_matrix.py --manifest",
+  "packages": {
+    "goldenmatch": {
+      "nav_group": "GoldenMatch",
+      "env_prefix": "GOLDENMATCH_",
+      "doc_path": "docs-site/goldenmatch/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenmatch",
+        "root": "packages/python/goldenmatch/goldenmatch",
+        "modules": {
+          "config_schema": "packages/python/goldenmatch/goldenmatch/config/schemas.py",
+          "cli": "packages/python/goldenmatch/goldenmatch/cli/main.py",
+          "mcp_server": "packages/python/goldenmatch/goldenmatch/mcp/server.py"
+        }
+      },
+      "config_models": [
+        {
+          "name": "GoldenMatchConfig",
+          "fields": [
+            {
+              "name": "input",
+              "type": "InputConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputConfig"
+              ],
+              "description": "Input files to load; omit when passing a DataFrame directly to the API."
+            },
+            {
+              "name": "output",
+              "type": "OutputConfig",
+              "required": false,
+              "default": "OutputConfig(path=None, format=None, directory=None, run_name=None, lineage_provenance=False)",
+              "nested": [
+                "OutputConfig"
+              ],
+              "description": "Where and how results are written."
+            },
+            {
+              "name": "match_settings",
+              "type": "MatchSettingsConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MatchSettingsConfig"
+              ],
+              "description": "Nested matchkeys container; an alternative to the top-level matchkeys field."
+            },
+            {
+              "name": "matchkeys",
+              "type": "list[MatchkeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MatchkeyConfig"
+              ],
+              "description": "Matchkeys defining how records are compared; takes precedence over match_settings."
+            },
+            {
+              "name": "blocking",
+              "type": "BlockingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingConfig"
+              ],
+              "description": "Candidate-generation configuration; required when any matchkey is weighted or probabilistic."
+            },
+            {
+              "name": "golden_rules",
+              "type": "GoldenRulesConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenRulesConfig"
+              ],
+              "description": "Survivorship rules for building one golden record per cluster."
+            },
+            {
+              "name": "standardization",
+              "type": "StandardizationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "StandardizationConfig"
+              ],
+              "description": "Per-column standardizers applied before matching."
+            },
+            {
+              "name": "validation",
+              "type": "ValidationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ValidationConfig"
+              ],
+              "description": "Validation rules and auto-fix settings applied to the input."
+            },
+            {
+              "name": "quality",
+              "type": "QualityConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "QualityConfig"
+              ],
+              "description": "GoldenCheck data-quality integration settings."
+            },
+            {
+              "name": "transform",
+              "type": "TransformConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "TransformConfig"
+              ],
+              "description": "GoldenFlow data-transformation integration settings."
+            },
+            {
+              "name": "llm_boost",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables active-learning LLM boosting of borderline matches."
+            },
+            {
+              "name": "llm_scorer",
+              "type": "LLMScorerConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "LLMScorerConfig"
+              ],
+              "description": "LLM pair-scoring configuration for borderline candidates."
+            },
+            {
+              "name": "llm_auto",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets auto-config enable and configure the LLM scorer automatically."
+            },
+            {
+              "name": "domain",
+              "type": "DomainConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DomainConfig"
+              ],
+              "description": "Domain feature-extraction configuration used before matchkeys."
+            },
+            {
+              "name": "backend",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Execution backend: None (default Polars in-memory), 'ray', 'duckdb', 'chunked', or 'bucket'."
+            },
+            {
+              "name": "distributed_routing",
+              "type": "DistributedRoutingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DistributedRoutingConfig"
+              ],
+              "description": "Per-stage distributed-routing pins; None lets the planner decide every stage."
+            },
+            {
+              "name": "semantic_blocking",
+              "type": "SemanticBlockingConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SemanticBlockingConfig"
+              ],
+              "description": "Opt-in semantic candidate-generation keys (ANN, initialism, alias) unioned into blocking."
+            },
+            {
+              "name": "allow_slow_path",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Permits falling back to a slower non-fused execution path when the fast path is ineligible."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'standard'",
+              "choices": [
+                "standard",
+                "scale"
+              ],
+              "description": "Execution mode: 'standard' in-memory/Ray (bit-identical) or 'scale' DataFusion spine (out-of-core, reduced features)."
+            },
+            {
+              "name": "planning_effort",
+              "type": "Literal",
+              "required": false,
+              "default": "'normal'",
+              "choices": [
+                "fast",
+                "normal",
+                "thinking",
+                "einstein"
+              ],
+              "description": "Auto-config planning-effort tier (spec 2026-06-06 §Phase 0). Controls how hard the controller searches: 'fast' = a single cheap pass; 'normal' (default) = today's interactive budget; 'thinking'/'einstein' spend the freed engine cycles on a larger sample, more refit iterations, and — at thinking+ — measuring real blocking on the full frame instead of extrapolating. Overridable via the GOLDENMATCH_PLANNING_EFFORT env var. Default 'normal' is byte-for-byte the prior behavior."
+            },
+            {
+              "name": "throughput",
+              "type": "ThroughputConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ThroughputConfig"
+              ],
+              "description": "Opt-in sketch-then-verify throughput tier for high-recall, low-cost dedup."
+            },
+            {
+              "name": "memory",
+              "type": "MemoryConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MemoryConfig"
+              ],
+              "description": "Learning Memory configuration for persisting corrections and learned thresholds."
+            },
+            {
+              "name": "identity",
+              "type": "IdentityConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "IdentityConfig"
+              ],
+              "description": "Identity Graph configuration for stable cross-run entity ids."
+            },
+            {
+              "name": "exclude_columns",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Column names to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking. GoldenFlow transforms skip them entirely (column passes through unchanged). Layered ADDITIVELY with GoldenCheck detector-derived exclusions (#404) -- the user list is OR'd with auto-detection, not a replacement. `QualityConfig.autoconfig_force_include` still wins on conflict (rescue beats every opt-out path). Column still appears in golden record output -- exclusion is about matching + transforming, not output. See spec docs/superpowers/specs/2026-05-21-unified-column-exclusions-design.md."
+            },
+            {
+              "name": "prepared_record_store",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When True, the prep stage (quality scan + transform + auto-fix) writes its output to a DuckDB-backed disk store keyed by config signature. Subsequent calls with the same config + data shape read prepared records from disk instead of re-prepping. Path via GOLDENMATCH_PREPARED_RECORD_STORE_DIR env var; persistence via GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST=1. Spec: docs/superpowers/specs/2026-05-15-distributed-plan-v1-design.md §Component 1."
+            },
+            {
+              "name": "partitioned_block_scoring",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When True AND prepared_record_store is True, the pipeline materializes blocks to the disk store as a side effect of build_blocks (Component 2 Phase 2 of Distributed Plan v1). Stages on-disk blocks for Component 3 (distributed scoring); no single-process win expected. Default off."
+            },
+            {
+              "name": "n_buckets",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Number of hash buckets for Component 2 v2 bucketed Parquet storage. None means use the heuristic default max(cpu_count() * 4, 64). Hard-capped at 1024. Spec: docs/superpowers/specs/2026-05-17-distributed-plan-component-2-v2-bucketed-storage-design.md §Configuration."
+            }
+          ]
+        },
+        {
+          "name": "InputConfig",
+          "fields": [
+            {
+              "name": "files",
+              "type": "list[InputFileConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "Input files to load and combine, used for deduplication across one or more sources."
+            },
+            {
+              "name": "file_a",
+              "type": "InputFileConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "First file in a two-source record-linkage (match) run."
+            },
+            {
+              "name": "file_b",
+              "type": "InputFileConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "InputFileConfig"
+              ],
+              "description": "Second file matched against file_a in a two-source record-linkage run."
+            }
+          ]
+        },
+        {
+          "name": "OutputConfig",
+          "fields": [
+            {
+              "name": "path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Destination file path for the primary results output."
+            },
+            {
+              "name": "format",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Output file format (e.g. csv or parquet); inferred from the path when unset."
+            },
+            {
+              "name": "directory",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Directory the run's output artifacts are written into."
+            },
+            {
+              "name": "run_name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Name identifying this run, used to key output subdirectories and lineage."
+            },
+            {
+              "name": "lineage_provenance",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Adds per-field golden-record provenance (winning value plus source row id) to the lineage sidecar."
+            }
+          ]
+        },
+        {
+          "name": "MatchSettingsConfig",
+          "fields": [
+            {
+              "name": "matchkeys",
+              "type": "list[MatchkeyConfig]",
+              "required": true,
+              "nested": [
+                "MatchkeyConfig"
+              ],
+              "description": "Matchkeys defining how records are compared and declared the same."
+            }
+          ]
+        },
+        {
+          "name": "MatchkeyConfig",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str",
+              "required": true,
+              "description": "Identifier for this matchkey, used in output and logs."
+            },
+            {
+              "name": "type",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "exact",
+                "weighted",
+                "probabilistic"
+              ],
+              "description": "Matching mode: exact equality, weighted per-field scoring, or probabilistic Fellegi-Sunter."
+            },
+            {
+              "name": "comparison",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Alias for 'type' accepting the same exact/weighted/probabilistic values."
+            },
+            {
+              "name": "fields",
+              "type": "list[MatchkeyField]",
+              "required": true,
+              "nested": [
+                "MatchkeyField"
+              ],
+              "description": "Fields compared to decide whether two records match under this matchkey."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Score at or above which a pair is accepted as a match; required for weighted matchkeys."
+            },
+            {
+              "name": "auto_threshold",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables automatic Otsu-style tuning of the accept threshold from the score distribution."
+            },
+            {
+              "name": "rerank",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables cross-encoder reranking of borderline pairs near the threshold."
+            },
+            {
+              "name": "rerank_model",
+              "type": "str",
+              "required": false,
+              "default": "'cross-encoder/ms-marco-MiniLM-L-6-v2'",
+              "description": "Cross-encoder model used to rerank borderline pairs when rerank is on."
+            },
+            {
+              "name": "rerank_band",
+              "type": "float",
+              "required": false,
+              "default": "0.1",
+              "description": "Half-width of the score band around the threshold within which pairs are reranked."
+            },
+            {
+              "name": "negative_evidence",
+              "type": "list[NegativeEvidenceField] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "NegativeEvidenceField"
+              ],
+              "description": "Fields whose disagreement penalizes the match score, catching false positives that agree on other fields."
+            },
+            {
+              "name": "em_iterations",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Maximum EM iterations when training probabilistic weights."
+            },
+            {
+              "name": "convergence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.001",
+              "description": "EM stops early once parameter change between iterations falls below this value."
+            },
+            {
+              "name": "link_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Probabilistic match probability at or above which a pair is auto-linked."
+            },
+            {
+              "name": "review_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Probabilistic match probability at or above which a pair is sent for manual review; must not exceed link_threshold."
+            },
+            {
+              "name": "model_path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "File where the trained probabilistic model is loaded from if present, or saved to after training."
+            },
+            {
+              "name": "missing",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "unobserved",
+                "disagree"
+              ],
+              "description": "How a missing value is treated probabilistically: 'unobserved' contributes nothing, 'disagree' counts against a match."
+            }
+          ],
+          "doc": "A matchkey: rule for declaring two records 'the same' on a field/field-set."
+        },
+        {
+          "name": "BlockingConfig",
+          "fields": [
+            {
+              "name": "keys",
+              "type": "list[BlockingKeyConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Blocking keys that generate candidate pairs; records sharing any key are compared."
+            },
+            {
+              "name": "max_block_size",
+              "type": "int",
+              "required": false,
+              "default": "5000",
+              "description": "Ceiling on how many records one block may hold before it is treated as oversized."
+            },
+            {
+              "name": "skip_oversized",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When true, blocks exceeding max_block_size are dropped rather than scored, guarding against mega-block blowups."
+            },
+            {
+              "name": "strategy",
+              "type": "Literal",
+              "required": false,
+              "default": "'static'",
+              "choices": [
+                "static",
+                "adaptive",
+                "sorted_neighborhood",
+                "multi_pass",
+                "ann",
+                "canopy",
+                "ann_pairs",
+                "learned",
+                "lsh",
+                "simhash",
+                "perceptual"
+              ],
+              "description": "Candidate-generation method that selects how pairs are proposed for scoring."
+            },
+            {
+              "name": "learned_sample_size",
+              "type": "int",
+              "required": false,
+              "default": "5000",
+              "description": "Number of sampled records the learned-predicate miner trains its blocking rules on."
+            },
+            {
+              "name": "learned_min_recall",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Minimum pair recall a learned predicate must retain to be accepted."
+            },
+            {
+              "name": "learned_min_reduction",
+              "type": "float",
+              "required": false,
+              "default": "0.9",
+              "description": "Minimum fraction of the full comparison space a learned predicate must eliminate."
+            },
+            {
+              "name": "learned_predicate_depth",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "Maximum number of conjoined conditions in a mined blocking predicate."
+            },
+            {
+              "name": "learned_cache_path",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "File where learned blocking predicates are persisted for reuse across runs."
+            },
+            {
+              "name": "auto_suggest",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets the engine discover blocking keys at runtime instead of using the static keys."
+            },
+            {
+              "name": "auto_select",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Lets the engine pick the best blocking strategy automatically."
+            },
+            {
+              "name": "sub_block_keys",
+              "type": "list[BlockingKeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Secondary keys used to split oversized blocks into smaller candidate sets."
+            },
+            {
+              "name": "window_size",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Sliding-window width, in sorted records, for sorted-neighborhood blocking."
+            },
+            {
+              "name": "sort_key",
+              "type": "list[SortKeyField] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SortKeyField"
+              ],
+              "description": "Ordered columns records are sorted on for sorted-neighborhood blocking."
+            },
+            {
+              "name": "passes",
+              "type": "list[BlockingKeyConfig] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BlockingKeyConfig"
+              ],
+              "description": "Sequence of blocking key sets applied in separate passes for multi_pass blocking."
+            },
+            {
+              "name": "union_mode",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "When true, candidate pairs from all passes are unioned rather than intersected."
+            },
+            {
+              "name": "max_total_comparisons",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Global cap on the number of candidate pairs generated across all blocks."
+            },
+            {
+              "name": "ann_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Text column embedded for approximate-nearest-neighbor blocking."
+            },
+            {
+              "name": "ann_model",
+              "type": "str",
+              "required": false,
+              "default": "'all-MiniLM-L6-v2'",
+              "description": "Embedding model used to vectorize records for ANN blocking."
+            },
+            {
+              "name": "ann_top_k",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Number of nearest neighbors retrieved per record in ANN blocking."
+            },
+            {
+              "name": "canopy",
+              "type": "CanopyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "CanopyConfig"
+              ],
+              "description": "Configuration for canopy clustering when the strategy is 'canopy'."
+            },
+            {
+              "name": "lsh",
+              "type": "LSHKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "LSHKeyConfig"
+              ],
+              "description": "MinHash/LSH configuration required when the strategy is 'lsh'."
+            },
+            {
+              "name": "simhash",
+              "type": "SimHashKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SimHashKeyConfig"
+              ],
+              "description": "SimHash/LSH configuration required when the strategy is 'simhash'."
+            },
+            {
+              "name": "perceptual",
+              "type": "PerceptualKeyConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "PerceptualKeyConfig"
+              ],
+              "description": "Perceptual-hash LSH configuration used when the strategy is 'perceptual'."
+            }
+          ]
+        },
+        {
+          "name": "GoldenRulesConfig",
+          "fields": [
+            {
+              "name": "default_strategy",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Survivorship strategy applied to any field without its own rule; required unless 'default' is set."
+            },
+            {
+              "name": "default",
+              "type": "GoldenFieldRule | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Full default rule whose strategy backfills default_strategy when the latter is unset."
+            },
+            {
+              "name": "field_rules",
+              "type": "dict[str, GoldenFieldRule | list[GoldenFieldRule]]",
+              "required": false,
+              "default": "{}",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Per-column survivorship rules, or an ordered list of conditional rules ending in a default clause."
+            },
+            {
+              "name": "field_groups",
+              "type": "list[GoldenGroupRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "GoldenGroupRule"
+              ],
+              "description": "Groups of columns resolved together so their values stay mutually consistent."
+            },
+            {
+              "name": "field_group_detection",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables automatic discovery of related column groups to resolve as units."
+            },
+            {
+              "name": "max_cluster_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Cluster size above which auto-split intervenes to break up likely over-merged clusters."
+            },
+            {
+              "name": "auto_split",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables splitting oversized clusters into tighter subclusters before building golden records."
+            },
+            {
+              "name": "quality_weighting",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Weights survivorship choices by per-source completeness and quality signals."
+            },
+            {
+              "name": "weak_cluster_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Cohesion score below which a cluster is flagged as weak and handled more conservatively."
+            },
+            {
+              "name": "split_edge_budget",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Cap on cumulative edge work spent auto-splitting clusters; None auto-scales from the row count."
+            },
+            {
+              "name": "adaptive",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables post-cluster refinement that re-picks per-field strategies from cluster health and profiles."
+            },
+            {
+              "name": "use_llm_for_ambiguous",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Falls back to one cached LLM call per field to pick a strategy when the heuristic refiner is undecided."
+            },
+            {
+              "name": "cluster_overrides",
+              "type": "dict[int, dict[str, GoldenFieldRule]] | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "GoldenFieldRule"
+              ],
+              "description": "Per-cluster field rules that supersede the top-level rules for the named clusters only."
+            }
+          ]
+        },
+        {
+          "name": "StandardizationConfig",
+          "fields": [
+            {
+              "name": "rules",
+              "type": "dict[str, list[str]]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-column ordered standardizer names applied before matching."
+            }
+          ]
+        },
+        {
+          "name": "ValidationConfig",
+          "fields": [
+            {
+              "name": "rules",
+              "type": "list[ValidationRuleConfig]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "ValidationRuleConfig"
+              ],
+              "description": "Per-column validation rules run against the input before matching."
+            },
+            {
+              "name": "auto_fix",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Runs GoldenFlow auto-fix on the data before validation executes."
+            }
+          ]
+        },
+        {
+          "name": "QualityConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables GoldenCheck quality scanning and fixes; auto-detected true when goldencheck is installed."
+            },
+            {
+              "name": "mode",
+              "type": "str",
+              "required": false,
+              "default": "'announced'",
+              "description": "How quality findings are surfaced: 'silent', 'announced', or 'disabled'."
+            },
+            {
+              "name": "fix_mode",
+              "type": "str",
+              "required": false,
+              "default": "'safe'",
+              "description": "How aggressively quality fixes are applied: 'safe', 'moderate', or 'none'."
+            },
+            {
+              "name": "domain",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Domain pack tuning the quality checks, such as 'healthcare', 'finance', or 'ecommerce'."
+            },
+            {
+              "name": "autoconfig_force_exclude",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns always excluded from matching regardless of auto-detection."
+            },
+            {
+              "name": "autoconfig_force_include",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns rescued from any auto-exclusion; wins on conflict with force_exclude."
+            }
+          ],
+          "doc": "GoldenCheck integration config for enhanced data quality."
+        },
+        {
+          "name": "TransformConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Enables GoldenFlow data transformation; auto-detected true when goldenflow is installed."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'announced'",
+              "choices": [
+                "silent",
+                "announced",
+                "disabled"
+              ],
+              "description": "How applied transforms are surfaced: 'silent', 'announced', or 'disabled'."
+            }
+          ],
+          "doc": "GoldenFlow integration config for data transformation."
+        },
+        {
+          "name": "LLMScorerConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on LLM scoring of borderline candidate pairs."
+            },
+            {
+              "name": "provider",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "LLM provider ('openai' or 'anthropic'); auto-detected from credentials when None."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "LLM model name (e.g. 'gpt-4o-mini'); auto-detected when None."
+            },
+            {
+              "name": "auto_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Score above which pairs are auto-accepted without an LLM call."
+            },
+            {
+              "name": "candidate_lo",
+              "type": "float",
+              "required": false,
+              "default": "0.75",
+              "description": "Lower bound of the score band whose pairs are sent to the LLM."
+            },
+            {
+              "name": "candidate_hi",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Upper bound of the score band whose pairs are sent to the LLM."
+            },
+            {
+              "name": "batch_size",
+              "type": "int",
+              "required": false,
+              "default": "75",
+              "description": "Number of pairs packed into a single LLM request."
+            },
+            {
+              "name": "max_workers",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Number of concurrent LLM requests."
+            },
+            {
+              "name": "calibration_sample_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Pairs sampled per calibration round to tune the accept threshold."
+            },
+            {
+              "name": "calibration_max_rounds",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Maximum threshold-calibration rounds before stopping."
+            },
+            {
+              "name": "calibration_convergence_delta",
+              "type": "float",
+              "required": false,
+              "default": "0.01",
+              "description": "Calibration stops once the threshold shift between rounds falls below this."
+            },
+            {
+              "name": "budget",
+              "type": "BudgetConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BudgetConfig"
+              ],
+              "description": "Cost and call limits governing LLM usage; None means unbounded."
+            },
+            {
+              "name": "mode",
+              "type": "str",
+              "required": false,
+              "default": "'pairwise'",
+              "description": "LLM scoring mode: 'pairwise' per-pair scoring or 'cluster' in-context block clustering."
+            },
+            {
+              "name": "cluster_max_size",
+              "type": "int",
+              "required": false,
+              "default": "100",
+              "description": "Maximum records per LLM cluster block in cluster mode."
+            },
+            {
+              "name": "cluster_min_size",
+              "type": "int",
+              "required": false,
+              "default": "5",
+              "description": "Block size below which cluster mode falls back to pairwise scoring."
+            }
+          ]
+        },
+        {
+          "name": "DomainConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on domain feature extraction as a pipeline step before matchkeys."
+            },
+            {
+              "name": "mode",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Domain to extract for ('product', 'person', 'bibliographic', 'company', or 'auto' to detect)."
+            },
+            {
+              "name": "confidence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Extraction confidence below which a record is routed to the LLM instead."
+            },
+            {
+              "name": "llm_validation",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Uses the LLM to validate low-confidence extractions."
+            },
+            {
+              "name": "budget",
+              "type": "BudgetConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "BudgetConfig"
+              ],
+              "description": "Cost and call limits for the domain-extraction LLM calls."
+            }
+          ]
+        },
+        {
+          "name": "DistributedRoutingConfig",
+          "fields": [
+            {
+              "name": "scoring",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed",
+                "in_process"
+              ],
+              "description": "Pins where pair scoring runs; 'auto' lets the planner choose distributed vs in-process."
+            },
+            {
+              "name": "clustering",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed_wcc",
+                "in_memory_scipy"
+              ],
+              "description": "Pins the clustering engine; 'auto' lets the planner choose distributed WCC vs in-memory scipy."
+            },
+            {
+              "name": "golden",
+              "type": "Literal",
+              "required": false,
+              "default": "'auto'",
+              "choices": [
+                "auto",
+                "distributed",
+                "in_process"
+              ],
+              "description": "Pins where golden-record building runs; 'auto' lets the planner choose distributed vs in-process."
+            }
+          ],
+          "doc": "Per-stage distributed-routing pins. ``auto`` lets the planner decide;"
+        },
+        {
+          "name": "SemanticBlockingConfig",
+          "fields": [
+            {
+              "name": "keys",
+              "type": "list[Literal]",
+              "required": false,
+              "default": "['ann', 'initialism', 'alias']",
+              "choices": [
+                "ann",
+                "initialism",
+                "alias"
+              ],
+              "description": "Which semantic blocking keys to union into candidate generation: 'ann' (embedding nearest-neighbors), 'initialism' (initialism expansion), 'alias' (alias-table lookups)."
+            },
+            {
+              "name": "ann_model",
+              "type": "str",
+              "required": false,
+              "default": "'inhouse'",
+              "description": "Embedding model id for the ANN key (e.g. 'inhouse')."
+            },
+            {
+              "name": "ann_top_k",
+              "type": "int",
+              "required": false,
+              "default": "20",
+              "description": "Number of ANN neighbors retrieved per record for candidate generation."
+            },
+            {
+              "name": "ann_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.5",
+              "description": "Minimum ANN similarity for a neighbor to become a candidate pair."
+            },
+            {
+              "name": "alias_tables",
+              "type": "list[Literal]",
+              "required": false,
+              "default": "['given_names', 'business']",
+              "choices": [
+                "given_names",
+                "business"
+              ],
+              "description": "Which alias tables the 'alias' key consults."
+            }
+          ],
+          "doc": "Opt-in semantic candidate-generation (recall-lever) config. Carries the"
+        },
+        {
+          "name": "ThroughputConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on the sketch-then-verify throughput tier in place of per-field fuzzy/FS scoring."
+            },
+            {
+              "name": "recall_target",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "description": "Desired blocking recall the sketch tier tunes its band count toward."
+            },
+            {
+              "name": "similarity_threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Overrides the default near-duplicate similarity cutoff; None uses the metric-specific default."
+            }
+          ],
+          "doc": "Opt-in sketch-then-verify throughput tier (#1083)."
+        },
+        {
+          "name": "MemoryConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Turns on Learning Memory so stored corrections and learned thresholds feed back into runs."
+            },
+            {
+              "name": "backend",
+              "type": "str",
+              "required": false,
+              "default": "'sqlite'",
+              "description": "Storage backend for the memory store ('sqlite' or 'postgres')."
+            },
+            {
+              "name": "path",
+              "type": "str",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "description": "SQLite file path for the memory store when the backend is sqlite."
+            },
+            {
+              "name": "connection",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Database connection string used when the backend is postgres."
+            },
+            {
+              "name": "trust",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{'human': 1.0, 'agent': 0.5}",
+              "description": "Per-source trust weights that scale how strongly a correction's origin influences learning."
+            },
+            {
+              "name": "learning",
+              "type": "LearningConfig",
+              "required": false,
+              "default": "LearningConfig(threshold_min_corrections=10, weights_min_corrections=50)",
+              "nested": [
+                "LearningConfig"
+              ],
+              "description": "Thresholds governing how many corrections are needed before rules are learned."
+            },
+            {
+              "name": "reanchor",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Re-anchors stored corrections to current rows by record hash so they survive row reordering."
+            },
+            {
+              "name": "dataset",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Dataset name scoping corrections so unrelated datasets do not share memory."
+            },
+            {
+              "name": "table_prefix",
+              "type": "str",
+              "required": false,
+              "default": "''",
+              "description": "Prefix applied to memory table names, letting multiple stores share one database."
+            }
+          ],
+          "doc": "Learning Memory configuration."
+        },
+        {
+          "name": "IdentityConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on the durable identity graph that assigns stable entity ids across runs after clustering."
+            },
+            {
+              "name": "backend",
+              "type": "str",
+              "required": false,
+              "default": "'sqlite'",
+              "description": "Storage backend for the identity graph ('sqlite' or 'postgres')."
+            },
+            {
+              "name": "path",
+              "type": "str",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "description": "SQLite file path for the identity graph when the backend is sqlite."
+            },
+            {
+              "name": "connection",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Database connection string used when the backend is postgres."
+            },
+            {
+              "name": "dataset",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Dataset name scoping identities so unrelated datasets do not share entity ids."
+            },
+            {
+              "name": "source_pk_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying each record's source primary key for stable record ids; a payload hash is used when unset."
+            },
+            {
+              "name": "emit_singletons",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Whether single-record clusters also get a durable entity id."
+            },
+            {
+              "name": "weak_confidence_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.6",
+              "description": "Cluster confidence below which the bottleneck pair is flagged as a conflict for steward review; 0 disables it."
+            },
+            {
+              "name": "stitching",
+              "type": "ChannelStitchConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "ChannelStitchConfig"
+              ],
+              "description": "Cross-device/channel stitching configuration; None leaves identity resolution unchanged."
+            },
+            {
+              "name": "survivorship",
+              "type": "SurvivorshipConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "SurvivorshipConfig"
+              ],
+              "description": "Identity golden-record survivorship configuration; None keeps the default flat golden record."
+            },
+            {
+              "name": "stabilization",
+              "type": "StabilizationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "StabilizationConfig"
+              ],
+              "description": "Cross-run entity stabilization configuration; None runs no stabilize pass."
+            },
+            {
+              "name": "mediation",
+              "type": "MediationConfig | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "MediationConfig"
+              ],
+              "description": "Conflict mediation workflow configuration; None leaves mediation unconfigured."
+            }
+          ],
+          "doc": "Identity Graph configuration."
+        },
+        {
+          "name": "InputFileConfig",
+          "fields": [
+            {
+              "name": "path",
+              "type": "str",
+              "required": true,
+              "description": "Filesystem path to the input data file."
+            },
+            {
+              "name": "id_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column holding a stable record identifier; a row index is used when unset."
+            },
+            {
+              "name": "source_label",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Human-readable label attached to records from this file."
+            },
+            {
+              "name": "source_name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Source name recorded on each record for provenance and source-priority survivorship."
+            },
+            {
+              "name": "column_map",
+              "type": "dict[str, str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Renames raw file columns to canonical names before matching."
+            },
+            {
+              "name": "delimiter",
+              "type": "str",
+              "required": false,
+              "default": "','",
+              "description": "Field delimiter for delimited text files."
+            },
+            {
+              "name": "encoding",
+              "type": "str",
+              "required": false,
+              "default": "'utf8'",
+              "description": "Character encoding used to decode the file."
+            },
+            {
+              "name": "sheet",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Worksheet name to read from an Excel workbook."
+            },
+            {
+              "name": "parse_mode",
+              "type": "str",
+              "required": false,
+              "default": "'auto'",
+              "description": "How the file is parsed: auto, delimited, fixed_width, key_value, block, or entity_extract."
+            },
+            {
+              "name": "header_row",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Zero-based row index that holds column headers."
+            },
+            {
+              "name": "has_header",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether the file has a header row; None lets the parser infer it."
+            },
+            {
+              "name": "skip_rows",
+              "type": "list[int] | None",
+              "required": false,
+              "default": "None",
+              "description": "Row indices to skip while reading, such as banner or junk lines."
+            }
+          ]
+        },
+        {
+          "name": "MatchkeyField",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Source column this field compares on; may be given as 'column' instead."
+            },
+            {
+              "name": "column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Alias for 'field' naming the source column to compare."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before scoring, in order."
+            },
+            {
+              "name": "scorer",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Similarity comparator used to score agreement between the two values."
+            },
+            {
+              "name": "weight",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Relative importance of this field's agreement within a weighted matchkey."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Embedding model name used when the scorer is 'embedding'."
+            },
+            {
+              "name": "columns",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Set of source columns fused into one vector when the scorer is 'record_embedding'."
+            },
+            {
+              "name": "column_weights",
+              "type": "dict[str, float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Per-column weights blending the inputs for the 'record_embedding' scorer."
+            },
+            {
+              "name": "levels",
+              "type": "int",
+              "required": false,
+              "default": "2",
+              "description": "Number of probabilistic agreement bands (2=agree/disagree, 3=agree/partial/disagree)."
+            },
+            {
+              "name": "partial_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.8",
+              "description": "Similarity at or above which a 3-level comparison counts as a partial agreement."
+            },
+            {
+              "name": "tf_adjustment",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Enables Winkler term-frequency weighting so agreement on a rare value counts more than on a common one."
+            },
+            {
+              "name": "tf_freqs",
+              "type": "dict[str, float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Precomputed value-to-frequency table that drives data-driven downweighting of common values."
+            },
+            {
+              "name": "type",
+              "type": "Literal | None",
+              "required": false,
+              "default": "None",
+              "choices": [
+                "exact",
+                "weighted",
+                "probabilistic"
+              ],
+              "description": "Workbench hint for which matchkey kind to wrap this field in when translating a flat field list."
+            },
+            {
+              "name": "em_iterations",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Per-field cap on EM training iterations for a probabilistic comparison."
+            },
+            {
+              "name": "level_thresholds",
+              "type": "list[float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Descending similarity cutoffs defining each custom probabilistic band; must hold levels-1 entries."
+            }
+          ]
+        },
+        {
+          "name": "NegativeEvidenceField",
+          "fields": [
+            {
+              "name": "field",
+              "type": "str",
+              "required": true,
+              "description": "Column whose disagreement between two records counts as evidence against a match."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before the disagreement check."
+            },
+            {
+              "name": "scorer",
+              "type": "str",
+              "required": true,
+              "description": "Similarity comparator used to decide whether the two values disagree."
+            },
+            {
+              "name": "threshold",
+              "type": "float",
+              "required": true,
+              "description": "Similarity below which the two values are treated as disagreeing and the penalty fires."
+            },
+            {
+              "name": "penalty",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Flat 0-1 amount subtracted from a weighted/exact score on disagreement."
+            },
+            {
+              "name": "penalty_bits",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Fixed log-likelihood-ratio penalty in bits applied on disagreement for probabilistic matchkeys, overriding EM."
+            },
+            {
+              "name": "derive_from",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Source columns space-joined to synthesize the compared field when it is not present in the raw frame."
+            }
+          ],
+          "doc": "v1.11: a field whose disagreement subtracts from a weighted matchkey's"
+        },
+        {
+          "name": "BlockingKeyConfig",
+          "fields": [
+            {
+              "name": "fields",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns whose combined values form the blocking key; records sharing a key become candidate pairs."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to every field before deriving the block key."
+            },
+            {
+              "name": "field_transforms",
+              "type": "dict[str, list[str]]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-field transform chains overriding the key-level transforms for the named fields only."
+            }
+          ]
+        },
+        {
+          "name": "SortKeyField",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column records are sorted on for sorted-neighborhood blocking."
+            },
+            {
+              "name": "transforms",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Normalization steps applied to the value before sorting."
+            }
+          ]
+        },
+        {
+          "name": "CanopyConfig",
+          "fields": [
+            {
+              "name": "fields",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns used to compute cheap similarity when forming canopies."
+            },
+            {
+              "name": "loose_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.3",
+              "description": "Loose similarity at or above which a record joins a canopy as a candidate."
+            },
+            {
+              "name": "tight_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.7",
+              "description": "Tight similarity at or above which a record is removed from the pool so it seeds no new canopy."
+            },
+            {
+              "name": "max_canopy_size",
+              "type": "int",
+              "required": false,
+              "default": "500",
+              "description": "Ceiling on records in one canopy, capping the candidate pairs it can generate."
+            }
+          ]
+        },
+        {
+          "name": "LSHKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Text column MinHash/LSH blocks on to group near-duplicate strings."
+            },
+            {
+              "name": "mode",
+              "type": "Literal",
+              "required": false,
+              "default": "'char'",
+              "choices": [
+                "char",
+                "word"
+              ],
+              "description": "Whether shingles are character-grams or word-grams before hashing."
+            },
+            {
+              "name": "k",
+              "type": "int",
+              "required": false,
+              "default": "3",
+              "description": "Shingle size (number of chars or words per gram)."
+            },
+            {
+              "name": "num_perms",
+              "type": "int",
+              "required": false,
+              "default": "128",
+              "description": "Number of MinHash permutations; more permutations sharpen the similarity estimate at higher cost."
+            },
+            {
+              "name": "seed",
+              "type": "int",
+              "required": false,
+              "default": "0",
+              "description": "Random seed making the MinHash permutations reproducible."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Target Jaccard similarity from which the band/row split is derived when num_bands is unset."
+            },
+            {
+              "name": "num_bands",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Explicit LSH band count (must divide num_perms); overrides threshold when set."
+            }
+          ],
+          "doc": "MinHash/LSH blocking on a text column (#1081)."
+        },
+        {
+          "name": "SimHashKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Text column embedded then SimHash-blocked to group semantically near records."
+            },
+            {
+              "name": "num_planes",
+              "type": "int",
+              "required": false,
+              "default": "256",
+              "description": "Number of random hyperplanes the embedding is projected through to form the SimHash signature."
+            },
+            {
+              "name": "seed",
+              "type": "int",
+              "required": false,
+              "default": "0",
+              "description": "Random seed making the SimHash hyperplanes reproducible."
+            },
+            {
+              "name": "threshold",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Target cosine similarity from which the band/row split is derived when num_bands is unset."
+            },
+            {
+              "name": "num_bands",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Explicit LSH band count (must divide num_planes); overrides threshold when set."
+            },
+            {
+              "name": "model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Embedding model used to vectorize the column; None uses the in-house ER embedder."
+            }
+          ],
+          "doc": "SimHash/LSH blocking on a text column via dense embeddings (#1082)."
+        },
+        {
+          "name": "PerceptualKeyConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column holding fixed-width hex perceptual hashes to block media near-duplicates on."
+            },
+            {
+              "name": "num_bands",
+              "type": "int",
+              "required": false,
+              "default": "16",
+              "description": "Number of contiguous bit-bands the hash is split into; more bands raise recall and candidate pairs."
+            },
+            {
+              "name": "hash_bits",
+              "type": "int",
+              "required": false,
+              "default": "64",
+              "description": "Total bit width of the perceptual hash; must be a positive multiple of num_bands."
+            }
+          ],
+          "doc": "Banded hamming-LSH blocking over a column of perceptual hashes (ADR 0022)."
+        },
+        {
+          "name": "GoldenFieldRule",
+          "fields": [
+            {
+              "name": "strategy",
+              "type": "str",
+              "required": true,
+              "description": "Survivorship strategy that picks the winning value for a field across a cluster's records."
+            },
+            {
+              "name": "date_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying recency, required by the 'most_recent' strategy."
+            },
+            {
+              "name": "source_priority",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Ordered source names preferred first, required by the 'source_priority' strategy."
+            },
+            {
+              "name": "when",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Predicate over already-resolved fields gating whether this rule applies."
+            },
+            {
+              "name": "validate_with",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Name of a goldenflow validator that filters candidate values before survivorship.",
+              "alias": "validate"
+            }
+          ]
+        },
+        {
+          "name": "GoldenGroupRule",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str",
+              "required": true,
+              "description": "Identifier for this group of columns that must survive together."
+            },
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Related columns resolved as a unit so their values stay from a single source record."
+            },
+            {
+              "name": "category",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional label categorizing the group for reporting."
+            },
+            {
+              "name": "strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_complete'",
+              "description": "Survivorship strategy applied to the group as a whole when choosing the winning record."
+            },
+            {
+              "name": "date_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column supplying recency, required by the group's 'most_recent' strategy."
+            },
+            {
+              "name": "source_priority",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Ordered source names preferred first, required by the group's 'source_priority' strategy."
+            },
+            {
+              "name": "anchor",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column whose non-null presence selects the source record, required by and only valid with the 'anchor' strategy."
+            },
+            {
+              "name": "allow_fill",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "When true, individually missing values in the winning record may be filled from other records."
+            }
+          ]
+        },
+        {
+          "name": "ValidationRuleConfig",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column the validation rule is checked against."
+            },
+            {
+              "name": "rule_type",
+              "type": "Literal",
+              "required": true,
+              "choices": [
+                "regex",
+                "min_length",
+                "max_length",
+                "not_null",
+                "in_set",
+                "format"
+              ],
+              "description": "Kind of check applied to the column's values."
+            },
+            {
+              "name": "params",
+              "type": "dict",
+              "required": false,
+              "default": "{}",
+              "description": "Rule-specific parameters, such as the pattern, length bound, or allowed set."
+            },
+            {
+              "name": "action",
+              "type": "Literal",
+              "required": false,
+              "default": "'flag'",
+              "choices": [
+                "null",
+                "quarantine",
+                "flag"
+              ],
+              "description": "What happens to a failing value: null it out, quarantine the row, or just flag it."
+            }
+          ]
+        },
+        {
+          "name": "BudgetConfig",
+          "fields": [
+            {
+              "name": "max_cost_usd",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Hard cap on total LLM spend for the run; calls stop once it is reached."
+            },
+            {
+              "name": "max_calls",
+              "type": "int | None",
+              "required": false,
+              "default": "None",
+              "description": "Hard cap on the number of LLM requests for the run."
+            },
+            {
+              "name": "escalation_model",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Pricier model borderline pairs are escalated to for a second opinion."
+            },
+            {
+              "name": "escalation_band",
+              "type": "list[float]",
+              "required": false,
+              "default": "[0.8, 0.9]",
+              "description": "Score band [low, high] whose pairs are escalated to the pricier model."
+            },
+            {
+              "name": "escalation_budget_pct",
+              "type": "float",
+              "required": false,
+              "default": "20",
+              "description": "Percentage of the budget reserved for escalation to the pricier model."
+            },
+            {
+              "name": "warn_at_pct",
+              "type": "float",
+              "required": false,
+              "default": "80",
+              "description": "Percentage of the budget spent at which a warning is emitted."
+            }
+          ]
+        },
+        {
+          "name": "LearningConfig",
+          "fields": [
+            {
+              "name": "threshold_min_corrections",
+              "type": "int",
+              "required": false,
+              "default": "10",
+              "description": "Minimum stored corrections before learned thresholds are tuned from them."
+            },
+            {
+              "name": "weights_min_corrections",
+              "type": "int",
+              "required": false,
+              "default": "50",
+              "description": "Minimum stored corrections before learned field weights are tuned from them."
+            }
+          ],
+          "doc": "Learning Memory learning parameters."
+        },
+        {
+          "name": "ChannelStitchConfig",
+          "fields": [
+            {
+              "name": "enabled",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Turns on cross-device/channel stitching so a caller can join a person's records across channels."
+            },
+            {
+              "name": "device_keys",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Columns whose shared non-null value is a near-certain same-person signal; empty uses the defaults."
+            },
+            {
+              "name": "channel_column",
+              "type": "str",
+              "required": false,
+              "default": "'channel'",
+              "description": "Column carrying an explicit channel label per record."
+            },
+            {
+              "name": "channel_map",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Exact source-name to channel overrides that beat substring channel inference."
+            },
+            {
+              "name": "channel_trust",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-channel trust weight in (0, 1] used to downweight cross-channel matches; empty uses the defaults."
+            },
+            {
+              "name": "adjust_cross_channel",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Scales probabilistic match scores by the two channels' trust factor."
+            },
+            {
+              "name": "prob_threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "description": "Drops probabilistic stitch edges whose post-adjustment weight falls below this."
+            }
+          ],
+          "doc": "Cross-device / channel stitching configuration (#1110, epic #1108)."
+        },
+        {
+          "name": "SurvivorshipConfig",
+          "fields": [
+            {
+              "name": "field_strategies",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-column survivorship strategy overrides; unlisted columns fall back to default_strategy."
+            },
+            {
+              "name": "default_strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_complete'",
+              "description": "Survivorship strategy applied to any column without its own override."
+            },
+            {
+              "name": "timestamp_column",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Column with a per-record timestamp enabling most_recent survivorship and per-cell provenance."
+            },
+            {
+              "name": "learn_from_corrections",
+              "type": "bool",
+              "required": false,
+              "default": "False",
+              "description": "Folds per-field strategies learned from steward corrections into field_strategies."
+            }
+          ],
+          "doc": "Golden-record survivorship configuration (#1111, epic #1108)."
+        },
+        {
+          "name": "StabilizationConfig",
+          "fields": [
+            {
+              "name": "min_runs",
+              "type": "int",
+              "required": false,
+              "default": "3",
+              "description": "Distinct runs of cross-entity overlap evidence required before two entities auto-consolidate."
+            },
+            {
+              "name": "winner_strategy",
+              "type": "str",
+              "required": false,
+              "default": "'most_records'",
+              "description": "Which entity survives a consolidation: most_records, oldest, newest, or lowest_id."
+            },
+            {
+              "name": "min_score",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "description": "Minimum max-edge score for a cross-entity pair to count as overlap evidence."
+            }
+          ],
+          "doc": "Cross-run entity stabilization -- Identity v3 (#1112, epic #1108)."
+        },
+        {
+          "name": "MediationConfig",
+          "fields": [
+            {
+              "name": "auto_apply",
+              "type": "bool",
+              "required": false,
+              "default": "True",
+              "description": "Whether a 'distinct' mediation verdict actually splits the record out or is only recorded."
+            }
+          ],
+          "doc": "Conflict mediation workflow -- Identity v3 (#1113, epic #1108)."
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8200",
+              "help": "Port for the A2A server"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host to bind to"
+            }
+          ]
+        },
+        {
+          "command": "analyze-blocking",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to analyze"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Config file with matchkeys"
+            }
+          ]
+        },
+        {
+          "command": "anomalies",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--sensitivity",
+              "type": "text",
+              "required": false,
+              "default": "'medium'",
+              "help": "low, medium, or high"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write anomalies to a CSV instead of printing"
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Max rows to print"
+            }
+          ]
+        },
+        {
+          "command": "autoconfig",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files as path or path:source_name"
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write committed config to this path instead of stdout."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Pin a domain rulebook (electronics, software, …) instead of auto-detecting."
+            },
+            {
+              "name": "--show-controller",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Render the controller telemetry panel on stderr."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Include indicator priors + decision trace in the panel."
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress all stderr output (panel + status messages)."
+            }
+          ]
+        },
+        {
+          "command": "compare-clusters",
+          "options": [
+            {
+              "name": "file_a",
+              "type": "text",
+              "required": true,
+              "help": "First cluster JSON file (baseline / ER1)"
+            },
+            {
+              "name": "file_b",
+              "type": "text",
+              "required": true,
+              "help": "Second cluster JSON file (comparison / ER2)"
+            },
+            {
+              "name": "--details",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show per-cluster transformation details"
+            },
+            {
+              "name": "--case-type",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter details by case: unchanged, merged, partitioned, overlapping"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            }
+          ]
+        },
+        {
+          "command": "config delete",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to delete"
+            }
+          ]
+        },
+        {
+          "command": "config list",
+          "options": []
+        },
+        {
+          "command": "config load",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to load"
+            },
+            {
+              "name": "--dest",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Destination path"
+            }
+          ]
+        },
+        {
+          "command": "config save",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name"
+            },
+            {
+              "name": "config_path",
+              "type": "text",
+              "required": true,
+              "help": "Path to config YAML file"
+            }
+          ]
+        },
+        {
+          "command": "config show",
+          "options": [
+            {
+              "name": "name",
+              "type": "text",
+              "required": true,
+              "help": "Preset name to display"
+            }
+          ]
+        },
+        {
+          "command": "dedupe",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files as path or path:source_name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to YAML config file (optional - auto-detects if omitted)"
+            },
+            {
+              "name": "--tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Open the interactive review TUI instead of running directly (auto-config path only)."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Deprecated: non-interactive is now the default. Accepted for back-compat (no-op)."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Override embedding model selection"
+            },
+            {
+              "name": "--preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Preview results without writing files"
+            },
+            {
+              "name": "--preview-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Number of records for preview sample"
+            },
+            {
+              "name": "--preview-random",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Random sample instead of first N"
+            },
+            {
+              "name": "--output-golden",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output golden records"
+            },
+            {
+              "name": "--output-clusters",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output cluster info"
+            },
+            {
+              "name": "--output-dupes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output duplicate records"
+            },
+            {
+              "name": "--output-unique",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output unique records"
+            },
+            {
+              "name": "--output-all",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output all result types"
+            },
+            {
+              "name": "--output-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate summary report"
+            },
+            {
+              "name": "--html-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate standalone HTML report"
+            },
+            {
+              "name": "--dashboard",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after data quality dashboard"
+            },
+            {
+              "name": "--across-files-only",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Only match across different sources"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output format (csv, parquet)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run name for output files"
+            },
+            {
+              "name": "--auto-fix",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Run auto-fix before matching"
+            },
+            {
+              "name": "--auto-block",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-suggest blocking keys"
+            },
+            {
+              "name": "--chunked",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Large dataset mode - process in chunks for files >1M records"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Records per chunk in chunked mode"
+            },
+            {
+              "name": "--diff",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after CSV diff"
+            },
+            {
+              "name": "--diff-html",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after HTML diff with highlighting"
+            },
+            {
+              "name": "--merge-preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show merge preview (what will change) without writing"
+            },
+            {
+              "name": "--anomalies",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Detect suspicious/fake records"
+            },
+            {
+              "name": "--anomaly-sensitivity",
+              "type": "text",
+              "required": false,
+              "default": "'medium'",
+              "help": "low, medium, or high"
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Boost accuracy with LLM-labeled training data"
+            },
+            {
+              "name": "--llm-retrain",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Force re-labeling (ignore saved model)"
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "LLM provider: auto, anthropic, or openai"
+            },
+            {
+              "name": "--llm-max-labels",
+              "type": "integer",
+              "required": false,
+              "default": "500",
+              "help": "Max pairs to label with LLM"
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Processing backend: default, bucket, chunked, ray, duckdb"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely. Layered with config.exclude_columns when both are present."
+            },
+            {
+              "name": "--show-controller",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Render AutoConfigController telemetry (stop_reason, decisions, Path Y) when auto-config ran. No-op for runs with an explicit --config."
+            },
+            {
+              "name": "--suggest",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show verified config-improvement suggestions for this run."
+            },
+            {
+              "name": "--heal",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Apply the suggestion heal loop and print the applied trail."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Verbose output"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress output"
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Launch interactive TUI with demo data"
+            },
+            {
+              "name": "--report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate HTML report"
+            },
+            {
+              "name": "--dashboard",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate before/after dashboard"
+            },
+            {
+              "name": "--graph",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate cluster graph"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress animated output"
+            }
+          ]
+        },
+        {
+          "command": "evaluate",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--ground-truth",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Ground truth CSV path (required unless --certify)"
+            },
+            {
+              "name": "--col-a",
+              "type": "text",
+              "required": false,
+              "default": "'id_a'",
+              "help": "Ground truth column A"
+            },
+            {
+              "name": "--col-b",
+              "type": "text",
+              "required": false,
+              "default": "'id_b'",
+              "help": "Ground truth column B"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Override match threshold"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            },
+            {
+              "name": "--min-f1",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum F1 score (exit code 1 if below). For CI/CD quality gates."
+            },
+            {
+              "name": "--min-precision",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum precision (exit code 1 if below)"
+            },
+            {
+              "name": "--min-recall",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Minimum recall (exit code 1 if below)"
+            },
+            {
+              "name": "--certify",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Estimate recall WITHOUT ground truth (unsupervised, via capture-recapture over the config's matchkeys/passes; needs >=3)."
+            },
+            {
+              "name": "--audit-out",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "With --certify: emit a stratified audit sample CSV to label for a SAFE recall lower bound."
+            },
+            {
+              "name": "--audit-in",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "With --certify: read a labelled audit sample and print the audit-calibrated SAFE lower bound."
+            },
+            {
+              "name": "--audit-n",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Audit samples per stratum (default 50)."
+            },
+            {
+              "name": "--threshold-sweep",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Sweep the link threshold over scored pairs: P/R/F1 table + recommended cut (+ Fellegi-Sunter m/u model report when a probabilistic matchkey ran)."
+            }
+          ]
+        },
+        {
+          "command": "explain",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--pair",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Explain a pair: 'id_a,id_b'"
+            },
+            {
+              "name": "--cluster",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Explain a cluster by id"
+            }
+          ]
+        },
+        {
+          "command": "identity conflicts",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities in this dataset."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity history",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Maximum number of events to return."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity list",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities in this dataset."
+            },
+            {
+              "name": "--status",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Filter to identities with this status."
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Maximum number of identities to return."
+            },
+            {
+              "name": "--offset",
+              "type": "integer",
+              "required": false,
+              "default": "0",
+              "help": "Number of identities to skip for pagination."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity merge",
+          "options": [
+            {
+              "name": "keep",
+              "type": "text",
+              "required": true,
+              "help": "entity_id to keep"
+            },
+            {
+              "name": "absorb",
+              "type": "text",
+              "required": true,
+              "help": "entity_id to absorb"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason recorded in the event log."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            }
+          ]
+        },
+        {
+          "command": "identity migrate",
+          "options": [
+            {
+              "name": "--dsn",
+              "type": "text",
+              "required": true,
+              "help": "Postgres DSN; can also be set via GOLDENMATCH_IDENTITY_DSN."
+            },
+            {
+              "name": "--stamp-existing",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Stamp an existing v1 schema at revision 0001 without re-creating tables."
+            },
+            {
+              "name": "--revision",
+              "type": "text",
+              "required": false,
+              "default": "'head'",
+              "help": "Target revision (default: head)."
+            }
+          ]
+        },
+        {
+          "command": "identity migrate-ids",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--dsn",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database connection string for the identity store."
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Report what would change; mutate nothing."
+            }
+          ]
+        },
+        {
+          "command": "identity resolve",
+          "options": [
+            {
+              "name": "record_id",
+              "type": "text",
+              "required": true,
+              "help": "`{source}:{pk}` to look up"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity show",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Emit results as JSON instead of a table."
+            }
+          ]
+        },
+        {
+          "command": "identity split",
+          "options": [
+            {
+              "name": "entity_id",
+              "type": "text",
+              "required": true,
+              "help": "The entity_id of the identity to operate on."
+            },
+            {
+              "name": "record_ids",
+              "type": "text",
+              "required": true,
+              "help": "record_ids to move to a new identity"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason recorded in the event log."
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/identity.db'",
+              "help": "Path to the identity graph database."
+            }
+          ]
+        },
+        {
+          "command": "import-splink",
+          "options": [
+            {
+              "name": "input_path",
+              "type": "text",
+              "required": true,
+              "help": "Splink settings or trained-model JSON file"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "'goldenmatch.yaml'",
+              "help": "Output YAML config path"
+            },
+            {
+              "name": "--model-out",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Persist imported trained m/u as an FS model JSON; sets model_path in the config"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail on any lossy mapping (warnings), not just errors"
+            },
+            {
+              "name": "--upgrade",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run the data-aware upgrade pass against this dataset (parquet/csv): four levers -- tf_tables, distance_thresholds, fan_out (negative evidence + cluster-guard tuning), calibration. Writes the UPGRADED config/model to --output/--model-out and the faithful baseline alongside as out.baseline.yaml/model.baseline.json."
+            },
+            {
+              "name": "--splink-clusters",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reference cluster mapping (parquet/csv) from the prior Splink run, for agreement measurement. First column = id, second column = cluster_id."
+            },
+            {
+              "name": "--labels",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional ground-truth cluster mapping (parquet/csv) for true pairwise + B-cubed F1 measurement. First column = id, second column = cluster_id."
+            },
+            {
+              "name": "--sample-cap",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Row cap for --upgrade lever computation and measurement (seeded subsample above it)"
+            },
+            {
+              "name": "--no-measure",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Skip the baseline-vs-upgraded measurement pass"
+            },
+            {
+              "name": "--id-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column holding each row's id for --upgrade measurement/reference joins (default: auto-detect unique_id/id/record_id)"
+            }
+          ]
+        },
+        {
+          "command": "incremental",
+          "options": [
+            {
+              "name": "base_file",
+              "type": "text",
+              "required": true,
+              "help": "Base dataset file path"
+            },
+            {
+              "name": "--new-records",
+              "type": "path",
+              "required": true,
+              "help": "New records CSV to match"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output CSV path"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Override threshold"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
+            }
+          ]
+        },
+        {
+          "command": "ingest-docs run",
+          "options": [
+            {
+              "name": "docs",
+              "type": "text",
+              "required": true,
+              "help": "Document paths (PDF/image)."
+            },
+            {
+              "name": "--schema",
+              "type": "text",
+              "required": true,
+              "help": "Target schema JSON file."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": true,
+              "help": "Write records here (.csv or .parquet)."
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "'vlm'",
+              "help": "Extraction backend."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "'gpt-4o'",
+              "help": "Vision model."
+            }
+          ]
+        },
+        {
+          "command": "ingest-docs suggest-schema",
+          "options": [
+            {
+              "name": "sample",
+              "type": "text",
+              "required": true,
+              "help": "A representative document (PDF/image)."
+            },
+            {
+              "name": "--out",
+              "type": "text",
+              "required": true,
+              "help": "Write the proposed schema JSON here."
+            },
+            {
+              "name": "--backend",
+              "type": "text",
+              "required": false,
+              "default": "'vlm'",
+              "help": "Extraction backend."
+            },
+            {
+              "name": "--model",
+              "type": "text",
+              "required": false,
+              "default": "'gpt-4o'",
+              "help": "Vision model."
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output path for generated config"
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to load"
+            }
+          ]
+        },
+        {
+          "command": "label",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'ground_truth.csv'",
+              "help": "Output ground truth CSV"
+            },
+            {
+              "name": "--n",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Number of pairs to label"
+            },
+            {
+              "name": "--strategy",
+              "type": "text",
+              "required": false,
+              "default": "'borderline'",
+              "help": "Pair selection: borderline, random, or hardest"
+            },
+            {
+              "name": "--append",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Append to existing ground truth file"
+            }
+          ]
+        },
+        {
+          "command": "lineage",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Write lineage.json here (default: print a summary)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "'lineage'",
+              "help": "Run name for the lineage file"
+            },
+            {
+              "name": "--max-pairs",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Cap on lineage records (0 = no cap)"
+            },
+            {
+              "name": "--nl",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Include natural-language explanations"
+            }
+          ]
+        },
+        {
+          "command": "match",
+          "options": [
+            {
+              "name": "target",
+              "type": "text",
+              "required": true,
+              "help": "Target file as path or path:source_name"
+            },
+            {
+              "name": "--against",
+              "type": "text",
+              "required": true,
+              "help": "Reference files as path or path:source_name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to YAML config file (optional - auto-detects if omitted)"
+            },
+            {
+              "name": "--preview",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Preview results without writing files"
+            },
+            {
+              "name": "--preview-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Number of records for preview sample"
+            },
+            {
+              "name": "--preview-random",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Random sample instead of first N"
+            },
+            {
+              "name": "--output-matched",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output matched records"
+            },
+            {
+              "name": "--output-unmatched",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output unmatched records"
+            },
+            {
+              "name": "--output-scores",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output score details"
+            },
+            {
+              "name": "--output-all",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output all result types"
+            },
+            {
+              "name": "--output-report",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Generate summary report"
+            },
+            {
+              "name": "--match-mode",
+              "type": "text",
+              "required": false,
+              "default": "'best'",
+              "help": "Match mode: best or all"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output format (csv, parquet)"
+            },
+            {
+              "name": "--run-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run name for output files"
+            },
+            {
+              "name": "--auto-fix",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Run auto-fix before matching"
+            },
+            {
+              "name": "--auto-block",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-suggest blocking keys"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch never picks these for matchkeys/blocking; GoldenFlow transforms skip them entirely."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Verbose output"
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress output"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Data files to load"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "HTTP host (only for http transport)"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8200",
+              "help": "HTTP port (only for http transport)"
+            }
+          ]
+        },
+        {
+          "command": "memory add",
+          "options": [
+            {
+              "name": "--decision",
+              "type": "text",
+              "required": true,
+              "help": "approve | reject | field_correct"
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset key (required)"
+            },
+            {
+              "name": "--id-a",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Pair-level: first row id"
+            },
+            {
+              "name": "--id-b",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Pair-level: second row id"
+            },
+            {
+              "name": "--cluster-id",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: cluster id the correction targets"
+            },
+            {
+              "name": "--field-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: column being corrected"
+            },
+            {
+              "name": "--original-value",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: original chosen value"
+            },
+            {
+              "name": "--corrected-value",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Field-level: the value the reviewer changed it to"
+            },
+            {
+              "name": "--reason",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional reason"
+            },
+            {
+              "name": "--matchkey-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional matchkey scope"
+            },
+            {
+              "name": "--source",
+              "type": "text",
+              "required": false,
+              "default": "'steward'",
+              "help": "Source: steward (1.0 trust) | agent (0.5) | boost | unmerge"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory export",
+          "options": [
+            {
+              "name": "out",
+              "type": "text",
+              "required": true,
+              "help": "Output CSV path"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory import",
+          "options": [
+            {
+              "name": "src",
+              "type": "text",
+              "required": true,
+              "help": "Source CSV path"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory learn",
+          "options": [
+            {
+              "name": "--matchkey-name",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Limit learning to this matchkey"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory show",
+          "options": [
+            {
+              "name": "id_a",
+              "type": "integer",
+              "required": true,
+              "help": "First record ID"
+            },
+            {
+              "name": "id_b",
+              "type": "integer",
+              "required": true,
+              "help": "Second record ID"
+            },
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "memory stats",
+          "options": [
+            {
+              "name": "--path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Memory DB path"
+            }
+          ]
+        },
+        {
+          "command": "pprl auto-config",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to analyze (CSV)"
+            },
+            {
+              "name": "--security",
+              "type": "text",
+              "required": false,
+              "default": "'high'",
+              "help": "Security level: standard, high, paranoid"
+            },
+            {
+              "name": "--llm",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Use LLM for enhanced recommendations"
+            }
+          ]
+        },
+        {
+          "command": "pprl link",
+          "options": [
+            {
+              "name": "--file-a",
+              "type": "path",
+              "required": true,
+              "help": "Party A data file (CSV)"
+            },
+            {
+              "name": "--file-b",
+              "type": "path",
+              "required": true,
+              "help": "Party B data file (CSV)"
+            },
+            {
+              "name": "--fields",
+              "type": "text",
+              "required": true,
+              "help": "Comma-separated field names to match on"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.85",
+              "help": "Match threshold"
+            },
+            {
+              "name": "--security",
+              "type": "text",
+              "required": false,
+              "default": "'high'",
+              "help": "Security level: standard, high, paranoid"
+            },
+            {
+              "name": "--protocol",
+              "type": "text",
+              "required": false,
+              "default": "'trusted_third_party'",
+              "help": "Protocol: trusted_third_party or smc"
+            },
+            {
+              "name": "--scorer",
+              "type": "text",
+              "required": false,
+              "default": "'dice'",
+              "help": "Similarity scorer: dice or jaccard"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output CSV path for cluster assignments"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenFlow transforms skip them entirely; PPRL bloom filters never hash them."
+            }
+          ]
+        },
+        {
+          "command": "profile",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "File(s) to profile"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show detailed per-column info"
+            },
+            {
+              "name": "--suggest-fixes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show what auto-fix would do (dry run)"
+            },
+            {
+              "name": "--exclusions",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show GoldenCheck auto-config column exclusions (#404). Lists columns auto-config will skip (audit timestamps, foreign IDs, sentinel values, etc) and why."
+            }
+          ]
+        },
+        {
+          "command": "review",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Input files (path or path:source_name). Omit to review only the pending queue."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--job",
+              "type": "text",
+              "required": false,
+              "default": "'review'",
+              "help": "Review-queue job name for freshly-gated pairs"
+            },
+            {
+              "name": "--queue-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "SQLite review queue path (default: sibling of the config's memory store, else .goldenmatch/review_queue.db)"
+            },
+            {
+              "name": "--memory-path",
+              "type": "text",
+              "required": false,
+              "default": "'.goldenmatch/memory.db'",
+              "help": "Learning Memory SQLite path"
+            },
+            {
+              "name": "--merge-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.95",
+              "help": "Scores above this auto-merge (skip review)"
+            },
+            {
+              "name": "--review-threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.75",
+              "help": "Scores >= this go to review"
+            },
+            {
+              "name": "--decided-by",
+              "type": "text",
+              "required": false,
+              "default": "'cli'",
+              "help": "Steward identifier recorded on each decision"
+            },
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "50",
+              "help": "Max pairs to review this session"
+            }
+          ]
+        },
+        {
+          "command": "rollback",
+          "options": [
+            {
+              "name": "run_id",
+              "type": "text",
+              "required": true,
+              "help": "Run ID to rollback"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory containing run log"
+            }
+          ]
+        },
+        {
+          "command": "runs",
+          "options": [
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory containing run log"
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Data files to process"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--every",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Run interval (e.g. 1h, 30m, 6h, 1d)"
+            },
+            {
+              "name": "--cron",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Cron schedule (e.g. '0 6 * * *')"
+            },
+            {
+              "name": "--output-dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Output directory"
+            }
+          ]
+        },
+        {
+          "command": "sensitivity",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Input files (path or path:source_name)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": true,
+              "help": "Config YAML path"
+            },
+            {
+              "name": "--sweep",
+              "type": "text",
+              "required": true,
+              "help": "Sweep spec: field:start:stop:step (repeatable)"
+            },
+            {
+              "name": "--sample",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Random sample size for speed"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save results to JSON"
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "files",
+              "type": "text",
+              "required": true,
+              "help": "Data files to load"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Server host"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8080",
+              "help": "Server port"
+            }
+          ]
+        },
+        {
+          "command": "serve-ui",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Optional run dir or project dir."
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'127.0.0.1'",
+              "help": "Host to bind."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "5050",
+              "help": "Port (0 = pick free, default 5050 matches Vite proxy)."
+            },
+            {
+              "name": "--dev",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Skip static; expect Vite at :5173."
+            },
+            {
+              "name": "--open",
+              "type": "boolean",
+              "required": false,
+              "default": "True",
+              "help": "Open the UI in a browser once the server starts."
+            }
+          ]
+        },
+        {
+          "command": "setup",
+          "options": []
+        },
+        {
+          "command": "sync",
+          "options": [
+            {
+              "name": "--source-type",
+              "type": "text",
+              "required": false,
+              "default": "'postgres'",
+              "help": "Database type"
+            },
+            {
+              "name": "--connection-string",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database URL"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": true,
+              "help": "Source table name"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--output-mode",
+              "type": "text",
+              "required": false,
+              "default": "'separate'",
+              "help": "separate or in_place"
+            },
+            {
+              "name": "--full-rescan",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Force full rescan"
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Match without writing results"
+            },
+            {
+              "name": "--incremental-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column for incremental detection"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Records per chunk"
+            },
+            {
+              "name": "--exclude-columns",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated columns to skip across the suite. GoldenMatch auto-config never picks these for matchkeys/blocking; GoldenFlow transforms skip them. Layered with config.exclude_columns when both are set."
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable debug-level logging output."
+            },
+            {
+              "name": "--quiet",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Suppress informational output."
+            }
+          ]
+        },
+        {
+          "command": "unmerge",
+          "options": [
+            {
+              "name": "record_id",
+              "type": "integer",
+              "required": true,
+              "help": "Record row ID to unmerge from its cluster"
+            },
+            {
+              "name": "--clusters",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to clusters CSV from a previous run"
+            },
+            {
+              "name": "--pairs",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to scored pairs CSV (id_a,id_b,score)"
+            },
+            {
+              "name": "--shatter",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Shatter the entire cluster into singletons"
+            },
+            {
+              "name": "--threshold",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "help": "Min score threshold for re-clustering"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Where to write the re-clustered CSV (default: <clusters>.unmerged.csv)"
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "--source-type",
+              "type": "text",
+              "required": false,
+              "default": "'postgres'",
+              "help": "Database type"
+            },
+            {
+              "name": "--connection-string",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Database URL"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": true,
+              "help": "Table to watch"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Config YAML file"
+            },
+            {
+              "name": "--interval",
+              "type": "integer",
+              "required": false,
+              "default": "30",
+              "help": "Seconds between polls"
+            },
+            {
+              "name": "--output-mode",
+              "type": "text",
+              "required": false,
+              "default": "'separate'",
+              "help": "separate or in_place"
+            },
+            {
+              "name": "--incremental-column",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column for change detection"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "add_correction",
+          "description": "Add a Learning Memory correction. Two shapes:"
+        },
+        {
+          "name": "agent_approve_reject",
+          "description": "Approve or reject a review queue pair"
+        },
+        {
+          "name": "agent_compare_strategies",
+          "description": "Compare ER strategies on your data"
+        },
+        {
+          "name": "agent_deduplicate",
+          "description": "Deduplicate ONE dataset: auto-configures matching, runs the full entity-resolution pipeline, and returns the duplicate clusters with confidence gating (auto-merge / needs-review / reject) plus per-decision reasoning. Takes a file path or an uploaded dataset; pass output_path to also write the golden (deduplicated) records to CSV. Operates on a single source -- to link records across TWO datasets use agent_match_sources instead."
+        },
+        {
+          "name": "agent_explain_cluster",
+          "description": "Explain why records are in the same cluster"
+        },
+        {
+          "name": "agent_explain_pair",
+          "description": "Natural language explanation for a record pair"
+        },
+        {
+          "name": "agent_match_sources",
+          "description": "Link records across TWO datasets (not dedupe one): auto-selects a matching strategy, scores cross-source pairs, and returns the matched pairs with confidence. Takes two file paths or uploaded datasets (file_a / file_b); pass output_path to also write the matched pairs to CSV. To find duplicates WITHIN a single dataset use agent_deduplicate instead."
+        },
+        {
+          "name": "agent_review_queue",
+          "description": "Get borderline pairs awaiting approval"
+        },
+        {
+          "name": "analyze_blocking",
+          "description": "Diagnose blocking on the loaded dataset: returns ranked blocking key candidates with block counts, max block size, total candidate comparisons, and estimated recall. Use it to explain why matching is slow or produces too many candidate pairs."
+        },
+        {
+          "name": "analyze_data",
+          "description": "Profile a dataset (read-only, runs no matching and writes nothing): column stats, the detected domain/entity type, data-quality signals, and a recommended entity-resolution strategy. Takes a file path or an uploaded dataset. Use it before deduplicating to understand the data and preview the strategy the auto-config would pick."
+        },
+        {
+          "name": "auto_configure",
+          "description": "Run AutoConfigController on a CSV; return the committed GoldenMatchConfig (incl. negative_evidence / Path Y when chosen) plus telemetry — stop_reason, health, decision trace, indicator column priors. Programmatic equivalent of `goldenmatch autoconfig`."
+        },
+        {
+          "name": "certify_recall",
+          "description": "Estimate match RECALL without ground truth (unsupervised). Treats each auto-configured matchkey/pass as a decorrelated system and uses capture-recapture over their overlaps to estimate how many true matches were missed. Returns a point estimate (a safe lower bound additionally needs a small labelled audit; see `goldenmatch evaluate --certify --audit-out`). Needs >=3 decorrelated systems."
+        },
+        {
+          "name": "compare_clusters",
+          "description": "Compare two ER clustering outcomes on the same dataset without ground truth (CCMS): classifies each cluster as unchanged / merged / partitioned / overlapping and returns the Talburt-Wang Index. Both inputs are JSON cluster files (as written by export-style output)."
+        },
+        {
+          "name": "config_weaknesses",
+          "description": "Diagnose weaknesses in the loaded run's auto-config: columns admitted that shouldn't be (source/provenance labels, per-row IDs), oversized or shared-value blocks, null sinks, low-signal matchkeys, and over-merging. Returns ranked findings, each with a plain-English explanation + a concrete fix, plus a one-paragraph summary."
+        },
+        {
+          "name": "controller_telemetry",
+          "description": "Return the AutoConfigController telemetry from the most recent `auto_configure` or `agent_deduplicate` call in this MCP session. Same JSON shape as the web /api/v1/controller/telemetry endpoint."
+        },
+        {
+          "name": "convert_splink_config",
+          "description": "Convert a Splink settings JSON (bare or trained) into a GoldenMatch config. Pass the settings as an inline JSON string -- no filesystem access needed. Returns the config as YAML, a findings report (severity/splink_path/message/mapped_to per finding), a summary, and -- when the Splink input carried trained m/u probabilities -- the imported EM model as a dict you can persist yourself. strict=True fails on ANY lossy mapping (not just hard errors)."
+        },
+        {
+          "name": "create_domain",
+          "description": "Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.)."
+        },
+        {
+          "name": "dedupe",
+          "description": "Alias for `find_duplicates`. Find duplicate matches for a record. Provide field values to search against the loaded dataset."
+        },
+        {
+          "name": "documents_ingest",
+          "description": "Extract records from documents (PDF/image) against a target schema into rows ready for dedupe_df. Returns records + an ingest report."
+        },
+        {
+          "name": "documents_suggest_schema",
+          "description": "Propose a target extraction schema (JSON) from a sample document image/PDF."
+        },
+        {
+          "name": "evaluate",
+          "description": "Score the loaded run against ground-truth pairs. Loads a ground-truth CSV (id_a,id_b columns) and returns precision, recall, and F1 for the current clustering."
+        },
+        {
+          "name": "explain_cluster",
+          "description": "Alias for `agent_explain_cluster`. Explain why records are in the same cluster"
+        },
+        {
+          "name": "explain_match",
+          "description": "Explain why two records match or don't match. Shows per-field score breakdown."
+        },
+        {
+          "name": "explain_pair",
+          "description": "Alias for `explain_match`. Explain why two records match or don't match. Shows per-field score breakdown."
+        },
+        {
+          "name": "explain_routing",
+          "description": "Human-readable explanation of why each stage is routed the way it is, with the driver-RAM projection that drove it."
+        },
+        {
+          "name": "export_results",
+          "description": "Export matching results to a file (CSV or JSON)."
+        },
+        {
+          "name": "find_duplicates",
+          "description": "Find duplicate matches for a record. Provide field values to search against the loaded dataset."
+        },
+        {
+          "name": "fix_quality",
+          "description": "Run GoldenCheck scan and apply fixes to a CSV file. Returns the fixed data summary and a manifest of all fixes applied. Requires goldencheck: pip install goldenmatch[quality]"
+        },
+        {
+          "name": "get_cluster",
+          "description": "Get details of a specific cluster: all member records and their field values."
+        },
+        {
+          "name": "get_golden_record",
+          "description": "Get the merged golden (canonical) record for a cluster."
+        },
+        {
+          "name": "get_stats",
+          "description": "Get dataset statistics: record count, cluster count, match rate, cluster sizes."
+        },
+        {
+          "name": "identity_audit",
+          "description": "Export the append-only identity audit log in commit order: every event with actor / trust / timestamp / reason, so a reviewer can reconstruct exactly which actor changed what, when, and why. Optionally filtered by dataset / actor."
+        },
+        {
+          "name": "identity_audit_seal",
+          "description": "Anchor the append-only audit log with a tamper-evidence seal: a chained sha256 root over every event since the last seal. Cheap and idempotent (a no-op when nothing new has been logged). Run it periodically (or after a batch of stewardship actions) so the history becomes provably untampered. Optionally scoped to a dataset. Publish/mirror the returned root_hash to make tampering detectable by an external party."
+        },
+        {
+          "name": "identity_audit_verify",
+          "description": "Verify the append-only audit log against its seal chain. Replays the per-event content hashes and the seal roots to detect content edits, deletion, reordering, and insertion of any sealed event. Returns {ok, events_checked, seals_checked} plus the ids of any content mismatches / broken seals / missing sealed events. Optionally scoped to a dataset."
+        },
+        {
+          "name": "identity_claim",
+          "description": "Claim a record into an identity, moving it out of any prior entity ('this record belongs to that identity'). Emits a provenance-stamped `claimed` event on both the gaining and losing entities."
+        },
+        {
+          "name": "identity_conflicts",
+          "description": "List evidence edges marked `conflicts_with`."
+        },
+        {
+          "name": "identity_history",
+          "description": "Return the temporal event log for an identity."
+        },
+        {
+          "name": "identity_list",
+          "description": "List identities, optionally filtered by dataset/status."
+        },
+        {
+          "name": "identity_merge",
+          "description": "Manually merge two identities. All records from `absorb_entity_id` are reassigned to `keep_entity_id`. The merge events are stamped with `actor`/`trust` provenance so the audit log records who merged these and on what authority."
+        },
+        {
+          "name": "identity_profile",
+          "description": "MDM profile of one entity: record count + per-source breakdown, golden record, confidence, conflict count, canonical version (structural-event count), and first/last activity. Returns {found: false} when no such entity exists."
+        },
+        {
+          "name": "identity_resolve",
+          "description": "Resolve a record_id to its durable identity. Returns the full identity view (members, evidence edges, recent events) or null when no identity exists for that record."
+        },
+        {
+          "name": "identity_resolve_conflict",
+          "description": "Adjudicate a `conflicts_with` pair: 'same' keeps the entity intact, 'distinct' splits the second record out into a new identity, 'defer' only logs. Records a durable mediation verdict + event with actor/trust provenance, and stops the conflict re-surfacing in the open-conflicts queue."
+        },
+        {
+          "name": "identity_show",
+          "description": "Fetch the full detail of one identity by entity_id: its member records, evidence edges, and recent event log. Returns {found: false} when no such entity exists."
+        },
+        {
+          "name": "identity_split",
+          "description": "Split a subset of records off an identity into a brand-new identity. The original keeps the remaining records. The split events carry `actor`/`trust` provenance."
+        },
+        {
+          "name": "identity_stats",
+          "description": "Graph-level summary / health stats: entities by status, total records, records-per-entity distribution, conflict total, source mix, and the largest entities. Optionally scoped to a dataset."
+        },
+        {
+          "name": "identity_worklist",
+          "description": "Prioritized steward worklist: active entities needing attention (open conflicts and/or confidence below weak_confidence), highest conflict count first."
+        },
+        {
+          "name": "incremental",
+          "description": "Match a batch of new records against an existing base dataset (without re-running the whole base). Returns matched (new_row_id, base_row_id, score) pairs plus counts. Auto-configures from the base file if no config is given."
+        },
+        {
+          "name": "learn_thresholds",
+          "description": "Force a MemoryLearner pass over accumulated corrections. Returns the list of LearnedAdjustments produced (matchkey_name, threshold, sample_size, learned_at). Requires >= 10 corrections per matchkey before threshold tuning fires; otherwise returns an empty list."
+        },
+        {
+          "name": "lineage",
+          "description": "Field-level provenance for the loaded run: for each scored pair, the per-field scores that produced the match, plus cluster id. Optionally write a lineage JSON to a directory."
+        },
+        {
+          "name": "lint_routing",
+          "description": "Flag config/env overrides that force a slow path (e.g. CLUSTERING_THRESHOLD=0 when the edge set fits driver RAM). ERROR at scale; would_refuse mirrors the runtime guard."
+        },
+        {
+          "name": "list_clusters",
+          "description": "List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts."
+        },
+        {
+          "name": "list_corrections",
+          "description": "List stored Learning Memory corrections, optionally filtered by dataset. Returns id_a, id_b, decision, source, trust, reason, matchkey_name, dataset, original_score, created_at."
+        },
+        {
+          "name": "list_domains",
+          "description": "List available domain extraction rulebooks (built-in + user-defined)."
+        },
+        {
+          "name": "list_plugins",
+          "description": "List all registered goldenmatch plugins by category. Includes the 22 v1.18.2 predefined plugins (numeric/format/business/aggregation) plus any user-registered plugins via entry-points or PluginRegistry.register_*(). Each entry includes name, source (builtin or user), category, and the first line of the merge docstring."
+        },
+        {
+          "name": "list_runs",
+          "description": "List previous dedupe/match runs (for rollback) from the run log."
+        },
+        {
+          "name": "match",
+          "description": "Alias for `match_record`. Match a single record against the loaded dataset in real-time. Paste a record's fields and instantly see if it matches any existing record. Uses the configured matchkeys, scorers, and thresholds. Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
+        },
+        {
+          "name": "match_record",
+          "description": "Match a single record against the loaded dataset in real-time. Paste a record's fields and instantly see if it matches any existing record. Uses the configured matchkeys, scorers, and thresholds. Example: {\"name\": \"John Smith\", \"email\": \"john@test.com\", \"zip\": \"10001\"}"
+        },
+        {
+          "name": "memory_export",
+          "description": "Return all corrections as a list of dicts (CSV-shaped). Caller is responsible for writing the file. Optionally filter by dataset."
+        },
+        {
+          "name": "memory_import",
+          "description": "Import corrections from a list of dicts (the exact shape memory_export returns). Upserts into the store: higher trust wins, same trust = latest wins. Returns the count imported."
+        },
+        {
+          "name": "memory_stats",
+          "description": "Return Learning Memory status: total correction count, last learn time, and current learned adjustments. Cheap; safe for status checks."
+        },
+        {
+          "name": "plan_routing",
+          "description": "Project per-stage distributed routing (scoring/clustering/golden) for a given data shape + cluster. Pure; no controller run."
+        },
+        {
+          "name": "pprl_auto_config",
+          "description": "Analyze the loaded dataset and recommend optimal PPRL (privacy-preserving record linkage) configuration. Returns recommended fields, bloom filter parameters, threshold, and explanation."
+        },
+        {
+          "name": "pprl_link",
+          "description": "Run privacy-preserving record linkage between two parties' data. Computes bloom filters, matches records without sharing raw data. Specify fields, threshold, and security level."
+        },
+        {
+          "name": "profile",
+          "description": "Alias for `profile_data`. Get data quality profile: column types, null rates, unique counts, sample values."
+        },
+        {
+          "name": "profile_data",
+          "description": "Get data quality profile: column types, null rates, unique counts, sample values."
+        },
+        {
+          "name": "retrieve_similar",
+          "description": "Semantic retrieval (#1089): return the records in a CSV most similar to a free-text query, ranked by cosine similarity. Embeds the chosen column and the query with the zero-config in-house embedder (no cloud/torch by default) and runs ANN search. The read side of the RAG entity-canonicalization epic -- fetch candidate records by query without running a full dedupe."
+        },
+        {
+          "name": "review_config",
+          "description": "Run the config healer over the loaded dataset: analyze the dedupe run and return ranked, self-verified suggestions for improving the matching config (thresholds, scorers, negative evidence, blocking). Each suggestion carries an id, kind, target, rationale, and a machine-applicable patch. Requires the native kernel (pip install goldenmatch[native]); returns an empty list otherwise."
+        },
+        {
+          "name": "rollback",
+          "description": "Undo a previous run by DELETING its output files (looked up by run_id in the run log). Destructive: removes the files that run wrote. Use list_runs first to find the run_id."
+        },
+        {
+          "name": "run_transforms",
+          "description": "Run GoldenFlow data transforms on a CSV file. Normalizes phone numbers (E.164), dates (ISO), categorical spelling, and Unicode issues. Returns a manifest of transforms applied. Requires goldenflow: pip install goldenmatch[transform]"
+        },
+        {
+          "name": "scan_quality",
+          "description": "Run GoldenCheck data quality scan on a CSV file. Returns issues found (encoding errors, Unicode problems, format violations) without applying fixes. Requires goldencheck: pip install goldenmatch[quality]"
+        },
+        {
+          "name": "schema_match",
+          "description": "Auto-map columns between two files with different schemas. Returns proposed (col_a, col_b) mappings with a confidence score and method (synonym / name_sim / composite). Useful before matching two sources."
+        },
+        {
+          "name": "sensitivity",
+          "description": "Parameter-sensitivity analysis: sweep one or more config parameters across a range and report how stable the clustering is at each value (CCMS unchanged %). Use it to find robust thresholds. Auto-configures the file if no config is given."
+        },
+        {
+          "name": "shatter_cluster",
+          "description": "Break an entire cluster into individual records. All members become singletons. Use when a cluster is completely wrong."
+        },
+        {
+          "name": "suggest_config",
+          "description": "Analyze bad merges and suggest config changes. Provide examples of incorrect merges (pairs that should NOT have matched) and GoldenMatch will identify which fields/thresholds to tighten. Example: [{\"record_a\": {...}, \"record_b\": {...}, \"reason\": \"different people\"}]"
+        },
+        {
+          "name": "suggest_pprl",
+          "description": "Check if data needs privacy-preserving matching"
+        },
+        {
+          "name": "test_domain",
+          "description": "Test a domain extraction rulebook against sample records. Shows what features would be extracted from the loaded data."
+        },
+        {
+          "name": "unmerge_record",
+          "description": "Remove a record from its cluster. The record becomes a singleton. Remaining cluster members are re-clustered using stored pair scores. Use this to fix bad merges."
+        },
+        {
+          "name": "upload_dataset",
+          "description": "Upload a local file's bytes to the server and get back a server-side path to reuse across other tools (analyze_data, auto_configure, agent_deduplicate, ...). No hosting needed. Send base64 (default) or raw text via `encoding`. Uploaded files are ephemeral scratch, reaped after GOLDENMATCH_MCP_UPLOAD_TTL (default 24h); re-upload if you need a path older than that. Max size GOLDENMATCH_MCP_MAX_UPLOAD_BYTES (default 64MB) -- above it, pass a public http(s) URL as file_path instead."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Scorers",
+          "target": "goldenmatch.config.schemas:VALID_SCORERS",
+          "applies": "`MatchkeyField.scorer` / `NegativeEvidenceField.scorer`",
+          "values": [
+            {
+              "value": "alias_match",
+              "meaning": "Matches known name aliases and nicknames (Bob <-> Robert).",
+              "best_for": "Names with nicknames",
+              "range": "0 or 1"
+            },
+            {
+              "value": "audio_fp",
+              "meaning": "Audio-fingerprint similarity.",
+              "best_for": "Audio clips",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "date",
+              "meaning": "Damerau-Levenshtein over canonical ISO date digits; typo-tolerant.",
+              "best_for": "Dates (dob, birth_date)",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "dice",
+              "meaning": "Dice coefficient over character bigrams / bloom filters.",
+              "best_for": "PPRL",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "embedding",
+              "meaning": "Cosine similarity of a model embedding of the field.",
+              "best_for": "Semantic matching",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "ensemble",
+              "meaning": "Best of several sub-scorers (max of jaro_winkler / token_sort / soundex).",
+              "best_for": "Names with reordering",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "exact",
+              "meaning": "Exact string equality after transforms.",
+              "best_for": "Email, phone, ID",
+              "range": "0 or 1"
+            },
+            {
+              "value": "initialism_match",
+              "meaning": "Matches initials/acronyms against their expansions.",
+              "best_for": "Acronyms, initials",
+              "range": "0 or 1"
+            },
+            {
+              "value": "jaccard",
+              "meaning": "Jaccard overlap of token/character sets or bloom filters.",
+              "best_for": "PPRL",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "jaro_winkler",
+              "meaning": "Jaro-Winkler edit distance with a shared-prefix bonus.",
+              "best_for": "Names",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "levenshtein",
+              "meaning": "Normalized Levenshtein edit distance.",
+              "best_for": "General strings",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "phash",
+              "meaning": "Perceptual-hash Hamming similarity.",
+              "best_for": "Images",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "qgram",
+              "meaning": "Q-gram (n-gram) overlap similarity.",
+              "best_for": "General strings, typos",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "radial",
+              "meaning": "Rotation/crop-invariant radial-variance similarity.",
+              "best_for": "Rotated/cropped images",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "record_embedding",
+              "meaning": "Cosine similarity of an embedding over several columns.",
+              "best_for": "Cross-field semantic",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "soundex_match",
+              "meaning": "Phonetic Soundex-code equality.",
+              "best_for": "Names",
+              "range": "0 or 1"
+            },
+            {
+              "value": "token_sort",
+              "meaning": "Sort the tokens, then ratio; order-insensitive.",
+              "best_for": "Names, addresses",
+              "range": "0.0-1.0"
+            }
+          ]
+        },
+        {
+          "title": "Blocking strategies",
+          "target": "goldenmatch.config.schemas:BlockingConfig.strategy",
+          "applies": "`BlockingConfig.strategy`",
+          "values": [
+            {
+              "value": "adaptive",
+              "meaning": "Static plus recursive sub-blocking of oversized blocks.",
+              "best_for": "Default choice"
+            },
+            {
+              "value": "ann",
+              "meaning": "Approximate nearest-neighbor over embeddings.",
+              "best_for": "Semantic matching"
+            },
+            {
+              "value": "ann_pairs",
+              "meaning": "Direct-pair ANN scoring (skips block materialization).",
+              "best_for": "Faster ANN"
+            },
+            {
+              "value": "canopy",
+              "meaning": "Cheap loose canopy pre-grouping.",
+              "best_for": "Text-heavy data"
+            },
+            {
+              "value": "learned",
+              "meaning": "Data-driven mined blocking predicates.",
+              "best_for": "Auto-discovered rules"
+            },
+            {
+              "value": "lsh",
+              "meaning": "MinHash / LSH sketching on a text column.",
+              "best_for": "Near-duplicate text"
+            },
+            {
+              "value": "multi_pass",
+              "meaning": "Union candidate pairs from several blocking passes.",
+              "best_for": "Noisy data, best recall"
+            },
+            {
+              "value": "perceptual",
+              "meaning": "Banded-Hamming LSH over perceptual image hashes.",
+              "best_for": "Near-duplicate images"
+            },
+            {
+              "value": "simhash",
+              "meaning": "SimHash LSH over embeddings.",
+              "best_for": "Semantic near-duplicate text"
+            },
+            {
+              "value": "sorted_neighborhood",
+              "meaning": "Slide a window over sorted records.",
+              "best_for": "Typos in the blocking key"
+            },
+            {
+              "value": "static",
+              "meaning": "Group records by an exact blocking key.",
+              "best_for": "Clean data with reliable keys"
+            }
+          ]
+        },
+        {
+          "title": "Simple transforms",
+          "target": "goldenmatch.config.schemas:VALID_SIMPLE_TRANSFORMS",
+          "applies": "`transforms` chains",
+          "values": [
+            {
+              "value": "alpha_only",
+              "meaning": "Keep only alphabetic characters."
+            },
+            {
+              "value": "digits_only",
+              "meaning": "Keep only digits."
+            },
+            {
+              "value": "first_token",
+              "meaning": "Keep the first whitespace token."
+            },
+            {
+              "value": "last_token",
+              "meaning": "Keep the last whitespace token."
+            },
+            {
+              "value": "lowercase",
+              "meaning": "Lowercase the value."
+            },
+            {
+              "value": "metaphone",
+              "meaning": "Metaphone phonetic encoding."
+            },
+            {
+              "value": "normalize_whitespace",
+              "meaning": "Collapse runs of whitespace to single spaces."
+            },
+            {
+              "value": "soundex",
+              "meaning": "Soundex phonetic encoding."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim leading/trailing whitespace."
+            },
+            {
+              "value": "strip_all",
+              "meaning": "Remove all whitespace."
+            },
+            {
+              "value": "token_sort",
+              "meaning": "Sort the whitespace tokens alphabetically."
+            },
+            {
+              "value": "uppercase",
+              "meaning": "Uppercase the value."
+            }
+          ]
+        },
+        {
+          "title": "Survivorship strategies",
+          "target": "goldenmatch.config.schemas:VALID_STRATEGIES",
+          "applies": "`GoldenFieldRule.strategy`",
+          "values": [
+            {
+              "value": "confidence_majority",
+              "meaning": "Value backed by the highest total match confidence.",
+              "best_for": "Weighting by match quality"
+            },
+            {
+              "value": "first_non_null",
+              "meaning": "First non-null value in row order.",
+              "best_for": "Pre-ordered inputs"
+            },
+            {
+              "value": "longest_value",
+              "meaning": "The longest, most detailed value.",
+              "best_for": "Truncated/abbreviated values"
+            },
+            {
+              "value": "majority_vote",
+              "meaning": "Most frequent value across the cluster.",
+              "best_for": "Many redundant sources"
+            },
+            {
+              "value": "most_complete",
+              "meaning": "Value from the record with the fewest nulls.",
+              "best_for": "Default; sparse records"
+            },
+            {
+              "value": "most_recent",
+              "meaning": "Value from the newest record (needs date_column).",
+              "best_for": "Time-stamped sources"
+            },
+            {
+              "value": "source_priority",
+              "meaning": "Value from the highest-priority source (needs source_priority).",
+              "best_for": "A trusted source ranking"
+            },
+            {
+              "value": "unanimous_or_null",
+              "meaning": "The value only if every record agrees, else null.",
+              "best_for": "Zero-tolerance fields"
+            }
+          ]
+        },
+        {
+          "title": "Group survivorship strategies",
+          "target": "goldenmatch.config.schemas:_GROUP_STRATEGIES",
+          "applies": "`GoldenGroupRule.strategy`",
+          "values": [
+            {
+              "value": "anchor",
+              "meaning": "Take all group columns from the anchor column's winning row.",
+              "best_for": "Tying the group to one key field"
+            },
+            {
+              "value": "most_complete",
+              "meaning": "Take all group columns from the most-complete row.",
+              "best_for": "Default; a coherent row"
+            },
+            {
+              "value": "most_recent",
+              "meaning": "Take the group from the newest row.",
+              "best_for": "Time-stamped groups"
+            },
+            {
+              "value": "source_priority",
+              "meaning": "Take the group from the highest-priority source.",
+              "best_for": "A trusted source ranking"
+            }
+          ]
+        },
+        {
+          "title": "Standardizers",
+          "target": "goldenmatch.config.schemas:VALID_STANDARDIZERS",
+          "applies": "`StandardizationConfig.rules`",
+          "values": [
+            {
+              "value": "address",
+              "meaning": "Normalize a postal address."
+            },
+            {
+              "value": "email",
+              "meaning": "Lowercase and canonicalize an email address."
+            },
+            {
+              "value": "name_lower",
+              "meaning": "Lowercase a name."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name."
+            },
+            {
+              "value": "name_upper",
+              "meaning": "Uppercase a name."
+            },
+            {
+              "value": "phone",
+              "meaning": "Normalize a phone number."
+            },
+            {
+              "value": "state",
+              "meaning": "Normalize a US state to its 2-letter code."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim whitespace."
+            },
+            {
+              "value": "trim_whitespace",
+              "meaning": "Collapse and trim whitespace."
+            },
+            {
+              "value": "zip5",
+              "meaning": "Normalize a US ZIP to 5 digits."
+            }
+          ]
+        },
+        {
+          "title": "Matchkey types",
+          "target": "goldenmatch.config.schemas:_VALID_MK_TYPES",
+          "applies": "`MatchkeyConfig.type`",
+          "values": [
+            {
+              "value": "exact",
+              "meaning": "All fields must match exactly; fastest, no scoring.",
+              "best_for": "Reliable keys, max speed"
+            },
+            {
+              "value": "probabilistic",
+              "meaning": "Fellegi-Sunter scoring with EM-learned agreement weights.",
+              "best_for": "Unknown field reliability, best recall"
+            },
+            {
+              "value": "weighted",
+              "meaning": "Weighted mean of per-field scores compared to a threshold.",
+              "best_for": "Tunable fuzzy matching"
+            }
+          ]
+        },
+        {
+          "title": "Backends",
+          "target": "goldenmatch.core.execution_plan:BackendName",
+          "applies": "`GoldenMatchConfig.backend` / `--backend`",
+          "values": [
+            {
+              "value": "bucket",
+              "meaning": "Memory-bounded field-hash bucket scorer (the in-memory default route).",
+              "best_for": "< 500K, default (native on)"
+            },
+            {
+              "value": "chunked",
+              "meaning": "Chunked in-memory execution to cap peak memory.",
+              "best_for": "5M+ on one machine"
+            },
+            {
+              "value": "duckdb",
+              "meaning": "DuckDB-backed out-of-core execution.",
+              "best_for": "500K-50M, out-of-core"
+            },
+            {
+              "value": "polars-direct",
+              "meaning": "Straight in-memory Polars execution.",
+              "best_for": "< 500K, native kernel absent"
+            },
+            {
+              "value": "ray",
+              "meaning": "Distributed execution on a Ray cluster.",
+              "best_for": "50M+, distributed"
+            }
+          ]
+        },
+        {
+          "title": "Clustering strategies",
+          "target": "goldenmatch.core.execution_plan:ClusteringStrategy",
+          "applies": "planner cluster route",
+          "values": [
+            {
+              "value": "distributed_wcc",
+              "meaning": "Distributed weakly-connected-components on a cluster.",
+              "best_for": "Ray cluster, 100M+"
+            },
+            {
+              "value": "in_memory",
+              "meaning": "In-memory union-find clustering.",
+              "best_for": "Default; graph fits in RAM"
+            },
+            {
+              "value": "partitioned_union_find",
+              "meaning": "Disk-partitioned union-find for large pair sets.",
+              "best_for": "Huge single-box pair sets"
+            },
+            {
+              "value": "streaming_cc",
+              "meaning": "Streaming connected-components.",
+              "best_for": "Chunked / out-of-core runs"
+            }
+          ]
+        },
+        {
+          "title": "Planning efforts",
+          "target": "goldenmatch.core.autoconfig_controller:_PLANNING_EFFORTS",
+          "applies": "`planning_effort`",
+          "values": [
+            {
+              "value": "einstein",
+              "meaning": "Maximum auto-config search; slowest and most thorough.",
+              "best_for": "Max quality, cost no object"
+            },
+            {
+              "value": "fast",
+              "meaning": "Single cheap auto-config pass.",
+              "best_for": "Quick iteration"
+            },
+            {
+              "value": "normal",
+              "meaning": "Default interactive auto-config budget (byte-identical to historical).",
+              "best_for": "Default balance"
+            },
+            {
+              "value": "thinking",
+              "meaning": "Extra refit iterations plus full-frame blocking measurement.",
+              "best_for": "Harder datasets"
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "AGENT": [
+          "GOLDENMATCH_AGENT_TOKEN"
+        ],
+        "ALLOWED": [
+          "GOLDENMATCH_ALLOWED_ROOT"
+        ],
+        "ANALYTICS": [
+          "GOLDENMATCH_ANALYTICS"
+        ],
+        "ANN": [
+          "GOLDENMATCH_ANN_BACKEND",
+          "GOLDENMATCH_ANN_HNSW_EF_CONSTRUCTION",
+          "GOLDENMATCH_ANN_HNSW_EF_SEARCH",
+          "GOLDENMATCH_ANN_HNSW_M",
+          "GOLDENMATCH_ANN_HNSW_MAX_K",
+          "GOLDENMATCH_ANN_HNSW_MIN"
+        ],
+        "API": [
+          "GOLDENMATCH_API_CORS_ORIGINS",
+          "GOLDENMATCH_API_TOKEN"
+        ],
+        "ATTRIBUTE": [
+          "GOLDENMATCH_ATTRIBUTE_DEMOTION"
+        ],
+        "AUTO": [
+          "GOLDENMATCH_AUTO_SEMANTIC_BLOCKING"
+        ],
+        "AUTOCONFIG": [
+          "GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE",
+          "GOLDENMATCH_AUTOCONFIG_FORCE_EXCLUDE",
+          "GOLDENMATCH_AUTOCONFIG_FORCE_INCLUDE",
+          "GOLDENMATCH_AUTOCONFIG_INDICATOR_BUDGET",
+          "GOLDENMATCH_AUTOCONFIG_LLM",
+          "GOLDENMATCH_AUTOCONFIG_MEMORY",
+          "GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC",
+          "GOLDENMATCH_AUTOCONFIG_SAMPLE_STRATEGY",
+          "GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_COMMIT",
+          "GOLDENMATCH_AUTOCONFIG_ZERO_LABEL_STABILITY"
+        ],
+        "BASE": [
+          "GOLDENMATCH_BASE_STORE"
+        ],
+        "BENCH": [
+          "GOLDENMATCH_BENCH_DUMP_PAIRS"
+        ],
+        "BLOCKING": [
+          "GOLDENMATCH_BLOCKING_CARDINALITY_SCALER",
+          "GOLDENMATCH_BLOCKING_DEGENERATE_MAX_AVG_BLOCK_SIZE",
+          "GOLDENMATCH_BLOCKING_DEGENERATE_THRESHOLD",
+          "GOLDENMATCH_BLOCKING_MAX_RATIO",
+          "GOLDENMATCH_BLOCKING_MIN_RATIO",
+          "GOLDENMATCH_BLOCKING_PAIRS_PER_ROW",
+          "GOLDENMATCH_BLOCKING_PASS_MIN_WEAKPOS",
+          "GOLDENMATCH_BLOCKING_PRUNE_PASSES"
+        ],
+        "BRIDGE": [
+          "GOLDENMATCH_BRIDGE_REQUIRE_PY"
+        ],
+        "BUCKET": [
+          "GOLDENMATCH_BUCKET_DEBUG",
+          "GOLDENMATCH_BUCKET_DEFAULT",
+          "GOLDENMATCH_BUCKET_SLIM_PROJECTION",
+          "GOLDENMATCH_BUCKET_VEC_MAX",
+          "GOLDENMATCH_BUCKET_VEC_MIN"
+        ],
+        "CLUSTER": [
+          "GOLDENMATCH_CLUSTER_SPLIT_EDGE_BUDGET"
+        ],
+        "COLUMNAR": [
+          "GOLDENMATCH_COLUMNAR_PIPELINE"
+        ],
+        "CONFIG": [
+          "GOLDENMATCH_CONFIG_LINT"
+        ],
+        "DATABASE": [
+          "GOLDENMATCH_DATABASE_URL"
+        ],
+        "DISCRIMINATIVE": [
+          "GOLDENMATCH_DISCRIMINATIVE_TAU",
+          "GOLDENMATCH_DISCRIMINATIVE_VETO"
+        ],
+        "DISTRIBUTED": [
+          "GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE",
+          "GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD",
+          "GOLDENMATCH_DISTRIBUTED_FS_TRAIN_ROWS",
+          "GOLDENMATCH_DISTRIBUTED_GOLDEN_THRESHOLD",
+          "GOLDENMATCH_DISTRIBUTED_OP_RESERVATION",
+          "GOLDENMATCH_DISTRIBUTED_PIPELINE",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_CONCURRENCY",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS",
+          "GOLDENMATCH_DISTRIBUTED_SCORE_PROJECT",
+          "GOLDENMATCH_DISTRIBUTED_SHUFFLE_PARTS",
+          "GOLDENMATCH_DISTRIBUTED_WCC",
+          "GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH",
+          "GOLDENMATCH_DISTRIBUTED_WCC_SEED"
+        ],
+        "DUCKDB": [
+          "GOLDENMATCH_DUCKDB_SCORE_DB"
+        ],
+        "EMBEDDING": [
+          "GOLDENMATCH_EMBEDDING_PROVIDER"
+        ],
+        "ENABLE": [
+          "GOLDENMATCH_ENABLE_DISTRIBUTED_RAY"
+        ],
+        "FACILITY": [
+          "GOLDENMATCH_FACILITY_NAME_NE"
+        ],
+        "FD": [
+          "GOLDENMATCH_FD_NEGATIVE_EVIDENCE"
+        ],
+        "FIELD": [
+          "GOLDENMATCH_FIELD_GROUP_SURVIVORSHIP"
+        ],
+        "FRAME": [
+          "GOLDENMATCH_FRAME",
+          "GOLDENMATCH_FRAME_LANE"
+        ],
+        "FS": [
+          "GOLDENMATCH_FS_ARROW_STREAM",
+          "GOLDENMATCH_FS_AUTOCONFIG_V2",
+          "GOLDENMATCH_FS_BATCH_ROWS",
+          "GOLDENMATCH_FS_BUCKET_NATIVE",
+          "GOLDENMATCH_FS_CALIBRATED",
+          "GOLDENMATCH_FS_DEFAULT_BUCKET",
+          "GOLDENMATCH_FS_EM_SAMPLE_ROWS",
+          "GOLDENMATCH_FS_MAX_PASS_PAIRS",
+          "GOLDENMATCH_FS_MISSING",
+          "GOLDENMATCH_FS_MONOTONIC",
+          "GOLDENMATCH_FS_NATIVE",
+          "GOLDENMATCH_FS_REQUIRE_POSITIVE_EVIDENCE",
+          "GOLDENMATCH_FS_VECTORIZED",
+          "GOLDENMATCH_FS_VEC_MAX_ELEMS",
+          "GOLDENMATCH_FS_WORKERS"
+        ],
+        "FUSED": [
+          "GOLDENMATCH_FUSED_BLOCK_CONCURRENCY",
+          "GOLDENMATCH_FUSED_BYTES_PER_CELL",
+          "GOLDENMATCH_FUSED_BYTES_PER_PAIR",
+          "GOLDENMATCH_FUSED_PRESSURE_FRACTION",
+          "GOLDENMATCH_FUSED_RSS_SCALE"
+        ],
+        "GOLDEN": [
+          "GOLDENMATCH_GOLDEN_FUSED",
+          "GOLDENMATCH_GOLDEN_SLIM_MULTIDF",
+          "GOLDENMATCH_GOLDEN_STRATEGY_STRICT",
+          "GOLDENMATCH_GOLDEN_TUNER_MIN_CORRECTIONS"
+        ],
+        "GPU": [
+          "GOLDENMATCH_GPU_API_KEY",
+          "GOLDENMATCH_GPU_ENDPOINT",
+          "GOLDENMATCH_GPU_MODE"
+        ],
+        "HEAL": [
+          "GOLDENMATCH_HEAL_MIN_HEALTH_GAIN",
+          "GOLDENMATCH_HEAL_STEP_CAP"
+        ],
+        "IDENTITY": [
+          "GOLDENMATCH_IDENTITY_BATCH_FINGERPRINT",
+          "GOLDENMATCH_IDENTITY_DSN"
+        ],
+        "INHOUSE": [
+          "GOLDENMATCH_INHOUSE_MODEL"
+        ],
+        "LLAMA": [
+          "GOLDENMATCH_LLAMA_GGUF"
+        ],
+        "LLM": [
+          "GOLDENMATCH_LLM_BASE_URL",
+          "GOLDENMATCH_LLM_MODEL"
+        ],
+        "MATCH": [
+          "GOLDENMATCH_MATCH_FUSED",
+          "GOLDENMATCH_MATCH_LOG_FLUSH_PAIRS"
+        ],
+        "MCP": [
+          "GOLDENMATCH_MCP_ALLOW_PUBLIC",
+          "GOLDENMATCH_MCP_MAX_UPLOAD_BYTES",
+          "GOLDENMATCH_MCP_SESSION_MAX",
+          "GOLDENMATCH_MCP_SESSION_TTL",
+          "GOLDENMATCH_MCP_TOKEN",
+          "GOLDENMATCH_MCP_UPLOAD_TTL"
+        ],
+        "MULTISOURCE": [
+          "GOLDENMATCH_MULTISOURCE_AUTOCONFIG"
+        ],
+        "NATIVE": [
+          "GOLDENMATCH_NATIVE",
+          "GOLDENMATCH_NATIVE_ADDRESS_NORMALIZE",
+          "GOLDENMATCH_NATIVE_RAYON_MIN_BLOOM_ROWS",
+          "GOLDENMATCH_NATIVE_RAYON_MIN_PAIRS",
+          "GOLDENMATCH_NATIVE_SKETCH_RAYON_MIN_ROWS"
+        ],
+        "NE": [
+          "GOLDENMATCH_NE_TUNER_MIN_CORRECTIONS"
+        ],
+        "NOISE": [
+          "GOLDENMATCH_NOISE_AWARE_SCORERS",
+          "GOLDENMATCH_NOISE_AWARE_TARGET"
+        ],
+        "PERCEPTUAL": [
+          "GOLDENMATCH_PERCEPTUAL_AUTOCONFIG"
+        ],
+        "PLANNER": [
+          "GOLDENMATCH_PLANNER_BUCKET"
+        ],
+        "PLANNING": [
+          "GOLDENMATCH_PLANNING_EFFORT"
+        ],
+        "PREP": [
+          "GOLDENMATCH_PREP_STAGED_COLLECT"
+        ],
+        "PREPARED": [
+          "GOLDENMATCH_PREPARED_RECORD_STORE_DIR",
+          "GOLDENMATCH_PREPARED_RECORD_STORE_PERSIST"
+        ],
+        "QUALITY": [
+          "GOLDENMATCH_QUALITY_AWARE_BLOCKING",
+          "GOLDENMATCH_QUALITY_GATED_REVIEW"
+        ],
+        "SAIL": [
+          "GOLDENMATCH_SAIL_IDENTITY_ID_SCHEME"
+        ],
+        "SEMANTIC": [
+          "GOLDENMATCH_SEMANTIC_BLOCKING_THRESHOLD"
+        ],
+        "SKIP": [
+          "GOLDENMATCH_SKIP_MATCH_LOG"
+        ],
+        "STANDARDIZE": [
+          "GOLDENMATCH_STANDARDIZE_STAGED"
+        ],
+        "STREAMING": [
+          "GOLDENMATCH_STREAMING_BLOCK_WORKERS"
+        ],
+        "SUGGEST": [
+          "GOLDENMATCH_SUGGEST_COHESION",
+          "GOLDENMATCH_SUGGEST_COVERAGE_CAP",
+          "GOLDENMATCH_SUGGEST_FULL_DIST",
+          "GOLDENMATCH_SUGGEST_HEALTH",
+          "GOLDENMATCH_SUGGEST_MAX_VERIFY",
+          "GOLDENMATCH_SUGGEST_ON_DEDUPE",
+          "GOLDENMATCH_SUGGEST_RECALL_COH_ABS",
+          "GOLDENMATCH_SUGGEST_RECALL_MIN_SHED",
+          "GOLDENMATCH_SUGGEST_RECALL_RATIO",
+          "GOLDENMATCH_SUGGEST_VERIFY"
+        ],
+        "SYNC": [
+          "GOLDENMATCH_SYNC_STREAMING_THRESHOLD"
+        ],
+        "TF": [
+          "GOLDENMATCH_TF_NAME_WEIGHTING"
+        ],
+        "THROUGHPUT": [
+          "GOLDENMATCH_THROUGHPUT",
+          "GOLDENMATCH_THROUGHPUT_RECALL",
+          "GOLDENMATCH_THROUGHPUT_SIMILARITY"
+        ],
+        "UDF": [
+          "GOLDENMATCH_UDF_IMPORTS"
+        ],
+        "VECTOR": [
+          "GOLDENMATCH_VECTOR_INDEX_DIR"
+        ],
+        "WEAKNESS": [
+          "GOLDENMATCH_WEAKNESS_LLM",
+          "GOLDENMATCH_WEAKNESS_LLM_MODEL"
+        ],
+        "WEB": [
+          "GOLDENMATCH_WEB_TOKEN"
+        ]
+      }
+    },
+    "goldencheck": {
+      "nav_group": "GoldenCheck",
+      "env_prefix": "GOLDENCHECK_",
+      "doc_path": "docs-site/goldencheck/config-matrix.mdx",
+      "source": {
+        "import_name": "goldencheck",
+        "root": "packages/python/goldencheck/goldencheck",
+        "modules": {
+          "config_schema": "packages/python/goldencheck/goldencheck/config/schema.py",
+          "cli": "packages/python/goldencheck/goldencheck/cli/main.py",
+          "mcp_server": "packages/python/goldencheck/goldencheck/mcp/server.py"
+        }
+      },
+      "config_models": [
+        {
+          "name": "GoldenCheckConfig",
+          "fields": [
+            {
+              "name": "version",
+              "type": "int",
+              "required": false,
+              "default": "1",
+              "description": "Schema version of this configuration file, used to handle format changes across releases."
+            },
+            {
+              "name": "settings",
+              "type": "Settings",
+              "required": false,
+              "default": "Settings(sample_size=100000, severity_threshold='warning', fail_on='error')",
+              "nested": [
+                "Settings"
+              ],
+              "description": "Global run settings such as sampling size and severity handling that apply to the whole check."
+            },
+            {
+              "name": "columns",
+              "type": "dict[str, ColumnRule]",
+              "required": false,
+              "default": "{}",
+              "nested": [
+                "ColumnRule"
+              ],
+              "description": "Per-column validation rules keyed by column name."
+            },
+            {
+              "name": "relations",
+              "type": "list[RelationRule]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "RelationRule"
+              ],
+              "description": "Cross-column relationship rules applied across multiple columns."
+            },
+            {
+              "name": "ignore",
+              "type": "list[IgnoreEntry]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "IgnoreEntry"
+              ],
+              "description": "List of column and check pairs whose findings should be excluded from results."
+            }
+          ]
+        },
+        {
+          "name": "Settings",
+          "fields": [
+            {
+              "name": "sample_size",
+              "type": "int",
+              "required": false,
+              "default": "100000",
+              "description": "Maximum number of rows sampled from the dataset when running checks, capping work on large tables."
+            },
+            {
+              "name": "severity_threshold",
+              "type": "str",
+              "required": false,
+              "default": "'warning'",
+              "description": "Minimum severity level at which a finding is reported, so anything below this floor is suppressed from results."
+            },
+            {
+              "name": "fail_on",
+              "type": "str",
+              "required": false,
+              "default": "'error'",
+              "description": "Severity level that causes the overall run to fail once a finding at or above it is produced."
+            }
+          ]
+        },
+        {
+          "name": "ColumnRule",
+          "fields": [
+            {
+              "name": "type",
+              "type": "str",
+              "required": true,
+              "description": "Expected data type for the column, used to flag values that do not conform to it."
+            },
+            {
+              "name": "required",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether the column must be present in the dataset, failing the check when it is missing."
+            },
+            {
+              "name": "nullable",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether null values are permitted in the column, flagging nulls when set to false."
+            },
+            {
+              "name": "format",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Named format the column values must match, such as an email or date pattern, for validating string shape."
+            },
+            {
+              "name": "unique",
+              "type": "bool | None",
+              "required": false,
+              "default": "None",
+              "description": "Whether every value in the column must be distinct, flagging duplicate values when set to true."
+            },
+            {
+              "name": "range",
+              "type": "list[float] | None",
+              "required": false,
+              "default": "None",
+              "description": "Inclusive lower and upper numeric bounds that column values must fall within."
+            },
+            {
+              "name": "enum",
+              "type": "list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Closed set of allowed values for the column, flagging any value outside this list."
+            },
+            {
+              "name": "outlier_stddev",
+              "type": "float | None",
+              "required": false,
+              "default": "None",
+              "description": "Number of standard deviations from the mean beyond which a numeric value is flagged as an outlier."
+            }
+          ]
+        },
+        {
+          "name": "RelationRule",
+          "fields": [
+            {
+              "name": "type",
+              "type": "str",
+              "required": true,
+              "description": "Kind of cross-column relationship to enforce, for example a uniqueness or foreign-key style constraint."
+            },
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns that participate in the relationship, evaluated together as a group."
+            }
+          ]
+        },
+        {
+          "name": "IgnoreEntry",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Column whose check results should be suppressed from the report."
+            },
+            {
+              "name": "check",
+              "type": "str",
+              "required": true,
+              "description": "Specific check on that column to skip, silencing its findings for that column."
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for the A2A server"
+            }
+          ]
+        },
+        {
+          "command": "baseline",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "CSV/Parquet/Excel file to profile"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output YAML path"
+            },
+            {
+              "name": "--skip",
+              "type": "text",
+              "required": false,
+              "default": "[]",
+              "help": "Techniques to skip"
+            },
+            {
+              "name": "--update",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Update existing baseline"
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Print results to stdout."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack to apply."
+            }
+          ]
+        },
+        {
+          "command": "denial-constraints",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to mine for denial constraints."
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Fraction of rows/pairs a DC must hold for (default: engine default)."
+            },
+            {
+              "name": "--sample-size",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Bound the cross-tuple (pairwise) pass."
+            },
+            {
+              "name": "--max-constraints",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Cap the ranked number of DCs reported."
+            }
+          ]
+        },
+        {
+          "command": "diff",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to compare."
+            },
+            {
+              "name": "file2",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Second file (omit to compare against git)."
+            },
+            {
+              "name": "--ref",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Git ref to compare against (default: HEAD)."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            }
+          ]
+        },
+        {
+          "command": "evaluate",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to scan."
+            },
+            {
+              "name": "--ground-truth",
+              "type": "path",
+              "required": true,
+              "help": "JSON file with expected findings."
+            },
+            {
+              "name": "--min-f1",
+              "type": "float",
+              "required": false,
+              "default": "0.0",
+              "help": "Minimum F1 score; exit 1 if below."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            }
+          ]
+        },
+        {
+          "command": "fix",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to fix."
+            },
+            {
+              "name": "--mode",
+              "type": "text",
+              "required": false,
+              "default": "'safe'",
+              "help": "Fix mode: safe, moderate, or aggressive."
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output file path."
+            },
+            {
+              "name": "--dry-run",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show fixes without writing."
+            },
+            {
+              "name": "--force",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Required for aggressive mode."
+            }
+          ]
+        },
+        {
+          "command": "history",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Filter history by file."
+            },
+            {
+              "name": "--last",
+              "type": "integer",
+              "required": false,
+              "default": "None",
+              "help": "Show last N scans."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to scan for initial rules."
+            },
+            {
+              "name": "--yes",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Accept defaults, skip interactive prompts."
+            }
+          ]
+        },
+        {
+          "command": "learn",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to analyze."
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output path for rules (default: goldencheck_rules.json)."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: 'stdio' or 'http'"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "refs",
+          "options": [
+            {
+              "name": "child",
+              "type": "path",
+              "required": true,
+              "help": "Child/fact file holding the foreign key(s)."
+            },
+            {
+              "name": "parent",
+              "type": "path",
+              "required": true,
+              "help": "Parent/dimension file holding the key(s)."
+            },
+            {
+              "name": "--on",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "FK mapping 'child_col=parent_col' (repeatable). Omit to auto-detect same-named parent-key columns."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--fail-on",
+              "type": "text",
+              "required": false,
+              "default": "'error'",
+              "help": "CI exit threshold: error/warning/info."
+            }
+          ]
+        },
+        {
+          "command": "review",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to profile and validate."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to goldencheck.yml."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM enhancement pass."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack: healthcare, finance, ecommerce."
+            }
+          ]
+        },
+        {
+          "command": "scan",
+          "options": [
+            {
+              "name": "files",
+              "type": "path",
+              "required": true,
+              "help": "Data file(s) to profile."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            },
+            {
+              "name": "--llm-boost",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM enhancement pass."
+            },
+            {
+              "name": "--llm-provider",
+              "type": "text",
+              "required": false,
+              "default": "'anthropic'",
+              "help": "LLM provider: anthropic or openai."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack: healthcare, finance, ecommerce."
+            },
+            {
+              "name": "--smart",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Auto-triage: pin high-confidence, dismiss low."
+            },
+            {
+              "name": "--guided",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Walk through findings one at a time."
+            },
+            {
+              "name": "--no-history",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Don't record this scan in history."
+            },
+            {
+              "name": "--webhook",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "URL to POST findings to."
+            },
+            {
+              "name": "--notify-on",
+              "type": "text",
+              "required": false,
+              "default": "'grade-drop'",
+              "help": "Trigger: grade-drop, any-error, any-warning."
+            },
+            {
+              "name": "--html",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Generate HTML report at this path."
+            },
+            {
+              "name": "--baseline",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to baseline YAML"
+            },
+            {
+              "name": "--no-baseline",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Ignore baseline files"
+            },
+            {
+              "name": "--deep",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Profile the full dataset (skip the 100K sample cap)."
+            },
+            {
+              "name": "--denial",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Also mine denial constraints (opt-in; slower)."
+            }
+          ]
+        },
+        {
+          "command": "scan-db",
+          "options": [
+            {
+              "name": "connection",
+              "type": "text",
+              "required": true,
+              "help": "Database connection string (postgres://, snowflake://, etc.)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Table name to scan."
+            },
+            {
+              "name": "--query",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Custom SQL query."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output as JSON."
+            },
+            {
+              "name": "--html",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Generate HTML report."
+            },
+            {
+              "name": "--sample-size",
+              "type": "integer",
+              "required": false,
+              "default": "100000",
+              "help": "Max rows to fetch."
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "files",
+              "type": "path",
+              "required": true,
+              "help": "Data files to scan on schedule."
+            },
+            {
+              "name": "--interval",
+              "type": "text",
+              "required": false,
+              "default": "'daily'",
+              "help": "Interval: hourly, daily, weekly, 5min, 15min, 30min, or seconds."
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack."
+            },
+            {
+              "name": "--webhook",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Webhook URL for notifications."
+            },
+            {
+              "name": "--notify-on",
+              "type": "text",
+              "required": false,
+              "default": "'grade-drop'",
+              "help": "Trigger: grade-drop, any-error, any-warning."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "JSON output per scan."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host to bind to."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port to listen on."
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "file",
+              "type": "path",
+              "required": true,
+              "help": "Data file to validate."
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Path to goldencheck.yml."
+            },
+            {
+              "name": "--no-tui",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Disable TUI and print Rich output instead."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Output results as JSON."
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "directory",
+              "type": "path",
+              "required": true,
+              "help": "Directory to watch."
+            },
+            {
+              "name": "--interval",
+              "type": "integer",
+              "required": false,
+              "default": "60",
+              "help": "Poll interval in seconds."
+            },
+            {
+              "name": "--pattern",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Glob pattern (e.g., '*.csv')."
+            },
+            {
+              "name": "--exit-on",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Exit on severity: error or warning."
+            },
+            {
+              "name": "--json",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "JSON output per scan."
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "analyze_data",
+          "description": "Analyze a data file to detect its domain, profile columns, and recommend a scanning strategy. Returns domain detection, column count, row count, strategy decisions, and alternative approaches."
+        },
+        {
+          "name": "approve_reject",
+          "description": "Approve (pin) or reject (dismiss) a review queue item. Decision must be 'pin' or 'dismiss'."
+        },
+        {
+          "name": "auto_configure",
+          "description": "Scan a data file, triage findings by confidence, and generate goldencheck.yml content from the pinned findings. Optionally accepts constraints to filter or adjust the generated config."
+        },
+        {
+          "name": "compare_domains",
+          "description": "Scan a file with every available domain pack (plus base/no-domain) and compare health scores. Recommends the best-fitting domain."
+        },
+        {
+          "name": "explain_column",
+          "description": "Get a natural-language health narrative for a specific column. Scans the file, profiles the column, and explains all findings."
+        },
+        {
+          "name": "explain_finding",
+          "description": "Explain a single finding in natural language. Requires the finding as a JSON dict and the file_path to load a profile for context."
+        },
+        {
+          "name": "get_column_detail",
+          "description": "Get detailed profile and findings for a specific column."
+        },
+        {
+          "name": "get_domain_info",
+          "description": "Get detailed info about a specific domain pack — lists all semantic types, their name hints, and suppression rules."
+        },
+        {
+          "name": "health_score",
+          "description": "Get the health score (A-F, 0-100) for a data file. Quick summary of overall data quality."
+        },
+        {
+          "name": "install_domain",
+          "description": "Download a community domain pack from the goldencheck-types repository and save it for use in future scans."
+        },
+        {
+          "name": "list_checks",
+          "description": "List all available profiler checks and what they detect. No arguments needed."
+        },
+        {
+          "name": "list_domains",
+          "description": "List all available domain packs (healthcare, finance, ecommerce, etc.). Domain packs provide specialized semantic type definitions for specific data domains."
+        },
+        {
+          "name": "pipeline_handoff",
+          "description": "Generate a structured quality attestation JSON for a data file. Includes health score, findings summary, pinned rules, and attestation status (PASS, PASS_WITH_WARNINGS, REVIEW_REQUIRED, FAIL)."
+        },
+        {
+          "name": "profile",
+          "description": "Profile a data file and return column-level statistics: type, null%, unique%, min/max, top values, detected formats. Also returns a health score (A-F) based on finding severity."
+        },
+        {
+          "name": "review_queue",
+          "description": "List all pending review items for a given job. Returns items that need human decision (medium-confidence findings)."
+        },
+        {
+          "name": "review_stats",
+          "description": "Get review queue statistics for a job — counts of pending, pinned, and dismissed items."
+        },
+        {
+          "name": "scan",
+          "description": "Scan a data file (CSV, Parquet, Excel) for data quality issues. Returns findings with severity, confidence, affected rows, and sample values. No configuration needed — rules are discovered from the data."
+        },
+        {
+          "name": "suggest_fix",
+          "description": "Preview fixes for a data file without applying them. Shows what would change (columns, fix types, rows affected, before/after samples)."
+        },
+        {
+          "name": "validate",
+          "description": "Validate a data file against pinned rules in goldencheck.yml. Returns validation findings (existence, required, unique, enum, range checks)."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Finding severity",
+          "target": "goldencheck.models.finding:Severity",
+          "applies": "`Settings.severity_threshold` / `fail_on`",
+          "values": [
+            {
+              "value": "ERROR",
+              "meaning": "Highest severity; fails the run at the default fail_on=error."
+            },
+            {
+              "value": "INFO",
+              "meaning": "Informational finding; never fails the run."
+            },
+            {
+              "value": "WARNING",
+              "meaning": "Advisory finding; fails only when fail_on=warning."
+            }
+          ]
+        },
+        {
+          "title": "Denial-constraint operators",
+          "target": "goldencheck.denial.models:Op",
+          "applies": "mined denial constraints",
+          "values": [
+            {
+              "value": "<",
+              "meaning": "Less than."
+            },
+            {
+              "value": "=",
+              "meaning": "Equal."
+            },
+            {
+              "value": ">",
+              "meaning": "Greater than."
+            },
+            {
+              "value": "≠",
+              "meaning": "Not equal."
+            },
+            {
+              "value": "≤",
+              "meaning": "Less than or equal."
+            },
+            {
+              "value": "≥",
+              "meaning": "Greater than or equal."
+            }
+          ]
+        },
+        {
+          "title": "Check types",
+          "target": "goldencheck.models.finding:CHECK_TYPES",
+          "applies": "`Finding.check`",
+          "values": [
+            {
+              "value": "benford_drift",
+              "meaning": "Leading-digit (Benford) distribution drifted."
+            },
+            {
+              "value": "bound_violation",
+              "meaning": "A value crossed a learned baseline bound."
+            },
+            {
+              "value": "cardinality",
+              "meaning": "A column's distinct-value count / ratio."
+            },
+            {
+              "value": "composite_key",
+              "meaning": "A candidate multi-column key."
+            },
+            {
+              "value": "correlation_break",
+              "meaning": "A previously strong correlation weakened."
+            },
+            {
+              "value": "cross_column",
+              "meaning": "A cross-column relationship finding."
+            },
+            {
+              "value": "cross_column_validation",
+              "meaning": "A cross-column validation rule failed."
+            },
+            {
+              "value": "denial_constraint",
+              "meaning": "A mined denial constraint is violated."
+            },
+            {
+              "value": "distribution_drift",
+              "meaning": "A column's value distribution drifted."
+            },
+            {
+              "value": "drift_detection",
+              "meaning": "General distribution drift versus the baseline."
+            },
+            {
+              "value": "duplicate_rows",
+              "meaning": "Fully duplicated rows."
+            },
+            {
+              "value": "encoding_detection",
+              "meaning": "Suspect character encoding / mojibake."
+            },
+            {
+              "value": "entropy_drift",
+              "meaning": "A column's entropy drifted."
+            },
+            {
+              "value": "enum",
+              "meaning": "A value is outside the allowed enum set."
+            },
+            {
+              "value": "existence",
+              "meaning": "A column the config expects is present."
+            },
+            {
+              "value": "fd_violation",
+              "meaning": "Rows violate a functional dependency."
+            },
+            {
+              "value": "format_detection",
+              "meaning": "The detected value format (email, phone, ...)."
+            },
+            {
+              "value": "functional_dependency",
+              "meaning": "A discovered functional dependency."
+            },
+            {
+              "value": "future_dated",
+              "meaning": "A date is in the future."
+            },
+            {
+              "value": "fuzzy_duplicate_values",
+              "meaning": "Near-duplicate values within a column."
+            },
+            {
+              "value": "identity_safe_pk",
+              "meaning": "A column is a safe, stable primary key."
+            },
+            {
+              "value": "key_uniqueness_loss",
+              "meaning": "A key lost uniqueness versus the baseline."
+            },
+            {
+              "value": "near_duplicate_rows",
+              "meaning": "Near-duplicate rows (fuzzy)."
+            },
+            {
+              "value": "new_correlation",
+              "meaning": "A new column correlation appeared."
+            },
+            {
+              "value": "new_pattern",
+              "meaning": "A new value pattern appeared."
+            },
+            {
+              "value": "null_correlation",
+              "meaning": "Nulls in two columns co-occur suspiciously."
+            },
+            {
+              "value": "nullability",
+              "meaning": "A column's null rate exceeds the allowed bound."
+            },
+            {
+              "value": "pattern_consistency",
+              "meaning": "Values deviate from the column's dominant pattern."
+            },
+            {
+              "value": "pattern_drift",
+              "meaning": "A column's dominant pattern changed."
+            },
+            {
+              "value": "range",
+              "meaning": "A value falls outside the allowed range."
+            },
+            {
+              "value": "range_distribution",
+              "meaning": "Value distribution versus the expected range."
+            },
+            {
+              "value": "referential_integrity",
+              "meaning": "A foreign-key reference is unmatched."
+            },
+            {
+              "value": "required",
+              "meaning": "A required column contains no nulls."
+            },
+            {
+              "value": "sequence_detection",
+              "meaning": "A column is a monotonic sequence / counter."
+            },
+            {
+              "value": "stale_data",
+              "meaning": "Data is older than the freshness bound."
+            },
+            {
+              "value": "temporal_order",
+              "meaning": "Dates violate an expected ordering."
+            },
+            {
+              "value": "temporal_order_drift",
+              "meaning": "Temporal ordering changed versus the baseline."
+            },
+            {
+              "value": "type_drift",
+              "meaning": "A column's inferred type changed."
+            },
+            {
+              "value": "type_inference",
+              "meaning": "The inferred data type for a column."
+            },
+            {
+              "value": "unique",
+              "meaning": "A column declared unique has duplicates."
+            },
+            {
+              "value": "uniqueness",
+              "meaning": "The observed uniqueness of a column."
+            },
+            {
+              "value": "unmapped_column",
+              "meaning": "A column has no rule and no inferred type."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "AGENT": [
+          "GOLDENCHECK_AGENT_TOKEN"
+        ],
+        "FORCE": [
+          "GOLDENCHECK_FORCE_TUI"
+        ],
+        "LLM": [
+          "GOLDENCHECK_LLM_BUDGET",
+          "GOLDENCHECK_LLM_MODEL"
+        ],
+        "NATIVE": [
+          "GOLDENCHECK_NATIVE"
+        ],
+        "SCAN": [
+          "GOLDENCHECK_SCAN_THREADS"
+        ]
+      }
+    },
+    "goldenflow": {
+      "nav_group": "GoldenFlow",
+      "env_prefix": "GOLDENFLOW_",
+      "doc_path": "docs-site/goldenflow/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenflow",
+        "root": "packages/python/goldenflow/goldenflow",
+        "modules": {
+          "config_schema": "packages/python/goldenflow/goldenflow/config/schema.py",
+          "cli": "packages/python/goldenflow/goldenflow/cli/main.py",
+          "mcp_server": "packages/python/goldenflow/goldenflow/mcp/server.py"
+        }
+      },
+      "config_models": [
+        {
+          "name": "GoldenFlowConfig",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Path or identifier of the input dataset to read records from."
+            },
+            {
+              "name": "output",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Path or identifier where the transformed dataset is written."
+            },
+            {
+              "name": "transforms",
+              "type": "list[TransformSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "TransformSpec"
+              ],
+              "description": "Per-column transform specs that standardize values by applying ordered ops."
+            },
+            {
+              "name": "splits",
+              "type": "list[SplitSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "SplitSpec"
+              ],
+              "description": "Split specs that break one column into several target columns."
+            },
+            {
+              "name": "renames",
+              "type": "dict[str, str]",
+              "required": false,
+              "default": "{}",
+              "description": "Mapping of existing column names to new names to rename them to."
+            },
+            {
+              "name": "drop",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Names of columns to remove from the output."
+            },
+            {
+              "name": "filters",
+              "type": "list[FilterSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "FilterSpec"
+              ],
+              "description": "Filter specs that keep only rows satisfying each condition."
+            },
+            {
+              "name": "dedup",
+              "type": "DedupSpec | None",
+              "required": false,
+              "default": "None",
+              "nested": [
+                "DedupSpec"
+              ],
+              "description": "Optional deduplication spec that collapses duplicate rows by key columns."
+            },
+            {
+              "name": "mappings",
+              "type": "list[MappingSpec]",
+              "required": false,
+              "default": "[]",
+              "nested": [
+                "MappingSpec"
+              ],
+              "description": "Mapping specs that copy source columns to targets with optional transforms."
+            }
+          ]
+        },
+        {
+          "name": "TransformSpec",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column the transform operations are applied to."
+            },
+            {
+              "name": "ops",
+              "type": "list[str]",
+              "required": true,
+              "description": "Ordered list of transform-op names applied in sequence to the column."
+            }
+          ]
+        },
+        {
+          "name": "SplitSpec",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column whose values are split into multiple columns."
+            },
+            {
+              "name": "target",
+              "type": "list[str]",
+              "required": true,
+              "description": "Names of the output columns produced by the split."
+            },
+            {
+              "name": "method",
+              "type": "str",
+              "required": true,
+              "description": "Splitting method that determines how the source value is divided."
+            }
+          ]
+        },
+        {
+          "name": "FilterSpec",
+          "fields": [
+            {
+              "name": "column",
+              "type": "str",
+              "required": true,
+              "description": "Name of the column the filter condition is evaluated against."
+            },
+            {
+              "name": "condition",
+              "type": "str",
+              "required": true,
+              "description": "Predicate expression that rows must satisfy to be kept."
+            }
+          ]
+        },
+        {
+          "name": "DedupSpec",
+          "fields": [
+            {
+              "name": "columns",
+              "type": "list[str]",
+              "required": true,
+              "description": "Columns whose combined values define what counts as a duplicate row."
+            },
+            {
+              "name": "keep",
+              "type": "Literal",
+              "required": false,
+              "default": "'first'",
+              "choices": [
+                "first",
+                "last"
+              ],
+              "description": "Which duplicate to retain within each group, either the first or last occurrence."
+            }
+          ]
+        },
+        {
+          "name": "MappingSpec",
+          "fields": [
+            {
+              "name": "source",
+              "type": "str",
+              "required": true,
+              "description": "Name of the source column to read values from."
+            },
+            {
+              "name": "target",
+              "type": "str | list[str]",
+              "required": true,
+              "description": "Name or names of the target column(s) the source values are written to."
+            },
+            {
+              "name": "transform",
+              "type": "str | list[str] | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional transform op or ordered list of ops applied while mapping source to target."
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8150",
+              "help": "Port the A2A agent server listens on."
+            }
+          ]
+        },
+        {
+          "command": "demo",
+          "options": [
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "Path('.')",
+              "help": "Directory where the sample data and config files are written."
+            }
+          ]
+        },
+        {
+          "command": "diff",
+          "options": [
+            {
+              "name": "before",
+              "type": "path",
+              "required": true,
+              "help": "Before file"
+            },
+            {
+              "name": "after",
+              "type": "path",
+              "required": true,
+              "help": "After file"
+            }
+          ]
+        },
+        {
+          "command": "history",
+          "options": [
+            {
+              "name": "--limit",
+              "type": "integer",
+              "required": false,
+              "default": "20",
+              "help": "Number of recent runs to show"
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "data",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Data file to profile"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'goldenflow.yaml'",
+              "help": "Path where the generated config file is written."
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Input data file"
+            }
+          ]
+        },
+        {
+          "command": "learn",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "'goldenflow.yaml'",
+              "help": "Output config path"
+            }
+          ]
+        },
+        {
+          "command": "map",
+          "options": [
+            {
+              "name": "--source",
+              "type": "path",
+              "required": true,
+              "help": "Source data file"
+            },
+            {
+              "name": "--target",
+              "type": "path",
+              "required": true,
+              "help": "Target data file or schema"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Mapping config"
+            },
+            {
+              "name": "--output",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Save mapping config"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8150",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "profile",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            }
+          ]
+        },
+        {
+          "command": "schedule",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Data file to transform"
+            },
+            {
+              "name": "--every",
+              "type": "text",
+              "required": false,
+              "default": "'1h'",
+              "help": "Interval (e.g., 5m, 1h, 30s)"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied on each scheduled run."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where transformed files are written."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Network interface the REST API server binds to."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port the REST API server listens on."
+            }
+          ]
+        },
+        {
+          "command": "stream",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--chunk-size",
+              "type": "integer",
+              "required": false,
+              "default": "10000",
+              "help": "Rows per batch"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied to each streamed batch."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where the combined transformed file is written."
+            }
+          ]
+        },
+        {
+          "command": "transform",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config file"
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Output directory"
+            },
+            {
+              "name": "--domain",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Domain pack to use"
+            },
+            {
+              "name": "--from-findings",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Read findings from stdin"
+            },
+            {
+              "name": "--llm",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable LLM-enhanced transforms"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Fail if any transform errors occur"
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": true,
+              "help": "Input data file"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config file describing which transforms to apply."
+            }
+          ]
+        },
+        {
+          "command": "watch",
+          "options": [
+            {
+              "name": "path",
+              "type": "path",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory to watch"
+            },
+            {
+              "name": "--config",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "YAML config applied to each new or changed file."
+            },
+            {
+              "name": "--output-dir",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Directory where transformed files are written."
+            },
+            {
+              "name": "--interval",
+              "type": "float",
+              "required": false,
+              "default": "2.0",
+              "help": "Poll interval in seconds"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "diff",
+          "description": "Compare two data files and show what changed (added, removed, modified rows)."
+        },
+        {
+          "name": "explain_transform",
+          "description": "Describe what a specific transform does, its mode, and input types."
+        },
+        {
+          "name": "learn",
+          "description": "Generate a YAML config from data patterns."
+        },
+        {
+          "name": "list_domains",
+          "description": "List available domain packs (e.g., people_hr, ecommerce, finance)."
+        },
+        {
+          "name": "list_transforms",
+          "description": "List all registered transforms with their modes, input types, and auto-apply status."
+        },
+        {
+          "name": "map",
+          "description": "Auto-map schemas between source and target files."
+        },
+        {
+          "name": "profile",
+          "description": "Profile a data file showing column types, nulls, and patterns."
+        },
+        {
+          "name": "select_from_findings",
+          "description": "Map GoldenCheck findings to recommended GoldenFlow transforms. Bridge tool for Check-to-Flow handoff."
+        },
+        {
+          "name": "transform",
+          "description": "Clean / normalize a data file with GoldenFlow transforms (phone, date, unicode, casing, categorical, and more) and write the transformed file. Zero-config auto-detects and applies transforms; pass a config to control them. See list_transforms for what's available. Does not deduplicate or match -- it only reshapes column values."
+        },
+        {
+          "name": "validate",
+          "description": "Dry-run transform on a file. Shows what would change without writing output."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Transform ops",
+          "target": "goldenflow.transforms:list_transforms",
+          "applies": "`TransformSpec.ops`",
+          "values": [
+            {
+              "value": "aba_validate",
+              "meaning": "Validate a US ABA bank routing number: exactly 9 digits plus the"
+            },
+            {
+              "value": "abs_value",
+              "meaning": "Return the absolute value."
+            },
+            {
+              "value": "account_mask",
+              "meaning": "Mask account numbers showing only last 4 digits."
+            },
+            {
+              "value": "address_expand",
+              "meaning": "Replace street abbreviations (St, Ave...) with full forms."
+            },
+            {
+              "value": "address_standardize",
+              "meaning": "Replace full street suffixes (Street, Avenue...) with abbreviations."
+            },
+            {
+              "value": "age_from_dob",
+              "meaning": "Compute age in years from a date of birth."
+            },
+            {
+              "value": "boolean_normalize",
+              "meaning": "Parse loose boolean-ish strings (yes/no/y/n/1/0/true/false/t/f)."
+            },
+            {
+              "value": "carceral_abbreviate",
+              "meaning": "Expand carceral facility-type abbreviations and state-complex aliases."
+            },
+            {
+              "value": "carceral_name_normalize",
+              "meaning": "Full carceral name pipeline: org-strip + uppercase + punctuation strip"
+            },
+            {
+              "value": "carceral_org_strip",
+              "meaning": "Strip leading operator-org prefix from a carceral facility name."
+            },
+            {
+              "value": "category_auto_correct",
+              "meaning": "Auto-correct categorical misspellings and case variants."
+            },
+            {
+              "value": "category_from_file",
+              "meaning": "Load mapping from a CSV/YAML file and standardize values."
+            },
+            {
+              "value": "category_llm_correct",
+              "meaning": "LLM-enhanced categorical correction."
+            },
+            {
+              "value": "category_standardize",
+              "meaning": "Map variant values to canonical values. mapping: {canonical: [variant1, variant2, ...]}"
+            },
+            {
+              "value": "cc_brand",
+              "meaning": "Detect the card brand (visa/mastercard/amex/...) or null. Native-first."
+            },
+            {
+              "value": "cc_format",
+              "meaning": "Group a valid payment-card number (Amex 4-6-5, else 4-4-4-4...);"
+            },
+            {
+              "value": "cc_mask",
+              "meaning": "Mask a payment-card number to stars + last 4 digits."
+            },
+            {
+              "value": "cc_validate",
+              "meaning": "Validate a payment-card number via the Luhn checksum."
+            },
+            {
+              "value": "clamp",
+              "meaning": "Clip values into [min_val, max_val]."
+            },
+            {
+              "value": "collapse_whitespace",
+              "meaning": "Collapse runs of whitespace to single spaces."
+            },
+            {
+              "value": "comma_decimal",
+              "meaning": "Convert European decimal format (1.234,56) to float (1234.56)."
+            },
+            {
+              "value": "company_extract_legal",
+              "meaning": "Extract the canonical legal-form token (``inc``/``llc``/...) or null."
+            },
+            {
+              "value": "company_normalize",
+              "meaning": "Composite company dedup key: lowercase, drop leading 'the', strip legal"
+            },
+            {
+              "value": "company_strip_legal",
+              "meaning": "Strip trailing legal-form suffixes, preserving the core name's case."
+            },
+            {
+              "value": "country_standardize",
+              "meaning": "Normalize country names to ISO 3166-1 alpha-2 codes."
+            },
+            {
+              "value": "currency_strip",
+              "meaning": "Strip currency symbols and thousand separators, return numeric."
+            },
+            {
+              "value": "cusip_format",
+              "meaning": "Standardize CUSIP identifiers (9 chars, uppercase)."
+            },
+            {
+              "value": "cusip_validate",
+              "meaning": "Validate a CUSIP. Native-first over goldenflow-core."
+            },
+            {
+              "value": "date_eu",
+              "meaning": "Parse a European (DD/MM/YYYY) date."
+            },
+            {
+              "value": "date_iso8601",
+              "meaning": "Parse/format a date as ISO-8601."
+            },
+            {
+              "value": "date_parse",
+              "meaning": "Auto-detect format and normalize to ISO 8601."
+            },
+            {
+              "value": "date_shift",
+              "meaning": "Shift dates by a number of days (positive = forward, negative = backward)."
+            },
+            {
+              "value": "date_us",
+              "meaning": "Parse a US (MM/DD/YYYY) date."
+            },
+            {
+              "value": "date_validate",
+              "meaning": "Validate if value is a parseable date. Returns True/False/None."
+            },
+            {
+              "value": "datetime_iso8601",
+              "meaning": "Parse to ISO 8601 datetime (with time component)."
+            },
+            {
+              "value": "double_metaphone_alt",
+              "meaning": "Alternate Double Metaphone code. Native-first."
+            },
+            {
+              "value": "double_metaphone_primary",
+              "meaning": "Primary Double Metaphone code (blocking key). Native-first."
+            },
+            {
+              "value": "ean_validate",
+              "meaning": "Validate an EAN-8, UPC-A, or EAN-13 via its GTIN mod-10 checksum."
+            },
+            {
+              "value": "ein_format",
+              "meaning": "Normalize EIN to XX-XXXXXXX format. Native-first."
+            },
+            {
+              "value": "email_canonical",
+              "meaning": "Full dedup key: email_normalize + alias googlemail.com -> gmail.com so"
+            },
+            {
+              "value": "email_extract_domain",
+              "meaning": "Extract the lowercased domain from an email address."
+            },
+            {
+              "value": "email_lowercase",
+              "meaning": "Lowercase the entire email address (trim + lowercase)."
+            },
+            {
+              "value": "email_mask",
+              "meaning": "PII mask: keep the first local char, star the rest, keep @domain"
+            },
+            {
+              "value": "email_normalize",
+              "meaning": "Normalize email: lowercase, strip +tags, strip dots from Gmail local part."
+            },
+            {
+              "value": "email_validate",
+              "meaning": "Validate email format. Returns True/False/None."
+            },
+            {
+              "value": "extract_day",
+              "meaning": "Extract the day of month as an integer (1-31)."
+            },
+            {
+              "value": "extract_day_of_week",
+              "meaning": "Extract the day of week name (Monday, Tuesday, etc.)."
+            },
+            {
+              "value": "extract_month",
+              "meaning": "Extract the month as an integer (1-12)."
+            },
+            {
+              "value": "extract_numbers",
+              "meaning": "Extract all numbers from text, joined by spaces."
+            },
+            {
+              "value": "extract_quarter",
+              "meaning": "Extract the quarter (1-4) from a date."
+            },
+            {
+              "value": "extract_year",
+              "meaning": "Extract the year as an integer."
+            },
+            {
+              "value": "fill_zero",
+              "meaning": "Replace null values with 0."
+            },
+            {
+              "value": "fix_mojibake",
+              "meaning": "Fix common UTF-8/Latin-1 mojibake by re-encoding."
+            },
+            {
+              "value": "fraction_to_decimal",
+              "meaning": "Parse a fraction or mixed number (1/2, 3 3/4) to a float. Native-first."
+            },
+            {
+              "value": "gender_standardize",
+              "meaning": "Standardize gender strings to ``M``/``F``; anything else passes"
+            },
+            {
+              "value": "iban_format",
+              "meaning": "Group a valid IBAN into 4-char blocks; ``null`` for invalid input."
+            },
+            {
+              "value": "iban_validate",
+              "meaning": "Validate an IBAN via structural checks + the ISO 7064 mod-97 check."
+            },
+            {
+              "value": "icd10_format",
+              "meaning": "Standardize ICD-10 codes (uppercase, insert dot after 3rd char)."
+            },
+            {
+              "value": "imei_validate",
+              "meaning": "Validate an IMEI: exactly 15 digits plus the Luhn checksum."
+            },
+            {
+              "value": "initial_expand",
+              "meaning": "Returns (series, flagged_rows). Values with initials are unchanged but flagged."
+            },
+            {
+              "value": "isbn_normalize",
+              "meaning": "Canonicalize a valid ISBN-10/13 to its 13-digit form; ``null`` for"
+            },
+            {
+              "value": "isbn_validate",
+              "meaning": "Validate an ISBN-10 or ISBN-13 via its checksum."
+            },
+            {
+              "value": "isin_validate",
+              "meaning": "Validate an ISIN (ISO 6166). Native-first over goldenflow-core."
+            },
+            {
+              "value": "latlng_pack",
+              "meaning": "Pack ``lat`` + ``lng`` into a single ``latlng`` column shaped"
+            },
+            {
+              "value": "lowercase",
+              "meaning": "Lowercase the value."
+            },
+            {
+              "value": "luhn_validate",
+              "meaning": "Generic Luhn check-digit validation. Native-first over goldenflow-core."
+            },
+            {
+              "value": "merge_name",
+              "meaning": "Merge first_name and last_name columns into a full_name column."
+            },
+            {
+              "value": "mls_normalize",
+              "meaning": "Normalize MLS listing IDs (uppercase, strip whitespace)."
+            },
+            {
+              "value": "name_initials",
+              "meaning": "Initials of each whitespace token (letter-leading tokens only)."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name (title-case + Mc/O' fixups)."
+            },
+            {
+              "value": "name_script",
+              "meaning": "Detect the dominant Unicode script in a name: ``Unknown`` for empty"
+            },
+            {
+              "value": "name_transliterate",
+              "meaning": "ASCII-fold a name via an explicit curated diacritic map. Non-ASCII"
+            },
+            {
+              "value": "nickname_standardize",
+              "meaning": "Map common nicknames to formal first names."
+            },
+            {
+              "value": "normalize_line_endings",
+              "meaning": "Normalize \\r\\n and \\r to \\n."
+            },
+            {
+              "value": "normalize_quotes",
+              "meaning": "Replace smart/curly quotes with straight quotes."
+            },
+            {
+              "value": "normalize_unicode",
+              "meaning": "Normalize to Unicode NFC form."
+            },
+            {
+              "value": "npi_validate",
+              "meaning": "Validate a US NPI. Native-first over goldenflow-core."
+            },
+            {
+              "value": "null_standardize",
+              "meaning": "Map null-sentinel strings (n/a, null, none, na, nil, nan, -, empty) to"
+            },
+            {
+              "value": "ordinal_to_int",
+              "meaning": "Parse an English ordinal (1st/2nd/3rd) to its integer. Native-first."
+            },
+            {
+              "value": "pad_left",
+              "meaning": "Left-pad strings to a fixed width."
+            },
+            {
+              "value": "pad_right",
+              "meaning": "Right-pad strings to a fixed width."
+            },
+            {
+              "value": "percentage_normalize",
+              "meaning": "Strip trailing %, parse to float, divide by 100."
+            },
+            {
+              "value": "phone_country_code",
+              "meaning": "Extract the country calling code as an integer."
+            },
+            {
+              "value": "phone_digits",
+              "meaning": "Keep only the phone number's digits."
+            },
+            {
+              "value": "phone_e164",
+              "meaning": "Format a phone number as E.164."
+            },
+            {
+              "value": "phone_national",
+              "meaning": "Format a phone number in national format."
+            },
+            {
+              "value": "phone_validate",
+              "meaning": "Flag whether the phone number is valid."
+            },
+            {
+              "value": "remove_digits",
+              "meaning": "Remove all digit characters from text."
+            },
+            {
+              "value": "remove_emojis",
+              "meaning": "Remove emoji characters from text."
+            },
+            {
+              "value": "remove_html_tags",
+              "meaning": "Strip HTML tags from text."
+            },
+            {
+              "value": "remove_punctuation",
+              "meaning": "Strip punctuation characters."
+            },
+            {
+              "value": "remove_urls",
+              "meaning": "Strip URLs (http/https) from text."
+            },
+            {
+              "value": "roman_to_int",
+              "meaning": "Parse a Roman numeral to its integer (canonical forms only, 1..=3999)."
+            },
+            {
+              "value": "round",
+              "meaning": "Round to n decimal places (round-half-away-from-zero, see the"
+            },
+            {
+              "value": "scientific_to_decimal",
+              "meaning": "Convert scientific notation (1.5e3) to decimal (1500.0)."
+            },
+            {
+              "value": "sku_normalize",
+              "meaning": "Normalize SKU identifiers (uppercase, strip whitespace, remove special chars)."
+            },
+            {
+              "value": "soundex",
+              "meaning": "Soundex phonetic key. Native-first over goldenflow-core."
+            },
+            {
+              "value": "split_address",
+              "meaning": "Parse 'street, city, state zip' into separate columns."
+            },
+            {
+              "value": "split_name",
+              "meaning": "Split 'First Last' into first_name and last_name columns."
+            },
+            {
+              "value": "split_name_reverse",
+              "meaning": "Split 'Last, First' into first_name and last_name columns."
+            },
+            {
+              "value": "ssn_format",
+              "meaning": "Normalize SSN to XXX-XX-XXXX format. Native-first over goldenflow-core."
+            },
+            {
+              "value": "ssn_mask",
+              "meaning": "Mask SSN to ***-**-XXXX (last 4 visible). Native-first."
+            },
+            {
+              "value": "ssn_validate",
+              "meaning": "Flag whether the value is a valid US Social Security Number."
+            },
+            {
+              "value": "state_abbreviate",
+              "meaning": "Normalize state name to a 2-letter abbreviation (unmatched -> original)."
+            },
+            {
+              "value": "state_expand",
+              "meaning": "Expand a 2-letter state abbreviation to its full name (unmatched -> original)."
+            },
+            {
+              "value": "strip",
+              "meaning": "Trim leading/trailing whitespace."
+            },
+            {
+              "value": "strip_middle",
+              "meaning": "Keep only the first and last whitespace tokens (drop the middle)."
+            },
+            {
+              "value": "strip_suffixes",
+              "meaning": "Strip trailing professional suffixes (Jr/Sr/II/MD/PhD/etc.) from names."
+            },
+            {
+              "value": "strip_titles",
+              "meaning": "Strip leading personal titles (Mr/Mrs/Ms/Dr/Prof/etc.) from names."
+            },
+            {
+              "value": "swift_format",
+              "meaning": "Normalize a valid SWIFT/BIC code to uppercase (spaces stripped);"
+            },
+            {
+              "value": "swift_validate",
+              "meaning": "Validate a SWIFT/BIC code via structural checks (length 8/11 +"
+            },
+            {
+              "value": "title_case",
+              "meaning": "Title-case the value."
+            },
+            {
+              "value": "to_integer",
+              "meaning": "Parse string to integer, truncating any decimal part."
+            },
+            {
+              "value": "truncate",
+              "meaning": "Truncate string to the first n characters."
+            },
+            {
+              "value": "unit_normalize",
+              "meaning": "Normalize unit/apartment/suite designations."
+            },
+            {
+              "value": "uppercase",
+              "meaning": "Uppercase the value."
+            },
+            {
+              "value": "url_canonical",
+              "meaning": "Composite dedup key: ensure scheme, lowercase scheme+host, strip www.,"
+            },
+            {
+              "value": "url_extract_domain",
+              "meaning": "Extract domain from a URL."
+            },
+            {
+              "value": "url_normalize",
+              "meaning": "Normalize URLs: ensure scheme, lowercase domain, strip trailing slash."
+            },
+            {
+              "value": "url_strip_tracking",
+              "meaning": "Remove tracking query params (utm_*, gclid, fbclid, ...), preserving the"
+            },
+            {
+              "value": "url_strip_www",
+              "meaning": "Strip a leading ``www.`` label from the host, preserving scheme, path,"
+            },
+            {
+              "value": "vat_format",
+              "meaning": "Normalize a valid EU VAT number to its compact uppercase form (prefix"
+            },
+            {
+              "value": "vat_validate",
+              "meaning": "Validate an EU VAT number: structural check (country prefix + length +"
+            },
+            {
+              "value": "zip_normalize",
+              "meaning": "Normalize a US ZIP to 5-digit form (strip +4, zero-pad all-digit, preserve"
+            }
+          ]
+        },
+        {
+          "title": "Domain packs",
+          "target": "goldenflow.domains:_DOMAINS",
+          "applies": "`learn_config(domain=...)`",
+          "values": [
+            {
+              "value": "carceral",
+              "meaning": "Corrections / justice field pack."
+            },
+            {
+              "value": "ecommerce",
+              "meaning": "E-commerce / retail field pack."
+            },
+            {
+              "value": "finance",
+              "meaning": "Financial-services field pack."
+            },
+            {
+              "value": "healthcare",
+              "meaning": "Healthcare field pack."
+            },
+            {
+              "value": "people_hr",
+              "meaning": "People / HR field pack."
+            },
+            {
+              "value": "real_estate",
+              "meaning": "Real-estate field pack."
+            }
+          ]
+        },
+        {
+          "title": "Canonicalize kinds",
+          "target": "goldenflow.canonicalize:CanonicalizeKind",
+          "applies": "`canonicalize` op",
+          "values": [
+            {
+              "value": "email",
+              "meaning": "Canonical email form."
+            },
+            {
+              "value": "name",
+              "meaning": "Canonical person-name form."
+            },
+            {
+              "value": "phone",
+              "meaning": "Canonical phone form."
+            },
+            {
+              "value": "postal",
+              "meaning": "Canonical postal-address form."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "ENGINE": [
+          "GOLDENFLOW_ENGINE"
+        ],
+        "FUSED": [
+          "GOLDENFLOW_FUSED_APPLY"
+        ],
+        "LLM": [
+          "GOLDENFLOW_LLM"
+        ],
+        "NATIVE": [
+          "GOLDENFLOW_NATIVE",
+          "GOLDENFLOW_NATIVE_CSV_PARALLEL_MIN_BYTES"
+        ]
+      }
+    },
+    "goldenpipe": {
+      "nav_group": "GoldenPipe",
+      "env_prefix": "GOLDENPIPE_",
+      "doc_path": "docs-site/goldenpipe/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenpipe",
+        "root": "packages/python/goldenpipe/goldenpipe",
+        "modules": {
+          "config_schema": "packages/python/goldenpipe/goldenpipe/models/config.py",
+          "cli": "packages/python/goldenpipe/goldenpipe/cli/main.py",
+          "mcp_server": "packages/python/goldenpipe/goldenpipe/mcp/server.py"
+        },
+        "entry_points": {
+          "goldenpipe.stages": {
+            "goldenanalysis.report": "goldenpipe.adapters.analysis:AnalysisReportStage",
+            "goldencheck.scan": "goldenpipe.adapters.check:ScanStage",
+            "goldenflow.transform": "goldenpipe.adapters.flow:TransformStage",
+            "goldenmatch.dedupe": "goldenpipe.adapters.match:DedupeStage",
+            "goldenmatch.dedupe_fused": "goldenpipe.adapters.match:FusedDedupeStage",
+            "goldenmatch.identity_resolve": "goldenpipe.adapters.identity:IdentityResolveStage",
+            "infer_schema": "goldenpipe.stages.infer_schema:infer_schema_stage"
+          }
+        }
+      },
+      "config_models": [
+        {
+          "name": "PipelineConfig",
+          "fields": [
+            {
+              "name": "pipeline",
+              "type": "str",
+              "required": true,
+              "description": "Name of the pipeline, identifying this end-to-end configuration in runs and logs."
+            },
+            {
+              "name": "source",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional default input location that stages read from when they do not specify their own source."
+            },
+            {
+              "name": "output",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional default destination where the pipeline writes its final results."
+            },
+            {
+              "name": "stages",
+              "type": "list[StageSpec | str]",
+              "required": true,
+              "nested": [
+                "StageSpec"
+              ],
+              "description": "Ordered list of stages to run, each given as a full StageSpec or a shorthand string naming the adapter to use."
+            },
+            {
+              "name": "decisions",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Recorded pipeline decision entries that capture the choices and rationale behind this configuration."
+            }
+          ],
+          "doc": "Top-level pipeline configuration."
+        },
+        {
+          "name": "StageSpec",
+          "fields": [
+            {
+              "name": "name",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Optional human-readable label for this stage, used in logs and as the key other stages reference in their needs list."
+            },
+            {
+              "name": "use",
+              "type": "str",
+              "required": true,
+              "description": "Identifier of the adapter that runs this stage, such as goldenmatch.dedupe, naming which suite tool to invoke."
+            },
+            {
+              "name": "needs",
+              "type": "list[str]",
+              "required": false,
+              "default": "[]",
+              "description": "Names of stages that must finish before this one runs, defining the dependency order in the pipeline graph."
+            },
+            {
+              "name": "skip_if",
+              "type": "str | None",
+              "required": false,
+              "default": "None",
+              "description": "Condition expression that, when it evaluates true at runtime, causes this stage to be skipped rather than executed."
+            },
+            {
+              "name": "on_error",
+              "type": "Literal",
+              "required": false,
+              "default": "'continue'",
+              "choices": [
+                "continue",
+                "abort"
+              ],
+              "description": "What to do when this stage raises an error: continue on to later stages or abort the whole pipeline."
+            },
+            {
+              "name": "config",
+              "type": "dict[str, Any]",
+              "required": false,
+              "default": "{}",
+              "description": "Free-form settings dictionary passed straight through to the named adapter to configure how the tool runs."
+            }
+          ],
+          "doc": "Configuration for a single pipeline stage."
+        }
+      ],
+      "cli": [
+        {
+          "command": "agent-serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8250",
+              "help": "Port for A2A server"
+            }
+          ]
+        },
+        {
+          "command": "init",
+          "options": [
+            {
+              "name": "--dir",
+              "type": "text",
+              "required": false,
+              "default": "'.'",
+              "help": "Directory to create config in"
+            }
+          ]
+        },
+        {
+          "command": "interactive",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional data file to load (press 'r' to run)."
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional pipeline YAML config."
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport type: stdio or http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8250",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "run",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Input file path"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Pipeline YAML config"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Output file path"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Show reasoning and timing"
+            },
+            {
+              "name": "--identity-path",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Enable Identity Graph; persist to this SQLite path"
+            },
+            {
+              "name": "--identity-dataset",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Identity Graph dataset namespace"
+            },
+            {
+              "name": "--identity-source-pk",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Column to derive `{source}:{source_pk}` record_id from"
+            },
+            {
+              "name": "--identity-weak-threshold",
+              "type": "float",
+              "required": false,
+              "default": "None",
+              "help": "Auto-flag bottleneck pair as conflicts_with when cluster confidence < this. Defaults to 0.6 (per IdentityConfig)."
+            }
+          ]
+        },
+        {
+          "command": "serve",
+          "options": [
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8000",
+              "help": "Port for REST API"
+            }
+          ]
+        },
+        {
+          "command": "stages",
+          "options": []
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Pipeline YAML config"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "explain_pipeline",
+          "description": "Explain what a pipeline config does"
+        },
+        {
+          "name": "list_stages",
+          "description": "List all discovered pipeline stages"
+        },
+        {
+          "name": "run_pipeline",
+          "description": "Run a pipeline on a file OR inline data (records / csv_text) and return per-stage status, reasoning and timing PLUS the deduped output (golden-record count + preview, unique/duplicate counts, cluster count, match stats). Give a `stages` list or `config_path` to control the chain, or omit both for zero-config auto."
+        },
+        {
+          "name": "validate_pipeline",
+          "description": "Validate pipeline wiring"
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Stage status",
+          "target": "goldenpipe.models.context:StageStatus",
+          "applies": "per-stage result status",
+          "values": [
+            {
+              "value": "failed",
+              "meaning": "Stage raised an error."
+            },
+            {
+              "value": "skipped",
+              "meaning": "Stage skipped by its skip_if condition."
+            },
+            {
+              "value": "success",
+              "meaning": "Stage completed successfully."
+            }
+          ]
+        },
+        {
+          "title": "Pipeline status",
+          "target": "goldenpipe.models.context:PipeStatus",
+          "applies": "run result status",
+          "values": [
+            {
+              "value": "failed",
+              "meaning": "One or more stages failed the run."
+            },
+            {
+              "value": "partial",
+              "meaning": "Some stages succeeded and some failed."
+            },
+            {
+              "value": "success",
+              "meaning": "Every stage succeeded."
+            }
+          ]
+        },
+        {
+          "title": "Column types",
+          "target": "goldenpipe.models.column_context:ColumnType",
+          "applies": "column classification",
+          "values": [
+            {
+              "value": "address",
+              "meaning": "Postal address."
+            },
+            {
+              "value": "date",
+              "meaning": "Date/time value."
+            },
+            {
+              "value": "description",
+              "meaning": "Long free text."
+            },
+            {
+              "value": "email",
+              "meaning": "Email address."
+            },
+            {
+              "value": "geo",
+              "meaning": "Geographic coordinate."
+            },
+            {
+              "value": "identifier",
+              "meaning": "Unique identifier / key."
+            },
+            {
+              "value": "name",
+              "meaning": "Person or entity name."
+            },
+            {
+              "value": "numeric",
+              "meaning": "Numeric measure."
+            },
+            {
+              "value": "phone",
+              "meaning": "Phone number."
+            },
+            {
+              "value": "string",
+              "meaning": "Free-form string."
+            },
+            {
+              "value": "zip",
+              "meaning": "Postal/ZIP code."
+            }
+          ]
+        },
+        {
+          "title": "Cardinality bands",
+          "target": "goldenpipe.models.column_context:CardinalityBand",
+          "applies": "column cardinality band",
+          "values": [
+            {
+              "value": "",
+              "meaning": "Unset / unknown."
+            },
+            {
+              "value": "high",
+              "meaning": "Many distinct values (near-unique)."
+            },
+            {
+              "value": "low",
+              "meaning": "Few distinct values."
+            },
+            {
+              "value": "mid",
+              "meaning": "Moderate distinct values."
+            },
+            {
+              "value": "skip",
+              "meaning": "Excluded from cardinality analysis."
+            }
+          ]
+        },
+        {
+          "title": "Repair fixers",
+          "target": "goldenpipe.repair_host:FIXERS",
+          "applies": "repair-op allowlist",
+          "values": [
+            {
+              "value": "date_parse",
+              "meaning": "Parse a date into ISO form."
+            },
+            {
+              "value": "email_canonical",
+              "meaning": "Canonicalize an email (dedupe dots/plus)."
+            },
+            {
+              "value": "email_normalize",
+              "meaning": "Lowercase/normalize an email."
+            },
+            {
+              "value": "fix_mojibake",
+              "meaning": "Repair UTF-8/Latin-1 mojibake."
+            },
+            {
+              "value": "name_proper",
+              "meaning": "Proper-case a name."
+            },
+            {
+              "value": "normalize_unicode",
+              "meaning": "Normalize to Unicode NFC."
+            },
+            {
+              "value": "phone_national",
+              "meaning": "Normalize a phone to national format."
+            },
+            {
+              "value": "zip_normalize",
+              "meaning": "Normalize a ZIP code."
+            }
+          ]
+        },
+        {
+          "title": "Stages",
+          "target": "goldenpipe.engine.registry:BUILTIN_STAGES",
+          "applies": "`StageSpec.use`",
+          "values": [
+            {
+              "value": "goldenanalysis.report",
+              "meaning": "Run GoldenAnalysis metrics + reporting."
+            },
+            {
+              "value": "goldencheck.scan",
+              "meaning": "Run a GoldenCheck data-quality scan."
+            },
+            {
+              "value": "goldenflow.transform",
+              "meaning": "Run GoldenFlow transforms / standardization."
+            },
+            {
+              "value": "goldenmatch.dedupe",
+              "meaning": "Run GoldenMatch dedupe / entity resolution."
+            },
+            {
+              "value": "goldenmatch.dedupe_fused",
+              "meaning": "Run the fused GoldenMatch dedupe kernel."
+            },
+            {
+              "value": "goldenmatch.identity_resolve",
+              "meaning": "Resolve records against the identity graph."
+            },
+            {
+              "value": "infer_schema",
+              "meaning": "Infer the source schema (via infermap)."
+            },
+            {
+              "value": "load",
+              "meaning": "Load a source file into the pipeline frame."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "GOLDENPIPE_NATIVE"
+        ]
+      }
+    },
+    "infermap": {
+      "nav_group": "InferMap",
+      "env_prefix": "INFERMAP_",
+      "doc_path": "docs-site/infermap/config-matrix.mdx",
+      "source": {
+        "import_name": "infermap",
+        "root": "packages/python/infermap/infermap",
+        "modules": {
+          "constructor": "packages/python/infermap/infermap/engine.py",
+          "cli": "packages/python/infermap/infermap/cli.py",
+          "mcp_server": "packages/python/infermap/infermap/mcp/server.py"
+        }
+      },
+      "constructors": [
+        {
+          "name": "MapEngine",
+          "fields": [
+            {
+              "name": "min_confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.2"
+            },
+            {
+              "name": "sample_size",
+              "type": "int",
+              "required": false,
+              "default": "500"
+            },
+            {
+              "name": "scorers",
+              "type": "any",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "config_path",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "return_score_matrix",
+              "type": "bool",
+              "required": false,
+              "default": "False"
+            },
+            {
+              "name": "calibrator",
+              "type": "Calibrator \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "domains",
+              "type": "list[str] \\| None",
+              "required": false,
+              "default": "None"
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "apply",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source CSV file to apply mapping to"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Path to mapping config YAML (required)"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": true,
+              "help": "Output CSV path (required)"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        },
+        {
+          "command": "inspect",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data to inspect (CSV path, schema YAML, etc.)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Table name for DB sources"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        },
+        {
+          "command": "map",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data (CSV path, DataFrame, DB URI, schema YAML)"
+            },
+            {
+              "name": "target",
+              "type": "text",
+              "required": true,
+              "help": "Target data (same variety of inputs)"
+            },
+            {
+              "name": "--table",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Optional table name for DB sources"
+            },
+            {
+              "name": "--required",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated required target field names"
+            },
+            {
+              "name": "--schema-file",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Path to schema YAML file"
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "'table'",
+              "help": "Output format: table, json, or yaml"
+            },
+            {
+              "name": "--output",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Save mapping config to this YAML file"
+            },
+            {
+              "name": "--min-confidence",
+              "type": "float",
+              "required": false,
+              "default": "0.2",
+              "help": "Minimum confidence threshold (default 0.2, was 0.3 before v0.3)"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            },
+            {
+              "name": "--debug",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable debug logging"
+            }
+          ]
+        },
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "Transport: 'stdio' or 'http'"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host for HTTP transport"
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8100",
+              "help": "Port for HTTP transport"
+            }
+          ]
+        },
+        {
+          "command": "validate",
+          "options": [
+            {
+              "name": "source",
+              "type": "text",
+              "required": true,
+              "help": "Source data to validate (CSV path, etc.)"
+            },
+            {
+              "name": "--config",
+              "type": "text",
+              "required": true,
+              "help": "Path to mapping config YAML (required)"
+            },
+            {
+              "name": "--required",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Comma-separated required field names"
+            },
+            {
+              "name": "--strict",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit code 1 if required fields unmapped"
+            },
+            {
+              "name": "--verbose",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Enable verbose logging"
+            }
+          ]
+        }
+      ],
+      "mcp_tools": [
+        {
+          "name": "apply",
+          "description": "Apply a saved mapping config to a source CSV, renaming columns according to the mapping and writing the result to an output file."
+        },
+        {
+          "name": "inspect",
+          "description": "Inspect a data source — show fields, types, sample values, null rates, unique rates, and statistics."
+        },
+        {
+          "name": "map",
+          "description": "Map source columns to target schema using a weighted scorer pipeline with optimal 1:1 assignment. Returns mappings with confidence scores and human-readable reasoning."
+        },
+        {
+          "name": "validate",
+          "description": "Validate that a source file's columns satisfy a saved mapping config. Reports missing source columns and unmapped required fields."
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Data types",
+          "target": "infermap.types:VALID_DTYPES",
+          "applies": "`FieldInfo.dtype`",
+          "values": [
+            {
+              "value": "boolean",
+              "meaning": "True/false."
+            },
+            {
+              "value": "date",
+              "meaning": "Calendar date."
+            },
+            {
+              "value": "datetime",
+              "meaning": "Date and time."
+            },
+            {
+              "value": "float",
+              "meaning": "Decimal number."
+            },
+            {
+              "value": "integer",
+              "meaning": "Whole number."
+            },
+            {
+              "value": "string",
+              "meaning": "Text."
+            }
+          ]
+        },
+        {
+          "title": "Semantic pattern types",
+          "target": "infermap.scorers.pattern_type:SEMANTIC_TYPES",
+          "applies": "pattern-type detection",
+          "values": [
+            {
+              "value": "currency",
+              "meaning": "Currency amount."
+            },
+            {
+              "value": "date_iso",
+              "meaning": "ISO-8601 date."
+            },
+            {
+              "value": "email",
+              "meaning": "Email address."
+            },
+            {
+              "value": "ip_v4",
+              "meaning": "IPv4 address."
+            },
+            {
+              "value": "phone",
+              "meaning": "Phone number."
+            },
+            {
+              "value": "url",
+              "meaning": "Web URL."
+            },
+            {
+              "value": "uuid",
+              "meaning": "UUID."
+            },
+            {
+              "value": "zip_us",
+              "meaning": "US ZIP code."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "INFERMAP_NATIVE"
+        ]
+      }
+    },
+    "goldenanalysis": {
+      "nav_group": "GoldenAnalysis",
+      "env_prefix": "GOLDENANALYSIS_",
+      "doc_path": "docs-site/goldenanalysis/config-matrix.mdx",
+      "source": {
+        "import_name": "goldenanalysis",
+        "root": "packages/python/goldenanalysis/goldenanalysis",
+        "modules": {
+          "config_schema": "packages/python/goldenanalysis/goldenanalysis/models/policy.py",
+          "constructor": "packages/python/goldenanalysis/goldenanalysis/_api.py",
+          "cli": "packages/python/goldenanalysis/goldenanalysis/cli/main.py"
+        },
+        "entry_points": {
+          "goldenanalysis.analyzers": {
+            "cluster.distribution": "goldenanalysis.analyzers.cluster_dist:ClusterDistributionAnalyzer",
+            "frame.summary": "goldenanalysis.analyzers.frame_summary:FrameSummaryAnalyzer",
+            "match.rates": "goldenanalysis.analyzers.match_rates:MatchRatesAnalyzer",
+            "quality.rollup": "goldenanalysis.analyzers.quality_rollup:QualityRollupAnalyzer"
+          }
+        }
+      },
+      "config_models": [
+        {
+          "name": "RegressionPolicy",
+          "fields": [
+            {
+              "name": "default_pct",
+              "type": "float",
+              "required": false,
+              "default": "10.0",
+              "description": "Percent change from the baseline that counts as a regression for any metric without a per-metric override."
+            },
+            {
+              "name": "per_metric",
+              "type": "dict[str, float]",
+              "required": false,
+              "default": "{}",
+              "description": "Per-metric percent thresholds keyed by metric name, overriding default_pct for those metrics."
+            }
+          ],
+          "doc": "Per-metric regression thresholds (percent). Falls back to ``default_pct``."
+        }
+      ],
+      "constructors": [
+        {
+          "name": "analyze",
+          "fields": [
+            {
+              "name": "df",
+              "type": "pl.DataFrame",
+              "required": true
+            },
+            {
+              "name": "analyzers",
+              "type": "Sequence[str] \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "dataset",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "run_id",
+              "type": "str \\| None",
+              "required": false,
+              "default": "None"
+            },
+            {
+              "name": "generated_at",
+              "type": "datetime \\| None",
+              "required": false,
+              "default": "None"
+            }
+          ]
+        }
+      ],
+      "cli": [
+        {
+          "command": "mcp-serve",
+          "options": [
+            {
+              "name": "--transport",
+              "type": "text",
+              "required": false,
+              "default": "'stdio'",
+              "help": "stdio | http"
+            },
+            {
+              "name": "--host",
+              "type": "text",
+              "required": false,
+              "default": "'0.0.0.0'",
+              "help": "Host interface to bind when transport is http."
+            },
+            {
+              "name": "--port",
+              "type": "integer",
+              "required": false,
+              "default": "8300",
+              "help": "HTTP port (A2A convention: Analysis = 8300)."
+            }
+          ]
+        },
+        {
+          "command": "regressions",
+          "options": [
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset name whose run history to check."
+            },
+            {
+              "name": "--history",
+              "type": "path",
+              "required": true,
+              "help": "ReportHistory path (.jsonl or .db)."
+            },
+            {
+              "name": "--baseline",
+              "type": "text",
+              "required": false,
+              "default": "'rolling_median'",
+              "help": "Baseline strategy to compare against, e.g. rolling_median."
+            },
+            {
+              "name": "--window",
+              "type": "integer",
+              "required": false,
+              "default": "7",
+              "help": "Number of prior runs the baseline is computed over."
+            },
+            {
+              "name": "--policy",
+              "type": "text",
+              "required": false,
+              "default": "None",
+              "help": "Per-metric gates: JSON or \"key=pct,key=pct\"."
+            },
+            {
+              "name": "--fail-on-regression",
+              "type": "boolean",
+              "required": false,
+              "default": "False",
+              "help": "Exit 1 if any regression is flagged (CI gate)."
+            }
+          ]
+        },
+        {
+          "command": "report",
+          "options": [
+            {
+              "name": "input",
+              "type": "path",
+              "required": true,
+              "help": "A .parquet/.csv frame, or a .json AnalysisReport to re-render."
+            },
+            {
+              "name": "--analyzers",
+              "type": "text",
+              "required": false,
+              "default": "'all'",
+              "help": "Comma-separated analyzer names, or 'all'."
+            },
+            {
+              "name": "--format",
+              "type": "text",
+              "required": false,
+              "default": "'markdown'",
+              "help": "markdown | json"
+            },
+            {
+              "name": "--out",
+              "type": "path",
+              "required": false,
+              "default": "None",
+              "help": "Write the report here instead of (also) printing."
+            }
+          ]
+        },
+        {
+          "command": "trend",
+          "options": [
+            {
+              "name": "--metric",
+              "type": "text",
+              "required": true,
+              "help": "Metric key to trend, e.g. cluster.singleton_ratio."
+            },
+            {
+              "name": "--dataset",
+              "type": "text",
+              "required": true,
+              "help": "Dataset name whose run history to read."
+            },
+            {
+              "name": "--history",
+              "type": "path",
+              "required": true,
+              "help": "ReportHistory path (.jsonl or .db)."
+            },
+            {
+              "name": "--last",
+              "type": "integer",
+              "required": false,
+              "default": "30",
+              "help": "Number of most recent runs to include in the trend."
+            }
+          ]
+        }
+      ],
+      "vocabularies": [
+        {
+          "title": "Metric direction",
+          "target": "goldenanalysis.models.report:Direction",
+          "applies": "`Metric.direction`",
+          "values": [
+            {
+              "value": "higher_better",
+              "meaning": "A higher value is better; flag a regression on a decrease."
+            },
+            {
+              "value": "lower_better",
+              "meaning": "A lower value is better; flag a regression on an increase."
+            },
+            {
+              "value": "neutral",
+              "meaning": "No preferred direction; never flags a regression."
+            }
+          ]
+        },
+        {
+          "title": "Regression baseline",
+          "target": "goldenanalysis.models.policy:Baseline",
+          "applies": "`--baseline`",
+          "values": [
+            {
+              "value": "last_known_good",
+              "meaning": "Compare against the last run marked good."
+            },
+            {
+              "value": "previous",
+              "meaning": "Compare against the immediately prior run."
+            },
+            {
+              "value": "rolling_median",
+              "meaning": "Compare against the rolling median of recent runs."
+            }
+          ]
+        },
+        {
+          "title": "Analyzers",
+          "target": "goldenanalysis.registry:_FALLBACK",
+          "applies": "`analyze(analyzers=...)`",
+          "values": [
+            {
+              "value": "cluster.distribution",
+              "meaning": "GoldenMatch clusters: count, singletons, size percentiles, reduction ratio."
+            },
+            {
+              "value": "frame.summary",
+              "meaning": "Generic frame stats: row/column counts, null ratio, duplicate ratio, memory."
+            },
+            {
+              "value": "match.rates",
+              "meaning": "GoldenMatch results: pair count, match rate, threshold, recall estimate, score histogram."
+            },
+            {
+              "value": "quality.rollup",
+              "meaning": "GoldenCheck / GoldenFlow rollup: findings, health score, rows changed, rules fired."
+            }
+          ]
+        }
+      ],
+      "env_vars": {
+        "NATIVE": [
+          "GOLDENANALYSIS_NATIVE"
+        ]
+      }
+    }
+  },
+  "rust_crates": [
+    {
+      "name": "analysis-core",
+      "path": "packages/rust/extensions/analysis-core"
+    },
+    {
+      "name": "analysis-native",
+      "path": "packages/rust/extensions/analysis-native"
+    },
+    {
+      "name": "fingerprint-wasm",
+      "path": "packages/rust/extensions/fingerprint-wasm"
+    },
+    {
+      "name": "goldencheck-core",
+      "path": "packages/rust/extensions/goldencheck-core"
+    },
+    {
+      "name": "goldencheck-native",
+      "path": "packages/rust/extensions/goldencheck-native"
+    },
+    {
+      "name": "goldencheck-wasm",
+      "path": "packages/rust/extensions/goldencheck-wasm"
+    },
+    {
+      "name": "goldenembed",
+      "path": "packages/rust/extensions/goldenembed"
+    },
+    {
+      "name": "goldenembed-core",
+      "path": "packages/rust/extensions/goldenembed-core"
+    },
+    {
+      "name": "goldenembed-wasm",
+      "path": "packages/rust/extensions/goldenembed-wasm"
+    },
+    {
+      "name": "goldenflow-core",
+      "path": "packages/rust/extensions/goldenflow-core"
+    },
+    {
+      "name": "goldenflow-native",
+      "path": "packages/rust/extensions/native-flow"
+    },
+    {
+      "name": "goldenflow-wasm",
+      "path": "packages/rust/extensions/goldenflow-wasm"
+    },
+    {
+      "name": "goldenflow_duckdb",
+      "path": "packages/rust/extensions/goldenflow-duckdb"
+    },
+    {
+      "name": "goldengraph-cabi",
+      "path": "packages/rust/extensions/goldengraph-cabi"
+    },
+    {
+      "name": "goldengraph-core",
+      "path": "packages/rust/extensions/goldengraph-core"
+    },
+    {
+      "name": "goldengraph-native",
+      "path": "packages/rust/extensions/goldengraph-native"
+    },
+    {
+      "name": "goldengraph-wasm",
+      "path": "packages/rust/extensions/goldengraph-wasm"
+    },
+    {
+      "name": "goldenhnsw",
+      "path": "packages/rust/extensions/goldenhnsw"
+    },
+    {
+      "name": "goldenhnsw-wasm",
+      "path": "packages/rust/extensions/goldenhnsw-wasm"
+    },
+    {
+      "name": "goldenmatch-analysis-wasm",
+      "path": "packages/rust/extensions/analysis-wasm"
+    },
+    {
+      "name": "goldenmatch-autoconfig-core",
+      "path": "packages/rust/extensions/autoconfig-core"
+    },
+    {
+      "name": "goldenmatch-autoconfig-wasm",
+      "path": "packages/rust/extensions/autoconfig-wasm"
+    },
+    {
+      "name": "goldenmatch-bridge",
+      "path": "packages/rust/extensions/bridge"
+    },
+    {
+      "name": "goldenmatch-datafusion-udf",
+      "path": "packages/rust/extensions/datafusion-udf"
+    },
+    {
+      "name": "goldenmatch-documents-core",
+      "path": "packages/rust/extensions/documents-core"
+    },
+    {
+      "name": "goldenmatch-documents-wasm",
+      "path": "packages/rust/extensions/documents-wasm"
+    },
+    {
+      "name": "goldenmatch-embed-py",
+      "path": "packages/rust/extensions/embed-py"
+    },
+    {
+      "name": "goldenmatch-fingerprint-core",
+      "path": "packages/rust/extensions/fingerprint-core"
+    },
+    {
+      "name": "goldenmatch-fs-core",
+      "path": "packages/rust/extensions/fs-core"
+    },
+    {
+      "name": "goldenmatch-fs-wasm",
+      "path": "packages/rust/extensions/fs-wasm"
+    },
+    {
+      "name": "goldenmatch-graph-core",
+      "path": "packages/rust/extensions/graph-core"
+    },
+    {
+      "name": "goldenmatch-graph-layout",
+      "path": "packages/rust/extensions/graph-layout"
+    },
+    {
+      "name": "goldenmatch-hnsw-py",
+      "path": "packages/rust/extensions/hnsw-py"
+    },
+    {
+      "name": "goldenmatch-native",
+      "path": "packages/rust/extensions/native"
+    },
+    {
+      "name": "goldenmatch-perceptual-core",
+      "path": "packages/rust/extensions/perceptual-core"
+    },
+    {
+      "name": "goldenmatch-perceptual-wasm",
+      "path": "packages/rust/extensions/perceptual-wasm"
+    },
+    {
+      "name": "goldenmatch-score-core",
+      "path": "packages/rust/extensions/score-core"
+    },
+    {
+      "name": "goldenmatch-score-wasm",
+      "path": "packages/rust/extensions/score-wasm"
+    },
+    {
+      "name": "goldenmatch-sketch-core",
+      "path": "packages/rust/extensions/sketch-core"
+    },
+    {
+      "name": "goldenmatch-suggest-core",
+      "path": "packages/rust/extensions/suggest-core"
+    },
+    {
+      "name": "goldenmatch-suggest-wasm",
+      "path": "packages/rust/extensions/suggest-wasm"
+    },
+    {
+      "name": "goldenmatch_pg",
+      "path": "packages/rust/extensions/postgres"
+    },
+    {
+      "name": "goldenpipe-core",
+      "path": "packages/rust/extensions/goldenpipe-core"
+    },
+    {
+      "name": "goldenpipe-native",
+      "path": "packages/rust/extensions/goldenpipe-native"
+    },
+    {
+      "name": "goldenpipe-wasm",
+      "path": "packages/rust/extensions/goldenpipe-wasm"
+    },
+    {
+      "name": "goldenprofile-cabi",
+      "path": "packages/rust/extensions/goldenprofile-cabi"
+    },
+    {
+      "name": "goldenprofile-core",
+      "path": "packages/rust/extensions/goldenprofile-core"
+    },
+    {
+      "name": "goldenprofile-native",
+      "path": "packages/rust/extensions/goldenprofile-native"
+    },
+    {
+      "name": "goldenprofile-wasm",
+      "path": "packages/rust/extensions/goldenprofile-wasm"
+    },
+    {
+      "name": "graph-wasm",
+      "path": "packages/rust/extensions/graph-wasm"
+    },
+    {
+      "name": "infermap-core",
+      "path": "packages/rust/extensions/infermap-core"
+    },
+    {
+      "name": "infermap-native",
+      "path": "packages/rust/extensions/infermap-native"
+    },
+    {
+      "name": "infermap-wasm",
+      "path": "packages/rust/extensions/infermap-wasm"
+    },
+    {
+      "name": "sketch-wasm",
+      "path": "packages/rust/extensions/sketch-wasm"
+    }
+  ]
+}

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/manifest_tool.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/manifest_tool.py
@@ -1,0 +1,179 @@
+"""`suite_manifest` -- a suite-native MCP tool that serves SLICES of the generated
+agent-navigation manifest (docs/agent-manifest.json).
+
+The manifest is a ~300 KB structured index of every package's config schema, CLI,
+MCP tools, vocabularies, env knobs, and source-file map. Handing an agent the whole
+file to answer one question ("which scorer suits names", "where does goldenpipe's
+MCP server live") wastes context, so this tool exposes progressive-disclosure
+slices: an overview, one package, one section of a package, or a keyword search
+across everything -- returning only the matching leaves plus where each is defined.
+
+The manifest is generated + CI-gated by scripts/config_matrix, so what this tool
+serves is always in sync with the live code (it never re-derives anything).
+"""
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from mcp.types import Tool
+
+TOOL_NAME = "suite_manifest"
+
+_SECTIONS = ["overview", "config", "cli", "mcp", "vocab", "env", "source", "rust_crates"]
+_PACKAGES = ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "infermap", "goldenanalysis"]
+_SECTION_KEY = {  # section arg -> manifest package key
+    "config": "config_models", "cli": "cli", "mcp": "mcp_tools",
+    "vocab": "vocabularies", "env": "env_vars", "source": "source",
+}
+
+TOOL = Tool(
+    name=TOOL_NAME,
+    description=(
+        "Look up Golden Suite config / CLI / MCP tools / vocabularies / env knobs / "
+        "source-file locations WITHOUT grepping the repo. Serves slices of a generated, "
+        "CI-gated manifest so answers always match the live code. Usage: no args -> an "
+        "overview (packages + surface counts); `package` -> that package's counts + where "
+        "its schema/CLI/MCP live; `package`+`section` -> that slice (section one of "
+        "config/cli/mcp/vocab/env/source); `section=rust_crates` -> the Rust crate map; "
+        "`query` alone -> a keyword search across every vocabulary value, tool, config "
+        "field, env var, CLI command, and crate, each with where it's defined."
+    ),
+    inputSchema={
+        "type": "object",
+        "properties": {
+            "package": {"type": "string", "enum": _PACKAGES,
+                        "description": "Restrict to one package."},
+            "section": {"type": "string", "enum": _SECTIONS,
+                        "description": "Which slice of the package to return."},
+            "query": {"type": "string",
+                      "description": "Case-insensitive substring. With no package/section, searches everything."},
+        },
+        "required": [],
+    },
+)
+
+
+# --- manifest loading (located, not re-derived) ------------------------------
+
+_CACHE: dict[str, Any] = {}
+
+
+def _manifest_path() -> Path | None:
+    env = os.environ.get("GOLDENSUITE_MANIFEST_PATH")
+    if env:
+        p = Path(env)
+        return p if p.exists() else None
+    for parent in Path(__file__).resolve().parents:
+        cand = parent / "docs" / "agent-manifest.json"
+        if cand.exists():
+            return cand
+    return None
+
+
+def load_manifest() -> dict | None:
+    if "m" not in _CACHE:
+        p = _manifest_path()
+        _CACHE["m"] = json.loads(p.read_text(encoding="utf-8")) if p else None
+    return _CACHE["m"]
+
+
+# --- slicing -----------------------------------------------------------------
+
+
+def _overview(m: dict) -> dict:
+    pkgs = {}
+    for name, p in m["packages"].items():
+        pkgs[name] = {
+            "nav_group": p.get("nav_group"),
+            "env_prefix": p.get("env_prefix"),
+            "config_models": len(p.get("config_models", [])),
+            "cli_commands": len(p.get("cli", [])),
+            "mcp_tools": len(p.get("mcp_tools", [])),
+            "vocabularies": [v["title"] for v in p.get("vocabularies", [])],
+            "env_groups": len(p.get("env_vars", {})),
+        }
+    return {"schema": m.get("schema"), "packages": pkgs, "rust_crates": len(m.get("rust_crates", []))}
+
+
+def _search(m: dict, query: str) -> dict:
+    q = query.lower()
+    hits: list[dict] = []
+    for name, p in m["packages"].items():
+        for model in p.get("config_models", []):
+            for f in model["fields"]:
+                if q in f["name"].lower():
+                    hits.append({"kind": "config_field", "package": name,
+                                 "value": f"{model['name']}.{f['name']}", "type": f.get("type")})
+        for cmd in p.get("cli", []):
+            if q in cmd["command"].lower():
+                hits.append({"kind": "cli_command", "package": name, "value": cmd["command"]})
+        for t in p.get("mcp_tools", []):
+            if q in t["name"].lower() or q in t.get("description", "").lower():
+                hits.append({"kind": "mcp_tool", "package": name, "value": t["name"],
+                             "description": t.get("description")})
+        for vocab in p.get("vocabularies", []):
+            for val in vocab["values"]:
+                if q in val["value"].lower() or q in val.get("meaning", "").lower():
+                    hits.append({"kind": "vocab_value", "package": name,
+                                 "value": val["value"], "vocab": vocab["title"],
+                                 "meaning": val.get("meaning")})
+        for group, envs in p.get("env_vars", {}).items():
+            for e in envs:
+                if q in e.lower():
+                    hits.append({"kind": "env_var", "package": name, "value": e, "group": group})
+    for c in m.get("rust_crates", []):
+        if q in c["name"].lower() or q in (c.get("path") or "").lower():
+            hits.append({"kind": "rust_crate", "value": c["name"], "path": c.get("path")})
+    return {"query": query, "count": len(hits), "hits": hits}
+
+
+def _package_slice(m: dict, package: str, section: str, query: str) -> dict:
+    p = m["packages"].get(package)
+    if p is None:
+        return {"error": f"unknown package: {package}", "packages": list(m["packages"])}
+    if not section or section == "overview":
+        return {"package": package, "nav_group": p.get("nav_group"),
+                "env_prefix": p.get("env_prefix"), "source": p.get("source"),
+                "counts": _overview(m)["packages"][package]}
+    data = p.get(_SECTION_KEY.get(section, section))
+    if not query:
+        return {"package": package, "section": section, "data": data}
+    # Filter the slice by the query on its most obvious text field.
+    ql = query.lower()
+    if section == "config":
+        data = [{**mo, "fields": [f for f in mo["fields"] if ql in json.dumps(f).lower()]}
+                for mo in (data or [])]
+        data = [mo for mo in data if mo["fields"]]
+    elif isinstance(data, list):
+        data = [d for d in data if ql in json.dumps(d).lower()]
+    elif isinstance(data, dict):
+        data = {k: v for k, v in data.items() if ql in json.dumps({k: v}).lower()}
+    return {"package": package, "section": section, "query": query, "data": data}
+
+
+def make_dispatch() -> Callable[[str, dict], dict]:
+    def dispatch(name: str, args: dict) -> dict:
+        m = load_manifest()
+        if m is None:
+            return {"error": "agent manifest not found; set GOLDENSUITE_MANIFEST_PATH or run "
+                             "from a checkout where docs/agent-manifest.json exists"}
+        package = str(args.get("package") or "").strip()
+        section = str(args.get("section") or "").strip()
+        query = str(args.get("query") or "").strip()
+        if section == "rust_crates":
+            crates = m.get("rust_crates", [])
+            if query:
+                ql = query.lower()
+                crates = [c for c in crates if ql in c["name"].lower() or ql in (c.get("path") or "").lower()]
+            return {"section": "rust_crates", "count": len(crates), "crates": crates}
+        if package:
+            return _package_slice(m, package, section, query)
+        if query:
+            return _search(m, query)
+        return _overview(m)
+
+    return dispatch

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/manifest_tool.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/manifest_tool.py
@@ -63,6 +63,10 @@ _CACHE: dict[str, Any] = {}
 
 
 def _manifest_path() -> Path | None:
+    # 1) explicit override; 2) the canonical file in a repo checkout (freshest
+    # during active editing); 3) the copy bundled next to this module, which is
+    # the only one present in a pip-installed / deployed server. (2) and (3) are
+    # byte-identical -- the config-matrix gate keeps them in lockstep.
     env = os.environ.get("GOLDENSUITE_MANIFEST_PATH")
     if env:
         p = Path(env)
@@ -71,7 +75,8 @@ def _manifest_path() -> Path | None:
         cand = parent / "docs" / "agent-manifest.json"
         if cand.exists():
             return cand
-    return None
+    bundled = Path(__file__).resolve().parent / "agent-manifest.json"
+    return bundled if bundled.exists() else None
 
 
 def load_manifest() -> dict | None:

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/server.py
@@ -60,6 +60,8 @@ CURATED_TOOLS: frozenset[str] = frozenset({
     "analyze_frame", "detect_regressions",
     # discovery meta-tool -- how a client reaches the ~80 non-headline tools
     "suite_find_tools",
+    # navigation meta-tool -- look up config/CLI/tools/vocab/env/source without grepping
+    "suite_manifest",
     # composite workflow tools -- one-call happy paths
     "dedupe_file", "match_sources", "assess_file", "clean_and_dedupe",
 })
@@ -400,6 +402,19 @@ def _aggregate() -> tuple[list[Tool], dict[str, Callable[[str, dict], dict]]]:
         logger.warning(
             "goldensuite-mcp: %r already registered by %s; discovery meta-tool not added",
             _FIND_TOOLS_NAME, seen[_FIND_TOOLS_NAME],
+        )
+
+    # Register the navigation meta-tool (serves slices of the generated agent
+    # manifest). Suite-native, like the discovery tool -- guard against a clash.
+    from goldensuite_mcp import manifest_tool
+    if manifest_tool.TOOL_NAME not in seen:
+        all_tools.append(manifest_tool.TOOL)
+        name_to_dispatch[manifest_tool.TOOL_NAME] = manifest_tool.make_dispatch()
+        seen[manifest_tool.TOOL_NAME] = "goldensuite"
+    else:
+        logger.warning(
+            "goldensuite-mcp: %r already registered by %s; manifest meta-tool not added",
+            manifest_tool.TOOL_NAME, seen[manifest_tool.TOOL_NAME],
         )
 
     return all_tools, name_to_dispatch

--- a/packages/python/goldensuite-mcp/pyproject.toml
+++ b/packages/python/goldensuite-mcp/pyproject.toml
@@ -58,3 +58,9 @@ goldenanalysis = { workspace = true }
 [tool.hatch.build.targets.wheel]
 packages = ["goldensuite_mcp"]
 
+# Ship the bundled agent manifest so `suite_manifest` works on the deployed
+# (pip-installed) server, where the repo's docs/ tree is absent. Generated + gated
+# byte-identical to docs/agent-manifest.json (scripts/gen_config_matrix.py --manifest).
+[tool.hatch.build.targets.wheel.force-include]
+"goldensuite_mcp/agent-manifest.json" = "goldensuite_mcp/agent-manifest.json"
+

--- a/packages/python/goldensuite-mcp/tests/test_find_tools.py
+++ b/packages/python/goldensuite-mcp/tests/test_find_tools.py
@@ -23,13 +23,16 @@ def test_find_tools_dispatch_returns_full_catalog(monkeypatch):
     from goldensuite_mcp.server import _aggregate
 
     tools, dispatch = _aggregate()
-    real_tool_names = {t.name for t in tools} - {"suite_find_tools"}
+    # The catalog is every REAL tool -- not the suite-native meta-tools
+    # (suite_find_tools lists itself never; suite_manifest is navigation, not a
+    # callable data tool, and registers after this snapshot).
+    real_tool_names = {t.name for t in tools} - {"suite_find_tools", "suite_manifest"}
     out = dispatch["suite_find_tools"]("suite_find_tools", {})
     returned = {r["name"] for r in out["tools"]}
     assert out["count"] == len(real_tool_names)
-    # It enumerates every real tool but NOT itself.
     assert returned == real_tool_names
     assert "suite_find_tools" not in returned
+    assert "suite_manifest" not in returned
 
 
 def test_find_tools_entries_carry_schema(monkeypatch):

--- a/packages/python/goldensuite-mcp/tests/test_manifest_tool.py
+++ b/packages/python/goldensuite-mcp/tests/test_manifest_tool.py
@@ -1,0 +1,75 @@
+"""Tests for the `suite_manifest` navigation meta-tool.
+
+It serves progressive-disclosure slices of the generated agent manifest
+(docs/agent-manifest.json) so an agent can look up config / CLI / MCP tools /
+vocabularies / env knobs / source locations without grepping. These pin: it's
+in the default listing, the overview enumerates every package, a package+section
+slice and the rust_crates slice return data, and keyword search finds a known
+vocab value with where it's defined.
+"""
+from __future__ import annotations
+
+from goldensuite_mcp.manifest_tool import load_manifest, make_dispatch
+
+
+def _have_manifest() -> bool:
+    return load_manifest() is not None
+
+
+def test_manifest_tool_in_default_listing(monkeypatch):
+    monkeypatch.delenv("GOLDENSUITE_MCP_TOOLS", raising=False)
+    from goldensuite_mcp.server import _aggregate, _apply_tool_filter
+
+    tools, _ = _aggregate()
+    listed = {t.name for t in _apply_tool_filter(tools)}
+    assert "suite_manifest" in listed
+
+
+def test_overview_lists_every_package():
+    if not _have_manifest():
+        return  # manifest only present in a repo checkout
+    out = make_dispatch()("suite_manifest", {})
+    assert set(out["packages"]) == {
+        "goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "infermap", "goldenanalysis"
+    }
+    assert out["rust_crates"] > 0
+    assert out["packages"]["goldenmatch"]["mcp_tools"] > 0
+
+
+def test_package_section_slice():
+    if not _have_manifest():
+        return
+    out = make_dispatch()("suite_manifest", {"package": "goldenmatch", "section": "vocab"})
+    titles = {v["title"] for v in out["data"]}
+    assert "Scorers" in titles
+
+
+def test_rust_crates_slice():
+    if not _have_manifest():
+        return
+    out = make_dispatch()("suite_manifest", {"section": "rust_crates", "query": "score"})
+    assert out["count"] > 0
+    assert all("score" in c["name"].lower() or "score" in (c.get("path") or "").lower()
+               for c in out["crates"])
+
+
+def test_search_finds_vocab_value_with_location():
+    if not _have_manifest():
+        return
+    out = make_dispatch()("suite_manifest", {"query": "jaro_winkler"})
+    kinds = {h["kind"] for h in out["hits"]}
+    assert "vocab_value" in kinds
+    hit = next(h for h in out["hits"] if h["kind"] == "vocab_value" and h["value"] == "jaro_winkler")
+    assert hit["package"] == "goldenmatch"
+    assert hit["vocab"] == "Scorers"
+
+
+def test_missing_manifest_is_graceful(monkeypatch, tmp_path):
+    # Point at a nonexistent path and clear the cache -> a clean error, not a crash.
+    import goldensuite_mcp.manifest_tool as mt
+
+    monkeypatch.setenv("GOLDENSUITE_MANIFEST_PATH", str(tmp_path / "nope.json"))
+    mt._CACHE.clear()
+    out = make_dispatch()("suite_manifest", {})
+    mt._CACHE.clear()
+    assert "error" in out

--- a/scripts/config_matrix/manifest.py
+++ b/scripts/config_matrix/manifest.py
@@ -1,0 +1,257 @@
+"""Agent-navigation manifest: a structured-JSON view of the SAME source of truth
+the config-matrix docs render from.
+
+Motivation: coding agents shouldn't have to grep the tree to answer "what
+scorers exist / which MCP tools does goldenpipe expose / what's the type and
+default of GoldenMatchConfig.threshold / which env knobs tune goldenmatch". The
+config-matrix registry (registry.py) + resolvers (render.py) already extract all
+of that from live code, and the docs are CI-gated against drift. This module
+reuses those exact resolvers to emit one machine-readable JSON instead of MDX
+tables, so the manifest is derived from -- and gated against -- the same code.
+It is NOT a second source of truth: `manifest_is_current()` folds into the same
+`--check` gate, so the manifest can never silently diverge from the code (or the
+docs).
+
+Determinism: every collection is built in a stable order (registry definition
+order, deterministic model BFS, sorted vocab values / tool names / CLI commands,
+source-sorted env scan) so the committed JSON is byte-stable across a Windows dev
+box and the Linux CI runner -- the same discipline the MDX gate needs.
+"""
+from __future__ import annotations
+
+import importlib
+import inspect
+import json
+import typing
+from pathlib import Path
+
+from pydantic_core import PydanticUndefined
+
+from .registry import REGISTRY, PackageSpec
+from .render import (
+    ROOT,
+    _import,
+    _meaning,
+    _neutral_repr,
+    _reachable_models,
+    _resolve_gloss,
+    _resolve_vocab,
+    _warmup,
+    render_type,
+    scan_env_vars,
+    tool_field,
+)
+
+SCHEMA_ID = "goldenmatch.agent-manifest/v1"
+MANIFEST_PATH = "docs/agent-manifest.json"
+_REGEN = "python scripts/gen_config_matrix.py --manifest"
+
+
+# --- field / kwarg extraction (shared shape for schema + constructor) --------
+
+
+def _default(default: object, factory=None) -> tuple[bool, str | None]:
+    """(required, default_repr). Mirrors render._default_repr but structured, and
+    uses the platform-neutral repr so the JSON doesn't flap by OS."""
+    if default is PydanticUndefined and factory is None:
+        return True, None
+    if factory is not None:
+        try:
+            default = factory()
+        except Exception:
+            return False, "(factory)"
+    if default is inspect.Parameter.empty:
+        return True, None
+    return False, _neutral_repr(default)
+
+
+def _field(name: str, ann: object, description, alias, required: bool, default: str | None) -> dict:
+    type_str, choices, nested = render_type(ann)
+    out: dict = {"name": name, "type": type_str, "required": required}
+    if default is not None:
+        out["default"] = default
+    if choices:
+        out["choices"] = choices
+    if nested:
+        out["nested"] = list(dict.fromkeys(n.__name__ for n in nested))
+    if description:
+        out["description"] = description.strip()
+    if alias:
+        out["alias"] = alias
+    return out
+
+
+def _config_models(roots: list[str]) -> list[dict]:
+    models, seen = [], set()
+    for target in roots:
+        for model in _reachable_models(_import(target)):
+            if model in seen:
+                continue
+            seen.add(model)
+            fields = []
+            for fname, fi in model.model_fields.items():
+                required, default = _default(fi.default, fi.default_factory)
+                fields.append(_field(fname, fi.annotation, fi.description,
+                                     getattr(fi, "alias", None), required, default))
+            entry: dict = {"name": model.__name__, "fields": fields}
+            doc = (model.__doc__ or "").strip().splitlines()
+            if doc:
+                entry["doc"] = doc[0].strip()
+            models.append(entry)
+    return models
+
+
+def _constructors(targets: list[str]) -> list[dict]:
+    out = []
+    for target in targets:
+        obj = _import(target)
+        func = obj.__init__ if isinstance(obj, type) else obj
+        fields = []
+        for pname, p in inspect.signature(func).parameters.items():
+            if pname in ("self", "args", "kwargs") or p.kind in (p.VAR_POSITIONAL, p.VAR_KEYWORD):
+                continue
+            required = p.default is inspect.Parameter.empty
+            default = None if required else _neutral_repr(p.default)
+            fields.append(_field(pname, p.annotation, None, None, required, default))
+        out.append({"name": obj.__name__, "fields": fields})
+    return out
+
+
+# --- CLI (Typer -> click), structured mirror of render.render_cli_section ----
+
+
+def _cli(cli_module: str) -> list[dict]:
+    from typer.main import get_command
+
+    group = get_command(importlib.import_module(cli_module).app)
+    commands: list[dict] = []
+
+    def _emit(prefix: str, cmd) -> None:
+        sub = getattr(cmd, "commands", None)
+        if sub:
+            for name in sorted(sub):
+                _emit(f"{prefix}{name} ", sub[name])
+            return
+        options = []
+        for p in cmd.params:
+            ptype = getattr(p, "type", None)
+            opt: dict = {
+                "name": _opt_name(p),
+                "type": getattr(ptype, "name", "text"),
+                "required": bool(getattr(p, "required", False)),
+            }
+            if not opt["required"]:
+                opt["default"] = _neutral_repr(p.default)
+            choices = getattr(ptype, "choices", None)
+            if choices:
+                opt["choices"] = list(choices)
+            if getattr(p, "help", None):
+                opt["help"] = p.help
+            options.append(opt)
+        commands.append({"command": prefix.strip(), "options": options})
+
+    for name in sorted(group.commands):
+        _emit(f"{name} ", group.commands[name])
+    return commands
+
+
+def _opt_name(p) -> str:
+    longs = [o for o in getattr(p, "opts", []) if o.startswith("--")]
+    if longs:
+        return longs[0]
+    return (getattr(p, "opts", None) or [getattr(p, "name", "?")])[0]
+
+
+# --- MCP tools ---------------------------------------------------------------
+
+
+def _mcp_tools(mcp_module: str) -> list[dict]:
+    try:
+        mod = importlib.import_module(mcp_module)
+    except ModuleNotFoundError:
+        return []
+    tools = getattr(mod, "TOOLS", None) or []
+    out = []
+    for t in sorted(tools, key=lambda t: tool_field(t, "name")):
+        desc = tool_field(t, "description").strip().splitlines()
+        out.append({"name": tool_field(t, "name"), "description": desc[0] if desc else ""})
+    return out
+
+
+# --- vocabularies (values + meaning + any decision columns) ------------------
+
+
+def _vocabularies(vocabs) -> list[dict]:
+    out = []
+    for entry in vocabs:
+        title, target, applies = entry[0], entry[1], entry[2]
+        gloss = entry[3] if len(entry) > 3 else None
+        glosses = _resolve_gloss(target, gloss)
+        values = []
+        for v in sorted(set(_resolve_vocab(target))):
+            g = glosses.get(v, "")
+            item: dict = {"value": v}
+            meaning = _meaning(g)
+            if meaning:
+                item["meaning"] = meaning
+            if isinstance(g, dict):
+                for k in sorted(g):
+                    if k != "meaning":
+                        item[k] = g[k]
+            values.append(item)
+        out.append({"title": title, "target": target, "applies": applies, "values": values})
+    return out
+
+
+# --- assembly ----------------------------------------------------------------
+
+
+def build_package(spec: PackageSpec) -> dict:
+    _warmup(getattr(spec, "vocab_warmup", []))
+    pkg: dict = {"nav_group": spec.nav_group, "env_prefix": spec.env_prefix, "doc_path": spec.doc_path}
+    if spec.schema_roots:
+        pkg["config_models"] = _config_models(spec.schema_roots)
+    if spec.constructors:
+        pkg["constructors"] = _constructors(spec.constructors)
+    if getattr(spec, "cli_module", None):
+        pkg["cli"] = _cli(spec.cli_module)
+    if getattr(spec, "mcp_module", None):
+        tools = _mcp_tools(spec.mcp_module)
+        if tools:
+            pkg["mcp_tools"] = tools
+    if spec.vocabs:
+        pkg["vocabularies"] = _vocabularies(spec.vocabs)
+    pkg["env_vars"] = scan_env_vars(spec.env_prefix, spec.src_dirs)
+    return pkg
+
+
+def build_manifest() -> dict:
+    return {
+        "schema": SCHEMA_ID,
+        "note": (
+            "Generated from scripts/config_matrix (same registry + resolvers as the "
+            f"CI-gated config-matrix docs). DO NOT EDIT. Regenerate: {_REGEN}"
+        ),
+        "packages": {name: build_package(spec) for name, spec in REGISTRY.items()},
+    }
+
+
+def manifest_json() -> str:
+    """Canonical serialization -- the exact bytes the gate compares."""
+    return json.dumps(build_manifest(), indent=2, ensure_ascii=False, sort_keys=False) + "\n"
+
+
+def _path() -> Path:
+    return ROOT / MANIFEST_PATH
+
+
+def write_manifest() -> Path:
+    p = _path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(manifest_json(), encoding="utf-8", newline="\n")
+    return p
+
+
+def manifest_is_current() -> bool:
+    p = _path()
+    return p.exists() and p.read_text(encoding="utf-8") == manifest_json()

--- a/scripts/config_matrix/manifest.py
+++ b/scripts/config_matrix/manifest.py
@@ -46,6 +46,11 @@ from .render import (
 
 SCHEMA_ID = "goldenmatch.agent-manifest/v1"
 MANIFEST_PATH = "docs/agent-manifest.json"
+# Byte-identical copy bundled into goldensuite-mcp so the deployed (pip-installed)
+# MCP server's `suite_manifest` tool works without the repo's docs/ tree. Gated
+# equal to MANIFEST_PATH, so the two can never diverge.
+BUNDLED_PATH = "packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json"
+_MANIFEST_PATHS = (MANIFEST_PATH, BUNDLED_PATH)
 _REGEN = "python scripts/gen_config_matrix.py --manifest"
 
 
@@ -327,17 +332,19 @@ def manifest_json() -> str:
     return json.dumps(build_manifest(), indent=2, ensure_ascii=False, sort_keys=False) + "\n"
 
 
-def _path() -> Path:
-    return ROOT / MANIFEST_PATH
-
-
-def write_manifest() -> Path:
-    p = _path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(manifest_json(), encoding="utf-8", newline="\n")
-    return p
+def write_manifest() -> list[Path]:
+    """Write the canonical manifest AND its bundled copy (identical bytes)."""
+    body = manifest_json()
+    written = []
+    for rel in _MANIFEST_PATHS:
+        p = ROOT / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(body, encoding="utf-8", newline="\n")
+        written.append(p)
+    return written
 
 
 def manifest_is_current() -> bool:
-    p = _path()
-    return p.exists() and p.read_text(encoding="utf-8") == manifest_json()
+    body = manifest_json()
+    return all((ROOT / rel).exists() and (ROOT / rel).read_text(encoding="utf-8") == body
+               for rel in _MANIFEST_PATHS)

--- a/scripts/config_matrix/manifest.py
+++ b/scripts/config_matrix/manifest.py
@@ -20,8 +20,10 @@ box and the Linux CI runner -- the same discipline the MDX gate needs.
 from __future__ import annotations
 
 import importlib
+import importlib.util
 import inspect
 import json
+import tomllib
 import typing
 from pathlib import Path
 
@@ -203,12 +205,95 @@ def _vocabularies(vocabs) -> list[dict]:
     return out
 
 
+# --- structural map (the "where does it live" half of don't-grep) -----------
+# Derived from authoritative sources only: the Python import system resolves a
+# module to its actual file (so it can't name a path that doesn't exist), the
+# package's pyproject declares its entry points, and each crate's Cargo.toml
+# names itself. Nothing here is hand-maintained.
+
+
+def _rel(path: str | None) -> str | None:
+    """Absolute filesystem path -> repo-relative POSIX path (deterministic across
+    a Windows dev box and the Linux CI runner)."""
+    if not path:
+        return None
+    try:
+        return Path(path).resolve().relative_to(ROOT).as_posix()
+    except ValueError:
+        return None
+
+
+def _module_file(target: str) -> str | None:
+    """'pkg.mod:attr' or 'pkg.mod' -> the module's source file, repo-relative."""
+    mod = target.partition(":")[0]
+    try:
+        spec = importlib.util.find_spec(mod)
+    except (ImportError, ValueError):
+        return None
+    return _rel(spec.origin) if spec else None
+
+
+def _entry_points(pyproject: Path) -> dict:
+    if not pyproject.exists():
+        return {}
+    data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    eps = data.get("project", {}).get("entry-points", {})
+    return {group: dict(sorted(entries.items())) for group, entries in sorted(eps.items())}
+
+
+def _source(spec: PackageSpec) -> dict:
+    import_name = spec.src_dirs[0].rsplit("/", 1)[-1]
+    modules: dict[str, str] = {}
+    if spec.schema_roots:
+        f = _module_file(spec.schema_roots[0])
+        if f:
+            modules["config_schema"] = f
+    if spec.constructors:
+        f = _module_file(spec.constructors[0])
+        if f:
+            modules["constructor"] = f
+    if getattr(spec, "cli_module", None):
+        f = _module_file(spec.cli_module)
+        if f:
+            modules["cli"] = f
+    if getattr(spec, "mcp_module", None):
+        f = _module_file(spec.mcp_module)
+        if f:
+            modules["mcp_server"] = f
+    out: dict = {"import_name": import_name, "root": spec.src_dirs[0]}
+    if modules:
+        out["modules"] = modules
+    eps = _entry_points(ROOT / spec.src_dirs[0].rsplit("/", 1)[0] / "pyproject.toml")
+    if eps:
+        out["entry_points"] = eps
+    return out
+
+
+def _rust_crates() -> list[dict]:
+    """Every Rust crate under packages/rust/extensions, name + path, read from the
+    Cargo.toml `[package].name` -- the authoritative crate registry."""
+    ext = ROOT / "packages" / "rust" / "extensions"
+    crates: list[dict] = []
+    for cargo in ext.rglob("Cargo.toml"):
+        if "target" in cargo.parts:
+            continue
+        try:
+            data = tomllib.loads(cargo.read_text(encoding="utf-8"))
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        name = data.get("package", {}).get("name")
+        if name:
+            crates.append({"name": name, "path": _rel(str(cargo.parent))})
+    return sorted(crates, key=lambda c: c["name"])
+
+
 # --- assembly ----------------------------------------------------------------
 
 
 def build_package(spec: PackageSpec) -> dict:
     _warmup(getattr(spec, "vocab_warmup", []))
     pkg: dict = {"nav_group": spec.nav_group, "env_prefix": spec.env_prefix, "doc_path": spec.doc_path}
+    pkg["source"] = _source(spec)
     if spec.schema_roots:
         pkg["config_models"] = _config_models(spec.schema_roots)
     if spec.constructors:
@@ -233,6 +318,7 @@ def build_manifest() -> dict:
             f"CI-gated config-matrix docs). DO NOT EDIT. Regenerate: {_REGEN}"
         ),
         "packages": {name: build_package(spec) for name, spec in REGISTRY.items()},
+        "rust_crates": _rust_crates(),
     }
 
 

--- a/scripts/gen_config_matrix.py
+++ b/scripts/gen_config_matrix.py
@@ -82,7 +82,8 @@ def main(argv: list[str]) -> int:
             print(f"wrote {write_docs(REGISTRY[name])}")
         return 0
     if "--manifest" in argv:
-        print(f"wrote {write_manifest()}")
+        for p in write_manifest():
+            print(f"wrote {p}")
         return 0
     if "--manifest-check" in argv:
         if manifest_is_current():

--- a/scripts/gen_config_matrix.py
+++ b/scripts/gen_config_matrix.py
@@ -4,6 +4,14 @@
   python scripts/gen_config_matrix.py --check [pkg|all]     # exit 1 if any is stale
   python scripts/gen_config_matrix.py --refs  [pkg|all]     # exit 1 if a doc names a dead env knob OR omits a canonical scorer/strategy/...
   python scripts/gen_config_matrix.py --coverage [pkg|all]  # report NL-explanation coverage per package
+  python scripts/gen_config_matrix.py --manifest            # regenerate the agent-navigation JSON (all packages)
+  python scripts/gen_config_matrix.py --manifest-check      # exit 1 if the agent manifest is stale
+
+The agent manifest (docs/agent-manifest.json) is a structured-JSON view of the
+SAME live surface these docs render from -- so agents can look up config /
+vocabularies / CLI / MCP tools / env knobs without grepping. It needs all six
+packages importable, so it lives outside the per-package --check legs; its gate
+home is scripts/test_config_matrix.py (the full-workspace goldenmatch leg).
 
 Each suite package's config surface (pydantic tree / constructor kwargs / vocab
 constants / <PREFIX>_* env scan) is the source of truth; the committed page's
@@ -17,6 +25,7 @@ import sys
 from config_matrix import REGISTRY
 from config_matrix.coverage import coverage, format_report
 from config_matrix.crossref import stale_env_refs, undocumented_vocab
+from config_matrix.manifest import MANIFEST_PATH, manifest_is_current, write_manifest
 from config_matrix.render import docs_are_current, write_docs
 
 
@@ -72,6 +81,17 @@ def main(argv: list[str]) -> int:
         for name in _targets(argv):
             print(f"wrote {write_docs(REGISTRY[name])}")
         return 0
+    if "--manifest" in argv:
+        print(f"wrote {write_manifest()}")
+        return 0
+    if "--manifest-check" in argv:
+        if manifest_is_current():
+            print(f"OK    agent manifest: {MANIFEST_PATH}")
+            return 0
+        print(f"STALE agent manifest: {MANIFEST_PATH}", file=sys.stderr)
+        print("::error::agent manifest stale. Run: python scripts/gen_config_matrix.py --manifest",
+              file=sys.stderr)
+        return 1
     print(__doc__)
     return 2
 

--- a/scripts/test_config_matrix.py
+++ b/scripts/test_config_matrix.py
@@ -12,6 +12,7 @@ import pytest
 from config_matrix import REGISTRY
 from config_matrix.coverage import coverage
 from config_matrix.crossref import stale_env_refs, undocumented_vocab, vocab_column_gaps
+from config_matrix.manifest import MANIFEST_PATH, manifest_is_current, manifest_json
 from config_matrix.render import (
     MARKER_END,
     MARKER_START,
@@ -121,3 +122,21 @@ def test_render_is_deterministic(name):
     # memory addresses (goldenflow's TransformInfo) or set-ordering leaking in.
     spec = REGISTRY[name]
     assert render_generated_block(spec) == render_generated_block(spec)
+
+
+def test_agent_manifest_current():
+    # The agent-navigation JSON (docs/agent-manifest.json) is a structured view of
+    # the SAME live surface these docs render from. It must match a fresh build, so
+    # a new config knob / CLI option / MCP tool / vocab value / env var can't ship
+    # without regenerating it -- keeping the "don't grep, look it up" store honest.
+    assert manifest_is_current(), (
+        f"{MANIFEST_PATH} is stale vs the live config surface. "
+        "Run: python scripts/gen_config_matrix.py --manifest"
+    )
+
+
+def test_agent_manifest_is_deterministic():
+    # Byte-stable across builds (same discipline as the MDX gate): no set-ordering
+    # or object-repr leaks, so the committed JSON doesn't flap between a Windows dev
+    # box and the Linux CI runner.
+    assert manifest_json() == manifest_json()


### PR DESCRIPTION
## What

Prototype of a **native, look-it-up-instead-of-grep** store for coding agents, built exactly the way you asked: **generated from the source-of-truth, CI-gated config-matrix docs** rather than a new parallel index.

`docs/agent-manifest.json` is a structured-JSON index of every suite package's:
- **config schema** (pydantic models: fields, types, defaults, choices, descriptions)
- **CLI commands** + options (Typer→click)
- **MCP tools** (name + description)
- **enumerated vocabularies** with `best_for` / `range` decision hints (scorers, blocking strategies, survivorship, backends, ...)
- **`<PREFIX>_*` env knobs**, grouped

for all six packages — so an agent answers "what scorers exist and which suits names / what MCP tools does goldenpipe expose / what's the type+default of `GoldenMatchConfig.threshold` / which env vars tune goldenmatch" from one file.

## Why it can't rot

It is **not a second source of truth.** It renders from the *same* `scripts/config_matrix` registry + resolvers that drive the CI-gated `config-matrix.mdx` docs, and it's gated for drift by `scripts/test_config_matrix.py` (the full-workspace `goldenmatch` leg, where all six packages are installed). A new config knob / CLI option / MCP tool / vocab value / env var can't ship without regenerating it — same discipline the MDX gate already enforces. **Zero `ci.yml` changes needed** — the existing `config_matrix` filter + job already run the gate.

## Coverage (this build)

50 config models, 105 MCP tools, 105 CLI commands, 27 vocabularies, 72 env groups across the 6 packages. 303 KB. 46/46 config-matrix gate tests pass locally.

## Changes

- `scripts/config_matrix/manifest.py` — structured-JSON renderer reusing the registry + type/vocab/env/MCP resolvers; deterministic ordering so the committed JSON is byte-stable Windows-dev ↔ Linux-CI.
- `scripts/gen_config_matrix.py` — `--manifest` (write) / `--manifest-check` (gate).
- `scripts/test_config_matrix.py` — currency + determinism gates.
- `.github/filters.yml` — hand-edits to the committed JSON re-trigger the gate.
- `AGENTS.md` — tells agents the manifest exists and when to query it.
- `.gitattributes` — mark generated + force `eol=lf`.

## Open decisions for review

1. **Location/name** — `docs/agent-manifest.json`. Alternative: repo root, or `.well-known/`-style. Where do you want agents to find it?
2. **Consumption** — right now it's a file an agent reads. Natural follow-on: an MCP tool that serves *slices* (e.g. `lookup_vocab("scorers")`) so an agent doesn't pull 303 KB for one answer. Worth doing?
3. **Scope** — currently config/CLI/MCP/vocab/env (the config-matrix surface). Should it also carry a package→entry-point→core-kernel structural map (the other half of "don't grep")?

Not arming auto-merge — this adds a committed artifact + gate, your call on the above first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)