### PR TITLE
fix(goldengraph): harden NL semantic bridge (post-#1969 review)

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -148,3 +148,24 @@ extraction) only runs in `mode="auto"` -- so exercising this end-to-end in the
 bench needs `GOLDENGRAPH_QA_MODE=auto`. Making the chain-attempt fire inside
 local/hybrid before synthesis (so the win is default, not auto-only) is the next
 follow-up.
+
+### Post-#1969 hardening (2026-07-21, review-driven)
+Three fixes on top of the semantic bridge, all in `_extract_nl_chain_slots`:
+- **Synonym-ONLY hops now bridge.** The `if not hits: return None, None` early return
+  ran BEFORE the bridge, so a 1-hop query whose sole relation word is a pure synonym
+  ("Who is the spouse of Christopher Nolan?") had empty lexical `hits` and abstained
+  even with a valid embedder — contradicting the tier's intent. The early return moved
+  AFTER the bridge (now a post-guard `if not hits`), so the bridge runs with zero
+  lexical hits; the no-embedder path stays byte-identical (empty hits still abstains).
+- **The WHOLE bridge is exception-wrapped, not just `embed()`.** A malformed-but-right-
+  length embedder return (scalar / `None` / non-numeric entries) raises inside
+  `_cos()`/`_embed_bridge_predicate` during the similarity loop, NOT at `embed()` time.
+  The `try/except` now spans the embed calls + length check + cosine loop, so any
+  vector-shape failure degrades to "no bridge -> completeness guard abstains" (the
+  advertised failure mode) instead of propagating and crashing the query.
+- **`GOLDENGRAPH_NL_EMBED_BRIDGE_MIN` env parsing is test-locked** (`_embed_bridge_min`):
+  non-float and non-finite (`nan`/`inf`) fall back to the 0.55 default; any finite value
+  clamps into `[0, 1]` — so a misconfigured env var can neither silently disable the
+  bridge (`nan`) nor make it bind anything (a negative floor).
+Tests: `tests/test_nl_chain.py` (synonym-only fires with embedder / abstains without;
+malformed-embedder degrades; env parse+clamp).

--- a/packages/python/goldengraph/goldengraph/route.py
+++ b/packages/python/goldengraph/goldengraph/route.py
@@ -345,8 +345,11 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
             continue
         covered.add(ci)
         hits.append((abs(cp - max(anchor_pos, 0)), pred))
-    if not hits:
-        return None, None
+    # NOTE: do NOT early-return on empty `hits` here -- a synonym-ONLY hop (e.g. a
+    # 1-hop "Who is the spouse of X?", where the sole relation word is a pure
+    # synonym the lexical rule can't ground) has no lexical hit yet, and the
+    # semantic bridge below is exactly what should ground it. The final
+    # empty-`hits` check (after bridge + guard) handles the genuine no-relation case.
     # SEMANTIC BRIDGE (opt-in via `embedder`): the guard below abstains on an
     # unmapped relation-position word. Before abstaining, try to ground exactly
     # those words -- the true synonyms the lexical stem rule can't reach ("spouse"
@@ -358,29 +361,28 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
                       for ci, (_cp, _ct, nx) in enumerate(content)
                       if ci not in covered and nx in _REL_MARKERS]
         if unresolved:
+            # The WHOLE bridge is wrapped: not just the embed() calls but the
+            # cosine loop too, because a malformed-but-right-length embedder return
+            # (a scalar, None, or non-numeric entries) raises inside _cos()/
+            # _embed_bridge_predicate rather than at embed() time. ANY failure ->
+            # no bridge -> the completeness guard abstains (the advertised mode).
             try:
                 # Materialize (a generator/array both -> list) so the length check
                 # below is real and zip can't silently truncate candidates.
                 pred_vecs = list(embedder.embed([p.replace("_", " ") for p, _ in pred_index]))
                 tok_vecs = list(embedder.embed([t for _ci, _cp, t in unresolved]))
-            except Exception:  # noqa: BLE001 - embedder failure -> no bridge, guard abstains
-                pred_vecs = None
-                tok_vecs = None  # split (not chained) so the static analyzer sees the use
-            # A wrong-length return is an embedder contract violation; treat it as a
-            # failure (no bridge -> the guard abstains) rather than let zip drop
-            # candidates and shift which predicate wins.
-            if (
-                pred_vecs is not None
-                and tok_vecs is not None
-                and len(pred_vecs) == len(pred_index)
-                and len(tok_vecs) == len(unresolved)
-            ):
-                thr = _embed_bridge_min()
-                for (ci, cp, _t), tv in zip(unresolved, tok_vecs):
-                    pred = _embed_bridge_predicate(tv, pred_index, pred_vecs, thr)
-                    if pred is not None:
-                        covered.add(ci)
-                        hits.append((abs(cp - max(anchor_pos, 0)), pred))
+                # A wrong-length return is an embedder contract violation; treat it
+                # as a failure (no bridge) rather than let zip drop candidates and
+                # shift which predicate wins.
+                if len(pred_vecs) == len(pred_index) and len(tok_vecs) == len(unresolved):
+                    thr = _embed_bridge_min()
+                    for (ci, cp, _t), tv in zip(unresolved, tok_vecs):
+                        pred = _embed_bridge_predicate(tv, pred_index, pred_vecs, thr)
+                        if pred is not None:
+                            covered.add(ci)
+                            hits.append((abs(cp - max(anchor_pos, 0)), pred))
+            except Exception:  # noqa: BLE001 - any embedder/vector failure -> no bridge, guard abstains
+                pass
     # COMPLETENESS GUARD: abstain if an UNMAPPED content word sits in a relation
     # position (immediately before "of"/"by") -- that's a hop we couldn't ground
     # (e.g. "spouse of" with no stem to "married_to" AND no embedder to bridge it).
@@ -392,6 +394,12 @@ def _extract_nl_chain_slots(query: str, predicates, entity_names, *, embedder=No
     for ci, (_cp, _ct, nx) in enumerate(content):
         if ci not in covered and nx in _REL_MARKERS:
             return None, None
+    # No relation grounded at all (a pure lookup like "What is Inception?", or a
+    # synonym-only hop the bridge couldn't reach) -> abstain rather than return an
+    # empty chain. (This replaces the pre-bridge early return, moved AFTER the
+    # bridge so synonym-only hops get their chance to ground.)
+    if not hits:
+        return None, None
     # proximity-to-anchor order is the first-tried HINT (the walk validates it).
     # Keep every occurrence -- multiplicity matters (a relation can repeat in a
     # chain), so do NOT dedup.

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -257,6 +257,42 @@ def test_nl_embedder_low_similarity_still_abstains():
     assert p.relation_chain is None
 
 
+def test_embed_bridge_min_env_parsing_and_clamping(monkeypatch):
+    # The cosine floor is read from GOLDENGRAPH_NL_EMBED_BRIDGE_MIN. A misconfigured
+    # env var must never silently disable the bridge (nan) or make it bind anything
+    # (a negative / out-of-range floor): non-float and non-finite fall back to the
+    # 0.55 default, and any finite value is clamped into the meaningful [0, 1] range.
+    from goldengraph.route import _embed_bridge_min
+
+    # unset -> default
+    monkeypatch.delenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", raising=False)
+    assert _embed_bridge_min() == 0.55
+
+    # a valid in-range value passes through untouched
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "0.7")
+    assert _embed_bridge_min() == 0.7
+
+    # non-float -> default (not a crash)
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "not-a-number")
+    assert _embed_bridge_min() == 0.55
+
+    # nan would make every cosine comparison False and silently disable the bridge
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "nan")
+    assert _embed_bridge_min() == 0.55
+
+    # inf is non-finite -> default
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "inf")
+    assert _embed_bridge_min() == 0.55
+
+    # a negative floor would bind anything -> clamp up to 0.0
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "-0.3")
+    assert _embed_bridge_min() == 0.0
+
+    # above 1.0 is not a meaningful cosine floor -> clamp down to 1.0
+    monkeypatch.setenv("GOLDENGRAPH_NL_EMBED_BRIDGE_MIN", "1.5")
+    assert _embed_bridge_min() == 1.0
+
+
 def test_nl_unknown_anchor_abstains():
     g = _film_graph()
     p = _profile("Who directed Titanic?", g)  # Titanic is not in the slice

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -257,6 +257,52 @@ def test_nl_embedder_low_similarity_still_abstains():
     assert p.relation_chain is None
 
 
+def test_nl_synonym_only_single_hop_bridged_by_embedder():
+    # A synonym-ONLY hop (the sole relation word is a pure synonym with NO lexical
+    # hit) has empty lexical `hits`. The bridge now runs even with no lexical hits
+    # (the empty-`hits` early return was moved AFTER the bridge), so
+    # "Who is the spouse of Christopher Nolan?" grounds spouse->married to and walks
+    # the single hop instead of abstaining.
+    g = _film_graph()
+    p = classify_query(
+        "Who is the spouse of Christopher Nolan?",
+        predicates=_slice_predicates(g),
+        entity_names=_slice_entity_names(g),
+        embedder=_SynEmbedder(),
+    )
+    assert p.relation_chain == ("married to",)
+    assert plan_query(p).mode == "chain"
+    assert _trace_chain_any_order(g, p.anchor_surface, p.relation_chain) == "Emma Thomas"
+
+
+def test_nl_synonym_only_single_hop_abstains_without_embedder():
+    # Back-compat: the SAME synonym-only hop with NO embedder must still abstain.
+    # (The removed pre-bridge early return is replaced by the post-guard empty-hits
+    # check, so the no-embedder path is byte-identical to before.)
+    g = _film_graph()
+    p = _profile("Who is the spouse of Christopher Nolan?", g)
+    assert p.relation_chain is None
+
+
+def test_nl_malformed_embedder_vectors_degrade_to_abstain():
+    # A right-LENGTH but malformed embedder return (None / non-numeric entries)
+    # parses fine at embed() time but raises inside _cos() during the similarity
+    # loop. The bridge wraps the WHOLE computation, so this degrades to
+    # "no bridge -> guard abstains" instead of propagating and crashing the query.
+    class _MalformedEmbedder:
+        def embed(self, texts):
+            return [None for _ in texts]  # correct count, but _cos(None, ...) raises
+
+    g = _film_graph()
+    p = classify_query(
+        "Who is the spouse of the director of Inception?",
+        predicates=_slice_predicates(g),
+        entity_names=_slice_entity_names(g),
+        embedder=_MalformedEmbedder(),
+    )
+    assert p.relation_chain is None
+
+
 def test_embed_bridge_min_env_parsing_and_clamping(monkeypatch):
     # The cosine floor is read from GOLDENGRAPH_NL_EMBED_BRIDGE_MIN. A misconfigured
     # env var must never silently disable the bridge (nan) or make it bind anything


### PR DESCRIPTION
## What and why

Follow-up to #1969 (semantic synonym bridge for NL multi-hop routing), addressing the Copilot review that landed as #1969 was merging. Two of those comments are genuine gaps in the just-shipped feature (not nits), plus the test-coverage ask. All three are fixed here. The merged code was conservative (never produced wrong output) — these are correctness/robustness improvements, not a regression fix.

## Changes

All in `route._extract_nl_chain_slots`:

- **Synonym-ONLY hops now bridge.** The `if not hits: return None, None` early return ran *before* the semantic bridge, so a 1-hop query whose sole relation word is a pure synonym (`"Who is the spouse of Christopher Nolan?"`) had empty lexical `hits` and abstained *even with a valid embedder* — contradicting the semantic tier's stated intent. Moved the empty-`hits` check to *after* the bridge (post-guard). The no-embedder path stays byte-identical: empty hits still abstains.
- **The whole bridge is exception-wrapped, not just the `embed()` calls.** A malformed-but-right-length embedder return (a scalar, `None`, or non-numeric entries) parses fine at `embed()` time but raises inside `_cos()` / `_embed_bridge_predicate` during the similarity loop. The `try/except` now spans embed + length check + cosine loop, so any vector-shape failure degrades to "no bridge -> completeness guard abstains" (the advertised failure mode) instead of propagating and crashing the query.
- **`GOLDENGRAPH_NL_EMBED_BRIDGE_MIN` env parsing is test-locked** (`_embed_bridge_min`): non-float / non-finite (`nan`/`inf`) fall back to the 0.55 default, any finite value clamps into `[0, 1]` — so a misconfigured env var can neither silently disable the bridge (`nan`) nor make it bind anything (a negative floor). The code was already correct; this adds the missing regression test.

The `tok_vecs` "unused variable" flag from the code-quality bot was a false positive (the var is read at three points); the exception-wrap refactor above removes the `pred_vecs = tok_vecs = None` pattern entirely, so that flag no longer applies either.

## Testing

`python -m pytest packages/python/goldengraph/tests/` -> **359 passed, 8 skipped**; `ruff check` clean on the changed files. New wheel-free tests in `tests/test_nl_chain.py`: synonym-only hop fires with an embedder / abstains without one; malformed embedder degrades to abstain; env parse + clamp.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` updated (pre-1.0 KG engine; additive hardening, no shipped-API change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_