### PR TITLE
test(distributed): fix degenerate-shape controller memory test (allow_red_config)

### DIFF
--- a/packages/python/goldenmatch/tests/test_distributed_controller.py
+++ b/packages/python/goldenmatch/tests/test_distributed_controller.py
@@ -58,8 +58,20 @@ def test_controller_distributed_path_does_not_materialize_full_df(tmp_path, monk
     helper -- not on process RSS. The old RSS-growth proxy was meaningless and
     flaky: a materialized 100K-row frame is only ~30 MB, but the threshold was
     400 MB, so the check only ever measured Ray's variable runtime overhead
-    (it grew 703 MB on one shared-runner run, 18 MB on another). A non-degenerate
-    surname pool also avoids the soundex-collapse pair explosion."""
+    (it grew 703 MB on one shared-runner run, 18 MB on another).
+
+    This is a MEMORY test, orthogonal to config health. The cycled 26x30 name
+    pool at 100K rows is a genuinely degenerate shape (780 distinct records,
+    each ~128x duplicated -> "everything matches"), so the controller correctly
+    commits a RED config. Post-#715 the RED-refuse at ``n >= REFUSE_AT_N``
+    (100K) is gated on ``allow_red_config``, NOT ``confidence_required`` (see
+    the #739 note in the package CLAUDE.md) -- so ``confidence_required=False``
+    no longer bypasses it and ``auto_configure_df`` raises
+    ``ControllerNotConfidentError`` before the sample-boundedness assertions run.
+    ``allow_red_config=True`` is the documented "run the degenerate config
+    anyway" escape hatch: it lets the controller RETURN the RED config, so the
+    driver-sample spy still captures the bounded sample heights this test exists
+    to check."""
     import goldenmatch.distributed.sample as sample_mod
     import polars as pl
     from goldenmatch import auto_configure_df
@@ -87,7 +99,7 @@ def test_controller_distributed_path_does_not_materialize_full_df(tmp_path, monk
     monkeypatch.setattr(sample_mod, "take_sample_distributed", _spy)
 
     ds = read_csv_partitioned(str(csv), n_partitions=8)
-    config = auto_configure_df(ds, confidence_required=False)
+    config = auto_configure_df(ds, allow_red_config=True)
     assert config is not None
 
     assert collected_heights, "controller pulled no distributed sample"


### PR DESCRIPTION
## What and why

`test_distributed_controller.py::test_controller_distributed_path_does_not_materialize_full_df` has been failing deterministically in the advisory `distributed_broad` lane (surfaced by CI on an unrelated PR). It's a **memory test** — it spies on `take_sample_distributed` to assert the distributed controller never collects the full df to the driver — but its `26×30` cycled name pool at 100K rows is a **genuinely degenerate shape**: 780 distinct records, each ~128× duplicated ("everything matches"), so the controller correctly commits a RED config.

Post-#715 the RED-refuse at `n >= REFUSE_AT_N` (100K) is gated on `allow_red_config`, **not** `confidence_required` (the #739 contract documented in the package CLAUDE.md). The test passed `confidence_required=False`, which no longer bypasses the refuse, so `auto_configure_df` raised `ControllerNotConfidentError` before the sample-boundedness assertions ran.

This is a **stale test, not a controller regression** — bisected to reproduce identically on pre-FS-cluster `autoconfig.py`, so it's independent of any recent FS work. The RED-refuse on a degenerate shape is correct and intended behavior.

## Changes

- `test_controller_distributed_path_does_not_materialize_full_df`: swap `confidence_required=False` → `allow_red_config=True` (the documented "run the degenerate config anyway" escape hatch), so the controller returns the RED config and the driver-sample spy still verifies boundedness. Docstring updated to explain the degeneracy + the post-#715 gate. No controller/source behavior change.

## Testing

- `pytest test_distributed_controller.py::test_controller_distributed_path_does_not_materialize_full_df` -> **1 passed** (23s). Driver-sample heights `[5000, 20000]` — both ≤ the 20K cap and < the 100K row count, so the memory assertion is fully preserved.
- Verified the failure reproduces on pre-FS-cluster `autoconfig.py` (bisect), confirming it's a stale test rather than a recent regression.
- `ruff check` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed file
- [ ] Package `CHANGELOG.md` updated if behavior changed (N/A — test-only, no library behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (N/A — the #739/#715 contract is already documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_