### PR TITLE
fix(autoconfig): keep the blocking spine arrow-native under a profile emitter

### DIFF
--- a/packages/python/goldenmatch/goldenmatch/core/blocker.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocker.py
@@ -37,8 +37,16 @@ def _emit_blocking_profile(
     if not _emitter_stack.get():
         return
 
-    # n_rows is computed here, only when an emitter is active.
-    n_rows: int = lf.select(pl.len()).collect().item()
+    # n_rows is computed here, only when an emitter is active. Backend-agnostic:
+    # the polars-free blocking spine (e.g. the autoconfig sample path) hands us an
+    # arrow/seam Frame whose row count comes from ``.height``; a polars LazyFrame
+    # still needs a ``collect()``. Keeps profile emission off the polars round-trip.
+    from goldenmatch.core.frame import is_polars_lazyframe, to_frame
+    n_rows: int = (
+        lf.select(pl.len()).collect().item()
+        if is_polars_lazyframe(lf)
+        else to_frame(lf).height
+    )
 
     # Determine keys_used: prefer passes if truthy, else keys if truthy, else []
     if config.passes:
@@ -1304,14 +1312,16 @@ def build_blocks(lf: Any, config: BlockingConfig) -> list[BlockResult]:
             # op, so that conversion still uses pyarrow under the hood).
             # multi_pass is dual-rep too: it delegates each pass to
             # _build_static_blocks (seam-native via derive_block_key), so it stays
-            # arrow when no polars-only feature (multi-key auto-select or an active
-            # profile emitter) is in play. This is the common zero-config shape
-            # (the #1207 per-identifier union), so keeping it off the polars round
-            # trip is the load-bearing blocking-spine eviction for zero-config.
+            # arrow when no polars-only feature (multi-key auto-select) is in play.
+            # This is the common zero-config shape (the #1207 per-identifier union),
+            # so keeping it off the polars round trip is the load-bearing
+            # blocking-spine eviction for zero-config. An active profile emitter no
+            # longer forces polars here: _emit_blocking_profile reads n_rows off the
+            # seam Frame (.height), so the autoconfig sample path (which always runs
+            # under an emitter) stays arrow-native / polars-free.
             _needs_polars = (
                 config.strategy not in ("static", "adaptive", "multi_pass")
                 or (config.auto_select and config.keys and len(config.keys) > 1)
-                or bool(_emitter_stack.get())
             )
             lf = (
                 cast(pl.DataFrame, pl.from_arrow(native)).lazy()


### PR DESCRIPTION
Fixes the `goldengraph-pipeline` Crossover capability gate (last red step of the polars-free lane).

## Root cause

The autoconfig controller runs every sample-pipeline iteration inside `profile_capture()`, so `_emitter_stack.get()` was truthy in `build_blocks` and forced the arrow input back through `pl.from_arrow(native).lazy()`. In the polars-free lane that raises `ModuleNotFoundError` on **every** iteration (`n_errored=4`), the controller falls back to a RED-sentinel config, and downstream ER quality tanks — the Crossover gate assertion `graph dominates the lexical floor (worst margin 0.005 >= 0.08)` fails.

Traceback: `autoconfig_controller.run → _run_pipeline_sample → run_dedupe_df → _run_dedupe_pipeline → _score_probabilistic_matchkey → blocker.build_blocks:1317 → pl.from_arrow(native).lazy()`.

## Fix

`_emit_blocking_profile` only needed the polars LazyFrame to read `n_rows`; everything else comes from the `BlockResult` list. So:

- Read `n_rows` off the seam Frame `.height` when the input is not a polars LazyFrame.
- Drop `_emitter_stack.get()` from the `_needs_polars` gate in `build_blocks`.

`static`/`adaptive`/`multi_pass` now stay arrow-native while profiling; non-static strategies and multi-key auto-select still take the polars round-trip (unchanged). Polars input is unaffected — it never reaches this branch (`native.lazy()` handles it upstream).

## Verification (local, polars-free venv + prebuilt native wheel)

- `auto_configure_df` on a 6k-row arrow table now returns a real `bucket`/`static` config with zero polars errors (was `n_errored=4`, RED sentinel).
- Arrow/polars autoconfig parity: `test_autoconfig_arrow_native_parity.py` + `test_autoconfig_dtype_arrow_parity.py` (18 passed, with polars installed).
- No regressions: blocker + arrow-size-parity + controller + adaptive + multipass + union suites (123 passed).

The full Crossover gate needs goldengraph + the native wheel, so it is verified here via a manual `goldengraph-pipeline` `workflow_dispatch` on this branch (that workflow does not trigger on `goldenmatch/core/**` paths).

## Note

`goldengraph-pipeline.yml` does not run on `packages/python/goldenmatch/goldenmatch/**` changes, so a core change like this one is not auto-gated by the only real-execution pipeline signal. Worth considering adding core paths to its `on.push.paths` in a follow-up.