### PR TITLE
fix(suggest-quality): gym-gate treats a runs-but-unmeasurable pair as advisory (#1934)

### DIFF
--- a/scripts/suggest_quality/cli.py
+++ b/scripts/suggest_quality/cli.py
@@ -34,6 +34,15 @@ _GYM_BASELINE = Path(__file__).resolve().parent / "baselines" / "gym_scorecard.j
 # Tolerance for gym recovery% non-regression (absolute drop allowed).
 RECOVERY_GATE_TOL: float = 0.05
 
+# Per-pair current statuses that are genuinely UNMEASURABLE this run (#1934):
+# ``no_damage`` = the perturbation no longer degrades F1 (the config drifted
+# degenerate enough that the damage is a no-op); ``n/a`` = the perturbation no
+# longer applies to this dataset's ceiling config. Neither is a suggestion-
+# recovery regression -- there is nothing to recover -- so a blessed-ok pair that
+# lands here is advisory (SKIPPED), not a MISSING failure. ``error`` and a truly
+# absent record are NOT in this set: those stay MISSING (a real regression).
+_UNMEASURABLE_PAIR_STATUSES: frozenset[str] = frozenset({"no_damage", "n/a"})
+
 
 # ── determinism helper ────────────────────────────────────────────────────────
 
@@ -875,17 +884,23 @@ def _cmd_gym_gate(records: list[dict], native_version: str, git_sha: str) -> int
 
     Fails (exit 1) when:
       - zero ok records this run (gate certifies nothing)
-      - a blessed built-rule pair is MISSING from this run (absent for a reason
-        OTHER than a degenerate ceiling -- see below)
+      - a blessed built-rule pair is MISSING from this run (genuinely absent, or
+        errored -- see the unmeasurable exceptions below)
       - any built-rule pair's recovery_pct_live/raw drops > RECOVERY_GATE_TOL vs blessed
       - the COMMON-population headline_live/raw drops > RECOVERY_GATE_TOL vs blessed
 
-    NEW pairs (in this run but not in baseline) are informational. A blessed pair
-    whose dataset was SKIPPED this run for a degenerate zero-config ceiling (#1620)
-    is advisory, not a failure -- recovery% is unmeasurable against a broken
-    ceiling, so re-failing the guard's own deliberate skip is wrong (re-bless to
-    drop it). Headlines compare over the COMMON measurable population so a dataset
-    leaving the set (degenerate) can't phantom-shift the mean and fail the gate.
+    NEW pairs (in this run but not in baseline) are informational. Two UNMEASURABLE
+    cases are advisory (SKIPPED), not failures, because recovery% is undefined and
+    there is nothing to recover -- re-failing them would just re-fail the guard's
+    own deliberate skip:
+      - the whole dataset was SKIPPED this run for a degenerate zero-config ceiling
+        (#1620/#1975), OR
+      - the dataset RAN but THIS pair is ``no_damage``/``n/a`` this run (#1934 -- the
+        config drifted degenerate enough that the damage no longer bites, even
+        though the ceiling cleared the degenerate-skip floor).
+    ``error`` and truly-absent pairs stay MISSING (real regressions). Headlines
+    compare over the COMMON measurable population so a dataset leaving the set
+    (degenerate) can't phantom-shift the mean and fail the gate.
     """
     baseline = _loads_gym_baseline()
     base_pairs: dict[str, dict] = baseline.get("pairs", {})
@@ -945,10 +960,26 @@ def _cmd_gym_gate(records: list[dict], native_version: str, git_sha: str) -> int
         cur = cur_pairs.get(key)
         if cur is None or cur.get("status") != "ok":
             dataset_name = key.split("/", 1)[0]
+            cur_status = None if cur is None else cur.get("status")
             if dataset_name in degenerate_skipped:
-                # Unmeasurable this run (degenerate ceiling) -> advisory, not a fail.
+                # Whole dataset unmeasurable this run (degenerate ceiling,
+                # #1620/#1975) -> advisory, not a fail.
                 rows.append((key, "*", "ok", "degenerate ceiling", "  n/a", "SKIPPED"))
+            elif cur_status in _UNMEASURABLE_PAIR_STATUSES:
+                # #1934: the dataset RAN (ceiling cleared the degenerate-skip
+                # floor), but THIS pair is unmeasurable this run -- either the
+                # damage no longer degrades F1 (``no_damage``: the config drifted
+                # degenerate enough that the perturbation is a no-op) or the
+                # perturbation no longer applies (``n/a``). recovery%% is undefined,
+                # so there is nothing to recover and this is NOT a suggestion-
+                # recovery regression. Advisory, not a fail -- same philosophy as
+                # the dataset-level degenerate-ceiling skip, extended to the
+                # per-pair "runs but bites nothing" case the ceiling floor misses.
+                rows.append(
+                    (key, "*", "ok", f"unmeasurable ({cur_status})", "  n/a", "SKIPPED")
+                )
             else:
+                # Genuinely absent (cur is None) or errored -> real MISSING.
                 rows.append((key, "*", "ok", "absent/non-ok", "  n/a", "MISSING"))
             continue
 
@@ -1049,8 +1080,9 @@ def _cmd_gym_gate(records: list[dict], native_version: str, git_sha: str) -> int
         f"{n_skipped} skipped)"
     )
     if n_skipped:
-        print(f"  note: {n_skipped} blessed pair(s) SKIPPED (degenerate ceiling this "
-              f"run) -- advisory; re-bless to drop them from the baseline.")
+        print(f"  note: {n_skipped} blessed pair(s) SKIPPED (unmeasurable this run -- "
+              f"degenerate ceiling or no_damage/n-a) -- advisory; re-bless to drop "
+              f"them from the baseline.")
 
     return 0 if verdict == "PASS" else 1
 

--- a/scripts/suggest_quality/tests/test_gym_gate_unmeasurable_pair_1934.py
+++ b/scripts/suggest_quality/tests/test_gym_gate_unmeasurable_pair_1934.py
@@ -1,0 +1,98 @@
+"""gym-gate #1934: a blessed built-rule pair that RAN this run but is unmeasurable
+(``no_damage``/``n/a`` -- the config drifted degenerate enough that the damage no
+longer bites, even though the dataset's ceiling cleared the #1620 degenerate-skip
+floor) is SKIPPED (advisory), not MISSING (fail). ``error`` / truly-absent pairs
+stay MISSING.
+
+Pins the residual bench-suggest-quality failure #1975 did NOT cover: ncvr_synthetic's
+ceiling sat just ABOVE the 0.50 floor, so run_catalog did not emit a degenerate-skip
+sentinel; it ran the full pipeline, its 5 damage scenarios came back no_damage, and
+the gate re-failed them as MISSING -- despite zero recovery regression.
+"""
+from scripts.suggest_quality import cli
+
+
+def _bpair(rec_live, rec_raw, *, ok=True, built=True):
+    return {
+        "status": "ok" if ok else "error",
+        "builds_on_existing_rule": built,
+        "recovery_pct_live": rec_live,
+        "recovery_pct_raw": rec_raw,
+    }
+
+
+def _baseline():
+    return {
+        "headline_live": 0.75,
+        "headline_raw": 0.85,
+        "pairs": {
+            "good/threshold_too_low": _bpair(1.0, 1.0),
+            "degen/threshold_too_low": _bpair(0.5, 0.7),
+        },
+    }
+
+
+def _ok_record(dataset, live, raw):
+    return {"dataset": dataset, "name": "threshold_too_low", "status": "ok",
+            "builds_on_existing_rule": True,
+            "recovery_pct_live": live, "recovery_pct_raw": raw,
+            "expected_rule": "r"}
+
+
+def _status_record(dataset, status):
+    # A record that RAN but is non-ok this run (no_damage / n/a / error).
+    return {"dataset": dataset, "name": "threshold_too_low", "status": status,
+            "builds_on_existing_rule": True}
+
+
+def test_no_damage_pair_is_advisory_not_missing(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_loads_gym_baseline", _baseline)
+    # 'degen' ran but its damage no longer degrades -> status no_damage (unmeasurable).
+    records = [_ok_record("good", 1.0, 1.0), _status_record("degen", "no_damage")]
+    rc = cli._cmd_gym_gate(records, "test", "deadbeef")
+    out = capsys.readouterr().out
+    assert "SKIPPED" in out
+    assert "MISSING" not in out
+    assert rc == 0, out
+    assert "0 missing" in out and "1 skipped" in out
+
+
+def test_na_pair_is_advisory_not_missing(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_loads_gym_baseline", _baseline)
+    records = [_ok_record("good", 1.0, 1.0), _status_record("degen", "n/a")]
+    rc = cli._cmd_gym_gate(records, "test", "deadbeef")
+    out = capsys.readouterr().out
+    assert "SKIPPED" in out
+    assert "MISSING" not in out
+    assert rc == 0, out
+
+
+def test_errored_pair_still_missing(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_loads_gym_baseline", _baseline)
+    # A genuine error is NOT unmeasurable-benign -> stays MISSING/FAIL.
+    records = [_ok_record("good", 1.0, 1.0), _status_record("degen", "error")]
+    rc = cli._cmd_gym_gate(records, "test", "deadbeef")
+    out = capsys.readouterr().out
+    assert "MISSING" in out
+    assert rc == 1, out
+
+
+def test_absent_pair_still_missing(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_loads_gym_baseline", _baseline)
+    # 'degen' simply absent (no record at all) -> MISSING/FAIL.
+    records = [_ok_record("good", 1.0, 1.0)]
+    rc = cli._cmd_gym_gate(records, "test", "deadbeef")
+    out = capsys.readouterr().out
+    assert "MISSING" in out
+    assert rc == 1, out
+
+
+def test_real_regression_not_masked_by_unmeasurable_skip(monkeypatch, capsys):
+    monkeypatch.setattr(cli, "_loads_gym_baseline", _baseline)
+    # 'good' recovery craters (real regression) while 'degen' is no_damage-skipped;
+    # the real drop must still gate -- the unmeasurable skip doesn't mask it.
+    records = [_ok_record("good", 0.2, 0.2), _status_record("degen", "no_damage")]
+    rc = cli._cmd_gym_gate(records, "test", "deadbeef")
+    out = capsys.readouterr().out
+    assert rc == 1, out
+    assert "FAIL" in out


### PR DESCRIPTION
## What and why

Completes the fix for main-health **#1934** (bench-suggest-quality gym-gate red on `main`). #1975 (merged) fixed the headline drag — `headline_raw` now passes — but the nightly still failed, and I diagnosed why:

#1975 made a dataset **SKIPPED** (advisory) when its zero-config ceiling fell **below** the 0.50 degenerate-skip floor. But `ncvr_synthetic`'s ceiling now sits **just above** the floor, so `run_catalog` does *not* emit a skip sentinel — it runs the full pipeline (visible in the failing run as ~14 min of `build_clusters: … 63 clusters OVERSIZED` on a committed RED config), and its 5 damage scenarios come back **`no_damage`** (the config drifted degenerate enough that the damage no longer degrades F1). The gate then re-failed those blessed-`ok` pairs as **MISSING** → `FAIL (…5 missing)`, despite zero recovery regression.

## Changes

- **`scripts/suggest_quality/cli.py` (`_cmd_gym_gate`)**: a blessed built-rule pair whose *current* record ran but is `no_damage`/`n/a` (genuinely unmeasurable — recovery% undefined, nothing to recover) is now **SKIPPED** (advisory), the same philosophy as the dataset-level degenerate-ceiling skip, extended to the per-pair "runs but bites nothing" case the ceiling floor misses. `error` and truly-absent pairs **stay MISSING** — so the fix **cannot mask a real recovery regression**. Added the `_UNMEASURABLE_PAIR_STATUSES` constant; updated the gate docstring + closing note.

## Testing

- **`scripts/suggest_quality/tests/test_gym_gate_unmeasurable_pair_1934.py`** (new): `no_damage`/`n/a` → SKIPPED + PASS; `error`/absent → MISSING + FAIL; a real recovery-pct drop on a still-measured pair still FAILs (not masked).
- Existing `test_gym_gate_degenerate_skip.py` + `test_gym_ceiling_floor.py` unchanged — **13 pass total**.
- `ruff` clean.

## Notes

- Safe by construction: only `no_damage`/`n/a` reclassify to advisory; `error`/absent remain MISSING.
- The full `ncvr_synthetic` gym (50K, degenerate, oversized clusters) OOMs in a small sandbox, so the end-to-end confirmation that its pairs are `no_damage` is a fresh gym-gate CI run. I'll trigger the heavy `workflow_dispatch` gym-gate on this branch to confirm before merge.
- Once `main` is clean, main-health #1934 auto-closes on its next scheduled run (it's a `github-actions`-maintained issue — I won't close it manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_