### PR TITLE
release(goldenmatch): 3.8.0

### DIFF
--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -6,6 +6,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 
 ## [Unreleased]
 
+## [3.8.0] - 2026-07-22
+
+### Added
+
+- **Opt-in FS columnar cluster path (`GOLDENMATCH_FS_COLUMNAR_CLUSTER`, default OFF)
+  — #1811.** On the eligible single-Fellegi-Sunter-matchkey in-memory bucket dedupe
+  path, the Arrow pair stream (`score_buckets_arrow`) is threaded straight to the
+  shipped, parity-gated columnar cluster path (`build_clusters_columnar` over
+  `_columnar_pairs_df`) instead of extending the driver-resident `all_pairs` Python
+  `list[tuple]`. At 14M on tight-blocking/dup-dense data that list runs to hundreds
+  of millions of tuples held on the driver through scoring → clustering — the
+  late-stage OOM of #1811. This removes the scoring-phase accumulator; the in-memory
+  analogue of the out-of-core `GOLDENMATCH_FS_OOC_ARROW_CLUSTER`. Default-OFF is inert
+  (byte-unchanged); eligibility mirrors the weighted columnar lane's downstream-safety
+  (single matchkey, no across-files / semantic-blocking / llm / boost) plus the FS
+  bucket route.
+- **Kernelized `radial` + `audio_fp` scorers (17/19 kernel-backed) — #2008.** The
+  radial and audio-fingerprint scorers are now backed by the native `score-core`
+  kernel (`radial` + `audio_fp` in `score.rs`), moving the `scorer_kernels` coverage
+  to 17 of 19; cross-surface parity locked (`test_native_perceptual_scorer_parity`).
+  Host code degrades gracefully to the pure-Python reference when the published
+  `goldenmatch-native` wheel predates these symbols.
+
+### Changed
+
+- Dependency bumps: `setuptools` 81.0.0 → 83.0.0 (#2001), `pyasn1` 0.6.3 → 0.6.4 (#2000).
+
 ## [3.7.0] - 2026-07-21
 
 ### Fixed

--- a/packages/python/goldenmatch/goldenmatch/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/__init__.py
@@ -28,7 +28,7 @@ Quick start:
 All features are accessible via `import goldenmatch as gm`.
 """
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"
 
 # ── Native Core surface ───────────────────────────────────────────────────
 # goldenmatch.native: graph/pair primitives + native string scorers, re-exported

--- a/packages/python/goldenmatch/pyproject.toml
+++ b/packages/python/goldenmatch/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "goldenmatch"
 
-version = "3.7.0"
+version = "3.8.0"
 description = "Entity resolution toolkit — deduplicate records, match across sources, and maintain golden records"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/python/goldenmatch/server.json
+++ b/packages/python/goldenmatch/server.json
@@ -4,7 +4,7 @@
   "title": "GoldenMatch",
   "description": "Find duplicate records in 30 seconds. Zero-config entity resolution, 97.2% F1 out of the box.",
   "websiteUrl": "https://docs.bensevern.dev/",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "repository": {
     "url": "https://github.com/benseverndev-oss/goldenmatch",
     "source": "github"
@@ -13,7 +13,7 @@
     {
       "registryType": "pypi",
       "identifier": "goldenmatch",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## What and why

Cut goldenmatch 3.8.0. Bundles everything merged to `main` since 3.7.0 (a release reflects main's state, not a single PR). Minor bump: the new capabilities are backward-compatible and either default-OFF or graceful-fallback, so existing runs are unchanged.

## Changes

- Version lockstep to `3.8.0`: `pyproject.toml`, `goldenmatch/__init__.py`, `server.json` (both the server and the pypi-package version fields).
- `CHANGELOG.md`: new `[3.8.0]` section covering:
  - **#1811** opt-in FS columnar cluster path (`GOLDENMATCH_FS_COLUMNAR_CLUSTER`, default OFF) — removes the scoring-phase driver-resident `all_pairs` list on the eligible single-FS-matchkey bucket dedupe path (the 14M late-stage OOM).
  - **#2008** kernelized `radial` + `audio_fp` scorers (17/19 kernel-backed; host degrades gracefully to pure-Python when the published native wheel predates the symbols).
  - Dependency bumps: setuptools 83.0.0 (#2001), pyasn1 0.6.4 (#2000).

## Testing

- Version-only + CHANGELOG change; no code touched. Release is cut via `cut-goldenmatch-release.yml -f version=3.8.0` after this merges (validates the pyproject / `__init__` / server.json lockstep + tag-is-new, then tags and publishes).

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a — version bump only)
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a)

Follow-up (not in this PR): golden-suite 0.3.4 lockstep bump (floor `goldenmatch>=3.8`) after 3.8.0 lands on PyPI; an optional `goldenmatch-native` republish would move #2008's radial/audio_fp scorers off the pure-Python fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_