### PR TITLE
fix(docs): register goldengraph-native in the PyPI badge roster

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The headline package, **GoldenMatch**, does the matching — fuzzy + exact + pro
 [![DBLP-ACM F1](https://img.shields.io/badge/DBLP--ACM%20F1-96.4%25-d4a017)](packages/python/goldenmatch/README.md#benchmarks)
 
 <!-- Reach -->
-[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldenmatch-embed+golden-suite)
+[![PyPI downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fpypi-downloads.json)](https://pepy.tech/projects?q=goldenmatch+goldencheck+goldenpipe+goldenflow+goldenanalysis+infermap+goldencheck-types+goldensuite-mcp+goldenmatch-duckdb+goldenmatch-native+goldenflow-native+goldencheck-native+goldenanalysis-native+goldengraph-native+goldenmatch-embed+golden-suite)
 [![npm downloads (suite)](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbenseverndev-oss%2Fgoldenmatch%2Fbadges%2Fnpm-downloads.json)](https://www.npmjs.com/~benzsevern)
 [![GitHub stars](https://img.shields.io/github/stars/benseverndev-oss/goldenmatch?style=flat&color=d4a017&logo=github)](https://github.com/benseverndev-oss/goldenmatch/stargazers)
 

--- a/scripts/suite_download_badges.py
+++ b/scripts/suite_download_badges.py
@@ -43,10 +43,11 @@ PYPI_PACKAGES = [
     "goldenflow-native",
     "goldencheck-native",
     "goldenanalysis-native",
+    "goldengraph-native",
     "goldenmatch-embed",
     # PENDING FIRST PYPI RELEASE -- add once published (pypistats 404s until then):
-    # "goldenmatch-kg", "goldengraph", "goldengraph-native". Their pepy.tech link
-    # in the root README aggregate badge must be extended in lockstep.
+    # "goldenmatch-kg", "goldengraph". Their pepy.tech link in the root README
+    # aggregate badge must be extended in lockstep.
 ]
 # Every TS package with a `publish-<pkg>-js.yml` → npm workflow. goldenmatch-wasm-runtime
 # is a workspace dep with no publish workflow, so it has no npm download count.


### PR DESCRIPTION
## What and why

`docs_consistency` (in `ci-required`) is red on `main` and every open PR. #1953 added `.github/workflows/publish-goldengraph-native.yml` but never added `goldengraph-native` to the badge script's `PYPI_PACKAGES` (nor to the publish-badge `EXCEPTIONS`), so `check_docs_consistency.py`'s "PyPI publishers ↔ badge PYPI_PACKAGES" symmetric-diff gate fails. Found while triaging CI on #1957.

## Changes

- `scripts/suite_download_badges.py`: add `goldengraph-native` to `PYPI_PACKAGES` (it's a real published PyPI dependency as of #1955), grouped with the other `*-native` extras; drop it from the "PENDING FIRST PYPI RELEASE" comment.
- `README.md`: extend the pepy.tech `?q=` aggregate-download-badge link with `goldengraph-native` in lockstep (satisfies the "README pepy.tech ?q= link == PYPI_PACKAGES" check).

## Testing

- `python scripts/check_docs_consistency.py` — all checks PASS (was `[FAIL] PyPI publishers <-> badge PYPI_PACKAGES -- ['goldengraph-native']`).

## Checklist

- [x] Tests added/updated and passing locally for the changed package (the docs-consistency gate itself)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated in lockstep (README badge link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_