### PR TITLE
Architecture-aware dead-code detection (spec + Phase 1 module-level prototype)

### DIFF
--- a/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+++ b/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
@@ -145,6 +145,46 @@ thousands of `score` uses) is masked, as is a dead-but-doc-mentioned symbol. Hig
 a **scope-aware AST reference resolver** (resolve each `Name`/`Attribute` load to its binding via
 per-file import resolution) — **Phase 2b**, higher FP, managed by the `dead_code_deferred` map.
 
+**Phase 2b — scope-aware symbols** (`--scoped`): resolves every `Name`/`Attribute` load through
+each file's import bindings (`from m import s` → `sym_binds`; `import m`/`from p import submod` →
+`mod_binds`) to the concrete `(module, symbol)` it references — across package source **plus** the
+sibling `<pkg>/tests` suite — so a dead symbol is no longer masked by a same-named token elsewhere.
+Survivors split into **strong** (no resolved use *and* no bare-string reference in package source)
+vs **string-referenced** (unused-by-resolver but the name appears as a source string literal —
+`__all__` export / dispatch registry / FFI mirror; a low-confidence quarantine, verify before
+cutting). Result on goldenmatch: **72 unused / 2375 undecorated top-level def/class — 37 strong,
+35 string-referenced.** The string-referenced bucket correctly quarantines public API
+(`_api.dedupe`/`score_strings`/`pprl_link`), MCP-dispatched `identity.profile.*`, and Alembic
+`upgrade` — all live via string dispatch, all kept out of the strong list. The strong list is
+mostly known out-of-band surfaces (5 connector classes via `load_connector()` `"module:Class"`
+dispatch, 4 Alembic `downgrade` runtime hooks, 6 refdata `_reload` maintenance helpers, model
+loaders `load_cross_encoder`/`get_smart_embedder`), plus a **genuine-dead core of ≥7** (zero
+in-code references in any language, docs excluded):
+
+| Symbol | Why dead |
+|---|---|
+| `distributed.clustering._label_prop_threshold` | last call site removed by the #956 routing rewrite (the spec claimed callers/tests kept it; the resolver found none — 7 refs are all in specs/plans) |
+| `distributed.pipeline._join_clusters_to_rows` | its own docstring says it was replaced by the scale broadcast-join path |
+| `distributed.pipeline._write_golden_output` | zero references |
+| `distributed.golden._per_partition_golden` | zero references |
+| `core.cluster.get_cluster_pair_scores` | zero references (public name, never wired) |
+| `web.runs.lineage_pair_keys` | zero references |
+| `core.perceptual._dct1d_matrix` | zero references |
+
+**Two real resolver-substrate bugs surfaced (and fixed in the tool):** (1) two source files
+(`core/autoconfig_planner.py`, `core/execution_plan.py`) carry a **UTF-8 BOM** — read as plain
+`utf-8` they fail `ast.parse` and get *silently skipped*, dropping every use they contain (this
+false-flagged the 3 `autoconfig_native.plan_*` symbols they call); fixed by reading `utf-8-sig`
+everywhere the tool feeds `ast.parse`. (2) the goldenmatch test suite is a **sibling** of the
+source root (`<pkg>/tests`, not under `<pkg>/<pkg>`), so the first cut scanned only source and
+falsely flagged every test-only-consumed symbol — 219 → 75 once the sibling suite was included.
+Both are the same class of "the substrate under-scans" bug the Phase-1 agent-codemap edge finding
+was. **Phase 2b enforcement** (a symbol-level `dead_code_deferred` map + `--check` gate) and the
+removal of the genuine-dead core are follow-ons: the symbol map can't live in the module-level
+`parity/dead_code/<pkg>.yaml` (symbol keys read as phantom modules there), so it needs its own
+sidecar; the 7-symbol deletion touches the distributed engine + perceptual + web and is a
+separately-reviewed cleanup, not part of the detector PR.
+
 ## Non-goals / limits
 
 - The prototype does not do symbol-level analysis (Phase 2) — it reports whole-module orphans.

--- a/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+++ b/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
@@ -122,6 +122,29 @@ Modeled on `check_api_parity.py` / `check_native_symbols.py` (AST-based, allowli
 - **Phase 4: populate `parity/native_symbols/*.allow`** from the FFI greps and add a REST/web
   route manifest — closes the two grep-only root gaps — then promote the gate into `ci-required`.
 
+## Prototype results (2026-07-22, goldenmatch-Python)
+
+**Phase 1 — modules** (`check_dead_code.py`, self-built AST graph): **14 orphans / 406 modules.**
+All classifiable (`parity/dead_code/goldenmatch.yaml`): 13 legitimate out-of-band surfaces —
+connector `load_connector()` dynamic dispatch (5), Alembic migration runtime (5), codegen
+(`config_lint.docgen`), maintenance regen scripts (2) — plus **1 genuine candidate**,
+`goldenmatch.sail.session` (an unwired Spark-session helper: no module and no test imports it;
+`sail/__init__` imports pyspark lazily inside the identity builders, not via this helper). At
+module granularity goldenmatch is effectively clean.
+
+Incidental substrate finding: the first pass (over `agent-codemap.json`) false-flagged ~35 real
+modules because the codemap under-records `from <pkg> import <submodule>` edges — a soundness
+bug in a committed, CI-gated artifact (fix tracked separately; the gate now self-builds its graph).
+
+**Phase 2 — symbols** (`--symbols`, bare-name occurrence scan): **0 unreferenced / 2280
+undecorated top-level def/class symbols.** Mechanism validated (a planted unique
+`def zz_...` is correctly flagged). So goldenmatch has no uniquely-named, truly-unreferenced
+top-level symbols. **Recall caveat:** the bare-name occurrence test is low-FP but low-recall — a
+dead symbol whose name collides with any unrelated token (a dead `def score` hidden behind the
+thousands of `score` uses) is masked, as is a dead-but-doc-mentioned symbol. Higher recall needs
+a **scope-aware AST reference resolver** (resolve each `Name`/`Attribute` load to its binding via
+per-file import resolution) — **Phase 2b**, higher FP, managed by the `dead_code_deferred` map.
+
 ## Non-goals / limits
 
 - The prototype does not do symbol-level analysis (Phase 2) — it reports whole-module orphans.

--- a/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+++ b/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
@@ -1,0 +1,131 @@
+# Architecture-aware dead-code detection
+
+**Status:** draft (prototype landed for goldenmatch-Python module layer)
+**Date:** 2026-07-22
+
+## Problem
+
+Off-the-shelf dead-code tools (`vulture`, `ts-prune`, Rust `dead_code`) are wrong for this
+repo. In a **Rust + Arrow-native source-of-truth, fused-compute** codebase, *"never runs by
+default"* is not *"dead."* The patterns that make the thesis work look exactly like dead code
+to a naive scanner:
+
+| Pattern | Why it looks dead | Why it is load-bearing |
+|---|---|---|
+| Pure-Python/TS **fallbacks** (`_native_loader` → `GOLDENMATCH_*_NATIVE=0`) | native is default-on, so the fallback branch has 0 coverage in the normal lane | it is the *lossy reference fallback* the reference-mode roadmap depends on; and the only path in the `nopolars` lane |
+| **Parity oracles** (`GOLDENMATCH_FS_EM_BLOCK_SLIM=0` = "full-width parity oracle") | never runs by default | it is the correctness ground-truth the kernel is diffed against |
+| **Opt-in kernels/features** (default-OFF `GOLDENMATCH_*` flags, ~163 of them) | unreached unless the flag is set | shipped capability, gated on by users |
+| **FFI/ABI exports** (`wrap_pyfunction!`, `#[wasm_bindgen]`, cabi, `#[pg_extern]`) | no in-language caller | called by name/ABI across the language boundary — invisible to same-language analysis |
+| **Public API** (`__all__`, `package.json` exports) | no internal caller | PyPI/npm consumers |
+
+The inverse failure — **phantom-live** code — matters just as much: a "primary" path that
+*looks* live but silently never executes because an exception-swallowing fallback always fires
+(the #688 rayon park; the goldengraph `ModuleNotFoundError: polars` that RED-committed for
+weeks). That is dead code masquerading as the hot path.
+
+## Definition of dead (thesis-consistent)
+
+> Code is **dead** iff it is unreachable from every declared surface **and** every FFI/ABI
+> export, is **not** the pure-language reference/fallback for a kernel, is **not** a parity
+> oracle, is **not** gated behind a declared opt-in flag, and is **not** in the
+> out-of-band-tested `omit` set. Everything else — even at 0% default coverage — is
+> **dormant-but-load-bearing**.
+
+Reachability, not coverage, is the primary signal. Coverage in CI runs only the native-ON +
+polars-present lanes (shards 1-3 + heavy); the fallback (`GOLDENMATCH_NATIVE=0`), `nopolars`,
+and arrow-frame lanes carry no `--cov`, so a coverage-first verdict would delete precisely the
+reference/fallback contract. Coverage is used only as *corroboration* and for the phantom-live
+check.
+
+## Prior art in this repo (reuse, don't reinvent)
+
+The repo already encodes reachability in a CI-enforced drift-gate ecosystem (18 `check_*` +
+5 `gen_*`, most in `ci-required`). The dead-code gate is modeled on it:
+
+- **`docs/agent-codemap.json`** (`agent_codemap.py`, `--check`/`--write`, gated): a pure-AST
+  import graph over the Python source — 404 goldenmatch modules with per-module `imports`.
+  The AST walk captures function-level *lazy* imports too, so it is a **sound module-level
+  reachability substrate**.
+- **`parity/*.yaml`** (`check_api_parity.py`, `api_parity` gate): machine-readable names for
+  MCP tools / CLI commands / A2A skills / scorers / transforms / blocking strategies /
+  `scorer_kernels`. Includes **`scorer_kernels_deferred`** — a flat `name → reason` map
+  validated by `check_scorer_coverage` (uncovered / stale / phantom / missing-reason). This is
+  the exact template for `dead_code_deferred`.
+- **`docs/agent-manifest.json`** (`gen_config_matrix.py --manifest`): config models, CLI, MCP,
+  `env_vars`, and the `rust_crates` roster.
+- **config-matrix** (`scan_env_vars` regex, "scanned from source, complete"): the ~163
+  `GOLDENMATCH_*` flags — every opt-in/oracle entry point, by name.
+- **`goldenmatch/core/_native_loader.py`**: `_COMPONENT_SYMBOLS` (component → native symbol)
+  + grep-stable `native_enabled("<comp>")` / `native_module()` call sites + `_FALLBACK_ONLY`.
+  Enumerates the native-fallback branches by call site (fallback *function names* are
+  inconsistent — `_py` / `_python` / inline — so do NOT match on name).
+- **`parity/native_symbols/*.allow`** (`check_native_symbols.py`, `native_symbols` gate): the
+  pre-built — currently **empty** — slot for FFI-root allowlists.
+
+## Roots and allow-list (where each comes from)
+
+**Reachability roots** (a symbol/module reached from any of these is live):
+
+| Root | Machine source today |
+|---|---|
+| MCP tools / CLI / A2A / scorers / transforms / blocking | `parity/goldenmatch.yaml` (names) + declaring modules |
+| Config models, env-flag-gated paths (~163) | `agent-manifest.json` + config-matrix |
+| Public API | `goldenmatch/__init__.py::__all__` |
+| Rust crate roster | `agent-manifest.json::rust_crates` |
+| Rust→Python / WASM / C-ABI / pgrx exports | **grep-only today** → populate `parity/native_symbols/*.allow` |
+| REST / web routes | **grep-only today** (path/decorator dispatch) → small new manifest |
+| Plugin entry points | `plugins/registry.py::_GROUPS` + external `pyproject` entry_points |
+| Tests / benches | pytest/vitest/cargo-test collection |
+
+**Dormant-but-load-bearing allow-list** (unreached-by-default but NOT dead):
+
+- native fallbacks — from `_COMPONENT_SYMBOLS` + `native_enabled(...)` call sites.
+- env-gated paths — from `scan_env_vars("GOLDENMATCH_", ...)`.
+- parity oracles / opt-in / kill-switch — **the one gap**: classification is prose only today
+  (greppable vocabulary: `parity oracle`, `byte-identical`, `default OFF`, `kill-switch`, "the
+  #662 kill-switch pattern"). Formalized via the `dead_code_deferred` map below.
+
+## The gate: `scripts/check_dead_code.py`
+
+Modeled on `check_api_parity.py` / `check_native_symbols.py` (AST-based, allowlist-driven,
+`--check`/`--write`, per-package matrix job).
+
+1. **Substrate**: reachability graph from `agent-codemap.json`.
+2. **Roots**: union of the table above (start with the machine-enumerable ones; populate the
+   FFI/route gaps).
+3. **Dormant allow-list**: native-fallback call sites + env-gated paths + the
+   `dead_code_deferred` map.
+4. **Verdict**: unreached from all roots **AND** not dormant **AND** not in the coverage-`omit`
+   set = genuinely-dead suspect.
+5. **Discipline**: every suspect is either **deleted** or added to
+   **`dead_code_deferred:`** in `parity/<pkg>.yaml` — a flat `symbol/module → reason` map with a
+   prefixed vocabulary (`oracle --` / `fallback --` / `surface --` / `dead --`), validated by
+   four rules mirroring `check_scorer_coverage`: *uncovered* (a suspect neither reachable nor
+   deferred → fail), *stale* (deferred but now reachable), *phantom* (deferred but not a real
+   symbol), *missing-reason*.
+6. **Companion phantom-live check**: assert the native/primary branch actually has coverage in
+   its own lane (native lane), so a silent-always-fallback is caught as phantom-dead.
+
+## Phased rollout
+
+- **Phase 1 (this PR): module-level orphans, goldenmatch-Python.** Robust and low-false-positive
+  — a module either is reached over the import graph or is not. Naturally immune to the
+  fallback/oracle trap (fallback *modules* are still imported; only a *branch* is dormant).
+  Prototype: `scripts/check_dead_code.py`.
+- **Phase 2: symbol-level** (unused top-level `def`/`class`) with the `dead_code_deferred`
+  discipline + repo-wide identifier/string-literal reference scan to keep FP low.
+- **Phase 3: TS** via `knip` (needs a `knip.json` with all `package.json` `exports`/`bin` +
+  the three vitest configs + `tests/parity/**` + `examples/*.ts` as entries) and **Rust** via
+  whole-graph `cargo-udeps` per standalone crate (per-crate `dead_code` over-reports because
+  `-core` libs are consumed cross-crate and `-native`/`-wasm` pub fns are reached only through
+  export macros).
+- **Phase 4: populate `parity/native_symbols/*.allow`** from the FFI greps and add a REST/web
+  route manifest — closes the two grep-only root gaps — then promote the gate into `ci-required`.
+
+## Non-goals / limits
+
+- The prototype does not do symbol-level analysis (Phase 2) — it reports whole-module orphans.
+- It trusts `agent-codemap.json` as the import graph; entry surfaces reached only via string
+  dispatch (MCP/A2A/CLI/route handlers) are added as explicit roots.
+- Coverage is not consulted in Phase 1 (reachability is sufficient and more robust); it enters
+  in the phantom-live companion check (Phase 2+).

--- a/parity/dead_code/goldenmatch.yaml
+++ b/parity/dead_code/goldenmatch.yaml
@@ -1,0 +1,37 @@
+# dead_code_deferred (goldenmatch) -- module-level classification map.
+# Spec: docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+# Every module that check_dead_code.py flags as reachable from no in-process surface must be
+# EITHER deleted OR listed here with a reason. Reason prefix vocabulary:
+#   surface --  reached out-of-band (external runtime, dynamic dispatch, codegen); NOT dead
+#   fallback -- pure-language reference for a native kernel (native-off path)
+#   oracle --   parity ground-truth the kernel is diffed against
+#   dead --     confirmed dead; scheduled for removal (with the removal ref)
+#
+# Bootstrap 2026-07-22 (Phase 1, module granularity). Format: `module: reason`.
+
+# -- dynamic connector dispatch: load_connector() resolves a string -> "module:Class" map
+#    (connectors/base.py); no static import, so invisible to reachability. Optional deps.
+goldenmatch.connectors.bigquery: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
+goldenmatch.connectors.databricks: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
+goldenmatch.connectors.hubspot: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
+goldenmatch.connectors.salesforce: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
+goldenmatch.connectors.snowflake: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
+
+# -- codegen invoked by a repo script, not imported by the package
+goldenmatch.core.config_lint.docgen: "surface -- codegen, invoked by scripts/gen_lint_docs.py"
+
+# -- Alembic migration runtime loads env + versions by convention (goldenmatch identity migrate)
+goldenmatch.db.alembic.env: "surface -- Alembic runtime entry (loaded by the alembic command)"
+goldenmatch.db.alembic.versions.0001_identity_v1: "surface -- Alembic migration (runtime-discovered)"
+goldenmatch.db.alembic.versions.0002_provenance_actor_trust: "surface -- Alembic migration (runtime-discovered)"
+goldenmatch.db.alembic.versions.0003_audit_hash_chain: "surface -- Alembic migration (runtime-discovered)"
+goldenmatch.db.alembic.versions.0004_claim_authority: "surface -- Alembic migration (runtime-discovered)"
+
+# -- maintenance regeneration scripts (run by hand to refresh committed reference data)
+goldenmatch.refdata.scripts: "surface -- maintenance package (regen scripts, not runtime)"
+goldenmatch.refdata.scripts.fetch_census_surnames: "surface -- maintenance regen script"
+
+# -- GENUINE CANDIDATE: no module and no test imports it; sail/__init__ imports pyspark lazily
+#    inside the identity builders, not via this session helper. Owner review: wire, expose as
+#    [sail]-extra public API, or remove. Left deferred pending that decision.
+goldenmatch.sail.session: "dead -- unwired Spark-session helper; no importer (owner review, see spec)"

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""Architecture-aware dead-code gate (Phase 1: module-level orphans).
+
+Spec: docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+
+In a Rust + Arrow-native, fused-compute codebase, "never runs by default" is NOT
+"dead": pure-language fallbacks, parity oracles, and default-OFF opt-in kernels are
+dormant-but-load-bearing. Off-the-shelf tools delete exactly those. This gate instead
+computes REACHABILITY from the repo's declared surfaces + FFI/ABI exports and reports
+only modules reachable from none of them -- then requires each survivor to be deleted
+or classified into a `dead_code_deferred` map (mirroring `scorer_kernels_deferred`).
+
+Phase 1 works at MODULE granularity over the committed AST import graph
+(`docs/agent-codemap.json`, whose walk captures lazy/function-level imports too), so it
+is naturally immune to the fallback/oracle trap: a fallback *module* is still imported;
+only a *branch* inside it is dormant. Symbol-level analysis is Phase 2.
+
+Usage:
+  python scripts/check_dead_code.py [pkg]           # report (default pkg: goldenmatch)
+  python scripts/check_dead_code.py [pkg] --check    # exit 1 if uncovered orphans exist
+"""
+from __future__ import annotations
+
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+CODEMAP = REPO / "docs" / "agent-codemap.json"
+
+# Entry-surface hubs invoked from OUTSIDE the import graph (console_scripts, server
+# bootstraps, plugin discovery). A module reached from any of these is live. Matched as
+# a substring of the module dotted-path; `{pkg}` is filled per package.
+_ENTRY_HUBS = (
+    "{pkg}",                 # top __init__ -- the public API surface (__all__ re-exports)
+    "{pkg}.__main__",
+    "{pkg}.cli.main",        # console_scripts: {pkg} = {pkg}.cli.main:app
+    "{pkg}.mcp.server",      # MCP stdio/http server bootstrap
+    "{pkg}.a2a.server",      # A2A agent server bootstrap
+    "{pkg}.api.server",      # REST server bootstrap
+    "{pkg}.web.app",         # FastAPI app factory
+    "{pkg}.plugins.registry",
+    "{pkg}.plugins.builtin",  # entry-point-discovered plugin classes
+)
+
+
+def _load_pkg(pkg: str) -> dict:
+    data = json.loads(CODEMAP.read_text())
+    pkgs = data["packages"]
+    if pkg not in pkgs:
+        sys.exit(f"error: package {pkg!r} not in agent-codemap.json (have: {sorted(pkgs)})")
+    return pkgs[pkg]
+
+
+def _src_root(pkg: str) -> Path:
+    """The `<pkg>/<pkg>/` source dir from the codemap's `root` field."""
+    return REPO / _load_pkg(pkg)["root"]
+
+
+def _module_name(path: Path, src_root: Path, pkg: str) -> str:
+    rel = path.relative_to(src_root).with_suffix("")
+    parts = list(rel.parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join([pkg, *parts]) if parts else pkg
+
+
+def build_graph_ast(pkg: str) -> tuple[dict[str, dict], dict[str, set[str]]]:
+    """Build the module set + internal import graph with a DIRECT AST scan of the source
+    tree -- NOT via agent-codemap.json, which under-records `from <pkg> import <submodule>`
+    edges (verified: `from goldenmatch.core import sketch` etc. are absent from the codemap).
+    Resolving imports needs the full module set first, so this is two passes."""
+    src_root = _src_root(pkg)
+    # Exclude in-package test code (some packages embed a `tests/` subpackage) -- it is not
+    # shippable surface and its modules would false-flag as orphans.
+    files = [
+        p for p in src_root.rglob("*.py")
+        if "tests" not in p.relative_to(src_root).parts
+        and not p.name.startswith("test_")
+        and p.name != "conftest.py"
+    ]
+    modules: dict[str, dict] = {}
+    for f in files:
+        name = _module_name(f, src_root, pkg)
+        purpose = ""
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8", errors="ignore"))
+            doc = ast.get_docstring(tree)
+            purpose = (doc or "").strip().splitlines()[0] if doc else ""
+        except SyntaxError:
+            tree = None
+        modules[name] = {"file": str(f.relative_to(REPO)), "purpose": purpose, "_tree": tree}
+    known = set(modules)
+
+    def resolve(target: str) -> str | None:
+        """Map a dotted import target to the internal module it names (or its nearest
+        internal package ancestor). `from a.b import c` may name module `a.b.c` OR symbol
+        `c` of module `a.b` -- try the longer first."""
+        if target in known:
+            return target
+        anc = ".".join(target.split(".")[:-1])
+        return anc if anc in known else None
+
+    graph: dict[str, set[str]] = {}
+    for name, m in modules.items():
+        edges: set[str] = set()
+        tree = m.pop("_tree")
+        if tree is None:
+            graph[name] = edges
+            continue
+        pkg_of = name if m["file"].endswith("__init__.py") else name.rsplit(".", 1)[0]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for a in node.names:
+                    if (r := resolve(a.name)):
+                        edges.add(r)
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:  # relative: from . / .. import X
+                    base_parts = pkg_of.split(".")
+                    up = node.level - 1
+                    base = ".".join(base_parts[: len(base_parts) - up]) if up else pkg_of
+                    mod = f"{base}.{node.module}" if node.module else base
+                else:
+                    mod = node.module or ""
+                if not mod.startswith(pkg):
+                    continue
+                # each imported name may itself be a submodule (from pkg import submod)
+                for a in node.names:
+                    if (r := resolve(f"{mod}.{a.name}")):
+                        edges.add(r)
+                if (r := resolve(mod)):
+                    edges.add(r)
+        graph[name] = edges
+    return modules, graph
+
+
+def _ancestors(mod: str) -> list[str]:
+    """`a.b.c` -> [`a`, `a.b`] -- Python imports every parent package to reach a submodule."""
+    parts = mod.split(".")
+    return [".".join(parts[:i]) for i in range(1, len(parts))]
+
+
+def _scan_test_imports(pkg: str, src_root: Path) -> set[str]:
+    """Modules imported by the test suite are exercised (roots) even if no source imports
+    them. tests/ lives beside the package dir (../tests from the {pkg}/{pkg} source root)."""
+    tests_dir = src_root.parent / "tests"
+    if not tests_dir.is_dir():
+        return set()
+    hit: set[str] = set()
+    pat = re.compile(rf"\b(?:from|import)\s+({re.escape(pkg)}(?:\.[A-Za-z0-9_]+)*)")
+    for f in tests_dir.rglob("*.py"):
+        try:
+            text = f.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for m in pat.finditer(text):
+            hit.add(m.group(1))
+    return hit
+
+
+def _load_deferred(pkg: str) -> dict[str, str]:
+    """`{module: reason}` classification map at parity/dead_code/<pkg>.yaml (optional; a
+    dedicated sibling file, mirroring parity/native_symbols/, so it doesn't perturb the
+    api_parity gate). Reason convention: `surface --` (out-of-band runtime / dynamic
+    dispatch / codegen) / `fallback --` (native-off reference) / `oracle --` (parity
+    ground-truth) / `dead --` (scheduled for removal). Tiny hand-rolled reader -- no yaml dep."""
+    pf = REPO / "parity" / "dead_code" / f"{pkg}.yaml"
+    if not pf.is_file():
+        return {}
+    out: dict[str, str] = {}
+    for raw in pf.read_text().splitlines():
+        if raw.lstrip().startswith("#") or not raw.strip():
+            continue
+        m = re.match(r"^([A-Za-z0-9_.]+):\s*(.+?)\s*$", raw)
+        if m:
+            out[m.group(1)] = m.group(2).strip().strip('"').strip("'")
+    return out
+
+
+def analyze(pkg: str) -> dict:
+    src_root = _src_root(pkg)
+    modules, graph = build_graph_ast(pkg)
+    known = set(modules)
+
+    # adjacency + ancestor packages of each import (Python loads parents to reach a submodule)
+    adj: dict[str, set[str]] = {}
+    for name, edges in graph.items():
+        e = set(edges)
+        for imp in list(edges):
+            e.update(a for a in _ancestors(imp) if a in known)
+        adj[name] = e
+
+    # roots: entry hubs (present in the tree) + test-imported modules (+ ancestors)
+    roots: set[str] = set()
+    for hub in _ENTRY_HUBS:
+        h = hub.format(pkg=pkg)
+        if h in known:
+            roots.add(h)
+    test_roots = {t for t in _scan_test_imports(pkg, src_root) if t in known}
+    roots |= test_roots
+    for r in list(roots):
+        roots.update(a for a in _ancestors(r) if a in known)
+
+    # BFS reachability
+    reachable: set[str] = set()
+    stack = list(roots)
+    while stack:
+        cur = stack.pop()
+        if cur in reachable:
+            continue
+        reachable.add(cur)
+        stack.extend(adj.get(cur, ()))
+    # a package __init__ is live if any submodule is live (Python loads the parent)
+    for name in list(reachable):
+        reachable.update(a for a in _ancestors(name) if a in known)
+
+    deferred = _load_deferred(pkg)
+    orphans = sorted(known - reachable)
+    uncovered = [o for o in orphans if o not in deferred]
+    stale = sorted(d for d in deferred if d in reachable)          # deferred but now live
+    phantom = sorted(d for d in deferred if d not in known)         # deferred but not a module
+
+    return {
+        "pkg": pkg,
+        "total": len(known),
+        "reachable": len(reachable),
+        "roots": sorted(roots),
+        "test_only_roots": sorted(test_roots - {r for r in roots if r in adj and adj[r]}),
+        "orphans": orphans,
+        "uncovered": uncovered,
+        "deferred": deferred,
+        "stale_deferrals": stale,
+        "phantom_deferrals": phantom,
+        "modules": modules,
+    }
+
+
+def main(argv: list[str]) -> int:
+    args = [a for a in argv if not a.startswith("--")]
+    check = "--check" in argv
+    pkg = args[0] if args else "goldenmatch"
+    r = analyze(pkg)
+
+    print(f"== dead-code (module-level) :: {pkg} ==")
+    print(f"modules={r['total']}  reachable={r['reachable']}  "
+          f"orphans={len(r['orphans'])}  uncovered={len(r['uncovered'])}  "
+          f"deferred={len(r['deferred'])}")
+    if r["orphans"]:
+        print("\n-- orphan modules (reachable from no declared surface) --")
+        for o in r["orphans"]:
+            tag = "  [DEFERRED]" if o in r["deferred"] else ""
+            print(f"  {o}{tag}")
+            print(f"      {r['modules'][o]['file']}")
+            purpose = (r['modules'][o].get('purpose') or '').strip().splitlines()[:1]
+            if purpose:
+                print(f"      → {purpose[0][:100]}")
+    if r["stale_deferrals"]:
+        print("\n-- STALE deferrals (now reachable; remove from dead_code_deferred) --")
+        for s in r["stale_deferrals"]:
+            print(f"  {s}")
+    if r["phantom_deferrals"]:
+        print("\n-- PHANTOM deferrals (not a real module) --")
+        for s in r["phantom_deferrals"]:
+            print(f"  {s}")
+
+    ok = not r["uncovered"] and not r["stale_deferrals"] and not r["phantom_deferrals"]
+    if check:
+        if ok:
+            print("\nOK: every orphan is classified in dead_code_deferred.")
+            return 0
+        print(f"\nFAIL: {len(r['uncovered'])} uncovered orphan(s) -- delete them or add a "
+              f"dead_code_deferred entry (oracle-- / fallback-- / surface-- / dead--).")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -237,10 +237,94 @@ def analyze(pkg: str) -> dict:
     }
 
 
+_IDENT = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_SCAN_EXT = {".py", ".rs", ".ts", ".tsx", ".mjs", ".cjs", ".mdx", ".md",
+             ".yaml", ".yml", ".json", ".toml", ".sql", ".ipynb"}
+_SCAN_SKIP = {".git", "node_modules", "target", "dist", "build", ".venv",
+              "__pycache__", ".mypy_cache", ".ruff_cache", ".pytest_cache", "htmlcov"}
+
+
+def _repo_text_files():
+    for p in REPO.rglob("*"):
+        if not p.is_file() or p.suffix not in _SCAN_EXT:
+            continue
+        if any(part in _SCAN_SKIP for part in p.parts):
+            continue
+        yield p
+
+
+def analyze_symbols(pkg: str) -> dict:
+    """Phase 2: module-level (top-level) `def`/`class` symbols referenced NOWHERE in the
+    whole repo -- code, string literals, tests, other languages, docs. A symbol whose total
+    repo-wide identifier occurrences do not exceed its definition count has zero references.
+
+    Architecture-aware without special-casing: because the scan counts occurrences inside
+    STRING LITERALS and across ALL file types, names that are exported (`__all__` string),
+    string-dispatched (MCP/A2A/scorer registries), FFI-exported (Rust/TS mirrors), or
+    referenced only by tests are all automatically kept alive. The one form the occurrence
+    count can't see is DECORATOR registration (`@app.command`, `@router.get`, `@pytest.fixture`,
+    pydantic validators), so decorated defs/classes are excluded from suspicion up front."""
+    src_root = _src_root(pkg)
+    files = [
+        p for p in src_root.rglob("*.py")
+        if "tests" not in p.relative_to(src_root).parts
+        and not p.name.startswith("test_") and p.name != "conftest.py"
+    ]
+    # candidate top-level symbols: {name: [(module_file, lineno), ...]}
+    cands: dict[str, list[tuple[str, int]]] = {}
+    for f in files:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+        rel = str(f.relative_to(REPO))
+        for node in tree.body:  # top-level only
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                if node.decorator_list:            # decorator may register out-of-band
+                    continue
+                if node.name.startswith("__") and node.name.endswith("__"):
+                    continue
+                cands.setdefault(node.name, []).append((rel, node.lineno))
+    names = set(cands)
+
+    # repo-wide occurrence count, restricted to candidate names (cheap)
+    counts: dict[str, int] = dict.fromkeys(names, 0)
+    for p in _repo_text_files():
+        try:
+            text = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        for tok in _IDENT.findall(text):
+            if tok in counts:
+                counts[tok] += 1
+
+    dead = []
+    for name, defs in cands.items():
+        if counts[name] <= len(defs):  # occurrences never exceed the definition(s) => unreferenced
+            for (file, line) in defs:
+                dead.append((name, file, line))
+    dead.sort(key=lambda t: (t[1], t[2]))
+    return {"pkg": pkg, "n_symbols": len(cands), "dead": dead}
+
+
 def main(argv: list[str]) -> int:
     args = [a for a in argv if not a.startswith("--")]
     check = "--check" in argv
     pkg = args[0] if args else "goldenmatch"
+
+    if "--symbols" in argv:
+        s = analyze_symbols(pkg)
+        print(f"== dead-code (symbol-level) :: {pkg} ==")
+        print(f"top-level def/class symbols (undecorated)={s['n_symbols']}  "
+              f"unreferenced_anywhere={len(s['dead'])}")
+        for name, file, line in s["dead"]:
+            print(f"  {name}\n      {file}:{line}")
+        print("\nnote: LOW-recall / low-FP pass -- flags only symbols whose bare name occurs "
+              "NOWHERE else in the repo (code+strings+tests+other langs+docs). A dead symbol "
+              "whose name collides with any unrelated token is masked; higher recall needs a "
+              "scope-aware AST reference resolver (Phase 2b).")
+        return 0
+
     r = analyze(pkg)
 
     print(f"== dead-code (module-level) :: {pkg} ==")

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -16,8 +16,10 @@ is naturally immune to the fallback/oracle trap: a fallback *module* is still im
 only a *branch* inside it is dormant. Symbol-level analysis is Phase 2.
 
 Usage:
-  python scripts/check_dead_code.py [pkg]           # report (default pkg: goldenmatch)
+  python scripts/check_dead_code.py [pkg]           # module-level report (default: goldenmatch)
   python scripts/check_dead_code.py [pkg] --check    # exit 1 if uncovered orphans exist
+  python scripts/check_dead_code.py [pkg] --symbols  # Phase 2a: bare-name symbol scan (low-FP)
+  python scripts/check_dead_code.py [pkg] --scoped   # Phase 2b: scope-aware symbol resolver
 """
 from __future__ import annotations
 
@@ -86,7 +88,7 @@ def build_graph_ast(pkg: str) -> tuple[dict[str, dict], dict[str, set[str]]]:
         name = _module_name(f, src_root, pkg)
         purpose = ""
         try:
-            tree = ast.parse(f.read_text(encoding="utf-8", errors="ignore"))
+            tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
             doc = ast.get_docstring(tree)
             purpose = (doc or "").strip().splitlines()[0] if doc else ""
         except SyntaxError:
@@ -152,7 +154,7 @@ def _scan_test_imports(pkg: str, src_root: Path) -> set[str]:
     pat = re.compile(rf"\b(?:from|import)\s+({re.escape(pkg)}(?:\.[A-Za-z0-9_]+)*)")
     for f in tests_dir.rglob("*.py"):
         try:
-            text = f.read_text(encoding="utf-8", errors="ignore")
+            text = f.read_text(encoding="utf-8-sig", errors="ignore")
         except OSError:
             continue
         for m in pat.finditer(text):
@@ -274,7 +276,7 @@ def analyze_symbols(pkg: str) -> dict:
     cands: dict[str, list[tuple[str, int]]] = {}
     for f in files:
         try:
-            tree = ast.parse(f.read_text(encoding="utf-8", errors="ignore"))
+            tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
         except SyntaxError:
             continue
         rel = str(f.relative_to(REPO))
@@ -291,7 +293,7 @@ def analyze_symbols(pkg: str) -> dict:
     counts: dict[str, int] = dict.fromkeys(names, 0)
     for p in _repo_text_files():
         try:
-            text = p.read_text(encoding="utf-8", errors="ignore")
+            text = p.read_text(encoding="utf-8-sig", errors="ignore")
         except OSError:
             continue
         for tok in _IDENT.findall(text):
@@ -307,10 +309,164 @@ def analyze_symbols(pkg: str) -> dict:
     return {"pkg": pkg, "n_symbols": len(cands), "dead": dead}
 
 
+def _attr_chain(node: ast.AST) -> list[str] | None:
+    """Leftmost-first dotted names of a Name/Attribute load chain (`a.b.c` -> [a,b,c])."""
+    parts: list[str] = []
+    cur = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Name):
+        parts.append(cur.id)
+        return list(reversed(parts))
+    return None
+
+
+def analyze_symbols_scoped(pkg: str) -> dict:
+    """Phase 2b: SCOPE-AWARE unused top-level symbols. Resolves every Name/Attribute load
+    through each file's import bindings to the concrete (module, symbol) it references -- so a
+    dead `def score` in module X is no longer masked by an unrelated `score` token elsewhere.
+
+    A top-level def/class M.S is a candidate if no resolved use targets it and it isn't
+    referenced as a bare STRING literal anywhere in the package source (that keep-alive covers
+    __all__ exports + dispatch registries + FFI/cross-lang mirrors, without the whole-repo
+    prose masking of Phase 2a). Decorated defs excluded (out-of-band registration)."""
+    src_root = _src_root(pkg)
+    known_modules, _ = build_graph_ast(pkg)  # source-only module set
+
+    def is_src(p: Path) -> bool:
+        parts = p.relative_to(src_root).parts
+        return "tests" not in parts and not p.name.startswith("test_") and p.name != "conftest.py"
+
+    # candidate defs (source only): {(module, name): (file, line)}
+    src_files = [p for p in src_root.rglob("*.py") if is_src(p)]
+    defs: dict[tuple[str, str], tuple[str, int]] = {}
+    top_names: dict[str, set[str]] = {}
+    for f in src_files:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        mod = _module_name(f, src_root, pkg)
+        names: set[str] = set()
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                names.add(node.name)
+                if node.decorator_list or (node.name.startswith("__") and node.name.endswith("__")):
+                    continue
+                defs[(mod, node.name)] = (str(f.relative_to(REPO)), node.lineno)
+        top_names[mod] = names
+
+    # resolve uses across source, in-package tests, AND the sibling test suite (the real
+    # goldenmatch tests live at <pkg>/tests, a SIBLING of the <pkg>/<pkg> source root -- not
+    # under it -- so a source-only scan falsely flags every test-only-consumed symbol).
+    all_py = list(src_root.rglob("*.py"))
+    ext_tests = src_root.parent / "tests"
+    if ext_tests.is_dir():
+        all_py += list(ext_tests.rglob("*.py"))
+    used: set[tuple[str, str]] = set()
+    for f in all_py:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        # external test files are not package modules (no same-module / relative-import
+        # resolution applies -- they import the package absolutely)
+        in_tree = src_root in f.parents
+        this_mod = _module_name(f, src_root, pkg) if in_tree else None
+        pkg_of = (this_mod if f.name == "__init__.py" else this_mod.rsplit(".", 1)[0]) if this_mod else pkg
+        sym_binds: dict[str, tuple[str, str]] = {}   # local -> (module, orig)  [symbol import]
+        mod_binds: dict[str, str] = {}               # local -> module          [module alias]
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for a in node.names:
+                    if a.name == pkg or a.name.startswith(pkg + "."):
+                        mod_binds[a.asname or a.name.split(".")[0]] = a.name
+            elif isinstance(node, ast.ImportFrom):
+                if node.level:
+                    base_parts = pkg_of.split(".")
+                    base = ".".join(base_parts[: len(base_parts) - (node.level - 1)])
+                    m = f"{base}.{node.module}" if node.module else base
+                else:
+                    m = node.module or ""
+                if not (m == pkg or m.startswith(pkg + ".")):
+                    continue
+                for a in node.names:
+                    local = a.asname or a.name
+                    if f"{m}.{a.name}" in known_modules:      # from pkg import submodule
+                        mod_binds[local] = f"{m}.{a.name}"
+                    else:                                      # from module import symbol
+                        sym_binds[local] = (m, a.name)
+        # walk loads
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+                if node.id in sym_binds:
+                    used.add(sym_binds[node.id])
+                elif node.id in top_names.get(this_mod, ()):   # same-module use
+                    used.add((this_mod, node.id))
+            elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
+                chain = _attr_chain(node)
+                if not chain:
+                    continue
+                base = chain[0]
+                if base in mod_binds and len(chain) >= 2:
+                    used.add((mod_binds[base], chain[1]))
+                elif base in sym_binds and len(chain) >= 2:
+                    m, orig = sym_binds[base]
+                    used.add((m, orig))                        # attr on an imported symbol => symbol used
+                elif base == pkg:                              # goldenmatch.a.b.SYM
+                    for i in range(len(chain) - 1, 0, -1):
+                        mod = ".".join(chain[:i])
+                        if mod in known_modules:
+                            used.add((mod, chain[i]))
+                            break
+
+    # string-literal keep-alive, scoped to PACKAGE SOURCE (dispatch/registry/__all__/FFI names)
+    string_names: set[str] = set()
+    for f in src_files:
+        try:
+            tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
+        except SyntaxError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if node.value.isidentifier():
+                    string_names.add(node.value)
+
+    strong, dynamic = [], []
+    for (mod, name), (file, line) in sorted(defs.items()):
+        if (mod, name) in used:
+            continue
+        (dynamic if name in string_names else strong).append((mod, name, file, line))
+    return {"pkg": pkg, "n_defs": len(defs), "strong": strong, "dynamic": dynamic}
+
+
 def main(argv: list[str]) -> int:
     args = [a for a in argv if not a.startswith("--")]
     check = "--check" in argv
     pkg = args[0] if args else "goldenmatch"
+
+    if "--scoped" in argv or "--symbols2" in argv:
+        s = analyze_symbols_scoped(pkg)
+        print(f"== dead-code (symbol-level, SCOPE-AWARE) :: {pkg} ==")
+        print(f"undecorated top-level def/class={s['n_defs']}  "
+              f"unused_resolved={len(s['strong']) + len(s['dynamic'])}  "
+              f"(strong={len(s['strong'])}  string-referenced={len(s['dynamic'])})")
+        if s["strong"]:
+            print("\n-- STRONG candidates (no resolved use, no bare-string reference) --")
+            for mod, name, file, line in s["strong"]:
+                print(f"  {mod}.{name}\n      {file}:{line}")
+        if s["dynamic"]:
+            print("\n-- string-referenced (unused by resolver, but name appears as a source "
+                  "string literal -- likely dispatch/registry/__all__/FFI; verify before cutting) --")
+            for mod, name, file, line in s["dynamic"]:
+                print(f"  {mod}.{name}\n      {file}:{line}")
+        print("\nnote: HIGHER-recall / higher-FP pass -- resolves Name/Attribute loads through each "
+              "file's import bindings, so a dead `def score` is no longer masked by unrelated `score` "
+              "tokens. FP sources: decorator-free registration via getattr/globals(), reflection, and "
+              "cross-language (Rust/TS) callers that don't mirror the name as a string. Classify "
+              "survivors into parity/dead_code/<pkg>.yaml.")
+        return 0
 
     if "--symbols" in argv:
         s = analyze_symbols(pkg)


### PR DESCRIPTION
## What and why

Adds a dead-code detector that is consistent with the core thesis (Rust + Arrow-native source-of-truth → fused compute). Off-the-shelf tools are wrong here: *"never runs by default" ≠ "dead."* Pure-language fallbacks, parity oracles, and default-OFF opt-in kernels are dormant-but-load-bearing and would be deleted by a naive scanner. This gate computes **reachability** from the repo's declared surfaces + FFI/ABI boundaries, and requires each unreachable survivor to be deleted or classified — mirroring the existing `scorer_kernels_deferred` discipline.

## Changes

- **Spec:** `docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md` — the definition of dead, the reachability model, which roots/dormant-classes are already machine-enumerable (from `parity/*.yaml`, `agent-manifest.json`, config-matrix, `_native_loader`), and the phased rollout.
- **Prototype:** `scripts/check_dead_code.py` (Phase 1, module granularity). Builds its **own** AST import graph, computes reachability from entry hubs + test imports, and reports modules reachable from no surface. `--check` fails on any uncovered orphan.
- **Classification map:** `parity/dead_code/goldenmatch.yaml` (a dedicated sibling file, mirroring `parity/native_symbols/`, so it doesn't perturb the `api_parity` gate). Reason vocabulary: `surface --` / `fallback --` / `oracle --` / `dead --`.

## Findings on goldenmatch

- **Substrate bug found:** the first pass (trusting `docs/agent-codemap.json`) false-flagged ~35 real modules because the codemap under-records `from <pkg> import <submodule>` edges (`from goldenmatch.core import sketch`, `from goldenmatch import native`, router assembly, `from . import synonym`). Verified. The tool now builds its own graph; **fixing `agent_codemap.py` is a tracked follow-up** (it's a committed, CI-gated artifact other gates rely on).
- **Accurate result: 14 module orphans**, all classifiable — 13 legitimate out-of-band surfaces (connector `load_connector()` dynamic dispatch, Alembic migration runtime, codegen + maintenance scripts) + **1 genuine candidate** (`sail.session`, an unwired Spark-session helper: no module and no test imports it — owner review).
- At module granularity goldenmatch is essentially clean; genuinely-dead code (if any) lives at symbol level → Phase 2.

## Testing

- `python scripts/check_dead_code.py goldenmatch` → 14 orphans, all classified.
- `python scripts/check_dead_code.py goldenmatch --check` → exit 0 (green); removing any entry → exit 1 (delete-or-classify enforced).

## Scope / limits

- Phase 1 is module-level only (robust, low-FP). Symbol-level (Phase 2), TS `knip` + Rust `cargo-udeps` (Phase 3), and populating `parity/native_symbols/*.allow` from the FFI greps (Phase 4) are staged in the spec. Not yet wired into `ci-required`.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (the gate self-verifies; unit-test harness is a Phase-2 follow-up)
- [ ] `pre-commit run --all-files` is clean
- [x] Package `CHANGELOG.md` updated if behavior changed (n/a — new opt-in tooling, no runtime change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (spec added; CLAUDE.md note is a follow-up once the gate graduates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_