### PR TITLE
Scorer -core kernel coverage: spec + Wave 1 (qgram kernelized, 5/19 -> 6/19)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**5 of 19 scorers are kernel-backed** (the reference fast path); the other 14 are pure-language fallbacks with no `-core` kernel.
+**6 of 19 scorers are kernel-backed** (the reference fast path); the other 13 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `qgram` |
 | WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `name_freq_weighted_jw`, `phash`, `qgram`, `radial`, `record_embedding`, `soundex_match` |
+| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding`, `soundex_match` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -1,7 +1,7 @@
 # Full `-core` kernel coverage for the scorer surface (5/19 -> full)
 
 **Date:** 2026-07-21
-**Status:** Proposed (scoping / design)
+**Status:** Proposed (scoping / design). **Wave 1 `qgram` landed in this same PR** (5/19 -> 6/19); the baseline figures below describe the pre-PR starting point.
 **Motivation:** The generated suite-matrix reports **"5 of 19 scorers are kernel-backed"**
 (`docs-site/suite-matrix.mdx`, computed by `gen_suite_matrix.py::_substrate_lines` from the
 `scorer_kernels` parity surface). This spec scopes what it takes to close that gap -- and argues
@@ -11,14 +11,18 @@ that a literal "19/19" is the wrong target.
 
 The Rust / Arrow-native `-core` kernels are the reference implementation for scoring; each language
 surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language
-fallback. Today only **5 scorers** have a kernel:
+fallback. At the pre-PR baseline only **5 scorers** had a kernel:
 
 - **shared** (Python arrow bucket kernel + TS WASM): `exact`, `jaro_winkler`, `levenshtein`, `token_sort`
 - **python-only** (arrow bucket kernel, TS falls back): `date`
 
-The other **14 are fallback-only**: `dice`, `jaccard`, `qgram`, `soundex_match`, `ensemble`,
-`embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`, `radial`,
-`given_name_aliased_jw`, `name_freq_weighted_jw`.
+The other **14 were fallback-only** at that baseline: `dice`, `jaccard`, `qgram`, `soundex_match`,
+`ensemble`, `embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`,
+`radial`, `given_name_aliased_jw`, `name_freq_weighted_jw`.
+
+**Update (this PR):** `qgram` is now kernelized (Wave 1) -- it has a `score-core` kernel on the
+Python arrow-bucket fast path, so the current state is **6/19** with **13** fallbacks remaining.
+`qgram` reads as `python_only` in the `scorer_kernels` partition (no TS WASM port yet, like `date`).
 
 "Kernel-backed" in the metric means *a kernel exists in at least one language* (a union), so the
 denominator (19) also counts scorers that live in only one language. The metric is emitted by
@@ -92,7 +96,7 @@ minimal. Recommend **defer or explicitly decline**.
 
 | Wave | Scorers | Risk | Rationale |
 |---|---|---|---|
-| **1** | `qgram`, `soundex_match`, `initialism_match` | low | pure strings on the proven template; `soundex_match` is half-wired already |
+| **1** | `qgram` ✅ (landed this PR), `soundex_match`, `initialism_match` | low | pure strings on the proven template; `soundex_match` is half-wired already |
 | **2** | `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk |
 | **3** | `phash`, `dice`, `jaccard` | low-med | wiring existing kernels (`perceptual-core`, `bloom.rs`), not new algorithms |
 | **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -111,7 +111,8 @@ on us, and step 4 is the real work.
 1. **`score-core`** (`packages/rust/extensions/score-core/src/lib.rs`): add the primitive
    (`pub fn <scorer>_similarity` + a `score_one` id, or a dedicated fn). Exports today:
    `jaro_winkler_similarity`, `levenshtein_similarity`, `token_sort_ratio`,
-   `token_sort_normalized_ratio`, `date_similarity`, `score_one(id: 0..4)`.
+   `token_sort_normalized_ratio`, `date_similarity`, `qgram_similarity`,
+   `score_one(id: 0..5)` (id 5 = qgram, added by the Wave-1 qgram cut).
 2. **`native` wheel** (`packages/rust/extensions/native/src/score.rs`): add a `#[pyfunction]` shim,
    register it in `native/src/lib.rs` (`m.add_function(...)` -- required for the `native_symbols`
    gate), and wire the id into `score_field_matrix` (`:1220`) and/or `score_block_pairs*`.

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -1,0 +1,162 @@
+# Full `-core` kernel coverage for the scorer surface (5/19 -> full)
+
+**Date:** 2026-07-21
+**Status:** Proposed (scoping / design)
+**Motivation:** The generated suite-matrix reports **"5 of 19 scorers are kernel-backed"**
+(`docs-site/suite-matrix.mdx`, computed by `gen_suite_matrix.py::_substrate_lines` from the
+`scorer_kernels` parity surface). This spec scopes what it takes to close that gap -- and argues
+that a literal "19/19" is the wrong target.
+
+## Problem
+
+The Rust / Arrow-native `-core` kernels are the reference implementation for scoring; each language
+surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language
+fallback. Today only **5 scorers** have a kernel:
+
+- **shared** (Python arrow bucket kernel + TS WASM): `exact`, `jaro_winkler`, `levenshtein`, `token_sort`
+- **python-only** (arrow bucket kernel, TS falls back): `date`
+
+The other **14 are fallback-only**: `dice`, `jaccard`, `qgram`, `soundex_match`, `ensemble`,
+`embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`, `radial`,
+`given_name_aliased_jw`, `name_freq_weighted_jw`.
+
+"Kernel-backed" in the metric means *a kernel exists in at least one language* (a union), so the
+denominator (19) also counts scorers that live in only one language. The metric is emitted by
+`scripts/emit_python_surface.py::_scorer_kernels` (= the bucket `_NATIVE_SCORER_IDS` keys) and
+`scripts/emit_ts_surface.mjs` (= `WASM_COVERED_SCORERS`), partitioned in `parity/goldenmatch.yaml`
+and gated by `api_parity`.
+
+## Why "19/19" is the wrong literal target
+
+Three of the 14 are not string-scorer-kernel candidates at all:
+
+1. **`embedding`, `record_embedding` are model-backed, not string primitives.** They embed values
+   (Vertex / torch / MiniLM) and cosine them; `record_embedding` is record-level (multi-column),
+   not field-level. Their acceleration is the **`goldenembed-core` / `goldenembed-wasm`** subsystem,
+   not the rapidfuzz-style scorer kernel. Writing a "scorer kernel" for them is a category error.
+   -> **Reframe out of the denominator** (or report them as "covered by goldenembed").
+2. **`ensemble` is a meta-scorer** -- `max(jaro_winkler, token_sort, soundex_match * 0.8)`
+   (`core/scorer.py:565`). It has no primitive of its own; once its three components are
+   kernel-backed it is **kernel-backed by construction**. Nearly free, no new kernel.
+
+So the real algorithmic surface to kernelize is **11 scorers**, and the honest end state is
+
+> **"16 of 16 algorithmic scorers kernel-backed; the embedding pair delegated to goldenembed."**
+
+Because the suite-matrix line is *generated*, it updates itself once the manifest changes -- no prose
+edit needed. (Independently, the current wording should say "union across languages (4 in both)" so
+the "5" is not misread as "5 in both languages" -- see Non-goals.)
+
+## The three kernel families (not one effort)
+
+### Family A -- clean string scorers (copy the `jaro_winkler` template)
+
+String-in / float-out / NxN-matrixable, same shape as the 5 already kernel-backed. Highest value:
+each replaces an O(N^2) pure-Python double loop.
+
+| Scorer | Impl (file:line) | What it computes | Extra work vs template |
+|---|---|---|---|
+| `qgram` | `core/scorer.py:1019` (`_qgram_score_matrix:1036`) | char-trigram Jaccard on raw strings (`#`-padded n-gram sets) | none -- pure string primitive |
+| `soundex_match` | `core/scorer.py:701`; field-map `id 4` at `:484` | `1.0` if `jellyfish.soundex(a)==soundex(b)` | **half-done** -- already in `_NATIVE_FIELD_SCORER_IDS`, not the bucket path; finish the wiring |
+| `initialism_match` | `core/scorer.py:101`, `:716` | `1.0` if one string is the other's initialism (`derive_initialism`) | cross-keyed (raw vs derived), so a *pairwise* kernel, not a hash-group |
+| `given_name_aliased_jw` | `refdata/scorer.py:177` | `max(jw, 1.0 if known given-name alias)` (William<->Bill) | needs the alias table in-kernel |
+| `name_freq_weighted_jw` | `refdata/scorer.py:69` | `jw * (floor + (1-floor)*mean_rarity)` from census/`tf_freqs` | needs the freq table in-kernel; TS port is static-only (declared delta) |
+| `alias_match` | `core/scorer.py:125`, `:741` | `1.0` if same business/given-name canonical | needs canonicalization tables in-kernel |
+
+The in-kernel-table mechanism already exists: `native/src/score.rs::set_name_reference_data`
+(`:56`) / `has_name_reference_data` (`:72`). `name_freq_weighted_jw` already threads a `tf_freqs=`
+kwarg through `_fuzzy_score_matrix` and the plugin protocol.
+
+### Family B -- bit / hex vectors (a different kernel, mostly wiring)
+
+Not rapidfuzz string scorers; these consume hex-decoded bit vectors. In several cases the kernel
+already exists elsewhere and only needs routing into the scorer path.
+
+| Scorer | Impl (file:line) | What it computes | Note |
+|---|---|---|---|
+| `phash` | `core/scorer.py:889`, `:901` | `1 - hamming(hexA,hexB)/bits` on perceptual image hashes | a Rust `perceptual-core` phash/hamming kernel **already exists** (SQL surface) -- wire it into the scorer path |
+| `dice` | `core/scorer.py:796`, `:812` | PPRL: `2*popcount(A&B)/(popA+popB)` over hex bloom filters | reuse the existing native bloom kernel (`bloom.rs`); mind the documented TS char-bigram `dice` divergence |
+| `jaccard` | `core/scorer.py:804`, `:851` | PPRL: `popcount(A&B)/popcount(A|B)` over hex blooms | same as dice |
+
+### Family C -- bespoke perceptual, low ROI
+
+| Scorer | Impl (file:line) | Why deferred |
+|---|---|---|
+| `audio_fp` | `core/scorer.py:937`, `:944` | best-offset-aligned BER on hex audio fingerprints; **alignment search, not NxN-vectorizable**, symmetric pairwise loop |
+| `radial` | `core/scorer.py:967`, `:976` | rotation-aligned Pearson on radial profiles; angular alignment search, same shape |
+
+Blocks for these are small and the primitive is a per-pair alignment search, so the perf upside is
+minimal. Recommend **defer or explicitly decline**.
+
+## Waves
+
+| Wave | Scorers | Risk | Rationale |
+|---|---|---|---|
+| **1** | `qgram`, `soundex_match`, `initialism_match` | low | pure strings on the proven template; `soundex_match` is half-wired already |
+| **2** | `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk |
+| **3** | `phash`, `dice`, `jaccard` | low-med | wiring existing kernels (`perceptual-core`, `bloom.rs`), not new algorithms |
+| **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |
+| **4 (defer/decline)** | `audio_fp`, `radial` | -- | bespoke alignment search, low perf upside |
+| **n/a** | `embedding`, `record_embedding` | -- | model-backed; reframe under goldenembed, exclude from denominator |
+
+Landing Waves 1-3 + `ensemble`, and reframing the embedding pair, takes the metric to full
+algorithmic coverage.
+
+## Per-scorer work unit (the template)
+
+Each scorer follows the same six steps. **The `api_parity` gate only checks the id-map is present
+and the manifest agrees -- it does NOT assert numeric parity.** Proving `kernel == pure-Python` is
+on us, and step 4 is the real work.
+
+1. **`score-core`** (`packages/rust/extensions/score-core/src/lib.rs`): add the primitive
+   (`pub fn <scorer>_similarity` + a `score_one` id, or a dedicated fn). Exports today:
+   `jaro_winkler_similarity`, `levenshtein_similarity`, `token_sort_ratio`,
+   `token_sort_normalized_ratio`, `date_similarity`, `score_one(id: 0..4)`.
+2. **`native` wheel** (`packages/rust/extensions/native/src/score.rs`): add a `#[pyfunction]` shim,
+   register it in `native/src/lib.rs` (`m.add_function(...)` -- required for the `native_symbols`
+   gate), and wire the id into `score_field_matrix` (`:1220`) and/or `score_block_pairs*`.
+3. **Python id maps:** add `"<scorer>": <id>` to `backends/score_buckets.py::_NATIVE_SCORER_IDS`
+   (`:214`, bucket path) and/or `core/scorer.py::_NATIVE_FIELD_SCORER_IDS` (`:479`, field path),
+   **capability-guarded** like `date` so a stale published wheel declines to the Python mirror
+   (the #688 silent-slow-fallback class). NB the two id maps are distinct namespaces --
+   bucket `id 4 = date`, field `id 4 = soundex_match` -- do not collide.
+4. **Pure-Python mirror + parity test:** keep the existing `_<scorer>_score_matrix` byte/4dp
+   identical to the kernel; add a `tests/test_native_*_parity.py` case asserting `pure == kernel`.
+5. **`score-wasm`** (`packages/rust/extensions/score-wasm/src/lib.rs`): add the id to
+   `score_matrix_impl`; **TS backend** (`src/core/wasm/backend.ts`): add to `SCORER_ID`
+   (auto-joins `WASM_COVERED_SCORERS`); regenerate the committed wasm fixture (the `fixture_drift`
+   gate re-checks it).
+6. **Manifest:** update the `scorer_kernels:` partition in `parity/goldenmatch.yaml`
+   (shared / python_only / ts_only) in the **same PR**, or `api_parity` reddens.
+
+## Risks / parity edges
+
+- **Reference fidelity.** A Rust reimplementation must match the Python reference *exactly*:
+  `soundex_match` must equal `jellyfish.soundex`; the name scorers must use the exact census-2010 /
+  alias / given-name tables the refdata ships. A drifting reimpl silently changes match output.
+- **Table shipping.** Waves 2 kernels need refdata tables loaded into the kernel via
+  `set_name_reference_data`; the load path must be deterministic and the table content pinned so
+  `native == pure`.
+- **`dice`/`jaccard` cross-language divergence.** TS `diceCoefficient` is a char-bigram set variant;
+  Python is bloom popcount. Pick the reference explicitly rather than paper over it.
+- **Wheel skew (#688).** Every new kernel symbol must be capability-guarded AND the published wheel
+  republished in the same change, or every `pip install goldenmatch[native]` env silently keeps
+  hitting the slow fallback. `scripts/check_native_wheel.py` is the advisory.
+- **`native_symbols` gate.** A new `wrap_pyfunction!` must be registered with a `::`-qualified path
+  and reflected in the host reference scan, or the gate flags referenced-but-not-registered.
+
+## Non-goals
+
+- **Waves 4** (`audio_fp`, `radial`) and the **embedding pair** are explicitly out of scope for a
+  scorer kernel here.
+- **Independent doc fix (do regardless):** change the generated wording in
+  `gen_suite_matrix.py::_substrate_lines` from "N of M scorers are kernel-backed" to make clear the
+  count is a **union across languages** (e.g. "5 have a kernel in >=1 language; 4 in both"), so the
+  ratio is not misread. This does not depend on any kernel work landing.
+
+## Recommendation
+
+Ship **Waves 1-2** first (the six clean string scorers -- real perf, lowest risk, proven template),
+then **Wave 3** (cheap wiring of existing kernels), take `ensemble` for free, **defer Wave 4**, and
+**reframe the embedding pair** under goldenembed. End state: full algorithmic kernel coverage with an
+honest, self-updating suite-matrix line.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -221,6 +221,12 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # score_field_matrix path), where id 4 is soundex_match -- different kernel,
     # different namespace; date is not wired into that path.
     "date": 4,
+    # id 5 = qgram (char-trigram Jaccard, score-core score_one). Same wheel-skew
+    # story as date: routing is GUARDED on the `qgram_similarity` capability
+    # symbol at the gating site below, so a stale wheel (pre-qgram, whose
+    # score_one catch-all scores id 5 as 0.0) declines to the pure-Python
+    # per-pair mirror (`_qgram_score_single`) instead of silently zeroing.
+    "qgram": 5,
 }
 
 
@@ -309,6 +315,14 @@ def _resolve_score_pair_callable(
         # (native id 4); byte-identical to the kernel (native-parity asserted).
         from goldenmatch.core.scorer import _date_similarity_py
         return _date_similarity_py
+    if scorer_name == "qgram":
+        # Character-trigram Jaccard (n=3). Per-pair mirror of the matrix path
+        # (_qgram_score_matrix) AND of score-core::qgram_similarity (native
+        # id 5); the three are parity-asserted in tests/test_native_qgram_parity.py.
+        # Making qgram fast-path eligible routes qgram configs through the bucket
+        # backend (native or this per-pair mirror) instead of the slow matrix path.
+        from goldenmatch.core.scorer import _qgram_score_single
+        return _qgram_score_single
     if scorer_name == "dice":
         # Delegate to the existing per-pair implementation in core/scorer.py
         # (_dice_score_single, bigram set Dice coefficient). Matrix path is
@@ -1018,8 +1032,14 @@ def score_buckets(
             # per-pair path (which mirrors the kernel) score the whole block.
             _mod = native_module()
             _date_ok = _mod is not None and hasattr(_mod, "date_similarity")
+            _qgram_ok = _mod is not None and hasattr(_mod, "qgram_similarity")
             has_date = any(spec[3] == "date" for spec in _field_specs)
-            if all(i is not None for i in ids) and not (has_date and not _date_ok):
+            has_qgram = any(spec[3] == "qgram" for spec in _field_specs)
+            # Wheel-skew: decline native entirely when a field uses a scorer whose
+            # capability symbol the loaded kernel lacks (score_one would silently
+            # zero that id); the pure-Python per-pair mirror scores the block.
+            _skew_block = (has_date and not _date_ok) or (has_qgram and not _qgram_ok)
+            if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]
 
     # Track 1 Fix B: build the native ExcludeSet ONCE here, BEFORE the bucket

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -1036,10 +1036,13 @@ def _qgram_score_single(val_a: str, val_b: str, n: int = 3) -> float:
 def _qgram_score_matrix(values: list, n: int = 3) -> np.ndarray:
     """NxN character-n-gram Jaccard matrix on raw strings.
 
-    Clear O(N^2) loop -- qgram is a short-code scorer, blocks are small and
-    it stays on the Python path (no native dispatch). None values score 0.0
-    against everything (including the diagonal), mirroring how the bloom
-    matrices treat missing values.
+    Clear O(N^2) loop. This is the matrix fallback: qgram configs now route
+    through the bucket backend, which scores via the score-core kernel
+    (``score_one`` id 5) or its byte-identical per-pair mirror
+    ``_qgram_score_single``; this matrix path serves the non-bucket
+    (``find_fuzzy_matches``) route and is the parity reference. None values
+    score 0.0 against everything (including the diagonal), mirroring how the
+    bloom matrices treat missing values.
     """
     size = len(values)
     out = np.zeros((size, size), dtype=np.float64)

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -40,7 +40,7 @@ class TestNativeScorerIdMaps:
     # kernel. `score_field_matrix` shares 0-3 (it delegates to score_one) but its
     # id 4 is soundex_match, a DIFFERENT namespace -- pinned separately so the two
     # can't silently collide.
-    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4}
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):

--- a/packages/python/goldenmatch/tests/test_native_qgram_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_qgram_parity.py
@@ -1,0 +1,93 @@
+"""Parity for the q-gram bucket kernel (score-core id 5).
+
+qgram was the first Wave-1 scorer cut to a `-core` kernel (spec
+`docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md`). Three
+things must agree, and this file pins all three:
+
+1. native `qgram_similarity` (Rust score-core) == pure-Python `_qgram_score_single`
+   -- the kernel-vs-fallback contract the `GOLDENMATCH_NATIVE=auto` route relies on.
+2. `_qgram_score_single` (the new bucket per-pair mirror) == `_qgram_score_matrix`
+   diagonal/off-diagonal -- so making qgram fast-path eligible is output-neutral
+   vs the old slow matrix path.
+3. the bucket kernel `score_block_pairs` dispatching scorer id 5 == the per-pair
+   mirror -- the end-to-end path the metric now counts.
+
+Parity is asserted EXACTLY (not approx): both sides compute the same integer
+`|A & B| / |A | B|` division, so the f64 results are bit-identical on the ASCII /
+common-Latin inputs a short-code scorer sees. (Rust `to_lowercase` vs Python
+`str.lower()` can differ on exotic codepoints -- the documented ASCII/Latin-scope
+edge; the corpus stays in that scope.)
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.core.scorer import _qgram_score_matrix, _qgram_score_single
+
+_FIXED = [
+    ("", ""), ("a", ""), ("", "b"), ("abc", "abc"), ("ABC", "abc"),
+    ("abc", "abd"), ("abcd", "abce"), ("ab", "xy"),
+    ("John Smith", "Jon Smyth"), ("Smith John", "John Smith"),
+    ("SKU-1234", "SKU-1235"), ("widget", "widgets"), ("MacDonald", "Macdonald"),
+    ("café", "cafe"), ("naïve", "naive"),
+]
+
+
+def _corpus() -> list[tuple[str, str]]:
+    rng = random.Random(20260721)
+    alphabet = "abcdefghijklmnopqrstuvwxyz ABCDEFGHIJ0123456789-#"
+    def rand_str() -> str:
+        return "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 14)))
+    return _FIXED + [(rand_str(), rand_str()) for _ in range(1500)]
+
+
+def test_qgram_native_matches_pure():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "qgram_similarity"):
+        pytest.skip("native qgram kernel not built / wheel predates qgram_similarity")
+    for a, b in _corpus():
+        assert n.qgram_similarity(a, b) == _qgram_score_single(a, b), f"qgram {a!r} {b!r}"
+
+
+def test_qgram_per_pair_mirror_matches_matrix():
+    # Output-neutrality: the bucket per-pair mirror must equal the matrix path
+    # it replaces for qgram configs, off-diagonal and on the diagonal.
+    values = ["abc", "abd", "abc", "xyz", "abce", "", "ab"]
+    mat = _qgram_score_matrix(values)
+    for i, a in enumerate(values):
+        assert mat[i, i] == 1.0
+        for j in range(i + 1, len(values)):
+            assert mat[i, j] == _qgram_score_single(a, values[j]), f"{a!r} {values[j]!r}"
+
+
+def test_qgram_bucket_kernel_id5_matches_mirror():
+    """score_block_pairs dispatching scorer id 5 == the per-pair mirror.
+
+    One block, one qgram field, weight 1.0, threshold 0.0 so every pair emits;
+    the kernel's per-pair score must equal `_qgram_score_single`.
+    """
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "qgram_similarity"):
+        pytest.skip("native qgram kernel not built / wheel predates qgram_similarity")
+
+    values = ["widget", "widgets", "gadget", "widget", "wdget"]
+    row_ids = list(range(len(values)))
+    sizes = [len(values)]              # one block holding every row
+    field_values = [values]            # one field
+    ids = [5]                          # qgram
+    weights = [1.0]
+    total_weight = 1.0
+    threshold = 0.0
+    emitted = n.score_block_pairs(
+        row_ids, sizes, field_values, ids, weights, total_weight, threshold, []
+    )
+    got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            expected = _qgram_score_single(values[i], values[j])
+            if expected >= threshold:
+                assert got[(i, j)] == pytest.approx(expected, abs=1e-12), (
+                    f"{values[i]!r} {values[j]!r}"
+                )

--- a/packages/python/goldenmatch/tests/test_native_qgram_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_qgram_parity.py
@@ -88,6 +88,7 @@ def test_qgram_bucket_kernel_id5_matches_mirror():
         for j in range(i + 1, len(values)):
             expected = _qgram_score_single(values[i], values[j])
             if expected >= threshold:
-                assert got[(i, j)] == pytest.approx(expected, abs=1e-12), (
-                    f"{values[i]!r} {values[j]!r}"
-                )
+                # Exact: one qgram field, weight 1.0, total_weight 1.0 -> the
+                # kernel's emitted score is score_one(id 5) in f64 with no
+                # downcast, so it is bit-identical to the pure mirror.
+                assert got[(i, j)] == expected, f"{values[i]!r} {values[j]!r}"

--- a/packages/python/goldenmatch/tests/test_native_qgram_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_qgram_parity.py
@@ -12,9 +12,10 @@ things must agree, and this file pins all three:
 3. the bucket kernel `score_block_pairs` dispatching scorer id 5 == the per-pair
    mirror -- the end-to-end path the metric now counts.
 
-Parity is asserted EXACTLY (not approx): both sides compute the same integer
-`|A & B| / |A | B|` division, so the f64 results are bit-identical on the ASCII /
-common-Latin inputs a short-code scorer sees. (Rust `to_lowercase` vs Python
+Parity is asserted EXACTLY (not approx): both sides compute the same
+`|A ∩ B| / |A ∪ B|` ratio of integer set counts (an f64 division of two ints),
+so the results are bit-identical on the ASCII / common-Latin inputs a short-code
+scorer sees. (Rust `to_lowercase` vs Python
 `str.lower()` can differ on exotic codepoints -- the documented ASCII/Latin-scope
 edge; the corpus stays in that scope.)
 """

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -98,6 +98,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::levenshtein_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::token_sort_ratio, m)?)?;
     m.add_function(wrap_pyfunction!(score::date_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::qgram_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -235,6 +235,18 @@ pub fn date_similarity(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::date_similarity(a, b)
 }
 
+/// Character-trigram Jaccard (q-gram) similarity (score-core id 5). Exposed as
+/// its own #[pyfunction] capability marker, exactly like `date_similarity`:
+/// `score_one` / `score_block_pairs` dispatch id 5, but a stale published wheel
+/// (pre-qgram) would hit score_one's catch-all and silently return 0.0 for id 5,
+/// so the Python caller gates the native q-gram route on
+/// `hasattr(_native, "qgram_similarity")` and falls back to the pure-Python
+/// per-pair mirror (`_qgram_score_single`) otherwise.
+#[pyfunction]
+pub fn qgram_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::qgram_similarity(a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -150,13 +150,15 @@ fn qgram_set(s: &str) -> std::collections::HashSet<[char; 3]> {
     chars.extend(std::iter::repeat_n('#', N - 1));
     chars.extend(lower.chars());
     chars.extend(std::iter::repeat_n('#', N - 1));
-    let mut set = std::collections::HashSet::new();
     if chars.len() < N {
-        return set;
+        return std::collections::HashSet::new();
     }
-    // Grams are stored as a fixed `[char; N]` (N=3) rather than an allocated
-    // `String`, so scoring many pairs doesn't heap-allocate per trigram; the
-    // set membership semantics are identical (codepoint-wise equality).
+    // The gram count is known (chars.len() - N + 1), so pre-size the set to avoid
+    // rehashing while inserting. Grams are stored as a fixed `[char; N]` (N=3)
+    // rather than an allocated `String`, so scoring many pairs doesn't
+    // heap-allocate per trigram; set membership semantics are identical
+    // (codepoint-wise equality).
+    let mut set = std::collections::HashSet::with_capacity(chars.len() - N + 1);
     for i in 0..=(chars.len() - N) {
         set.insert([chars[i], chars[i + 1], chars[i + 2]]);
     }
@@ -180,11 +182,14 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
     }
     let sa = qgram_set(a);
     let sb = qgram_set(b);
-    let union = sa.union(&sb).count();
+    // One hash-lookup pass for the intersection, then |A ∪ B| = |A| + |B| - |A ∩ B|
+    // arithmetically (avoids a second `union()` pass over the sets).
+    let inter = sa.intersection(&sb).count();
+    let union = sa.len() + sb.len() - inter;
     if union == 0 {
         return 0.0;
     }
-    sa.intersection(&sb).count() as f64 / union as f64
+    inter as f64 / union as f64
 }
 
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -147,9 +147,9 @@ fn qgram_set(s: &str) -> std::collections::HashSet<[char; 3]> {
     // case mapping requires).
     let lower = s.to_lowercase();
     let mut chars: Vec<char> = Vec::with_capacity(lower.chars().count() + 2 * (N - 1));
-    chars.extend(std::iter::repeat('#').take(N - 1));
+    chars.extend(std::iter::repeat_n('#', N - 1));
     chars.extend(lower.chars());
-    chars.extend(std::iter::repeat('#').take(N - 1));
+    chars.extend(std::iter::repeat_n('#', N - 1));
     let mut set = std::collections::HashSet::new();
     if chars.len() < N {
         return set;

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -133,9 +133,54 @@ pub fn date_similarity(a: &str, b: &str) -> f64 {
     }
 }
 
+/// Character-trigram (q-gram) Jaccard set for one raw string, mirroring Python
+/// `goldenmatch.core.scorer._qgram_set` (n=3): lowercase, pad each side with
+/// `n-1` `#` sentinels, and take the set of length-`n` codepoint substrings.
+/// Padding means even the empty string yields the all-`#` gram, so the set is
+/// never empty for n>=2 (the Python `if not union` branch is unreachable, but
+/// `qgram_similarity` guards it anyway).
+fn qgram_set(s: &str) -> std::collections::HashSet<String> {
+    const N: usize = 3;
+    let pad = "#".repeat(N - 1);
+    let padded = format!("{pad}{}{pad}", s.to_lowercase());
+    let chars: Vec<char> = padded.chars().collect();
+    let mut set = std::collections::HashSet::new();
+    if chars.len() < N {
+        return set;
+    }
+    for i in 0..=(chars.len() - N) {
+        set.insert(chars[i..i + N].iter().collect::<String>());
+    }
+    set
+}
+
+/// Character-trigram (q-gram) Jaccard similarity on two raw strings, the
+/// reference for `goldenmatch.core.scorer._qgram_score_single` (n=3):
+/// `|A & B| / |A | B|` over the padded q-gram sets. Identical strings (incl.
+/// both empty) score 1.0; an empty union scores 0.0.
+///
+/// Unicode note: lowercasing uses Rust `str::to_lowercase` (Unicode default
+/// case mapping), which matches Python `str.lower()` across ASCII and common
+/// Latin. A handful of exotic codepoints can differ -- the same ASCII/Latin
+/// scoped parity edge documented for the infermap scorers. q-gram is a
+/// short-code scorer (SKUs / codes / names), so inputs are ASCII-dominant in
+/// practice.
+pub fn qgram_similarity(a: &str, b: &str) -> f64 {
+    if a == b {
+        return 1.0;
+    }
+    let sa = qgram_set(a);
+    let sb = qgram_set(b);
+    let union = sa.union(&sb).count();
+    if union == 0 {
+        return 0.0;
+    }
+    sa.intersection(&sb).count() as f64 / union as f64
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact, 4=date.
+/// 2=token_sort, 3=exact, 4=date, 5=qgram.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -156,6 +201,7 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         // with a!=b falls through to the catch-all 0.0, same as every other id.
         3 if a == b => 1.0,
         4 => date_similarity(a, b),
+        5 => qgram_similarity(a, b),
         _ => 0.0,
     }
 }
@@ -205,6 +251,37 @@ mod tests {
         assert_eq!(date_similarity("abc", "abc"), 1.0);
         let s = date_similarity("1980-01-01", "Jan 1 1980");
         assert!((s - levenshtein_similarity("1980-01-01", "Jan 1 1980")).abs() < 1e-12);
+    }
+
+    #[test]
+    fn qgram_identity_and_jaccard() {
+        // identical (incl. empty) -> 1.0
+        assert_eq!(qgram_similarity("abc", "abc"), 1.0);
+        assert_eq!(qgram_similarity("", ""), 1.0);
+        // case-insensitive: same q-gram sets after lowercasing
+        assert_eq!(qgram_similarity("ABC", "abc"), 1.0);
+        // disjoint short strings share only the all-`#` padding gram is false here:
+        // "ab" -> {##a,#ab,ab#} lower; "xy" -> {##x,#xy,xy#}; no overlap -> 0.0
+        assert_eq!(qgram_similarity("ab", "xy"), 0.0);
+        // one empty, one not: union non-empty, intersection empty -> 0.0
+        assert_eq!(qgram_similarity("", "x"), 0.0);
+        // partial overlap is strictly between 0 and 1
+        let s = qgram_similarity("abcd", "abce");
+        assert!(s > 0.0 && s < 1.0, "got {s}");
+    }
+
+    #[test]
+    fn qgram_matches_hand_computed_jaccard() {
+        // "abc" -> {##a,#ab,abc,bc#,c##}; "abd" -> {##a,#ab,abd,bd#,d##}
+        // intersection {##a,#ab} = 2, union = 8 -> 0.25
+        let s = qgram_similarity("abc", "abd");
+        assert!((s - 0.25).abs() < 1e-12, "got {s}");
+    }
+
+    #[test]
+    fn score_one_id5_is_qgram() {
+        assert_eq!(score_one(5, "abc", "abc"), 1.0);
+        assert_eq!(score_one(5, "abc", "abd"), qgram_similarity("abc", "abd"));
     }
 
     #[test]

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -141,9 +141,15 @@ pub fn date_similarity(a: &str, b: &str) -> f64 {
 /// `qgram_similarity` guards it anyway).
 fn qgram_set(s: &str) -> std::collections::HashSet<[char; 3]> {
     const N: usize = 3;
-    let pad = "#".repeat(N - 1);
-    let padded = format!("{pad}{}{pad}", s.to_lowercase());
-    let chars: Vec<char> = padded.chars().collect();
+    // Build the padded codepoint sequence directly into one Vec -- (N-1) `#`
+    // sentinels, the lowercased chars, then (N-1) `#` -- with no intermediate
+    // padding/`format!` `String` allocations (only `to_lowercase`, which Unicode
+    // case mapping requires).
+    let lower = s.to_lowercase();
+    let mut chars: Vec<char> = Vec::with_capacity(lower.chars().count() + 2 * (N - 1));
+    chars.extend(std::iter::repeat('#').take(N - 1));
+    chars.extend(lower.chars());
+    chars.extend(std::iter::repeat('#').take(N - 1));
     let mut set = std::collections::HashSet::new();
     if chars.len() < N {
         return set;

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -139,7 +139,7 @@ pub fn date_similarity(a: &str, b: &str) -> f64 {
 /// Padding means even the empty string yields the all-`#` gram, so the set is
 /// never empty for n>=2 (the Python `if not union` branch is unreachable, but
 /// `qgram_similarity` guards it anyway).
-fn qgram_set(s: &str) -> std::collections::HashSet<String> {
+fn qgram_set(s: &str) -> std::collections::HashSet<[char; 3]> {
     const N: usize = 3;
     let pad = "#".repeat(N - 1);
     let padded = format!("{pad}{}{pad}", s.to_lowercase());
@@ -148,15 +148,18 @@ fn qgram_set(s: &str) -> std::collections::HashSet<String> {
     if chars.len() < N {
         return set;
     }
+    // Grams are stored as a fixed `[char; N]` (N=3) rather than an allocated
+    // `String`, so scoring many pairs doesn't heap-allocate per trigram; the
+    // set membership semantics are identical (codepoint-wise equality).
     for i in 0..=(chars.len() - N) {
-        set.insert(chars[i..i + N].iter().collect::<String>());
+        set.insert([chars[i], chars[i + 1], chars[i + 2]]);
     }
     set
 }
 
 /// Character-trigram (q-gram) Jaccard similarity on two raw strings, the
 /// reference for `goldenmatch.core.scorer._qgram_score_single` (n=3):
-/// `|A & B| / |A | B|` over the padded q-gram sets. Identical strings (incl.
+/// `|A ∩ B| / |A ∪ B|` over the padded q-gram sets. Identical strings (incl.
 /// both empty) score 1.0; an empty union scores 0.0.
 ///
 /// Unicode note: lowercasing uses Rust `str::to_lowercase` (Unicode default

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,7 +305,8 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date` has an arrow-native kernel on Python but no TS WASM port yet.
+# python_only: `date` and `qgram` have an arrow-native (bucket) kernel on Python
+# but no TS WASM port yet.
 scorer_kernels:
   shared:
   - exact
@@ -314,4 +315,5 @@ scorer_kernels:
   - token_sort
   python_only:
   - date
+  - qgram
   ts_only: []


### PR DESCRIPTION
## What and why

The generated suite-matrix reported **"5 of 19 scorers are kernel-backed."** This PR adds the scoping spec for closing that gap **and** lands the first Wave-1 scorer: `qgram` now has a Rust `-core` kernel and is the reference implementation with a byte-identical pure-Python fallback. Suite-matrix now reads **6 of 19**.

## Changes

**Spec** (`docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md`)
- Reframes 19/19 (the `embedding`/`record_embedding` pair is model-backed → goldenembed; `ensemble` is a free meta-composition), classifies the ~11 real scorers into three kernel families, and sequences them into waves with the per-scorer work template and parity/wheel-skew risks.

**Wave 1 — `qgram` kernelized** (char-trigram Jaccard, n=3)
- `score-core`: `qgram_similarity` + `qgram_set`, wired as `score_one` id 5 (+ Rust unit tests). Lowercasing uses `to_lowercase` — the documented ASCII/Latin-scope parity edge, fine for a short-code scorer.
- `native`: `qgram_similarity` `#[pyfunction]` capability marker, registered in `lib.rs` — mirrors `date_similarity`, so a stale published wheel declines to the pure path instead of silently scoring id 5 as 0.0.
- `score_buckets.py`: qgram becomes fast-path eligible (per-pair mirror `_qgram_score_single`) and gets `_NATIVE_SCORER_IDS` id 5, guarded by a `qgram_similarity` wheel-skew check alongside `date`'s.
- Manifest `parity/goldenmatch.yaml`: `scorer_kernels.python_only += qgram`; `docs-site/suite-matrix.mdx` regenerated (6 of 19).
- New `tests/test_native_qgram_parity.py`: native == pure == matrix == bucket-kernel (exact equality).

## Testing

- `cargo test` (score-core): 15 pass, incl. 3 new qgram tests
- `pytest tests/test_native_qgram_parity.py` (native forced on): 3 pass — native `qgram_similarity` bit-identical to `_qgram_score_single` over 1500+ pairs
- 169 existing scorer/bucket parity tests pass with native on (no regression)
- `scorer_kernels` emitter == manifest; `gen_suite_matrix.py --check` current; `check_native_symbols.py goldenmatch` OK
- Built the in-tree `_native.abi3.so` locally to run the above

CI will re-verify in the native/api_parity/python lanes.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (spec + regenerated suite-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr