### PR TITLE
feat(pg): in-DB stateful identity resolution — gm_resolve (#1913 P1)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -481,6 +481,11 @@ rust_pgrx:
   # rebuild + re-smoke this lane.
   - 'packages/rust/extensions/goldencheck-core/**'
   - 'packages/rust/extensions/Cargo.toml'
+  # The psql smoke (incl. the #1913 gm_resolve identity write path) lives in
+  # ci.yml, and the lane's dep/SQL install lines are hand-maintained there, so
+  # a change to the workflow (or this filter) must re-run the lane.
+  - '.github/workflows/ci.yml'
+  - '.github/filters.yml'
 rust_cores:
   # ANY Rust extension change re-validates EVERY committed TS wasm
   # parity fixture (the fixture_drift job regenerates them all and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2839,9 +2839,11 @@ jobs:
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
           # handwritten ones into PG's extension dir so `CREATE EXTENSION`
-          # (installs default_version, now 0.13.0) and `ALTER EXTENSION ... UPDATE`
+          # (installs default_version, now 0.14.0) and `ALTER EXTENSION ... UPDATE`
           # find them. The schema files are the canonical declaration of public
           # function signatures.
+          cp sql/goldenmatch_pg--0.14.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.13.0--0.14.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.13.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.12.0--0.13.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.12.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
@@ -2868,6 +2870,9 @@ jobs:
           PYTHON_SITE=$(python -c "import site; print(site.getsitepackages()[0])")
           sudo rm -f /usr/lib/python3/dist-packages/typing_extensions.py
           sudo pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow 2>/dev/null || true
+          # psycopg is the identity postgres-backend requirement: gm_resolve's
+          # embedded-Python identity store connects back to this cluster with it.
+          sudo pip install --break-system-packages 'psycopg[binary]' 2>/dev/null || true
           echo "${PYTHON_SITE}" | sudo tee /usr/lib/python3/dist-packages/goldenmatch.pth
 
       - name: psql smoke (scalar scorer, dedupe, autoconfig)
@@ -3122,6 +3127,61 @@ jobs:
               END IF;
               RAISE NOTICE 'gm_embed smoke passed: dim=%', array_length(v_gm, 1);
             END$$;
+          EOSQL
+          # In-DB identity write path (#1913 P1): gm_resolve resolves a table
+          # into a Postgres-native identity dataset and, on a second run,
+          # ABSORBS a new record into an existing stable id (the incremental /
+          # durable-spine proof). The identity store connects back to THIS
+          # cluster via the goldenmatch.identity_dsn GUC over the loopback
+          # socket (peer auth as postgres). The GUC is set at SESSION level in
+          # the SAME connection that calls gm_resolve: a namespaced custom GUC
+          # is accepted as a placeholder before the extension .so loads, and
+          # _PG_init adopts that value when the first goldenmatch function call
+          # loads the library. (ALTER SYSTEM would fail here — the GUC isn't
+          # registered until the lib loads.) Passed via psql -v so ${PGPORT}
+          # interpolates while the quoted heredoc keeps the DO $$ blocks intact.
+          sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 \
+            -v dsn="host=/var/run/postgresql port=${PGPORT} dbname=postgres user=postgres" <<'EOSQL'
+            SET goldenmatch.identity_dsn = :'dsn';
+            CREATE TABLE id_people (id TEXT, email TEXT, name TEXT);
+            INSERT INTO id_people VALUES
+              ('1', 'a@x.com', 'Al'),
+              ('2', 'a@x.com', 'Alice'),
+              ('3', 'b@y.com', 'Bob');
+            -- exact-email matchkey + source_pk_column so record ids are stable
+            -- across runs. gm_resolve injects enabled/backend/connection/dataset.
+            SELECT goldenmatch.gm_configure('idjob',
+              '{"matchkeys":[{"name":"email_key","type":"exact","fields":[{"field":"email","scorer":"exact"}]}],"identity":{"source_pk_column":"id"}}');
+            -- Run 1: creates the graph in this DB (the two a@x.com rows form one
+            -- identity; b@y.com forms another) -> created >= 1.
+            DO $$
+            DECLARE s jsonb;
+            BEGIN
+              s := goldenmatch.gm_resolve('idjob', 'id_people', 'people')::jsonb;
+              IF (s->>'created')::int < 1 THEN
+                RAISE EXCEPTION 'gm_resolve run1: expected created>=1, got %', s;
+              END IF;
+              RAISE NOTICE 'gm_resolve run1: %', s;
+            END $$;
+            -- Add a new record sharing a@x.com; re-resolve must ABSORB it into the
+            -- existing identity (not create a new one) -> absorbed_records >= 1,
+            -- still exactly 2 identities, one now owning 3 source records.
+            INSERT INTO id_people VALUES ('4', 'a@x.com', 'Alex');
+            DO $$
+            DECLARE s jsonb; n_nodes int; max_recs int;
+            BEGIN
+              s := goldenmatch.gm_resolve('idjob', 'id_people', 'people')::jsonb;
+              IF (s->>'absorbed_records')::int < 1 THEN
+                RAISE EXCEPTION 'gm_resolve run2: expected absorbed_records>=1 (incremental), got %', s;
+              END IF;
+              SELECT count(*) INTO n_nodes FROM identity_nodes;
+              SELECT max(c) INTO max_recs
+                FROM (SELECT count(*) c FROM source_records GROUP BY entity_id) q;
+              IF n_nodes <> 2 OR max_recs <> 3 THEN
+                RAISE EXCEPTION 'gm_resolve incremental: expected 2 stable identities + an entity with 3 records, got nodes=% max_recs=%', n_nodes, max_recs;
+              END IF;
+              RAISE NOTICE 'gm_resolve run2 (absorb): % nodes=% max_recs=%', s, n_nodes, max_recs;
+            END $$;
           EOSQL
           echo "=== PG ${PG_VERSION} smoke passed ==="
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2822,7 +2822,12 @@ jobs:
         # arrow-native, so the pgrx lane runs polars-free against current source
         # too (drops the #1747 stopgap here as well). goldenflow's base has no
         # polars dep (it's a [polars] extra), so this stays polars-free.
-        run: pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow pyarrow
+        # psycopg[binary] rides along because gm_resolve (#1913) opens the
+        # identity postgres store from THIS embedded interpreter — it must be
+        # importable in the same site as goldenmatch, not just the system
+        # python. (Identity resolution is fail-open, so a missing psycopg would
+        # silently return an empty summary and skip the write.)
+        run: pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow pyarrow 'psycopg[binary]'
 
       - name: Install cargo-pgrx
         # 0.12.9 pin matches the pgrx version in
@@ -3140,8 +3145,17 @@ jobs:
           # loads the library. (ALTER SYSTEM would fail here — the GUC isn't
           # registered until the lib loads.) Passed via psql -v so ${PGPORT}
           # interpolates while the quoted heredoc keeps the DO $$ blocks intact.
+          # On any failure here, dump the Postgres server log tail: identity
+          # resolution is fail-open, so a psycopg/DSN problem surfaces as a
+          # Python WARNING in the server log rather than a psql error, and the
+          # run1 guard below (empty summary) turns that into a hard failure.
+          identity_smoke_failed() {
+            echo "::error::gm_resolve smoke failed on PG ${PG_VERSION}; server log tail:"
+            sudo tail -n 120 "/var/log/postgresql/postgresql-${PG_VERSION}-main.log" 2>/dev/null || true
+            exit 1
+          }
           sudo -u postgres psql -p "${PGPORT}" -v ON_ERROR_STOP=1 \
-            -v dsn="host=/var/run/postgresql port=${PGPORT} dbname=postgres user=postgres" <<'EOSQL'
+            -v dsn="host=/var/run/postgresql port=${PGPORT} dbname=postgres user=postgres" <<'EOSQL' || identity_smoke_failed
             SET goldenmatch.identity_dsn = :'dsn';
             CREATE TABLE id_people (id TEXT, email TEXT, name TEXT);
             INSERT INTO id_people VALUES
@@ -3153,13 +3167,15 @@ jobs:
             SELECT goldenmatch.gm_configure('idjob',
               '{"matchkeys":[{"name":"email_key","type":"exact","fields":[{"field":"email","scorer":"exact"}]}],"identity":{"source_pk_column":"id"}}');
             -- Run 1: creates the graph in this DB (the two a@x.com rows form one
-            -- identity; b@y.com forms another) -> created >= 1.
+            -- identity; b@y.com forms another) -> created >= 1. An empty summary
+            -- ('{}') means identity resolution fail-opened (e.g. the store could
+            -- not connect) -- treat that as a hard failure, not a silent skip.
             DO $$
             DECLARE s jsonb;
             BEGIN
               s := goldenmatch.gm_resolve('idjob', 'id_people', 'people')::jsonb;
-              IF (s->>'created')::int < 1 THEN
-                RAISE EXCEPTION 'gm_resolve run1: expected created>=1, got %', s;
+              IF s->>'created' IS NULL OR (s->>'created')::int < 1 THEN
+                RAISE EXCEPTION 'gm_resolve run1: expected created>=1 (empty summary => identity write skipped/failed), got %', s;
               END IF;
               RAISE NOTICE 'gm_resolve run1: %', s;
             END $$;
@@ -3171,7 +3187,7 @@ jobs:
             DECLARE s jsonb; n_nodes int; max_recs int;
             BEGIN
               s := goldenmatch.gm_resolve('idjob', 'id_people', 'people')::jsonb;
-              IF (s->>'absorbed_records')::int < 1 THEN
+              IF s->>'absorbed_records' IS NULL OR (s->>'absorbed_records')::int < 1 THEN
                 RAISE EXCEPTION 'gm_resolve run2: expected absorbed_records>=1 (incremental), got %', s;
               END IF;
               SELECT count(*) INTO n_nodes FROM identity_nodes;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2818,16 +2818,16 @@ jobs:
         # (and goldenflow, for the goldenflow_* transform functions) at
         # runtime. The package install here is what `init()` in the
         # bridge will find when Postgres starts.
-        # Local base goldenmatch (NO [polars]) -- the bridge core-API surface is
-        # arrow-native, so the pgrx lane runs polars-free against current source
-        # too (drops the #1747 stopgap here as well). goldenflow's base has no
-        # polars dep (it's a [polars] extra), so this stays polars-free.
-        # psycopg[binary] rides along because gm_resolve (#1913) opens the
-        # identity postgres store from THIS embedded interpreter — it must be
-        # importable in the same site as goldenmatch, not just the system
-        # python. (Identity resolution is fail-open, so a missing psycopg would
-        # silently return an empty summary and skip the write.)
-        run: pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow pyarrow 'psycopg[binary]'
+        # [polars] IS required here: the core dedupe/score/autoconfig surface is
+        # arrow-native and runs polars-free, but gm_resolve (#1913) drives the
+        # identity write path (dedupe_df -> _resolve_identities ->
+        # resolve_clusters), which builds polars frames — without polars,
+        # identity resolution fail-opens ("No module named 'polars'") and returns
+        # an empty summary. psycopg[binary] likewise: the identity postgres store
+        # connects from THIS embedded interpreter, so both must be importable in
+        # the same site as goldenmatch. (goldenflow stays base — its transforms
+        # are the polars-native extra we don't exercise here.)
+        run: pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch[polars]" goldenflow pyarrow 'psycopg[binary]'
 
       - name: Install cargo-pgrx
         # 0.12.9 pin matches the pgrx version in
@@ -2874,10 +2874,12 @@ jobs:
         run: |
           PYTHON_SITE=$(python -c "import site; print(site.getsitepackages()[0])")
           sudo rm -f /usr/lib/python3/dist-packages/typing_extensions.py
-          sudo pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch" goldenflow 2>/dev/null || true
-          # psycopg is the identity postgres-backend requirement: gm_resolve's
-          # embedded-Python identity store connects back to this cluster with it.
-          sudo pip install --break-system-packages 'psycopg[binary]' 2>/dev/null || true
+          # [polars] + psycopg mirror the bridge-target install: whichever
+          # interpreter pyo3 embeds (this system python, or PYTHON_SITE via the
+          # .pth below) must be able to import both for gm_resolve's identity
+          # write path (#1913) — polars for resolve_clusters, psycopg for the
+          # postgres identity store.
+          sudo pip install --break-system-packages "${GITHUB_WORKSPACE}/packages/python/goldenmatch[polars]" goldenflow 'psycopg[binary]' 2>/dev/null || true
           echo "${PYTHON_SITE}" | sudo tee /usr/lib/python3/dist-packages/goldenmatch.pth
 
       - name: psql smoke (scalar scorer, dedupe, autoconfig)

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -105,6 +105,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.14.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.13.0--0.14.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.13.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.12.0--0.13.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.12.0.sql "${EXT_DIR}/"

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -233,6 +233,15 @@ class DedupeResult:
     # config; goldenmatch.core.config_lint.Finding). Empty unless the linter
     # flagged something. Advisory in the default warn mode.
     lint_findings: list = field(default_factory=list)
+    # Identity-graph resolution summary for THIS run (#1913): counts of
+    # created / absorbed / merged identities + edges/events written, when
+    # config.identity.enabled routed clustering through the durable identity
+    # store. None when identity resolution was disabled or skipped (the
+    # additive default). Mirrors the pipeline result's identity_summary so
+    # callers -- and the goldenmatch-pg gm_resolve bridge -- can read the
+    # write outcome off the public result without reaching into the pipeline
+    # dict.
+    identity_summary: dict | None = None
     # Native-kernel dispatch summary for THIS run (#1048, #957): did the scoring
     # hot path dispatch to the Rust kernel, or fall back to pure Python?
     # `result.native.hot_path_native` confirms dispatch directly instead of
@@ -523,6 +532,7 @@ def dedupe(
             result.get("postflight_report"), _mem
         ),
         memory_stats=_mem,
+        identity_summary=result.get("identity_summary"),
         golden_fused_used=bool(result.get("golden_fused_used", False)),
         match_fused_capacity_mode=bool(result.get("match_fused_capacity_mode", False)),
     )
@@ -785,6 +795,7 @@ def dedupe_df(
         memory_stats=_mem,
         recall_certificate=_recall_cert,
         lint_findings=_lint_findings,
+        identity_summary=result.get("identity_summary"),
         native=_native,
         llm_cost=(
             {

--- a/packages/python/goldenmatch/tests/identity/test_identity_summary_result.py
+++ b/packages/python/goldenmatch/tests/identity/test_identity_summary_result.py
@@ -1,0 +1,60 @@
+"""#1913 (P1 foundation): DedupeResult surfaces the identity-graph resolution
+summary so callers -- and the goldenmatch-pg gm_resolve bridge -- can read the
+write outcome off the public result instead of the internal pipeline dict."""
+from __future__ import annotations
+
+import polars as pl
+
+from goldenmatch import dedupe_df
+from goldenmatch.config.schemas import (
+    GoldenMatchConfig,
+    IdentityConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+
+
+def _people_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "__source__": ["crm"] * 4,
+            "id": ["1", "2", "3", "4"],
+            "email": ["a@x.com", "a@x.com", "b@y.com", "c@z.com"],
+            "name": ["Al", "Alice", "Bob", "Cara"],
+        }
+    )
+
+
+def _email_key_matchkeys() -> list[MatchkeyConfig]:
+    return [
+        MatchkeyConfig(
+            name="email_key",
+            type="exact",
+            fields=[MatchkeyField(field="email", scorer="exact")],
+        )
+    ]
+
+
+def test_dedupe_df_surfaces_identity_summary(tmp_path):
+    cfg = GoldenMatchConfig(
+        matchkeys=_email_key_matchkeys(),
+        identity=IdentityConfig(
+            enabled=True,
+            backend="sqlite",
+            path=str(tmp_path / "identity.db"),
+            dataset="people",
+            source_pk_column="id",
+        ),
+    )
+    res = dedupe_df(_people_df(), config=cfg)
+    # The two a@x.com rows form one identity; the two singletons form one each.
+    assert res.identity_summary is not None
+    assert isinstance(res.identity_summary, dict)
+    assert res.identity_summary.get("created", 0) >= 1
+
+
+def test_identity_summary_none_when_disabled(tmp_path):
+    # No identity config -> the field stays None (additive default, no writes).
+    cfg = GoldenMatchConfig(matchkeys=_email_key_matchkeys())
+    res = dedupe_df(_people_df(), config=cfg)
+    assert res.identity_summary is None

--- a/packages/python/goldenmatch/tests/identity/test_identity_summary_result.py
+++ b/packages/python/goldenmatch/tests/identity/test_identity_summary_result.py
@@ -4,7 +4,6 @@ write outcome off the public result instead of the internal pipeline dict."""
 from __future__ import annotations
 
 import polars as pl
-
 from goldenmatch import dedupe_df
 from goldenmatch.config.schemas import (
     GoldenMatchConfig,

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -872,6 +872,117 @@ pub fn identity_list(dataset: &str, status: &str, db_path: &str) -> Result<Strin
     })
 }
 
+/// Resolve `rows_json` into a Postgres-native identity dataset (#1913 P1).
+///
+/// This is the in-database *write* entrypoint the read-only `identity_*`
+/// wrappers above deliberately lacked. It runs `dedupe_df` with the config's
+/// `identity` section forced to the Postgres backend + the supplied `dsn`, so
+/// the pipeline's post-clustering identity hook writes the durable,
+/// event-sourced graph (nodes / source_records / evidence_edges / events) into
+/// the extension's own database instead of an external SQLite file.
+///
+/// The entire resolution engine is reused unchanged — stable UUIDv7 ids,
+/// create/absorb/merge from `preflight_existing` overlap, the append-only event
+/// log, conflict edges — so re-running against the same `dataset` absorbs new
+/// records into existing ids incrementally (the durable-spine requirement). No
+/// resolution logic is re-implemented in Rust/SQL (see the #1913 design).
+///
+/// - `dsn` — libpq connection string for the identity store (the same database
+///   the extension runs in; the pgrx layer supplies it from the
+///   `goldenmatch.identity_dsn` GUC). Empty is rejected up front.
+/// - `dataset` — identity dataset scoping key; empty preserves whatever the
+///   stored config's `identity.dataset` carries.
+/// - `run_name` — names this resolve run for idempotent event replay; empty
+///   lets the pipeline stamp a timestamp run name.
+///
+/// Returns the identity resolution summary JSON (`created` / `absorbed_records`
+/// / `merged` / `edges_added` / `events_emitted` / `conflicts_flagged`), or
+/// `"{}"` when the pipeline reported no identity summary (resolution skipped).
+pub fn resolve_identities(
+    rows_json: &str,
+    config_json: &str,
+    dsn: &str,
+    dataset: &str,
+    run_name: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "resolve_identities requires a non-empty identity DSN (set the \
+             goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+
+    Python::with_gil(|py| {
+        let gm = py.import("goldenmatch")?;
+        let json_mod = py.import("json")?;
+
+        let df = convert::json_to_arrow_df(py, rows_json)?;
+
+        // Merge the identity write-path settings into the stored config dict,
+        // then validate into a GoldenMatchConfig. Doing the surgery on the dict
+        // (rather than on the built Pydantic object) keeps it simple and dodges
+        // assignment-validation quirks; a non-dict/garbage blob coerces to {}.
+        let loaded = json_mod.call_method1("loads", (config_json,))?;
+        let cfg_map: Bound<'_, PyDict> = match loaded.downcast::<PyDict>() {
+            Ok(d) => d.clone(),
+            Err(_) => PyDict::new(py),
+        };
+
+        // Preserve any existing identity sub-config (e.g. source_pk_column,
+        // emit_singletons) and override only the backend/connection/enabled.
+        let identity_map: Bound<'_, PyDict> = match cfg_map.get_item("identity")? {
+            Some(v) => match v.downcast::<PyDict>() {
+                Ok(d) => d.clone(),
+                Err(_) => PyDict::new(py),
+            },
+            None => PyDict::new(py),
+        };
+        identity_map.set_item("enabled", true)?;
+        identity_map.set_item("backend", "postgres")?;
+        identity_map.set_item("connection", dsn)?;
+        if !dataset.is_empty() {
+            identity_map.set_item("dataset", dataset)?;
+        }
+        cfg_map.set_item("identity", &identity_map)?;
+
+        // Name the run for idempotent replay when the caller supplies one.
+        if !run_name.is_empty() {
+            let output_map: Bound<'_, PyDict> = match cfg_map.get_item("output")? {
+                Some(v) => match v.downcast::<PyDict>() {
+                    Ok(d) => d.clone(),
+                    Err(_) => PyDict::new(py),
+                },
+                None => PyDict::new(py),
+            };
+            output_map.set_item("run_name", run_name)?;
+            cfg_map.set_item("output", &output_map)?;
+        }
+
+        let schemas_mod = py.import("goldenmatch.config.schemas")?;
+        let gm_config_cls = schemas_mod.getattr("GoldenMatchConfig")?;
+        let cfg = gm_config_cls.call_method1("model_validate", (cfg_map,))?;
+
+        let kwargs = PyDict::new(py);
+        kwargs.set_item("config", cfg)?;
+        let result = gm.call_method("dedupe_df", (df,), Some(&kwargs))?;
+
+        // Read `identity_summary` off the public DedupeResult (surfaced in the
+        // #1913 PR-A change). `None` -> resolution was disabled/skipped.
+        let summary = result.getattr("identity_summary")?;
+        if summary.is_none() {
+            return Ok("{}".to_string());
+        }
+        let dumps_kwargs = PyDict::new(py);
+        dumps_kwargs.set_item("default", py.import("builtins")?.getattr("str")?)?;
+        let s: String = json_mod
+            .call_method("dumps", (summary,), Some(&dumps_kwargs))?
+            .extract()?;
+        Ok(s)
+    })
+}
+
 // ─── Correction CRUD (Phase 6A of #437 surface sync) ────────────────────
 //
 // File pair-level + field-level + cluster-decision corrections into the
@@ -2197,6 +2308,23 @@ mod tests {
             Err(e) => require_or_skip(e, "identity_resolve_not_found"),
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── resolve_identities (write path, #1913) ──────────────────────────────
+
+    #[test]
+    fn test_resolve_identities_rejects_empty_dsn() {
+        // The empty-DSN guard fires before any Postgres connection is
+        // attempted, so this asserts the contract without a live database
+        // (the create/absorb round-trip is exercised end-to-end by the
+        // rust_pgrx CI smoke against a real cluster).
+        match resolve_identities("[]", "{}", "   ", "people", "run1") {
+            Ok(json) => panic!("expected empty-DSN rejection, got Ok({json})"),
+            Err(BridgeError::InvalidConfig(msg)) => {
+                assert!(msg.contains("DSN"), "unexpected message: {msg}");
+            }
+            Err(e) => require_or_skip(e, "resolve_identities_rejects_empty_dsn"),
+        }
     }
 
     // ── identity_view ───────────────────────────────────────────────────────

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.13.0'
+default_version = '0.14.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.13.0--0.14.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.13.0--0.14.0.sql
@@ -1,0 +1,16 @@
+-- Upgrade goldenmatch_pg 0.13.0 -> 0.14.0
+--
+-- Adds gm_resolve(): the in-database stateful identity write path (#1913 P1).
+-- Resolves a configured job's table into a Postgres-native identity dataset
+-- (create/absorb/merge, incremental across runs). Identity writes go to the
+-- DSN configured via the goldenmatch.identity_dsn GUC (or the backend
+-- GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL env).
+
+CREATE FUNCTION "gm_resolve"(
+    "job_name" TEXT,
+    "table_name" TEXT,
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_resolve_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.14.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.14.0.sql
@@ -1,0 +1,827 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+-- In-DB stateful identity resolution (#1913 P1). Resolves a job's table into a
+-- Postgres-native identity dataset (create/absorb/merge, incremental across
+-- runs). Writes go to the DSN from the goldenmatch.identity_dsn GUC.
+CREATE FUNCTION "gm_resolve"(
+    "job_name" TEXT,
+    "table_name" TEXT,
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_resolve_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- Two-table record linkage: match a target table against a reference table,
+-- returning the (target_id, reference_id, score) linkage as rows. target_id /
+-- reference_id are 0-based row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';
+
+-- goldenmatch_hnsw_pairs (added in 0.10.0): native HNSW ANN blocking over a
+-- row-major flat real[] corpus. See the 0.9.0->0.10.0 migration for details.
+CREATE FUNCTION "goldenmatch_hnsw_pairs"(
+    "flat_vecs" real[],
+    "dim" INT,
+    "k" INT,
+    "threshold" DOUBLE PRECISION
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_hnsw_pairs_wrapper';
+
+-- goldenmatch_lsh_pairs (added in 0.11.0): native MinHash-LSH token blocking
+-- over a text[] corpus. See the 0.10.0->0.11.0 migration for details.
+CREATE FUNCTION "goldenmatch_lsh_pairs"(
+    "texts" TEXT[],
+    "mode" TEXT,
+    "k" INT,
+    "num_perms" INT,
+    "num_bands" INT,
+    "seed" BIGINT
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_lsh_pairs_wrapper';
+
+-- goldenmatch_perceptual_phash (added in 0.12.0): native-direct (no CPython)
+-- 64-bit DCT perceptual image hash over a row-major flat luma grid + its row
+-- width. The kernel resizes to 32x32 internally. The unsigned 64-bit hash is
+-- returned bit-reinterpreted as BIGINT. See the 0.11.0->0.12.0 migration.
+CREATE FUNCTION "goldenmatch_perceptual_phash"(
+    "grid" double precision[],
+    "ncols" INT
+) RETURNS BIGINT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_phash_wrapper';
+
+-- goldenmatch_perceptual_hamming (added in 0.12.0): Hamming distance between two
+-- 64-bit pHashes (the near-duplicate blocking predicate). Correct on the BIGINT
+-- bit patterns goldenmatch_perceptual_phash returns.
+CREATE FUNCTION "goldenmatch_perceptual_hamming"(
+    "a" BIGINT,
+    "b" BIGINT
+) RETURNS INT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_hamming_wrapper';
+
+-- ── GoldenCheck deep-profiling surface (added in 0.13.0) ────────────────────
+-- Native-direct (no CPython) over the pyo3-free goldencheck-core kernels — the
+-- same reference kernel the goldencheck[native] wheel + the DuckDB goldencheck_*
+-- UDFs run (cross-surface parity roadmap P5). The multi-column functions take a
+-- column-major flat text[] (all of column 0's rows, then column 1's, …) + n_cols.
+
+-- goldencheck_benford: leading-digit (1..9) histogram; element d-1 is the count
+-- of values whose first significant digit is d (non-positive/non-finite skipped).
+CREATE FUNCTION "goldencheck_benford"(
+    "values" double precision[]
+) RETURNS BIGINT[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_benford_wrapper';
+
+-- goldencheck_near_duplicates: cluster near-duplicate string values; one
+-- (cluster, member) row per clustered element (member = 0-based position);
+-- singletons omitted; NULL elements treated as the empty string.
+CREATE FUNCTION "goldencheck_near_duplicates"(
+    "values" TEXT[],
+    "min_similarity" DOUBLE PRECISION
+) RETURNS TABLE ("cluster" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_near_duplicates_wrapper';
+
+-- goldencheck_discover_fds: strict single-column functional dependencies among
+-- n_cols equal-length columns; (det, dep) 0-based column-index pairs.
+CREATE FUNCTION "goldencheck_discover_fds"(
+    "flat" TEXT[],
+    "n_cols" INT
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_fds_wrapper';
+
+-- goldencheck_discover_approx_fds: near-strict FDs + their violation counts;
+-- (det, dep, violations) where det->dep holds for >= min_confidence of rows.
+CREATE FUNCTION "goldencheck_discover_approx_fds"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "min_confidence" DOUBLE PRECISION
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT, "violations" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_approx_fds_wrapper';
+
+-- goldencheck_composite_keys: minimal composite keys (column subsets of size
+-- 2..max_size whose tuples are all distinct); one (key_id, col_index) row per
+-- column in each key. Constant + individually-unique columns are excluded first.
+CREATE FUNCTION "goldencheck_composite_keys"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "max_size" INT
+) RETURNS TABLE ("key_id" BIGINT, "col_index" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_composite_keys_wrapper';

--- a/packages/rust/extensions/postgres/src/lib.rs
+++ b/packages/rust/extensions/postgres/src/lib.rs
@@ -1,4 +1,6 @@
+use pgrx::guc::{GucContext, GucFlags, GucRegistry, GucSetting};
 use pgrx::prelude::*;
+use std::ffi::CStr;
 
 pgrx::pg_module_magic!();
 
@@ -10,6 +12,30 @@ mod kernels;
 mod pipeline;
 mod quick;
 mod spi;
+
+/// libpq DSN for the in-DB identity store used by `gm_resolve()` (#1913).
+///
+/// Superuser-set (`ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` or a
+/// session `SET`). When unset, `gm_resolve()` falls back to the backend
+/// `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` env, and errors
+/// clearly if none is configured.
+pub static IDENTITY_DSN: GucSetting<Option<&'static CStr>> =
+    GucSetting::<Option<&'static CStr>>::new(None);
+
+#[pg_guard]
+pub extern "C" fn _PG_init() {
+    GucRegistry::define_string_guc(
+        "goldenmatch.identity_dsn",
+        "libpq DSN for the in-DB identity store used by gm_resolve().",
+        "When set, gm_resolve() opens a second libpq connection to this DSN and \
+         writes the durable, event-sourced identity graph there (the same \
+         database the extension runs in). Superuser-set; falls back to the \
+         GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env.",
+        &IDENTITY_DSN,
+        GucContext::Suset,
+        GucFlags::default(),
+    );
+}
 
 #[cfg(test)]
 pub mod pg_test {

--- a/packages/rust/extensions/postgres/src/pipeline.rs
+++ b/packages/rust/extensions/postgres/src/pipeline.rs
@@ -324,6 +324,113 @@ pub fn gm_drop(job_name: String) -> String {
     })
 }
 
+/// Resolve a configured job's table into a Postgres-native identity dataset
+/// (#1913 P1 — the in-DB stateful write path).
+///
+/// Loads `job_name`'s stored config, reads `table_name`, and hands them to the
+/// bridge `resolve_identities`, which runs `dedupe_df` with the identity graph
+/// pointed at the DSN from the `goldenmatch.identity_dsn` GUC (or the backend
+/// env). The durable graph (nodes / source_records / evidence_edges / events)
+/// is written into that database; re-running against the same `dataset`
+/// absorbs new records into existing stable ids (incremental resolve).
+///
+/// Returns the identity resolution summary JSON (`created` / `absorbed_records`
+/// / `merged` / `edges_added` / `events_emitted` / `conflicts_flagged`).
+///
+/// NOTE (transaction isolation, per the #1913 design §3.1): the identity writes
+/// commit on the bridge's own libpq connection, NOT the caller's SQL
+/// transaction. `gm_resolve` is a batch op; replay is idempotent
+/// (`has_run_event` / edge-UNIQUE guards), so a failed run converges on re-run.
+#[pg_extern]
+pub fn gm_resolve(job_name: String, table_name: String, dataset: String) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB identity resolution needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+
+    let config_query = format!(
+        "SELECT config_json::text FROM goldenmatch._jobs WHERE name = '{}'",
+        job_name.replace('\'', "''")
+    );
+    let config_json = Spi::connect(|client| {
+        let result = client
+            .select(&config_query, None, None)
+            .unwrap_or_else(|e| pgrx::error!("goldenmatch: {}", e));
+        for row in result {
+            if let Ok(Some(cfg)) = row.get::<String>(1) {
+                return Ok(cfg);
+            }
+        }
+        Err(format!("Job '{}' not found", job_name))
+    });
+    let config_json = match config_json {
+        Ok(c) => c,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    };
+
+    set_job_status(&job_name, "running");
+
+    let rows_json = match spi::read_table_as_json(&table_name) {
+        Ok(json) => json,
+        Err(e) => {
+            set_job_status(&job_name, "failed");
+            pgrx::error!("goldenmatch: {}", e);
+        }
+    };
+
+    // A distinct run name per call (microsecond clock stamp) so a second
+    // resolve emits fresh absorb/merge events rather than being deduped as a
+    // replay of the first — the incremental-across-runs contract.
+    let stamp = Spi::get_one::<String>("SELECT to_char(clock_timestamp(), 'YYYYMMDDHH24MISSUS')")
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let run_name = format!("gm_resolve:{}:{}", job_name.replace(':', "_"), stamp);
+
+    let summary_json = match goldenmatch_bridge::api::resolve_identities(
+        &rows_json,
+        &config_json,
+        &dsn,
+        &dataset,
+        &run_name,
+    ) {
+        Ok(s) => s,
+        Err(e) => {
+            set_job_status(&job_name, "failed");
+            pgrx::error!("goldenmatch: {}", e);
+        }
+    };
+
+    set_job_status(&job_name, "completed");
+    summary_json
+}
+
+/// Resolve the identity DSN: the `goldenmatch.identity_dsn` GUC first, then the
+/// `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` backend env. Returns
+/// `None` (→ a clear error at the call site) when nothing is configured. A
+/// blank/whitespace value is treated as unset.
+fn resolve_identity_dsn() -> Option<String> {
+    if let Some(cstr) = crate::IDENTITY_DSN.get() {
+        if let Ok(s) = cstr.to_str() {
+            if !s.trim().is_empty() {
+                return Some(s.to_string());
+            }
+        }
+    }
+    for var in ["GOLDENMATCH_IDENTITY_DSN", "GOLDENMATCH_DATABASE_URL"] {
+        if let Ok(s) = std::env::var(var) {
+            if !s.trim().is_empty() {
+                return Some(s);
+            }
+        }
+    }
+    None
+}
+
 fn set_job_status(job_name: &str, status: &str) {
     let sql = format!(
         "UPDATE goldenmatch._jobs SET status = '{}' WHERE name = '{}'",


### PR DESCRIPTION
## What and why

Implements #1913 **P1 — the in-database stateful identity WRITE path** for `goldenmatch-pg`. The extension could do batch dedupe but had no way to maintain durable golden identities in Postgres: the identity SQL functions were read-only and took an external SQLite `db_path`. This adds `gm_resolve`, which resolves a table into a **Postgres-native, event-sourced identity dataset** (create/absorb/merge, incremental across runs with stable UUIDv7 ids) by reusing the entire Python resolution engine through the bridge — no resolver re-implemented in Rust/SQL (per the design at `docs/superpowers/specs/2026-07-19-goldenmatch-pg-in-db-identity-write-path-design.md`).

## Changes

**Python (foundation):**
- `DedupeResult.identity_summary: dict | None` — surfaces the per-run identity resolution summary (already computed by `_resolve_identities`) on the public result. `None` when identity resolution is disabled/skipped (additive, byte-identical for existing callers). This is what the bridge reads back.

**Bridge (`goldenmatch-bridge`):**
- `resolve_identities(rows, config, dsn, dataset, run_name)` — merges the identity write-path settings (`backend=postgres` + `connection=dsn`, optional `dataset`/`run_name`) into the stored config, runs `dedupe_df`, and returns the `identity_summary` JSON. Empty DSN is rejected up front (unit-tested).

**pgrx extension (`goldenmatch_pg` 0.13.0 → 0.14.0):**
- `gm_resolve(job, table, dataset)` `#[pg_extern]` — loads the job config, reads the table, calls the bridge with the DSN from the new `goldenmatch.identity_dsn` GUC (superuser-set; falls back to `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL`; errors clearly if unset). A per-call microsecond run name keeps re-resolves emitting fresh absorb events.
- `goldenmatch.identity_dsn` GUC registered in `_PG_init`.
- SQL version bump: new `--0.14.0.sql` base + `--0.13.0--0.14.0.sql` migration; `default_version` + Cargo version bumped; `cp` lines added to `ci.yml` + `publish-goldenmatch-pg.yml`. `pgrx_sql_sync` passes (69 externs = 69 CREATE FUNCTION).

**CI:** the `rust_pgrx` smoke sets the GUC at session level (a namespaced placeholder adopted when the `.so` loads — `ALTER SYSTEM` can't, the GUC isn't registered until then), resolves a table twice, and asserts create on run 1 then absorb + stable ids on run 2 (the incremental proof). Installs `psycopg[binary]` for the identity postgres backend.

Transaction isolation (design §3.1): identity writes commit on the bridge's own libpq connection, not the caller's SQL transaction; replay is idempotent (`has_run_event` / edge-UNIQUE), so a failed run converges on re-run. P2 (read the in-DB dataset), P3 (steward merge/split), P4 (Arrow read) follow.

## Testing

- Bridge builds + `cargo test -p goldenmatch-bridge` → 47 passed (incl. the empty-DSN guard).
- Postgres crate compiles + `cargo fmt --check` clean against pgrx 0.12.9.
- `scripts/check_pgrx_sql_sync.py` → OK (69/69).
- `ARROW_DEFAULT_MEMORY_POOL=system python -m pytest tests/identity/test_identity_summary_result.py -q` → 2 passed.
- **End-to-end against real PostgreSQL 16** (full `cargo pgrx install` + the exact CI smoke SQL): run1 `created=2`, run2 `absorbed_records=1`, 2 stable identities, one owning 3 source records.

## Checklist

- [x] Tests added/updated and passing locally for the changed packages
- [x] `cargo fmt --check` clean; `pgrx_sql_sync` green
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / design doc landed (#1913 design merged separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf