### PR TITLE
Remove 6 dead symbols found by the scope-aware dead-code detector

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -2292,7 +2292,6 @@
             "cluster_dict_to_frames",
             "cluster_frames_to_dict",
             "compute_cluster_confidence",
-            "get_cluster_pair_scores",
             "metadata_height",
             "split_oversized_cluster",
             "split_oversized_cluster_to_size",
@@ -4966,7 +4965,6 @@
             "_build_clusters_scipy_fallback",
             "_derive_touched_ids",
             "_emit_boundary_pairs",
-            "_label_prop_threshold",
             "_phase_a_local_cc",
             "_phase_b_merge_boundaries",
             "_propagate_one_step",
@@ -5023,7 +5021,6 @@
           "defines": [
             "_collect_and_call_in_memory",
             "_golden_cluster_threshold",
-            "_per_partition_golden",
             "build_golden_records_distributed",
             "build_golden_records_smart",
             "materialize_golden_dataframe"
@@ -5087,7 +5084,6 @@
           "defines": [
             "_ensure_global_row_id",
             "_join_assignments_distributed",
-            "_join_clusters_to_rows",
             "_phase4_pipeline_enabled",
             "_phase5_cluster",
             "_phase5_pipeline_enabled",
@@ -5095,7 +5091,6 @@
             "_run_phase2_cheat_line",
             "_run_phase4_pipeline",
             "_run_phase5_pipeline",
-            "_write_golden_output",
             "run_dedupe_pipeline_distributed"
           ],
           "imports": [
@@ -5104,7 +5099,6 @@
             "goldenmatch._polars_lazy",
             "goldenmatch.config.schemas",
             "goldenmatch.core.autoconfig",
-            "goldenmatch.core.frame",
             "goldenmatch.core.golden",
             "goldenmatch.distributed.clustering",
             "goldenmatch.distributed.golden",
@@ -7409,7 +7403,6 @@
             "cluster_detail",
             "cluster_summaries",
             "discover_runs",
-            "lineage_pair_keys",
             "load_clusters_df",
             "load_lineage",
             "load_run_manifest",

--- a/packages/python/goldenmatch/goldenmatch/core/cluster.py
+++ b/packages/python/goldenmatch/goldenmatch/core/cluster.py
@@ -1401,19 +1401,6 @@ def add_to_cluster(
     return clusters
 
 
-def get_cluster_pair_scores(
-    cluster_members: list[int],
-    all_pairs: list[tuple[int, int, float]],
-) -> dict[tuple[int, int], float]:
-    """Get pair scores for a specific cluster. Call on-demand, not in hot path."""
-    member_set = set(cluster_members)
-    return {
-        (a, b): s
-        for a, b, s in all_pairs
-        if a in member_set and b in member_set
-    }
-
-
 def unmerge_record(
     record_id: int,
     clusters: dict[int, dict],

--- a/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/clustering.py
@@ -118,19 +118,6 @@ def label_propagation(
     )
 
 
-# Pair-count threshold above which we route to distributed label propagation.
-# Below this, driver-side scipy.csgraph dominates (per run 26119800863:
-# label-prop on 8.3M pairs ran > 14 min; scipy on the same shape would be
-# seconds). Splink-Spark follows the same pattern: DuckDB backend below
-# the scale where Spark is necessary; Spark above.
-#
-# 50M chosen as a conservative threshold:
-#  - 50M pairs = ~1.2 GB driver memory for the (int64, int64, float64) triple
-#  - scipy.csgraph on that scale: ~30-60s, manageable on 64 GB box
-#  - Above 50M, driver materialization starts to compete with Ray's overhead
-# Override via GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD env var (pairs).
-_LABEL_PROP_PAIR_THRESHOLD = 50_000_000
-
 # Mersenne prime for the randomized-contraction affine hash (#844). Vertex ids
 # must be < _RC_PRIME; row ids at 346M are ~2**28, well under 2**31-1 ~= 2.1B.
 # Keeps h(x)=(A*x+B) % p in i64 range: A,x,B < 2**31 => A*x < 2**62 < 2**63.
@@ -159,18 +146,6 @@ def _wcc_algorithm() -> str:
     """
     import os
     return os.environ.get("GOLDENMATCH_DISTRIBUTED_WCC", "two_phase").lower()
-
-
-def _label_prop_threshold() -> int:
-    import os
-
-    raw = os.environ.get("GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD")
-    if raw is None:
-        return _LABEL_PROP_PAIR_THRESHOLD
-    try:
-        return int(raw)
-    except ValueError:
-        return _LABEL_PROP_PAIR_THRESHOLD
 
 
 # Peak driver bytes per scored pair on the in-memory scipy route: ~24 B for the

--- a/packages/python/goldenmatch/goldenmatch/distributed/golden.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/golden.py
@@ -35,27 +35,6 @@ def _golden_cluster_threshold() -> int:
         return _GOLDEN_CLUSTER_THRESHOLD
 
 
-def _per_partition_golden(  # pyright: ignore[reportUnusedFunction]
-    batch: pa.Table,
-    rules: GoldenRulesConfig,
-    user_columns: list[str],
-) -> pa.Table:
-    """Worker-side: pyarrow batch -> Polars -> in-memory builder -> pyarrow."""
-    import polars as pl
-    import pyarrow as pa
-
-    from goldenmatch.core.golden import build_golden_records_batch
-
-    df = pl.from_arrow(batch)
-    assert isinstance(df, pl.DataFrame)  # pa.Table input always yields DataFrame
-    if df.height == 0:
-        return pa.Table.from_pylist([])
-    results = build_golden_records_batch(df, rules)
-    if not results:
-        return pa.Table.from_pylist([])
-    return pa.Table.from_pylist(results)
-
-
 def build_golden_records_distributed(
     multi_ds: Dataset,
     rules: GoldenRulesConfig,

--- a/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
+++ b/packages/python/goldenmatch/goldenmatch/distributed/pipeline.py
@@ -321,8 +321,8 @@ def _join_assignments_distributed(
     num_partitions: int | None = None,
 ) -> Dataset:
     """Annotate each input row with ``__cluster_id__`` via a DISTRIBUTED hash
-    join -- the scale replacement for ``_join_clusters_to_rows``'s broadcast
-    ``member_to_cid`` dict (which was O(members) on the driver).
+    join -- avoids the O(members) driver-side broadcast ``member_to_cid`` dict
+    the earlier in-memory join used.
 
     ``assignments_ds`` rows: {member_id, cluster_id, cluster_size, oversized}.
     Only MULTI-MEMBER clusters survive (``cluster_size > 1``), matching the old
@@ -371,62 +371,3 @@ def _join_assignments_distributed(
         return df.to_arrow()
 
     return joined.map_batches(_drop_member, batch_format="pyarrow")
-
-
-def _join_clusters_to_rows(ds: Dataset, clusters: dict) -> Dataset:
-    """Annotate each row with __cluster_id__ via a small broadcast lookup.
-
-    Only multi-member clusters are kept; singletons are filtered out.
-    The cluster dict is small (~cluster_count entries); broadcast via
-    ray.put to avoid re-serializing it per batch.
-    """
-    import ray
-
-    member_to_cid: dict[int, int] = {}
-    for cid, info in clusters.items():
-        if info.get("size", 0) > 1:
-            for m in info["members"]:
-                member_to_cid[m] = cid
-
-    if not member_to_cid:
-        # No multi-member clusters; return an empty slice of the input schema.
-        return ds.limit(0)
-
-    map_ref = ray.put(member_to_cid)
-
-    def _annotate(batch: Any) -> Any:  # noqa: ANN401  # batch: pa.Table -> pa.Table
-        import polars as pl
-        import ray as _ray
-        df = pl.from_arrow(batch)
-        assert isinstance(df, pl.DataFrame)
-        if "__row_id__" not in df.columns:
-            df = df.with_row_index("__row_id__").with_columns(
-                pl.col("__row_id__").cast(pl.Int64)
-            )
-        lookup_raw = _ray.get(map_ref)
-        lookup: dict[int, int] = dict(lookup_raw) if not isinstance(lookup_raw, dict) else lookup_raw
-        # W4e: seam ops (map_column default= == replace_strict(keys, vals,
-        # default); filter_not_in([-1]) == != -1, nulls unreachable post-default).
-        from goldenmatch.core.frame import to_frame
-
-        out = (
-            to_frame(df)
-            .map_column("__row_id__", "__cluster_id__", lookup, default=-1)
-            .filter_not_in("__cluster_id__", [-1])
-        )
-        return out.to_arrow()
-
-    return ds.map_batches(_annotate, batch_format="pyarrow")
-
-
-def _write_golden_output(golden: Any, output_path: str) -> None:
-    """Write golden records to parquet at end of Phase 5 pipeline."""
-    if isinstance(golden, list):
-        if golden:
-            pl.DataFrame(golden).write_parquet(output_path)
-        return
-    # Polars DataFrame
-    if hasattr(golden, "write_parquet"):
-        golden.write_parquet(output_path)
-    else:
-        pl.DataFrame(golden).write_parquet(output_path)

--- a/packages/python/goldenmatch/goldenmatch/web/runs.py
+++ b/packages/python/goldenmatch/goldenmatch/web/runs.py
@@ -118,18 +118,3 @@ def source_row(ref: RunRef, row_id: int) -> dict:
         raise IndexError(row_id)
     row = src.slice(row_id, 1).select_dicts(list(src.columns))[0]
     return {"row_id": row_id, "columns": row}
-
-
-def lineage_pair_keys(ref: RunRef) -> set[tuple[int, int]]:
-    """Set of canonical (min, max) pair keys present in this run's lineage.
-
-    Used to scope labels to "pairs that appeared in this run." Canonicalized
-    so it joins cleanly with the labels store (which also canonicalizes via
-    web/labels.py::_canonical_pair).
-    """
-    lineage = load_lineage(ref)
-    out: set[tuple[int, int]] = set()
-    for p in lineage.get("pairs", []):
-        a, b = int(p["row_id_a"]), int(p["row_id_b"])
-        out.add((a, b) if a <= b else (b, a))
-    return out


### PR DESCRIPTION
## What and why

The scope-aware symbol resolver added in #2020 (`scripts/check_dead_code.py --scoped`) flagged a genuine-dead core of unreferenced top-level defs in goldenmatch-Python. This is the reviewed cleanup PR that removes them — kept separate from the detector PR so each is independently reviewable.

Every symbol here was verified to have **zero references in any language**: no code caller, no `getattr`/reflection/Ray-remote, no `__all__` export, no test. The only occurrences were the definition itself plus docs/spec mentions.

## Removed (6 symbols, 133 lines)

| Symbol | Why it was dead |
|---|---|
| `distributed/clustering.py::_label_prop_threshold` (+ its now-orphaned exclusive constant `_LABEL_PROP_PAIR_THRESHOLD`) | the #956 memory-aware routing rewrite replaced it with `_route_distributed`, which reads `GOLDENMATCH_DISTRIBUTED_CLUSTERING_THRESHOLD` itself. The old spec claimed "other callers/tests reference it" — none do (the 7 remaining refs are all in docs/specs). |
| `distributed/pipeline.py::_join_clusters_to_rows` | its own docstring said it was replaced by the distributed hash-join `_join_assignments_distributed`. That function's docstring is updated to stop naming the removed helper. |
| `distributed/pipeline.py::_write_golden_output` | zero references — and its bare `pl` use was never bound locally, so it could never have run. |
| `distributed/golden.py::_per_partition_golden` | zero references; already carried `# pyright: ignore[reportUnusedFunction]`. `build_golden_records_distributed` calls `build_golden_records_batch` directly. |
| `core/cluster.py::get_cluster_pair_scores` | public-named but never wired into any caller. |
| `web/runs.py::lineage_pair_keys` | never wired into any labels-scoping caller. |

## Kept (correctly, after review)

`core/perceptual.py::_dct1d_matrix` — the detector flagged it, but its docstring shows it is the **reference generator that produced the committed bit-exact `DCT_BASIS` constant**. That is a dormant-but-load-bearing oracle (the same class as the refdata regen scripts), not dead code; deleting it would erase the provenance of the constant. This is exactly why the detector's "strong" list gets human review rather than blind deletion.

## Testing

- All 5 edited files compile; `ruff check` clean (no orphaned imports left behind).
- `tests/test_cluster.py` passes (27).
- Repo-wide grep confirms no test references any removed symbol.
- `import goldenmatch` succeeds.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (removal only; existing cluster suite passes, no test referenced the removed symbols)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a — internal dead-code removal; the detector spec in #2020 documents the finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_