### PR TITLE
fix(fs): make weak-positive blocking-pass pruning work on the arrow lane (71s→32.6s when enabled)

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -8,6 +8,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ### Fixed
 
+- **Weak-positive blocking-pass pruning now runs on the FS arrow lane.**
+  `GOLDENMATCH_BLOCKING_PRUNE_PASSES=1` invoked `select_passes` (polars-native:
+  `with_row_index` / `group_by`) directly on `df`, but the FS routed / arrow
+  lane passes a pyarrow `Table` -- so it threw `AttributeError`, was swallowed
+  into "keep all passes", and pruning was a silent no-op for every arrow-lane FS
+  caller. `_maybe_prune_blocking_passes` now coerces a Table / LazyFrame to
+  polars first. With the pruner actually running on a representative sample it
+  cuts a redundant 6-pass zero-config FS scheme (3 first-name + 2 last-name
+  transform variants + zip) to 3 passes (one name axis per field + zip),
+  measured **71s -> 32.6s at 1M, F1 unchanged 1.000** (P=R=1.0) on realistic
+  person data -- recall-safe because it drops only redundant transform *variants*
+  of the same field, keeping each blocking *axis*. Still opt-in; a default-on
+  flip for the FS path is gated on the `bench-probabilistic` panel.
 - **Learned blocking no longer clobbers the #1207 strong-identifier union at
   >=50k rows (#1316).** Auto-config forced `strategy="learned"` unconditionally
   at `total_rows >= 50_000`, discarding the per-identifier blocking union that

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3659,7 +3659,7 @@ def _maybe_promote_blocking_to_adaptive(
 
 def _maybe_prune_blocking_passes(
     blocking: BlockingConfig | None,
-    df: pl.DataFrame,
+    df: Any,  # pl.DataFrame | pl.LazyFrame | pa.Table (the arrow lane)
 ) -> BlockingConfig | None:
     """Opt-in weak-positive-aware pruning of multi-pass blocking passes.
 
@@ -3699,7 +3699,9 @@ def _maybe_prune_blocking_passes(
         if is_polars_lazyframe(prune_df):
             prune_df = prune_df.collect()
         elif not isinstance(prune_df, pl.DataFrame):
-            prune_df = pl.from_arrow(prune_df)
+            # pl.from_arrow on a Table always yields a DataFrame (Series only for
+            # an Array/ChunkedArray input, which this never is).
+            prune_df = cast("pl.DataFrame", pl.from_arrow(prune_df))
 
         result = select_passes(prune_df, list(passes), min_marginal_weak_positive=floor)
     except Exception:

--- a/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
+++ b/packages/python/goldenmatch/goldenmatch/core/autoconfig.py
@@ -3688,8 +3688,20 @@ def _maybe_prune_blocking_passes(
         floor = 1
     try:
         from goldenmatch.core.blocking_pass_selection import select_passes
+        from goldenmatch.core.frame import is_polars_lazyframe
 
-        result = select_passes(df, list(passes), min_marginal_weak_positive=floor)
+        # select_passes is polars-native (with_row_index / group_by), but the FS
+        # routed / arrow lane passes `df` as a pyarrow Table (or a LazyFrame).
+        # Coerce first so pruning actually RUNS -- without this the arrow lane
+        # threw AttributeError, was swallowed below into "keep all passes", and
+        # this whole opt-in was a silent no-op for every arrow-lane FS caller.
+        prune_df = df
+        if is_polars_lazyframe(prune_df):
+            prune_df = prune_df.collect()
+        elif not isinstance(prune_df, pl.DataFrame):
+            prune_df = pl.from_arrow(prune_df)
+
+        result = select_passes(prune_df, list(passes), min_marginal_weak_positive=floor)
     except Exception:
         logger.warning("blocking pass selection failed; keeping all passes", exc_info=True)
         return blocking

--- a/packages/python/goldenmatch/tests/test_blocking_pass_selection.py
+++ b/packages/python/goldenmatch/tests/test_blocking_pass_selection.py
@@ -104,6 +104,17 @@ class TestAutoconfigHook:
         out = _maybe_prune_blocking_passes(self._cfg(), _dataset())
         assert [p.fields for p in out.passes] == [["b"]]
 
+    def test_enabled_prunes_arrow_lane(self, monkeypatch):
+        # The FS routed/arrow lane passes a pyarrow Table, not a polars frame.
+        # Before the coercion fix select_passes threw AttributeError
+        # (`with_row_index`), which was swallowed into "keep all passes" -- so
+        # pruning was a silent no-op for EVERY arrow-lane FS caller. Same input,
+        # same expected pruning as the polars lane.
+        monkeypatch.setenv("GOLDENMATCH_BLOCKING_PRUNE_PASSES", "1")
+        monkeypatch.setenv("GOLDENMATCH_BLOCKING_PASS_MIN_WEAKPOS", "3")
+        out = _maybe_prune_blocking_passes(self._cfg(), _dataset().to_arrow())
+        assert [p.fields for p in out.passes] == [["b"]]
+
     def test_noop_for_non_multipass(self, monkeypatch):
         monkeypatch.setenv("GOLDENMATCH_BLOCKING_PRUNE_PASSES", "1")
         cfg = BlockingConfig(strategy="static", keys=[_PASS_A])


### PR DESCRIPTION
## What and why

Follow-up to #1981 (FS correctness) and #1985 (the wall — 410s→71s). This closes the remaining blocking-quality gap: zero-config FS at 1.2M was still ~71s vs the hand-tuned explicit config's 20.7s because it emits redundant recall passes (3 first-name + 2 last-name transform variants + zip).

The weak-positive pass pruner (`GOLDENMATCH_BLOCKING_PRUNE_PASSES`) already existed and was already wired into `auto_configure_probabilistic_df` — but it was **a silent no-op on the FS path**. `_maybe_prune_blocking_passes` called the polars-native `select_passes` (`with_row_index` / `group_by`) directly on `df`, and the FS routed / arrow lane passes a pyarrow `Table` → `AttributeError`, swallowed by the surrounding `try/except` into "keep all passes". So no arrow-lane FS caller ever pruned.

## The fix

Coerce a `Table` / `LazyFrame` to polars before calling `select_passes`. That's it — the pruner logic is unchanged.

## Measured (realistic person data, 1M, single-box `bucket`)

| config | passes | wall | F1 |
|---|---|---|---|
| zero-config, unpruned (post-#1985) | 6 | 71s | 1.000 |
| zero-config, **pruned (this PR)** | 3 | **32.6s** | **1.000** |
| explicit (zip-only, recall-*unsafe*) | 1 | 20.7s | 1.000 |

**2.2× faster at identical F1.** The pruner drops the 4 redundant transform *variants* (soundex / prefix / token_sort on the same field) and keeps one blocking *axis* per field (a name pass + zip), so it's recall-safe — unlike the zip-only explicit config, which would miss dups that don't share a zip.

## Scope / caveats

- **Still opt-in** (`GOLDENMATCH_BLOCKING_PRUNE_PASSES=1`). This PR makes the opt-in *work*; it does not flip the default.
- The pruner judges recall-redundancy from a **representative sample** (needs duplicates present). A head sample of a base-then-dup fixture has none, so pruning correctly no-ops there — real data intersperses dups.
- **Default-on for the FS path is a tracked follow-up gated on the `bench-probabilistic` panel** (Febrl/DBLP-ACM/historical), the standing recall guard — the synthetic fixture has dups sharing zip, so it can't prove recall-safety on data where they don't.

## Testing

- `pytest tests/test_blocking_pass_selection.py` → 10 passed, incl. new `test_enabled_prunes_arrow_lane` (a `pa.Table` input prunes identically to the polars lane — before the fix it silently kept all passes).
- `ruff check` clean on changed files.
- End-to-end 1M measurement above.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [x] Package `CHANGELOG.md` updated
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_