### PR TITLE
feat(score): kernelize soundex_match with full jellyfish parity (Wave 1, 6/19 -> 7/19)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**6 of 19 scorers are kernel-backed** (the reference fast path); the other 13 are pure-language fallbacks with no `-core` kernel.
+**7 of 19 scorers are kernel-backed** (the reference fast path); the other 12 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `qgram` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `qgram`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding`, `soundex_match` |
+| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -1,7 +1,7 @@
 # Full `-core` kernel coverage for the scorer surface (5/19 -> full)
 
 **Date:** 2026-07-21
-**Status:** Proposed (scoping / design). **Wave 1 `qgram` landed in this same PR** (5/19 -> 6/19); the baseline figures below describe the pre-PR starting point.
+**Status:** Proposed (scoping / design). **Wave 1 landing incrementally:** `qgram` (5/19 -> 6/19) and `soundex_match` (6/19 -> 7/19) are now kernel-backed; the baseline figures below describe the pre-work starting point.
 **Motivation:** The generated suite-matrix reports **"5 of 19 scorers are kernel-backed"**
 (`docs-site/suite-matrix.mdx`, computed by `gen_suite_matrix.py::_substrate_lines` from the
 `scorer_kernels` parity surface). This spec scopes what it takes to close that gap -- and argues
@@ -20,9 +20,13 @@ The other **14 were fallback-only** at that baseline: `dice`, `jaccard`, `qgram`
 `ensemble`, `embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`,
 `radial`, `given_name_aliased_jw`, `name_freq_weighted_jw`.
 
-**Update (this PR):** `qgram` is now kernelized (Wave 1) -- it has a `score-core` kernel on the
-Python arrow-bucket fast path, so the current state is **6/19** with **13** fallbacks remaining.
-`qgram` reads as `python_only` in the `scorer_kernels` partition (no TS WASM port yet, like `date`).
+**Update:** `qgram` and `soundex_match` are now kernelized (Wave 1) -- each has a `score-core`
+kernel on the Python arrow-bucket fast path, so the current state is **7/19** with **12** fallbacks
+remaining. Both read as `python_only` in the `scorer_kernels` partition (no TS WASM port yet, like
+`date`). `soundex_match`'s kernel replicates `jellyfish.soundex` byte-for-byte INCLUDING its Unicode
+step (NFKD normalize + `str.upper` via the `unicode-normalization` crate), so native==pure on leading
+non-alpha / accented input too -- which also closes the same latent gap in the field-matrix path
+(both now dispatch the shared `score-core::soundex`).
 
 "Kernel-backed" in the metric means *a kernel exists in at least one language* (a union), so the
 denominator (19) also counts scorers that live in only one language. The metric is emitted by
@@ -96,7 +100,7 @@ minimal. Recommend **defer or explicitly decline**.
 
 | Wave | Scorers | Risk | Rationale |
 |---|---|---|---|
-| **1** | `qgram` ✅ (landed this PR), `soundex_match`, `initialism_match` | low | pure strings on the proven template; `soundex_match` is half-wired already |
+| **1** | `qgram` ✅, `soundex_match` ✅ (both landed), `initialism_match` | low | pure strings on the proven template; `soundex_match` reused the existing Rust kernel, upgraded to full jellyfish Unicode parity |
 | **2** | `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk |
 | **3** | `phash`, `dice`, `jaccard` | low-med | wiring existing kernels (`perceptual-core`, `bloom.rs`), not new algorithms |
 | **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -227,6 +227,14 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # score_one catch-all scores id 5 as 0.0) declines to the pure-Python
     # per-pair mirror (`_qgram_score_single`) instead of silently zeroing.
     "qgram": 5,
+    # id 6 = soundex_match (binary soundex-code equality, score-core score_one).
+    # Same wheel-skew story: guarded on the `soundex_similarity` capability symbol
+    # so a stale wheel declines to the pure-Python per-pair jellyfish mirror. NB
+    # score_one id 6 uses NAIVE code equality (two empty codes -> match), matching
+    # `_resolve_score_pair_callable`'s `jf.soundex(a)==jf.soundex(b)` bucket mirror
+    # -- NOT the field-matrix path's id 4=soundex (empty codes non-matching;
+    # a separate id namespace).
+    "soundex_match": 6,
 }
 
 
@@ -1033,12 +1041,18 @@ def score_buckets(
             _mod = native_module()
             _date_ok = _mod is not None and hasattr(_mod, "date_similarity")
             _qgram_ok = _mod is not None and hasattr(_mod, "qgram_similarity")
+            _soundex_ok = _mod is not None and hasattr(_mod, "soundex_similarity")
             has_date = any(spec[3] == "date" for spec in _field_specs)
             has_qgram = any(spec[3] == "qgram" for spec in _field_specs)
+            has_soundex = any(spec[3] == "soundex_match" for spec in _field_specs)
             # Wheel-skew: decline native entirely when a field uses a scorer whose
             # capability symbol the loaded kernel lacks (score_one would silently
             # zero that id); the pure-Python per-pair mirror scores the block.
-            _skew_block = (has_date and not _date_ok) or (has_qgram and not _qgram_ok)
+            _skew_block = (
+                (has_date and not _date_ok)
+                or (has_qgram and not _qgram_ok)
+                or (has_soundex and not _soundex_ok)
+            )
             if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]
 

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -37,10 +37,12 @@ class TestBucketHashSeedSingleSource:
 
 class TestNativeScorerIdMaps:
     # The canonical Rust score-core `score_one` dispatch (lib.rs): the block-pair
-    # kernel. `score_field_matrix` shares 0-3 (it delegates to score_one) but its
-    # id 4 is soundex_match, a DIFFERENT namespace -- pinned separately so the two
-    # can't silently collide.
-    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5}
+    # (bucket) kernel. `score_field_matrix` shares ids 0-3 (it delegates to
+    # score_one) but ids 4+ are a DIFFERENT namespace -- in the bucket map
+    # 4=date/5=qgram/6=soundex_match; in the field-matrix map 4=soundex_match.
+    # `soundex_match` therefore lives in BOTH maps at DIFFERENT ids (bucket 6,
+    # field 4); the two are pinned separately so they can't silently collide.
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):
@@ -51,7 +53,8 @@ class TestNativeScorerIdMaps:
 
     def test_shared_ids_agree_across_the_two_namespaces(self):
         # 0-3 are delegated by score_field_matrix to score_one, so they MUST be
-        # identical in both Python dicts; only id 4 diverges (date vs soundex).
+        # identical in both Python dicts; ids 4+ diverge by namespace (bucket
+        # date/qgram/soundex vs field-matrix soundex).
         for name in ("jaro_winkler", "levenshtein", "token_sort", "exact"):
             assert _NATIVE_SCORER_IDS[name] == _NATIVE_FIELD_SCORER_IDS[name]
 

--- a/packages/python/goldenmatch/tests/test_native_soundex_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_soundex_parity.py
@@ -1,0 +1,104 @@
+"""Parity for the soundex_match bucket kernel (score-core id 6) vs jellyfish.
+
+soundex was already a Rust kernel in the *field-matrix* path (native id 4); Wave 1
+moves the impl into `score-core` with FULL `jellyfish.soundex` parity (NFKD
+normalize + Unicode uppercase + literal-first-char seed) and wires it into the
+*bucket* path via `score_one` id 6, so it becomes kernel-backed in the metric
+(the scorer_kernels surface reads the bucket `_NATIVE_SCORER_IDS`).
+
+Full parity means native `soundex_similarity(a, b)` is bit-identical to the
+bucket per-pair mirror `1.0 if jellyfish.soundex(a) == jellyfish.soundex(b) else
+0.0` (`_resolve_score_pair_callable("soundex_match")`) over EVERY input --
+including leading non-alpha (`123`, `3M`), embedded symbols (`O'Brien`), and
+Unicode (`Ürüm`, `José`, `ß`), where the pre-Wave-1 ASCII-only kernel diverged.
+The exact per-string codes are pinned in score-core's cargo tests; this batteries
+the equality semantics the kernel actually uses over thousands of pairs.
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.core import scorer as _scorer_mod
+
+_jf = _scorer_mod.jellyfish
+
+
+def _mirror(a: str, b: str) -> float:
+    # exactly `_resolve_score_pair_callable("soundex_match")`'s lambda
+    return 1.0 if _jf.soundex(a) == _jf.soundex(b) else 0.0
+
+
+# Adversarial vocabulary: alpha names (incl. H/W rule + collisions), leading
+# non-alpha, embedded symbols/digits, empty, and Unicode (NFKD + upper edges).
+_VOCAB = [
+    "Robert", "Rupert", "Ashcraft", "Ashcroft", "Tymczak", "Pfister", "Honeyman",
+    "Smith", "Smyth", "Jackson", "Gutierrez", "Catherine", "Katherine", "Lloyd",
+    "Lee", "OBrien", "O'Brien", "McDonald", "MacDonald", "van der Berg",
+    "123", "3M", "4abc", "1B2", "99", "S1S", "AB-BA", "-x", "x-y", "A1B", " Robert",
+    "", "a", "AA", "H", "W", "HW", "WH",
+    "José", "Ürüm", "naïve", "Zoë", "ß", "Œuvre", "Åke", "Muñoz", "Håkan", "Ægir",
+]
+
+
+def _corpus() -> list[tuple[str, str]]:
+    rng = random.Random(20260721)
+    alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"
+    mixed = alpha + "0123456789 -'.éüößÅ"
+    def rand(pool: str) -> str:
+        return "".join(rng.choice(pool) for _ in range(rng.randint(0, 12)))
+    pairs = [(x, y) for x in _VOCAB for y in _VOCAB]  # every ordered pair incl self
+    pairs += [(rand(alpha), rand(alpha)) for _ in range(1500)]
+    pairs += [(rand(mixed), rand(mixed)) for _ in range(1500)]
+    return pairs
+
+
+def test_soundex_native_matches_jellyfish_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "soundex_similarity"):
+        pytest.skip("native soundex kernel not built / wheel predates soundex_similarity")
+    for a, b in _corpus():
+        assert n.soundex_similarity(a, b) == _mirror(a, b), f"soundex {a!r} {b!r}"
+
+
+def test_soundex_full_parity_non_alpha_and_unicode():
+    # The cases the pre-Wave-1 ASCII-only kernel got wrong; now byte-identical.
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "soundex_similarity"):
+        pytest.skip("native soundex kernel not built")
+    # 123 -> "1000", 456 -> "4000" (distinct); 123 vs 123 match.
+    assert n.soundex_similarity("123", "456") == _mirror("123", "456") == 0.0
+    assert n.soundex_similarity("123", "123") == 1.0
+    # 3M -> "3500"; Robert/Rupert collide; Ürüm code is stable under NFKD.
+    assert n.soundex_similarity("Robert", "Rupert") == 1.0
+    assert n.soundex_similarity("Ürüm", "Ürüm") == 1.0
+
+
+def test_soundex_bucket_kernel_id6_matches_mirror():
+    """score_block_pairs dispatching scorer id 6 == the per-pair jellyfish mirror.
+
+    One block, one soundex_match field, weight 1.0, threshold 0.0 so every pair
+    emits; the kernel's per-pair score must equal the mirror.
+    """
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "soundex_similarity"):
+        pytest.skip("native soundex kernel not built")
+
+    values = ["Robert", "Rupert", "Smith", "Smyth", "3M", "José"]
+    row_ids = list(range(len(values)))
+    sizes = [len(values)]
+    field_values = [values]
+    ids = [6]                          # soundex_match
+    weights = [1.0]
+    total_weight = 1.0
+    threshold = 0.0
+    emitted = n.score_block_pairs(
+        row_ids, sizes, field_values, ids, weights, total_weight, threshold, []
+    )
+    got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            expected = _mirror(values[i], values[j])
+            if expected >= threshold:
+                assert got[(i, j)] == expected, f"{values[i]!r} {values[j]!r}"

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -603,6 +603,7 @@ name = "goldenmatch-score-core"
 version = "0.1.0"
 dependencies = [
  "rapidfuzz",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -1164,6 +1165,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1190,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "version_check"

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -99,6 +99,7 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::token_sort_ratio, m)?)?;
     m.add_function(wrap_pyfunction!(score::date_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::qgram_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::soundex_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -247,6 +247,18 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::qgram_similarity(a, b)
 }
 
+/// Soundex-match similarity (score-core id 6): binary 1.0/0.0 on soundex-code
+/// equality. Exposed as its own #[pyfunction] capability marker, like
+/// `date_similarity`/`qgram_similarity`: `score_one`/`score_block_pairs`
+/// dispatch id 6, but a stale published wheel (pre-soundex-bucket) would hit
+/// score_one's catch-all and silently return 0.0 for id 6, so the Python caller
+/// gates the native soundex route on `hasattr(_native, "soundex_similarity")`
+/// and falls back to the pure-Python per-pair jellyfish mirror otherwise.
+#[pyfunction]
+pub fn soundex_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::score_one(6, a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)
@@ -1123,57 +1135,11 @@ pub fn score_block_pairs_fs_arrow(
 // upper triangle + mirrors -- saves ~half the work on symmetric calls.
 // ----------------------------------------------------------------------------
 
-/// Soundex code matching `jellyfish.soundex` byte-for-byte. ASCII letters
-/// only; non-letter input returns the empty string (caller treats empty
-/// codes as non-matching, mirroring Python's `_soundex_score_matrix`).
-fn soundex(s: &str) -> String {
-    // Take the first alphabetic char as the seed letter (uppercased).
-    let mut iter = s.chars();
-    let first = loop {
-        match iter.next() {
-            Some(c) if c.is_ascii_alphabetic() => break c.to_ascii_uppercase(),
-            Some(_) => continue,
-            None => return String::new(),
-        }
-    };
-    let mut out = String::with_capacity(4);
-    out.push(first);
-    let mut last_code = soundex_code(first);
-    for c in iter {
-        if !c.is_ascii_alphabetic() {
-            continue;
-        }
-        let code = soundex_code(c.to_ascii_uppercase());
-        // Skip Hs and Ws between consonants (jellyfish ignores them but does
-        // not reset last_code).
-        if code == b'0' && (c.eq_ignore_ascii_case(&'H') || c.eq_ignore_ascii_case(&'W')) {
-            continue;
-        }
-        if code != b'0' && code != last_code {
-            out.push(code as char);
-            if out.len() == 4 {
-                break;
-            }
-        }
-        last_code = code;
-    }
-    while out.len() < 4 {
-        out.push('0');
-    }
-    out
-}
-
-fn soundex_code(c: char) -> u8 {
-    match c {
-        'B' | 'F' | 'P' | 'V' => b'1',
-        'C' | 'G' | 'J' | 'K' | 'Q' | 'S' | 'X' | 'Z' => b'2',
-        'D' | 'T' => b'3',
-        'L' => b'4',
-        'M' | 'N' => b'5',
-        'R' => b'6',
-        _ => b'0',
-    }
-}
+// `soundex` moved to `goldenmatch-score-core` (the single reference for the
+// soundex surfaces): the field-matrix path below and the bucket `score_one`
+// path (id 6) now share `goldenmatch_score_core::soundex`. See score-core's
+// `soundex` + its `soundex_matches_jellyfish_reference` test.
+use goldenmatch_score_core::soundex;
 
 /// Read an Arrow Utf8 / LargeUtf8 column into a Vec<String>, mapping null
 /// entries to empty strings (matches the slow path's caller convention --
@@ -1389,35 +1355,8 @@ where
 mod tests {
     use super::*;
 
-    #[test]
-    fn soundex_characterizes_implementation_output() {
-        assert_eq!(soundex("Robert"), "R163");
-        assert_eq!(soundex("Ashcraft"), "A261");
-        assert_eq!(soundex("Tymczak"), "T522");
-    }
-
-    #[test]
-    fn soundex_pads_short_codes_to_four() {
-        assert_eq!(soundex("Lee").len(), 4);
-        assert_eq!(soundex("A"), "A000");
-    }
-
-    #[test]
-    fn soundex_non_alpha_is_empty() {
-        assert_eq!(soundex("123"), "");
-        assert_eq!(soundex(""), "");
-    }
-
-    #[test]
-    fn soundex_code_table() {
-        assert_eq!(soundex_code('B'), b'1'); // B F P V
-        assert_eq!(soundex_code('C'), b'2'); // C G J K Q S X Z
-        assert_eq!(soundex_code('D'), b'3'); // D T
-        assert_eq!(soundex_code('L'), b'4'); // L
-        assert_eq!(soundex_code('M'), b'5'); // M N
-        assert_eq!(soundex_code('R'), b'6'); // R
-        assert_eq!(soundex_code('A'), b'0'); // vowels / other
-    }
+    // soundex tests moved to `goldenmatch-score-core` (the impl now lives there;
+    // native re-uses it via `use goldenmatch_score_core::soundex`).
 
     #[test]
     fn fs_level_from_sim_custom_thresholds_count_inclusive() {

--- a/packages/rust/extensions/score-core/Cargo.toml
+++ b/packages/rust/extensions/score-core/Cargo.toml
@@ -21,3 +21,6 @@ name = "goldenmatch_score_core"
 # Same pin the `native` crate uses, so the scorers are byte-identical across the
 # native ext and the FFI UDFs (parity by construction — one source of truth).
 rapidfuzz = "0.5.0"
+# `soundex` replicates `jellyfish.soundex` byte-for-byte, incl. its Unicode step
+# `unicodedata.normalize("NFKD", s).upper()`; this provides the NFKD normalizer.
+unicode-normalization = "0.1"

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -288,16 +288,11 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         3 if a == b => 1.0,
         4 => date_similarity(a, b),
         5 => qgram_similarity(a, b),
-        // id=6 = soundex_match: binary 1.0/0.0 on soundex-code equality. Naive
-        // equality (two empty codes compare EQUAL -> 1.0), matching the bucket
-        // per-pair mirror `1.0 if jf.soundex(a)==jf.soundex(b) else 0.0`.
-        6 => {
-            if soundex(a) == soundex(b) {
-                1.0
-            } else {
-                0.0
-            }
-        }
+        // id=6 = soundex_match: binary 1.0/0.0 on soundex-code equality. Guard
+        // arm collapses the if/else into the match (clippy::collapsible-match),
+        // like id 3; a soundex mismatch falls through to the 0.0 catch-all.
+        // Matches the bucket per-pair mirror `1.0 if jf.soundex(a)==jf.soundex(b) else 0.0`.
+        6 if soundex(a) == soundex(b) => 1.0,
         _ => 0.0,
     }
 }

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -10,6 +10,7 @@
 //! rapidfuzz.
 use rapidfuzz::distance::{damerau_levenshtein, jaro_winkler, levenshtein};
 use rapidfuzz::fuzz;
+use unicode_normalization::UnicodeNormalization;
 
 // Fellegi–Sunter EM training core (pyo3-free numeric heart). PR-C / C1 of the
 // FS Rust+Arrow-only epic; the `native` crate will add the Arrow/#[pyfunction]
@@ -192,9 +193,80 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
     inter as f64 / union as f64
 }
 
+/// American Soundex matching `jellyfish.soundex` byte-for-byte, INCLUDING its
+/// Unicode handling. Mirrors the jellyfish reference exactly
+/// (`jellyfish/_jellyfish.py::soundex`):
+///
+/// - empty input -> `""`.
+/// - `unicodedata.normalize("NFKD", s).upper()`: NFKD decomposition (an accented letter becomes base-letter + combining mark) then Unicode uppercase (`ß` -> `"SS"`).
+/// - seed = the LITERAL first char (kept as-is, not coded); `last` = its would-be code, or None if the seed isn't a coded consonant.
+/// - each subsequent char: a coded consonant appends its code when it differs from `last` (adjacent-dup collapse); ANY other char resets `last` to None UNLESS it is `H`/`W` (which leave `last` untouched).
+/// - stop at 4 output chars; right-pad with `0`.
+///
+/// This is the single reference for every `goldenmatch` soundex surface: the
+/// `native` field-matrix kernel and the bucket `score_one` path both call it.
+/// Rust `nfkd()` (the `unicode-normalization` crate) plus `str::to_uppercase`
+/// implement the same Unicode algorithms as Python's `unicodedata.normalize`
+/// and `str.upper`, so the result is byte-identical to jellyfish (batteried in
+/// `tests/test_native_soundex_parity.py`).
+pub fn soundex(s: &str) -> String {
+    if s.is_empty() {
+        return String::new();
+    }
+    let normalized: String = s.nfkd().collect::<String>().to_uppercase();
+    let chars: Vec<char> = normalized.chars().collect();
+    if chars.is_empty() {
+        return String::new();
+    }
+    let mut result = String::with_capacity(4);
+    result.push(chars[0]); // literal seed (jellyfish `result = [s[0]]`)
+    let mut count = 1usize;
+    let mut last = soundex_code(chars[0]); // would-be code of the seed, or None
+    for &c in &chars[1..] {
+        match soundex_code(c) {
+            Some(code) => {
+                if Some(code) != last {
+                    result.push(code);
+                    count += 1;
+                }
+                last = Some(code);
+            }
+            None => {
+                // Non-coded char (vowel / mark / digit / symbol): reset the
+                // dedup state, EXCEPT H/W which jellyfish leaves alone.
+                if c != 'H' && c != 'W' {
+                    last = None;
+                }
+            }
+        }
+        if count == 4 {
+            break;
+        }
+    }
+    for _ in count..4 {
+        result.push('0');
+    }
+    result
+}
+
+/// Soundex digit for a coded consonant (uppercase), else `None`. Vowels
+/// (A/E/I/O/U/Y), H, W, and every non-letter map to `None` (jellyfish's
+/// "not in any replacement set" branch).
+fn soundex_code(c: char) -> Option<char> {
+    match c {
+        'B' | 'F' | 'P' | 'V' => Some('1'),
+        'C' | 'G' | 'J' | 'K' | 'Q' | 'S' | 'X' | 'Z' => Some('2'),
+        'D' | 'T' => Some('3'),
+        'L' => Some('4'),
+        'M' | 'N' => Some('5'),
+        'R' => Some('6'),
+        _ => None,
+    }
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact, 4=date, 5=qgram.
+/// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -216,6 +288,16 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         3 if a == b => 1.0,
         4 => date_similarity(a, b),
         5 => qgram_similarity(a, b),
+        // id=6 = soundex_match: binary 1.0/0.0 on soundex-code equality. Naive
+        // equality (two empty codes compare EQUAL -> 1.0), matching the bucket
+        // per-pair mirror `1.0 if jf.soundex(a)==jf.soundex(b) else 0.0`.
+        6 => {
+            if soundex(a) == soundex(b) {
+                1.0
+            } else {
+                0.0
+            }
+        }
         _ => 0.0,
     }
 }
@@ -296,6 +378,58 @@ mod tests {
     fn score_one_id5_is_qgram() {
         assert_eq!(score_one(5, "abc", "abc"), 1.0);
         assert_eq!(score_one(5, "abc", "abd"), qgram_similarity("abc", "abd"));
+    }
+
+    #[test]
+    fn soundex_matches_jellyfish_reference() {
+        // Canonical alphabetic jellyfish values.
+        assert_eq!(soundex("Robert"), "R163");
+        assert_eq!(soundex("Rupert"), "R163"); // Robert/Rupert collide
+        assert_eq!(soundex("Ashcraft"), "A261"); // H/W skip rule
+        assert_eq!(soundex("Tymczak"), "T522");
+        assert_eq!(soundex("Pfister"), "P236"); // adjacent same-code (P,F -> 1) coalesces
+        assert_eq!(soundex("Honeyman"), "H555");
+        // Empty -> empty (jellyfish `if not s`).
+        assert_eq!(soundex(""), "");
+        // Leading non-alpha: jellyfish seeds on the LITERAL first char (NOT the
+        // first letter) and codes the rest -- full-parity cases probed from
+        // jellyfish itself.
+        assert_eq!(soundex("123"), "1000");
+        assert_eq!(soundex("3M"), "3500");
+        assert_eq!(soundex("4abc"), "4120");
+        // Mid-string non-letter resets the dedup state (S..1..S -> both S's coded).
+        assert_eq!(soundex("S1S"), "S200");
+        // Unicode: NFKD fold + uppercase. Ürüm -> U + r(6) + m(5); ß.upper()="SS".
+        assert_eq!(soundex("Ürüm"), "U650");
+        assert_eq!(soundex("José"), "J200");
+        assert_eq!(soundex("ß"), "S000");
+    }
+
+    #[test]
+    fn soundex_pads_short_codes_to_four() {
+        assert_eq!(soundex("Lee").len(), 4);
+        assert_eq!(soundex("A"), "A000");
+    }
+
+    #[test]
+    fn soundex_code_table() {
+        assert_eq!(soundex_code('B'), Some('1')); // B F P V
+        assert_eq!(soundex_code('C'), Some('2')); // C G J K Q S X Z
+        assert_eq!(soundex_code('D'), Some('3')); // D T
+        assert_eq!(soundex_code('L'), Some('4')); // L
+        assert_eq!(soundex_code('M'), Some('5')); // M N
+        assert_eq!(soundex_code('R'), Some('6')); // R
+        assert_eq!(soundex_code('A'), None); // vowels
+        assert_eq!(soundex_code('1'), None); // non-letter
+    }
+
+    #[test]
+    fn score_one_id6_is_soundex_match() {
+        assert_eq!(score_one(6, "Robert", "Rupert"), 1.0); // same code
+        assert_eq!(score_one(6, "Robert", "Smith"), 0.0); // different code
+        // full jellyfish parity: soundex("123")="1000" != soundex("456")="4000"
+        assert_eq!(score_one(6, "123", "456"), 0.0);
+        assert_eq!(score_one(6, "123", "123"), 1.0);
     }
 
     #[test]

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,8 +305,8 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date` and `qgram` have an arrow-native (bucket) kernel on Python
-# but no TS WASM port yet.
+# python_only: `date`, `qgram`, `soundex_match` have an arrow-native (bucket)
+# kernel on Python but no TS WASM port yet.
 scorer_kernels:
   shared:
   - exact
@@ -316,4 +316,5 @@ scorer_kernels:
   python_only:
   - date
   - qgram
+  - soundex_match
   ts_only: []


### PR DESCRIPTION
## What and why

Second Wave-1 scorer from the `-core` kernel coverage spec. `soundex_match` already had a Rust kernel in the **field-matrix** path (native id 4), but only ASCII-alpha-validated. This moves it into `score-core` with **full `jellyfish.soundex` parity** — including Unicode — and wires it into the **bucket** path via `score_one` id 6, so `soundex_match` becomes kernel-backed in the metric. Suite-matrix now reads **7 of 19**.

## The parity work

The pre-existing ASCII-only kernel diverged from jellyfish on leading non-alpha and Unicode input. The new `score-core::soundex` replicates jellyfish's algorithm exactly (from `jellyfish/_jellyfish.py`):

- `unicodedata.normalize("NFKD", s).upper()` — NFKD decomposition + Unicode uppercase, via the `unicode-normalization` crate + `str::to_uppercase`
- literal first-char seed (not first-*letter*), dedup-reset on any non-coded char except `H`/`W`

Result: native == pure on `123`→`1000`, `3M`→`3500`, `Ürüm`→`U650`, `ß`→`S000`, etc. This also **closes the same latent Unicode gap in the field-matrix path** — both surfaces now dispatch the single shared `score-core::soundex`.

## Changes

- **`score-core`**: `soundex` reimplemented for full jellyfish parity; `score_one` id 6 (+ Rust unit tests pinning the exact codes). New dep `unicode-normalization`.
- **`native`**: `soundex` delegates to `score-core` (removed the local dup); `soundex_similarity` `#[pyfunction]` capability marker + registration.
- **`score_buckets.py`**: `soundex_match` → `_NATIVE_SCORER_IDS` id 6 (already fast-path eligible) + wheel-skew guard alongside date/qgram.
- Manifest + regenerated suite-matrix (7/19); cross-surface id-map test; new `test_native_soundex_parity.py` (native == jellyfish over thousands of pairs incl non-alpha + Unicode); spec updated.

## Testing

- `cargo clippy --all-targets -- -D warnings` clean (score-core + native)
- score-core cargo: 19/19; soundex parity + cross-surface + field-matrix: 21/21
- broader scorer/bucket/qgram/NE-gate regression: 187/187 (native on)
- `scorer_kernels` emitter == manifest; `native_symbols` OK; `gen_suite_matrix.py --check` current
- Rebuilt the in-tree `_native.abi3.so` to run the above

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (spec + regenerated suite-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_