### PR TITLE
Route goldengraph chat to a separate provider (OpenRouter) from embeddings

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -292,7 +292,18 @@ jobs:
       - name: Run env A/B (real LLM, budget-capped, one shared graph)
         working-directory: packages/python/goldenmatch/benchmarks/er-kg-bench
         env:
+          # Embeddings (text-embedding-3-large) stay on OpenAI: OpenRouter serves NO
+          # embeddings endpoint, and the daily cap that blocked run #167 was on the
+          # gpt-4o-mini CHAT model only (embeddings have a separate, un-exhausted limit).
           OPENAI_API_KEY: ${{ secrets.GOLDENGRAPH_OPENAI_API_KEY }}
+          # goldengraph CHAT (extraction + synthesis) -> OpenRouter, bypassing the
+          # gpt-4o-mini requests-per-day cap. GOLDENGRAPH_LLM_* overrides only the chat
+          # client (llm.py); the embedder above is untouched. Model must be the OpenRouter
+          # id (`openai/gpt-4o-mini`), read by the engine via OPENAI_MODEL (_chat_model()).
+          # Revert to all-OpenAI by dropping these three lines.
+          GOLDENGRAPH_LLM_BASE_URL: https://openrouter.ai/api/v1
+          GOLDENGRAPH_LLM_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENAI_MODEL: openai/gpt-4o-mini
           POLARS_SKIP_CPU_CHECK: "1"
           # datasets pulls a fresh-pip pyarrow whose bundled mimalloc SIGSEGVs on the
           # pipeline's worker threads -- the documented repo standard for any lane that

--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -221,3 +221,39 @@ wheel for the matcher and never set the flag.*
   auto-off → embedding matcher); the full-stack path is exercised in the `goldengraph_native`
   / pipeline CI lanes (which build the wheel) and was proven end-to-end by the bench A/B.
   NEXT lever (chosen): probe the synthesis-precision gap (answer retrieved, answered wrong).
+
+## Self-consistency voting MEASURED (small, opt-in) — same-graph env-A/B (2026-07-22)
+Self-consistency voting (`GOLDENGRAPH_SYNTH_SAMPLES`, `synthesize.complete_many` +
+`_vote_answer` majority vote) was built but default-off (=1). To decide default-on we
+needed a CONFOUND-FREE measurement: `head_to_head` rebuilds the KG each run, and
+stochastic-extraction build variance swings even a retrieval-only metric
+(`support_recall` +-0.26 between rebuilds of the SAME corpus) — swamping a
+downstream-only change. The instrument is `run_engine_ab_env`
+(`benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py`): build the KG ONCE, answer every
+question under N answer-time env-configs on the IDENTICAL graph, so the metric deltas
+are purely the knob's effect. Dispatch via `bench-graphrag-qa.yml` mode `env_ab`,
+`ab_env=NAME:v1,v2`.
+- **MEASURED (MuSiQue N=100, identical graph, run 29876692154):** =1 -> =5 lifts every
+  quality metric ~+6% RELATIVE but tiny ABSOLUTE — `answer_match` 0.1700->0.1800
+  (+0.010), `answer_match_entity` 0.2462->0.2615 (+0.0153), `token_f1` 0.2210->0.2334
+  (+0.0124). **CONTROL: `support_recall` 0.8292 == 0.8292 (delta 0.0000)** across arms —
+  the proof the graph was truly shared (voting can't touch retrieval); this is what a
+  build-variance run CANNOT give you. Cost: ~5x synthesis (5 completions/answer).
+- **DECISION: keep `SYNTH_SAMPLES=1` default (opt-in).** The lift is REAL (clean,
+  same-direction on all three quality metrics, control passed) but too small to justify
+  ~5x synthesis cost as a ZERO-CONFIG default. `=5` is a documented, measured quality
+  knob. The bottleneck is synthesis PRECISION (the ~34-36% answer-in-ball-wrong-node
+  bucket), which voting barely dents — the real lever is a better synthesizer
+  (node-selection / prompt), not more samples of the same one.
+
+## CHAT / embedding provider split (2026-07-22)
+`OpenAIClient._ensure_client` (`llm.py`) reads `GOLDENGRAPH_LLM_BASE_URL` /
+`GOLDENGRAPH_LLM_API_KEY` first, falling back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`
+(unset -> byte-identical to before). This routes goldengraph's CHAT (extraction +
+synthesis) to a separate provider WITHOUT moving the embedder — the embedder is a bare
+`OpenAI()` reading `OPENAI_*`, and **OpenRouter serves no embeddings endpoint**. Why it
+exists: OpenAI's per-model requests-per-day cap (Usage Tier 1: gpt-4o-mini RPD 10000)
+blocked a bench run mid-synthesis; the cap is on the CHAT model only (embeddings have a
+separate, un-exhausted limit), so the fix is to split providers (chat->OpenRouter,
+embeds->OpenAI), not move everything. The `env_ab` bench job wires this via
+`OPENROUTER_API_KEY` + model `openai/gpt-4o-mini` (revertible by dropping 3 env lines).

--- a/packages/python/goldengraph/goldengraph/llm.py
+++ b/packages/python/goldengraph/goldengraph/llm.py
@@ -42,13 +42,28 @@ class OpenAIClient:
 
             import openai  # lazy: only needed for the real provider
 
+            # CHAT-specific provider overrides (GOLDENGRAPH_LLM_*), falling back to the
+            # generic OPENAI_* env. This lets goldengraph's CHAT (extraction + synthesis)
+            # target a different provider -- e.g. OpenRouter to dodge an OpenAI per-model
+            # daily cap -- WITHOUT moving the embedder, which is a bare `OpenAI()` reading
+            # OPENAI_BASE_URL/OPENAI_API_KEY (and OpenRouter serves no embeddings endpoint).
+            # Unset GOLDENGRAPH_LLM_* -> byte-identical to the prior OPENAI_*-only behavior.
+            #
             # The bench workflow sets OPENAI_BASE_URL='' on the OpenAI-API path (it
             # is only non-empty for a local Ollama run). The openai SDK treats an
             # empty-string base_url as a literal (invalid) URL -> APIConnectionError,
             # and passing base_url=None does NOT help -- the SDK re-reads the empty
             # env var itself. So pass an explicit default when the env is empty.
-            base_url = os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1"
-            api_key = os.environ.get("OPENAI_API_KEY") or None
+            base_url = (
+                os.environ.get("GOLDENGRAPH_LLM_BASE_URL")
+                or os.environ.get("OPENAI_BASE_URL")
+                or "https://api.openai.com/v1"
+            )
+            api_key = (
+                os.environ.get("GOLDENGRAPH_LLM_API_KEY")
+                or os.environ.get("OPENAI_API_KEY")
+                or None
+            )
             self._client = openai.OpenAI(base_url=base_url, api_key=api_key)
         return self._client
 

--- a/packages/python/goldengraph/tests/test_llm_provider_split.py
+++ b/packages/python/goldengraph/tests/test_llm_provider_split.py
@@ -1,0 +1,57 @@
+"""GOLDENGRAPH_LLM_BASE_URL / GOLDENGRAPH_LLM_API_KEY route goldengraph's CHAT client
+to a separate provider (e.g. OpenRouter) WITHOUT moving the embedder, which reads the
+generic OPENAI_* env. Unset -> byte-identical to the OPENAI_*-only behavior.
+
+Constructs the REAL openai client (no network at construction) to read the resolved
+base_url/api_key, so `openai` must be importable (the engine lanes install it)."""
+import pytest
+
+from goldengraph.llm import OpenAIClient
+
+openai = pytest.importorskip("openai")
+
+_OR = "https://openrouter.ai/api/v1"
+
+
+def _resolved(monkeypatch, env: dict):
+    for k in ("GOLDENGRAPH_LLM_BASE_URL", "GOLDENGRAPH_LLM_API_KEY",
+              "OPENAI_BASE_URL", "OPENAI_API_KEY"):
+        monkeypatch.delenv(k, raising=False)
+    for k, v in env.items():
+        monkeypatch.setenv(k, v)
+    client = OpenAIClient(model="m")._ensure_client()
+    return str(client.base_url), client.api_key
+
+
+def test_chat_env_overrides_openai(monkeypatch):
+    # GOLDENGRAPH_LLM_* wins for the chat client even when OPENAI_* is also set
+    # (OPENAI_* stays pointed at OpenAI for the embedder).
+    base, key = _resolved(monkeypatch, {
+        "GOLDENGRAPH_LLM_BASE_URL": _OR,
+        "GOLDENGRAPH_LLM_API_KEY": "or-key",
+        "OPENAI_BASE_URL": "",  # the bench's OpenAI-API sentinel (empty)
+        "OPENAI_API_KEY": "oa-key",
+    })
+    assert base.rstrip("/") == _OR
+    assert key == "or-key"
+
+
+def test_falls_back_to_openai_env_when_chat_unset(monkeypatch):
+    # No GOLDENGRAPH_LLM_* -> byte-identical to the prior OPENAI_*-only path.
+    base, key = _resolved(monkeypatch, {
+        "OPENAI_BASE_URL": "https://api.openai.com/v1",
+        "OPENAI_API_KEY": "oa-key",
+    })
+    assert base.rstrip("/") == "https://api.openai.com/v1"
+    assert key == "oa-key"
+
+
+def test_empty_openai_base_url_defaults(monkeypatch):
+    # The empty-string OPENAI_BASE_URL sentinel must still yield the real OpenAI URL
+    # (the SDK treats '' as an invalid literal URL), with no chat override present.
+    base, key = _resolved(monkeypatch, {
+        "OPENAI_BASE_URL": "",
+        "OPENAI_API_KEY": "oa-key",
+    })
+    assert base.rstrip("/") == "https://api.openai.com/v1"
+    assert key == "oa-key"


### PR DESCRIPTION
## What and why

The same-graph env_ab bench run (#167) died on OpenAI's `gpt-4o-mini` **requests-per-day** cap (`429 RPD 10000/10000` — the org is on Usage Tier 1, which caps daily requests). That cap is on the **chat** model only; goldengraph's **embeddings** (`text-embedding-3-large`) use a different model with a separate, un-exhausted limit — and OpenRouter serves no embeddings endpoint. So the fix is to **split providers**: route chat to OpenRouter (no daily cap), keep embeddings on OpenAI.

## Changes

- `goldengraph/llm.py`: `OpenAIClient._ensure_client` now reads `GOLDENGRAPH_LLM_BASE_URL` / `GOLDENGRAPH_LLM_API_KEY` first, falling back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`. This overrides **only** the chat client; the embedder is a bare `OpenAI()` reading `OPENAI_*` and is untouched. Unset `GOLDENGRAPH_LLM_*` → byte-identical to the prior behavior.
- `.github/workflows/bench-graphrag-qa.yml` (`goldengraph_env_ab` job): point goldengraph chat (extraction + synthesis) at OpenRouter via `GOLDENGRAPH_LLM_*` + `secrets.OPENROUTER_API_KEY`, model `openai/gpt-4o-mini`; keep `OPENAI_API_KEY` (embeddings) on OpenAI. Revertible by dropping the three env lines.
- `tests/test_llm_provider_split.py`: chat env wins over `OPENAI_*`; falls back when unset; the empty-`OPENAI_BASE_URL` sentinel still defaults to the real OpenAI URL.

## Testing

- `python -m pytest tests/test_llm_provider_split.py tests/test_llm_seed.py -q` → 6 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (bench wiring; no gotcha change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_