### PR TITLE
fix(goldengraph): port resolve/ingest/schema_discovery to Arrow-native frames (unbreak main)

### DIFF
--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -212,14 +212,16 @@ def _gm_cluster(rows: list[dict]) -> list[list[int]]:
     SAME calibrated resolver `resolve()` uses within a document, but over the
     multi-column compound key (`_FEATURE_COLS`) so the controller has real signal
     instead of a near-unique name. Returns multi-member clusters' member indices.
-    goldenmatch + polars import lazily so the package (and injected-matcher tests)
+    goldenmatch + pyarrow import lazily so the package (and injected-matcher tests)
     need neither."""
     import goldenmatch as gm
-    import polars as pl
+    import pyarrow as pa
 
     if not rows:
         return []
-    df = pl.DataFrame({c: [r.get(c, "") for r in rows] for c in _FEATURE_COLS})
+    # Arrow-native (repo standard) -- goldenmatch's dedupe surface is arrow-first,
+    # so we stay polars-free.
+    df = pa.table({c: [r.get(c, "") for r in rows] for c in _FEATURE_COLS})
     result = gm.dedupe_df(df)
     out: list[list[int]] = []
     for info in result.clusters.values():

--- a/packages/python/goldengraph/goldengraph/resolve.py
+++ b/packages/python/goldengraph/goldengraph/resolve.py
@@ -88,12 +88,15 @@ def _fuzzy_resolve(mentions: list[Mention], *, use_context: bool) -> list[Resolv
         return []
 
     import goldenmatch as gm
-    import polars as pl
+    import pyarrow as pa
 
     cols = {"name": [m.name for m in mentions], "type": [m.typ for m in mentions]}
     if use_context and any(m.context for m in mentions):
         cols["context"] = [m.context for m in mentions]
-    df = pl.DataFrame(cols)
+    # Arrow-native (repo standard): goldenmatch's dedupe surface is arrow-first
+    # (pa.Table in, pa.Table out — v3.0.0), so we build a pyarrow table and stay
+    # polars-free. `result.clusters` is frame-type-independent.
+    df = pa.table(cols)
     result = gm.dedupe_df(df)
 
     n = len(mentions)

--- a/packages/python/goldengraph/goldengraph/schema_discovery.py
+++ b/packages/python/goldengraph/goldengraph/schema_discovery.py
@@ -106,12 +106,14 @@ def _cluster_predicates_gm(predicates):
     string signal to match on -- the honest test of whether calibrated matching beats naive clustering.
     Fail-open: any error -> each predicate its own cluster (caller's deterministic backbone can follow)."""
     import goldenmatch as gm
-    import polars as pl
+    import pyarrow as pa
 
     uniq = sorted({p for p in predicates if _norm(p)})
     if len(uniq) < 2:
         return [[u] for u in uniq]
-    df = pl.DataFrame({"predicate": [_norm(u) for u in uniq]})
+    # Arrow-native (repo standard) -- goldenmatch's dedupe surface is arrow-first,
+    # so we stay polars-free.
+    df = pa.table({"predicate": [_norm(u) for u in uniq]})
     try:
         result = gm.dedupe_df(df, fuzzy={"predicate": 0.82}, confidence_required=False)
     except Exception:


### PR DESCRIPTION
## What and why

`main` is red on the **`goldengraph-pipeline`** lane: `test_resolve_groups_exact_duplicates` dies with `ModuleNotFoundError: No module named 'polars'` at `resolve.py:96`. Root cause: goldenmatch made polars an **optional extra** (arrow-native, v3.0.0), but goldengraph built `pl.DataFrame`s to feed `gm.dedupe_df`, and the standalone lane installs base goldenmatch (no `[polars]`) — so the frame construction hard-failed. The lane isn't in `ci-required`, so it sat red on main.

Rather than reintroduce polars, this ports goldengraph to the repo's **Arrow-native** standard: build a `pa.table` instead of a `pl.DataFrame` and hand it to `gm.dedupe_df` (whose surface is arrow-first — `pa.Table` in, `pa.Table` out). `result.clusters` is frame-type-independent, so downstream is unchanged.

## Changes

- `resolve.py::_fuzzy_resolve` — `pl.DataFrame(cols)` → `pa.table(cols)`
- `ingest.py::_gm_cluster` — same
- `schema_discovery.py::_cluster_predicates_gm` — same

## Testing

Verified **polars-free** locally (import blocked via a meta-path finder, simulating the lane's env):
- `resolve` groups exact duplicates → 2 entities
- `ingest._gm_cluster` → `[[0, 1]]`
- `schema_discovery._cluster_predicates_gm` clusters near-synonym predicates correctly

Regression-free with polars present: **312 goldengraph tests pass either way** (the 7 local errors are the `goldengraph_native` wheel fixtures, which CI builds).

## Note (separate, larger — not in this PR)

goldenmatch's zero-config path routes to the probabilistic (FS) scorer by default (#1874), and `_score_probabilistic_matchkey` still uses polars via `_polars_lazy`, so `auto_configure_df` degrades to a RED fallback config on a polars-free box. Clustering stays correct for these cases, but fully porting goldenmatch's FS pipeline (pipeline.py has ~77 `pl.` refs) to arrow-native is a separate core effort worth tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_