### PR TITLE
chore(release): goldenmatch 3.6.0

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,7 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-07-20
+
 ### Changed
+
+- **Zero-config now routes probabilistic-shaped datasets to Fellegi-Sunter
+  by default (#1874).** A dataset with no surviving strong-identity exact
+  matchkey (identifier/email/phone) and 2+ fuzzy fields is served by the
+  EM-weighted FS path instead of exact+weighted matchkeys -- measured F1
+  lifts on error-heavy PII (historical_50k 0.62 -> 0.78) with no regression
+  where a strong key survives. Kill-switch:
+  `GOLDENMATCH_AUTOCONFIG_ROUTE_PROBABILISTIC=0`.
 
 - **Config-healer loop cost is now bounded and tunable (#1404).** `heal` (and
   the `review_config` / `suggest_from_result` verify path it drives) could run up
@@ -26,6 +36,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
     `GOLDENMATCH_HEAL_MIN_HEALTH_GAIN` stops the loop once cluster-health gain
     flattens (fail-open — a result without clusters never triggers a stop). Off
     by default. `GOLDENMATCH_HEAL_STEP_CAP` also exposes the outer cap.
+
+### Added
+
+- **`DedupeResult.identity_summary` (#1913).** The per-run identity-
+  resolution summary (entities created/absorbed/merged) is now surfaced on
+  the public result -- `None` when identity resolution is disabled. Backs the
+  in-Postgres `gm_resolve` write path in `goldenmatch-pg`.
+- **Small-N Fellegi-Sunter routing floor (#1947).** Below
+  `GOLDENMATCH_FS_ROUTE_MIN_ROWS` rows (default 500) a probabilistic-shaped
+  dataset stays on the robust weighted path -- FS EM is data-starved at small
+  N and under-merges fuzzy-close variants. `0` disables the floor. Every
+  dataset that validated the FS default is far above it, so routing there is
+  unchanged.
+
+### Fixed
+
+- **Net-zero-evidence filter kills scale-growing FS over-merge (#1899,
+  default ON).** Pairs whose only agreement is on absent (unobserved) fields
+  no longer accrue spurious match weight; ported to the numpy and native
+  kernels.
+- **FS at 1M rows (#1896).** A pairs-budget blocking gate stops a low-
+  cardinality pass from compounding into a megablock, and an Arrow pair-
+  stream plus EM block-sample cut the FS memory peak.
+- **Unobserved `record_embedding` masked out of the weighted score
+  (#1859).** A record with no embedding no longer contributes max agreement.
+- **Arrow-native auto-config blocking profile emitter (#1946).** The
+  controller's sample iterations no longer force an arrow->polars round trip
+  just to count rows, so zero-config runs correctly (no degraded RED-sentinel
+  config) on a base, polars-free install. Byte-identical with polars present.
 
 ## [3.5.0] - 2026-07-18
 

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.5.0"
+__version__ = "3.6.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.5.0"
+version = "3.6.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary

Version bump to **goldenmatch 3.6.0** for the release cut that follows the fully-landed #1913 in-database identity write path (P1–P4) and the #1874 Fellegi-Sunter default-routing floor (#1947).

Bumps the four lockstep version spots:
- `packages/python/goldenmatch/pyproject.toml`
- `packages/python/goldenmatch/goldenmatch/__init__.py`
- `packages/python/goldenmatch/server.json` (×2: package + MCP registry)
- `packages/python/goldenmatch/CHANGELOG.md` (new `## [3.6.0]` section)

## CHANGELOG 3.6.0

**Changed**
- Zero-config routes probabilistic-shaped datasets to Fellegi-Sunter by default (#1874).
- Config-healer loop cost is now bounded and tunable (#1404).

**Added**
- `DedupeResult.identity_summary` — per-run identity-resolution summary; backs the in-Postgres `gm_resolve` write path (#1913).
- Small-N Fellegi-Sunter routing floor (`GOLDENMATCH_FS_ROUTE_MIN_ROWS`, default 500) (#1947).

**Fixed**
- Net-zero-evidence filter kills scale-growing FS over-merge (#1899).
- FS at 1M rows — pairs-budget blocking gate + Arrow pair-stream (#1896).
- Unobserved `record_embedding` masked out of the weighted score (#1859).
- Arrow-native auto-config blocking profile emitter (#1946).

## Release mechanics

No code changes — version + CHANGELOG only. Once merged, the release is cut with `cut-goldenmatch-release.yml` (`workflow_dispatch`, `version=3.6.0`), which pushes the bare `v3.6.0` tag from CI and calls `publish-goldenmatch.yml` reusably (PyPI → cosign sign/attest → draft GitHub Release with assets → publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_