### PR TITLE
Add same-graph env-A/B harness for confound-free GoldenGraph knob measurement

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -24,7 +24,7 @@ on:
         description: "all | goldengraph | lightrag | ms_graphrag | graphiti | text_rag | goldenmatch_rag | goldenmatch_entity_rag (head_to_head mode only)"
         default: "all"
       mode:
-        description: "head_to_head | local_vs_auto_ab | scorecard | aggregation_llm | temporal_llm | crossover_llm | kg_capability | router_capability | extraction_f1 | synthesis_gold | retrieval_coverage"
+        description: "head_to_head | local_vs_auto_ab | env_ab | scorecard | aggregation_llm | temporal_llm | crossover_llm | kg_capability | router_capability | extraction_f1 | synthesis_gold | retrieval_coverage"
         default: "head_to_head"
       budget_usd:
         description: "hard cost cap per (engine, ambiguity) run"
@@ -38,6 +38,9 @@ on:
       opts:
         description: "newline KEY=VALUE passthrough -> env (overrides the baked bench defaults). Keys: GOLDENGRAPH_QA_MODE(local|hybrid) GOLDENGRAPH_HYBRID_FILTER(none|path) GOLDENGRAPH_QA_PASSAGE_K GOLDENGRAPH_QA_RETRIEVAL_HOPS GOLDENGRAPH_QA_NODE_BUDGET GOLDENGRAPH_CROSS_DOC_LINK GOLDENGRAPH_LINK_THRESHOLD GOLDENGRAPH_PROFILE_LINK GOLDENGRAPH_PROFILE_MERGE_THRESHOLD GOLDENGRAPH_BUILD_WORKERS GOLDENGRAPH_BUILD_DEBUG GOLDENGRAPH_EXTRACTOR(api|rebel|gliner) GOLDENGRAPH_LITERAL_ATTRS GOLDENGRAPH_QA_TRACE GOLDENGRAPH_QA_TRACE_LIMIT GOLDENGRAPH_DISTILL_LOG(1) TEXT_RAG_TOP_K GOLDENMATCH_RAG_TOP_K SCORECARD_BUDGET_USD LOCAL_EMBED_MODEL"
         default: ""
+      ab_env:
+        description: "env_ab mode ONLY: the answer-time env var + values to A/B on ONE shared graph, as NAME:v1,v2[,..]. e.g. GOLDENGRAPH_SYNTH_SAMPLES:1,5 measures self-consistency voting free of build variance."
+        default: "GOLDENGRAPH_SYNTH_SAMPLES:1,5"
 
 permissions:
   contents: read
@@ -235,6 +238,86 @@ jobs:
         with:
           name: graphrag-qa-local-vs-auto-ab
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_local_vs_auto_ab.*
+          if-no-files-found: ignore
+
+  goldengraph_env_ab:
+    needs: setup
+    if: ${{ inputs.mode == 'env_ab' }}
+    runs-on: large-new-64GB
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Resolve bench env (baked defaults, then opts override)
+        env:
+          OPTS: ${{ inputs.opts }}
+        run: |
+          {
+            echo "GOLDENGRAPH_BUILD_WORKERS=12"
+            echo "GOLDENGRAPH_LINK_THRESHOLD=0.82"
+            echo "GOLDENGRAPH_PROFILE_MERGE_THRESHOLD=0.72"
+            echo "GOLDENGRAPH_QA_RETRIEVAL_HOPS=6"
+            echo "GOLDENGRAPH_QA_NODE_BUDGET=256"
+            echo "GOLDENGRAPH_EXTRACTOR=api"
+            printf '%s\n' "$OPTS"
+          } | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' >> "$GITHUB_ENV"
+      - name: Parse ab_env (NAME:v1,v2 -> --env / --values)
+        env:
+          AB_ENV: ${{ inputs.ab_env }}
+        run: |
+          python3 - <<'PY' >> "$GITHUB_ENV"
+          import os
+          spec = os.environ["AB_ENV"].strip()
+          name, _, values = spec.partition(":")
+          name = name.strip()
+          values = values.strip()
+          if not name or not values or "," not in values:
+              raise SystemExit(f"ab_env must be NAME:v1,v2[,..], got {spec!r}")
+          print(f"AB_VAR={name}")
+          print(f"AB_VALUES={values}")
+          PY
+      - name: Install goldenmatch + native engine wheel + goldengraph + datasets
+        run: |
+          python -m pip install --upgrade pip maturin pytest goldenmatch datasets openai
+          maturin build --release \
+            -m packages/rust/extensions/goldengraph-native/Cargo.toml --out dist
+          maturin build --release \
+            -m packages/rust/extensions/goldenprofile-native/Cargo.toml --out dist
+          python -m pip install dist/*.whl
+          python -m pip install --no-deps -e packages/python/goldengraph
+          python -m pip install --no-deps -e packages/python/goldenmatch
+      - name: Run env A/B (real LLM, budget-capped, one shared graph)
+        working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
+        env:
+          OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          POLARS_SKIP_CPU_CHECK: "1"
+          # datasets pulls a fresh-pip pyarrow whose bundled mimalloc SIGSEGVs on the
+          # pipeline's worker threads -- the documented repo standard for any lane that
+          # pip-installs goldenmatch/pyarrow and runs the pipeline (goldengraph resolve).
+          ARROW_DEFAULT_MEMORY_POOL: system
+        run: |
+          mkdir -p results
+          python -m erkgbench.qa_e2e.run_env_ab \
+            --corpus "${{ inputs.corpus }}" \
+            --max-questions "${{ inputs.max_questions }}" \
+            --ambiguity "0.5" \
+            --env "$AB_VAR" \
+            --values "$AB_VALUES" \
+            --budget-usd "${{ inputs.budget_usd }}" \
+            ${{ inputs.judge == 'true' && '--judge' || '' }} \
+            --out-md "results/RESULTS_QA_ENV_AB.md" \
+            --out-json "results/results_qa_env_ab.json"
+          echo "### Env A/B ($AB_VAR)" >> "$GITHUB_STEP_SUMMARY"
+          cat results/RESULTS_QA_ENV_AB.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload env A/B results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: graphrag-qa-env-ab
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/results/results_qa_env_ab.*
           if-no-files-found: ignore
 
   lightrag:

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -3,6 +3,7 @@ the harness builds the KG once, answers every question, scores via metrics, and
 enforces a hard USD cap via goldenmatch's BudgetTracker."""
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 from dataclasses import dataclass
@@ -423,6 +424,95 @@ def run_engine_ab(
         "total_cost_usd": round(enforce.total_cost_usd, 6),
         "n_answered": answered,
     }
+
+
+def run_engine_ab_env(
+    engine, corpus, *, model: str, budget_usd: float, arms, judge=None
+) -> dict:
+    """Same-graph env-A/B: build the KG ONCE, then answer every question under EACH
+    env-config arm against the IDENTICAL graph. The ONLY variable is the answer-time
+    environment (e.g. `GOLDENGRAPH_SYNTH_SAMPLES=1` vs `=5`), so build variance -- which
+    otherwise swamps a downstream-only change under head_to_head's rebuild-per-run
+    (support_recall swung +-0.26 on a retrieval-only metric voting cannot touch) -- is
+    removed by construction.
+
+    `arms` is a list of `(label, env_dict)`; each `env_dict` maps env-var name -> value
+    (str) applied around the answer call and restored afterward, so the arms don't leak
+    into each other or the build. Unlike `run_engine_ab`, the engine's `answer()` is
+    called WITHOUT a `mode=` kwarg -- the knob under test lives entirely in the env, so
+    ANY env-gated behavior is A/B-able without an engine-level mode hook.
+
+    One shared budget bounds the WHOLE run (build + every arm); a question is only started
+    when the budget can afford answering it under every arm, so the arms stay aligned
+    (same n_answered). Per-arm answer cost is attributed separately for the report.
+
+    Returns `{"arms": {label: scorecard}, "comparison": {...}, "build_cost_usd",
+    "total_cost_usd", "n_answered"}`."""
+    arms = list(arms)
+    labels = [label for label, _ in arms]
+    # Duplicate labels would collapse the `scored`/`arms` dict keys into one arm and
+    # silently produce a misleading one-arm "A/B" -- reject rather than mislead.
+    if len(set(labels)) != len(labels):
+        raise ValueError(f"run_engine_ab_env arm labels must be unique, got {labels!r}")
+    enforce = BudgetTracker(BudgetConfig(max_cost_usd=budget_usd))
+    # Attribution-only trackers (effectively uncapped) for per-arm answer cost.
+    arm_trackers = {label: BudgetTracker(BudgetConfig(max_cost_usd=10**9)) for label in labels}
+
+    build = engine.build_kg(corpus)
+    enforce.record_usage(build.input_tokens, build.output_tokens, model)
+    build_cost = enforce.total_cost_usd
+
+    scored: dict[str, list[dict]] = {label: [] for label in labels}
+    answered = 0
+    for q in corpus.questions:
+        # A question costs one answer PER arm; only start it if the budget can afford
+        # the whole set, so every arm answers exactly the same questions.
+        if enforce.budget_exhausted or not enforce.can_send(
+            _estimate_tokens(q.question) * len(arms)
+        ):
+            break
+        for label, env in arms:
+            with _env_overrides(env):
+                ans = engine.answer(build.handle, q.question)
+            enforce.record_usage(ans.input_tokens, ans.output_tokens, model)
+            arm_trackers[label].record_usage(ans.input_tokens, ans.output_tokens, model)
+            scored[label].append(_score_question(ans, q, judge))
+        answered += 1
+
+    arm_cards = {
+        label: _build_scorecard(
+            engine, corpus, model, scored[label],
+            answered=answered,
+            cost_usd=arm_trackers[label].total_cost_usd,
+            budget_exhausted=enforce.budget_exhausted,
+        )
+        for label in labels
+    }
+    return {
+        "arms": arm_cards,
+        "comparison": _ab_comparison(arm_cards, labels),
+        "build_cost_usd": round(build_cost, 6),
+        "total_cost_usd": round(enforce.total_cost_usd, 6),
+        "n_answered": answered,
+    }
+
+
+@contextlib.contextmanager
+def _env_overrides(env: dict):
+    """Apply `env` (name->value) to os.environ for the duration, then restore the prior
+    state EXACTLY -- keys that were absent are deleted, keys that were set are put back to
+    their old value. So an arm's config can't leak into the next arm or the shared build."""
+    saved: dict[str, str | None] = {k: os.environ.get(k) for k in env}
+    try:
+        for k, v in env.items():
+            os.environ[k] = str(v)
+        yield
+    finally:
+        for k, old in saved.items():
+            if old is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = old
 
 
 #: The headline metrics compared side-by-side across the A/B arms.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_env_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/run_env_ab.py
@@ -1,0 +1,145 @@
+"""CLI: same-graph env-A/B for the goldengraph QA engine.
+
+Builds the KG ONCE, then answers every question under N answer-time env-configs
+against the IDENTICAL graph. Because the graph is shared, the metric deltas are
+purely the effect of the env knob, not build variance -- the confound that made a
+head_to_head rebuild-per-run comparison of a downstream-only change unreliable (a
+retrieval-only metric, support_recall, swung +-0.26 between rebuilds of the "same"
+corpus, swamping the change under test).
+
+Generic over ANY env-gated answer-time behavior: `--env NAME --values v1,v2,...`
+produces one arm per value (`NAME=v1`, `NAME=v2`, ...). The headline use is
+`--env GOLDENGRAPH_SYNTH_SAMPLES --values 1,5` -- does self-consistency voting
+(complete_many + majority vote) actually help, measured on the identical graph?
+
+`--self-test` uses a mock engine (no LLM) whose answer reads the env under test, so
+the A/B plumbing is CI-validated without a provider, mirroring run_qa_e2e.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+from .harness import AnswerResult, BuildResult, run_engine_ab_env
+from .run_qa_e2e import _build_engine, _chat_model, _load_corpus, _make_judge
+
+
+class _MockEnvABEngine:
+    """No-LLM engine whose answer VARIES by the env var under test, so the self-test
+    exercises the A/B split (distinct arms) without a provider. It reads
+    `GOLDENGRAPH_SYNTH_SAMPLES`: value "1" gives a non-answer, anything else names the
+    gold -- a stand-in for "the env knob changes the answer"."""
+
+    name = "mock-env-ab"
+    fidelity = "self-test"
+
+    def build_kg(self, corpus) -> BuildResult:
+        return BuildResult(handle={"n": len(corpus.documents)}, input_tokens=1, output_tokens=1)
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        samples = os.environ.get("GOLDENGRAPH_SYNTH_SAMPLES", "1")
+        text = "(no answer)" if samples == "1" else "Ada"
+        return AnswerResult(text=text, retrieved_fact_ids=("d1",), input_tokens=1, output_tokens=1)
+
+
+def _write_ab(result: dict, *, md_path: Path, json_path: Path, env_name: str) -> None:
+    json_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    arms = result["arms"]
+    labels = list(arms)
+    lines = [
+        f"# GoldenGraph QA -- same-graph env-A/B (`{env_name}`)",
+        "",
+        f"- corpus: `{arms[labels[0]]['corpus']}`  model: `{arms[labels[0]]['model']}`",
+        f"- questions answered (per arm): **{result['n_answered']}**",
+        f"- build cost: ${result['build_cost_usd']}  total (build + all arms): "
+        f"${result['total_cost_usd']}",
+        "",
+        "| metric | " + " | ".join(labels) + " | delta (2nd - 1st) |",
+        "| --- | " + " | ".join("---" for _ in labels) + " | --- |",
+    ]
+    for metric, per_label in result["comparison"].items():
+        cells = []
+        for label in labels:
+            v = per_label.get(label)
+            cells.append("-" if v is None else f"{v:.4f}" if isinstance(v, float) else str(v))
+        d = per_label.get("delta")
+        d_cell = "-" if d is None else f"{d:+.4f}"
+        lines.append(f"| {metric} | " + " | ".join(cells) + f" | {d_cell} |")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--engine", default="goldengraph")
+    p.add_argument("--self-test", action="store_true")
+    p.add_argument("--corpus", choices=("engineered", "musique", "hotpotqa", "2wikimultihop"),
+                   required=True)
+    p.add_argument("--max-questions", type=int, default=50)
+    p.add_argument("--ambiguity", type=float, default=0.5)
+    p.add_argument("--musique-path", default=None)
+    p.add_argument("--corpus-path", default=None)
+    p.add_argument(
+        "--env", required=True,
+        help="name of the answer-time env var to A/B (e.g. GOLDENGRAPH_SYNTH_SAMPLES)",
+    )
+    p.add_argument(
+        "--values", required=True,
+        help="comma-separated values to A/B, in order (delta = 2nd - 1st). "
+        "e.g. '1,5' -> arms GOLDENGRAPH_SYNTH_SAMPLES=1 and =5.",
+    )
+    p.add_argument(
+        "--model", default=None,
+        help="chat model override. When given, sets OPENAI_MODEL so _chat_model() + the "
+        "engine both honor it; omit to use the env/default (gpt-4o-mini).",
+    )
+    p.add_argument("--budget-usd", type=float, default=25.0)
+    p.add_argument("--judge", action="store_true", help="score the format-fair LLM-judge metric too")
+    p.add_argument("--judge-model", default="gpt-4o-mini")
+    p.add_argument("--out-md", required=True)
+    p.add_argument("--out-json", required=True)
+    args = p.parse_args(argv)
+
+    values = [v.strip() for v in args.values.split(",") if v.strip()]
+    if len(values) < 2:
+        raise SystemExit("--values must list at least two values to A/B (e.g. '1,5')")
+    # One arm per value: (label, env_dict) where env_dict overrides ONLY the var under test.
+    arms = [(f"{args.env}={v}", {args.env: v}) for v in values]
+
+    # Honor --model by exporting OPENAI_MODEL BEFORE building the engine / reading
+    # _chat_model() (both are env-driven); omitted -> the env/default is used.
+    if args.model:
+        os.environ["OPENAI_MODEL"] = args.model
+
+    out_md = Path(args.out_md).resolve()
+    out_json = Path(args.out_json).resolve()
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+
+    corpus = _load_corpus(
+        args.corpus, args.max_questions, args.musique_path, args.ambiguity,
+        corpus_path=args.corpus_path,
+    )
+    engine = _MockEnvABEngine() if args.self_test else _build_engine(args.engine)
+    judge = _make_judge(args.judge_model) if (args.judge and not args.self_test) else None
+
+    result = run_engine_ab_env(
+        engine, corpus, model=_chat_model(), budget_usd=args.budget_usd, arms=arms, judge=judge,
+    )
+    _write_ab(result, md_path=out_md, json_path=out_json, env_name=args.env)
+
+    cmp = result["comparison"]
+    labels = list(result["arms"])
+    print(f"wrote {out_md} ({result['n_answered']} q/arm, ${result['total_cost_usd']})")
+    for metric in ("answer_match", "token_f1", "support_recall"):
+        per = cmp.get(metric, {})
+        cells = "  ".join(
+            f"{label}={per.get(label):.4f}" for label in labels if isinstance(per.get(label), float)
+        )
+        d = per.get("delta")
+        print(f"  {metric}: {cells}" + (f"  (delta {d:+.4f})" if isinstance(d, float) else ""))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_env_ab.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_env_ab.py
@@ -1,0 +1,123 @@
+"""Same-graph env-A/B plumbing (no LLM). Locks: one shared build, every arm answers
+the same questions under its own env-config (applied then restored), per-arm
+scorecards + a legible delta -- so the paid headline that measures a env-gated knob
+(e.g. GOLDENGRAPH_SYNTH_SAMPLES self-consistency voting) is CI-validated end to end
+and free of the build-variance confound that made head_to_head unreliable."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from erkgbench.qa_e2e.corpora import Document, QACorpus, QAItem  # noqa: E402
+from erkgbench.qa_e2e.harness import AnswerResult, BuildResult, run_engine_ab_env  # noqa: E402
+
+_ENV = "GOLDENGRAPH_SYNTH_SAMPLES"
+
+
+class _EnvVaryingEngine:
+    name = "mock-env-ab"
+    fidelity = "self-test"
+
+    def __init__(self):
+        self.builds = 0
+
+    def build_kg(self, corpus) -> BuildResult:
+        self.builds += 1  # the A/B must build EXACTLY once
+        return BuildResult(handle={"n": len(corpus.documents)}, input_tokens=500, output_tokens=50)
+
+    def answer(self, handle, question: str) -> AnswerResult:
+        # The answer reads the env under test -- "5" names the gold, "1" does not, so
+        # the two arms score differently. Note: NO mode= kwarg -- the knob is env-only.
+        text = "Ada" if os.environ.get(_ENV) == "5" else "nope"
+        return AnswerResult(text=text, retrieved_fact_ids=("d1",), input_tokens=100, output_tokens=10)
+
+
+def _toy_corpus(n=3):
+    return QACorpus(
+        name="toy",
+        documents=(Document(id="d1", text="Acme was founded by Ada."),),
+        questions=tuple(
+            QAItem(
+                id=f"q{i}",
+                question="Who founded Acme?",
+                gold_answer="Ada",
+                gold_supporting_fact_ids=("d1",),
+                hop_count=1,
+                ambiguity_level=0.0,
+            )
+            for i in range(n)
+        ),
+    )
+
+
+def _arms():
+    return [(f"{_ENV}=1", {_ENV: "1"}), (f"{_ENV}=5", {_ENV: "5"})]
+
+
+def test_env_ab_builds_once_and_splits_arms():
+    engine = _EnvVaryingEngine()
+    res = run_engine_ab_env(
+        engine, _toy_corpus(3), model="gpt-4o-mini", budget_usd=25.0, arms=_arms()
+    )
+    assert engine.builds == 1  # ONE shared graph, not one per arm
+    assert set(res["arms"]) == {f"{_ENV}=1", f"{_ENV}=5"}
+    # Both arms answered the SAME number of questions (aligned A/B).
+    assert res["arms"][f"{_ENV}=1"]["n_answered"] == res["arms"][f"{_ENV}=5"]["n_answered"] == 3
+    assert res["n_answered"] == 3
+    # =5 names the gold -> 1.0; =1 does not -> 0.0. The delta surfaces the win.
+    assert res["arms"][f"{_ENV}=5"]["answer_match"] == 1.0
+    assert res["arms"][f"{_ENV}=1"]["answer_match"] == 0.0
+    assert res["comparison"]["answer_match"]["delta"] == 1.0
+    # Per-arm answer cost is attributed; the shared build cost is separate.
+    assert res["build_cost_usd"] > 0.0
+    assert res["total_cost_usd"] > 0.0
+
+
+def test_env_ab_restores_environ():
+    # The arm env-overrides must not leak: after the run, the var is back to its prior
+    # state (here: unset). This is the guarantee that arms don't contaminate each other.
+    prior = os.environ.pop(_ENV, None)
+    try:
+        engine = _EnvVaryingEngine()
+        run_engine_ab_env(engine, _toy_corpus(2), model="gpt-4o-mini", budget_usd=25.0, arms=_arms())
+        assert _ENV not in os.environ  # restored to absent
+    finally:
+        if prior is not None:
+            os.environ[_ENV] = prior
+
+
+def test_env_ab_restores_prior_value():
+    # A pre-existing value is restored EXACTLY, not deleted.
+    os.environ[_ENV] = "sentinel"
+    try:
+        engine = _EnvVaryingEngine()
+        run_engine_ab_env(engine, _toy_corpus(2), model="gpt-4o-mini", budget_usd=25.0, arms=_arms())
+        assert os.environ[_ENV] == "sentinel"
+    finally:
+        os.environ.pop(_ENV, None)
+
+
+def test_env_ab_rejects_duplicate_labels():
+    # Duplicate labels collapse the arms dict into one -> a misleading one-arm "A/B".
+    import pytest
+
+    engine = _EnvVaryingEngine()
+    with pytest.raises(ValueError, match="unique"):
+        run_engine_ab_env(
+            engine, _toy_corpus(2), model="gpt-4o-mini", budget_usd=25.0,
+            arms=[(f"{_ENV}=1", {_ENV: "1"}), (f"{_ENV}=1", {_ENV: "1"})],
+        )
+
+
+def test_env_ab_budget_cap_keeps_arms_aligned():
+    # A tiny budget stops the loop, but a question is only started when EVERY arm can
+    # be afforded -> the arms never desync (equal n_answered), even mid-truncation.
+    engine = _EnvVaryingEngine()
+    res = run_engine_ab_env(
+        engine, _toy_corpus(50), model="gpt-4o", budget_usd=0.02, arms=_arms()
+    )
+    assert res["arms"][f"{_ENV}=1"]["n_answered"] == res["arms"][f"{_ENV}=5"]["n_answered"]
+    assert res["n_answered"] <= 50


### PR DESCRIPTION
## What and why

The `head_to_head` bench rebuilds the KG on every run, so a downstream-only change (answer-time only) is swamped by stochastic-extraction build variance: `support_recall`, a retrieval-only metric a synthesis change cannot touch, swung +-0.26 between rebuilds of the *same* corpus. That confound made the first self-consistency-voting measurement (`GOLDENGRAPH_SYNTH_SAMPLES=1` vs `=5`) uninterpretable. This adds a same-graph A/B: build the KG ONCE, answer every question under N answer-time env-configs on the IDENTICAL graph, so the metric deltas are purely the knob's effect.

## Changes

- `run_engine_ab_env` + `_env_overrides` in `harness.py`: builds once, then for each question answers under every `(label, env_dict)` arm with `os.environ` save/apply/restore around a plain `answer()` call (no `mode=` hook needed, so ANY env-gated behavior is A/B-able). Reuses `_score_question`/`_build_scorecard`/`_ab_comparison`; duplicate-label reject + shared-budget alignment mirror `run_engine_ab`.
- `run_env_ab.py` CLI: `--env NAME --values v1,v2,...` produces one arm per value; `--self-test` mock engine reads the env under test so the plumbing is CI-validated without a provider.
- `bench-graphrag-qa.yml`: new `env_ab` mode + `goldengraph_env_ab` job + one `ab_env` input (`NAME:v1,v2`, keeps the workflow at the 10-input dispatch cap). Carries `ARROW_DEFAULT_MEMORY_POOL=system` per the repo standard for pipeline lanes.
- `test_qa_env_ab.py`: build-once, arm-split scoring, environ restore (absent + prior value), duplicate-label reject, budget-cap alignment.

## Testing

- `python -m pytest tests/test_qa_env_ab.py tests/test_qa_local_vs_auto_ab.py tests/test_qa_harness.py -q` -> 16 passed (the shared-scorecard refactor is proven un-regressed).
- `python -m erkgbench.qa_e2e.run_env_ab --self-test --corpus engineered --env GOLDENGRAPH_SYNTH_SAMPLES --values 1,5 ...` -> writes the MD/JSON A/B report.

Headline paid run to dispatch after merge: `mode=env_ab`, `ab_env=GOLDENGRAPH_SYNTH_SAMPLES:1,5` on MuSiQue -> a build-variance-free measurement of whether self-consistency voting helps.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (bench harness, no gotcha change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_