### PR TITLE
release(goldenmatch): 3.7.0

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-07-21
+
 ### Fixed
 
 - **Zero-config Fellegi-Sunter recall no longer collapses at scale (candidate-pair

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.6.0"
+version = "3.7.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## What and why

Cut the accumulated `[Unreleased]` work as **goldenmatch 3.7.0** (minor — new features under `Added`). 3.6.0 is the current PyPI release.

Headline items in this release:
- **Zero-config Fellegi-Sunter scale-recall fix** — candidate-pair projection (saturation-aware) + recall-safe identity-field compounding + memory-aware pair budget. F1 recovered from 0.03 to **1.0 at 25M single-box** (32.6 GB / 5.9 min), verified on the `gate-fs-zeroconfig` CI runner.
- **Out-of-core single-box streaming FS dedupe** (opt-in, the ≥40M scale path) + **bounded bucket streaming** for the in-RAM route.
- **FS EM `build_blocks` memory-peak fixes** (default-on, byte-identical) and **blocking pair-budget pruning** (~6x wall at scale).
- Arrow-native auto-config fixes (`auto_configure_df(pa.Table)`, silent blocking degradation).

## Changes

- Version bump **3.6.0 → 3.7.0** in `pyproject.toml`, `goldenmatch/__init__.py`, and `server.json` (server + package fields) — lockstep, as `cut-goldenmatch-release.yml` validates.
- `CHANGELOG.md`: `[Unreleased]` → `## [3.7.0] - 2026-07-21`, fresh empty `[Unreleased]` added.

## Testing

- Version lockstep verified across all three files; `import goldenmatch` → `__version__ == "3.7.0"`; `server.json` valid JSON.
- No code changes — release metadata only.

## Release flow (post-merge)

Once merged, `cut-goldenmatch-release.yml` (`workflow_dispatch`, `version=3.7.0`) pushes the `v3.7.0` tag from CI → `publish-goldenmatch.yml` builds → PyPI → cosign-sign → signed GitHub Release → MCP-registry sync. golden-suite lockstep bump follows once 3.7.0 is on PyPI.

## Checklist

- [x] Version bumped in all lockstep spots (pyproject / `__init__` / server.json)
- [x] `CHANGELOG.md` dated entry created
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_