### PR TITLE
fix(er-kg-bench): port qa_e2e/adapter dedupe frames to Arrow-native (green goldengraph-pipeline gates)

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/adapters/goldenmatch_adapter.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import goldenmatch as gm
 import numpy as np
-import polars as pl
+import pyarrow as pa
 
 from .base import ZERO_COST, AdapterBase, Record, cluster_by_pairwise
 
@@ -72,7 +72,7 @@ class GoldenMatchAdapter(AdapterBase):
         if self.mode in ("auto_fields", "auto_fields_semantic", "auto_llm"):
             data["entity_type"] = [r.entity_type for r in ordered]
             data["context"] = [r.context for r in ordered]
-        df = pl.DataFrame(data)
+        df = pa.table(data)
 
         # Zero-config: no exact/fuzzy kwargs -> dedupe_df calls auto_configure_df.
         # auto_fields_semantic turns on the opt-in semantic-blocking candidate union

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/argctx_resolve.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/argctx_resolve.py
@@ -114,7 +114,7 @@ def resolve_gm(feats):
     type signature (exact) + connected-entity-name blob (fuzzy). Fixes the impoverished-features
     problem of the earlier gm-over-strings null. Fail-open: any error -> singletons."""
     import goldenmatch as gm
-    import polars as pl
+    import pyarrow as pa
 
     phrases = sorted(feats)
     if len(phrases) < 2:
@@ -124,7 +124,7 @@ def resolve_gm(feats):
         ts = feats[p]["types"].most_common(1)[0][0] if feats[p]["types"] else ("?", "?")
         names = sorted({n for pair in feats[p]["pairs"] for n in pair})
         rows.append({"type_sig": f"{ts[0]}>{ts[1]}", "neighbors": " | ".join(names), "phrase": p})
-    df = pl.DataFrame({c: [r[c] for r in rows] for c in ("type_sig", "neighbors", "phrase")})
+    df = pa.table({c: [r[c] for r in rows] for c in ("type_sig", "neighbors", "phrase")})
     try:
         result = gm.dedupe_df(df, exact=["type_sig"], fuzzy={"neighbors": 0.5},
                               confidence_required=False)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/dials.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/dials.py
@@ -59,9 +59,11 @@ def name_only_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]
 def goldengraph_keys(corpus: QACorpus, g: GoldGraph) -> dict[tuple[str, str], str]:
     rows = _entity_surfaces(g)
     import goldenmatch as gm
-    import polars as pl
+    import pyarrow as pa
 
-    df = pl.DataFrame(
+    # Arrow-native (repo standard): goldenmatch's dedupe surface is arrow-first,
+    # so we stay polars-free.
+    df = pa.table(
         {"name": [s for (_e, s, _t) in rows], "type": [t for (_e, _s, t) in rows]}
     )
     # rerank OFF: name+type is two fields, under the 3-field cross-encoder trigger.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/stark_resolve.py
@@ -21,11 +21,11 @@ def resolve_aliases(alias_nodes, method: str):
         return list(groups.values())
     if method == "er":
         import goldenmatch as gm
-        import polars as pl
+        import pyarrow as pa
 
         if not alias_nodes:
             return []
-        df = pl.DataFrame({"name": [name for _, name in alias_nodes]})
+        df = pa.table({"name": [name for _, name in alias_nodes]})
         result = gm.dedupe_df(df)
         seen: set[int] = set()
         clusters: list[list[str]] = []


### PR DESCRIPTION
## What and why

Follow-up to #1942/#1943. With the goldengraph pipeline tests now green, the `goldengraph-pipeline` lane's later **deterministic gate steps** (ablation / aggregation / temporal / scorecard / router / unified / tier / crossover) — previously *skipped* because the earlier step failed — now run, and exposed more `pl.DataFrame → gm.dedupe_df` sites in the er-kg-bench harness that fail polars-free (the lane installs base goldenmatch, no `[polars]`). Same class as #1942.

## Changes

Port the frame construction to `pa.table` (goldenmatch's dedupe surface is arrow-first; downstream reads `result.clusters`, frame-type-independent):
- `qa_e2e/dials.py::goldengraph_keys`
- `qa_e2e/argctx_resolve.py`
- `stark_resolve.py` (er method)
- `adapters/goldenmatch_adapter.py` — also drops the module-level `import polars` (pl was used only for the frame)

Left `goldenmatch_rag.py` alone: its frame feeds goldenmatch's RAG retrieval (`retrieve_similar_records`, polars-typed) and is LLM/embedder-gated, so the deterministic key-free gates never build it.

## Testing

Verified polars-free (import-blocked) against **source** goldenmatch — the exact lane test set passes:
- `packages/python/goldengraph/tests` → 346 passed
- all `tests/test_qa_*` gate files → **51 passed, 4 skipped**, no `pl.` reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_