### PR TITLE
release(golden-suite): 0.3.4 — floor goldenmatch>=3.8 (lockstep)

### DIFF
--- a/packages/python/golden-suite/CHANGELOG.md
+++ b/packages/python/golden-suite/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to golden-suite are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/); this project uses semantic
 versioning.
 
+## [0.3.4] - 2026-07-22
+
+- Floor bump: `goldenmatch[polars]>=3.8`. 3.8.0 adds the opt-in FS columnar-cluster
+  path (`GOLDENMATCH_FS_COLUMNAR_CLUSTER` + the `GOLDENMATCH_FS_SCORED_PAIRS_MAX`
+  shed) that keeps the driver off the O(pairs) Python list at 14M scale (#1811 /
+  #2006), plus the kernelized `radial` / `audio_fp` scorers (17/19 kernel-backed,
+  #2008). Mandating the new baseline keeps the advertised suite honest.
+
 ## [0.3.3] - 2026-07-21
 
 - Floor bump: `goldenmatch[polars]>=3.7`. 3.7.0 lands the zero-config

--- a/packages/python/golden-suite/golden_suite/__init__.py
+++ b/packages/python/golden-suite/golden_suite/__init__.py
@@ -20,7 +20,7 @@ import importlib
 import os
 from importlib import metadata
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 
 # PyPI distribution name -> import module name. Keep in lockstep with pyproject deps.
 _COMPONENTS: dict[str, str] = {

--- a/packages/python/golden-suite/pyproject.toml
+++ b/packages/python/golden-suite/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "golden-suite"
-version = "0.3.3"
+version = "0.3.4"
 description = "One-line, perf-optimized install for the entire Golden Suite — goldenmatch, goldencheck, goldenflow, goldenpipe, GoldenSchema (infermap), goldenanalysis, native acceleration on by default"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -37,7 +37,7 @@ classifiers = [
 dependencies = [
     # --- suite (floors track the current majors) ---
     "goldenpipe[golden-suite]>=1.4",    # orchestrator + check/flow/match/analysis
-    "goldenmatch[polars]>=3.7",         # entity resolution: dedupe, match, golden records (>=3.7: zero-config Fellegi-Sunter scale-recall fix — saturation-aware candidate-pair projection + recall-safe identity-field compounding + memory-aware pair budget, F1 0.03->1.0 at 25M single-box; plus out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
+    "goldenmatch[polars]>=3.8",         # entity resolution: dedupe, match, golden records (>=3.7: zero-config Fellegi-Sunter scale-recall fix — saturation-aware candidate-pair projection + recall-safe identity-field compounding + memory-aware pair budget, F1 0.03->1.0 at 25M single-box; plus out-of-core streaming FS for the >=40M path; [polars] keeps the wall-optimization paths + the classic lane on for suite installs)
     "goldencheck[polars]>=3.2",       # data validation (>=3.0.0 = Arrow-native Polars-free default scan; [polars] kept for the scan_dataframe(pl.DataFrame) overload goldenmatch's quality bridge uses, also pulled transitively by goldenmatch)
     "goldenflow>=2.1.0",                 # transform / standardize / normalize (>=2.1.0 = owned auto-detect profile kernel; native floor >=0.27.0)
     "infermap>=0.6",                  # GoldenSchema: inference-driven schema mapping


### PR DESCRIPTION
## What and why

golden-suite lockstep after goldenmatch **3.8.0** landed on PyPI. Per the standing rule, a member release drags golden-suite: bump the floor and cut a new meta-package release so the advertised baseline is mandated (not just picked up on a fresh install).

## Changes

- `goldenmatch[polars]>=3.7` → `>=3.8` (the new baseline: opt-in FS columnar-cluster + `scored_pairs` shed for the #1811 14M driver-RSS win — #1811/#2006; kernelized `radial`/`audio_fp` scorers — #2008).
- Version `0.3.3` → `0.3.4` in `pyproject.toml` + `golden_suite/__init__.py`; CHANGELOG `[0.3.4]` entry. Deps-only meta-package, no code.

## Testing

- Version + floor bump only. The floor `>=3.8` is satisfiable (goldenmatch 3.8.0 is published to PyPI); CI resolves golden-suite floors against the workspace, which carries 3.8.0 post-#2010.
- Publish path after merge: `workflow_dispatch` on `publish-golden-suite.yml` (ref = main HEAD) → PyPI (the sandbox can't push tags; the workflow builds + uploads directly).

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a — deps-only bump)
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_