### PR TITLE
ci(goldenmatch): run the full FS suite in the pure-Python fallback lane (#1805)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -537,6 +537,13 @@ jobs:
         # native, so those tests can't hold here by construction. This lane proves
         # the pure-Python behavior path, not native dispatch (that's the `native`
         # lane's job).
+        #
+        # FS suite (#1805): native is authoritative-by-default for Fellegi-Sunter,
+        # and every native FS parity test is skipif-gated on the kernel, so the
+        # pure-Python FS path had NO dedicated fallback coverage beyond
+        # test_probabilistic.py. The full FS suite (NE + n-level + bucket + the
+        # probabilistic variants) now runs here under GOLDENMATCH_NATIVE=0 with the
+        # native-dispatch assertions deselected, closing that hole.
         run: |
           uv run pytest \
             packages/python/goldenmatch/tests/test_cluster.py \
@@ -546,6 +553,19 @@ jobs:
             packages/python/goldenmatch/tests/test_pipeline.py \
             packages/python/goldenmatch/tests/test_pairs.py \
             packages/python/goldenmatch/tests/test_probabilistic.py \
+            packages/python/goldenmatch/tests/test_probabilistic_vectorized.py \
+            packages/python/goldenmatch/tests/test_probabilistic_determinism.py \
+            packages/python/goldenmatch/tests/test_probabilistic_parallel.py \
+            packages/python/goldenmatch/tests/test_probabilistic_bench_dump.py \
+            packages/python/goldenmatch/tests/test_fs_ne_e2e.py \
+            packages/python/goldenmatch/tests/test_fs_ne_em.py \
+            packages/python/goldenmatch/tests/test_fs_ne_guards.py \
+            packages/python/goldenmatch/tests/test_fs_ne_schema.py \
+            packages/python/goldenmatch/tests/test_fs_ne_scoring.py \
+            packages/python/goldenmatch/tests/test_nlevel_banding.py \
+            packages/python/goldenmatch/tests/test_nlevel_em.py \
+            packages/python/goldenmatch/tests/test_nlevel_schema.py \
+            packages/python/goldenmatch/tests/test_fs_bucket_native.py \
             -k "not native and not Native" \
             -n auto --timeout=120 --timeout-method=thread -q
 


### PR DESCRIPTION
## What and why

Addresses one checkbox of the #1805 FS-coverage epic: **"Pure-Python lane runs the full FS suite."**

Native is authoritative-by-default for Fellegi-Sunter, and every native FS parity test is `skipif`-gated on the kernel — so the `python_goldenmatch_fallback` lane (`GOLDENMATCH_NATIVE=0`) had **no dedicated pure-Python FS coverage beyond `test_probabilistic.py`**. The NE, n-level, and bucket FS behavior paths were unexercised in fallback mode despite being the non-authoritative path real users hit on musl / unsupported platforms / `GOLDENMATCH_NATIVE=0`.

## Changes

- **`.github/workflows/ci.yml`** (`python_goldenmatch_fallback` lane): add the rest of the FS suite to the pytest invocation —
  - NE family: `test_fs_ne_{e2e,em,guards,schema,scoring}`
  - n-level family: `test_nlevel_{banding,em,schema}`
  - `test_fs_bucket_native`
  - probabilistic variants: `test_probabilistic_{vectorized,determinism,parallel,bench_dump}`

  The existing `-k "not native and not Native"` filter already deselects the native-dispatch assertions that can't hold under `GOLDENMATCH_NATIVE=0`, so these run their pure-Python behavior paths.

## Testing

- Verified locally under `GOLDENMATCH_NATIVE=0` with the same `-k` filter: **119 pass** (79 FS NE/n-level/bucket + 40 probabilistic variants), 31 native-dispatch tests correctly deselected, 1 skip.
- Confirmed the one registration in `test_fs_ne_guards.py` is scoped inside its asserting test (xdist-safe under the lane's `-n auto`).
- `ci.yml` YAML validated.

## Notes

- CI-config only, no library code change. Editing `ci.yml` re-runs the full matrix, which exercises the expanded lane directly.
- This is one of four checkboxes in #1805; the epic stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_