### PR TITLE
feat(goldengraph): enable anti-shatter cross-doc linking by default

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -213,6 +213,10 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
           POLARS_SKIP_CPU_CHECK: "1"
+          # datasets pulls a fresh-pip pyarrow whose bundled mimalloc SIGSEGVs on the
+          # pipeline's worker threads -- the documented repo standard for any lane that
+          # pip-installs goldenmatch/pyarrow and runs the pipeline (goldengraph resolve).
+          ARROW_DEFAULT_MEMORY_POOL: system
         run: |
           mkdir -p results
           python -m erkgbench.qa_e2e.run_local_vs_auto_ab \

--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -24,7 +24,7 @@ on:
         description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag | goldenmatch_rag | goldenmatch_entity_rag (head_to_head mode only)"
         default: "all"
       mode:
-        description: "head_to_head | scorecard | aggregation_llm | temporal_llm | crossover_llm | kg_capability | router_capability | extraction_f1 | synthesis_gold | retrieval_coverage"
+        description: "head_to_head | local_vs_auto_ab | scorecard | aggregation_llm | temporal_llm | crossover_llm | kg_capability | router_capability | extraction_f1 | synthesis_gold | retrieval_coverage"
         default: "head_to_head"
       budget_usd:
         description: "hard cost cap per (engine, ambiguity) run"
@@ -168,6 +168,69 @@ jobs:
         with:
           name: graphrag-distill-goldengraph-amb${{ matrix.ambiguity }}
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/distill_goldengraph_amb${{ matrix.ambiguity }}.jsonl
+          if-no-files-found: ignore
+
+  # Same-run local-vs-auto A/B: ONE shared graph, every question answered under both
+  # mode=local (default path, chain routing on) and mode=auto -> the deltas are purely
+  # the answer-time routing's effect. The headline for "is chain routing worth making
+  # the local default?". Single run (no ambiguity matrix); opts still override env.
+  goldengraph_ab:
+    needs: setup
+    if: ${{ inputs.mode == 'local_vs_auto_ab' }}
+    runs-on: large-new-64GB
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Resolve bench env (baked defaults, then opts override)
+        env:
+          OPTS: ${{ inputs.opts }}
+        run: |
+          {
+            echo "GOLDENGRAPH_BUILD_WORKERS=12"
+            echo "GOLDENGRAPH_LINK_THRESHOLD=0.82"
+            echo "GOLDENGRAPH_PROFILE_MERGE_THRESHOLD=0.72"
+            echo "GOLDENGRAPH_QA_RETRIEVAL_HOPS=6"
+            echo "GOLDENGRAPH_QA_NODE_BUDGET=256"
+            echo "GOLDENGRAPH_EXTRACTOR=api"
+            printf '%s\n' "$OPTS"
+          } | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' >> "$GITHUB_ENV"
+      - name: Install goldenmatch + native engine wheel + goldengraph + datasets
+        run: |
+          python -m pip install --upgrade pip maturin pytest goldenmatch datasets openai
+          maturin build --release \
+            -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
+          maturin build --release \
+            -m packages/rust/extensions/goldenprofile-native/Cargo.toml --out dist
+          python -m pip install dist/*.whl
+          python -m pip install --no-deps -e packages/python/goldengraph
+          python -m pip install --no-deps -e packages/python/goldenmatch
+      - name: Run local-vs-auto A/B (real LLM, budget-capped, one shared graph)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+        run: |
+          mkdir -p results
+          python -m erkgbench.qa_e2e.run_local_vs_auto_ab \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --ambiguity "0.5" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
+            --out-md "results/RESULTS_QA_LOCAL_VS_AUTO_AB.md" \
+            --out-json "results/results_qa_local_vs_auto_ab.json"
+          echo "### Local-vs-auto A/B" >> "$GITHUB_STEP_SUMMARY"
+          cat results/RESULTS_QA_LOCAL_VS_AUTO_AB.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload A/B results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-local-vs-auto-ab
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_local_vs_auto_ab.*
           if-no-files-found: ignore
 
   lightrag:

--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -142,12 +142,36 @@ tests unchanged). `embedder` threads `ask` -> `resolve_profile` -> `classify_que
 synonyms -- the no-torch char-ngram embedder only shares the morphological cases the
 stem rule already covers. Tests: `tests/test_nl_chain.py` (`_SynEmbedder` stub:
 spouse~married_to fires; an orthogonal word stays below the floor and abstains).
-NOTE the reachability gotcha: the bench's goldengraph engine runs `ask` in
-`mode="local"` by default (`engines/goldengraph.py`), and the NL routing (chain
-extraction) only runs in `mode="auto"` -- so exercising this end-to-end in the
-bench needs `GOLDENGRAPH_QA_MODE=auto`. Making the chain-attempt fire inside
-local/hybrid before synthesis (so the win is default, not auto-only) is the next
-follow-up.
+NOTE the reachability gotcha (NOW RESOLVED, see next section): the bench's goldengraph
+engine runs `ask` in `mode="local"` by default (`engines/goldengraph.py`), and the NL
+routing (chain extraction) originally only ran in `mode="auto"`.
+
+## NL chain routing is the DEFAULT local/hybrid path (2026-07-21)
+Closes the reachability gotcha above: the template-free chain walk now fires for
+`mode="local"` and `mode="hybrid"` BEFORE synthesis, so the routing win reaches the
+DEFAULT answer path (the bench + most callers run `mode="local"`), not just `mode="auto"`.
+- **`answer.ask`** — factored the auto path's routing into two shared helpers
+  (`_resolve_and_plan` = resolve profile + schema-canon + plan; `_chain_answer_from_profile`
+  = the ordered/any-order walk) so `auto` and the new local/hybrid attempt share ONE
+  implementation. In the local/hybrid branch, before seed retrieval, it runs the chain
+  attempt and returns on a completed walk; a None (no chain plan, or the walk hit a
+  missing edge) falls through to today's retrieval+synthesis, unchanged. Skipped when we
+  arrived via `auto` (it already tried the chain).
+- **Gate `GOLDENGRAPH_QA_LOCAL_CHAIN` (default ON; `=0`/`false` restores the pre-change
+  pure-synthesis local/hybrid path, byte-identical)** — `_local_chain_enabled()`. Off is
+  the baseline arm of the A/B. A non-chain local query (no groundable relation) is never
+  hijacked (plan.mode != "chain" -> falls through), so this only ADDS answers, never
+  changes an existing synthesis answer.
+- **Same-run local-vs-auto A/B** (`benchmarks/er-kg-bench/erkgbench/qa_e2e`):
+  `harness.run_engine_ab` builds the KG ONCE and answers every question under BOTH modes
+  against the identical graph (removing build variance), scoring per-arm via the
+  single-sourced `_score_question`/`_build_scorecard` (the same metrics `run_engine` uses).
+  Entry `run_local_vs_auto_ab.py` (`--self-test` CI-validates the plumbing); the
+  goldengraph engine's `answer(handle, q, mode=)` gained a per-call mode override.
+  Dispatchable via `bench-graphrag-qa.yml` mode `local_vs_auto_ab`. Tests:
+  `tests/test_nl_chain.py` (mode=local/hybrid route to the LLM-free chain; gate-off +
+  non-chain query fall through to synthesis) + `tests/test_qa_local_vs_auto_ab.py`
+  (one shared build, aligned arms, delta).
 
 ### Post-#1969 hardening (2026-07-21, review-driven)
 Three fixes on top of the semantic bridge, all in `_extract_nl_chain_slots`:

--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -193,3 +193,31 @@ Three fixes on top of the semantic bridge, all in `_extract_nl_chain_slots`:
   bridge (`nan`) nor make it bind anything (a negative floor).
 Tests: `tests/test_nl_chain.py` (synonym-only fires with embedder / abstains without;
 malformed-embedder degrades; env parse+clamp).
+
+## Anti-shatter cross-doc linking is DEFAULT ON (2026-07-21)
+The "multi-hop shatter" — the same entity mentioned in two documents living as two
+un-merged graph nodes, so a multi-hop question can't traverse across docs — was the #1
+addressable QA-failure class (measured 28% of MuSiQue N=100 misses; support_recall only
+0.59). ROOT CAUSE was NOT a missing capability: the anti-shatter stack existed and was
+well-built, but it was **off by default** (`GOLDENGRAPH_CROSS_DOC_LINK`/`PROFILE_LINK`
+unset → cross-doc merge fell back to an exact `record_key`, which the docstring itself
+says type/case jitter defeats ~97.6% of the time). The bench even *built the goldenprofile
+wheel for the matcher and never set the flag.*
+- **`resolve._key_payload` default is now `name_ci_type`** (case-folded name + COARSE
+  canonical type; homograph-safe). `GOLDENGRAPH_XDOC_KEY=exact` restores the legacy
+  verbatim `(name, typ)` key; `name`/`name_ci` are the more/less aggressive relaxations.
+- **`ingest._cross_doc_link_enabled` default 0→1** (`GOLDENGRAPH_CROSS_DOC_LINK=0` opts out).
+- **`ingest._profile_link_enabled` default `auto`** — ON when the separate
+  `goldenprofile-native` wheel is importable (cached `_goldenprofile_available()` probe),
+  else OFF so the linker degrades to the embedding-cosine matcher instead of hard-failing
+  an install lacking the wheel. `=1` forces on (raises later if truly absent), `=0` off.
+- **MEASURED (MuSiQue N=100, trace A/B, run 29851193442 vs the linking-off baseline):**
+  RETRIEVAL-shatter misses **27→6 (−78%)**; shatter-probe SCORING-miss under-merges
+  **18→4**; **support_recall 0.59→0.85**; entity-subset answer_match 0.231→0.277 (+20% rel).
+  Overall answer_match barely moved (0.17→0.18) because fixing retrieval SHIFTED the
+  bottleneck to synthesis (now the #1 bucket, ~36%: answer is in the ball, synthesizer
+  picks the wrong node) + extraction of non-entity answers. No precision regression.
+- Local suite runs the DEGRADED path (no `goldenprofile-native` wheel → profile-link
+  auto-off → embedding matcher); the full-stack path is exercised in the `goldengraph_native`
+  / pipeline CI lanes (which build the wheel) and was proven end-to-end by the bench A/B.
+  NEXT lever (chosen): probe the synthesis-precision gap (answer retrieved, answered wrong).

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -509,16 +509,24 @@ def ask(
     # reaches the default answer path -- not just mode='auto'. Skip when we arrived via
     # auto (it already attempted the chain). A None answer (no chain plan, or the walk
     # hit a missing edge) falls through to today's retrieval+synthesis, unchanged.
+    # Materialize the entity list ONCE and reuse it for both routing (_resolve_and_plan)
+    # and seeding (seed_by_query), so the default-path chain attempt doesn't double-scan
+    # entities on a non-chain / fall-through query. Stays None when the chain attempt is
+    # skipped (gate off / arrived via auto) -> seed_by_query self-scans, byte-identical.
+    slice_entities = None
     if not entered_auto and _local_chain_enabled():
+        slice_entities = list(slice_graph.entities())
         profile, plan = _resolve_and_plan(
             query, slice_graph, embedder=embedder,
             query_classifier=query_classifier, query_schema=query_schema,
+            slice_entities=slice_entities,
         )
         if plan.mode == "chain":
             ans = _chain_answer_from_profile(slice_graph, profile, provenance_out=provenance_out)
             if ans is not None:
                 return ans
-    seeds = seed_by_query(slice_graph, query, embedder, k=k, index=entity_index)
+    seeds = seed_by_query(slice_graph, query, embedder, k=k, index=entity_index,
+                          entities=slice_entities)
     _retrieve = _retrieve_local_bridged if _bridge_enabled() else _retrieve_local
     subgraph = _retrieve(slice_graph, seeds, max_hops=hops, node_budget=node_budget)
     # Hand the synthesis the seed entity NAMES (the query-relevant anchors) so the

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -426,7 +426,9 @@ def _local_chain_enabled() -> bool:
     baseline arm of the local-vs-auto A/B."""
     import os
 
-    return os.environ.get("GOLDENGRAPH_QA_LOCAL_CHAIN", "1") not in ("0", "false", "")
+    # Case/whitespace-insensitive so FALSE / False / " false " all disable, matching the
+    # documented "0/false" contract (an empty value also disables, as before).
+    return os.environ.get("GOLDENGRAPH_QA_LOCAL_CHAIN", "1").strip().lower() not in ("0", "false", "")
 
 
 def ask(

--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -376,6 +376,59 @@ def _retrieve_local_bridged(slice_graph, seeds, *, max_hops: int, node_budget: i
     return {"entities": list(ents.values()), "edges": edges}
 
 
+def _resolve_and_plan(query, slice_graph, *, embedder, query_classifier=None,
+                      query_schema=None, slice_entities=None):
+    """Shared front half of routing: resolve the query profile against the slice's
+    OWN vocab (entity names + edge predicates), canonicalize its relation(s) through
+    the discovered schema so a relabeled cluster doesn't strand the query, then plan.
+    Returns ``(profile, plan)``. Single-sourced so mode='auto' and the default
+    local/hybrid chain attempt share ONE routing implementation."""
+    if slice_entities is None:
+        slice_entities = list(slice_graph.entities())
+    profile = resolve_profile(
+        query,
+        predicates=_slice_predicates(slice_graph, entities=slice_entities),
+        entity_names=_slice_entity_names(slice_graph, entities=slice_entities),
+        embedder=embedder,  # lets the NL extractor bridge synonym relations to predicates
+        llm_classifier=query_classifier,
+    )
+    if query_schema is not None:
+        if profile.relation:
+            profile.relation = _canon_query_rel(profile.relation, query_schema)
+        if profile.relation_chain:
+            profile.relation_chain = tuple(
+                _canon_query_rel(r, query_schema) for r in profile.relation_chain
+            )
+    return profile, plan_query(profile)
+
+
+def _chain_answer_from_profile(slice_graph, profile, *, provenance_out=None):
+    """Run the deterministic LLM-free multi-hop walk for a chain-plan profile.
+    Engineered template -> authoritative order (single walk); free NL -> the extracted
+    order is a HINT the graph validates (try permutations). Returns the answer, or
+    None (anchor/chain missing, or the walk hit a missing/mislabeled edge) so the
+    caller falls through to retrieval+synthesis -- never worse than the status quo."""
+    if not (profile.anchor_surface and profile.relation_chain):
+        return None
+    if profile.chain_ordered:
+        return trace_chain(slice_graph, profile.anchor_surface,
+                           profile.relation_chain, refs_out=provenance_out)
+    return _trace_chain_any_order(slice_graph, profile.anchor_surface,
+                                  profile.relation_chain, refs_out=provenance_out)
+
+
+def _local_chain_enabled() -> bool:
+    """`GOLDENGRAPH_QA_LOCAL_CHAIN` gate (default ON). On -> mode='local'/'hybrid'
+    attempt the deterministic LLM-free multi-hop chain walk BEFORE synthesis, so the
+    template-free NL routing win reaches the DEFAULT answer path (the bench and most
+    callers run mode='local'), not just mode='auto'. Set to 0/false to restore the
+    pure retrieval+synthesis local/hybrid path, byte-identical to pre-change -- the
+    baseline arm of the local-vs-auto A/B."""
+    import os
+
+    return os.environ.get("GOLDENGRAPH_QA_LOCAL_CHAIN", "1") not in ("0", "false", "")
+
+
 def ask(
     query: str,
     store,
@@ -411,26 +464,15 @@ def ask(
     job). Each community is contextualized with its immediate (1-hop) neighborhood.
     """
     slice_graph = store.as_of(valid_t, tx_t)
+    entered_auto = mode == "auto"
     if mode == "auto":
-        slice_entities = list(slice_graph.entities())  # one entities() walk, reused below
-        profile = resolve_profile(
-            query,
-            predicates=_slice_predicates(slice_graph, entities=slice_entities),
-            entity_names=_slice_entity_names(slice_graph, entities=slice_entities),
-            embedder=embedder,  # lets the NL extractor bridge synonym relations to predicates
-            llm_classifier=query_classifier,
+        # Query-side schema canonicalization inside _resolve_and_plan routes the query's
+        # relation(s) through the discovered schema so they match the (relabeled) canonical
+        # edge predicates -- else a cluster relabeled to a synonym strands every query.
+        profile, plan = _resolve_and_plan(
+            query, slice_graph, embedder=embedder,
+            query_classifier=query_classifier, query_schema=query_schema,
         )
-        # Query-side schema canonicalization: route the query's relation(s) through the discovered
-        # schema so they match the (relabeled) canonical edge predicates. Without this, a cluster
-        # relabeled to a non-canonical synonym strands every query that used the canonical word.
-        if query_schema is not None:
-            if profile.relation:
-                profile.relation = _canon_query_rel(profile.relation, query_schema)
-            if profile.relation_chain:
-                profile.relation_chain = tuple(
-                    _canon_query_rel(r, query_schema) for r in profile.relation_chain
-                )
-        plan = plan_query(profile)
         if plan.mode == "aggregate" and profile.anchor_surface and profile.relation:
             return _format_aggregate(
                 aggregate_members(slice_graph, profile.anchor_surface, profile.relation,
@@ -446,15 +488,8 @@ def ask(
                 obj = asof_object(store.as_of(d, tx_t), profile.anchor_surface, profile.relation,
                                   refs_out=provenance_out)
                 return obj if obj is not None else "(unknown)"
-        if plan.mode == "chain" and profile.anchor_surface and profile.relation_chain:
-            # Engineered template -> authoritative order (single walk). Free-NL ->
-            # the order is a hint, so validate it against the graph (try permutations).
-            if profile.chain_ordered:
-                ans = trace_chain(slice_graph, profile.anchor_surface, profile.relation_chain,
-                                  refs_out=provenance_out)
-            else:
-                ans = _trace_chain_any_order(slice_graph, profile.anchor_surface,
-                                             profile.relation_chain, refs_out=provenance_out)
+        if plan.mode == "chain":
+            ans = _chain_answer_from_profile(slice_graph, profile, provenance_out=provenance_out)
             if ans is not None:
                 return ans
             # walk hit a missing/mislabeled edge -> fall through to the general retrieval+synthesis
@@ -469,6 +504,20 @@ def ask(
         return synthesize_global(query, views, llm)
     if mode not in ("local", "hybrid"):
         raise ValueError(f"mode must be 'local', 'hybrid', or 'global', got {mode!r}")
+    # DEFAULT-PATH chain routing (gated, default on): the template-free NL multi-hop
+    # walk now fires for mode='local'/'hybrid' BEFORE synthesis, so the routing win
+    # reaches the default answer path -- not just mode='auto'. Skip when we arrived via
+    # auto (it already attempted the chain). A None answer (no chain plan, or the walk
+    # hit a missing edge) falls through to today's retrieval+synthesis, unchanged.
+    if not entered_auto and _local_chain_enabled():
+        profile, plan = _resolve_and_plan(
+            query, slice_graph, embedder=embedder,
+            query_classifier=query_classifier, query_schema=query_schema,
+        )
+        if plan.mode == "chain":
+            ans = _chain_answer_from_profile(slice_graph, profile, provenance_out=provenance_out)
+            if ans is not None:
+                return ans
     seeds = seed_by_query(slice_graph, query, embedder, k=k, index=entity_index)
     _retrieve = _retrieve_local_bridged if _bridge_enabled() else _retrieve_local
     subgraph = _retrieve(slice_graph, seeds, max_hops=hops, node_budget=node_budget)

--- a/packages/python/goldengraph/goldengraph/embed.py
+++ b/packages/python/goldengraph/goldengraph/embed.py
@@ -63,7 +63,8 @@ class GoldenmatchEmbedder:
         return np.vstack(parts)
 
 
-def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5, index=None) -> list[int]:
+def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5, index=None,
+                  entities=None) -> list[int]:
     """Top-`k` entity ids in `slice_graph` (a `PyGraph` from `as_of`) nearest the
     query by cosine over canonical-name embeddings. Tie-break: ascending
     `entity_id` (deterministic — stub/zero vectors tie often).
@@ -79,12 +80,17 @@ def seed_by_query(slice_graph, query: str, embedder: Embedder, *, k: int = 5, in
     anchors, and embedding a raw value (a bare date / amount) both wastes budget and
     risks an empty/over-long input that 400s the WHOLE provider batch. Empty /
     whitespace names are dropped for the same reason (a provider rejects an empty
-    input). Without this, a literal-attrs run 400s on every answer at seed time."""
+    input). Without this, a literal-attrs run 400s on every answer at seed time.
+
+    `entities` (a precomputed ``list(slice_graph.entities())``) lets a caller that already
+    materialized the entity list -- e.g. the default-path chain router in ``ask`` -- reuse
+    it instead of re-scanning the graph. None (default) self-scans; byte-identical."""
     if index is not None:
         return index.query(query, embedder, k=k)
+    source = slice_graph.entities() if entities is None else entities
     ents = [
         e
-        for e in slice_graph.entities()
+        for e in source
         if not str(e.get("typ", "")).startswith("literal:")
         and str(e.get("canonical_name", "")).strip()
     ]

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -13,6 +13,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable
+from functools import lru_cache
 
 import numpy as np
 
@@ -155,16 +156,42 @@ def build_batch(
 
 
 def _cross_doc_link_enabled() -> bool:
-    return os.environ.get("GOLDENGRAPH_CROSS_DOC_LINK", "0") not in ("0", "false", "")
+    """Merge same entity across documents during ingest (the anti-shatter linker).
+    DEFAULT ON since 2026-07-21: with it off, cross-doc reconciliation was exact
+    `record_key` only, which type/case jitter defeated -> the multi-hop "shatter"
+    (measured 28% of QA misses on MuSiQue; enabling the stack cut it ~78%). Set
+    `GOLDENGRAPH_CROSS_DOC_LINK=0` to restore the exact-key-only behavior."""
+    return os.environ.get("GOLDENGRAPH_CROSS_DOC_LINK", "1").strip().lower() not in ("0", "false", "")
+
+
+@lru_cache(maxsize=1)
+def _goldenprofile_available() -> bool:
+    """True iff the separate `goldenprofile-native` wheel is importable, so the
+    profile matcher can run. Cached: probed once per process."""
+    try:
+        import goldenprofile_native  # noqa: F401  # pyright: ignore[reportMissingImports]
+    except Exception:  # noqa: BLE001 - any import failure -> matcher degrades, never crashes ingest
+        return False
+    return True
 
 
 def _profile_link_enabled() -> bool:
-    """Use the goldenprofile Semantic Signature engine as the cross-doc matcher
-    (`GOLDENGRAPH_PROFILE_LINK=1`). It replaces the ad-hoc embedding-cosine matcher
-    with the anti-shatter fusion scorer: a hard name+category gate (kills the Row-4
-    over-merge) plus a defining-attribute term that can only ADD confidence, never
-    veto (kills the Row-3 under-merge from divergent bridge neighborhoods)."""
-    return os.environ.get("GOLDENGRAPH_PROFILE_LINK", "0") not in ("0", "false", "")
+    """Use the goldenprofile Semantic Signature engine as the cross-doc matcher.
+    It replaces the ad-hoc embedding-cosine matcher with the anti-shatter fusion
+    scorer: a hard name+category gate (kills the over-merge) plus a defining-attribute
+    term that can only ADD confidence, never veto (kills the under-merge from divergent
+    bridge neighborhoods).
+
+    DEFAULT `auto` since 2026-07-21: ON when the `goldenprofile-native` wheel is
+    importable, else OFF so the linker degrades to the embedding-cosine matcher rather
+    than hard-failing an install that lacks the (separate) wheel. `GOLDENGRAPH_PROFILE_LINK=1`
+    forces it on (raises later if the wheel is truly absent); `=0` forces it off."""
+    val = os.environ.get("GOLDENGRAPH_PROFILE_LINK", "auto").strip().lower()
+    if val in ("0", "false", ""):
+        return False
+    if val in ("1", "true"):
+        return True
+    return _goldenprofile_available()  # "auto"
 
 
 def _profile_cluster(

--- a/packages/python/goldengraph/goldengraph/resolve.py
+++ b/packages/python/goldengraph/goldengraph/resolve.py
@@ -28,25 +28,31 @@ class ResolvedEntity:
 
 
 def _key_payload(name: str, typ: str) -> dict:
-    """The dict fed to `record_fingerprint` for cross-document reconciliation. Default is (name, typ) --
-    but an open-vocab extractor assigns a DIFFERENT `typ` to one entity per document (measured: 97.6% of
-    cross-doc fragmentation is type jitter -- 'schema matching' typed Process/Algorithm/method/... across
-    docs), so its record_keys never overlap and the store never unifies it. `GOLDENGRAPH_XDOC_KEY` relaxes
-    the key: `name` = name only (type-agnostic); `name_ci` = name, case-folded (also absorbs the ~case-only
-    name jitter); `name_ci_type` = case-folded name + the COARSE type (homograph-safe: same-name entities
-    of different coarse class stay separate, while per-doc type jitter within a class still collapses). Pure
-    + goldenmatch-free so the normalization is unit-tested without the fingerprint."""
+    """The dict fed to `record_fingerprint` for cross-document reconciliation. An open-vocab extractor
+    assigns a DIFFERENT `typ` to one entity per document (measured: 97.6% of cross-doc fragmentation is
+    type jitter -- 'schema matching' typed Process/Algorithm/method/... across docs; and the same entity
+    is name-cased differently), so an exact (name, typ) key never overlaps and the store never unifies it
+    -- the multi-hop "shatter". `GOLDENGRAPH_XDOC_KEY` selects the key:
+      - `name_ci_type` (**DEFAULT**, since 2026-07-21): case-folded name + the COARSE canonical type --
+        homograph-safe (same-name entities of different coarse class stay separate) while per-doc type
+        jitter within a class collapses. Measured to cut the multi-hop shatter ~78% (support_recall
+        0.59->0.85 on MuSiQue N=100) with no precision regression.
+      - `name`      = name only (type-agnostic, most aggressive; homograph-merge risk).
+      - `name_ci`   = name, case-folded (absorbs case-only name jitter, keeps raw type off the key).
+      - `exact`     = the legacy verbatim (name, typ) key (opt out of the relaxation).
+    Pure + goldenmatch-free so the normalization is unit-tested without the fingerprint."""
     import os
 
     mode = os.environ.get("GOLDENGRAPH_XDOC_KEY", "").strip().lower()
+    if mode == "exact":
+        return {"name": name, "typ": typ}
     if mode == "name":
         return {"name": name}
     if mode == "name_ci":
         return {"name": name.strip().lower()}
-    if mode == "name_ci_type":
-        from .schema import canonicalize_entity_type
-        return {"name": name.strip().lower(), "typ": canonicalize_entity_type(typ)}
-    return {"name": name, "typ": typ}
+    # Default (unset) and explicit `name_ci_type`: case-folded name + coarse type.
+    from .schema import canonicalize_entity_type
+    return {"name": name.strip().lower(), "typ": canonicalize_entity_type(typ)}
 
 
 def _record_key(name: str, typ: str) -> str:

--- a/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
+++ b/packages/python/goldengraph/tests/test_ingest_cross_doc_link.py
@@ -189,20 +189,29 @@ def test_store_without_as_of_is_a_noop():
     assert ingest._cross_doc_link(_Bare(), batch, at=5) == 0
 
 
-def test_gating_default_off(monkeypatch):
+def test_gating_default_on(monkeypatch):
+    # DEFAULT ON since the 2026-07-21 anti-shatter flip; =0 opts out (case-insensitive).
     monkeypatch.delenv("GOLDENGRAPH_CROSS_DOC_LINK", raising=False)
-    assert ingest._cross_doc_link_enabled() is False
+    assert ingest._cross_doc_link_enabled() is True
     monkeypatch.setenv("GOLDENGRAPH_CROSS_DOC_LINK", "1")
     assert ingest._cross_doc_link_enabled() is True
-    monkeypatch.setenv("GOLDENGRAPH_CROSS_DOC_LINK", "0")
-    assert ingest._cross_doc_link_enabled() is False
+    for off in ("0", "false", "False", ""):
+        monkeypatch.setenv("GOLDENGRAPH_CROSS_DOC_LINK", off)
+        assert ingest._cross_doc_link_enabled() is False, off
 
 
 # --- goldenprofile anti-shatter matcher (PR #1217 engine) -----------------
 
-def test_profile_link_gating_default_off(monkeypatch):
+def test_profile_link_gating_auto_default(monkeypatch):
+    # DEFAULT 'auto': ON iff goldenprofile-native is importable, so a default-on build
+    # degrades to the embedding matcher instead of hard-failing without the wheel.
     monkeypatch.delenv("GOLDENGRAPH_PROFILE_LINK", raising=False)
-    assert ingest._profile_link_enabled() is False
+    ingest._goldenprofile_available.cache_clear()
+    monkeypatch.setattr(ingest, "_goldenprofile_available", lambda: True)
+    assert ingest._profile_link_enabled() is True   # auto + wheel present -> on
+    monkeypatch.setattr(ingest, "_goldenprofile_available", lambda: False)
+    assert ingest._profile_link_enabled() is False  # auto + wheel absent -> off (degrade)
+    # explicit overrides ignore availability
     monkeypatch.setenv("GOLDENGRAPH_PROFILE_LINK", "1")
     assert ingest._profile_link_enabled() is True
     monkeypatch.setenv("GOLDENGRAPH_PROFILE_LINK", "0")

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -340,6 +340,21 @@ def test_embed_bridge_min_env_parsing_and_clamping(monkeypatch):
     assert _embed_bridge_min() == 1.0
 
 
+def test_local_chain_gate_case_and_whitespace_insensitive(monkeypatch):
+    # The GOLDENGRAPH_QA_LOCAL_CHAIN gate must honor its documented "0/false" contract
+    # regardless of case/whitespace -- else FALSE/" false " silently leave it enabled.
+    from goldengraph.answer import _local_chain_enabled
+
+    monkeypatch.delenv("GOLDENGRAPH_QA_LOCAL_CHAIN", raising=False)
+    assert _local_chain_enabled() is True  # default ON
+    for off in ("0", "false", "False", "FALSE", " false ", " 0 ", ""):
+        monkeypatch.setenv("GOLDENGRAPH_QA_LOCAL_CHAIN", off)
+        assert _local_chain_enabled() is False, off
+    for on in ("1", "true", "yes", "on"):
+        monkeypatch.setenv("GOLDENGRAPH_QA_LOCAL_CHAIN", on)
+        assert _local_chain_enabled() is True, on
+
+
 def test_nl_unknown_anchor_abstains():
     g = _film_graph()
     p = _profile("Who directed Titanic?", g)  # Titanic is not in the slice

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -17,6 +17,7 @@ routes to today's retrieval+synthesis path -- never worse than the status quo.
 
 from __future__ import annotations
 
+import goldengraph.answer as answer_mod  # module object for monkeypatching seed/synth seam
 from goldengraph.answer import (
     _slice_entity_names,
     _slice_predicates,
@@ -463,8 +464,6 @@ def test_ask_local_chain_gate_off_falls_through_to_synthesis(monkeypatch):
     # straight to retrieval+synthesis (the baseline arm of the local-vs-auto A/B).
     # Monkeypatch the seed + synth seam so the assertion doesn't depend on embedder/LLM
     # internals -- reaching synthesize_local at all proves the chain was skipped.
-    import goldengraph.answer as answer_mod
-
     monkeypatch.setenv("GOLDENGRAPH_QA_LOCAL_CHAIN", "0")
     monkeypatch.setattr(answer_mod, "seed_by_query", lambda *a, **k: [])
     monkeypatch.setattr(answer_mod, "synthesize_local", lambda *a, **k: "SYNTH")
@@ -486,8 +485,6 @@ def test_ask_local_non_chain_query_falls_through_to_synthesis(monkeypatch):
     # Even with the gate ON (default), a non-chain local query (no groundable relation)
     # must NOT be hijacked by the chain attempt -- it falls through to synthesis exactly
     # as before. Guards against the default-path change over-firing.
-    import goldengraph.answer as answer_mod
-
     monkeypatch.setattr(answer_mod, "seed_by_query", lambda *a, **k: [])
     monkeypatch.setattr(answer_mod, "synthesize_local", lambda *a, **k: "SYNTH")
 

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -421,3 +421,84 @@ def test_ask_auto_routes_nl_question_to_llm_free_chain():
         mode="auto",
     )
     assert out == "Emma Thomas"
+
+
+# --- end-to-end through ask(mode="local"/"hybrid"): chain routing is the DEFAULT ---
+
+def test_ask_local_routes_nl_question_to_llm_free_chain():
+    # The headline of the default-path change: mode="local" (the bench + most callers'
+    # default) now attempts the deterministic chain walk BEFORE synthesis, so the NL
+    # routing win reaches the default -- not just mode="auto". _UnusedLLM asserts
+    # synthesis never runs (the chain answered first, LLM-free).
+    g = _film_graph()
+    out = ask(
+        "Who is married to the person who directed Inception?",
+        _StubStore(g),
+        llm=_UnusedLLM(),
+        embedder=_UnusedEmbedder(),
+        valid_t=100,
+        tx_t=100,
+        mode="local",
+    )
+    assert out == "Emma Thomas"
+
+
+def test_ask_hybrid_routes_nl_question_to_llm_free_chain():
+    # mode="hybrid" gets the same default-path chain attempt.
+    g = _film_graph()
+    out = ask(
+        "Who is married to the person who directed Inception?",
+        _StubStore(g),
+        llm=_UnusedLLM(),
+        embedder=_UnusedEmbedder(),
+        valid_t=100,
+        tx_t=100,
+        mode="hybrid",
+    )
+    assert out == "Emma Thomas"
+
+
+def test_ask_local_chain_gate_off_falls_through_to_synthesis(monkeypatch):
+    # GOLDENGRAPH_QA_LOCAL_CHAIN=0 restores the pre-change local path: NO chain attempt,
+    # straight to retrieval+synthesis (the baseline arm of the local-vs-auto A/B).
+    # Monkeypatch the seed + synth seam so the assertion doesn't depend on embedder/LLM
+    # internals -- reaching synthesize_local at all proves the chain was skipped.
+    import goldengraph.answer as answer_mod
+
+    monkeypatch.setenv("GOLDENGRAPH_QA_LOCAL_CHAIN", "0")
+    monkeypatch.setattr(answer_mod, "seed_by_query", lambda *a, **k: [])
+    monkeypatch.setattr(answer_mod, "synthesize_local", lambda *a, **k: "SYNTH")
+
+    g = _film_graph()
+    out = ask(
+        "Who is married to the person who directed Inception?",
+        _StubStore(g),
+        llm=_UnusedLLM(),
+        embedder=_UnusedEmbedder(),
+        valid_t=100,
+        tx_t=100,
+        mode="local",
+    )
+    assert out == "SYNTH"  # chain skipped -> synthesis ran
+
+
+def test_ask_local_non_chain_query_falls_through_to_synthesis(monkeypatch):
+    # Even with the gate ON (default), a non-chain local query (no groundable relation)
+    # must NOT be hijacked by the chain attempt -- it falls through to synthesis exactly
+    # as before. Guards against the default-path change over-firing.
+    import goldengraph.answer as answer_mod
+
+    monkeypatch.setattr(answer_mod, "seed_by_query", lambda *a, **k: [])
+    monkeypatch.setattr(answer_mod, "synthesize_local", lambda *a, **k: "SYNTH")
+
+    g = _film_graph()
+    out = ask(
+        "What is Inception?",  # anchor present, no relation -> chain abstains
+        _StubStore(g),
+        llm=_UnusedLLM(),
+        embedder=_UnusedEmbedder(),
+        valid_t=100,
+        tx_t=100,
+        mode="local",
+    )
+    assert out == "SYNTH"

--- a/packages/python/goldengraph/tests/test_nl_chain.py
+++ b/packages/python/goldengraph/tests/test_nl_chain.py
@@ -17,7 +17,7 @@ routes to today's retrieval+synthesis path -- never worse than the status quo.
 
 from __future__ import annotations
 
-import goldengraph.answer as answer_mod  # module object for monkeypatching seed/synth seam
+from goldengraph import answer as answer_mod  # module object for monkeypatching seed/synth seam
 from goldengraph.answer import (
     _slice_entity_names,
     _slice_predicates,

--- a/packages/python/goldengraph/tests/test_xdoc_key.py
+++ b/packages/python/goldengraph/tests/test_xdoc_key.py
@@ -4,9 +4,21 @@ Pure test of the normalization (`_key_payload`) -- no goldenmatch / fingerprint 
 from goldengraph.resolve import _key_payload
 
 
-def test_default_key_uses_name_and_type(monkeypatch):
+def test_default_key_is_name_ci_type(monkeypatch):
+    # DEFAULT (unset) is now name_ci_type (2026-07-21 anti-shatter flip): case-folded
+    # name + coarse type, so per-doc type/case jitter collapses cross-doc.
     monkeypatch.delenv("GOLDENGRAPH_XDOC_KEY", raising=False)
+    assert _key_payload("Schema Matching", "Process") == {"name": "schema matching", "typ": "concept"}
+    # same entity, jittered type/case across docs -> ONE key by default
+    assert _key_payload("Schema Matching", "Process") == _key_payload("schema matching", "Algorithm")
+
+
+def test_exact_mode_restores_legacy_name_type(monkeypatch):
+    # `exact` is the opt-out that restores the pre-flip verbatim (name, typ) key.
+    monkeypatch.setenv("GOLDENGRAPH_XDOC_KEY", "exact")
     assert _key_payload("Schema Matching", "Process") == {"name": "Schema Matching", "typ": "Process"}
+    # verbatim -> type/case jitter no longer collapses (the old shatter behavior)
+    assert _key_payload("Schema Matching", "Process") != _key_payload("schema matching", "Algorithm")
 
 
 def test_name_mode_drops_type(monkeypatch):

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -273,9 +273,14 @@ class GoldenGraphQAEngine:
             latency_s=time.perf_counter() - t0,
         )
 
-    def answer(self, handle, question: str) -> AnswerResult:
+    def answer(self, handle, question: str, mode: str | None = None) -> AnswerResult:
         from goldengraph.answer import ask
 
+        # `mode` overrides the engine's configured retrieval mode for THIS call -- the
+        # same-run local-vs-auto A/B (harness.run_engine_ab) uses it to answer the same
+        # question under both modes against one shared graph. None -> the configured
+        # mode, byte-identical to the single-mode path.
+        retrieval_mode = mode or self._retrieval_mode
         t0 = time.perf_counter()
         before_in, before_out = self._synth_llm.input_tokens, self._synth_llm.output_tokens
         # `provenance_out` collects the source-doc ids of every edge the retrieval/traversal touched.
@@ -289,7 +294,7 @@ class GoldenGraphQAEngine:
             embedder=self._embedder,
             valid_t=handle["valid_t"],
             tx_t=handle["tx_t"],
-            mode=self._retrieval_mode,
+            mode=retrieval_mode,
             hops=self._retrieval_hops,
             node_budget=self._node_budget,
             passages=handle.get("passages"),

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -379,6 +379,10 @@ def run_engine_ab(
     Returns `{"arms": {mode: scorecard}, "comparison": {...}, "build_cost_usd",
     "total_cost_usd", "n_answered"}`."""
     modes = list(modes)
+    # Duplicate modes would collapse the `scored`/`arms` dict keys into a single arm and
+    # silently produce a misleading one-arm "A/B" -- reject rather than mislead.
+    if len(set(modes)) != len(modes):
+        raise ValueError(f"run_engine_ab modes must be unique, got {modes!r}")
     enforce = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
     # Attribution-only trackers (effectively uncapped) for per-arm answer cost.
     arm_trackers = {m: BudgetTracker(BudgetConfig(max_cost_usd=10**9)) for m in modes}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -246,6 +246,86 @@ def _localize_trace(engine, handle, corpus, *, limit: int = _TRACE_LIMIT) -> Non
         print(f"== shatter-probe verdicts {{{verdict_mix}}} ==", flush=True)
 
 
+def _score_question(ans, q, judge) -> dict:
+    """Score ONE answer against its gold. Single-sourced so `run_engine` and
+    `run_engine_ab` compute identical metrics. Returns the derived scalars plus the
+    persisted per-question record."""
+    am = metrics.answer_match(ans.text, q.gold_answer)
+    em = metrics.exact_match(ans.text, q.gold_answer)
+    f1 = metrics.token_f1(ans.text, q.gold_answer)
+    rec = metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
+    atype = metrics.classify_answer_type(q.gold_answer)
+    aj: float | None = None
+    if judge is not None:
+        # An empty prediction is a non-answer -- score it NO without a call.
+        aj = (
+            metrics.parse_judge(judge(metrics.judge_prompt(q.question, q.gold_answer, ans.text)))
+            if ans.text.strip()
+            else 0.0
+        )
+    return {
+        "am": am, "em": em, "f1": f1, "rec": rec, "atype": atype, "aj": aj,
+        # Persist the per-question record so a near-zero aggregate is debuggable
+        # post-hoc (wrong reasoning vs. async-corrupted output vs. phrasing the
+        # matcher misses). The prediction is truncated so a verbose engine can't
+        # bloat the artifact.
+        "record": {
+            "id": q.id,
+            "question": q.question,
+            "gold_answer": q.gold_answer,
+            "prediction": _truncate(ans.text),
+            "hop_count": q.hop_count,
+            "answer_type": atype,
+            "answer_match": am,
+            "answer_judge": aj,
+            "exact_match": em,
+            "token_f1": round(f1, 4),
+        },
+    }
+
+
+def _build_scorecard(engine, corpus, model, scored, *, answered, cost_usd, budget_exhausted) -> dict:
+    """Aggregate a list of `_score_question` outputs into the result dict. Byte-for-byte
+    the shape `run_engine` has always returned (locked by tests/test_qa_harness.py)."""
+    matches = [s["am"] for s in scored]
+    ems = [s["em"] for s in scored]
+    f1s = [s["f1"] for s in scored]
+    recalls = [s["rec"] for s in scored]
+    # answer_match restricted to entity-answerable golds -- the honest denominator for
+    # an entity-graph engine that can only ever emit a node (metrics.classify_answer_type).
+    matches_entity = [s["am"] for s in scored if s["atype"] == "entity"]
+    # Format-fair LLM-judge equivalence (None-safe: aj is a float only when a judge ran).
+    judges = [s["aj"] for s in scored if s["aj"] is not None]
+    judges_entity = [s["aj"] for s in scored if s["aj"] is not None and s["atype"] == "entity"]
+    type_counts: dict[str, int] = {}
+    for s in scored:
+        type_counts[s["atype"]] = type_counts.get(s["atype"], 0) + 1
+    # Decay = correctness by hop count (answer_match is the free-text correctness signal).
+    decay_rows = [(s["record"]["hop_count"], s["am"]) for s in scored]
+    return {
+        "engine": engine.name,
+        "fidelity": engine.fidelity,
+        "corpus": corpus.name,
+        "model": model,
+        "ambiguity": corpus.questions[0].ambiguity_level if corpus.questions else 0.0,
+        "n_questions": len(corpus.questions),
+        "n_answered": answered,
+        "answer_match": _mean(matches),
+        "answer_match_entity": _mean(matches_entity),
+        "n_entity_answerable": len(matches_entity),
+        "answer_type_counts": type_counts,
+        "answer_judge": _mean(judges) if judges else None,
+        "answer_judge_entity": _mean(judges_entity) if judges_entity else None,
+        "exact_match": _mean(ems),
+        "token_f1": _mean(f1s),
+        "support_recall": _mean(recalls),
+        "decay_curve": metrics.decay_curve(decay_rows),
+        "cost_usd": round(cost_usd, 6),
+        "budget_exhausted": budget_exhausted,
+        "per_question": [s["record"] for s in scored],
+    }
+
+
 def run_engine(
     engine: QAEngine, corpus, *, model: str, budget_usd: float, judge=None
 ) -> dict:
@@ -265,101 +345,102 @@ def run_engine(
     ):
         _localize_trace(engine, build.handle, corpus)
 
-    ems: list[float] = []
-    matches: list[float] = []
-    f1s: list[float] = []
-    recalls: list[float] = []
-    # answer_match restricted to entity-answerable golds -- the honest denominator
-    # for an entity-graph engine that can only ever emit a node (see
-    # metrics.classify_answer_type). Non-entity golds (dates/amounts/phrases) are
-    # unanswerable-by-construction and would otherwise mask the real accuracy.
-    matches_entity: list[float] = []
-    # Format-fair LLM-judge equivalence (None-safe: stays empty when no judge).
-    judges: list[float] = []
-    judges_entity: list[float] = []
-    type_counts: dict[str, int] = {}
-    decay_rows: list[tuple[int, float]] = []
-    records: list[dict] = []
+    scored: list[dict] = []
     answered = 0
     for q in corpus.questions:
         if tracker.budget_exhausted or not tracker.can_send(_estimate_tokens(q.question)):
             break
         ans = engine.answer(build.handle, q.question)
         tracker.record_usage(ans.input_tokens, ans.output_tokens, model)
-        am = metrics.answer_match(ans.text, q.gold_answer)
-        em = metrics.exact_match(ans.text, q.gold_answer)
-        f1 = metrics.token_f1(ans.text, q.gold_answer)
-        rec = metrics.supporting_fact_recall(ans.retrieved_fact_ids, q.gold_supporting_fact_ids)
-        atype = metrics.classify_answer_type(q.gold_answer)
-        type_counts[atype] = type_counts.get(atype, 0) + 1
-        aj: float | None = None
-        if judge is not None:
-            # An empty prediction is a non-answer -- score it NO without a call.
-            aj = (
-                metrics.parse_judge(judge(metrics.judge_prompt(q.question, q.gold_answer, ans.text)))
-                if ans.text.strip()
-                else 0.0
-            )
-            judges.append(aj)
-            if atype == "entity":
-                judges_entity.append(aj)
-        if atype == "entity":
-            matches_entity.append(am)
-        matches.append(am)
-        ems.append(em)
-        f1s.append(f1)
-        recalls.append(rec)
-        # Decay = correctness by hop count. answer_match (containment) is the
-        # meaningful correctness signal for free-text answers; exact_match reads ~0.
-        decay_rows.append((q.hop_count, am))
-        # Persist the per-question record so a near-zero aggregate is debuggable
-        # post-hoc (wrong reasoning vs. async-corrupted output vs. phrasing the
-        # matcher misses) -- the aggregate alone made the bench a black box. The
-        # prediction is truncated so a verbose engine can't bloat the artifact.
-        records.append(
-            {
-                "id": q.id,
-                "question": q.question,
-                "gold_answer": q.gold_answer,
-                "prediction": _truncate(ans.text),
-                "hop_count": q.hop_count,
-                "answer_type": atype,
-                "answer_match": am,
-                "answer_judge": aj,
-                "exact_match": em,
-                "token_f1": round(f1, 4),
-            }
-        )
+        scored.append(_score_question(ans, q, judge))
         answered += 1
 
-    return {
-        "engine": engine.name,
-        "fidelity": engine.fidelity,
-        "corpus": corpus.name,
-        "model": model,
-        # The corpus is single-ambiguity per run; record it so an ambiguity sweep can be
-        # aggregated into the decay curve (0.0 for MuSiQue / empty corpora).
-        "ambiguity": corpus.questions[0].ambiguity_level if corpus.questions else 0.0,
-        "n_questions": len(corpus.questions),
-        "n_answered": answered,
-        "answer_match": _mean(matches),
-        # answer_match over entity-answerable golds only + how many there were, so
-        # the headline can be read against the right denominator.
-        "answer_match_entity": _mean(matches_entity),
-        "n_entity_answerable": len(matches_entity),
-        "answer_type_counts": type_counts,
-        # Format-fair LLM-judge equivalence (None when no judge ran), overall + on
-        # the entity-answerable subset -- the apples-to-apples cross-engine number.
-        "answer_judge": _mean(judges) if judges else None,
-        "answer_judge_entity": _mean(judges_entity) if judges_entity else None,
-        "exact_match": _mean(ems),
-        "token_f1": _mean(f1s),
-        "support_recall": _mean(recalls),
-        "decay_curve": metrics.decay_curve(decay_rows),
-        "cost_usd": round(tracker.total_cost_usd, 6),
-        "budget_exhausted": tracker.budget_exhausted,
-        "per_question": records,
+    return _build_scorecard(
+        engine, corpus, model, scored,
+        answered=answered,
+        cost_usd=tracker.total_cost_usd,
+        budget_exhausted=tracker.budget_exhausted,
+    )
+
+
+def run_engine_ab(
+    engine, corpus, *, model: str, budget_usd: float, modes, judge=None
+) -> dict:
+    """Same-run A/B: build the KG ONCE, then answer every question under EACH mode in
+    `modes` against the IDENTICAL graph, so the only variable is answer-time routing
+    (e.g. local vs auto). Removes build variance from the comparison -- the deltas are
+    purely the mode's effect.
+
+    The engine's `answer()` must accept a `mode=` override (goldengraph does). One
+    shared budget bounds the WHOLE run (build + both arms); a question is only started
+    when the budget can afford answering it under every mode, so the arms stay aligned
+    (same n_answered). Per-arm answer cost is attributed separately for the report.
+
+    Returns `{"arms": {mode: scorecard}, "comparison": {...}, "build_cost_usd",
+    "total_cost_usd", "n_answered"}`."""
+    modes = list(modes)
+    enforce = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
+    # Attribution-only trackers (effectively uncapped) for per-arm answer cost.
+    arm_trackers = {m: BudgetTracker(BudgetConfig(max_cost_usd=10**9)) for m in modes}
+
+    build = engine.build_kg(corpus)
+    enforce.record_usage(build.input_tokens, build.output_tokens, model)
+    build_cost = enforce.total_cost_usd
+
+    scored: dict[str, list[dict]] = {m: [] for m in modes}
+    answered = 0
+    for q in corpus.questions:
+        # A question costs one answer PER mode; only start it if the budget can afford
+        # the whole set, so both arms answer exactly the same questions.
+        if enforce.budget_exhausted or not enforce.can_send(
+            _estimate_tokens(q.question) * len(modes)
+        ):
+            break
+        for m in modes:
+            ans = engine.answer(build.handle, q.question, mode=m)
+            enforce.record_usage(ans.input_tokens, ans.output_tokens, model)
+            arm_trackers[m].record_usage(ans.input_tokens, ans.output_tokens, model)
+            scored[m].append(_score_question(ans, q, judge))
+        answered += 1
+
+    arms = {
+        m: _build_scorecard(
+            engine, corpus, model, scored[m],
+            answered=answered,
+            cost_usd=arm_trackers[m].total_cost_usd,
+            budget_exhausted=enforce.budget_exhausted,
+        )
+        for m in modes
     }
+    return {
+        "arms": arms,
+        "comparison": _ab_comparison(arms, modes),
+        "build_cost_usd": round(build_cost, 6),
+        "total_cost_usd": round(enforce.total_cost_usd, 6),
+        "n_answered": answered,
+    }
+
+
+#: The headline metrics compared side-by-side across the A/B arms.
+_AB_METRICS = (
+    "answer_match", "answer_match_entity", "exact_match",
+    "token_f1", "support_recall", "answer_judge",
+)
+
+
+def _ab_comparison(arms: dict, modes: list) -> dict:
+    """Per-metric side-by-side of the arms, plus an explicit `<b> - <a>` delta for the
+    common 2-mode case (e.g. auto - local) so the headline is legible without math."""
+    out: dict = {}
+    for k in _AB_METRICS:
+        out[k] = {m: arms[m].get(k) for m in modes}
+        if len(modes) == 2:
+            a, b = arms[modes[0]].get(k), arms[modes[1]].get(k)
+            out[k]["delta"] = (
+                round(b - a, 4) if isinstance(a, (int, float)) and isinstance(b, (int, float))
+                else None
+            )
+    return out
 
 
 def _truncate(text: str, limit: int = 2000) -> str:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
@@ -1,0 +1,119 @@
+"""CLI: same-run local-vs-auto A/B for the goldengraph QA engine.
+
+Builds the KG ONCE, then answers every question under BOTH `mode="local"` (the
+default answer path -- now with the template-free NL chain routing firing before
+synthesis, `GOLDENGRAPH_QA_LOCAL_CHAIN`, default on) AND `mode="auto"` (the explicit
+query-router path) against the identical graph. Because the graph is shared, the
+metric deltas are purely the effect of answer-time routing, not build variance.
+
+This is the headline that answers "does making chain routing the default in `local`
+actually move the number, and how close does it get to `auto`?" -- run it after the
+default-path change (`goldengraph.answer._local_chain_enabled`). `--self-test` uses a
+mock engine (no LLM) so the A/B plumbing is CI-validated, mirroring run_qa_e2e.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .harness import AnswerResult, BuildResult, run_engine_ab
+from .run_qa_e2e import _build_engine, _chat_model, _load_corpus, _make_judge
+
+
+class _MockABEngine:
+    """No-LLM engine whose answer VARIES by mode, so the self-test exercises the A/B
+    split (two distinct arms) without a provider. `auto` names the gold; `local` does
+    not -- a stand-in for "routing changes the answer"."""
+
+    name = "mock-ab"
+    fidelity = "self-test"
+
+    def build_kg(self, corpus) -> BuildResult:
+        return BuildResult(handle={"n": len(corpus.documents)}, input_tokens=1, output_tokens=1)
+
+    def answer(self, handle, question: str, mode: str | None = None) -> AnswerResult:
+        text = "Ada" if mode == "auto" else "(no answer)"
+        return AnswerResult(text=text, retrieved_fact_ids=("d1",), input_tokens=1, output_tokens=1)
+
+
+def _write_ab(result: dict, *, md_path: Path, json_path: Path) -> None:
+    json_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    arms = result["arms"]
+    modes = list(arms)
+    lines = [
+        "# GoldenGraph QA -- same-run local-vs-auto A/B",
+        "",
+        f"- corpus: `{arms[modes[0]]['corpus']}`  model: `{arms[modes[0]]['model']}`",
+        f"- questions answered (per arm): **{result['n_answered']}**",
+        f"- build cost: ${result['build_cost_usd']}  total (build + both arms): "
+        f"${result['total_cost_usd']}",
+        "",
+        "| metric | " + " | ".join(modes) + " | delta (2nd - 1st) |",
+        "| --- | " + " | ".join("---" for _ in modes) + " | --- |",
+    ]
+    for metric, per_mode in result["comparison"].items():
+        cells = []
+        for m in modes:
+            v = per_mode.get(m)
+            cells.append("-" if v is None else f"{v:.4f}" if isinstance(v, float) else str(v))
+        d = per_mode.get("delta")
+        d_cell = "-" if d is None else f"{d:+.4f}"
+        lines.append(f"| {metric} | " + " | ".join(cells) + f" | {d_cell} |")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--engine", default="goldengraph", help="only goldengraph supports the mode A/B")
+    p.add_argument("--self-test", action="store_true")
+    p.add_argument("--corpus", choices=("engineered", "musique", "hotpotqa", "2wikimultihop"),
+                   required=True)
+    p.add_argument("--max-questions", type=int, default=50)
+    p.add_argument("--ambiguity", type=float, default=0.5)
+    p.add_argument("--musique-path", default=None)
+    p.add_argument("--corpus-path", default=None)
+    p.add_argument(
+        "--modes", default="local,auto",
+        help="comma-separated answer modes to A/B, in order (delta = 2nd - 1st). "
+        "Default 'local,auto' -- the headline comparison.",
+    )
+    p.add_argument("--model", default="gpt-4o-mini")
+    p.add_argument("--budget-usd", type=float, default=25.0)
+    p.add_argument("--judge", action="store_true", help="score the format-fair LLM-judge metric too")
+    p.add_argument("--judge-model", default="gpt-4o-mini")
+    p.add_argument("--out-md", required=True)
+    p.add_argument("--out-json", required=True)
+    args = p.parse_args(argv)
+
+    out_md = Path(args.out_md).resolve()
+    out_json = Path(args.out_json).resolve()
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+
+    corpus = _load_corpus(
+        args.corpus, args.max_questions, args.musique_path, args.ambiguity,
+        corpus_path=args.corpus_path,
+    )
+    engine = _MockABEngine() if args.self_test else _build_engine(args.engine)
+    judge = _make_judge(args.judge_model) if (args.judge and not args.self_test) else None
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+
+    result = run_engine_ab(
+        engine, corpus, model=_chat_model(), budget_usd=args.budget_usd, modes=modes, judge=judge,
+    )
+    _write_ab(result, md_path=out_md, json_path=out_json)
+
+    cmp = result["comparison"]
+    print(f"wrote {out_md} ({result['n_answered']} q/arm, ${result['total_cost_usd']})")
+    for metric in ("answer_match", "token_f1", "support_recall"):
+        per = cmp.get(metric, {})
+        cells = "  ".join(
+            f"{m}={per.get(m):.4f}" for m in modes if isinstance(per.get(m), float)
+        )
+        d = per.get("delta")
+        print(f"  {metric}: {cells}" + (f"  (delta {d:+.4f})" if isinstance(d, float) else ""))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
@@ -94,6 +94,13 @@ def main(argv: list[str] | None = None) -> int:
     modes = [m.strip() for m in args.modes.split(",") if m.strip()]
     if not modes:
         raise SystemExit("--modes must list at least one answer mode (e.g. 'local,auto')")
+    # run_engine_ab needs engine.answer(..., mode=) -- only the goldengraph engine has it.
+    # Reject other engines up front rather than fail later with a cryptic TypeError.
+    if not args.self_test and args.engine != "goldengraph":
+        raise SystemExit(
+            f"local-vs-auto A/B requires an engine whose answer() takes a per-call mode "
+            f"override; only 'goldengraph' qualifies, got {args.engine!r}"
+        )
     # Honor --model by exporting OPENAI_MODEL BEFORE building the engine / reading
     # _chat_model() (both are env-driven); omitted -> the env/default is used.
     if args.model:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_local_vs_auto_ab.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 from pathlib import Path
 
 from .harness import AnswerResult, BuildResult, run_engine_ab
@@ -78,13 +79,25 @@ def main(argv: list[str] | None = None) -> int:
         help="comma-separated answer modes to A/B, in order (delta = 2nd - 1st). "
         "Default 'local,auto' -- the headline comparison.",
     )
-    p.add_argument("--model", default="gpt-4o-mini")
+    p.add_argument(
+        "--model", default=None,
+        help="chat model override. When given, sets OPENAI_MODEL so _chat_model() + the "
+        "engine both honor it; omit to use the env/default (gpt-4o-mini).",
+    )
     p.add_argument("--budget-usd", type=float, default=25.0)
     p.add_argument("--judge", action="store_true", help="score the format-fair LLM-judge metric too")
     p.add_argument("--judge-model", default="gpt-4o-mini")
     p.add_argument("--out-md", required=True)
     p.add_argument("--out-json", required=True)
     args = p.parse_args(argv)
+
+    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
+    if not modes:
+        raise SystemExit("--modes must list at least one answer mode (e.g. 'local,auto')")
+    # Honor --model by exporting OPENAI_MODEL BEFORE building the engine / reading
+    # _chat_model() (both are env-driven); omitted -> the env/default is used.
+    if args.model:
+        os.environ["OPENAI_MODEL"] = args.model
 
     out_md = Path(args.out_md).resolve()
     out_json = Path(args.out_json).resolve()
@@ -96,7 +109,6 @@ def main(argv: list[str] | None = None) -> int:
     )
     engine = _MockABEngine() if args.self_test else _build_engine(args.engine)
     judge = _make_judge(args.judge_model) if (args.judge and not args.self_test) else None
-    modes = [m.strip() for m in args.modes.split(",") if m.strip()]
 
     result = run_engine_ab(
         engine, corpus, model=_chat_model(), budget_usd=args.budget_usd, modes=modes, judge=judge,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/unified_entry_eval.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/unified_entry_eval.py
@@ -76,7 +76,14 @@ def _routing(*, seed: int, n_anchors: int):
 
 def _budget_shared() -> bool:
     """ONE Budget across build-LLM (extraction) AND answer-LLM (synthesis): build a tiny store via the
-    facade (extraction spends), then a local ask (synthesis spends) on the SAME budget -> spent grows."""
+    facade (extraction spends), then a local ask (synthesis spends) on the SAME budget -> spent grows.
+
+    This probe measures the SYNTHESIS path's budget plumbing, so LLM-free chain routing is disabled for
+    the ask (`GOLDENGRAPH_QA_LOCAL_CHAIN=0`). Otherwise a chain-routable question like "Who founded
+    Acme?" now answers deterministically with ZERO synthesis spend -- which would read False here for a
+    reason orthogonal to budget sharing (the default-path chain routing, not a plumbing break)."""
+    import os
+
     from goldengraph.budget import Budget
     from goldengraph.graph import GoldenGraph
     from goldengraph_native import _native as ggn
@@ -90,7 +97,15 @@ def _budget_shared() -> bool:
         budget=b, store=ggn.PyStore(), corpus_records=1_000,
     )
     after_build = b.spent_tokens
-    gg.ask("Who founded Acme?", valid_t=_AS_OF, tx_t=_AS_OF, mode="local")
+    prev = os.environ.get("GOLDENGRAPH_QA_LOCAL_CHAIN")
+    os.environ["GOLDENGRAPH_QA_LOCAL_CHAIN"] = "0"  # force synthesis so the budget probe is meaningful
+    try:
+        gg.ask("Who founded Acme?", valid_t=_AS_OF, tx_t=_AS_OF, mode="local")
+    finally:
+        if prev is None:
+            os.environ.pop("GOLDENGRAPH_QA_LOCAL_CHAIN", None)
+        else:
+            os.environ["GOLDENGRAPH_QA_LOCAL_CHAIN"] = prev
     after_ask = b.spent_tokens
     return after_ask > after_build > 0
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_local_vs_auto_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_local_vs_auto_ab.py
@@ -1,0 +1,77 @@
+"""Same-run local-vs-auto A/B plumbing (no LLM). Locks: one shared build, both arms
+answer the same questions, per-mode scorecards + a legible delta -- so the paid
+headline that measures the default-path chain routing is CI-validated end to end."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from erkgbench.qa_e2e.corpora import Document, QACorpus, QAItem  # noqa: E402
+from erkgbench.qa_e2e.harness import AnswerResult, BuildResult, run_engine_ab  # noqa: E402
+
+
+class _ModeVaryingEngine:
+    name = "mock-ab"
+    fidelity = "self-test"
+
+    def __init__(self):
+        self.builds = 0
+
+    def build_kg(self, corpus) -> BuildResult:
+        self.builds += 1  # the A/B must build EXACTLY once
+        return BuildResult(handle={"n": len(corpus.documents)}, input_tokens=500, output_tokens=50)
+
+    def answer(self, handle, question: str, mode: str | None = None) -> AnswerResult:
+        # auto names the gold, local does not -> the two arms score differently.
+        text = "Ada" if mode == "auto" else "nope"
+        return AnswerResult(text=text, retrieved_fact_ids=("d1",), input_tokens=100, output_tokens=10)
+
+
+def _toy_corpus(n=3):
+    return QACorpus(
+        name="toy",
+        documents=(Document(id="d1", text="Acme was founded by Ada."),),
+        questions=tuple(
+            QAItem(
+                id=f"q{i}",
+                question="Who founded Acme?",
+                gold_answer="Ada",
+                gold_supporting_fact_ids=("d1",),
+                hop_count=1,
+                ambiguity_level=0.0,
+            )
+            for i in range(n)
+        ),
+    )
+
+
+def test_ab_builds_once_and_splits_arms():
+    engine = _ModeVaryingEngine()
+    res = run_engine_ab(
+        engine, _toy_corpus(3), model="gpt-4o-mini", budget_usd=25.0, modes=["local", "auto"]
+    )
+    assert engine.builds == 1  # ONE shared graph, not one per arm
+    assert set(res["arms"]) == {"local", "auto"}
+    # Both arms answered the SAME number of questions (aligned A/B).
+    assert res["arms"]["local"]["n_answered"] == res["arms"]["auto"]["n_answered"] == 3
+    assert res["n_answered"] == 3
+    # auto names the gold -> 1.0; local does not -> 0.0. The delta surfaces the win.
+    assert res["arms"]["auto"]["answer_match"] == 1.0
+    assert res["arms"]["local"]["answer_match"] == 0.0
+    assert res["comparison"]["answer_match"]["delta"] == 1.0
+    # Per-arm answer cost is attributed; the shared build cost is separate.
+    assert res["build_cost_usd"] > 0.0
+    assert res["total_cost_usd"] > 0.0
+
+
+def test_ab_budget_cap_keeps_arms_aligned():
+    # A tiny budget stops the loop, but a question is only started when BOTH arms can
+    # be afforded -> the arms never desync (equal n_answered), even mid-truncation.
+    engine = _ModeVaryingEngine()
+    res = run_engine_ab(
+        engine, _toy_corpus(50), model="gpt-4o", budget_usd=0.02, modes=["local", "auto"]
+    )
+    assert res["arms"]["local"]["n_answered"] == res["arms"]["auto"]["n_answered"]
+    assert res["n_answered"] <= 50

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_local_vs_auto_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_local_vs_auto_ab.py
@@ -66,6 +66,19 @@ def test_ab_builds_once_and_splits_arms():
     assert res["total_cost_usd"] > 0.0
 
 
+def test_ab_rejects_duplicate_modes():
+    # Duplicate modes collapse the arms dict into one -> a misleading one-arm "A/B".
+    # run_engine_ab must reject them rather than silently mislead.
+    import pytest
+
+    engine = _ModeVaryingEngine()
+    with pytest.raises(ValueError, match="unique"):
+        run_engine_ab(
+            engine, _toy_corpus(2), model="gpt-4o-mini", budget_usd=25.0,
+            modes=["local", "local"],
+        )
+
+
 def test_ab_budget_cap_keeps_arms_aligned():
     # A tiny budget stops the loop, but a question is only started when BOTH arms can
     # be afforded -> the arms never desync (equal n_answered), even mid-truncation.


### PR DESCRIPTION
## What and why

The **multi-hop shatter** — the same entity mentioned in two documents living as two un-merged graph nodes, so a multi-hop question can't traverse across docs — was diagnosed (via a MuSiQue N=100 `localize` trace) as the #1 addressable QA-failure class: **28% of misses**, and it capped `support_recall` at **0.59**.

**Root cause was not a missing capability.** GoldenGraph's anti-shatter stack (the `goldenprofile` fingerprint matcher + a relaxable cross-doc key) exists and is well-built — but it shipped **off by default**, so cross-doc merge fell back to an exact `record_key` that the docstring itself says type/case jitter defeats **~97.6%** of the time. The bench even builds the `goldenprofile-native` wheel *for* the matcher and never sets the flag. This PR makes the stack the default.

## Changes

- **`resolve._key_payload` default → `name_ci_type`** (case-folded name + coarse canonical type; homograph-safe). New `GOLDENGRAPH_XDOC_KEY=exact` restores the legacy verbatim `(name, typ)` key; `name`/`name_ci` remain the more/less aggressive relaxations.
- **`ingest._cross_doc_link_enabled` default `0`→`1`** (`GOLDENGRAPH_CROSS_DOC_LINK=0` opts out).
- **`ingest._profile_link_enabled` default `auto`** — ON when the separate `goldenprofile-native` wheel is importable (cached `_goldenprofile_available()` probe), else OFF so the linker **degrades to the embedding-cosine matcher** rather than hard-failing an install that lacks the wheel. `=1` forces on, `=0` off.

## Measured (MuSiQue N=100, trace A/B — treatment vs the linking-off baseline)

| metric | baseline (off) | treatment (on) | change |
| --- | --- | --- | --- |
| RETRIEVAL-shatter misses | 27 (28%) | **6 (7%)** | **−78%** |
| shatter-probe SCORING-miss (under-merges) | 18 | **4** | −78% |
| support_recall (right evidence retrieved) | 0.59 | **0.85** | **+0.26** |
| answer_match (entity subset) | 0.231 | **0.277** | +20% rel |
| answer_match (all) | 0.17 | 0.18 | +0.01 |

No precision regression. Overall `answer_match` barely moved because fixing retrieval **shifted the bottleneck to synthesis** (now the #1 bucket, ~36%: the answer is in the retrieved ball and the synthesizer picks the wrong node) — the chosen next lever.

## Testing

- `python -m pytest packages/python/goldengraph/tests/` → **365 passed, 8 skipped**; `ruff` clean.
- `test_xdoc_key.py`: new `name_ci_type` default + `exact` opt-out. `test_ingest_cross_doc_link.py`: gate default-on + profile-link `auto`/availability degradation.
- The local suite runs the **degraded path** (no `goldenprofile-native` wheel → profile-link auto-off → embedding matcher), proving the safe fallback. The **full stack** (with the wheel) is exercised in the `goldengraph_native` / pipeline CI lanes and was proven end-to-end by the bench A/B above.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on changed files
- [ ] Package `CHANGELOG.md` updated (pre-1.0 KG engine; default behavior change, gated + degrading)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_