### PR TITLE
feat(pg): in-SQL steward identity merge/split — gm_identity_merge/split (#1913 P3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2844,9 +2844,11 @@ jobs:
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
           # handwritten ones into PG's extension dir so `CREATE EXTENSION`
-          # (installs default_version, now 0.14.0) and `ALTER EXTENSION ... UPDATE`
+          # (installs default_version, now 0.15.0) and `ALTER EXTENSION ... UPDATE`
           # find them. The schema files are the canonical declaration of public
           # function signatures.
+          cp sql/goldenmatch_pg--0.15.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.14.0--0.15.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.14.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.13.0--0.14.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.13.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
@@ -3219,6 +3221,48 @@ jobs:
                 RAISE EXCEPTION 'identity_resolve(in-DB): expected an entity for dataframe:1, got %', rec;
               END IF;
               RAISE NOTICE 'identity read (in-DB, empty db_path): list=% resolve.entity=%', n, rec->>'entity_id';
+            END $$;
+            -- #1913 P3: in-SQL steward merge/split writes over the same in-DB
+            -- dataset. Split a record out of the 3-record identity into a fresh
+            -- one, then merge it back — asserting on the return-value contract +
+            -- record ownership (status enum internals stay the Python store's).
+            DO $$
+            DECLARE
+              big_entity text; rec_id text; split_res jsonb; new_eid text;
+              n_nodes int; new_recs int; merge_res jsonb; back_recs int; big_recs int;
+            BEGIN
+              -- The absorbed identity owns 3 records; pick it + one of its records.
+              SELECT entity_id INTO big_entity
+                FROM source_records GROUP BY entity_id ORDER BY count(*) DESC LIMIT 1;
+              SELECT record_id INTO rec_id
+                FROM source_records WHERE entity_id = big_entity LIMIT 1;
+
+              -- SPLIT: move that record into a brand-new identity.
+              split_res := goldenmatch.gm_identity_split('people', big_entity, rec_id)::jsonb;
+              new_eid := split_res->>'new_entity_id';
+              -- `moved` is the JSON array of moved record ids (not a count).
+              IF new_eid IS NULL OR jsonb_array_length(split_res->'moved') <> 1 THEN
+                RAISE EXCEPTION 'gm_identity_split: expected 1 moved record + a new_entity_id, got %', split_res;
+              END IF;
+              SELECT count(*) INTO n_nodes FROM identity_nodes;
+              SELECT count(*) INTO new_recs FROM source_records WHERE entity_id = new_eid;
+              IF n_nodes <> 3 OR new_recs <> 1 THEN
+                RAISE EXCEPTION 'gm_identity_split: expected 3 nodes + the new entity owning 1 record, got nodes=% new_recs=%', n_nodes, new_recs;
+              END IF;
+              RAISE NOTICE 'gm_identity_split: % (nodes=%)', split_res, n_nodes;
+
+              -- MERGE: absorb the split-out identity back into the big one.
+              merge_res := goldenmatch.gm_identity_merge('people', big_entity, new_eid)::jsonb;
+              IF merge_res->>'keep' <> big_entity OR merge_res->>'absorbed' <> new_eid THEN
+                RAISE EXCEPTION 'gm_identity_merge: expected keep=% absorbed=%, got %', big_entity, new_eid, merge_res;
+              END IF;
+              -- The absorbed entity's records move back to the keeper.
+              SELECT count(*) INTO back_recs FROM source_records WHERE entity_id = new_eid;
+              SELECT count(*) INTO big_recs  FROM source_records WHERE entity_id = big_entity;
+              IF back_recs <> 0 OR big_recs <> 3 THEN
+                RAISE EXCEPTION 'gm_identity_merge: expected absorbed entity to own 0 records + keeper to own 3, got absorbed=% keeper=%', back_recs, big_recs;
+              END IF;
+              RAISE NOTICE 'gm_identity_merge: % (keeper records=%)', merge_res, big_recs;
             END $$;
           EOSQL
           echo "=== PG ${PG_VERSION} smoke passed ==="

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -105,6 +105,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.15.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.14.0--0.15.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.14.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.13.0--0.14.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.13.0.sql "${EXT_DIR}/"

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -996,6 +996,110 @@ pub fn resolve_identities(
     })
 }
 
+/// Steward manual **merge** of two identities (#1913 P3).
+///
+/// Reassigns `absorb_entity_id`'s source records to `keep_entity_id`, retires
+/// the absorbed identity, and emits a `manual_merge` event on both — the
+/// durable corrections path. Reuses the Python `manual_merge` steward function
+/// unchanged (the same one `goldenmatch identity merge` calls), so no merge
+/// semantics are re-implemented in Rust/SQL.
+///
+/// - `dsn` — libpq connection string for the identity store (empty is rejected).
+/// - `reason` — optional free-text audit note; empty means "no reason recorded".
+///
+/// Returns the result JSON (`{"keep", "absorbed", "at"}`). A `ValueError` from
+/// the store (missing entity, non-active winner) propagates as a `BridgeError`
+/// so the caller can surface it.
+pub fn identity_merge(
+    dsn: &str,
+    keep_entity_id: &str,
+    absorb_entity_id: &str,
+    reason: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "identity_merge requires a non-empty identity DSN (set the \
+             goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let merge_fn = identity.getattr("manual_merge")?;
+        let store = open_identity_store(py, dsn)?;
+        let kwargs = PyDict::new(py);
+        if !reason.is_empty() {
+            kwargs.set_item("reason", reason)?;
+        }
+        // Bind the call result, close the store on BOTH paths (a bad steward id
+        // legitimately raises ValueError), then propagate.
+        let result = merge_fn.call(
+            (store.clone(), keep_entity_id, absorb_entity_id),
+            Some(&kwargs),
+        );
+        let _ = store.call_method0("close");
+        let result = result?;
+        let json_mod = py.import("json")?;
+        let dumps_kwargs = PyDict::new(py);
+        dumps_kwargs.set_item("default", py.import("builtins")?.getattr("str")?)?;
+        let s: String = json_mod
+            .call_method("dumps", (result,), Some(&dumps_kwargs))?
+            .extract()?;
+        Ok(s)
+    })
+}
+
+/// Steward manual **split** of a record out of an identity (#1913 P3).
+///
+/// Moves `record_id` into a fresh identity and emits a `manual_split` event on
+/// both the original and the new entity. Reuses the Python `manual_split`
+/// steward function (the one `goldenmatch identity split` calls); it takes a
+/// `list[str]` of record ids, so this single-record bridge wraps `record_id` in
+/// a one-element list.
+///
+/// - `dsn` — libpq connection string for the identity store (empty is rejected).
+/// - `reason` — optional free-text audit note; empty means "no reason recorded".
+///
+/// Returns the result JSON (`{"new_entity_id", "moved", "at"}`). A `ValueError`
+/// (missing entity, empty record set) propagates as a `BridgeError`.
+pub fn identity_split(
+    dsn: &str,
+    entity_id: &str,
+    record_id: &str,
+    reason: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "identity_split requires a non-empty identity DSN (set the \
+             goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let split_fn = identity.getattr("manual_split")?;
+        let store = open_identity_store(py, dsn)?;
+        let kwargs = PyDict::new(py);
+        if !reason.is_empty() {
+            kwargs.set_item("reason", reason)?;
+        }
+        // manual_split takes record_ids: list[str] -> wrap the single id.
+        let record_ids = vec![record_id];
+        let result = split_fn.call((store.clone(), entity_id, record_ids), Some(&kwargs));
+        let _ = store.call_method0("close");
+        let result = result?;
+        let json_mod = py.import("json")?;
+        let dumps_kwargs = PyDict::new(py);
+        dumps_kwargs.set_item("default", py.import("builtins")?.getattr("str")?)?;
+        let s: String = json_mod
+            .call_method("dumps", (result,), Some(&dumps_kwargs))?
+            .extract()?;
+        Ok(s)
+    })
+}
+
 // ─── Correction CRUD (Phase 6A of #437 surface sync) ────────────────────
 //
 // File pair-level + field-level + cluster-decision corrections into the

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.14.0'
+default_version = '0.15.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.14.0--0.15.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.14.0--0.15.0.sql
@@ -1,0 +1,27 @@
+-- Upgrade goldenmatch_pg 0.14.0 -> 0.15.0
+--
+-- Adds the in-SQL steward corrections path (#1913 P3):
+--   gm_identity_merge(dataset, entity_a, entity_b) -- manual merge (keep a,
+--     absorb b), emits a manual_merge event on both.
+--   gm_identity_split(dataset, entity_id, record_id) -- move a record into a
+--     fresh identity, emits a manual_split event on both.
+-- Both delegate to the Python steward path (manual_merge / manual_split) over
+-- the goldenmatch.identity_dsn store, completing the write surface P1/P2 began.
+
+CREATE FUNCTION "gm_identity_merge"(
+    "dataset" TEXT,
+    "entity_a" TEXT,
+    "entity_b" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_merge_wrapper';
+
+CREATE FUNCTION "gm_identity_split"(
+    "dataset" TEXT,
+    "entity_id" TEXT,
+    "record_id" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_split_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.15.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.15.0.sql
@@ -1,0 +1,845 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+-- In-DB stateful identity resolution (#1913 P1). Resolves a job's table into a
+-- Postgres-native identity dataset (create/absorb/merge, incremental across
+-- runs). Writes go to the DSN from the goldenmatch.identity_dsn GUC.
+CREATE FUNCTION "gm_resolve"(
+    "job_name" TEXT,
+    "table_name" TEXT,
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_resolve_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- Two-table record linkage: match a target table against a reference table,
+-- returning the (target_id, reference_id, score) linkage as rows. target_id /
+-- reference_id are 0-based row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';
+
+-- goldenmatch_hnsw_pairs (added in 0.10.0): native HNSW ANN blocking over a
+-- row-major flat real[] corpus. See the 0.9.0->0.10.0 migration for details.
+CREATE FUNCTION "goldenmatch_hnsw_pairs"(
+    "flat_vecs" real[],
+    "dim" INT,
+    "k" INT,
+    "threshold" DOUBLE PRECISION
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_hnsw_pairs_wrapper';
+
+-- goldenmatch_lsh_pairs (added in 0.11.0): native MinHash-LSH token blocking
+-- over a text[] corpus. See the 0.10.0->0.11.0 migration for details.
+CREATE FUNCTION "goldenmatch_lsh_pairs"(
+    "texts" TEXT[],
+    "mode" TEXT,
+    "k" INT,
+    "num_perms" INT,
+    "num_bands" INT,
+    "seed" BIGINT
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_lsh_pairs_wrapper';
+
+-- goldenmatch_perceptual_phash (added in 0.12.0): native-direct (no CPython)
+-- 64-bit DCT perceptual image hash over a row-major flat luma grid + its row
+-- width. The kernel resizes to 32x32 internally. The unsigned 64-bit hash is
+-- returned bit-reinterpreted as BIGINT. See the 0.11.0->0.12.0 migration.
+CREATE FUNCTION "goldenmatch_perceptual_phash"(
+    "grid" double precision[],
+    "ncols" INT
+) RETURNS BIGINT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_phash_wrapper';
+
+-- goldenmatch_perceptual_hamming (added in 0.12.0): Hamming distance between two
+-- 64-bit pHashes (the near-duplicate blocking predicate). Correct on the BIGINT
+-- bit patterns goldenmatch_perceptual_phash returns.
+CREATE FUNCTION "goldenmatch_perceptual_hamming"(
+    "a" BIGINT,
+    "b" BIGINT
+) RETURNS INT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_hamming_wrapper';
+
+-- ── GoldenCheck deep-profiling surface (added in 0.13.0) ────────────────────
+-- Native-direct (no CPython) over the pyo3-free goldencheck-core kernels — the
+-- same reference kernel the goldencheck[native] wheel + the DuckDB goldencheck_*
+-- UDFs run (cross-surface parity roadmap P5). The multi-column functions take a
+-- column-major flat text[] (all of column 0's rows, then column 1's, …) + n_cols.
+
+-- goldencheck_benford: leading-digit (1..9) histogram; element d-1 is the count
+-- of values whose first significant digit is d (non-positive/non-finite skipped).
+CREATE FUNCTION "goldencheck_benford"(
+    "values" double precision[]
+) RETURNS BIGINT[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_benford_wrapper';
+
+-- goldencheck_near_duplicates: cluster near-duplicate string values; one
+-- (cluster, member) row per clustered element (member = 0-based position);
+-- singletons omitted; NULL elements treated as the empty string.
+CREATE FUNCTION "goldencheck_near_duplicates"(
+    "values" TEXT[],
+    "min_similarity" DOUBLE PRECISION
+) RETURNS TABLE ("cluster" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_near_duplicates_wrapper';
+
+-- goldencheck_discover_fds: strict single-column functional dependencies among
+-- n_cols equal-length columns; (det, dep) 0-based column-index pairs.
+CREATE FUNCTION "goldencheck_discover_fds"(
+    "flat" TEXT[],
+    "n_cols" INT
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_fds_wrapper';
+
+-- goldencheck_discover_approx_fds: near-strict FDs + their violation counts;
+-- (det, dep, violations) where det->dep holds for >= min_confidence of rows.
+CREATE FUNCTION "goldencheck_discover_approx_fds"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "min_confidence" DOUBLE PRECISION
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT, "violations" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_approx_fds_wrapper';
+
+-- goldencheck_composite_keys: minimal composite keys (column subsets of size
+-- 2..max_size whose tuples are all distinct); one (key_id, col_index) row per
+-- column in each key. Constant + individually-unique columns are excluded first.
+CREATE FUNCTION "goldencheck_composite_keys"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "max_size" INT
+) RETURNS TABLE ("key_id" BIGINT, "col_index" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_composite_keys_wrapper';
+
+CREATE FUNCTION "gm_identity_merge"(
+    "dataset" TEXT,
+    "entity_a" TEXT,
+    "entity_b" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_merge_wrapper';
+
+CREATE FUNCTION "gm_identity_split"(
+    "dataset" TEXT,
+    "entity_id" TEXT,
+    "record_id" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_split_wrapper';

--- a/packages/rust/extensions/postgres/src/pipeline.rs
+++ b/packages/rust/extensions/postgres/src/pipeline.rs
@@ -409,6 +409,71 @@ pub fn gm_resolve(job_name: String, table_name: String, dataset: String) -> Stri
     summary_json
 }
 
+/// Steward manual **merge** of two identities in the in-DB dataset (#1913 P3).
+///
+/// `entity_a` is kept, `entity_b` is absorbed into it (its source records
+/// reassigned, the identity retired), with a `manual_merge` event on both.
+/// Delegates to the Python steward path (`manual_merge`) through the bridge over
+/// the `goldenmatch.identity_dsn` store — the same engine `goldenmatch identity
+/// merge` uses. Returns the result JSON (`{"keep", "absorbed", "at"}`).
+///
+/// `dataset` is accepted for API symmetry with `gm_resolve`; the identity ids
+/// (globally-unique UUIDv7) fully identify the entities, so it is used only as
+/// diagnostic context (entity ids are not dataset-scoped in the store).
+#[pg_extern]
+pub fn gm_identity_merge(dataset: String, entity_a: String, entity_b: String) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB identity merge needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+    match goldenmatch_bridge::api::identity_merge(&dsn, &entity_a, &entity_b, "") {
+        Ok(s) => s,
+        Err(e) => pgrx::error!(
+            "goldenmatch: gm_identity_merge(dataset={}, keep={}, absorb={}) failed: {}",
+            dataset,
+            entity_a,
+            entity_b,
+            e
+        ),
+    }
+}
+
+/// Steward manual **split** of a record out of an identity in the in-DB dataset
+/// (#1913 P3).
+///
+/// Moves `record_id` into a fresh identity, with a `manual_split` event on both
+/// the original and the new entity. Delegates to the Python steward path
+/// (`manual_split`) through the bridge over the `goldenmatch.identity_dsn`
+/// store. Returns the result JSON (`{"new_entity_id", "moved", "at"}`).
+///
+/// `dataset` is accepted for API symmetry with `gm_resolve` (used as diagnostic
+/// context only — the identity/record ids are not dataset-scoped in the store).
+#[pg_extern]
+pub fn gm_identity_split(dataset: String, entity_id: String, record_id: String) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB identity split needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+    match goldenmatch_bridge::api::identity_split(&dsn, &entity_id, &record_id, "") {
+        Ok(s) => s,
+        Err(e) => pgrx::error!(
+            "goldenmatch: gm_identity_split(dataset={}, entity={}, record={}) failed: {}",
+            dataset,
+            entity_id,
+            record_id,
+            e
+        ),
+    }
+}
+
 /// Resolve the identity DSN: the `goldenmatch.identity_dsn` GUC first, then the
 /// `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` backend env. Returns
 /// `None` (→ a clear error at the call site) when nothing is configured. A


### PR DESCRIPTION
## What and why

Completes the in-database identity **write** surface #1913 began. P1 (`gm_resolve`) + P2 (in-DB reads) shipped the resolve→query loop; **P3 adds the steward corrections path** — the issue's requirement 3 — so `goldenmatch-pg` can maintain a durable golden-identity spine end-to-end in Postgres (resolve, absorb, and now manual merge/split), not just batch dedupe.

## Changes

**Bridge (`goldenmatch-bridge`):**
- `identity_merge(dsn, keep, absorb, reason)` + `identity_split(dsn, entity_id, record_id, reason)` open the Postgres identity store (reusing `open_identity_store`) and delegate to the Python steward path — `manual_merge` / `manual_split`, the same functions `goldenmatch identity merge/split` call — so no merge/split semantics are re-implemented in Rust/SQL. `manual_split` takes `record_ids: list[str]`, so the single-record bridge wraps the id. The store is closed on **both** the success and error paths (a bad steward id legitimately raises `ValueError`), which propagates as a `BridgeError`.

**pgrx extension (`goldenmatch_pg` 0.14.0 → 0.15.0):**
- `gm_identity_merge(dataset, entity_a, entity_b)` (keep `a`, absorb `b`) and `gm_identity_split(dataset, entity_id, record_id)` `#[pg_extern]`s resolve the DSN from the `goldenmatch.identity_dsn` GUC (same as `gm_resolve`) and call the new bridge fns. `dataset` is accepted for API symmetry with `gm_resolve` — identity ids are globally-unique UUIDv7, so it's diagnostic context only.
- New `--0.15.0.sql` base + `--0.14.0--0.15.0.sql` migration; `.control` `default_version` + `Cargo.toml` `version` bumped; `cp sql/…` lines added to `ci.yml` + `publish-goldenmatch-pg.yml`. `pgrx_sql_sync` green (71/71).

**CI:** the `rust_pgrx` smoke now splits a record out of the 3-record identity (asserts a new entity owning the moved record) then merges it back (asserts the records return to the keeper) — a status-enum-agnostic check on the return contract + record ownership.

## Testing — validated end-to-end against real PostgreSQL 16

Full `cargo pgrx install` + smoke on a pristine DB:
- run1 `created=2`, run2 `absorbed_records=1`, `nodes=2`, one identity owning 3 records (P1/P2 baseline intact)
- **SPLIT**: `moved=["dataframe:2"]`, a fresh UUIDv7 identity, nodes 2→3, `manual_split` event
- **MERGE**: `keep`/`absorbed` correct, the absorbed entity's records return to the keeper (keeper owns 3 again), `manual_merge` event
- **error path**: `gm_identity_merge` on a non-existent id surfaces `ValueError: Both entity_ids must exist` as a clear pgrx error

Bridge + postgres crates compile (`--features pg16 --no-default-features`); `cargo fmt --check` clean on both.

## Follow-up

P4 (Arrow-native table read, #1883) is the remaining, independent phase — a separate PR after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_