### PR TITLE
ci(goldengraph-native): add PyPI publish + release-cut workflows

### DIFF
--- a/.github/workflows/cut-goldengraph-native.yml
+++ b/.github/workflows/cut-goldengraph-native.yml
@@ -1,0 +1,109 @@
+name: Cut goldengraph-native release
+
+# Manual release cutter for the compiled `goldengraph-native` engine wheel.
+#
+# Why this exists: a SIGNED tag has to be created with a key and `git push`ed.
+# The managed dev sandbox blocks tag pushes (HTTP 403), and the GitHub REST/MCP
+# surface can't create a *signed* ("Verified") tag at all. A runner's
+# GITHUB_TOKEN, by contrast, has `contents: write`, so CI can do it.
+#
+# This workflow: validates the version against the tree, creates + pushes the
+# `goldengraph-native-v<version>` tag (SIGNED when the NATIVE_TAG_SSH_SIGNING_KEY
+# secret is set; an unsigned annotated tag otherwise), publishes a GitHub Release
+# for it, then CALLS publish-goldengraph-native.yml (reusable workflow_call) to
+# build every platform wheel + upload to PyPI -- in the same run, so there is no
+# cross-workflow trigger to depend on (a GITHUB_TOKEN-created Release does not
+# re-trigger that workflow).
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version WITHOUT the leading v (must equal main's goldengraph-native pyproject/Cargo version), e.g. 0.1.0"
+        required: true
+        type: string
+
+permissions:
+  contents: write   # push the tag + create the GitHub Release
+
+jobs:
+  cut:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tagstep.outputs.tag }}
+    # Route the dispatch input through env so it is a shell variable, never
+    # interpolated into a run script (avoids actionlint expression-injection).
+    env:
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Guard - input version matches the tree and tag is new
+        run: |
+          set -euo pipefail
+          py=$(grep -m1 -E '^version' packages/rust/extensions/goldengraph-native/pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          rs=$(grep -m1 -E '^version' packages/rust/extensions/goldengraph-native/Cargo.toml      | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "requested=$VERSION  pyproject=$py  cargo=$rs"
+          if [ "$py" != "$VERSION" ] || [ "$rs" != "$VERSION" ]; then
+            echo "::error::version mismatch -- bump pyproject.toml + Cargo.toml to $VERSION on main first"
+            exit 1
+          fi
+          tag="goldengraph-native-v$VERSION"
+          if git ls-remote --exit-code --tags origin "refs/tags/$tag" >/dev/null 2>&1; then
+            echo "::error::tag $tag already exists on origin"
+            exit 1
+          fi
+
+      - name: Configure tag signing (SSH; optional)
+        id: sign
+        env:
+          SIGNING_KEY: ${{ secrets.NATIVE_TAG_SSH_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -n "${SIGNING_KEY:-}" ]; then
+            install -d -m 700 ~/.ssh
+            printf '%s\n' "$SIGNING_KEY" > ~/.ssh/tagsign
+            chmod 600 ~/.ssh/tagsign
+            ssh-keygen -y -f ~/.ssh/tagsign > ~/.ssh/tagsign.pub
+            git config --global gpg.format ssh
+            git config --global user.signingkey ~/.ssh/tagsign
+            echo "flag=-s" >> "$GITHUB_OUTPUT"
+            echo "Tag signing enabled (SSH key from NATIVE_TAG_SSH_SIGNING_KEY)."
+          else
+            echo "::warning::NATIVE_TAG_SSH_SIGNING_KEY not set -- creating an UNSIGNED annotated tag"
+            echo "flag=-a" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create + push the tag
+        id: tagstep
+        env:
+          FLAG: ${{ steps.sign.outputs.flag }}
+        run: |
+          set -euo pipefail
+          git config --global user.name  "goldenmatch release"
+          git config --global user.email "actions@github.com"
+          tag="goldengraph-native-v$VERSION"
+          git tag "$FLAG" "$tag" -m "goldengraph-native $VERSION"
+          git push origin "refs/tags/$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Publish GitHub Release for the tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="goldengraph-native-v$VERSION"
+          gh release create "$tag" --title "$tag" --verify-tag \
+            --notes "goldengraph-native $VERSION -- compiled knowledge-graph engine (PyStore / build_graph / neighborhood / communities). Wheels built + uploaded to PyPI by publish-goldengraph-native.yml."
+
+  # Build every platform wheel + upload to PyPI, in this same run, by calling the
+  # publish workflow as a reusable workflow (no GITHUB_TOKEN re-trigger needed).
+  publish:
+    needs: cut
+    uses: ./.github/workflows/publish-goldengraph-native.yml
+    with:
+      ref: ${{ needs.cut.outputs.tag }}
+      publish: true
+    secrets: inherit

--- a/.github/workflows/publish-goldengraph-native.yml
+++ b/.github/workflows/publish-goldengraph-native.yml
@@ -1,0 +1,156 @@
+name: Publish goldengraph-native to PyPI
+
+# Builds the compiled knowledge-graph engine (maturin/abi3 wheels) across
+# platforms and publishes to PyPI. `goldengraph-native` is the PyO3 binding for
+# the pyo3-free `goldengraph-core` crate (PyStore / build_graph / neighborhood /
+# communities + the 7 JSON-boundary symbols). Unlike goldenmatch, goldengraph is
+# native-authoritative -- the store / resolution engine is Rust-only with NO
+# pure-Python fallback -- so this wheel is a hard runtime prerequisite for the
+# `goldengraph` frontend, not an optional accelerator.
+#
+# Fires on a release tagged `goldengraph-native-v*` (kept distinct from the
+# Python `goldengraph-v*` and TS `goldengraph-js-v*` tags so the publish
+# workflows never cross-trigger). workflow_dispatch with a `ref` allows a
+# manual/retro build. Callable by cut-goldengraph-native.yml so one dispatch can
+# cut the tag AND publish in the same run.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Tag or commit to build (default: HEAD of main)"
+        required: false
+        default: ""
+      publish:
+        description: "Upload to PyPI (uncheck for a build-matrix dry run)"
+        type: boolean
+        required: false
+        default: true
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        required: false
+        default: ""
+      publish:
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+
+env:
+  # One manifest drives every job; abi3 means one wheel per platform (3.11+).
+  MANIFEST: packages/rust/extensions/goldengraph-native/Cargo.toml
+
+jobs:
+  linux:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheels (maturin, abi3, manylinux)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          manylinux: "2_28"
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-linux-${{ matrix.target }}
+          path: dist
+
+  windows:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: x64
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-windows-x64
+          path: dist
+
+  macos:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
+    # Both arches build on the Apple Silicon runner; x86_64 is a cross-compile.
+    # macos-13 (Intel) runners queue indefinitely in this org, so we don't
+    # depend on them.
+    runs-on: macos-14
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64, aarch64]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Build wheel (maturin, abi3)
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          target: ${{ matrix.target }}
+          args: --release --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-macos-${{ matrix.target }}
+          path: dist
+
+  sdist:
+    if: github.event_name != 'release' || startsWith(github.event.release.tag_name, 'goldengraph-native-v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+      - name: Build sdist
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b  # v1.51.0
+        with:
+          command: sdist
+          args: --out dist -m ${{ env.MANIFEST }}
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    needs: [linux, windows, macos, sdist]
+    # Release events always publish; a workflow_dispatch publishes only when the
+    # `publish` box is checked (unchecked = build-matrix dry run, no upload).
+    if: github.event_name == 'release' || inputs.publish
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          # Merge every wheels-* artifact into a single dist/ for upload.
+          pattern: wheels-*
+          path: dist
+          merge-multiple: true
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        with:
+          packages-dir: dist
+          password: ${{ secrets.PYPI_TOKEN }}
+          skip-existing: true


### PR DESCRIPTION
## Summary

Adds the release infrastructure to publish **`goldengraph-native`** (the compiled knowledge-graph engine) to PyPI — the prerequisite for shipping the `goldengraph` frontend.

goldengraph is **native-authoritative**: its store / resolution engine is the Rust `goldengraph-core` crate with **no pure-Python fallback**, so the `goldengraph-native` abi3 wheel is a hard runtime prerequisite, not an optional accelerator. Publishing `goldengraph` to PyPI therefore requires its engine wheel on PyPI first.

## What's added

Two workflows, mirroring the `goldenmatch-native` pair:

- **`publish-goldengraph-native.yml`** — builds abi3 wheels on linux (x86_64 + aarch64), windows (x64), macOS (both arches), and an sdist, then uploads to PyPI. Fires on a `goldengraph-native-v*` release or `workflow_dispatch`; reusable via `workflow_call`.
- **`cut-goldengraph-native.yml`** — CI-side tag cutter (the managed sandbox 403s on tag pushes): validates the requested version against `goldengraph-native/{pyproject,Cargo}.toml`, cuts `goldengraph-native-v<ver>` from a runner, publishes its GitHub Release, and reusably calls the publish in the same run.

The `goldengraph-native-v*` tag prefix is distinct from `goldengraph-v*` (Python frontend) and `goldengraph-js-v*` (npm), so the publish workflows never cross-trigger (verified by prefix check).

## Local validation

- `maturin build --release` → clean `goldengraph_native-0.1.0-cp311-abi3` wheel
- `maturin sdist` → clean sdist (the `goldengraph-core` path-dep vendors correctly)
- Installed the wheel into a fresh venv → imports, with all 7 JSON-boundary symbols (`build_graph_json`, `neighborhood_json`, `seeds_by_name_json`, `communities_json`, `store_append_json`, `store_as_of_json`, `store_history_json`) + `PyGraph`/`PyStore`/`build_graph`.

## No CI-lane impact

`goldengraph-pipeline.yml` builds the engine wheel in-tree and installs `goldengraph` with `--no-deps`; the loader resolves the in-tree `goldengraph._native` `.so` before any PyPI wheel. So a later hard `goldengraph-native` dependency pin (follow-up) doesn't disturb that lane. This PR adds workflow files only — no code paths change.

## Next steps (follow-ups, not in this PR)

1. After merge: `workflow_dispatch cut-goldengraph-native.yml version=0.1.0` → publish `goldengraph-native 0.1.0` to PyPI.
2. Pin `goldengraph-native>=0.1.0` as a real dependency in `packages/python/goldengraph/pyproject.toml` (drops the "not a PyPI dep yet" note) — the unblock for the goldengraph release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_