### PR TITLE
release(golden-suite): 0.3.3 — floor goldenmatch>=3.7 (lockstep)

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.3] - 2026-07-21
+
+- Floor bump: `goldenmatch[polars]>=3.7`. 3.7.0 lands the zero-config
+  Fellegi-Sunter scale-recall fix (saturation-aware candidate-pair projection +
+  recall-safe identity-field compounding + memory-aware pair budget — F1
+  recovered from 0.03 to 1.0 at 25M single-box, verified on CI), plus the
+  out-of-core single-box streaming FS path (`>=40M`) and bounded bucket
+  streaming. Mandating the new baseline keeps the advertised suite honest.
+
 ## [0.3.2] - 2026-07-19
 
 - Floor bump: `goldenmatch-native>=0.1.19`. 0.1.19 adds the

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.2"
+version = "0.3.3"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.5",         # entity resolution: dedupe, match, golden records (>=3.5: date-aware `date` scorer + the FS missing-value correctness wave (historical_50k F1 restored) + 100% native FS coverage; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.7",         # entity resolution: dedupe, match, golden records (>=3.7: zero-config Fellegi-Sunter scale-recall fix — saturation-aware candidate-pair projection + recall-safe identity-field compounding + memory-aware pair budget, F1 0.03->1.0 at 25M single-box; plus out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.2",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
## What and why

golden-suite lockstep for the **goldenmatch 3.7.0** release (now live on PyPI). Per the standing rule, whenever a bundled member cuts a PyPI release, golden-suite mandates the new baseline.

- Floor bump: `goldenmatch[polars]` **>=3.5 → >=3.7**. 3.7.0 carries the zero-config Fellegi-Sunter scale-recall fix (saturation-aware candidate-pair projection + recall-safe identity-field compounding + memory-aware pair budget — **F1 0.03 → 1.0 at 25M single-box**, verified on CI) plus the out-of-core single-box streaming FS path (≥40M) and bounded bucket streaming.
- golden-suite **0.3.2 → 0.3.3** in `pyproject.toml` + `golden_suite/__init__.py` (lockstep) + CHANGELOG.

Deps-only meta-package, no code. Branched off `main` (which already carries goldenmatch 3.7.0 in the uv workspace), so the `>=3.7` floor resolves in CI.

## Release flow (post-merge)

Once merged, `publish-golden-suite.yml` is dispatched (`workflow_dispatch`, builds from main HEAD) → PyPI. (The sandbox can't push a `golden-suite-v*` tag, and immutable-releases makes a hand-created release risky; the `workflow_dispatch` path publishes from main HEAD without a tag.)

## Checklist

- [x] Version bumped lockstep (pyproject + `__init__`)
- [x] Floor bumped to the new goldenmatch baseline
- [x] CHANGELOG dated entry
- [x] No secrets committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_