### PR TITLE
feat(ts): WASM-back the jaccard scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `jaccard`, `phash`, `radial`, `soundex_match` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `phash`, `radial`, `soundex_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -35,6 +35,13 @@
  * WASM matrix is byte-exact with the fallback on any valid (even-length) bloom hex —
  * the shape the `bloom_filter` transform always emits (malformed hex is the only
  * divergence, and never reaches a real PPRL/CLK column).
+ *
+ * `jaccard` (id 10) routes through score-core's `jaccard_similarity` (bloom-filter
+ * Jaccard: `popcount(A&B) / popcount(A|B)`). The kernel computes the union by
+ * inclusion-exclusion (`popcount(A)+popcount(B)-popcount(A&B)`) while the pure-TS
+ * `jaccardSimilarity` popcounts the actual bit-OR — algebraically identical for
+ * bloom filters — so the WASM matrix is byte-exact with the fallback on any valid
+ * (even-length) bloom hex, same as dice.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -44,6 +51,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   date: 4,
   qgram: 5,
   dice: 9,
+  jaccard: 10,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -224,3 +224,38 @@ d("WASM dice matches the pure-TS scoreField reference (exact)", () => {
     });
   }
 });
+
+// jaccard (score_one id 10) is bloom-filter Jaccard: popcount(A&B)/popcount(A|B).
+// The kernel derives the union by inclusion-exclusion (pcA+pcB-inter) and the pure-TS
+// `jaccardSimilarity` popcounts the actual bit-OR -- algebraically identical for bloom
+// filters -- so the WASM matrix is byte-exact with the fallback on any valid
+// even-length bloom hex (the min-length intersection covers differing byte lengths;
+// malformed hex is the only divergence and never reaches a real CLK column). Asserted
+// byte-exact.
+type JaccardCase = readonly [a: string, b: string, note: string];
+const JACCARD_CASES: readonly JaccardCase[] = [
+  ["ffff", "ffff", "identical -> 1.0"],
+  ["ff00", "00ff", "disjoint bits -> 0.0"],
+  ["deadbeef", "deadbe", "different byte lengths (union over the longer)"],
+  ["ABCD", "abcd", "uppercase hex parses same -> 1.0"],
+  ["0000", "ffff", "one side all-zero -> union>0, inter 0 -> 0.0"],
+  ["0000", "0000", "both all-zero -> union 0 -> 0.0"],
+  ["f0f0a5", "a5f0f0", "partial overlap"],
+];
+
+d("WASM jaccard matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of JACCARD_CASES) {
+    it(`jaccard("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "jaccard");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "jaccard");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,13 +25,14 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 7 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 8 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
         "dice",
         "exact",
         "given_name_aliased_jw",
+        "jaccard",
         "jaro_winkler",
         "levenshtein",
         "name_freq_weighted_jw",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,14 +305,14 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# shared: `qgram` (id 5), `date` (id 4), `dice` (id 9) are kernel-backed on BOTH
-# surfaces -- Python arrow-native (bucket) AND TS WASM (score-wasm delegates the id to
-# score_one; the WASM output is byte-exact with the pure-TS fallback -- qgram is
-# rational set-Jaccard, date's true-DL==OSA for the equal-length 8-digit inputs it
-# buckets, dice is integer bloom-popcount + one divide).
-# python_only: `soundex_match`, `initialism_match`, `alias_match`, `jaccard`, `phash`,
-# `ensemble`, `radial`, `audio_fp` have an arrow-native (bucket) kernel on Python but
-# no TS WASM port yet.
+# shared: `qgram` (id 5), `date` (id 4), `dice` (id 9), `jaccard` (id 10) are
+# kernel-backed on BOTH surfaces -- Python arrow-native (bucket) AND TS WASM (score-wasm
+# delegates the id to score_one; the WASM output is byte-exact with the pure-TS fallback
+# -- qgram is rational set-Jaccard, date's true-DL==OSA for the equal-length 8-digit
+# inputs it buckets, dice/jaccard are integer bloom-popcount + one divide).
+# python_only: `soundex_match`, `initialism_match`, `alias_match`, `phash`, `ensemble`,
+# `radial`, `audio_fp` have an arrow-native (bucket) kernel on Python but no TS WASM
+# port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
@@ -322,6 +322,7 @@ scorer_kernels:
   - date
   - dice
   - exact
+  - jaccard
   - jaro_winkler
   - levenshtein
   - qgram
@@ -331,7 +332,6 @@ scorer_kernels:
   - audio_fp
   - ensemble
   - initialism_match
-  - jaccard
   - phash
   - radial
   - soundex_match


### PR DESCRIPTION
## What and why

Fourth of the "clean 6" TS-WASM kernel-parity closures (after `qgram` #2013, `date` #2014, `dice` #2016) — this completes the **low-risk integer/rational batch**. Moves `jaccard` from **"Rust `-core` kernel — Python arrow-native only (TS falls back)"** to **"Rust `-core` kernel — Python + TS"**: the TS WASM path now dispatches `jaccard` to the shared `score-core` kernel (`score_one(10)` = `jaccard_similarity`) instead of the pure-TS fallback.

Clean `buildScoreMatrix` fall-through, so a one-line `SCORER_ID` add with **no Rust change**.

## Parity

Bloom-filter Jaccard is `popcount(A&B) / popcount(A|B)`. The kernel derives the union by **inclusion-exclusion** (`pcA+pcB-inter`) while the pure-TS `jaccardSimilarity` popcounts the actual **bit-OR** — algebraically identical for bloom filters — so the WASM matrix is **byte-exact** with the fallback on any valid even-length bloom hex. Confirmed over **80k valid-hex pairs**, 0 mismatches; asserted `.toBe()`.

## Changes

- **`src/core/wasm/backend.ts`**: `SCORER_ID` += `jaccard: 10` (+ doc).
- **`tests/unit/wasm-backend.test.ts`**: coverage assertion 9 → 10.
- **`tests/parity/wasm-scorer.test.ts`**: new byte-exact `jaccard` block.
- **`parity/goldenmatch.yaml`**: `jaccard` moved `python_only → shared`.
- **`docs-site/suite-matrix.mdx`**: regenerated — 8 shared scorers now kernel-backed on **both** surfaces.

## Testing

- `vitest run tests/parity tests/unit` — **57 pass** (jaccard block un-skipped with the built artifact).
- `tsc --noEmit` clean under the CI typecheck condition.
- Python gates: `check_scorer_coverage` OK, `gen_suite_matrix.py --check` OK.
- 80k-pair empirical parity run (0 mismatches).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `tsc --noEmit` clean; byte-exact WASM↔pure-TS parity asserted
- [ ] Package `CHANGELOG.md` updated if behavior changed (internal fast-path routing; output byte-identical, no user-facing behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs updated (`suite-matrix.mdx` regenerated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_