### PR TITLE
feat(ts): WASM-back the qgram scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `qgram`, `radial`, `soundex_match` |
+| Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -14,12 +14,19 @@
  * scorers need their census / alias reference-data tables injected once at
  * `enableWasm()` (the loader does this); until then the kernel degrades them to
  * plain Jaro-Winkler, the same table-absent fallback the pure-TS path takes.
+ *
+ * `qgram` (id 5) routes through score-core's `qgram_similarity` (char-trigram
+ * Jaccard: lowercase, `##`-pad each side, set intersection/union). The pure-TS
+ * `qgramScore` computes the identical set math, so the WASM matrix is byte-exact
+ * with the fallback on the ASCII/Latin inputs q-gram targets (short codes / SKUs
+ * / names) — the same parity bar the four core rapidfuzz scorers hold.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
   levenshtein: 1,
   token_sort: 2,
   exact: 3,
+  qgram: 5,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -115,3 +115,39 @@ d("WASM name scorers match the pure-TS scoreField reference (4dp)", () => {
     });
   }
 });
+
+// qgram (score_one id 5) is char-trigram Jaccard: WASM `qgram_similarity` and the
+// pure-TS `qgramScore` compute the identical set math (lowercase, `##`-pad each
+// side, |A∩B|/|A∪B|, with an a===b -> 1.0 short-circuit), so the WASM matrix
+// equals the pure-TS fallback exactly (not merely to tolerance — it is rational
+// set arithmetic, no rapidfuzz float divergence). This is the parity that lets
+// qgram move to the `scorer_kernels` SHARED partition (kernel-backed on both
+// Python arrow-native AND TS WASM). Reference is the pure-TS `scoreField`.
+type QgramCase = readonly [a: string, b: string, note: string];
+const QGRAM_CASES: readonly QgramCase[] = [
+  ["hello", "hello", "identical -> 1.0"],
+  ["SKU123", "sku123", "case-insensitive -> 1.0"],
+  ["abcdef", "abcxyz", "partial trigram overlap"],
+  ["cat", "dog", "disjoint -> low"],
+  ["café", "cafe", "accented BMP, partial overlap"],
+  ["ab", "abc", "short (n=3 padding still forms grams)"],
+  ["", "", "both empty -> identical short-circuit"],
+];
+
+d("WASM qgram matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of QGRAM_CASES) {
+    it(`qgram("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "qgram");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "qgram");
+      // Set-Jaccard is rational on both surfaces -> byte-exact, not just 4dp.
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,7 +25,7 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 4 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 5 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "exact",
@@ -33,6 +33,7 @@ describe("ScorerBackend singleton", () => {
         "jaro_winkler",
         "levenshtein",
         "name_freq_weighted_jw",
+        "qgram",
         "token_sort",
       ],
     );

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,9 +305,12 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# python_only: `date`, `qgram`, `soundex_match`, `initialism_match`, `alias_match`,
-# `dice`, `jaccard`, `phash`, `ensemble`, `radial`, `audio_fp` have an arrow-native
-# (bucket) kernel on Python but no TS WASM port yet.
+# shared: `qgram` (score_one id 5) is now kernel-backed on BOTH surfaces -- Python
+# arrow-native (bucket) AND TS WASM (score-wasm delegates id 5 to score_one; the
+# WASM char-trigram Jaccard is byte-exact with the pure-TS `qgramScore` fallback).
+# python_only: `date`, `soundex_match`, `initialism_match`, `alias_match`, `dice`,
+# `jaccard`, `phash`, `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket)
+# kernel on Python but no TS WASM port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
@@ -317,6 +320,7 @@ scorer_kernels:
   - exact
   - jaro_winkler
   - levenshtein
+  - qgram
   - token_sort
   python_only:
   - alias_match
@@ -327,7 +331,6 @@ scorer_kernels:
   - initialism_match
   - jaccard
   - phash
-  - qgram
   - radial
   - soundex_match
   ts_only:


### PR DESCRIPTION
## What and why

Closes the first of the "clean 6" TS-WASM kernel-parity gaps. Moves `qgram` from the suite-matrix substrate row **"Rust `-core` kernel — Python arrow-native only (TS falls back)"** to **"Rust `-core` kernel — Python + TS"**: the TypeScript WASM path now dispatches `qgram` to the shared `score-core` kernel instead of running the pure-TS fallback. Advances "every capability on every surface" — TS gets the reference fast path, not a re-implementation.

The `score-wasm` kernel *already* computes id 5 (`score_matrix_impl` delegates every non-special id to `score_one`, and `score_one(5)` is `qgram_similarity`), so this is a TS-side wiring change with **no Rust change**: adding `qgram: 5` to `SCORER_ID` flows through `WASM_COVERED_SCORERS`, the loader id lookup, and the `scoreMatrix` routing gate. `qgram` is a clean fall-through in `buildScoreMatrix` (unlike `soundex_match`/`ensemble`, which have O(n) hash-group specializations that bypass the backend), so the dispatcher is untouched.

## Changes

- **`src/core/wasm/backend.ts`**: `SCORER_ID` += `qgram: 5` (+ doc block explaining the parity).
- **`tests/unit/wasm-backend.test.ts`**: coverage assertion updated 6 → 7 scorers.
- **`tests/parity/wasm-scorer.test.ts`**: new `qgram` block asserting the WASM matrix equals the pure-TS `scoreField` reference **byte-exact** (`.toBe()`, not just 4dp) — char-trigram Jaccard is rational set math (lowercase, `##`-pad, `|A∩B|/|A∪B|`, `a===b → 1.0`) on both surfaces, so there is no rapidfuzz-style float divergence.
- **`parity/goldenmatch.yaml`**: `qgram` moved `python_only → shared` in `scorer_kernels`; explanatory comment updated.
- **`docs-site/suite-matrix.mdx`**: regenerated (qgram now in the "Python + TS" kernel row).

## Testing

- Built `score-wasm` locally (`build_wasm.sh`, wasm-bindgen 0.2.126 matching the pin), then `vitest run tests/parity tests/unit` — **3106 pass** (qgram parity block runs un-skipped with the artifact present).
- `tsc --noEmit` clean under the CI typecheck condition (artifact absent).
- Python gates: `check_scorer_coverage` OK, `gen_suite_matrix.py --check` OK, `scripts/test_suite_matrix.py` + `scripts/test_api_parity.py` (33 pass).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `tsc --noEmit` clean; byte-exact WASM↔pure-TS parity asserted
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal fast-path routing; output byte-identical, no user-facing behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (`suite-matrix.mdx` regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_