### PR TITLE
feat(pg): identity_* read functions serve the in-DB dataset on empty db_path (#1913 P2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3200,6 +3200,26 @@ jobs:
               END IF;
               RAISE NOTICE 'gm_resolve run2 (absorb): % nodes=% max_recs=%', s, n_nodes, max_recs;
             END $$;
+            -- #1913 P2: the read-only identity_* functions serve the SAME in-DB
+            -- dataset when db_path is empty (they use the goldenmatch.identity_dsn
+            -- GUC). Closes the loop: resolve then query in one database.
+            DO $$
+            DECLARE lst jsonb; n int; rec jsonb;
+            BEGIN
+              -- Empty db_path -> the in-DB Postgres store, not a SQLite file.
+              lst := goldenmatch.goldenmatch_identity_list('people', '', '')::jsonb;
+              n := jsonb_array_length(lst);
+              IF n <> 2 THEN
+                RAISE EXCEPTION 'identity_list(in-DB): expected 2 identities, got % -> %', n, lst;
+              END IF;
+              -- Resolve a record written by gm_resolve (source defaults to
+              -- "dataframe" when the table has no __source__ column).
+              rec := goldenmatch.goldenmatch_identity_resolve('dataframe:1', '')::jsonb;
+              IF rec->>'entity_id' IS NULL THEN
+                RAISE EXCEPTION 'identity_resolve(in-DB): expected an entity for dataframe:1, got %', rec;
+              END IF;
+              RAISE NOTICE 'identity read (in-DB, empty db_path): list=% resolve.entity=%', n, rec->>'entity_id';
+            END $$;
           EOSQL
           echo "=== PG ${PG_VERSION} smoke passed ==="
 

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -728,10 +728,38 @@ pub fn dedupe_clusters(
 //
 // Thin wrappers over ``goldenmatch.identity.query.*`` so the Postgres and
 // DuckDB extensions can serve the same JSON shape the Python/REST/MCP/A2A
-// surfaces serve. Every function takes the path to the identity SQLite/PG
-// store as an explicit argument; session-level settings are awkward to
-// thread through pgrx + pyo3, and explicit args make the SQL contract
-// obvious at the call site.
+// surfaces serve. Every function takes a ``store_ref`` for the identity store:
+// a SQLite file path, OR (since #1913 P2) a libpq DSN, which opens the
+// Postgres backend so the read surface serves the SAME in-DB dataset the
+// gm_resolve write path populates. The pgrx layer supplies the DSN from the
+// ``goldenmatch.identity_dsn`` GUC when the caller passes an empty db_path.
+
+/// True when ``store_ref`` is a libpq connection string (URI or keyword/value
+/// form) rather than a SQLite file path. A filesystem path never contains an
+/// ``=`` (libpq ``key=value``) and doesn't start with a ``postgres`` URI
+/// scheme, so this cleanly separates the two without a new argument.
+fn is_postgres_dsn(store_ref: &str) -> bool {
+    let t = store_ref.trim();
+    t.starts_with("postgresql://") || t.starts_with("postgres://") || t.contains('=')
+}
+
+/// Open an ``IdentityStore`` from a store reference: Postgres backend for a
+/// libpq DSN (#1913 P2), else a SQLite file path (the original behaviour).
+fn open_identity_store<'py>(
+    py: Python<'py>,
+    store_ref: &str,
+) -> Result<Bound<'py, PyAny>, BridgeError> {
+    let identity = py.import("goldenmatch.identity")?;
+    let store_cls = identity.getattr("IdentityStore")?;
+    let kwargs = PyDict::new(py);
+    if is_postgres_dsn(store_ref) {
+        kwargs.set_item("backend", "postgres")?;
+        kwargs.set_item("connection", store_ref)?;
+    } else {
+        kwargs.set_item("path", store_ref)?;
+    }
+    Ok(store_cls.call((), Some(&kwargs))?)
+}
 
 /// Resolve a `{source}:{source_pk}` style ``record_id`` to its identity
 /// view JSON. Returns ``{"found": false}`` when no identity owns the record.
@@ -739,11 +767,8 @@ pub fn identity_resolve(record_id: &str, db_path: &str) -> Result<String, Bridge
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
-        let store_cls = identity.getattr("IdentityStore")?;
         let find_by_record = identity.getattr("find_by_record")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("path", db_path)?;
-        let store = store_cls.call((), Some(&kwargs))?;
+        let store = open_identity_store(py, db_path)?;
         let view = find_by_record.call1((store.clone(), record_id))?;
         let _ = store.call_method0("close");
         let json_mod = py.import("json")?;
@@ -765,11 +790,8 @@ pub fn identity_view(entity_id: &str, db_path: &str) -> Result<String, BridgeErr
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
-        let store_cls = identity.getattr("IdentityStore")?;
         let get_entity = identity.getattr("get_entity")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("path", db_path)?;
-        let store = store_cls.call((), Some(&kwargs))?;
+        let store = open_identity_store(py, db_path)?;
         let view = get_entity.call1((store.clone(), entity_id))?;
         let _ = store.call_method0("close");
         let json_mod = py.import("json")?;
@@ -791,11 +813,8 @@ pub fn identity_history(entity_id: &str, db_path: &str) -> Result<String, Bridge
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
-        let store_cls = identity.getattr("IdentityStore")?;
         let history_fn = identity.getattr("history")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("path", db_path)?;
-        let store = store_cls.call((), Some(&kwargs))?;
+        let store = open_identity_store(py, db_path)?;
         let events = history_fn.call1((store.clone(), entity_id))?;
         let _ = store.call_method0("close");
         let json_mod = py.import("json")?;
@@ -814,11 +833,8 @@ pub fn identity_conflicts(dataset: &str, db_path: &str) -> Result<String, Bridge
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
-        let store_cls = identity.getattr("IdentityStore")?;
         let find_conflicts = identity.getattr("find_conflicts")?;
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("path", db_path)?;
-        let store = store_cls.call((), Some(&kwargs))?;
+        let store = open_identity_store(py, db_path)?;
         let conflicts_kwargs = PyDict::new(py);
         if dataset.is_empty() {
             conflicts_kwargs.set_item("dataset", py.None())?;
@@ -843,11 +859,8 @@ pub fn identity_list(dataset: &str, status: &str, db_path: &str) -> Result<Strin
     crate::init()?;
     Python::with_gil(|py| {
         let identity = py.import("goldenmatch.identity")?;
-        let store_cls = identity.getattr("IdentityStore")?;
         let list_entities = identity.getattr("list_entities")?;
-        let open_kwargs = PyDict::new(py);
-        open_kwargs.set_item("path", db_path)?;
-        let store = store_cls.call((), Some(&open_kwargs))?;
+        let store = open_identity_store(py, db_path)?;
         let list_kwargs = PyDict::new(py);
         if dataset.is_empty() {
             list_kwargs.set_item("dataset", py.None())?;
@@ -2308,6 +2321,23 @@ mod tests {
             Err(e) => require_or_skip(e, "identity_resolve_not_found"),
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ── identity read store-ref routing (#1913 P2) ──────────────────────────
+
+    #[test]
+    fn test_is_postgres_dsn_classifies_store_refs() {
+        // libpq URI + keyword/value forms -> Postgres backend.
+        assert!(is_postgres_dsn("postgresql://u:p@host:5432/db"));
+        assert!(is_postgres_dsn("postgres://host/db"));
+        assert!(is_postgres_dsn(
+            "host=/var/run/postgresql port=5432 dbname=postgres"
+        ));
+        assert!(is_postgres_dsn("dbname=identity"));
+        // SQLite file paths -> NOT a DSN (no '=' , no postgres URI scheme).
+        assert!(!is_postgres_dsn(".goldenmatch/identity.db"));
+        assert!(!is_postgres_dsn("/var/lib/goldenmatch/identity.sqlite"));
+        assert!(!is_postgres_dsn("C:/data/identity.db"));
     }
 
     // ── resolve_identities (write path, #1913) ──────────────────────────────

--- a/packages/rust/extensions/postgres/src/pipeline.rs
+++ b/packages/rust/extensions/postgres/src/pipeline.rs
@@ -412,8 +412,10 @@ pub fn gm_resolve(job_name: String, table_name: String, dataset: String) -> Stri
 /// Resolve the identity DSN: the `goldenmatch.identity_dsn` GUC first, then the
 /// `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` backend env. Returns
 /// `None` (→ a clear error at the call site) when nothing is configured. A
-/// blank/whitespace value is treated as unset.
-fn resolve_identity_dsn() -> Option<String> {
+/// blank/whitespace value is treated as unset. Shared with the read-only
+/// `goldenmatch_identity_*` functions (#1913 P2), which pass the DSN as the
+/// store ref when the caller supplies an empty `db_path`.
+pub(crate) fn resolve_identity_dsn() -> Option<String> {
     if let Some(cstr) = crate::IDENTITY_DSN.get() {
         if let Ok(s) = cstr.to_str() {
             if !s.trim().is_empty() {

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -321,48 +321,80 @@ pub fn goldenmatch_dedupe_full_telemetry(table_name: String, config_json: String
 // libpq DSN; for SQLite pass the filesystem path. Empty-string filters
 // (``dataset``, ``status``) mean "no filter on that dimension".
 
+/// Resolve the store reference the identity read functions hand to the bridge.
+///
+/// A non-empty `db_path` is used verbatim (a SQLite file path, or a libpq DSN
+/// the bridge routes to the Postgres backend). An EMPTY `db_path` (#1913 P2)
+/// means "the in-DB dataset": substitute the `goldenmatch.identity_dsn` GUC
+/// (or the `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` env) so the
+/// read surface serves the same Postgres identity graph `gm_resolve` writes.
+/// Empty is the sentinel because these functions are STRICT (SQL NULL never
+/// reaches them) and already treat empty `dataset`/`status` as "unset".
+fn identity_store_ref(db_path: String) -> String {
+    if !db_path.trim().is_empty() {
+        return db_path;
+    }
+    crate::pipeline::resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: identity read needs a db_path (SQLite path or DSN), \
+             or set `goldenmatch.identity_dsn` (or GOLDENMATCH_IDENTITY_DSN / \
+             GOLDENMATCH_DATABASE_URL) to serve the in-DB dataset"
+        )
+    })
+}
+
 /// Resolve a record_id (form: ``{source}:{source_pk}``) to its identity view.
-/// Returns ``{"found": false}`` when the record has no identity.
+/// Returns ``{"found": false}`` when the record has no identity. Empty
+/// ``db_path`` reads the in-DB Postgres dataset (#1913 P2).
 #[pg_extern]
 pub fn goldenmatch_identity_resolve(record_id: String, db_path: String) -> String {
-    match goldenmatch_bridge::api::identity_resolve(&record_id, &db_path) {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_resolve(&record_id, &store_ref) {
         Ok(json) => json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
 
-/// Return the full identity view JSON for ``entity_id``.
+/// Return the full identity view JSON for ``entity_id``. Empty ``db_path``
+/// reads the in-DB Postgres dataset (#1913 P2).
 #[pg_extern]
 pub fn goldenmatch_identity_view(entity_id: String, db_path: String) -> String {
-    match goldenmatch_bridge::api::identity_view(&entity_id, &db_path) {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_view(&entity_id, &store_ref) {
         Ok(json) => json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
 
-/// Return the temporal event log for an identity as a JSON array.
+/// Return the temporal event log for an identity as a JSON array. Empty
+/// ``db_path`` reads the in-DB Postgres dataset (#1913 P2).
 #[pg_extern]
 pub fn goldenmatch_identity_history(entity_id: String, db_path: String) -> String {
-    match goldenmatch_bridge::api::identity_history(&entity_id, &db_path) {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_history(&entity_id, &store_ref) {
         Ok(json) => json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
 
 /// List ``conflicts_with`` evidence edges as a JSON array. Empty ``dataset``
-/// returns conflicts across all datasets.
+/// returns conflicts across all datasets; empty ``db_path`` reads the in-DB
+/// Postgres dataset (#1913 P2).
 #[pg_extern]
 pub fn goldenmatch_identity_conflicts(dataset: String, db_path: String) -> String {
-    match goldenmatch_bridge::api::identity_conflicts(&dataset, &db_path) {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_conflicts(&dataset, &store_ref) {
         Ok(json) => json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
 
 /// List identities filtered by ``dataset`` / ``status`` (empty = no filter).
+/// Empty ``db_path`` reads the in-DB Postgres dataset (#1913 P2).
 #[pg_extern]
 pub fn goldenmatch_identity_list(dataset: String, status: String, db_path: String) -> String {
-    match goldenmatch_bridge::api::identity_list(&dataset, &status, &db_path) {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_list(&dataset, &status, &store_ref) {
         Ok(json) => json,
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }


### PR DESCRIPTION
## What and why

P1 (#1940) added the in-DB identity **write** path (`gm_resolve`). **P2 closes the loop**: the read-only `goldenmatch_identity_*` functions now serve the **same** Postgres-native identity dataset when the caller passes an empty `db_path`, instead of only a SQLite file — resolve then query in one database. Part of the #1913 design (P2).

## Changes

**Bridge (`goldenmatch-bridge`):**
- `open_identity_store(store_ref)` opens the Postgres backend for a libpq DSN (URI or `key=value`, detected by `is_postgres_dsn`) and a SQLite file path otherwise. All five `identity_*` bridge functions (`resolve`/`view`/`history`/`conflicts`/`list`) route through it. A SQLite path is byte-for-byte the prior behavior.

**pgrx extension:**
- `identity_store_ref(db_path)` substitutes the `goldenmatch.identity_dsn` GUC (or `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL`) when `db_path` is empty, and errors clearly when neither is set. Empty is the sentinel because these functions are `STRICT` (SQL NULL never reaches them) and already treat empty `dataset`/`status` as "unset".
- **No signature/SQL/version change** — implementation-only, like the `goldenmatch_score` de-bridge. `pgrx_sql_sync` stays 69/69.

**CI:** the `rust_pgrx` smoke now reads back what `gm_resolve` just wrote, via `identity_list('people','','')` (asserts 2 identities) and `identity_resolve('dataframe:1','')` (asserts an entity), all with an empty `db_path` against the in-DB store.

P3 (steward `merge`/`split` writes) and P4 (Arrow table read) follow.

## Testing

- `cargo test -p goldenmatch-bridge` → 48 passed (incl. the new `is_postgres_dsn` classification test; existing SQLite-path identity tests unchanged).
- Postgres crate compiles; `cargo fmt --check` clean on both crates; `scripts/check_pgrx_sql_sync.py` → OK (69/69).
- **End-to-end against real PostgreSQL 16** (full `cargo pgrx install` + smoke): after `gm_resolve` writes, `identity_list`/`identity_resolve`/`identity_view` all serve the in-DB store on empty `db_path`; SQLite-path back-compat unchanged; empty-`db_path` with no DSN gives the clear error.

## Checklist

- [x] Tests added/updated and passing locally for the changed crates
- [x] `cargo fmt --check` clean; `pgrx_sql_sync` green
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_