### PR TITLE
feat(agent-nav): committed code map for external agents browsing the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,3 +14,7 @@ pnpm-lock.yaml     linguist-generated=true -diff
 # trip on a CRLF checkout (Windows dev vs Linux CI).
 docs/agent-manifest.json  linguist-generated=true -diff eol=lf
 packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json  linguist-generated=true -diff eol=lf
+# Agent code map: static-AST structural index of the Python source, gated by
+# scripts/test_agent_codemap.py. Force LF so the byte-for-byte gate can't trip on
+# a CRLF checkout (Windows dev vs Linux CI).
+docs/agent-codemap.json  linguist-generated=true -diff eol=lf

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -414,6 +414,12 @@ config_matrix:
   - 'packages/python/*/llms.txt'
   - 'packages/python/*/README.md'
   - 'llms.txt'
+  # Agent code map (docs/agent-codemap.json): a static-AST structural map of the
+  # Python source, gated in the same job. Any .py move re-runs it (already covered
+  # above); these cover the generator, its gate, and a hand-edit of the committed JSON.
+  - 'scripts/agent_codemap.py'
+  - 'scripts/test_agent_codemap.py'
+  - 'docs/agent-codemap.json'
   - '.github/workflows/ci.yml'
   - '.github/filters.yml'
 # Native-symbol reconciliation gate: the goldenmatch host's

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3286,7 +3286,7 @@ jobs:
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Gate unit tests (determinism + markers; run once)
         if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py -q
+        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -1,0 +1,12068 @@
+{
+  "schema": "goldenmatch.agent-codemap/v1",
+  "note": "Structural map of the repo's Python source for coding agents. Generated from a static AST walk; DO NOT EDIT. Regenerate: python scripts/agent_codemap.py --write",
+  "packages": {
+    "goldenmatch": {
+      "root": "packages/python/goldenmatch/goldenmatch",
+      "module_count": 403,
+      "modules": [
+        {
+          "module": "goldenmatch",
+          "file": "packages/python/goldenmatch/goldenmatch/__init__.py",
+          "purpose": "GoldenMatch -- entity resolution toolkit.",
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.client",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._hashing",
+            "goldenmatch.core.agent",
+            "goldenmatch.core.anomaly",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.boost",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.compare_clusters",
+            "goldenmatch.core.config_edits",
+            "goldenmatch.core.config_optimizer",
+            "goldenmatch.core.diff",
+            "goldenmatch.core.domain_registry",
+            "goldenmatch.core.embedding_ops",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.explain",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.graph_er",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.learned_blocking",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.llm_budget",
+            "goldenmatch.core.llm_canonicalize",
+            "goldenmatch.core.llm_cluster",
+            "goldenmatch.core.llm_extract",
+            "goldenmatch.core.llm_labeler",
+            "goldenmatch.core.llm_scorer",
+            "goldenmatch.core.match_one",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.memory",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.profiler",
+            "goldenmatch.core.rag_surface",
+            "goldenmatch.core.recall_certificate",
+            "goldenmatch.core.retrieval",
+            "goldenmatch.core.review_queue",
+            "goldenmatch.core.rollback",
+            "goldenmatch.core.schema_match",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.screening",
+            "goldenmatch.core.sensitivity",
+            "goldenmatch.core.standardize",
+            "goldenmatch.core.streaming",
+            "goldenmatch.core.threshold",
+            "goldenmatch.core.validate",
+            "goldenmatch.core.vector_index",
+            "goldenmatch.core.vector_store",
+            "goldenmatch.identity",
+            "goldenmatch.output.report",
+            "goldenmatch.output.writer",
+            "goldenmatch.plugins.builtin",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.pprl.autoconfig",
+            "goldenmatch.pprl.protocol"
+          ]
+        },
+        {
+          "module": "goldenmatch._api",
+          "file": "packages/python/goldenmatch/goldenmatch/_api.py",
+          "purpose": "Clean top-level API for GoldenMatch.",
+          "defines": [
+            "DedupeResult",
+            "MatchResult",
+            "_attach_memory_to_postflight",
+            "_build_config",
+            "_capture_run",
+            "_detect_llm_provider",
+            "_extract_stats",
+            "_frame_columns",
+            "_frame_head_dicts",
+            "_frame_height",
+            "_frame_write_csv",
+            "_run_config_lint",
+            "_to_result_table",
+            "add_correction",
+            "dedupe",
+            "dedupe_df",
+            "evaluate",
+            "explain_pair_df",
+            "from_splink",
+            "get_memory",
+            "learn",
+            "load_config",
+            "match",
+            "match_df",
+            "memory_stats",
+            "pprl_link",
+            "score_pair_df",
+            "score_strings",
+            "upgrade_splink_conversion"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade",
+            "goldenmatch.core",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.analytics",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.config_lint",
+            "goldenmatch.core.diagnostics",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.explain",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.learner",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.recall_certificate",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.adapter",
+            "goldenmatch.pprl.autoconfig",
+            "goldenmatch.pprl.protocol",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch._exclusions_schema",
+          "file": "packages/python/goldenmatch/goldenmatch/_exclusions_schema.py",
+          "purpose": "Single source of the ``exclude_columns`` JSON Schema fragment.",
+          "defines": [
+            "merge_exclude_columns_into_config",
+            "parse_csv_exclude_columns"
+          ]
+        },
+        {
+          "module": "goldenmatch._polars_lazy",
+          "file": "packages/python/goldenmatch/goldenmatch/_polars_lazy.py",
+          "purpose": "Lazy Polars proxy -- W0 of the Polars eviction (spec:",
+          "defines": [
+            "_LazyPolars"
+          ]
+        },
+        {
+          "module": "goldenmatch.a2a",
+          "file": "packages/python/goldenmatch/goldenmatch/a2a/__init__.py"
+        },
+        {
+          "module": "goldenmatch.a2a.server",
+          "file": "packages/python/goldenmatch/goldenmatch/a2a/server.py",
+          "purpose": "A2A (Agent-to-Agent) protocol server for GoldenMatch.",
+          "defines": [
+            "TaskRegistry",
+            "_auth_middleware",
+            "_handle_agent_card",
+            "_handle_cancel_task",
+            "_handle_get_task",
+            "_handle_health",
+            "_handle_send_task",
+            "build_agent_card",
+            "create_app"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch.a2a.skills"
+          ]
+        },
+        {
+          "module": "goldenmatch.a2a.skills",
+          "file": "packages/python/goldenmatch/goldenmatch/a2a/skills.py",
+          "purpose": "Skill dispatch for the A2A protocol server.",
+          "defines": [
+            "_serialise_result",
+            "dispatch_skill"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch._api",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.agent",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.block_analyzer",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.review_queue",
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.surface",
+            "goldenmatch.core.transform",
+            "goldenmatch.mcp.agent_tools",
+            "goldenmatch.mcp.document_tools",
+            "goldenmatch.mcp.identity_tools",
+            "goldenmatch.mcp.memory_tools",
+            "goldenmatch.mcp.server"
+          ]
+        },
+        {
+          "module": "goldenmatch.api",
+          "file": "packages/python/goldenmatch/goldenmatch/api/__init__.py",
+          "purpose": "GoldenMatch REST API."
+        },
+        {
+          "module": "goldenmatch.api.server",
+          "file": "packages/python/goldenmatch/goldenmatch/api/server.py",
+          "purpose": "GoldenMatch REST API server — local HTTP server for real-time matching.",
+          "defines": [
+            "APIHandler",
+            "MatchServer",
+            "resolve_api_auth_token",
+            "start_server"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.explainer",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.recall_certificate",
+            "goldenmatch.core.retrieval",
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.surface",
+            "goldenmatch.web.controller_telemetry"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/__init__.py",
+          "purpose": "GoldenMatch backends -- alternative data storage engines.",
+          "imports": [
+            "goldenmatch.backends.duckdb_backend"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.datafusion_backend",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/datafusion_backend.py",
+          "purpose": "DataFusion block-scoring backend.",
+          "defines": [
+            "_ensure_datafusion",
+            "_ensure_native",
+            "_make_score_udf",
+            "_materialize_blocks_to_arrow",
+            "_validate_matchkey",
+            "score_blocks_datafusion"
+          ],
+          "imports": [
+            "goldenmatch._native"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.datafusion_spine",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/datafusion_spine.py",
+          "purpose": "DataFusion spine — Stage C orchestration (mode=\"scale\").",
+          "defines": [
+            "_all_ids_from_blocks",
+            "_golden_rules_knobs",
+            "_make_spine_ctx",
+            "_register_scorers",
+            "_resolve_single_weighted_matchkey",
+            "_score_and_dedup",
+            "_slim_golden_source",
+            "_validate_scale_mode_supported",
+            "run_spine"
+          ],
+          "imports": [
+            "goldenmatch.backends.datafusion_backend",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.cluster_pairscores",
+            "goldenmatch.core.golden"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.duckdb_backend",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/duckdb_backend.py",
+          "purpose": "DuckDB backend for GoldenMatch -- out-of-core processing for large datasets.",
+          "defines": [
+            "DuckDBBackend"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.ray_backend",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/ray_backend.py",
+          "purpose": "Ray distributed backend for large-scale entity resolution.",
+          "defines": [
+            "_KeyModeBlock",
+            "_ensure_ray",
+            "score_blocks_ray",
+            "shutdown_ray"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.scorer",
+            "goldenmatch.distributed.record_store"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.score_buckets",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/score_buckets.py",
+          "purpose": "In-process bucketed block scorer.",
+          "defines": [
+            "_bkt_debug_on",
+            "_default_n_buckets",
+            "_fs_bucket_native_enabled",
+            "_ne_effectively_empty",
+            "_resolve_fast_path",
+            "_resolve_ne_specs",
+            "_resolve_score_pair_callable",
+            "_score_block_vec",
+            "_vec_field_matrix",
+            "_warn_stale_native_wheel_once",
+            "pairs_to_pair_stream",
+            "score_buckets",
+            "score_buckets_arrow",
+            "score_probabilistic_external_blocks"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._hashing",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.scorer",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.backends.score_duckdb",
+          "file": "packages/python/goldenmatch/goldenmatch/backends/score_duckdb.py",
+          "purpose": "DuckDB-backed block scoring — out-of-core pair storage.",
+          "defines": [
+            "score_blocks_duckdb"
+          ],
+          "imports": [
+            "goldenmatch.core.scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/__init__.py"
+        },
+        {
+          "module": "goldenmatch.cli._controller_render",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/_controller_render.py",
+          "purpose": "Rich rendering of AutoConfigController telemetry for the CLI.",
+          "defines": [
+            "_column_priors",
+            "_committed_matchkeys",
+            "_decision_trace",
+            "_execution_plan",
+            "_execution_plan_short",
+            "_header",
+            "_health_verdict",
+            "_ne_penalty_label",
+            "_negative_evidence",
+            "_num",
+            "_pct",
+            "_profile_strip",
+            "_stop_reason",
+            "_truncate",
+            "capture_controller_state",
+            "render_controller_panel",
+            "render_short_status"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.agent_serve",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/agent_serve.py",
+          "purpose": "CLI command for the A2A agent server.",
+          "defines": [
+            "agent_serve_cmd"
+          ],
+          "imports": [
+            "goldenmatch.a2a.server"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.anomalies",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/anomalies.py",
+          "purpose": "CLI anomalies command -- standalone suspicious-record detection.",
+          "defines": [
+            "anomalies_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.core.anomaly",
+            "goldenmatch.core.ingest"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.autoconfig",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/autoconfig.py",
+          "purpose": "`goldenmatch autoconfig` — run AutoConfigController and report what it picked.",
+          "defines": [
+            "_config_to_yaml",
+            "_run_autoconfig",
+            "autoconfig_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli._controller_render",
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.compare",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/compare.py",
+          "purpose": "CLI compare-clusters command for GoldenMatch.",
+          "defines": [
+            "_load_clusters",
+            "compare_clusters_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.compare_clusters"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.dedupe",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/dedupe.py",
+          "purpose": "CLI dedupe command for GoldenMatch.",
+          "defines": [
+            "_emit_healer_surface",
+            "_load_combined_frame",
+            "_parse_file_source",
+            "_render_suggestion_lines",
+            "_resolve_column_maps",
+            "dedupe_cmd"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.cli._controller_render",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.settings",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.preview",
+            "goldenmatch.core.suggest.surface",
+            "goldenmatch.tui.app",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.demo",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/demo.py",
+          "purpose": "Built-in demo — zero-friction showcase of GoldenMatch.",
+          "defines": [
+            "demo_cmd"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.dashboard",
+            "goldenmatch.core.graph",
+            "goldenmatch.core.report",
+            "goldenmatch.tui.app",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.evaluate",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/evaluate.py",
+          "purpose": "CLI evaluate command for GoldenMatch.",
+          "defines": [
+            "_build_systems",
+            "_certify_ingest",
+            "_emit_audit_sample",
+            "_emit_threshold_sweep",
+            "_row_count",
+            "_run_certify",
+            "_system_pairsets",
+            "evaluate_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.recall_certificate",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.explain",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/explain.py",
+          "purpose": "CLI explain command -- natural-language explanation of a pair or cluster.",
+          "defines": [
+            "_print_fs_waterfall",
+            "explain_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.explain",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.identity",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/identity.py",
+          "purpose": "CLI: ``goldenmatch identity ...`` -- inspect and manage the Identity Graph.",
+          "defines": [
+            "_open",
+            "conflicts_cmd",
+            "history_cmd",
+            "list_cmd",
+            "merge_cmd",
+            "migrate_cmd",
+            "migrate_ids_cmd",
+            "resolve_cmd",
+            "show_cmd",
+            "split_cmd"
+          ],
+          "imports": [
+            "goldenmatch.identity"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.import_splink",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/import_splink.py",
+          "purpose": "CLI command: convert a Splink settings or trained-model JSON file into a",
+          "defines": [
+            "_baseline_path",
+            "_render_delta_table",
+            "_render_report_table",
+            "_write_pair",
+            "import_splink_cmd"
+          ],
+          "imports": [
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.splink_upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.incremental",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/incremental.py",
+          "purpose": "CLI incremental command for GoldenMatch.",
+          "defines": [
+            "incremental_cmd"
+          ],
+          "imports": [
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.incremental"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.ingest_docs",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/ingest_docs.py",
+          "purpose": "`goldenmatch ingest-docs` — suggest a schema from a sample, then ingest documents to rows.",
+          "defines": [
+            "run_cmd",
+            "suggest_schema_cmd"
+          ],
+          "imports": [
+            "goldenmatch.documents",
+            "goldenmatch.documents.config",
+            "goldenmatch.documents.schema_io",
+            "goldenmatch.documents.suggest"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.label",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/label.py",
+          "purpose": "CLI label command -- build ground truth by labeling pairs interactively.",
+          "defines": [
+            "label_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.pipeline"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.lineage",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/lineage.py",
+          "purpose": "CLI lineage command -- build + persist match lineage for a run.",
+          "defines": [
+            "lineage_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.lineage",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.main",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/main.py",
+          "purpose": "GoldenMatch CLI application.",
+          "defines": [
+            "_callback",
+            "_get_store",
+            "_print_banner",
+            "analyze_blocking_cmd",
+            "config_delete",
+            "config_list",
+            "config_load",
+            "config_save",
+            "config_show",
+            "init_cmd",
+            "interactive_cmd",
+            "profile_cmd"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch.cli.agent_serve",
+            "goldenmatch.cli.anomalies",
+            "goldenmatch.cli.autoconfig",
+            "goldenmatch.cli.compare",
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.cli.demo",
+            "goldenmatch.cli.evaluate",
+            "goldenmatch.cli.explain",
+            "goldenmatch.cli.identity",
+            "goldenmatch.cli.import_splink",
+            "goldenmatch.cli.incremental",
+            "goldenmatch.cli.ingest_docs",
+            "goldenmatch.cli.label",
+            "goldenmatch.cli.lineage",
+            "goldenmatch.cli.match",
+            "goldenmatch.cli.mcp_serve",
+            "goldenmatch.cli.memory",
+            "goldenmatch.cli.pprl",
+            "goldenmatch.cli.review",
+            "goldenmatch.cli.rollback",
+            "goldenmatch.cli.schedule",
+            "goldenmatch.cli.sensitivity",
+            "goldenmatch.cli.serve",
+            "goldenmatch.cli.serve_ui",
+            "goldenmatch.cli.setup",
+            "goldenmatch.cli.sync",
+            "goldenmatch.cli.watch",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.wizard",
+            "goldenmatch.core.analytics",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.block_analyzer",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.profiler",
+            "goldenmatch.core.quality_exclusions",
+            "goldenmatch.prefs.store",
+            "goldenmatch.tui.app"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.match",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/match.py",
+          "purpose": "CLI match command for GoldenMatch.",
+          "defines": [
+            "match_cmd"
+          ],
+          "imports": [
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.preview",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.mcp_serve",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/mcp_serve.py",
+          "purpose": "CLI command for starting the GoldenMatch MCP server.",
+          "defines": [
+            "mcp_serve_cmd"
+          ],
+          "imports": [
+            "goldenmatch.mcp.server"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.memory",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/memory.py",
+          "purpose": "CLI memory commands for GoldenMatch.",
+          "defines": [
+            "add_cmd",
+            "export_cmd",
+            "import_cmd",
+            "learn_cmd",
+            "show_cmd",
+            "stats_cmd"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.pprl",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/pprl.py",
+          "purpose": "CLI PPRL commands for GoldenMatch.",
+          "defines": [
+            "pprl_auto_config",
+            "pprl_link"
+          ],
+          "imports": [
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.pprl.autoconfig",
+            "goldenmatch.pprl.protocol"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.review",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/review.py",
+          "purpose": "CLI review command -- human-in-the-loop triage of borderline pairs.",
+          "defines": [
+            "_matchkey_fields",
+            "review_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.review_queue"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.rollback",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/rollback.py",
+          "purpose": "CLI commands for rollback and run history.",
+          "defines": [
+            "_clusters_from_df",
+            "_group_members",
+            "_load_scored_pairs",
+            "rollback_cmd",
+            "runs_cmd",
+            "unmerge_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.rollback"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.schedule",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/schedule.py",
+          "purpose": "CLI command for scheduled runs.",
+          "defines": [
+            "schedule_cmd"
+          ],
+          "imports": [
+            "goldenmatch.core.scheduler"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.sensitivity",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/sensitivity.py",
+          "purpose": "CLI sensitivity command for GoldenMatch.",
+          "defines": [
+            "_parse_sweep",
+            "sensitivity_cmd"
+          ],
+          "imports": [
+            "goldenmatch.cli.dedupe",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.sensitivity"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.serve",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/serve.py",
+          "purpose": "CLI command for starting the GoldenMatch REST API server.",
+          "defines": [
+            "serve_cmd"
+          ],
+          "imports": [
+            "goldenmatch.api.server",
+            "goldenmatch.config.loader",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.serve_ui",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/serve_ui.py",
+          "defines": [
+            "serve_ui_cmd"
+          ],
+          "imports": [
+            "goldenmatch.web.app",
+            "goldenmatch.web.state"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.setup",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/setup.py",
+          "purpose": "CLI command for launching the setup wizard.",
+          "defines": [
+            "setup_cmd"
+          ],
+          "imports": [
+            "goldenmatch.tui.screens.setup_wizard"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.sync",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/sync.py",
+          "purpose": "CLI command for database sync.",
+          "defines": [
+            "sync_cmd"
+          ],
+          "imports": [
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.settings",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.db.connector",
+            "goldenmatch.db.sync"
+          ]
+        },
+        {
+          "module": "goldenmatch.cli.watch",
+          "file": "packages/python/goldenmatch/goldenmatch/cli/watch.py",
+          "purpose": "CLI command for live stream mode — poll and match continuously.",
+          "defines": [
+            "watch_cmd"
+          ],
+          "imports": [
+            "goldenmatch.config.loader",
+            "goldenmatch.db.connector",
+            "goldenmatch.db.watch"
+          ]
+        },
+        {
+          "module": "goldenmatch.client",
+          "file": "packages/python/goldenmatch/goldenmatch/client.py",
+          "purpose": "GoldenMatch REST API client.",
+          "defines": [
+            "Client"
+          ]
+        },
+        {
+          "module": "goldenmatch.config",
+          "file": "packages/python/goldenmatch/goldenmatch/config/__init__.py"
+        },
+        {
+          "module": "goldenmatch.config.from_splink",
+          "file": "packages/python/goldenmatch/goldenmatch/config/from_splink.py",
+          "purpose": "Splink -> GoldenMatch config converter.",
+          "defines": [
+            "ConversionFinding",
+            "ConversionReport",
+            "RecognizedLevel",
+            "SplinkConversion",
+            "SplinkConversionError",
+            "_BlockConjunct",
+            "_agree_index_for",
+            "_convert_one_blocking_rule",
+            "_findings_preview",
+            "_load_settings",
+            "_patch_field_placeholders",
+            "_recognize_blocking_conjunct",
+            "_strip_outer_parens",
+            "convert_blocking",
+            "convert_comparison",
+            "convert_scalars",
+            "detect_trained",
+            "from_splink",
+            "import_em",
+            "recognize_level"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._paths",
+            "goldenmatch.core.probabilistic"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.loader",
+          "file": "packages/python/goldenmatch/goldenmatch/config/loader.py",
+          "purpose": "YAML config loader for GoldenMatch.",
+          "defines": [
+            "_normalize_golden_rules",
+            "_normalize_standardization",
+            "load_config"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.schemas",
+          "file": "packages/python/goldenmatch/goldenmatch/config/schemas.py",
+          "purpose": "Pydantic models for GoldenMatch configuration validation.",
+          "defines": [
+            "BlockingConfig",
+            "BlockingKeyConfig",
+            "BudgetConfig",
+            "CanopyConfig",
+            "ChannelStitchConfig",
+            "DistributedRoutingConfig",
+            "DomainConfig",
+            "FieldTransform",
+            "GoldenFieldRule",
+            "GoldenGroupRule",
+            "GoldenMatchConfig",
+            "GoldenRulesConfig",
+            "IdentityConfig",
+            "InputConfig",
+            "InputFileConfig",
+            "LLMScorerConfig",
+            "LSHKeyConfig",
+            "LearningConfig",
+            "MatchSettingsConfig",
+            "MatchkeyConfig",
+            "MatchkeyField",
+            "MediationConfig",
+            "MemoryConfig",
+            "NegativeEvidenceField",
+            "OutputConfig",
+            "PerceptualKeyConfig",
+            "QualityConfig",
+            "RulesPayload",
+            "SemanticBlockingConfig",
+            "SimHashKeyConfig",
+            "SortKeyField",
+            "StabilizationConfig",
+            "StandardizationConfig",
+            "SurvivorshipConfig",
+            "ThroughputConfig",
+            "TransformConfig",
+            "ValidationConfig",
+            "ValidationRuleConfig"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.settings",
+          "file": "packages/python/goldenmatch/goldenmatch/config/settings.py",
+          "purpose": "User settings persistence for GoldenMatch (global + project level).",
+          "defines": [
+            "UserSettings",
+            "load_global_settings",
+            "load_project_settings",
+            "load_settings",
+            "save_global_settings",
+            "save_project_settings"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.splink_upgrade",
+          "file": "packages/python/goldenmatch/goldenmatch/config/splink_upgrade.py",
+          "purpose": "Data-aware upgrade pass over a converted Splink config.",
+          "defines": [
+            "MeasurementResult",
+            "MigrationResult",
+            "PairwiseAgreement",
+            "RunStats",
+            "SplinkUpgradeError",
+            "TruthMetrics",
+            "_LeverContext",
+            "_estimate_within_block_prior",
+            "_lever_calibration",
+            "_lever_distance_thresholds",
+            "_lever_fan_out",
+            "_lever_tf_tables",
+            "_load_frame",
+            "_measure_mean_length",
+            "_resolve_levers",
+            "_sample",
+            "_validate_columns",
+            "upgrade_splink_conversion"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade_fanout",
+            "goldenmatch.config.splink_upgrade_measure",
+            "goldenmatch.core._paths",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.splink_upgrade_fanout",
+          "file": "packages/python/goldenmatch/goldenmatch/config/splink_upgrade_fanout.py",
+          "purpose": "The ``fan_out`` upgrade lever: negative-evidence suggestion + cluster-guard",
+          "defines": [
+            "_NECandidate",
+            "_ne_candidates",
+            "_random_pair_firing_rate",
+            "_suggest_negative_evidence",
+            "_tune_cluster_guard",
+            "run_fan_out_lever"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade",
+            "goldenmatch.config.splink_upgrade_measure",
+            "goldenmatch.core.autoconfig_negative_evidence",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.probabilistic"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.splink_upgrade_measure",
+          "file": "packages/python/goldenmatch/goldenmatch/config/splink_upgrade_measure.py",
+          "purpose": "Measurement stage for the Splink migration upgrade pass (Task U5).",
+          "defines": [
+            "_checked_reference",
+            "_cluster_sizes",
+            "_load_reference",
+            "_resolve_ids",
+            "_restricted_prf",
+            "_run_once",
+            "_run_stats",
+            "bcubed",
+            "pair_set",
+            "pairwise_prf",
+            "run_measurement",
+            "snowball_flag"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.config.splink_upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.config.wizard",
+          "file": "packages/python/goldenmatch/goldenmatch/config/wizard.py",
+          "purpose": "Interactive config wizard with smart field suggestions.",
+          "defines": [
+            "_matches_any",
+            "run_wizard",
+            "suggest_scorer",
+            "suggest_transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/__init__.py",
+          "purpose": "GoldenMatch connectors -- read/write data from external sources.",
+          "imports": [
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors._sql_common",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/_sql_common.py",
+          "purpose": "Shared helpers for the SQL-family source/sink connectors.",
+          "defines": [
+            "df_to_rows",
+            "require_mode",
+            "require_table",
+            "require_upsert_key",
+            "resolve_query",
+            "rows_to_dataframe"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.base",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/base.py",
+          "purpose": "Base connector class for GoldenMatch data sources.",
+          "defines": [
+            "BaseConnector",
+            "ConnectorError",
+            "load_connector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.bigquery",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/bigquery.py",
+          "purpose": "BigQuery connector for GoldenMatch.",
+          "defines": [
+            "BigQueryConnector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.databricks",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/databricks.py",
+          "purpose": "Databricks connector for GoldenMatch.",
+          "defines": [
+            "DatabricksConnector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.duckdb_source",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/duckdb_source.py",
+          "purpose": "DuckDB source/sink connector.",
+          "defines": [
+            "DuckDBSourceConnector",
+            "_quote_ident",
+            "_short_id"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors._sql_common",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.hubspot",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/hubspot.py",
+          "purpose": "HubSpot connector for GoldenMatch.",
+          "defines": [
+            "HubSpotConnector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.mongo",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/mongo.py",
+          "purpose": "MongoDB connector for GoldenMatch.",
+          "defines": [
+            "MongoConnector",
+            "_drop_internal",
+            "_flatten_doc",
+            "_looks_like_objectid"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.mysql",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/mysql.py",
+          "purpose": "MySQL / MariaDB source/sink connector.",
+          "defines": [
+            "MySQLConnector",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors._sql_common",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.object_storage",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/object_storage.py",
+          "purpose": "Object storage source/sink connector (S3 / GCS / Azure Blob).",
+          "defines": [
+            "ObjectStorageConnector",
+            "_is_azure_blob_https"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.postgres",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/postgres.py",
+          "purpose": "Postgres source/sink connector.",
+          "defines": [
+            "PostgresConnector",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors._sql_common",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.redshift",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/redshift.py",
+          "purpose": "Amazon Redshift source/sink connector.",
+          "defines": [
+            "RedshiftConnector",
+            "_quote_ident",
+            "_short_id"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors._sql_common",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.salesforce",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/salesforce.py",
+          "purpose": "Salesforce connector for GoldenMatch.",
+          "defines": [
+            "SalesforceConnector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.snowflake",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/snowflake.py",
+          "purpose": "Snowflake connector for GoldenMatch.",
+          "defines": [
+            "SnowflakeConnector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.connectors.sqlserver",
+          "file": "packages/python/goldenmatch/goldenmatch/connectors/sqlserver.py",
+          "purpose": "SQL Server / Azure SQL source/sink connector.",
+          "defines": [
+            "SqlServerConnector",
+            "_build_merge",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.connectors._sql_common",
+            "goldenmatch.connectors.base"
+          ]
+        },
+        {
+          "module": "goldenmatch.core",
+          "file": "packages/python/goldenmatch/goldenmatch/core/__init__.py"
+        },
+        {
+          "module": "goldenmatch.core._diagnostics_report",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_diagnostics_report.py",
+          "purpose": "Anomaly diagnostics + prefilled GitHub issue prompts (report primitives).",
+          "defines": [
+            "_issue_body",
+            "_scrub",
+            "environment_report",
+            "is_expected",
+            "issue_url",
+            "prompts_enabled",
+            "report_anomaly",
+            "report_exception",
+            "reset"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._hashing",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_hashing.py",
+          "purpose": "Canonical record fingerprint (cross-surface stable hash).",
+          "defines": [
+            "_fingerprint_py",
+            "_value_bytes",
+            "record_fingerprint",
+            "record_fingerprints_batch",
+            "record_fingerprints_batch_arrow"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._logging",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_logging.py",
+          "purpose": "Log-output sanitization (CodeQL py/log-injection mitigation).",
+          "defines": [
+            "sanitize_for_log"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._native_loader",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``goldenmatch._native`` acceleration module.",
+          "defines": [
+            "NativeDispatchSummary",
+            "_has_symbol",
+            "_maybe_report_import_anomaly",
+            "_record_dispatch",
+            "native_available",
+            "native_dispatch_report",
+            "native_enabled",
+            "native_module",
+            "reset_native_dispatch_log",
+            "reset_slow_path_warned",
+            "summarize_native_dispatch",
+            "warn_if_slow_path"
+          ],
+          "imports": [
+            "goldenmatch._native",
+            "goldenmatch.core.diagnostics"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._paths",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_paths.py",
+          "purpose": "Path validation (CodeQL py/path-injection mitigation).",
+          "defines": [
+            "PathOutsideAllowedRootError",
+            "safe_path"
+          ]
+        },
+        {
+          "module": "goldenmatch.core._perceptual_tables",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_perceptual_tables.py",
+          "purpose": "AUTO-GENERATED by scripts/gen_perceptual_tables.py -- DO NOT EDIT."
+        },
+        {
+          "module": "goldenmatch.core._profile_helpers",
+          "file": "packages/python/goldenmatch/goldenmatch/core/_profile_helpers.py",
+          "purpose": "Numeric helpers for profile emission. Used by scorer + cluster instrumentation.",
+          "defines": [
+            "data_profile_column_stats",
+            "hartigan_dip",
+            "histogram_20",
+            "mass_above",
+            "mass_borderline",
+            "transitivity_rate"
+          ],
+          "imports": [
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.acronym",
+          "file": "packages/python/goldenmatch/goldenmatch/core/acronym.py",
+          "purpose": "Initialism blocking transform — abbreviation candidate generation.",
+          "defines": [
+            "InitialismTransform",
+            "_legal_form_variants",
+            "_normalize_token_for_legal_check",
+            "derive_initialism",
+            "register_transforms"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.refdata"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.active_sampling",
+          "file": "packages/python/goldenmatch/goldenmatch/core/active_sampling.py",
+          "purpose": "Active sampling -- select the most informative pairs for LLM labeling.",
+          "defines": [
+            "_boundary_sampling",
+            "_combined_sampling",
+            "_disagreement_sampling",
+            "_diversity_sampling",
+            "_stratified_random",
+            "_uncertainty_sampling",
+            "estimate_label_savings",
+            "select_active_pairs"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.agent",
+          "file": "packages/python/goldenmatch/goldenmatch/core/agent.py",
+          "purpose": "Intelligence layer for autonomous entity resolution.",
+          "defines": [
+            "AgentSession",
+            "DataProfile",
+            "FieldProfile",
+            "StrategyDecision",
+            "_decision_to_config",
+            "_reasoning_frame",
+            "_select_strategy_tree",
+            "build_alternatives",
+            "profile_for_agent",
+            "select_strategy"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.domain_registry",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.review_queue",
+            "goldenmatch.web.controller_telemetry"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.analytics",
+          "file": "packages/python/goldenmatch/goldenmatch/core/analytics.py",
+          "purpose": "Opt-in, PII-safe product analytics.",
+          "defines": [
+            "_api_key",
+            "_build_payload",
+            "_distinct_id",
+            "_emit",
+            "_host",
+            "_post",
+            "_safe_value",
+            "_version",
+            "analytics_enabled",
+            "capture",
+            "duration_bucket",
+            "scale_bucket"
+          ],
+          "imports": [
+            "goldenmatch"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.ann_blocker",
+          "file": "packages/python/goldenmatch/goldenmatch/core/ann_blocker.py",
+          "purpose": "ANN (Approximate Nearest Neighbor) blocker for GoldenMatch.",
+          "defines": [
+            "ANNBlocker",
+            "_resolve_backend"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.anomaly",
+          "file": "packages/python/goldenmatch/goldenmatch/core/anomaly.py",
+          "purpose": "Anomaly detection -- flag suspicious records that aren't duplicates.",
+          "defines": [
+            "_is_likely_column",
+            "detect_anomalies",
+            "format_anomaly_report"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.api_connector",
+          "file": "packages/python/goldenmatch/goldenmatch/core/api_connector.py",
+          "purpose": "API connector -- pull records from CRMs and APIs for deduplication.",
+          "defines": [
+            "_fetch_graphql",
+            "_fetch_hubspot",
+            "_fetch_rest",
+            "_fetch_salesforce",
+            "fetch_from_api"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.arrow_derive",
+          "file": "packages/python/goldenmatch/goldenmatch/core/arrow_derive.py",
+          "purpose": "Polars-free derivation of transformed block-key / score columns (W2a).",
+          "defines": [
+            "_fmt_f32_array",
+            "_fmt_f64",
+            "_native_chain",
+            "_std_email",
+            "_std_name_lower",
+            "_std_name_proper",
+            "_std_name_upper",
+            "_std_null_if_empty",
+            "_std_phone",
+            "_std_strip",
+            "_std_trim_whitespace",
+            "_std_zip5",
+            "block_key",
+            "cast_utf8",
+            "matchkey_composite",
+            "matchkey_field_column",
+            "ne_joined_column",
+            "standardized_column",
+            "transformed_column"
+          ],
+          "imports": [
+            "goldenmatch.core.standardize",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig.py",
+          "purpose": "Auto-configuration engine for GoldenMatch zero-config mode.",
+          "defines": [
+            "AutoConfigDecisions",
+            "ColumnProfile",
+            "SemanticBlockingDecision",
+            "_adaptive_threshold",
+            "_arrow_to_polars_dtype_spelling",
+            "_auto_build_lsh_config",
+            "_auto_semantic_blocking_enabled",
+            "_blocking_pairs_per_row_budget",
+            "_bound_probabilistic_blocking_pairs",
+            "_build_compound_blocking",
+            "_build_strong_identifier_union",
+            "_call_llm_for_blocking",
+            "_check_source_overlap",
+            "_classify_by_data",
+            "_classify_by_name",
+            "_compute_max_safe_block",
+            "_concrete_dtype_spelling",
+            "_degenerate_blocking_config",
+            "_detect_source_partition",
+            "_detect_standardization_config",
+            "_diversify_probabilistic_blocking",
+            "_embedder_available",
+            "_emit_data_profile",
+            "_env_force_exclude",
+            "_env_force_include",
+            "_exact_matchkey_floor_py",
+            "_facility_name_ne_enabled",
+            "_field_group_detection_enabled",
+            "_fs_autoconfig_v2_enabled",
+            "_fs_total_pair_budget",
+            "_fuzzy_pass_transforms",
+            "_get_default_memory",
+            "_has_fuzzy_tolerant_transform",
+            "_is_person_name_column",
+            "_is_probabilistic_shape",
+            "_is_short_code",
+            "_is_text_corpus",
+            "_learned_block_cap",
+            "_legacy_auto_configure_v0",
+            "_llm_classify_columns",
+            "_llm_suggest_blocking_keys",
+            "_make_quality_column_profile",
+            "_match_mode_autoconfig",
+            "_maybe_active_domain_pack",
+            "_maybe_detect_field_groups",
+            "_maybe_promote_blocking_to_adaptive",
+            "_maybe_prune_blocking_passes",
+            "_multisource_autoconfig_enabled",
+            "_noise_aware_scorer",
+            "_noise_aware_scorers_enabled",
+            "_noise_aware_target_scorer",
+            "_norm_colname",
+            "_pass_specs",
+            "_pick_date_blocking_col",
+            "_pick_missing_semantics",
+            "_polars_datetime_spelling",
+            "_polars_scalar_spelling",
+            "_polars_string_spelling",
+            "_project_pairs_per_row",
+            "_project_pass_pairs",
+            "_promote_facility_fullname_ne",
+            "_quality_aware_blocking_enabled",
+            "_rebuild_from_decisions",
+            "_resolve_effective_exclusion_overrides",
+            "_route_to_probabilistic_enabled",
+            "_scale_safe_bounded_compound",
+            "_semantic_blocking_threshold",
+            "_source_correlated_exclusions",
+            "_source_disjoint",
+            "_text_corpus_blocking",
+            "_text_heavy_columns",
+            "_tf_name_weighting_enabled",
+            "_throughput_blocking",
+            "_typed_projected_block",
+            "_union_coverage",
+            "_warn_arrow_native_coerced_once",
+            "apply_auto_semantic_blocking",
+            "apply_quality_aware_blocking",
+            "auto_configure",
+            "auto_configure_df",
+            "auto_configure_probabilistic_df",
+            "build_blocking",
+            "build_matchkeys",
+            "build_probabilistic_matchkeys",
+            "decide_semantic_blocking",
+            "deterministic_routing",
+            "exact_matchkey_floor",
+            "profile_columns",
+            "select_model",
+            "sketchable_text_cols"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core._profile_helpers",
+            "goldenmatch.core.autoconfig_controller",
+            "goldenmatch.core.autoconfig_discriminative",
+            "goldenmatch.core.autoconfig_memory",
+            "goldenmatch.core.autoconfig_native",
+            "goldenmatch.core.autoconfig_planner",
+            "goldenmatch.core.autoconfig_policy",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.blocking_candidates",
+            "goldenmatch.core.blocking_pass_selection",
+            "goldenmatch.core.blocking_union_core",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.domain",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.execution_plan",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.perceptual_autoconfig",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.core.profiler",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.quality_exclusions",
+            "goldenmatch.core.survivorship.groups",
+            "goldenmatch.core.tf_tables",
+            "goldenmatch.core.throughput_verify",
+            "goldenmatch.distributed",
+            "goldenmatch.distributed._utils",
+            "goldenmatch.refdata.autoconfig_hooks",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_cluster_threshold_tuner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_cluster_threshold_tuner.py",
+          "purpose": "Cluster-decision threshold tuner (v1.20.x).",
+          "defines": [
+            "ThresholdSuggestion",
+            "tune_decision_threshold"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_controller",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_controller.py",
+          "purpose": "AutoConfigController — iterative auto-config with stage-emitted profiles.",
+          "defines": [
+            "AutoConfigController",
+            "ConfigValidationError",
+            "ControllerBudget",
+            "ControllerNotConfidentError",
+            "IndicatorContext",
+            "_assemble_v0_history_entry",
+            "_call_policy_propose",
+            "_first_red_subprofile",
+            "_identify_failing_subprofile",
+            "_pick_stratification_key",
+            "_should_measure_blocking",
+            "_stratified_sample",
+            "_zero_label_commit_enabled",
+            "resolve_planning_effort"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._profile_helpers",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_history",
+            "goldenmatch.core.autoconfig_memory",
+            "goldenmatch.core.autoconfig_negative_evidence",
+            "goldenmatch.core.autoconfig_planner",
+            "goldenmatch.core.autoconfig_planner_rules",
+            "goldenmatch.core.autoconfig_policy",
+            "goldenmatch.core.autoconfig_rules",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.blocking_candidates",
+            "goldenmatch.core.cluster_profile",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.distributed_routing_rules",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.fused_routing",
+            "goldenmatch.core.indicators",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.core.runtime_profile",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.throughput_verify",
+            "goldenmatch.core.zero_label_confidence",
+            "goldenmatch.distributed._utils",
+            "goldenmatch.distributed.record_store",
+            "goldenmatch.distributed.sample",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_discriminative",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_discriminative.py",
+          "purpose": "Discriminative-power veto for exact/identity matchkeys (#1351).",
+          "defines": [
+            "_agree",
+            "_norm",
+            "attribute_demotion_enabled",
+            "discriminative_power",
+            "identity_basket",
+            "should_demote_attribute_field",
+            "should_veto_exact",
+            "tau",
+            "veto_enabled"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_golden_strategy_tuner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_golden_strategy_tuner.py",
+          "purpose": "Adaptive golden-strategy tuner (v1.18.1, #intelligence-2).",
+          "defines": [
+            "StrategyTuning",
+            "_hit_rate",
+            "_min_corrections",
+            "_strategy_would_match",
+            "tune_field_strategy"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_history",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_history.py",
+          "purpose": "RunHistory + audit-trail dataclasses for AutoConfigController.",
+          "defines": [
+            "ErrorRecord",
+            "HistoryEntry",
+            "PolicyDecision",
+            "RunHistory"
+          ],
+          "imports": [
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.execution_plan"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_memory",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_memory.py",
+          "purpose": "Cross-dataset memory for the auto-config controller.",
+          "defines": [
+            "AutoConfigMemory",
+            "profile_signature"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_native",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_native.py",
+          "purpose": "Serialize/deserialize helpers between live Python dataclasses and the",
+          "defines": [
+            "build_planner_capabilities",
+            "column_profiles_from_json",
+            "column_stats_to_json",
+            "extrapolation_from_json",
+            "extrapolation_input_to_json",
+            "plan_from_json",
+            "plan_input_to_json"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_planner_rules",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.execution_plan",
+            "goldenmatch.core.runtime_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_ne_tuner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_ne_tuner.py",
+          "purpose": "Adaptive penalty / threshold tuner for negative evidence fields (#129).",
+          "defines": [
+            "NETuning",
+            "_f1_for_grid_point",
+            "_min_corrections",
+            "_score_correction",
+            "tune_ne_field"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_negative_evidence",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_negative_evidence.py",
+          "purpose": "v1.11: eager promotion of identity-prior columns to negative evidence.",
+          "defines": [
+            "_fd_negative_evidence_enabled",
+            "_is_exact_matchkey_field",
+            "_is_in_blocking",
+            "_is_in_matchkey_fields",
+            "_pick_scorer_for_column",
+            "promote_negative_evidence"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.quality"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_planner_rules",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_planner_rules.py",
+          "purpose": "Concrete planner rules for controller v3.",
+          "defines": [
+            "_bucket_suggested_plan",
+            "_chunked_plan",
+            "_duckdb_plan",
+            "_fast_box_plan",
+            "_has_ray",
+            "_is_bucket_suggested_eligible",
+            "_is_chunked_eligible",
+            "_is_duckdb_eligible",
+            "_is_fast_box_eligible",
+            "_is_pathological",
+            "_is_ray_eligible",
+            "_is_simple_eligible",
+            "_pathological_plan",
+            "_ray_auto_select_enabled",
+            "_ray_plan",
+            "_scoring_backend",
+            "_simple_plan",
+            "_user_override_plan",
+            "_user_set_backend",
+            "auto_chunk_size"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig_planner",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.execution_plan",
+            "goldenmatch.core.runtime_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_policy",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_policy.py",
+          "purpose": "RefitPolicy protocol + HeuristicRefitPolicy dispatcher.",
+          "defines": [
+            "HeuristicRefitPolicy",
+            "LLMRefitPolicy",
+            "RefitPolicy",
+            "apply_config_diff"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig_controller",
+            "goldenmatch.core.autoconfig_history",
+            "goldenmatch.core.autoconfig_rules",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.config_edits"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_rules",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_rules.py",
+          "purpose": "Default rule table for HeuristicRefitPolicy.",
+          "defines": [
+            "_blocking_recovery_target",
+            "_existing_blocking_fields",
+            "_first_weighted_mk",
+            "_is_derived",
+            "_llm_api_key_available",
+            "_near_dup_locked",
+            "_orthogonal_key",
+            "_precision_anchor_trigger",
+            "_with_lower_threshold",
+            "_with_multi_pass",
+            "_with_normalize_standardization",
+            "precision_anchor_would_fire",
+            "rule_blocking_adaptive_on_p99_outlier",
+            "rule_blocking_field_null_heavy",
+            "rule_blocking_key_swap",
+            "rule_blocking_singleton_trap",
+            "rule_blocking_too_coarse",
+            "rule_corruption_normalize",
+            "rule_cross_blocking_disagreement",
+            "rule_enable_llm_scorer",
+            "rule_low_reduction_ratio",
+            "rule_low_transitivity",
+            "rule_matchkey_demote_high_cardinality_field",
+            "rule_no_matches",
+            "rule_precision_anchor_threshold_raise",
+            "rule_recall_gap_suspected",
+            "rule_select_probabilistic_matchkey",
+            "rule_sparse_match_expand",
+            "rule_uniform_heavy_blocking",
+            "rule_unimodal_scoring"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_controller",
+            "goldenmatch.core.autoconfig_history",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.config_edits",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autoconfig_verify",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autoconfig_verify.py",
+          "purpose": "Auto-configuration verification: preflight + postflight checks.",
+          "defines": [
+            "BlockSizePercentiles",
+            "ClusterSizePercentiles",
+            "ConfigValidationError",
+            "OversizedCluster",
+            "PostflightAdjustment",
+            "PostflightReport",
+            "PostflightSignals",
+            "PreflightFinding",
+            "PreflightReport",
+            "ScoreHistogram",
+            "_check_block_sizes",
+            "_check_cardinality",
+            "_check_columns",
+            "_check_date_scorer",
+            "_check_remote_assets",
+            "_check_weight_confidence",
+            "_collect_referenced_columns",
+            "_empty_signals",
+            "_is_local_embedding_field",
+            "_render_blocking_line",
+            "_render_memory_line",
+            "_render_plan_line",
+            "_render_throughput_line",
+            "_repair_domain",
+            "_resolve_current_threshold",
+            "_sample_block_sizes",
+            "_sample_block_sizes_per_key",
+            "_signal_block_size_percentiles",
+            "_signal_blocking_recall",
+            "_signal_cluster_sizes",
+            "_signal_score_histogram",
+            "_signal_threshold_overlap",
+            "_signals_view",
+            "postflight",
+            "preflight"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.domain",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.throughput_verify"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.autofix",
+          "file": "packages/python/goldenmatch/goldenmatch/core/autofix.py",
+          "purpose": "Auto-fix module for common data issues in GoldenMatch.",
+          "defines": [
+            "auto_fix_dataframe"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.bench",
+          "file": "packages/python/goldenmatch/goldenmatch/core/bench.py",
+          "purpose": "Stage-level timing + candidate-pair accounting for the dedupe pipeline.",
+          "defines": [
+            "BenchmarkRecorder",
+            "_peak_rss_kb",
+            "bench_capture",
+            "current_recorder",
+            "record_metric",
+            "record_metrics",
+            "stage"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.block_analyzer",
+          "file": "packages/python/goldenmatch/goldenmatch/core/block_analyzer.py",
+          "purpose": "Block analyzer for GoldenMatch — auto-suggests optimal blocking keys.",
+          "defines": [
+            "BlockingSuggestion",
+            "_apply_candidate_transforms",
+            "_single_column_candidates",
+            "analyze_blocking",
+            "check_coverage",
+            "detect_column_type",
+            "estimate_recall",
+            "generate_candidates",
+            "score_candidate"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.blocker",
+          "file": "packages/python/goldenmatch/goldenmatch/core/blocker.py",
+          "purpose": "Blocker for GoldenMatch — groups records into blocks for comparison.",
+          "defines": [
+            "BlockResult",
+            "_ann_sub_block",
+            "_auto_split_block",
+            "_build_ann_blocks",
+            "_build_ann_pair_blocks",
+            "_build_block_key_expr",
+            "_build_canopy_blocks",
+            "_build_learned_blocks",
+            "_build_multi_pass_blocks",
+            "_build_sorted_neighborhood_blocks",
+            "_build_static_blocks",
+            "_emit_blocking_profile",
+            "_fast_static_block_sizes",
+            "_percentile",
+            "_sub_block",
+            "build_blocks",
+            "collect_blocking_fields",
+            "measure_blocking_profile",
+            "select_best_blocking_key"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.ann_blocker",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.canopy",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.learned_blocking",
+            "goldenmatch.core.lsh_blocker",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.perceptual_blocker",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.simhash_blocker",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.blocking_candidates",
+          "file": "packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py",
+          "purpose": "Blocking-key candidate classification (#408).",
+          "defines": [
+            "ColumnRole",
+            "_blocking_max_ratio",
+            "_blocking_min_ratio",
+            "classify_column_role",
+            "degenerate_guard_max_avg_block_size",
+            "degenerate_guard_threshold",
+            "estimate_avg_block_size",
+            "find_composite_blocking_keys",
+            "project_max_block_size",
+            "scale_cardinality_ratio_to_full_population"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.quality_exclusions"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.blocking_pass_selection",
+          "file": "packages/python/goldenmatch/goldenmatch/core/blocking_pass_selection.py",
+          "purpose": "Weak-positive-aware blocking-pass selection.",
+          "defines": [
+            "PassSelectionResult",
+            "_default_discriminative_fields",
+            "_make_weak_positive_fn",
+            "_pass_label",
+            "_pass_pairs",
+            "select_passes"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.blocker"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.blocking_union_core",
+          "file": "packages/python/goldenmatch/goldenmatch/core/blocking_union_core.py",
+          "purpose": "Shared decision core for the #1207 strong-identifier blocking union.",
+          "defines": [
+            "_native",
+            "_transforms_for",
+            "assemble_strong_id_union_pure",
+            "assemble_union",
+            "finalize_strong_id_union_pure",
+            "finalize_union",
+            "union_via_core_enabled"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.boost",
+          "file": "packages/python/goldenmatch/goldenmatch/core/boost.py",
+          "purpose": "LLM boost engine — feature extraction, classifier training, re-scoring.",
+          "defines": [
+            "_build_training_texts",
+            "_column_hash",
+            "_compute_pair_features",
+            "_sample_initial_pairs",
+            "_sample_uncertain_pairs",
+            "boost_accuracy",
+            "extract_feature_matrix",
+            "finetune_and_rescore",
+            "load_finetuned_and_rescore",
+            "load_model",
+            "save_model"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.cross_encoder",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.llm_labeler"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.candidate_store",
+          "file": "packages/python/goldenmatch/goldenmatch/core/candidate_store.py",
+          "purpose": "Pluggable candidate-row stores for single-record matching.",
+          "defines": [
+            "CandidateStore",
+            "FrameCandidateStore",
+            "LanceCandidateStore",
+            "build_base_store",
+            "lance_available",
+            "resolve_base_store_kind"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.canopy",
+          "file": "packages/python/goldenmatch/goldenmatch/core/canopy.py",
+          "purpose": "TF-IDF canopy clustering for GoldenMatch blocking.",
+          "defines": [
+            "build_canopies"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.chunked",
+          "file": "packages/python/goldenmatch/goldenmatch/core/chunked.py",
+          "purpose": "Large dataset mode — chunked processing for files that don't fit in memory.",
+          "defines": [
+            "ChunkedMatcher"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.backends.score_buckets",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.standardize",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cloud_ingest",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cloud_ingest.py",
+          "purpose": "Cloud storage ingest -- read files from S3, GCS, and Azure Blob.",
+          "defines": [
+            "_download_azure",
+            "_download_fsspec",
+            "_download_gcs",
+            "_download_s3",
+            "download_cloud_file",
+            "is_cloud_path"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cluster",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cluster.py",
+          "purpose": "Union-Find clustering for GoldenMatch.",
+          "defines": [
+            "ClusterFrames",
+            "UnionFind",
+            "_build_clusters_dict_path",
+            "_build_mst",
+            "_columnar_presplit",
+            "_confidence_fields",
+            "_emit_cluster_profile",
+            "_emit_cluster_profile_frames",
+            "_finalize_clusters",
+            "_is_pairs_dataframe",
+            "_measure_bridges",
+            "_pairs_df_to_list_numpy",
+            "_record_unmerge_corrections",
+            "_severe_bridge_count",
+            "_split_edge_work_budget",
+            "add_to_cluster",
+            "build_cluster_frames",
+            "build_clusters",
+            "build_clusters_arrow_native",
+            "build_clusters_columnar",
+            "build_clusters_v2_columnar",
+            "cluster_dict_to_frames",
+            "cluster_frames_to_dict",
+            "compute_cluster_confidence",
+            "get_cluster_pair_scores",
+            "metadata_height",
+            "split_oversized_cluster",
+            "split_oversized_cluster_to_size",
+            "unmerge_cluster",
+            "unmerge_record"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core._profile_helpers",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.distributed",
+            "goldenmatch.distributed.clustering"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cluster_edges_df",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cluster_edges_df.py",
+          "purpose": "Scale-mode cluster edge view backed by an embedded DataFusion (Apache Arrow)",
+          "defines": [
+            "_assign_to_arrow",
+            "_collect_runs",
+            "_confidence",
+            "_edge_stream_sql",
+            "_edges_sql",
+            "_make_context",
+            "_pairs_to_arrow",
+            "_rollup_sql",
+            "_supports_ordered_first_value",
+            "cluster_edges_datafusion"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cluster_pairscores",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cluster_pairscores.py",
+          "purpose": "Lazy per-cluster pair-score view (Phase 2 SP2). Decouples the identity",
+          "defines": [
+            "ClusterPairScores",
+            "_bucket_pairs"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cluster_profile",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cluster_profile.py",
+          "purpose": "ClusterProfile -- the \"what hardware is available\" signal for the",
+          "defines": [
+            "ClusterProfile",
+            "_from_descriptor",
+            "_probe",
+            "capture_cluster_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.collective",
+          "file": "packages/python/goldenmatch/goldenmatch/core/collective.py",
+          "purpose": "Collective entity resolution: neighborhood-similarity blend-and-iterate.",
+          "defines": [
+            "_coneighbor_pairs",
+            "_invert_clusters",
+            "_partition_signature",
+            "build_neighbor_index",
+            "collective_resolve",
+            "neighbor_cluster_set",
+            "relational_similarity"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.compare_clusters",
+          "file": "packages/python/goldenmatch/goldenmatch/core/compare_clusters.py",
+          "purpose": "CCMS — Case Count Metric System for comparing ER clustering outcomes.",
+          "defines": [
+            "ClusterCase",
+            "CompareResult",
+            "compare_clusters"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.complexity_profile",
+          "file": "packages/python/goldenmatch/goldenmatch/core/complexity_profile.py",
+          "purpose": "Stage-specific complexity sub-profiles + rollup, emitted by instrumented",
+          "defines": [
+            "BlockingProfile",
+            "ClusterProfile",
+            "ColumnPrior",
+            "ComplexityProfile",
+            "DataProfile",
+            "DomainProfile",
+            "FieldStats",
+            "HealthVerdict",
+            "IndicatorsProfile",
+            "MatchkeyProfile",
+            "ProfileMeta",
+            "ScoringProfile",
+            "SparsityVerdict",
+            "StopReason",
+            "ZeroLabelConfidenceProfile",
+            "_max_severity"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig_native"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_critique",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_critique.py",
+          "purpose": "Deterministic config-weakness generator (``diagnose_config``).",
+          "defines": [
+            "_add_blocking_pass",
+            "_apply_demote_to_blocking",
+            "_apply_exclude_column",
+            "_apply_raise_threshold",
+            "_clusters_of",
+            "_detect_distributed_over_merge",
+            "_detect_id_admitted",
+            "_detect_low_signal_key",
+            "_detect_null_sink",
+            "_detect_over_merge",
+            "_detect_oversized_block",
+            "_detect_source_admitted",
+            "_finding",
+            "_is_blocking_field",
+            "_matchkey_columns",
+            "_maybe_llm_summary",
+            "_merge_signal",
+            "_profiles_by_name",
+            "_revalidated",
+            "_safe",
+            "_safe_copy",
+            "_set_matchkeys",
+            "_signals_of",
+            "_strip_column_from_blocking",
+            "_strip_column_from_matchkeys",
+            "_template_summary",
+            "apply_hint",
+            "diagnose_config"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.llm_scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_edits",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_edits.py",
+          "purpose": "Shared ConfigEdit lever vocabulary.",
+          "defines": [
+            "BlockingKeyEdit",
+            "BlockingStrategyEdit",
+            "ConfigEdit",
+            "MatchkeyTypeSwap",
+            "ScorerSwap",
+            "ThresholdShift",
+            "WeightShift",
+            "_clamp",
+            "_perturbable_matchkeys",
+            "_revalidate",
+            "edit_from_spec",
+            "fold_edits",
+            "parse_llm_edits"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_lint",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_lint/__init__.py",
+          "purpose": "Pre-flight config linter: data-shape sanity checks on the resolved config.",
+          "imports": [
+            "goldenmatch.core.config_lint.profile",
+            "goldenmatch.core.config_lint.registry",
+            "goldenmatch.core.config_lint.rules"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_lint.docgen",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_lint/docgen.py",
+          "purpose": "Generate the config-linter docs FROM the rule registry.",
+          "defines": [
+            "docs_are_current",
+            "render_lint_docs",
+            "write_docs"
+          ],
+          "imports": [
+            "goldenmatch.core.config_lint.registry",
+            "goldenmatch.core.config_lint.rules"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_lint.profile",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_lint/profile.py",
+          "purpose": "Build the cheap data-shape facts the lint rules consult.",
+          "defines": [
+            "build_lint_input"
+          ],
+          "imports": [
+            "goldenmatch.core.config_lint.registry",
+            "goldenmatch.core.config_lint.rules"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_lint.registry",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_lint/registry.py",
+          "purpose": "Config lint registry — the single source of truth for pre-flight config rules.",
+          "defines": [
+            "ConfigLintError",
+            "Finding",
+            "LintInput",
+            "LintRule",
+            "RuleHit",
+            "Severity",
+            "all_rules",
+            "lint",
+            "register",
+            "slugify"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_lint.rules",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_lint/rules.py",
+          "purpose": "Pre-flight lint rules.",
+          "defines": [
+            "_blocking_keys",
+            "_check_inmem_at_scale",
+            "_check_near_unique",
+            "_check_null_heavy",
+            "_check_pair_explosion",
+            "_fuzzy_field_columns",
+            "referenced_columns"
+          ],
+          "imports": [
+            "goldenmatch.core.config_lint.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.config_optimizer",
+          "file": "packages/python/goldenmatch/goldenmatch/core/config_optimizer.py",
+          "purpose": "Agentic config optimizer: empirical lever search for auto-config.",
+          "defines": [
+            "CoordinateDescentProposer",
+            "GridProposer",
+            "LLMProposer",
+            "OptimizeResult",
+            "OptimizerTrial",
+            "Proposer",
+            "SearchState",
+            "_fingerprint",
+            "_resolve_proposer",
+            "_score_candidate",
+            "_score_confidence",
+            "_score_f1",
+            "_threshold_variants",
+            "optimize_config"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_controller",
+            "goldenmatch.core.autoconfig_policy",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.config_edits",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.profile_emitter"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.cross_encoder",
+          "file": "packages/python/goldenmatch/goldenmatch/core/cross_encoder.py",
+          "purpose": "Cross-encoder for Ditto-style entity matching (Level 3 boost).",
+          "defines": [
+            "_augment_single",
+            "_column_drop",
+            "_span_delete",
+            "_span_shuffle",
+            "augment_pair",
+            "augment_training_data",
+            "load_cross_encoder",
+            "merge_scores",
+            "score_pairs",
+            "serialize_record",
+            "train_cross_encoder"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.dashboard",
+          "file": "packages/python/goldenmatch/goldenmatch/core/dashboard.py",
+          "purpose": "Before/After Data Quality Dashboard — visual transformation report.",
+          "defines": [
+            "_build_dashboard_html",
+            "_detect_quality_issues",
+            "_esc",
+            "generate_dashboard"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.diagnostics",
+          "file": "packages/python/goldenmatch/goldenmatch/core/diagnostics.py",
+          "purpose": "GoldenMatch binding of the in-tree issue-reporter (``_diagnostics_report``).",
+          "defines": [
+            "_expected_exceptions",
+            "_version",
+            "guard_entrypoint",
+            "report_anomaly",
+            "report_unexpected"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch.core"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.diff",
+          "file": "packages/python/goldenmatch/goldenmatch/core/diff.py",
+          "purpose": "CSV diff export — side-by-side before/after showing every change.",
+          "defines": [
+            "_esc",
+            "_write_diff_html",
+            "generate_diff"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.distributed_routing_rules",
+          "file": "packages/python/goldenmatch/goldenmatch/core/distributed_routing_rules.py",
+          "purpose": "Distributed-routing rule layer: a post-pass over the 7 backend rules that",
+          "defines": [
+            "SlowPathRefusedError",
+            "_clustering_env_override",
+            "_config_pin",
+            "_decide",
+            "_driver_avail_ram_gb",
+            "_human",
+            "_projection_mode",
+            "apply_distributed_routing",
+            "enforce_routing",
+            "slow_path_overrides"
+          ],
+          "imports": [
+            "goldenmatch.core.autoconfig_controller",
+            "goldenmatch.core.cluster_profile",
+            "goldenmatch.core.execution_plan",
+            "goldenmatch.core.runtime_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.domain",
+          "file": "packages/python/goldenmatch/goldenmatch/core/domain.py",
+          "purpose": "Domain-aware feature extraction for entity resolution.",
+          "defines": [
+            "DomainProfile",
+            "ExtractionResult",
+            "SoftwareExtractionResult",
+            "_detect_product_subdomain",
+            "_emit_domain_profile",
+            "_extract_biblio_features_df",
+            "_extract_product_features_df",
+            "_extract_software_features_df",
+            "_tf_dom",
+            "detect_domain",
+            "extract_biblio_features",
+            "extract_features",
+            "extract_product_features",
+            "extract_software_features",
+            "model_contains",
+            "normalize_model"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.profile_emitter"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.domain_registry",
+          "file": "packages/python/goldenmatch/goldenmatch/core/domain_registry.py",
+          "purpose": "Custom domain registry -- user-defined extraction rulebooks.",
+          "defines": [
+            "DomainRulebook",
+            "discover_rulebooks",
+            "extract_with_rulebook",
+            "load_rulebook",
+            "match_domain",
+            "save_rulebook"
+          ],
+          "imports": [
+            "goldenmatch.core._logging",
+            "goldenmatch.core._paths"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.embedder",
+          "file": "packages/python/goldenmatch/goldenmatch/core/embedder.py",
+          "purpose": "Embedder for GoldenMatch — sentence-transformer embedding and caching.",
+          "defines": [
+            "Embedder",
+            "_ProviderEmbedder",
+            "_build_embedder",
+            "_make_inhouse_embedder",
+            "_make_llama_embedder",
+            "get_embedder",
+            "inhouse_embedding_available"
+          ],
+          "imports": [
+            "goldenmatch.core.gpu",
+            "goldenmatch.core.vertex_embedder",
+            "goldenmatch.embeddings.inhouse.model",
+            "goldenmatch.embeddings.providers"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.embedding_ops",
+          "file": "packages/python/goldenmatch/goldenmatch/core/embedding_ops.py",
+          "purpose": "Embedding ops -- drift detection, per-field model selection, canonicalization eval (#1093).",
+          "defines": [
+            "CanonicalizationEval",
+            "EmbeddingDriftReport",
+            "FieldModelChoice",
+            "_psi",
+            "embedding_drift",
+            "evaluate_canonicalization",
+            "select_field_model",
+            "select_field_models"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.evaluate",
+          "file": "packages/python/goldenmatch/goldenmatch/core/evaluate.py",
+          "purpose": "Evaluation engine -- precision, recall, F1 from ground truth pairs.",
+          "defines": [
+            "EvalResult",
+            "_canonical_gt",
+            "_dedup_pairs_max",
+            "_default_thresholds",
+            "evaluate_clusters",
+            "evaluate_pairs",
+            "fs_model_report",
+            "load_ground_truth_csv",
+            "probability_two_random_records_match",
+            "recommend_threshold",
+            "threshold_sweep"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.explain",
+          "file": "packages/python/goldenmatch/goldenmatch/core/explain.py",
+          "purpose": "Natural language explanations for match decisions.",
+          "defines": [
+            "_describe_score",
+            "_describe_scorer",
+            "_fmt_val",
+            "_fs_level_name",
+            "explain_cluster_nl",
+            "explain_pair_nl",
+            "format_fs_waterfall"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.lineage"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.explainer",
+          "file": "packages/python/goldenmatch/goldenmatch/core/explainer.py",
+          "purpose": "Match explainer — shows why two records matched with per-field breakdowns.",
+          "defines": [
+            "FieldExplanation",
+            "MatchExplanation",
+            "_score_field",
+            "explain_pair",
+            "format_explanation_text"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.frame",
+          "file": "packages/python/goldenmatch/goldenmatch/core/frame.py",
+          "purpose": "Backend-neutral Frame/Column seam for the Polars eviction (W0 scaffold).",
+          "defines": [
+            "ArrowColumn",
+            "ArrowFrame",
+            "Column",
+            "Frame",
+            "PolarsColumn",
+            "PolarsFrame",
+            "_arrow_dtype",
+            "_check_schema",
+            "_pa_array_typed",
+            "_polars_dtype",
+            "_semantic_dtype_name",
+            "column_from_values",
+            "concat_columns",
+            "concat_frames",
+            "empty_frame",
+            "frame_from_column_data",
+            "frame_from_columns",
+            "frame_from_records",
+            "frame_from_rows",
+            "is_polars_dataframe",
+            "is_polars_lazyframe",
+            "resolve_frame_backend",
+            "to_frame"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.standardize",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.fused_match",
+          "file": "packages/python/goldenmatch/goldenmatch/core/fused_match.py",
+          "purpose": "Fused Arrow-native match stage -- opt-in scale/composability entry.",
+          "defines": [
+            "_clusters_to_table",
+            "_covered_weighted_matchkey",
+            "_fused_fs_matchkey_covered",
+            "_match_fused_fs_symbol",
+            "_match_fused_symbol",
+            "_prep_frame",
+            "match_fused_fs_multipass_ready",
+            "match_fused_fs_ready",
+            "match_fused_multipass_ready",
+            "match_fused_ready",
+            "run_match_fused_arrow",
+            "run_match_fused_fs_arrow",
+            "run_match_fused_fs_multipass_arrow",
+            "run_match_fused_multipass_arrow"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.probabilistic"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.fused_routing",
+          "file": "packages/python/goldenmatch/goldenmatch/core/fused_routing.py",
+          "purpose": "Fused-routing helpers (controller auto-routing to the fused path).",
+          "defines": [
+            "_count_score_cols",
+            "_golden_uses_confidence_majority",
+            "config_needs_artifacts",
+            "estimate_classic_match_peak_rss_gb",
+            "maybe_route_fused_match"
+          ],
+          "imports": [
+            "goldenmatch.core.fused_match"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.golden",
+          "file": "packages/python/goldenmatch/goldenmatch/core/golden.py",
+          "purpose": "Golden record builder with per-field merge strategies.",
+          "defines": [
+            "ClusterProvenance",
+            "FieldProvenance",
+            "GoldenRecordResult",
+            "GroupProvenance",
+            "_build_golden_records_polars_native",
+            "_confidence_majority",
+            "_dispatch_custom_strategy",
+            "_first_non_null",
+            "_is_internal",
+            "_longest_value",
+            "_majority_vote",
+            "_most_complete",
+            "_most_recent",
+            "_multi_df_from_frames",
+            "_polars_importable",
+            "_polars_native_eligible",
+            "_source_priority",
+            "_stable_rid_expr",
+            "_stable_value_expr",
+            "_survivorship_active",
+            "_unanimous_or_null",
+            "assert_in_memory_survivorship",
+            "build_golden_record",
+            "build_golden_record_with_provenance",
+            "build_golden_records_batch",
+            "build_golden_records_df",
+            "build_golden_records_from_frames",
+            "golden_records_to_provenance",
+            "merge_field"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.survivorship.conditions",
+            "goldenmatch.core.survivorship.native",
+            "goldenmatch.core.survivorship.resolve",
+            "goldenmatch.distributed",
+            "goldenmatch.distributed.golden",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.golden_fused",
+          "file": "packages/python/goldenmatch/goldenmatch/core/golden_fused.py",
+          "purpose": "Fused Arrow-native golden-record production.",
+          "defines": [
+            "_ARROW_MOST_RECENT_ORDER_SAFE",
+            "_GoldenFusedClause",
+            "_GoldenFusedConditional",
+            "_GoldenFusedGroupSpec",
+            "_GoldenFusedResolutionPlan",
+            "_GoldenFusedSideChannels",
+            "_build_date_arrays",
+            "_build_provenance_records",
+            "_factorize_codes",
+            "_factorize_with_map",
+            "_gather_with_nulls",
+            "_is_internal",
+            "_most_recent_order_safe_dtypes",
+            "_native_golden_symbol",
+            "_rule_covered",
+            "golden_fused_ready",
+            "run_golden_fused_arrow"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.golden_fused_predicate",
+            "goldenmatch.core.survivorship.conditions"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.golden_fused_predicate",
+          "file": "packages/python/goldenmatch/goldenmatch/core/golden_fused_predicate.py",
+          "purpose": "Conditional-predicate lowering for the fused golden-record kernel (Stage 6).",
+          "defines": [
+            "PredInstr",
+            "_lower_node",
+            "_lowerable_node",
+            "_parse_body",
+            "lower_predicate",
+            "predicate_lowerable"
+          ],
+          "imports": [
+            "goldenmatch.core.survivorship.conditions"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.golden_rules_refiner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/golden_rules_refiner.py",
+          "purpose": "Post-cluster golden-rules refinement (#golden-strategies, v1.18).",
+          "defines": [
+            "RefinementSignals",
+            "_is_compliance_name",
+            "_is_mutable_field_name",
+            "_maybe_llm_strategy_pick",
+            "_pick_sibling_timestamp",
+            "_pick_strategy_for_field",
+            "compute_refinement_signals",
+            "refine_golden_rules"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_golden_strategy_tuner",
+            "goldenmatch.core.golden_strategy_llm"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.golden_strategy_llm",
+          "file": "packages/python/goldenmatch/goldenmatch/core/golden_strategy_llm.py",
+          "purpose": "LLM-assisted golden-strategy picks for ambiguous fields (closes #430).",
+          "defines": [
+            "_build_samples",
+            "_default_llm_caller",
+            "format_prompt",
+            "parse_llm_response",
+            "pick_strategy_via_llm"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.llm_scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.gpu",
+          "file": "packages/python/goldenmatch/goldenmatch/core/gpu.py",
+          "purpose": "GPU routing — auto-detect local GPU, route to remote endpoint, or CPU-safe fallback.",
+          "defines": [
+            "GPUMode",
+            "RemoteEmbedder",
+            "_has_cuda",
+            "_has_mps",
+            "detect_gpu_mode",
+            "get_device_string",
+            "get_gpu_status",
+            "get_smart_embedder",
+            "is_embedding_available"
+          ],
+          "imports": [
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.vertex_embedder"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.graph",
+          "file": "packages/python/goldenmatch/goldenmatch/core/graph.py",
+          "purpose": "Visual cluster graph — interactive HTML with force-directed network.",
+          "defines": [
+            "_build_graph_html",
+            "generate_cluster_graph"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.graph_er",
+          "file": "packages/python/goldenmatch/goldenmatch/core/graph_er.py",
+          "purpose": "Multi-table / graph entity resolution.",
+          "defines": [
+            "EntityType",
+            "GraphERResult",
+            "Relationship",
+            "_build_fk_lookup",
+            "_clusters_from_rid_to_cid",
+            "_cooccurrence_groups",
+            "_invert_clusters",
+            "_propagate_evidence",
+            "_run_collective",
+            "run_graph_er"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.collective",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.pipeline"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.incremental",
+          "file": "packages/python/goldenmatch/goldenmatch/core/incremental.py",
+          "purpose": "Incremental matching: match new records against an existing base dataset.",
+          "defines": [
+            "run_incremental"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.match_one",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.standardize"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.indicators",
+          "file": "packages/python/goldenmatch/goldenmatch/core/indicators.py",
+          "purpose": "Auto-config complexity indicators (v1.10).",
+          "defines": [
+            "_compute_corruption_score_inline",
+            "_compute_identity_score",
+            "_sparse_match_floor_py",
+            "compute_column_priors",
+            "compute_corruption_score",
+            "compute_cross_blocking_overlap",
+            "dispatch_compute_column_priors",
+            "dispatch_estimate_sparse_match_signal",
+            "estimate_full_pop_hits",
+            "estimate_sparse_match_signal",
+            "sparse_match_floor"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.distributed",
+            "goldenmatch.distributed.indicators"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.ingest",
+          "file": "packages/python/goldenmatch/goldenmatch/core/ingest.py",
+          "purpose": "File ingest utilities for GoldenMatch.",
+          "defines": [
+            "_arrow_route_eligible",
+            "_is_probably_utf8",
+            "apply_column_map",
+            "load_file",
+            "load_files",
+            "suggest_column_mapping",
+            "validate_columns"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._paths",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.io_arrow",
+            "goldenmatch.core.smart_ingest"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.io_arrow",
+          "file": "packages/python/goldenmatch/goldenmatch/core/io_arrow.py",
+          "purpose": "Polars-free Arrow IO front for GoldenMatch (Polars-eviction W1).",
+          "defines": [
+            "_base_convert_options",
+            "_read_csv_arrow",
+            "_read_csv_direct",
+            "_read_csv_from_text",
+            "_read_excel_arrow",
+            "_read_parquet_arrow",
+            "_temporal_override_types",
+            "read_table_arrow"
+          ],
+          "imports": [
+            "goldenmatch.core.ingest"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.learned_blocking",
+          "file": "packages/python/goldenmatch/goldenmatch/core/learned_blocking.py",
+          "purpose": "Learned blocking -- data-driven blocking predicate selection.",
+          "defines": [
+            "BlockingPredicate",
+            "BlockingRule",
+            "LoweringUnsupportedError",
+            "_apply_predicate",
+            "_compute_block_key",
+            "_safe_soundex",
+            "apply_learned_blocks",
+            "evaluate_rule",
+            "generate_predicates",
+            "learn_blocking_rules",
+            "load_learned_rules",
+            "lower_rule_to_key",
+            "lower_rules_to_blocking_config",
+            "save_learned_rules"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.blocker"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.lineage",
+          "file": "packages/python/goldenmatch/goldenmatch/core/lineage.py",
+          "purpose": "Lineage persistence -- save per-pair match explanations to a sidecar file.",
+          "defines": [
+            "_fs_waterfall_dict",
+            "_safe_cluster_audit",
+            "_serialize_golden_records",
+            "_serialize_provenance",
+            "build_lineage",
+            "golden_provenance_for_run",
+            "load_lineage",
+            "render_cluster_provenance_nl",
+            "render_field_condition_line",
+            "render_group_provenance_line",
+            "save_lineage",
+            "save_lineage_streaming"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._logging",
+            "goldenmatch.core._paths",
+            "goldenmatch.core.explain",
+            "goldenmatch.core.explainer",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.probabilistic"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_budget",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_budget.py",
+          "purpose": "LLM budget tracking -- cost accounting, model tiering, and graceful degradation.",
+          "defines": [
+            "BudgetTracker"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_canonicalize",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_canonicalize.py",
+          "purpose": "LLM entity canonicalization -- a defensible canonical record from a cluster (#1091).",
+          "defines": [
+            "CanonicalRecord",
+            "FieldProvenance",
+            "_build_prompt",
+            "_default_llm_call",
+            "_deterministic_choice",
+            "_deterministic_record",
+            "_field_order",
+            "_parse_llm_fields",
+            "canonicalize_cluster"
+          ],
+          "imports": [
+            "goldenmatch.core.llm_scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_cluster",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_cluster.py",
+          "purpose": "In-context LLM clustering -- send blocks of borderline records to an LLM",
+          "defines": [
+            "_apply_cluster_results",
+            "_build_components",
+            "_call_llm_cluster",
+            "_largest_component_size",
+            "_pairwise_fallback",
+            "_parse_cluster_response",
+            "_split_component",
+            "llm_cluster_pairs"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.llm_budget",
+            "goldenmatch.core.llm_scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_extract",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_extract.py",
+          "purpose": "LLM-based feature extraction for low-confidence records.",
+          "defines": [
+            "_call_anthropic",
+            "_call_openai",
+            "_parse_json_response",
+            "apply_llm_extractions",
+            "llm_extract_features"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_labeler",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_labeler.py",
+          "purpose": "LLM-powered pair labeling for GoldenMatch boost mode.",
+          "defines": [
+            "_call_anthropic",
+            "_call_llm_with_retry",
+            "_call_openai",
+            "build_prompt",
+            "detect_context",
+            "detect_provider",
+            "estimate_cost",
+            "get_default_model",
+            "label_pair",
+            "label_pairs",
+            "parse_response"
+          ],
+          "imports": [
+            "goldenmatch.config.settings"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.llm_scorer",
+          "file": "packages/python/goldenmatch/goldenmatch/core/llm_scorer.py",
+          "purpose": "LLM scorer -- use GPT/Claude to score borderline record pairs.",
+          "defines": [
+            "_batch_score",
+            "_call_anthropic",
+            "_call_openai",
+            "_compute_threshold",
+            "_detect_provider",
+            "_focused_sample",
+            "_iterative_calibrate",
+            "_openai_base_url",
+            "_record_llm_corrections",
+            "_stratified_sample",
+            "llm_explain_pair",
+            "llm_score_pairs"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.llm_budget",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.lsh_blocker",
+          "file": "packages/python/goldenmatch/goldenmatch/core/lsh_blocker.py",
+          "purpose": "MinHash/LSH blocking (#1081).",
+          "defines": [
+            "MinHashLSHBlocker",
+            "build_lsh_blocks"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core",
+            "goldenmatch.core.blocker"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.match_one",
+          "file": "packages/python/goldenmatch/goldenmatch/core/match_one.py",
+          "purpose": "Single-record matching -- match one record against an existing dataset.",
+          "defines": [
+            "_match_one_ann",
+            "_match_one_brute",
+            "match_one"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.candidate_store",
+            "goldenmatch.core.scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.matchkey",
+          "file": "packages/python/goldenmatch/goldenmatch/core/matchkey.py",
+          "purpose": "Matchkey builder for GoldenMatch.",
+          "defines": [
+            "_address_normalize_native",
+            "_build_field_expr_native",
+            "_emit_matchkey_profile",
+            "_list_eval",
+            "_try_native_chain",
+            "_try_native_transform",
+            "_xform_sig",
+            "build_matchkey_expr",
+            "compute_matchkeys",
+            "precompute_matchkey_transforms",
+            "precompute_matchkey_transforms_frame"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.refdata.addresses",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.memory",
+          "file": "packages/python/goldenmatch/goldenmatch/core/memory/__init__.py",
+          "purpose": "Learning Memory -- persistent corrections and rule learning.",
+          "imports": [
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.learner",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.memory.corrections",
+          "file": "packages/python/goldenmatch/goldenmatch/core/memory/corrections.py",
+          "purpose": "Apply pair-level corrections during scoring.",
+          "defines": [
+            "CorrectionStats",
+            "_build_hash_to_rids",
+            "apply_corrections",
+            "build_row_lookup",
+            "compute_field_hash",
+            "compute_record_hash"
+          ],
+          "imports": [
+            "goldenmatch.core.frame",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.memory.learner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/memory/learner.py",
+          "purpose": "MemoryLearner -- threshold tuning and field weight adjustment.",
+          "defines": [
+            "MemoryLearner"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.memory.store",
+          "file": "packages/python/goldenmatch/goldenmatch/core/memory/store.py",
+          "purpose": "MemoryStore -- SQLite/Postgres persistence for corrections and adjustments.",
+          "defines": [
+            "Correction",
+            "CorrectionSource",
+            "Decision",
+            "LearnedAdjustment",
+            "MemoryStore",
+            "_canon_pair",
+            "trust_for_source"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.merge_preview",
+          "file": "packages/python/goldenmatch/goldenmatch/core/merge_preview.py",
+          "purpose": "Merge preview -- show exactly what will change before merging.",
+          "defines": [
+            "format_preview_text",
+            "generate_merge_preview"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.pairs",
+          "file": "packages/python/goldenmatch/goldenmatch/core/pairs.py",
+          "purpose": "Native Core pair + candidate-estimation primitives.",
+          "defines": [
+            "block_histogram",
+            "candidate_pair_count",
+            "canonicalize_pairs",
+            "connected_components",
+            "dedup_pairs_max_score",
+            "dedup_pairs_max_score_arrow",
+            "dedup_pairs_max_score_columnar"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.perceptual",
+          "file": "packages/python/goldenmatch/goldenmatch/core/perceptual.py",
+          "purpose": "Pure-Python reference + fallback for the perceptual-core media-hash kernel.",
+          "defines": [
+            "_as_grid",
+            "_band_bins",
+            "_bilinear_resize",
+            "_dct1d_matrix",
+            "_dct2_topleft",
+            "_fingerprint_audio_python",
+            "_frame_band_energies",
+            "_hann",
+            "_pearson",
+            "_phash_image_python",
+            "_radial_variance_python",
+            "_twiddles",
+            "audio_ber",
+            "audio_ber_aligned",
+            "audio_fp_from_hex",
+            "audio_fp_hex",
+            "decode_audio_to_mono",
+            "decode_image_to_luma",
+            "fingerprint_audio",
+            "hamming",
+            "phash_hex",
+            "phash_image",
+            "phash_image_batch",
+            "popcount",
+            "radial_align_similarity",
+            "radial_from_hex",
+            "radial_hex",
+            "radial_variance"
+          ],
+          "imports": [
+            "goldenmatch.core",
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.perceptual_autoconfig",
+          "file": "packages/python/goldenmatch/goldenmatch/core/perceptual_autoconfig.py",
+          "purpose": "Perceptual media-as-evidence auto-config (ADR 0022, slice 3b).",
+          "defines": [
+            "_classify",
+            "apply_perceptual_autoconfig",
+            "build_perceptual_matchkey",
+            "detect_perceptual_hash_columns"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.perceptual_blocker"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.perceptual_blocker",
+          "file": "packages/python/goldenmatch/goldenmatch/core/perceptual_blocker.py",
+          "purpose": "Perceptual-hash LSH blocking (multimodal-ER crawl tier, ADR 0022).",
+          "defines": [
+            "PerceptualLSHBlocker",
+            "_divisor_band_counts",
+            "_parse_hash",
+            "build_perceptual_blocks",
+            "lsh_collision_probability",
+            "recommend_num_bands"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.blocker"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.pipeline",
+          "file": "packages/python/goldenmatch/goldenmatch/core/pipeline.py",
+          "purpose": "Pipeline orchestrator for GoldenMatch dedupe and list-match workflows.",
+          "defines": [
+            "_accumulate_block_candidate_pairs",
+            "_add_row_ids",
+            "_apply_domain_extraction",
+            "_apply_memory_post",
+            "_apply_memory_pre",
+            "_apply_postflight",
+            "_as_polars_df",
+            "_cast_user_cols_to_str",
+            "_columnar_pipeline_enabled",
+            "_default_distributed_partitions",
+            "_derive_review_queue_path",
+            "_dict_frame_to_arrow",
+            "_dump_bench_pairs",
+            "_enqueue_stale_pairs",
+            "_extract_matchkey_columns",
+            "_finalize_review_pairs",
+            "_frame_lane_eligible",
+            "_fs_arrow_stream_eligible",
+            "_fs_arrow_stream_enabled",
+            "_fs_em_sample_rows",
+            "_fs_external_blocks_route",
+            "_fs_use_bucket_route",
+            "_fused_needed_src_cols",
+            "_fused_result_from_clusters",
+            "_get_block_scorer",
+            "_get_required_columns",
+            "_golden_from_multi_df",
+            "_golden_records_to_df",
+            "_is_columnar_eligible",
+            "_load_input_frames",
+            "_open_identity_store",
+            "_open_memory_store",
+            "_prep_cache_clear",
+            "_prep_cache_signature",
+            "_prepare_probabilistic_review_scoring",
+            "_propagate_autoconfig_markers",
+            "_reject_probabilistic_matchkeys",
+            "_resolve_identities",
+            "_run_auto_suggest",
+            "_run_dedupe_pipeline",
+            "_run_fused_fs_match_short_circuit",
+            "_run_fused_match_short_circuit",
+            "_run_match_pipeline",
+            "_run_match_scoring_and_output",
+            "_score_partition_with_config",
+            "_score_probabilistic_matchkey",
+            "_semantic_blocking_pairs",
+            "_semantic_name_column",
+            "_split_pair_stream",
+            "_split_probabilistic_pairs",
+            "_try_fused_golden",
+            "_unwrap_llm_pairs",
+            "_use_bucket_scorer",
+            "run_dedupe",
+            "run_dedupe_df",
+            "run_match",
+            "run_match_df"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.backends.datafusion_backend",
+            "goldenmatch.backends.ray_backend",
+            "goldenmatch.backends.score_buckets",
+            "goldenmatch.backends.score_duckdb",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core",
+            "goldenmatch.core.acronym",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.bench",
+            "goldenmatch.core.block_analyzer",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.boost",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.cluster_pairscores",
+            "goldenmatch.core.domain",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.fused_match",
+            "goldenmatch.core.fused_routing",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.golden_fused",
+            "goldenmatch.core.golden_rules_refiner",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.llm_budget",
+            "goldenmatch.core.llm_cluster",
+            "goldenmatch.core.llm_extract",
+            "goldenmatch.core.llm_scorer",
+            "goldenmatch.core.lsh_blocker",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.learner",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.pairs",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.review_queue",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.simhash_blocker",
+            "goldenmatch.core.standardize",
+            "goldenmatch.core.transform",
+            "goldenmatch.core.validate",
+            "goldenmatch.distributed",
+            "goldenmatch.distributed._utils",
+            "goldenmatch.distributed.identity",
+            "goldenmatch.distributed.record_store",
+            "goldenmatch.identity",
+            "goldenmatch.output.report",
+            "goldenmatch.output.writer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.preview",
+          "file": "packages/python/goldenmatch/goldenmatch/core/preview.py",
+          "purpose": "Rich preview formatter for MatchEngine results.",
+          "defines": [
+            "format_preview_clusters",
+            "format_preview_golden",
+            "format_preview_stats",
+            "format_score_histogram"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.probabilistic",
+          "file": "packages/python/goldenmatch/goldenmatch/core/probabilistic.py",
+          "purpose": "Fellegi-Sunter probabilistic matching with EM-trained parameters.",
+          "defines": [
+            "ContinuousEMResult",
+            "EMResult",
+            "FSFieldContribution",
+            "FSModelMismatchError",
+            "FSWaterfall",
+            "_add_ne_matrix_contribution",
+            "_apply_tf_adjustment",
+            "_build_comparison_matrix",
+            "_build_continuous_matrix",
+            "_build_ne_matrix",
+            "_build_tf_tables",
+            "_em_ne_fields",
+            "_embedding_pair_sims",
+            "_emit_triu_pairs",
+            "_ensure_fs_name_refdata",
+            "_fallback_result",
+            "_field_score_matrix",
+            "_field_score_matrix_dedup",
+            "_field_values_for_block",
+            "_field_values_from_list",
+            "_fs_arrow_column",
+            "_fs_batch_rows",
+            "_fs_calibration_mode",
+            "_fs_embedding_vectors",
+            "_fs_link_threshold",
+            "_fs_monotonic_mode",
+            "_fs_name_refdata_available",
+            "_fs_native_eligible",
+            "_fs_native_enabled",
+            "_fs_ne_extend_cols",
+            "_fs_ne_weight_range",
+            "_fs_projection_cols",
+            "_fs_require_positive_evidence",
+            "_fs_scoring_workers",
+            "_fs_vec_guard",
+            "_fs_vec_max_elems",
+            "_fs_vectorized_enabled",
+            "_fs_vectorized_supported",
+            "_isotonic_nondecreasing",
+            "_levels_from_similarity",
+            "_ne_fired",
+            "_ne_scalar_contribution",
+            "_ne_scorer_vectorizable",
+            "_ne_u_probs_from_matrix",
+            "_record_concat_value",
+            "_record_concat_values",
+            "_row_lookup_for_pairs",
+            "_sample_blocked_pairs",
+            "_sample_blocked_pairs_with_fields",
+            "_sample_pairs",
+            "_scalar_tf_contribution",
+            "_score_fs_native_frame",
+            "_training_config_manifest",
+            "_training_pair_conditioning",
+            "_transform_field_value",
+            "_warn_ne_blocking_overlap",
+            "comparison_vector",
+            "compute_thresholds",
+            "continuous_scores",
+            "enforce_weight_monotonicity",
+            "estimate_m_from_labels",
+            "explain_pair_fs",
+            "fs_missing_mode",
+            "fs_model_preloaded",
+            "fs_regular_weight_sum",
+            "fs_weight_range",
+            "labels_from_corrections",
+            "labels_from_memory_store",
+            "labels_from_review_items",
+            "load_or_train_em",
+            "posterior_from_weight",
+            "prior_weight",
+            "probabilistic_block_scorer",
+            "resolve_thresholds",
+            "score_pair_probabilistic",
+            "score_probabilistic",
+            "score_probabilistic_blocks_batched",
+            "score_probabilistic_bucket_native",
+            "score_probabilistic_continuous",
+            "score_probabilistic_native",
+            "score_probabilistic_vectorized",
+            "score_probabilistic_vectorized_batch",
+            "train_em",
+            "train_em_continuous",
+            "vectorized_scorer_supported"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.tf_tables",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.refdata.surnames",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.probabilistic_fast",
+          "file": "packages/python/goldenmatch/goldenmatch/core/probabilistic_fast.py",
+          "purpose": "Fast per-pair Fellegi-Sunter scoring for the bucket scorer's fast path.",
+          "defines": [
+            "_resolve_probabilistic_fast_path",
+            "score_probabilistic_fast"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.backends.score_buckets",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.probabilistic"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.profile_emitter",
+          "file": "packages/python/goldenmatch/goldenmatch/core/profile_emitter.py",
+          "purpose": "Thread-local profile emitter stack.",
+          "defines": [
+            "ProfileEmitter",
+            "_NullEmitter",
+            "current_emitter",
+            "has_active_emitter",
+            "profile_capture"
+          ],
+          "imports": [
+            "goldenmatch.core.complexity_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.profiler",
+          "file": "packages/python/goldenmatch/goldenmatch/core/profiler.py",
+          "purpose": "Data quality profiler for GoldenMatch.",
+          "defines": [
+            "_as_column",
+            "_columns_as_polars_series",
+            "_count_all_empty_rows",
+            "_guess_type",
+            "_polars_importable",
+            "format_profile_report",
+            "profile_column",
+            "profile_dataframe"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.quality",
+          "file": "packages/python/goldenmatch/goldenmatch/core/quality.py",
+          "purpose": "GoldenCheck integration — enhanced data quality scanning before matching.",
+          "defines": [
+            "_goldencheck_available",
+            "_scan_and_fix",
+            "_scan_findings",
+            "_scan_only",
+            "_warn_quality_fix_needs_polars_once",
+            "blocking_risk",
+            "compute_quality_scores",
+            "fd_identity_scores",
+            "row_quality_floor",
+            "run_quality_check"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.fixer",
+            "goldencheck.engine.scanner",
+            "goldencheck.models.finding",
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.quality_exclusions",
+          "file": "packages/python/goldenmatch/goldenmatch/core/quality_exclusions.py",
+          "purpose": "Auto-config column-exclusion detectors (GoldenCheck preflight).",
+          "defines": [
+            "ColumnProfile",
+            "ExcludedColumn",
+            "_build_column_profile",
+            "_build_column_profile_seam",
+            "_sample_non_null_seam",
+            "_sample_non_null_values",
+            "detect_audit_column",
+            "detect_autoconfig_exclusions",
+            "detect_foreign_system_id",
+            "detect_free_text_notes",
+            "detect_sentinel_values",
+            "detect_soft_delete_flag",
+            "detect_system_hash"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.rag_surface",
+          "file": "packages/python/goldenmatch/goldenmatch/core/rag_surface.py",
+          "purpose": "Entity-aware RAG surface -- collapse retrieved records into canonical entities (#1092).",
+          "defines": [
+            "Entity",
+            "EntityRetrievalResult",
+            "_resolve_hits",
+            "entity_aware_retrieve"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.llm_canonicalize",
+            "goldenmatch.core.retrieval"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.recall_certificate",
+          "file": "packages/python/goldenmatch/goldenmatch/core/recall_certificate.py",
+          "purpose": "Unsupervised recall estimation for a multi-matchkey run (no ground truth).",
+          "defines": [
+            "RecallCertificate",
+            "RecallEstimate",
+            "_fit_capture_prob",
+            "audit_calibrated_bound",
+            "build_decorrelated_systems",
+            "certify_recall_df",
+            "clusters_to_pairs",
+            "estimate_recall",
+            "wilson_ci"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.report",
+          "file": "packages/python/goldenmatch/goldenmatch/core/report.py",
+          "purpose": "HTML report generator — standalone report with charts and match details.",
+          "defines": [
+            "_build_html",
+            "_compute_histogram",
+            "_escape",
+            "_render_explanation",
+            "generate_report"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.explainer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.retrieval",
+          "file": "packages/python/goldenmatch/goldenmatch/core/retrieval.py",
+          "purpose": "Semantic retrieval -- find records similar to a query string (#1089).",
+          "defines": [
+            "RetrievedRecord",
+            "retrieve_similar_records"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.ann_blocker",
+            "goldenmatch.core.embedder"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.review_queue",
+          "file": "packages/python/goldenmatch/goldenmatch/core/review_queue.py",
+          "purpose": "Confidence-gated review queue for human-in-the-loop pair decisions.",
+          "defines": [
+            "ReviewItem",
+            "ReviewQueue",
+            "_MemoryBackend",
+            "_SQLiteBackend",
+            "_llm_enabled",
+            "_quality_gated_review_enabled",
+            "_row_to_dict",
+            "gate_pairs",
+            "why_for_correction"
+          ],
+          "imports": [
+            "goldenmatch.core.explain",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.llm_scorer",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.rollback",
+          "file": "packages/python/goldenmatch/goldenmatch/core/rollback.py",
+          "purpose": "Undo/rollback -- revert a previous merge run.",
+          "defines": [
+            "_load_run_log",
+            "list_runs",
+            "rollback_run",
+            "save_run_snapshot"
+          ],
+          "imports": [
+            "goldenmatch.core._logging",
+            "goldenmatch.core._paths"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.runtime_profile",
+          "file": "packages/python/goldenmatch/goldenmatch/core/runtime_profile.py",
+          "purpose": "Runtime-introspection signals consumed by the controller-v3 planner.",
+          "defines": [
+            "RuntimeProfile",
+            "capture_runtime_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.scheduler",
+          "file": "packages/python/goldenmatch/goldenmatch/core/scheduler.py",
+          "purpose": "Scheduled runs -- cron-like scheduling with email digest.",
+          "defines": [
+            "ScheduledJob",
+            "_print_run_error",
+            "_print_run_result",
+            "_print_schedule_header",
+            "_print_schedule_summary",
+            "_print_waiting",
+            "parse_cron",
+            "parse_interval"
+          ],
+          "imports": [
+            "goldenmatch.config.loader",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.schema_match",
+          "file": "packages/python/goldenmatch/goldenmatch/core/schema_match.py",
+          "purpose": "Schema-free matching — auto-map columns between different schemas.",
+          "defines": [
+            "_detect_composites",
+            "_score_column_pair",
+            "_type_similarity",
+            "_value_overlap",
+            "apply_column_mapping",
+            "auto_map_columns"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.scorer",
+          "file": "packages/python/goldenmatch/goldenmatch/core/scorer.py",
+          "purpose": "Scorer for GoldenMatch — field-level and pair-level scoring.",
+          "defines": [
+            "__getattr__",
+            "_alias_match_single",
+            "_alias_score_matrix",
+            "_apply_negative_evidence",
+            "_apply_negative_evidence_to_exact_pairs",
+            "_audio_fp_score_matrix",
+            "_audio_fp_score_single",
+            "_build_null_mask",
+            "_concat_pair_frames",
+            "_cross_source_filter_df",
+            "_date_similarity_py",
+            "_dice_score_matrix",
+            "_dice_score_single",
+            "_emit_scoring_profile",
+            "_empty_pair_stream_df",
+            "_exact_score_matrix",
+            "_filter_target_ids_df",
+            "_find_exact_match_ids",
+            "_fuzzy_score_matrix",
+            "_get_transformed_values",
+            "_hex_to_bits",
+            "_initialism_match_single",
+            "_initialism_score_matrix",
+            "_iso_date_digits",
+            "_jaccard_score_matrix",
+            "_jaccard_score_single",
+            "_native_field_matrix",
+            "_norm_phash_hex",
+            "_pad_to_equal_length",
+            "_pair_stream_schema",
+            "_phash_score_matrix",
+            "_phash_score_single",
+            "_qgram_score_matrix",
+            "_qgram_score_single",
+            "_qgram_set",
+            "_radial_score_matrix",
+            "_radial_score_single",
+            "_record_embedding_score_matrix",
+            "_score_one_block",
+            "_score_one_block_columnar",
+            "_soundex_score_matrix",
+            "find_exact_matches",
+            "find_fuzzy_matches",
+            "find_fuzzy_matches_columnar",
+            "pairs_df_to_list",
+            "pairs_list_to_df",
+            "rerank_top_pairs",
+            "reset_ne_broken",
+            "score_blocks_columnar",
+            "score_blocks_parallel",
+            "score_field",
+            "score_pair"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core._profile_helpers",
+            "goldenmatch.core.acronym",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.cross_encoder",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.perceptual",
+            "goldenmatch.core.profile_emitter",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.refdata.business_aliases",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.screening",
+          "file": "packages/python/goldenmatch/goldenmatch/core/screening.py",
+          "purpose": "One-to-many screening -- screen a single record against a watchlist (#1095).",
+          "defines": [
+            "FieldReason",
+            "ScreeningHit",
+            "ScreeningResult",
+            "_ensure_row_id",
+            "_field_reasons",
+            "screen_record",
+            "screen_records"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.match_one",
+            "goldenmatch.core.scorer"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.sensitivity",
+          "file": "packages/python/goldenmatch/goldenmatch/core/sensitivity.py",
+          "purpose": "Parameter sensitivity analysis using CCMS cluster comparison.",
+          "defines": [
+            "SensitivityResult",
+            "SweepParam",
+            "SweepPoint",
+            "_apply_value",
+            "_generate_values",
+            "_get_current_value",
+            "_sample_files",
+            "_validate_field",
+            "run_sensitivity"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.compare_clusters",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.pipeline"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.simhash_blocker",
+          "file": "packages/python/goldenmatch/goldenmatch/core/simhash_blocker.py",
+          "purpose": "SimHash/LSH blocking over dense embeddings (#1082).",
+          "defines": [
+            "SimHashLSHBlocker",
+            "build_simhash_blocks"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.embedder"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.sketch",
+          "file": "packages/python/goldenmatch/goldenmatch/core/sketch.py",
+          "purpose": "Pure-Python reference + fallback for the sketch-core MinHash/LSH kernel.",
+          "defines": [
+            "_band_hashes_batch_python",
+            "_coefficients",
+            "_projection_matrix",
+            "_signature_batch_python",
+            "_simhash_band_hashes_batch_python",
+            "_word_tokens",
+            "band_hashes",
+            "band_hashes_batch",
+            "base_hash",
+            "estimate_jaccard",
+            "optimal_bands",
+            "shingle",
+            "signature",
+            "signature_batch",
+            "simhash_band_hashes",
+            "simhash_band_hashes_batch",
+            "simhash_signature",
+            "sketch_band_hashes",
+            "splitmix64"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.smart_ingest",
+          "file": "packages/python/goldenmatch/goldenmatch/core/smart_ingest.py",
+          "purpose": "Smart ingest preprocessor for GoldenMatch.",
+          "defines": [
+            "_header_score",
+            "_parse_delimited",
+            "detect_blocks",
+            "detect_delimiter",
+            "detect_encoding",
+            "detect_fixed_width",
+            "detect_header_row",
+            "detect_key_value",
+            "detect_skip_rows",
+            "extract_entities",
+            "parse_blocks",
+            "parse_fixed_width",
+            "parse_key_value",
+            "smart_load"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._paths"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.standardize",
+          "file": "packages/python/goldenmatch/goldenmatch/core/standardize.py",
+          "purpose": "Data standardization module for GoldenMatch.",
+          "defines": [
+            "_list_apply",
+            "_native_address",
+            "_native_email",
+            "_native_name_lower",
+            "_native_name_proper",
+            "_native_name_upper",
+            "_native_phone",
+            "_native_state",
+            "_native_strip",
+            "_native_trim_whitespace",
+            "_native_zip5",
+            "_null_if_empty",
+            "_staged_per_col_enabled",
+            "_try_build_native_chain",
+            "apply_standardization",
+            "get_standardizer",
+            "std_address",
+            "std_email",
+            "std_name_lower",
+            "std_name_proper",
+            "std_name_upper",
+            "std_phone",
+            "std_state",
+            "std_strip",
+            "std_trim_whitespace",
+            "std_zip5"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.bench"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.streaming",
+          "file": "packages/python/goldenmatch/goldenmatch/core/streaming.py",
+          "purpose": "Streaming / CDC mode -- continuous record matching.",
+          "defines": [
+            "StreamProcessor",
+            "StreamStats",
+            "run_stream"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.match_one",
+            "goldenmatch.identity.resolve"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/__init__.py",
+          "purpose": "Config-suggestion adapter for goldenmatch.",
+          "imports": [
+            "goldenmatch.core.suggest.adapter",
+            "goldenmatch.core.suggest.apply",
+            "goldenmatch.core.suggest.health",
+            "goldenmatch.core.suggest.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest.adapter",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/adapter.py",
+          "purpose": "Python adapter that drives the native ``suggest_config`` kernel.",
+          "defines": [
+            "_build_clusters_batch",
+            "_build_column_signals_batch",
+            "_build_scored_pairs_batch",
+            "_cached_blocking_risk",
+            "_collision_rates",
+            "_config_summary",
+            "_diagnostic_scored_pairs",
+            "_full_dist_enabled",
+            "_kernel_suggest",
+            "_matched_rate",
+            "_parse_suggestions",
+            "_raise_sheds_unjustified_recall",
+            "_recall_guard_params",
+            "_require_kernel",
+            "_resolve_max_verify",
+            "_verify_enabled_by_env",
+            "_verify_suggestions",
+            "_zero_threshold_config",
+            "review_config",
+            "suggest_from_result",
+            "variant_risk_cache"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.indicators",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.suggest.apply",
+            "goldenmatch.core.suggest.health",
+            "goldenmatch.core.suggest.types",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest.apply",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/apply.py",
+          "purpose": "apply_suggestion: apply a ConfigPatch to a GoldenMatchConfig.",
+          "defines": [
+            "_apply_add_negative_evidence",
+            "_apply_drop_matchkey",
+            "_apply_set_scorer",
+            "_apply_set_threshold",
+            "_find_matchkey",
+            "apply_suggestion"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.suggest.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest.health",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/health.py",
+          "purpose": "Unsupervised config-health proxy for the self-verification gate.",
+          "defines": [
+            "_cluster_min_edges",
+            "_cohesion_edge_below_cutoff",
+            "_cohesion_mean_bottomk",
+            "_cohesion_min",
+            "_coverage",
+            "_coverage_cap_from_env",
+            "_extract_threshold",
+            "_health_legacy",
+            "_select_cohesion",
+            "suggestion_health",
+            "suggestion_health_cohesion",
+            "suggestion_health_from_clusters"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest.surface",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/surface.py",
+          "purpose": "Shared orchestration for the config-suggestion (healer) surfaces: the free",
+          "defines": [
+            "HeadroomReason",
+            "HealOutcome",
+            "_resolve_min_health_gain",
+            "_resolve_step_cap",
+            "_safe_cluster_health",
+            "headroom_signal",
+            "heal",
+            "maybe_suggest",
+            "serialize_suggestions"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.suggest.adapter",
+            "goldenmatch.core.suggest.apply",
+            "goldenmatch.core.suggest.health"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.suggest.types",
+          "file": "packages/python/goldenmatch/goldenmatch/core/suggest/types.py",
+          "purpose": "Public types for the config-suggestion adapter.",
+          "defines": [
+            "Suggestion",
+            "SuggestionsNativeRequired"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/__init__.py",
+          "purpose": "Correlated survivorship: field groups + conditional/validated golden rules."
+        },
+        {
+          "module": "goldenmatch.core.survivorship.conditions",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/conditions.py",
+          "purpose": "Safe predicate evaluation + resolution ordering for conditional golden rules.",
+          "defines": [
+            "PredicateError",
+            "ResolutionError",
+            "_cmp",
+            "_validate",
+            "build_resolution_order",
+            "eval_predicate",
+            "referenced_names",
+            "select_conditional_strategy"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship.groups",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/groups.py",
+          "purpose": "Field-group detection: explicit > infermap-fed > heuristic. Spec section 2.",
+          "defines": [
+            "_disjoint_add",
+            "_infermap_canonical_map",
+            "_infermap_fed_groups",
+            "_match_members",
+            "_pack_groups",
+            "build_field_groups",
+            "detect_groups_heuristic"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "infermap",
+            "infermap.domain_pack"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship.native",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/native.py",
+          "purpose": "Vectorized survivorship resolution (provenance=False fast path).",
+          "defines": [
+            "_conditional_conf_name",
+            "_golden_df_to_rows",
+            "_group_conf_expr",
+            "_group_conf_name",
+            "_group_tie_expr",
+            "_populated_count_expr",
+            "_resolve_conditionals",
+            "_resolve_group",
+            "_resolve_scalars",
+            "_scalar_conf_expr",
+            "_scalar_conf_name",
+            "_scalar_resolution_rule",
+            "_scalar_strategy_native_ineligible",
+            "_scalar_value_expr",
+            "_sorted_for_group",
+            "_source_priority_eligible",
+            "build_survivorship_native",
+            "survivorship_native_eligible"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.survivorship.conditions",
+            "goldenmatch.core.survivorship.validate"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship.resolve",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/resolve.py",
+          "purpose": "Staged per-cluster survivorship resolution (Approach 1). Spec section 3.",
+          "defines": [
+            "resolve_cluster"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.survivorship.conditions",
+            "goldenmatch.core.survivorship.validate",
+            "goldenmatch.core.survivorship.winner"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship.validate",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/validate.py",
+          "purpose": "Candidate validation filter over GoldenFlow validator transforms. Fail-open. Spec 3.5.",
+          "defines": [
+            "_resolve_validator",
+            "goldenflow_filter"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.survivorship.winner",
+          "file": "packages/python/goldenmatch/goldenmatch/core/survivorship/winner.py",
+          "purpose": "Group-winner selection for lock-step field-group survivorship. Spec section 3.2/4.2.",
+          "defines": [
+            "GroupResult",
+            "_populated",
+            "_ranking",
+            "group_winner"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.tf_tables",
+          "file": "packages/python/goldenmatch/goldenmatch/core/tf_tables.py",
+          "purpose": "Per-value relative-frequency tables shared by the FS TF-adjustment and the",
+          "defines": [
+            "value_frequencies"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.threshold",
+          "file": "packages/python/goldenmatch/goldenmatch/core/threshold.py",
+          "purpose": "Threshold auto-tuning for GoldenMatch using Otsu's method.",
+          "defines": [
+            "suggest_threshold"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.throughput_verify",
+          "file": "packages/python/goldenmatch/goldenmatch/core/throughput_verify.py",
+          "purpose": "Sketch-then-verify throughput tier (#1083): banding, sketch-distance verify,",
+          "defines": [
+            "ThroughputNotApplicableError",
+            "ThroughputPosture",
+            "_band_match_prob",
+            "build_posture",
+            "expected_recall_lsh",
+            "metric_and_signature_len",
+            "resolve_throughput_config",
+            "score_sketch_pairs",
+            "select_banding"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.transform",
+          "file": "packages/python/goldenmatch/goldenmatch/core/transform.py",
+          "purpose": "GoldenFlow integration -- data transformation before matching.",
+          "defines": [
+            "_do_transform",
+            "_goldenflow_available",
+            "_warn_transform_needs_polars_once",
+            "build_transform",
+            "run_transform"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.frame",
+            "goldenmatch.distributed.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.validate",
+          "file": "packages/python/goldenmatch/goldenmatch/core/validate.py",
+          "purpose": "Column-level validation rules with quarantine support for GoldenMatch.",
+          "defines": [
+            "ValidationRule",
+            "_check_format_email",
+            "_check_format_phone",
+            "_check_format_zip5",
+            "validate_dataframe"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.vector_index",
+          "file": "packages/python/goldenmatch/goldenmatch/core/vector_index.py",
+          "purpose": "Persistent vector index -- stop rebuilding the embedding index every run (#1088).",
+          "defines": [
+            "VectorIndex",
+            "_atomic_write_bytes"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.ann_blocker",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.retrieval"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.vector_store",
+          "file": "packages/python/goldenmatch/goldenmatch/core/vector_store.py",
+          "purpose": "Pluggable vector-store backends behind one interface (#1088, epic #1087).",
+          "defines": [
+            "DuckDBVectorIndex",
+            "PgVectorIndex",
+            "VectorStore",
+            "_record_from_json",
+            "embed_texts",
+            "infer_backend",
+            "open_vector_index",
+            "prep_rows"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.retrieval",
+            "goldenmatch.core.vector_index"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.vertex_embedder",
+          "file": "packages/python/goldenmatch/goldenmatch/core/vertex_embedder.py",
+          "purpose": "Vertex AI Embeddings — Google Cloud managed embedding API.",
+          "defines": [
+            "VertexEmbedder",
+            "is_vertex_available"
+          ]
+        },
+        {
+          "module": "goldenmatch.core.zero_label_confidence",
+          "file": "packages/python/goldenmatch/goldenmatch/core/zero_label_confidence.py",
+          "purpose": "Zero-label (ZeroER-inspired) confidence scoring for auto-config.",
+          "defines": [
+            "_clamp",
+            "combine_zero_label_scores",
+            "compute_zero_label_confidence",
+            "perturbation_stability",
+            "profile_drift",
+            "score_cluster_bridge_risk",
+            "score_cluster_confidence",
+            "score_distribution_confidence",
+            "score_expected_precision",
+            "score_expected_recall",
+            "score_random_pair_contamination",
+            "score_transitivity",
+            "threshold_perturbations"
+          ],
+          "imports": [
+            "goldenmatch.core.complexity_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.db",
+          "file": "packages/python/goldenmatch/goldenmatch/db/__init__.py",
+          "purpose": "Database integration for GoldenMatch."
+        },
+        {
+          "module": "goldenmatch.db.alembic.env",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/env.py",
+          "purpose": "Alembic env for the GoldenMatch Identity Graph schema.",
+          "defines": [
+            "_get_dsn",
+            "run_migrations_offline",
+            "run_migrations_online"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.alembic.versions.0001_identity_v1",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0001_identity_v1.py",
+          "purpose": "Identity Graph schema v1 baseline.",
+          "defines": [
+            "downgrade",
+            "upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.alembic.versions.0002_provenance_actor_trust",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0002_provenance_actor_trust.py",
+          "purpose": "Provenance spine: actor + trust on identity events and evidence edges.",
+          "defines": [
+            "downgrade",
+            "upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.alembic.versions.0003_audit_hash_chain",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0003_audit_hash_chain.py",
+          "purpose": "Tamper-evident audit log: per-event entry_hash + audit_seals chain table.",
+          "defines": [
+            "downgrade",
+            "upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.alembic.versions.0004_claim_authority",
+          "file": "packages/python/goldenmatch/goldenmatch/db/alembic/versions/0004_claim_authority.py",
+          "purpose": "Claim-authority tier: claim_type + evidence_ref + previous_claim_id.",
+          "defines": [
+            "downgrade",
+            "upgrade"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.ann_index",
+          "file": "packages/python/goldenmatch/goldenmatch/db/ann_index.py",
+          "purpose": "Persistent FAISS ANN index manager for database integration.",
+          "defines": [
+            "PersistentANNIndex"
+          ],
+          "imports": [
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.blocking",
+          "file": "packages/python/goldenmatch/goldenmatch/db/blocking.py",
+          "purpose": "Database-side blocking — translate blocking keys into SQL WHERE clauses.",
+          "defines": [
+            "_apply_sql_transform",
+            "_escape_value",
+            "build_blocking_query"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.clusters",
+          "file": "packages/python/goldenmatch/goldenmatch/db/clusters.py",
+          "purpose": "Persistent cluster management for database integration.",
+          "defines": [
+            "add_to_cluster",
+            "create_cluster",
+            "get_cluster_for_record",
+            "get_cluster_members",
+            "get_cluster_size",
+            "get_clusters_for_records",
+            "merge_clusters",
+            "next_cluster_id"
+          ],
+          "imports": [
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.connector",
+          "file": "packages/python/goldenmatch/goldenmatch/db/connector.py",
+          "purpose": "Database connector interface and Postgres implementation.",
+          "defines": [
+            "DatabaseConnector",
+            "PostgresConnector",
+            "_normalize_chunk_schema",
+            "_quote_ident",
+            "create_connector"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.db.connector_mysql",
+            "goldenmatch.db.connector_snowflake",
+            "goldenmatch.db.connector_sqlserver"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.connector_mysql",
+          "file": "packages/python/goldenmatch/goldenmatch/db/connector_mysql.py",
+          "purpose": "MySQL / MariaDB sync-target connector.",
+          "defines": [
+            "MySQLConnector",
+            "_parse_uri",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.connector_snowflake",
+          "file": "packages/python/goldenmatch/goldenmatch/db/connector_snowflake.py",
+          "purpose": "Snowflake sync-target connector.",
+          "defines": [
+            "SnowflakeConnector",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.connector_sqlserver",
+          "file": "packages/python/goldenmatch/goldenmatch/db/connector_sqlserver.py",
+          "purpose": "SQL Server / Azure SQL sync-target connector.",
+          "defines": [
+            "SqlServerConnector",
+            "_quote_ident"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.hybrid_blocking",
+          "file": "packages/python/goldenmatch/goldenmatch/db/hybrid_blocking.py",
+          "purpose": "Hybrid blocking — SQL + ANN in parallel, union results.",
+          "defines": [
+            "_embed_record",
+            "find_candidates",
+            "find_candidates_batch"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.embedder",
+            "goldenmatch.db.ann_index",
+            "goldenmatch.db.blocking",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.metadata",
+          "file": "packages/python/goldenmatch/goldenmatch/db/metadata.py",
+          "purpose": "GoldenMatch metadata table management (gm_* tables).",
+          "defines": [
+            "config_hash",
+            "ensure_metadata_tables",
+            "get_state",
+            "log_match",
+            "log_matches_batch",
+            "new_run_id",
+            "update_state"
+          ],
+          "imports": [
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.reconcile",
+          "file": "packages/python/goldenmatch/goldenmatch/db/reconcile.py",
+          "purpose": "Reconciliation engine — merges new records into existing clusters.",
+          "defines": [
+            "ReconcileResult",
+            "_compute_golden",
+            "_get_current_golden",
+            "_get_current_version_id",
+            "_handle_multi_match",
+            "_handle_new_entity",
+            "_handle_single_match",
+            "_incremental_merge",
+            "_mark_not_current",
+            "_recompute_golden",
+            "_write_golden_version",
+            "reconcile_match"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.golden",
+            "goldenmatch.db.clusters",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.sync",
+          "file": "packages/python/goldenmatch/goldenmatch/db/sync.py",
+          "purpose": "Incremental sync orchestrator — matches new records against existing DB.",
+          "defines": [
+            "_cast_to_schema",
+            "_embed_next_chunk",
+            "_full_scan_pipeline",
+            "_full_scan_streaming",
+            "_incremental_pipeline",
+            "_index_block_sizes",
+            "_read_all",
+            "_read_all_lazy",
+            "_read_incremental",
+            "_score_block_streaming",
+            "run_sync"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.scorer",
+            "goldenmatch.db.ann_index",
+            "goldenmatch.db.clusters",
+            "goldenmatch.db.connector",
+            "goldenmatch.db.hybrid_blocking",
+            "goldenmatch.db.metadata",
+            "goldenmatch.db.reconcile",
+            "goldenmatch.db.writer"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.watch",
+          "file": "packages/python/goldenmatch/goldenmatch/db/watch.py",
+          "purpose": "Live stream mode — poll database for changes and match continuously.",
+          "defines": [
+            "_HealthHandler",
+            "_log_event",
+            "_log_waiting",
+            "_print_header",
+            "_print_summary",
+            "_remove_pid",
+            "_write_pid",
+            "watch",
+            "watch_daemon"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.db.connector",
+            "goldenmatch.db.metadata",
+            "goldenmatch.db.sync"
+          ]
+        },
+        {
+          "module": "goldenmatch.db.writer",
+          "file": "packages/python/goldenmatch/goldenmatch/db/writer.py",
+          "purpose": "Result write-back to database.",
+          "defines": [
+            "_write_in_place",
+            "_write_separate",
+            "write_golden_records"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.db.connector"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/__init__.py",
+          "purpose": "Distributed execution primitives for 50M+ row deduplication.",
+          "imports": [
+            "goldenmatch.distributed._utils",
+            "goldenmatch.distributed.clustering",
+            "goldenmatch.distributed.dataset",
+            "goldenmatch.distributed.golden",
+            "goldenmatch.distributed.identity",
+            "goldenmatch.distributed.sample",
+            "goldenmatch.distributed.scoring"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed._utils",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/_utils.py",
+          "purpose": "Tiny helpers shared across distributed submodules.",
+          "defines": [
+            "is_ray_dataset"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.clustering",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/clustering.py",
+          "purpose": "Distributed clustering via label propagation on Ray Datasets.",
+          "defines": [
+            "ConvergenceError",
+            "_annotate_cluster_sizes",
+            "_assert_scratch_shared_if_multinode",
+            "_attach_quality_metadata",
+            "_build_clusters_scipy_fallback",
+            "_derive_touched_ids",
+            "_emit_boundary_pairs",
+            "_label_prop_threshold",
+            "_phase_a_local_cc",
+            "_phase_b_merge_boundaries",
+            "_propagate_one_step",
+            "_rc_checkpoint",
+            "_rc_compose_distributed",
+            "_rc_compose_labels",
+            "_rc_contract_distributed",
+            "_rc_contract_round",
+            "_rc_normalize_distributed",
+            "_rc_normalize_to_min_member",
+            "_rc_rep_batch",
+            "_rc_rep_distributed",
+            "_rc_symmetrize",
+            "_rc_symmetrize_batch",
+            "_rc_union_isolated",
+            "_rc_wcc_polars",
+            "_resolve_use_label_prop",
+            "_route_distributed",
+            "_wcc_algorithm",
+            "_wcc_groupby_min_label",
+            "build_clusters_distributed",
+            "distributed_wcc",
+            "label_propagation",
+            "local_cc_assignments",
+            "materialize_cluster_dict",
+            "pairs_list_to_dataset",
+            "randomized_contraction_wcc",
+            "two_phase_wcc"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.dataset",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/dataset.py",
+          "purpose": "Partition-aware data loader on Ray Datasets.",
+          "defines": [
+            "_apply_plans_to_arrow_batch",
+            "apply_transforms_distributed",
+            "read_csv_partitioned",
+            "read_parquet_partitioned",
+            "read_partitioned"
+          ],
+          "imports": [
+            "goldenmatch.distributed.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.golden",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/golden.py",
+          "purpose": "Distributed golden record build via repartition(keys) + map_batches.",
+          "defines": [
+            "_collect_and_call_in_memory",
+            "_golden_cluster_threshold",
+            "_per_partition_golden",
+            "build_golden_records_distributed",
+            "build_golden_records_smart",
+            "materialize_golden_dataframe"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.golden"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.identity",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/identity.py",
+          "purpose": "Distributed identity resolution dispatch.",
+          "defines": [
+            "materialize_identity_assignments",
+            "resolve_identities_distributed"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster",
+            "goldenmatch.distributed._utils",
+            "goldenmatch.distributed.clustering",
+            "goldenmatch.identity.pool",
+            "goldenmatch.identity.resolve",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.identity_partition",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/identity_partition.py",
+          "purpose": "Arrow-native roadmap Phase 5 (#627): identity per-partition resolver",
+          "defines": [
+            "merge_partitioned_frames",
+            "partition_cluster_frames"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.indicators",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/indicators.py",
+          "purpose": "Distributed variants of full-df indicators (Phase 2).",
+          "defines": [
+            "_collect_indicator_sample",
+            "_ffr_native",
+            "compute_column_priors_distributed",
+            "estimate_sparse_match_signal_distributed"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.complexity_profile",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.indicators"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.pipeline",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/pipeline.py",
+          "purpose": "Distributed pipeline orchestrator.",
+          "defines": [
+            "_ensure_global_row_id",
+            "_join_assignments_distributed",
+            "_join_clusters_to_rows",
+            "_phase4_pipeline_enabled",
+            "_phase5_cluster",
+            "_phase5_pipeline_enabled",
+            "_row_columns",
+            "_run_phase2_cheat_line",
+            "_run_phase4_pipeline",
+            "_run_phase5_pipeline",
+            "_write_golden_output",
+            "run_dedupe_pipeline_distributed"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch._api",
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.distributed.clustering",
+            "goldenmatch.distributed.golden",
+            "goldenmatch.distributed.scoring"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.record_store",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/record_store.py",
+          "purpose": "DuckDB-backed prepared-record store.",
+          "defines": [
+            "PreparedRecordStore",
+            "_sanitize_signature",
+            "iter_buckets",
+            "load_bucket",
+            "load_prepared_records",
+            "materialize_bucketed_blocks",
+            "materialize_prepared_records"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._hashing",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.sample",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/sample.py",
+          "purpose": "Distributed sampling helper for the controller iteration loop.",
+          "defines": [
+            "_ffr_native",
+            "take_sample_distributed"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.scoring",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/scoring.py",
+          "purpose": "Distributed scoring via per-partition dedupe + cross-partition pair dedup.",
+          "defines": [
+            "_apply_ray_data_resource_tuning",
+            "_attach_colocation_keys",
+            "_block_shuffle_enabled",
+            "_dedup_num_partitions",
+            "_fs_training_sample",
+            "_has_colocation_plan",
+            "_native_worker_baseline",
+            "_prepare_fs_models",
+            "_project_to_scoring_columns",
+            "_score_blocks_block_shuffle",
+            "_score_blocks_legacy",
+            "_score_colocated_groups",
+            "_warn_worker_slow_path",
+            "dedup_pairs_distributed",
+            "score_blocks_distributed"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.autoconfig_verify",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.probabilistic",
+            "goldenmatch.core.standardize"
+          ]
+        },
+        {
+          "module": "goldenmatch.distributed.transforms",
+          "file": "packages/python/goldenmatch/goldenmatch/distributed/transforms.py",
+          "purpose": "Serializable transform plans for distributed pipelines.",
+          "defines": [
+            "TransformPlan",
+            "apply_plan"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/__init__.py",
+          "purpose": "Document/image ingest: turn PDFs/images into a records DataFrame for GoldenMatch.",
+          "defines": [
+            "_flat_extract",
+            "_generic_fallback",
+            "_ingest_one",
+            "_resolve_template",
+            "_structured_extract",
+            "ingest_documents"
+          ],
+          "imports": [
+            "goldenmatch.core._hashing",
+            "goldenmatch.documents.assemble",
+            "goldenmatch.documents.config",
+            "goldenmatch.documents.extractor",
+            "goldenmatch.documents.loader",
+            "goldenmatch.documents.templates",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents._openai",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/_openai.py",
+          "purpose": "Shared OpenAI-vision plumbing for the documents backends (extractor + schema suggest).",
+          "defines": [
+            "image_blocks",
+            "parse_message_text",
+            "urllib_transport"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.assemble",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/assemble.py",
+          "purpose": "Two-frame structured assemble: turn per-doc `_DocOutcome`s into a header frame",
+          "defines": [
+            "_ColUnion",
+            "_empty_header_frame",
+            "_frame_from_records",
+            "_header_sidecar_specs",
+            "_item_sidecar_specs",
+            "assemble_structured"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.classify",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/classify.py",
+          "purpose": "Doctype classification kernel: the fixed classify prompt + the response parser.",
+          "defines": [
+            "_pure_parse",
+            "_pure_prompt",
+            "_strip_fence",
+            "classify_prompt",
+            "parse_classify"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.config",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/config.py",
+          "purpose": "Backend resolution + fail-fast validation for document ingest.",
+          "defines": [
+            "resolve_api_key",
+            "resolve_extractor",
+            "resolve_structured"
+          ],
+          "imports": [
+            "goldenmatch.documents._openai",
+            "goldenmatch.documents.extractor",
+            "goldenmatch.documents.structured",
+            "goldenmatch.documents.vlm_backend",
+            "goldenmatch.documents.vlm_classifier"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.extractor",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/extractor.py",
+          "purpose": "The extractor seams: Protocols plus scripted fakes for tests.",
+          "defines": [
+            "Classifier",
+            "Extractor",
+            "FakeClassifier",
+            "FakeExtractor",
+            "FakeFallbackExtractor",
+            "FakeTemplateExtractor",
+            "FallbackExtractor",
+            "TemplateExtractor"
+          ],
+          "imports": [
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.loader",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/loader.py",
+          "purpose": "Load a document file into normalized PNG page images.",
+          "defines": [
+            "_import_fitz",
+            "_import_pil",
+            "_png",
+            "load_pages"
+          ],
+          "imports": [
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.schema_io",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/schema_io.py",
+          "purpose": "TargetSchema <-> JSON. Pure stdlib, offline. The serializable schema form used by the",
+          "defines": [
+            "load_schema",
+            "save_schema",
+            "schema_from_dict",
+            "schema_to_dict"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.structured",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/structured.py",
+          "purpose": "Structured-extract parse: turn a VLM structured response",
+          "defines": [
+            "VLMTemplateExtractor",
+            "_native_structured_parsed",
+            "_pure_structured_parsed",
+            "_record_parts",
+            "_structured_instruction",
+            "parse_structured"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents._openai",
+            "goldenmatch.documents.templates",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.suggest",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/suggest.py",
+          "purpose": "VLM-assisted target-schema suggestion: look at a sample document and PROPOSE fields.",
+          "defines": [
+            "_prompt",
+            "suggest_schema",
+            "suggest_schema_from_file"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents._openai",
+            "goldenmatch.documents.config",
+            "goldenmatch.documents.loader",
+            "goldenmatch.documents.schema_io",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.templates",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/templates.py",
+          "purpose": "Doctype template registry. Native (documents-core) is the source of truth;",
+          "defines": [
+            "_f",
+            "_from_native_json",
+            "_pure_list",
+            "_pure_template",
+            "_template_to_dict",
+            "get_template",
+            "list_templates"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.types",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/types.py",
+          "purpose": "Value types for document/image ingest. Stdlib only, offline-testable.",
+          "defines": [
+            "ClassifyResult",
+            "DocTemplate",
+            "ExtractResult",
+            "ExtractedRow",
+            "Field",
+            "IngestReport",
+            "PageImage",
+            "StructuredResult",
+            "TargetSchema",
+            "_DocOutcome",
+            "_coerce_confidence",
+            "_coerce_value",
+            "normalize_row_pure"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.vlm_backend",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/vlm_backend.py",
+          "purpose": "Cloud VLM extractor: one OpenAI vision call per document, schema-directed.",
+          "defines": [
+            "VLMExtractor",
+            "_instruction"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.documents._openai",
+            "goldenmatch.documents.schema_io",
+            "goldenmatch.documents.types"
+          ]
+        },
+        {
+          "module": "goldenmatch.documents.vlm_classifier",
+          "file": "packages/python/goldenmatch/goldenmatch/documents/vlm_classifier.py",
+          "purpose": "VLM-facing doctype collaborators: `VLMClassifier` (one classify call per doc)",
+          "defines": [
+            "VLMClassifier",
+            "VLMFallbackExtractor"
+          ],
+          "imports": [
+            "goldenmatch.documents._openai",
+            "goldenmatch.documents.classify",
+            "goldenmatch.documents.suggest",
+            "goldenmatch.documents.types",
+            "goldenmatch.documents.vlm_backend"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/__init__.py",
+          "purpose": "Local/private embedding runtime with a provider-agnostic contract.",
+          "defines": [
+            "embed_records",
+            "normalize_text",
+            "text_hash"
+          ],
+          "imports": [
+            "goldenmatch.embeddings.cache",
+            "goldenmatch.embeddings.providers"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.cache",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/cache.py",
+          "purpose": "Embedding cache keyed by ``(model_id, normalized_text_hash)``.",
+          "defines": [
+            "EmbeddingCache"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.inhouse",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/inhouse/__init__.py",
+          "purpose": "In-house, tailor-made embedding model for entity resolution.",
+          "imports": [
+            "goldenmatch.embeddings.inhouse.featurizer",
+            "goldenmatch.embeddings.inhouse.model",
+            "goldenmatch.embeddings.inhouse.trainer"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.inhouse.featurizer",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/inhouse/featurizer.py",
+          "purpose": "Deterministic character n-gram featurizer for the in-house embedder.",
+          "defines": [
+            "CharNGramFeaturizer",
+            "FeaturizerConfig"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.inhouse.model",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/inhouse/model.py",
+          "purpose": "In-house embedding model: char n-gram features -> learned linear projection.",
+          "defines": [
+            "EmbedModelConfig",
+            "GoldenEmbedModel",
+            "_random_projection"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.embeddings.inhouse.featurizer"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.inhouse.trainer",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/inhouse/trainer.py",
+          "purpose": "Supervised training for the in-house embedder — numpy only, no torch.",
+          "defines": [
+            "TrainConfig",
+            "TrainReport",
+            "_cosine",
+            "_separation",
+            "_train_cosine",
+            "_train_euclidean",
+            "train_embedder"
+          ],
+          "imports": [
+            "goldenmatch.embeddings.inhouse.featurizer",
+            "goldenmatch.embeddings.inhouse.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.embeddings.providers",
+          "file": "packages/python/goldenmatch/goldenmatch/embeddings/providers.py",
+          "purpose": "Embedding providers behind a single contract.",
+          "defines": [
+            "EmbeddingProvider",
+            "InHouseProvider",
+            "LlamaGGUFProvider",
+            "LocalProvider",
+            "NoneProvider",
+            "OpenAIProvider",
+            "SnowflakeCortexProvider",
+            "VertexProvider",
+            "resolve_provider"
+          ],
+          "imports": [
+            "goldenmatch.core.embedder",
+            "goldenmatch.core.vertex_embedder",
+            "goldenmatch.embeddings.inhouse.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/__init__.py",
+          "purpose": "Identity Graph -- durable, queryable graph of identities, source records,",
+          "imports": [
+            "goldenmatch.identity.audit",
+            "goldenmatch.identity.mediation",
+            "goldenmatch.identity.migrate_ids",
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.profile",
+            "goldenmatch.identity.query",
+            "goldenmatch.identity.resolve",
+            "goldenmatch.identity.stabilize",
+            "goldenmatch.identity.stitching",
+            "goldenmatch.identity.store",
+            "goldenmatch.identity.survivorship"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.audit",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/audit.py",
+          "purpose": "Tamper-evident audit log for the Identity Graph (#1078).",
+          "defines": [
+            "AuditVerification",
+            "_effective_hash",
+            "_fold_step",
+            "_normalize_dt",
+            "event_content_hash",
+            "seal_audit_log",
+            "verify_audit_chain"
+          ],
+          "imports": [
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.fingerprint_batch",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/fingerprint_batch.py",
+          "purpose": "Batch record fingerprinting for identity id derivation.",
+          "defines": [
+            "_canonical_payload",
+            "_int_upcast_dtypes",
+            "_is_unbatchable_arrow_type",
+            "_is_unbatchable_dtype",
+            "batch_fingerprints",
+            "batch_fingerprints_table",
+            "canonicalize_records_df",
+            "canonicalize_records_table"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core._hashing"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.mediation",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/mediation.py",
+          "purpose": "Conflict mediation workflow -- Identity v3 (#1113, epic #1108).",
+          "defines": [
+            "ConflictItem",
+            "ConflictResolution",
+            "MediationVerdict",
+            "_latest_verdicts",
+            "mediate_conflict",
+            "mediation_summary",
+            "open_conflicts",
+            "pair_verdict"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.query",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.migrate_ids",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/migrate_ids.py",
+          "purpose": "Migrate persisted identity record ids from the legacy ``{source}:hash:{12}``",
+          "defines": [
+            "MigrationReport",
+            "_begin",
+            "_commit",
+            "_count_edges_touching",
+            "_do_migrate",
+            "_existing_entity_for",
+            "_legacy_match",
+            "_merge_into",
+            "_recompute_h1_id",
+            "_rename_record",
+            "_rollback",
+            "migrate_record_ids"
+          ],
+          "imports": [
+            "goldenmatch.core._hashing",
+            "goldenmatch.identity.fingerprint_batch",
+            "goldenmatch.identity.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.model",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/model.py",
+          "purpose": "Identity Graph data classes.",
+          "defines": [
+            "AuditSeal",
+            "ClaimType",
+            "EdgeKind",
+            "EventKind",
+            "EvidenceEdge",
+            "EvidenceRef",
+            "IdentityAlias",
+            "IdentityEvent",
+            "IdentityNode",
+            "IdentityStatus",
+            "SourceRecord",
+            "canon_record_pair"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.mongo_backend",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/mongo_backend.py",
+          "purpose": "MongoDB-backed Identity Store.",
+          "defines": [
+            "MongoIdentityStore",
+            "_objectid_to_int",
+            "_to_edge",
+            "_to_event",
+            "_to_node",
+            "_to_record"
+          ],
+          "imports": [
+            "goldenmatch.identity.audit",
+            "goldenmatch.identity.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.pool",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/pool.py",
+          "purpose": "Process-singleton Postgres connection pool for IdentityStore.",
+          "defines": [
+            "get_identity_pool",
+            "reset_identity_pool"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.profile",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/profile.py",
+          "purpose": "Entity profiles + stewardship ops views -- MDM ops (#1114, epic #1108).",
+          "defines": [
+            "EntityProfile",
+            "IdentitySummary",
+            "WorklistItem",
+            "_iter_entities",
+            "entity_profile",
+            "identity_summary_stats",
+            "steward_worklist"
+          ],
+          "imports": [
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.query",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/query.py",
+          "purpose": "Read-side API for the Identity Graph.",
+          "defines": [
+            "IdentityView",
+            "_emit_claim_lifecycle",
+            "_require_active_entity",
+            "_resolve_prior_claim",
+            "amend_claim",
+            "claim_record",
+            "find_by_record",
+            "find_conflicts",
+            "get_entity",
+            "history",
+            "list_entities",
+            "manual_merge",
+            "manual_split",
+            "promote_claim",
+            "revoke_claim"
+          ],
+          "imports": [
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.resolve",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/resolve.py",
+          "purpose": "Identity resolution -- map run-local clusters to durable identity_ids.",
+          "defines": [
+            "ResolveSummary",
+            "_batch_fingerprint_enabled",
+            "_cluster_confidence",
+            "_frames_iter",
+            "_golden_record_from_members",
+            "_golden_record_from_payloads",
+            "_hash_payload",
+            "_match_record_rows",
+            "_node_age",
+            "_record_id_candidates",
+            "_row_to_payload",
+            "derive_record_id",
+            "match_record_to_entity",
+            "resolve_clusters",
+            "resolve_record_incremental"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._hashing",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.cluster_pairscores",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.match_one",
+            "goldenmatch.identity.fingerprint_batch",
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.stabilize",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/stabilize.py",
+          "purpose": "Cross-run entity stabilization -- Identity v3 (#1112, epic #1108).",
+          "defines": [
+            "ConsolidationGroup",
+            "OverlapCandidate",
+            "StabilizeReport",
+            "_all_active_entities",
+            "_apply_consolidation",
+            "_canon",
+            "_select_winner",
+            "entity_version",
+            "find_persistent_overlaps",
+            "stabilize_identities"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.stitching",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/stitching.py",
+          "purpose": "Cross-device / channel stitching model (#1110, epic #1108).",
+          "defines": [
+            "StitchGroup",
+            "StitchResult",
+            "adjust_score",
+            "channel_trust",
+            "classify_channel",
+            "cross_channel_factor",
+            "deterministic_stitch_pairs",
+            "stitch_frame"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.store",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/store.py",
+          "purpose": "IdentityStore -- SQLite/Postgres persistence for the Identity Graph.",
+          "defines": [
+            "IdentityStore",
+            "_row_get",
+            "_to_dt",
+            "new_entity_id"
+          ],
+          "imports": [
+            "goldenmatch.identity.audit",
+            "goldenmatch.identity.model",
+            "goldenmatch.identity.mongo_backend"
+          ]
+        },
+        {
+          "module": "goldenmatch.identity.survivorship",
+          "file": "packages/python/goldenmatch/goldenmatch/identity/survivorship.py",
+          "purpose": "Survivorship learning + per-cell golden-record provenance (#1111, epic #1108).",
+          "defines": [
+            "CellProvenance",
+            "FieldStrategyRecommendation",
+            "GoldenRecordWithProvenance",
+            "_record_id_for",
+            "_rule_for",
+            "_trust",
+            "build_golden_with_provenance",
+            "learn_field_survivorship",
+            "learned_field_strategies"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/__init__.py",
+          "purpose": "GoldenMatch MCP Server — expose entity resolution tools to Claude Desktop."
+        },
+        {
+          "module": "goldenmatch.mcp._ingest",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/_ingest.py",
+          "purpose": "Inline file ingestion for the MCP server.",
+          "defines": [
+            "_decode",
+            "_max_bytes",
+            "_reap",
+            "_safe_filename",
+            "_ttl",
+            "_uploads_dir",
+            "resolve_ingest_args",
+            "resolve_input_source"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp._session_ctx",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/_session_ctx.py",
+          "purpose": "Request-scoped MCP session id, threaded to tool handlers via a ContextVar",
+          "defines": [
+            "current_session_id",
+            "reset_current_session_id",
+            "session_key_from_context",
+            "set_current_session_id"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp._session_store",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/_session_store.py",
+          "purpose": "Bounded, TTL'd store of the last AgentSession per MCP session id.",
+          "defines": [
+            "SessionStore",
+            "_env_int"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.agent_tools",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/agent_tools.py",
+          "purpose": "Agent-level MCP tools for autonomous entity resolution.",
+          "defines": [
+            "_dispatch",
+            "_persist_session",
+            "_serialize_result",
+            "_write_agent_correction",
+            "_write_frame_csv",
+            "handle_agent_tool"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch._exclusions_schema",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._logging",
+            "goldenmatch.core.agent",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.incremental",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.core.quality",
+            "goldenmatch.core.recall_certificate",
+            "goldenmatch.core.retrieval",
+            "goldenmatch.core.sensitivity",
+            "goldenmatch.core.transform",
+            "goldenmatch.mcp",
+            "goldenmatch.mcp._session_ctx",
+            "goldenmatch.mcp._session_store",
+            "goldenmatch.mcp.server"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.document_tools",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/document_tools.py",
+          "purpose": "MCP tools for document/image ingest. Handlers return JSON-serializable dicts, matching",
+          "defines": [
+            "handle_document_tool"
+          ],
+          "imports": [
+            "goldenmatch.documents",
+            "goldenmatch.documents.config",
+            "goldenmatch.documents.schema_io",
+            "goldenmatch.documents.suggest"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.identity_tools",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py",
+          "purpose": "MCP tools for the Identity Graph.",
+          "defines": [
+            "_actor_trust",
+            "_dispatch",
+            "_open",
+            "handle_identity_tool"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store",
+            "goldenmatch.identity"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.memory_tools",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/memory_tools.py",
+          "purpose": "MCP tool surface for Learning Memory.",
+          "defines": [
+            "_adjustment_to_dict",
+            "_correction_to_dict",
+            "_dispatch",
+            "handle_memory_tool"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.learner",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.plugins.builtin",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.routing_tools",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/routing_tools.py",
+          "purpose": "Pure routing-projection helpers behind the plan/explain/lint MCP tools.",
+          "defines": [
+            "_build_plan",
+            "handle_routing_tool",
+            "run_explain_routing",
+            "run_lint_routing",
+            "run_plan_routing"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster_profile",
+            "goldenmatch.core.distributed_routing_rules",
+            "goldenmatch.core.execution_plan",
+            "goldenmatch.core.runtime_profile"
+          ]
+        },
+        {
+          "module": "goldenmatch.mcp.server",
+          "file": "packages/python/goldenmatch/goldenmatch/mcp/server.py",
+          "purpose": "GoldenMatch MCP Server — tools for entity resolution via Claude Desktop.",
+          "defines": [
+            "_RunState",
+            "_build_alias_tools",
+            "_golden_as_table",
+            "_handle_tool",
+            "_initialize",
+            "_load_clusters_json",
+            "_resolve_alias",
+            "_resolve_run_state",
+            "_safe_path_or_error",
+            "_tool_analyze_blocking",
+            "_tool_compare_clusters",
+            "_tool_config_weaknesses",
+            "_tool_convert_splink_config",
+            "_tool_create_domain",
+            "_tool_evaluate",
+            "_tool_explain_match",
+            "_tool_export_results",
+            "_tool_find_duplicates",
+            "_tool_get_cluster",
+            "_tool_get_golden_record",
+            "_tool_get_stats",
+            "_tool_lineage",
+            "_tool_list_clusters",
+            "_tool_list_domains",
+            "_tool_list_runs",
+            "_tool_match_record",
+            "_tool_pprl_auto_config",
+            "_tool_pprl_link",
+            "_tool_profile_data",
+            "_tool_review_config",
+            "_tool_rollback",
+            "_tool_schema_match",
+            "_tool_shatter_cluster",
+            "_tool_suggest_config",
+            "_tool_test_domain",
+            "_tool_unmerge_record",
+            "create_server",
+            "dispatch",
+            "resolve_http_auth_token",
+            "run_server",
+            "run_server_http"
+          ],
+          "imports": [
+            "goldenmatch.config.from_splink",
+            "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core._paths",
+            "goldenmatch.core.agent",
+            "goldenmatch.core.analytics",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.block_analyzer",
+            "goldenmatch.core.compare_clusters",
+            "goldenmatch.core.config_critique",
+            "goldenmatch.core.domain_registry",
+            "goldenmatch.core.evaluate",
+            "goldenmatch.core.explainer",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.match_one",
+            "goldenmatch.core.rollback",
+            "goldenmatch.core.schema_match",
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.surface",
+            "goldenmatch.mcp",
+            "goldenmatch.mcp._session_ctx",
+            "goldenmatch.mcp._session_store",
+            "goldenmatch.mcp.agent_tools",
+            "goldenmatch.mcp.document_tools",
+            "goldenmatch.mcp.identity_tools",
+            "goldenmatch.mcp.memory_tools",
+            "goldenmatch.mcp.routing_tools",
+            "goldenmatch.pprl.autoconfig",
+            "goldenmatch.pprl.protocol",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.native",
+          "file": "packages/python/goldenmatch/goldenmatch/native.py",
+          "purpose": "Public Native Core surface.",
+          "defines": [
+            "string_similarity"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.core.pairs"
+          ]
+        },
+        {
+          "module": "goldenmatch.output",
+          "file": "packages/python/goldenmatch/goldenmatch/output/__init__.py"
+        },
+        {
+          "module": "goldenmatch.output.report",
+          "file": "packages/python/goldenmatch/goldenmatch/output/report.py",
+          "purpose": "Report generators for GoldenMatch runs.",
+          "defines": [
+            "generate_dedupe_report",
+            "generate_match_report"
+          ]
+        },
+        {
+          "module": "goldenmatch.output.writer",
+          "file": "packages/python/goldenmatch/goldenmatch/output/writer.py",
+          "purpose": "Output writer for GoldenMatch results.",
+          "defines": [
+            "write_output"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/__init__.py",
+          "purpose": "GoldenMatch plugin system -- extensible scorers, transforms, blockers, connectors, and golden strategies.",
+          "imports": [
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.base",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/base.py",
+          "purpose": "Base protocols for GoldenMatch plugins.",
+          "defines": [
+            "ConnectorPlugin",
+            "GoldenStrategyPlugin",
+            "ScorerPlugin",
+            "TransformPlugin",
+            "VectorizedScorerPlugin"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.builtin",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/builtin/__init__.py",
+          "purpose": "Predefined golden-strategy plugins (v1.18.2, #predefined-merge-plugins).",
+          "defines": [
+            "register_builtins"
+          ],
+          "imports": [
+            "goldenmatch.plugins.builtin.aggregation",
+            "goldenmatch.plugins.builtin.business",
+            "goldenmatch.plugins.builtin.format",
+            "goldenmatch.plugins.builtin.numeric"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.builtin.aggregation",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/builtin/aggregation.py",
+          "purpose": "Aggregation / telemetry predefined plugins.",
+          "defines": [
+            "AgreementRateStrategy",
+            "CountDistinctStrategy",
+            "CountNonNullStrategy"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.builtin.business",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/builtin/business.py",
+          "purpose": "Business-shaped predefined plugins.",
+          "defines": [
+            "EnumCanonicalStrategy",
+            "FreshnessWithMaxAgeStrategy",
+            "LifecycleStageStrategy",
+            "RegexValidatedStrategy",
+            "SystemOfRecordStrategy",
+            "WeightedByRecencyStrategy",
+            "_parse_date"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.builtin.format",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/builtin/format.py",
+          "purpose": "Format-canonical predefined plugins.",
+          "defines": [
+            "BooleanNormalizeStrategy",
+            "ConcatUniqueStrategy",
+            "EmailNormalizeStrategy",
+            "PhoneDigitsOnlyStrategy",
+            "ShortestValueStrategy",
+            "UrlCanonicalStrategy",
+            "WhitespaceNormalizeStrategy",
+            "_canonicalize_email",
+            "_canonicalize_url"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.builtin.numeric",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/builtin/numeric.py",
+          "purpose": "Numeric-aggregate predefined plugins.",
+          "defines": [
+            "NumericMaxStrategy",
+            "NumericMeanStrategy",
+            "NumericMedianStrategy",
+            "NumericMinStrategy",
+            "NumericSumStrategy",
+            "NumericWeightedAverageStrategy",
+            "_to_float"
+          ]
+        },
+        {
+          "module": "goldenmatch.plugins.registry",
+          "file": "packages/python/goldenmatch/goldenmatch/plugins/registry.py",
+          "purpose": "Plugin registry -- discovers and manages GoldenMatch plugins via entry points.",
+          "defines": [
+            "PluginRegistry"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.builtin"
+          ]
+        },
+        {
+          "module": "goldenmatch.pprl",
+          "file": "packages/python/goldenmatch/goldenmatch/pprl/__init__.py",
+          "purpose": "GoldenMatch PPRL -- Privacy-Preserving Record Linkage."
+        },
+        {
+          "module": "goldenmatch.pprl.autoconfig",
+          "file": "packages/python/goldenmatch/goldenmatch/pprl/autoconfig.py",
+          "purpose": "Auto-configuration for PPRL -- analyze data and recommend optimal parameters.",
+          "defines": [
+            "FieldProfile",
+            "PPRLAutoConfigResult",
+            "_estimate_threshold",
+            "auto_configure_pprl",
+            "auto_configure_pprl_llm",
+            "profile_for_pprl"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.llm_scorer",
+            "goldenmatch.core.scorer",
+            "goldenmatch.pprl.protocol",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.pprl.protocol",
+          "file": "packages/python/goldenmatch/goldenmatch/pprl/protocol.py",
+          "purpose": "PPRL protocol implementation -- trusted third party and SMC modes.",
+          "defines": [
+            "LinkageResult",
+            "PPRLConfig",
+            "PartyData",
+            "_compute_match_bits",
+            "_secret_share_filters",
+            "compute_bloom_filters",
+            "link_smc",
+            "link_trusted_third_party",
+            "run_pprl"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.scorer",
+            "goldenmatch.utils.transforms"
+          ]
+        },
+        {
+          "module": "goldenmatch.prefs",
+          "file": "packages/python/goldenmatch/goldenmatch/prefs/__init__.py"
+        },
+        {
+          "module": "goldenmatch.prefs.store",
+          "file": "packages/python/goldenmatch/goldenmatch/prefs/store.py",
+          "purpose": "Persistent preset store for saving/loading GoldenMatch configs.",
+          "defines": [
+            "PresetStore"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/__init__.py",
+          "purpose": "Reference data — bundled OSS lookups that lift engine accuracy.",
+          "imports": [
+            "goldenmatch.core.acronym",
+            "goldenmatch.refdata.addresses",
+            "goldenmatch.refdata.business",
+            "goldenmatch.refdata.business_aliases",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.refdata.industries",
+            "goldenmatch.refdata.scorer",
+            "goldenmatch.refdata.surnames"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.addresses",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/addresses.py",
+          "purpose": "USPS-style address-token normalization.",
+          "defines": [
+            "AddressNormalizeTransform",
+            "_AddressState",
+            "_build_state_from_file",
+            "_load",
+            "_normalize_token",
+            "_reload",
+            "is_available",
+            "known_tokens",
+            "normalize_address",
+            "register_transforms"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.autoconfig_hooks",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/autoconfig_hooks.py",
+          "purpose": "Auto-config integration for the refdata packs.",
+          "defines": [
+            "_addresses_available",
+            "_business_available",
+            "_given_names_available",
+            "_industries_available",
+            "_surnames_available",
+            "refine_matchkey_field"
+          ],
+          "imports": [
+            "goldenmatch.refdata.addresses",
+            "goldenmatch.refdata.business",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.refdata.industries",
+            "goldenmatch.refdata.surnames"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.business",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/business.py",
+          "purpose": "Business-name normalization.",
+          "defines": [
+            "LegalFormStripTransform",
+            "_BusinessState",
+            "_build_state_from_file",
+            "_load",
+            "_normalize_token",
+            "_reload",
+            "entity_form_variants",
+            "is_available",
+            "known_variants",
+            "register_transforms",
+            "strip_legal_form"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.business_aliases",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/business_aliases.py",
+          "purpose": "Business / brand alias canonicalization for candidate-generation blocking.",
+          "defines": [
+            "BusinessCanonicalTransform",
+            "GivenNameCanonicalTransform",
+            "_BusinessAliasState",
+            "_build_state_from_file",
+            "_load",
+            "_normalize",
+            "_reload",
+            "canonical_company_form",
+            "is_available",
+            "known_canonicals",
+            "register_transforms"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.refdata.business",
+            "goldenmatch.refdata.given_names"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.given_names",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/given_names.py",
+          "purpose": "Given-name alias lookup.",
+          "defines": [
+            "_GivenNameState",
+            "_build_state_from_file",
+            "_load",
+            "_normalize",
+            "_reload",
+            "aliases_of",
+            "are_equivalent",
+            "canonical_form",
+            "export_alias_forms",
+            "is_available"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.industries",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/industries.py",
+          "purpose": "NAICS 2022 industry-code normalization.",
+          "defines": [
+            "NaicsNormalizeTransform",
+            "_IndustriesState",
+            "_build_state_from_file",
+            "_load",
+            "_norm_title",
+            "_reload",
+            "code_for_title",
+            "is_available",
+            "known_codes",
+            "known_titles",
+            "naics_normalize",
+            "register_transforms",
+            "title_for_code"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.scorer",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/scorer.py",
+          "purpose": "Reference-data-aware scorers.",
+          "defines": [
+            "GivenNameAliasedJW",
+            "NameFreqWeightedJW",
+            "_tf_rarity",
+            "register_scorers"
+          ],
+          "imports": [
+            "goldenmatch.plugins.base",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.refdata.surnames"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.scripts",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/scripts/__init__.py"
+        },
+        {
+          "module": "goldenmatch.refdata.scripts.fetch_census_surnames",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/scripts/fetch_census_surnames.py",
+          "purpose": "Regenerate ``goldenmatch/refdata/data/census_surnames_2010_top10k.csv``.",
+          "defines": [
+            "main"
+          ]
+        },
+        {
+          "module": "goldenmatch.refdata.surnames",
+          "file": "packages/python/goldenmatch/goldenmatch/refdata/surnames.py",
+          "purpose": "US Census 2010 top-10K surname frequency lookup.",
+          "defines": [
+            "_SurnameState",
+            "_build_state_from_file",
+            "_load",
+            "_normalize",
+            "_reload",
+            "export_counts",
+            "is_available",
+            "surname_count",
+            "surname_frequency",
+            "surname_idf",
+            "surname_rank"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/__init__.py",
+          "purpose": "Sail tier (distributed, Spark Connect) -- the distributed sibling of the",
+          "imports": [
+            "goldenmatch.sail.identity"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.clustering",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/clustering.py",
+          "purpose": "Weakly-connected components on Sail (Spark Connect) -- the Union-Find",
+          "defines": [
+            "_truncate_lineage",
+            "connected_components",
+            "connected_components_scale"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.golden",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/golden.py",
+          "purpose": "Golden-record survivorship on Sail (Spark Connect), distributed.",
+          "defines": [
+            "build_golden",
+            "make_merge_udf"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.golden"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.identity",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/identity.py",
+          "purpose": "S5: identity-on-Sail — distributed create + edge-emit (Stage S5).",
+          "defines": [
+            "IdentityGraphFrames",
+            "_id_scheme",
+            "build_identity_events",
+            "build_identity_graph",
+            "build_identity_nodes",
+            "build_same_as_edges",
+            "build_source_records",
+            "derive_record_ids",
+            "entity_id_for_members",
+            "mint_entity_ids",
+            "record_id_for_row"
+          ],
+          "imports": [
+            "goldenmatch.core._hashing",
+            "goldenmatch.identity.fingerprint_batch",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.pipeline",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/pipeline.py",
+          "purpose": "End-to-end Sail pipeline: load -> block -> score -> dedup -> WCC -> golden,",
+          "defines": [
+            "SailPipelineResult",
+            "_validate_sail_pipeline_supported",
+            "run_sail_pipeline"
+          ],
+          "imports": [
+            "goldenmatch.sail.clustering",
+            "goldenmatch.sail.golden",
+            "goldenmatch.sail.identity",
+            "goldenmatch.sail.scorers",
+            "goldenmatch.sail.scoring"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.scorers",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/scorers.py",
+          "purpose": "Scorers as Spark pandas UDFs for the Sail tier (Spark Connect).",
+          "defines": [
+            "_native_scores",
+            "_pure_scores",
+            "make_scorer_udf",
+            "score_batch"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.scoring",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/scoring.py",
+          "purpose": "S1 score+dedup on Sail (Spark Connect): a block self-join scored by a",
+          "defines": [
+            "score_and_dedup"
+          ],
+          "imports": [
+            "goldenmatch.sail.scorers"
+          ]
+        },
+        {
+          "module": "goldenmatch.sail.session",
+          "file": "packages/python/goldenmatch/goldenmatch/sail/session.py",
+          "purpose": "Sail (Spark Connect) session helpers. Sail is programmed via PySpark /",
+          "defines": [
+            "connect"
+          ]
+        },
+        {
+          "module": "goldenmatch.snowflake",
+          "file": "packages/python/goldenmatch/goldenmatch/snowflake/__init__.py",
+          "purpose": "Snowflake handler module -- the inside of the goldenmatch UDF surface."
+        },
+        {
+          "module": "goldenmatch.snowflake.udfs",
+          "file": "packages/python/goldenmatch/goldenmatch/snowflake/udfs.py",
+          "purpose": "Snowflake handler functions for goldenmatch UDFs and Stored Procedures.",
+          "defines": [
+            "DedupeClusters",
+            "DedupeFull",
+            "DedupePairs",
+            "_expr_apply",
+            "_identity_store",
+            "_import_dir",
+            "_polars",
+            "_resolve_db_path",
+            "_series_apply",
+            "canonicalize_address",
+            "canonicalize_url",
+            "correction_add",
+            "health_score",
+            "identity_conflicts",
+            "identity_history",
+            "identity_list",
+            "identity_resolve",
+            "identity_view",
+            "normalize_date",
+            "normalize_email",
+            "normalize_name_proper",
+            "normalize_phone",
+            "scan_table",
+            "strip",
+            "whitespace_normalize"
+          ],
+          "imports": [
+            "goldenflow.transforms.address",
+            "goldenflow.transforms.dates",
+            "goldenflow.transforms.email",
+            "goldenflow.transforms.names",
+            "goldenflow.transforms.phone",
+            "goldenflow.transforms.url",
+            "goldenmatch.identity.query",
+            "goldenmatch.identity.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/__init__.py",
+          "purpose": "GoldenSynonym — a trained, domain-aware synonym scorer (GS1: framework).",
+          "defines": [
+            "register_synonym_scorer"
+          ],
+          "imports": [
+            "goldenmatch.drug",
+            "goldenmatch.model",
+            "goldenmatch.plugins.registry",
+            "goldenmatch.providers",
+            "goldenmatch.scorer",
+            "goldenmatch.table"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.drug",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/drug.py",
+          "purpose": "The trained `drug` SynonymModel (GS2).",
+          "defines": [
+            "DrugSynonymModel",
+            "register_drug_model"
+          ],
+          "imports": [
+            "goldenmatch.synonym.providers",
+            "goldenmatch.synonym.train"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.model",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/model.py",
+          "purpose": "SynonymModel: the trained, per-domain semantic synonym scorer slot.",
+          "defines": [
+            "StubSynonymModel",
+            "SynonymModel"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.providers",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/providers.py",
+          "purpose": "Per-domain SynonymModel provider registry.",
+          "defines": [
+            "clear_synonym_models",
+            "register_synonym_model",
+            "resolve_synonym_model"
+          ],
+          "imports": [
+            "goldenmatch.synonym.model"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.scorer",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/scorer.py",
+          "purpose": "SynonymScorer: a pluggable, model-capable synonym ScorerPlugin.",
+          "defines": [
+            "SynonymScorer"
+          ],
+          "imports": [
+            "goldenmatch.synonym.model",
+            "goldenmatch.synonym.providers",
+            "goldenmatch.synonym.table"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.table",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/table.py",
+          "purpose": "Per-domain synonym alias table (the deterministic fast-path + GS2's training",
+          "defines": [
+            "SynonymTable",
+            "_normalize"
+          ]
+        },
+        {
+          "module": "goldenmatch.synonym.train",
+          "file": "packages/python/goldenmatch/goldenmatch/synonym/train.py",
+          "purpose": "Self-contained trainer for the drug SynonymModel (GS2).",
+          "defines": [
+            "_jaccard",
+            "_ngrams",
+            "_norm",
+            "_sigmoid",
+            "build_examples",
+            "load_groups",
+            "pair_features",
+            "save_model",
+            "train",
+            "train_default"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/__init__.py"
+        },
+        {
+          "module": "goldenmatch.tui.app",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/app.py",
+          "purpose": "GoldenMatch Interactive TUI -- main Textual application.",
+          "defines": [
+            "GoldenMatchApp"
+          ],
+          "imports": [
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.review_queue",
+            "goldenmatch.tui.engine",
+            "goldenmatch.tui.screens.autoconfig_screen",
+            "goldenmatch.tui.screens.triage_screen",
+            "goldenmatch.tui.sidebar",
+            "goldenmatch.tui.tabs.boost_tab",
+            "goldenmatch.tui.tabs.config_tab",
+            "goldenmatch.tui.tabs.controller_tab",
+            "goldenmatch.tui.tabs.corrections_tab",
+            "goldenmatch.tui.tabs.data_tab",
+            "goldenmatch.tui.tabs.export_tab",
+            "goldenmatch.tui.tabs.golden_tab",
+            "goldenmatch.tui.tabs.matches_tab",
+            "goldenmatch.tui.tabs.suggest_tab",
+            "goldenmatch.tui.widgets.progress_overlay",
+            "goldenmatch.tui.widgets.threshold_slider"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.engine",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/engine.py",
+          "purpose": "MatchEngine — shared foundation for TUI and preview mode.",
+          "defines": [
+            "ControllerTelemetry",
+            "EngineResult",
+            "EngineStats",
+            "MatchEngine"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.autofix",
+            "goldenmatch.core.blocker",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.golden",
+            "goldenmatch.core.ingest",
+            "goldenmatch.core.llm_cluster",
+            "goldenmatch.core.llm_scorer",
+            "goldenmatch.core.match_one",
+            "goldenmatch.core.matchkey",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.core.profiler",
+            "goldenmatch.core.scorer",
+            "goldenmatch.core.standardize",
+            "goldenmatch.core.validate"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.screens",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/__init__.py",
+          "purpose": "TUI screens for GoldenMatch."
+        },
+        {
+          "module": "goldenmatch.tui.screens.autoconfig_screen",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/autoconfig_screen.py",
+          "purpose": "Auto-config summary screen — first screen for zero-config mode.",
+          "defines": [
+            "AutoConfigScreen"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.screens.golden_edit_modal",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/golden_edit_modal.py",
+          "purpose": "Golden tab inline-edit modal (#437 surface sync, Phase 4).",
+          "defines": [
+            "GoldenEditModal",
+            "_build_correction",
+            "_get_store"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.screens.matches_correction_modal",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/matches_correction_modal.py",
+          "purpose": "Matches tab pair-correction modal (#437 surface sync, Phase 4).",
+          "defines": [
+            "MatchesCorrectionModal",
+            "_build_correction",
+            "_get_store"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.screens.setup_wizard",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/setup_wizard.py",
+          "purpose": "Setup wizard — guides users through GPU, API, and database configuration.",
+          "defines": [
+            "SetupWizard"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.screens.triage_screen",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/screens/triage_screen.py",
+          "purpose": "Guided review-queue triage screen.",
+          "defines": [
+            "TriageScreen"
+          ],
+          "imports": [
+            "goldenmatch.tui.screens.matches_correction_modal"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.sidebar",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/sidebar.py",
+          "purpose": "Sidebar widget showing config summary and live stats.",
+          "defines": [
+            "Sidebar"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/__init__.py"
+        },
+        {
+          "module": "goldenmatch.tui.tabs.boost_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/boost_tab.py",
+          "purpose": "Boost tab -- active learning with human-in-the-loop pair labeling.",
+          "defines": [
+            "BoostTab",
+            "record_boost_label"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.boost",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.memory.corrections",
+            "goldenmatch.core.memory.store",
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.config_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/config_tab.py",
+          "purpose": "Config tab -- matchkey builder with live feedback.",
+          "defines": [
+            "ConfigTab",
+            "FieldRow",
+            "MatchkeyCard"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.controller_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/controller_tab.py",
+          "purpose": "Controller tab — surfaces AutoConfigController telemetry (v1.7-v1.12).",
+          "defines": [
+            "ControllerTab",
+            "_decisions_list",
+            "_drift",
+            "_elapsed_ms",
+            "_health",
+            "_num",
+            "_pct",
+            "_stop_reason",
+            "_truncate"
+          ],
+          "imports": [
+            "goldenmatch.tui.engine"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.corrections_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/corrections_tab.py",
+          "purpose": "Corrections tab -- inspect MemoryStore corrections (#437 surface sync, Phase 4).",
+          "defines": [
+            "CorrectionsTab"
+          ],
+          "imports": [
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.data_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/data_tab.py",
+          "purpose": "Data tab — file browser and profiler display.",
+          "defines": [
+            "DataTab"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.export_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/export_tab.py",
+          "purpose": "Export tab — save config, presets, and run full jobs.",
+          "defines": [
+            "ExportTab"
+          ],
+          "imports": [
+            "goldenmatch.prefs.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.golden_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/golden_tab.py",
+          "purpose": "Golden tab — golden record preview with confidence scores.",
+          "defines": [
+            "GoldenTab"
+          ],
+          "imports": [
+            "goldenmatch.tui.engine",
+            "goldenmatch.tui.screens.golden_edit_modal"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.matches_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/matches_tab.py",
+          "purpose": "Matches tab -- cluster/match viewer with color-coded scores.",
+          "defines": [
+            "MatchesTab"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.tui.engine",
+            "goldenmatch.tui.screens.matches_correction_modal",
+            "goldenmatch.tui.widgets.threshold_slider"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.tabs.suggest_tab",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/tabs/suggest_tab.py",
+          "purpose": "Suggestions tab -- config-healer suggestions for the loaded dataset (Task 9).",
+          "defines": [
+            "SuggestTab"
+          ],
+          "imports": [
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.apply",
+            "goldenmatch.core.suggest.surface"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.widgets",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/widgets/__init__.py"
+        },
+        {
+          "module": "goldenmatch.tui.widgets.progress_overlay",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/widgets/progress_overlay.py",
+          "purpose": "Full-screen progress overlay for first-run matching.",
+          "defines": [
+            "ProgressOverlay"
+          ]
+        },
+        {
+          "module": "goldenmatch.tui.widgets.threshold_slider",
+          "file": "packages/python/goldenmatch/goldenmatch/tui/widgets/threshold_slider.py",
+          "purpose": "Live threshold slider widget with instant re-clustering.",
+          "defines": [
+            "ThresholdSlider"
+          ]
+        },
+        {
+          "module": "goldenmatch.utils",
+          "file": "packages/python/goldenmatch/goldenmatch/utils/__init__.py"
+        },
+        {
+          "module": "goldenmatch.utils.transforms",
+          "file": "packages/python/goldenmatch/goldenmatch/utils/transforms.py",
+          "purpose": "Field transform utilities for GoldenMatch.",
+          "defines": [
+            "_bloom_filter_transform",
+            "_clk_from_prepared",
+            "_parse_bloom_params",
+            "_prepare_bloom_input",
+            "apply_transform",
+            "apply_transforms",
+            "bloom_clk_batch"
+          ],
+          "imports": [
+            "goldenmatch.core._native_loader",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.web",
+          "file": "packages/python/goldenmatch/goldenmatch/web/__init__.py",
+          "purpose": "GoldenMatch local web UI."
+        },
+        {
+          "module": "goldenmatch.web.app",
+          "file": "packages/python/goldenmatch/goldenmatch/web/app.py",
+          "defines": [
+            "SPAStaticFiles",
+            "create_app",
+            "resolve_web_auth_token"
+          ],
+          "imports": [
+            "goldenmatch.web.routers",
+            "goldenmatch.web.state"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.controller_telemetry",
+          "file": "packages/python/goldenmatch/goldenmatch/web/controller_telemetry.py",
+          "purpose": "Serialize AutoConfigController output (ComplexityProfile + RunHistory) into",
+          "defines": [
+            "_blocking_summary",
+            "_cluster_summary",
+            "_column_priors",
+            "_committed_matchkeys_summary",
+            "_decisions",
+            "_errors",
+            "_execution_plan",
+            "_health_str",
+            "_indicators",
+            "_negative_evidence",
+            "_scoring_summary",
+            "_throughput_summary",
+            "_truncate_repr",
+            "serialize_telemetry"
+          ],
+          "imports": [
+            "goldenmatch.core.throughput_verify"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.labels",
+          "file": "packages/python/goldenmatch/goldenmatch/web/labels.py",
+          "purpose": "Web-UI label store.",
+          "defines": [
+            "_canonical_pair",
+            "append_label",
+            "read_labels_dedup"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.pair_prose",
+          "file": "packages/python/goldenmatch/goldenmatch/web/pair_prose.py",
+          "purpose": "Attach a one-line natural language explanation to lineage pair records.",
+          "defines": [
+            "enrich_pairs",
+            "prose_for_pair",
+            "with_prose"
+          ],
+          "imports": [
+            "goldenmatch.core.explain"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.preview",
+          "file": "packages/python/goldenmatch/goldenmatch/web/preview.py",
+          "defines": [
+            "_build_config",
+            "_clusters_csv",
+            "run_preview"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.frame",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.web.registry",
+            "goldenmatch.web.runs"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.registry",
+          "file": "packages/python/goldenmatch/goldenmatch/web/registry.py",
+          "defines": [
+            "PreviewEntry",
+            "PreviewRegistry"
+          ],
+          "imports": [
+            "goldenmatch.web.runs"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/__init__.py"
+        },
+        {
+          "module": "goldenmatch.web.routers.autoconfig",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/autoconfig.py",
+          "purpose": "POST /api/v1/autoconfig — let goldenmatch's profiler suggest a starting RulesPayload.",
+          "defines": [
+            "_autoconfigure",
+            "_pick_matchkeys",
+            "_ui_safe_field",
+            "autoconfigure"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.compare",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/compare.py",
+          "purpose": "POST /api/v1/compare — CCMS comparison of two runs on the same dataset.",
+          "defines": [
+            "CompareRequest",
+            "_clusters_dict",
+            "_find_run",
+            "compare"
+          ],
+          "imports": [
+            "goldenmatch.core.compare_clusters",
+            "goldenmatch.core.frame",
+            "goldenmatch.web"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.controller",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/controller.py",
+          "purpose": "GET /api/v1/controller/telemetry — surface the AutoConfigController's last",
+          "defines": [
+            "telemetry"
+          ],
+          "imports": [
+            "goldenmatch.web.controller_telemetry"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.documents",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/documents.py",
+          "purpose": "POST /api/v1/documents/{suggest-schema,ingest} -- HTTP surface over goldenmatch.documents.",
+          "defines": [
+            "_save_uploads",
+            "ingest_endpoint",
+            "suggest_schema_endpoint"
+          ],
+          "imports": [
+            "goldenmatch.documents",
+            "goldenmatch.documents.config",
+            "goldenmatch.documents.schema_io",
+            "goldenmatch.documents.suggest"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.domains",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/domains.py",
+          "purpose": "GET /api/v1/domains — list available domain rulebooks.",
+          "defines": [
+            "list_domains"
+          ],
+          "imports": [
+            "goldenmatch.core.domain_registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.evaluation",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/evaluation.py",
+          "purpose": "GET /api/v1/runs/{name}/evaluation — F1/precision/recall vs steward labels.",
+          "defines": [
+            "_find_run",
+            "run_evaluation"
+          ],
+          "imports": [
+            "goldenmatch.core.evaluate",
+            "goldenmatch.web",
+            "goldenmatch.web.labels",
+            "goldenmatch.web.pair_prose"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.identity",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/identity.py",
+          "purpose": "REST endpoints for the Identity Graph.",
+          "defines": [
+            "MergeRequest",
+            "SplitRequest",
+            "_store_for",
+            "by_record_endpoint",
+            "conflicts_endpoint",
+            "evidence_endpoint",
+            "get_endpoint",
+            "history_endpoint",
+            "list_endpoint",
+            "merge_endpoint",
+            "split_endpoint",
+            "stats"
+          ],
+          "imports": [
+            "goldenmatch.identity"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.labels",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/labels.py",
+          "defines": [
+            "LabelIn",
+            "_mirror_to_memory_store",
+            "list_labels",
+            "post_label"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.web.labels"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.match",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/match.py",
+          "purpose": "POST /api/v1/match — one-to-many target × reference workflow.",
+          "defines": [
+            "MatchRequest",
+            "_execute_match",
+            "_safe_resolve",
+            "match_run"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.web.preview"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.memory",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/memory.py",
+          "purpose": "GET /api/v1/memory/{corrections,stats} + POST /api/v1/memory/learn.",
+          "defines": [
+            "CorrectionCreate",
+            "_serialize_correction",
+            "create_correction",
+            "list_corrections",
+            "stats",
+            "trigger_learn"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.core.memory.store"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.plugins",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/plugins.py",
+          "purpose": "GET /api/v1/plugins (#predefined-merge-plugins surface sync, v1.19.0).",
+          "defines": [
+            "_build_response",
+            "list_plugins"
+          ],
+          "imports": [
+            "goldenmatch.plugins.builtin",
+            "goldenmatch.plugins.registry"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.preview",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/preview.py",
+          "defines": [
+            "PreviewRequest",
+            "SampleSpec",
+            "_reject_unsupported_scorers",
+            "preview"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.web.preview"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.project",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/project.py",
+          "defines": [
+            "get_project"
+          ],
+          "imports": [
+            "goldenmatch.web.rules",
+            "goldenmatch.web.runs"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.quality",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/quality.py",
+          "purpose": "GET /api/v1/quality — scan data.csv via GoldenCheck (no fixes applied).",
+          "defines": [
+            "_execute_scan",
+            "quality"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.quality"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.rules",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/rules.py",
+          "defines": [
+            "_seeded_rules",
+            "get_rules",
+            "put_rules",
+            "save_rules"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.web.rules"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.run",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/run.py",
+          "purpose": "POST /api/v1/run — execute a real (non-sampled) run, write to disk.",
+          "defines": [
+            "RunRequest",
+            "_execute_run",
+            "run_real"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.lineage",
+            "goldenmatch.core.pipeline",
+            "goldenmatch.web.preview",
+            "goldenmatch.web.settings"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.runs",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/runs.py",
+          "defines": [
+            "_find_run",
+            "clusters",
+            "detail",
+            "manifest",
+            "row",
+            "run_labels",
+            "run_review"
+          ],
+          "imports": [
+            "goldenmatch.web",
+            "goldenmatch.web.labels",
+            "goldenmatch.web.pair_prose"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.sensitivity",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/sensitivity.py",
+          "purpose": "POST /api/v1/sensitivity — sweep one parameter, compare each point to baseline.",
+          "defines": [
+            "SensitivityRequest",
+            "_execute_sweep",
+            "sensitivity"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.sensitivity",
+            "goldenmatch.web.preview"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.settings",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/settings.py",
+          "purpose": "GET / PUT /api/v1/settings — persisted user-level preferences.",
+          "defines": [
+            "get_settings",
+            "put_settings"
+          ],
+          "imports": [
+            "goldenmatch.web.settings"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.suggest",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/suggest.py",
+          "purpose": "GET /api/v1/suggest — config-healer suggestions for the workbench dataset.",
+          "defines": [
+            "_execute_suggest",
+            "suggest"
+          ],
+          "imports": [
+            "goldenmatch._polars_lazy",
+            "goldenmatch.core.autoconfig",
+            "goldenmatch.core.suggest",
+            "goldenmatch.core.suggest.surface",
+            "goldenmatch.web.preview"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.routers.unmerge",
+          "file": "packages/python/goldenmatch/goldenmatch/web/routers/unmerge.py",
+          "purpose": "POST /api/v1/runs/{name}/unmerge — surgically split a saved run's clusters.",
+          "defines": [
+            "UnmergeRequest",
+            "_find_run",
+            "_reconstruct_clusters",
+            "_record_steward_corrections",
+            "_write_back",
+            "post_unmerge"
+          ],
+          "imports": [
+            "goldenmatch._api",
+            "goldenmatch.core.cluster",
+            "goldenmatch.core.frame",
+            "goldenmatch.web"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.rules",
+          "file": "packages/python/goldenmatch/goldenmatch/web/rules.py",
+          "defines": [
+            "_extract_standardization",
+            "load_rules_from_yaml"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.runs",
+          "file": "packages/python/goldenmatch/goldenmatch/web/runs.py",
+          "defines": [
+            "RunManifest",
+            "RunRef",
+            "_load_source_df",
+            "cluster_detail",
+            "cluster_summaries",
+            "discover_runs",
+            "lineage_pair_keys",
+            "load_clusters_df",
+            "load_lineage",
+            "load_run_manifest",
+            "source_row"
+          ],
+          "imports": [
+            "goldenmatch.core.frame",
+            "goldenmatch.core.io_arrow"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.settings",
+          "file": "packages/python/goldenmatch/goldenmatch/web/settings.py",
+          "purpose": "Persisted user-level web UI preferences.",
+          "defines": [
+            "WebSettings",
+            "_config_dir",
+            "load_settings",
+            "save_settings",
+            "settings_path"
+          ]
+        },
+        {
+          "module": "goldenmatch.web.state",
+          "file": "packages/python/goldenmatch/goldenmatch/web/state.py",
+          "defines": [
+            "AppState"
+          ],
+          "imports": [
+            "goldenmatch.config.schemas",
+            "goldenmatch.web.registry"
+          ]
+        }
+      ]
+    },
+    "goldencheck": {
+      "root": "packages/python/goldencheck/goldencheck",
+      "module_count": 113,
+      "modules": [
+        {
+          "module": "goldencheck",
+          "file": "packages/python/goldencheck/goldencheck/__init__.py",
+          "purpose": "GoldenCheck — data validation that discovers rules from your data.",
+          "defines": [
+            "__getattr__"
+          ],
+          "imports": [
+            "goldencheck.agent",
+            "goldencheck.baseline",
+            "goldencheck.cell_quality",
+            "goldencheck.config.loader",
+            "goldencheck.config.schema",
+            "goldencheck.config.writer",
+            "goldencheck.denial.mine",
+            "goldencheck.denial.models",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.differ",
+            "goldencheck.engine.fixer",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.triage",
+            "goldencheck.engine.validator",
+            "goldencheck.functional_dependencies",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile",
+            "goldencheck.notebook",
+            "goldencheck.semantic.classifier"
+          ]
+        },
+        {
+          "module": "goldencheck._polars_lazy",
+          "file": "packages/python/goldencheck/goldencheck/_polars_lazy.py",
+          "purpose": "Lazy Polars proxy — Phase 0 of the Polars eviction (make Polars optional).",
+          "defines": [
+            "_LazyPolars"
+          ]
+        },
+        {
+          "module": "goldencheck.a2a",
+          "file": "packages/python/goldencheck/goldencheck/a2a/__init__.py",
+          "purpose": "GoldenCheck A2A (Agent-to-Agent) server.",
+          "imports": [
+            "goldencheck.a2a.server"
+          ]
+        },
+        {
+          "module": "goldencheck.a2a.server",
+          "file": "packages/python/goldencheck/goldencheck/a2a/server.py",
+          "purpose": "A2A (Agent-to-Agent) protocol server for GoldenCheck — aiohttp-based.",
+          "defines": [
+            "_check_auth",
+            "_handle_agent_card",
+            "_handle_task_cancel",
+            "_handle_task_get",
+            "_handle_tasks_send",
+            "_handle_tasks_send_subscribe",
+            "_sse_encode",
+            "create_a2a_app",
+            "run_a2a_server"
+          ],
+          "imports": [
+            "goldencheck.a2a.skills"
+          ]
+        },
+        {
+          "module": "goldencheck.a2a.skills",
+          "file": "packages/python/goldencheck/goldencheck/a2a/skills.py",
+          "purpose": "Skill dispatch for the GoldenCheck A2A server.",
+          "defines": [
+            "_extract_params",
+            "_finding_to_dict",
+            "_handle_analyze_data",
+            "_handle_compare_domains",
+            "_handle_configure",
+            "_handle_explain",
+            "_handle_fix",
+            "_handle_handoff",
+            "_handle_review",
+            "_handle_scan",
+            "_handle_validate",
+            "_review_item_to_dict",
+            "dispatch_skill"
+          ],
+          "imports": [
+            "goldencheck.agent.handoff",
+            "goldencheck.agent.intelligence",
+            "goldencheck.agent.review_queue",
+            "goldencheck.config.loader",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.fixer",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.triage",
+            "goldencheck.engine.validator",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.agent",
+          "file": "packages/python/goldencheck/goldencheck/agent/__init__.py",
+          "purpose": "GoldenCheck agent — intelligence layer, review queue, and pipeline handoff.",
+          "imports": [
+            "goldencheck.agent.handoff",
+            "goldencheck.agent.intelligence",
+            "goldencheck.agent.review_queue"
+          ]
+        },
+        {
+          "module": "goldencheck.agent.handoff",
+          "file": "packages/python/goldencheck/goldencheck/agent/handoff.py",
+          "purpose": "Pipeline handoff module — generates a structured handoff dict for downstream consumers.",
+          "defines": [
+            "_attestation",
+            "_build_columns",
+            "_compute_file_hash",
+            "findings_to_fbc",
+            "generate_handoff"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.agent.intelligence",
+          "file": "packages/python/goldencheck/goldencheck/agent/intelligence.py",
+          "purpose": "Intelligence layer — strategy selection, finding explanation, domain comparison.",
+          "defines": [
+            "AgentSession",
+            "StrategyDecision",
+            "_check_llm_available",
+            "_detect_domain",
+            "build_alternatives",
+            "compare_domains",
+            "explain_column",
+            "explain_finding",
+            "findings_to_fbc",
+            "select_strategy"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.sampler",
+            "goldencheck.engine.scanner",
+            "goldencheck.llm.providers",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile",
+            "goldencheck.semantic.classifier"
+          ]
+        },
+        {
+          "module": "goldencheck.agent.review_queue",
+          "file": "packages/python/goldencheck/goldencheck/agent/review_queue.py",
+          "purpose": "Confidence-gated review queue for GoldenCheck's DQ agent.",
+          "defines": [
+            "ReviewItem",
+            "ReviewQueue",
+            "_Backend",
+            "_MemoryBackend",
+            "_PostgresBackend",
+            "_SQLiteBackend",
+            "_finding_to_review_item"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline",
+          "file": "packages/python/goldencheck/goldencheck/baseline/__init__.py",
+          "purpose": "Deep profiling baseline — learn-once, monitor-forever.",
+          "defines": [
+            "create_baseline",
+            "load_baseline"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.constraints",
+            "goldencheck.baseline.correlation",
+            "goldencheck.baseline.models",
+            "goldencheck.baseline.patterns",
+            "goldencheck.baseline.priors",
+            "goldencheck.baseline.semantic",
+            "goldencheck.baseline.statistical",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.sampler",
+            "goldencheck.engine.scanner"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.constraints",
+          "file": "packages/python/goldencheck/goldencheck/baseline/constraints.py",
+          "purpose": "Constraint mining: functional dependencies, candidate keys, temporal orders.",
+          "defines": [
+            "_mine_candidate_keys",
+            "_mine_functional_dependencies",
+            "_mine_temporal_orders",
+            "mine_constraints"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.models"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.correlation",
+          "file": "packages/python/goldencheck/goldencheck/baseline/correlation.py",
+          "purpose": "Correlation analyzer — Pearson (numeric-numeric) and Cramer's V (categorical-categorical).",
+          "defines": [
+            "_cramers_v",
+            "_pearson_entry",
+            "_strength",
+            "analyze_correlations"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.models",
+            "goldencheck.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.models",
+          "file": "packages/python/goldencheck/goldencheck/baseline/models.py",
+          "purpose": "Pydantic models for deep profiling baseline profiles.",
+          "defines": [
+            "BaselineProfile",
+            "ConfidencePrior",
+            "CorrelationEntry",
+            "FunctionalDependency",
+            "PatternGrammar",
+            "StatProfile",
+            "TemporalOrder"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.patterns",
+          "file": "packages/python/goldencheck/goldencheck/baseline/patterns.py",
+          "purpose": "Pattern grammar inducer — derive regex grammars from string columns.",
+          "defines": [
+            "_escape_literal",
+            "_induce_column_grammars",
+            "_skeleton_to_regex",
+            "_to_skeleton",
+            "induce_patterns"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.models"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.priors",
+          "file": "packages/python/goldencheck/goldencheck/baseline/priors.py",
+          "purpose": "Confidence prior builder for deep profiling baseline.",
+          "defines": [
+            "apply_prior",
+            "build_priors"
+          ],
+          "imports": [
+            "goldencheck.baseline.models",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.semantic",
+          "file": "packages/python/goldencheck/goldencheck/baseline/semantic.py",
+          "purpose": "Semantic type inferrer — maps DataFrame columns to semantic type labels.",
+          "defines": [
+            "_infer_with_embeddings",
+            "_infer_with_keywords",
+            "_match_column_keywords",
+            "infer_semantic_types"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldencheck.baseline.statistical",
+          "file": "packages/python/goldencheck/goldencheck/baseline/statistical.py",
+          "purpose": "Statistical profiler — distributions, Benford's law, entropy, percentile bounds.",
+          "defines": [
+            "_categorical_entropy",
+            "_compute_benford",
+            "_extract_leading_digits",
+            "_fit_distribution",
+            "_histogram_entropy",
+            "_leading_digit_counts",
+            "_maybe_benford",
+            "_numeric_bounds",
+            "_params_to_dict",
+            "_profile_categorical",
+            "_profile_numeric",
+            "profile_statistical"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.models",
+            "goldencheck.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldencheck.cell_quality",
+          "file": "packages/python/goldencheck/goldencheck/cell_quality.py",
+          "purpose": "Per-cell data-quality scoring -- the bridge GoldenMatch consumes for",
+          "defines": [
+            "_apply",
+            "_clusters",
+            "_future_penalties",
+            "_fuzzy_penalties",
+            "cell_quality"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.core._native_loader",
+            "goldencheck.profilers.fuzzy_values"
+          ]
+        },
+        {
+          "module": "goldencheck.cli",
+          "file": "packages/python/goldencheck/goldencheck/cli/__init__.py"
+        },
+        {
+          "module": "goldencheck.cli.demo_data",
+          "file": "packages/python/goldencheck/goldencheck/cli/demo_data.py",
+          "purpose": "Generate sample data for the demo command.",
+          "defines": [
+            "generate_demo_csv"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldencheck.cli.init_wizard",
+          "file": "packages/python/goldencheck/goldencheck/cli/init_wizard.py",
+          "purpose": "Interactive setup wizard for goldencheck init.",
+          "defines": [
+            "run_init_wizard"
+          ],
+          "imports": [
+            "goldencheck.config.schema",
+            "goldencheck.config.writer",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.triage"
+          ]
+        },
+        {
+          "module": "goldencheck.cli.main",
+          "file": "packages/python/goldencheck/goldencheck/cli/main.py",
+          "purpose": "CLI entry points for GoldenCheck.",
+          "defines": [
+            "_DefaultCommandGroup",
+            "_cli_error_handler",
+            "_do_scan",
+            "_version_callback",
+            "agent_serve",
+            "baseline",
+            "demo",
+            "denial_constraints",
+            "diff",
+            "evaluate",
+            "fix",
+            "history",
+            "init",
+            "learn",
+            "main",
+            "mcp_serve",
+            "refs",
+            "review",
+            "scan",
+            "scan_db",
+            "schedule",
+            "serve",
+            "validate",
+            "watch"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldencheck._polars_lazy",
+            "goldencheck.a2a.server",
+            "goldencheck.baseline",
+            "goldencheck.cli.demo_data",
+            "goldencheck.cli.init_wizard",
+            "goldencheck.config.loader",
+            "goldencheck.config.schema",
+            "goldencheck.config.writer",
+            "goldencheck.denial.mine",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.db_scanner",
+            "goldencheck.engine.differ",
+            "goldencheck.engine.evaluate",
+            "goldencheck.engine.fixer",
+            "goldencheck.engine.history",
+            "goldencheck.engine.notifier",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.referential",
+            "goldencheck.engine.sampler",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.scheduler",
+            "goldencheck.engine.triage",
+            "goldencheck.engine.validator",
+            "goldencheck.engine.watcher",
+            "goldencheck.llm.rule_generator",
+            "goldencheck.mcp.server",
+            "goldencheck.models.finding",
+            "goldencheck.reporters.ci_reporter",
+            "goldencheck.reporters.html_reporter",
+            "goldencheck.reporters.json_reporter",
+            "goldencheck.reporters.rich_console",
+            "goldencheck.server",
+            "goldencheck.tui.app"
+          ]
+        },
+        {
+          "module": "goldencheck.config",
+          "file": "packages/python/goldencheck/goldencheck/config/__init__.py"
+        },
+        {
+          "module": "goldencheck.config.loader",
+          "file": "packages/python/goldencheck/goldencheck/config/loader.py",
+          "purpose": "Load goldencheck.yml configuration.",
+          "defines": [
+            "load_config"
+          ],
+          "imports": [
+            "goldencheck.config.schema"
+          ]
+        },
+        {
+          "module": "goldencheck.config.schema",
+          "file": "packages/python/goldencheck/goldencheck/config/schema.py",
+          "purpose": "Pydantic models for goldencheck.yml configuration.",
+          "defines": [
+            "ColumnRule",
+            "GoldenCheckConfig",
+            "IgnoreEntry",
+            "RelationRule",
+            "Settings"
+          ]
+        },
+        {
+          "module": "goldencheck.config.settings",
+          "file": "packages/python/goldencheck/goldencheck/config/settings.py",
+          "purpose": "Global and project settings persistence.",
+          "defines": [
+            "global_settings_path",
+            "load_settings",
+            "save_settings"
+          ]
+        },
+        {
+          "module": "goldencheck.config.writer",
+          "file": "packages/python/goldencheck/goldencheck/config/writer.py",
+          "purpose": "Write goldencheck.yml configuration.",
+          "defines": [
+            "save_config"
+          ],
+          "imports": [
+            "goldencheck.config.schema"
+          ]
+        },
+        {
+          "module": "goldencheck.core",
+          "file": "packages/python/goldencheck/goldencheck/core/__init__.py",
+          "purpose": "Core internals for GoldenCheck (native-kernel loader/gate)."
+        },
+        {
+          "module": "goldencheck.core._native_loader",
+          "file": "packages/python/goldencheck/goldencheck/core/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``goldencheck._native`` acceleration module.",
+          "defines": [
+            "_has_symbol",
+            "native_available",
+            "native_enabled",
+            "native_module"
+          ],
+          "imports": [
+            "goldencheck._native"
+          ]
+        },
+        {
+          "module": "goldencheck.core.frame",
+          "file": "packages/python/goldencheck/goldencheck/core/frame.py",
+          "purpose": "Backend-neutral Frame/Column seam for the Polars eviction (P0).",
+          "defines": [
+            "ArrowColumn",
+            "ArrowFrame",
+            "Column",
+            "Frame",
+            "NativeRequiredError",
+            "PolarsColumn",
+            "PolarsFrame",
+            "PyColumn",
+            "PyFrame",
+            "_VC_KEY",
+            "_arrow",
+            "_arrow_neutral_dtype",
+            "_date_kernel",
+            "_neutral_dtype",
+            "_regex_kernel",
+            "dtype_category",
+            "to_frame"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldencheck.core.kernels",
+          "file": "packages/python/goldencheck/goldencheck/core/kernels.py",
+          "purpose": "List-shaped programmatic entry points to the deep-profiling kernels.",
+          "defines": [
+            "_composite_fallback",
+            "benford_histogram",
+            "composite_key_search",
+            "denial_constraint_evidence",
+            "discover_approximate_fds",
+            "discover_functional_dependencies",
+            "near_duplicate_clusters"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.core._native_loader",
+            "goldencheck.denial.evidence",
+            "goldencheck.profilers.fuzzy_values",
+            "goldencheck.relations.approx_fd",
+            "goldencheck.relations.composite_key",
+            "goldencheck.relations.functional_dependency"
+          ]
+        },
+        {
+          "module": "goldencheck.denial",
+          "file": "packages/python/goldencheck/goldencheck/denial/__init__.py",
+          "purpose": "Denial-constraint discovery (opt-in). See docs/superpowers/specs/2026-07-08-goldencheck-denial-constraint-discovery-design.md.",
+          "imports": [
+            "goldencheck.denial.models"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.constants",
+          "file": "packages/python/goldencheck/goldencheck/denial/constants.py",
+          "purpose": "Tunables for denial-constraint discovery (Stage 1)."
+        },
+        {
+          "module": "goldencheck.denial.discover",
+          "file": "packages/python/goldencheck/goldencheck/denial/discover.py",
+          "purpose": "FastDC-style minimal-cover derivation of denial constraints from evidence.",
+          "defines": [
+            "_arity",
+            "_complement",
+            "_satisfied_count",
+            "discover",
+            "rank"
+          ],
+          "imports": [
+            "goldencheck.denial.constants"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.evidence",
+          "file": "packages/python/goldencheck/goldencheck/denial/evidence.py",
+          "purpose": "Pure-Python evidence-set builder for denial-constraint discovery.",
+          "defines": [
+            "_cmp",
+            "_evidence_python",
+            "_holds_cross",
+            "_holds_single_tuple",
+            "_pair_evidence_oracle",
+            "_row_evidence_oracle",
+            "_split",
+            "pair_evidence",
+            "row_evidence",
+            "space_to_kernel_args"
+          ],
+          "imports": [
+            "goldencheck.core",
+            "goldencheck.denial.models",
+            "goldencheck.denial.predicates"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.mine",
+          "file": "packages/python/goldencheck/goldencheck/denial/mine.py",
+          "purpose": "End-to-end denial-constraint discovery orchestrator + Finding-emitting profiler.",
+          "defines": [
+            "DenialConstraintProfiler",
+            "_Record",
+            "_discover_records",
+            "_friendly_if_then",
+            "_has_order_pred",
+            "_is_reportable",
+            "_is_tautological",
+            "_n_distinct_columns",
+            "_preds_from_mask",
+            "_rank_key",
+            "_render_examples",
+            "_render_negated",
+            "_split",
+            "discover_denial_constraints"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.denial.constants",
+            "goldencheck.denial.discover",
+            "goldencheck.denial.evidence",
+            "goldencheck.denial.models",
+            "goldencheck.denial.predicates",
+            "goldencheck.denial.validate",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.models",
+          "file": "packages/python/goldencheck/goldencheck/denial/models.py",
+          "purpose": "Denial-constraint data models.",
+          "defines": [
+            "DenialConstraint",
+            "Op",
+            "Predicate"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.predicates",
+          "file": "packages/python/goldencheck/goldencheck/denial/predicates.py",
+          "purpose": "Column encoding + the bounded predicate space for denial-constraint discovery.",
+          "defines": [
+            "EncodedColumn",
+            "PredicateSpace",
+            "_build_domain",
+            "_classify",
+            "_cmp",
+            "_comparison_support",
+            "_ops_for",
+            "build_predicate_space",
+            "encode_columns",
+            "predicate_holds"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.denial.constants",
+            "goldencheck.denial.models"
+          ]
+        },
+        {
+          "module": "goldencheck.denial.validate",
+          "file": "packages/python/goldencheck/goldencheck/denial/validate.py",
+          "purpose": "Ground-truth g1 validation for candidate denial constraints.",
+          "defines": [
+            "is_single_tuple",
+            "validate_cross_tuple",
+            "validate_single_tuple"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.denial.constants",
+            "goldencheck.denial.models",
+            "goldencheck.denial.predicates"
+          ]
+        },
+        {
+          "module": "goldencheck.drift",
+          "file": "packages/python/goldencheck/goldencheck/drift/__init__.py",
+          "purpose": "Drift detection — compare current data against a baseline profile.",
+          "imports": [
+            "goldencheck.drift.detector"
+          ]
+        },
+        {
+          "module": "goldencheck.drift.detector",
+          "file": "packages/python/goldencheck/goldencheck/drift/detector.py",
+          "purpose": "Drift detector — compare a current DataFrame against a saved BaselineProfile.",
+          "defines": [
+            "_check_benford_drift",
+            "_check_bound_violation",
+            "_check_constraints",
+            "_check_correlations",
+            "_check_distribution_drift",
+            "_check_entropy_drift_categorical",
+            "_check_entropy_drift_numeric",
+            "_check_fd_violations",
+            "_check_key_uniqueness",
+            "_check_patterns",
+            "_check_semantic",
+            "_check_statistical",
+            "_check_temporal_order_drift",
+            "_compute_benford_pvalue",
+            "_compute_correlation",
+            "_entropy",
+            "_entropy_numeric",
+            "run_drift_checks"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.baseline.correlation",
+            "goldencheck.baseline.models",
+            "goldencheck.baseline.patterns",
+            "goldencheck.baseline.semantic",
+            "goldencheck.baseline.statistical",
+            "goldencheck.core._native_loader",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine",
+          "file": "packages/python/goldencheck/goldencheck/engine/__init__.py"
+        },
+        {
+          "module": "goldencheck.engine.confidence",
+          "file": "packages/python/goldencheck/goldencheck/engine/confidence.py",
+          "purpose": "Post-scan confidence processing.",
+          "defines": [
+            "apply_confidence_downgrade",
+            "apply_corroboration_boost"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.csv_infer",
+          "file": "packages/python/goldencheck/goldencheck/engine/csv_infer.py",
+          "purpose": "Pure-Python reference implementation of goldencheck's OWN CSV type-inference",
+          "defines": [
+            "_coerce",
+            "_infer_type",
+            "_is_bool",
+            "_is_float",
+            "_is_int",
+            "_read_rows",
+            "infer_and_type",
+            "read_csv_owned"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.db_scanner",
+          "file": "packages/python/goldencheck/goldencheck/engine/db_scanner.py",
+          "purpose": "Database scanner — scan tables directly from Postgres, Snowflake, BigQuery, or any SQLAlchemy URL.",
+          "defines": [
+            "_mask_password",
+            "_read_sql",
+            "scan_database"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.scanner",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.differ",
+          "file": "packages/python/goldencheck/goldencheck/engine/differ.py",
+          "purpose": "Diff engine — compare two versions of a data file.",
+          "defines": [
+            "DiffReport",
+            "FindingChange",
+            "SchemaChange",
+            "StatChange",
+            "diff_files",
+            "format_diff_report"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.evaluate",
+          "file": "packages/python/goldencheck/goldencheck/engine/evaluate.py",
+          "purpose": "Evaluate scan results against expected findings (ground truth).",
+          "defines": [
+            "evaluate_scan"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.fixer",
+          "file": "packages/python/goldencheck/goldencheck/engine/fixer.py",
+          "purpose": "Auto-fix engine — applies automated data quality fixes.",
+          "defines": [
+            "FixEntry",
+            "FixReport",
+            "_coerce_numeric",
+            "_fill_nulls_with_mode",
+            "_fix_smart_quotes",
+            "_has_match",
+            "_normalize_unicode",
+            "_remove_invisible_chars",
+            "_standardize_case",
+            "_strip_control_chars",
+            "_trim_whitespace",
+            "apply_fixes"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.history",
+          "file": "packages/python/goldencheck/goldencheck/engine/history.py",
+          "purpose": "Scan history — append-only JSONL log of scan results.",
+          "defines": [
+            "ScanRecord",
+            "get_previous_scan",
+            "load_history",
+            "record_scan"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.notifier",
+          "file": "packages/python/goldencheck/goldencheck/engine/notifier.py",
+          "purpose": "Webhook notifier — POST scan results to external URLs.",
+          "defines": [
+            "send_webhook",
+            "should_notify"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldencheck.engine.history",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.reader",
+          "file": "packages/python/goldencheck/goldencheck/engine/reader.py",
+          "purpose": "File reader — loads CSV, Parquet, and Excel files into Polars DataFrames.",
+          "defines": [
+            "_coerce_column",
+            "_cols_to_table",
+            "_read_csv_columns",
+            "_read_csv_columns_owned",
+            "_read_excel_columns",
+            "_read_parquet_columns",
+            "read_columns",
+            "read_file",
+            "read_file_arrow"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.core._native_loader",
+            "goldencheck.engine.csv_infer"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.referential",
+          "file": "packages/python/goldencheck/goldencheck/engine/referential.py",
+          "purpose": "Referential-integrity checks across TWO files (foreign-key validation).",
+          "defines": [
+            "_is_key",
+            "_parse_on",
+            "auto_detect_mappings",
+            "check_referential_integrity",
+            "referential_integrity_files"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.engine.reader",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.sampler",
+          "file": "packages/python/goldencheck/goldencheck/engine/sampler.py",
+          "purpose": "Smart sampling for large datasets.",
+          "defines": [
+            "_owned_stride_indices",
+            "maybe_sample"
+          ],
+          "imports": [
+            "goldencheck.core.frame"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.scanner",
+          "file": "packages/python/goldencheck/goldencheck/engine/scanner.py",
+          "purpose": "Scanner — orchestrates all profilers and collects findings.",
+          "defines": [
+            "_coerce_to_arrow_frame",
+            "_post_classification_checks",
+            "_profile_column",
+            "_run_relation",
+            "_sample_for_return",
+            "_scan_dataframe_impl",
+            "_scan_threads",
+            "_to_polars",
+            "scan_columns",
+            "scan_dataframe",
+            "scan_file",
+            "scan_file_columns",
+            "scan_file_with_llm"
+          ],
+          "imports": [
+            "goldencheck.baseline",
+            "goldencheck.baseline.models",
+            "goldencheck.baseline.priors",
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.denial.mine",
+            "goldencheck.drift",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.sampler",
+            "goldencheck.llm.budget",
+            "goldencheck.llm.merger",
+            "goldencheck.llm.parser",
+            "goldencheck.llm.providers",
+            "goldencheck.llm.rule_generator",
+            "goldencheck.llm.sample_block",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile",
+            "goldencheck.profilers.cardinality",
+            "goldencheck.profilers.drift_detection",
+            "goldencheck.profilers.encoding_detection",
+            "goldencheck.profilers.format_detection",
+            "goldencheck.profilers.freshness",
+            "goldencheck.profilers.fuzzy_values",
+            "goldencheck.profilers.nullability",
+            "goldencheck.profilers.pattern_consistency",
+            "goldencheck.profilers.range_distribution",
+            "goldencheck.profilers.sequence_detection",
+            "goldencheck.profilers.type_inference",
+            "goldencheck.profilers.uniqueness",
+            "goldencheck.relations.age_validation",
+            "goldencheck.relations.approx_duplicate",
+            "goldencheck.relations.approx_fd",
+            "goldencheck.relations.composite_key",
+            "goldencheck.relations.functional_dependency",
+            "goldencheck.relations.identity_safe_pk",
+            "goldencheck.relations.null_correlation",
+            "goldencheck.relations.numeric_cross",
+            "goldencheck.relations.temporal",
+            "goldencheck.semantic.classifier",
+            "goldencheck.semantic.suppression"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.scheduler",
+          "file": "packages/python/goldencheck/goldencheck/engine/scheduler.py",
+          "purpose": "Scheduled scans — run goldencheck on a cron schedule.",
+          "defines": [
+            "run_schedule"
+          ],
+          "imports": [
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.history",
+            "goldencheck.engine.notifier",
+            "goldencheck.engine.scanner",
+            "goldencheck.models.finding",
+            "goldencheck.reporters.json_reporter"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.triage",
+          "file": "packages/python/goldencheck/goldencheck/engine/triage.py",
+          "purpose": "Auto-triage engine — classify findings into pin/dismiss/review buckets.",
+          "defines": [
+            "TriageResult",
+            "auto_triage"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.validator",
+          "file": "packages/python/goldencheck/goldencheck/engine/validator.py",
+          "purpose": "Validator — checks data against pinned rules in goldencheck.yml.",
+          "defines": [
+            "_check_column",
+            "validate_file"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.config.schema",
+            "goldencheck.engine.reader",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.engine.watcher",
+          "file": "packages/python/goldencheck/goldencheck/engine/watcher.py",
+          "purpose": "Watch engine — poll a directory for data file changes and re-scan.",
+          "defines": [
+            "watch_directory"
+          ],
+          "imports": [
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.scanner",
+            "goldencheck.models.finding",
+            "goldencheck.reporters.json_reporter"
+          ]
+        },
+        {
+          "module": "goldencheck.functional_dependencies",
+          "file": "packages/python/goldencheck/goldencheck/functional_dependencies.py",
+          "purpose": "Discovered functional dependencies as a structured API -- the bridge",
+          "defines": [
+            "FunctionalDependency",
+            "_approx_triples",
+            "_strict_pairs",
+            "functional_dependencies"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.relations"
+          ]
+        },
+        {
+          "module": "goldencheck.llm",
+          "file": "packages/python/goldencheck/goldencheck/llm/__init__.py"
+        },
+        {
+          "module": "goldencheck.llm.budget",
+          "file": "packages/python/goldencheck/goldencheck/llm/budget.py",
+          "purpose": "LLM cost tracking and budget enforcement.",
+          "defines": [
+            "CostReport",
+            "check_budget",
+            "estimate_cost",
+            "get_budget_limit"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.merger",
+          "file": "packages/python/goldencheck/goldencheck/llm/merger.py",
+          "purpose": "Merge LLM response into existing findings list.",
+          "defines": [
+            "_ensure_keywords",
+            "_strip_suppression_suffix",
+            "merge_llm_findings"
+          ],
+          "imports": [
+            "goldencheck.llm.prompts",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.parser",
+          "file": "packages/python/goldencheck/goldencheck/llm/parser.py",
+          "purpose": "Parse and validate LLM JSON responses.",
+          "defines": [
+            "parse_llm_response"
+          ],
+          "imports": [
+            "goldencheck.llm.prompts"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.prompts",
+          "file": "packages/python/goldencheck/goldencheck/llm/prompts.py",
+          "purpose": "LLM prompt templates and response Pydantic models.",
+          "defines": [
+            "LLMColumnAssessment",
+            "LLMDowngrade",
+            "LLMIssue",
+            "LLMRelation",
+            "LLMResponse",
+            "LLMUpgrade"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.providers",
+          "file": "packages/python/goldencheck/goldencheck/llm/providers.py",
+          "purpose": "LLM provider wrappers for Anthropic and OpenAI.",
+          "defines": [
+            "call_llm",
+            "check_llm_available"
+          ],
+          "imports": [
+            "goldencheck.llm.prompts"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.rule_generator",
+          "file": "packages/python/goldencheck/goldencheck/llm/rule_generator.py",
+          "purpose": "LLM-powered rule generation — analyzes data samples and generates validation rules.",
+          "defines": [
+            "GeneratedRule",
+            "RuleGenerationResponse",
+            "RuleParams",
+            "_apply_single_rule",
+            "_call_llm_for_rules",
+            "apply_rules",
+            "generate_rules",
+            "load_rules",
+            "save_rules"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.llm.budget",
+            "goldencheck.llm.providers",
+            "goldencheck.llm.sample_block",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.llm.sample_block",
+          "file": "packages/python/goldencheck/goldencheck/llm/sample_block.py",
+          "purpose": "Build representative sample blocks from DataFrame + findings.",
+          "defines": [
+            "build_sample_blocks"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.mcp",
+          "file": "packages/python/goldencheck/goldencheck/mcp/__init__.py",
+          "purpose": "GoldenCheck MCP server — expose scan, validate, and profile as MCP tools."
+        },
+        {
+          "module": "goldencheck.mcp.agent_tools",
+          "file": "packages/python/goldencheck/goldencheck/mcp/agent_tools.py",
+          "purpose": "Agent-level MCP tools for GoldenCheck — strategy, review, handoff, and explanation.",
+          "defines": [
+            "_finding_from_dict",
+            "_get_review_queue",
+            "_rules_to_yaml",
+            "_serialize_findings",
+            "_tool_analyze_data",
+            "_tool_approve_reject",
+            "_tool_auto_configure",
+            "_tool_compare_domains",
+            "_tool_explain_column",
+            "_tool_explain_finding",
+            "_tool_pipeline_handoff",
+            "_tool_review_queue",
+            "_tool_review_stats",
+            "_tool_suggest_fix"
+          ],
+          "imports": [
+            "goldencheck.agent.handoff",
+            "goldencheck.agent.intelligence",
+            "goldencheck.agent.review_queue",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.fixer",
+            "goldencheck.engine.reader",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.triage",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.mcp.server",
+          "file": "packages/python/goldencheck/goldencheck/mcp/server.py",
+          "purpose": "MCP server exposing GoldenCheck tools for Claude Desktop and other MCP clients.",
+          "defines": [
+            "_findings_by_column",
+            "_serialize_findings",
+            "_tool_get_column_detail",
+            "_tool_get_domain_info",
+            "_tool_health_score",
+            "_tool_install_domain",
+            "_tool_list_checks",
+            "_tool_list_domains",
+            "_tool_profile",
+            "_tool_scan",
+            "_tool_validate",
+            "create_server",
+            "run_server",
+            "run_server_http"
+          ],
+          "imports": [
+            "goldencheck.config.loader",
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.scanner",
+            "goldencheck.engine.validator",
+            "goldencheck.mcp.agent_tools",
+            "goldencheck.models.finding",
+            "goldencheck.semantic.classifier"
+          ]
+        },
+        {
+          "module": "goldencheck.models",
+          "file": "packages/python/goldencheck/goldencheck/models/__init__.py"
+        },
+        {
+          "module": "goldencheck.models.finding",
+          "file": "packages/python/goldencheck/goldencheck/models/finding.py",
+          "purpose": "Finding model — represents a single validation finding.",
+          "defines": [
+            "Finding",
+            "Severity"
+          ]
+        },
+        {
+          "module": "goldencheck.models.profile",
+          "file": "packages/python/goldencheck/goldencheck/models/profile.py",
+          "purpose": "Profile models — column and dataset profiles.",
+          "defines": [
+            "ColumnProfile",
+            "DatasetProfile"
+          ]
+        },
+        {
+          "module": "goldencheck.notebook",
+          "file": "packages/python/goldencheck/goldencheck/notebook.py",
+          "purpose": "Jupyter notebook display hooks for GoldenCheck results.",
+          "defines": [
+            "ScanResult",
+            "_col_profile_row",
+            "_finding_to_html",
+            "_health_badge",
+            "findings_to_html",
+            "profile_to_html"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers",
+          "file": "packages/python/goldencheck/goldencheck/profilers/__init__.py"
+        },
+        {
+          "module": "goldencheck.profilers.base",
+          "file": "packages/python/goldencheck/goldencheck/profilers/base.py",
+          "purpose": "Base profiler interface.",
+          "defines": [
+            "BaseProfiler"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.cardinality",
+          "file": "packages/python/goldencheck/goldencheck/profilers/cardinality.py",
+          "purpose": "Cardinality profiler — detects low-cardinality columns that may be enum candidates.",
+          "defines": [
+            "CardinalityProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.drift_detection",
+          "file": "packages/python/goldencheck/goldencheck/profilers/drift_detection.py",
+          "purpose": "Drift detection profiler — detects distribution drift between first and second half of data.",
+          "defines": [
+            "DriftDetectionProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.encoding_detection",
+          "file": "packages/python/goldencheck/goldencheck/profilers/encoding_detection.py",
+          "purpose": "Encoding detection profiler — detects encoding anomalies in string columns.",
+          "defines": [
+            "EncodingDetectionProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.format_detection",
+          "file": "packages/python/goldencheck/goldencheck/profilers/format_detection.py",
+          "purpose": "Format detection profiler — detects email, phone, and URL patterns in string columns.",
+          "defines": [
+            "FormatDetectionProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.freshness",
+          "file": "packages/python/goldencheck/goldencheck/profilers/freshness.py",
+          "purpose": "Freshness / staleness profiler for date & datetime columns.",
+          "defines": [
+            "FreshnessProfiler",
+            "_looks_like_update_column"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.fuzzy_values",
+          "file": "packages/python/goldencheck/goldencheck/profilers/fuzzy_values.py",
+          "purpose": "Fuzzy near-duplicate VALUE detection (column profiler).",
+          "defines": [
+            "FuzzyValuesProfiler",
+            "_python_clusters"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.nullability",
+          "file": "packages/python/goldencheck/goldencheck/profilers/nullability.py",
+          "purpose": "Nullability profiler — detects required vs. optional columns.",
+          "defines": [
+            "NullabilityProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.pattern_consistency",
+          "file": "packages/python/goldencheck/goldencheck/profilers/pattern_consistency.py",
+          "purpose": "Pattern consistency profiler — detects inconsistent string patterns within a column.",
+          "defines": [
+            "PatternConsistencyProfiler",
+            "_generalize",
+            "_generalize_series"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.range_distribution",
+          "file": "packages/python/goldencheck/goldencheck/profilers/range_distribution.py",
+          "purpose": "Range and distribution profiler — detects outliers and reports min/max for numeric columns.",
+          "defines": [
+            "RangeDistributionProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.sequence_detection",
+          "file": "packages/python/goldencheck/goldencheck/profilers/sequence_detection.py",
+          "purpose": "Sequence gap detection profiler — detects gaps in sequential integer columns.",
+          "defines": [
+            "SequenceDetectionProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.type_inference",
+          "file": "packages/python/goldencheck/goldencheck/profilers/type_inference.py",
+          "purpose": "Type inference profiler — detects mixed types and type mismatches.",
+          "defines": [
+            "TypeInferenceProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.profilers.uniqueness",
+          "file": "packages/python/goldencheck/goldencheck/profilers/uniqueness.py",
+          "purpose": "Uniqueness profiler — detects primary key candidates and duplicates.",
+          "defines": [
+            "UniquenessProfiler"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding",
+            "goldencheck.profilers.base"
+          ]
+        },
+        {
+          "module": "goldencheck.relations",
+          "file": "packages/python/goldencheck/goldencheck/relations/__init__.py"
+        },
+        {
+          "module": "goldencheck.relations.age_validation",
+          "file": "packages/python/goldencheck/goldencheck/relations/age_validation.py",
+          "purpose": "Age vs DOB cross-validation profiler.",
+          "defines": [
+            "AgeValidationProfiler",
+            "_age_mismatch",
+            "_is_age_column",
+            "_is_dob_column",
+            "_parse_date32"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.approx_duplicate",
+          "file": "packages/python/goldencheck/goldencheck/relations/approx_duplicate.py",
+          "purpose": "Approximate / exact duplicate-row detection (cross-column relation profiler).",
+          "defines": [
+            "ApproxDuplicateProfiler",
+            "_cast_str",
+            "_exact_signature",
+            "_normalized_signature",
+            "_py_duplicate_signatures"
+          ],
+          "imports": [
+            "goldencheck._polars_lazy",
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.approx_fd",
+          "file": "packages/python/goldencheck/goldencheck/relations/approx_fd.py",
+          "purpose": "Approximate functional-dependency VIOLATION detection (cross-column relation).",
+          "defines": [
+            "ApproximateFDProfiler",
+            "_discover_python",
+            "_group_modes",
+            "_intern",
+            "_select_candidates",
+            "_violation_rows"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.composite_key",
+          "file": "packages/python/goldencheck/goldencheck/relations/composite_key.py",
+          "purpose": "Composite-key discovery (cross-column relation profiler).",
+          "defines": [
+            "CompositeKeyProfiler",
+            "_has_single_column_key",
+            "_python_search",
+            "_select_candidates"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.functional_dependency",
+          "file": "packages/python/goldencheck/goldencheck/relations/functional_dependency.py",
+          "purpose": "Strict functional-dependency discovery (cross-column relation profiler).",
+          "defines": [
+            "FunctionalDependencyProfiler",
+            "_discover_python",
+            "_select_candidates"
+          ],
+          "imports": [
+            "goldencheck.core._native_loader",
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.identity_safe_pk",
+          "file": "packages/python/goldencheck/goldencheck/relations/identity_safe_pk.py",
+          "purpose": "Identity-safe PK preflight profiler (closes goldenmatch issue #207).",
+          "defines": [
+            "IdentitySafePkProfiler",
+            "_column_qualifies_as_pk",
+            "_looks_like_pk_column",
+            "_looks_like_value_column"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.null_correlation",
+          "file": "packages/python/goldencheck/goldencheck/relations/null_correlation.py",
+          "purpose": "Null correlation profiler — detects columns whose null patterns are highly correlated.",
+          "defines": [
+            "NullCorrelationProfiler",
+            "_UnionFind"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.numeric_cross",
+          "file": "packages/python/goldencheck/goldencheck/relations/numeric_cross.py",
+          "purpose": "Numeric cross-column validation — detects value > max violations and age/DOB mismatches.",
+          "defines": [
+            "NumericCrossColumnProfiler",
+            "_find_max_pairs"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.relations.temporal",
+          "file": "packages/python/goldencheck/goldencheck/relations/temporal.py",
+          "purpose": "Temporal order profiler — checks that start-like date columns precede end-like columns.",
+          "defines": [
+            "TemporalOrderProfiler",
+            "_find_date_pairs",
+            "_try_cast_to_date"
+          ],
+          "imports": [
+            "goldencheck.core.frame",
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.reporters",
+          "file": "packages/python/goldencheck/goldencheck/reporters/__init__.py"
+        },
+        {
+          "module": "goldencheck.reporters.ci_reporter",
+          "file": "packages/python/goldencheck/goldencheck/reporters/ci_reporter.py",
+          "purpose": "CI reporter — determines exit code based on findings and fail_on threshold.",
+          "defines": [
+            "report_ci"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.reporters.html_reporter",
+          "file": "packages/python/goldencheck/goldencheck/reporters/html_reporter.py",
+          "purpose": "HTML report generator — shareable data quality report.",
+          "defines": [
+            "report_html"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.reporters.json_reporter",
+          "file": "packages/python/goldencheck/goldencheck/reporters/json_reporter.py",
+          "purpose": "JSON reporter — machine-readable output matching spec schema.",
+          "defines": [
+            "report_json"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.reporters.rich_console",
+          "file": "packages/python/goldencheck/goldencheck/reporters/rich_console.py",
+          "purpose": "Rich console reporter — prints findings as formatted table.",
+          "defines": [
+            "report_rich"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.semantic",
+          "file": "packages/python/goldencheck/goldencheck/semantic/__init__.py"
+        },
+        {
+          "module": "goldencheck.semantic.classifier",
+          "file": "packages/python/goldencheck/goldencheck/semantic/classifier.py",
+          "purpose": "Semantic type classifier — infers what each column represents.",
+          "defines": [
+            "ColumnClassification",
+            "TypeDef",
+            "_check_format_match",
+            "_check_value_signals",
+            "_count_matches",
+            "_load_yaml_types",
+            "_match_by_name",
+            "_match_by_value",
+            "classify_columns",
+            "list_available_domains",
+            "load_type_defs"
+          ],
+          "imports": [
+            "goldencheck.core.frame"
+          ]
+        },
+        {
+          "module": "goldencheck.semantic.suppression",
+          "file": "packages/python/goldencheck/goldencheck/semantic/suppression.py",
+          "purpose": "Suppression engine — downgrades irrelevant findings based on column semantic type.",
+          "defines": [
+            "apply_suppression"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.semantic.classifier"
+          ]
+        },
+        {
+          "module": "goldencheck.server",
+          "file": "packages/python/goldencheck/goldencheck/server.py",
+          "purpose": "REST API server for GoldenCheck — scan files via HTTP.",
+          "defines": [
+            "GoldenCheckHandler",
+            "_build_response",
+            "_validate_remote_url",
+            "run_server"
+          ],
+          "imports": [
+            "goldencheck.engine.confidence",
+            "goldencheck.engine.scanner",
+            "goldencheck.mcp.server",
+            "goldencheck.models.finding",
+            "goldencheck.semantic.classifier"
+          ]
+        },
+        {
+          "module": "goldencheck.tui",
+          "file": "packages/python/goldencheck/goldencheck/tui/__init__.py"
+        },
+        {
+          "module": "goldencheck.tui.app",
+          "file": "packages/python/goldencheck/goldencheck/tui/app.py",
+          "purpose": "Main TUI application for GoldenCheck.",
+          "defines": [
+            "GoldenCheckApp"
+          ],
+          "imports": [
+            "goldencheck.config.schema",
+            "goldencheck.config.writer",
+            "goldencheck.models.finding",
+            "goldencheck.models.profile",
+            "goldencheck.tui.column_detail",
+            "goldencheck.tui.findings",
+            "goldencheck.tui.overview",
+            "goldencheck.tui.rules"
+          ]
+        },
+        {
+          "module": "goldencheck.tui.column_detail",
+          "file": "packages/python/goldencheck/goldencheck/tui/column_detail.py",
+          "purpose": "Column Detail tab — per-column profile information.",
+          "defines": [
+            "ColumnDetailPane"
+          ],
+          "imports": [
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.tui.findings",
+          "file": "packages/python/goldencheck/goldencheck/tui/findings.py",
+          "purpose": "Findings tab — DataTable with pin toggle.",
+          "defines": [
+            "FindingsPane"
+          ],
+          "imports": [
+            "goldencheck.models.finding"
+          ]
+        },
+        {
+          "module": "goldencheck.tui.overview",
+          "file": "packages/python/goldencheck/goldencheck/tui/overview.py",
+          "purpose": "Overview tab — health score and dataset stats.",
+          "defines": [
+            "OverviewPane"
+          ],
+          "imports": [
+            "goldencheck.models.finding",
+            "goldencheck.models.profile"
+          ]
+        },
+        {
+          "module": "goldencheck.tui.rules",
+          "file": "packages/python/goldencheck/goldencheck/tui/rules.py",
+          "purpose": "Rules tab — pinned rules from findings + existing config rules.",
+          "defines": [
+            "RulesPane"
+          ],
+          "imports": [
+            "goldencheck.config.schema",
+            "goldencheck.models.finding"
+          ]
+        }
+      ]
+    },
+    "goldenflow": {
+      "root": "packages/python/goldenflow/goldenflow",
+      "module_count": 74,
+      "modules": [
+        {
+          "module": "goldenflow",
+          "file": "packages/python/goldenflow/goldenflow/__init__.py",
+          "defines": [
+            "transform",
+            "transform_df",
+            "transform_file"
+          ],
+          "imports": [
+            "goldenflow.canonicalize",
+            "goldenflow.config.learner",
+            "goldenflow.config.loader",
+            "goldenflow.config.schema",
+            "goldenflow.connectors.file",
+            "goldenflow.domains",
+            "goldenflow.domains.base",
+            "goldenflow.engine.columnar",
+            "goldenflow.engine.differ",
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector",
+            "goldenflow.engine.transformer",
+            "goldenflow.mapping.schema_mapper",
+            "goldenflow.notebook",
+            "goldenflow.transforms",
+            "goldenflow.transforms.address",
+            "goldenflow.transforms.auto_correct",
+            "goldenflow.transforms.categorical",
+            "goldenflow.transforms.company",
+            "goldenflow.transforms.dates",
+            "goldenflow.transforms.email",
+            "goldenflow.transforms.identifiers",
+            "goldenflow.transforms.names",
+            "goldenflow.transforms.numeric",
+            "goldenflow.transforms.phone",
+            "goldenflow.transforms.phonetic",
+            "goldenflow.transforms.text",
+            "goldenflow.transforms.url"
+          ]
+        },
+        {
+          "module": "goldenflow._polars_lazy",
+          "file": "packages/python/goldenflow/goldenflow/_polars_lazy.py",
+          "purpose": "Lazy Polars proxy — Phase 4a of the Polars eviction (make Polars optional).",
+          "defines": [
+            "_LazyPolars"
+          ]
+        },
+        {
+          "module": "goldenflow.a2a",
+          "file": "packages/python/goldenflow/goldenflow/a2a/__init__.py",
+          "purpose": "A2A agent server for GoldenFlow."
+        },
+        {
+          "module": "goldenflow.a2a.server",
+          "file": "packages/python/goldenflow/goldenflow/a2a/server.py",
+          "purpose": "A2A protocol server for GoldenFlow (aiohttp) -- port 8150.",
+          "defines": [
+            "agent_card",
+            "create_app",
+            "handle_task",
+            "health",
+            "run_server"
+          ],
+          "imports": [
+            "goldenflow.mcp.server"
+          ]
+        },
+        {
+          "module": "goldenflow.api",
+          "file": "packages/python/goldenflow/goldenflow/api/__init__.py"
+        },
+        {
+          "module": "goldenflow.api.server",
+          "file": "packages/python/goldenflow/goldenflow/api/server.py",
+          "defines": [
+            "create_app"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenflow._polars_lazy",
+            "goldenflow.engine.transformer",
+            "goldenflow.mapping.schema_mapper",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.canonicalize",
+          "file": "packages/python/goldenflow/goldenflow/canonicalize.py",
+          "purpose": "Pure, language-portable per-value field canonicalizers (#1128).",
+          "defines": [
+            "_ascii_lower",
+            "_ascii_upper",
+            "_ascii_ws_split",
+            "_canon_email",
+            "_canon_name",
+            "_canon_phone",
+            "_canon_postal",
+            "_collapse_ws",
+            "canonicalize"
+          ]
+        },
+        {
+          "module": "goldenflow.cli",
+          "file": "packages/python/goldenflow/goldenflow/cli/__init__.py"
+        },
+        {
+          "module": "goldenflow.cli.errors",
+          "file": "packages/python/goldenflow/goldenflow/cli/errors.py",
+          "defines": [
+            "cli_error_handler"
+          ]
+        },
+        {
+          "module": "goldenflow.cli.init_wizard",
+          "file": "packages/python/goldenflow/goldenflow/cli/init_wizard.py",
+          "purpose": "Interactive setup wizard for GoldenFlow config.",
+          "defines": [
+            "run_wizard"
+          ],
+          "imports": [
+            "goldenflow.config.loader",
+            "goldenflow.config.schema",
+            "goldenflow.connectors.file",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector"
+          ]
+        },
+        {
+          "module": "goldenflow.cli.main",
+          "file": "packages/python/goldenflow/goldenflow/cli/main.py",
+          "defines": [
+            "_version_callback",
+            "agent_serve",
+            "demo",
+            "diff",
+            "history",
+            "init_cmd",
+            "interactive",
+            "learn",
+            "main",
+            "map_cmd",
+            "mcp_serve",
+            "profile",
+            "schedule",
+            "serve",
+            "stream",
+            "transform",
+            "validate",
+            "watch"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenflow.a2a.server",
+            "goldenflow.api.server",
+            "goldenflow.cli.errors",
+            "goldenflow.cli.init_wizard",
+            "goldenflow.cli.schedule",
+            "goldenflow.cli.watch",
+            "goldenflow.config.learner",
+            "goldenflow.config.loader",
+            "goldenflow.config.schema",
+            "goldenflow.connectors.file",
+            "goldenflow.domains",
+            "goldenflow.engine",
+            "goldenflow.engine.differ",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector",
+            "goldenflow.engine.transformer",
+            "goldenflow.history",
+            "goldenflow.llm.corrector",
+            "goldenflow.mapping.schema_mapper",
+            "goldenflow.mcp.server",
+            "goldenflow.reporters.rich_console",
+            "goldenflow.streaming",
+            "goldenflow.tui.app"
+          ]
+        },
+        {
+          "module": "goldenflow.cli.schedule",
+          "file": "packages/python/goldenflow/goldenflow/cli/schedule.py",
+          "purpose": "Schedule periodic transforms.",
+          "defines": [
+            "_parse_cron_interval",
+            "run_schedule"
+          ],
+          "imports": [
+            "goldenflow.config.loader",
+            "goldenflow.config.schema",
+            "goldenflow.engine.transformer"
+          ]
+        },
+        {
+          "module": "goldenflow.cli.watch",
+          "file": "packages/python/goldenflow/goldenflow/cli/watch.py",
+          "purpose": "Watch a directory for file changes and auto-transform.",
+          "defines": [
+            "watch_directory"
+          ],
+          "imports": [
+            "goldenflow.config.loader",
+            "goldenflow.config.schema",
+            "goldenflow.engine.transformer"
+          ]
+        },
+        {
+          "module": "goldenflow.config",
+          "file": "packages/python/goldenflow/goldenflow/config/__init__.py"
+        },
+        {
+          "module": "goldenflow.config.learner",
+          "file": "packages/python/goldenflow/goldenflow/config/learner.py",
+          "defines": [
+            "learn_config"
+          ],
+          "imports": [
+            "goldenflow.config.schema",
+            "goldenflow.connectors.file",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector"
+          ]
+        },
+        {
+          "module": "goldenflow.config.loader",
+          "file": "packages/python/goldenflow/goldenflow/config/loader.py",
+          "defines": [
+            "load_config",
+            "merge_configs",
+            "save_config"
+          ],
+          "imports": [
+            "goldenflow.config.schema"
+          ]
+        },
+        {
+          "module": "goldenflow.config.schema",
+          "file": "packages/python/goldenflow/goldenflow/config/schema.py",
+          "defines": [
+            "DedupSpec",
+            "FilterSpec",
+            "GoldenFlowConfig",
+            "MappingSpec",
+            "SplitSpec",
+            "TransformSpec"
+          ]
+        },
+        {
+          "module": "goldenflow.connectors",
+          "file": "packages/python/goldenflow/goldenflow/connectors/__init__.py",
+          "imports": [
+            "goldenflow.connectors.file"
+          ]
+        },
+        {
+          "module": "goldenflow.connectors.database",
+          "file": "packages/python/goldenflow/goldenflow/connectors/database.py",
+          "defines": [
+            "read_database_columns",
+            "read_table",
+            "write_table"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.connectors.file",
+          "file": "packages/python/goldenflow/goldenflow/connectors/file.py",
+          "defines": [
+            "read_file",
+            "write_file"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.connectors.gcs",
+          "file": "packages/python/goldenflow/goldenflow/connectors/gcs.py",
+          "purpose": "Google Cloud Storage connector for GoldenFlow.",
+          "defines": [
+            "_parse_gcs_uri",
+            "read_gcs",
+            "write_gcs"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.connectors.file"
+          ]
+        },
+        {
+          "module": "goldenflow.connectors.s3",
+          "file": "packages/python/goldenflow/goldenflow/connectors/s3.py",
+          "purpose": "AWS S3 connector for GoldenFlow.",
+          "defines": [
+            "_parse_s3_uri",
+            "read_s3",
+            "write_s3"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.connectors.file"
+          ]
+        },
+        {
+          "module": "goldenflow.core",
+          "file": "packages/python/goldenflow/goldenflow/core/__init__.py",
+          "purpose": "Internal core utilities for GoldenFlow (native loader, etc.)."
+        },
+        {
+          "module": "goldenflow.core._native_loader",
+          "file": "packages/python/goldenflow/goldenflow/core/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``goldenflow._native`` acceleration module.",
+          "defines": [
+            "_has_symbol",
+            "native_available",
+            "native_enabled",
+            "native_module"
+          ],
+          "imports": [
+            "goldenflow._native"
+          ]
+        },
+        {
+          "module": "goldenflow.domains",
+          "file": "packages/python/goldenflow/goldenflow/domains/__init__.py",
+          "defines": [
+            "load_domain"
+          ],
+          "imports": [
+            "goldenflow.domains.base"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.base",
+          "file": "packages/python/goldenflow/goldenflow/domains/base.py",
+          "defines": [
+            "DomainPack"
+          ],
+          "imports": [
+            "goldenflow.config.schema"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.carceral",
+          "file": "packages/python/goldenflow/goldenflow/domains/carceral.py",
+          "purpose": "Carceral (U.S. prisons, jails, detention centers) domain pack.",
+          "defines": [
+            "_expand_abbreviations",
+            "_strip_operator_prefix",
+            "carceral_abbreviate",
+            "carceral_name_normalize",
+            "carceral_org_strip",
+            "latlng_pack"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.ecommerce",
+          "file": "packages/python/goldenflow/goldenflow/domains/ecommerce.py",
+          "defines": [
+            "sku_normalize"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.finance",
+          "file": "packages/python/goldenflow/goldenflow/domains/finance.py",
+          "defines": [
+            "account_mask",
+            "cusip_format"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.healthcare",
+          "file": "packages/python/goldenflow/goldenflow/domains/healthcare.py",
+          "defines": [
+            "icd10_format"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.people_hr",
+          "file": "packages/python/goldenflow/goldenflow/domains/people_hr.py",
+          "defines": [
+            "ssn_validate"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.domains.real_estate",
+          "file": "packages/python/goldenflow/goldenflow/domains/real_estate.py",
+          "defines": [
+            "mls_normalize"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.domains.base",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.engine",
+          "file": "packages/python/goldenflow/goldenflow/engine/__init__.py"
+        },
+        {
+          "module": "goldenflow.engine.columnar",
+          "file": "packages/python/goldenflow/goldenflow/engine/columnar.py",
+          "purpose": "Columnar (Polars-free) transform execution — Phase 1 of the Polars eviction",
+          "defines": [
+            "ColumnarResult",
+            "_accepted_string",
+            "_apply_special",
+            "_autoconfig_columns",
+            "_cast_utf8",
+            "_frame_level_blocked",
+            "_numeric_inmem_ok",
+            "_sample3",
+            "_scalar_fn",
+            "_spec_ready",
+            "_spec_scalar_ready",
+            "_spec_special_ready",
+            "_spec_string_ready",
+            "_split_inmem_ok",
+            "_stringify_for_column",
+            "_transform_via_columns",
+            "columnar_engine_selected",
+            "columnar_file_ready",
+            "config_is_columnar_ready",
+            "native_columns_ready",
+            "read_csv_columns",
+            "read_excel_columns",
+            "read_parquet_columns",
+            "transform",
+            "transform_columns",
+            "transform_columns_native",
+            "transform_columns_public",
+            "transform_file"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.core._native_loader",
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector",
+            "goldenflow.transforms",
+            "goldenflow.transforms._chain",
+            "goldenflow.transforms.auto_correct",
+            "goldenflow.transforms.names"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.differ",
+          "file": "packages/python/goldenflow/goldenflow/engine/differ.py",
+          "defines": [
+            "DiffResult",
+            "diff_dataframes"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.frame",
+          "file": "packages/python/goldenflow/goldenflow/engine/frame.py",
+          "purpose": "Backend-agnostic columnar container — the seam for evicting Polars as a hard",
+          "defines": [
+            "Frame",
+            "PolarsFrame",
+            "to_frame"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.manifest",
+          "file": "packages/python/goldenflow/goldenflow/engine/manifest.py",
+          "defines": [
+            "Manifest",
+            "TransformError",
+            "TransformRecord"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.profiler_bridge",
+          "file": "packages/python/goldenflow/goldenflow/engine/profiler_bridge.py",
+          "defines": [
+            "ColumnProfile",
+            "DatasetProfile",
+            "_infer_type",
+            "_infer_type_list",
+            "_infer_type_list_native_or_pure",
+            "_kernel_profile_dtypes",
+            "_map_goldencheck_semantic_type",
+            "_override_type_by_column_name",
+            "_profile_column",
+            "_profile_column_native_or_pure",
+            "_scalar_type_hint",
+            "profile_columns",
+            "profile_dataframe"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldenflow._polars_lazy",
+            "goldenflow.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.selector",
+          "file": "packages/python/goldenflow/goldenflow/engine/selector.py",
+          "defines": [
+            "select_from_findings",
+            "select_transforms"
+          ],
+          "imports": [
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.engine.transformer",
+          "file": "packages/python/goldenflow/goldenflow/engine/transformer.py",
+          "defines": [
+            "TransformEngine",
+            "TransformResult"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.connectors.file",
+            "goldenflow.engine",
+            "goldenflow.engine.frame",
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector",
+            "goldenflow.history",
+            "goldenflow.llm.corrector",
+            "goldenflow.transforms",
+            "goldenflow.transforms._chain",
+            "goldenmatch.core.bench"
+          ]
+        },
+        {
+          "module": "goldenflow.history",
+          "file": "packages/python/goldenflow/goldenflow/history.py",
+          "purpose": "Track transform runs for comparison over time.",
+          "defines": [
+            "RunRecord",
+            "generate_run_id",
+            "get_run",
+            "list_runs",
+            "save_run"
+          ]
+        },
+        {
+          "module": "goldenflow.llm",
+          "file": "packages/python/goldenflow/goldenflow/llm/__init__.py"
+        },
+        {
+          "module": "goldenflow.llm.corrector",
+          "file": "packages/python/goldenflow/goldenflow/llm/corrector.py",
+          "purpose": "LLM-enhanced categorical correction.",
+          "defines": [
+            "_ask_llm_for_corrections",
+            "_get_value_summary",
+            "category_llm_correct"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.mapping",
+          "file": "packages/python/goldenflow/goldenflow/mapping/__init__.py"
+        },
+        {
+          "module": "goldenflow.mapping.name_similarity",
+          "file": "packages/python/goldenflow/goldenflow/mapping/name_similarity.py",
+          "defines": [
+            "name_similarity"
+          ]
+        },
+        {
+          "module": "goldenflow.mapping.profile_similarity",
+          "file": "packages/python/goldenflow/goldenflow/mapping/profile_similarity.py",
+          "defines": [
+            "profile_similarity"
+          ],
+          "imports": [
+            "goldenflow.engine.profiler_bridge"
+          ]
+        },
+        {
+          "module": "goldenflow.mapping.schema_mapper",
+          "file": "packages/python/goldenflow/goldenflow/mapping/schema_mapper.py",
+          "defines": [
+            "ColumnMapping",
+            "SchemaMapper"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.mapping.name_similarity",
+            "goldenflow.mapping.profile_similarity"
+          ]
+        },
+        {
+          "module": "goldenflow.mcp",
+          "file": "packages/python/goldenflow/goldenflow/mcp/__init__.py"
+        },
+        {
+          "module": "goldenflow.mcp.server",
+          "file": "packages/python/goldenflow/goldenflow/mcp/server.py",
+          "purpose": "MCP server for GoldenFlow -- 10 tools for data transformation.",
+          "defines": [
+            "create_server",
+            "handle_tool",
+            "run_server",
+            "run_server_http"
+          ],
+          "imports": [
+            "goldenflow.config.learner",
+            "goldenflow.config.loader",
+            "goldenflow.connectors.file",
+            "goldenflow.domains",
+            "goldenflow.engine.differ",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.selector",
+            "goldenflow.engine.transformer",
+            "goldenflow.mapping.schema_mapper",
+            "goldenflow.transforms"
+          ]
+        },
+        {
+          "module": "goldenflow.notebook",
+          "file": "packages/python/goldenflow/goldenflow/notebook.py",
+          "purpose": "Jupyter notebook integration for GoldenFlow.",
+          "defines": [
+            "_manifest_repr_html",
+            "_profile_repr_html",
+            "_transform_result_repr_html"
+          ],
+          "imports": [
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.transformer"
+          ]
+        },
+        {
+          "module": "goldenflow.reporters",
+          "file": "packages/python/goldenflow/goldenflow/reporters/__init__.py"
+        },
+        {
+          "module": "goldenflow.reporters.json_reporter",
+          "file": "packages/python/goldenflow/goldenflow/reporters/json_reporter.py",
+          "defines": [
+            "manifest_to_json"
+          ],
+          "imports": [
+            "goldenflow.engine.manifest"
+          ]
+        },
+        {
+          "module": "goldenflow.reporters.rich_console",
+          "file": "packages/python/goldenflow/goldenflow/reporters/rich_console.py",
+          "defines": [
+            "print_diff",
+            "print_manifest",
+            "print_profile"
+          ],
+          "imports": [
+            "goldenflow.engine.differ",
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge"
+          ]
+        },
+        {
+          "module": "goldenflow.streaming",
+          "file": "packages/python/goldenflow/goldenflow/streaming.py",
+          "purpose": "Streaming/incremental transform processing for GoldenFlow.",
+          "defines": [
+            "StreamProcessor"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.config.schema",
+            "goldenflow.engine.transformer"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms",
+          "file": "packages/python/goldenflow/goldenflow/transforms/__init__.py",
+          "defines": [
+            "TransformInfo",
+            "get_transform",
+            "list_transforms",
+            "parse_transform_name",
+            "register_transform",
+            "registry"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms._chain",
+          "file": "packages/python/goldenflow/goldenflow/transforms/_chain.py",
+          "purpose": "Fused columnar apply bridge — run a whole run of owned string->string transforms",
+          "defines": [
+            "_native_if_on",
+            "apply_chain_native",
+            "fusable_f64_names",
+            "fusable_names",
+            "fused_enabled",
+            "is_fusable"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms._fastpath",
+          "file": "packages/python/goldenflow/goldenflow/transforms/_fastpath.py",
+          "purpose": "Vectorized-fast-path-with-residual-fallback helper.",
+          "defines": [
+            "apply_with_residual"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms._native",
+          "file": "packages/python/goldenflow/goldenflow/transforms/_native.py",
+          "purpose": "Thin Arrow bridge from the Polars Series transforms to the goldenflow-native",
+          "defines": [
+            "_aba_kernel_runner",
+            "_address_kernel_runner",
+            "_as_f64_series",
+            "_as_str_series",
+            "_categorical_kernel_runner",
+            "_cc_kernel_runner",
+            "_company_kernel_runner",
+            "_ean_kernel_runner",
+            "_email_kernel_runner",
+            "_iban_kernel_runner",
+            "_imei_kernel_runner",
+            "_isbn_kernel_runner",
+            "_kernel_runner",
+            "_name_kernel_runner",
+            "_names_ext_kernel_runner",
+            "_numeric_array_kernel_runner",
+            "_numeric_kernel_runner",
+            "_split_name_runner",
+            "_str_kernel_runner",
+            "_swift_kernel_runner",
+            "_text_kernel_runner",
+            "_text_param_kernel_runner",
+            "_url_kernel_runner",
+            "_vat_kernel_runner",
+            "aba_validate_native",
+            "abs_value_native",
+            "address_expand_native",
+            "address_standardize_native",
+            "boolean_normalize_native",
+            "build_canonical_map_native",
+            "category_normalize_key_native",
+            "cc_brand_native",
+            "cc_format_native",
+            "cc_mask_native",
+            "cc_validate_native",
+            "clamp_native",
+            "collapse_whitespace_native",
+            "comma_decimal_native",
+            "company_extract_legal_native",
+            "company_normalize_native",
+            "company_strip_legal_native",
+            "country_standardize_native",
+            "currency_strip_native",
+            "cusip_validate_native",
+            "double_metaphone_native",
+            "ean_validate_native",
+            "ein_format_native",
+            "email_canonical_native",
+            "email_extract_domain_native",
+            "email_lowercase_native",
+            "email_mask_native",
+            "email_normalize_native",
+            "email_validate_native",
+            "extract_numbers_native",
+            "fill_zero_native",
+            "fix_mojibake_native",
+            "fraction_to_decimal_native",
+            "gender_standardize_native",
+            "has_initial_native",
+            "iban_format_native",
+            "iban_validate_native",
+            "imei_validate_native",
+            "isbn_normalize_native",
+            "isbn_validate_native",
+            "isin_validate_native",
+            "lowercase_native",
+            "luhn_validate_native",
+            "merge_name_native",
+            "name_initials_native",
+            "name_proper_native",
+            "name_script_native",
+            "name_transliterate_native",
+            "nickname_standardize_native",
+            "normalize_line_endings_native",
+            "normalize_quotes_native",
+            "normalize_unicode_native",
+            "npi_validate_native",
+            "null_standardize_native",
+            "ordinal_to_int_native",
+            "pad_left_native",
+            "pad_right_native",
+            "percentage_normalize_native",
+            "phone_country_code_native",
+            "phone_digits_native",
+            "phone_e164_native",
+            "phone_national_native",
+            "remove_digits_native",
+            "remove_emojis_native",
+            "remove_html_tags_native",
+            "remove_punctuation_native",
+            "remove_urls_native",
+            "roman_to_int_native",
+            "round_native",
+            "scientific_to_decimal_native",
+            "soundex_native",
+            "split_address_native",
+            "split_name_native",
+            "split_name_reverse_native",
+            "ssn_format_native",
+            "ssn_mask_native",
+            "state_abbreviate_native",
+            "state_expand_native",
+            "strip_middle_native",
+            "strip_native",
+            "strip_suffixes_native",
+            "strip_titles_native",
+            "swift_format_native",
+            "swift_validate_native",
+            "title_case_native",
+            "to_integer_native",
+            "truncate_native",
+            "unit_normalize_native",
+            "uppercase_native",
+            "url_canonical_native",
+            "url_extract_domain_native",
+            "url_normalize_native",
+            "url_strip_tracking_native",
+            "url_strip_www_native",
+            "vat_format_native",
+            "vat_validate_native",
+            "zip_normalize_native"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms._normalize_unicode_map",
+          "file": "packages/python/goldenflow/goldenflow/transforms/_normalize_unicode_map.py",
+          "purpose": "GENERATED by scripts/gen_normalize_unicode_map.py -- do not hand-edit."
+        },
+        {
+          "module": "goldenflow.transforms.address",
+          "file": "packages/python/goldenflow/goldenflow/transforms/address.py",
+          "defines": [
+            "_address_expand_py",
+            "_address_expand_series",
+            "_address_standardize_py",
+            "_address_standardize_series",
+            "_ascii_lower",
+            "_ci_startswith",
+            "_country_standardize_py",
+            "_is_ascii_alpha",
+            "_is_ascii_digit",
+            "_is_word_char",
+            "_is_zip",
+            "_parse_state_zip_tail",
+            "_replace_word_bounded",
+            "_split_address_py",
+            "_state_abbreviate_py",
+            "_state_abbreviate_series",
+            "_state_expand_py",
+            "_state_expand_series",
+            "_sub_leading_hash",
+            "_sub_leading_token",
+            "_try_parse_address",
+            "_unit_normalize_py",
+            "_zip_normalize_py",
+            "_zip_normalize_series",
+            "address_expand",
+            "address_standardize",
+            "country_standardize",
+            "split_address",
+            "state_abbreviate",
+            "state_expand",
+            "unit_normalize",
+            "zip_normalize"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.auto_correct",
+          "file": "packages/python/goldenflow/goldenflow/transforms/auto_correct.py",
+          "defines": [
+            "_build_canonical_map",
+            "category_auto_correct",
+            "category_auto_correct_columnar"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.categorical",
+          "file": "packages/python/goldenflow/goldenflow/transforms/categorical.py",
+          "defines": [
+            "_boolean_normalize_py",
+            "_category_from_file_factory",
+            "_category_normalize_key_py",
+            "_category_normalize_key_series",
+            "_category_passthrough",
+            "_gender_standardize_py",
+            "_null_standardize_py",
+            "boolean_normalize",
+            "category_from_file",
+            "category_standardize",
+            "gender_standardize",
+            "null_standardize"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.company",
+          "file": "packages/python/goldenflow/goldenflow/transforms/company.py",
+          "purpose": "Company/organization dedup-normalization transforms.",
+          "defines": [
+            "_company_extract_legal_py",
+            "_company_normalize_py",
+            "_company_strip_legal_py",
+            "_is_legal",
+            "_last_ws",
+            "_legal_key",
+            "company_extract_legal",
+            "company_normalize",
+            "company_strip_legal"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.dates",
+          "file": "packages/python/goldenflow/goldenflow/transforms/dates.py",
+          "defines": [
+            "_age_from_dob_factory",
+            "_age_scalar",
+            "_date_eu_py",
+            "_date_iso8601_py",
+            "_date_shift_factory",
+            "_date_shift_scalar",
+            "_date_us_py",
+            "_date_validate_py",
+            "_datetime_iso8601_py",
+            "_extract_day_of_week_py",
+            "_extract_day_py",
+            "_extract_month_py",
+            "_extract_quarter_py",
+            "_extract_year_py",
+            "_parse_date",
+            "_parsed_date_expr",
+            "age_from_dob",
+            "date_eu",
+            "date_iso8601",
+            "date_parse",
+            "date_shift",
+            "date_us",
+            "date_validate",
+            "datetime_iso8601",
+            "extract_day",
+            "extract_day_of_week",
+            "extract_month",
+            "extract_quarter",
+            "extract_year"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._fastpath"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.email",
+          "file": "packages/python/goldenflow/goldenflow/transforms/email.py",
+          "defines": [
+            "_email_canonical_py",
+            "_email_extract_domain_py",
+            "_email_lowercase_py",
+            "_email_mask_py",
+            "_email_normalize_py",
+            "_email_validate_py",
+            "email_canonical",
+            "email_extract_domain",
+            "email_lowercase",
+            "email_mask",
+            "email_normalize",
+            "email_validate"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.identifiers",
+          "file": "packages/python/goldenflow/goldenflow/transforms/identifiers.py",
+          "defines": [
+            "_aba_validate_py",
+            "_cc_brand_py",
+            "_cc_format_py",
+            "_cc_group",
+            "_cc_mask_py",
+            "_cc_normalized_digits",
+            "_cc_strip_sep",
+            "_cc_validate_py",
+            "_cusip_validate_py",
+            "_cusip_value",
+            "_ean_gtin_checksum_ok",
+            "_ean_validate_py",
+            "_ein_format_py",
+            "_extract_digits",
+            "_iban_format_py",
+            "_iban_group4",
+            "_iban_mod97_ok",
+            "_iban_normalize",
+            "_iban_validate_py",
+            "_imei_validate_py",
+            "_isbn10_checksum_ok",
+            "_isbn13_check_digit",
+            "_isbn13_checksum_ok",
+            "_isbn_normalize_case",
+            "_isbn_normalize_py",
+            "_isbn_validate_py",
+            "_isin_validate_py",
+            "_luhn_ok",
+            "_luhn_validate_py",
+            "_npi_validate_py",
+            "_ssn_format_py",
+            "_ssn_mask_py",
+            "_swift_format_py",
+            "_swift_normalize",
+            "_swift_validate_py",
+            "_vat_de_checksum_ok",
+            "_vat_fixed_ok",
+            "_vat_format_py",
+            "_vat_it_checksum_ok",
+            "_vat_pos_ok",
+            "_vat_split_prefix",
+            "_vat_structural_ok",
+            "_vat_validate_py",
+            "aba_validate",
+            "cc_brand",
+            "cc_format",
+            "cc_mask",
+            "cc_validate",
+            "cusip_validate",
+            "ean_validate",
+            "ein_format",
+            "iban_format",
+            "iban_validate",
+            "imei_validate",
+            "isbn_normalize",
+            "isbn_validate",
+            "isin_validate",
+            "luhn_validate",
+            "npi_validate",
+            "ssn_format",
+            "ssn_mask",
+            "swift_format",
+            "swift_validate",
+            "vat_format",
+            "vat_validate"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.names",
+          "file": "packages/python/goldenflow/goldenflow/transforms/names.py",
+          "defines": [
+            "_classify_char",
+            "_has_initial_py",
+            "_has_initial_series",
+            "_merge_name_py",
+            "_name_initials_py",
+            "_name_proper_py",
+            "_name_script_py",
+            "_name_transliterate_py",
+            "_nickname_standardize_py",
+            "_split_name_py",
+            "_split_name_reverse_py",
+            "_strip_middle_py",
+            "_strip_suffixes_py",
+            "_strip_suffixes_series",
+            "_strip_titles_py",
+            "_strip_titles_series",
+            "initial_expand",
+            "merge_name",
+            "name_initials",
+            "name_proper",
+            "name_script",
+            "name_transliterate",
+            "nickname_standardize",
+            "split_name",
+            "split_name_reverse",
+            "strip_middle",
+            "strip_suffixes",
+            "strip_titles"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.numeric",
+          "file": "packages/python/goldenflow/goldenflow/transforms/numeric.py",
+          "defines": [
+            "_abs_f64_py",
+            "_clamp_f64_py",
+            "_comma_decimal_py",
+            "_currency_strip_py",
+            "_currency_strip_series",
+            "_fraction_to_decimal_py",
+            "_fraction_to_decimal_series",
+            "_int_to_roman",
+            "_ordinal_suffix",
+            "_ordinal_to_int_py",
+            "_ordinal_to_int_series",
+            "_parse_fraction",
+            "_percentage_normalize_py",
+            "_percentage_normalize_series",
+            "_roman_to_int_py",
+            "_roman_to_int_series",
+            "_round_f64_py",
+            "_scientific_to_decimal_py",
+            "_to_integer_py",
+            "_to_integer_series",
+            "abs_value",
+            "clamp",
+            "comma_decimal",
+            "currency_strip",
+            "fill_zero",
+            "fraction_to_decimal",
+            "ordinal_to_int",
+            "percentage_normalize",
+            "roman_to_int",
+            "round_values",
+            "scientific_to_decimal",
+            "to_integer"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.phone",
+          "file": "packages/python/goldenflow/goldenflow/transforms/phone.py",
+          "defines": [
+            "_e164_fast_expr",
+            "_parse_phone",
+            "_phone_country_code_py",
+            "_phone_digits_py",
+            "_phone_e164_py",
+            "_phone_national_py",
+            "_phone_validate_py",
+            "phone_country_code",
+            "phone_digits",
+            "phone_e164",
+            "phone_national",
+            "phone_validate"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._fastpath",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.phonetic",
+          "file": "packages/python/goldenflow/goldenflow/transforms/phonetic.py",
+          "purpose": "Phonetic key transforms -- blocking/match keys for entity resolution.",
+          "defines": [
+            "_dm_component",
+            "_dm_greek_ch",
+            "_dm_initial_anger_exception",
+            "_dm_initial_g_for_kj",
+            "_dm_initial_greek_ch",
+            "_dm_slice",
+            "_double_metaphone_alt_py",
+            "_double_metaphone_primary_py",
+            "_double_metaphone_py",
+            "_soundex_py",
+            "double_metaphone_alt",
+            "double_metaphone_primary",
+            "soundex"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.text",
+          "file": "packages/python/goldenflow/goldenflow/transforms/text.py",
+          "defines": [
+            "_collapse_whitespace_py",
+            "_collapse_whitespace_series",
+            "_extract_numbers_py",
+            "_extract_numbers_series",
+            "_fix_mojibake_py",
+            "_lowercase_py",
+            "_lowercase_series",
+            "_normalize_line_endings_py",
+            "_normalize_line_endings_series",
+            "_normalize_quotes_py",
+            "_normalize_quotes_series",
+            "_normalize_unicode_py",
+            "_pad_left_py",
+            "_pad_right_py",
+            "_remove_digits_py",
+            "_remove_digits_series",
+            "_remove_emojis_py",
+            "_remove_emojis_series",
+            "_remove_html_tags_py",
+            "_remove_html_tags_series",
+            "_remove_punctuation_py",
+            "_remove_punctuation_series",
+            "_remove_urls_py",
+            "_remove_urls_series",
+            "_strip_py",
+            "_strip_series",
+            "_title_case_py",
+            "_title_case_series",
+            "_truncate_py",
+            "_uppercase_py",
+            "_uppercase_series",
+            "collapse_whitespace",
+            "extract_numbers",
+            "fix_mojibake",
+            "lowercase",
+            "normalize_line_endings",
+            "normalize_quotes",
+            "normalize_unicode",
+            "pad_left",
+            "pad_right",
+            "remove_digits",
+            "remove_emojis",
+            "remove_html_tags",
+            "remove_punctuation",
+            "remove_urls",
+            "strip",
+            "title_case",
+            "truncate",
+            "uppercase"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native",
+            "goldenflow.transforms._normalize_unicode_map"
+          ]
+        },
+        {
+          "module": "goldenflow.transforms.url",
+          "file": "packages/python/goldenflow/goldenflow/transforms/url.py",
+          "defines": [
+            "_strip_tracking_query",
+            "_url_canonical_py",
+            "_url_extract_domain_py",
+            "_url_normalize_py",
+            "_url_strip_tracking_py",
+            "_url_strip_www_py",
+            "url_canonical",
+            "url_extract_domain",
+            "url_normalize",
+            "url_strip_tracking",
+            "url_strip_www"
+          ],
+          "imports": [
+            "goldenflow._polars_lazy",
+            "goldenflow.transforms",
+            "goldenflow.transforms._native"
+          ]
+        },
+        {
+          "module": "goldenflow.tui",
+          "file": "packages/python/goldenflow/goldenflow/tui/__init__.py"
+        },
+        {
+          "module": "goldenflow.tui.app",
+          "file": "packages/python/goldenflow/goldenflow/tui/app.py",
+          "defines": [
+            "ExportTab",
+            "GoldenFlowApp",
+            "MapTab",
+            "ProfileTab",
+            "TransformTab"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenflow.config.loader",
+            "goldenflow.connectors.file",
+            "goldenflow.engine.manifest",
+            "goldenflow.engine.profiler_bridge",
+            "goldenflow.engine.transformer",
+            "goldenflow.mapping.schema_mapper",
+            "goldenflow.transforms"
+          ]
+        }
+      ]
+    },
+    "goldenpipe": {
+      "root": "packages/python/goldenpipe/goldenpipe",
+      "module_count": 53,
+      "modules": [
+        {
+          "module": "goldenpipe",
+          "file": "packages/python/goldenpipe/goldenpipe/__init__.py",
+          "purpose": "GoldenPipe -- pluggable pipeline framework for data quality.",
+          "imports": [
+            "goldenpipe._api",
+            "goldenpipe.config.loader",
+            "goldenpipe.decisions",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage",
+            "goldenpipe.pipeline"
+          ]
+        },
+        {
+          "module": "goldenpipe._api",
+          "file": "packages/python/goldenpipe/goldenpipe/_api.py",
+          "purpose": "Python API -- convenience functions for running pipelines.",
+          "defines": [
+            "run",
+            "run_df",
+            "run_stages"
+          ],
+          "imports": [
+            "goldenpipe.config.loader",
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.reporter",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.engine.runner",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "goldenpipe.pipeline"
+          ]
+        },
+        {
+          "module": "goldenpipe.a2a",
+          "file": "packages/python/goldenpipe/goldenpipe/a2a/__init__.py",
+          "purpose": "A2A agent server."
+        },
+        {
+          "module": "goldenpipe.a2a.server",
+          "file": "packages/python/goldenpipe/goldenpipe/a2a/server.py",
+          "purpose": "A2A protocol server for GoldenPipe (aiohttp).",
+          "defines": [
+            "agent_card",
+            "create_app",
+            "handle_task",
+            "health",
+            "run_server"
+          ],
+          "imports": [
+            "goldenpipe.mcp.server"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/__init__.py",
+          "purpose": "Golden Suite adapters with lazy imports + built-in LoadStage.",
+          "defines": [
+            "LoadStage"
+          ],
+          "imports": [
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.analysis",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/analysis.py",
+          "purpose": "GoldenAnalysis terminal reporting stage -- Phase 5.",
+          "defines": [
+            "AnalysisReportStage"
+          ],
+          "imports": [
+            "goldenanalysis",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.check",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/check.py",
+          "purpose": "GoldenCheck adapter -- scans the in-memory frame (scan_dataframe), falling",
+          "defines": [
+            "ScanStage"
+          ],
+          "imports": [
+            "goldencheck",
+            "goldenpipe.models.column_context",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage",
+            "goldenpipe.repair_host"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.engine",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/engine.py",
+          "purpose": "Remote (in-engine) stages -- relocatable-stage contract, Phase C.",
+          "defines": [
+            "EngineFlowTransformStage",
+            "EngineNormalizeStage",
+            "RemoteStage"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenpipe.models.context",
+            "goldenpipe.models.frame",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.flow",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/flow.py",
+          "purpose": "GoldenFlow adapter -- wraps transform_df().",
+          "defines": [
+            "TransformStage"
+          ],
+          "imports": [
+            "goldenflow",
+            "goldenpipe.models.column_context",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage",
+            "goldenpipe.repair_host"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.identity",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/identity.py",
+          "purpose": "GoldenMatch Identity Graph adapter -- v1.2.",
+          "defines": [
+            "IdentityResolveStage",
+            "decide_identity"
+          ],
+          "imports": [
+            "goldenmatch.identity",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.adapters.match",
+          "file": "packages/python/goldenpipe/goldenpipe/adapters/match.py",
+          "purpose": "GoldenMatch adapter -- wraps dedupe_df().",
+          "defines": [
+            "DedupeStage",
+            "FusedDedupeStage",
+            "_build_config_from_contexts",
+            "_throughput_from_hint"
+          ],
+          "imports": [
+            "goldenmatch",
+            "goldenmatch.config.schemas",
+            "goldenmatch.core.fused_match",
+            "goldenpipe.compiler.e2e",
+            "goldenpipe.models.column_context",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.api",
+          "file": "packages/python/goldenpipe/goldenpipe/api/__init__.py",
+          "purpose": "REST API server."
+        },
+        {
+          "module": "goldenpipe.api.server",
+          "file": "packages/python/goldenpipe/goldenpipe/api/server.py",
+          "purpose": "FastAPI REST API for GoldenPipe.",
+          "defines": [
+            "RunRequest",
+            "create_app"
+          ],
+          "imports": [
+            "goldenpipe",
+            "goldenpipe._api",
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.models.config"
+          ]
+        },
+        {
+          "module": "goldenpipe.autoconfig_glue",
+          "file": "packages/python/goldenpipe/goldenpipe/autoconfig_glue.py",
+          "purpose": "Host glue for the auto-config brain (Polars/InferMap in; Pydantic out).",
+          "defines": [
+            "build_planner_input",
+            "enforce_confidence",
+            "plan_to_config",
+            "profile_complexity",
+            "profile_context"
+          ],
+          "imports": [
+            "goldenpipe.autoconfig_planner",
+            "goldenpipe.errors",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "infermap"
+          ]
+        },
+        {
+          "module": "goldenpipe.autoconfig_planner",
+          "file": "packages/python/goldenpipe/goldenpipe/autoconfig_planner.py",
+          "purpose": "Plan-first auto-config decision core (portable — NO Polars/Pydantic).",
+          "defines": [
+            "ComplexityProfile",
+            "PipePlan",
+            "PipePlannerRule",
+            "PipeProfile",
+            "PlannedStage",
+            "PlannerInput",
+            "_default_plan",
+            "apply_scale_hints",
+            "band_of",
+            "default_evidence",
+            "plan_pipeline"
+          ],
+          "imports": [
+            "goldenpipe.autoconfig_planner_rules"
+          ]
+        },
+        {
+          "module": "goldenpipe.autoconfig_planner_rules",
+          "file": "packages/python/goldenpipe/goldenpipe/autoconfig_planner_rules.py",
+          "purpose": "Concrete planner rules for the goldenpipe auto-config brain.",
+          "defines": [
+            "_confident_schema_plan",
+            "_is_confident_schema",
+            "_is_low_confidence",
+            "_is_pathological",
+            "_low_confidence_plan",
+            "_pathological_plan"
+          ],
+          "imports": [
+            "goldenpipe.autoconfig_planner"
+          ]
+        },
+        {
+          "module": "goldenpipe.cli",
+          "file": "packages/python/goldenpipe/goldenpipe/cli/__init__.py"
+        },
+        {
+          "module": "goldenpipe.cli.main",
+          "file": "packages/python/goldenpipe/goldenpipe/cli/main.py",
+          "purpose": "GoldenPipe CLI -- pipeline framework for data quality.",
+          "defines": [
+            "agent_serve",
+            "init",
+            "interactive",
+            "mcp_serve",
+            "run",
+            "serve",
+            "stages",
+            "validate"
+          ],
+          "imports": [
+            "goldenpipe._api",
+            "goldenpipe.a2a.server",
+            "goldenpipe.api.server",
+            "goldenpipe.config.loader",
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.mcp.server",
+            "goldenpipe.tui.app"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/__init__.py"
+        },
+        {
+          "module": "goldenpipe.compiler.capture",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/capture.py",
+          "purpose": "Host: reconstruct each executed stage's concrete config for the IR record.",
+          "defines": [
+            "_match_config_from_ctx",
+            "_normalize_match_config",
+            "_profile_columns",
+            "capture_stage"
+          ],
+          "imports": [
+            "goldenpipe.adapters.match"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler.compiled_runner",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/compiled_runner.py",
+          "purpose": "Opt-in compiler entry point: reuses the classic Runner (execution byte-identical)",
+          "defines": [
+            "compile_and_run"
+          ],
+          "imports": [
+            "goldenpipe.compiler.capture",
+            "goldenpipe.compiler.ir",
+            "goldenpipe.engine.runner"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler.e2e",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/e2e.py",
+          "purpose": "End-to-end field lineage (SP3): stitch SP2 field-lineage (pre-match Flow-clean +",
+          "defines": [
+            "end_to_end_lineage",
+            "format_end_to_end",
+            "surface_golden_provenance"
+          ],
+          "imports": [
+            "goldenmatch.core.lineage",
+            "goldenpipe.compiler.lineage"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler.ir",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/ir.py",
+          "purpose": "Pure IR + lower — the SP2 mirror of goldenpipe-core/src/ir.rs. Deterministic,",
+          "defines": [
+            "_node",
+            "lower"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler.lineage",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/lineage.py",
+          "purpose": "Host lineage: compute field-level provenance from a compiled pipeline (via the",
+          "defines": [
+            "field_lineage",
+            "format_lineage"
+          ],
+          "imports": [
+            "goldenpipe.compiler.provenance"
+          ]
+        },
+        {
+          "module": "goldenpipe.compiler.provenance",
+          "file": "packages/python/goldenpipe/goldenpipe/compiler/provenance.py",
+          "purpose": "Pure field-level provenance over the SP1 IR — the mirror of",
+          "defines": [
+            "_note",
+            "provenance"
+          ]
+        },
+        {
+          "module": "goldenpipe.config",
+          "file": "packages/python/goldenpipe/goldenpipe/config/__init__.py",
+          "purpose": "Configuration loading.",
+          "imports": [
+            "goldenpipe.config.loader"
+          ]
+        },
+        {
+          "module": "goldenpipe.config.loader",
+          "file": "packages/python/goldenpipe/goldenpipe/config/loader.py",
+          "purpose": "YAML config loading and normalization.",
+          "defines": [
+            "load_config"
+          ],
+          "imports": [
+            "goldenpipe.models.config"
+          ]
+        },
+        {
+          "module": "goldenpipe.core",
+          "file": "packages/python/goldenpipe/goldenpipe/core/__init__.py",
+          "purpose": "goldenpipe.core -- native-loader + planner-json parity surface (SP2)."
+        },
+        {
+          "module": "goldenpipe.core._native_loader",
+          "file": "packages/python/goldenpipe/goldenpipe/core/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``goldenpipe._native`` binding.",
+          "defines": [
+            "_has_symbol",
+            "apply_decision_json",
+            "apply_scale_hints_json",
+            "auto_config_json",
+            "band_of_json",
+            "build_repair_plan_json",
+            "evaluate_builtin_json",
+            "lower_json",
+            "native_available",
+            "native_enabled",
+            "native_module",
+            "plan_pipeline_json",
+            "provenance_json",
+            "resolve_json",
+            "skip_if_falsy_json"
+          ],
+          "imports": [
+            "goldenpipe._native"
+          ]
+        },
+        {
+          "module": "goldenpipe.core._planner_json",
+          "file": "packages/python/goldenpipe/goldenpipe/core/_planner_json.py",
+          "purpose": "The JSON face of the pure-Python planner — the SP2 parity surface (SHIPPED).",
+          "defines": [
+            "_Stub",
+            "_StubRegistry",
+            "_info",
+            "_plan_from_dict",
+            "_plan_to_dict",
+            "_planned_to_dict",
+            "_profile_from_dict",
+            "apply_decision_json",
+            "apply_scale_hints_json",
+            "auto_config_json",
+            "band_of_json",
+            "build_repair_plan_json",
+            "evaluate_builtin_json",
+            "lower_json",
+            "plan_pipeline_json",
+            "provenance_json",
+            "resolve_json",
+            "skip_if_falsy_json"
+          ],
+          "imports": [
+            "goldenpipe",
+            "goldenpipe.autoconfig_planner",
+            "goldenpipe.compiler",
+            "goldenpipe.compiler.provenance",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.engine.router",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage",
+            "goldenpipe.pipeline"
+          ]
+        },
+        {
+          "module": "goldenpipe.decisions",
+          "file": "packages/python/goldenpipe/goldenpipe/decisions.py",
+          "purpose": "Built-in decision functions for pipeline routing.",
+          "defines": [
+            "pii_router",
+            "row_count_gate",
+            "severity_gate"
+          ],
+          "imports": [
+            "goldenpipe.models.context"
+          ]
+        },
+        {
+          "module": "goldenpipe.engine",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/__init__.py",
+          "purpose": "Pipeline engine modules."
+        },
+        {
+          "module": "goldenpipe.engine.registry",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/registry.py",
+          "purpose": "Stage registry -- discover, register, and retrieve stages.",
+          "defines": [
+            "StageRegistry"
+          ],
+          "imports": [
+            "goldenpipe.adapters",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.engine.reporter",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/reporter.py",
+          "purpose": "Reporter -- builds PipeResult from PipeContext after execution.",
+          "defines": [
+            "Reporter"
+          ],
+          "imports": [
+            "goldenpipe.models.context"
+          ]
+        },
+        {
+          "module": "goldenpipe.engine.resolver",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/resolver.py",
+          "purpose": "Pipeline resolver -- dependency-DAG planner (spec §3.1). Config-order-authoritative",
+          "defines": [
+            "AmbiguousProducerError",
+            "CycleError",
+            "ExecutionPlan",
+            "PlannedStage",
+            "Resolver",
+            "UnknownNeedError",
+            "WiringError",
+            "_Node"
+          ],
+          "imports": [
+            "goldenpipe.engine.registry",
+            "goldenpipe.models.config"
+          ]
+        },
+        {
+          "module": "goldenpipe.engine.router",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/router.py",
+          "purpose": "Decision router -- apply routing decisions to execution plan.",
+          "defines": [
+            "Router"
+          ],
+          "imports": [
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context"
+          ]
+        },
+        {
+          "module": "goldenpipe.engine.runner",
+          "file": "packages/python/goldenpipe/goldenpipe/engine/runner.py",
+          "purpose": "Pipeline runner -- execute stages with error handling and routing.",
+          "defines": [
+            "Runner"
+          ],
+          "imports": [
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.engine.router",
+            "goldenpipe.models.context"
+          ]
+        },
+        {
+          "module": "goldenpipe.errors",
+          "file": "packages/python/goldenpipe/goldenpipe/errors.py",
+          "purpose": "goldenpipe-local exceptions.",
+          "defines": [
+            "PipeNotConfidentError"
+          ]
+        },
+        {
+          "module": "goldenpipe.mcp",
+          "file": "packages/python/goldenpipe/goldenpipe/mcp/__init__.py",
+          "purpose": "MCP server for GoldenPipe."
+        },
+        {
+          "module": "goldenpipe.mcp.server",
+          "file": "packages/python/goldenpipe/goldenpipe/mcp/server.py",
+          "purpose": "MCP server with pipeline tools.",
+          "defines": [
+            "_build_tools",
+            "_frame_head_dicts",
+            "_frame_rows",
+            "_is_frame",
+            "_result_to_dict",
+            "_summarize_output",
+            "create_server",
+            "explain_pipeline_tool",
+            "list_stages_tool",
+            "run_pipeline_tool",
+            "run_server",
+            "run_server_http",
+            "validate_pipeline_tool"
+          ],
+          "imports": [
+            "goldenpipe.config.loader",
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.models.config",
+            "goldenpipe.pipeline"
+          ]
+        },
+        {
+          "module": "goldenpipe.models",
+          "file": "packages/python/goldenpipe/goldenpipe/models/__init__.py",
+          "purpose": "Data models for GoldenPipe.",
+          "imports": [
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage"
+          ]
+        },
+        {
+          "module": "goldenpipe.models.column_context",
+          "file": "packages/python/goldenpipe/goldenpipe/models/column_context.py",
+          "purpose": "Column context — shared column metadata flowing between pipeline stages.",
+          "defines": [
+            "CardinalityBand",
+            "ColumnContext",
+            "ColumnType",
+            "_apply_cardinality_signal",
+            "_classify_by_name",
+            "_compute_cardinality_bands",
+            "_normalize_dtype",
+            "build_contexts_from_check",
+            "enrich_contexts_from_flow"
+          ]
+        },
+        {
+          "module": "goldenpipe.models.config",
+          "file": "packages/python/goldenpipe/goldenpipe/models/config.py",
+          "purpose": "Pipeline configuration models (Pydantic).",
+          "defines": [
+            "PipelineConfig",
+            "StageSpec"
+          ]
+        },
+        {
+          "module": "goldenpipe.models.context",
+          "file": "packages/python/goldenpipe/goldenpipe/models/context.py",
+          "purpose": "Core data models: PipeContext, StageResult, Decision, PipeResult.",
+          "defines": [
+            "Decision",
+            "PipeContext",
+            "PipeResult",
+            "PipeStatus",
+            "StageResult",
+            "StageStatus"
+          ],
+          "imports": [
+            "goldenpipe.models.frame"
+          ]
+        },
+        {
+          "module": "goldenpipe.models.frame",
+          "file": "packages/python/goldenpipe/goldenpipe/models/frame.py",
+          "purpose": "Relocatable-stage seam: an Arrow-capable frame handle (Phase A).",
+          "defines": [
+            "DuckDBFrame",
+            "Frame",
+            "LocalFrame"
+          ]
+        },
+        {
+          "module": "goldenpipe.models.stage",
+          "file": "packages/python/goldenpipe/goldenpipe/models/stage.py",
+          "purpose": "Stage protocol and @stage decorator.",
+          "defines": [
+            "Stage",
+            "StageInfo",
+            "_FunctionStage",
+            "stage"
+          ],
+          "imports": [
+            "goldenpipe.models.context"
+          ]
+        },
+        {
+          "module": "goldenpipe.pipeline",
+          "file": "packages/python/goldenpipe/goldenpipe/pipeline.py",
+          "purpose": "Pipeline -- thin wrapper over the engine layer.",
+          "defines": [
+            "Pipeline"
+          ],
+          "imports": [
+            "goldenpipe.autoconfig_glue",
+            "goldenpipe.autoconfig_planner",
+            "goldenpipe.engine.registry",
+            "goldenpipe.engine.reporter",
+            "goldenpipe.engine.resolver",
+            "goldenpipe.engine.runner",
+            "goldenpipe.models.config",
+            "goldenpipe.models.context",
+            "goldenpipe.models.frame"
+          ]
+        },
+        {
+          "module": "goldenpipe.repair",
+          "file": "packages/python/goldenpipe/goldenpipe/repair.py",
+          "purpose": "Pure repair-plan kernel — the SP2 mirror of goldenpipe-core/src/repair.rs.",
+          "defines": [
+            "_all",
+            "_ascii_lower",
+            "_is_alnum_upper",
+            "_is_ascii_ws",
+            "_is_digit",
+            "_is_upper",
+            "_lookup",
+            "_luhn_ok",
+            "_v_aba",
+            "_v_credit_card",
+            "_v_cusip",
+            "_v_ean",
+            "_v_iban",
+            "_v_imei",
+            "_v_isbn",
+            "_v_isin",
+            "_v_npi",
+            "_v_swift",
+            "build_repair_plan",
+            "fine_type",
+            "resolve_tag"
+          ]
+        },
+        {
+          "module": "goldenpipe.repair_host",
+          "file": "packages/python/goldenpipe/goldenpipe/repair_host.py",
+          "purpose": "Host glue for repair-plan: sample polars columns, build ColumnInputs, call the",
+          "defines": [
+            "_coarse_str",
+            "attach_repair_plan",
+            "build_column_inputs",
+            "merge_transforms",
+            "repair_transform_specs",
+            "sample_column"
+          ],
+          "imports": [
+            "goldenpipe.repair"
+          ]
+        },
+        {
+          "module": "goldenpipe.stages",
+          "file": "packages/python/goldenpipe/goldenpipe/stages/__init__.py",
+          "purpose": "Built-in stages for goldenpipe."
+        },
+        {
+          "module": "goldenpipe.stages.infer_schema",
+          "file": "packages/python/goldenpipe/goldenpipe/stages/infer_schema.py",
+          "purpose": "infer_schema — stage 0 of GoldenPipe. Runs InferMap to label columns.",
+          "defines": [
+            "_result_to_inferred_schema",
+            "_validate_flags",
+            "infer_schema_stage"
+          ],
+          "imports": [
+            "goldenpipe.models.context",
+            "goldenpipe.models.stage",
+            "infermap"
+          ]
+        },
+        {
+          "module": "goldenpipe.tui",
+          "file": "packages/python/goldenpipe/goldenpipe/tui/__init__.py",
+          "purpose": "Textual TUI for GoldenPipe."
+        },
+        {
+          "module": "goldenpipe.tui.app",
+          "file": "packages/python/goldenpipe/goldenpipe/tui/app.py",
+          "purpose": "GoldenPipe TUI -- 4-tab pipeline interface (Pipeline / Config / Results / Log).",
+          "imports": [
+            "goldenpipe._api"
+          ]
+        }
+      ]
+    },
+    "infermap": {
+      "root": "packages/python/infermap/infermap",
+      "module_count": 30,
+      "modules": [
+        {
+          "module": "infermap",
+          "file": "packages/python/infermap/infermap/__init__.py",
+          "purpose": "infermap — inference-driven schema mapping engine.",
+          "defines": [
+            "map"
+          ],
+          "imports": [
+            "infermap.config",
+            "infermap.detect",
+            "infermap.domain_pack",
+            "infermap.engine",
+            "infermap.errors",
+            "infermap.identity",
+            "infermap.providers",
+            "infermap.scorers",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap._native_loader",
+          "file": "packages/python/infermap/infermap/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``infermap._native`` accelerator.",
+          "defines": [
+            "_has_symbol",
+            "native_available",
+            "native_enabled",
+            "native_module"
+          ],
+          "imports": [
+            "infermap._native"
+          ]
+        },
+        {
+          "module": "infermap.assignment",
+          "file": "packages/python/infermap/infermap/assignment.py",
+          "purpose": "Optimal assignment via the Hungarian algorithm.",
+          "defines": [
+            "optimal_assign"
+          ]
+        },
+        {
+          "module": "infermap.calibration",
+          "file": "packages/python/infermap/infermap/calibration.py",
+          "purpose": "Confidence calibration for infermap.",
+          "defines": [
+            "Calibrator",
+            "IdentityCalibrator",
+            "IsotonicCalibrator",
+            "PlattCalibrator",
+            "calibrator_from_dict",
+            "load_calibrator",
+            "save_calibrator"
+          ]
+        },
+        {
+          "module": "infermap.cli",
+          "file": "packages/python/infermap/infermap/cli.py",
+          "purpose": "infermap CLI — map, apply, inspect, validate commands.",
+          "defines": [
+            "_print_table",
+            "_setup_logging",
+            "apply",
+            "inspect",
+            "main",
+            "map",
+            "mcp_serve",
+            "validate"
+          ],
+          "imports": [
+            "infermap.config",
+            "infermap.engine",
+            "infermap.errors",
+            "infermap.mcp.server",
+            "infermap.providers"
+          ]
+        },
+        {
+          "module": "infermap.config",
+          "file": "packages/python/infermap/infermap/config.py",
+          "purpose": "infermap config — load saved mapping configurations.",
+          "defines": [
+            "from_config"
+          ],
+          "imports": [
+            "infermap.errors",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.detect",
+          "file": "packages/python/infermap/infermap/detect.py",
+          "purpose": "Lightweight domain-pack auto-detection from column names.",
+          "defines": [
+            "_detect_core",
+            "_detect_core_pure",
+            "_hint_matches",
+            "_tokens",
+            "detect_domain",
+            "detect_domain_detailed"
+          ],
+          "imports": [
+            "infermap._native_loader"
+          ]
+        },
+        {
+          "module": "infermap.dictionaries",
+          "file": "packages/python/infermap/infermap/dictionaries/__init__.py",
+          "purpose": "Domain alias dictionaries shipped with infermap.",
+          "defines": [
+            "UnknownDomainError",
+            "available_domains",
+            "load_domain",
+            "merge_domains"
+          ]
+        },
+        {
+          "module": "infermap.domain_pack",
+          "file": "packages/python/infermap/infermap/domain_pack.py",
+          "purpose": "DomainPackTarget — adapts a goldencheck-types DomainPack as an InferMap target.",
+          "defines": [
+            "DomainPackTarget"
+          ],
+          "imports": [
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.engine",
+          "file": "packages/python/infermap/infermap/engine.py",
+          "purpose": "MapEngine — orchestrates schema extraction, scoring, and assignment.",
+          "defines": [
+            "MapEngine",
+            "_common_affix_tokens",
+            "_default_scorers_with_domains",
+            "_populate_canonical_names"
+          ],
+          "imports": [
+            "infermap.assignment",
+            "infermap.calibration",
+            "infermap.dictionaries",
+            "infermap.domain_pack",
+            "infermap.providers",
+            "infermap.scorers",
+            "infermap.scorers.alias",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.errors",
+          "file": "packages/python/infermap/infermap/errors.py",
+          "purpose": "infermap exception classes.",
+          "defines": [
+            "ApplyError",
+            "ConfigError",
+            "InferMapError"
+          ]
+        },
+        {
+          "module": "infermap.identity",
+          "file": "packages/python/infermap/infermap/identity.py",
+          "purpose": "InferMap -> Identity Graph bridge.",
+          "defines": [
+            "AliasWriteResult",
+            "_is_alias_kind",
+            "write_aliases_from_mapping"
+          ],
+          "imports": [
+            "goldenmatch.identity",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.mcp",
+          "file": "packages/python/infermap/infermap/mcp/__init__.py"
+        },
+        {
+          "module": "infermap.mcp.server",
+          "file": "packages/python/infermap/infermap/mcp/server.py",
+          "purpose": "MCP server exposing InferMap tools for Claude Desktop and other MCP clients.",
+          "defines": [
+            "_handle_apply",
+            "_handle_inspect",
+            "_handle_map",
+            "_handle_validate",
+            "create_server",
+            "run_server",
+            "run_server_http"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.config",
+            "infermap.dictionaries",
+            "infermap.engine",
+            "infermap.providers",
+            "infermap.scorers"
+          ]
+        },
+        {
+          "module": "infermap.providers",
+          "file": "packages/python/infermap/infermap/providers/__init__.py",
+          "purpose": "infermap providers — auto-detection and dispatch.",
+          "defines": [
+            "detect_provider",
+            "extract_schema"
+          ],
+          "imports": [
+            "infermap.providers.db",
+            "infermap.providers.file",
+            "infermap.providers.memory",
+            "infermap.providers.schema_file",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.providers.base",
+          "file": "packages/python/infermap/infermap/providers/base.py",
+          "purpose": "Provider Protocol definition.",
+          "defines": [
+            "Provider"
+          ],
+          "imports": [
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.providers.db",
+          "file": "packages/python/infermap/infermap/providers/db.py",
+          "purpose": "DBProvider — connects to databases and extracts SchemaInfo.",
+          "defines": [
+            "DBProvider",
+            "_duckdb_type_to_infermap",
+            "_parse_connection",
+            "_pg_type_to_infermap",
+            "_quote_ident",
+            "_sqlite_type_to_infermap"
+          ],
+          "imports": [
+            "infermap.errors",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.providers.file",
+          "file": "packages/python/infermap/infermap/providers/file.py",
+          "purpose": "FileProvider — reads CSV, Parquet, and Excel files via Polars.",
+          "defines": [
+            "FileProvider",
+            "_normalize_dtype",
+            "_profile_series"
+          ],
+          "imports": [
+            "infermap.errors",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.providers.memory",
+          "file": "packages/python/infermap/infermap/providers/memory.py",
+          "purpose": "InMemoryProvider — accepts Polars DF, Pandas DF, or list[dict].",
+          "defines": [
+            "InMemoryProvider",
+            "_to_polars"
+          ],
+          "imports": [
+            "infermap.providers.file",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.providers.schema_file",
+          "file": "packages/python/infermap/infermap/providers/schema_file.py",
+          "purpose": "SchemaFileProvider — reads YAML/JSON schema definition files.",
+          "defines": [
+            "SchemaFileProvider"
+          ],
+          "imports": [
+            "infermap.errors",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers",
+          "file": "packages/python/infermap/infermap/scorers/__init__.py",
+          "purpose": "infermap scorer registry and helpers.",
+          "defines": [
+            "_FunctionScorer",
+            "default_scorers",
+            "scorer"
+          ],
+          "imports": [
+            "infermap.alias",
+            "infermap.base",
+            "infermap.exact",
+            "infermap.fuzzy_name",
+            "infermap.initialism",
+            "infermap.llm",
+            "infermap.pattern_type",
+            "infermap.profile",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.alias",
+          "file": "packages/python/infermap/infermap/scorers/alias.py",
+          "purpose": "Alias scorer — matches fields that are known synonyms of each other.",
+          "defines": [
+            "AliasScorer",
+            "_get_canonical",
+            "build_lookup"
+          ],
+          "imports": [
+            "infermap.dictionaries",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.base",
+          "file": "packages/python/infermap/infermap/scorers/base.py",
+          "purpose": "Scorer protocol definition.",
+          "defines": [
+            "Scorer"
+          ],
+          "imports": [
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.exact",
+          "file": "packages/python/infermap/infermap/scorers/exact.py",
+          "purpose": "Exact name scorer — case-insensitive exact field name match.",
+          "defines": [
+            "ExactScorer",
+            "_exact_score",
+            "_exact_score_pure"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.fuzzy_name",
+          "file": "packages/python/infermap/infermap/scorers/fuzzy_name.py",
+          "purpose": "Fuzzy name scorer — Jaro-Winkler similarity on normalized field names.",
+          "defines": [
+            "FuzzyNameScorer",
+            "_fuzzy_name_score",
+            "_fuzzy_name_score_pure",
+            "_normalize"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.initialism",
+          "file": "packages/python/infermap/infermap/scorers/initialism.py",
+          "purpose": "Initialism / abbreviation scorer.",
+          "defines": [
+            "InitialismScorer",
+            "_initialism_score",
+            "_is_prefix_concat",
+            "_score_pair",
+            "_tokenize"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.llm",
+          "file": "packages/python/infermap/infermap/scorers/llm.py",
+          "purpose": "LLM scorer stub — returns None (abstain).",
+          "defines": [
+            "LLMScorer"
+          ],
+          "imports": [
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.pattern_type",
+          "file": "packages/python/infermap/infermap/scorers/pattern_type.py",
+          "purpose": "Pattern-type scorer — detects semantic types from sample values via regex.",
+          "defines": [
+            "PatternTypeScorer",
+            "_classify_with_pct",
+            "_match_types_batch",
+            "_match_types_pure",
+            "classify_field"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.scorers.profile",
+          "file": "packages/python/infermap/infermap/scorers/profile.py",
+          "purpose": "Profile scorer — compares statistical profiles of two fields.",
+          "defines": [
+            "ProfileScorer",
+            "_avg_value_length",
+            "_profile_score",
+            "_profile_score_pure",
+            "_similarity"
+          ],
+          "imports": [
+            "infermap._native_loader",
+            "infermap.types"
+          ]
+        },
+        {
+          "module": "infermap.types",
+          "file": "packages/python/infermap/infermap/types.py",
+          "purpose": "infermap core dataclasses.",
+          "defines": [
+            "FieldInfo",
+            "FieldMapping",
+            "MapResult",
+            "SchemaInfo",
+            "ScorerResult"
+          ],
+          "imports": [
+            "infermap.errors"
+          ]
+        }
+      ]
+    },
+    "goldenanalysis": {
+      "root": "packages/python/goldenanalysis/goldenanalysis",
+      "module_count": 30,
+      "modules": [
+        {
+          "module": "goldenanalysis",
+          "file": "packages/python/goldenanalysis/goldenanalysis/__init__.py",
+          "purpose": "GoldenAnalysis — read-only cross-cutting analysis/metrics/reporting for the Golden Suite.",
+          "defines": [
+            "__dir__",
+            "__getattr__"
+          ],
+          "imports": [
+            "goldenanalysis._api",
+            "goldenanalysis.history",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis._api",
+          "file": "packages/python/goldenanalysis/goldenanalysis/_api.py",
+          "purpose": "Top-level analyze entrypoints — resolve analyzers, run them over an artifact,",
+          "defines": [
+            "_artifact_compatible_analyzers",
+            "_assemble_report",
+            "_frame_compatible_analyzers",
+            "analyze",
+            "analyze_match",
+            "analyze_pipeline"
+          ],
+          "imports": [
+            "goldenanalysis.adapters",
+            "goldenanalysis.adapters.match",
+            "goldenanalysis.adapters.pipe",
+            "goldenanalysis.models",
+            "goldenanalysis.registry"
+          ]
+        },
+        {
+          "module": "goldenanalysis._regressions",
+          "file": "packages/python/goldenanalysis/goldenanalysis/_regressions.py",
+          "purpose": "Pure regression decision logic — baseline strategy + direction-aware policy.",
+          "defines": [
+            "baseline_value",
+            "delta_pct",
+            "evaluate_metric",
+            "is_regression"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/__init__.py",
+          "purpose": "Artifact adapters normalize a producer's output into an ``AnalyzerInput``.",
+          "imports": [
+            "goldenanalysis.adapters.frame"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters.check",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/check.py",
+          "purpose": "``check`` adapter — GoldenCheck scan output → ``AnalyzerInput.artifacts``.",
+          "defines": [
+            "CheckArtifactAdapter"
+          ],
+          "imports": [
+            "goldenanalysis.models",
+            "goldencheck"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters.flow",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/flow.py",
+          "purpose": "``flow`` adapter — GoldenFlow ``TransformResult`` → ``AnalyzerInput.artifacts``.",
+          "defines": [
+            "FlowArtifactAdapter"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters.frame",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/frame.py",
+          "purpose": "The generic ``frame`` adapter — the always-available, zero-suite-dep path.",
+          "defines": [
+            "FrameArtifactAdapter"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters.match",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/match.py",
+          "purpose": "``match`` adapter — GoldenMatch ``DedupeResult`` → ``AnalyzerInput.artifacts``.",
+          "defines": [
+            "MatchArtifactAdapter",
+            "_normalize_cert",
+            "_primary_threshold"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.adapters.pipe",
+          "file": "packages/python/goldenanalysis/goldenanalysis/adapters/pipe.py",
+          "purpose": "``pipe`` adapter — GoldenPipe ``PipeResult`` → ``AnalyzerInput.artifacts``.",
+          "defines": [
+            "PipeArtifactAdapter",
+            "_dataset_from_source"
+          ],
+          "imports": [
+            "goldenanalysis.adapters.match",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/__init__.py",
+          "purpose": "Analyzers: the composable units that compute metrics over an ``AnalyzerInput``.",
+          "imports": [
+            "goldenanalysis.analyzers.base"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers.base",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/base.py",
+          "purpose": "The ``Analyzer`` protocol.",
+          "defines": [
+            "Analyzer"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers.cluster_dist",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/cluster_dist.py",
+          "purpose": "``cluster.distribution`` — cluster-size shape from a GoldenMatch result.",
+          "defines": [
+            "ClusterDistributionAnalyzer"
+          ],
+          "imports": [
+            "goldenanalysis.core",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers.frame_summary",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/frame_summary.py",
+          "purpose": "``frame.summary`` — generic frame metrics, zero suite deps, always available.",
+          "defines": [
+            "FrameSummaryAnalyzer"
+          ],
+          "imports": [
+            "goldenanalysis.core",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers.match_rates",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/match_rates.py",
+          "purpose": "``match.rates`` — match metrics from a GoldenMatch result's artifacts.",
+          "defines": [
+            "MatchRatesAnalyzer",
+            "_cert_values"
+          ],
+          "imports": [
+            "goldenanalysis.core",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.analyzers.quality_rollup",
+          "file": "packages/python/goldenanalysis/goldenanalysis/analyzers/quality_rollup.py",
+          "purpose": "``quality.rollup`` — a single \"is the data healthy\" view rolling up both",
+          "defines": [
+            "QualityRollupAnalyzer",
+            "_get",
+            "_health_score",
+            "_severity_name"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.cli",
+          "file": "packages/python/goldenanalysis/goldenanalysis/cli/__init__.py",
+          "purpose": "GoldenAnalysis command-line interface."
+        },
+        {
+          "module": "goldenanalysis.cli.main",
+          "file": "packages/python/goldenanalysis/goldenanalysis/cli/main.py",
+          "purpose": "``goldenanalysis`` CLI.",
+          "defines": [
+            "_open_history",
+            "_parse_policy",
+            "mcp_serve",
+            "regressions",
+            "report",
+            "trend"
+          ],
+          "imports": [
+            "goldenanalysis",
+            "goldenanalysis.history",
+            "goldenanalysis.mcp",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.core",
+          "file": "packages/python/goldenanalysis/goldenanalysis/core/__init__.py",
+          "purpose": "Core aggregation primitives + the native-loader gate (Phase 4 seam)."
+        },
+        {
+          "module": "goldenanalysis.core._native_loader",
+          "file": "packages/python/goldenanalysis/goldenanalysis/core/_native_loader.py",
+          "purpose": "Loader + gate for the optional ``goldenanalysis._native`` accelerator.",
+          "defines": [
+            "_has_symbol",
+            "native_available",
+            "native_enabled",
+            "native_module"
+          ],
+          "imports": [
+            "goldenanalysis._native"
+          ]
+        },
+        {
+          "module": "goldenanalysis.core.aggregate",
+          "file": "packages/python/goldenanalysis/goldenanalysis/core/aggregate.py",
+          "purpose": "Pure-Python/Polars aggregation primitives.",
+          "defines": [
+            "_cluster_size_histogram_pure",
+            "_distinct_count_pure",
+            "_duplicate_row_ratio_pure",
+            "_histogram_native",
+            "_histogram_pure",
+            "_max_native",
+            "_max_pure",
+            "_mean_native",
+            "_mean_pure",
+            "_min_native",
+            "_min_pure",
+            "_null_ratio_per_column_pure",
+            "_quantile_native",
+            "_quantile_pure",
+            "cluster_size_histogram",
+            "distinct_count",
+            "duplicate_row_ratio",
+            "histogram",
+            "max",
+            "mean",
+            "min",
+            "null_ratio_per_column",
+            "quantile"
+          ],
+          "imports": [
+            "goldenanalysis.core._native_loader"
+          ]
+        },
+        {
+          "module": "goldenanalysis.history",
+          "file": "packages/python/goldenanalysis/goldenanalysis/history.py",
+          "purpose": "``ReportHistory`` — an append-only store of ``AnalysisReport``s for cross-run",
+          "defines": [
+            "ReportHistory",
+            "_as_float",
+            "_prior_series"
+          ],
+          "imports": [
+            "goldenanalysis._regressions",
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.mcp",
+          "file": "packages/python/goldenanalysis/goldenanalysis/mcp/__init__.py",
+          "purpose": "Optional MCP server for GoldenAnalysis (the ``[mcp]`` extra)."
+        },
+        {
+          "module": "goldenanalysis.mcp.server",
+          "file": "packages/python/goldenanalysis/goldenanalysis/mcp/server.py",
+          "purpose": "MCP server with read-only GoldenAnalysis tools.",
+          "defines": [
+            "_build_tools",
+            "_open_history",
+            "analyze_frame_tool",
+            "create_server",
+            "detect_regressions_tool",
+            "get_trend_tool",
+            "list_analyzers_tool",
+            "run_server",
+            "run_server_http"
+          ],
+          "imports": [
+            "goldenanalysis",
+            "goldenanalysis.history",
+            "goldenanalysis.models",
+            "goldenanalysis.registry"
+          ]
+        },
+        {
+          "module": "goldenanalysis.models",
+          "file": "packages/python/goldenanalysis/goldenanalysis/models/__init__.py",
+          "purpose": "GoldenAnalysis domain models.",
+          "imports": [
+            "goldenanalysis.models.analyzer",
+            "goldenanalysis.models.policy",
+            "goldenanalysis.models.report"
+          ]
+        },
+        {
+          "module": "goldenanalysis.models.analyzer",
+          "file": "packages/python/goldenanalysis/goldenanalysis/models/analyzer.py",
+          "purpose": "Analyzer I/O types: ``AnalyzerInfo``, ``AnalyzerInput``, ``AnalyzerResult``.",
+          "defines": [
+            "AnalyzerInfo",
+            "AnalyzerInput",
+            "AnalyzerResult"
+          ],
+          "imports": [
+            "goldenanalysis.models.report"
+          ]
+        },
+        {
+          "module": "goldenanalysis.models.policy",
+          "file": "packages/python/goldenanalysis/goldenanalysis/models/policy.py",
+          "purpose": "Cross-run models: ``Baseline``, ``RegressionPolicy``, ``Regression``, ``TrendSeries``.",
+          "defines": [
+            "Regression",
+            "RegressionPolicy",
+            "TrendSeries"
+          ],
+          "imports": [
+            "goldenanalysis.models.report"
+          ]
+        },
+        {
+          "module": "goldenanalysis.models.report",
+          "file": "packages/python/goldenanalysis/goldenanalysis/models/report.py",
+          "purpose": "Core report domain types: ``Metric``, ``AnalysisTable``, ``AnalysisReport``.",
+          "defines": [
+            "AnalysisReport",
+            "AnalysisTable",
+            "Metric"
+          ],
+          "imports": [
+            "goldenanalysis.render"
+          ]
+        },
+        {
+          "module": "goldenanalysis.narrative",
+          "file": "packages/python/goldenanalysis/goldenanalysis/narrative.py",
+          "purpose": "Narrative generation — a one-paragraph NL summary templated from the flagged",
+          "defines": [
+            "_pretty",
+            "_top_finding_class",
+            "build_narrative"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        },
+        {
+          "module": "goldenanalysis.registry",
+          "file": "packages/python/goldenanalysis/goldenanalysis/registry.py",
+          "purpose": "Analyzer discovery via the ``goldenanalysis.analyzers`` entry-point group.",
+          "defines": [
+            "_entry_point_names",
+            "_resolve_class",
+            "available_analyzers",
+            "load_analyzer"
+          ],
+          "imports": [
+            "goldenanalysis.analyzers.base"
+          ]
+        },
+        {
+          "module": "goldenanalysis.render",
+          "file": "packages/python/goldenanalysis/goldenanalysis/render.py",
+          "purpose": "Markdown rendering for ``AnalysisReport``.",
+          "defines": [
+            "_fmt_value",
+            "format_markdown"
+          ],
+          "imports": [
+            "goldenanalysis.models"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/scripts/agent_codemap.py
+++ b/scripts/agent_codemap.py
@@ -1,0 +1,168 @@
+"""Generate (or check) docs/agent-codemap.json -- a committed structural map of the
+repo's Python source, for OTHER PEOPLE'S coding agents browsing the codebase.
+
+The config manifest (docs/agent-manifest.json) answers "what can I configure / call".
+This answers the other half an agent spends turns rediscovering: "what modules
+exist, what does each do, what does each define, and how are they wired" -- so an
+external agent orients without grepping the tree.
+
+It is COMMITTED (a SessionStart hook would only help the maintainer's own machine,
+not a stranger's agent) and CI-gated for drift, so it ships with the repo and can't
+go stale. Built from a pure `ast` walk -- no package imports, no runtime env -- so
+it is cheap and deterministic. The package list comes from the config-matrix
+registry, so "which packages" stays single-sourced.
+
+Regenerate:  python scripts/agent_codemap.py --write
+Check (CI):  python scripts/agent_codemap.py --check
+"""
+from __future__ import annotations
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from config_matrix.registry import REGISTRY  # noqa: E402
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA_ID = "goldenmatch.agent-codemap/v1"
+CODEMAP_PATH = "docs/agent-codemap.json"
+
+# Import names of every mapped package -> used to keep only INTRA-REPO import edges
+# (an agent tracing architecture cares about goldenmatch->goldencheck, not ->numpy).
+_PKG_IMPORT_NAMES = frozenset(s.src_dirs[0].rsplit("/", 1)[-1] for s in REGISTRY.values())
+
+_SKIP_DIR_PARTS = frozenset({"tests", "__pycache__", "test"})
+
+
+def _module_name(file: Path, src_root: Path) -> str:
+    """packages/.../goldenmatch/core/scorer.py -> 'goldenmatch.core.scorer'."""
+    rel = file.relative_to(src_root.parent).with_suffix("")
+    parts = list(rel.parts)
+    if parts[-1] == "__init__":
+        parts.pop()
+    return ".".join(parts)
+
+
+def _intra_repo_import(module: str | None) -> str | None:
+    if not module:
+        return None
+    top = module.split(".", 1)[0]
+    return module if top in _PKG_IMPORT_NAMES else None
+
+
+def _resolve_relative(node: ast.ImportFrom, current: str) -> str | None:
+    """`from ..core import x` inside pkg.a.b -> the absolute base module."""
+    base = current.split(".")
+    # level 1 = current package (drop the module itself); level 2 = one more up, etc.
+    trimmed = base[: len(base) - node.level]
+    if node.module:
+        trimmed = trimmed + node.module.split(".")
+    return ".".join(trimmed) if trimmed else None
+
+
+def _analyze(file: Path, src_root: Path) -> dict | None:
+    try:
+        tree = ast.parse(file.read_text(encoding="utf-8", errors="ignore"))
+    except (SyntaxError, OSError):
+        return None
+    module = _module_name(file, src_root)
+    defines: list[str] = []
+    imports: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            defines.append(node.name)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for a in node.names:
+                hit = _intra_repo_import(a.name)
+                if hit:
+                    imports.add(hit)
+        elif isinstance(node, ast.ImportFrom):
+            target = _resolve_relative(node, module) if node.level else node.module
+            hit = _intra_repo_import(target)
+            if hit and hit != module:
+                imports.add(hit)
+    doc = ast.get_docstring(tree)
+    entry: dict = {"module": module, "file": file.relative_to(ROOT).as_posix()}
+    if doc:
+        entry["purpose"] = doc.strip().splitlines()[0].strip()
+    if defines:
+        entry["defines"] = sorted(defines)
+    if imports:
+        entry["imports"] = sorted(imports)
+    return entry
+
+
+def _walk_package(src_root: Path) -> list[dict]:
+    modules: list[dict] = []
+    for file in src_root.rglob("*.py"):
+        if _SKIP_DIR_PARTS & set(file.parts):
+            continue
+        if file.name.startswith("test_") or file.name.endswith("_test.py") or file.name == "conftest.py":
+            continue
+        entry = _analyze(file, src_root)
+        if entry:
+            modules.append(entry)
+    return sorted(modules, key=lambda m: m["module"])
+
+
+def build_codemap() -> dict:
+    packages = {}
+    for name, spec in REGISTRY.items():
+        src_root = ROOT / spec.src_dirs[0]
+        modules = _walk_package(src_root) if src_root.exists() else []
+        packages[name] = {
+            "root": spec.src_dirs[0],
+            "module_count": len(modules),
+            "modules": modules,
+        }
+    return {
+        "schema": SCHEMA_ID,
+        "note": (
+            "Structural map of the repo's Python source for coding agents. Generated "
+            "from a static AST walk; DO NOT EDIT. Regenerate: python scripts/agent_codemap.py --write"
+        ),
+        "packages": packages,
+    }
+
+
+def codemap_json() -> str:
+    return json.dumps(build_codemap(), indent=2, ensure_ascii=False) + "\n"
+
+
+def _path() -> Path:
+    return ROOT / CODEMAP_PATH
+
+
+def write_codemap() -> Path:
+    p = _path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(codemap_json(), encoding="utf-8", newline="\n")
+    return p
+
+
+def codemap_is_current() -> bool:
+    p = _path()
+    return p.exists() and p.read_text(encoding="utf-8") == codemap_json()
+
+
+def main(argv: list[str]) -> int:
+    if "--write" in argv:
+        print(f"wrote {write_codemap()}")
+        return 0
+    if "--check" in argv:
+        if codemap_is_current():
+            print(f"OK    agent code map: {CODEMAP_PATH}")
+            return 0
+        print(f"STALE agent code map: {CODEMAP_PATH}", file=sys.stderr)
+        print("::error::agent code map stale. Run: python scripts/agent_codemap.py --write",
+              file=sys.stderr)
+        return 1
+    print(__doc__)
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/test_agent_codemap.py
+++ b/scripts/test_agent_codemap.py
@@ -1,0 +1,43 @@
+"""Gate for the committed agent code map (docs/agent-codemap.json).
+
+The map is a static-AST structural view of the Python source, committed so other
+people's coding agents get it on clone. It must match a fresh walk (so a moved /
+renamed / added module can't leave it stale) and be byte-deterministic.
+Regenerate with: python scripts/agent_codemap.py --write
+"""
+from __future__ import annotations
+
+from agent_codemap import CODEMAP_PATH, build_codemap, codemap_is_current, codemap_json
+
+
+def test_codemap_current():
+    assert codemap_is_current(), (
+        f"{CODEMAP_PATH} is stale vs the Python source. "
+        "Run: python scripts/agent_codemap.py --write"
+    )
+
+
+def test_codemap_deterministic():
+    assert codemap_json() == codemap_json()
+
+
+def test_codemap_covers_every_registry_package():
+    m = build_codemap()
+    assert set(m["packages"]) == {
+        "goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "infermap", "goldenanalysis"
+    }
+    # Every package resolved to real modules, and every entry carries a location.
+    for name, p in m["packages"].items():
+        assert p["module_count"] > 0, f"{name} mapped 0 modules"
+        for mod in p["modules"]:
+            assert mod["module"] and mod["file"]
+
+
+def test_codemap_locates_a_known_symbol():
+    # A concrete "don't grep" check: score_buckets is findable via the map.
+    m = build_codemap()
+    gm = m["packages"]["goldenmatch"]["modules"]
+    hit = next((mod for mod in gm if "score_buckets" in mod.get("defines", [])), None)
+    assert hit is not None, "score_buckets not located in the code map"
+    assert hit["file"].endswith(".py")
+    assert hit.get("imports"), "expected intra-repo import edges for the scorer module"


### PR DESCRIPTION
## What

`docs/agent-codemap.json` — the "where does it live / how is it wired" half of don't-grep, for **other people's** coding agents that clone or browse the repo. Per module across the six core packages: import path, file, one-line purpose (from the module docstring), top-level `defines` (classes/functions), and intra-repo `imports` (architecture edges). **703 modules, ~425 KB.**

Concrete win: `goldenmatch.backends.score_buckets` resolves from the map alone — purpose, that it defines `score_buckets` / `score_buckets_arrow`, and everything it imports — no grep.

## Why committed (not a hook)

A SessionStart hook only helps the maintainer's own machine. A stranger's agent gets whatever's **in the repo**, so the map has to be committed. Freshness comes from a CI drift gate instead of a local hook. Built from a pure `ast` walk (no package imports, no runtime env, fully deterministic), and the package list comes from the config-matrix registry so "which packages" stays single-sourced.

## Gating

`scripts/test_agent_codemap.py` (currency + determinism + a "locate `score_buckets`" smoke) runs inside the existing `config_matrix` gate job on the goldenmatch leg — no new CI job. The `config_matrix` filter already re-runs on any `packages/python/*/*.py` change (exactly when the map moves); added the generator, its gate, and the committed JSON to that filter.

## Relationship to the manifest (#1924)

Complementary, not overlapping:
- **agent-manifest.json** (#1924) — *what can I configure / call*: config schema, CLI, MCP tools, vocabularies, env knobs.
- **agent-codemap.json** (this) — *what exists where + how it's wired*: module tree, purposes, symbols, import edges.

## Notes for review

- **Depends on merge order with #1924** — both touch `.github/filters.yml` and `.gitattributes` in the same regions. If #1924 lands first (it's queued), this may need a trivial rebase in the queue.
- **Deliberately deferred:** cross-linking this + the manifest from `llms.txt` / `AGENTS.md` (and fixing the stale `io.github.benzsevern/*` registry namespace in `llms.txt`) is a separate discoverability pass, best done once both artifacts are on `main`.
- **Not yet covered:** Rust/TS source (Python only for v1); the manifest already lists the 54 Rust crates + paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)