### PR TITLE
test(distributed): first real-Ray FS e2e proof + measured distributed FS F1

### DIFF
--- a/.github/workflows/bench-fs-distributed.yml
+++ b/.github/workflows/bench-fs-distributed.yml
@@ -1,11 +1,17 @@
 name: bench-fs-distributed
 
-# Phase 3c — Fellegi-Sunter dedupe at scale on the bucket backend.
-# workflow_dispatch ONLY (never runs in normal CI). Confirms the Phase 3a
-# FS-on-bucket path holds at 5M+ rows: wall + peak RSS + F1 against known
-# injected duplicates. The bucket backend carries the Ray/DataFusion
-# distribution wiring, so a healthy single-node bucket run is the prerequisite
-# for the distributed claim.
+# Fellegi-Sunter dedupe at scale — two legs.
+#   * `bench` (default): the Phase 3a FS-on-BUCKET single-box path at 5M+ rows
+#     (wall + peak RSS + F1 against injected duplicates). The bucket backend
+#     carries the Ray/DataFusion distribution wiring, so a healthy single-node
+#     bucket run is the prerequisite for the distributed claim.
+#   * `bench_distributed` (opt-in, `-f distributed=true`): the FIRST MEASURED
+#     distributed FS F1 -- the FS config driven through the Phase-5 Ray pipeline
+#     (GOLDENMATCH_DISTRIBUTED_PIPELINE=2: score -> block-shuffle ->
+#     randomized_contraction WCC), F1-scored via the same injected-dup oracle.
+#     Simulated single-box Ray cluster (regression check, not a multi-node parity
+#     proof; the 100M multi-node FS proof is a follow-on).
+# workflow_dispatch (+ a weekly scheduled bucket gate). Never runs in normal CI.
 #
 # Dispatch:
 #   gh workflow run bench-fs-distributed.yml --ref claude/review-technical-work-en9SG \
@@ -47,6 +53,18 @@ on:
         description: "Build the native extension before running"
         required: false
         default: "true"
+      distributed:
+        description: "Also run the Phase-5 DISTRIBUTED FS leg (Ray, simulated single-box cluster) for the first MEASURED distributed FS F1"
+        required: false
+        default: "false"
+      dist_rows:
+        description: "Distributed leg: base row count (simulated single-box Ray)"
+        required: false
+        default: "1000000"
+      dist_partitions:
+        description: "Distributed leg: Ray Dataset partition count"
+        required: false
+        default: "64"
 
 permissions:
   contents: read
@@ -118,6 +136,77 @@ jobs:
         with:
           name: fs-distributed-${{ inputs.rows || '5000000' }}-${{ inputs.backend || 'bucket' }}
           path: /tmp/fs_dist.log
+          retention-days: 30
+
+  bench_distributed:
+    # The FIRST MEASURED distributed FS F1. Opt-in (`-f distributed=true`); every
+    # other distributed bench in the repo runs a WEIGHTED/exact config, so FS
+    # (probabilistic) quality on the Phase-5 Ray engine has never been measured.
+    # This runs `bench_fs_distributed.py --distributed`, which drives the FS
+    # config through GOLDENMATCH_DISTRIBUTED_PIPELINE=2 (score -> block-shuffle ->
+    # randomized_contraction WCC), persists the cluster assignments, and F1-scores
+    # them against the injected-duplicate ground truth using the SAME oracle
+    # (`evaluate_clusters`) as the single-box bucket leg.
+    #
+    # Honest scoping (mirrors bench-phase5-simulated): this is a SIMULATED
+    # single-box Ray cluster (one NIC, one disk, shared page cache) -- a
+    # regression check that FS runs end-to-end on the distributed engine with
+    # correct recall, NOT a multi-node Splink-Spark parity proof. The multi-node
+    # 100M FS proof is a follow-on (needs a real Ray cluster + a shared
+    # GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://... for the WCC checkpoint).
+    if: ${{ inputs.distributed == 'true' }}
+    runs-on: ${{ inputs.runner || 'large-new-64GB' }}
+    timeout-minutes: 90
+    env:
+      GOLDENMATCH_AUTOCONFIG_MEMORY: "0"
+      # Any lane that pip-installs + runs the pipeline sets the Arrow allocator
+      # knob (mimalloc SIGSEGVs on the ThreadPoolExecutor/polars workers) and the
+      # jemalloc page-decay knob (caps allocator retention at scale).
+      ARROW_DEFAULT_MEMORY_POOL: system
+      _RJEM_MALLOC_CONF: "dirty_decay_ms:1000,muzzy_decay_ms:0"
+      # Pin the per-task scoring CPU reservation to 1 so the block-shuffle
+      # HashShuffleAggregator actors can't starve the _score op on a single-box
+      # simulated cluster (the module default of 2 is tuned for a many-core
+      # multi-node box).
+      GOLDENMATCH_DISTRIBUTED_SCORE_NUM_CPUS: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install goldenmatch with ray extra
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e packages/python/goldenmatch[ray]
+          # pandas is a runtime dep of ray.data (not declared in the [ray] extra).
+          pip install psutil pandas
+
+      - name: FS dedupe DISTRIBUTED (Phase-5 Ray) — wall + F1
+        run: |
+          set -o pipefail
+          python packages/python/goldenmatch/scripts/bench_fs_distributed.py \
+            --distributed \
+            --rows "${{ inputs.dist_rows || '1000000' }}" \
+            --dup-frac "${{ inputs.dup_frac || '0.2' }}" \
+            --partitions "${{ inputs.dist_partitions || '64' }}" \
+            --block-shuffle 1 \
+            ${{ github.event_name == 'schedule' && '--min-f1 0.85' || '' }} \
+            | tee /tmp/fs_dist_ray.log
+          {
+            echo "### distributed FS (Phase-5 Ray, simulated single-box)"
+            echo "- rows=\`${{ inputs.dist_rows || '1000000' }}\`  partitions=\`${{ inputs.dist_partitions || '64' }}\`  block_shuffle=\`1\`"
+            echo ""
+            sed -n '/## bench-fs-distributed/,$p' /tmp/fs_dist_ray.log
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: fs-distributed-ray-${{ inputs.dist_rows || '1000000' }}
+          path: /tmp/fs_dist_ray.log
           retention-days: 30
 
   route_parity:

--- a/packages/python/goldenmatch/scripts/bench_fs_distributed.py
+++ b/packages/python/goldenmatch/scripts/bench_fs_distributed.py
@@ -23,6 +23,7 @@ plus a markdown block the workflow tees into the job summary.
 from __future__ import annotations
 
 import argparse
+import os
 import random
 import resource
 import time
@@ -153,6 +154,90 @@ def _peak_rss_gb() -> float:
     return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / (1024.0 * 1024.0)
 
 
+def _clusters_from_assignments(assignments_dir: str) -> dict:
+    """Read the Phase-5 cluster-assignment parquet (one part file per partition)
+    and rebuild the ``{cluster_id: {"members": [...]}}`` shape ``evaluate_clusters``
+    consumes -- so the DISTRIBUTED run is F1-scored with the exact same oracle as
+    the single-box bucket run (no second scoring surface to drift)."""
+    import glob
+    import os
+
+    parts = glob.glob(os.path.join(assignments_dir, "**", "*.parquet"), recursive=True)
+    if not parts:
+        raise FileNotFoundError(f"no assignment parquet under {assignments_dir}")
+    frame = pl.concat([pl.read_parquet(p) for p in parts], how="vertical_relaxed")
+    clusters: dict[int, dict] = {}
+    for cid, member in zip(
+        frame["cluster_id"].to_list(), frame["member_id"].to_list()
+    ):
+        clusters.setdefault(int(cid), {"members": []})["members"].append(int(member))
+    for info in clusters.values():
+        info["size"] = len(info["members"])
+    return clusters
+
+
+def run_distributed(df, args) -> tuple[dict, float, float]:
+    """Run the FS config through the Phase-5 DISTRIBUTED pipeline
+    (GOLDENMATCH_DISTRIBUTED_PIPELINE=2) on a Ray Dataset and return
+    ``(clusters_dict, wall_seconds, peak_rss_gb)``.
+
+    This is the FIRST harness that measures FS (probabilistic) quality on the
+    distributed engine -- every prior distributed bench used a weighted/exact
+    config. It writes the generated frame (carrying a global ``__row_id__`` == row
+    position, which the Phase-5 scorer/join both require) to parquet, reads it as
+    a partitioned Ray Dataset, runs score -> (block-shuffle) -> WCC, persists the
+    cluster assignments, and rebuilds the clusters dict for the shared oracle.
+
+    block-shuffle ON (default) exercises the recall-complete path (co-locate on
+    the FS blocking key + randomized_contraction WCC). On a MULTI-node cluster
+    the WCC needs a shared ``GOLDENMATCH_DISTRIBUTED_WCC_SCRATCH=gs://...`` (the
+    WCC asserts this itself); a single-box simulated cluster needs no scratch.
+    """
+    import tempfile
+
+    os.environ.setdefault("GOLDENMATCH_ENABLE_DISTRIBUTED_RAY", "1")
+    os.environ["GOLDENMATCH_DISTRIBUTED_PIPELINE"] = "2"
+    os.environ["GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE"] = (
+        "1" if args.block_shuffle else "0"
+    )
+    if args.block_shuffle:
+        # Below the 50M-pair threshold build_clusters_distributed otherwise routes
+        # to the driver-collecting scipy fallback regardless of algorithm; pin the
+        # threshold to 0 so the recall-complete run actually exercises the
+        # distributed randomized_contraction WCC (setdefault: operator can override).
+        os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_WCC", "randomized_contraction")
+        os.environ.setdefault("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD", "0")
+
+    from goldenmatch.distributed import read_parquet_partitioned
+    from goldenmatch.distributed.pipeline import run_dedupe_pipeline_distributed
+
+    df_ids = df.with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64),
+    )
+    cfg = _fs_cfg(backend="bucket")  # backend is per-partition; ignored by Phase-5
+
+    workdir = tempfile.mkdtemp(prefix="fs_phase5_")
+    input_dir = os.path.join(workdir, "input")
+    assignments_dir = os.path.join(workdir, "assignments")
+    os.makedirs(input_dir, exist_ok=True)
+    df_ids.write_parquet(os.path.join(input_dir, "part-0.parquet"))
+
+    ds = read_parquet_partitioned(input_dir, n_partitions=args.partitions)
+
+    t0 = time.perf_counter()
+    run_dedupe_pipeline_distributed(
+        ds,
+        config=cfg,
+        confidence_required=False,
+        assignments_output_path=assignments_dir,
+        _skip_golden=True,
+    )
+    wall = time.perf_counter() - t0
+    rss = _peak_rss_gb()
+    clusters = _clusters_from_assignments(assignments_dir)
+    return clusters, wall, rss
+
+
 def evaluate_scale_gate(
     f1: float,
     wall_seconds: float,
@@ -209,34 +294,58 @@ def main() -> int:
                     help="gate: exit non-zero if wall > this ceiling")
     ap.add_argument("--max-peak-rss-gb", type=float, default=None,
                     help="gate: exit non-zero if peak RSS > this ceiling")
+    ap.add_argument("--distributed", action="store_true",
+                    help="run the FS config through the Phase-5 DISTRIBUTED Ray "
+                         "pipeline (GOLDENMATCH_DISTRIBUTED_PIPELINE=2) instead of "
+                         "the single-box bucket dedupe -- the first MEASURED "
+                         "distributed FS F1. Requires the [ray] extra.")
+    ap.add_argument("--partitions", type=int, default=64,
+                    help="distributed mode: Ray Dataset partition count")
+    ap.add_argument("--block-shuffle", dest="block_shuffle", type=int, default=1,
+                    help="distributed mode: 1 = recall-complete block-shuffle + "
+                         "randomized_contraction WCC (default); 0 = legacy "
+                         "per-partition scoring")
     args = ap.parse_args()
 
+    mode = "distributed" if args.distributed else "single-box"
     print(f"[gen] {args.rows} base rows + {int(args.rows*args.dup_frac)} dups "
-          f"(backend={args.backend})", flush=True)
+          f"(mode={mode}, backend={args.backend})", flush=True)
     t_gen = time.perf_counter()
     df, gt = gen_with_gt(args.rows, args.dup_frac, args.seed)
     print(f"[gen] {df.height} total rows, {len(gt)} GT pairs in "
           f"{time.perf_counter()-t_gen:.1f}s", flush=True)
 
-    from goldenmatch import dedupe_df
     from goldenmatch.core.evaluate import evaluate_clusters
 
-    cfg = (_zero_config_cfg(df, args.backend) if args.config_mode == "zero"
-           else _fs_cfg(args.backend))
-    print(f"[config] mode={args.config_mode} "
-          f"matchkey_fields={[f.field for m in cfg.get_matchkeys() for f in m.fields]}",
-          flush=True)
-    t0 = time.perf_counter()
-    result = dedupe_df(df, config=cfg, confidence_required=False)
-    wall = time.perf_counter() - t0
-    rss = _peak_rss_gb()
+    if args.distributed:
+        if args.config_mode == "zero":
+            raise SystemExit(
+                "--distributed currently supports the explicit FS config only "
+                "(zero-config on a Ray Dataset is a separate follow-on)."
+            )
+        print(f"[config] mode=explicit distributed block_shuffle={args.block_shuffle} "
+              f"partitions={args.partitions}", flush=True)
+        clusters, wall, rss = run_distributed(df, args)
+        backend_label = f"ray-phase5(shuffle={args.block_shuffle})"
+    else:
+        from goldenmatch import dedupe_df
+        cfg = (_zero_config_cfg(df, args.backend) if args.config_mode == "zero"
+               else _fs_cfg(args.backend))
+        print(f"[config] mode={args.config_mode} "
+              f"matchkey_fields={[f.field for m in cfg.get_matchkeys() for f in m.fields]}",
+              flush=True)
+        t0 = time.perf_counter()
+        result = dedupe_df(df, config=cfg, confidence_required=False)
+        wall = time.perf_counter() - t0
+        rss = _peak_rss_gb()
+        clusters = result.clusters
+        backend_label = args.backend
 
-    clusters = result.clusters
     multi = sum(1 for c in clusters.values() if len(c.get("members", [])) > 1)
     ev = evaluate_clusters(clusters, gt)
 
     for k, v in [
-        ("ROWS", df.height), ("BACKEND", args.backend),
+        ("ROWS", df.height), ("BACKEND", backend_label), ("MODE", mode),
         ("WALL_SECONDS", f"{wall:.3f}"), ("PEAK_RSS_GB", f"{rss:.2f}"),
         ("CLUSTERS_TOTAL", len(clusters)), ("CLUSTERS_MULTI", multi),
         ("GT_PAIRS", len(gt)),
@@ -246,7 +355,7 @@ def main() -> int:
         print(f"{k}={v}", flush=True)
 
     print("\n## bench-fs-distributed")
-    print(f"- rows: **{df.height}**  backend: `{args.backend}`")
+    print(f"- rows: **{df.height}**  mode: `{mode}`  backend: `{backend_label}`")
     print(f"- wall: **{wall:.1f}s**  peak RSS: **{rss:.2f} GB**")
     print(f"- multi-member clusters: {multi}  (GT pairs: {len(gt)})")
     print(f"- **P={ev.precision:.3f}  R={ev.recall:.3f}  F1={ev.f1:.3f}**")

--- a/packages/python/goldenmatch/tests/test_distributed_fs_e2e.py
+++ b/packages/python/goldenmatch/tests/test_distributed_fs_e2e.py
@@ -1,0 +1,282 @@
+"""Real-Ray end-to-end integration tests for the FELLEGI-SUNTER (probabilistic)
+matchkey type on the Phase-5 distributed pipeline.
+
+Before this file, distributed FS coverage stopped at the per-partition kernel
+(`_score_partition_with_config`) and driver model-prep (`_prepare_fs_models`),
+both exercised only with a duck-typed fake Dataset -- NOT through real Ray
+dispatch, and NEVER through the full `_run_phase5_pipeline` (score -> shuffle ->
+distributed WCC -> golden). Every real-Ray distributed test and bench used a
+WEIGHTED / exact config; nothing asserted that an FS config survives
+`score_blocks_distributed` on a real Ray Dataset and recovers the injected
+clusters. This closes that rung between "FS kernel unit-tested with a fake
+Dataset" and "100M FS bench".
+
+What each test proves on a REAL local Ray runtime:
+  * scoring: `score_blocks_distributed(ds, fs_cfg)` trains ONE EMResult on the
+    driver (`_prepare_fs_models`), ships it to workers, and the per-partition
+    `score_buckets` FS branch recovers the injected duplicate pairs across
+    input-partition boundaries (block-shuffle co-locates on the FS blocking key).
+  * e2e (block-shuffle ON): `_run_phase5_pipeline` with an explicit probabilistic
+    config runs score -> block-shuffle -> randomized_contraction WCC and the
+    persisted cluster assignments recover the injected clusters.
+  * e2e (legacy, single partition): the FS kernel + `local_cc_assignments`
+    recover the clusters when everything is co-located in one partition.
+
+Gated on `ray` being importable; collection falls through when the [ray] extra
+is absent. Self-contained (xdist worker isolation): the synthetic generator and
+FS config builder are inline, not imported from scripts/.
+"""
+from __future__ import annotations
+
+import itertools
+import random
+
+import polars as pl
+import pytest
+
+ray = pytest.importorskip("ray")
+
+
+@pytest.fixture(scope="module")
+def _ray_local():
+    """Module-scoped Ray init so startup is paid once. ignore_reinit_error in
+    case an earlier test module already touched ray.
+
+    Two knobs matter for the block-shuffle FS path on a SMALL local cluster:
+      * ``num_cpus`` is oversubscribed (6 logical slots on a smaller box). The
+        block-shuffle path spawns long-lived ``HashShuffleAggregator`` actors
+        that each hold a CPU slot; with too few slots those actors starve the
+        ``_score`` op (which reserves ``_SCORE_NUM_CPUS``) and the run deadlocks
+        with ~0% CPU. The data here is tiny, so oversubscribing slots only
+        relieves scheduling, it does not overcommit real work.
+      * ``_SCORE_NUM_CPUS`` is pinned to 1 (its module default of 2 is tuned for
+        a 64 GB / many-core distributed box). Saved/restored around the module.
+    """
+    from goldenmatch.distributed import scoring
+
+    saved_cpus = scoring._SCORE_NUM_CPUS
+    scoring._SCORE_NUM_CPUS = 1
+    ray.init(
+        local_mode=False, ignore_reinit_error=True,
+        num_cpus=6, logging_level="WARNING",
+    )
+    try:
+        yield
+    finally:
+        ray.shutdown()
+        scoring._SCORE_NUM_CPUS = saved_cpus
+
+
+def _gen_fs_data(
+    n_base: int = 200, dup_frac: float = 0.2, seed: int = 7,
+) -> tuple[pl.DataFrame, set[tuple[int, int]]]:
+    """Synthetic person-shape frame with a GLOBAL ``__row_id__`` == row position
+    and injected near-duplicates, plus the ground-truth within-entity pair set.
+
+    Each base row is its own entity. A dup copies an ORIGINAL base (no
+    dup-of-dup chains) with a transposed first name but the SAME email (an exact
+    FS signal) and the SAME zip (so the dup lands in its base's blocking block).
+    GT is the full per-entity CLIQUE in ``__row_id__`` space. Names are
+    high-entropy (varied prefixes) so genuinely different people are separable.
+    """
+    rng = random.Random(seed)
+    cons, vow = "bcdfghjklmnprstvwz", "aeiou"
+
+    def _name() -> str:
+        return "".join(
+            rng.choice(cons) + rng.choice(vow) for _ in range(rng.randint(3, 4))
+        )
+
+    def _typo(s: str) -> str:
+        if len(s) < 4:
+            return s
+        j = rng.randrange(len(s) - 1)
+        return s[:j] + s[j + 1] + s[j] + s[j + 2:]
+
+    n_zip = max(1, n_base // 40)
+    rows: list[dict] = []
+    entity: list[int] = []
+    for i in range(n_base):
+        f, l = _name(), _name()
+        rows.append({
+            "first_name": f, "last_name": l,
+            "email": f"{f}.{l}.{i}@example.com",
+            "zip": f"{rng.randrange(n_zip):05d}",
+        })
+        entity.append(i)
+
+    for _ in range(int(n_base * dup_frac)):
+        base_idx = rng.randrange(n_base)
+        src = rows[base_idx]
+        rows.append({
+            "first_name": _typo(src["first_name"]),
+            "last_name": src["last_name"],
+            "email": src["email"],
+            "zip": src["zip"],
+        })
+        entity.append(base_idx)
+
+    groups: dict[int, list[int]] = {}
+    for idx, e in enumerate(entity):
+        groups.setdefault(e, []).append(idx)
+    gt: set[tuple[int, int]] = set()
+    for members in groups.values():
+        if len(members) >= 2:
+            for a, b in itertools.combinations(sorted(members), 2):
+                gt.add((a, b))
+
+    df = pl.DataFrame(rows).with_row_index("__row_id__").with_columns(
+        pl.col("__row_id__").cast(pl.Int64),
+    )
+    return df, gt
+
+
+def _fs_cfg():
+    """Explicit Fellegi-Sunter config: one probabilistic matchkey (name +
+    exact email) blocked on zip -- the same shape the FS bench uses."""
+    from goldenmatch.config.schemas import (
+        BlockingConfig,
+        BlockingKeyConfig,
+        GoldenMatchConfig,
+        MatchkeyConfig,
+        MatchkeyField,
+    )
+    return GoldenMatchConfig(
+        matchkeys=[MatchkeyConfig(name="fs", type="probabilistic", fields=[
+            MatchkeyField(field="first_name", scorer="jaro_winkler", levels=3,
+                          partial_threshold=0.85),
+            MatchkeyField(field="last_name", scorer="jaro_winkler", levels=2,
+                          partial_threshold=0.85),
+            MatchkeyField(field="email", scorer="exact", levels=2),
+        ])],
+        blocking=BlockingConfig(keys=[BlockingKeyConfig(fields=["zip"])]),
+    )
+
+
+def _pairs_from_assignments(assignments_dir: str) -> set[tuple[int, int]]:
+    """Read the Phase-5 cluster-assignment parquet (Ray writes one part file per
+    partition into a directory) and expand each multi-member cluster into its
+    canonical (min, max) within-cluster pair set."""
+    import glob
+    import os
+
+    parts = glob.glob(os.path.join(assignments_dir, "**", "*.parquet"), recursive=True)
+    assert parts, f"no assignment parquet written under {assignments_dir}"
+    frame = pl.concat([pl.read_parquet(p) for p in parts], how="vertical_relaxed")
+
+    clusters: dict[int, list[int]] = {}
+    for row in frame.iter_rows(named=True):
+        clusters.setdefault(int(row["cluster_id"]), []).append(int(row["member_id"]))
+    pairs: set[tuple[int, int]] = set()
+    for members in clusters.values():
+        if len(members) >= 2:
+            for a, b in itertools.combinations(sorted(members), 2):
+                pairs.add((a, b))
+    return pairs
+
+
+def _recall(found: set[tuple[int, int]], gt: set[tuple[int, int]]) -> float:
+    if not gt:
+        return 1.0
+    return len(found & gt) / len(gt)
+
+
+# ── Test 1: distributed FS scoring recovers the injected pairs ───────
+
+def test_fs_scoring_distributed_recovers_pairs(_ray_local, monkeypatch):
+    """`score_blocks_distributed` with a probabilistic config trains one EMResult
+    on the driver, ships it to workers, and the per-partition FS scorer recovers
+    the injected duplicate pairs -- ACROSS input partitions (block-shuffle ON co-
+    locates on the zip blocking key). This is the missing real-Ray FS scoring
+    coverage; the existing distributed-scoring test only exercised a weighted
+    config."""
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE", "1")
+    from goldenmatch.distributed.scoring import score_blocks_distributed
+
+    df, gt = _gen_fs_data()
+    ds = ray.data.from_arrow(df.to_arrow()).repartition(3)
+
+    pairs_ds = score_blocks_distributed(ds, _fs_cfg())
+    rows = list(pairs_ds.take_all())
+    assert rows, "FS distributed scoring produced no pairs"
+    assert {"id_a", "id_b", "score"} <= set(rows[0].keys())
+
+    found = {
+        (min(int(r["id_a"]), int(r["id_b"])), max(int(r["id_a"]), int(r["id_b"])))
+        for r in rows
+    }
+    recall = _recall(found, gt)
+    assert recall >= 0.9, (
+        f"FS distributed scoring recall {recall:.3f} < 0.9 "
+        f"({len(found & gt)}/{len(gt)} GT pairs recovered)"
+    )
+
+
+# ── Test 2: full Phase-5 e2e (block-shuffle ON) recovers clusters ────
+
+def test_fs_phase5_e2e_recovers_clusters_block_shuffle(
+    _ray_local, monkeypatch, tmp_path,
+):
+    """`_run_phase5_pipeline` with an explicit FS config runs score ->
+    block-shuffle -> randomized_contraction WCC end to end; the persisted cluster
+    assignments recover the injected clusters. Exercises the recall-complete
+    distributed path (block-shuffle co-location + real distributed WCC) with FS
+    scores for the first time."""
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE", "1")
+    from goldenmatch.distributed.pipeline import _run_phase5_pipeline
+
+    df, gt = _gen_fs_data()
+    ds = ray.data.from_arrow(df.to_arrow()).repartition(3)
+    assignments_dir = str(tmp_path / "assignments")
+
+    _run_phase5_pipeline(
+        ds,
+        config=_fs_cfg(),
+        confidence_required=False,
+        assignments_output_path=assignments_dir,
+        _skip_golden=True,
+    )
+
+    found = _pairs_from_assignments(assignments_dir)
+    recall = _recall(found, gt)
+    assert recall >= 0.9, (
+        f"FS Phase-5 e2e (block-shuffle) cluster recall {recall:.3f} < 0.9 "
+        f"({len(found & gt)}/{len(gt)} GT pairs recovered)"
+    )
+    # Sanity: the FS scores did not collapse every record into one giant cluster.
+    assert len(found) < len(gt) * 20, (
+        f"over-merge: {len(found)} recovered pairs vs {len(gt)} GT pairs"
+    )
+
+
+# ── Test 3: Phase-5 e2e legacy path (single partition) ───────────────
+
+def test_fs_phase5_e2e_legacy_single_partition(
+    _ray_local, monkeypatch, tmp_path,
+):
+    """With block-shuffle OFF and a single input partition, everything is
+    co-located, so the legacy per-partition FS kernel + `local_cc_assignments`
+    must recover the clusters. Proves the FS scoring kernel is correct under real
+    Ray worker serialization of the driver-trained EMResult, independent of the
+    block-shuffle machinery."""
+    monkeypatch.setenv("GOLDENMATCH_DISTRIBUTED_BLOCK_SHUFFLE", "0")
+    from goldenmatch.distributed.pipeline import _run_phase5_pipeline
+
+    df, gt = _gen_fs_data()
+    ds = ray.data.from_arrow(df.to_arrow()).repartition(1)
+    assignments_dir = str(tmp_path / "assignments_legacy")
+
+    _run_phase5_pipeline(
+        ds,
+        config=_fs_cfg(),
+        confidence_required=False,
+        assignments_output_path=assignments_dir,
+        _skip_golden=True,
+    )
+
+    found = _pairs_from_assignments(assignments_dir)
+    recall = _recall(found, gt)
+    assert recall >= 0.9, (
+        f"FS Phase-5 e2e (legacy, 1 partition) cluster recall {recall:.3f} < 0.9 "
+        f"({len(found & gt)}/{len(gt)} GT pairs recovered)"
+    )


### PR DESCRIPTION
## What and why

Fellegi-Sunter (probabilistic) entity resolution was FS-capable-in-code on the Phase-5 Ray engine but FS-unproven: nothing exercised a probabilistic config through real Ray dispatch or the full pipeline, and every distributed bench used a WEIGHTED/exact config, so distributed FS quality had never been measured. This adds the missing rung between "FS kernel unit-tested with a fake Dataset" and a 100M FS bench.

## Changes

- **`tests/test_distributed_fs_e2e.py`** (new, real-Ray, `skipif` no ray): proves `score_blocks_distributed` trains one `EMResult` on the driver, ships it to workers, and the per-partition `score_buckets` FS branch recovers the injected duplicate pairs ACROSS input partitions; and that `_run_phase5_pipeline` with an explicit probabilistic config recovers the injected clusters via block-shuffle then randomized_contraction WCC (and via the legacy single-partition path).
  - Surfaced integration gap: on a small local cluster the block-shuffle `HashShuffleAggregator` actors starve the `_score` op's CPU reservation and deadlock. Documented + worked around in the fixture (oversubscribed logical slots + `_SCORE_NUM_CPUS` pinned to 1) - a test-infra concern on tiny clusters, not a production bug (production runs many-core).
- **`scripts/bench_fs_distributed.py`**: add a `--distributed` mode that drives the FS config through `GOLDENMATCH_DISTRIBUTED_PIPELINE=2`, persists cluster assignments, and F1-scores them with the SAME `evaluate_clusters` oracle as the single-box bucket leg - the first MEASURED distributed FS F1.
- **`bench-fs-distributed.yml`**: opt-in `bench_distributed` job (`-f distributed=true`) running the distributed leg on a simulated single-box Ray cluster. Honestly scoped as a regression check, not a multi-node parity proof; the 100M multi-node FS proof is a follow-on (needs a real cluster + a shared `gs://` WCC scratch).

## Testing

Ran in a fresh venv with the `[ray]` extra installed:

- `pytest tests/test_distributed_fs_e2e.py` -> 3 passed in 15.4s (scoring recovers pairs; e2e block-shuffle recovers clusters; e2e legacy single-partition recovers clusters).
- `bench_fs_distributed.py --distributed --rows 2000 --block-shuffle 1` -> P=R=F1=1.0000, wall 12.6s.
- `bench_fs_distributed.py --distributed --rows 1500 --partitions 1 --block-shuffle 0` -> P=R=F1=1.0000 (legacy path).
- `ruff check` clean on both new/changed files; workflow YAML validated; agent-codemap regen is a no-op.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (N/A - test + bench + workflow only, no library behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (deferred - can add a distributed-FS note once the multi-node proof lands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_