### PR TITLE
docs: reference-checked recipes pages for goldencheck / goldenflow / goldenpipe

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -105,6 +105,7 @@
               "goldencheck/overview",
               "goldencheck/checks",
               "goldencheck/config-matrix",
+              "goldencheck/recipes",
               "goldencheck/cli",
               "goldencheck/native",
               "goldencheck/integrations"
@@ -116,6 +117,7 @@
               "goldenflow/overview",
               "goldenflow/transforms",
               "goldenflow/config-matrix",
+              "goldenflow/recipes",
               "goldenflow/cli",
               "goldenflow/performance"
             ]
@@ -125,7 +127,8 @@
             "pages": [
               "goldenpipe/overview",
               "goldenpipe/stages",
-              "goldenpipe/config-matrix"
+              "goldenpipe/config-matrix",
+              "goldenpipe/recipes"
             ]
           },
           {

--- a/docs-site/goldencheck/recipes.mdx
+++ b/docs-site/goldencheck/recipes.mdx
@@ -1,0 +1,60 @@
+---
+title: "Validation recipes"
+description: "Copy-paste GoldenCheck configs for common jobs: validate a customer file, enforce enums and ranges, and catch outliers."
+keywords: ["goldencheck", "recipes", "validation", "schema", "config"]
+---
+
+The [config matrix](/goldencheck/config-matrix) lists every check type. This page is the task-shaped shortcut. `goldencheck scan your.csv` profiles and flags issues with no config; write a config when you want to *enforce* a schema. Every config below is a complete, valid file (CI validates each against the live schema).
+
+```bash
+goldencheck scan your.csv --config recipe.yaml
+```
+
+## Validate a customer file
+
+**You have** a contact file and a contract for what "valid" means. **You want** required fields present, emails well-formed, and IDs unique.
+
+```yaml
+version: 1
+columns:
+  customer_id:
+    type: string
+    required: true
+    unique: true
+  email:
+    type: string
+    required: true
+    format: email
+  phone:
+    type: string
+    nullable: true
+```
+
+## Enforce enums and ranges
+
+**You have** status and numeric columns that must stay within known bounds. **You want** any out-of-range or unexpected value flagged.
+
+```yaml
+version: 1
+columns:
+  status:
+    type: string
+    enum: [active, inactive, pending]
+  age:
+    type: int
+    range: [0, 120]
+```
+
+## Catch numeric outliers
+
+**You have** a measure column where extreme values usually mean bad data. **You want** statistical outliers surfaced.
+
+`outlier_stddev` flags values more than N standard deviations from the mean.
+
+```yaml
+version: 1
+columns:
+  amount:
+    type: float
+    outlier_stddev: 3.0
+```

--- a/docs-site/goldenflow/recipes.mdx
+++ b/docs-site/goldenflow/recipes.mdx
@@ -1,0 +1,56 @@
+---
+title: "Transform recipes"
+description: "Copy-paste GoldenFlow configs for common jobs: standardize contact data, clean and dedupe, and reshape columns."
+keywords: ["goldenflow", "recipes", "transforms", "standardize", "config"]
+---
+
+The [config matrix](/goldenflow/config-matrix) lists every transform. This page is the task-shaped shortcut. `goldenflow transform your.csv` auto-detects and fixes most things with no config; reach for one of these when you want to pin the exact transforms. Every config below is a complete, valid file (CI validates each against the live schema).
+
+```bash
+goldenflow transform your.csv --config recipe.yaml
+```
+
+## Standardize contact data
+
+**You have** names, phones, and emails in inconsistent formats. **You want** them normalized to a canonical shape.
+
+```yaml
+transforms:
+  - column: phone
+    ops: [strip, phone_e164]
+  - column: email
+    ops: [strip, email_lowercase]
+  - column: first_name
+    ops: [strip, name_proper]
+  - column: last_name
+    ops: [strip, name_proper]
+```
+
+## Clean, then drop duplicates
+
+**You have** a contact export with formatting noise and repeat rows. **You want** a clean, de-duplicated file in one pass.
+
+Transforms run first, so dedup compares the *normalized* values (two rows that differ only by email casing collapse to one).
+
+```yaml
+transforms:
+  - column: email
+    ops: [strip, email_lowercase]
+dedup:
+  columns: [email]
+  keep: first
+```
+
+## Reshape for a downstream system
+
+**You have** columns that don't match the target schema. **You want** to rename, drop, and standardize in one config.
+
+```yaml
+transforms:
+  - column: signup_date
+    ops: [date_iso8601]
+renames:
+  email_address: email
+  fname: first_name
+drop: [internal_id]
+```

--- a/docs-site/goldenpipe/recipes.mdx
+++ b/docs-site/goldenpipe/recipes.mdx
@@ -1,0 +1,61 @@
+---
+title: "Pipeline recipes"
+description: "Copy-paste GoldenPipe configs that wire the suite together: full clean-and-dedupe, profile-and-report, and dedupe-then-resolve-identities."
+keywords: ["goldenpipe", "recipes", "pipeline", "orchestration", "config"]
+---
+
+The [config matrix](/goldenpipe/config-matrix) lists every stage. This page is the task-shaped shortcut: a few complete pipelines that wire the suite packages together. Every config below is a complete, valid file (CI validates each against the live schema).
+
+```bash
+goldenpipe run recipe.yaml
+```
+
+## Clean and dedupe end to end
+
+**You have** a raw file. **You want** to scan it, standardize it, and dedupe it in one declarative run.
+
+Stages run in order; each `use` names a registered stage (see the [Stages](/goldenpipe/config-matrix#stages) table).
+
+```yaml
+pipeline: clean_and_dedupe
+source: raw.csv
+stages:
+  - name: scan
+    use: goldencheck.scan
+  - name: standardize
+    use: goldenflow.transform
+  - name: dedupe
+    use: goldenmatch.dedupe
+```
+
+## Profile, then report
+
+**You have** a dataset you want a quality read on. **You want** a scan followed by a cross-cutting report, no matching.
+
+```yaml
+pipeline: profile_and_report
+source: data.csv
+stages:
+  - name: infer
+    use: infer_schema
+  - name: scan
+    use: goldencheck.scan
+  - name: report
+    use: goldenanalysis.report
+```
+
+## Dedupe, then resolve durable identities
+
+**You have** records that arrive over time. **You want** to dedupe and then assign stable entity IDs that survive across runs.
+
+```yaml
+pipeline: dedupe_and_resolve
+source: contacts.csv
+stages:
+  - name: standardize
+    use: goldenflow.transform
+  - name: dedupe
+    use: goldenmatch.dedupe
+  - name: identities
+    use: goldenmatch.identity_resolve
+```

--- a/scripts/test_config_matrix.py
+++ b/scripts/test_config_matrix.py
@@ -115,30 +115,45 @@ def test_full_explanation_coverage_maintained(name):
     )
 
 
-def test_recipe_configs_validate():
-    # Every ```yaml block on the recipes page must be a COMPLETE, valid config --
-    # validated through the same load_config path a real file takes. A renamed or
-    # removed field / scorer / strategy makes the snippet fail schema validation,
-    # so the copy-paste recipes can never rot into referencing a dead knob.
+# package -> (recipes page, "module:load_config", minimum config blocks). Each
+# config-driven package's recipes page is validated through the SAME load_config a
+# real file takes, so a renamed/removed field can't rot the copy-paste recipes.
+_RECIPE_PAGES = {
+    "goldenmatch": ("docs-site/goldenmatch/recipes.mdx", "goldenmatch.config.loader:load_config", 6),
+    "goldencheck": ("docs-site/goldencheck/recipes.mdx", "goldencheck.config.loader:load_config", 3),
+    "goldenflow": ("docs-site/goldenflow/recipes.mdx", "goldenflow.config.loader:load_config", 3),
+    "goldenpipe": ("docs-site/goldenpipe/recipes.mdx", "goldenpipe.config.loader:load_config", 3),
+}
+
+
+@pytest.mark.parametrize("name", list(_RECIPE_PAGES))
+def test_recipe_configs_validate(name):
+    # Every ```yaml block on a package's recipes page must be a COMPLETE, valid
+    # config validated through its real load_config. A renamed/removed field or
+    # vocab value fails schema validation, so the recipes can't reference a dead knob.
+    import importlib
     import os
     import re
     import tempfile
+    from pathlib import Path
 
     from config_matrix.render import ROOT
-    from goldenmatch.config.loader import load_config
 
-    page = ROOT / "docs-site" / "goldenmatch" / "recipes.mdx"
-    blocks = re.findall(r"```yaml\n(.*?)```", page.read_text(encoding="utf-8"), re.DOTALL)
-    assert len(blocks) >= 6, f"expected >=6 config blocks on the recipes page, found {len(blocks)}"
+    rel, target, minimum = _RECIPE_PAGES[name]
+    mod, fn = target.split(":")
+    load_config = getattr(importlib.import_module(mod), fn)
+
+    blocks = re.findall(r"```yaml\n(.*?)```", (ROOT / rel).read_text(encoding="utf-8"), re.DOTALL)
+    assert len(blocks) >= minimum, f"expected >={minimum} config blocks on {rel}, found {len(blocks)}"
     errors = []
     for i, block in enumerate(blocks, 1):
         tmp = tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False, encoding="utf-8")
         try:
             tmp.write(block)
             tmp.close()
-            load_config(tmp.name)
+            load_config(Path(tmp.name))  # Path works for every package's loader
         except Exception as exc:  # noqa: BLE001 -- surface which recipe is broken
-            errors.append(f"recipe block #{i}: {str(exc)[:200]}")
+            errors.append(f"{rel} block #{i}: {str(exc)[:200]}")
         finally:
             os.unlink(tmp.name)
     assert not errors, "invalid recipe config(s):\n" + "\n".join(errors)


### PR DESCRIPTION
Extends the curated human layer (the task-shaped counterpart to the exhaustive config matrix) to the three config-driven suite packages, matching the goldenmatch recipes page.

## New pages
- **goldenflow/recipes** — standardize contact data, clean+dedupe, reshape for a downstream system.
- **goldencheck/recipes** — validate a customer file, enforce enums/ranges, catch numeric outliers.
- **goldenpipe/recipes** — full clean+dedupe pipeline, profile+report, dedupe+resolve-identities.

## Can't rot
Every ` ```yaml ` block is a complete, valid config. The recipe gate is generalized to parametrize over all four packages, each validated through its **own** `load_config` — a renamed field / dead stage / removed transform fails schema validation. All four pages pass; wired into nav next to each matrix.

## Deliberately scoped out (not cargo-culted)
"Best for" decision hints on the other packages' **mechanical** vocabs (42 check types, 124 transforms, dtypes) — there's no "which do I pick" choice there, so a decision column would be noise. The decision-prose stale-ref gate already covers all six packages. Recipes are the genuine task-oriented value.

Doc consistency + links (74 pages) + `mint validate` + `broken-links --check-anchors` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015cfpPuUz8gHAaKub9Ne5Yd