### PR TITLE
feat(goldengraph): pin goldengraph-native as a real PyPI dependency

### DIFF
--- a/packages/python/goldengraph/pyproject.toml
+++ b/packages/python/goldengraph/pyproject.toml
@@ -11,10 +11,14 @@ requires-python = ">=3.11"
 license = { text = "MIT" }
 authors = [{ name = "Ben Severn", email = "benzsevern@gmail.com" }]
 # goldenmatch provides the zero-config resolution controller (dedupe_df), the
-# :h1: record fingerprint, and the LLM budget tracker. goldengraph-native (the
-# engine: PyStore/build_graph) is installed alongside via maturin (it is not a
-# PyPI dep yet), mirroring how the native binding is provided in CI.
-dependencies = ["goldenmatch>=2.0"]
+# :h1: record fingerprint, and the LLM budget tracker. goldengraph-native is the
+# compiled knowledge-graph engine (PyStore / build_graph / neighborhood /
+# communities); goldengraph is native-authoritative with NO pure-Python fallback,
+# so the engine wheel is a hard runtime dependency. (In dev/CI the in-tree build
+# at goldengraph/_native.abi3.so shadows the wheel -- see
+# scripts/build_goldengraph_native.py -- so the goldengraph-pipeline lane, which
+# installs with --no-deps, is unaffected by this pin.)
+dependencies = ["goldenmatch>=2.0", "goldengraph-native>=0.1.0"]
 
 [project.optional-dependencies]
 openai = ["openai>=1.0"]


### PR DESCRIPTION
## Summary

`goldengraph-native 0.1.0` is now published on PyPI (all 6 artifacts: linux x86_64/aarch64, macOS x86_64/arm64, windows, sdist). This PR pins it as a **real runtime dependency** of `goldengraph` and drops the stale "not a PyPI dep yet" note.

```diff
-dependencies = ["goldenmatch>=2.0"]
+dependencies = ["goldenmatch>=2.0", "goldengraph-native>=0.1.0"]
```

## Why a hard dependency

goldengraph is **native-authoritative**: its store / resolution engine (`PyStore` / `build_graph` / `neighborhood` / `communities`) lives entirely in the Rust `goldengraph-core` crate, exposed via the `goldengraph-native` abi3 wheel, with **no pure-Python fallback**. Before this pin, a fresh `pip install goldengraph` would import fine but raise the moment any store/graph primitive ran. This is the unblock for publishing `goldengraph` itself to PyPI.

## No CI-lane impact

- `goldengraph-pipeline.yml` builds the engine wheel in-tree and installs `goldengraph` with `--no-deps`, and the loader resolves the in-tree `goldengraph/_native.abi3.so` before any PyPI wheel — so the parity lane still exercises current source, and dependency resolution is skipped there.
- `goldengraph` is excluded from the uv workspace, so the pin does not enter the main `uv.lock` (no `goldenmatch[native]`-style footgun).

## Follow-up (goldengraph release, Release 4)

With the engine now pinnable, publishing `goldengraph` still needs: a `goldengraph-v*` publish workflow + CI-side cutter (mirroring this session's goldenmatch-native pair), a CHANGELOG, and a bump off `0.1.0` to a release version. I'll bring a concrete plan for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Niut21Sy5VqRyG2LTziThf)_