### PR TITLE
fix(release): use github.sha (not the tag) for release target_commitish

### DIFF
--- a/.github/workflows/publish-goldenmatch.yml
+++ b/.github/workflows/publish-goldenmatch.yml
@@ -129,7 +129,16 @@ jobs:
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v2
         with:
           tag_name: ${{ env.TAG }}
-          target_commitish: ${{ inputs.ref || github.sha }}
+          # target_commitish MUST be a branch name or commit SHA -- never a tag.
+          # The reusable-call path (cut-goldenmatch-release.yml) passes inputs.ref
+          # = the bare v-tag, which the old `inputs.ref || github.sha` fed here
+          # verbatim -> GitHub 422 `invalid field target_commitish` (the tag ref
+          # is not a valid commitish), which skipped the GitHub Release for
+          # v3.5.0 AND v3.6.0 even though PyPI published fine. github.sha is
+          # always a valid commit: the pushed tag's commit (push), the dispatch
+          # ref's HEAD (dispatch), or the caller's HEAD = the tag's commit
+          # (workflow_call). For an already-created tag GitHub ignores it anyway.
+          target_commitish: ${{ github.sha }}
           name: goldenmatch ${{ env.TAG }}
           body_path: ${{ env.NOTES_FILE }}
           draft: true


### PR DESCRIPTION
## Summary

Fixes a **recurring release-infra bug** that has now skipped the GitHub Release for **both v3.5.0 and v3.6.0** — even though PyPI published successfully each time.

## Root cause

`cut-goldenmatch-release.yml` cuts the bare `v<version>` tag from a runner, then calls `publish-goldenmatch.yml` reusably with `inputs.ref = v<version>` (the tag). The softprops release step fed that straight into `target_commitish`:

```yaml
target_commitish: ${{ inputs.ref || github.sha }}   # = "v3.6.0"
```

`target_commitish` must be a **branch name or commit SHA — never a tag ref**, so GitHub rejects it:

```
Creating new GitHub release for tag v3.6.0 using commit "v3.6.0"...
GitHub release failed with status: 422
{"errors":[{"resource":"Release","code":"invalid","field":"target_commitish"}]}
```

The `Create draft release` step failed → `Publish the release` was skipped → no GitHub Release. (PyPI publish + cosign sign + attest all ran *before* that step and succeeded, which is why the packages shipped.)

## Fix

```yaml
target_commitish: ${{ github.sha }}
```

`github.sha` is a valid commit across all three triggers — the pushed tag's commit (`push`), the dispatch ref's HEAD (`workflow_dispatch`), and the caller's HEAD = the tag's commit (`workflow_call`). For an already-created tag GitHub ignores `target_commitish` anyway. The `push: tags` path is unchanged (empty `inputs` already resolved to `github.sha`).

## Follow-up (this session)

- v3.6.0 is already on PyPI; once this merges I'll re-run `publish-goldenmatch.yml` (`workflow_dispatch`, `tag=v3.6.0`) to create the now-missing GitHub Release (`skip-existing` no-ops the PyPI upload), which also auto-fires `publish-mcp.yml` on `release: published`.
- The same `target_commitish` pattern in the sibling `publish-<pkg>.yml` / `publish-<pkg>-native.yml` workflows is worth an audit; this PR fixes the one on the active release path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_