### PR TITLE
fix(ci): gate-fs-zeroconfig didn't gate — pipefail so F1-floor failures actually fail

### DIFF
--- a/.github/workflows/gate-fs-zeroconfig.yml
+++ b/.github/workflows/gate-fs-zeroconfig.yml
@@ -74,6 +74,11 @@ jobs:
           GOLDENMATCH_NATIVE: "1"
           GOLDENMATCH_FS_NATIVE: "1"
         run: |
+          # pipefail is LOAD-BEARING: the script exits 1 when F1 < --min-f1
+          # (the whole point of the gate), but `| tee` would otherwise mask that
+          # exit code with tee's 0 -- so the gate reported SUCCESS on a real
+          # F1=0.03 regression at 30M. Without this the gate does not gate.
+          set -o pipefail
           uv run python packages/python/goldenmatch/scripts/bench_fs_distributed.py \
             --rows "${{ github.event.inputs.rows || '1000000' }}" \
             --dup-frac 0.2 \


### PR DESCRIPTION
## What and why

The zero-config FS F1 gate (`gate-fs-zeroconfig.yml`, from #1981) **did not actually gate.** `bench_fs_distributed.py` exits `1` when F1 < `--min-f1`, but the step piped it through `| tee "$GITHUB_STEP_SUMMARY"` with no `pipefail` — so tee's exit `0` masked the script's exit `1`.

Found the hard way: a manual 25M dispatch (run 29859372053) measured **zero-config FS F1 = 0.0300 (recall 1.5%) at 30M rows**, printed `::error::... F1 0.0300 < floor 0.90`, and the workflow still reported **`conclusion: success`**. A real quality regression sailed through green.

## The fix

`set -o pipefail` in the gate step, so the pipeline propagates the script's exit code.

## Scope note

This makes the gate *gate*. It does **not** by itself catch the specific 30M collapse: the nightly runs at the `rows` default of 1M, where zero-config FS F1 is ~1.0 — the quality collapse happens somewhere between 1M and 30M. Raising the nightly scale to cover that is a follow-up, tracked with the recall-collapse diagnosis (the 30M F1=0.03 is a genuine, separate scale-dependent quality bug — `email` *was* admitted, so it's not the #1981 identifier issue; it's the scoring/EM side).

## Testing

Workflow-only change. Verified the two halves of the bug directly: `scripts/bench_fs_distributed.py` has `return 1` on `ev.f1 < args.min_f1` (line ~213), and the step lacked `pipefail`. `goldenmatch-kg.yml` was scanned and cleared (its `| tee` pipes `echo`, which never fails — not a masking case).

## Checklist

- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_