### PR TITLE
perf/hygiene(fs): range() prep-ids + prune stale golden.parquet (post-#1959 review follow-ups)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+### Changed
+
+- **Out-of-core streaming FS refinements (review follow-ups, opt-in path only).**
+  `_prep_all_ids` returns a `range` instead of a 25–50M-element Python list when
+  `__row_id__` is contiguous (the pipeline-generated common case), avoiding a
+  multi-GB transient before the pyarrow int64 array on the ≥40M streaming path.
+  `stream_fs_dedupe_output` and `dedupe_to_parquet`'s in-memory fallback now
+  remove a stale `golden.parquet` left by a prior run into the same `out_dir`
+  when a run produces no golden rows, so the on-disk file set matches the
+  returned `golden_path=None`.
+
 ### Added
 
 - **Bounded bucket streaming for the in-RAM FS route

--- a/packages/python/goldenmatch/goldenmatch/_api.py
+++ b/packages/python/goldenmatch/goldenmatch/_api.py
@@ -664,6 +664,11 @@ def dedupe_to_parquet(
     if golden is not None:
         _golden_rows = golden.num_rows if hasattr(golden, "num_rows") else golden.height
     golden_count = _frame_write_parquet(golden, golden_path) if _golden_rows else 0
+    if not golden_count and _os.path.exists(golden_path):
+        # Remove a golden.parquet left by a PRIOR run into the same out_dir so
+        # the on-disk file set matches the returned golden_path=None (unique/
+        # dupes are always rewritten; only golden is conditional).
+        _os.unlink(golden_path)
     return {
         "output_dir": out_dir,
         "unique_path": unique_path if unique is not None else None,

--- a/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/fs_out_of_core.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 import concurrent.futures
 import os
 import tempfile
+from collections.abc import Sequence
 from typing import Any
 
 from goldenmatch.config.schemas import BlockingConfig, MatchkeyConfig
@@ -549,6 +550,12 @@ def stream_fs_dedupe_output(
         )
         golden_count = len(records)
         pl.DataFrame(records).write_parquet(golden_path)
+    elif _os.path.exists(golden_path):
+        # No golden rows this run: remove a golden.parquet left by a PRIOR run
+        # into the same out_dir, so the on-disk file set matches the returned
+        # golden_path=None / golden_count=0 (unique/dupes are COPY-overwritten;
+        # only golden is conditionally written, so only it can go stale).
+        _os.unlink(golden_path)
 
     import pyarrow.parquet as _pq
 
@@ -568,10 +575,25 @@ def _default_golden_rules():
     return GoldenRulesConfig(default_strategy="most_complete")
 
 
-def _prep_all_ids(con: Any) -> list[int]:
+def _prep_all_ids(con: Any) -> Sequence[int]:
     """Every ``__row_id__`` in ``prep`` — the singleton-folding id set. Singletons
     (rows in no pair) must be present in the cluster assignments or
-    ``stream_fs_dedupe_output``'s INNER JOIN silently drops them."""
+    ``stream_fs_dedupe_output``'s INNER JOIN silently drops them.
+
+    When the ids are CONTIGUOUS (min..max with no gaps — the pipeline-generated
+    common case, since ``__row_id__`` is a dense global row index), return a
+    ``range`` instead of materialising a 25-50M-element Python list (which
+    ``fetchall()`` would, then get copied again into the downstream pyarrow
+    int64 array in ``build_clusters_arrow_native``). ``__row_id__`` is unique per
+    row, so ``max - min + 1 == count`` iff the set is exactly ``{min..max}``.
+    Falls back to the explicit list when there are gaps (e.g. a filtered prep)."""
+    lo, hi, n = con.execute(
+        "SELECT min(__row_id__), max(__row_id__), count(*) FROM prep"
+    ).fetchone()
+    if not n:
+        return []
+    if int(hi) - int(lo) + 1 == int(n):
+        return range(int(lo), int(hi) + 1)
     return [r[0] for r in con.execute("SELECT __row_id__ FROM prep").fetchall()]
 
 

--- a/packages/python/goldenmatch/tests/test_fs_out_of_core.py
+++ b/packages/python/goldenmatch/tests/test_fs_out_of_core.py
@@ -246,6 +246,57 @@ def test_streaming_output_routes_and_excludes_xform(tmp_path):
     con.close()
 
 
+def test_streaming_output_removes_stale_golden_on_reuse(tmp_path):
+    """No multi-member clusters this run -> golden_path None AND a golden.parquet
+    left by a prior run into the same out_dir is removed (file set matches the
+    returned paths)."""
+    import types
+
+    import duckdb
+    from goldenmatch.backends.fs_out_of_core import stream_fs_dedupe_output
+
+    # a golden.parquet from a "prior run" already sits in the out_dir
+    stale = tmp_path / "golden.parquet"
+    pl.DataFrame({"x": [1]}).write_parquet(stale)
+    assert stale.exists()
+
+    con = duckdb.connect(":memory:")
+    prep = pl.DataFrame({"__row_id__": [1, 2, 3], "name": ["a", "b", "c"]})
+    con.register("p", prep.to_arrow())
+    con.execute("CREATE TABLE prep AS SELECT * FROM p")
+    con.unregister("p")
+    assignments = [(1, 10), (2, 20), (3, 30)]  # all singletons -> no golden
+    res = stream_fs_dedupe_output(
+        con, "prep", assignments, types.SimpleNamespace(golden_rules=None), str(tmp_path)
+    )
+    con.close()
+
+    assert res["golden_count"] == 0
+    assert res["golden_path"] is None
+    assert not stale.exists()  # stale prior-run golden removed
+
+
+def test_prep_all_ids_range_when_contiguous_else_list():
+    """_prep_all_ids returns a range (no 25-50M-elem list) when __row_id__ is
+    contiguous, and falls back to an explicit list when there are gaps."""
+    import duckdb
+    from goldenmatch.backends.fs_out_of_core import _prep_all_ids
+
+    con = duckdb.connect(":memory:")
+    con.execute("CREATE TABLE prep(__row_id__ BIGINT)")
+    con.executemany("INSERT INTO prep VALUES (?)", [(i,) for i in range(6)])
+    got = _prep_all_ids(con)
+    assert isinstance(got, range) and list(got) == [0, 1, 2, 3, 4, 5]
+
+    con.execute("DELETE FROM prep WHERE __row_id__ = 3")  # introduce a gap
+    got = _prep_all_ids(con)
+    assert isinstance(got, list) and sorted(got) == [0, 1, 2, 4, 5]
+
+    con.execute("DELETE FROM prep")
+    assert list(_prep_all_ids(con)) == []
+    con.close()
+
+
 def test_end_to_end_streaming_dedupe(tmp_path):
     """run_fs_dedupe_streaming: prep -> store -> score -> cluster -> streamed
     parquet output. Rows preserved (unique + dupes == N), planted dups found,

--- a/packages/python/goldenmatch/tests/test_lazy_cluster_dict.py
+++ b/packages/python/goldenmatch/tests/test_lazy_cluster_dict.py
@@ -23,7 +23,7 @@ import copy
 import pickle
 
 import pytest
-from goldenmatch.core.cluster import LazyClusterDict
+from goldenmatch.core.cluster import LazyClusterDict, cluster_frames_to_dict
 
 
 def test_lazy_dict_defers_until_read():
@@ -242,12 +242,12 @@ def _config():
 
 
 def test_pipeline_leaves_clusters_lazy_and_ships_stats(monkeypatch):
-    from goldenmatch.core.pipeline import run_dedupe_df
+    import goldenmatch.core.pipeline as pipeline_mod
 
     monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
     monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
 
-    result = run_dedupe_df(_fixture_df(), _config(), source_name="t")
+    result = pipeline_mod.run_dedupe_df(_fixture_df(), _config(), source_name="t")
 
     # frames-out path -> clusters is the lazy handle, not yet materialized.
     clusters = result["clusters"]
@@ -271,20 +271,20 @@ def test_pipeline_leaves_clusters_lazy_and_ships_stats(monkeypatch):
 
 def test_dedupe_df_stats_do_not_force_cluster_build(monkeypatch):
     import goldenmatch as gm
-    import goldenmatch.core.cluster as cluster_mod
     import goldenmatch.core.pipeline as pipeline_mod
 
     monkeypatch.setenv("GOLDENMATCH_CLUSTER_FRAMES_OUT", "1")
     monkeypatch.setenv("GOLDENMATCH_AUTOCONFIG_MEMORY", "0")
 
     runs = {"n": 0}
-    orig = cluster_mod.cluster_frames_to_dict
+    orig = cluster_frames_to_dict
 
     def counting(frames):
         runs["n"] += 1
         return orig(frames)
 
-    monkeypatch.setattr(cluster_mod, "cluster_frames_to_dict", counting)
+    # pipeline calls cluster_frames_to_dict via its own module-level import, so
+    # patching pipeline_mod is what intercepts the lazy build here.
     monkeypatch.setattr(pipeline_mod, "cluster_frames_to_dict", counting)
 
     res = gm.dedupe_df(_fixture_df(), config=_config())


### PR DESCRIPTION
## What and why

Fast-follow on the merged #1959 (out-of-core streaming FS). These are the Copilot review items from that PR that were legitimate but not worth evicting an already-queued PR to fix inline. All touch the opt-in out-of-core path only; the default path is byte-unchanged.

## Changes

- **`_prep_all_ids` returns a `range` when `__row_id__` is contiguous** (the pipeline-generated common case, since `__row_id__` is a dense global row index) instead of materialising a 25-50M-element Python list via `fetchall()` that then gets copied again into the downstream pyarrow int64 array. Avoids a multi-GB transient on the >=40M streaming path. `__row_id__` is unique per row, so `max - min + 1 == count` iff the set is exactly `{min..max}`; falls back to the explicit list on gaps. `build_clusters` / `build_clusters_arrow_native` accept it (a `Sequence`) - runtime-verified by the existing end-to-end tests.
- **Prune a stale `golden.parquet` on `out_dir` reuse.** `stream_fs_dedupe_output` and `dedupe_to_parquet`'s in-memory fallback now remove a `golden.parquet` left by a prior run into the same `out_dir` when a run produces no golden rows, so the on-disk file set matches the returned `golden_path=None` / `golden_count=0`. (unique/dupes are always rewritten; only golden is conditional, so only it can go stale.)
- **`tests/test_lazy_cluster_dict.py`: single import style** for `goldenmatch.core.cluster` / `goldenmatch.core.pipeline` (github-code-quality nits). The `pipeline_mod`-only monkeypatch was verified sufficient by the test (pipeline calls `cluster_frames_to_dict` via its own module-level import).
- Regenerate `docs/agent-codemap.json` for the shifted line map.

## Testing

Root `.venv`, `ARROW_DEFAULT_MEMORY_POOL=system`, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`:

- `pytest tests/test_fs_out_of_core.py tests/test_lazy_cluster_dict.py tests/test_api.py tests/test_pipeline.py` -> 99 passed (incl. 2 new: `test_streaming_output_removes_stale_golden_on_reuse`, `test_prep_all_ids_range_when_contiguous_else_list`).
- `ruff check packages/python/goldenmatch` -> clean.
- `uv run pyright` (project config) -> 0 errors; `config_matrix --check all` clean; `agent_codemap` test green.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated (behavior refinement on the unreleased OOC path)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / codemap regenerated

Follow-up to #1959 (merged). Opt-in path only; default path byte-unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_