### PR TITLE
feat(score): kernelize alias_match into the bucket path (Wave 2, 8/19 -> 9/19)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**8 of 19 scorers are kernel-backed** (the reference fast path); the other 11 are pure-language fallbacks with no `-core` kernel.
+**9 of 19 scorers are kernel-backed** (the reference fast path); the other 10 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `date`, `initialism_match`, `qgram`, `soundex_match` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `date`, `initialism_match`, `qgram`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `alias_match`, `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
+| Language fallback — no `-core` kernel | `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -352,6 +352,7 @@
           "defines": [
             "_bkt_debug_on",
             "_default_n_buckets",
+            "_ensure_alias_tables_installed",
             "_ensure_legal_forms_installed",
             "_fs_bounded_stream_enabled",
             "_fs_bucket_native_enabled",
@@ -379,6 +380,7 @@
             "goldenmatch.core.probabilistic",
             "goldenmatch.core.scorer",
             "goldenmatch.plugins.registry",
+            "goldenmatch.refdata",
             "goldenmatch.refdata.business"
           ]
         },

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -1,7 +1,7 @@
 # Full `-core` kernel coverage for the scorer surface (5/19 -> full)
 
 **Date:** 2026-07-21
-**Status:** Proposed (scoping / design). **Landing incrementally:** `qgram` (5/19 -> 6/19) and `soundex_match` (6/19 -> 7/19) landed in Wave 1; `initialism_match` (7/19 -> 8/19) is the first Wave-2 cut; the baseline figures below describe the pre-work starting point.
+**Status:** Proposed (scoping / design). **Landing incrementally:** `qgram` (5/19 -> 6/19) and `soundex_match` (6/19 -> 7/19) landed in Wave 1; `initialism_match` (7/19 -> 8/19) and `alias_match` (8/19 -> 9/19) are the first Wave-2 cuts; the baseline figures below describe the pre-work starting point.
 **Motivation:** The generated suite-matrix reports **"5 of 19 scorers are kernel-backed"**
 (`docs-site/suite-matrix.mdx`, computed by `gen_suite_matrix.py::_substrate_lines` from the
 `scorer_kernels` parity surface). This spec scopes what it takes to close that gap -- and argues
@@ -20,9 +20,9 @@ The other **14 were fallback-only** at that baseline: `dice`, `jaccard`, `qgram`
 `ensemble`, `embedding`, `record_embedding`, `alias_match`, `audio_fp`, `initialism_match`, `phash`,
 `radial`, `given_name_aliased_jw`, `name_freq_weighted_jw`.
 
-**Update:** `qgram` and `soundex_match` (Wave 1) and `initialism_match` (Wave 2 start) are now
-kernelized -- each has a `score-core` kernel on the Python arrow-bucket fast path, so the current
-state is **8/19** with **11** fallbacks remaining. All three read as `python_only` in the
+**Update:** `qgram` and `soundex_match` (Wave 1) and `initialism_match` + `alias_match` (Wave 2
+start) are now kernelized -- each has a `score-core` kernel on the Python arrow-bucket fast path, so
+the current state is **9/19** with **10** fallbacks remaining. All read as `python_only` in the
 `scorer_kernels` partition (no TS WASM port yet, like `date`). `soundex_match`'s kernel replicates
 `jellyfish.soundex` byte-for-byte INCLUDING its Unicode step (NFKD normalize + `str.upper` via the
 `unicode-normalization` crate), so native==pure on leading non-alpha / accented input too -- which
@@ -33,7 +33,14 @@ table argument without breaking the uniform `(id, a, b)` dispatch, the ~77-entry
 `entity_form_variants()` set is installed once into a process-global `OnceLock` via a native
 `set_legal_form_variants` shim, and the Python fast-path guard routes native only when BOTH the
 `initialism_similarity` capability symbol is present AND the install succeeded (else it declines to
-the pure `_initialism_match_single` mirror).
+the pure `_initialism_match_single` mirror). `alias_match` (`score_one` id 8) ports the business +
+given-name canonicalization (`refdata.business_aliases.canonical_company_form` +
+`given_names.canonical_form` + `_alias_match_single`) byte-for-byte: the kernel rebuilds the
+`strip_legal_form` trailing-suffix regex from a host-shipped variant list (via the `regex` crate) and
+looks up two host-installed maps -- the business `surface->canonical` map and a PRE-RESOLVED given-name
+`normalized -> min(canonical)` map (the lex-first resolution is done host-side, so the kernel needs no
+alias graph). Same two-part guard (`set_business_aliases`/`set_given_name_canonicals` +
+`alias_match_similarity` symbol) declining to the pure `_alias_match_single` mirror.
 
 "Kernel-backed" in the metric means *a kernel exists in at least one language* (a union), so the
 denominator (19) also counts scorers that live in only one language. The metric is emitted by
@@ -76,7 +83,7 @@ each replaces an O(N^2) pure-Python double loop.
 | `initialism_match` ✅ | `core/scorer.py:101`, `:716` | `1.0` if one string is the other's initialism (`derive_initialism`) | **landed** -- `score_one` id 7; needed the legal-form table in-kernel (installed once via a global `OnceLock` + `set_legal_form_variants` shim, keeping the `(id, a, b)` dispatch uniform) |
 | `given_name_aliased_jw` | `refdata/scorer.py:177` | `max(jw, 1.0 if known given-name alias)` (William<->Bill) | needs the alias table in-kernel |
 | `name_freq_weighted_jw` | `refdata/scorer.py:69` | `jw * (floor + (1-floor)*mean_rarity)` from census/`tf_freqs` | needs the freq table in-kernel; TS port is static-only (declared delta) |
-| `alias_match` | `core/scorer.py:125`, `:741` | `1.0` if same business/given-name canonical | needs canonicalization tables in-kernel |
+| `alias_match` ✅ | `core/scorer.py:125`, `:741` | `1.0` if same business/given-name canonical | **landed** -- `score_one` id 8; ships the business alias + strip-legal-form variant + pre-resolved given-name maps in-kernel (the lex-first resolution done host-side), rebuilding the strip regex via the `regex` crate |
 
 The in-kernel-table mechanism already exists: `native/src/score.rs::set_name_reference_data`
 (`:56`) / `has_name_reference_data` (`:72`). `name_freq_weighted_jw` already threads a `tf_freqs=`
@@ -108,7 +115,7 @@ minimal. Recommend **defer or explicitly decline**.
 | Wave | Scorers | Risk | Rationale |
 |---|---|---|---|
 | **1** | `qgram` ✅, `soundex_match` ✅ (both landed) | low | pure strings on the proven template; `soundex_match` reused the existing Rust kernel, upgraded to full jellyfish Unicode parity |
-| **2** | `initialism_match` ✅ (landed), `given_name_aliased_jw`, `name_freq_weighted_jw`, `alias_match` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk. `initialism_match` proved the in-kernel table mechanism: the ~77-entry `entity_form_variants()` set is installed once into a `score-core` `OnceLock` via a native `set_legal_form_variants` shim, keeping `score_one(id, a, b)` uniform |
+| **2** | `initialism_match` ✅, `alias_match` ✅ (both landed), `given_name_aliased_jw`, `name_freq_weighted_jw` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk. `initialism_match` proved the in-kernel table mechanism (the ~77-entry `entity_form_variants()` set installed once into a `score-core` `OnceLock` via a native `set_legal_form_variants` shim, keeping `score_one(id, a, b)` uniform); `alias_match` extended it to two maps + a rebuilt-in-kernel strip regex |
 | **3** | `phash`, `dice`, `jaccard` | low-med | wiring existing kernels (`perceptual-core`, `bloom.rs`), not new algorithms |
 | **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |
 | **4 (defer/decline)** | `audio_fp`, `radial` | -- | bespoke alignment search, low perf upside |
@@ -127,8 +134,9 @@ on us, and step 4 is the real work.
    (`pub fn <scorer>_similarity` + a `score_one` id, or a dedicated fn). Exports today:
    `jaro_winkler_similarity`, `levenshtein_similarity`, `token_sort_ratio`,
    `token_sort_normalized_ratio`, `date_similarity`, `qgram_similarity`, `soundex`,
-   `set_legal_forms` + `initialism_match`, `score_one(id: 0..7)` (id 5 = qgram, id 6 =
-   soundex_match, id 7 = initialism_match against the installed legal-form set).
+   `set_legal_forms` + `initialism_match`, `set_business_aliases` + `set_given_name_canonicals` +
+   `alias_match`, `score_one(id: 0..8)` (id 5 = qgram, id 6 = soundex_match, id 7 = initialism_match
+   against the installed legal-form set, id 8 = alias_match against the installed alias tables).
 2. **`native` wheel** (`packages/rust/extensions/native/src/score.rs`): add a `#[pyfunction]` shim,
    register it in `native/src/lib.rs` (`m.add_function(...)` -- required for the `native_symbols`
    gate), and wire the id into `score_field_matrix` (`:1220`) and/or `score_block_pairs*`.

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -243,6 +243,14 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # legal-form set until the host ships `entity_form_variants()`), else it
     # declines to the pure-Python per-pair mirror (`_initialism_match_single`).
     "initialism_match": 7,
+    # id 8 = alias_match (business + given-name canonical equality, score-core
+    # score_one). Two-part wheel-skew guard at the gating site below: routing to
+    # native id 8 requires BOTH the `alias_match_similarity` capability symbol (a
+    # stale pre-alias wheel hits score_one's catch-all -> silent 0.0) AND a
+    # successful install of the business + given-name tables (id 8 scores against
+    # empty tables until the host ships them), else it declines to the pure-Python
+    # per-pair mirror (`_alias_match_single`).
+    "alias_match": 8,
 }
 
 
@@ -287,6 +295,70 @@ def _ensure_legal_forms_installed() -> bool:
     except Exception:
         _LEGAL_FORMS_INSTALLED = False
     return _LEGAL_FORMS_INSTALLED
+
+
+# Same tri-state as _LEGAL_FORMS_INSTALLED, for the alias_match business +
+# given-name canonical tables.
+_ALIAS_TABLES_INSTALLED: bool | None = None
+
+
+def _ensure_alias_tables_installed() -> bool:
+    """Install the business + given-name canonical tables into score-core's
+    process-global state (via the native ``set_business_aliases`` /
+    ``set_given_name_canonicals`` shims) exactly once, so ``score_one`` id 8
+    (alias_match) canonicalizes the same way the pure ``_alias_match_single`` does.
+
+    Ships:
+      * business ``strip_legal_form`` variants (``business._state.variants_normalized``)
+        -- rebuilt kernel-side into the trailing-suffix regex -- plus the raw
+        ``surface_to_canonical`` alias map.
+      * a PRE-RESOLVED given-name ``normalized -> min(canonical set)`` map, so the
+        kernel needs no alias graph, only a normalize + lookup.
+
+    Returns True once installed on a kernel exposing ``set_business_aliases``,
+    ``set_given_name_canonicals`` AND ``alias_match_similarity``; False when the
+    loaded kernel lacks a symbol (a stale pre-alias wheel) or the refdata packs
+    are unavailable, so the gating site declines the native id-8 route and lets
+    the pure ``_alias_match_single`` mirror score the block. Idempotent +
+    memoized; the OnceLocks are first-wins and the tables are deterministic.
+    """
+    global _ALIAS_TABLES_INSTALLED
+    if _ALIAS_TABLES_INSTALLED is not None:
+        return _ALIAS_TABLES_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_business_aliases")
+        or not hasattr(_mod, "set_given_name_canonicals")
+        or not hasattr(_mod, "alias_match_similarity")
+    ):
+        _ALIAS_TABLES_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata import business as _business
+        from goldenmatch.refdata import business_aliases as _ba
+        from goldenmatch.refdata import given_names as _gn
+
+        _business._load()
+        _ba._load()
+        _gn._load()
+        # Refdata packs must be present for the kernel to canonicalize; without
+        # them the pure mirror is the only faithful path.
+        if _business._state is None or _ba._state is None or _gn._state is None:
+            _ALIAS_TABLES_INSTALLED = False
+            return False
+        # Bool returns (first-wins) intentionally ignored: deterministic content.
+        _mod.set_business_aliases(
+            list(_business._state.variants_normalized),
+            list(_ba._state.surface_to_canonical.items()),
+        )
+        _mod.set_given_name_canonicals(
+            [(k, min(v)) for k, v in _gn._state.canonicals.items()]
+        )
+        _ALIAS_TABLES_INSTALLED = True
+    except Exception:
+        _ALIAS_TABLES_INSTALLED = False
+    return _ALIAS_TABLES_INSTALLED
 
 
 # Single source in core._hashing (re-exported here for back-compat). The
@@ -394,6 +466,19 @@ def _resolve_score_pair_callable(
         # declines to THIS mirror otherwise.
         from goldenmatch.core.scorer import _initialism_match_single
         return _initialism_match_single
+    if scorer_name == "alias_match":
+        # Business + given-name canonical equality (1.0/0.0). Per-pair mirror of
+        # the matrix path (core/scorer.py:_alias_score_matrix) AND of
+        # score-core::alias_match (native id 8); parity-asserted in
+        # tests/test_native_alias_parity.py. Making it fast-path eligible routes
+        # alias_match configs through the bucket backend (native id 8 or this
+        # per-pair mirror) instead of the slow matrix path. The native id-8 kernel
+        # needs the business + given-name tables installed
+        # (`set_business_aliases`/`set_given_name_canonicals`); the gating site
+        # below guards on both the `alias_match_similarity` symbol AND a successful
+        # install, and declines to THIS mirror otherwise.
+        from goldenmatch.core.scorer import _alias_match_single
+        return _alias_match_single
     if scorer_name == "dice":
         # Delegate to the existing per-pair implementation in core/scorer.py
         # (_dice_score_single, bigram set Dice coefficient). Matrix path is
@@ -1118,6 +1203,13 @@ def score_buckets(
             # forms. Only evaluated when a field actually uses initialism (avoids
             # the refdata load + install on every unrelated block).
             _initialism_ok = has_initialism and _ensure_legal_forms_installed()
+            has_alias = any(spec[3] == "alias_match" for spec in _field_specs)
+            # alias_match (id 8) has the same TWO-part guard as initialism: the
+            # capability symbol AND a successful business+given-name table install
+            # (id 8 scores against empty tables until the host ships them).
+            # `_ensure_alias_tables_installed` folds both into one memoized bool;
+            # only evaluated when a field actually uses alias_match.
+            _alias_ok = has_alias and _ensure_alias_tables_installed()
             # Wheel-skew: decline native entirely when a field uses a scorer whose
             # capability symbol the loaded kernel lacks (score_one would silently
             # zero that id); the pure-Python per-pair mirror scores the block.
@@ -1126,6 +1218,7 @@ def score_buckets(
                 or (has_qgram and not _qgram_ok)
                 or (has_soundex and not _soundex_ok)
                 or (has_initialism and not _initialism_ok)
+                or (has_alias and not _alias_ok)
             )
             if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -42,7 +42,7 @@ class TestNativeScorerIdMaps:
     # 4=date/5=qgram/6=soundex_match; in the field-matrix map 4=soundex_match.
     # `soundex_match` therefore lives in BOTH maps at DIFFERENT ids (bucket 6,
     # field 4); the two are pinned separately so they can't silently collide.
-    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7}
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7, "alias_match": 8}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):

--- a/packages/python/goldenmatch/tests/test_native_alias_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_alias_parity.py
@@ -1,0 +1,145 @@
+"""Parity for the alias_match bucket kernel (score-core id 8) vs the pure Python
+reference `_alias_match_single`.
+
+Wave 2 moves `alias_match` into `score-core` (`canonical_company_form` +
+`canonical_form` + `_alias_match_single`, byte-for-byte with
+`refdata.business_aliases` / `refdata.given_names` / `core.scorer`) and wires it
+into the *bucket* path via `score_one` id 8, so `alias_match` becomes
+kernel-backed in the metric (the scorer_kernels surface reads the bucket
+`_NATIVE_SCORER_IDS`).
+
+Like initialism_match, id 8 reads host-installed tables (business legal-form
+variants + surface->canonical map; a pre-resolved given-name
+`normalized -> min(canonical)` map). Without them, id 8 canonicalizes nothing and
+diverges. Every test installs both tables first, exactly as the fast-path guard
+(`_ensure_alias_tables_installed`) does before routing alias_match native.
+
+Parity means native `alias_match_similarity(a, b)` (and the bucket id-8 dispatch)
+is bit-identical to `_alias_match_single(a, b)` over adversarial input: business
+names with legal-form suffixes (single + compound + multi-word), alias-map
+surfaces (Google/Alphabet), given-name nicknames, casing, punctuation, empties.
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.core.scorer import _alias_match_single
+
+
+def _install(n) -> bool:
+    from goldenmatch.refdata import business as _business
+    from goldenmatch.refdata import business_aliases as _ba
+    from goldenmatch.refdata import given_names as _gn
+
+    _business._load()
+    _ba._load()
+    _gn._load()
+    if _business._state is None or _ba._state is None or _gn._state is None:
+        return False
+    n.set_business_aliases(
+        list(_business._state.variants_normalized),
+        list(_ba._state.surface_to_canonical.items()),
+    )
+    n.set_given_name_canonicals([(k, min(v)) for k, v in _gn._state.canonicals.items()])
+    return True
+
+
+def _mirror(a: str, b: str) -> float:
+    return _alias_match_single(a, b)
+
+
+# Adversarial vocabulary: business surfaces + legal-form suffixes (single,
+# compound, multi-word), alias-map pairs, given-name nicknames, punctuation,
+# casing, empties.
+_VOCAB = [
+    "Acme Inc", "Acme Incorporated", "Acme, LLC", "Acme Holdings Inc.",
+    "Acme Limited Liability Company", "Acme", "acme", "ACME CORP",
+    "Google", "Alphabet", "Google Inc", "Facebook", "Meta", "Globex", "Initech",
+    "Bob", "Robert", "Bill", "William", "Kate", "Catherine", "Bobby", "Will",
+    "Xavier", "Zelda", "", "   ", "...", "-", "Co", "Ltd", "GmbH",
+    "Jones & Co", "Smith Ltd.", "Nestlé S.A.", "Société Générale",
+]
+
+
+def _corpus() -> list[tuple[str, str]]:
+    rng = random.Random(20260721)
+    comps = ["Acme", "Google", "Alphabet", "Facebook", "Meta", "Globex", "Initech",
+             "Umbrella", "Wayne", "Stark"]
+    forms = ["Inc", "Inc.", "LLC", "Ltd", "GmbH", "Corp", "Corporation", "Holdings",
+             "Company", "Co", "Limited Liability Company", ""]
+    givens = ["Bob", "Robert", "Bill", "William", "Kate", "Catherine", "Bobby",
+              "Will", "Kathy", "Xavier", "Zelda", "Rob"]
+    def mk() -> str:
+        r = rng.random()
+        if r < 0.45:
+            return (rng.choice(comps) + " " + rng.choice(forms)).strip()
+        if r < 0.85:
+            return rng.choice(givens)
+        return "".join(rng.choice("abcABC .,-") for _ in range(rng.randint(0, 10)))
+    pairs = [(x, y) for x in _VOCAB for y in _VOCAB]  # every ordered pair incl self
+    pairs += [(mk(), mk()) for _ in range(3000)]
+    return pairs
+
+
+def test_alias_native_matches_pure_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "alias_match_similarity"):
+        pytest.skip("native alias kernel not built / wheel predates alias_match_similarity")
+    if not _install(n):
+        pytest.skip("refdata packs unavailable")
+    for a, b in _corpus():
+        assert n.alias_match_similarity(a, b) == _mirror(a, b), f"alias {a!r} {b!r}"
+
+
+def test_alias_business_and_given_name_paths():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "alias_match_similarity"):
+        pytest.skip("native alias kernel not built")
+    if not _install(n):
+        pytest.skip("refdata packs unavailable")
+    # Business: legal-form strip (single, iterative compound, multi-word) + alias map.
+    assert n.alias_match_similarity("Acme Inc", "Acme Incorporated") == 1.0
+    assert n.alias_match_similarity("Acme, LLC", "Acme") == 1.0
+    assert n.alias_match_similarity("Acme Holdings Inc.", "acme") == 1.0
+    assert n.alias_match_similarity("Acme Limited Liability Company", "Acme") == 1.0
+    assert n.alias_match_similarity("Google", "Alphabet") == _mirror("Google", "Alphabet")
+    assert n.alias_match_similarity("Acme", "Globex") == 0.0
+    # Given-name: nickname canonical equality (+ a non-match).
+    assert n.alias_match_similarity("Bob", "Robert") == 1.0
+    assert n.alias_match_similarity("Kate", "Catherine") == 1.0
+    assert n.alias_match_similarity("Bob", "Bill") == 0.0
+    # Empty both -> no canonical -> 0.0.
+    assert n.alias_match_similarity("", "") == 0.0
+
+
+def test_alias_bucket_kernel_id8_matches_mirror():
+    """score_block_pairs dispatching scorer id 8 == the pure per-pair mirror.
+
+    One block, one alias_match field, weight 1.0, threshold 0.0 so every pair
+    emits; the kernel's per-pair score must equal the mirror.
+    """
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "alias_match_similarity"):
+        pytest.skip("native alias kernel not built")
+    if not _install(n):
+        pytest.skip("refdata packs unavailable")
+
+    values = ["Acme Inc", "Acme Incorporated", "Google", "Alphabet", "Bob", "Robert"]
+    row_ids = list(range(len(values)))
+    sizes = [len(values)]
+    field_values = [values]
+    ids = [8]                          # alias_match
+    weights = [1.0]
+    total_weight = 1.0
+    threshold = 0.0
+    emitted = n.score_block_pairs(
+        row_ids, sizes, field_values, ids, weights, total_weight, threshold, []
+    )
+    got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+    for i in range(len(values)):
+        for j in range(i + 1, len(values)):
+            expected = _mirror(values[i], values[j])
+            if expected >= threshold:
+                assert got[(i, j)] == expected, f"{values[i]!r} {values[j]!r}"

--- a/packages/rust/extensions/native/Cargo.lock
+++ b/packages/rust/extensions/native/Cargo.lock
@@ -603,6 +603,7 @@ name = "goldenmatch-score-core"
 version = "0.1.0"
 dependencies = [
  "rapidfuzz",
+ "regex",
  "unicode-normalization",
 ]
 

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -102,6 +102,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::soundex_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::set_legal_form_variants, m)?)?;
     m.add_function(wrap_pyfunction!(score::initialism_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::set_business_aliases, m)?)?;
+    m.add_function(wrap_pyfunction!(score::set_given_name_canonicals, m)?)?;
+    m.add_function(wrap_pyfunction!(score::alias_match_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -283,6 +283,38 @@ pub fn initialism_similarity(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::score_one(7, a, b)
 }
 
+/// Install the business alias table for `alias_match` (score-core id 8): the
+/// normalized legal-form variant list (rebuilt into the strip-legal-form regex)
+/// + the surface->canonical alias map. `OnceLock` first-wins (returns `True`
+/// only on the first call). Must be called before routing alias_match native.
+#[pyfunction]
+pub fn set_business_aliases(
+    variants: Vec<String>,
+    surface_to_canonical: Vec<(String, String)>,
+) -> bool {
+    goldenmatch_score_core::set_business_aliases(variants, surface_to_canonical)
+}
+
+/// Install the given-name canonical map for `alias_match`: `normalized ->
+/// min(canonical set)` (lex-first resolution done host-side). `OnceLock`
+/// first-wins. Must be called before routing alias_match native.
+#[pyfunction]
+pub fn set_given_name_canonicals(pairs: Vec<(String, String)>) -> bool {
+    goldenmatch_score_core::set_given_name_canonicals(pairs)
+}
+
+/// Alias-match similarity (score-core id 8): 1.0 iff both values share a
+/// non-empty business OR given-name canonical, against the globally-installed
+/// tables. Own #[pyfunction] capability marker like the other bucket kernels: a
+/// stale published wheel lacking this symbol would hit score_one's catch-all
+/// (silent 0.0) for id 8, so the Python caller gates the native route on
+/// `hasattr(_native, "alias_match_similarity")` AND a successful table install,
+/// falling back to the pure `_alias_match_single` mirror otherwise.
+#[pyfunction]
+pub fn alias_match_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::score_one(8, a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)

--- a/packages/rust/extensions/score-core/Cargo.toml
+++ b/packages/rust/extensions/score-core/Cargo.toml
@@ -24,3 +24,17 @@ rapidfuzz = "0.5.0"
 # `soundex` replicates `jellyfish.soundex` byte-for-byte, incl. its Unicode step
 # `unicodedata.normalize("NFKD", s).upper()`; this provides the NFKD normalizer.
 unicode-normalization = "0.1"
+# `alias_match`'s business canonicalization ports `refdata.business.strip_legal_form`,
+# which strips a trailing legal-form suffix via a data-built regex
+# `[\s,\-.]+(?:<variant>...)[\s.,]*$` (IGNORECASE). Rebuilt here from the host-shipped
+# variant list so the kernel canonicalizes byte-for-byte with the Python reference.
+# OPTIONAL behind the default `alias` feature: `alias_match` (id 8) is a Python-bucket
+# kernel only, so the wasm surface (`score-wasm`) turns the feature OFF to keep the
+# heavy `regex` engine out of the edge bundle. `native`/`datafusion-udf` inherit the
+# default and get it.
+regex = { version = "1", optional = true }
+
+[features]
+default = ["alias"]
+# `alias` pulls in `regex` and compiles the alias_match (score_one id 8) subsystem.
+alias = ["dep:regex"]

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -11,6 +11,11 @@
 use rapidfuzz::distance::{damerau_levenshtein, jaro_winkler, levenshtein};
 use rapidfuzz::fuzz;
 use unicode_normalization::UnicodeNormalization;
+// `alias_match` (score_one id 8) + its `regex`-backed strip_legal_form live behind
+// the default `alias` feature; `pub use` re-exports the public fns at the crate
+// root so callers keep the flat `goldenmatch_score_core::{alias_match, ...}` path.
+#[cfg(feature = "alias")]
+pub use alias::{alias_match, set_business_aliases, set_given_name_canonicals};
 
 // Fellegi–Sunter EM training core (pyo3-free numeric heart). PR-C / C1 of the
 // FS Rust+Arrow-only epic; the `native` crate will add the Arrow/#[pyfunction]
@@ -390,9 +395,183 @@ fn legal_forms() -> &'static std::collections::HashSet<String> {
     LEGAL_FORMS.get_or_init(std::collections::HashSet::new)
 }
 
+// ---- alias_match (business + given-name canonical equality) ------------------
+// Ports `refdata.business_aliases.canonical_company_form` +
+// `refdata.given_names.canonical_form` + `core.scorer._alias_match_single`. Two
+// host-installed tables keep `score_one(id, a, b)` uniform (no per-call table arg):
+//  * business: the `strip_legal_form` variant list, rebuilt here into the SAME
+//    trailing-suffix regex Python compiles, plus the surface->canonical alias map.
+//  * given-name: a PRE-RESOLVED `normalized -> min(canonical set)` map -- the
+//    Python `min(canon_set)` lex-first resolution is done host-side, so the kernel
+//    needs no alias graph, only a normalize + lookup.
+#[cfg(feature = "alias")]
+mod alias {
+    use regex::Regex;
+
+struct BusinessAliasTable {
+    strip_re: Regex,
+    surface_to_canonical: std::collections::HashMap<String, String>,
+}
+
+static BUSINESS_ALIAS: std::sync::OnceLock<BusinessAliasTable> = std::sync::OnceLock::new();
+static GIVEN_NAME_CANON: std::sync::OnceLock<std::collections::HashMap<String, String>> =
+    std::sync::OnceLock::new();
+
+/// Collapse whitespace runs to a single space and trim, mirroring Python
+/// `re.sub(r"\s+", " ", s).strip()`. NOTE: `char::is_whitespace()` uses the
+/// Unicode White_Space property, which (like the `regex` crate's `\s`) differs
+/// from Python `re`'s `\s` on the C1 separators `\x1c`-`\x1f`/`\x85`; an
+/// ASCII-scoped parity edge shared with the other refdata ports (business names
+/// are ASCII/Latin in practice).
+fn collapse_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_ws = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !prev_ws {
+                out.push(' ');
+            }
+            prev_ws = true;
+        } else {
+            out.push(ch);
+            prev_ws = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Rust port of `refdata.business.strip_legal_form`: whitespace-collapse, then
+/// iteratively (bounded to 4, like Python) remove a trailing legal-form suffix
+/// via the installed regex. The `$`-anchored pattern strips exactly the LAST
+/// token per pass, so compound suffixes ("Acme Holdings Inc.") peel one at a time.
+fn strip_legal_form(value: &str, table: &BusinessAliasTable) -> String {
+    let mut cleaned = collapse_ws(value);
+    if cleaned.is_empty() {
+        return cleaned;
+    }
+    for _ in 0..4 {
+        // `Regex::replace` == Python `pattern.sub("", ...)`: the `$` anchor admits
+        // one match, then `.trim()` mirrors the Python `.strip()`.
+        let new = table.strip_re.replace(&cleaned, "").trim().to_string();
+        if new == cleaned || new.is_empty() {
+            // Python: `cleaned = new if new else cleaned` -- keep `cleaned` when a
+            // strip would empty the string; otherwise `new == cleaned` (no-op).
+            if !new.is_empty() {
+                cleaned = new;
+            }
+            break;
+        }
+        cleaned = new;
+    }
+    cleaned
+}
+
+/// Business `_normalize`: `strip_legal_form` -> whitespace-collapse -> lowercase,
+/// byte-for-byte with `refdata.business_aliases._normalize`.
+fn business_normalize(name: &str, table: &BusinessAliasTable) -> String {
+    let stripped = strip_legal_form(name, table);
+    collapse_ws(&stripped).to_lowercase()
+}
+
+/// `refdata.business_aliases.canonical_company_form` (table always installed here):
+/// normalize, then map surface->canonical with a passthrough default.
+fn canonical_company_form(name: &str, table: &BusinessAliasTable) -> String {
+    let norm = business_normalize(name, table);
+    if norm.is_empty() {
+        return String::new();
+    }
+    table
+        .surface_to_canonical
+        .get(&norm)
+        .cloned()
+        .unwrap_or(norm)
+}
+
+/// Given-name `_normalize`: keep only alphabetic chars, lowercase -- byte-for-byte
+/// with `refdata.given_names._normalize` (`"".join(c for c in s if c.isalpha()).lower()`).
+fn given_normalize(name: &str) -> String {
+    name.chars()
+        .filter(|c| c.is_alphabetic())
+        .collect::<String>()
+        .to_lowercase()
+}
+
+/// `refdata.given_names.canonical_form` via the pre-resolved lex-first map:
+/// normalize, then look up `min(canonical set)` with a passthrough default.
+fn canonical_given_form(name: &str, gmap: &std::collections::HashMap<String, String>) -> String {
+    let norm = given_normalize(name);
+    if norm.is_empty() {
+        return String::new();
+    }
+    gmap.get(&norm).cloned().unwrap_or(norm)
+}
+
+/// Install the business alias table. `variants` are the normalized legal-form
+/// variants (`refdata.business._state.variants_normalized`), rebuilt here into the
+/// SAME regex Python compiles -- `[\s,\-.]+(?:v...)[\s.,]*$` (IGNORECASE), variants
+/// sorted DESCENDING by char length so multi-word forms are preferred (Python's
+/// `sorted(key=lambda s: (-len(s), s))`). `surface_to_canonical` is the raw alias
+/// map. `OnceLock` first-wins; returns `false` if already set or the regex fails.
+pub fn set_business_aliases(
+    variants: Vec<String>,
+    surface_to_canonical: Vec<(String, String)>,
+) -> bool {
+    let mut sorted = variants;
+    sorted.sort_by(|a, b| {
+        b.chars()
+            .count()
+            .cmp(&a.chars().count())
+            .then_with(|| a.cmp(b))
+    });
+    let alt = sorted
+        .iter()
+        .map(|v| regex::escape(v))
+        .collect::<Vec<_>>()
+        .join("|");
+    let pattern = format!(r"(?i)[\s,\-.]+(?:{alt})[\s.,]*$");
+    let strip_re = match Regex::new(&pattern) {
+        Ok(re) => re,
+        Err(_) => return false,
+    };
+    BUSINESS_ALIAS
+        .set(BusinessAliasTable {
+            strip_re,
+            surface_to_canonical: surface_to_canonical.into_iter().collect(),
+        })
+        .is_ok()
+}
+
+/// Install the given-name canonical map (`normalized -> min(canonical set)`,
+/// lex-first resolution done host-side). `OnceLock` first-wins.
+pub fn set_given_name_canonicals(pairs: Vec<(String, String)>) -> bool {
+    GIVEN_NAME_CANON.set(pairs.into_iter().collect()).is_ok()
+}
+
+/// `1.0` if both values canonicalize to the same NON-EMPTY business alias OR the
+/// same given-name canonical; else `0.0`. Byte-for-byte with
+/// `_alias_match_single`. Returns `0.0` for a half whose table isn't installed --
+/// the Python fast-path guard requires BOTH installed before routing here.
+pub fn alias_match(a: &str, b: &str) -> f64 {
+    if let Some(table) = BUSINESS_ALIAS.get() {
+        let cb_a = canonical_company_form(a, table);
+        if !cb_a.is_empty() && cb_a == canonical_company_form(b, table) {
+            return 1.0;
+        }
+    }
+    if let Some(gmap) = GIVEN_NAME_CANON.get() {
+        let cg_a = canonical_given_form(a, gmap);
+        if !cg_a.is_empty() && cg_a == canonical_given_form(b, gmap) {
+            return 1.0;
+        }
+    }
+    0.0
+}
+} // mod alias
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
-/// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match, 7=initialism_match.
+/// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match, 7=initialism_match,
+/// 8=alias_match.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -424,6 +603,14 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         // `_initialism_match_single`; the Python fast-path guard requires the
         // table to be installed before routing here.
         7 => initialism_match(a, b, legal_forms()),
+        // id=8 = alias_match: 1.0 iff both values share a non-empty business OR
+        // given-name canonical, against the host-installed tables (empty until
+        // `set_business_aliases`/`set_given_name_canonicals`). Byte-for-byte with
+        // `_alias_match_single`; the Python fast-path guard requires both installed.
+        // Behind the `alias` feature (off for the wasm surface); id 8 falls to the
+        // 0.0 catch-all there, which wasm never routes.
+        #[cfg(feature = "alias")]
+        8 => alias_match(a, b),
         _ => 0.0,
     }
 }
@@ -609,6 +796,58 @@ mod tests {
         // ("Acme Industries LLC" -> initials "AI"). With an empty table it would
         // be "AIL" != "AI" -> 0.0, so this asserts the global table is wired.
         assert_eq!(score_one(7, "Acme Industries LLC", "AI"), 1.0);
+    }
+
+    #[cfg(feature = "alias")]
+    #[test]
+    fn score_one_id8_is_alias_match_against_global_tables() {
+        // The ONLY test that installs the alias OnceLocks (business + given-name),
+        // so no different-content setter races it. Representative subsets of
+        // refdata.business._state.variants_normalized / business_aliases +
+        // given_names (norm -> min(canonical)).
+        let variants: Vec<String> = [
+            "inc", "incorporated", "corp", "corporation", "llc", "ltd", "gmbh",
+            "co", "company", "holdings", "limited liability company",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        let biz: Vec<(String, String)> = [
+            ("acme", "acme"),
+            ("google", "alphabet"),
+            ("alphabet", "alphabet"),
+        ]
+        .iter()
+        .map(|(a, b)| (a.to_string(), b.to_string()))
+        .collect();
+        let given: Vec<(String, String)> = [
+            ("bob", "robert"),
+            ("robert", "robert"),
+            ("bill", "william"),
+            ("william", "william"),
+            ("kate", "catherine"),
+            ("catherine", "catherine"),
+        ]
+        .iter()
+        .map(|(a, b)| (a.to_string(), b.to_string()))
+        .collect();
+        assert!(set_business_aliases(variants, biz));
+        assert!(set_given_name_canonicals(given));
+
+        // Business: legal-form strip + alias map (ground truth from the Python ref).
+        assert_eq!(score_one(8, "Acme Inc", "Acme Incorporated"), 1.0);
+        assert_eq!(score_one(8, "Acme, LLC", "Acme"), 1.0);
+        assert_eq!(score_one(8, "Acme Holdings Inc.", "acme"), 1.0); // iterative strip
+        assert_eq!(score_one(8, "Acme Limited Liability Company", "Acme"), 1.0); // multi-word
+        assert_eq!(score_one(8, "Google", "Alphabet"), 1.0); // alias map
+        assert_eq!(score_one(8, "Acme", "Globex"), 0.0); // distinct passthrough
+        // Given-name: nickname canonical equality.
+        assert_eq!(score_one(8, "Bob", "Robert"), 1.0);
+        assert_eq!(score_one(8, "Bill", "William"), 1.0);
+        assert_eq!(score_one(8, "Kate", "Catherine"), 1.0);
+        assert_eq!(score_one(8, "Bob", "Bill"), 0.0); // different canonicals
+        // Empty both -> no canonical -> 0.0.
+        assert_eq!(score_one(8, "", ""), 0.0);
     }
 
     #[test]

--- a/packages/rust/extensions/score-wasm/Cargo.toml
+++ b/packages/rust/extensions/score-wasm/Cargo.toml
@@ -18,7 +18,10 @@ name = "goldenmatch_score_wasm"
 crate-type = ["cdylib", "rlib"]  # cdylib for wasm; rlib so host unit tests link
 
 [dependencies]
-goldenmatch-score-core = { path = "../score-core" }
+# default-features = false drops the `alias` feature (score_one id 8 + the `regex`
+# engine): alias_match is a Python-bucket-only kernel with no wasm export, so the
+# edge bundle stays free of the heavy `regex` dependency.
+goldenmatch-score-core = { path = "../score-core", default-features = false }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,8 +305,8 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date`, `qgram`, `soundex_match`, `initialism_match` have an
-# arrow-native (bucket) kernel on Python but no TS WASM port yet.
+# python_only: `date`, `qgram`, `soundex_match`, `initialism_match`, `alias_match`
+# have an arrow-native (bucket) kernel on Python but no TS WASM port yet.
 scorer_kernels:
   shared:
   - exact
@@ -314,6 +314,7 @@ scorer_kernels:
   - levenshtein
   - token_sort
   python_only:
+  - alias_match
   - date
   - initialism_match
   - qgram


### PR DESCRIPTION
## What and why

Second Wave-2 scorer from the `-core` kernel-coverage spec. `alias_match` (business + given-name canonical equality) was fallback-only; this ports it into `score-core` (byte-for-byte with `refdata.business_aliases.canonical_company_form` + `given_names.canonical_form` + `core.scorer._alias_match_single`) and wires it into the bucket fast path via `score_one` id 8, so it becomes kernel-backed. Suite-matrix now reads **9 of 19**.

## The port

`alias_match` returns 1.0 iff both values share a non-empty business OR given-name canonical. Ship **pre-resolved maps** so the kernel only does normalize + lookup:

- **Business**: the kernel rebuilds `strip_legal_form`'s trailing-suffix regex (`[\s,\-.]+(?:variant)[\s.,]*$`, IGNORECASE, variants sorted DESC by length) from a host-shipped variant list via the `regex` crate, then normalizes (strip → collapse-ws → lower) and looks up the `surface->canonical` alias map.
- **Given-name**: a PRE-RESOLVED `normalized -> min(canonical set)` map — the Python `min(canon_set)` lex-first resolution is done host-side, so the kernel needs no alias graph, only keep-alpha-lower + lookup.

Validated **byte-identical to the pure reference over 8,000 randomized pairs** (legal-form suffixes single/compound/multi-word, alias-map surfaces, nicknames, punctuation, casing, Unicode) plus the pinned cargo/Python ground-truth cases.

**Edge-safety:** the alias_match subsystem (+ `regex`) sits behind a default-on `alias` cargo feature; `score-wasm` sets `default-features = false` so the heavy `regex` engine stays out of the edge WASM bundle (alias_match has no wasm export — id 8 falls to the 0.0 catch-all there).

## Changes

- **`score-core`**: `alias` feature (`regex` optional) wrapping the alias_match subsystem; `score_one` id 8 (+ cargo tests pinning ground truth; builds/clippy-clean with AND without the feature).
- **`native`**: `set_business_aliases` / `set_given_name_canonicals` setters + `alias_match_similarity` `#[pyfunction]` capability marker, registered.
- **`score-wasm`**: `default-features = false` on the score-core dep.
- **`score_buckets.py`**: `alias_match` -> `_NATIVE_SCORER_IDS` id 8; `_resolve_score_pair_callable` branch (pure `_alias_match_single` mirror); a two-part wheel-skew guard (`_ensure_alias_tables_installed`) routing native only when the `alias_match_similarity` symbol is present AND both tables installed, else declining to the pure mirror.
- Manifest + regenerated suite-matrix (9/19) + regenerated `agent-codemap.json`; cross-surface id-map `_SCORE_ONE_IDS += alias_match:8`; new `test_native_alias_parity.py`; spec updated.

## Testing

- `cargo test` (score-core): 23/23; `cargo clippy --all-targets -- -D warnings` clean both with `alias` on AND `--no-default-features` (the wasm config); `cargo build --no-default-features` clean
- `test_native_alias_parity.py`: 3/3 (native == pure over the full adversarial corpus + bucket id-8 dispatch); ad-hoc 8,000-pair fuzz: 0 mismatches
- Regression: cross-surface id-map + qgram/soundex/initialism parity + fast-path gate + `test_scorer.py`: green
- `gen_suite_matrix.py --check` OK (9/19); `check_native_symbols.py goldenmatch` OK; config_matrix gate (`test_agent_codemap.py` + `test_config_matrix.py`): green; Python `scorer_kernels` emitter includes `alias_match`
- Rebuilt the in-tree `_native.abi3.so`

(The api_parity gate's TS-side emitter needs the built TS dist — a CI-only surface; the TS `WASM_COVERED_SCORERS` is unchanged, so `scorer_kernels.ts_only` stays empty.)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (spec + regenerated suite-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_