### PR TITLE
fix(ci): goldengraph-pipeline installs goldenmatch from source, not stale PyPI (green main)

### DIFF
--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -45,7 +45,16 @@ jobs:
           python-version: "3.12"
       - name: Install goldenmatch + build/install the goldengraph-native engine wheel
         run: |
-          python -m pip install --upgrade pip maturin pytest goldenmatch
+          python -m pip install --upgrade pip maturin pytest
+          # Install goldenmatch from MONOREPO SOURCE, not PyPI. goldengraph's
+          # zero-config resolve runs goldenmatch's arrow-native FS path, whose
+          # polars-free blocking spine (blocker.py's `to_frame(native)` branch,
+          # the "blocking-spine eviction for zero-config") the last PyPI release
+          # predates -- against a stale published goldenmatch the polars-free
+          # resolve hard-fails at `pl.from_arrow`. Source keeps the lane honest
+          # for the CURRENT monorepo state and stays polars-free (base install,
+          # no [polars] extra -- goldengraph is Arrow-native by design).
+          python -m pip install -e packages/python/goldenmatch
           maturin build --release \
             -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
           python -m pip install dist/*.whl


### PR DESCRIPTION
## What and why

Follow-up to #1942 (which ported goldengraph's frames to `pa.table`). The `goldengraph-pipeline` lane **stayed red**: goldengraph's zero-config `dedupe_df` runs goldenmatch's **arrow-native FS path**, whose polars-free blocking spine — `blocker.py`'s `to_frame(native)` branch, the "blocking-spine eviction for zero-config" — the **last PyPI goldenmatch release predates**. Against that stale published wheel the polars-free resolve hard-fails at `pl.from_arrow` in `build_blocks`. (The FS *scoring* itself is arrow-native — confirmed by tracing the exact polars touch-points.)

So the fix is not "add polars" — it's to stop testing goldengraph against a **stale published** goldenmatch.

## Change

Install goldenmatch from **monorepo source** (`pip install -e packages/python/goldenmatch`) instead of PyPI, so the lane validates goldengraph against the current monorepo goldenmatch (which has the arrow-native blocking branch). Base install (no `[polars]`) keeps it polars-free, matching goldengraph's Arrow-native design. Standard monorepo convention (every other lane tests source); avoids the documented PyPI-staleness footgun.

## Testing

With `polars` import-blocked (simulating the lane's env) against **source** goldenmatch:
- full goldengraph suite passes (**312**, minus native-wheel fixtures which CI builds)
- `resolve` groups exact dups (2 entities), `ingest._gm_cluster` → `[[0,1]]`, `schema._cluster_predicates_gm` clusters near-synonyms
- `pl.from_arrow` never reached on the final dedupe

## Note (separate follow-up, not in this PR)

The auto-config **sample** iterations still force the polars blocking path when a profile emitter is active (`_emit_blocking_profile` consumes a polars frame), so zero-config degrades to a fallback config on a polars-free box (resolution stays correct; config just untuned). Making the profile-emitter blocking path arrow-native would remove that last wart — worth a scoped follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_