### PR TITLE
parity: gate Python<->TS blocking-strategy parity

### DIFF
--- a/packages/typescript/goldenmatch/src/core/config-edits.ts
+++ b/packages/typescript/goldenmatch/src/core/config-edits.ts
@@ -22,7 +22,7 @@ import { getMatchkeys, VALID_SCORERS } from "./types.js";
 
 const PERTURBABLE_TYPES = new Set<string>(["weighted", "probabilistic"]);
 
-const VALID_BLOCKING_STRATEGIES = new Set<string>([
+export const VALID_BLOCKING_STRATEGIES = new Set<string>([
   "static",
   "adaptive",
   "sorted_neighborhood",

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -561,6 +561,7 @@ export {
   editFromSpec,
   parseLlmEdits,
   foldEdits,
+  VALID_BLOCKING_STRATEGIES,
   type ConfigEdit,
 } from "./config-edits.js";
 

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -283,3 +283,21 @@ transforms:
   - uppercase
   python_only: []
   ts_only: []
+# blocking_strategies surface (config.schemas BlockingConfig.strategy <->
+# config-edits.ts VALID_BLOCKING_STRATEGIES). python_only: lsh + simhash (MinHash /
+# SimHash LSH) and perceptual (image-hash LSH) have no TS port yet.
+blocking_strategies:
+  shared:
+  - adaptive
+  - ann
+  - ann_pairs
+  - canopy
+  - learned
+  - multi_pass
+  - sorted_neighborhood
+  - static
+  python_only:
+  - lsh
+  - perceptual
+  - simhash
+  ts_only: []

--- a/scripts/check_api_parity.py
+++ b/scripts/check_api_parity.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-SURFACES = ("mcp_tools", "cli_commands", "a2a_skills", "scorers", "transforms")
+SURFACES = ("mcp_tools", "cli_commands", "a2a_skills", "scorers", "transforms", "blocking_strategies")
 
 
 class ParityFailure(NamedTuple):

--- a/scripts/emit_python_surface.py
+++ b/scripts/emit_python_surface.py
@@ -65,6 +65,16 @@ def _transforms() -> list[str]:
     return sorted(VALID_SIMPLE_TRANSFORMS)
 
 
+def _blocking_strategies() -> list[str]:
+    # goldenmatch config surface: the accepted blocking-strategy names. Mirrors TS
+    # `VALID_BLOCKING_STRATEGIES` (config-edits.ts); intended cross-language deltas
+    # are declared in parity/goldenmatch.yaml (lsh/perceptual/simhash are Python-only).
+    from typing import get_args
+
+    from goldenmatch.config.schemas import BlockingConfig
+    return sorted(get_args(BlockingConfig.model_fields["strategy"].annotation))
+
+
 # The only per-package variance on the Python side is the CLI module path.
 _CLI_MODULE = {
     "goldenmatch": "goldenmatch.cli.main",
@@ -82,7 +92,8 @@ REGISTRY = {
           # Scorer/transform config surfaces are goldenmatch-only (no extra needed:
           # config.schemas imports without the mcp/a2a stacks). Other packages
           # never declare these surfaces, so they're skipped for them.
-          **({"scorers": (_scorers, None), "transforms": (_transforms, None)}
+          **({"scorers": (_scorers, None), "transforms": (_transforms, None),
+              "blocking_strategies": (_blocking_strategies, None)}
              if pkg == "goldenmatch" else {})}
     for pkg, mod in _CLI_MODULE.items()
 }

--- a/scripts/emit_ts_surface.mjs
+++ b/scripts/emit_ts_surface.mjs
@@ -64,10 +64,11 @@ async function emit(pkg) {
     // types.ts is bundled (not its own tsup entry) -> dist/core/types.js does
     // not exist. The `./core` export entry (dist/core/index.js) re-exports both.
     const t = await load("dist/core/index.js");
-    if (!t.VALID_SCORERS || !t.VALID_TRANSFORMS)
-      throw new Error(`${pkg}: expected VALID_SCORERS + VALID_TRANSFORMS in dist/core/index.js`);
+    if (!t.VALID_SCORERS || !t.VALID_TRANSFORMS || !t.VALID_BLOCKING_STRATEGIES)
+      throw new Error(`${pkg}: expected VALID_SCORERS + VALID_TRANSFORMS + VALID_BLOCKING_STRATEGIES in dist/core/index.js`);
     descriptor.scorers = [...t.VALID_SCORERS].sort();
     descriptor.transforms = [...t.VALID_TRANSFORMS].sort();
+    descriptor.blocking_strategies = [...t.VALID_BLOCKING_STRATEGIES].sort();
   }
 
   return descriptor;


### PR DESCRIPTION
Closes the TypeScript half of the gap analysis. The `api_parity` gate already keeps five Py↔TS surfaces in lockstep (`mcp_tools`, `cli_commands`, `a2a_skills`, `scorers`, `transforms`) — but **not blocking strategies**, even though both languages implement them (`BlockingConfig.strategy` in Python, `VALID_BLOCKING_STRATEGIES` in TS `config-edits.ts`). A strategy added to one side could silently drift.

## Change
- New `blocking_strategies` parity surface across both emitters + the gate.
- TS `VALID_BLOCKING_STRATEGIES` exported from the core barrel so the emitter can read it.
- Manifest partition: **shared** = the 8 common strategies (static, adaptive, sorted_neighborhood, multi_pass, ann, ann_pairs, canopy, learned); **python_only** = `lsh` / `perceptual` / `simhash` (LSH + image-hash blockers with no TS port); **ts_only** = none.

## Verified
Python emitter yields all 11 strategies; the manifest partitions the real Py/TS sets cleanly; a negative test (TS gains `lsh`) is caught; all 22 api_parity unit tests pass. The TS build + emit is exercised by CI's `api_parity` job (TS build OOMs locally, so that leg is CI-verified).

Note on the earlier "TS not introspected" framing: it was too broad — `api_parity` already covered the main surfaces. This adds the one config vocab both sides implement that wasn't gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd