### PR TITLE
Ship synthesis node-disambiguation (GOLDENGRAPH_SYNTH_SELECT) default-on: +18.7% rel entity-subset

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -246,6 +246,32 @@ are purely the knob's effect. Dispatch via `bench-graphrag-qa.yml` mode `env_ab`
   bucket), which voting barely dents — the real lever is a better synthesizer
   (node-selection / prompt), not more samples of the same one.
 
+## Synthesis node-disambiguation is DEFAULT ON (`GOLDENGRAPH_SYNTH_SELECT`, 2026-07-22)
+The synthesis-PRECISION lever the voting note points at. Mining the confound-free env-A/B
+(#168) localized the synthesis miss as WRONG-NODE selection, not reasoning: on entity
+questions the model returns a plausible NEIGHBOR of the answer — the containing GROUP
+instead of the member (Karen Fairchild -> Little Big Town), the famous adjacent PERSON
+instead of the body (Politburo -> Stalin), a related EVENT instead of the thing
+(SuperSonics -> 1950 NBA draft), the wrong same-type SIBLING (Josh Radnor -> Bob Saget).
+The prior `_LOCAL_PROMPT` only guarded "don't answer with the entity you HELD going into
+the final hop"; it did NOT guard "don't answer with a plausible neighbor".
+- **`synthesize._SELECT_PREAMBLE`** (inserted before the answer clause by `_local_prompt()`
+  when `_select_enabled()`) forces an explicit disambiguation: state the KIND of thing the
+  question asks for, enumerate candidate answer nodes with types, then pick the type-matching
+  FAR-END node — not the most-famous neighbor, not the group when a member is asked, not a
+  related event when the thing is asked. Composes with `GOLDENGRAPH_LITERAL_ATTRS`.
+- **MEASURED default-on (same-graph env-A/B run 29888086667, MuSiQue N=100, SELECT 0 vs 1
+  on the IDENTICAL graph; `support_recall` 0.8417 == 0.8417 across arms = the control that
+  proves retrieval was untouched):** entity-subset answer_match **0.2462 -> 0.2923 (+18.7%
+  rel)**, answer_match 0.18 -> 0.20, token_f1 0.224 -> 0.263 — all up, same direction, at
+  **~no extra cost** (one call with a longer prompt; total $10.88 ~= the SELECT-off $10.38).
+  Contrast voting (=5): +0.015 entity at ~5x cost. SELECT is ~3x the lift at ~1/5 the cost —
+  which is why it ships DEFAULT ON while voting stays opt-in.
+- **`GOLDENGRAPH_SYNTH_SELECT=0` (or `false`/'') restores the pre-clause prompt
+  byte-identical** (`_local_prompt()` == `_LOCAL_PROMPT`; locked by
+  `tests/test_synthesis_select.py`). NEXT: broader-N / multi-seed confirmation, and whether
+  the same type-check helps the hybrid path (`_HYBRID_PROMPT`, currently unchanged).
+
 ## CHAT / embedding provider split (2026-07-22)
 `OpenAIClient._ensure_client` (`llm.py`) reads `GOLDENGRAPH_LLM_BASE_URL` /
 `GOLDENGRAPH_LLM_API_KEY` first, falling back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -132,15 +132,19 @@ _ANSWER_LITERAL = (
 )
 _LOCAL_TAIL = "Question: {q}\n{sub}"
 
-# Node-DISAMBIGUATION preamble (env-gated, default off). Targets the measured
+# Node-DISAMBIGUATION preamble (env-gated, DEFAULT ON 2026-07-22). Targets the measured
 # synthesis-precision failure mode: on entity questions the model returns a plausible
 # NEIGHBOR of the answer rather than the answer -- the containing GROUP instead of the
 # member (Karen Fairchild -> Little Big Town), the famous adjacent PERSON instead of the
 # body (Politburo -> Stalin), a related EVENT instead of the thing (SuperSonics -> 1950
-# NBA draft), the wrong same-type SIBLING (Josh Radnor -> Bob Saget). The existing prompt
-# only guards "don't answer with the entity you HELD"; this guards "don't answer with a
+# NBA draft), the wrong same-type SIBLING (Josh Radnor -> Bob Saget). The prior prompt
+# only guarded "don't answer with the entity you HELD"; this guards "don't answer with a
 # plausible neighbor" by forcing an explicit type-check + candidate enumeration before
-# committing. Experiment knob for the same-graph env-A/B (GOLDENGRAPH_SYNTH_SELECT:0,1).
+# committing. MEASURED default-on (same-graph env-A/B run 29888086667, MuSiQue N=100,
+# support_recall identical across arms = the control): entity-subset answer_match
+# 0.2462 -> 0.2923 (+18.7% rel), answer_match 0.18 -> 0.20, token_f1 0.224 -> 0.263, at
+# ~no extra cost (one call, longer prompt). `GOLDENGRAPH_SYNTH_SELECT=0` restores the
+# pre-clause prompt byte-identical.
 _SELECT_PREAMBLE = (
     "Before you commit, DISAMBIGUATE the final node so you do not return a plausible "
     "NEIGHBOR of the answer instead of the answer itself:\n"
@@ -168,9 +172,10 @@ def _literals_enabled() -> bool:
 
 
 def _select_enabled() -> bool:
-    """`GOLDENGRAPH_SYNTH_SELECT` (default 0/off). On -> insert `_SELECT_PREAMBLE`
-    before the answer clause. Off -> the prompt is byte-identical to the pre-flag one."""
-    return os.environ.get("GOLDENGRAPH_SYNTH_SELECT", "0") not in ("0", "false", "")
+    """`GOLDENGRAPH_SYNTH_SELECT` (DEFAULT 1/on since 2026-07-22; measured +18.7% rel on
+    entity-subset in the same-graph A/B). On -> insert `_SELECT_PREAMBLE` before the answer
+    clause. `=0`/`false` -> the prompt is byte-identical to the pre-clause one."""
+    return os.environ.get("GOLDENGRAPH_SYNTH_SELECT", "1") not in ("0", "false", "")
 
 
 def _local_prompt() -> str:

--- a/packages/python/goldengraph/goldengraph/synthesize.py
+++ b/packages/python/goldengraph/goldengraph/synthesize.py
@@ -132,6 +132,29 @@ _ANSWER_LITERAL = (
 )
 _LOCAL_TAIL = "Question: {q}\n{sub}"
 
+# Node-DISAMBIGUATION preamble (env-gated, default off). Targets the measured
+# synthesis-precision failure mode: on entity questions the model returns a plausible
+# NEIGHBOR of the answer rather than the answer -- the containing GROUP instead of the
+# member (Karen Fairchild -> Little Big Town), the famous adjacent PERSON instead of the
+# body (Politburo -> Stalin), a related EVENT instead of the thing (SuperSonics -> 1950
+# NBA draft), the wrong same-type SIBLING (Josh Radnor -> Bob Saget). The existing prompt
+# only guards "don't answer with the entity you HELD"; this guards "don't answer with a
+# plausible neighbor" by forcing an explicit type-check + candidate enumeration before
+# committing. Experiment knob for the same-graph env-A/B (GOLDENGRAPH_SYNTH_SELECT:0,1).
+_SELECT_PREAMBLE = (
+    "Before you commit, DISAMBIGUATE the final node so you do not return a plausible "
+    "NEIGHBOR of the answer instead of the answer itself:\n"
+    "- State the KIND of thing the question asks for: a specific person, an organization "
+    "or governing body, a place, a work or event, or a specific MEMBER of a group rather "
+    "than the group itself.\n"
+    "- From the Entities list, briefly list every node that could be the final answer, "
+    "each with its type.\n"
+    "- Pick the ONE whose type matches what the question asks AND that sits on the far end "
+    "of the final hop. Do NOT default to the most famous or most-mentioned neighbor; do "
+    "NOT return the containing GROUP or parent when a specific member is asked, nor a "
+    "related EVENT or work when the thing itself is asked.\n"
+)
+
 _LOCAL_PROMPT = _LOCAL_HEAD + _ANSWER_ENTITY + _LOCAL_TAIL
 _LOCAL_PROMPT_LITERALS = _LOCAL_HEAD + _ANSWER_LITERAL + _LOCAL_TAIL
 
@@ -142,6 +165,21 @@ def _literals_enabled() -> bool:
     import os
 
     return os.environ.get("GOLDENGRAPH_LITERAL_ATTRS", "0") not in ("0", "false", "")
+
+
+def _select_enabled() -> bool:
+    """`GOLDENGRAPH_SYNTH_SELECT` (default 0/off). On -> insert `_SELECT_PREAMBLE`
+    before the answer clause. Off -> the prompt is byte-identical to the pre-flag one."""
+    return os.environ.get("GOLDENGRAPH_SYNTH_SELECT", "0") not in ("0", "false", "")
+
+
+def _local_prompt() -> str:
+    """Compose the local-synthesis prompt from the head, the optional disambiguation
+    preamble (`GOLDENGRAPH_SYNTH_SELECT`), the answer clause (entity vs literal, per
+    `GOLDENGRAPH_LITERAL_ATTRS`), and the tail. Both flags off == `_LOCAL_PROMPT`."""
+    answer = _ANSWER_LITERAL if _literals_enabled() else _ANSWER_ENTITY
+    select = _SELECT_PREAMBLE if _select_enabled() else ""
+    return _LOCAL_HEAD + select + answer + _LOCAL_TAIL
 _MAP_PROMPT = "Summarize this community as it bears on the question.\nQuestion: {q}\n{sub}"
 _REDUCE_PROMPT = (
     "Answer the question by combining these community summaries.\n"
@@ -189,8 +227,7 @@ def synthesize_local(
     seeds = ", ".join(dict.fromkeys(s for s in (seed_names or []) if s)) or (
         "(none identified -- choose the most relevant entities yourself)"
     )
-    prompt = _LOCAL_PROMPT_LITERALS if _literals_enabled() else _LOCAL_PROMPT
-    filled = prompt.format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
+    filled = _local_prompt().format(q=query, seeds=seeds, sub=_format_subgraph(subgraph))
     n = _synth_samples()
     if n > 1 and hasattr(llm, "complete_many"):
         try:

--- a/packages/python/goldengraph/tests/test_synthesis_select.py
+++ b/packages/python/goldengraph/tests/test_synthesis_select.py
@@ -22,20 +22,23 @@ _SUB = {
 }
 
 
-def test_default_off_is_byte_identical(monkeypatch):
+def test_default_on_inserts_preamble(monkeypatch):
+    # DEFAULT (unset) is now ON (2026-07-22 flip: measured +18.7% rel entity-subset).
     monkeypatch.delenv("GOLDENGRAPH_SYNTH_SELECT", raising=False)
     monkeypatch.delenv("GOLDENGRAPH_LITERAL_ATTRS", raising=False)
-    assert _select_enabled() is False
-    # Composed prompt with both flags off == the pre-flag entity prompt, exactly.
-    assert _local_prompt() == _LOCAL_PROMPT
-    assert _SELECT_PREAMBLE not in _local_prompt()
+    assert _select_enabled() is True
+    assert _SELECT_PREAMBLE in _local_prompt()
+    assert _local_prompt() != _LOCAL_PROMPT
 
 
-def test_flag_values_off(monkeypatch):
+def test_explicit_off_is_byte_identical(monkeypatch):
+    # `=0`/`false`/'' opt out -> the composed prompt is the pre-clause entity prompt, exactly.
+    monkeypatch.delenv("GOLDENGRAPH_LITERAL_ATTRS", raising=False)
     for off in ("0", "false", ""):
         monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", off)
         assert _select_enabled() is False, off
         assert _local_prompt() == _LOCAL_PROMPT, off
+        assert _SELECT_PREAMBLE not in _local_prompt(), off
 
 
 def test_flag_on_inserts_preamble_before_answer_clause(monkeypatch):
@@ -57,8 +60,8 @@ def test_flag_on_reaches_the_actual_prompt(monkeypatch):
     assert _SELECT_PREAMBLE in llm.prompts[0]
 
 
-def test_flag_off_absent_from_actual_prompt(monkeypatch):
-    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SELECT", raising=False)
+def test_explicit_off_absent_from_actual_prompt(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", "0")
     llm = RecordingLLM("Answer: Acme")
     synthesize_local("Who founded Acme?", _SUB, llm)
     assert _SELECT_PREAMBLE not in llm.prompts[0]

--- a/packages/python/goldengraph/tests/test_synthesis_select.py
+++ b/packages/python/goldengraph/tests/test_synthesis_select.py
@@ -1,0 +1,73 @@
+"""GOLDENGRAPH_SYNTH_SELECT node-disambiguation preamble (synthesis-precision experiment).
+
+The measured synthesis miss is WRONG-NODE selection: the model returns a plausible
+NEIGHBOR of the answer (group vs member, famous adjacent person vs body, related event
+vs thing). The flag inserts `_SELECT_PREAMBLE` before the answer clause to force a
+type-check + candidate enumeration. Default off MUST be byte-identical. Pure, no live LLM."""
+from __future__ import annotations
+
+from conftest import RecordingLLM
+
+from goldengraph.synthesize import (
+    _LOCAL_PROMPT,
+    _SELECT_PREAMBLE,
+    _local_prompt,
+    _select_enabled,
+    synthesize_local,
+)
+
+_SUB = {
+    "entities": [{"entity_id": 0, "canonical_name": "Acme", "typ": "org"}],
+    "edges": [],
+}
+
+
+def test_default_off_is_byte_identical(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SELECT", raising=False)
+    monkeypatch.delenv("GOLDENGRAPH_LITERAL_ATTRS", raising=False)
+    assert _select_enabled() is False
+    # Composed prompt with both flags off == the pre-flag entity prompt, exactly.
+    assert _local_prompt() == _LOCAL_PROMPT
+    assert _SELECT_PREAMBLE not in _local_prompt()
+
+
+def test_flag_values_off(monkeypatch):
+    for off in ("0", "false", ""):
+        monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", off)
+        assert _select_enabled() is False, off
+        assert _local_prompt() == _LOCAL_PROMPT, off
+
+
+def test_flag_on_inserts_preamble_before_answer_clause(monkeypatch):
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", "1")
+    monkeypatch.delenv("GOLDENGRAPH_LITERAL_ATTRS", raising=False)
+    p = _local_prompt()
+    assert _SELECT_PREAMBLE in p
+    # Ordering: the disambiguation preamble sits BEFORE the "Answer:" format clause,
+    # which itself sits before the trailing Question line.
+    assert p.index(_SELECT_PREAMBLE) < p.index("prefixed 'Answer: '") < p.index("Question: {q}")
+
+
+def test_flag_on_reaches_the_actual_prompt(monkeypatch):
+    # End-to-end through synthesize_local: the preamble is in the prompt the LLM sees.
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", "1")
+    llm = RecordingLLM("Answer: Acme")
+    assert synthesize_local("Who founded Acme?", _SUB, llm) == "Acme"
+    assert len(llm.prompts) == 1
+    assert _SELECT_PREAMBLE in llm.prompts[0]
+
+
+def test_flag_off_absent_from_actual_prompt(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_SYNTH_SELECT", raising=False)
+    llm = RecordingLLM("Answer: Acme")
+    synthesize_local("Who founded Acme?", _SUB, llm)
+    assert _SELECT_PREAMBLE not in llm.prompts[0]
+
+
+def test_composes_with_literals_flag(monkeypatch):
+    # SELECT + LITERAL_ATTRS both on: preamble present AND the literal answer clause used.
+    monkeypatch.setenv("GOLDENGRAPH_SYNTH_SELECT", "1")
+    monkeypatch.setenv("GOLDENGRAPH_LITERAL_ATTRS", "1")
+    p = _local_prompt()
+    assert _SELECT_PREAMBLE in p
+    assert "literal VALUE leaf" in p  # the _ANSWER_LITERAL clause


### PR DESCRIPTION
## What and why

Anti-shatter fixed retrieval and shifted goldengraph's QA bottleneck to **synthesis**. Mining the confound-free env-A/B (#168) localized the miss as **wrong-node selection, not reasoning** — on entity questions the model returns a plausible *neighbor* of the answer:

| gold | prediction | failure |
|---|---|---|
| Karen Fairchild | Little Big Town | member → the group containing them |
| the Politburo | Joseph Stalin | body → famous adjacent person |
| Seattle SuperSonics | 1950 NBA draft | team → related event |
| Josh Radnor | Bob Saget | wrong same-type sibling |

The prior prompt only guarded "don't answer with the entity you *held* going into the final hop" — not "don't answer with a plausible *neighbor*." `_SELECT_PREAMBLE` closes that: state the KIND of thing asked for → enumerate candidate nodes with types → pick the type-matching far-end node.

## Measured (same-graph env-A/B, run 29888086667, MuSiQue N=100, SELECT 0 vs 1)

| metric | SELECT=0 | SELECT=1 | delta | rel |
|---|---|---|---|---|
| answer_match | 0.1800 | 0.2000 | +0.0200 | +11.1% |
| **answer_match_entity** (n=65) | 0.2462 | 0.2923 | **+0.0461** | **+18.7%** |
| token_f1 | 0.2241 | 0.2627 | +0.0386 | +17.2% |
| **support_recall** (control) | 0.8417 | 0.8417 | +0.0000 | — |

`support_recall` byte-identical across arms = the graph was truly shared, so the deltas are purely the clause's effect. All quality metrics up, same direction, no regression, at **~no extra cost** ($10.88 ≈ the SELECT-off $10.38 — one call with a longer prompt). That's ~3× voting's lift (+0.015 entity) at ~1/5 the cost — which is why this ships **default-on** while voting stays opt-in.

## Changes

- `synthesize.py`: `_select_enabled()` default `0`→`1`. `GOLDENGRAPH_SYNTH_SELECT=0` (or `false`/`''`) restores the pre-clause prompt **byte-identical** (`_local_prompt()` == `_LOCAL_PROMPT`).
- `tests/test_synthesis_select.py`: default (unset) now inserts the preamble; explicit-off is the byte-identical lock. Full synthesis + nl-chain + literal-attrs suites green (84 tests).
- `goldengraph/CLAUDE.md`: document the measurement + the flip.

## Testing

- `python -m pytest tests/test_synthesis_select.py tests/test_synthesis_self_consistency.py tests/test_synthesize_format.py tests/test_hybrid_synthesis.py tests/test_nl_chain.py tests/test_literal_attributes.py -q` → 84 passed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated (measurement + default flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5