### PR TITLE
perf(fs): thread n_rows_full so zero-config FS blocking prunes at scale (410s→71s)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -21,6 +21,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   excluding the ambiguous bare `identifier` type (row PKs) for config hygiene.
   FS path only; the weighted/exact matchkey path is unchanged.
 
+- **Zero-config FS blocking pair-budget now prunes at scale (~6x wall).** The FS
+  blocking pair-budget (`_bound_probabilistic_blocking_pairs`) is documented to
+  extrapolate each pass's candidate pairs to the full population, but
+  `auto_configure_probabilistic_df` never passed `n_rows_full` -- so on the
+  auto-config sample the bound measured pairs at sample scale (a 66M-at-1.2M pass
+  reads as ~1.8M at a 200K sample), stayed under budget, and never pruned, leaving
+  redundant giant-block soundex passes. Threading the full row count lets the
+  bound bound the oversized name passes at true scale: measured zero-config FS
+  wall 410s -> 71s at 1.2M (F1 unchanged at 1.000). The FS routing call site and
+  the bench/gate helper now pass `n_rows_full`.
+
 - **FS `missing="unobserved"`: a partial-observation pair no longer normalizes to
   1.0 (#1854).** The min-max score range accumulated only over the OBSERVED
   fields, so a pair agreeing on its single observed field had `total == pair_max`

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -4400,7 +4400,9 @@ def _legacy_auto_configure_v0(  # pyright: ignore[reportUnusedFunction]  # kept 
         )
         _prob_route = False
     if _prob_route:
-        routed = auto_configure_probabilistic_df(df, llm_provider=llm_provider)
+        routed = auto_configure_probabilistic_df(
+            df, llm_provider=llm_provider, n_rows_full=total_rows
+        )
         # Parity with the deterministic tail: attach the preflight report so a
         # routed FS config carries the same verification/diagnostic the default
         # path does (the config-lint + auto-repair surface). Standardization is
@@ -4988,6 +4990,8 @@ def _detect_standardization_config(profiles: list[ColumnProfile]) -> Any:
 def auto_configure_probabilistic_df(
     df: Any,  # pl.DataFrame | pl.LazyFrame | pa.Table (arrow lane)
     llm_provider: str | None = None,
+    *,
+    n_rows_full: int | None = None,
 ) -> GoldenMatchConfig:
     """Build a Fellegi-Sunter *probabilistic* config straight from a DataFrame.
 
@@ -5031,7 +5035,14 @@ def auto_configure_probabilistic_df(
     # diversified ones) by candidate pairs Σ C(block,2), not just block rows —
     # the row ceiling let ~12.9B-pair configs (dob-YEAR + name-soundex mega-
     # passes) through and OOM-killed gm_probabilistic at 1M. See #1803.
-    blocking = _bound_probabilistic_blocking_pairs(blocking, profiles, df)
+    # `n_rows_full` is load-bearing: auto-config profiles a SAMPLE, and the bound
+    # extrapolates each pass's Σ C(block,2) to the full population. Without it the
+    # bound measures pairs at sample scale (a 66M-at-1.2M pass looks like ~1.8M at
+    # a 200K sample) and never prunes, leaving redundant recall passes that make
+    # the wall ~20x the discriminative-key config at scale.
+    blocking = _bound_probabilistic_blocking_pairs(
+        blocking, profiles, df, n_rows_full=n_rows_full
+    )
     return GoldenMatchConfig(
         matchkeys=matchkeys,
         blocking=blocking,

--- a/packages/python/goldenmatch/scripts/bench_fs_distributed.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_distributed.py
@@ -143,7 +143,7 @@ def _zero_config_cfg(df, backend: str):
     from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
 
     sample = df.head(200_000)
-    cfg = auto_configure_probabilistic_df(sample.to_arrow())
+    cfg = auto_configure_probabilistic_df(sample.to_arrow(), n_rows_full=df.height)
     cfg.backend = backend
     return cfg
 

--- a/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
+++ b/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
@@ -429,3 +429,29 @@ def test_v2_config_runs_end_to_end(monkeypatch):
     assert "dob" in fields  # lever #1 active under v2
     result = dedupe_df(df, config=cfg)
     assert result.dupes is not None and result.dupes.num_rows > 0
+
+
+def test_auto_config_threads_n_rows_full_to_pair_bound(monkeypatch):
+    """auto_configure_probabilistic_df MUST pass n_rows_full to the pair-budget
+    bound so it extrapolates each pass's Sum C(block,2) to the FULL population and
+    prunes oversized passes at scale. Without the thread the bound measures pairs
+    at SAMPLE scale (a 66M-at-1.2M pass reads as ~1.8M at a 200K sample), never
+    fires, and the zero-config FS wall is ~6x the pruned config (410s vs 71s at
+    1.2M). Locks the wiring so it cannot be silently dropped."""
+    import goldenmatch.core.autoconfig as ac
+
+    seen: dict = {}
+    orig = ac._bound_probabilistic_blocking_pairs
+
+    def spy(blocking, profiles, df=None, *, n_rows_full=None):
+        seen["n_rows_full"] = n_rows_full
+        return orig(blocking, profiles, df, n_rows_full=n_rows_full)
+
+    monkeypatch.setattr(ac, "_bound_probabilistic_blocking_pairs", spy)
+    df = pl.DataFrame({
+        "first_name": ["ana", "bob", "cat", "dan"] * 25,
+        "last_name": ["xu", "yi", "zed", "wu"] * 25,
+        "email": [f"u{i}@e.com" for i in range(100)],
+    })
+    ac.auto_configure_probabilistic_df(df, n_rows_full=5_000_000)
+    assert seen.get("n_rows_full") == 5_000_000

--- a/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
+++ b/packages/python/goldenmatch/tests/test_fs_autoconfig_v2.py
@@ -23,6 +23,7 @@ from goldenmatch.core.autoconfig import (
     _bound_probabilistic_blocking_pairs,
     _diversify_probabilistic_blocking,
     _fs_total_pair_budget,
+    auto_configure_probabilistic_df,
     build_probabilistic_matchkeys,
 )
 
@@ -413,7 +414,6 @@ def test_pair_gate_default_budget_is_noop_at_unit_scale(monkeypatch):
 def test_v2_config_runs_end_to_end(monkeypatch):
     monkeypatch.setenv(ON, "1")
     from goldenmatch import dedupe_df
-    from goldenmatch.core.autoconfig import auto_configure_probabilistic_df
 
     df = pl.DataFrame({
         "first_name": ["John", "Jon", "Mary", "Marie", "Robert", "Bob",
@@ -438,20 +438,20 @@ def test_auto_config_threads_n_rows_full_to_pair_bound(monkeypatch):
     at SAMPLE scale (a 66M-at-1.2M pass reads as ~1.8M at a 200K sample), never
     fires, and the zero-config FS wall is ~6x the pruned config (410s vs 71s at
     1.2M). Locks the wiring so it cannot be silently dropped."""
-    import goldenmatch.core.autoconfig as ac
-
     seen: dict = {}
-    orig = ac._bound_probabilistic_blocking_pairs
+    orig = _bound_probabilistic_blocking_pairs
 
     def spy(blocking, profiles, df=None, *, n_rows_full=None):
         seen["n_rows_full"] = n_rows_full
         return orig(blocking, profiles, df, n_rows_full=n_rows_full)
 
-    monkeypatch.setattr(ac, "_bound_probabilistic_blocking_pairs", spy)
+    monkeypatch.setattr(
+        "goldenmatch.core.autoconfig._bound_probabilistic_blocking_pairs", spy
+    )
     df = pl.DataFrame({
         "first_name": ["ana", "bob", "cat", "dan"] * 25,
         "last_name": ["xu", "yi", "zed", "wu"] * 25,
         "email": [f"u{i}@e.com" for i in range(100)],
     })
-    ac.auto_configure_probabilistic_df(df, n_rows_full=5_000_000)
+    auto_configure_probabilistic_df(df, n_rows_full=5_000_000)
     assert seen.get("n_rows_full") == 5_000_000


### PR DESCRIPTION
## What and why

Follow-up to #1981 (which fixed zero-config FS *correctness* — F1 0→1.0 at scale). This fixes the *wall*: after the correctness fix, zero-config FS at 1.2M was still **~410s** vs the hand-tuned explicit config's 20.7s, because its blocking shipped redundant giant-block `soundex` passes.

Root cause: `_bound_probabilistic_blocking_pairs` is documented to bound each pass's `Σ C(block,2)` **extrapolated to the full population** — but `auto_configure_probabilistic_df` never passed `n_rows_full`. Auto-config profiles a *sample*, so the bound measured pairs at sample scale (a 66M-at-1.2M pass reads as ~1.8M at a 200K sample), stayed under budget, and **never pruned**. The pruner was already there; it just wasn't told the real scale.

## Measured (realistic person data, 1.2M, single-box `bucket`)

| | wall | F1 | peak RSS |
|---|---|---|---|
| zero-config **before** (no `n_rows_full`) | 410s | 1.000 | — |
| zero-config **after** (this PR) | **71.2s** | **1.000** | 2.29 GB |

**5.8× faster, F1 unchanged at 1.000** (P=R=1.0). The bound replaces the giant single-field `soundex` blocks with reducer-bounded compound blocks (`[first_name, last_name]`), removing the O(block²) giant-block penalty — so the wall drops far more than the pair count (58M vs 66M). At 25M this extrapolates to ~25 min (vs the pre-fix ~2h), keeping the name-pass recall insurance the zip-only explicit config lacks.

## Changes

- `core/autoconfig.py`: add a keyword-only `n_rows_full` to `auto_configure_probabilistic_df` and thread it to `_bound_probabilistic_blocking_pairs`. The FS routing call site passes `total_rows`; the bench/gate helper passes the full frame height.
- `tests/test_fs_autoconfig_v2.py`: `test_auto_config_threads_n_rows_full_to_pair_bound` — a spy that locks the threading so it can't be silently dropped.
- `scripts/bench_fs_distributed.py`: the zero-config gate helper passes `n_rows_full` (so the nightly FS scale gate exercises the pruned path).
- CHANGELOG entry.

## Testing

Root `.venv`, `ARROW_DEFAULT_MEMORY_POOL=system`, `GOLDENMATCH_AUTOCONFIG_MEMORY=0`:
- Regression sweep (`test_fs_autoconfig_v2` / `probabilistic_721` / `probabilistic_entry` / `probabilistic_routing` / `blocking_candidates_e2e` / `autoconfig_regressions` / `bucket_default_routing` / `fs_bucket_native`) → **114 passed**.
- New wiring test → passed.
- End-to-end: zero-config FS at 1.2M → wall 410s→71.2s, F1 1.000 (measured).
- `ruff check` clean.

Recall guard: the existing `bench-probabilistic` panel (Febrl/DBLP-ACM/historical) is the standing check that pruning doesn't cost recall on real data — the bound *bounds* oversized passes (reducer field) rather than dropping them.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_