### PR TITLE
feat(ts): port BlockingKeyConfig.field_transforms + exact fromSplink mixed-rule mapping (#1832)

### DIFF
--- a/packages/typescript/goldenmatch/src/core/blocker.ts
+++ b/packages/typescript/goldenmatch/src/core/blocker.ts
@@ -32,12 +32,18 @@ function buildBlockKey(
   keyConfig: BlockingKeyConfig,
 ): string | null {
   const parts: string[] = [];
+  const perField = keyConfig.fieldTransforms;
   for (const field of keyConfig.fields) {
     const raw = row[field];
     if (raw === null || raw === undefined) return null;
     const str = String(raw);
-    if (keyConfig.transforms.length > 0) {
-      const val = applyTransforms(str, keyConfig.transforms);
+    // #1832: a field listed in fieldTransforms derives its component with its
+    // OWN chain; others fall back to the key-level transforms. Mirrors Python
+    // blocker.py's per-field derivation so a Python-written config with per-field
+    // blocking transforms produces the SAME block membership here.
+    const transforms = perField?.[field] ?? keyConfig.transforms;
+    if (transforms.length > 0) {
+      const val = applyTransforms(str, transforms);
       if (val === null || val === undefined) return null;
       parts.push(val);
     } else {

--- a/packages/typescript/goldenmatch/src/core/config/from-splink.ts
+++ b/packages/typescript/goldenmatch/src/core/config/from-splink.ts
@@ -513,54 +513,66 @@ function convertOneBlockingRule(rule: unknown, idx: number, report: ConversionRe
     recognized.push(r);
   }
 
-  // Dedupe repeated fields (order-preserving): `l.a = r.a AND l.a = r.a` is
-  // one field, not two identical key components.
-  const fields: string[] = [];
-  for (const r of recognized) if (!fields.includes(r.field)) fields.push(r.field);
-
-  // BlockingKeyConfig.transforms is ONE chain applied uniformly to every
-  // field in the key -- there is no per-field transform slot. A mixed rule
-  // (plain equality on one column + SUBSTR on another) is therefore
-  // approximated as a single key carrying the substring transform for ALL
-  // fields. This is safe for blocking (candidate generation only needs to be
-  // a superset of true matches). If two conjuncts specify SUBSTR at
-  // different offsets, there is no single chain that represents both, so the
-  // rule is dropped.
-  const transformValues = new Set<string>(
-    recognized.filter((r) => r.transform !== null).map((r) => r.transform as string),
-  );
-  if (transformValues.size > 1) {
-    report.warn(rulePath, `conflicting SUBSTR offsets across fields, rule dropped: ${sqlNorm}`, null);
-    return null;
-  }
-  const transforms = transformValues.size > 0 ? [[...transformValues][0]!] : [];
-
-  const key: BlockingKeyConfig = { fields, transforms };
-  const plainFields: string[] = [];
+  // Per-field transform chain (order-preserving on first sight of each field).
+  // Each field derives its OWN block-key component via `field_transforms`, so a
+  // mixed rule (plain equality on one column + SUBSTR on another) maps EXACTLY
+  // rather than widening the SUBSTR to every field (the pre-#1832 lossy
+  // approximation). `l.a = r.a AND l.a = r.a` is still one field.
+  //
+  // Same-field collisions:
+  //   - two DIFFERENT SUBSTR offsets on one field have no representable chain
+  //     (neither offset subsumes the other) -> the rule is dropped;
+  //   - plain equality AND SUBSTR on one field keep the SUBSTR (it subsumes the
+  //     equality: `a = b` implies `substr(a) = substr(b)`), so candidates stay a
+  //     superset of Splink's.
+  const perFieldTransform = new Map<string, string | null>();
   for (const r of recognized) {
-    if (r.transform === null && !plainFields.includes(r.field)) plainFields.push(r.field);
+    const existing = perFieldTransform.get(r.field);
+    if (existing === undefined) {
+      perFieldTransform.set(r.field, r.transform);
+    } else if (existing === r.transform) {
+      // identical repeat -- nothing to do
+    } else if (existing !== null && r.transform !== null) {
+      report.warn(rulePath, `conflicting SUBSTR offsets on field ${r.field}, rule dropped: ${sqlNorm}`, null);
+      return null;
+    } else {
+      // one plain + one SUBSTR on the same field: keep the SUBSTR
+      perFieldTransform.set(r.field, existing ?? r.transform);
+    }
   }
-  if (transforms.length > 0 && plainFields.length > 0) {
-    // LOSSY: the key-level chain applies the substring transform to field(s)
-    // Splink compared with plain equality. Warn (not info) so strict=true
-    // gates on it, matching the approx-warn convention used for comparison
-    // levels above.
-    report.warn(
-      rulePath,
-      `approximate mapping, blocking key widened: ${transforms[0]} applied to all fields ` +
-        `including plain-equality field(s) ${JSON.stringify(plainFields)} (GoldenMatch transforms ` +
-        "are key-level); candidates are a superset of Splink's, precision may drop (superset " +
-        "guarantee assumes skip_oversized stays False, the converter's emitted default) " +
-        `(${sqlNorm})`,
-      null,
-    );
-  } else {
+
+  const fields = [...perFieldTransform.keys()];
+  const chainFor = (f: string): readonly string[] => {
+    const t = perFieldTransform.get(f);
+    return t != null ? [t] : [];
+  };
+
+  // Uniform iff every field carries the same transform value -- keep the
+  // key-level `transforms` representation (byte-compatible with pre-#1832 for
+  // all-plain and all-same-SUBSTR rules). Otherwise emit per-field chains.
+  const first = perFieldTransform.get(fields[0]!) ?? null;
+  const uniform = fields.every((f) => (perFieldTransform.get(f) ?? null) === first);
+
+  if (uniform) {
+    const transforms = first != null ? [first] : [];
+    const key: BlockingKeyConfig = { fields, transforms };
     report.info(
       rulePath,
       `converted to blocking key fields=${JSON.stringify(fields)} transforms=${JSON.stringify(transforms)}`,
       null,
     );
+    return key;
   }
+
+  const fieldTransforms: Record<string, readonly string[]> = {};
+  for (const f of fields) fieldTransforms[f] = chainFor(f);
+  const key: BlockingKeyConfig = { fields, transforms: [], fieldTransforms };
+  report.info(
+    rulePath,
+    `converted to blocking key with per-field transforms fields=${JSON.stringify(fields)} ` +
+      `fieldTransforms=${JSON.stringify(fieldTransforms)}`,
+    null,
+  );
   return key;
 }
 

--- a/packages/typescript/goldenmatch/src/core/config/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/config/loader.ts
@@ -138,7 +138,14 @@ function camelizeKeys(obj: unknown): unknown {
   if (typeof obj === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
-      result[snakeToCamel(key)] = camelizeKeys(val);
+      const camelKey = snakeToCamel(key);
+      // `field_transforms` is a map keyed by USER FIELD NAMES (data, not config
+      // keys). Preserve its value verbatim so a field like `first_name` keeps
+      // its key and still matches the `fields` array (#1832) -- recursing would
+      // rewrite the inner key to `firstName` and silently break the per-field
+      // lookup in buildBlockKey (the values are string[] chains, nothing to
+      // camelize anyway).
+      result[camelKey] = camelKey === "fieldTransforms" ? val : camelizeKeys(val);
     }
     return result;
   }
@@ -521,11 +528,24 @@ function parseBlockingKeyConfig(
   ctx: string,
 ): BlockingKeyConfig {
   const obj = asObj(raw, ctx);
+  // #1832: honor per-field transform chains so a Python-written config carrying
+  // `field_transforms` produces the SAME block membership in TS. Absent it, the
+  // loader dropped the key and blocks came out FINER than intended (silent
+  // recall loss vs the config's declared per-field derivation).
+  const fieldTransforms =
+    typeof obj.fieldTransforms === "object" && obj.fieldTransforms !== null
+      ? Object.fromEntries(
+          Object.entries(obj.fieldTransforms as Record<string, unknown>).map(
+            ([f, chain]) => [f, Array.isArray(chain) ? (chain as string[]) : []],
+          ),
+        )
+      : undefined;
   return {
     fields: Array.isArray(obj.fields) ? (obj.fields as string[]) : [],
     transforms: Array.isArray(obj.transforms)
       ? (obj.transforms as string[])
       : [],
+    ...(fieldTransforms !== undefined ? { fieldTransforms } : {}),
   };
 }
 

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -145,6 +145,14 @@ export type MatchkeyConfig =
 export interface BlockingKeyConfig {
   readonly fields: readonly string[];
   readonly transforms: readonly string[];
+  /**
+   * Per-field transform chains (#1826/#1832). A field listed here derives its
+   * block-key component with its OWN chain; fields absent here fall back to the
+   * key-level `transforms`. Mirrors Python `BlockingKeyConfig.field_transforms`,
+   * so a Python-written config with per-field blocking transforms produces the
+   * same block membership in the TS runtime instead of silently ignoring them.
+   */
+  readonly fieldTransforms?: Readonly<Record<string, readonly string[]>>;
 }
 
 export interface SortKeyField {

--- a/packages/typescript/goldenmatch/tests/unit/blocker.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/blocker.test.ts
@@ -66,6 +66,50 @@ describe("buildStaticBlocks", () => {
     expect(blocks[0]!.rows.length).toBe(2);
   });
 
+  it("honors per-field transforms (#1832): substr on one field, plain on the other", () => {
+    // fieldTransforms truncates `dob` to its year; `surname` stays plain. The
+    // two rows share year(dob) and surname, so they block together even though
+    // their full dob strings differ. A key-level chain (no fieldTransforms)
+    // would either truncate surname too or not truncate dob at all.
+    const rows: Row[] = [
+      { __row_id__: 0, surname: "Smith", dob: "1990-01-15" },
+      { __row_id__: 1, surname: "Smith", dob: "1990-11-30" },
+    ];
+    const config: BlockingConfig = makeBlockingConfig({
+      strategy: "static",
+      keys: [
+        {
+          fields: ["surname", "dob"],
+          transforms: [],
+          fieldTransforms: { dob: ["substring:0:4"] },
+        },
+      ],
+    });
+    const blocks = buildStaticBlocks(rows, config);
+    expect(blocks.length).toBe(1);
+    expect(blocks[0]!.rows.length).toBe(2);
+  });
+
+  it("per-field transforms keep distinct fields apart (#1832)", () => {
+    // Same surname + same dob-year would collide, but different years must not.
+    const rows: Row[] = [
+      { __row_id__: 0, surname: "Smith", dob: "1990-01-15" },
+      { __row_id__: 1, surname: "Smith", dob: "1991-01-15" },
+    ];
+    const config: BlockingConfig = makeBlockingConfig({
+      strategy: "static",
+      keys: [
+        {
+          fields: ["surname", "dob"],
+          transforms: [],
+          fieldTransforms: { dob: ["substring:0:4"] },
+        },
+      ],
+    });
+    const blocks = buildStaticBlocks(rows, config);
+    expect(blocks.length).toBe(0);
+  });
+
   it("oversized block with skipOversized=true is dropped", () => {
     const rows: Row[] = Array.from({ length: 10 }, (_, i) => ({
       __row_id__: i,

--- a/packages/typescript/goldenmatch/tests/unit/config-loader.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/config-loader.test.ts
@@ -73,6 +73,32 @@ describe("parseConfig", () => {
     expect(config.blocking?.keys.length).toBe(1);
   });
 
+  it("parses snake_case field_transforms with verbatim field-name keys (#1832)", () => {
+    // A Python-written config carries `field_transforms` keyed by field names
+    // (some snake_case). The outer key camelizes to `fieldTransforms`, but the
+    // INNER field-name keys must stay verbatim so they match the `fields` array
+    // and buildBlockKey's per-field lookup resolves.
+    const raw = {
+      blocking: {
+        strategy: "static",
+        keys: [
+          {
+            fields: ["surname", "first_name", "dob"],
+            transforms: [],
+            field_transforms: { dob: ["substring:0:4"], first_name: ["lowercase"] },
+          },
+        ],
+      },
+    };
+    const config = parseConfig(raw);
+    const key = config.blocking?.keys[0];
+    expect(key?.fields).toEqual(["surname", "first_name", "dob"]);
+    expect(key?.fieldTransforms).toEqual({
+      dob: ["substring:0:4"],
+      first_name: ["lowercase"],
+    });
+  });
+
   it("normalizes golden_rules.default -> defaultStrategy", () => {
     const raw = {
       golden_rules: {

--- a/packages/typescript/goldenmatch/tests/unit/from-splink.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/from-splink.test.ts
@@ -512,7 +512,10 @@ describe("convertBlocking", () => {
     expect(report.hasWarnings).toBe(false);
   });
 
-  it("widens a mixed equality+SUBSTR conjunction with a warning", () => {
+  it("maps a mixed equality+SUBSTR conjunction to per-field transforms (#1832)", () => {
+    // Pre-#1832 this widened the SUBSTR onto the plain-equality field and warned.
+    // Now each field derives its OWN block-key component via fieldTransforms, so
+    // the mapping is exact (no widening, no precision loss) and info-only.
     const rule = 'l."surname" = r."surname" AND SUBSTR(l."dob", 1, 4) = SUBSTR(r."dob", 1, 4)';
     const report = new ConversionReport();
     const config = convertBlocking([rule], report);
@@ -522,14 +525,22 @@ describe("convertBlocking", () => {
     expect(config?.keys.length).toBe(1);
     const key = config!.keys[0]!;
     expect(key.fields).toEqual(["surname", "dob"]);
-    expect(key.transforms).toEqual(["substring:0:4"]);
+    // Key-level transforms empty; per-field chains carry the exact mapping.
+    expect(key.transforms).toEqual([]);
+    expect(key.fieldTransforms).toEqual({ surname: [], dob: ["substring:0:4"] });
+    expect(report.hasWarnings).toBe(false);
+    expect(report.findings.filter((f) => f.severity === "info").length).toBe(1);
+  });
+
+  it("drops a rule with conflicting SUBSTR offsets on the SAME field (#1832)", () => {
+    const rule = 'SUBSTR(l."dob", 1, 4) = SUBSTR(r."dob", 1, 4) AND SUBSTR(l."dob", 1, 6) = SUBSTR(r."dob", 1, 6)';
+    const report = new ConversionReport();
+    const config = convertBlocking([rule], report);
+
+    expect(config).toBeNull();
     const warnings = report.findings.filter((f) => f.severity === "warning");
     expect(warnings.length).toBe(1);
-    expect(report.hasWarnings).toBe(true);
-    const msg = warnings[0]!.message;
-    expect(msg.includes("widened") || msg.includes("approximate")).toBe(true);
-    expect(msg).toContain("surname");
-    expect(msg).toContain("skip_oversized");
+    expect(warnings[0]!.message).toContain("conflicting SUBSTR offsets on field dob");
   });
 
   it("treats a pure SUBSTR rule as info-only", () => {
@@ -650,15 +661,20 @@ describe("convertBlocking", () => {
     expect(warnings[0]!.message).toContain("not a SQL string");
   });
 
-  it("drops a rule with conflicting SUBSTR offsets", () => {
+  it("maps different-field SUBSTR offsets to per-field transforms (#1832)", () => {
+    // Pre-#1832 different SUBSTR offsets across fields were unrepresentable
+    // (one key-level chain) so the whole rule was dropped. Per-field chains now
+    // carry each offset exactly.
     const rule = "SUBSTR(l.a, 1, 4) = SUBSTR(r.a, 1, 4) AND SUBSTR(l.b, 1, 2) = SUBSTR(r.b, 1, 2)";
     const report = new ConversionReport();
     const config = convertBlocking([rule], report);
 
-    expect(config).toBeNull();
-    const warnings = report.findings.filter((f) => f.severity === "warning");
-    expect(warnings.length).toBe(1);
-    expect(warnings[0]!.message).toContain("conflicting SUBSTR offsets");
+    expect(config).not.toBeNull();
+    const key = config!.keys[0]!;
+    expect(key.fields).toEqual(["a", "b"]);
+    expect(key.transforms).toEqual([]);
+    expect(key.fieldTransforms).toEqual({ a: ["substring:0:4"], b: ["substring:0:2"] });
+    expect(report.hasWarnings).toBe(false);
   });
 
   it("drops SUBSTR with start=0", () => {
@@ -709,7 +725,9 @@ describe("convertBlocking", () => {
 
     expect(config).not.toBeNull();
     expect(config?.keys[0]!.fields).toEqual(["surname", "dob"]);
-    expect(config?.keys[0]!.transforms).toEqual(["substring:0:4"]);
+    // #1832: mixed rule -> per-field chains, not a widened key-level transform.
+    expect(config?.keys[0]!.transforms).toEqual([]);
+    expect(config?.keys[0]!.fieldTransforms).toEqual({ surname: [], dob: ["substring:0:4"] });
   });
 
   it("strips whole-rule paren wrapping", () => {


### PR DESCRIPTION
## What and why

Fixes #1832 (P2) - the TS twin of the Python `field_transforms` work (#1831). Brings the edge-safe TS surface to parity: blocking keys can carry per-field transform chains, so a mixed plain-equality/SUBSTR Splink rule maps exactly instead of widening the whole key, and a Python-written config's `field_transforms` is no longer silently ignored (which produced FINER blocks than intended - silent recall loss).

## Changes

- **`src/core/types.ts`**: add optional `fieldTransforms` to `BlockingKeyConfig` (mirrors Python `BlockingKeyConfig.field_transforms`).
- **`src/core/blocker.ts`** `buildBlockKey`: a field listed in `fieldTransforms` derives its block-key component with its OWN chain; fields absent there fall back to the key-level `transforms`. Mirrors Python `blocker.py`'s per-field derivation, so a Python-written config yields the SAME block membership.
- **`src/core/config/from-splink.ts`** `convertOneBlockingRule`: emit `fieldTransforms` for mixed rules instead of widening the single transform onto every field (the pre-#1832 lossy approximation) or dropping different-field SUBSTR offsets. A single field carrying two DIFFERENT SUBSTR offsets is still dropped (unrepresentable - neither subsumes the other); plain-equality + SUBSTR on one field keeps the SUBSTR (superset-safe). All-uniform rules keep the byte-compatible key-level `transforms` shape.
- **`src/core/config/loader.ts`**: `parseBlockingKeyConfig` now parses `fieldTransforms`; `camelizeKeys` preserves its inner field-name keys verbatim (a recursive camelize would rewrite `first_name` to `firstName` and silently break the per-field lookup against the `fields` array).

## Testing

- `pnpm --filter goldenmatch typecheck` - clean (strict, `noUncheckedIndexedAccess` + `exactOptionalPropertyTypes`).
- `pnpm --filter goldenmatch test` - 3148 passed, 1 expected fail, 17 skipped.
- New/updated tests: mixed-rule per-field emission + same-field/different-field SUBSTR offset cases (from-splink); per-field block membership, both agreeing and diverging (blocker); snake_case `field_transforms` round-trip with verbatim field-name keys (config-loader).

## Notes

- TS-only parity port; no Python or runtime-behavior change on the Python side. FS/WASM is unaffected (blocking-key derivation and `fromSplink` are pure-TS, not the wasm scorer path).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `pnpm --filter goldenmatch typecheck` clean
- [ ] Package `CHANGELOG.md` updated if behavior changed (no TS package CHANGELOG.md exists; wave history lives in the package CLAUDE.md)
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_