### PR TITLE
feat(score): kernelize dice/jaccard/phash into the bucket path (Wave 3, 9/19 -> 12/19) + design spec

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**9 of 19 scorers are kernel-backed** (the reference fast path); the other 10 are pure-language fallbacks with no `-core` kernel.
+**12 of 19 scorers are kernel-backed** (the reference fast path); the other 7 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `date`, `initialism_match`, `qgram`, `soundex_match` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `date`, `dice`, `initialism_match`, `jaccard`, `phash`, `qgram`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `audio_fp`, `dice`, `embedding`, `ensemble`, `given_name_aliased_jw`, `jaccard`, `name_freq_weighted_jw`, `phash`, `radial`, `record_embedding` |
+| Language fallback — no `-core` kernel | `audio_fp`, `embedding`, `ensemble`, `given_name_aliased_jw`, `name_freq_weighted_jw`, `radial`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md
+++ b/docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md
@@ -1,0 +1,222 @@
+# Block-aware bucket scoring for the bloom/hash scorers (dice / jaccard / phash)
+
+**Date:** 2026-07-21
+**Status:** Proposed (design / scoping). Follow-on to the `-core` scorer-kernel coverage work
+(`2026-07-21-scorer-kernel-full-coverage-design.md`, which took the metric 5/19 → 9/19 and added
+the `scorer_kernels` coverage floor). This scopes the next three fallbacks — `dice`, `jaccard`,
+`phash` — which the coverage manifest currently marks `deferred` as "matrix-semantics-dependent."
+
+## TL;DR
+
+The "these need a block-aware kernel" framing was **half right**. After reading the actual code:
+
+- **`dice` and `jaccard` do NOT need block-awareness.** Their per-pair functions (`_dice_score_single`
+  / `_jaccard_score_single`) are bloom-hex with **integer popcounts** + a single float64 divide, and
+  their coefficients are **popcount-based** so zero-padding is invariant. A Rust `score_one` kernel
+  using `u.count_ones()` is **byte-exact** with the per-pair function. They already run on the bucket
+  per-pair loop today, so a native id is a byte-exact speed-up with **zero output change**. → do these
+  now, **9/19 → 11/19**, on the proven `score_one` template.
+- **`phash` is the only one with a real block dependency** — its denominator is bit-*length*, so the
+  matrix path pads to the block-**global** max. But phash **currently declines to the matrix path**
+  (it's not bucket-eligible at all), so kernelizing it into the bucket path is a *new* path either
+  way. A per-pair kernel matching `_phash_score_single` (pairwise pad, float64) is the cheap option;
+  matching `_phash_score_matrix` exactly needs the block-aware mechanism.
+- The **general block-aware bucket mechanism** is still worth designing — it's the right tool for any
+  scorer whose per-pair value depends on block-global state (phash's global-max; future
+  IDF/normalization scorers). It is designed here, with phash as its one concrete candidate consumer.
+
+**Recommendation:** ship `dice` + `jaccard` per-pair now (Phase 1, clean); take `phash` per-pair with
+a documented output characterization (Phase 2, one decision to confirm); build the block-aware
+mechanism (Phase 3) only if byte-exact-with-`_phash_score_matrix` is required, or when a genuinely
+block-global scorer (a future IDF-weighted comparator) lands.
+
+## What the code actually does (corrected diagnosis)
+
+The `scorer_kernels` metric reads the **bucket** map `_NATIVE_SCORER_IDS`
+(`scripts/emit_python_surface.py::_scorer_kernels` → `backends.score_buckets`). A scorer counts iff
+it's in that map. dice/jaccard/phash are absent, so adding them there (with a `score_one` id + a
+byte-parity Rust kernel) is what makes them count. There are two native scoring surfaces:
+
+| Surface | Rust fn | Shape | Ids | Counts toward metric? |
+|---|---|---|---|---|
+| **bucket** | `score_block_pairs` / `_arrow` | whole block columns in, **per-pair `score_one(id,a,b)`** inside, emits pairs ≥ threshold | `_NATIVE_SCORER_IDS` (0=jw … 8=alias) | **yes** |
+| **field-matrix** | `score_field_matrix` | whole columns in, returns **NxM float32 matrix** | `_NATIVE_FIELD_SCORER_IDS` (0-4, soundex=4) | no |
+
+`score_block_pairs_arrow` **already receives the whole block's columns** (`field_arrays_arrow`, one
+Arrow array per field, plus `size_list` block run-lengths). The block data is present; the limitation
+is purely that dispatch is per-pair `score_one`. `score_field_matrix` is the existing block-aware
+pattern (column in → matrix out) to reuse.
+
+### The per-pair functions are exact integer popcount (not float32, not bigram)
+
+```python
+# core/scorer.py  — the per-pair references (bucket path uses these)
+def _dice_score_single(a, b):
+    ba, bb = _pad_to_equal_length(_hex_to_bits(a), _hex_to_bits(b))   # PAIRWISE pad
+    inter = np.unpackbits(np.bitwise_and(ba, bb)).sum()               # INTEGER popcount
+    total = np.unpackbits(ba).sum() + np.unpackbits(bb).sum()         # INTEGER popcount
+    return float(2.0 * inter / total) if total > 0 else 0.0           # one float64 divide
+
+def _jaccard_score_single(a, b):   # ... union = popcount(a|b); inter/union
+def _phash_score_single(a, b):     # dist = popcount(a^b); 1 - dist/(bits_a.size*8)  (PAIRWISE)
+```
+
+- The comment in `_resolve_score_pair_callable` calling `_dice_score_single` a "bigram set Dice
+  coefficient" is **stale** — it's bloom-hex (hex-decode + bit ops), identical in *kind* to
+  `_dice_score_matrix`.
+- **Dice/Jaccard are padding-invariant:** the denominators are popcounts of `a`, `b`, and `a&b`/`a|b`
+  — trailing zero bytes change none of them. So pairwise-pad and global-max-pad give the *same value*.
+- **The only single-vs-matrix divergence for dice/jaccard is float32:** `_dice_score_matrix` builds a
+  `float32` bit-matrix and computes the intersection with a float32 matmul (`bit_matrix @ bit_matrix.T`),
+  so it rounds to ~1e-7. Measured: `_dice_score_single('ab12','cd34')=0.5333333333` vs
+  `_dice_score_matrix=0.5333333611` — a float32 artifact, nothing else. A Rust `count_ones()` kernel
+  has **no float32 error** (integer popcount + float64 divide) → byte-exact with the *single*.
+
+### phash is genuinely block-dependent — and currently off the bucket path
+
+```python
+def _phash_score_matrix(values):
+    # ... valid mask (try/except ValueError -> 0), then:
+    max_len = max(len(b) for b in bit_arrays)         # block-GLOBAL max bit length
+    bit_matrix = np.zeros((n, max_len), dtype=np.float32)   # float32
+    hamming = popcounts[:,None] + popcounts[None,:] - 2.0*intersection
+    sim = 1.0 - hamming / max_len                     # denominator = GLOBAL max
+    sim = np.where(valid[:,None] & valid[None,:], sim, 0.0)   # invalid hex -> 0
+```
+
+Three ways `_phash_score_single` (pairwise, float64, raises on bad hex) differs from
+`_phash_score_matrix` (global-max, float32, bad hex → 0):
+
+1. **Padding**: `1 - dist/(pairwise bits)` vs `1 - dist/(block-global bits)`. Identical when all
+   block hashes are equal length (the normal 64-bit pHash case); diverges only on **≥3-element
+   mixed-length blocks** (a 2-element block's pairwise max == its global max, which is why the
+   divergence is invisible in a naive two-value test).
+2. **float32 vs float64** (as with dice/jaccard).
+3. **Invalid hex**: single raises (would crash the bucket per-pair loop); matrix scores 0.
+
+And critically: `_resolve_score_pair_callable` has **no `phash` branch**, so phash resolves to `None`
+→ the matchkey declines the fast path entirely → phash runs on the slow `find_fuzzy_matches` **matrix**
+path. So phash's *current* output IS `_phash_score_matrix` (global-max/float32/bad-hex→0). Any
+bucket kernel for phash is a **new code path**, and the design choice is which reference it matches.
+
+## Phase 1 — `dice` + `jaccard` as `score_one` ids (clean, do now)
+
+The exact qgram/soundex template. **9/19 → 11/19.**
+
+1. **`score-core`** (`lib.rs`): `dice_similarity(a,b)` / `jaccard_similarity(a,b)` + `score_one`
+   ids 9, 10. Decode hex → bytes; pairwise-pad (or, equivalently since padding-invariant, compare
+   over `min(len)` bytes + count the tail of the longer as pure popcount — either is exact); integer
+   `count_ones()`:
+   ```rust
+   // dice: 2*|a&b| / (|a| + |b|)
+   fn dice_similarity(a: &str, b: &str) -> f64 {
+       let (pa, pb) = match (decode_hex(a), decode_hex(b)) { (Some(x), Some(y)) => (x, y), _ => return 0.0 };
+       let (inter, total) = popcounts(&pa, &pb);   // inter = Σ (pa[i] & pb[i]).count_ones(); total = Σ pa.count_ones() + Σ pb.count_ones()
+       if total == 0 { 0.0 } else { 2.0 * inter as f64 / total as f64 }
+   }
+   ```
+   Pure integer arithmetic → **byte-exact** with `_dice_score_single` on valid hex. No `regex`, no
+   `unicode-normalization`, no table — this is a pure primitive, so it stays in the default feature
+   set (unlike alias's `regex` gate).
+2. **`native`**: `dice_similarity` / `jaccard_similarity` `#[pyfunction]` capability markers +
+   registration.
+3. **`score_buckets.py`**: `_NATIVE_SCORER_IDS += {"dice": 9, "jaccard": 10}` + a wheel-skew guard
+   (`hasattr(_mod, "dice_similarity")`) alongside date/qgram/soundex — a stale wheel declines to the
+   existing per-pair `_dice_score_single` mirror (which the bucket path already uses). **No install
+   step** (no table), so the guard is one-part (symbol only), simpler than initialism/alias.
+4. **Also make them `_VEC_SUPPORTED`** *(optional, perf)*: add exact matrix forms in
+   `_vec_field_matrix` that use **integer** popcount + float64 (not the float32 `_dice_score_matrix`),
+   so the vectorized lane can batch them byte-identically to the per-pair loop. Small numpy change
+   (`np.uint64` view + `np.bitwise_count`, or keep the per-pair loop for these). Not required for the
+   kernel; do it only if a dice/jaccard workload shows the per-pair loop is hot.
+5. Manifest: **move `dice`, `jaccard` from `scorer_kernels_deferred` → `scorer_kernels.python_only`**
+   (the coverage gate enforces this — leaving them in `deferred` after they gain a kernel now fails
+   with `stale_deferral`). Regenerate suite-matrix (11/19) + agent-codemap; cross-surface id-map;
+   `test_native_dice_jaccard_parity.py` (native == `_*_single` over a hex-CLK corpus + the id 9/10
+   bucket dispatch); spec/CLAUDE.md.
+
+**The one edge to pin: invalid hex.** The single functions raise; a `score_one` kernel returning f64
+can't. Decision: **the kernel treats unparseable hex as "no bits" → 0.0** (matches the phash matrix's
+bad-hex→0 intent and never crashes the loop). dice/jaccard are PPRL/CLK scorers whose inputs are
+always valid fixed-width hex, so this edge doesn't arise in practice; the parity test asserts it
+explicitly and the mirror (`_dice_score_single`) is documented as the valid-hex reference. (If we
+want the bucket per-pair mirror itself to stop raising, wrap it in the `_resolve_score_pair_callable`
+branch — a one-line `try/except → 0.0` — so kernel and mirror agree on the edge too.)
+
+## Phase 2 — `phash` (one decision to confirm)
+
+phash isn't bucket-eligible today (declines to the matrix path). Two ways to make it kernel-backed:
+
+**Option A — per-pair `score_one` id 11, matching `_phash_score_single` (pairwise/float64).** Cheap,
+same template as Phase 1. Consequence: routing phash onto the bucket path changes its output vs the
+current matrix path on (i) ≥3-element mixed-length blocks, (ii) float32→float64, (iii) invalid hex.
+For **fixed-length pHashes with valid hex** — the real-world case (image pHash is always 16 hex / 64
+bits) — only float32→float64 differs, i.e. a *precision improvement*, and pairwise==global. So Option
+A is byte-exact-in-practice and arguably more correct. **Risk:** if a deployment feeds mixed-length
+or non-64-bit pHashes, the bucket and matrix backends would disagree. Mitigate by adding a per-pair
+`phash` branch to `_resolve_score_pair_callable` (so the bucket path itself is defined) + a parity
+test on fixed-length hashes + a documented note that mixed-length phash is backend-sensitive.
+
+**Option B — block-aware kernel matching `_phash_score_matrix` exactly** (global-max/float32/bad-hex→0).
+Preserves the current output bit-for-bit, at the cost of the Phase-3 mechanism + replicating float32
+matmul semantics in Rust (a `f32` accumulate to match numpy — fiddly but doable). Only worth it if
+byte-exact-with-today's-output is a hard requirement.
+
+**Recommendation: Option A**, gated on confirming that phash inputs are fixed-length pHashes in the
+workloads we care about (they are, by construction). It makes phash kernel-backed (**11/19 → 12/19**)
+on the proven template, with pairwise/float64 as the honest, more-correct reference; the coverage
+manifest's phash entry moves from `deferred` to `scorer_kernels.python_only` with a note that its
+reference is `_phash_score_single`, not `_phash_score_matrix`.
+
+## Phase 3 — the general block-aware bucket mechanism (design; build when needed)
+
+The capability the "block-aware kernel" name refers to. Design it now; build it only for Option B or
+a future genuinely-block-global scorer (an IDF/normalization comparator). The infrastructure already
+exists — `score_block_pairs_arrow` holds the whole block, and `score_field_matrix` already turns a
+column into an NxN matrix.
+
+**Mechanism.** Introduce a second class of bucket scorer — **matrix scorers** — alongside the per-pair
+`score_one` ids:
+
+- A new map `_NATIVE_BLOCK_MATRIX_SCORER_IDS` (or a tagged union in the existing map) marks a field's
+  scorer as block-aware. Its native id routes not to `score_one(id,a,b)` per pair but to a
+  per-(block, field) call that returns the block's NxN contribution matrix (the `score_field_matrix`
+  shape, extended to the semantics that scorer needs — e.g. phash's global-max hamming).
+- `score_block_pairs_arrow` gains a branch: for a matrix-scorer field, compute its NxN block matrix
+  once (block-global state available: max length, IDF over the block, etc.); for a `score_one` field,
+  the existing per-pair loop. Then the **combine** step is unchanged — weighted sum of per-field
+  contributions ÷ observed weight, threshold-emit the upper triangle. (This is exactly what the
+  Python `_score_block_vec` lane already does — per-field matrix, weighted combine, triu emit — so
+  the Python fallback for block-aware scorers is `_score_block_vec` with the scorer's matrix fn.)
+- Parity reference for a matrix scorer is its `_<scorer>_score_matrix` (block-aware by definition),
+  so byte-parity is achievable where the per-pair `score_one` path structurally cannot reach it.
+
+**Why not just always use matrix scorers?** Per-pair `score_one` is cheaper for the common string
+scorers (no N² matrix materialization when the block is large and sparse in emitted pairs) and is the
+established path. Matrix scorers are the escape hatch for the minority whose value needs block context.
+
+**Candidate consumers:** `phash` (Option B), and later a block/dataset-normalized comparator — note
+`name_freq_weighted_jw` needs *dataset*-global TF, not *block*-global, so it's a related-but-distinct
+"install a table" case (like alias's `set_legal_forms`), not this block-matrix mechanism.
+
+## Non-goals / out of scope
+
+- **Reconciling the bucket-vs-matrix backend divergence for phash** (global-max/float32 vs
+  pairwise/float64). That's a pre-existing inconsistency between the `bucket` and `polars-direct`
+  backends; this spec picks the bucket reference and documents it, but does not change the
+  `find_fuzzy_matches` matrix path.
+- **`ensemble`** stays `declined` (measured Febrl3 recall regression; separate matter).
+- **The ts_only name scorers** (`given_name_aliased_jw` / `name_freq_weighted_jw`) are a TS-WASM
+  track, unrelated to this mechanism.
+
+## Rollout
+
+1. **Phase 1 PR**: dice + jaccard `score_one` ids 9/10 (+ optional exact vec-matrix), byte-parity
+   tests, manifest move deferred→kernels, 11/19. Low risk, no output change.
+2. **Phase 2 PR**: phash per-pair id 11 (Option A) after confirming fixed-length-pHash assumption;
+   12/19. One documented behavior characterization.
+3. **Phase 3**: build the matrix-scorer mechanism only if Option B is required or a block-global
+   scorer lands. Design captured here so it isn't re-derived.
+
+Each phase re-runs the byte-parity discipline (kernel == the per-pair reference over an adversarial
+hex corpus) and the `scorer_kernels` coverage gate (which now *forces* the deferred→kernels move).

--- a/docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md
+++ b/docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md
@@ -1,10 +1,12 @@
 # Block-aware bucket scoring for the bloom/hash scorers (dice / jaccard / phash)
 
 **Date:** 2026-07-21
-**Status:** Proposed (design / scoping). Follow-on to the `-core` scorer-kernel coverage work
-(`2026-07-21-scorer-kernel-full-coverage-design.md`, which took the metric 5/19 → 9/19 and added
-the `scorer_kernels` coverage floor). This scopes the next three fallbacks — `dice`, `jaccard`,
-`phash` — which the coverage manifest currently marks `deferred` as "matrix-semantics-dependent."
+**Status:** **Phases 1 & 2 landed** (dice/jaccard/phash kernelized as `score_one` ids 9/10/11,
+**9/19 → 12/19**); Phase 3 (the general block-aware matrix-scorer mechanism) remains designed-but-not-built.
+Follow-on to the `-core` scorer-kernel coverage work (`2026-07-21-scorer-kernel-full-coverage-design.md`,
+which took the metric 5/19 → 9/19 and added the `scorer_kernels` coverage floor). This scoped the next
+three fallbacks — `dice`, `jaccard`, `phash` — which the coverage manifest previously marked `deferred`
+as "matrix-semantics-dependent."
 
 ## TL;DR
 
@@ -211,12 +213,19 @@ established path. Matrix scorers are the escape hatch for the minority whose val
 
 ## Rollout
 
-1. **Phase 1 PR**: dice + jaccard `score_one` ids 9/10 (+ optional exact vec-matrix), byte-parity
-   tests, manifest move deferred→kernels, 11/19. Low risk, no output change.
-2. **Phase 2 PR**: phash per-pair id 11 (Option A) after confirming fixed-length-pHash assumption;
-   12/19. One documented behavior characterization.
-3. **Phase 3**: build the matrix-scorer mechanism only if Option B is required or a block-global
+1. **Phase 1 ✅ landed**: dice + jaccard `score_one` ids 9/10 (integer popcount, byte-exact),
+   byte-parity tests (`test_native_bloom_hash_parity.py`, 0 mismatches over thousands of pairs),
+   manifest move deferred→kernels. No output change (they already ran on the bucket per-pair path).
+2. **Phase 2 ✅ landed**: phash per-pair id 11 (Option A). This made phash bucket-eligible for the
+   first time (it previously declined to the matrix path); it now uses the PAIRWISE float64
+   `_phash_score_single` — byte-identical for fixed-length pHashes, a float64 precision improvement
+   elsewhere. **12/19.**
+3. **Phase 3 — not built.** The matrix-scorer mechanism (§Phase 3) stays designed-only; build it
+   only if byte-exact-with-`_phash_score_matrix` becomes a requirement or a genuinely block-global
    scorer lands. Design captured here so it isn't re-derived.
+
+The optional exact-float64 vec-matrix forms for dice/jaccard/phash (so the `_score_block_vec` lane
+can batch them) are a deferred perf follow-up — the kernels don't need them.
 
 Each phase re-runs the byte-parity discipline (kernel == the per-pair reference over an adversarial
 hex corpus) and the `scorer_kernels` coverage gate (which now *forces* the deferred→kernels move).

--- a/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
+++ b/docs/superpowers/specs/2026-07-21-scorer-kernel-full-coverage-design.md
@@ -116,7 +116,7 @@ minimal. Recommend **defer or explicitly decline**.
 |---|---|---|---|
 | **1** | `qgram` ✅, `soundex_match` ✅ (both landed) | low | pure strings on the proven template; `soundex_match` reused the existing Rust kernel, upgraded to full jellyfish Unicode parity |
 | **2** | `initialism_match` ✅, `alias_match` ✅ (both landed), `given_name_aliased_jw`, `name_freq_weighted_jw` | medium | string base + refdata table shipped in-kernel (mechanism exists); table fidelity is the risk. `initialism_match` proved the in-kernel table mechanism (the ~77-entry `entity_form_variants()` set installed once into a `score-core` `OnceLock` via a native `set_legal_form_variants` shim, keeping `score_one(id, a, b)` uniform); `alias_match` extended it to two maps + a rebuilt-in-kernel strip regex |
-| **3** | `phash`, `dice`, `jaccard` | **blocked** | NOT "just wiring" -- all three are matrix-semantics-dependent (see the note below), so the per-pair `score_one` pattern can't reach byte-parity; each needs a block-aware kernel or a resolved-semantics decision first |
+| **3** | `dice` ✅, `jaccard` ✅, `phash` ✅ (all landed) | low | The "matrix-semantics" worry was a misdiagnosis: the per-pair single functions use INTEGER popcount (byte-exact via `count_ones()`), and the single-vs-matrix gap was only the numpy matrix path's float32. dice/jaccard are padding-invariant; phash uses the pairwise `_phash_score_single` (Option A). `score_one` ids 9/10/11, **9/19 -> 12/19**. See `2026-07-21-block-aware-bucket-kernel-design.md` |
 | **free** | `ensemble` | trivial | composes Wave-1 kernels; kernel-backed by construction |
 | **4 (defer/decline)** | `audio_fp`, `radial` | -- | bespoke alignment search, low perf upside |
 | **n/a** | `embedding`, `record_embedding` | -- | model-backed; reframe under goldenembed, exclude from denominator |
@@ -132,10 +132,12 @@ algorithmic coverage.
 > disambiguated first, and `phash` is matrix-semantics-dependent — `_phash_score_matrix` pads all
 > block hashes to the block-GLOBAL max bit-length (`sim = 1 - dist/max_len`), which a per-pair
 > `score_one` kernel can't replicate (it can only pad pairwise), so it diverges on mixed-length
-> blocks. **The clean per-pair string primitives (qgram, soundex, initialism, alias) are exactly the
-> ones that fit the `score_one` pattern; the rest need a block-aware kernel path or a semantics
-> decision, which is why the pragmatic frontier lands at 9/19 + the coverage floor, not a forced
-> 19/19.**
+> blocks — but its per-pair `_phash_score_single` (pairwise) is a perfectly good bucket reference
+> (Option A), so phash kernelized after all. **UPDATE:** dice/jaccard/phash all landed as `score_one`
+> ids 9/10/11 (**12/19**) — the "matrix-semantics" worry was a misdiagnosis (the single functions use
+> integer popcount; only the numpy *matrix* path was float32). The real frontier now: `ensemble`
+> (measured regression), the ts_only name scorers (TS-WASM track), and the model-backed/bespoke pair
+> — none a clean `score_one` cut. See `2026-07-21-block-aware-bucket-kernel-design.md`.
 
 ## Coverage floor (the gate that keeps the metric honest)
 

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -251,6 +251,18 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # empty tables until the host ships them), else it declines to the pure-Python
     # per-pair mirror (`_alias_match_single`).
     "alias_match": 8,
+    # ids 9/10/11 = dice / jaccard / phash (bloom-hex + hex-hamming, score-core
+    # score_one). Byte-exact with the per-pair `_dice_score_single` /
+    # `_jaccard_score_single` / `_phash_score_single` (integer popcount + one f64
+    # divide -- the numpy MATRIX forms are float32, a separate path). Guarded on
+    # the `dice_similarity` / `jaccard_similarity` / `phash_similarity` capability
+    # symbols so a stale wheel declines to those pure mirrors. dice/jaccard are
+    # padding-invariant; phash matches the PAIRWISE `_phash_score_single` (Option A
+    # in docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md),
+    # NOT the block-global `_phash_score_matrix`.
+    "dice": 9,
+    "jaccard": 10,
+    "phash": 11,
 }
 
 
@@ -480,16 +492,32 @@ def _resolve_score_pair_callable(
         from goldenmatch.core.scorer import _alias_match_single
         return _alias_match_single
     if scorer_name == "dice":
-        # Delegate to the existing per-pair implementation in core/scorer.py
-        # (_dice_score_single, bigram set Dice coefficient). Matrix path is
-        # vectorized via _dice_score_matrix; per-pair is the same coefficient
-        # one pair at a time. Unblocks fast path for workloads where
-        # auto-config or explicit config picks dice on a string field.
+        # Bloom-hex Dice coefficient (2*|A&B|/(|A|+|B|)). Per-pair mirror of
+        # score-core::dice_similarity (native id 9); parity-asserted in
+        # tests/test_native_bloom_hash_parity.py. Integer popcount, so it's
+        # byte-exact with the kernel (the numpy _dice_score_matrix is float32, a
+        # separate path). The gating site guards on the `dice_similarity` symbol
+        # and declines to THIS mirror otherwise.
         from goldenmatch.core.scorer import _dice_score_single
         return _dice_score_single
     if scorer_name == "jaccard":
+        # Bloom-hex Jaccard (|A&B|/|A|B|). Per-pair mirror of
+        # score-core::jaccard_similarity (native id 10); same integer-popcount
+        # byte-parity story as dice.
         from goldenmatch.core.scorer import _jaccard_score_single
         return _jaccard_score_single
+    if scorer_name == "phash":
+        # Perceptual-hash Hamming similarity (1 - dist/nbits). Per-pair mirror of
+        # score-core::phash_similarity (native id 11). NOTE: this makes phash
+        # fast-path eligible for the FIRST time -- it previously declined to the
+        # slow `find_fuzzy_matches` MATRIX path (`_phash_score_matrix`, float32 +
+        # block-GLOBAL max-length padding). The bucket path uses this PAIRWISE
+        # float64 `_phash_score_single` instead (Option A in
+        # docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md):
+        # byte-identical for fixed-length pHashes (the normal 64-bit case), and a
+        # precision improvement (float64) elsewhere. Guarded on `phash_similarity`.
+        from goldenmatch.core.scorer import _phash_score_single
+        return _phash_score_single
     if scorer_name == "ensemble":
         # DECLINE the fast path for ensemble (return None -> find_fuzzy_matches
         # slow path). A prior per-pair reimplementation (max(jw, ts, sx*0.8))
@@ -1190,9 +1218,15 @@ def score_buckets(
             _date_ok = _mod is not None and hasattr(_mod, "date_similarity")
             _qgram_ok = _mod is not None and hasattr(_mod, "qgram_similarity")
             _soundex_ok = _mod is not None and hasattr(_mod, "soundex_similarity")
+            _dice_ok = _mod is not None and hasattr(_mod, "dice_similarity")
+            _jaccard_ok = _mod is not None and hasattr(_mod, "jaccard_similarity")
+            _phash_ok = _mod is not None and hasattr(_mod, "phash_similarity")
             has_date = any(spec[3] == "date" for spec in _field_specs)
             has_qgram = any(spec[3] == "qgram" for spec in _field_specs)
             has_soundex = any(spec[3] == "soundex_match" for spec in _field_specs)
+            has_dice = any(spec[3] == "dice" for spec in _field_specs)
+            has_jaccard = any(spec[3] == "jaccard" for spec in _field_specs)
+            has_phash = any(spec[3] == "phash" for spec in _field_specs)
             has_initialism = any(spec[3] == "initialism_match" for spec in _field_specs)
             # initialism_match (id 7) has a TWO-part guard: the capability symbol
             # AND a successful legal-form install (id 7 scores against an empty
@@ -1219,6 +1253,9 @@ def score_buckets(
                 or (has_soundex and not _soundex_ok)
                 or (has_initialism and not _initialism_ok)
                 or (has_alias and not _alias_ok)
+                or (has_dice and not _dice_ok)
+                or (has_jaccard and not _jaccard_ok)
+                or (has_phash and not _phash_ok)
             )
             if all(i is not None for i in ids) and not _skew_block:
                 native_scorer_ids = ids  # type: ignore[assignment]

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -42,7 +42,7 @@ class TestNativeScorerIdMaps:
     # 4=date/5=qgram/6=soundex_match; in the field-matrix map 4=soundex_match.
     # `soundex_match` therefore lives in BOTH maps at DIFFERENT ids (bucket 6,
     # field 4); the two are pinned separately so they can't silently collide.
-    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7, "alias_match": 8}
+    _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7, "alias_match": 8, "dice": 9, "jaccard": 10, "phash": 11}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):

--- a/packages/python/goldenmatch/tests/test_native_bloom_hash_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_bloom_hash_parity.py
@@ -1,0 +1,119 @@
+"""Parity for the dice / jaccard / phash bucket kernels (score-core ids 9/10/11)
+vs the pure Python references `_dice_score_single` / `_jaccard_score_single` /
+`_phash_score_single`.
+
+These are the bloom-hex + hex-hamming scorers. Wave 3 kernelizes them as per-pair
+`score_one` ids (integer popcount + one f64 divide -- byte-exact with the single
+functions, unlike the numpy MATRIX forms which compute in float32). See
+docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md.
+
+- dice/jaccard: padding-invariant (popcount denominators), so the kernel is
+  byte-parity regardless of hash length.
+- phash: matches the PAIRWISE `_phash_score_single` (nbits = the longer of the two
+  hashes), NOT the block-global `_phash_score_matrix` -- the Option-A choice. This
+  makes phash bucket-eligible for the first time (it previously declined to the
+  matrix path).
+
+Parity is asserted over thousands of random hex pairs (fixed-width + variable
+length) plus edges: empty, odd-length (phash left-pads), `0x` prefix, and
+unparseable hex (the kernel returns 0.0 where the single functions raise -- an
+edge that never occurs for real CLK / pHash inputs, pinned here explicitly).
+"""
+from __future__ import annotations
+
+import random
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.core import scorer as _scorer
+
+
+def _corpus() -> list[tuple[str, str]]:
+    rng = random.Random(20260721)
+    hexchars = "0123456789abcdef"
+    def rand_hex(nbytes: int) -> str:
+        return "".join(rng.choice(hexchars) for _ in range(nbytes * 2))
+    pairs: list[tuple[str, str]] = []
+    # Fixed-width (the normal CLK / 64-bit pHash case) dominates; some variable.
+    for _ in range(3000):
+        nb = rng.choice([1, 2, 8, 8, 8, 16, 16])
+        a = rand_hex(nb)
+        b = rand_hex(rng.choice([nb, nb, rng.randint(1, 16)]))
+        pairs.append((a, b))
+    # Mixed-case + edges -- all VALID even-length hex (no 0x prefix, no odd
+    # length), since dice/jaccard don't normalize and `bytes.fromhex` raises
+    # otherwise. phash's own normalize-edges are tested separately below.
+    pairs += [
+        ("ABCD", "abcd"), ("FFFF", "0F0F"), ("00", "00"), ("00", "ff"),
+        ("abcd", "abcd"), ("ab", "abcd"), ("", ""), ("abcd", ""),
+    ]
+    return pairs
+
+
+def test_dice_native_matches_pure_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "dice_similarity"):
+        pytest.skip("native dice kernel not built / wheel predates dice_similarity")
+    for a, b in _corpus():
+        assert n.dice_similarity(a, b) == _scorer._dice_score_single(a, b), f"dice {a!r} {b!r}"
+
+
+def test_jaccard_native_matches_pure_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "jaccard_similarity"):
+        pytest.skip("native jaccard kernel not built")
+    for a, b in _corpus():
+        assert n.jaccard_similarity(a, b) == _scorer._jaccard_score_single(a, b), f"jaccard {a!r} {b!r}"
+
+
+def test_phash_native_matches_pure_pairwise_mirror():
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "phash_similarity"):
+        pytest.skip("native phash kernel not built")
+    for a, b in _corpus():
+        assert n.phash_similarity(a, b) == _scorer._phash_score_single(a, b), f"phash {a!r} {b!r}"
+    # phash's own normalize edges: odd length is left-padded ("f" -> "0f"), and a
+    # leading `0x`/`0X` is stripped -- inputs dice/jaccard would raise on.
+    for a, b in [("f", "f"), ("0x00ff", "ff00"), ("0X0f", "0f"), ("f", "ff")]:
+        assert n.phash_similarity(a, b) == _scorer._phash_score_single(a, b), f"phash edge {a!r} {b!r}"
+
+
+def test_bloom_hash_invalid_hex_is_zero_not_raise():
+    # The single functions RAISE on unparseable hex; the score_one kernel can't
+    # raise, so it returns 0.0 (never crashes the block loop). This edge doesn't
+    # occur for real CLK / pHash inputs -- pinned so the divergence is explicit.
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "dice_similarity"):
+        pytest.skip("native bloom/hash kernels not built")
+    for bad in ("zz", "xyz", "gg"):
+        assert n.dice_similarity(bad, "abcd") == 0.0
+        assert n.jaccard_similarity(bad, "abcd") == 0.0
+        assert n.phash_similarity(bad, "abcd") == 0.0
+        with pytest.raises(ValueError):
+            _scorer._dice_score_single(bad, "abcd")
+
+
+def test_bloom_hash_bucket_kernel_ids_9_10_11_match_mirror():
+    """score_block_pairs dispatching ids 9/10/11 == the pure per-pair mirrors.
+
+    One block per scorer, weight 1.0, threshold 0.0 so every pair emits.
+    """
+    n = _native_loader.native_module()
+    if n is None or not hasattr(n, "dice_similarity"):
+        pytest.skip("native bloom/hash kernels not built")
+    values = ["abcd", "abce", "0f0f", "ffff", "1234"]
+    row_ids = list(range(len(values)))
+    for scorer_id, mirror in (
+        (9, _scorer._dice_score_single),
+        (10, _scorer._jaccard_score_single),
+        (11, _scorer._phash_score_single),
+    ):
+        emitted = n.score_block_pairs(
+            row_ids, [len(values)], [values], [scorer_id], [1.0], 1.0, 0.0, []
+        )
+        got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+        for i in range(len(values)):
+            for j in range(i + 1, len(values)):
+                assert got[(i, j)] == mirror(values[i], values[j]), (
+                    f"id={scorer_id} {values[i]!r} {values[j]!r}"
+                )

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -105,6 +105,9 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(score::set_business_aliases, m)?)?;
     m.add_function(wrap_pyfunction!(score::set_given_name_canonicals, m)?)?;
     m.add_function(wrap_pyfunction!(score::alias_match_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::dice_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::jaccard_similarity, m)?)?;
+    m.add_function(wrap_pyfunction!(score::phash_similarity, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs, m)?)?;
     m.add_function(wrap_pyfunction!(score::score_block_pairs_fs_arrow, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -315,6 +315,28 @@ pub fn alias_match_similarity(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::score_one(8, a, b)
 }
 
+/// Dice / Jaccard / phash bloom-hex similarities (score-core ids 9/10/11): integer
+/// popcount over hex-decoded bloom filters / pHashes, byte-exact with the Python
+/// `_dice_score_single` / `_jaccard_score_single` / `_phash_score_single`. Each is
+/// its own #[pyfunction] capability marker like the other bucket kernels: a stale
+/// wheel lacking the symbol hits score_one's catch-all (silent 0.0) for that id,
+/// so the Python caller gates the native route on `hasattr(_native, "<name>")` and
+/// falls back to the pure per-pair mirror otherwise.
+#[pyfunction]
+pub fn dice_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::dice_similarity(a, b)
+}
+
+#[pyfunction]
+pub fn jaccard_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::jaccard_similarity(a, b)
+}
+
+#[pyfunction]
+pub fn phash_similarity(a: &str, b: &str) -> f64 {
+    goldenmatch_score_core::phash_similarity(a, b)
+}
+
 #[pyfunction]
 pub fn token_sort_ratio(a: &str, b: &str) -> f64 {
     goldenmatch_score_core::token_sort_ratio(a, b)

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -568,10 +568,124 @@ pub fn alias_match(a: &str, b: &str) -> f64 {
 }
 } // mod alias
 
+// ---- bloom / hash scorers (dice / jaccard / phash) --------------------------
+// Byte-exact ports of `core.scorer._dice_score_single` / `_jaccard_score_single`
+// / `_phash_score_single`: hex-decode -> INTEGER popcount -> a single f64 divide.
+// The Python single functions use `np.unpackbits(...).sum()` (an integer count)
+// then one float64 division, so `count_ones()` here is bit-exact -- unlike the
+// numpy MATRIX forms (`_dice_score_matrix` etc.), which compute in float32 and
+// round to ~1e-7. Pure primitives (no table/regex) -> no feature gate.
+//
+// Padding is PAIRWISE, matching `_pad_to_equal_length`. dice/jaccard are
+// padding-INVARIANT (their denominators are popcounts, unchanged by trailing
+// zero bytes), so this is also matrix-parity for them; phash's denominator is
+// bit-LENGTH, so it matches the PAIRWISE `_phash_score_single` (NOT the
+// block-global `_phash_score_matrix` -- the Option-A choice in the
+// `2026-07-21-block-aware-bucket-kernel-design.md` spec).
+
+/// Decode an even-length hex string to bytes, or `None` if malformed. The Python
+/// single functions raise `ValueError` on bad hex (`bytes.fromhex`); a `score_one`
+/// kernel can't raise, so unparseable hex -> `None` -> score `0.0` (never crashes
+/// the block loop). PPRL CLK / image pHash inputs are always valid fixed-width hex,
+/// so this edge doesn't arise in practice; it's asserted in the parity test.
+/// (Python `bytes.fromhex` also skips ASCII whitespace between pairs; CLK/pHash hex
+/// has none, so this strict decoder is byte-parity on the real inputs.)
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    let bytes = s.as_bytes();
+    if !bytes.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 2);
+    let mut i = 0;
+    while i < bytes.len() {
+        let hi = (bytes[i] as char).to_digit(16)?;
+        let lo = (bytes[i + 1] as char).to_digit(16)?;
+        out.push((hi * 16 + lo) as u8);
+        i += 2;
+    }
+    Some(out)
+}
+
+fn popcount_bytes(b: &[u8]) -> u32 {
+    b.iter().map(|x| x.count_ones()).sum()
+}
+
+/// `_norm_phash_hex`: strip an optional `0x`/`0X` prefix, left-pad an odd length
+/// to even so the hex decodes. (Python `s[:2]` on a <2-char string is the string
+/// itself and never matches `"0x"`/`"0X"`, so the prefix strip needs len >= 2.)
+fn norm_phash_hex(s: &str) -> String {
+    let s = if s.len() >= 2 && (s.starts_with("0x") || s.starts_with("0X")) {
+        &s[2..]
+    } else {
+        s
+    };
+    if !s.len().is_multiple_of(2) {
+        format!("0{s}")
+    } else {
+        s.to_string()
+    }
+}
+
+/// Dice coefficient `2*|A&B| / (|A|+|B|)` on two hex bloom filters; byte-for-byte
+/// with `_dice_score_single`. Padding-invariant (popcount denominators).
+pub fn dice_similarity(a: &str, b: &str) -> f64 {
+    let (pa, pb) = match (decode_hex(a), decode_hex(b)) {
+        (Some(x), Some(y)) => (x, y),
+        _ => return 0.0,
+    };
+    let m = pa.len().min(pb.len());
+    let inter: u32 = (0..m).map(|i| (pa[i] & pb[i]).count_ones()).sum();
+    let total = popcount_bytes(&pa) + popcount_bytes(&pb);
+    if total == 0 {
+        0.0
+    } else {
+        2.0 * inter as f64 / total as f64
+    }
+}
+
+/// Jaccard `|A&B| / |A|B|` on two hex bloom filters; byte-for-byte with
+/// `_jaccard_score_single`. `|A|B| = |A|+|B|-|A&B|` (inclusion-exclusion), which
+/// is padding-invariant.
+pub fn jaccard_similarity(a: &str, b: &str) -> f64 {
+    let (pa, pb) = match (decode_hex(a), decode_hex(b)) {
+        (Some(x), Some(y)) => (x, y),
+        _ => return 0.0,
+    };
+    let m = pa.len().min(pb.len());
+    let inter: u32 = (0..m).map(|i| (pa[i] & pb[i]).count_ones()).sum();
+    let total = popcount_bytes(&pa) + popcount_bytes(&pb);
+    let union = total - inter;
+    if union == 0 {
+        0.0
+    } else {
+        inter as f64 / union as f64
+    }
+}
+
+/// Perceptual-hash Hamming similarity `1 - dist / nbits` on two hex pHashes;
+/// byte-for-byte with `_phash_score_single`. PAIRWISE padding: `nbits` is the
+/// longer of the two hashes in bits (a trailing byte XOR implicit zero is the
+/// byte itself, so it counts in `dist`). Empty -> `nbits == 0` -> `0.0`.
+pub fn phash_similarity(a: &str, b: &str) -> f64 {
+    let (pa, pb) = match (decode_hex(&norm_phash_hex(a)), decode_hex(&norm_phash_hex(b))) {
+        (Some(x), Some(y)) => (x, y),
+        _ => return 0.0,
+    };
+    let nbits = pa.len().max(pb.len()) * 8;
+    if nbits == 0 {
+        return 0.0;
+    }
+    let m = pa.len().min(pb.len());
+    let mut dist: u32 = (0..m).map(|i| (pa[i] ^ pb[i]).count_ones()).sum();
+    dist += popcount_bytes(&pa[m..]); // tail of the longer ^ 0 = the byte itself
+    dist += popcount_bytes(&pb[m..]); // (exactly one of these slices is non-empty)
+    1.0 - dist as f64 / nbits as f64
+}
+
 /// Scorer dispatch matching `score_buckets._resolve_score_pair_callable`'s
 /// fast-path scale, all on [0, 1]. ids: 0=jaro_winkler, 1=levenshtein,
 /// 2=token_sort, 3=exact, 4=date, 5=qgram, 6=soundex_match, 7=initialism_match,
-/// 8=alias_match.
+/// 8=alias_match, 9=dice, 10=jaccard, 11=phash.
 ///
 /// NOTE: id=2 returns the UNSCALED `fuzz::ratio` ([0,1], NOT *100). This is
 /// deliberate and must not be reconciled with `token_sort_ratio`'s *100 form:
@@ -611,6 +725,13 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         // 0.0 catch-all there, which wasm never routes.
         #[cfg(feature = "alias")]
         8 => alias_match(a, b),
+        // ids 9/10/11 = dice / jaccard / phash (bloom-hex + hex-hamming, integer
+        // popcount). Byte-exact with the `_*_score_single` per-pair references the
+        // bucket path already uses; the Python guard gates each on its capability
+        // symbol so a stale wheel declines to those mirrors.
+        9 => dice_similarity(a, b),
+        10 => jaccard_similarity(a, b),
+        11 => phash_similarity(a, b),
         _ => 0.0,
     }
 }
@@ -848,6 +969,36 @@ mod tests {
         assert_eq!(score_one(8, "Bob", "Bill"), 0.0); // different canonicals
         // Empty both -> no canonical -> 0.0.
         assert_eq!(score_one(8, "", ""), 0.0);
+    }
+
+    #[test]
+    fn score_one_ids_9_10_11_are_dice_jaccard_phash() {
+        // Ground truth from core.scorer._dice_score_single / _jaccard_score_single
+        // / _phash_score_single. Exact f64 (integer popcount + one f64 divide, same
+        // op order as the Python single functions) -- no float32 rounding.
+        // dice = 2*|A&B| / (|A|+|B|)
+        assert_eq!(score_one(9, "ab12", "cd34"), 2.0 * 4.0 / 15.0);
+        assert_eq!(score_one(9, "ffff", "0f0f"), 2.0 * 8.0 / 24.0);
+        assert_eq!(score_one(9, "ab", "abcd"), 2.0 * 5.0 / 15.0); // pairwise pad invariant
+        assert_eq!(score_one(9, "00ff", "ff00"), 0.0); // disjoint
+        assert_eq!(score_one(9, "abcd", "abcd"), 1.0);
+        assert_eq!(score_one(9, "0000", "ffff"), 0.0); // empty A -> total>0, inter 0
+        // jaccard = |A&B| / |A|B|
+        assert_eq!(score_one(10, "ab12", "cd34"), 4.0 / 11.0);
+        assert_eq!(score_one(10, "ffff", "0f0f"), 0.5);
+        assert_eq!(score_one(10, "ab", "abcd"), 0.5);
+        assert_eq!(score_one(10, "abcd", "abcd"), 1.0);
+        assert_eq!(score_one(10, "00ff", "ff00"), 0.0);
+        // phash = 1 - dist/nbits (PAIRWISE nbits)
+        assert_eq!(score_one(11, "ab12", "cd34"), 0.5625);
+        assert_eq!(score_one(11, "ffff", "0f0f"), 0.5);
+        assert_eq!(score_one(11, "ab", "abcd"), 0.6875); // pairwise pad: nbits=16
+        assert_eq!(score_one(11, "abcd", "abcd"), 1.0);
+        assert_eq!(score_one(11, "0x00ff", "ff00"), 0.0); // 0x prefix stripped
+        assert_eq!(score_one(11, "f", "f"), 1.0); // odd length left-padded to "0f"
+        // Unparseable hex -> 0.0 (kernel can't raise like the single fns do).
+        assert_eq!(score_one(9, "zz", "abcd"), 0.0);
+        assert_eq!(score_one(11, "", ""), 0.0); // nbits == 0
     }
 
     #[test]

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,8 +305,9 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date`, `qgram`, `soundex_match`, `initialism_match`, `alias_match`
-# have an arrow-native (bucket) kernel on Python but no TS WASM port yet.
+# python_only: `date`, `qgram`, `soundex_match`, `initialism_match`, `alias_match`,
+# `dice`, `jaccard`, `phash` have an arrow-native (bucket) kernel on Python but no
+# TS WASM port yet.
 scorer_kernels:
   shared:
   - exact
@@ -316,7 +317,10 @@ scorer_kernels:
   python_only:
   - alias_match
   - date
+  - dice
   - initialism_match
+  - jaccard
+  - phash
   - qgram
   - soundex_match
   ts_only: []
@@ -329,13 +333,10 @@ scorer_kernels:
 # kernelize (with the blocker); `declined --` = won't (with why); `n/a --` = not a
 # string kernel. Removing a scorer's kernel without adding it here fails CI.
 scorer_kernels_deferred:
-  dice: "deferred -- dual-semantics: bigram-set Dice per-pair vs PPRL bloom-filter hex Dice in the matrix path; disambiguate which the scorer name means before kernelizing"
-  jaccard: "deferred -- dual-semantics like dice (bigram-set vs PPRL bloom-filter hex); disambiguate before kernelizing"
   ensemble: "declined -- a per-pair reimpl measurably regressed Febrl3 recall (0.922->0.782); the float32 matrix ensemble is the source of truth, so it stays off the bucket/fast path. Kernelizing means re-opening that measurement"
   embedding: "n/a -- model-backed (sentence-transformers / Vertex); belongs to goldenembed, not a string kernel"
   record_embedding: "n/a -- model-backed multi-field embedding"
   given_name_aliased_jw: "deferred -- ts_only scorer; its kernel home is the TS WASM surface (WASM_COVERED_SCORERS), not the Python bucket"
   name_freq_weighted_jw: "deferred -- ts_only; also uses a dynamic per-dataset tf table that does not fit the static-global in-kernel table mechanism"
-  phash: "deferred -- hex-hamming similarity, but matrix-semantics-dependent like dice/jaccard: _phash_score_matrix pads all block hashes to the block-GLOBAL max bit-length (sim = 1 - dist/max_len) while a score_one per-pair kernel can only pad pairwise -> diverges on mixed-length blocks; invalid hex also differs (matrix -> 0, single raises). True parity needs a block-aware kernel, not the score_one id pattern"
   radial: "declined -- bespoke rotation-aligned Pearson on radial profiles; angular alignment search, low perf upside (small blocks)"
   audio_fp: "declined -- bespoke best-offset-aligned BER on hex audio fingerprints; alignment search, low perf upside"


### PR DESCRIPTION
## What and why

Kernelizes `dice`, `jaccard`, `phash` as bucket `score_one` ids (**9/19 → 12/19**), plus the design spec that scoped them. Approved by the maintainer (Phase 1 + phash via Option A).

**The "block-aware kernel" premise was a misdiagnosis** (documented in the spec, `docs/superpowers/specs/2026-07-21-block-aware-bucket-kernel-design.md`): the per-pair single functions use **integer popcount** + one float64 divide, so a Rust `count_ones()` kernel is **byte-exact** with them. The single-vs-matrix gap people worried about was only the numpy *matrix* path's **float32** rounding. dice/jaccard are also **padding-invariant** (popcount denominators). So all three kernelize cleanly as per-pair `score_one` ids — no block-awareness needed.

## Changes

- **`score-core`**: `dice_similarity` / `jaccard_similarity` / `phash_similarity` + `score_one` ids 9/10/11. Pure primitives (hex-decode + integer popcount, no table/regex → no feature gate). dice/jaccard padding-invariant; **phash uses the PAIRWISE `_phash_score_single` (Option A)**, not the block-global `_phash_score_matrix`. Unparseable hex → `0.0` (a `score_one` kernel can't raise like the single fns; PPRL/pHash inputs are always valid hex). Cargo tests pin ground truth (24/24, clippy clean with + without the `alias` feature).
- **`native`**: three `#[pyfunction]` capability markers, registered.
- **`score_buckets.py`**: `_NATIVE_SCORER_IDS` 9/10/11; a **new `phash` branch** in `_resolve_score_pair_callable` (`_phash_score_single` mirror) — this makes phash bucket-eligible for the first time (it previously declined to the slow matrix path); one-part wheel-skew guard (symbol only, no install) for all three.
- Manifest: move dice/jaccard/phash `scorer_kernels_deferred` → `scorer_kernels.python_only` (the coverage gate from #1983 *enforces* this — `stale_deferral` otherwise). suite-matrix (12/19) + `agent-codemap.json` regenerated; cross-surface id-map `_SCORE_ONE_IDS += dice/jaccard/phash`; new `test_native_bloom_hash_parity.py`; both specs updated.
- **Spec** (`2026-07-21-block-aware-bucket-kernel-design.md`): Phases 1+2 marked landed; Phase 3 (general block-aware matrix-scorer mechanism) stays designed-but-not-built for a future block-global scorer.

## Behavior note (phash)

phash moves from the `find_fuzzy_matches` matrix path (float32, block-global-max padding) to the bucket per-pair path (float64, pairwise padding). **Byte-identical for fixed-length pHashes** (the normal 64-bit case); a float64 precision improvement elsewhere. This is the Option-A choice the maintainer approved.

## Testing

- `cargo test` (score-core): 24/24; `cargo clippy --all-targets -- -D warnings` clean both with `alias` on AND `--no-default-features`
- `test_native_bloom_hash_parity.py`: native == the per-pair single functions over thousands of pairs (fixed + variable length) + edges + the invalid-hex→0 characterization + the id 9/10/11 bucket dispatch; ad-hoc **20,000-pair fuzz: 0 mismatches** each
- Regression: cross-surface id-map, fast-path gate, vectorized-fallback, `test_scorer.py`, arrow bucket, qgram/soundex/alias parity, `test_api_parity.py` (incl. the coverage gate): **178 passed**
- `gen_suite_matrix.py --check` OK (12/19); `check_native_symbols.py goldenmatch` OK; config_matrix / agent-codemap gates: 54 passed; Python `scorer_kernels` emitter includes dice/jaccard/phash
- Rebuilt the in-tree `_native.abi3.so`

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (spec + regenerated suite-matrix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr