### PR TITLE
ci(fs): scheduled FS scale gate + moderate-scale route parity (#1805)

### DIFF
--- a/.github/workflows/bench-fs-distributed.yml
+++ b/.github/workflows/bench-fs-distributed.yml
@@ -11,6 +11,12 @@ name: bench-fs-distributed
 #   gh workflow run bench-fs-distributed.yml --ref claude/review-technical-work-en9SG \
 #     -f rows=5000000 -f backend=bucket
 on:
+  # Weekly scheduled FS scale gate (#1805 checkbox 3): the guard against a
+  # >=500K FS regression sitting below every PR gate, the way #1792/#1798 did.
+  # Scheduled runs apply F1 / wall / peak-RSS thresholds; workflow_dispatch stays
+  # measure-only unless the caller passes its own gate flags.
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC
   workflow_dispatch:
     inputs:
       rows:
@@ -47,12 +53,18 @@ permissions:
 
 jobs:
   bench:
-    runs-on: ${{ inputs.runner }}
+    # `inputs.*` are empty on the `schedule` trigger, so every input falls back to
+    # its dispatch default via `|| '<default>'` -- the scheduled gate runs 5M on
+    # the 64GB runner with F1/wall/RSS thresholds applied.
+    runs-on: ${{ inputs.runner || 'large-new-64GB' }}
     timeout-minutes: 90
     env:
       # Explicit config is passed, so the controller never runs; keep memory off
       # for determinism (mirrors the other bench lanes).
       GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      # Standing scale knobs (root CLAUDE.md): jemalloc page-decay caps allocator
+      # retention so the peak-RSS gate reflects the true live working set.
+      _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
       GOLDENMATCH_FS_NATIVE: ${{ inputs.fs_native == 'true' && '1' || '0' }}
       # Default backend (polars-direct/None) routes FS through the bucket scorer
       # unless this is 0 -- the legacy batched leg of the item-3 parity A/B.
@@ -86,13 +98,15 @@ jobs:
         run: |
           set -o pipefail
           uv run python packages/python/goldenmatch/scripts/bench_fs_distributed.py \
-            --rows "${{ inputs.rows }}" \
-            --dup-frac "${{ inputs.dup_frac }}" \
-            --backend "${{ inputs.backend }}" | tee /tmp/fs_dist.log
+            --rows "${{ inputs.rows || '5000000' }}" \
+            --dup-frac "${{ inputs.dup_frac || '0.2' }}" \
+            --backend "${{ inputs.backend || 'bucket' }}" \
+            ${{ github.event_name == 'schedule' && '--min-f1 0.85 --max-wall-seconds 2400 --max-peak-rss-gb 55' || '' }} \
+            | tee /tmp/fs_dist.log
           {
             echo "### inputs"
-            echo "- rows=\`${{ inputs.rows }}\`  dup_frac=\`${{ inputs.dup_frac }}\`  backend=\`${{ inputs.backend }}\`"
-            echo "- runner=\`${{ inputs.runner }}\`  FS_NATIVE=\`${{ env.GOLDENMATCH_FS_NATIVE }}\`"
+            echo "- rows=\`${{ inputs.rows || '5000000' }}\`  dup_frac=\`${{ inputs.dup_frac || '0.2' }}\`  backend=\`${{ inputs.backend || 'bucket' }}\`"
+            echo "- runner=\`${{ inputs.runner || 'large-new-64GB' }}\`  FS_NATIVE=\`${{ env.GOLDENMATCH_FS_NATIVE }}\`  gate=\`${{ github.event_name == 'schedule' && 'on' || 'off' }}\`"
             echo ""
             # The driver prints a markdown block after the KEY=VALUE lines.
             sed -n '/## bench-fs-distributed/,$p' /tmp/fs_dist.log
@@ -102,6 +116,45 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: fs-distributed-${{ inputs.rows }}-${{ inputs.backend }}
+          name: fs-distributed-${{ inputs.rows || '5000000' }}-${{ inputs.backend || 'bucket' }}
           path: /tmp/fs_dist.log
+          retention-days: 30
+
+  route_parity:
+    # #1805 checkbox 4: raise the max FS route-vs-route parity scale. The per-PR
+    # suite pins arrow-vs-polars FS membership parity at a few hundred rows
+    # (test_fs_frame_lane_parity_1805); this runs the SAME axis at a moderate
+    # scale the per-PR suite can't afford, so a scale-dependent frame-backend
+    # divergence surfaces. Light enough for a normal runner (no native build).
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      ARROW_DEFAULT_MEMORY_POOL: system
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39  # v3
+        with:
+          enable-cache: true
+          cache-dependency-glob: |
+            uv.lock
+            **/pyproject.toml
+
+      - name: Sync workspace
+        run: uv sync --all-packages
+
+      - name: FS route parity at moderate scale
+        run: |
+          set -o pipefail
+          uv run python packages/python/goldenmatch/scripts/bench_fs_route_parity.py \
+            --rows 20000 --dup-frac 0.2 | tee /tmp/fs_route_parity.log
+          sed -n '/## bench-fs-route-parity/,$p' /tmp/fs_route_parity.log >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: fs-route-parity-20000
+          path: /tmp/fs_route_parity.log
           retention-days: 30

--- a/packages/python/goldenmatch/scripts/bench_fs_distributed.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_distributed.py
@@ -153,6 +153,47 @@ def _peak_rss_gb() -> float:
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024.0 * 1024.0)
 
 
+def evaluate_scale_gate(
+    f1: float,
+    wall_seconds: float,
+    peak_rss_gb: float,
+    *,
+    min_f1: float | None = None,
+    max_wall_seconds: float | None = None,
+    max_peak_rss_gb: float | None = None,
+    rows: int = 0,
+    config_mode: str = "explicit",
+) -> list[str]:
+    """Pure gate: return a list of ``::error::`` messages for every threshold the
+    measured run breached (empty list = PASS). Extracted from ``main`` so the
+    scheduled-scale-gate decision (issue #1805 checkbox 3) is unit-testable
+    without running a 5M dedupe -- mirrors ``scripts/qis_gate.py::evaluate_gate``.
+
+    Each threshold is independent and optional (``None`` = not gated), so the
+    same driver serves the ad-hoc ``workflow_dispatch`` bench (no thresholds) and
+    the weekly scheduled gate (all three set). All breaches are reported, not
+    just the first, so one run surfaces every regression.
+    """
+    errors: list[str] = []
+    if min_f1 is not None and f1 < min_f1:
+        errors.append(
+            f"::error::{config_mode}-config FS F1 {f1:.4f} < floor {min_f1:.2f} "
+            f"at {rows} rows -- quality regression (matchkeys/blocking dropped "
+            f"the identity signal?)"
+        )
+    if max_wall_seconds is not None and wall_seconds > max_wall_seconds:
+        errors.append(
+            f"::error::FS dedupe wall {wall_seconds:.1f}s > ceiling "
+            f"{max_wall_seconds:.0f}s at {rows} rows -- scale-perf regression"
+        )
+    if max_peak_rss_gb is not None and peak_rss_gb > max_peak_rss_gb:
+        errors.append(
+            f"::error::FS dedupe peak RSS {peak_rss_gb:.2f} GB > ceiling "
+            f"{max_peak_rss_gb:.1f} GB at {rows} rows -- memory regression"
+        )
+    return errors
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--rows", type=int, default=5_000_000)
@@ -164,6 +205,10 @@ def main() -> int:
                          "(the zero-config quality-at-scale gate)")
     ap.add_argument("--min-f1", type=float, default=None,
                     help="gate: exit non-zero if F1 < this floor")
+    ap.add_argument("--max-wall-seconds", type=float, default=None,
+                    help="gate: exit non-zero if wall > this ceiling")
+    ap.add_argument("--max-peak-rss-gb", type=float, default=None,
+                    help="gate: exit non-zero if peak RSS > this ceiling")
     args = ap.parse_args()
 
     print(f"[gen] {args.rows} base rows + {int(args.rows*args.dup_frac)} dups "
@@ -206,12 +251,17 @@ def main() -> int:
     print(f"- multi-member clusters: {multi}  (GT pairs: {len(gt)})")
     print(f"- **P={ev.precision:.3f}  R={ev.recall:.3f}  F1={ev.f1:.3f}**")
 
-    if args.min_f1 is not None and ev.f1 < args.min_f1:
-        print(f"::error::{args.config_mode}-config FS F1 {ev.f1:.4f} < floor "
-              f"{args.min_f1:.2f} at {df.height} rows -- zero-config quality "
-              f"regression (matchkeys/blocking dropped the identity signal?)")
-        return 1
-    return 0
+    errors = evaluate_scale_gate(
+        ev.f1, wall, rss,
+        min_f1=args.min_f1,
+        max_wall_seconds=args.max_wall_seconds,
+        max_peak_rss_gb=args.max_peak_rss_gb,
+        rows=df.height,
+        config_mode=args.config_mode,
+    )
+    for msg in errors:
+        print(msg)
+    return 1 if errors else 0
 
 
 if __name__ == "__main__":

--- a/packages/python/goldenmatch/scripts/bench_fs_route_parity.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_route_parity.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+"""Issue #1805 (checkbox 4) — moderate-scale FS route-vs-route parity.
+
+No route-vs-route FS parity ran above ~150 rows in the test suite (Febrl3 ~5k
+only in the opt-in bench). This runs the arrow-lane vs polars-lane FS parity
+(the same axis PR-A pins at a few hundred rows in the per-PR suite) at a
+MODERATE scale the per-PR suite can't afford, in the scheduled lane: a
+scale-dependent frame-backend divergence in the FS score/block path would
+surface here.
+
+The EM is pinned via a persisted ``model_path`` so training is identical across
+lanes (FS EM is sample-order sensitive; the frame backend is the axis under
+test). Cluster membership must be identical. Exits non-zero on divergence.
+
+Usage:
+    uv run python packages/python/goldenmatch/scripts/bench_fs_route_parity.py \
+        --rows 20000 --dup-frac 0.2
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import tempfile
+import time
+
+
+def _fs_cfg(model_path: str):
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="fs", type="probabilistic", model_path=model_path, fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3, partial_threshold=0.85),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2, partial_threshold=0.85),
+            MatchkeyField(field="email", scorer="exact", levels=2),
+        ])],
+        blocking=BlockingConfig(strategy="static", keys=[BlockingKeyConfig(fields=["zip"])]),
+    )
+
+
+def membership(clusters) -> frozenset:
+    """Canonical multi-member cluster membership: frozenset of frozensets of
+    row-ids. The comparable shape across routes (pure, unit-tested)."""
+    return frozenset(
+        frozenset(int(m) for m in c.get("members", []))
+        for c in (clusters or {}).values()
+        if len(c.get("members", [])) > 1
+    )
+
+
+def _pin_model(df, cfg) -> None:
+    from goldenmatch.core.blocker import build_blocks
+    from goldenmatch.core.probabilistic import train_em
+
+    mk = cfg.matchkeys[0]
+    blocks = build_blocks(df.lazy(), cfg.blocking)
+    train_em(df, mk, blocks=blocks, blocking_fields=["zip"], seed=42).save_json(mk.model_path)
+
+
+def _dedupe_on_lane(df, cfg, lane: str):
+    import goldenmatch as gm
+
+    os.environ["GOLDENMATCH_FRAME"] = lane
+    os.environ["GOLDENMATCH_FS_NATIVE"] = "0"  # isolate the frame axis
+    t0 = time.perf_counter()
+    res = gm.dedupe_df(df, config=cfg, confidence_required=False)
+    return membership(res.clusters), time.perf_counter() - t0
+
+
+def check_route_parity(rows: int, dup_frac: float, seed: int) -> tuple[bool, str]:
+    """Run FS dedupe under arrow + polars at ``rows`` scale and compare cluster
+    membership. Returns ``(ok, detail)``. Importable so the parity mechanism is
+    unit-tested at small scale before the scheduled lane runs it at 10-50k."""
+    import importlib.util
+    import pathlib
+
+    # Reuse the distributed bench's ground-truth generator.
+    spec = importlib.util.spec_from_file_location(
+        "bench_fs_distributed", pathlib.Path(__file__).parent / "bench_fs_distributed.py")
+    bfd = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(bfd)
+    df, _gt = bfd.gen_with_gt(rows, dup_frac, seed)
+    df = df.with_row_index("__row_id__")
+
+    with tempfile.TemporaryDirectory() as td:
+        cfg = _fs_cfg(os.path.join(td, "fs_model.json"))
+        _pin_model(df, cfg)
+        arrow, wa = _dedupe_on_lane(df, cfg, "arrow")
+        polars, wp = _dedupe_on_lane(df, cfg, "polars")
+
+    if not arrow:
+        return False, f"no multi-member clusters at {df.height} rows (parity vacuous)"
+    if arrow != polars:
+        return False, (f"arrow-vs-polars FS divergence at {df.height} rows: "
+                       f"only-arrow={len(arrow - polars)} only-polars={len(polars - arrow)}")
+    return True, (f"arrow==polars at {df.height} rows: {len(arrow)} multi-member "
+                  f"clusters (arrow {wa:.1f}s / polars {wp:.1f}s)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=20_000)
+    ap.add_argument("--dup-frac", type=float, default=0.2)
+    ap.add_argument("--seed", type=int, default=7)
+    args = ap.parse_args()
+
+    ok, detail = check_route_parity(args.rows, args.dup_frac, args.seed)
+    print(f"\n## bench-fs-route-parity\n- {'PASS' if ok else 'FAIL'}: {detail}")
+    if not ok:
+        print(f"::error::FS route parity broke -- {detail}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/tests/test_bench_fs_route_parity_1805.py
+++ b/packages/python/goldenmatch/tests/test_bench_fs_route_parity_1805.py
@@ -1,0 +1,53 @@
+"""Issue #1805 (checkbox 4) — verify the moderate-scale FS route-parity
+mechanism (`bench_fs_route_parity`) at SMALL scale.
+
+The scheduled lane runs `check_route_parity` at 10-50k rows (too slow for the
+per-PR suite). This exercises the SAME code path at a few hundred rows so the
+parity mechanism itself (EM pinning + arrow/polars membership compare) is
+proven in the normal suite, and unit-tests the pure `membership` comparator.
+Skips when polars is absent (the polars lane needs it).
+"""
+import importlib.util
+import os
+import pathlib
+
+import pytest
+
+_spec = importlib.util.spec_from_file_location(
+    "bench_fs_route_parity",
+    pathlib.Path(__file__).parent.parent / "scripts" / "bench_fs_route_parity.py",
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+_HAS_POLARS = importlib.util.find_spec("polars") is not None
+
+
+def test_membership_comparator_ignores_singletons_and_canonicalizes():
+    clusters = {
+        7: {"members": [3, 1, 2]},   # multi-member -> kept, order-independent
+        8: {"members": [9]},          # singleton -> dropped
+        9: {"members": []},           # empty -> dropped
+    }
+    assert _mod.membership(clusters) == frozenset({frozenset({1, 2, 3})})
+
+
+@pytest.mark.skipif(not _HAS_POLARS, reason="polars lane requires the optional polars dependency")
+def test_route_parity_holds_at_small_scale():
+    # Save/restore the env check_route_parity mutates directly (CI hygiene:
+    # a leaked GOLDENMATCH_FRAME=polars would poison later tests).
+    saved = {k: os.environ.get(k) for k in ("GOLDENMATCH_FRAME", "GOLDENMATCH_FS_NATIVE")}
+    try:
+        ok, detail = _mod.check_route_parity(rows=400, dup_frac=0.2, seed=7)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+    assert ok, detail
+    assert "arrow==polars" in detail
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/python/goldenmatch/tests/test_bench_fs_scale_gate_1805.py
+++ b/packages/python/goldenmatch/tests/test_bench_fs_scale_gate_1805.py
@@ -1,0 +1,70 @@
+"""Issue #1805 (checkbox 3) — unit tests for the FS scheduled-scale-gate
+decision (`bench_fs_distributed.evaluate_scale_gate`).
+
+The gate turns the FS scale bench (F1 + wall + peak RSS at 5M) into a
+fail-on-regression check so a ≥500K FS regression can't sit below every CI gate
+the way #1792 / #1798 did. This pins the PURE decision logic so it's verified
+without a 5M dedupe (mirrors `scripts/test_qis_gate.py`): each threshold is
+independent and optional, and every breach is reported (not just the first).
+"""
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "bench_fs_distributed",
+    pathlib.Path(__file__).parent.parent / "scripts" / "bench_fs_distributed.py",
+)
+_bfd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_bfd)
+evaluate_scale_gate = _bfd.evaluate_scale_gate
+
+
+def test_all_thresholds_met_is_clean():
+    assert evaluate_scale_gate(
+        0.95, 100.0, 10.0,
+        min_f1=0.90, max_wall_seconds=200.0, max_peak_rss_gb=20.0,
+    ) == []
+
+
+def test_no_thresholds_never_gates():
+    # workflow_dispatch ad-hoc bench: measure only, never fail.
+    assert evaluate_scale_gate(0.01, 9999.0, 999.0) == []
+
+
+def test_f1_floor_breach():
+    errs = evaluate_scale_gate(0.80, 100.0, 10.0, min_f1=0.90, rows=5_000_000)
+    assert len(errs) == 1
+    assert "F1" in errs[0] and "::error::" in errs[0]
+
+
+def test_wall_ceiling_breach():
+    errs = evaluate_scale_gate(0.95, 2000.0, 10.0, max_wall_seconds=1800.0)
+    assert len(errs) == 1
+    assert "wall" in errs[0]
+
+
+def test_rss_ceiling_breach():
+    errs = evaluate_scale_gate(0.95, 100.0, 45.0, max_peak_rss_gb=40.0)
+    assert len(errs) == 1
+    assert "RSS" in errs[0]
+
+
+def test_every_breach_is_reported_not_just_first():
+    errs = evaluate_scale_gate(
+        0.50, 3000.0, 99.0,
+        min_f1=0.90, max_wall_seconds=1800.0, max_peak_rss_gb=40.0,
+    )
+    assert len(errs) == 3
+
+
+def test_threshold_is_inclusive_boundary_passes():
+    # Exactly at the limit is NOT a breach (strict < / >).
+    assert evaluate_scale_gate(
+        0.90, 1800.0, 40.0,
+        min_f1=0.90, max_wall_seconds=1800.0, max_peak_rss_gb=40.0,
+    ) == []
+
+
+if __name__ == "__main__":  # pragma: no cover
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What and why

Closes #1805 checkboxes 3 and 4. Every FS bench workflow was `workflow_dispatch`-only, so a ≥500K FS regression sat structurally below every gate that could fail it — the reason #1792 and #1798 were both user-found rather than caught by CI.

## Changes

**Checkbox 3 — scheduled scale gate:**
- `bench-fs-distributed.yml` gains a **weekly schedule** (Mondays 06:00 UTC). Scheduled runs apply F1 / wall / peak-RSS thresholds; `workflow_dispatch` stays measure-only (unchanged) unless the caller passes gate flags. Inputs fall back to their dispatch defaults via `|| '<default>'`, so the schedule runs 5M/bucket on the 64GB runner. Adds the standing `_RJEM_MALLOC_CONF` page-decay knob so the peak-RSS gate reflects the true live working set, not allocator retention.
- Initial thresholds are **generous safety tripwires** (`F1>=0.85`, `wall<=2400s`, `RSS<=55GB`) — meant to catch a real regression, not enforce a tight SLA; tighten after the first green scheduled run establishes a baseline (the `qis_gate` posture).
- `bench_fs_distributed.py`: extracted a pure `evaluate_scale_gate()` (every breach reported, each threshold independent + optional) plus `--max-wall-seconds` / `--max-peak-rss-gb` flags. Unit-tested in `test_bench_fs_scale_gate_1805.py`, mirroring `scripts/test_qis_gate.py` — no 5M run needed to verify the decision logic.

**Checkbox 4 — raise max parity scale:**
- `bench_fs_route_parity.py` runs arrow-lane vs polars-lane FS membership parity at a **moderate scale (20k)** — the axis the per-PR suite pins at a few hundred rows (`test_fs_frame_lane_parity_1805`, PR #1997) — so a scale-dependent frame-backend divergence surfaces. EM pinned via `model_path` to isolate the frame axis. Added as a `route_parity` job (normal runner, no native build).
- Its mechanism (EM pinning + membership compare) + the pure `membership` comparator are unit-tested at 400 rows in `test_bench_fs_route_parity_1805.py`, so the scheduled script is proven in the normal suite.

## Testing

- `python -m pytest tests/test_bench_fs_scale_gate_1805.py tests/test_bench_fs_route_parity_1805.py` -> 9 passed.
- Driver smoke: `bench_fs_distributed.py --rows 2000 --min-f1 0.5 --max-wall-seconds 600 --max-peak-rss-gb 40` -> exit 0 (F1 0.9977); `--min-f1 1.01` -> exit 1 with `::error::` (gate fails correctly).
- `python -c "import yaml; yaml.safe_load(...)"` on the workflow -> OK.
- `ruff check` clean; `python scripts/agent_codemap.py --check` -> OK.
- The 5M scheduled run itself can't execute in the dev sandbox (64GB runner); its gate-decision logic is unit-tested, and the route-parity mechanism is verified at 400 rows.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

New CI gate + bench tooling, no library behavior change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_