### PR TITLE
feat(ts): WASM-back the date scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
+| Rust `-core` kernel — Python + TS | `date`, `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `dice`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -20,12 +20,21 @@
  * `qgramScore` computes the identical set math, so the WASM matrix is byte-exact
  * with the fallback on the ASCII/Latin inputs q-gram targets (short codes / SKUs
  * / names) — the same parity bar the four core rapidfuzz scorers hold.
+ *
+ * `date` (id 4) routes through score-core's `date_similarity`: parse `YYYY-MM-DD`
+ * to 8 digits, Damerau-Levenshtein bucketed 0->1.0 / 1->0.90 / 2->0.75 / >=3->0.0,
+ * else `levenshtein` on the raw strings. The kernel uses rapidfuzz TRUE DL and the
+ * pure-TS `dateSimilarity` uses OSA — but for EQUAL-length inputs (both sides are
+ * 8 digits) OSA and true-DL first diverge only at distance 3, which both bucket to
+ * 0.0, so the two are byte-exact for every date pair (exhaustively verified; the
+ * non-ISO branch is plain `levenshtein`, itself an exact shared kernel).
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
   levenshtein: 1,
   token_sort: 2,
   exact: 3,
+  date: 4,
   qgram: 5,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -151,3 +151,40 @@ d("WASM qgram matches the pure-TS scoreField reference (exact)", () => {
     });
   }
 });
+
+// date (score_one id 4) parses YYYY-MM-DD -> 8 digits and buckets the
+// Damerau-Levenshtein distance (0->1.0, 1->0.90, 2->0.75, >=3->0.0), else falls
+// back to plain levenshtein. The WASM kernel uses rapidfuzz TRUE DL; the pure-TS
+// `dateSimilarity` uses OSA. For EQUAL-length inputs (both 8 digits) OSA and
+// true-DL first diverge only at distance 3 -- which both bucket to 0.0 -- so the
+// two surfaces are byte-exact on every date pair (exhaustively verified over the
+// distance-<=2 region). The non-ISO branch is plain levenshtein (an exact shared
+// kernel). Reference is the pure-TS `scoreField`; asserted byte-exact.
+type DateCase = readonly [a: string, b: string, note: string];
+const DATE_CASES: readonly DateCase[] = [
+  ["1990-05-12", "1990-05-12", "same date -> 1.0"],
+  ["1990-05-12", "1990-05-21", "adjacent-digit transposition -> DL 1 -> 0.90"],
+  ["1990-05-12", "1990-06-12", "one digit typo -> 0.90"],
+  ["1990-05-12", "1991-06-12", "two edits -> 0.75"],
+  ["1990-05-12", "2003-11-28", "unrelated -> DL>=3 -> 0.0"],
+  ["2001-02-13", "2010-02-31", "multi-transposition, DL still bucketed"],
+  ["1990-05-12", "not-a-date", "non-ISO b -> levenshtein fallback"],
+  ["12 May 1990", "12 May 1991", "both non-ISO -> levenshtein fallback"],
+];
+
+d("WASM date matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of DATE_CASES) {
+    it(`date("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "date");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "date");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,9 +25,10 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 5 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 6 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
+        "date",
         "exact",
         "given_name_aliased_jw",
         "jaro_winkler",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,18 +305,20 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# shared: `qgram` (score_one id 5) is now kernel-backed on BOTH surfaces -- Python
-# arrow-native (bucket) AND TS WASM (score-wasm delegates id 5 to score_one; the
-# WASM char-trigram Jaccard is byte-exact with the pure-TS `qgramScore` fallback).
-# python_only: `date`, `soundex_match`, `initialism_match`, `alias_match`, `dice`,
-# `jaccard`, `phash`, `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket)
-# kernel on Python but no TS WASM port yet.
+# shared: `qgram` (id 5) and `date` (id 4) are kernel-backed on BOTH surfaces --
+# Python arrow-native (bucket) AND TS WASM (score-wasm delegates the id to score_one;
+# the WASM output is byte-exact with the pure-TS fallback -- qgram is rational
+# set-Jaccard, date's true-DL==OSA for the equal-length 8-digit inputs it buckets).
+# python_only: `soundex_match`, `initialism_match`, `alias_match`, `dice`, `jaccard`,
+# `phash`, `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket) kernel on
+# Python but no TS WASM port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
 # (Python accepts them via the plugin fallback); a real, declared Python<->TS delta.
 scorer_kernels:
   shared:
+  - date
   - exact
   - jaro_winkler
   - levenshtein
@@ -325,7 +327,6 @@ scorer_kernels:
   python_only:
   - alias_match
   - audio_fp
-  - date
   - dice
   - ensemble
   - initialism_match


### PR DESCRIPTION
## What and why

Second of the "clean 6" TS-WASM kernel-parity closures (after `qgram`, #2013). Moves `date` from the suite-matrix substrate row **"Rust `-core` kernel — Python arrow-native only (TS falls back)"** to **"Rust `-core` kernel — Python + TS"**: the TypeScript WASM path now dispatches `date` to the shared `score-core` kernel (`score_one(4)` = `date_similarity`) instead of the pure-TS fallback.

`date` is a clean `buildScoreMatrix` fall-through (like `qgram`), so this is a one-line `SCORER_ID` add with **no Rust change** — the `score-wasm` kernel already computes id 4.

## The parity subtlety (resolved)

The kernel uses rapidfuzz **true Damerau-Levenshtein**; the pure-TS `dateSimilarity` uses **OSA**. OSA and true-DL *can* differ at distance 2 for **unequal-length** strings — which would flip a date bucket (0.75 vs 0.0). But both date inputs are exactly **8 digits (equal length)**, and an exhaustive enumeration shows OSA and true-DL first diverge only at **distance 3** for equal-length strings — and the scorer buckets everything ≥3 to `0.0` — so the two surfaces are **byte-exact on every date pair**. Also confirmed empirically: 120k random + adversarial ISO pairs, **0 mismatches**. The non-ISO branch is plain `levenshtein`, itself an exact shared kernel.

## Changes

- **`src/core/wasm/backend.ts`**: `SCORER_ID` += `date: 4` (+ doc block on the DL/OSA equal-length argument).
- **`tests/unit/wasm-backend.test.ts`**: coverage assertion 7 → 8 scorers.
- **`tests/parity/wasm-scorer.test.ts`**: new `date` block asserting the WASM matrix equals the pure-TS `scoreField` **byte-exact** (`.toBe()`) — same-date / adjacent-transposition / typo / two-edit / unrelated buckets + the non-ISO levenshtein fallback.
- **`parity/goldenmatch.yaml`**: `date` moved `python_only → shared` in `scorer_kernels`.
- **`docs-site/suite-matrix.mdx`**: regenerated (date now in the "Python + TS" kernel row).

## Testing

- `vitest run tests/parity tests/unit` — **43 pass** (date block runs un-skipped with the built artifact).
- `tsc --noEmit` clean under the CI typecheck condition (artifact absent).
- Python gates: `check_scorer_coverage` OK, `gen_suite_matrix.py --check` OK.
- Exhaustive OSA-vs-true-DL proof + 120k-pair empirical parity run (0 mismatches).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `tsc --noEmit` clean; byte-exact WASM↔pure-TS parity asserted
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal fast-path routing; output byte-identical, no user-facing behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (`suite-matrix.mdx` regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_