### PR TITLE
test(fs): complete #1805 checkbox 1 route-vs-route parity matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -566,6 +566,10 @@ jobs:
             packages/python/goldenmatch/tests/test_nlevel_em.py \
             packages/python/goldenmatch/tests/test_nlevel_schema.py \
             packages/python/goldenmatch/tests/test_fs_bucket_native.py \
+            packages/python/goldenmatch/tests/test_fs_tf_route_matrix_1805.py \
+            packages/python/goldenmatch/tests/test_fs_match_mode_bucket_1805.py \
+            packages/python/goldenmatch/tests/test_fs_model_path_native_parity_1805.py \
+            packages/python/goldenmatch/tests/test_fs_frame_lane_parity_1805.py \
             -k "not native and not Native" \
             -n auto --timeout=120 --timeout-method=thread -q
 

--- a/packages/python/goldenmatch/tests/test_fs_frame_lane_parity_1805.py
+++ b/packages/python/goldenmatch/tests/test_fs_frame_lane_parity_1805.py
@@ -1,0 +1,129 @@
+"""Issue #1805 (checkbox 1) — arrow-lane vs polars-lane FS parity.
+
+`GOLDENMATCH_FRAME` (default ``arrow`` since v3.0) selects the frame backend the
+whole pipeline flows through. The frame-backend differential gate
+(`test_frame_backend_differential.py`) runs both lanes but its configs are
+explicitly exact/weighted only -- NO probabilistic/EM matchkey -- and the
+bucket-vs-legacy matrix pins BOTH runs to the polars lane to remove the
+arrow-vs-polars confound. So an FS (probabilistic) config had never been run
+through both lanes and compared: an arrow/polars divergence in the FS
+score/block path (the class the frame gate exists to catch) was uncovered.
+
+This runs one moderate FS `dedupe_df` under each lane and asserts identical
+cluster membership. The EM is pinned via a persisted `model_path` so training is
+identical across lanes (FS EM is sample-order sensitive; the frame axis is what
+we isolate). The fixture keeps true pairs well above and non-pairs well below
+threshold so a benign f32/f64 wobble can't flip a borderline decision. Skips
+when polars is absent (the arrow lane is the polars-free default).
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+
+import pytest
+
+_HAS_POLARS = importlib.util.find_spec("polars") is not None
+
+pytestmark = pytest.mark.skipif(
+    not _HAS_POLARS, reason="polars lane requires the optional polars dependency"
+)
+
+
+def _fixture(n_entities: int = 120):
+    """Two rows per entity: a base + a typo'd near-duplicate sharing an exact
+    email (a strong FS agreement). Emails are unique per entity, so no pair
+    crosses entities; each entity is a clean 2-member cluster. Blocked by a
+    coarse zip so blocks hold several entities."""
+    import polars as pl
+
+    first = ["john", "mary", "peter", "susan", "david", "karen", "brian", "nancy"]
+    last = ["smith", "jones", "brown", "davis", "wilson", "clark", "lewis", "young"]
+    rows = []
+    rid = 0
+    for e in range(n_entities):
+        f = first[e % len(first)]
+        l = last[(e // len(first)) % len(last)]
+        z = f"{10000 + (e % 6):05d}"
+        email = f"e{e}@x.com"
+        rows.append({"__row_id__": rid, "first_name": f, "last_name": l, "email": email, "zip": z})
+        rid += 1
+        # near-dup: adjacent-transpose the first name (keeps jaro_winkler high)
+        ff = (f[:2] + f[3] + f[2] + f[4:]) if len(f) >= 5 else f + "x"
+        rows.append({"__row_id__": rid, "first_name": ff, "last_name": l, "email": email, "zip": z})
+        rid += 1
+    return pl.DataFrame(rows)
+
+
+def _config(model_path: str):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(
+            name="fs", type="probabilistic", model_path=model_path,
+            fields=[
+                MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.8),
+                MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2, partial_threshold=0.85),
+                MatchkeyField(field="email", scorer="exact", levels=2),
+            ],
+        )],
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["zip"])]),
+    )
+
+
+def _members(res) -> frozenset:
+    cl = res.clusters or {}
+    return frozenset(
+        frozenset(int(m) for m in c.get("members", []))
+        for c in cl.values()
+        if len(c.get("members", [])) > 1
+    )
+
+
+def _dedupe_on_lane(df, cfg, lane: str, monkeypatch):
+    import goldenmatch as gm
+
+    monkeypatch.setenv("GOLDENMATCH_FRAME", lane)
+    # Isolate the frame axis from the native-kernel axis.
+    monkeypatch.setenv("GOLDENMATCH_FS_NATIVE", "0")
+    return _members(gm.dedupe_df(df, config=cfg, confidence_required=False))
+
+
+def _pin_model(tmp_path, df, cfg) -> str:
+    """Train the EM once and persist it so both lanes reuse the identical model
+    (via load_or_train_em's model_path seam)."""
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.probabilistic import train_em
+
+    mk = cfg.matchkeys[0]
+    blocks = build_blocks(df.lazy(), cfg.blocking)
+    train_em(df, mk, blocks=blocks, blocking_fields=["zip"], seed=42).save_json(mk.model_path)
+    return mk.model_path
+
+
+def test_fs_arrow_polars_cluster_membership_parity(tmp_path, monkeypatch):
+    model_path = str(tmp_path / "fs_model.json")
+    df = _fixture()
+    cfg = _config(model_path)
+    _pin_model(tmp_path, df, cfg)
+    assert os.path.exists(model_path)
+
+    arrow = _dedupe_on_lane(df, cfg, "arrow", monkeypatch)
+    polars = _dedupe_on_lane(df, cfg, "polars", monkeypatch)
+
+    # The fixture must actually merge (else parity is vacuous).
+    assert arrow, "fixture produced no multi-member clusters"
+    assert arrow == polars, (
+        f"arrow-vs-polars FS divergence: only-arrow={len(arrow - polars)} "
+        f"only-polars={len(polars - arrow)}"
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/python/goldenmatch/tests/test_fs_match_mode_bucket_1805.py
+++ b/packages/python/goldenmatch/tests/test_fs_match_mode_bucket_1805.py
@@ -1,0 +1,144 @@
+"""Issue #1805 (checkbox 1) — match-mode scope (`across_files_only` /
+`target_ids`) on the FS bucket route.
+
+The audit found ZERO FS-route tests for the two-table / cross-source match
+modes even though the FS bucket route honors both (`score_buckets` takes
+`across_files_only` + `source_lookup` and `target_ids`, filtering internally at
+`backends/score_buckets.py`). `target_ids` had a single batched-route test
+(`test_probabilistic_parallel.py`); `across_files_only` on FS had none.
+
+These pin the bucket route (bucket-python unconditionally; bucket-native behind
+`_fs_native_enabled()`): the mode must (a) keep every genuinely cross-side pair
+and (b) drop every same-side pair, and the filtered set must equal the
+unfiltered set minus its same-side pairs (the filter is scope-only, it must not
+perturb scores or invent pairs). One 4-row fixture drives both modes: a
+cross-side duplicate (survives) and a same-side duplicate (dropped).
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.probabilistic import _fs_native_enabled, train_em
+
+native_required = pytest.mark.skipif(
+    not _fs_native_enabled(),
+    reason="native FS kernel not built/enabled (GOLDENMATCH_FS_NATIVE + built _native)",
+)
+
+
+def _mk() -> MatchkeyConfig:
+    return MatchkeyConfig(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2, partial_threshold=0.85),
+            MatchkeyField(field="email", scorer="exact", levels=2),
+        ],
+    )
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["zip"])])
+
+
+def _fixture() -> pl.DataFrame:
+    """One zip block. Rows 0/1 are a cross-side duplicate (shared email, typo'd
+    first name); rows 2/3 are a same-side duplicate (shared email). Distinct
+    emails across the two entities keep 0/1 vs 2/3 from matching."""
+    return pl.DataFrame({
+        "__row_id__": [0, 1, 2, 3],
+        # `__source__` mirrors _SOURCE_LOOKUP: the bucket across-files path reads
+        # the source off the frame, while source_lookup is the external/batched
+        # scorer's view -- pass both so every route sees the same membership.
+        "__source__": ["a", "b", "a", "a"],
+        "first_name": ["John", "Jon", "Mary", "Mari"],
+        "last_name": ["Smith", "Smith", "Jones", "Jones"],
+        "email": ["john@x.com", "john@x.com", "mary@x.com", "mary@x.com"],
+        "zip": ["10001", "10001", "10001", "10001"],
+    })
+
+
+# Membership per mode. across_files_only: source A/B. target_ids: two-table set.
+# Both are chosen so (0,1) straddles (survives) and (2,3) is same-side (dropped).
+_SOURCE_LOOKUP = {0: "a", 1: "b", 2: "a", 3: "a"}
+_TARGET_IDS = {1, 2, 3}
+
+
+def _pairset(pairs) -> set[tuple[int, int]]:
+    return {(min(a, b), max(a, b)) for a, b, _s in pairs}
+
+
+def _run(*, native: bool, monkeypatch, **score_kwargs):
+    from goldenmatch.backends.score_buckets import score_buckets
+
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", "1" if native else "0")
+    df = _fixture()
+    mk = _mk()
+    em = train_em(df, mk, n_sample_pairs=200, seed=42)
+    return _pairset(score_buckets(df, _blocking(), mk, set(), em_result=em, **score_kwargs))
+
+
+def _side_across(a: int, b: int) -> bool:
+    return _SOURCE_LOOKUP[a] != _SOURCE_LOOKUP[b]
+
+
+def _side_target(a: int, b: int) -> bool:
+    return (a in _TARGET_IDS) != (b in _TARGET_IDS)
+
+
+# ── across_files_only ─────────────────────────────────────────────────────────
+
+
+def test_bucket_python_across_files_only(monkeypatch):
+    unfiltered = _run(native=False, monkeypatch=monkeypatch)
+    filtered = _run(native=False, monkeypatch=monkeypatch,
+                    across_files_only=True, source_lookup=_SOURCE_LOOKUP)
+
+    # Anchor: the unfiltered set contains a same-source pair to drop.
+    assert any(not _side_across(a, b) for a, b in unfiltered), unfiltered
+    # Every surviving pair is cross-source, and the filter is scope-only.
+    assert all(_side_across(a, b) for a, b in filtered), filtered
+    assert filtered == {p for p in unfiltered if _side_across(*p)}
+    assert (0, 1) in filtered and (2, 3) not in filtered
+
+
+@native_required
+def test_bucket_native_across_files_only(monkeypatch):
+    unfiltered = _run(native=True, monkeypatch=monkeypatch)
+    filtered = _run(native=True, monkeypatch=monkeypatch,
+                    across_files_only=True, source_lookup=_SOURCE_LOOKUP)
+    assert any(not _side_across(a, b) for a, b in unfiltered), unfiltered
+    assert filtered == {p for p in unfiltered if _side_across(*p)}
+    assert (0, 1) in filtered and (2, 3) not in filtered
+
+
+# ── target_ids (two-table linkage scope) ──────────────────────────────────────
+
+
+def test_bucket_python_target_ids(monkeypatch):
+    unfiltered = _run(native=False, monkeypatch=monkeypatch)
+    filtered = _run(native=False, monkeypatch=monkeypatch, target_ids=_TARGET_IDS)
+
+    assert any(not _side_target(a, b) for a, b in unfiltered), unfiltered
+    assert all(_side_target(a, b) for a, b in filtered), filtered
+    assert filtered == {p for p in unfiltered if _side_target(*p)}
+    assert (0, 1) in filtered and (2, 3) not in filtered
+
+
+@native_required
+def test_bucket_native_target_ids(monkeypatch):
+    unfiltered = _run(native=True, monkeypatch=monkeypatch)
+    filtered = _run(native=True, monkeypatch=monkeypatch, target_ids=_TARGET_IDS)
+    assert any(not _side_target(a, b) for a, b in unfiltered), unfiltered
+    assert filtered == {p for p in unfiltered if _side_target(*p)}
+    assert (0, 1) in filtered and (2, 3) not in filtered
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/python/goldenmatch/tests/test_fs_model_path_native_parity_1805.py
+++ b/packages/python/goldenmatch/tests/test_fs_model_path_native_parity_1805.py
@@ -1,0 +1,123 @@
+"""Issue #1805 (checkbox 1) — a persisted FS model (`model_path`) reused on the
+native / bucket-native routes must score identically to the vectorized route.
+
+`TestModelReuseSkipsBuildBlocks` (test_probabilistic.py) proves a preloaded
+model skips `build_blocks`, and `TestNativeFSParity` proves native == vectorized
+-- but only ever on a *freshly trained* EM. Neither covers the join: load an EM
+from disk (the Splink train-once/reuse seam, `load_or_train_em`) and confirm the
+native kernel and the bucket-native kernel produce byte-identical pairs to the
+vectorized reference under THAT loaded model. A serialization round-trip that
+perturbed a weight would silently shift native scoring on every reuse.
+
+The vectorized route is the reference. Native and bucket-native ride the
+existing `_fs_native_enabled()` skipif; bucket-python runs unconditionally.
+"""
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from goldenmatch.config.schemas import (
+    BlockingConfig,
+    BlockingKeyConfig,
+    MatchkeyConfig,
+    MatchkeyField,
+)
+from goldenmatch.core.probabilistic import (
+    _fs_native_enabled,
+    fs_model_preloaded,
+    load_or_train_em,
+    score_probabilistic_vectorized,
+    train_em,
+)
+
+native_required = pytest.mark.skipif(
+    not _fs_native_enabled(),
+    reason="native FS kernel not built/enabled (GOLDENMATCH_FS_NATIVE + built _native)",
+)
+
+
+def _mk(**kw) -> MatchkeyConfig:
+    defaults = dict(
+        name="fs", type="probabilistic",
+        fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.8),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2, partial_threshold=0.85),
+            MatchkeyField(field="email", scorer="exact", levels=2),
+        ],
+    )
+    defaults.update(kw)
+    return MatchkeyConfig(**defaults)
+
+
+def _blocking() -> BlockingConfig:
+    return BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["zip"])])
+
+
+def _df() -> pl.DataFrame:
+    """Six rows in ONE zip block: two near-dup families sharing an email + a
+    singleton, so the whole-frame scorers and the single-block bucket route see
+    the same pair universe."""
+    return pl.DataFrame({
+        "__row_id__": [1, 2, 3, 4, 5, 6],
+        "first_name": ["John", "Jon", "Jonn", "Jane", "Janet", "Zoe"],
+        "last_name": ["Smith", "Smith", "Smyth", "Doe", "Doe", "Xu"],
+        "email": ["j@x.com", "j@x.com", "j@x.com", "jane@x.com", "jane@x.com", "zoe@x.com"],
+        "zip": ["90210", "90210", "90210", "90210", "90210", "90210"],
+    })
+
+
+def _pairset(pairs) -> dict[tuple[int, int], float]:
+    return {(min(a, b), max(a, b)): round(s, 4) for a, b, s in pairs}
+
+
+def _preloaded_em(tmp_path, df, mk):
+    """Train once, persist, then reload via the model_path reuse seam. Returns
+    the EM that came off disk (asserted preloaded)."""
+    path = str(tmp_path / "fs_model.json")
+    train_em(df, mk, n_sample_pairs=200, seed=42).save_json(path)
+    reuse = _mk(model_path=path)
+    em = load_or_train_em(df, reuse)
+    assert fs_model_preloaded(reuse), "fixture must exercise the on-disk reuse path"
+    return reuse, em
+
+
+def _reference(df, mk, em) -> dict[tuple[int, int], float]:
+    return _pairset(score_probabilistic_vectorized(df, mk, em))
+
+
+def test_bucket_python_matches_vectorized_under_preloaded_model(tmp_path, monkeypatch):
+    from goldenmatch.backends.score_buckets import score_buckets
+
+    df = _df()
+    mk, em = _preloaded_em(tmp_path, df, _mk())
+    ref = _reference(df, mk, em)
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", "0")
+    got = _pairset(score_buckets(df, _blocking(), mk, set(), em_result=em))
+    assert got == ref
+
+
+@native_required
+def test_native_matches_vectorized_under_preloaded_model(tmp_path):
+    from goldenmatch.core.probabilistic import score_probabilistic_native
+
+    df = _df()
+    mk, em = _preloaded_em(tmp_path, df, _mk())
+    ref = _reference(df, mk, em)
+    got = _pairset(score_probabilistic_native(df, mk, em))
+    assert got == ref
+
+
+@native_required
+def test_bucket_native_matches_vectorized_under_preloaded_model(tmp_path, monkeypatch):
+    from goldenmatch.backends.score_buckets import score_buckets
+
+    df = _df()
+    mk, em = _preloaded_em(tmp_path, df, _mk())
+    ref = _reference(df, mk, em)
+    monkeypatch.setenv("GOLDENMATCH_FS_BUCKET_NATIVE", "1")
+    got = _pairset(score_buckets(df, _blocking(), mk, set(), em_result=em))
+    assert got == ref
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What and why

Completes checkbox 1 of #1805 (extend the route-vs-route FS parity matrix). TF adjustment landed in #1994; this adds the three remaining named features, each a real coverage gap the audit (FS_PIPELINE_ANALYSIS_2026-07-15) flagged.

## Changes

- **`test_fs_match_mode_bucket_1805.py`** — match-mode scope on the FS bucket route. `across_files_only` had zero FS-route tests; `target_ids` had one (batched). Pins that `score_buckets` keeps every genuinely cross-side pair, drops every same-side pair, and the filtered set equals unfiltered-minus-same-side (scope-only filter, no score perturbation). Bucket-python unconditionally; bucket-native behind `_fs_native_enabled()`.
- **`test_fs_model_path_native_parity_1805.py`** — a persisted EM (`model_path`) reloaded from disk must score identically on the native and bucket-native kernels vs the vectorized reference. Prior tests covered build-blocks skipping (`TestModelReuseSkipsBuildBlocks`) OR fresh-EM native parity (`TestNativeFSParity`), never the join (reuse a serialized model AND check native score parity).
- **`test_fs_frame_lane_parity_1805.py`** — arrow-lane vs polars-lane FS parity. The frame differential gate is exact/weighted-only and the bucket matrix pins a single lane, so an FS config had never run through both `GOLDENMATCH_FRAME` lanes. EM pinned via `model_path` to isolate the frame axis from EM sample-order; skips when polars is absent (the arrow lane is the polars-free default).
- **`ci.yml`** — wires all four #1805 FS parity files (incl. the TF file from #1994) into the `python_goldenmatch_fallback` lane so the non-native routes run under `GOLDENMATCH_NATIVE=0`.

Scope note: this completes checkbox 1. Checkboxes 3 (scheduled scale gate) + 4 (raise max parity scale) are a follow-up PR.

## Testing

- `ARROW_DEFAULT_MEMORY_POOL=system python -m pytest tests/test_fs_{tf_route_matrix,match_mode_bucket,model_path_native_parity,frame_lane_parity}_1805.py` -> 15 passed (native kernel + polars both present in this env, so every gated route ran).
- Fallback-lane simulation `GOLDENMATCH_NATIVE=0 ... -k "not native and not Native"` -> 8 passed, 7 deselected.
- Frame-lane parity run 3x -> stable.
- `ruff check` clean; `python scripts/agent_codemap.py --check` -> OK.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

Test-only change (plus a CI lane addition), no behavior change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_