### PR TITLE
refactor(soundex): canonical in-house soundex, drop jellyfish as the reference

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -3166,7 +3166,8 @@
           "imports": [
             "goldenmatch._polars_lazy",
             "goldenmatch.config.schemas",
-            "goldenmatch.core.blocker"
+            "goldenmatch.core.blocker",
+            "goldenmatch.utils.transforms"
           ]
         },
         {
@@ -4070,6 +4071,7 @@
             "_score_one_block",
             "_score_one_block_columnar",
             "_soundex_score_matrix",
+            "_soundex_score_single",
             "find_exact_matches",
             "find_fuzzy_matches",
             "find_fuzzy_matches_columnar",
@@ -6965,7 +6967,8 @@
             "_prepare_bloom_input",
             "apply_transform",
             "apply_transforms",
-            "bloom_clk_batch"
+            "bloom_clk_batch",
+            "canonical_soundex"
           ],
           "imports": [
             "goldenmatch.core._native_loader",

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -146,8 +146,8 @@ def _vec_field_matrix(values: list, scorer_name: str):
         # bonus, all float64). The soundex bonus reuses `_soundex_score_matrix`,
         # the SAME matrix the per-pair soundex_match callable is byte-parity with
         # (asserted in tests/test_score_buckets_vectorized_fallback.py), so the
-        # ensemble vec form agrees with `_ensemble_score_single`'s
-        # `jellyfish.soundex(a)==jellyfish.soundex(b)` empty-code-match semantics.
+        # ensemble vec form agrees with `_ensemble_score_single`'s canonical
+        # soundex empty-code-guard semantics (garbage/empty never matches).
         from goldenmatch.core.scorer import _soundex_score_matrix
         jw = np.asarray(cdist(values, values, scorer=JaroWinkler.similarity, dtype=np.float64))
         ts = np.asarray(cdist(values, values, scorer=token_sort_ratio, dtype=np.float64)) / 100.0
@@ -477,11 +477,11 @@ def _resolve_score_pair_callable(
     if scorer_name == "exact":
         return lambda a, b: 1.0 if a == b else 0.0
     if scorer_name == "soundex_match":
-        # Pure-Python jellyfish.soundex; per-pair binary match. Identical
-        # to the matrix path's soundex_match (core/scorer.py:88), just
-        # one call at a time instead of cdist-batched.
-        import jellyfish as _jf
-        return lambda a, b: 1.0 if _jf.soundex(a) == _jf.soundex(b) else 0.0
+        # GoldenMatch canonical soundex (byte-matches score-core); per-pair binary
+        # match with the empty-code guard (garbage/empty never matches). Identical
+        # to the matrix path's soundex_match, just one call at a time.
+        from goldenmatch.core.scorer import _soundex_score_single
+        return _soundex_score_single
     if scorer_name == "date":
         # Date-aware scorer (#1858). Per-pair mirror of score-core::date_similarity
         # (native id 4); byte-identical to the kernel (native-parity asserted).

--- a/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
+++ b/packages/python/goldenmatch/goldenmatch/core/arrow_derive.py
@@ -173,9 +173,9 @@ def transformed_column(arr: Any, transforms: Sequence[str]) -> Any:
         # Known phonetic transforms resolve to their (Rust) callables
         # directly, skipping apply_transform's name-dispatch per value.
         if _t == "soundex":
-            import jellyfish
+            from goldenmatch.utils.transforms import canonical_soundex
 
-            _fn = jellyfish.soundex
+            _fn = canonical_soundex
         elif _t == "metaphone":
             import jellyfish
 

--- a/packages/python/goldenmatch/goldenmatch/core/explainer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/explainer.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-import jellyfish
 from rapidfuzz.distance import JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
 
 from goldenmatch.config.schemas import MatchkeyField
-from goldenmatch.utils.transforms import apply_transforms
+from goldenmatch.utils.transforms import apply_transforms, canonical_soundex
 
 
 @dataclass
@@ -150,11 +149,13 @@ def _score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | N
     elif scorer == "token_sort":
         return token_sort_ratio(val_a, val_b) / 100.0
     elif scorer == "soundex_match":
-        return 1.0 if jellyfish.soundex(val_a) == jellyfish.soundex(val_b) else 0.0
+        ca = canonical_soundex(val_a)
+        return 1.0 if ca and ca == canonical_soundex(val_b) else 0.0
     elif scorer == "ensemble":
         jw = JaroWinkler.similarity(val_a, val_b)
         ts = token_sort_ratio(val_a, val_b) / 100.0
-        sx = 0.8 if jellyfish.soundex(val_a) == jellyfish.soundex(val_b) else 0.0
+        ca = canonical_soundex(val_a)
+        sx = 0.8 if ca and ca == canonical_soundex(val_b) else 0.0
         return max(jw, ts, sx)
     else:
         return 0.0

--- a/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
+++ b/packages/python/goldenmatch/goldenmatch/core/learned_blocking.py
@@ -69,11 +69,11 @@ _TRANSFORM_MAP = {
 
 
 def _safe_soundex(val: str) -> str:
-    try:
-        import jellyfish
-        return jellyfish.soundex(val)
-    except Exception:
-        return val[:4].upper()
+    # GoldenMatch canonical soundex (byte-matches the score-core kernel); pure,
+    # never raises. A no-letter value -> "" (filtered as an empty block key).
+    from goldenmatch.utils.transforms import canonical_soundex
+
+    return canonical_soundex(val)
 
 
 def generate_predicates(columns: list[str]) -> list[BlockingPredicate]:

--- a/packages/python/goldenmatch/goldenmatch/core/scorer.py
+++ b/packages/python/goldenmatch/goldenmatch/core/scorer.py
@@ -7,7 +7,6 @@ import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-import jellyfish
 import numpy as np
 from rapidfuzz.distance import DamerauLevenshtein, JaroWinkler, Levenshtein
 from rapidfuzz.fuzz import token_sort_ratio
@@ -23,7 +22,7 @@ from goldenmatch.core._profile_helpers import (
 )
 from goldenmatch.core.complexity_profile import ScoringProfile
 from goldenmatch.core.profile_emitter import current_emitter, has_active_emitter
-from goldenmatch.utils.transforms import apply_transforms
+from goldenmatch.utils.transforms import apply_transforms, canonical_soundex
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +189,7 @@ def score_field(val_a: str | None, val_b: str | None, scorer: str) -> float | No
     elif scorer == "token_sort":
         return token_sort_ratio(val_a, val_b) / 100.0
     elif scorer == "soundex_match":
-        return 1.0 if jellyfish.soundex(val_a) == jellyfish.soundex(val_b) else 0.0
+        return _soundex_score_single(val_a, val_b)
     elif scorer == "ensemble":
         # Scalar twin of the NxN `ensemble` branch in `_fuzzy_score_matrix`:
         # element-wise max of jaro_winkler, token_sort, and soundex*0.8. The
@@ -692,6 +691,15 @@ def _record_embedding_score_matrix(
     return np.asarray(sim, dtype=np.float64)
 
 
+def _soundex_score_single(val_a: str, val_b: str) -> float:
+    """Per-pair ``soundex_match``: 1.0 iff a NON-EMPTY canonical soundex code is
+    shared. Byte-for-byte with score-core ``soundex_match`` (id 6) -- the
+    empty-code guard means garbage/empty never matches (no placeholder
+    mega-clustering)."""
+    ca = canonical_soundex(val_a)
+    return 1.0 if ca and ca == canonical_soundex(val_b) else 0.0
+
+
 def _soundex_score_matrix(values: list) -> np.ndarray:
     """NxN soundex match matrix.
 
@@ -703,7 +711,9 @@ def _soundex_score_matrix(values: list) -> np.ndarray:
     m = _native_field_matrix(values, "soundex_match")
     if m is not None:
         return m
-    codes = [jellyfish.soundex(v) if v is not None else None for v in values]
+    # Empty code (no phonetic content) -> None so it matches NOTHING in the
+    # exact-match matrix, mirroring score-core `soundex_match`'s empty-guard.
+    codes = [(canonical_soundex(v) or None) if v is not None else None for v in values]
     return _exact_score_matrix(codes)
 
 
@@ -1048,7 +1058,8 @@ def _ensemble_score_single(val_a: str, val_b: str) -> float:
     jw = JaroWinkler.similarity(val_a, val_b)
     ts = token_sort_ratio(val_a, val_b) / 100.0
     try:
-        sx = 0.8 if jellyfish.soundex(val_a) == jellyfish.soundex(val_b) else 0.0
+        ca = canonical_soundex(val_a)
+        sx = 0.8 if ca and ca == canonical_soundex(val_b) else 0.0
     except Exception:
         sx = 0.0
     return max(jw, ts, sx)

--- a/packages/python/goldenmatch/goldenmatch/utils/transforms.py
+++ b/packages/python/goldenmatch/goldenmatch/utils/transforms.py
@@ -28,23 +28,43 @@ _SOUNDEX_CODE = {
 
 def canonical_soundex(s: str) -> str:
     """GoldenMatch canonical American Soundex code, or ``""`` when the value has
-    no ASCII-letter content. Byte-identical to score-core ``soundex``."""
-    letters = [c for c in unicodedata.normalize("NFKD", s).upper() if "A" <= c <= "Z"]
-    if not letters:
-        return ""
-    result = [letters[0]]  # seed = first surviving letter
-    last = _SOUNDEX_CODE.get(letters[0])  # would-be code of the seed, or None
-    for c in letters[1:]:
-        code = _SOUNDEX_CODE.get(c)
-        if code is not None:
-            if code != last:
-                result.append(code)
-            last = code
-        elif c not in ("H", "W"):
-            # Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
+    no ASCII-letter content. Byte-identical to score-core ``soundex``.
+
+    Spec (Unicode-folding standard Soundex): NFKD-fold + uppercase, then walk the
+    string. ASCII ``[A-Z]`` are letters (seed / code / H-W-transparent / vowel-break);
+    EVERY other char -- digit, punctuation, whitespace, and the combining marks NFKD
+    leaves behind -- is a SEPARATOR that breaks the coding run (resets adjacency) but
+    is otherwise skipped and never seeds. This makes multi-token values
+    (``"joseph bradshaw"``) code each token's boundary consonant instead of merging
+    across the gap, and folds accents to their base letter (``José`` -> ``J200``,
+    ``Muñoz`` -> ``M520``). On pure-ASCII input this equals classic American Soundex
+    (word separators break the run) -- the historical behavior real person-name
+    blocking/scoring depends on. A value with no surviving letter yields ``""``.
+    """
+    result: list[str] = []  # [seed, digit, digit, digit]
+    last: str | None = None  # code of the previous letter (None after seed/vowel/separator)
+    for c in unicodedata.normalize("NFKD", s).upper():
+        if "A" <= c <= "Z":
+            if not result:
+                result.append(c)  # seed = first surviving letter
+                last = _SOUNDEX_CODE.get(c)  # seed's would-be code suppresses a same-code follower
+                continue
+            code = _SOUNDEX_CODE.get(c)
+            if code is not None:
+                if code != last:
+                    result.append(code)
+                last = code
+            elif c not in ("H", "W"):
+                # Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
+                last = None
+            if len(result) == 4:
+                break
+        else:
+            # Separator (digit / punctuation / whitespace / combining mark): break
+            # the coding run so a same code across the gap is re-emitted, not merged.
             last = None
-        if len(result) == 4:
-            break
+    if not result:
+        return ""
     return "".join(result).ljust(4, "0")
 
 

--- a/packages/python/goldenmatch/goldenmatch/utils/transforms.py
+++ b/packages/python/goldenmatch/goldenmatch/utils/transforms.py
@@ -4,8 +4,48 @@ from __future__ import annotations
 
 import hashlib
 import re
+import unicodedata
 
 import jellyfish
+
+# GoldenMatch canonical American Soundex -- the pure-Python reference that
+# byte-matches the Rust `goldenmatch-score-core::soundex` kernel (the single
+# source of truth for every soundex surface). Deliberately NOT jellyfish: NFKD +
+# uppercase, keep only ASCII [A-Z], then standard Soundex; a value with no
+# surviving letter (empty / all-digit / all-punctuation) -> "". This drops the
+# jellyfish quirks (`"123"->"1000"`, `"Þór"->"Þ600"`) that diverged from the TS
+# port and let placeholder columns mega-cluster. See score-core's `soundex` +
+# tests/test_native_soundex_parity.py for the cross-surface parity contract.
+_SOUNDEX_CODE = {
+    "B": "1", "F": "1", "P": "1", "V": "1",
+    "C": "2", "G": "2", "J": "2", "K": "2", "Q": "2", "S": "2", "X": "2", "Z": "2",
+    "D": "3", "T": "3",
+    "L": "4",
+    "M": "5", "N": "5",
+    "R": "6",
+}
+
+
+def canonical_soundex(s: str) -> str:
+    """GoldenMatch canonical American Soundex code, or ``""`` when the value has
+    no ASCII-letter content. Byte-identical to score-core ``soundex``."""
+    letters = [c for c in unicodedata.normalize("NFKD", s).upper() if "A" <= c <= "Z"]
+    if not letters:
+        return ""
+    result = [letters[0]]  # seed = first surviving letter
+    last = _SOUNDEX_CODE.get(letters[0])  # would-be code of the seed, or None
+    for c in letters[1:]:
+        code = _SOUNDEX_CODE.get(c)
+        if code is not None:
+            if code != last:
+                result.append(code)
+            last = code
+        elif c not in ("H", "W"):
+            # Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
+            last = None
+        if len(result) == 4:
+            break
+    return "".join(result).ljust(4, "0")
 
 
 def apply_transform(value: str | None, transform: str) -> str | None:
@@ -38,7 +78,7 @@ def apply_transform(value: str | None, transform: str) -> str | None:
         end = int(parts[2])
         return value[start:end]
     elif transform == "soundex":
-        return jellyfish.soundex(value)
+        return canonical_soundex(value)
     elif transform == "metaphone":
         return jellyfish.metaphone(value)
     elif transform == "digits_only":

--- a/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_field_matrix_parity.py
@@ -75,9 +75,13 @@ def _offdiag(m: np.ndarray) -> np.ndarray:
     return out
 
 
-def test_native_soundex_matches_jellyfish():
+def test_native_soundex_matches_canonical():
+    # Mirror = canonical soundex with the empty-code guard (empty -> None so it
+    # matches nothing), exactly what the native field-matrix kernel does
+    # (`!code.is_empty() && a == b`). Diverges from jellyfish on garbage/exotic.
+    from goldenmatch.utils.transforms import canonical_soundex
     py_mat = scorer._exact_score_matrix(
-        [scorer.jellyfish.soundex(v) if v else None for v in _VALUES]
+        [(canonical_soundex(v) or None) if v else None for v in _VALUES]
     )
     rs_mat = _native_field_matrix(_VALUES, "soundex_match")
     assert rs_mat is not None

--- a/packages/python/goldenmatch/tests/test_native_soundex_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_soundex_parity.py
@@ -1,18 +1,19 @@
-"""Parity for the soundex_match bucket kernel (score-core id 6) vs jellyfish.
+"""Parity for the soundex_match kernel (score-core id 6) vs the pure-Python
+`canonical_soundex` reference.
 
-soundex was already a Rust kernel in the *field-matrix* path (native id 4); Wave 1
-moves the impl into `score-core` with FULL `jellyfish.soundex` parity (NFKD
-normalize + Unicode uppercase + literal-first-char seed) and wires it into the
-*bucket* path via `score_one` id 6, so it becomes kernel-backed in the metric
-(the scorer_kernels surface reads the bucket `_NATIVE_SCORER_IDS`).
+soundex is kernel-backed on both the bucket path (`score_one` id 6) and the
+field-matrix path (native id 4). As of the canonical-soundex cutover the kernel
+is NOT jellyfish: `NFKD` + uppercase, keep only ASCII `[A-Z]`, then standard
+Soundex, and a value with no surviving letter -> `""`. The `soundex_match` scorer
+adds an empty-code guard (garbage/empty never matches, not even another empty
+code -- so placeholder columns can't mega-cluster).
 
-Full parity means native `soundex_similarity(a, b)` is bit-identical to the
-bucket per-pair mirror `1.0 if jellyfish.soundex(a) == jellyfish.soundex(b) else
-0.0` (`_resolve_score_pair_callable("soundex_match")`) over EVERY input --
-including leading non-alpha (`123`, `3M`), embedded symbols (`O'Brien`), and
-Unicode (`Ürüm`, `José`, `ß`), where the pre-Wave-1 ASCII-only kernel diverged.
-The exact per-string codes are pinned in score-core's cargo tests; this batteries
-the equality semantics the kernel actually uses over thousands of pairs.
+This batteries native `soundex_similarity(a, b)` (== `score_one(6)`) against the
+pure-Python mirror `_soundex_score_single` (which uses `canonical_soundex` + the
+same empty guard) over thousands of pairs, INCLUDING the inputs where the kernel
+now diverges from jellyfish on purpose: garbage (`123`, `!!`, ``), exotic
+non-decomposable letters (`Þór`, `Æthel`), and accented consonants (`Muñoz`).
+The exact per-string codes are pinned in score-core's cargo tests.
 """
 from __future__ import annotations
 
@@ -20,32 +21,30 @@ import random
 
 import pytest
 from goldenmatch.core import _native_loader
-from goldenmatch.core import scorer as _scorer_mod
+from goldenmatch.core.scorer import _soundex_score_single
 
-_jf = _scorer_mod.jellyfish
-
-
-def _mirror(a: str, b: str) -> float:
-    # exactly `_resolve_score_pair_callable("soundex_match")`'s lambda
-    return 1.0 if _jf.soundex(a) == _jf.soundex(b) else 0.0
+# The pure-Python reference the native kernel must reproduce byte-for-byte.
+_mirror = _soundex_score_single
 
 
-# Adversarial vocabulary: alpha names (incl. H/W rule + collisions), leading
-# non-alpha, embedded symbols/digits, empty, and Unicode (NFKD + upper edges).
+# Adversarial vocabulary: alpha names (incl. H/W rule + collisions), garbage
+# (leading/embedded/only non-alpha), empty, accented Latin, and exotic
+# non-decomposable letters.
 _VOCAB = [
     "Robert", "Rupert", "Ashcraft", "Ashcroft", "Tymczak", "Pfister", "Honeyman",
     "Smith", "Smyth", "Jackson", "Gutierrez", "Catherine", "Katherine", "Lloyd",
     "Lee", "OBrien", "O'Brien", "McDonald", "MacDonald", "van der Berg",
     "123", "3M", "4abc", "1B2", "99", "S1S", "AB-BA", "-x", "x-y", "A1B", " Robert",
-    "", "a", "AA", "H", "W", "HW", "WH",
+    "", "a", "AA", "H", "W", "HW", "WH", "!!", "000", "---",
     "José", "Ürüm", "naïve", "Zoë", "ß", "Œuvre", "Åke", "Muñoz", "Håkan", "Ægir",
+    "Þór", "Æthel", "Đặng", "Ñoño",
 ]
 
 
 def _corpus() -> list[tuple[str, str]]:
-    rng = random.Random(20260721)
+    rng = random.Random(20260722)
     alpha = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJ"
-    mixed = alpha + "0123456789 -'.éüößÅ"
+    mixed = alpha + "0123456789 -'.éüößÅñÞÆ"
     def rand(pool: str) -> str:
         return "".join(rng.choice(pool) for _ in range(rng.randint(0, 12)))
     pairs = [(x, y) for x in _VOCAB for y in _VOCAB]  # every ordered pair incl self
@@ -54,7 +53,7 @@ def _corpus() -> list[tuple[str, str]]:
     return pairs
 
 
-def test_soundex_native_matches_jellyfish_mirror():
+def test_soundex_native_matches_canonical_mirror():
     n = _native_loader.native_module()
     if n is None or not hasattr(n, "soundex_similarity"):
         pytest.skip("native soundex kernel not built / wheel predates soundex_similarity")
@@ -62,21 +61,23 @@ def test_soundex_native_matches_jellyfish_mirror():
         assert n.soundex_similarity(a, b) == _mirror(a, b), f"soundex {a!r} {b!r}"
 
 
-def test_soundex_full_parity_non_alpha_and_unicode():
-    # The cases the pre-Wave-1 ASCII-only kernel got wrong; now byte-identical.
+def test_soundex_empty_guard_and_folding():
+    # The cases the canonical spec changed vs jellyfish; now byte-identical native<->pure.
     n = _native_loader.native_module()
     if n is None or not hasattr(n, "soundex_similarity"):
         pytest.skip("native soundex kernel not built")
-    # 123 -> "1000", 456 -> "4000" (distinct); 123 vs 123 match.
+    # Garbage -> "" -> never matches, not even another garbage value.
     assert n.soundex_similarity("123", "456") == _mirror("123", "456") == 0.0
-    assert n.soundex_similarity("123", "123") == 1.0
-    # 3M -> "3500"; Robert/Rupert collide; Ürüm code is stable under NFKD.
+    assert n.soundex_similarity("123", "123") == 0.0  # identical garbage -> no match
+    assert n.soundex_similarity("000", "---") == 0.0
+    # Real names collide / fold as expected.
     assert n.soundex_similarity("Robert", "Rupert") == 1.0
-    assert n.soundex_similarity("Ürüm", "Ürüm") == 1.0
+    assert n.soundex_similarity("Muñoz", "Munoz") == 1.0  # ñ folds to n
+    assert n.soundex_similarity("José", "Jose") == 1.0
 
 
 def test_soundex_bucket_kernel_id6_matches_mirror():
-    """score_block_pairs dispatching scorer id 6 == the per-pair jellyfish mirror.
+    """score_block_pairs dispatching scorer id 6 == the canonical per-pair mirror.
 
     One block, one soundex_match field, weight 1.0, threshold 0.0 so every pair
     emits; the kernel's per-pair score must equal the mirror.
@@ -85,7 +86,7 @@ def test_soundex_bucket_kernel_id6_matches_mirror():
     if n is None or not hasattr(n, "soundex_similarity"):
         pytest.skip("native soundex kernel not built")
 
-    values = ["Robert", "Rupert", "Smith", "Smyth", "3M", "José"]
+    values = ["Robert", "Rupert", "Smith", "Smyth", "3M", "José", "123", "Muñoz"]
     row_ids = list(range(len(values)))
     sizes = [len(values)]
     field_values = [values]

--- a/packages/python/goldenmatch/tests/test_native_soundex_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_soundex_parity.py
@@ -2,11 +2,14 @@
 `canonical_soundex` reference.
 
 soundex is kernel-backed on both the bucket path (`score_one` id 6) and the
-field-matrix path (native id 4). As of the canonical-soundex cutover the kernel
-is NOT jellyfish: `NFKD` + uppercase, keep only ASCII `[A-Z]`, then standard
-Soundex, and a value with no surviving letter -> `""`. The `soundex_match` scorer
-adds an empty-code guard (garbage/empty never matches, not even another empty
-code -- so placeholder columns can't mega-cluster).
+field-matrix path (native id 4). The canonical in-house kernel is a Unicode-folding
+STANDARD Soundex: `NFKD` + uppercase, then walk the string -- ASCII `[A-Z]` code as
+classic Soundex, every other char (digit / punctuation / whitespace / combining
+mark / exotic letter) is a SEPARATOR that breaks the coding run but never seeds, and
+a value with no surviving letter -> `""`. On pure ASCII this equals jellyfish EXCEPT
+jellyfish seeds a leading digit; it folds accents jellyfish drops (`Muñoz` -> `M520`).
+The `soundex_match` scorer adds an empty-code guard (garbage/empty never matches, not
+even another empty code -- so placeholder columns can't mega-cluster).
 
 This batteries native `soundex_similarity(a, b)` (== `score_one(6)`) against the
 pure-Python mirror `_soundex_score_single` (which uses `canonical_soundex` + the

--- a/packages/python/goldenmatch/tests/test_property_invariants.py
+++ b/packages/python/goldenmatch/tests/test_property_invariants.py
@@ -105,6 +105,13 @@ _nonempty_ascii = st.text(
     min_size=1,
     max_size=64,
 )
+# soundex identity needs at least one ASCII LETTER: canonical soundex maps a
+# no-letter value (digits/punctuation/space) to "" -> the empty-code guard makes
+# it NON-matching even against itself (garbage never matches). So the "score(a,a)
+# == 1.0" invariant holds only for inputs with real phonetic content.
+_nonempty_ascii_alpha = _nonempty_ascii.filter(
+    lambda s: any("a" <= c.lower() <= "z" for c in s)
+)
 
 # Dict strategy for fingerprint tests: str keys (no __ prefix, nonempty),
 # values from the supported primitive types (no NaN floats -- by spec they raise).
@@ -161,7 +168,7 @@ _SCORER_NONEMPTY_STRATEGY: dict = {
     "levenshtein": _nonempty_text,
     "token_sort": _nonempty_text,
     "qgram": _nonempty_text,
-    "soundex_match": _nonempty_ascii,
+    "soundex_match": _nonempty_ascii_alpha,
 }
 
 # Standardizers that are idempotent by design (empirically verified above)

--- a/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
+++ b/packages/python/goldenmatch/tests/test_score_pair_callable_class_a.py
@@ -29,18 +29,19 @@ def test_class_a_scorer_resolves_to_callable(scorer_name):
 
 def test_soundex_match_matches_matrix_path():
     """Per-pair soundex_match must produce the same 0/1 score as the matrix
-    path in core/scorer.py:88. Same jellyfish.soundex under the hood."""
-    import jellyfish
+    path. Both use canonical GoldenMatch soundex + the empty-code guard (garbage
+    / empty never matches -- see core/scorer._soundex_score_single)."""
+    from goldenmatch.core.scorer import _soundex_score_single
     fn = _resolve_score_pair_callable("soundex_match")
     pairs = [
         ("Smith", "Smyth"),    # same soundex -> 1.0
         ("Robert", "Rupert"),  # same soundex -> 1.0
         ("Smith", "Jones"),    # different -> 0.0
-        ("", ""),              # edge
+        ("", ""),              # empty code -> guarded to 0.0 (never matches)
+        ("123", "456"),        # garbage -> "" -> 0.0
     ]
     for a, b in pairs:
-        expected = 1.0 if jellyfish.soundex(a) == jellyfish.soundex(b) else 0.0
-        assert fn(a, b) == expected, f"soundex_match({a!r},{b!r})"
+        assert fn(a, b) == _soundex_score_single(a, b), f"soundex_match({a!r},{b!r})"
 
 
 def test_dice_matches_matrix_path():

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -200,17 +200,24 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
 
 /// GoldenMatch canonical American Soundex -- the in-house reference for every
 /// `goldenmatch` soundex surface (the bucket `score_one` path, the Python
-/// pure/blocking fallbacks, and the TS port). Deliberately NOT jellyfish:
+/// pure/blocking fallbacks, and the TS port). A Unicode-folding STANDARD Soundex:
 ///
-/// - `NFKD`-normalize + Unicode-uppercase, then keep ONLY ASCII letters `[A-Z]`.
-///   Accents fold away (`José` -> `J200`, `Ürüm` -> `U650`, `ß` -> `S000`);
-///   every non-letter -- digits, punctuation, whitespace, combining marks, and
-///   exotic non-decomposable letters (`þ`/`Æ`/`Đ`) -- is DROPPED, not seeded as a
-///   literal the way jellyfish does (`"123" -> "1000"`, `"Þór" -> "Þ600"`).
-/// - Standard Soundex over the surviving letters: seed = the first letter, code
-///   `B..R` per `soundex_code`, adjacent duplicate codes collapse, `H`/`W` are
-///   transparent (skip without breaking a run), vowels (incl. `Y`) break the run;
-///   right-pad to four with `0`.
+/// - `NFKD`-normalize + Unicode-uppercase, then walk the string. ASCII letters
+///   `[A-Z]` are seed / coded consonant / `H`-`W`-transparent / vowel-break as in
+///   classic Soundex; EVERY other char -- digit, punctuation, whitespace, the
+///   combining marks NFKD strips off accents, and exotic non-decomposable letters
+///   (`þ`/`Æ`/`Đ`) -- is a SEPARATOR that breaks the coding run (resets adjacency)
+///   but is skipped and never seeds. So multi-token values code each token's
+///   boundary consonant instead of merging it away (`"joseph bradshaw" -> "J211"`,
+///   NOT `"J216"`), and accents fold to their base letter (`José` -> `J200`,
+///   `Muñoz` -> `M520`). On PURE-ASCII input this equals classic American Soundex
+///   (word separators break the run) -- the historical behavior real person-name
+///   blocking/scoring depends on; it also equals jellyfish on ASCII EXCEPT that
+///   jellyfish nonsensically seeds a leading digit (`"1st" -> "1230"`) where this
+///   seeds the first real letter.
+/// - Standard Soundex over each letter run: seed = the first letter, code `B..R`
+///   per `soundex_code`, adjacent duplicate codes collapse, `H`/`W` transparent,
+///   vowels (incl. `Y`) break the run; right-pad to four with `0`.
 /// - NO surviving letter (empty / all-digit / all-punctuation) -> `""`. A value
 ///   with no phonetic content has no code; on the blocking side an empty key is
 ///   filtered (no giant garbage block), and the `soundex_match` scorer treats an
@@ -223,39 +230,45 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
 /// (the ASCII/Latin-scoped Unicode-version parity edge the other kernels document
 /// applies here too). Cross-surface parity in `tests/test_native_soundex_parity.py`.
 pub fn soundex(s: &str) -> String {
-    let letters: Vec<char> = s
-        .nfkd()
-        .collect::<String>()
-        .to_uppercase()
-        .chars()
-        .filter(|c| c.is_ascii_uppercase())
-        .collect();
-    if letters.is_empty() {
-        return String::new();
-    }
+    let normalized: String = s.nfkd().collect::<String>().to_uppercase();
     let mut result = String::with_capacity(4);
-    result.push(letters[0]); // seed = first surviving letter
-    let mut count = 1usize;
-    let mut last = soundex_code(letters[0]); // would-be code of the seed, or None
-    for &c in &letters[1..] {
-        match soundex_code(c) {
-            Some(code) => {
-                if Some(code) != last {
-                    result.push(code);
-                    count += 1;
-                }
-                last = Some(code);
+    let mut count = 0usize; // chars pushed so far (seed + digits)
+    let mut last: Option<char> = None; // code of the previous letter (None after seed/vowel/separator)
+    for c in normalized.chars() {
+        if c.is_ascii_uppercase() {
+            if count == 0 {
+                result.push(c); // seed = first surviving letter
+                count = 1;
+                last = soundex_code(c); // seed's would-be code suppresses a same-code follower
+                continue;
             }
-            None => {
-                // Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
-                if c != 'H' && c != 'W' {
-                    last = None;
+            match soundex_code(c) {
+                Some(code) => {
+                    if Some(code) != last {
+                        result.push(code);
+                        count += 1;
+                    }
+                    last = Some(code);
+                }
+                None => {
+                    // Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
+                    if c != 'H' && c != 'W' {
+                        last = None;
+                    }
                 }
             }
+            if count == 4 {
+                break;
+            }
+        } else {
+            // Separator (digit / punctuation / whitespace / combining mark): break the
+            // coding run so a same code across the gap is re-emitted, not merged, and
+            // never seed on a non-letter.
+            last = None;
         }
-        if count == 4 {
-            break;
-        }
+    }
+    if count == 0 {
+        return String::new();
     }
     for _ in count..4 {
         result.push('0');
@@ -1037,35 +1050,44 @@ mod tests {
 
     #[test]
     fn soundex_canonical_in_house() {
-        // Alphabetic names: standard American Soundex, UNCHANGED from jellyfish
-        // (the in-house spec only diverges on non-letters / exotic letters).
+        // Alphabetic single-token names: standard American Soundex, byte-identical
+        // to jellyfish (the in-house spec agrees on all pure-ASCII letter runs).
         assert_eq!(soundex("Robert"), "R163");
         assert_eq!(soundex("Rupert"), "R163"); // Robert/Rupert collide
         assert_eq!(soundex("Ashcraft"), "A261"); // H/W skip rule
         assert_eq!(soundex("Tymczak"), "T522");
         assert_eq!(soundex("Pfister"), "P236"); // adjacent same-code (P,F -> 1) coalesces
         assert_eq!(soundex("Honeyman"), "H555");
-        // Accented Latin folds via NFKD -- byte-identical to jellyfish here too.
+        // Multi-token names: a separator (space) BREAKS the coding run, so the code
+        // on each side of the gap is kept -- it is NOT merged the way stripping
+        // separators would. This is the historical behavior person-name blocking
+        // depends on (matches jellyfish; the strip variant regressed it).
+        assert_eq!(soundex("joseph bradshaw"), "J211"); // P then B kept (not merged to "J216")
+        assert_eq!(soundex("warren nale"), "W655"); // N | N kept (not merged to "W654")
+        // Accented Latin folds via NFKD to the base letter -- byte-identical here.
         assert_eq!(soundex("Ürüm"), "U650");
         assert_eq!(soundex("José"), "J200");
+        assert_eq!(soundex("Muñoz"), "M520"); // ñ folds to n (jellyfish drops it -> "M200")
         assert_eq!(soundex("ß"), "S000"); // upper() -> "SS" -> dup-collapse
         // No surviving letter -> "" (the DIVERGENCE from jellyfish, which would
         // seed the literal digit/symbol: "123" -> "1000").
         assert_eq!(soundex(""), "");
         assert_eq!(soundex("123"), "");
         assert_eq!(soundex("!!"), "");
-        // Non-letters are DROPPED, not seeded/coded (jellyfish: "3M"->"3500",
-        // "4abc"->"4120", "S1S"->"S200" -- it seeds the literal + a mid non-letter
-        // resets the run). In-house: drop them first, then standard Soundex.
-        assert_eq!(soundex("3M"), "M000"); // -> "M"
-        assert_eq!(soundex("4abc"), "A120"); // -> "ABC"
-        assert_eq!(soundex("12ab"), "A100"); // -> "AB"
-        assert_eq!(soundex("S1S"), "S000"); // -> "SS" (adjacent -> collapse), not "S200"
-        // Exotic non-decomposable letters are dropped (jellyfish keeps the raw
-        // char as the literal seed: "Þór"->"Þ600", "Æthel"->"Æ340").
-        assert_eq!(soundex("Þór"), "O600"); // -> "OR"
-        assert_eq!(soundex("Æthel"), "T400"); // -> "THEL"
-        assert_eq!(soundex("Đặng"), "A520"); // -> "ANG"
+        // Non-letters are SEPARATORS (break the run) and never seed. A leading
+        // separator is skipped; a MID separator breaks adjacency so a same code
+        // across the gap is re-emitted (unlike jellyfish, which seeds a leading
+        // digit: "3M"->"3500", "S1S"->"S200" matches us on the break but "1st"
+        // differs by seed).
+        assert_eq!(soundex("3M"), "M000"); // leading sep -> seed M
+        assert_eq!(soundex("4abc"), "A120"); // leading sep -> "abc"
+        assert_eq!(soundex("12ab"), "A100"); // leading seps -> "ab"
+        assert_eq!(soundex("S1S"), "S200"); // S | S: the "1" breaks adjacency -> 2 re-emitted
+        // Exotic non-decomposable letters are separators too (jellyfish keeps the
+        // raw char as the literal seed: "Þór"->"Þ600", "Æthel"->"Æ340").
+        assert_eq!(soundex("Þór"), "O600"); // Þ sep -> "or"
+        assert_eq!(soundex("Æthel"), "T400"); // Æ sep -> "thel"
+        assert_eq!(soundex("Đặng"), "A520"); // Đ + combining seps -> "ang"
     }
 
     #[test]

--- a/packages/rust/extensions/score-core/src/lib.rs
+++ b/packages/rust/extensions/score-core/src/lib.rs
@@ -198,36 +198,46 @@ pub fn qgram_similarity(a: &str, b: &str) -> f64 {
     inter as f64 / union as f64
 }
 
-/// American Soundex matching `jellyfish.soundex` byte-for-byte, INCLUDING its
-/// Unicode handling. Mirrors the jellyfish reference exactly
-/// (`jellyfish/_jellyfish.py::soundex`):
+/// GoldenMatch canonical American Soundex -- the in-house reference for every
+/// `goldenmatch` soundex surface (the bucket `score_one` path, the Python
+/// pure/blocking fallbacks, and the TS port). Deliberately NOT jellyfish:
 ///
-/// - empty input -> `""`.
-/// - `unicodedata.normalize("NFKD", s).upper()`: NFKD decomposition (an accented letter becomes base-letter + combining mark) then Unicode uppercase (`ß` -> `"SS"`).
-/// - seed = the LITERAL first char (kept as-is, not coded); `last` = its would-be code, or None if the seed isn't a coded consonant.
-/// - each subsequent char: a coded consonant appends its code when it differs from `last` (adjacent-dup collapse); ANY other char resets `last` to None UNLESS it is `H`/`W` (which leave `last` untouched).
-/// - stop at 4 output chars; right-pad with `0`.
+/// - `NFKD`-normalize + Unicode-uppercase, then keep ONLY ASCII letters `[A-Z]`.
+///   Accents fold away (`José` -> `J200`, `Ürüm` -> `U650`, `ß` -> `S000`);
+///   every non-letter -- digits, punctuation, whitespace, combining marks, and
+///   exotic non-decomposable letters (`þ`/`Æ`/`Đ`) -- is DROPPED, not seeded as a
+///   literal the way jellyfish does (`"123" -> "1000"`, `"Þór" -> "Þ600"`).
+/// - Standard Soundex over the surviving letters: seed = the first letter, code
+///   `B..R` per `soundex_code`, adjacent duplicate codes collapse, `H`/`W` are
+///   transparent (skip without breaking a run), vowels (incl. `Y`) break the run;
+///   right-pad to four with `0`.
+/// - NO surviving letter (empty / all-digit / all-punctuation) -> `""`. A value
+///   with no phonetic content has no code; on the blocking side an empty key is
+///   filtered (no giant garbage block), and the `soundex_match` scorer treats an
+///   empty code as a non-match against ANYTHING (see `soundex_match`).
 ///
-/// This is the single reference for every `goldenmatch` soundex surface: the
-/// `native` field-matrix kernel and the bucket `score_one` path both call it.
-/// Rust `nfkd()` (the `unicode-normalization` crate) plus `str::to_uppercase`
-/// implement the same Unicode algorithms as Python's `unicodedata.normalize`
-/// and `str.upper`, so the result is byte-identical to jellyfish (batteried in
-/// `tests/test_native_soundex_parity.py`).
+/// Rust `nfkd()` (`unicode-normalization`) + `str::to_uppercase` implement the
+/// same Unicode algorithms as Python `unicodedata.normalize("NFKD", …).upper()`
+/// and JS `String.prototype.normalize("NFKD")` / `toUpperCase()`, so the result
+/// is byte-identical across the Rust / Python-fallback / TS-fallback surfaces
+/// (the ASCII/Latin-scoped Unicode-version parity edge the other kernels document
+/// applies here too). Cross-surface parity in `tests/test_native_soundex_parity.py`.
 pub fn soundex(s: &str) -> String {
-    if s.is_empty() {
-        return String::new();
-    }
-    let normalized: String = s.nfkd().collect::<String>().to_uppercase();
-    let chars: Vec<char> = normalized.chars().collect();
-    if chars.is_empty() {
+    let letters: Vec<char> = s
+        .nfkd()
+        .collect::<String>()
+        .to_uppercase()
+        .chars()
+        .filter(|c| c.is_ascii_uppercase())
+        .collect();
+    if letters.is_empty() {
         return String::new();
     }
     let mut result = String::with_capacity(4);
-    result.push(chars[0]); // literal seed (jellyfish `result = [s[0]]`)
+    result.push(letters[0]); // seed = first surviving letter
     let mut count = 1usize;
-    let mut last = soundex_code(chars[0]); // would-be code of the seed, or None
-    for &c in &chars[1..] {
+    let mut last = soundex_code(letters[0]); // would-be code of the seed, or None
+    for &c in &letters[1..] {
         match soundex_code(c) {
             Some(code) => {
                 if Some(code) != last {
@@ -237,8 +247,7 @@ pub fn soundex(s: &str) -> String {
                 last = Some(code);
             }
             None => {
-                // Non-coded char (vowel / mark / digit / symbol): reset the
-                // dedup state, EXCEPT H/W which jellyfish leaves alone.
+                // Vowels (A/E/I/O/U/Y) break the run; H/W stay transparent.
                 if c != 'H' && c != 'W' {
                     last = None;
                 }
@@ -252,6 +261,24 @@ pub fn soundex(s: &str) -> String {
         result.push('0');
     }
     result
+}
+
+/// `soundex_match` scorer: `1.0` iff two values share a NON-EMPTY soundex code,
+/// else `0.0`. The empty-code guard is load-bearing -- a value with no phonetic
+/// content (empty / all-digit / all-punctuation -> `soundex` returns `""`) never
+/// matches, INCLUDING another empty-code value, so placeholder columns
+/// (`"000"`, `"-"`, `""`) can't mega-cluster into one phonetic bucket. Byte-for-byte
+/// with the Python `_soundex_score_single` + TS `soundexMatch` fallbacks.
+pub fn soundex_match(a: &str, b: &str) -> f64 {
+    let ca = soundex(a);
+    if ca.is_empty() {
+        return 0.0;
+    }
+    if ca == soundex(b) {
+        1.0
+    } else {
+        0.0
+    }
 }
 
 /// Soundex digit for a coded consonant (uppercase), else `None`. Vowels
@@ -889,11 +916,11 @@ pub fn score_one(scorer_id: u8, a: &str, b: &str) -> f64 {
         3 if a == b => 1.0,
         4 => date_similarity(a, b),
         5 => qgram_similarity(a, b),
-        // id=6 = soundex_match: binary 1.0/0.0 on soundex-code equality. Guard
-        // arm collapses the if/else into the match (clippy::collapsible-match),
-        // like id 3; a soundex mismatch falls through to the 0.0 catch-all.
-        // Matches the bucket per-pair mirror `1.0 if jf.soundex(a)==jf.soundex(b) else 0.0`.
-        6 if soundex(a) == soundex(b) => 1.0,
+        // id=6 = soundex_match: 1.0 iff a NON-EMPTY soundex code is shared, else
+        // 0.0 (the empty-code guard lives in `soundex_match` -- garbage/empty never
+        // matches, so placeholder columns can't mega-cluster). Matches the bucket
+        // per-pair mirror `_soundex_score_single`.
+        6 => soundex_match(a, b),
         // id=7 = initialism_match against the host-installed legal-form set (empty
         // until `set_legal_forms` is called). Byte-for-byte with
         // `_initialism_match_single`; the Python fast-path guard requires the
@@ -1009,28 +1036,49 @@ mod tests {
     }
 
     #[test]
-    fn soundex_matches_jellyfish_reference() {
-        // Canonical alphabetic jellyfish values.
+    fn soundex_canonical_in_house() {
+        // Alphabetic names: standard American Soundex, UNCHANGED from jellyfish
+        // (the in-house spec only diverges on non-letters / exotic letters).
         assert_eq!(soundex("Robert"), "R163");
         assert_eq!(soundex("Rupert"), "R163"); // Robert/Rupert collide
         assert_eq!(soundex("Ashcraft"), "A261"); // H/W skip rule
         assert_eq!(soundex("Tymczak"), "T522");
         assert_eq!(soundex("Pfister"), "P236"); // adjacent same-code (P,F -> 1) coalesces
         assert_eq!(soundex("Honeyman"), "H555");
-        // Empty -> empty (jellyfish `if not s`).
-        assert_eq!(soundex(""), "");
-        // Leading non-alpha: jellyfish seeds on the LITERAL first char (NOT the
-        // first letter) and codes the rest -- full-parity cases probed from
-        // jellyfish itself.
-        assert_eq!(soundex("123"), "1000");
-        assert_eq!(soundex("3M"), "3500");
-        assert_eq!(soundex("4abc"), "4120");
-        // Mid-string non-letter resets the dedup state (S..1..S -> both S's coded).
-        assert_eq!(soundex("S1S"), "S200");
-        // Unicode: NFKD fold + uppercase. Ürüm -> U + r(6) + m(5); ß.upper()="SS".
+        // Accented Latin folds via NFKD -- byte-identical to jellyfish here too.
         assert_eq!(soundex("Ürüm"), "U650");
         assert_eq!(soundex("José"), "J200");
-        assert_eq!(soundex("ß"), "S000");
+        assert_eq!(soundex("ß"), "S000"); // upper() -> "SS" -> dup-collapse
+        // No surviving letter -> "" (the DIVERGENCE from jellyfish, which would
+        // seed the literal digit/symbol: "123" -> "1000").
+        assert_eq!(soundex(""), "");
+        assert_eq!(soundex("123"), "");
+        assert_eq!(soundex("!!"), "");
+        // Non-letters are DROPPED, not seeded/coded (jellyfish: "3M"->"3500",
+        // "4abc"->"4120", "S1S"->"S200" -- it seeds the literal + a mid non-letter
+        // resets the run). In-house: drop them first, then standard Soundex.
+        assert_eq!(soundex("3M"), "M000"); // -> "M"
+        assert_eq!(soundex("4abc"), "A120"); // -> "ABC"
+        assert_eq!(soundex("12ab"), "A100"); // -> "AB"
+        assert_eq!(soundex("S1S"), "S000"); // -> "SS" (adjacent -> collapse), not "S200"
+        // Exotic non-decomposable letters are dropped (jellyfish keeps the raw
+        // char as the literal seed: "Þór"->"Þ600", "Æthel"->"Æ340").
+        assert_eq!(soundex("Þór"), "O600"); // -> "OR"
+        assert_eq!(soundex("Æthel"), "T400"); // -> "THEL"
+        assert_eq!(soundex("Đặng"), "A520"); // -> "ANG"
+    }
+
+    #[test]
+    fn soundex_match_empty_code_never_matches() {
+        // Non-empty shared code -> 1.0; different -> 0.0.
+        assert_eq!(soundex_match("Robert", "Rupert"), 1.0);
+        assert_eq!(soundex_match("Robert", "Smith"), 0.0);
+        // Empty code (garbage) never matches -- not even another empty code, so
+        // placeholder columns don't collapse into one phonetic bucket.
+        assert_eq!(soundex_match("123", "456"), 0.0); // both "" -> still 0.0
+        assert_eq!(soundex_match("123", "123"), 0.0); // identical garbage -> 0.0
+        assert_eq!(soundex_match("", ""), 0.0);
+        assert_eq!(soundex_match("123", "Robert"), 0.0); // "" vs a real code
     }
 
     #[test]
@@ -1055,9 +1103,9 @@ mod tests {
     fn score_one_id6_is_soundex_match() {
         assert_eq!(score_one(6, "Robert", "Rupert"), 1.0); // same code
         assert_eq!(score_one(6, "Robert", "Smith"), 0.0); // different code
-        // full jellyfish parity: soundex("123")="1000" != soundex("456")="4000"
+        // Empty-code guard: garbage never matches (id 6 == soundex_match).
         assert_eq!(score_one(6, "123", "456"), 0.0);
-        assert_eq!(score_one(6, "123", "123"), 1.0);
+        assert_eq!(score_one(6, "123", "123"), 0.0); // both "" -> guarded to 0.0
     }
 
     fn _legal_forms() -> std::collections::HashSet<String> {

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -378,7 +378,11 @@ export function tokenSortRatio(a: string, b: string): number {
  * Soundex match: 1.0 if soundex codes equal, else 0.0.
  */
 export function soundexMatch(a: string, b: string): number {
-  return soundex(a) === soundex(b) ? 1.0 : 0.0;
+  // Empty code (no phonetic content) never matches -- not even another empty
+  // code -- so placeholder columns don't mega-cluster. Byte-for-byte with
+  // score-core `soundex_match` (id 6) + the Python `_soundex_score_single`.
+  const ca = soundex(a);
+  return ca !== "" && ca === soundex(b) ? 1.0 : 0.0;
 }
 
 // ---------------------------------------------------------------------------
@@ -685,9 +689,15 @@ function exactScoreMatrix(values: (string | null)[]): number[][] {
   return matrix;
 }
 
-/** Soundex score matrix: group by soundex code, 1.0 for same code. */
+/** Soundex score matrix: group by soundex code, 1.0 for same code. Empty codes
+ * (no phonetic content) map to null so they match NOTHING -- the empty-guard that
+ * mirrors score-core `soundex_match` and keeps placeholders from mega-clustering. */
 function soundexScoreMatrix(values: (string | null)[]): number[][] {
-  const codes = values.map((v) => (v !== null ? soundex(v) : null));
+  const codes = values.map((v) => {
+    if (v === null) return null;
+    const c = soundex(v);
+    return c === "" ? null : c;
+  });
   return exactScoreMatrix(codes);
 }
 

--- a/packages/typescript/goldenmatch/src/core/transforms.ts
+++ b/packages/typescript/goldenmatch/src/core/transforms.ts
@@ -118,8 +118,11 @@ const SOUNDEX_MAP: Record<string, string> = {
  * Vowels (A/E/I/O/U/Y) DO reset, so "Pfister" and "Jackson" work correctly.
  */
 export function soundex(value: string): string {
-  const clean = value.toUpperCase().replace(/[^A-Z]/g, "");
-  if (clean.length === 0) return "0000";
+  // Canonical GoldenMatch soundex (byte-matches score-core `soundex`): NFKD-fold
+  // + uppercase + keep only ASCII [A-Z] (so José->JOSE, Ñoño->NONO), then standard
+  // Soundex. No surviving letter -> "" (empty key; garbage never matches / blocks).
+  const clean = value.normalize("NFKD").toUpperCase().replace(/[^A-Z]/g, "");
+  if (clean.length === 0) return "";
 
   const firstLetter = clean[0]!;
   let code = firstLetter;

--- a/packages/typescript/goldenmatch/src/core/transforms.ts
+++ b/packages/typescript/goldenmatch/src/core/transforms.ts
@@ -118,30 +118,44 @@ const SOUNDEX_MAP: Record<string, string> = {
  * Vowels (A/E/I/O/U/Y) DO reset, so "Pfister" and "Jackson" work correctly.
  */
 export function soundex(value: string): string {
-  // Canonical GoldenMatch soundex (byte-matches score-core `soundex`): NFKD-fold
-  // + uppercase + keep only ASCII [A-Z] (so José->JOSE, Ñoño->NONO), then standard
-  // Soundex. No surviving letter -> "" (empty key; garbage never matches / blocks).
-  const clean = value.normalize("NFKD").toUpperCase().replace(/[^A-Z]/g, "");
-  if (clean.length === 0) return "";
+  // Canonical GoldenMatch soundex (byte-matches score-core `soundex`): a
+  // Unicode-folding STANDARD Soundex. NFKD-fold + uppercase, then walk the string.
+  // ASCII [A-Z] are seed / coded consonant / H-W-transparent / vowel-break; EVERY
+  // other char (digit, punctuation, whitespace, the combining marks NFKD strips off
+  // accents, exotic non-decomposable letters) is a SEPARATOR that breaks the coding
+  // run but never seeds. So multi-token names code each token's boundary consonant
+  // ("joseph bradshaw"->"J211", not merged to "J216"), accents fold to their base
+  // letter (José->J200, Muñoz->M520), and no-letter -> "" (empty key; garbage never
+  // matches / blocks). On pure ASCII this equals classic American Soundex.
+  const norm = value.normalize("NFKD").toUpperCase();
+  let code = "";
+  let lastDigit = "0"; // "0" = no previous letter code (after seed/vowel/separator)
 
-  const firstLetter = clean[0]!;
-  let code = firstLetter;
-  let lastDigit = SOUNDEX_MAP[firstLetter] ?? "0";
-
-  for (let i = 1; i < clean.length && code.length < 4; i++) {
-    const ch = clean[i]!;
-    const digit = SOUNDEX_MAP[ch];
-    if (digit && digit !== lastDigit) {
-      code += digit;
-      lastDigit = digit;
-    } else if (!digit) {
-      // Vowel / H / W / Y — only H and W are transparent (do NOT reset)
-      if (ch !== "H" && ch !== "W") {
-        lastDigit = "0";
+  for (let i = 0; i < norm.length && code.length < 4; i++) {
+    const ch = norm[i]!;
+    if (ch >= "A" && ch <= "Z") {
+      if (code.length === 0) {
+        code = ch; // seed = first surviving letter
+        lastDigit = SOUNDEX_MAP[ch] ?? "0"; // seed's code suppresses a same-code follower
+        continue;
       }
+      const digit = SOUNDEX_MAP[ch];
+      if (digit && digit !== lastDigit) {
+        code += digit;
+        lastDigit = digit;
+      } else if (!digit) {
+        // Vowel / H / W / Y — only H and W are transparent (do NOT reset)
+        if (ch !== "H" && ch !== "W") {
+          lastDigit = "0";
+        }
+      }
+    } else {
+      // Separator: break the coding run so a same code across the gap re-emits.
+      lastDigit = "0";
     }
   }
 
+  if (code.length === 0) return "";
   return (code + "0000").slice(0, 4);
 }
 

--- a/packages/typescript/goldenmatch/tests/unit/transforms.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/transforms.test.ts
@@ -99,6 +99,22 @@ describe("soundex", () => {
     expect(soundex("José")).toBe("J200");
     expect(soundex("Ñoño")).toBe("N500");
     expect(soundex("Muñoz")).toBe(soundex("Munoz"));
+    expect(soundex("Muñoz")).toBe("M520"); // ñ folds to n (jellyfish drops it -> M200)
+  });
+
+  it("separators break the coding run (standard Soundex, not strip-and-merge)", () => {
+    // A space/punctuation between tokens BREAKS adjacency, so a code on each side
+    // of the gap is kept -- stripping separators instead would merge them and
+    // regress person-name blocking/scoring. Byte-matches score-core `soundex`.
+    expect(soundex("joseph bradshaw")).toBe("J211"); // P then B kept (not "J216")
+    expect(soundex("warren nale")).toBe("W655"); // N | N kept (not "W654")
+    expect(soundex("S1S")).toBe("S200"); // the "1" breaks S|S adjacency -> 2 re-emitted
+    // Non-letters never seed: a leading digit is skipped, the first letter seeds.
+    expect(soundex("3M")).toBe("M000");
+    expect(soundex("4abc")).toBe("A120");
+    // Exotic non-decomposable letters are separators too.
+    expect(soundex("Þór")).toBe("O600");
+    expect(soundex("Æthel")).toBe("T400");
   });
 
   it("returns 4-character code for real names", () => {

--- a/packages/typescript/goldenmatch/tests/unit/transforms.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/transforms.test.ts
@@ -87,11 +87,21 @@ describe("soundex", () => {
     expect(soundex("Rupert")).toBe("R163");
   });
 
-  it("empty string -> 0000", () => {
-    expect(soundex("")).toBe("0000");
+  it("no surviving letter -> empty string (canonical spec, not 0000)", () => {
+    // Garbage / empty has no phonetic content -> "" (empty key filtered in
+    // blocking, never matches in scoring). Diverges from jellyfish on purpose.
+    expect(soundex("")).toBe("");
+    expect(soundex("123")).toBe("");
+    expect(soundex("!!")).toBe("");
   });
 
-  it("returns 4-character code", () => {
+  it("NFKD-folds accented letters (José -> J200, Ñoño -> N500)", () => {
+    expect(soundex("José")).toBe("J200");
+    expect(soundex("Ñoño")).toBe("N500");
+    expect(soundex("Muñoz")).toBe(soundex("Munoz"));
+  });
+
+  it("returns 4-character code for real names", () => {
     expect(soundex("Washington").length).toBe(4);
   });
 });


### PR DESCRIPTION
## What and why

Redefines soundex as GoldenMatch's **own** spec across every surface, with the Rust `score-core` kernel as the single reference — jellyfish is no longer the arbiter. This is the **prerequisite** that unblocks WASM-backing `soundex_match` + `ensemble` on the TS surface: their pure-TS `soundex` diverged from the kernel on non-ASCII / garbage inputs, so the kernel and the fallback weren't byte-identical (which the "kernel-backed" contract requires).

## The spec (Unicode-folding standard Soundex)

`NFKD` + uppercase, then walk the string. ASCII `[A-Z]` code as classic American Soundex (seed / consonant code / `H`-`W`-transparent / vowel-break). **Every other char — digit, punctuation, whitespace, the NFKD combining marks that fold off accents, and exotic non-decomposable letters (`Þ`/`Æ`/`Đ`) — is a SEPARATOR** that breaks the coding run but never seeds. A value with **no surviving letter** → `""`. The `soundex_match` scorer adds an **empty-code guard**: an empty code never matches, not even another empty code, so garbage/placeholder columns can't mega-cluster.

Two consequences of the separator rule:
- **Multi-token names code each token's boundary consonant** instead of merging across the gap: `"joseph bradshaw" → "J211"` (not `"J216"`), `"warren nale" → "W655"` (not `"W654"`). This is the historical person-name behavior blocking/scoring depends on.
- **Accents fold to their base letter**: `José → J200`, `Muñoz → M520` (jellyfish drops the `ñ` → `M200`).

On **pure ASCII this equals classic American Soundex** and is byte-identical to jellyfish, except jellyfish nonsensically seeds a leading digit (`"1st" → "1230"`) where this seeds the first real letter. So real names are unaffected; only garbage/leading-non-letter/accented-consonant inputs differ.

> **Correction vs the first cut of this PR:** the initial spec filtered to `[A-Z]` (STRIPPING separators), which merged codes across token boundaries and **regressed the `quality_gate`**: historical_50k F1 collapsed **0.8129 → 0.5291** (precision 0.93 → 0.38 — over-merging in the `ensemble` scorer; blocking recall was fine). Diagnosed end-to-end (jellyfish restores it, strip does not, separator-aware restores it), fixed by the separator semantics above.

## Surfaces (all conform to one spec — byte-identical native ↔ pure ↔ TS)

- **score-core**: `soundex` rewritten (separator-aware) + `soundex_match` helper (empty-guard); `score_one(6)` uses it; ensemble inherits. Native field-matrix picks up the new `soundex` for free.
- **Python**: one `canonical_soundex` in `utils/transforms.py` replaces **every** `jellyfish.soundex` call site (scorer soundex/matrix/ensemble, explainer, arrow-derive, learned blocking, the `soundex` blocking transform, the bucket per-pair callable). `_soundex_score_single` is the shared per-pair reference.
- **TS**: `soundex` walks the NFKD string with separators breaking the run; `soundexMatch` + `soundexScoreMatrix` gain the empty-guard; `ensembleScore` inherits.
- **Postgres** inherits automatically (its `soundex_match` bridges to Python).

## Testing

- `cargo test` score-core (27, incl. `soundex_canonical_in_house` with the multi-token + separator cases); clippy clean.
- **`quality_gate` PASSES (exit 0):** historical_50k **0.8129 → 0.8244** (default) / 0.826 → 0.8245 (probabilistic); ncvr_synthetic **0.9901 → 0.9932**; febrl3 + anchor_person_match unchanged.
- `pytest` soundex/scorer/field-matrix/property/probabilistic/quality-gate sweeps pass (native == pure soundex parity over thousands of adversarial pairs, incl. garbage/exotic/accented + the multi-token separator cases).
- `vitest` transforms suite (42, incl. a multi-token separator regression case); `tsc --noEmit` clean (pre-existing spike-file warning aside).

## Follow-ups (now unblocked)

- WASM-back `soundex_match` (`SCORER_ID` += id 6 → the "Python + TS" kernel row).
- WASM-back `ensemble` (needs a normalized-ensemble score-wasm arm; its soundex component is now byte-exact).

## Checklist

- [x] Tests added/updated and passing locally for the changed packages
- [x] Cross-surface byte-parity re-blessed (cargo/pytest/vitest); tsc + ruff + clippy clean
- [x] `quality_gate` (ci-required) passes locally on all datasets
- [x] No secrets, tokens, or `.env` files committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_