### PR TITLE
docs: enforce canonical per-section shape with a CI-gated source of truth

### DIFF
--- a/.claude/doc-surfaces.md
+++ b/.claude/doc-surfaces.md
@@ -98,6 +98,23 @@ All scripts are stdlib-only and anchored to the repo root via `Path(__file__)`.
   the missing README table row / `docs.json` nav entry / fix the broken nav link
   or orphan page, or bump the lagging CHANGELOG/version.
 
+- **Tier 1 - `scripts/check_docs_sections.py`** (REQUIRED CI gate, a step in the
+  `docs_consistency` job). The SOURCE OF TRUTH for "what a package section looks
+  like" — the within-section shape the other gates never enforced. Per package
+  section (`SECTIONS`, the 6 suite packages): (a) **spine** — every section has
+  the required pages (`overview`, `config-matrix`, `recipes`) as real `.mdx`; (b)
+  **overview-first** — the nav group opens with `<pkg>/overview`; (c) **page
+  order** — FLAT sections order pages canonically (overview → concept pages in
+  authored order → the reference band `config-matrix`→`recipes`→`cli`→
+  `native`/`performance`→`integrations`); nested sections (goldenmatch) are
+  spine/overview-checked only. Plus, over EVERY `docs-site/**/*.mdx`: (d)
+  **frontmatter** — `title`+`description`+`keywords` all present and non-empty;
+  (e) **title style** — sentence case (first word + proper nouns/acronyms
+  capitalized, nothing else). Generated pages (config-matrix / config-linter /
+  suite-matrix) must pass too — fix their GENERATOR, not the file. Adding a
+  package = add it to `SECTIONS`. Pure-logic unit tests in
+  `scripts/test_docs_sections.py`.
+
 - **Tier 2 - `scripts/check_docs_staleness.py`** (ADVISORY CI job, `--base`/
   `--head`, default `origin/main..HEAD`). Diff-aware. The **flag rule** (gating
   within the job): adding/removing a `GOLDENMATCH_*` env flag in

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -781,6 +781,8 @@ docs:
   - '**/server.json'
   - 'scripts/check_docs_consistency.py'
   - 'scripts/check_docs_links.py'
+  - 'scripts/check_docs_sections.py'
+  - 'scripts/test_docs_sections.py'
   - 'scripts/check_benchmark_claims.py'
   - 'docs/benchmark-claims.json'
   - 'scripts/check_docs_staleness.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3404,6 +3404,8 @@ jobs:
         run: python scripts/check_docs_consistency.py
       - name: Doc links + frontmatter (in-body cross-links resolve; MDX frontmatter valid)
         run: python scripts/check_docs_links.py
+      - name: Doc sections (canonical per-section shape; spine + order + frontmatter + title case)
+        run: python scripts/check_docs_sections.py
       - name: Benchmark claims consistent with source of truth
         run: python scripts/check_benchmark_claims.py
 
@@ -3460,7 +3462,7 @@ jobs:
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Gate unit tests (determinism + markers; run once)
         if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py -q
+        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"

--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -136,8 +136,9 @@
             "pages": [
               "goldenanalysis/overview",
               "goldenanalysis/analyzers",
-              "goldenanalysis/config-matrix",
               "goldenanalysis/cross-run",
+              "goldenanalysis/config-matrix",
+              "goldenanalysis/recipes",
               "goldenanalysis/native"
             ]
           },
@@ -146,7 +147,8 @@
             "pages": [
               "infermap/overview",
               "infermap/mapping",
-              "infermap/config-matrix"
+              "infermap/config-matrix",
+              "infermap/recipes"
             ]
           },
           {

--- a/docs-site/goldenanalysis/config-matrix.mdx
+++ b/docs-site/goldenanalysis/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of GoldenAnalysis config options and vocabularies -- generated so it never drifts."
+keywords: ["goldenanalysis", "config matrix", "configuration", "reference", "analyzers", "metrics"]
 ---
 
 The exhaustive, always-current reference for GoldenAnalysis configuration.

--- a/docs-site/goldenanalysis/recipes.mdx
+++ b/docs-site/goldenanalysis/recipes.mdx
@@ -1,0 +1,64 @@
+---
+title: "Analysis recipes"
+description: "Copy-paste GoldenAnalysis snippets for common jobs: score a dedupe run, roll a whole pipeline into one report, and gate CI on a cross-run regression."
+keywords: ["goldenanalysis", "recipes", "report", "metrics", "cross-run", "regression", "ci gate"]
+---
+
+The [config matrix](/goldenanalysis/config-matrix) lists every analyzer and knob, and [Analyzers](/goldenanalysis/analyzers) explains the metric model. This page is the task-shaped shortcut: a few complete, copy-paste snippets for the jobs you actually reach for. Every entrypoint returns one `AnalysisReport` (`.to_markdown()` / `.to_json()`).
+
+## Score a dedupe run
+
+**You have** a GoldenMatch dedupe result. **You want** match rate, recall, and the cluster-size distribution as one comparable report.
+
+```python
+import goldenanalysis as ga
+from goldenmatch import dedupe_df
+
+result = dedupe_df(df, certify=True)           # certify=True attaches the recall certificate
+report = ga.analyze_match(result, dataset="customers")
+
+print(report.to_markdown())
+report.metrics        # match.rate, match.recall_safe_bound, cluster.singleton_ratio, ...
+```
+
+`certify=True` is what makes `match.recall_safe_bound` — the alerting metric for unsupervised runs — available to the `match.rates` analyzer.
+
+## Roll a whole pipeline into one report
+
+**You have** a full GoldenPipe run (check + flow + match artifacts). **You want** every applicable analyzer to fan out into a single report for the data steward.
+
+```python
+import goldenanalysis as ga
+
+report = ga.analyze_pipeline(pipe_result)      # runs each analyzer whose artifacts are present
+report.analyzers_run                            # e.g. ["frame.summary", "match.rates", "quality.rollup"]
+report.source                                   # {"unavailable": [...]} records what could not be computed
+open("report.md", "w").write(report.to_markdown())
+```
+
+Analyzers degrade gracefully: each emits what its present artifacts support and records the rest in `report.source`, so a partial run still produces a report.
+
+## Gate CI on a cross-run regression
+
+**You have** reports accumulating over time. **You want** a nightly CI job that fails when a quality metric regresses versus a rolling baseline.
+
+```python
+from goldenanalysis import ReportHistory, RegressionPolicy
+
+hist = ReportHistory(path=".golden/analysis.jsonl")
+hist.append(report)                             # after each run
+
+# Direction-aware, per-metric thresholds: a 2% gate on recall catches a quiet 0.97 -> 0.89 drop.
+policy = RegressionPolicy(default_pct=10.0, per_metric={"match.recall_safe_bound": 2.0})
+flagged = hist.detect_regressions("customers", baseline="rolling_median", policy=policy)
+
+if flagged:
+    raise SystemExit(1)                         # fail the job on any flagged regression
+```
+
+Or from the CLI, which exits non-zero on any flag:
+
+```bash
+goldenanalysis regressions --dataset customers --history .golden/analysis.jsonl \
+  --policy "match.recall_safe_bound=2" --fail-on-regression
+```

--- a/docs-site/goldencheck/config-matrix.mdx
+++ b/docs-site/goldencheck/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of GoldenCheck config knobs -- generated from the schema so it never drifts."
+keywords: ["goldencheck", "config matrix", "configuration", "reference", "checks", "validation"]
 ---
 
 The exhaustive, always-current reference for GoldenCheck configuration: the

--- a/docs-site/goldenflow/config-matrix.mdx
+++ b/docs-site/goldenflow/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of GoldenFlow config knobs and its transform vocabulary -- generated so it never drifts."
+keywords: ["goldenflow", "config matrix", "configuration", "reference", "transforms"]
 ---
 
 The exhaustive, always-current reference for GoldenFlow configuration: the

--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ER Agent"
+title: "ER agent"
 description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 40 skills, confidence-gated review queue, and Python API."
 keywords: ["agent", "A2A", "entity resolution", "autonomous", "review queue", "MCP"]
 ---

--- a/docs-site/goldenmatch/blocking.mdx
+++ b/docs-site/goldenmatch/blocking.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Blocking Strategies"
+title: "Blocking strategies"
 description: "Reduce the O(N²) comparison space with GoldenMatch's 10 blocking strategies: static, adaptive, sorted neighborhood, multi-pass, ANN hybrid, ANN, canopy, learned, MinHash/LSH, and SimHash."
 keywords: ["blocking", "entity resolution", "deduplication", "ann", "adaptive", "multi-pass", "learned blocking", "sorted neighborhood", "minhash", "lsh", "simhash", "near-duplicate"]
 ---

--- a/docs-site/goldenmatch/config-linter.mdx
+++ b/docs-site/goldenmatch/config-linter.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config linter"
 description: "Pre-flight checks the config linter runs against your data shape before a dedupe/match run — what each rule flags, when it fires, and why. Generated from the rule registry; do not edit by hand."
+keywords: ["goldenmatch", "config linter", "pre-flight", "validation", "rules", "configuration", "blocking"]
 ---
 
 {/* GENERATED FILE — do not edit. Source of truth: goldenmatch/core/config_lint/rules.py. Regenerate: python scripts/gen_lint_docs.py --write */}

--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of GoldenMatch config knobs, their valid values, and how they combine -- generated from the schema so it never drifts."
+keywords: ["goldenmatch", "config matrix", "configuration", "reference", "scorers", "blocking", "env vars"]
 ---
 
 This is the exhaustive reference for **every** GoldenMatch config knob: the

--- a/docs-site/goldenmatch/domain-packs.mdx
+++ b/docs-site/goldenmatch/domain-packs.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Domain Packs"
+title: "Domain packs"
 description: "Built-in and custom YAML rulebooks that extract structured fields from unstructured product descriptions and other domain-specific text."
 keywords: ["domain packs", "rulebooks", "field extraction", "product matching", "electronics", "healthcare", "financial"]
 ---

--- a/docs-site/goldenmatch/identity-graph.mdx
+++ b/docs-site/goldenmatch/identity-graph.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Identity Graph"
+title: "Identity graph"
 description: "Durable, queryable identity graph with stable entity IDs, evidence edges, and a consistent JSON view across Python, SQL, REST, MCP, A2A, and the web UI."
 keywords: ["identity graph", "entity resolution", "stable ids", "entity_id", "deduplication", "provenance"]
 ---

--- a/docs-site/goldenmatch/learning-memory.mdx
+++ b/docs-site/goldenmatch/learning-memory.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Learning Memory"
+title: "Learning memory"
 description: "Persist steward corrections, unmerge decisions, and LLM votes across runs so the same false positive never comes back."
 keywords: ["learning memory", "corrections", "threshold learning", "steward", "feedback loop"]
 ---

--- a/docs-site/goldenmatch/llm.mdx
+++ b/docs-site/goldenmatch/llm.mdx
@@ -1,5 +1,5 @@
 ---
-title: "LLM Integration"
+title: "LLM integration"
 description: "Use GPT-4o-mini or Claude to score borderline pairs that fuzzy matching alone cannot resolve, with budget caps, model tiering, and iterative calibration."
 keywords: ["llm", "gpt-4o-mini", "claude", "borderline scoring", "budget", "calibration", "cluster mode"]
 ---

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCP Server"
+title: "MCP server"
 description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 78 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
 keywords: ["mcp", "claude desktop", "model context protocol", "entity resolution", "learning memory"]
 ---

--- a/docs-site/goldenmatch/migrating-to-v2.mdx
+++ b/docs-site/goldenmatch/migrating-to-v2.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Migrating to v2.0"
 description: "Step-by-step guide for upgrading from GoldenMatch 1.x to 2.0."
+keywords: ["goldenmatch", "migration", "upgrade", "v2", "2.0", "breaking changes"]
 ---
 
 GoldenMatch 2.0 removes four deprecated items that have had a deprecation

--- a/docs-site/goldenmatch/migrating-to-v3.mdx
+++ b/docs-site/goldenmatch/migrating-to-v3.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Migrating to v3"
 description: "GoldenMatch 3.0.0: Arrow-native results and the Arrow frame backend by default"
+keywords: ["goldenmatch", "migration", "upgrade", "v3", "3.0", "arrow", "breaking changes"]
 ---
 
 GoldenMatch 3.0.0 completes the public half of the Polars-eviction program:

--- a/docs-site/goldenmatch/reference-data.mdx
+++ b/docs-site/goldenmatch/reference-data.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Reference Data"
+title: "Reference data"
 description: "The five bundled reference-data packs that auto-config picks up automatically: surnames, given names, business, addresses, and NAICS industry codes."
 keywords: ["reference data", "surnames", "given names", "address normalize", "NAICS", "auto-config", "refdata"]
 ---

--- a/docs-site/goldenmatch/streaming.mdx
+++ b/docs-site/goldenmatch/streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Streaming & Incremental"
+title: "Streaming & incremental"
 description: "Single-record matching, micro-batch streaming, and CLI-based incremental matching against existing data in real time."
 keywords: ["streaming", "incremental", "match_one", "StreamProcessor", "watch", "sync", "database"]
 ---

--- a/docs-site/goldenpipe/config-matrix.mdx
+++ b/docs-site/goldenpipe/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of GoldenPipe pipeline-config knobs and vocabularies -- generated so it never drifts."
+keywords: ["goldenpipe", "config matrix", "configuration", "reference", "stages", "pipeline"]
 ---
 
 The exhaustive, always-current reference for GoldenPipe configuration: the

--- a/docs-site/infermap/config-matrix.mdx
+++ b/docs-site/infermap/config-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Config matrix"
 description: "The full matrix of InferMap config options and vocabularies -- generated so it never drifts."
+keywords: ["infermap", "config matrix", "configuration", "reference", "scorers", "mapping"]
 ---
 
 The exhaustive, always-current reference for InferMap (GoldenSchema) configuration.

--- a/docs-site/infermap/recipes.mdx
+++ b/docs-site/infermap/recipes.mdx
@@ -1,0 +1,70 @@
+---
+title: "Mapping recipes"
+description: "Copy-paste InferMap snippets for common jobs: map a messy export to your canonical schema, reuse a saved mapping as a validation gate, and add a custom alias or domain pack."
+keywords: ["infermap", "recipes", "schema mapping", "column matching", "config", "validation", "alias"]
+---
+
+The [config matrix](/infermap/config-matrix) lists every `MapEngine` knob and vocabulary, and [Mapping](/infermap/mapping) explains how the scorers combine. This page is the task-shaped shortcut: a few complete snippets for the jobs you actually reach for.
+
+## Map a messy export to your canonical schema
+
+**You have** a source file whose column names don't match your target. **You want** the best 1:1 mapping and the renamed frame.
+
+```python
+import infermap
+import polars as pl
+
+result = infermap.map("crm_export.csv", "canonical_customers.csv")
+for m in result.mappings:
+    print(f"{m.source} -> {m.target}  ({m.confidence:.0%})  {m.reason}")
+
+renamed = result.apply(pl.read_csv("crm_export.csv"))   # rename source columns to target names
+```
+
+Each mapping carries a confidence in `0.0..1.0` and a human-readable reason, so a low-confidence pair is easy to spot and override before you apply it.
+
+## Reuse a saved mapping as a validation gate
+
+**You have** recurring files from the same source. **You want** to pin the mapping once and fail fast when a new drop is missing a required field.
+
+```python
+result = infermap.map("crm_export.csv", "canonical_customers.csv")
+result.to_config("crm_mapping.yaml")            # commit this
+```
+
+Then validate each incoming file against the pinned config — non-zero exit on a missing required field makes it a CI gate:
+
+```bash
+infermap validate new_drop.csv --config crm_mapping.yaml \
+  --required first_name,last_name,email --strict
+```
+
+Apply the pinned mapping without re-inferring:
+
+```bash
+infermap apply new_drop.csv --config crm_mapping.yaml --output clean.csv
+```
+
+## Add a custom alias or domain pack
+
+**You have** source names your target schema doesn't know about (`cust_ref` really is `customer_id`). **You want** InferMap to resolve them without lowering `min_confidence`.
+
+```yaml
+# mapping_rules.yaml — engine config (domains, aliases, scorer weights)
+domains: [finance]
+aliases:
+  customer_id: [cust_ref, acct_no]
+  email: [email_addr, contact_email]
+scorers:
+  FuzzyName:
+    weight: 0.4
+```
+
+```python
+from infermap import MapEngine
+
+engine = MapEngine(config_path="mapping_rules.yaml")   # loads domains + aliases + scorer weights
+result = engine.map("crm_export.csv", "canonical_customers.csv")
+```
+
+Aliases feed the `AliasScorer` (weight 0.95), so a known alias resolves with high confidence instead of relying on the fuzzy-name tie-breaker. (Note this is the engine **config** file — distinct from the saved **mapping** an earlier `result.to_config(...)` writes, which `infermap apply`/`from_config` consume.)

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Suite surface matrix"
 description: "Cross-package view of the Golden Suite: capability counts, the Rust -core compute substrate, Python/TypeScript parity, and auto-detected gaps — generated and gated in CI."
+keywords: ["golden suite", "suite matrix", "cross-package", "parity", "capabilities", "rust core", "reference"]
 ---
 
 The per-package [config matrices](/goldenmatch/config-matrix) each describe one package. This is the **cross-package** view. The anchor is the **Rust / Arrow-native / fused `-core` kernel**: it is the reference implementation, and the Python and TypeScript surfaces are ports that either dispatch to it (the fast path) or run a byte-identical pure-language fallback. So the sections below read against that reference — how the packages line up, which scorers a kernel actually backs vs which are fallback-only, where the two language ports diverge, and what's missing where. Everything below the line is generated from the parity manifests + AST (`scripts/gen_suite_matrix.py`) and verified in CI, so it can't drift.
@@ -17,8 +18,8 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 | `goldencheck` | 19 | 43 | 9 | 19 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
-| `goldenanalysis` | 4 | 8 | — | 4 | — | Yes |
-| `infermap` | 4 | 19 | — | 5 | — | Yes |
+| `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
+| `infermap` | 4 | 19 | — | 5 | Yes | Yes |
 | **suite** | **119** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
@@ -61,7 +62,6 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 ## Gaps & asymmetries (auto-detected)
 
-- **No recipes page:** `goldenanalysis`, `infermap` (thinner / auto-driven config surfaces).
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `analyze_blocking`, `certify_recall`, `compare_clusters`, `config_weaknesses`, `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `export_results`, `get_cluster`, `get_golden_record`, `get_stats`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_profile`, `identity_resolve_conflict`, `identity_show`, `identity_stats`, `identity_worklist`, `incremental`, `lineage`, `lint_routing`, `list_clusters`, `list_domains`, `list_plugins`, `list_runs`, `memory_import`, `plan_routing`, `pprl_auto_config`, `pprl_link`, `retrieve_similar`, `rollback`, `schema_match`, `sensitivity`, `shatter_cluster`, `test_domain`, `unmerge_record`, `upload_dataset`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `list_blocking_strategies`, `list_scorers`, `list_strategies`, `list_transforms`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.

--- a/packages/python/goldenmatch/goldenmatch/core/config_lint/docgen.py
+++ b/packages/python/goldenmatch/goldenmatch/core/config_lint/docgen.py
@@ -21,6 +21,7 @@ _HEADER = """\
 ---
 title: "Config linter"
 description: "Pre-flight checks the config linter runs against your data shape before a dedupe/match run — what each rule flags, when it fires, and why. Generated from the rule registry; do not edit by hand."
+keywords: ["goldenmatch", "config linter", "pre-flight", "validation", "rules", "configuration", "blocking"]
 ---
 
 {/* GENERATED FILE — do not edit. Source of truth: goldenmatch/core/config_lint/rules.py. Regenerate: python scripts/gen_lint_docs.py --write */}

--- a/scripts/check_docs_sections.py
+++ b/scripts/check_docs_sections.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Per-section documentation-consistency gate: every docs-site package section
+conforms to ONE canonical shape, so the sections stop drifting apart.
+
+This module is the SOURCE OF TRUTH for "what a package section looks like". The
+other doc gates cover cross-cutting structure -- nav integrity + orphan detection
+(``check_docs_consistency.py``), in-body links + frontmatter parse
+(``check_docs_links.py``), the Mintlify render (``mint validate``), and the
+per-package config-matrix generation (``gen_config_matrix.py``). None of them
+enforce the WITHIN-section shape, which is exactly where the drift lived: one
+section had a ``recipes`` page and another didn't, titles mixed Title-Case and
+sentence case, and generated pages silently dropped ``keywords``.
+
+Five checks, all deterministic and stdlib-only (~1s):
+
+  1. spine        -- every package section carries the required pages
+                     (``overview``, ``config-matrix``, ``recipes``) as real
+                     ``.mdx`` files, so no section is structurally thinner than
+                     its siblings.
+  2. overview-1st -- the section's nav group opens with ``<pkg>/overview``.
+  3. page-order   -- FLAT sections order their pages canonically: ``overview``
+                     first, then the section-specific concept pages (their
+                     authored order preserved), then the REFERENCE band
+                     (``config-matrix`` -> ``recipes`` -> ``cli`` ->
+                     ``native``/``performance`` -> ``integrations``) in fixed
+                     order. Nested sections (goldenmatch's Guides/Features/...
+                     subgroups) are exempt from ordering but still spine- and
+                     overview-first-checked.
+  4. frontmatter  -- every ``docs-site/**/*.mdx`` carries ``title`` +
+                     ``description`` + ``keywords``, all non-empty (``keywords``
+                     a non-empty list).
+  5. title-style  -- titles are sentence case: the first word plus proper nouns
+                     and acronyms are capitalized, nothing else -- so the sidebar
+                     reads uniformly.
+
+Adding a package section = add it to ``SECTIONS``. Generated pages
+(config-matrix, config-linter, suite-matrix) must satisfy the same rules; fix
+them in their GENERATOR, not the file (the checks here are format-only, so they
+never fight the generated block).
+
+Run: ``python scripts/check_docs_sections.py``
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DOCS = ROOT / "docs-site"
+
+# --- the contract (source of truth) -----------------------------------------
+
+# The package sections gated for shape. Each has a `docs-site/<pkg>/` directory
+# and a matching top-level nav group. Adding a suite package = add it here.
+SECTIONS = (
+    "goldenmatch",
+    "goldencheck",
+    "goldenflow",
+    "goldenpipe",
+    "goldenanalysis",
+    "infermap",
+)
+
+# The canonical spine every section must carry as real files.
+REQUIRED_PAGES = ("overview", "config-matrix", "recipes")
+
+# Reference-band pages, in canonical tail order. Any page not listed here and not
+# `overview` is a section-specific concept page: it sorts into the MIDDLE band and
+# keeps its authored order.
+REFERENCE_ORDER = ("config-matrix", "recipes", "cli", "native", "performance", "integrations")
+
+# Words that stay capitalized anywhere in a title (proper nouns / brands), matched
+# case-insensitively. The authored capitalization is trusted (we don't re-check a
+# brand's internal caps like GoldenMatch/DuckDB), only that the word is allowed to
+# start uppercase mid-title. Acronyms (all-caps tokens) and digit-bearing tokens
+# (v2.0, GPT-4o) are allowed structurally and need not be listed.
+PROPER_NOUNS = frozenset({
+    "goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis",
+    "goldenpipe", "infermap", "goldenschema", "goldengraph", "golden", "suite",
+    "python", "typescript", "javascript", "node", "rust", "arrow", "polars",
+    "duckdb", "postgresql", "postgres", "sqlite", "ray", "bloom", "claude",
+    "gpt", "openai", "anthropic", "docker", "dbt", "neo4j", "llamaindex",
+    "graphiti", "graphrag", "splink", "bayesian", "hungarian", "jaro-winkler",
+    "fellegi-sunter", "minhash", "simhash", "railway", "smithery", "mintlify",
+})
+
+
+# --- frontmatter parsing (stdlib-only) --------------------------------------
+
+def _frontmatter(text: str) -> dict[str, str]:
+    """Return the raw top-level `key: value` lines of the frontmatter block.
+
+    Values are returned verbatim (still quoted / still a `[...]` list); the
+    per-check logic interprets them. Missing block => empty dict.
+    """
+    m = re.match(r"^---\n(.*?)\n---\n", text, re.DOTALL)
+    if not m:
+        return {}
+    out: dict[str, str] = {}
+    for line in m.group(1).splitlines():
+        km = re.match(r"^([A-Za-z_][A-Za-z0-9_]*):\s*(.*)$", line)
+        if km:
+            out[km.group(1)] = km.group(2).strip()
+    return out
+
+
+def _unquote(value: str) -> str:
+    v = value.strip()
+    if len(v) >= 2 and v[0] in "\"'" and v[-1] == v[0]:
+        return v[1:-1]
+    return v
+
+
+def _is_nonempty_list(value: str) -> bool:
+    v = value.strip()
+    if not (v.startswith("[") and v.endswith("]")):
+        return False
+    return bool(v[1:-1].strip())
+
+
+# --- title sentence-case checker --------------------------------------------
+
+def _is_acronym(core: str) -> bool:
+    """All-caps token (>= 2 letters), tolerating a trailing plural 's' (IDs)."""
+    base = core[:-1] if core.endswith("s") and len(core) > 2 else core
+    return len(base) >= 2 and base.isalpha() and base.isupper()
+
+
+def title_violations(title: str) -> list[str]:
+    """Words in `title` that break sentence case. Empty list => OK."""
+    bad: list[str] = []
+    for idx, tok in enumerate(title.split()):
+        first_alpha = next((c for c in tok if c.isalpha()), None)
+        if first_alpha is None:
+            continue  # pure punctuation / number token, e.g. "&", "(the"
+        core = tok.strip("()[]{}.,:;!?–—")
+        has_digit = any(c.isdigit() for c in tok)
+        if not first_alpha.isupper():
+            # starts lowercase: only the first word must be capitalized, and a
+            # digit-led version token (v1, v2.0) is a legitimate first word.
+            if idx == 0 and not has_digit:
+                bad.append(f"{tok!r} (first word should be capitalized)")
+            continue
+        # starts uppercase: justified for the first word, acronyms, digit tokens,
+        # or an allow-listed proper noun; otherwise it is stray Title-Case.
+        if idx == 0 or has_digit or _is_acronym(core) or core.lower() in PROPER_NOUNS:
+            continue
+        bad.append(f"{tok!r} (use sentence case)")
+    return bad
+
+
+# --- section ordering -------------------------------------------------------
+
+def _slot(slug: str) -> tuple[int, int]:
+    """(band, index-within-band). band 0=overview, 1=concept, 2=reference."""
+    if slug == "overview":
+        return (0, 0)
+    if slug in REFERENCE_ORDER:
+        return (2, REFERENCE_ORDER.index(slug))
+    return (1, 0)
+
+
+def expected_order(slugs: list[str]) -> list[str]:
+    """The canonical order for a flat section's page slugs."""
+    order = sorted(range(len(slugs)), key=lambda i: (_slot(slugs[i])[0], _slot(slugs[i])[1], i))
+    return [slugs[i] for i in order]
+
+
+# --- nav helpers ------------------------------------------------------------
+
+def _load_nav() -> list[dict]:
+    data = json.loads((DOCS / "docs.json").read_text(encoding="utf-8"))
+    groups: list[dict] = []
+    for tab in data.get("navigation", {}).get("tabs", []):
+        groups.extend(tab.get("groups", []))
+    return groups
+
+
+def _section_group(groups: list[dict], pkg: str) -> dict | None:
+    """The nav group whose pages contain `<pkg>/overview`."""
+    def has_overview(pages: object) -> bool:
+        if isinstance(pages, list):
+            return any(has_overview(p) for p in pages)
+        if isinstance(pages, dict):
+            return has_overview(pages.get("pages", []))
+        return pages == f"{pkg}/overview"
+
+    for g in groups:
+        if has_overview(g.get("pages", [])):
+            return g
+    return None
+
+
+# --- the checks -------------------------------------------------------------
+
+def check() -> list[str]:
+    problems: list[str] = []
+
+    # 4 + 5: frontmatter schema + title style over EVERY docs-site page.
+    for path in sorted(DOCS.rglob("*.mdx")):
+        rel = path.relative_to(ROOT)
+        fm = _frontmatter(path.read_text(encoding="utf-8"))
+        for key in ("title", "description", "keywords"):
+            if key not in fm:
+                problems.append(f"{rel}: frontmatter missing `{key}`")
+        if fm.get("title") and not _unquote(fm["title"]):
+            problems.append(f"{rel}: frontmatter `title` is empty")
+        if fm.get("description") and not _unquote(fm["description"]):
+            problems.append(f"{rel}: frontmatter `description` is empty")
+        if "keywords" in fm and not _is_nonempty_list(fm["keywords"]):
+            problems.append(f"{rel}: frontmatter `keywords` must be a non-empty list")
+        if fm.get("title"):
+            for v in title_violations(_unquote(fm["title"])):
+                problems.append(f"{rel}: title not sentence case: {v}")
+
+    groups = _load_nav()
+
+    for pkg in SECTIONS:
+        pkg_dir = DOCS / pkg
+        # 1: spine present as real files.
+        for page in REQUIRED_PAGES:
+            if not (pkg_dir / f"{page}.mdx").exists():
+                problems.append(
+                    f"{pkg}: missing required spine page `{pkg}/{page}.mdx` "
+                    f"(every section must have {', '.join(REQUIRED_PAGES)})"
+                )
+
+        group = _section_group(groups, pkg)
+        if group is None:
+            problems.append(f"{pkg}: no nav group contains `{pkg}/overview`")
+            continue
+
+        pages = group.get("pages", [])
+        # 2: overview first.
+        if not pages or pages[0] != f"{pkg}/overview":
+            problems.append(f"{pkg}: nav group must open with `{pkg}/overview`")
+
+        # 3: canonical order for FLAT sections only (all top-level entries are
+        # string page refs). Nested sections are exempt from ordering.
+        if all(isinstance(p, str) for p in pages):
+            slugs = [p.split("/", 1)[1] if "/" in p else p for p in pages]
+            want = expected_order(slugs)
+            if slugs != want:
+                problems.append(
+                    f"{pkg}: nav pages out of canonical order.\n"
+                    f"       got:  {slugs}\n"
+                    f"       want: {want}"
+                )
+
+    return problems
+
+
+def main() -> int:
+    problems = check()
+    if problems:
+        print("Section-consistency check FAILED:\n", file=sys.stderr)
+        for p in problems:
+            print(f"::error::docs-section: {p}", file=sys.stderr)
+            print(f"  - {p}", file=sys.stderr)
+        print(
+            f"\n{len(problems)} problem(s). Fix the file (or its generator, for "
+            "generated pages) so every section matches the canonical shape.",
+            file=sys.stderr,
+        )
+        return 1
+    n = len(list(DOCS.rglob("*.mdx")))
+    print(f"Section-consistency check OK: {len(SECTIONS)} sections, {n} pages "
+          "conform to the canonical shape.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/gen_suite_matrix.py
+++ b/scripts/gen_suite_matrix.py
@@ -238,6 +238,7 @@ def _compose(block: str) -> str:
         'description: "Cross-package view of the Golden Suite: capability counts, the Rust '
         '-core compute substrate, Python/TypeScript parity, and auto-detected gaps — '
         'generated and gated in CI."\n'
+        'keywords: ["golden suite", "suite matrix", "cross-package", "parity", "capabilities", "rust core", "reference"]\n'
         "---\n\n"
         "The per-package [config matrices](/goldenmatch/config-matrix) each describe one "
         "package. This is the **cross-package** view. The anchor is the **Rust / "

--- a/scripts/test_docs_sections.py
+++ b/scripts/test_docs_sections.py
@@ -1,0 +1,69 @@
+"""Gate + unit tests for the per-section docs-consistency contract.
+
+``test_sections_conform`` mirrors the CI ``check_docs_sections.py`` run (the real
+docs must pass). The rest unit-test the pure logic -- title sentence-casing and
+canonical page ordering -- so a bad rule is caught here, not only by staring at
+the sidebar.
+"""
+from __future__ import annotations
+
+import check_docs_sections as s
+
+
+def test_sections_conform():
+    problems = s.check()
+    assert problems == [], "docs-site sections violate the canonical contract:\n" + "\n".join(problems)
+
+
+# --- title sentence-case --------------------------------------------------
+
+def test_title_ok_sentence_case():
+    for good in [
+        "GoldenMatch overview",       # brand first word
+        "Config matrix",
+        "Blocking strategies",
+        "MCP server",                 # acronym stays capped, word does not
+        "GoldenMatch API quick reference",
+        "Interactive TUI",
+        "REST API",
+        "Migrating to v2.0",          # digit-bearing version token
+        "v1 vs v2 at a glance",       # digit-led first word
+        "Amortized Bayesian ER (exploratory)",  # allow-listed proper noun + acronym
+        "Native acceleration & deep profiling",
+        "Data-quality–aware matching",
+        "Config suggestions (the healing loop)",
+    ]:
+        assert s.title_violations(good) == [], f"false positive on {good!r}"
+
+
+def test_title_flags_title_case():
+    for bad in ["Blocking Strategies", "Domain Packs", "Identity Graph",
+                "Learning Memory", "Reference Data", "MCP Server", "ER Agent"]:
+        assert s.title_violations(bad), f"missed Title-Case in {bad!r}"
+
+
+def test_title_flags_lowercase_first_word():
+    assert s.title_violations("blocking strategies")
+
+
+# --- canonical ordering ---------------------------------------------------
+
+def test_order_reference_band_tail_in_fixed_order():
+    got = ["overview", "checks", "config-matrix", "recipes", "cli", "native", "integrations"]
+    assert s.expected_order(got) == got
+
+
+def test_order_concept_pages_precede_reference_band():
+    # a concept page authored AFTER config-matrix must sort BEFORE it.
+    got = ["overview", "analyzers", "config-matrix", "cross-run", "native"]
+    assert s.expected_order(got) == ["overview", "analyzers", "cross-run", "config-matrix", "native"]
+
+
+def test_order_overview_forced_first():
+    got = ["mapping", "config-matrix", "overview", "recipes"]
+    assert s.expected_order(got)[0] == "overview"
+
+
+def test_order_concept_pages_keep_authored_relative_order():
+    got = ["overview", "zebra", "alpha", "config-matrix"]
+    assert s.expected_order(got) == ["overview", "zebra", "alpha", "config-matrix"]


### PR DESCRIPTION
## What and why

The Mintlify docs had drifted apart per section: some package sections had a `recipes` page and others didn't, page titles mixed Title-Case and sentence case, and the generated pages silently dropped `keywords`. The existing doc gates cover cross-cutting structure (nav integrity, orphan detection, internal links, config-matrix generation, `mint validate`) but nothing enforced the *within-section* shape, so sections kept diverging. This adds a single CI-gated source of truth for what a package section looks like, and brings every section into conformance.

## Changes

- **New gate `scripts/check_docs_sections.py`** (the source of truth), wired into the required `docs_consistency` CI job. It enforces, per package section:
  - **spine** — every section carries `overview` + `config-matrix` + `recipes`
  - **overview-first** + **canonical page order** for flat sections (overview -> concept pages in authored order -> reference band `config-matrix` -> `recipes` -> `cli` -> `native`/`performance` -> `integrations`); nested sections (goldenmatch) are spine/overview-checked only
  - **frontmatter schema** over every `docs-site/**/*.mdx` — `title` + `description` + `keywords`, all non-empty
  - **sentence-case titles** (proper nouns / acronyms allow-listed)
- **Authored the two missing spine pages** — `goldenanalysis/recipes.mdx` and `infermap/recipes.mdx`, written against the real APIs — and reordered the goldenanalysis nav so concept pages precede the reference band.
- **Added the 10 missing `keywords` blocks.** For the two *generated* pages (`config-linter`, `suite-matrix`) the fix went into the GENERATOR (`docgen.py`, `gen_suite_matrix.py`), then regenerated; the rest are hand-authored pages.
- **Normalized 9 Title-Case titles** to sentence case (e.g. `Blocking Strategies` -> `Blocking strategies`, `MCP Server` -> `MCP server`).
- **`scripts/test_docs_sections.py`** — pure-logic unit tests (title casing, ordering) appended to the scripts-test CI leg.
- Documented the new gate in `.claude/doc-surfaces.md`.

## Testing

- `python scripts/check_docs_sections.py` -> OK: 6 sections, 77 pages conform
- `python scripts/check_docs_links.py` -> OK: 77 pages, frontmatter parses, links resolve
- `pytest scripts/test_docs_sections.py` -> 8 passed
- `mint validate --disable-openapi` -> build validation passed
- `mint broken-links --check-anchors` -> no broken links
- Generated pages re-checked current: `gen_suite_matrix.py --check`, `gen_lint_docs.py --check`

Note: `check_docs_consistency.py` reports one pre-existing, unrelated failure on `main` (`goldengraph-native` roster mismatch) that is outside the scope of this change.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed (docs-only; no package behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_