### PR TITLE
fix(fs): admit shared identity identifiers to zero-config FS + gate it (fixes F1=0 at scale)

### DIFF
--- a/.github/workflows/gate-fs-zeroconfig.yml
+++ b/.github/workflows/gate-fs-zeroconfig.yml
@@ -1,0 +1,83 @@
+# Zero-config Fellegi-Sunter quality-at-scale gate.
+#
+# qis_gate exercises the WEIGHTED zero-config path; the PROBABILISTIC (F-S) path
+# was never gated at scale -- which is how zero-config FS silently found ZERO
+# duplicates (F1=0) at 1M on realistic person data (a shared `email` identifier
+# dropped by the perfect-surrogate rule, collapsing the EM model). This gate runs
+# TRUE zero-config FS (auto_configure_probabilistic_df) on realistic-cardinality
+# data and FAILS if F1 falls below the floor, so that class cannot regress
+# silently again. The per-PR guard for the specific identifier-admission rule is
+# the unit test tests/test_fs_autoconfig_v2.py; this is the broader end-to-end
+# watch (scheduled + on demand), analogous to bench-quality-scale / qis_gate.
+#
+# SCALE MATTERS -- keep `rows` >= 1_000_000. The regression is scale-dependent:
+# measured pre-fix F1 was 0.0 at 1M but a healthy 0.997 at 240K (the atomic name
+# fields alone still discriminate at small N; the EM model only collapses once
+# the identifier is the load-bearing signal at scale). A sub-1M gate is falsely
+# green -- it passes even with the bug present.
+name: gate-fs-zeroconfig
+
+on:
+  workflow_dispatch:
+    inputs:
+      rows:
+        description: "Base row count (dups added on top at dup_frac)"
+        required: false
+        default: "1000000"
+      min_f1:
+        description: "F1 floor -- fail below this"
+        required: false
+        default: "0.90"
+      runner:
+        description: "Runner label"
+        required: false
+        default: "large-new-64GB"
+  schedule:
+    - cron: "0 4 * * *"  # nightly 04:00 UTC
+
+permissions:
+  contents: read
+
+env:
+  ARROW_DEFAULT_MEMORY_POOL: system
+  _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+  GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+
+jobs:
+  gate:
+    runs-on: ${{ github.event.inputs.runner || 'large-new-64GB' }}
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32  # v2
+        with:
+          workspaces: packages/rust/extensions/native
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: Build native extension (FS kernel)
+        run: uv run python scripts/build_native.py
+
+      - name: Zero-config FS F1 gate
+        env:
+          GOLDENMATCH_NATIVE: "1"
+          GOLDENMATCH_FS_NATIVE: "1"
+        run: |
+          uv run python packages/python/goldenmatch/scripts/bench_fs_distributed.py \
+            --rows "${{ github.event.inputs.rows || '1000000' }}" \
+            --dup-frac 0.2 \
+            --backend bucket \
+            --config-mode zero \
+            --min-f1 "${{ github.event.inputs.min_f1 || '0.90' }}" \
+            | tee "$GITHUB_STEP_SUMMARY"

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Fixed
 
+- **Zero-config Fellegi-Sunter admits shared identity identifiers (email/phone)
+  at cardinality 1.0.** FS auto-config dropped every `card == 1.0` exact field as
+  a "perfect surrogate", but that also discarded identity-bearing identifiers
+  (email/phone) that duplicates carry verbatim -- FS's single strongest signal.
+  Because cardinality is measured on a config sample that can under-represent
+  duplicates, this silently collapsed the EM model to zero matches at scale
+  (measured: zero-config FS F1 0.0 at 1M on realistic person data; recovers to
+  1.0 with the identifier admitted). `build_probabilistic_matchkeys` now admits
+  `email`/`phone` at `card >= 1.0` (an FS comparison field self-regulates -- a
+  true PK to neutral, a shared identifier to a large weight) while still
+  excluding the ambiguous bare `identifier` type (row PKs) for config hygiene.
+  FS path only; the weighted/exact matchkey path is unchanged.
+
 - **FS `missing="unobserved"`: a partial-observation pair no longer normalizes to
   1.0 (#1854).** The min-max score range accumulated only over the OBSERVED
   fields, so a pair agreeing on its single observed field had `total == pair_max`

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4823,12 +4823,29 @@ def build_probabilistic_matchkeys(profiles: list[ColumnProfile]) -> list[Matchke
 
         scorer, _weight, transforms = scorer_info
 
-        # The one hard gate, applied uniformly to every exact-scorer field
-        # (identifier/email/phone): a perfectly-unique column (card == 1.0) is a
-        # per-record surrogate key -- it is never shared, so an agreement carries
-        # zero shared-identity signal. Exclude it for config hygiene. (Mirrors the
-        # exact path's >= 1.0 upper bound; previously the prob path gated none.)
-        if scorer == "exact" and p.cardinality_ratio >= 1.0:
+        # Perfect-surrogate hygiene gate, but NOT for identity-bearing VALUE types
+        # (email / phone). A card == 1.0 exact field is EITHER a per-record
+        # surrogate (a row PK -- never shared, no identity signal, correctly
+        # excluded) OR a shared real-world identifier a duplicate carries verbatim
+        # -- F-S's single strongest signal. Cardinality alone cannot tell them
+        # apart, AND the ratio is measured on a SAMPLE that under-represents
+        # duplicates (a head sample of base-then-dup data sees a shared email as
+        # perfectly unique), so a blanket >= 1.0 exclusion silently drops the best
+        # comparison field and collapses the whole EM model to zero matches at
+        # scale (measured: zero-config FS F1 0.0 at 1M on realistic person data).
+        # Unlike the exact-matchkey path (a card==1.0 key emits zero blocking pairs
+        # and is useless), an F-S exact field is a COMPARISON field scored on pairs
+        # from OTHER blocking: a true PK self-regulates to neutral (m~=u, ~0 EM
+        # weight) while a shared identifier carries a large weight -- so admitting
+        # is neutral-to-helpful, never harmful (#721 self-regulation). We admit
+        # only `email`/`phone` (unambiguously identity-bearing values) and keep
+        # excluding the ambiguous bare `identifier` type, which also covers row PKs
+        # (e.g. `record_id`) -- those stay out for config hygiene.
+        if (
+            scorer == "exact"
+            and p.cardinality_ratio >= 1.0
+            and p.col_type not in ("email", "phone")
+        ):
             continue
 
         # Lever #2a: drop redundant person-name composites when atomic parts exist.

--- a/packages/python/goldenmatch/scripts/bench_fs_distributed.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_distributed.py
@@ -132,6 +132,22 @@ def _fs_cfg(backend: str):
     )
 
 
+def _zero_config_cfg(df, backend: str):
+    """The ZERO-CONFIG FS path -- auto_configure_probabilistic_df on a bounded
+    head sample (auto-config only ever samples). This is the path the
+    identifier-admission fix lives in: on realistic data whose sample under-
+    represents duplicates it used to drop the shared `email` identifier and
+    collapse the EM model to F1=0. The gate asserts zero-config produces a
+    WORKING config (F1 above --min-f1), so that regression cannot return
+    silently -- qis_gate only covers the weighted path."""
+    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
+
+    sample = df.head(200_000)
+    cfg = auto_configure_probabilistic_df(sample.to_arrow())
+    cfg.backend = backend
+    return cfg
+
+
 def _peak_rss_gb() -> float:
     # ru_maxrss is KiB on Linux.
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024.0 * 1024.0)
@@ -143,6 +159,11 @@ def main() -> int:
     ap.add_argument("--dup-frac", type=float, default=0.2)
     ap.add_argument("--backend", default="bucket")
     ap.add_argument("--seed", type=int, default=7)
+    ap.add_argument("--config-mode", choices=["explicit", "zero"], default="explicit",
+                    help="explicit = hand-written FS config; zero = auto-config "
+                         "(the zero-config quality-at-scale gate)")
+    ap.add_argument("--min-f1", type=float, default=None,
+                    help="gate: exit non-zero if F1 < this floor")
     args = ap.parse_args()
 
     print(f"[gen] {args.rows} base rows + {int(args.rows*args.dup_frac)} dups "
@@ -155,8 +176,13 @@ def main() -> int:
     from goldenmatch import dedupe_df
     from goldenmatch.core.evaluate import evaluate_clusters
 
+    cfg = (_zero_config_cfg(df, args.backend) if args.config_mode == "zero"
+           else _fs_cfg(args.backend))
+    print(f"[config] mode={args.config_mode} "
+          f"matchkey_fields={[f.field for m in cfg.get_matchkeys() for f in m.fields]}",
+          flush=True)
     t0 = time.perf_counter()
-    result = dedupe_df(df, config=_fs_cfg(args.backend))
+    result = dedupe_df(df, config=cfg, confidence_required=False)
     wall = time.perf_counter() - t0
     rss = _peak_rss_gb()
 
@@ -179,6 +205,12 @@ def main() -> int:
     print(f"- wall: **{wall:.1f}s**  peak RSS: **{rss:.2f} GB**")
     print(f"- multi-member clusters: {multi}  (GT pairs: {len(gt)})")
     print(f"- **P={ev.precision:.3f}  R={ev.recall:.3f}  F1={ev.f1:.3f}**")
+
+    if args.min_f1 is not None and ev.f1 < args.min_f1:
+        print(f"::error::{args.config_mode}-config FS F1 {ev.f1:.4f} < floor "
+              f"{args.min_f1:.2f} at {df.height} rows -- zero-config quality "
+              f"regression (matchkeys/blocking dropped the identity signal?)")
+        return 1
     return 0
 
 

--- a/packages/python/goldenmatch/tests/test_autoconfig_probabilistic_721.py
+++ b/packages/python/goldenmatch/tests/test_autoconfig_probabilistic_721.py
@@ -7,9 +7,15 @@ diverging from the exact path (#715). The admission rule (decided 2026-06-05):
   * identifiers ARE admitted as exact-scorer comparison fields (no lower
     cardinality floor -- F-S self-regulates a weak identifier via a higher u /
     smaller EM weight, so we don't hard-gate low cardinality);
-  * the ONLY hard gate is ``cardinality_ratio >= 1.0`` (a perfect surrogate key
-    carries no shared-identity signal), applied uniformly to EVERY exact-scorer
-    field -- which newly covers email/phone too (previously ungated).
+  * the ``cardinality_ratio >= 1.0`` hard gate (a perfect surrogate key carries
+    no shared-identity signal) excludes the ambiguous bare ``identifier`` type
+    (row PKs), but NOT identity-bearing VALUE types (``email``/``phone``): a
+    shared email/phone a duplicate carries verbatim is F-S's single strongest
+    signal, and the ratio is measured on a sample that can under-represent
+    duplicates -- excluding it collapsed the EM model to zero matches at scale
+    (F1=0 at 1M). An F-S exact field is a COMPARISON field (not a pair-generating
+    exact matchkey), so a true PK self-regulates to neutral (m~=u) while a shared
+    identifier carries a large weight -- admitting email/phone is never harmful.
 
 m/u estimation + blocking-field exclusion are EM's job at train time, not this
 builder's -- these tests only assert field membership + scorer.
@@ -62,15 +68,28 @@ def test_surrogate_key_identifier_excluded():
     assert "full_name" in fields  # the rest of the matchkey is intact
 
 
-def test_surrogate_key_email_excluded_uniform_gate():
-    """The card>=1.0 gate is uniform across exact-scorer fields: a perfectly
-    unique email is now excluded too (previously ungated in the prob path)."""
+def test_card1_email_admitted_not_treated_as_surrogate():
+    """A card == 1.0 email is a shared identity-bearing VALUE, NOT a per-record
+    surrogate: it is admitted (unlike the bare `identifier` PK above). The ratio
+    is sample-measured and can read 1.0 when duplicates are under-represented, so
+    excluding it collapsed zero-config FS to F1=0 at scale. F-S self-regulates a
+    truly-never-shared value to neutral, so admitting is safe."""
     profiles = [
         ColumnProfile("email", "Utf8", "email", 0.9,
                       null_rate=0.0, cardinality_ratio=1.0),
         _name(),
     ]
-    assert "email" not in _prob_fields(build_probabilistic_matchkeys(profiles))
+    assert "email" in _prob_fields(build_probabilistic_matchkeys(profiles))
+
+
+def test_card1_phone_admitted_not_treated_as_surrogate():
+    """Same carve-out for phone -- an identity-bearing value type."""
+    profiles = [
+        ColumnProfile("phone", "Utf8", "phone", 0.9,
+                      null_rate=0.0, cardinality_ratio=1.0),
+        _name(),
+    ]
+    assert "phone" in _prob_fields(build_probabilistic_matchkeys(profiles))
 
 
 def test_high_card_email_still_admitted():

--- a/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
+++ b/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
@@ -71,6 +71,29 @@ def test_default_unset_is_v2(monkeypatch):
     assert "gender" not in fields
 
 
+def test_card1_shared_identifier_admitted_pk_excluded():
+    """A card==1.0 exact field is ambiguous: a shared identity-bearing VALUE
+    (email/phone a duplicate carries verbatim -- F-S's single strongest signal)
+    OR a per-record surrogate (a row PK). The ratio is measured on a SAMPLE that
+    under-represents duplicates, so a blanket >= 1.0 exclusion silently drops the
+    best comparison field and collapses EM to zero matches at scale (measured:
+    zero-config FS F1 0.0 at 1M realistic person data). Admit email/phone;
+    keep excluding the ambiguous bare `identifier` (covers row PKs)."""
+    profiles = [
+        _p("first_name", "name", card=0.42),
+        _p("surname", "name", card=0.74),
+        _p("email", "email", card=1.0),          # shared identifier -> ADMIT
+        _p("phone", "phone", card=1.0),           # shared identifier -> ADMIT
+        _p("record_id", "identifier", card=1.0),  # row PK -> EXCLUDE (hygiene)
+    ]
+    mks = build_probabilistic_matchkeys(profiles)
+    fields = _fields(mks)
+    assert "email" in fields, "card==1.0 email is the strongest F-S signal, must admit"
+    assert "phone" in fields, "card==1.0 phone must admit"
+    assert "record_id" not in fields, "per-record surrogate PK stays excluded"
+    assert _scorer_of(mks, "email") == "exact"
+
+
 def test_explicit_off_is_legacy(monkeypatch):
     monkeypatch.setenv(ON, "0")
     fields = _fields(build_probabilistic_matchkeys(_person_profiles()))


### PR DESCRIPTION
## What and why

Zero-config **Fellegi-Sunter** finds **zero duplicates at scale** on clean realistic data. Root cause: `build_probabilistic_matchkeys` dropped every `card == 1.0` exact field as a "perfect surrogate" — which also discarded identity-bearing identifiers (`email`/`phone`) that duplicates carry verbatim, FS's single strongest signal. Cardinality is measured on a config **sample** that can under-represent duplicates (a shared email looks perfectly unique in a duplicate-sparse sample), so this silently collapsed the EM model to zero matches.

**Scope:** this is the **FS / probabilistic** auto-config path (`auto_configure_probabilistic_df`, explicit `type: probabilistic`, and the FS-routed / out-of-core scale path). The *default* `dedupe_df` on this data routes to the **weighted** path, which keeps `email` as an exact matchkey and is unaffected — so this is not a regression in the default entry point, but it *is* broken for everyone using FS at scale (the path behind the "FS beats Splink" numbers and the OOC ≥40M work).

**Measured** — realistic person data (60K distinct names, unique email, dups sharing email+zip), single-box `bucket` engine:

| rows | config | wall | F1 | dups |
|---|---|---|---|---|
| 1.2M | explicit (hand-written: email exact + zip-only blocking) | 20.7s | **1.000** | 181,316 |
| 1.2M | zero-config **before** fix | 307s | **0.000** | 0 |
| 1.2M | zero-config **after** fix | ~410s | **1.000** | 181,179 |
| 240K | zero-config **before** fix | 38s | 0.997 | — |

The bug is **scale-dependent**: at 240K the atomic name fields alone still discriminate (F1 0.997), but at 1M the EM model collapses once the identifier is the load-bearing signal. The engine was never the problem — the auto-config was handing it a degenerate config.

## Changes

- **Fix** (`core/autoconfig.py::build_probabilistic_matchkeys`): admit `card >= 1.0` exact fields of identity-bearing **value** types (`email`/`phone`). An FS exact field is a *comparison* field scored on pairs from other blocking (not a pair-generating exact matchkey), so a shared identifier carries a large EM weight while a true per-record surrogate self-regulates to neutral (`m ≈ u`) — admitting is neutral-to-helpful, never harmful (#721). The ambiguous bare `identifier` type (row PKs like `record_id`) stays excluded for config hygiene. FS path only.
- **Unit test** (`tests/test_fs_autoconfig_v2.py`): `email`/`phone` at card 1.0 admitted, `record_id` (PK) excluded — the cheap per-PR regression guard, in `ci-required`.
- **Scale gate** (`scripts/bench_fs_distributed.py` `--config-mode zero` / `--min-f1`, `gate-fs-zeroconfig.yml`): nightly + on-demand gate running TRUE zero-config FS on realistic data at 1M, failing under F1 0.90. `qis_gate` only covers the weighted path — FS zero-config quality at scale was ungated. Must run ≥1M (a sub-1M gate is falsely green, per the scale-dependence above).
- CHANGELOG entry.

## Testing

Root `.venv`, `ARROW_DEFAULT_MEMORY_POOL=system`, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`:
- `pytest tests/test_fs_autoconfig_v2.py` → 33 passed (incl. the new lock test).
- `pytest tests/test_probabilistic.py tests/test_autoconfig_regressions.py` → 143 passed (1 pre-existing `TestNativeFSParity::test_native_matches_numpy_with_missing_values` failure, confirmed failing on clean `main` with the local native build — a native/numpy FS divergence unrelated to this change).
- Gate smoke: `bench_fs_distributed.py --config-mode zero --min-f1 0.90` at 240K → F1 1.0, exit 0; and confirmed the gate needs ≥1M to catch the regression (pre-fix passes at 240K, fails at 1M).
- `ruff check` clean on all changed files.

## Follow-up (not in this PR)

The **wall**: zero-config FS blocking still emits redundant recall passes (~66M candidate pairs on realistic 1.2M), so the wall is ~410s vs the explicit config's 20.7s. Curating those passes (lean on the discriminative key when it already covers recall) is the remaining lever to a practical single-box FS wall to 25M — tracked separately.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta