### PR TITLE
feat(score): kernelize initialism_match into the bucket path (Wave 2, 7/19 -> 8/19)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**7 of 19 scorers are kernel-backed** (the reference fast path); the other 12 are pure-language fallbacks with no `-core` kernel.
+**8 of 19 scorers are kernel-backed** (the reference fast path); the other 11 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `qgram`, `soundex_match` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `initialism_match`, `qgram`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
+| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -352,6 +352,7 @@
           "defines": [
             "_bkt_debug_on",
             "_default_n_buckets",
+            "_ensure_legal_forms_installed",
             "_fs_bounded_stream_enabled",
             "_fs_bucket_native_enabled",
             "_ne_effectively_empty",
@@ -377,7 +378,8 @@
             "goldenmatch.core.matchkey",
             "goldenmatch.core.probabilistic",
             "goldenmatch.core.scorer",
-            "goldenmatch.plugins.registry"
+            "goldenmatch.plugins.registry",
+            "goldenmatch.refdata.business"
           ]
         },
         {

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -1,7 +1,7 @@
 # Full `-core` kernel coverage for the scorer surface (5/19 -> full)
 
 **Date:** 2026-07-21
-**Status:** Proposed (scoping / design). **Wave 1 landing incrementally:** `qgram` (5/19 -> 6/19) and `soundex_match` (6/19 -> 7/19) are now kernel-backed; the baseline figures below describe the pre-work starting point.
+**Status:** Proposed (scoping / design). **Landing incrementally:** `qgram` (5/19 -> 6/19) and `soundex_match` (6/19 -> 7/19) landed in Wave 1; `initialism_match` (7/19 -> 8/19) is the first Wave-2 cut; the baseline figures below describe the pre-work starting point.
 **Motivation:** The generated suite-matrix reports **"5 of 19 scorers are kernel-backed"**
 (`docs-site/suite-matrix.mdx`, computed by `gen_suite_matrix.py::_substrate_lines` from the
 `scorer_kernels` parity surface). This spec scopes what it takes to close that gap -- and argues
@@ -20,13 +20,20 @@ The other **14 were fallback-only** at that baseline: `dice`, `jaccard`, `qgram`
 `ensemble`, `embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`,
 `radial`, `given_name_aliased_jw`, `name_freq_weighted_jw`.
 
-**Update:** `qgram` and `soundex_match` are now kernelized (Wave 1) -- each has a `score-core`
-kernel on the Python arrow-bucket fast path, so the current state is **7/19** with **12** fallbacks
-remaining. Both read as `python_only` in the `scorer_kernels` partition (no TS WASM port yet, like
-`date`). `soundex_match`'s kernel replicates `jellyfish.soundex` byte-for-byte INCLUDING its Unicode
-step (NFKD normalize + `str.upper` via the `unicode-normalization` crate), so native==pure on leading
-non-alpha / accented input too -- which also closes the same latent gap in the field-matrix path
-(both now dispatch the shared `score-core::soundex`).
+**Update:** `qgram` and `soundex_match` (Wave 1) and `initialism_match` (Wave 2 start) are now
+kernelized -- each has a `score-core` kernel on the Python arrow-bucket fast path, so the current
+state is **8/19** with **11** fallbacks remaining. All three read as `python_only` in the
+`scorer_kernels` partition (no TS WASM port yet, like `date`). `soundex_match`'s kernel replicates
+`jellyfish.soundex` byte-for-byte INCLUDING its Unicode step (NFKD normalize + `str.upper` via the
+`unicode-normalization` crate), so native==pure on leading non-alpha / accented input too -- which
+also closes the same latent gap in the field-matrix path (both now dispatch the shared
+`score-core::soundex`). `initialism_match` ports `derive_initialism` + `_initialism_match_single`
+byte-for-byte into `score-core` (`score_one` id 7); because a per-pair kernel can't take a legal-form
+table argument without breaking the uniform `(id, a, b)` dispatch, the ~77-entry
+`entity_form_variants()` set is installed once into a process-global `OnceLock` via a native
+`set_legal_form_variants` shim, and the Python fast-path guard routes native only when BOTH the
+`initialism_similarity` capability symbol is present AND the install succeeded (else it declines to
+the pure `_initialism_match_single` mirror).
 
 "Kernel-backed" in the metric means *a kernel exists in at least one language* (a union), so the
 denominator (19) also counts scorers that live in only one language. The metric is emitted by
@@ -66,7 +73,7 @@ each replaces an O(N^2) pure-Python double loop.
 |---|---|---|---|
 | `qgram` | `core/scorer.py:1019` (`_qgram_score_matrix:1036`) | char-trigram Jaccard on raw strings (`#`-padded n-gram sets) | none -- pure string primitive |
 | `soundex_match` | `core/scorer.py:701`; field-map `id 4` at `:484` | `1.0` if `jellyfish.soundex(a)==soundex(b)` | **half-done** -- already in `_NATIVE_FIELD_SCORER_IDS`, not the bucket path; finish the wiring |
-| `initialism_match` | `core/scorer.py:101`, `:716` | `1.0` if one string is the other's initialism (`derive_initialism`) | cross-keyed (raw vs derived), so a *pairwise* kernel, not a hash-group |
+| `initialism_match` ✅ | `core/scorer.py:101`, `:716` | `1.0` if one string is the other's initialism (`derive_initialism`) | **landed** -- `score_one` id 7; needed the legal-form table in-kernel (installed once via a global `OnceLock` + `set_legal_form_variants` shim, keeping the `(id, a, b)` dispatch uniform) |
 | `given_name_aliased_jw` | `refdata/scorer.py:177` | `max(jw, 1.0 if known given-name alias)` (William<->Bill) | needs the alias table in-kernel |
 | `name_freq_weighted_jw` | `refdata/scorer.py:69` | `jw * (floor + (1-floor)*mean_rarity)` from census/`tf_freqs` | needs the freq table in-kernel; TS port is static-only (declared delta) |
 | `alias_match` | `core/scorer.py:125`, `:741` | `1.0` if same business/given-name canonical | needs canonicalization tables in-kernel |
@@ -100,8 +107,8 @@ minimal. Recommend **defer or explicitly decline**.
 
 | Wave | Scorers | Risk | Rationale |
 |---|---|---|---|
-| **1** | `qgram` ✅, `soundex_match` ✅ (both landed), `initialism_match` | low | pure strings on the proven template; `soundex_match` reused the existing Rust kernel, upgraded to full jellyfish Unicode parity |
-| **2** | `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk |
+| **1** | `qgram` ✅, `soundex_match` ✅ (both landed) | low | pure strings on the proven template; `soundex_match` reused the existing Rust kernel, upgraded to full jellyfish Unicode parity |
+| **2** | `initialism_match` ✅ (landed), `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk. `initialism_match` proved the in-kernel table mechanism: the ~77-entry `entity_form_variants()` set is installed once into a `score-core` `OnceLock` via a native `set_legal_form_variants` shim, keeping `score_one(id, a, b)` uniform |
 | **3** | `phash`, `dice`, `jaccard` | low-med | wiring existing kernels (`perceptual-core`, `bloom.rs`), not new algorithms |
 | **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |
 | **4 (defer/decline)** | `audio_fp`, `radial` | -- | bespoke alignment search, low perf upside |
@@ -119,8 +126,9 @@ on us, and step 4 is the real work.
 1. **`score-core`** (`packages/rust/extensions/score-core/src/lib.rs`): add the primitive
    (`pub fn <scorer>_similarity` + a `score_one` id, or a dedicated fn). Exports today:
    `jaro_winkler_similarity`, `levenshtein_similarity`, `token_sort_ratio`,
-   `token_sort_normalized_ratio`, `date_similarity`, `qgram_similarity`,
-   `score_one(id: 0..5)` (id 5 = qgram, added by the Wave-1 qgram cut).
+   `token_sort_normalized_ratio`, `date_similarity`, `qgram_similarity`, `soundex`,
+   `set_legal_forms` + `initialism_match`, `score_one(id: 0..7)` (id 5 = qgram, id 6 =
+   soundex_match, id 7 = initialism_match against the installed legal-form set).
 2. **`native` wheel** (`packages/rust/extensions/native/src/score.rs`): add a `#[pyfunction]` shim,
    register it in `native/src/lib.rs` (`m.add_function(...)` -- required for the `native_symbols`
    gate), and wire the id into `score_field_matrix` (`:1220`) and/or `score_block_pairs*`.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -235,7 +235,58 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # -- NOT the field-matrix path's id 4=soundex (empty codes non-matching;
     # a separate id namespace).
     "soundex_match": 6,
+    # id 7 = initialism_match (abbreviation matcher, score-core score_one).
+    # Two-part wheel-skew guard at the gating site below: routing to native id 7
+    # requires BOTH the `initialism_similarity` capability symbol (a stale
+    # pre-initialism wheel hits score_one's catch-all -> silent 0.0) AND a
+    # successful `set_legal_form_variants` install (id 7 scores against an empty
+    # legal-form set until the host ships `entity_form_variants()`), else it
+    # declines to the pure-Python per-pair mirror (`_initialism_match_single`).
+    "initialism_match": 7,
 }
+
+
+# Cached tri-state for the one-time legal-form install into the native kernel:
+# None = not yet attempted, True = installed on a capable kernel, False = kernel
+# lacks the symbols (stale wheel) so the initialism native route is declined.
+_LEGAL_FORMS_INSTALLED: bool | None = None
+
+
+def _ensure_legal_forms_installed() -> bool:
+    """Install ``entity_form_variants()`` into score-core's process-global
+    legal-form table (via the native ``set_legal_form_variants`` shim) exactly
+    once, so ``score_one`` id 7 (initialism_match) drops legal forms the same way
+    the pure ``derive_initialism`` does.
+
+    Returns True once the table is installed on a kernel exposing BOTH
+    ``set_legal_form_variants`` and ``initialism_similarity``; False when the
+    loaded kernel lacks either symbol (a stale pre-initialism wheel), so the
+    gating site declines the native id-7 route and lets the pure per-pair mirror
+    (``_initialism_match_single``) score the block. Idempotent + memoized: the
+    OnceLock is first-wins and the variant set is deterministic, so a benign
+    re-install (another caller won the race) still leaves the correct table.
+    """
+    global _LEGAL_FORMS_INSTALLED
+    if _LEGAL_FORMS_INSTALLED is not None:
+        return _LEGAL_FORMS_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_legal_form_variants")
+        or not hasattr(_mod, "initialism_similarity")
+    ):
+        _LEGAL_FORMS_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata.business import entity_form_variants
+
+        # Bool return (first-wins) is intentionally ignored: whether we or another
+        # caller installed it, the deterministic content is now in place.
+        _mod.set_legal_form_variants(list(entity_form_variants()))
+        _LEGAL_FORMS_INSTALLED = True
+    except Exception:
+        _LEGAL_FORMS_INSTALLED = False
+    return _LEGAL_FORMS_INSTALLED
 
 
 # Single source in core._hashing (re-exported here for back-compat). The
@@ -331,6 +382,18 @@ def _resolve_score_pair_callable(
         # backend (native or this per-pair mirror) instead of the slow matrix path.
         from goldenmatch.core.scorer import _qgram_score_single
         return _qgram_score_single
+    if scorer_name == "initialism_match":
+        # Abbreviation matcher (1.0/0.0). Per-pair mirror of the matrix path
+        # (core/scorer.py:736) AND of score-core::initialism_match (native id 7);
+        # parity-asserted in tests/test_native_initialism_parity.py. Making it
+        # fast-path eligible routes initialism_match configs through the bucket
+        # backend (native id 7 or this per-pair mirror) instead of the slow
+        # matrix path. The native id-7 kernel needs the legal-form table
+        # installed (`set_legal_form_variants`); the gating site below guards on
+        # both the `initialism_similarity` symbol AND a successful install, and
+        # declines to THIS mirror otherwise.
+        from goldenmatch.core.scorer import _initialism_match_single
+        return _initialism_match_single
     if scorer_name == "dice":
         # Delegate to the existing per-pair implementation in core/scorer.py
         # (_dice_score_single, bigram set Dice coefficient). Matrix path is
@@ -1045,6 +1108,16 @@ def score_buckets(
             has_date = any(spec[3] == "date" for spec in _field_specs)
             has_qgram = any(spec[3] == "qgram" for spec in _field_specs)
             has_soundex = any(spec[3] == "soundex_match" for spec in _field_specs)
+            has_initialism = any(spec[3] == "initialism_match" for spec in _field_specs)
+            # initialism_match (id 7) has a TWO-part guard: the capability symbol
+            # AND a successful legal-form install (id 7 scores against an empty
+            # legal-form set until the host ships `entity_form_variants()`).
+            # `_ensure_legal_forms_installed` folds both checks (symbol presence +
+            # install) into one memoized bool, so an uninstalled/stale kernel
+            # declines to the pure per-pair mirror instead of dropping no legal
+            # forms. Only evaluated when a field actually uses initialism (avoids
+            # the refdata load + install on every unrelated block).
+            _initialism_ok = has_initialism and _ensure_legal_forms_installed()
             # Wheel-skew: decline native entirely when a field uses a scorer whose
             # capability symbol the loaded kernel lacks (score_one would silently
             # zero that id); the pure-Python per-pair mirror scores the block.
@@ -1052,6 +1125,7 @@ def score_buckets(
                 (has_date and not _date_ok)
                 or (has_qgram and not _qgram_ok)
                 or (has_soundex and not _soundex_ok)
+                or (has_initialism and not _initialism_ok)
             )
             if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -42,7 +42,7 @@ class TestNativeScorerIdMaps:
     # 4=date/5=qgram/6=soundex_match; in the field-matrix map 4=soundex_match.
     # `soundex_match` therefore lives in BOTH maps at DIFFERENT ids (bucket 6,
     # field 4); the two are pinned separately so they can't silently collide.
-    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6}
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):

--- a/packages/python/goldenmatch/tests/test_native_initialism_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_initialism_parity.py
@@ -1,0 +1,130 @@
+"""Parity for the initialism_match bucket kernel (score-core id 7) vs the pure
+Python reference `_initialism_match_single`.
+
+Wave 2 moves `initialism_match` into `score-core` (`derive_initialism` +
+`initialism_match`, byte-for-byte with `goldenmatch.core.acronym.derive_initialism`
++ `core.scorer._initialism_match_single`) and wires it into the *bucket* path via
+`score_one` id 7, so `initialism_match` becomes kernel-backed in the metric (the
+scorer_kernels surface reads the bucket `_NATIVE_SCORER_IDS`).
+
+Unlike the other bucket kernels, id 7 reads a process-global legal-form variant
+set that the host installs once via the native `set_legal_form_variants` shim
+(`refdata.business.entity_form_variants()`, ~77 lowercase entries). Without it,
+id 7 would drop no legal forms and diverge (`Acme Industries LLC` -> `AIL` not
+`AI`). Every test here installs the table first, exactly as the fast-path guard
+(`_ensure_legal_forms_installed`) does before routing initialism native.
+
+Parity means native `initialism_similarity(a, b)` (and the bucket id-7 dispatch)
+is bit-identical to `_initialism_match_single(a, b)` over adversarial input:
+acronyms, multi-word company names, legal-form suffixes, parentheticals,
+punctuation-only tokens, single tokens, and Unicode.
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.core.scorer import _initialism_match_single
+from goldenmatch.refdata.business import entity_form_variants
+
+
+def _install(n) -> None:
+    # Idempotent (OnceLock first-wins); the variant set is deterministic.
+    n.set_legal_form_variants(list(entity_form_variants()))
+
+
+def _mirror(a: str, b: str) -> float:
+    return _initialism_match_single(a, b)
+
+
+# Adversarial vocabulary: acronyms (lone + as own key), full expansions,
+# legal-form suffixes (dropped), descriptive tokens (kept), parentheticals,
+# punctuation-only tokens, single tokens, digits, and Unicode.
+_VOCAB = [
+    "IBM", "International Business Machines", "Indian Banana Market",
+    "International Business Machines Corporation (Armonk, NY)",
+    "Acme Industries LLC", "AI", "Acme Industries Inc", "AII",
+    "Apple", "Apricot", "Apple Inc", "GmbH", "AB", "3M Company", "3M",
+    "General Motors", "GM", "GM Corp", "a b c", "ABC", "ABCDEFG",
+    "The Coca Cola Company", "TCCC", "Coca Cola", "CC",
+    "", "   ", "...", "-", "A.B.C.", "U.S.A.", "USA",
+    "Société Générale", "SG", "Ærø Bank", "Æ B", "Nestlé S.A.", "Nestlé",
+    "Foo (bar) Baz", "FB", "Foo Bar", "Ltd", "Co", "X Y Z Ltd",
+]
+
+
+def _corpus() -> list[tuple[str, str]]:
+    rng = random.Random(20260721)
+    words = ["International", "Business", "Machines", "Corporation", "LLC",
+             "Inc", "Ltd", "GmbH", "Acme", "Industries", "Group", "Holdings",
+             "IBM", "AI", "3M", "Co", "The", "Société", "Générale", "Æ"]
+    def rand_name() -> str:
+        k = rng.randint(0, 4)
+        return " ".join(rng.choice(words) for _ in range(k))
+    pairs = [(x, y) for x in _VOCAB for y in _VOCAB]  # every ordered pair incl self
+    pairs += [(rand_name(), rand_name()) for _ in range(2000)]
+    return pairs
+
+
+def test_initialism_native_matches_pure_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "initialism_similarity"):
+        pytest.skip("native initialism kernel not built / wheel predates initialism_similarity")
+    _install(n)
+    for a, b in _corpus():
+        assert n.initialism_similarity(a, b) == _mirror(a, b), f"initialism {a!r} {b!r}"
+
+
+def test_initialism_legal_form_dropping_and_acronym_key():
+    # The cases that depend on the installed legal-form table + acronym rules.
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "initialism_similarity"):
+        pytest.skip("native initialism kernel not built")
+    _install(n)
+    # "LLC" dropped -> "Acme Industries" -> "AI" == "AI".
+    assert n.initialism_similarity("Acme Industries LLC", "AI") == 1.0
+    # Expansion <-> acronym both directions.
+    assert n.initialism_similarity("International Business Machines", "IBM") == 1.0
+    assert n.initialism_similarity("IBM", "International Business Machines") == 1.0
+    # Lone non-acronym -> "" -> never matches another lone non-acronym.
+    assert n.initialism_similarity("Apple", "Apricot") == 0.0
+    # Same-initials collision is a match by design.
+    assert n.initialism_similarity(
+        "International Business Machines", "Indian Banana Market"
+    ) == 1.0
+    # 7-char token exceeds the acronym cap -> "" -> no self-key match.
+    assert n.initialism_similarity("ABCDEFG", "ABCDEFG") == _mirror("ABCDEFG", "ABCDEFG")
+
+
+def test_initialism_bucket_kernel_id7_matches_mirror():
+    """score_block_pairs dispatching scorer id 7 == the pure per-pair mirror.
+
+    One block, one initialism_match field, weight 1.0, threshold 0.0 so every
+    pair emits; the kernel's per-pair score must equal the mirror.
+    """
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "initialism_similarity"):
+        pytest.skip("native initialism kernel not built")
+    _install(n)
+
+    values = [
+        "International Business Machines", "IBM", "Acme Industries LLC", "AI",
+        "Apple", "Société Générale",
+    ]
+    row_ids = list(range(len(values)))
+    sizes = [len(values)]
+    field_values = [values]
+    ids = [7]                          # initialism_match
+    weights = [1.0]
+    total_weight = 1.0
+    threshold = 0.0
+    emitted = n.score_block_pairs(
+        row_ids, sizes, field_values, ids, weights, total_weight, threshold, []
+    )
+    got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            expected = _mirror(values[i], values[j])
+            if expected >= threshold:
+                assert got[(i, j)] == expected, f"{values[i]!r} {values[j]!r}"

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -100,6 +100,8 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::date_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::qgram_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::soundex_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::set_legal_form_variants, m)?)?;
+    m.add_function(wrap_pyfunction!(score::initialism_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -259,6 +259,30 @@ pub fn soundex_similarity(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::score_one(6, a, b)
 }
 
+/// Install the host-shipped legal-form variant set (`entity_form_variants()`,
+/// ~77 lowercase-normalized entries) into score-core's process-global table,
+/// which `initialism_match` (score-core id 7) reads. `OnceLock` first-wins:
+/// returns `True` only on the first call; later calls no-op (`False`). The
+/// Python caller MUST call this once before routing `initialism_match` through
+/// the native kernel, else id 7 scores against an empty legal-form set.
+#[pyfunction]
+pub fn set_legal_form_variants(forms: Vec<String>) -> bool {
+    goldenmatch_score_core::set_legal_forms(forms.into_iter().collect())
+}
+
+/// Initialism-match similarity (score-core id 7): 1.0 iff either name is the
+/// other's derived initialism (or the two initialisms are equal), against the
+/// globally-installed legal-form set. Own #[pyfunction] capability marker like
+/// `qgram_similarity`/`soundex_similarity`: a stale published wheel lacking this
+/// symbol would hit score_one's catch-all (silent 0.0) for id 7, so the Python
+/// caller gates the native route on `hasattr(_native, "initialism_similarity")`
+/// AND a successful `set_legal_form_variants`, falling back to the pure path
+/// (`_initialism_match_single`) otherwise.
+#[pyfunction]
+pub fn initialism_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::score_one(7, a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -365,9 +365,34 @@ pub fn initialism_match(a: &str, b: &str, legal_forms: &std::collections::HashSe
     }
 }
 
+// The legal-form variant set for `initialism_match` is process-global state,
+// installed once by the host (`refdata.business.entity_form_variants()`, ~77
+// entries), so that `score_one(7, ...)` stays a UNIFORM `(id, a, b)` call — the
+// dispatch signature can't carry a per-call table without breaking the
+// `_NATIVE_SCORER_IDS == score_one` id-map invariant every other scorer holds.
+static LEGAL_FORMS: std::sync::OnceLock<std::collections::HashSet<String>> =
+    std::sync::OnceLock::new();
+
+/// Install the caller-shipped legal-form variant set for `initialism_match`.
+/// `OnceLock` semantics: only the FIRST call wins (returns `true`); later calls
+/// are ignored (`false`). The host ships the deterministic 77-entry
+/// `entity_form_variants()` once before routing initialism through the kernel;
+/// until then `score_one(7, ...)` scores against an EMPTY set (no legal-form
+/// dropping), which is why the Python fast-path guard also gates on this being
+/// set. Content is deterministic, so the first-wins race is benign.
+pub fn set_legal_forms(forms: std::collections::HashSet<String>) -> bool {
+    LEGAL_FORMS.set(forms).is_ok()
+}
+
+/// The installed legal-form set, or an empty set if the host never called
+/// `set_legal_forms` (kernel stays defined but drops no legal forms).
+fn legal_forms() -> &'static std::collections::HashSet<String> {
+    LEGAL_FORMS.get_or_init(std::collections::HashSet::new)
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match.
+/// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match, 7=initialism_match.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -394,6 +419,11 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         // like id 3; a soundex mismatch falls through to the 0.0 catch-all.
         // Matches the bucket per-pair mirror `1.0 if jf.soundex(a)==jf.soundex(b) else 0.0`.
         6 if soundex(a) == soundex(b) => 1.0,
+        // id=7 = initialism_match against the host-installed legal-form set (empty
+        // until `set_legal_forms` is called). Byte-for-byte with
+        // `_initialism_match_single`; the Python fast-path guard requires the
+        // table to be installed before routing here.
+        7 => initialism_match(a, b, legal_forms()),
         _ => 0.0,
     }
 }
@@ -564,6 +594,21 @@ mod tests {
         // known false positive: same initials -> 1.0 by design
         assert_eq!(initialism_match("International Business Machines", "Indian Banana Market", &lf), 1.0);
         assert_eq!(initialism_match("Acme Industries LLC", "AI", &lf), 1.0);
+    }
+
+    #[test]
+    fn score_one_id7_is_initialism_match_against_global_table() {
+        // This is the ONLY test that installs the process-global legal-form set
+        // (OnceLock first-wins), so it never races a different-content setter;
+        // every other initialism test passes a LOCAL table to the `*_single` fns.
+        assert!(set_legal_forms(_legal_forms()));
+        // Table-INDEPENDENT (no legal-form tokens involved): dispatch works.
+        assert_eq!(score_one(7, "International Business Machines", "IBM"), 1.0);
+        assert_eq!(score_one(7, "Apple", "Apricot"), 0.0);
+        // Table-DEPENDENT: only 1.0 because "LLC" is dropped as a legal form
+        // ("Acme Industries LLC" -> initials "AI"). With an empty table it would
+        // be "AIL" != "AI" -> 0.0, so this asserts the global table is wired.
+        assert_eq!(score_one(7, "Acme Industries LLC", "AI"), 1.0);
     }
 
     #[test]

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -264,6 +264,107 @@ fn soundex_code(c: char) -> Option<char> {
     }
 }
 
+// ---- initialism_match (abbreviation matcher) --------------------------------
+// Mirrors `goldenmatch.core.acronym.derive_initialism` +
+// `core.scorer._initialism_match_single`. `legal_forms` is the caller-shipped
+// entity-form variant set (`refdata.business.entity_form_variants()`, ~77 entries,
+// already lowercase-normalized); passing it in keeps this fn pyo3-/refdata-free.
+
+/// Remove every `(...)` group, mirroring the Python `\([^)]*\)` substitution:
+/// a `(` with the nearest following `)` (and everything between) is dropped; a
+/// `(` with no later `)` is kept literally (the regex requires the close).
+fn strip_parentheticals(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == '(' {
+            if let Some(rel) = chars[i + 1..].iter().position(|&c| c == ')') {
+                i += rel + 2; // skip "(...)" inclusive
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
+}
+
+/// Python `token.strip().rstrip(".,").lower()` (the per-token legal-form key).
+fn normalize_token_for_legal(token: &str) -> String {
+    token
+        .trim()
+        .trim_end_matches(['.', ','])
+        .to_lowercase()
+}
+
+/// Python `str.isupper()`: at least one cased char and no lowercase char.
+fn py_isupper(s: &str) -> bool {
+    s.chars().any(char::is_uppercase) && !s.chars().any(char::is_lowercase)
+}
+
+/// Python `str.isalpha()`: non-empty and every char alphabetic.
+fn py_isalpha(s: &str) -> bool {
+    !s.is_empty() && s.chars().all(char::is_alphabetic)
+}
+
+/// Abbreviation block key for a name, byte-for-byte with
+/// `acronym.derive_initialism`: strip parentheticals; tokenize on whitespace,
+/// dropping punctuation-only tokens (no ASCII letter) and legal-form tokens
+/// (normalized form in `legal_forms`); then a lone all-caps alphabetic 2-6 char
+/// token returns itself uppercased, >=2 tokens return the first-ASCII-letter of
+/// each uppercased, else `""`.
+pub fn derive_initialism(text: &str, legal_forms: &std::collections::HashSet<String>) -> String {
+    let stripped = strip_parentheticals(text);
+    let mut cleaned: Vec<&str> = Vec::new();
+    for token in stripped.split_whitespace() {
+        if !token.chars().any(|c| c.is_ascii_alphabetic()) {
+            continue; // punctuation-only / digits-only (`_ANY_ALPHA` = [A-Za-z])
+        }
+        if legal_forms.contains(&normalize_token_for_legal(token)) {
+            continue;
+        }
+        cleaned.push(token);
+    }
+    if cleaned.len() == 1 {
+        let tok = cleaned[0];
+        let n = tok.chars().count();
+        if py_isupper(tok) && py_isalpha(tok) && (2..=6).contains(&n) {
+            return tok.to_uppercase();
+        }
+        return String::new();
+    }
+    if cleaned.is_empty() {
+        return String::new();
+    }
+    // First ASCII letter of each token (`_FIRST_ALPHA` = [A-Za-z]), uppercased.
+    let mut initials = String::with_capacity(cleaned.len());
+    for token in &cleaned {
+        if let Some(c) = token.chars().find(|c| c.is_ascii_alphabetic()) {
+            initials.push(c.to_ascii_uppercase());
+        }
+    }
+    if initials.chars().count() < 2 {
+        return String::new();
+    }
+    initials
+}
+
+/// `1.0` if either string is the other's initialism, or the two initialisms are
+/// equal (non-empty); else `0.0`. Byte-for-byte with `_initialism_match_single`.
+pub fn initialism_match(a: &str, b: &str, legal_forms: &std::collections::HashSet<String>) -> f64 {
+    let ia = derive_initialism(a, legal_forms);
+    let ib = derive_initialism(b, legal_forms);
+    let matched = (!ia.is_empty() && ia == b)
+        || (!ib.is_empty() && a == ib)
+        || (!ia.is_empty() && !ib.is_empty() && ia == ib);
+    if matched {
+        1.0
+    } else {
+        0.0
+    }
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
 /// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match.
@@ -425,6 +526,44 @@ mod tests {
         // full jellyfish parity: soundex("123")="1000" != soundex("456")="4000"
         assert_eq!(score_one(6, "123", "456"), 0.0);
         assert_eq!(score_one(6, "123", "123"), 1.0);
+    }
+
+    fn _legal_forms() -> std::collections::HashSet<String> {
+        // subset of refdata.business.entity_form_variants() relevant to the tests
+        ["inc", "corp", "corporation", "llc", "ltd", "gmbh", "ab", "company", "co"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect()
+    }
+
+    #[test]
+    fn derive_initialism_matches_python_reference() {
+        let lf = _legal_forms();
+        // ground truth from goldenmatch.core.acronym.derive_initialism
+        assert_eq!(derive_initialism("IBM", &lf), "IBM"); // lone acronym -> itself
+        assert_eq!(derive_initialism("Apple", &lf), ""); // lone non-acronym
+        assert_eq!(derive_initialism("International Business Machines", &lf), "IBM");
+        assert_eq!(
+            derive_initialism("International Business Machines Corporation (Armonk, NY)", &lf),
+            "IBM" // parenthetical stripped, "Corporation" dropped
+        );
+        assert_eq!(derive_initialism("Acme Industries LLC", &lf), "AI"); // keep descriptive
+        assert_eq!(derive_initialism("GmbH", &lf), ""); // lone legal form -> dropped
+        assert_eq!(derive_initialism("AB", &lf), ""); // "ab" is a legal form (Aktiebolag)
+        assert_eq!(derive_initialism("ABCDEFG", &lf), ""); // 7 chars > acronym cap
+        assert_eq!(derive_initialism("3M Company", &lf), ""); // "3M" not alpha; Company dropped
+        assert_eq!(derive_initialism("a b c", &lf), "ABC"); // first-alpha of each, upper
+    }
+
+    #[test]
+    fn initialism_match_matches_python_reference() {
+        let lf = _legal_forms();
+        assert_eq!(initialism_match("International Business Machines", "IBM", &lf), 1.0);
+        assert_eq!(initialism_match("IBM", "International Business Machines", &lf), 1.0);
+        assert_eq!(initialism_match("Apple", "Apricot", &lf), 0.0);
+        // known false positive: same initials -> 1.0 by design
+        assert_eq!(initialism_match("International Business Machines", "Indian Banana Market", &lf), 1.0);
+        assert_eq!(initialism_match("Acme Industries LLC", "AI", &lf), 1.0);
     }
 
     #[test]

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,8 +305,8 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date`, `qgram`, `soundex_match` have an arrow-native (bucket)
-# kernel on Python but no TS WASM port yet.
+# python_only: `date`, `qgram`, `soundex_match`, `initialism_match` have an
+# arrow-native (bucket) kernel on Python but no TS WASM port yet.
 scorer_kernels:
   shared:
   - exact
@@ -315,6 +315,7 @@ scorer_kernels:
   - token_sort
   python_only:
   - date
+  - initialism_match
   - qgram
   - soundex_match
   ts_only: []


### PR DESCRIPTION
## What and why

First Wave-2 scorer from the `-core` kernel-coverage spec. `initialism_match` was fallback-only; this ports the abbreviation matcher into `score-core` (`derive_initialism` + `initialism_match`, byte-for-byte with `goldenmatch.core.acronym.derive_initialism` + `core.scorer._initialism_match_single`) and wires it into the bucket fast path via `score_one` id 7, so it becomes kernel-backed in the metric. Suite-matrix now reads **8 of 19**.

## The in-kernel-table mechanism

Unlike the pure string scorers, `initialism_match` needs the ~77-entry legal-form variant set (`refdata.business.entity_form_variants()`) to drop legal-form tokens ("Acme Industries LLC" -> "AI", not "AIL"). A per-pair kernel can't take a table argument without breaking the uniform `(id, a, b)` dispatch that keeps `_NATIVE_SCORER_IDS == score_one`. So the set is installed once into a `score-core` process-global `OnceLock` via a native `set_legal_form_variants` shim; `score_one` id 7 reads it. This proves the in-kernel-table mechanism for the rest of Wave 2 (`given_name_aliased_jw` / `name_freq_weighted_jw` / `alias_match`).

The Rust normalization matches the Python reference exactly: `token.strip().rstrip(".,").lower()` compared against the lowercase `entity_form_variants()` set.

## Changes

- **`score-core`**: process-global legal-form `OnceLock` + `set_legal_forms`; `score_one` id 7 dispatches `initialism_match` against it (+ Rust unit tests: `derive_initialism` / `initialism_match` vs the Python reference, and `score_one` id 7 incl. a table-dependent case pinning the global install).
- **`native`**: `set_legal_form_variants` + `initialism_similarity` `#[pyfunction]`s, registered in `lib.rs`.
- **`score_buckets.py`**: `initialism_match` -> `_NATIVE_SCORER_IDS` id 7; `_resolve_score_pair_callable` branch returning the pure `_initialism_match_single` mirror (makes it fast-path eligible); a two-part wheel-skew guard (`_ensure_legal_forms_installed`) that routes native only when the `initialism_similarity` capability symbol is present AND the legal-form table installed, else declines to the pure mirror.
- Manifest (`parity/goldenmatch.yaml` `scorer_kernels.python_only += initialism_match`) + regenerated suite-matrix (8/19); cross-surface id-map `_SCORE_ONE_IDS += initialism_match:7`; new `test_native_initialism_parity.py` (native == pure over thousands of pairs incl. acronyms, legal forms, parentheticals, punctuation, Unicode); spec updated.

## Testing

- `cargo test` (score-core): 22/22; `cargo clippy --all-targets -- -D warnings` clean (score-core)
- `test_native_initialism_parity.py`: 3/3 (native == pure over the full adversarial corpus + bucket id-7 dispatch)
- Regression: cross-surface id-map + qgram/soundex parity + fast-path gate + vectorized fallback + `test_scorer.py` + arrow/stale-wheel bucket: 112 passed
- `gen_suite_matrix.py --check` OK (8/19); `check_native_symbols.py goldenmatch` OK; Python `scorer_kernels` emitter includes `initialism_match`
- Rebuilt the in-tree `_native.abi3.so` to exercise the native id-7 path

(The api_parity gate's TS-side emitter needs the built TS dist -- a CI-only surface; the TS `WASM_COVERED_SCORERS` is unchanged, so `scorer_kernels.ts_only` stays empty.)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (spec + regenerated suite-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_