### PR TITLE
fix(autoconfig): port composite blocking search to the Frame seam (arrow-native, #1852 tail)

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2096,6 +2096,7 @@
           ],
           "imports": [
             "goldenmatch._polars_lazy",
+            "goldenmatch.core.frame",
             "goldenmatch.core.quality_exclusions"
           ]
         },

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -24,6 +24,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   (`test_build_blocking_id_union_arrow_parity`). Complements the earlier
   `_build_compound_blocking` fix (mode 1, the crash).
 
+- **`auto_configure_df(pa.Table)` no longer raises `AttributeError: 'height'`
+  in composite blocking search (#1852 tail).** When every exact-eligible column
+  is a perfectly-unique surrogate key, auto-config goes fuzzy-only and
+  `build_blocking` falls into composite-key search. `find_composite_blocking_keys`
+  and `estimate_avg_block_size` (`core/blocking_candidates.py`) still ran raw
+  polars idioms (`df.height`, `df.select(...).n_unique()`) on the input frame,
+  which is a `pa.Table` by default under `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` —
+  crashing on the arrow-native lane. Both are now routed through the backend-
+  neutral `Frame` seam (`to_frame` + `joint_n_unique`), matching the earlier
+  `build_blocking` ports. This branch is only reached on an all-unique-identifier
+  (join-table / order-shaped) frame, which is why the #1852 wide/sparse gate never
+  exercised it; locked by `test_auto_configure_all_unique_ids_arrow_parity`.
+
 ## [3.6.0] - 2026-07-20
 
 ### Changed

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -272,9 +272,11 @@ def find_composite_blocking_keys(
 
     Enumerates pairs of mid-cardinality columns (each with ratio in
     ``[0.05, 0.5]`` so the joint cardinality lands in a sane band).
-    For each pair, computes joint cardinality via
-    ``df.select(c1, c2).n_unique()`` and picks the pair whose joint
-    cardinality is closest to ``n_rows / target_avg_block_size``.
+    For each pair, computes joint cardinality via the backend-neutral
+    ``frame.joint_n_unique([c1, c2])`` seam (equivalent to
+    ``df.select(c1, c2).n_unique()`` on the polars lane; arrow-safe -- see
+    #1852 tail) and picks the pair whose joint cardinality is closest to
+    ``n_rows / target_avg_block_size``.
 
     Returns the column names of the best pair, or ``None`` when no
     pair lands in ``[n_rows/100, n_rows/2]`` (avg block size 2-100).

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 from goldenmatch._polars_lazy import pl
 from goldenmatch.core.quality_exclusions import ColumnProfile
@@ -262,7 +263,7 @@ def classify_column_role(
 
 
 def find_composite_blocking_keys(
-    df: pl.DataFrame,
+    df: pl.DataFrame | Any,  # #1852 tail: also accepts pa.Table (routed via to_frame)
     column_roles: list[ColumnRole],
     *,
     target_avg_block_size: int = DEFAULT_COMPOSITE_TARGET_AVG_BLOCK_SIZE,
@@ -282,7 +283,21 @@ def find_composite_blocking_keys(
     a documented follow-up. Pair search covers 95% of
     healthcare/finance/retail shapes.
     """
-    n_rows = df.height
+    # #1852 tail: route column/height/joint-cardinality ops through the
+    # backend-neutral Frame seam so this runs polars-free on a ``pa.Table``
+    # (the default under GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1). The raw
+    # ``df.height`` / ``df.columns`` / ``df.select(...).n_unique()`` idioms
+    # AttributeError'd on arrow -- reached only when compound blocking is
+    # ATTEMPTED (all exact-eligible columns are perfect-surrogate keys, so
+    # autoconfig goes fuzzy-only and falls into composite search), which is
+    # why #1852's wide/sparse gate never exercised it. Idempotent for a
+    # ``pl.DataFrame`` -> byte-identical on the polars lane. Local import
+    # mirrors the autoconfig.py convention (no top-level frame import).
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(df)
+
+    n_rows = frame.height
     if n_rows < 2:
         return None
 
@@ -309,11 +324,11 @@ def find_composite_blocking_keys(
 
     for i, c1 in enumerate(mid_card_names):
         for c2 in mid_card_names[i + 1:]:
-            if c1 not in df.columns or c2 not in df.columns:
+            if c1 not in frame.columns or c2 not in frame.columns:
                 evaluated.append((c1, c2, 0, "field_missing_from_df"))
                 continue
             try:
-                joint_card = int(df.select([c1, c2]).n_unique())
+                joint_card = frame.joint_n_unique([c1, c2])
             except Exception as exc:  # pragma: no cover -- defensive
                 logger.debug(
                     "find_composite_blocking_keys: skipping (%s, %s): %s",
@@ -363,7 +378,7 @@ def find_composite_blocking_keys(
 
 
 def estimate_avg_block_size(
-    sample_df: pl.DataFrame,
+    sample_df: pl.DataFrame | Any,  # #1852 tail: also accepts pa.Table (routed via to_frame)
     blocking_field_names: list[str],
     full_population_n_rows: int,
 ) -> float:
@@ -377,13 +392,19 @@ def estimate_avg_block_size(
     Returns 1.0 when no fields are given (caller treats that as a
     degenerate config that should be rejected).
     """
-    if not blocking_field_names or sample_df.height == 0:
+    # #1852 tail: same Frame-seam port as find_composite_blocking_keys so the
+    # degenerate-blocking estimate runs polars-free on a ``pa.Table``.
+    from goldenmatch.core.frame import to_frame
+
+    frame = to_frame(sample_df)
+    sample_height = frame.height
+    if not blocking_field_names or sample_height == 0:
         return 1.0
-    fields_in_df = [f for f in blocking_field_names if f in sample_df.columns]
+    fields_in_df = [f for f in blocking_field_names if f in frame.columns]
     if not fields_in_df:
         return 1.0
     try:
-        sample_distinct = int(sample_df.select(fields_in_df).n_unique())
+        sample_distinct = frame.joint_n_unique(fields_in_df)
     except Exception as exc:  # pragma: no cover -- defensive
         logger.debug("estimate_avg_block_size failed: %s", exc)
         return 1.0
@@ -399,14 +420,14 @@ def estimate_avg_block_size(
     # is preserved.
     if os.environ.get("GOLDENMATCH_BLOCKING_CARDINALITY_SCALER", "").lower() == "observed":
         scaled_distinct = max(
-            int(sample_distinct * (full_population_n_rows / sample_df.height)),
+            int(sample_distinct * (full_population_n_rows / sample_height)),
             1,
         )
     else:
         import math
         scaled_distinct = max(int(
             sample_distinct * math.sqrt(
-                full_population_n_rows / sample_df.height,
+                full_population_n_rows / sample_height,
             ),
         ), 1)
     return full_population_n_rows / scaled_distinct

--- a/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
+++ b/packages/python/goldenmatch/goldenmatch/core/blocking_candidates.py
@@ -271,12 +271,14 @@ def find_composite_blocking_keys(
     """Search for a 2-column composite blocking key.
 
     Enumerates pairs of mid-cardinality columns (each with ratio in
-    ``[0.05, 0.5]`` so the joint cardinality lands in a sane band).
-    For each pair, computes joint cardinality via the backend-neutral
-    ``frame.joint_n_unique([c1, c2])`` seam (equivalent to
-    ``df.select(c1, c2).n_unique()`` on the polars lane; arrow-safe -- see
-    #1852 tail) and picks the pair whose joint cardinality is closest to
-    ``n_rows / target_avg_block_size``.
+    ``[0.05, 0.5]`` so the joint cardinality lands in a sane band). Each
+    candidate column is materialized once through the backend-neutral Frame
+    seam (``frame.column(name).to_list()``); for each pair the joint
+    cardinality is ``len(set(zip(c1, c2)))`` -- identical null-combo semantics
+    to ``frame.joint_n_unique([c1, c2])`` / the old
+    ``df.select(c1, c2).n_unique()`` (arrow-safe -- see #1852 tail), but without
+    re-materializing a shared column across the O(M^2) pairs. Picks the pair
+    whose joint cardinality is closest to ``n_rows / target_avg_block_size``.
 
     Returns the column names of the best pair, or ``None`` when no
     pair lands in ``[n_rows/100, n_rows/2]`` (avg block size 2-100).
@@ -324,13 +326,24 @@ def find_composite_blocking_keys(
     best_pair: tuple[str, str] | None = None
     best_distance = float("inf")
 
+    # #1965 review: materialize each candidate column's values ONCE. Joint
+    # cardinality is then `len(set(zip(col1, col2)))` per pair -- byte-identical
+    # to `frame.joint_n_unique` (null combos counted) but without re-running the
+    # arrow `to_pylist` on a shared column for every one of the O(M^2) pairs.
+    frame_cols = set(frame.columns)
+    col_values = {
+        name: frame.column(name).to_list()
+        for name in mid_card_names
+        if name in frame_cols
+    }
+
     for i, c1 in enumerate(mid_card_names):
         for c2 in mid_card_names[i + 1:]:
-            if c1 not in frame.columns or c2 not in frame.columns:
+            if c1 not in frame_cols or c2 not in frame_cols:
                 evaluated.append((c1, c2, 0, "field_missing_from_df"))
                 continue
             try:
-                joint_card = frame.joint_n_unique([c1, c2])
+                joint_card = len(set(zip(col_values[c1], col_values[c2])))
             except Exception as exc:  # pragma: no cover -- defensive
                 logger.debug(
                     "find_composite_blocking_keys: skipping (%s, %s): %s",

--- a/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_arrow_native_parity.py
@@ -286,3 +286,39 @@ def test_arrow_native_config_matchkey_equivalence(shape):
     finally:
         _arrow_native(False)
     assert _config_matchkeys(cfg_pl) == _config_matchkeys(cfg_pa)
+
+
+def _all_unique_id_shape():
+    """25 rows where every exact-eligible column is a PERFECTLY-UNIQUE surrogate
+    key (cardinality_ratio 1.0). Auto-config excludes all of them (#876 perfect-
+    surrogate guard), goes fuzzy-only, and `build_blocking` then falls into
+    composite search (`find_composite_blocking_keys`) -- the branch that the
+    #1852 wide/sparse gate never reached. Before the composite-search port, that
+    path called `df.height` / `df.select(...).n_unique()` on a `pa.Table` and
+    raised `AttributeError` on the arrow-native lane. Deterministic (no RNG)."""
+    return {
+        "order_id": [f"o{i}" for i in range(25)],
+        "account_id": [f"a{i}" for i in range(25)],
+        "order_number": [f"ORD-{i:04d}" for i in range(25)],
+        "total_amount": [f"{i}.00" for i in range(25)],
+        "status": ["active"] * 25,
+    }
+
+
+def test_auto_configure_all_unique_ids_arrow_parity():
+    """#1852 tail: `auto_configure_df` on an all-unique-surrogate-key frame runs
+    on a `pa.Table` (was `AttributeError: 'pyarrow.lib.Table' has no attribute
+    'height'` in `find_composite_blocking_keys` / `estimate_avg_block_size`) and
+    yields the SAME matchkeys as the polars baseline."""
+    from goldenmatch.core.autoconfig import auto_configure_df
+
+    data = _all_unique_id_shape()
+    _arrow_native(False)
+    cfg_pl = auto_configure_df(pl.DataFrame(data), _skip_finalize=True)
+    _arrow_native(True)
+    try:
+        # Must not raise on the arrow-native lane (the crash this fixes).
+        cfg_pa = auto_configure_df(pa.table(data), _skip_finalize=True)
+    finally:
+        _arrow_native(False)
+    assert _config_matchkeys(cfg_pl) == _config_matchkeys(cfg_pa)


### PR DESCRIPTION
## What and why

Fixes #1964 — a residual `#1852` tail on a **branch neither #1852 nor #1963 reached**. `auto_configure_df(pa.Table)` raises `AttributeError: 'pyarrow.lib.Table' has no attribute 'height'` when every exact-eligible column is a perfectly-unique surrogate key: auto-config excludes them all (#876 perfect-surrogate guard), goes fuzzy-only, and `build_blocking` falls into **composite-key search**.

`core/blocking_candidates.py::find_composite_blocking_keys` (the crash) and `estimate_avg_block_size` (same latent idioms) still ran raw polars on the input frame — `df.height`, `df.columns`, `df.select([...]).n_unique()` — which is a `pa.Table` by default under `GOLDENMATCH_AUTOCONFIG_ARROW_NATIVE=1` (default since 2026-07-14).

## Changes

- Route both functions through the backend-neutral `Frame` seam: `to_frame(df)` + `frame.height` / `frame.columns` / `frame.joint_n_unique(cols)`. `joint_n_unique` is the seam method built for composite cardinality and is byte-equivalent to `df.select(cols).n_unique()` on the polars lane — so the polars path is unchanged. Local `to_frame` import mirrors the `autoconfig.py` convention.
- CHANGELOG `[Unreleased]` entry.
- New parity test `test_auto_configure_all_unique_ids_arrow_parity` (all-unique-id fixture): asserts the arrow lane no longer raises and yields the **same matchkeys** as the polars baseline.

## Reproduction

25-row order-shaped table with two unique id columns (from the issue):

| input | before | after |
|---|---|---|
| `pa.Table`, `ARROW_NATIVE=1` | `AttributeError: 'height'` | OK — `canopy` blocking, matchkeys == polars |
| `pl.DataFrame` / flag `=0` | OK | OK (unchanged) |

## Testing

Root goldenmatch `[polars]`, `ARROW_DEFAULT_MEMORY_POOL=system`, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`:

- `tests/test_autoconfig_arrow_native_parity.py` → **12 passed** (incl. the new test).
- `tests/test_blocking_candidates.py tests/test_blocking_candidates_e2e.py` → **41 passed**.
- `tests/test_autoconfig.py tests/test_autoconfig_blocking_cost_715.py tests/test_autoconfig_blocking_union_1207.py` → **138 passed, 3 skipped**.
- `ruff check` on the changed files → clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated (crash fix)
- [x] No secrets, tokens, or `.env` files committed

Complements #1852 (parent) and #1963 (the `build_blocking` helper ports); the polars path is byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_