### PR TITLE
fix(autoconfig): arrow-native build_blocking silently degraded blocking on wide/sparse frames (#1852 mode 2)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Fixed
+
+- **Arrow-native auto-config no longer silently degrades blocking on
+  wide/sparse frames (#1852, mode 2).** With
+  `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` (default since 2026-07-14), three
+  `build_blocking` helpers still ran raw-polars idioms on the input frame:
+  `_id_pass_scale_safe_nonnull` (the #1207 per-identifier union gate),
+  `_name_path_primary`'s geo-compound sizing, and `_llm_suggest_blocking_keys`.
+  On a `pa.Table` the first two AttributeError'd into a bare `except` that
+  returned `False`/`continue`, so the strong-identifier blocking union and
+  name+geo compounding silently collapsed to name-only blocking — a recall/
+  precision divergence between the arrow and polars lanes (the `_llm_*` path
+  crashed outright on an arrow+LLM-blocking run). All three now route through
+  the backend-neutral `Frame` seam, so arrow and polars select identical
+  blocking passes. Locked by a wide/sparse config-equality parity test
+  (`test_build_blocking_id_union_arrow_parity`). Complements the earlier
+  `_build_compound_blocking` fix (mode 1, the crash).
+
 ## [3.6.0] - 2026-07-20
 
 ### Changed

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -1946,22 +1946,32 @@ def _llm_suggest_blocking_keys(
 
     Returns a validated BlockingConfig or None if suggestions are invalid.
     """
+    # #1852: coerce to the Frame seam once so the cardinality/block stats run
+    # polars-free on a ``pa.Table`` (arrow-native lane). The raw ``df[...]`` /
+    # ``df.group_by(...)`` idioms below AttributeError'd on arrow; the first one
+    # (``df[p.name].n_unique()``) is unguarded, so an arrow+LLM-blocking run
+    # crashed outright rather than degrading.
+    from goldenmatch.core.frame import to_frame as _tf
+
+    frame = _tf(df)
+    frame_height = frame.height
+
     # Build prompt with cardinality stats (all non-numeric columns, including date)
     col_stats = []
     for p in profiles:
         if p.col_type == "numeric":
             continue
-        n_unique = df[p.name].n_unique()
-        max_block = df.group_by(p.name).len().get_column("len").max()
+        n_unique = frame.column(p.name).n_unique()
+        max_block = frame.group_len([p.name]).column("len").max()
         col_stats.append(
-            f"  {p.name}: type={p.col_type}, {n_unique:,} unique / {df.height:,} rows, "
+            f"  {p.name}: type={p.col_type}, {n_unique:,} unique / {frame_height:,} rows, "
             f"max_block={max_block:,}"
         )
 
     prompt = (
         "You are a data deduplication expert. Given these column profiles with cardinality stats:\n"
         + "\n".join(col_stats)
-        + f"\n\nDataset: {df.height:,} rows. Max safe block size: {max_safe_block:,}.\n"
+        + f"\n\nDataset: {frame_height:,} rows. Max safe block size: {max_safe_block:,}.\n"
         "Suggest 2-3 multi-pass compound blocking key combinations.\n"
         "Each pass: 2 columns that together keep max block under the safe limit.\n"
         "Prioritize recall — different passes should cover different match scenarios "
@@ -1992,7 +2002,7 @@ def _llm_suggest_blocking_keys(
         return None
 
     # Validate each suggestion
-    valid_columns = set(df.columns)
+    valid_columns = set(frame.columns)
     validated_passes: list[BlockingKeyConfig] = []
 
     for suggestion in suggested_passes:
@@ -2005,7 +2015,7 @@ def _llm_suggest_blocking_keys(
             continue
 
         try:
-            max_block = int(df.group_by(fields).len().get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]  # polars max() typed as PythonLiteral; "len" column is int64 at runtime
+            max_block = int(frame.group_len(fields).column("len").max() or 0)  # #1852: seam
         except Exception:
             logger.info("LLM suggestion rejected — group_by failed for %s", fields)
             continue
@@ -3216,15 +3226,21 @@ def build_blocking(
         non-null rows), so a bounded id (zip) or a mistyped low-cardinality
         ``identifier`` with a genuinely large non-null block is still dropped.
         """
-        try:
-            sub = df.filter(pl.col(field).is_not_null())
-            if sub.height == 0:
-                return False
-            g = sub.group_by(field).len()
-            sb = int(g.get_column("len").max() or 0)  # pyright: ignore[reportArgumentType]
-            sd = int(g.height)
-        except Exception:  # pragma: no cover -- defensive
+        # #1852: route through the ``_bf`` Frame seam so this runs polars-free on
+        # a ``pa.Table`` (the default under GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1).
+        # The old ``df.filter(pl.col(...))`` idioms AttributeError'd on arrow and
+        # the bare ``except`` swallowed it into ``return False`` -- every strong-id
+        # pass was then silently rejected, so the #1207 union collapsed to the
+        # name-only fallback on the arrow lane (the "silent zero/degraded blocking"
+        # of #1852). ``filter_valid_key`` drops exactly the null + sentinel keys
+        # the runtime static blocker drops (what this non-null projection means),
+        # so the measured block matches what actually forms.
+        sub = _bf.filter_valid_key(field)
+        if sub.height == 0:
             return False
+        g = sub.group_len([field])
+        sb = int(g.column("len").max() or 0)
+        sd = int(g.height)
         # Full-N projection unchanged: sample_n / effective_n_full stay the FULL
         # row counts; only the measured block/distinct exclude the null bucket.
         pb = _typed_projected_block(_col_types, [field], sb, effective_n_full, sample_n, sd)
@@ -3398,12 +3414,13 @@ def build_blocking(
             # Pick the geo column that reduces max block size the most
             geo_results: list[tuple[ColumnProfile, int]] = []
             for g in geo_cols:
-                try:
-                    max_block = df.group_by([g.name, best_name]).len().get_column("len").max()
-                    if max_block is not None:
-                        geo_results.append((g, int(max_block)))  # pyright: ignore[reportArgumentType]  # polars max() returns PythonLiteral
-                except Exception:
-                    continue
+                # #1852: ``_bf`` seam (was ``df.group_by(...)``, which
+                # AttributeError'd on a ``pa.Table`` -> the ``except: continue``
+                # silently skipped every geo column, so name+geo compounding never
+                # formed on the arrow lane).
+                max_block = _bf.group_len([g.name, best_name]).column("len").max()
+                if max_block is not None:
+                    geo_results.append((g, int(max_block)))
             if geo_results:
                 geo_results.sort(key=lambda x: x[1])
                 candidate, candidate_block = geo_results[0]

--- a/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
@@ -197,6 +197,79 @@ def test_build_compound_blocking_accepts_arrow_table():
     ]
 
 
+def _wide_sparse_union_shape():
+    """Deterministic wide/sparse CRM diagonal union: 4 strong-id columns, each
+    present only in ITS OWN source (75% null overall), plus a shared name +
+    geo. No single exact key clears the 0.20 null ceiling, so ``build_blocking``
+    routes into the #1207 per-identifier blocking UNION -- whose scale-safety
+    gate (``_id_pass_scale_safe_nonnull``) used raw ``df.filter(pl.col(...))``
+    under a bare ``except`` that turned the AttributeError on a ``pa.Table``
+    into ``return False`` for EVERY id pass. The union then silently collapsed
+    to the name-only fallback on the arrow lane (the second, subtler #1852
+    failure mode -- degraded blocking, not a crash). No RNG so the pa/pl inputs
+    are byte-identical by construction."""
+    n = 120  # rows per source
+    first = ["John", "Jane", "Bob", "Alice", "Sam", "Mary"]
+    last = ["Smith", "Jones", "Lee", "Brown", "Davis", "Miller"]
+    city = ["Boston", "Austin", "Denver", "Reno"]
+    ids = ["account_id", "owner_id", "order_id", "who_id"]
+    cols: dict[str, list] = {c: [] for c in ["first", "last", "city", *ids]}
+    for idc in ids:
+        for i in range(n):
+            cols["first"].append(first[i % len(first)])
+            cols["last"].append(last[(i // 2) % len(last)])
+            cols["city"].append(city[i % len(city)])
+            for k in ids:
+                cols[k].append(f"{idc[:2].upper()}{i:05d}" if k == idc else None)
+    return cols
+
+
+def _blocking_passes(blk) -> list[tuple[str, ...]]:
+    out: list[tuple[str, ...]] = []
+    if blk is not None:
+        if blk.keys:
+            out += [tuple(k.fields) for k in blk.keys]
+        if getattr(blk, "passes", None):
+            out += [tuple(p.fields) for p in blk.passes]
+    return out
+
+
+def test_build_blocking_id_union_arrow_parity():
+    """#1852 (mode 2): ``build_blocking`` on a wide/sparse frame emits the SAME
+    per-identifier blocking union on a ``pa.Table`` as on a ``pl.DataFrame``.
+
+    Feeds IDENTICAL profiles + n_rows_full to ``build_blocking`` for both
+    backends (as ``test_build_compound_blocking_accepts_arrow_table`` does),
+    so the only variable is the frame backend -- no ``Frame.sample`` in play,
+    hence a byte-deterministic cross-backend assertion. Before #1852 the arrow
+    branch dropped the id union and fell to name-only blocking; the passes then
+    differed (a silent recall/precision divergence, not an exception)."""
+    from goldenmatch.core.autoconfig import build_blocking, profile_columns
+
+    data = _wide_sparse_union_shape()
+    pl_df = pl.DataFrame(data)
+    # One profile set, shared across both backends (isolates build_blocking).
+    profiles = profile_columns(pl_df)
+
+    blk_pl = build_blocking(profiles, pl_df, n_rows_full=pl_df.height)
+    blk_pa = build_blocking(profiles, pa.table(data), n_rows_full=pl_df.height)
+
+    passes_pl = _blocking_passes(blk_pl)
+    passes_pa = _blocking_passes(blk_pa)
+
+    # The id union actually formed (not the name-only fallback): the strong-id
+    # columns appear as passes on the polars baseline...
+    id_cols = {"account_id", "owner_id", "order_id", "who_id"}
+    assert id_cols & {f for fields in passes_pl for f in fields}, (
+        f"baseline should block on the strong ids, got {passes_pl}"
+    )
+    # ...and the arrow lane selects the identical passes.
+    assert passes_pa == passes_pl, (
+        f"arrow blocking diverged from polars: arrow={passes_pa} polars={passes_pl}"
+    )
+    assert blk_pa.strategy == blk_pl.strategy
+
+
 @pytest.mark.parametrize("shape", ["exact-id-plus-names", "shared-email-switchboard"])
 def test_arrow_native_config_matchkey_equivalence(shape):
     """On shapes without a near-tie blocking choice, the arrow-native config's


### PR DESCRIPTION
## What and why

Picks up the **second, subtler failure mode** documented in the #1852 resolution comment. #1852 mode 1 (the `AttributeError` crash in `_build_compound_blocking`) was fixed, but the follow-up comment warned that porting the crash alone "converts a loud crash into a silent config divergence" — the arrow lane then **silently produces the wrong blocking**. That mode was still live on `main`.

With `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` (default since 2026-07-14), three `build_blocking` helpers still ran raw-polars idioms on the input frame — which is a `pa.Table` by default:

| helper | idiom | effect on a `pa.Table` |
|---|---|---|
| `_id_pass_scale_safe_nonnull` (#1207 per-identifier union gate) | `df.filter(pl.col(field).is_not_null())`, `.height`, `.get_column`, under `except: return False` | AttributeError → `False` for **every** strong-id pass → #1207 union collapses to name-only blocking |
| `_name_path_primary` geo-compound | `df.group_by([g.name, best_name])…` under `except: continue` | name+geo compounding silently never forms |
| `_llm_suggest_blocking_keys` | `df[col].n_unique()`, `df.group_by(...)`, `df.height`, `df.columns` (first is unguarded) | crashes outright on an arrow+LLM-blocking run |

## Changes

- Route all three helpers through the backend-neutral `Frame` seam (`_bf` / `to_frame`) — the same seam `build_blocking` already uses for its other column/height/group ops — and remove the bug-hiding bare `except`s.
- `filter_valid_key` is the correct seam for the "non-null projection": it drops exactly the null + sentinel keys the runtime static blocker drops, i.e. what that projection is meant to measure.
- CHANGELOG `[Unreleased]` entry.
- New parity test `test_build_blocking_id_union_arrow_parity` (wide/sparse CRM diagonal union) — feeds **identical profiles** to `build_blocking` for `pa.Table` vs `pl.DataFrame`, so the only variable is the backend and the cross-backend assertion is byte-deterministic (no `Frame.sample`).

## Reproduction

Wide/sparse CRM diagonal union, 4 strong-id columns each 75% null:

| backend | blocking passes (before) | after |
|---|---|---|
| `pl.DataFrame` | `account_id, owner_id, order_id, who_id` | (same) |
| `pa.Table` (default) | `first, last` (id union silently dropped) | `account_id, owner_id, order_id, who_id` |

## Testing

Root goldenmatch `[polars]`, `ARROW_DEFAULT_MEMORY_POOL=system`, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`:

- `tests/test_autoconfig_arrow_native_parity.py` → **12 passed** (incl. the new test).
- `tests/test_autoconfig_blocking_union_1207.py tests/test_autoconfig_blocking_cost_715.py tests/test_autoconfig_adaptive_blocking.py tests/test_auto_semantic_blocking.py tests/test_autoconfig_llm_smoke.py` → **50 passed, 1 skipped**.
- `tests/test_autoconfig.py tests/test_autoconfig_dtype_arrow_parity.py tests/test_autoconfig_integration.py` → **137 passed, 3 skipped**.
- `ruff check` on the changed files → clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated (behavior fix)
- [x] No secrets, tokens, or `.env` files committed

Fixes the mode-2 half of #1852 (which was closed after mode 1); the polars path is byte-unchanged (only arrow-lane behavior converges to it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_