### PR TITLE
docs(agent-nav): cross-link the generated maps + fix stale MCP registry namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,11 @@ Scope work to one package where possible: `uv run pytest packages/python/<pkg>`.
 - **Only `.github/workflows/` at the repo root runs.** Workflow files left under
   `packages/*/.github/` are orphaned and silently ignored.
 
-## Look it up instead of grepping: `docs/agent-manifest.json`
+## Look it up instead of grepping: the generated maps
+
+Two committed, CI-gated JSON maps let you answer most "where / what" questions
+without searching the tree — `docs/agent-manifest.json` (config & capability
+surface) and `docs/agent-codemap.json` (source structure).
 
 `docs/agent-manifest.json` is a generated, machine-readable index of every
 package's **config schema, CLI commands, MCP tools, enumerated vocabularies
@@ -84,6 +88,14 @@ regenerate with `python scripts/gen_config_matrix.py --manifest`.
 **Via MCP:** the `goldensuite-mcp` server exposes a `suite_manifest` tool that
 serves slices of this file (overview / one package / one section / keyword
 search) so you don't pull the whole 300 KB for one lookup.
+
+`docs/agent-codemap.json` is the structural companion: a static-AST map of the
+six packages' Python source. Per module it lists the file, a one-line purpose
+(from the module docstring), the top-level classes/functions it defines, and its
+intra-repo imports — so you can answer "which module defines `score_buckets`",
+"what does `goldenmatch.backends.score_buckets` connect to", or "what modules
+make up goldencheck's engine" without grepping. Gated by
+`scripts/test_agent_codemap.py`; regenerate with `python scripts/agent_codemap.py --write`.
 
 ## Where the deep context lives
 

--- a/llms.txt
+++ b/llms.txt
@@ -25,7 +25,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 ## AI-native surface
 - Every package ships an MCP server (119 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
-- Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benzsevern/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
+- Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 
 ## Polyglot & edge
 - Python (PyPI) + TypeScript (npm), tracked to 4-decimal scorer parity via a cross-language harness
@@ -39,6 +39,12 @@ pip install goldenmatch && goldenmatch dedupe customers.csv   # dedupe a CSV in 
 npm install goldenmatch                                        # TypeScript / Edge
 pip install goldenpipe[full]                                   # Check + Flow + Match together
 ```
+
+## For coding agents (navigate without grepping)
+- `AGENTS.md` (repo root) — orientation map: layout, build/test, the landmines, and where deep context lives.
+- `docs/agent-manifest.json` — generated, CI-gated index of every package's config schema, CLI, MCP tools, vocabularies (with `best_for` hints), env knobs, source-file locations, and Rust crates. "What can I configure or call."
+- `docs/agent-codemap.json` — generated, CI-gated structural map of the Python source: per module, its purpose, what it defines, and its intra-repo imports. "What exists where and how it's wired."
+- Both are derived from the code and gated against drift, so they can't go stale. Via MCP, `goldensuite-mcp`'s `suite_manifest` tool serves slices of the manifest.
 
 ## Docs
 - [Repository + full README](https://github.com/benseverndev-oss/goldenmatch)


### PR DESCRIPTION
## What

The discoverability pass, so external agents that land on the convention entry points find the machine-readable maps we added.

- **`llms.txt`** — new "For coding agents" section pointing at `AGENTS.md`, `docs/agent-manifest.json`, and `docs/agent-codemap.json`, saying what each answers.
- **`AGENTS.md`** — the "look it up instead of grepping" section now covers **both** maps (manifest = config & capability surface; codemap = source structure).
- **Bug fix:** `llms.txt` advertised the MCP Registry namespace as `io.github.benzsevern/*` — the pre-org-transfer personal namespace. The listings live under `io.github.benseverndev-oss/*`, so an agent consuming `llms.txt` to reach the registry got the wrong identifier.

## Gates

`check_llms_counts` passes — no capability-count patterns added (suite total still verifies at 119 tools). No gate checks doc-link existence.

## Ordering

References `docs/agent-codemap.json`, which lands via #1931 (queued ahead of this). Arms behind it, so by merge time both maps are on `main`. Even in the worst ordering it's a briefly-dead relative doc link that self-heals — not a CI failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)