### PR TITLE
docs(pg): mark the #1913 in-DB identity design as implemented (as-built)

### DIFF
--- a/docs/superpowers/specs/2026-07-19-goldenmatch-pg-in-db-identity-write-path-design.md
+++ b/docs/superpowers/specs/2026-07-19-goldenmatch-pg-in-db-identity-write-path-design.md
@@ -1,7 +1,14 @@
 # goldenmatch-pg: in-database stateful identity resolution (write path)
 
-- **Issue:** #1913
-- **Status:** design (pre-implementation)
+- **Issue:** #1913 (closed — completed)
+- **Status:** implemented (P1–P4 shipped, `rust_pgrx` CI-proven). As-built:
+  P1 `gm_resolve` (#1940), P2 in-DB `goldenmatch_identity_*` reads on empty
+  `db_path` (#1941), P3 `gm_identity_merge` / `gm_identity_split` (#1949),
+  P4 Arrow-native columnar table read (#1951, #1957). §3.1's own-libpq-connection
+  choice (not SPI) shipped as designed; same-transaction atomicity (§9) remains a
+  deferred open question. The `rust_pgrx` smoke (`.github/workflows/ci.yml`,
+  `ci-required`, PG 15/16/17) exercises create → absorb → in-DB read → split →
+  merge end-to-end.
 - **Related:** #1912 (per-record identity writes are round-trip-bound — an in-DB
   write path should be set-based / pipelined from the start), #1883 (table read
   is a JSON handoff, not Arrow), the Identity Graph v2 contract


### PR DESCRIPTION
## What and why

While closing #1913 (in-database stateful identity write path — verified fully shipped: P1 `gm_resolve`, P2 in-DB `goldenmatch_identity_*` reads, P3 `gm_identity_merge`/`gm_identity_split`, P4 Arrow read, all `rust_pgrx` CI-proven on PG 15/16/17), I found the design doc still read `Status: design (pre-implementation)`. Docs-only fix to make it an accurate as-built record so a future reader isn't misled.

## Changes

- `docs/superpowers/specs/2026-07-19-goldenmatch-pg-in-db-identity-write-path-design.md`: front-matter `Status` → `implemented`, with the phase→PR map (#1940/#1941/#1949/#1951/#1957), the CI-proof pointer, and a note that §3.1's own-libpq-connection choice shipped as designed while §9's same-transaction atomicity remains a deferred open question.

## Testing

Docs-only; no code change.

## Checklist

- [x] No code/behavior change (documentation only)
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_