### PR TITLE
feat(ts): WASM-back the dice scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `dice`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -28,6 +28,13 @@
  * 8 digits) OSA and true-DL first diverge only at distance 3, which both bucket to
  * 0.0, so the two are byte-exact for every date pair (exhaustively verified; the
  * non-ISO branch is plain `levenshtein`, itself an exact shared kernel).
+ *
+ * `dice` (id 9) routes through score-core's `dice_similarity` (Sorensen-Dice on two
+ * hex bloom filters: `2*popcount(A&B) / (popcount(A)+popcount(B))`). The pure-TS
+ * `diceCoefficient` does the identical integer popcount + one f64 divide, so the
+ * WASM matrix is byte-exact with the fallback on any valid (even-length) bloom hex —
+ * the shape the `bloom_filter` transform always emits (malformed hex is the only
+ * divergence, and never reaches a real PPRL/CLK column).
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -36,6 +43,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   exact: 3,
   date: 4,
   qgram: 5,
+  dice: 9,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -188,3 +188,39 @@ d("WASM date matches the pure-TS scoreField reference (exact)", () => {
     });
   }
 });
+
+// dice (score_one id 9) is Sorensen-Dice on two hex bloom filters:
+// 2*popcount(A&B)/(popcount(A)+popcount(B)). WASM `dice_similarity` and the pure-TS
+// `diceCoefficient` do the identical integer popcount + one f64 divide, so the WASM
+// matrix equals the pure-TS fallback byte-exact on any valid (even-length) bloom hex
+// -- the shape the `bloom_filter` transform always emits (varied byte lengths handled
+// by the min-length intersection; malformed hex is the only divergence and never
+// reaches a real CLK column). Inputs are valid CLK-style hex; asserted byte-exact.
+type DiceCase = readonly [a: string, b: string, note: string];
+const DICE_CASES: readonly DiceCase[] = [
+  ["ffff", "ffff", "identical -> 1.0"],
+  ["ff00", "00ff", "disjoint bits -> 0.0"],
+  ["deadbeef", "deadbe", "different byte lengths (min-len intersection)"],
+  ["ABCD", "abcd", "uppercase hex parses same -> 1.0"],
+  ["0000", "ffff", "one side all-zero -> 0.0"],
+  ["0000", "0000", "both all-zero -> total 0 -> 0.0"],
+  ["f0f0a5", "a5f0f0", "partial overlap"],
+];
+
+d("WASM dice matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of DICE_CASES) {
+    it(`dice("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "dice");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "dice");
+      // Integer popcount + one f64 divide on both surfaces -> byte-exact.
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,10 +25,11 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 6 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 7 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
+        "dice",
         "exact",
         "given_name_aliased_jw",
         "jaro_winkler",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,13 +305,14 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# shared: `qgram` (id 5) and `date` (id 4) are kernel-backed on BOTH surfaces --
-# Python arrow-native (bucket) AND TS WASM (score-wasm delegates the id to score_one;
-# the WASM output is byte-exact with the pure-TS fallback -- qgram is rational
-# set-Jaccard, date's true-DL==OSA for the equal-length 8-digit inputs it buckets).
-# python_only: `soundex_match`, `initialism_match`, `alias_match`, `dice`, `jaccard`,
-# `phash`, `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket) kernel on
-# Python but no TS WASM port yet.
+# shared: `qgram` (id 5), `date` (id 4), `dice` (id 9) are kernel-backed on BOTH
+# surfaces -- Python arrow-native (bucket) AND TS WASM (score-wasm delegates the id to
+# score_one; the WASM output is byte-exact with the pure-TS fallback -- qgram is
+# rational set-Jaccard, date's true-DL==OSA for the equal-length 8-digit inputs it
+# buckets, dice is integer bloom-popcount + one divide).
+# python_only: `soundex_match`, `initialism_match`, `alias_match`, `jaccard`, `phash`,
+# `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket) kernel on Python but
+# no TS WASM port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
@@ -319,6 +320,7 @@ blocking_strategies:
 scorer_kernels:
   shared:
   - date
+  - dice
   - exact
   - jaro_winkler
   - levenshtein
@@ -327,7 +329,6 @@ scorer_kernels:
   python_only:
   - alias_match
   - audio_fp
-  - dice
   - ensemble
   - initialism_match
   - jaccard


### PR DESCRIPTION
## What and why

Third of the "clean 6" TS-WASM kernel-parity closures (after `qgram` #2013, `date` #2014). Moves `dice` from the substrate row **"Rust `-core` kernel — Python arrow-native only (TS falls back)"** to **"Rust `-core` kernel — Python + TS"**: the TS WASM path now dispatches `dice` to the shared `score-core` kernel (`score_one(9)` = `dice_similarity`) instead of the pure-TS fallback.

`dice` is a clean `buildScoreMatrix` fall-through, so this is a one-line `SCORER_ID` add with **no Rust change**.

## Parity

Sørensen-Dice on two hex bloom filters is **integer popcount + one f64 divide** (`2·popcount(A&B) / (popcount(A)+popcount(B))`) on both surfaces, so the WASM matrix is **byte-exact** with the pure-TS `diceCoefficient` on any valid even-length bloom hex — the shape the `bloom_filter` transform always emits (differing byte lengths are handled by the min-length intersection; malformed hex is the only divergence and never reaches a real CLK column). Confirmed over **80k valid-hex pairs** (varied lengths + edge cases), 0 mismatches; asserted `.toBe()`.

## Changes

- **`src/core/wasm/backend.ts`**: `SCORER_ID` += `dice: 9` (+ doc).
- **`tests/unit/wasm-backend.test.ts`**: coverage assertion 8 → 9.
- **`tests/parity/wasm-scorer.test.ts`**: new byte-exact `dice` block (identical / disjoint / mixed byte-length / uppercase-hex / all-zero cases).
- **`parity/goldenmatch.yaml`**: `dice` moved `python_only → shared` in `scorer_kernels`.
- **`docs-site/suite-matrix.mdx`**: regenerated (dice now in the "Python + TS" kernel row).

## Testing

- `vitest run tests/parity tests/unit` — **50 pass** (dice block runs un-skipped with the built artifact).
- `tsc --noEmit` clean under the CI typecheck condition (artifact absent).
- Python gates: `check_scorer_coverage` OK, `gen_suite_matrix.py --check` OK.
- 80k-pair empirical parity run (0 mismatches).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `tsc --noEmit` clean; byte-exact WASM↔pure-TS parity asserted
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal fast-path routing; output byte-identical, no user-facing behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (`suite-matrix.mdx` regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_