### PR TITLE
feat(goldengraph): semantic synonym bridge for NL multi-hop routing

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -126,3 +126,25 @@ query-name embedding — were already refuted, see `results/RESULTS_PATH_AWARE_R
   (96.8%) — up from **0%** LLM-free before (they fell to ~0.15–0.28 paid synthesis).
   By hop: 2-hop 100%, 3-hop 93%, 4-hop 97%. Tests: `tests/test_nl_chain.py`
   (wheel-free; fires, safe abstentions, ordering, multiplicity, end-to-end `ask`).
+
+## NL chain routing — semantic synonym bridge (2026-07-21)
+Follow-up to the template-free NL routing (#1966): the lexical stem rule grounds
+morphological variants ("director"->"directed_by") but not pure synonyms
+("spouse"->"married_to", no shared characters), which hit the completeness guard
+and abstained. `route._extract_nl_chain_slots(..., embedder=)` now bridges exactly
+those guard-triggering words (uncovered AND before an "of"/"by" marker) by embedding
+cosine against the predicate phrases: `_embed_bridge_predicate` picks the closest
+predicate above `GOLDENGRAPH_NL_EMBED_BRIDGE_MIN` (default 0.55). Scoped to the
+guard words only (not every content word) so it lifts the synonym boundary without
+a spurious-match surface; `embedder is None` is byte-identical to #1966 (all prior
+tests unchanged). `embedder` threads `ask` -> `resolve_profile` -> `classify_query`
+(the embedder `ask` already carries). Needs a SEMANTIC embedder to bridge true
+synonyms -- the no-torch char-ngram embedder only shares the morphological cases the
+stem rule already covers. Tests: `tests/test_nl_chain.py` (`_SynEmbedder` stub:
+spouse~married_to fires; an orthogonal word stays below the floor and abstains).
+NOTE the reachability gotcha: the bench's goldengraph engine runs `ask` in
+`mode="local"` by default (`engines/goldengraph.py`), and the NL routing (chain
+extraction) only runs in `mode="auto"` -- so exercising this end-to-end in the
+bench needs `GOLDENGRAPH_QA_MODE=auto`. Making the chain-attempt fire inside
+local/hybrid before synthesis (so the win is default, not auto-only) is the next
+follow-up.

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -417,6 +417,7 @@ def ask(
             query,
             predicates=_slice_predicates(slice_graph, entities=slice_entities),
             entity_names=_slice_entity_names(slice_graph, entities=slice_entities),
+            embedder=embedder,  # lets the NL extractor bridge synonym relations to predicates
             llm_classifier=query_classifier,
         )
         # Query-side schema canonicalization: route the query's relation(s) through the discovered

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -364,7 +364,8 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
                 pred_vecs = list(embedder.embed([p.replace("_", " ") for p, _ in pred_index]))
                 tok_vecs = list(embedder.embed([t for _ci, _cp, t in unresolved]))
             except Exception:  # noqa: BLE001 - embedder failure -> no bridge, guard abstains
-                pred_vecs = tok_vecs = None
+                pred_vecs = None
+                tok_vecs = None  # split (not chained) so the static analyzer sees the use
             # A wrong-length return is an embedder contract violation; treat it as a
             # failure (no bridge -> the guard abstains) rather than let zip drop
             # candidates and shift which predicate wins.

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -262,11 +262,49 @@ def _find_anchor(query: str, entity_names) -> tuple[str | None, int]:
 _REL_MARKERS = frozenset({"of", "by"})
 
 
-def _extract_nl_chain_slots(query: str, predicates, entity_names):
+def _embed_bridge_min() -> float:
+    """Cosine floor for the semantic relation bridge (`GOLDENGRAPH_NL_EMBED_BRIDGE_MIN`,
+    default 0.55). Set high enough that a filler noun doesn't spuriously bind a
+    predicate; a non-float falls back to the default."""
+    import os
+
+    try:
+        return float(os.environ.get("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "0.55"))
+    except ValueError:
+        return 0.55
+
+
+def _cos(a, b) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(y * y for y in b) ** 0.5
+    return dot / (na * nb) if na and nb else 0.0
+
+
+def _embed_bridge_predicate(token_vec, pred_index, pred_vecs, threshold) -> str | None:
+    """The predicate whose phrase embedding is closest (cosine) to ``token_vec``,
+    or None below ``threshold``. Ties resolve to the first (lexicographically
+    smallest, since ``pred_index`` is pre-sorted) via the strict-improvement test."""
+    best_pred, best_cos = None, -1.0
+    for (pred, _ptoks), pv in zip(pred_index, pred_vecs):
+        c = _cos(token_vec, pv)
+        if c > best_cos:
+            best_pred, best_cos = pred, c
+    return best_pred if best_cos >= threshold else None
+
+
+def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=None):
     """(anchor, relation_chain) from a natural-language multi-hop question, or
     (None, None). Grounded in the slice vocab. The returned order is a proximity
     HINT -- the caller's walk validates it against the graph (only the ordering
-    that reaches a terminal completes), so a wrong hint is self-correcting."""
+    that reaches a terminal completes), so a wrong hint is self-correcting.
+
+    With an ``embedder``, an unmapped relation-position word (before an "of"/"by"
+    marker) that the lexical stem rule couldn't ground -- a true SYNONYM like
+    "spouse" for the "married_to" predicate -- is bridged by embedding cosine, so
+    such questions fire the chain instead of abstaining. The bridge is scoped to
+    the guard-triggering words only (not every content word), so it lifts the
+    documented synonym boundary without opening a spurious-match surface."""
     if not predicates or not entity_names:
         return None, None
     anchor, anchor_pos = _find_anchor(query, entity_names)
@@ -303,14 +341,37 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names):
         hits.append((abs(cp - max(anchor_pos, 0)), pred))
     if not hits:
         return None, None
+    # SEMANTIC BRIDGE (opt-in via `embedder`): the guard below abstains on an
+    # unmapped relation-position word. Before abstaining, try to ground exactly
+    # those words -- the true synonyms the lexical stem rule can't reach ("spouse"
+    # -> "married_to") -- by embedding cosine against the predicate phrases. Scoped
+    # to the guard-triggering words only (uncovered AND before an "of"/"by" marker),
+    # so it lifts the synonym boundary without embedding every content word.
+    if embedder is not None:
+        unresolved = [(ci, content[ci][0], content[ci][1])
+                      for ci, (_cp, _ct, nx) in enumerate(content)
+                      if ci not in covered and nx in _REL_MARKERS]
+        if unresolved:
+            try:
+                pred_vecs = embedder.embed([p.replace("_", " ") for p, _ in pred_index])
+                tok_vecs = embedder.embed([t for _ci, _cp, t in unresolved])
+            except Exception:  # noqa: BLE001 - embedder failure -> no bridge, guard abstains
+                pred_vecs = tok_vecs = None
+            if pred_vecs is not None and tok_vecs is not None:
+                thr = _embed_bridge_min()
+                for (ci, cp, _t), tv in zip(unresolved, tok_vecs):
+                    pred = _embed_bridge_predicate(tv, pred_index, pred_vecs, thr)
+                    if pred is not None:
+                        covered.add(ci)
+                        hits.append((abs(cp - max(anchor_pos, 0)), pred))
     # COMPLETENESS GUARD: abstain if an UNMAPPED content word sits in a relation
     # position (immediately before "of"/"by") -- that's a hop we couldn't ground
-    # (e.g. "spouse of" with no stem to "married_to"). Firing the partial chain
-    # would walk short and return a WRONG intermediate node (the None-fallthrough
-    # can't catch a chain that completes early). Abstaining routes to today's
-    # retrieval+synthesis path -- never worse than the status quo. Filler nouns
-    # ("the film Inception") are NOT before a marker, so they don't trip this; the
-    # uncovered-synonym case is the documented boundary (needs the embed/LLM tier).
+    # (e.g. "spouse of" with no stem to "married_to" AND no embedder to bridge it).
+    # Firing the partial chain would walk short and return a WRONG intermediate node
+    # (the None-fallthrough can't catch a chain that completes early). Abstaining
+    # routes to today's retrieval+synthesis path -- never worse than the status quo.
+    # Filler nouns ("the film Inception") are NOT before a marker, so they don't
+    # trip this; the uncovered-synonym case is what the semantic bridge above lifts.
     for ci, (_cp, _ct, nx) in enumerate(content):
         if ci not in covered and nx in _REL_MARKERS:
             return None, None
@@ -321,12 +382,13 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names):
     return anchor, tuple(pred for _dist, pred in hits)
 
 
-def classify_query(query: str, *, predicates=None, entity_names=None) -> QueryProfile:
+def classify_query(query: str, *, predicates=None, entity_names=None, embedder=None) -> QueryProfile:
     """Heuristic intent + slot extraction. `predicates` is the slice's stored predicate
     ids (underscored); `entity_names` is the slice's entity canonical names. Both ground
     the template-free NL multi-hop chain extractor -- when they yield an anchor + relation
     chain, a natural-language multi-hop question routes to the deterministic `chain` walk
-    instead of LLM synthesis-over-the-ball. When either is absent, behavior is unchanged."""
+    instead of LLM synthesis-over-the-ball. When either is absent, behavior is unchanged.
+    An optional `embedder` lets the extractor bridge synonym relation words to predicates."""
     intent = _detect_intent(query)
     if intent is QueryIntent.AGGREGATE:
         anchor, relation = _extract_agg_slots(query, predicates)
@@ -346,7 +408,7 @@ def classify_query(query: str, *, predicates=None, entity_names=None) -> QueryPr
     # director of X?" classifies as LOOKUP). Grounded + conservative; trace_chain's
     # None-fallthrough makes a mis-parse degrade to the general path, never a wrong answer.
     if intent in (QueryIntent.MULTI_HOP, QueryIntent.LOOKUP):
-        anchor, chain = _extract_nl_chain_slots(query, predicates, entity_names)
+        anchor, chain = _extract_nl_chain_slots(query, predicates, entity_names, embedder=embedder)
         if anchor and chain:
             return QueryProfile(intent=QueryIntent.MULTI_HOP, anchor_surface=anchor,
                                 relation_chain=chain, confidence=0.85, chain_ordered=False)
@@ -392,12 +454,12 @@ class QueryClassifier(Protocol):
     def classify(self, query: str, *, predicates=None) -> QueryProfile: ...
 
 
-def resolve_profile(query: str, *, predicates=None, entity_names=None,
+def resolve_profile(query: str, *, predicates=None, entity_names=None, embedder=None,
                     llm_classifier: QueryClassifier | None = None) -> QueryProfile:
     """Two-tier: heuristic FIRST; escalate to the injected classifier ONLY when the heuristic is
     below MIN_CONF AND a classifier is given; the classifier's result wins only if strictly more
     confident (so a confidently-abstaining tier-2 keeps the heuristic -> safe local route)."""
-    h = classify_query(query, predicates=predicates, entity_names=entity_names)
+    h = classify_query(query, predicates=predicates, entity_names=entity_names, embedder=embedder)
     if h.confidence >= MIN_CONF or llm_classifier is None:
         return h
     ll = llm_classifier.classify(query, predicates=predicates)

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -265,13 +265,19 @@ _REL_MARKERS = frozenset({"of", "by"})
 def _embed_bridge_min() -> float:
     """Cosine floor for the semantic relation bridge (`GOLDENGRAPH_NL_EMBED_BRIDGE_MIN`,
     default 0.55). Set high enough that a filler noun doesn't spuriously bind a
-    predicate; a non-float falls back to the default."""
+    predicate. A non-float, non-finite (`nan`/`inf`), or out-of-range value falls
+    back / clamps to a sane cosine floor -- `nan` would silently disable the bridge
+    and a negative floor would make it bind anything, both env-misconfig footguns."""
+    import math
     import os
 
     try:
-        return float(os.environ.get("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "0.55"))
+        v = float(os.environ.get("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "0.55"))
     except ValueError:
         return 0.55
+    if not math.isfinite(v):
+        return 0.55
+    return min(1.0, max(0.0, v))  # cosine floor is only meaningful in [0, 1]
 
 
 def _cos(a, b) -> float:
@@ -353,11 +359,21 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
                       if ci not in covered and nx in _REL_MARKERS]
         if unresolved:
             try:
-                pred_vecs = embedder.embed([p.replace("_", " ") for p, _ in pred_index])
-                tok_vecs = embedder.embed([t for _ci, _cp, t in unresolved])
+                # Materialize (a generator/array both -> list) so the length check
+                # below is real and zip can't silently truncate candidates.
+                pred_vecs = list(embedder.embed([p.replace("_", " ") for p, _ in pred_index]))
+                tok_vecs = list(embedder.embed([t for _ci, _cp, t in unresolved]))
             except Exception:  # noqa: BLE001 - embedder failure -> no bridge, guard abstains
                 pred_vecs = tok_vecs = None
-            if pred_vecs is not None and tok_vecs is not None:
+            # A wrong-length return is an embedder contract violation; treat it as a
+            # failure (no bridge -> the guard abstains) rather than let zip drop
+            # candidates and shift which predicate wins.
+            if (
+                pred_vecs is not None
+                and tok_vecs is not None
+                and len(pred_vecs) == len(pred_index)
+                and len(tok_vecs) == len(unresolved)
+            ):
                 thr = _embed_bridge_min()
                 for (ci, cp, _t), tv in zip(unresolved, tok_vecs):
                     pred = _embed_bridge_predicate(tv, pred_index, pred_vecs, thr)

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -400,8 +400,10 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
 
 
 def classify_query(query: str, *, predicates=None, entity_names=None, embedder=None) -> QueryProfile:
-    """Heuristic intent + slot extraction. `predicates` is the slice's stored predicate
-    ids (underscored); `entity_names` is the slice's entity canonical names. Both ground
+    """Heuristic intent + slot extraction. `predicates` is the slice's stored edge
+    predicate strings AS-IS -- underscored ids ("works_at") or space-form phrases
+    ("directed by"), whatever the graph holds; the extractor normalizes both via
+    `_predicate_salient_tokens`. `entity_names` is the slice's entity canonical names. Both ground
     the template-free NL multi-hop chain extractor -- when they yield an anchor + relation
     chain, a natural-language multi-hop question routes to the deterministic `chain` walk
     instead of LLM synthesis-over-the-ball. When either is absent, behavior is unchanged.

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -194,6 +194,51 @@ def test_nl_noun_synonym_abstains():
     assert plan_query(p).mode != "chain"
 
 
+class _SynEmbedder:
+    """Deterministic 3-D stub: 'spouse' ~ 'married to'; 'friend' orthogonal to both
+    predicates. Lets the semantic bridge be tested without a real model."""
+
+    _V = {
+        "married to": [1.0, 0.0, 0.0],
+        "directed by": [0.0, 1.0, 0.0],
+        "spouse": [0.95, 0.05, 0.0],   # cosine ~0.998 with "married to"
+        "friend": [0.0, 0.0, 1.0],     # cosine 0 with both predicates
+    }
+
+    def embed(self, texts):
+        return [self._V.get(t, [0.0, 0.0, 0.0]) for t in texts]
+
+
+def test_nl_synonym_bridged_by_embedder():
+    # "spouse" has no shared stem with "married to", so it abstains without an
+    # embedder (test_nl_noun_synonym_abstains). WITH one, the semantic bridge grounds
+    # it and the full 2-hop chain fires -> Emma Thomas.
+    g = _film_graph()
+    p = classify_query(
+        "Who is the spouse of the director of Inception?",
+        predicates=_slice_predicates(g),
+        entity_names=_slice_entity_names(g),
+        embedder=_SynEmbedder(),
+    )
+    assert p.relation_chain == ("directed by", "married to")
+    assert plan_query(p).mode == "chain"
+    assert _trace_chain_any_order(g, p.anchor_surface, p.relation_chain) == "Emma Thomas"
+
+
+def test_nl_embedder_low_similarity_still_abstains():
+    # An unmapped relation word that embeds FAR from every predicate ("friend")
+    # must NOT be force-bridged -- the cosine floor keeps it uncovered, so the
+    # guard still abstains rather than fabricate a hop.
+    g = _film_graph()
+    p = classify_query(
+        "Who is the friend of the director of Inception?",
+        predicates=_slice_predicates(g),
+        entity_names=_slice_entity_names(g),
+        embedder=_SynEmbedder(),
+    )
+    assert p.relation_chain is None
+
+
 def test_nl_unknown_anchor_abstains():
     g = _film_graph()
     p = _profile("Who directed Titanic?", g)  # Titanic is not in the slice

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -225,6 +225,24 @@ def test_nl_synonym_bridged_by_embedder():
     assert _trace_chain_any_order(g, p.anchor_surface, p.relation_chain) == "Emma Thomas"
 
 
+def test_nl_broken_embedder_length_mismatch_abstains():
+    # An embedder that returns the wrong number of vectors is a contract violation;
+    # the bridge must treat it as a failure (abstain), not let zip silently drop
+    # candidates and fabricate a partial chain.
+    class _BadEmbedder:
+        def embed(self, texts):
+            return [[1.0, 0.0, 0.0]]  # always length 1, regardless of input count
+
+    g = _film_graph()
+    p = classify_query(
+        "Who is the spouse of the director of Inception?",
+        predicates=_slice_predicates(g),
+        entity_names=_slice_entity_names(g),
+        embedder=_BadEmbedder(),
+    )
+    assert p.relation_chain is None
+
+
 def test_nl_embedder_low_similarity_still_abstains():
     # An unmapped relation word that embeds FAR from every predicate ("friend")
     # must NOT be force-bridged -- the cosine floor keeps it uncovered, so the


### PR DESCRIPTION
## What and why

Follow-up to #1966 (template-free NL multi-hop routing). That extractor grounds relation words to predicates lexically — exact + a shared-≥5-char-stem rule — which bridges *morphological* variants (`director`→`directed_by`, `location`→`located_in`) but **not pure synonyms** (`spouse`→`married_to`, no shared characters). Those hit the completeness guard and abstained (safe, but left multi-hop recall on the table). This adds the semantic tier.

## Changes

- **`route._extract_nl_chain_slots(..., embedder=)`** — before the completeness guard abstains, it bridges **exactly the guard-triggering words** (uncovered *and* immediately before an `of`/`by` marker) via embedding cosine against the predicate phrases. `_embed_bridge_predicate` picks the closest predicate above `GOLDENGRAPH_NL_EMBED_BRIDGE_MIN` (default 0.55; deterministic tie-break via the pre-sorted index).
- **Scoped + conservative** — only the words that would otherwise abstain are embedded (not every content word), so it lifts the synonym boundary without opening a spurious-match surface. `embedder=None` is **byte-identical to #1966** (all prior tests unchanged).
- **Threading** — the `embedder` flows `ask` → `resolve_profile` → `classify_query` → the extractor (the same embedder `ask` already carries). An embedder that raises is caught → no bridge → the guard abstains as before.
- Needs a **semantic** embedder to bridge true synonyms; the no-torch char-ngram embedder only covers the morphological cases the stem rule already handles.

## Testing

- `tests/test_nl_chain.py`: `_SynEmbedder` stub (3-D, `spouse`~`married_to`, `friend` orthogonal). `"Who is the spouse of the director of Inception?"` now fires the full 2-hop chain → `Emma Thomas`; `"Who is the friend of …"` stays below the cosine floor and abstains; without an embedder it still abstains (unchanged).
- Full goldengraph suite: **354 passed, 8 skipped**; `ruff` clean.

## Note: end-to-end reachability (found while wiring the paid headline)

The bench's goldengraph engine runs `ask` in **`mode="local"`** (`engines/goldengraph.py`), but NL routing (chain extraction) only fires in **`mode="auto"`**. So exercising this end-to-end in the `bench-graphrag-qa` lane needs `GOLDENGRAPH_QA_MODE=auto` (I dispatched a MuSiQue N=50 run that way). Making the chain-attempt fire inside `local`/`hybrid` before synthesis — so the win is the *default*, not auto-only — is the natural next follow-up (documented in `CLAUDE.md`).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` updated (pre-1.0 KG engine; additive + gated by an optional embedder)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_