### PR TITLE
feat(score-wasm): kernelize the name scorers on TS-WASM (12/19 -> 14/19)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -26,14 +26,14 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 The Rust / Arrow-native / fused `-core` kernels are the source of truth for scoring; each language surface either dispatches to the kernel (the fast path) or runs a byte-identical pure-language **fallback**. This tracks which scorers a kernel actually backs vs which are fallback-only. Sources: Python `_NATIVE_SCORER_IDS` (arrow bucket kernel) and TS `WASM_COVERED_SCORERS` (`-core` WASM), gated as the `scorer_kernels` api_parity surface.
 
-**12 of 19 scorers are kernel-backed** (the reference fast path); the other 7 are pure-language fallbacks with no `-core` kernel.
+**14 of 19 scorers are kernel-backed** (the reference fast path); the other 5 are pure-language fallbacks with no `-core` kernel.
 
 | Substrate | Scorers |
 |---|---|
 | Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
 | Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `date`, `dice`, `initialism_match`, `jaccard`, `phash`, `qgram`, `soundex_match` |
-| WASM `-core` kernel — TS only (Python falls back) | — |
-| Language fallback — no `-core` kernel | `audio_fp`, `embedding`, `ensemble`, `given_name_aliased_jw`, `name_freq_weighted_jw`, `radial`, `record_embedding` |
+| WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
+| Language fallback — no `-core` kernel | `audio_fp`, `embedding`, `ensemble`, `radial`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)
 

--- a/docs/superpowers/specs/2026-07-21-name-scorer-wasm-kernels-design.md
+++ b/docs/superpowers/specs/2026-07-21-name-scorer-wasm-kernels-design.md
@@ -1,0 +1,104 @@
+# TS-WASM kernels for the name scorers (`given_name_aliased_jw` / `name_freq_weighted_jw`)
+
+**Date:** 2026-07-21
+**Status:** Proposed → implementing. Feasibility verified (see below). Follow-on to the scorer-kernel
+coverage work: these are the two `ts_only` scorers the coverage manifest marks `deferred` to "the TS
+WASM surface." Kernelizing them there takes the metric **12/19 → 14/19**.
+
+## Why WASM (not the Python bucket)
+
+`given_name_aliased_jw` and `name_freq_weighted_jw` are `scorers.ts_only` — they live in TS's
+`VALID_SCORERS` (Python accepts them via the plugin fallback) and their *reference* implementation is
+the pure-TS `scoreField` path. The `scorer_kernels` metric counts a scorer as kernel-backed if it's in
+the Python bucket `_NATIVE_SCORER_IDS` **or** the TS `WASM_COVERED_SCORERS`. So the right kernel home is
+TS/WASM: add them to `WASM_COVERED_SCORERS` with a real `score-wasm` kernel byte-parity (4dp) with the
+pure-TS path.
+
+## The design (verified feasible)
+
+**The Rust kernel already exists.** `fs-core` has `name_freq_weighted_sim(a, b, &dyn SurnameFreq)` and
+`given_name_aliased_sim(a, b, &dyn NameAliases)` — byte-identical to the TS static-census branch (same
+constants `0.95/0.70/0.6`, same OOV→plain-JW gate). They take **injected** reference-data trait objects;
+`fs-core` bundles no data. The pyo3 `native` crate already consumes them via `set_name_reference_data`.
+
+**Feasibility gates (both pass):**
+1. **`fs-core` compiles to `wasm32-unknown-unknown`** — verified (`cargo build --target
+   wasm32-unknown-unknown --release` clean). Its only dep is `score-core` (already wasm-proven by the
+   existing `score-wasm` build).
+2. **IDF byte-parity** — `fs-core::SurnameIdfTable::from_counts` uses the *exact* `surnames.surname_idf`
+   formula `clamp[0,1]( ln(total/count) / ln(total/min) )` with the same `normalize_name`
+   (alpha-only + lowercase). The only cross-language wobble is JS `Math.log` vs Rust `f64::ln` (≤1 ULP),
+   which is far inside the WASM surface's parity bar: the existing `wasm-scorer.test.ts` asserts
+   `toBeCloseTo(expected, 4)` (WASM rapidfuzz vs the pure-TS JW impl already differ slightly), NOT
+   byte-exact. So **4dp is the standard**, and a log ULP never shows.
+
+**Table injection, NOT embedding (the key edge-safety decision).** `score-wasm` deliberately stays lean
+(`score-core` with `default-features = false`, no `regex`/`alias`). The census surname table (~176 KB)
+and given-name aliases are ALREADY committed in the TS modules `censusSurnames.ts` /
+`givenNameAliases.ts` for the pure path. So the WASM kernel does **not** embed them (no ~240 KB base64
+bloat in the edge bundle, the tension `parity/goldenmatch.yaml`'s deferral note flagged). Instead, the
+TS loader **injects** the data into the WASM module once at `enableWasm()`, mirroring the native
+`set_name_reference_data` pattern — `fs-core` builds the trait tables from the passed data.
+
+### Rust — `score-wasm`
+
+- Add `goldenmatch-fs-core` dep with `default-features = false` on its `score-core` edge (so `score-wasm`
+  stays regex/alias-free; `fs-core`'s `score-core` dep is made `default-features = false` — `fs-core`
+  uses only jaro_winkler/levenshtein/token_sort/score_one, none behind the `alias` feature; the `native`
+  build unions `alias` back in via its own direct `score-core` dep, so it's unaffected).
+- Two process-global `OnceLock`s: `SURNAME_IDF: SurnameIdfTable`, `NAME_ALIASES: AliasTable`.
+- Two `#[wasm_bindgen]` setters:
+  - `set_surname_idf(names: Vec<String>, counts: Vec<f64>)` → `SurnameIdfTable::from_counts(zip(...))`.
+  - `set_name_aliases(forms: Vec<String>, canonicals: Vec<String>)` → parallel *edge* arrays
+    (`forms[i]` belongs to canonical `canonicals[i]`); group by form → `AliasTable::from_forms`.
+    (Two flat `Vec<String>` — wasm-bindgen-friendly, no nested Vec.)
+- `score_matrix_impl` gains two id branches (ids **20 = given_name_aliased_jw**, **21 =
+  name_freq_weighted_jw** — ≥20 to leave headroom above `score_one`'s 0..=8): call the fs-core sim with
+  the installed table; if a table isn't installed, fall back to plain JW (`score_one(0)`) — the
+  table-absent behavior the pure path also degrades to.
+- Native-side Rust tests set the tables directly (fs-core's own goldens: `William/Bill → 1.0`,
+  `smith/smyth` borderline-weighted).
+
+### TypeScript
+
+- `src/core/wasm/backend.ts`: `SCORER_ID += { given_name_aliased_jw: 20, name_freq_weighted_jw: 21 }`
+  → `WASM_COVERED_SCORERS` auto-includes them.
+- The loader (`src/core/wasm/loader.ts`): after the artifact loads, call `set_surname_idf(CENSUS names,
+  counts)` and `set_name_aliases(alias edges)` — the data taken from the same `censusSurnames.ts` /
+  `givenNames.ts` state the pure path builds (single-sourced injection helpers `censusInjectionData` /
+  `aliasInjectionEdges`), so there is ONE source of table truth per surface.
+- `tests/unit/wasm-backend.test.ts`: update the expected `WASM_COVERED_SCORERS` set (+2).
+- `tests/parity/wasm-scorer.test.ts`: add goldens for the two scorers (asserted `toBeCloseTo(_, 4)` vs
+  the pure-TS `scoreField`), exercised after `enableWasm()` installs the tables.
+
+### Manifest / metric
+
+- Move `given_name_aliased_jw` / `name_freq_weighted_jw` from `scorer_kernels_deferred` →
+  `scorer_kernels.ts_only` in `parity/goldenmatch.yaml` (the coverage gate *enforces* this once they're
+  covered — `stale_deferral` otherwise). Regenerate suite-matrix (**14/19**) + agent-codemap.
+- The `api_parity` `scorer_kernels` surface now shows them as `ts_only` (Python has no bucket kernel for
+  them — a real Python↔TS delta, correctly declared).
+
+## Parity + validation
+
+- **Reference:** the pure-TS `scoreField` path (`given_name_aliased_jw` / `name_freq_weighted_jw`) is the
+  byte-parity target; the WASM kernel matches it to 4dp (the surface standard). fs-core's own Rust
+  goldens are the cross-surface oracle.
+- **Local-validation reality:** the Rust side (fs-core→wasm build, score-wasm build, fs-core-backed unit
+  tests) is fully local. The full wasm-bindgen artifact + TS vitest parity chain is what the CI
+  `wasm_score` lane runs from source (`build_wasm.sh` + `wasm-scorer.test.ts`, in `ci-required`); the TS
+  wiring is authored to the mapped patterns and validated there.
+
+## Non-goals
+
+- **The dynamic per-dataset `tf_freqs` branch** of `name_freq_weighted_jw` (Python builds a per-column TF
+  table; `MatchkeyField.tf_freqs`). The TS port is static-census-only by design, so the WASM kernel is
+  too — that's the scorer's TS reference. (The Python dynamic branch is a separate, Python-bucket
+  concern and not part of this scorer's ts_only surface.)
+- Embedding the census/alias tables in the wasm bundle (rejected — injected at init instead).
+
+## Rollout
+
+One PR: `score-wasm` fs-core dep + setters + ids 20/21 (+ Rust tests) → TS `SCORER_ID` +
+loader injection + parity/backend tests → manifest move + suite-matrix (14/19). Gated by the
+`wasm_score` CI lane (builds + runs the parity test) and the `api_parity` coverage gate.

--- a/packages/rust/extensions/fs-core/Cargo.toml
+++ b/packages/rust/extensions/fs-core/Cargo.toml
@@ -22,4 +22,9 @@ name = "goldenmatch_fs_core"
 # surfaces). Reference data (census / aliases) is injected by the host, never
 # bundled here (see the 2026-07-17 fs-core design).
 [dependencies]
-goldenmatch-score-core = { path = "../score-core" }
+# `default-features = false` drops score-core's `alias` feature (id 8 + the `regex`
+# engine) -- fs-core uses only jaro_winkler/levenshtein/token_sort/score_one, none
+# behind `alias`, so it stays lean. This keeps the edge `score-wasm` bundle (which
+# depends on fs-core for the name scorers) regex-free; the `native` crate unions
+# `alias` back in via its own direct score-core dependency, so it's unaffected.
+goldenmatch-score-core = { path = "../score-core", default-features = false }

--- a/packages/rust/extensions/score-wasm/Cargo.lock
+++ b/packages/rust/extensions/score-wasm/Cargo.lock
@@ -15,16 +15,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "goldenmatch-fs-core"
+version = "0.1.0"
+dependencies = [
+ "goldenmatch-score-core",
+]
+
+[[package]]
 name = "goldenmatch-score-core"
 version = "0.1.0"
 dependencies = [
  "rapidfuzz",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "goldenmatch-score-wasm"
 version = "0.1.0"
 dependencies = [
+ "goldenmatch-fs-core",
  "goldenmatch-score-core",
  "wasm-bindgen",
 ]
@@ -77,10 +86,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "wasm-bindgen"

--- a/packages/rust/extensions/score-wasm/Cargo.toml
+++ b/packages/rust/extensions/score-wasm/Cargo.toml
@@ -22,6 +22,11 @@ crate-type = ["cdylib", "rlib"]  # cdylib for wasm; rlib so host unit tests link
 # engine): alias_match is a Python-bucket-only kernel with no wasm export, so the
 # edge bundle stays free of the heavy `regex` dependency.
 goldenmatch-score-core = { path = "../score-core", default-features = false }
+# `fs-core` carries the name scorers (name_freq_weighted_jw / given_name_aliased_jw)
+# as `*_sim` fns over INJECTED reference-data tables -- it bundles no data and its
+# only dep is `score-core` (default-features = false, so no regex reaches the edge
+# bundle). The TS loader injects the census / alias tables at `enableWasm()`.
+goldenmatch-fs-core = { path = "../fs-core" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2"

--- a/packages/rust/extensions/score-wasm/src/lib.rs
+++ b/packages/rust/extensions/score-wasm/src/lib.rs
@@ -7,12 +7,51 @@
 //! `token_sort_normalized_ratio` (the TS-parity lowercase+strip normalize), NOT
 //! the un-normalized `score_one(2)` (which the FFI/native path depends on); every
 //! other id (incl. 4=date, the #1858 date-aware scorer) delegates to `score_one`.
+//! ids 20/21 are the score-wasm-only name scorers over `fs-core` (`given_name_-
+//! aliased_jw` / `name_freq_weighted_jw`), scoring against reference-data tables
+//! the TS loader injects once at `enableWasm()`.
 //!
 //! Boundary design: the batch `score_matrix` entry crosses the JS<->WASM boundary
 //! ONCE per NxN block (values arrive as one separator-joined string), never per
-//! pair — per the perf-audit lesson that boundary cost dwarfs a single scorer.
+//! pair -- per the perf-audit lesson that boundary cost dwarfs a single scorer.
 
+use goldenmatch_fs_core::{
+    given_name_aliased_sim, name_freq_weighted_sim, AliasTable, SurnameIdfTable,
+};
 use goldenmatch_score_core::{score_one, token_sort_normalized_ratio};
+use std::sync::OnceLock;
+
+// Injected reference-data tables for the two name scorers (ids 20/21). The TS
+// loader passes the SAME census / alias data the pure path uses into the setters
+// once at `enableWasm()`; fs-core bundles no data, so nothing is embedded in the
+// wasm bundle. `OnceLock` first-wins; the data is deterministic.
+static SURNAME_IDF: OnceLock<SurnameIdfTable> = OnceLock::new();
+static NAME_ALIASES: OnceLock<AliasTable> = OnceLock::new();
+
+// Name-scorer ids, distinct from `score_one`'s 0..=8 (>= 20 leaves headroom for
+// score_one growth) so `score_matrix_impl` can branch on them.
+const ID_GIVEN_NAME_ALIASED_JW: u8 = 20;
+const ID_NAME_FREQ_WEIGHTED_JW: u8 = 21;
+
+/// Install the surname-IDF table from host-shipped census `(name, count)` pairs
+/// (`SurnameIdfTable::from_counts` computes the idf with the shared
+/// `surnames.surname_idf` formula). Shared by the wasm setter + native tests.
+pub fn install_surname_idf(names: Vec<String>, counts: Vec<f64>) {
+    let _ = SURNAME_IDF.set(SurnameIdfTable::from_counts(names.into_iter().zip(counts)));
+}
+
+/// Install the given-name alias table from parallel `(form, canonical)` EDGE
+/// arrays (`forms[i]` is a member of canonical `canonicals[i]`) -- grouped by
+/// form into `AliasTable::from_forms`. Two flat arrays keep the wasm-bindgen
+/// boundary simple (no nested Vec).
+pub fn install_name_aliases(forms: Vec<String>, canonicals: Vec<String>) {
+    let mut grouped: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for (form, canon) in forms.into_iter().zip(canonicals) {
+        grouped.entry(form).or_default().push(canon);
+    }
+    let _ = NAME_ALIASES.set(AliasTable::from_forms(grouped));
+}
 
 /// Full row-major NxN similarity matrix for `values` under `scorer_id`.
 /// Diagonal = 0.0 and the matrix is symmetric, matching the pure-TS
@@ -25,10 +64,20 @@ pub fn score_matrix_impl(values: &[&str], scorer_id: u8) -> Vec<f64> {
         for j in (i + 1)..n {
             // id=2 (token_sort) uses the TS-parity normalized path (lowercase +
             // strip + token-sort), NOT score_one(2)'s un-normalized fuzz::ratio.
-            let s = if scorer_id == 2 {
-                token_sort_normalized_ratio(values[i], values[j])
-            } else {
-                score_one(scorer_id, values[i], values[j])
+            // ids 20/21 = the fs-core name scorers over the installed tables; if a
+            // table isn't installed the sim degrades to plain JW -- the same
+            // table-absent fallback the pure TS path takes.
+            let s = match scorer_id {
+                2 => token_sort_normalized_ratio(values[i], values[j]),
+                ID_GIVEN_NAME_ALIASED_JW => match NAME_ALIASES.get() {
+                    Some(t) => given_name_aliased_sim(values[i], values[j], t),
+                    None => score_one(0, values[i], values[j]),
+                },
+                ID_NAME_FREQ_WEIGHTED_JW => match SURNAME_IDF.get() {
+                    Some(t) => name_freq_weighted_sim(values[i], values[j], t),
+                    None => score_one(0, values[i], values[j]),
+                },
+                _ => score_one(scorer_id, values[i], values[j]),
             };
             out[i * n + j] = s;
             out[j * n + i] = s;
@@ -72,6 +121,38 @@ mod tests {
     }
 
     #[test]
+    fn name_scorer_ids_20_21_dispatch_to_fs_core() {
+        // The ONLY test that installs the process-global name-scorer tables
+        // (OnceLock first-wins), so it never races a different-content setter.
+        install_name_aliases(
+            vec![
+                "william".into(), "bill".into(), "robert".into(), "bob".into(),
+            ],
+            vec![
+                "william".into(), "william".into(), "robert".into(), "robert".into(),
+            ],
+        );
+        // Tiny census table: smith common, smyth rare, jones mid.
+        install_surname_idf(
+            vec!["smith".into(), "smyth".into(), "jones".into()],
+            vec![2_000_000.0, 100.0, 500_000.0],
+        );
+
+        // id 20 = given_name_aliased_jw: William/Bill share a canonical -> 1.0.
+        let m = score_matrix_impl(&["William", "Bill"], ID_GIVEN_NAME_ALIASED_JW);
+        assert_eq!(m[1], 1.0);
+        // Non-alias falls back to plain JW.
+        let m2 = score_matrix_impl(&["William", "Walter"], ID_GIVEN_NAME_ALIASED_JW);
+        assert_eq!(m2[1], score_one(0, "William", "Walter"));
+
+        // id 21 = name_freq_weighted_jw: dispatches to the fs-core sim over the
+        // installed table (byte-identical to calling the sim directly).
+        let table = SURNAME_IDF.get().unwrap();
+        let m3 = score_matrix_impl(&["smith", "smyth"], ID_NAME_FREQ_WEIGHTED_JW);
+        assert_eq!(m3[1], name_freq_weighted_sim("smith", "smyth", table));
+    }
+
+    #[test]
     fn token_sort_id2_normalizes_and_is_order_invariant() {
         // id=2 must use the TS-parity normalized path: order-invariant + case/
         // punctuation-insensitive. "John SMITH" vs "smith john" -> 1.0.
@@ -87,7 +168,7 @@ mod tests {
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use super::score_matrix_impl;
+    use super::{install_name_aliases, install_surname_idf, score_matrix_impl};
     use wasm_bindgen::prelude::*;
 
     /// JS entry: `values` is one string with fields joined by `sep` (a 1-char
@@ -101,5 +182,20 @@ mod wasm {
             values.split(sep).collect()
         };
         score_matrix_impl(&parts, scorer_id)
+    }
+
+    /// Install the surname-IDF table for `name_freq_weighted_jw` (id 21). Called
+    /// once by the TS loader at `enableWasm()` with the census `(name, count)`
+    /// data the pure path uses (`censusSurnames.ts`).
+    #[wasm_bindgen]
+    pub fn set_surname_idf(names: Vec<String>, counts: Vec<f64>) {
+        install_surname_idf(names, counts);
+    }
+
+    /// Install the given-name alias table for `given_name_aliased_jw` (id 20) from
+    /// parallel `(form, canonical)` edge arrays.
+    #[wasm_bindgen]
+    pub fn set_name_aliases(forms: Vec<String>, canonicals: Vec<String>) {
+        install_name_aliases(forms, canonicals);
     }
 }

--- a/packages/typescript/goldenmatch/src/core/refdata/givenNames.ts
+++ b/packages/typescript/goldenmatch/src/core/refdata/givenNames.ts
@@ -52,6 +52,32 @@ export function isAvailable(): boolean {
   return load() !== null;
 }
 
+/**
+ * Parallel `(form, canonical)` EDGE arrays for injecting into the score-wasm
+ * `given_name_aliased_jw` kernel (`set_name_aliases`). Flattened from the SAME
+ * `form -> Set<canonical>` map `buildState` builds for the pure path — so
+ * fs-core's `AliasTable::from_forms` regroups them into the identical
+ * form→canonical-set structure, and `are_equivalent` is byte-parity with
+ * `areEquivalent` below (set-intersection + the reflexive normalize-collide
+ * shortcut, which fs-core also carries). `null` when the table is unavailable.
+ */
+export function aliasInjectionEdges(): {
+  forms: string[];
+  canonicals: string[];
+} | null {
+  const state = load();
+  if (state === null) return null;
+  const forms: string[] = [];
+  const canonicals: string[] = [];
+  for (const [form, cset] of state.canonicals) {
+    for (const c of cset) {
+      forms.push(form);
+      canonicals.push(c);
+    }
+  }
+  return forms.length === 0 ? null : { forms, canonicals };
+}
+
 /** True iff a and b share at least one canonical. Symmetric, reflexive. */
 export function areEquivalent(a: string | null, b: string | null): boolean {
   if (a === null || b === null) return false;

--- a/packages/typescript/goldenmatch/src/core/refdata/surnames.ts
+++ b/packages/typescript/goldenmatch/src/core/refdata/surnames.ts
@@ -56,6 +56,29 @@ export function surnameRank(name: string | null): number | null {
   return r === undefined ? null : r;
 }
 
+/**
+ * Raw census `(name, count)` columns for injecting into the score-wasm
+ * `name_freq_weighted_jw` kernel (fs-core's `SurnameIdfTable::from_counts`
+ * recomputes the idf with the SAME `clamp(log(total/count)/log(total/min))`
+ * formula, so the wasm idf matches `surnameIdf` above to f64 tolerance). Returns
+ * every row verbatim — fs-core normalizes the names internally, exactly as
+ * `buildState` does, so the total/min/per-name idf are identical. `null` when
+ * the table is unavailable (nothing to inject → kernel stays plain-JW).
+ */
+export function censusInjectionData(): {
+  names: string[];
+  counts: number[];
+} | null {
+  if (load() === null) return null;
+  const names: string[] = [];
+  const counts: number[] = [];
+  for (const [rawName, , count] of CENSUS_SURNAMES) {
+    names.push(rawName);
+    counts.push(count);
+  }
+  return names.length === 0 ? null : { names, counts };
+}
+
 export function surnameIdf(name: string | null): number | null {
   if (name === null) return null;
   const state = load();

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -6,19 +6,31 @@
  * setSyncEmbedder(null) module-singleton pattern for test isolation.
  */
 
-/** Scorer ids understood by the score-wasm kernel (match score-core::score_one). */
+/**
+ * Scorer ids understood by the score-wasm kernel. Ids 0..=3 match
+ * score-core::score_one; ids 20/21 are the score-wasm-only name scorers (over
+ * fs-core's `given_name_aliased_sim` / `name_freq_weighted_sim`, ≥20 to leave
+ * headroom above score_one's 0..=8 — see score-wasm/src/lib.rs). The name
+ * scorers need their census / alias reference-data tables injected once at
+ * `enableWasm()` (the loader does this); until then the kernel degrades them to
+ * plain Jaro-Winkler, the same table-absent fallback the pure-TS path takes.
+ */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
   levenshtein: 1,
   token_sort: 2,
   exact: 3,
+  given_name_aliased_jw: 20,
+  name_freq_weighted_jw: 21,
 };
 
 /**
  * Scorers the WASM matrix path accelerates. token_sort (id 2) routes through
  * score-core's `token_sort_normalized_ratio` (the TS-parity lowercase + strip +
  * token-sort normalize), so the WASM result matches the pure-TS `tokenSortRatio`
- * (NOT score-core's un-normalized `score_one(2)`).
+ * (NOT score-core's un-normalized `score_one(2)`). The two name scorers
+ * (ids 20/21) reproduce the pure-TS `scoreField` name branches to 4dp (WASM
+ * rapidfuzz JW vs the pure-TS JW differ within the surface's tolerance).
  */
 export const WASM_COVERED_SCORERS: ReadonlySet<string> = new Set(
   Object.keys(SCORER_ID),

--- a/packages/typescript/goldenmatch/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/loader.ts
@@ -13,6 +13,8 @@ import {
 } from "goldenmatch-wasm-runtime";
 import { SCORER_ID } from "./backend.js";
 import type { ScorerBackend } from "./backend.js";
+import { censusInjectionData } from "../refdata/surnames.js";
+import { aliasInjectionEdges } from "../refdata/givenNames.js";
 
 export type { LoadOptions };
 
@@ -42,8 +44,32 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<ScorerBacke
     // lib type (this package typechecks without the DOM lib).
     default: (input: { module_or_path: Uint8Array }) => Promise<unknown>;
     score_matrix: (values: string, sep: string, scorerId: number) => Float64Array;
+    // Reference-data setters for the two name scorers (ids 20/21). Optional so
+    // an older artifact without them degrades gracefully (kernel falls back to
+    // plain JW for those ids); the CI-built artifact always carries them.
+    set_surname_idf?: (names: string[], counts: Float64Array) => void;
+    set_name_aliases?: (forms: string[], canonicals: string[]) => void;
   };
   await glue.default({ module_or_path: bytes });
+
+  // Inject the census / alias reference-data ONCE (mirrors the native
+  // `set_name_reference_data` pattern) so `name_freq_weighted_jw` /
+  // `given_name_aliased_jw` score over the SAME tables the pure-TS path uses —
+  // fs-core bundles no data. The kernel's OnceLock is first-wins; a second
+  // enableWasm() after disableWasm() re-instantiates a fresh module, so the
+  // per-module set runs against a clean OnceLock each time.
+  if (typeof glue.set_surname_idf === "function") {
+    const census = censusInjectionData();
+    if (census !== null) {
+      glue.set_surname_idf(census.names, Float64Array.from(census.counts));
+    }
+  }
+  if (typeof glue.set_name_aliases === "function") {
+    const aliases = aliasInjectionEdges();
+    if (aliases !== null) {
+      glue.set_name_aliases(aliases.forms, aliases.canonicals);
+    }
+  }
 
   const SEP = "\x1e";
   return {

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -27,7 +27,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { enableWasm, disableWasm } from "../../src/core/wasm/index.js";
-import { scoreMatrix } from "../../src/core/scorer.js";
+import { scoreMatrix, scoreField } from "../../src/core/scorer.js";
 
 const artifact = fileURLToPath(
   new URL("../../src/core/wasm/artifacts/score_wasm_bg.wasm", import.meta.url),
@@ -75,6 +75,43 @@ d("WASM scorer matches rapidfuzz/Python goldens", () => {
       // crossing); the off-diagonal cell is the pair score.
       const m = scoreMatrix([a, b], scorer);
       expect(m[0]![1]!).toBeCloseTo(expected, 4);
+    });
+  }
+});
+
+// The two fs-core name scorers (ids 20/21) score over the census / alias tables
+// the loader injects at enableWasm(). Their reference is the pure-TS `scoreField`
+// name branch (NOT a rapidfuzz golden), matched to 4dp — the surface bar (WASM
+// rapidfuzz JW vs the pure-TS JW differ within tolerance; #879 aligned them).
+// These cases also PROVE injection ran: without the census table the borderline
+// common-surname pair would score plain JW (~0.90) instead of the down-weighted
+// value (~0.56), and without the alias table William/Bill would score ~0.55
+// instead of 1.0 — both far outside 4dp.
+type NameCase = readonly [scorer: string, a: string, b: string, note: string];
+const NAME_CASES: readonly NameCase[] = [
+  ["given_name_aliased_jw", "William", "Bill", "alias -> 1.0 (proves alias inject)"],
+  ["given_name_aliased_jw", "Robert", "Bob", "alias -> 1.0"],
+  ["given_name_aliased_jw", "William", "Walter", "non-alias -> plain JW"],
+  ["name_freq_weighted_jw", "Smith", "Smyth", "borderline common -> down-weighted (proves census inject)"],
+  ["name_freq_weighted_jw", "Smith", "Smith", "exact (jw>=0.95) -> plain JW = 1.0"],
+  ["name_freq_weighted_jw", "Xzzyqwb", "Xzzyqwc", "OOV borderline -> plain JW"],
+];
+
+d("WASM name scorers match the pure-TS scoreField reference (4dp)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [scorer, a, b, note] of NAME_CASES) {
+    it(`${scorer}("${a}","${b}") ${note}`, () => {
+      // scoreField never consults the WASM backend — it is the pure-TS
+      // reference regardless of enable state.
+      const ref = scoreField(a, b, scorer);
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], scorer);
+      expect(m[0]![1]!).toBeCloseTo(ref!, 4);
     });
   }
 });

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,9 +25,16 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers jaro_winkler / levenshtein / token_sort / exact", () => {
+  it("covers the 4 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
-      ["exact", "jaro_winkler", "levenshtein", "token_sort"],
+      [
+        "exact",
+        "given_name_aliased_jw",
+        "jaro_winkler",
+        "levenshtein",
+        "name_freq_weighted_jw",
+        "token_sort",
+      ],
     );
   });
 });

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -308,6 +308,10 @@ blocking_strategies:
 # python_only: `date`, `qgram`, `soundex_match`, `initialism_match`, `alias_match`,
 # `dice`, `jaccard`, `phash` have an arrow-native (bucket) kernel on Python but no
 # TS WASM port yet.
+# ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
+# name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
+# over fs-core, injected census/alias tables) but have no Python bucket kernel
+# (Python accepts them via the plugin fallback); a real, declared Python<->TS delta.
 scorer_kernels:
   shared:
   - exact
@@ -323,7 +327,9 @@ scorer_kernels:
   - phash
   - qgram
   - soundex_match
-  ts_only: []
+  ts_only:
+  - given_name_aliased_jw
+  - name_freq_weighted_jw
 # scorer_kernels_deferred: the COVERAGE FLOOR. Every scorer in the `scorers` surface
 # that is NOT kernel-backed (absent from `scorer_kernels`) MUST appear here with a
 # reason -- the `check_scorer_coverage` gate FAILS on any uncovered scorer, so a new
@@ -336,7 +342,5 @@ scorer_kernels_deferred:
   ensemble: "declined -- a per-pair reimpl measurably regressed Febrl3 recall (0.922->0.782); the float32 matrix ensemble is the source of truth, so it stays off the bucket/fast path. Kernelizing means re-opening that measurement"
   embedding: "n/a -- model-backed (sentence-transformers / Vertex); belongs to goldenembed, not a string kernel"
   record_embedding: "n/a -- model-backed multi-field embedding"
-  given_name_aliased_jw: "deferred -- ts_only scorer; its kernel home is the TS WASM surface (WASM_COVERED_SCORERS), not the Python bucket"
-  name_freq_weighted_jw: "deferred -- ts_only; also uses a dynamic per-dataset tf table that does not fit the static-global in-kernel table mechanism"
   radial: "declined -- bespoke rotation-aligned Pearson on radial profiles; angular alignment search, low perf upside (small blocks)"
   audio_fp: "declined -- bespoke best-offset-aligned BER on hex audio fingerprints; alignment search, low perf upside"


### PR DESCRIPTION
## What and why

The two census/alias person-name scorers `given_name_aliased_jw` and `name_freq_weighted_jw` are `scorers.ts_only` -- their reference is the pure-TS `scoreField` path, so their kernel home is the TS WASM surface (`WASM_COVERED_SCORERS`), not the Python bucket. Kernelizing them there takes the `scorer_kernels` coverage metric from 12/19 to 14/19.

## Changes

**Rust (`score-wasm`)**
- Depend on `fs-core` (which carries `given_name_aliased_sim` / `name_freq_weighted_sim` over INJECTED reference-data traits), with its `score-core` edge `default-features = false` so no `regex`/`alias` reaches the edge bundle (verified regex-free on wasm32). `native` unions `alias` back via its own direct `score-core` dep, so it is unaffected.
- Two process-global `OnceLock` tables (`SURNAME_IDF` / `NAME_ALIASES`) + two `#[wasm_bindgen]` setters (`set_surname_idf` / `set_name_aliases`, flat parallel arrays -- no nested Vec across the boundary). Tables are INJECTED at `enableWasm()`, never embedded (no ~240 KB base64 bloat).
- `score_matrix_impl` gains ids 20/21; a table-absent id degrades to plain Jaro-Winkler, the same fallback the pure-TS path takes.

**TypeScript**
- `SCORER_ID += { given_name_aliased_jw: 20, name_freq_weighted_jw: 21 }` so `WASM_COVERED_SCORERS` auto-covers them.
- The loader injects the census (`censusInjectionData`) + alias edges (`aliasInjectionEdges`) from the SAME refdata state the pure path builds, so there is one source of table truth per surface. Setters are optional-guarded (an old artifact degrades gracefully).
- `wasm-scorer` parity test: 6 name-scorer cases asserting WASM == pure-TS `scoreField` to 4dp (also proves injection ran -- the Smith/Smyth down-weighting and William/Bill -> 1.0 cases fail without the tables). `wasm-backend` covered-set updated (+2).

**Manifest / docs**
- `given_name_aliased_jw` / `name_freq_weighted_jw` move `scorer_kernels_deferred` -> `scorer_kernels.ts_only` in `parity/goldenmatch.yaml` (a real, declared Python<->TS delta; Python has no bucket kernel for them). Suite-matrix regenerated (14/19). Design spec added.

## Testing

- `cargo test -p goldenmatch-score-wasm` -- 5/5 native tests pass.
- `cargo build --target wasm32-unknown-unknown --release` -- clean; `cargo tree` confirms the wasm dep tree is regex-free.
- `cargo clippy -p goldenmatch-score-wasm` -- clean.
- `bash build_wasm.sh` then `pnpm --filter goldenmatch typecheck` -- clean (CI-equivalent state).
- `npx vitest run tests/unit/wasm-backend.test.ts tests/parity/wasm-scorer.test.ts` -- 28/28 pass (full artifact build; end-to-end injection + ids 20/21 + 4dp parity).
- Coverage floor re-verified: 14 kernel-backed + 5 deferred = 19, no uncovered / no stale deferral.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_