### PR TITLE
feat(ts): WASM-back the soundex_match scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `phash`, `radial`, `soundex_match` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `phash`, `radial` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -42,6 +42,16 @@
  * `jaccardSimilarity` popcounts the actual bit-OR — algebraically identical for
  * bloom filters — so the WASM matrix is byte-exact with the fallback on any valid
  * (even-length) bloom hex, same as dice.
+ *
+ * `soundex_match` (id 6) routes through score-core's `soundex_match` (1.0 iff a
+ * NON-EMPTY canonical soundex code is shared, else 0.0 — the empty-code guard means
+ * garbage/empty never matches). The kernel's `soundex` and the pure-TS `soundex`
+ * transform are the SAME Unicode-folding standard-Soundex spec (separators break the
+ * coding run; NFKD folds accents; no-letter -> ""), so the WASM matrix is byte-exact
+ * with the pure-TS `soundexMatch` fallback. Like `exact`, the bucket path intercepts
+ * soundex_match with an O(n) hash-group specialization (`buildScoreMatrix`), so this
+ * id is exercised only when `scoreMatrix` is called directly — but the kernel is
+ * reachable and byte-exact, which is the "kernel-backed / shared" contract.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -50,6 +60,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   exact: 3,
   date: 4,
   qgram: 5,
+  soundex_match: 6,
   dice: 9,
   jaccard: 10,
   given_name_aliased_jw: 20,

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -259,3 +259,39 @@ d("WASM jaccard matches the pure-TS scoreField reference (exact)", () => {
     });
   }
 });
+
+// soundex_match (score_one id 6): 1.0 iff a NON-EMPTY canonical soundex code is
+// shared, else 0.0 (empty-code guard). The kernel `soundex` and the pure-TS
+// `soundex` transform are the SAME Unicode-folding standard-Soundex spec
+// (separators break the coding run; NFKD folds accents; no-letter -> ""), so the
+// WASM matrix is byte-exact with the pure-TS `soundexMatch` fallback -- including
+// the multi-token separator cases the strip variant regressed. Asserted byte-exact.
+type SoundexCase = readonly [a: string, b: string, note: string];
+const SOUNDEX_CASES: readonly SoundexCase[] = [
+  ["Robert", "Rupert", "collide on R163 -> 1.0"],
+  ["Smith", "Smyth", "collide on S530 -> 1.0"],
+  ["Robert", "Smith", "different codes -> 0.0"],
+  ["joseph bradshaw", "joseph bradshaw", "multi-token J211 -> 1.0 (separator-aware)"],
+  ["Muñoz", "Munoz", "accent folds to M520 -> 1.0"],
+  ["123", "456", "both no-letter -> '' -> empty-guard 0.0"],
+  ["123", "123", "identical garbage -> '' -> 0.0 (never self-matches)"],
+  ["", "", "both empty -> 0.0"],
+  ["café", "cafe", "accented vowel folds -> collide"],
+];
+
+d("WASM soundex_match matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of SOUNDEX_CASES) {
+    it(`soundex_match("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "soundex_match");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "soundex_match");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,7 +25,7 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 8 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 9 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
@@ -37,6 +37,7 @@ describe("ScorerBackend singleton", () => {
         "levenshtein",
         "name_freq_weighted_jw",
         "qgram",
+        "soundex_match",
         "token_sort",
       ],
     );
@@ -59,19 +60,35 @@ describe("scoreMatrix backend swap", () => {
     expect(m[0]![1]).toBe(0); // came from the stub, not pure-TS (~0.9)
   });
 
-  it("ignores the backend for an UNCOVERED scorer (soundex_match stays pure-TS)", () => {
+  it("routes soundex_match through the backend now that it's covered", () => {
+    const calls: string[] = [];
+    setScorerBackend({
+      scoreMatrix: (values, name) => {
+        calls.push(name);
+        return new Float64Array(values.length * values.length); // all zeros
+      },
+    });
+    // soundex_match (score_one id 6) is WASM-covered -> routes to the backend.
+    // Robert/Rupert share soundex R163 (pure-TS would be 1.0); the stub returns
+    // 0, proving the WASM path (not pure-TS) ran.
+    const m = scoreMatrix(["Robert", "Rupert"], "soundex_match");
+    expect(calls).toEqual(["soundex_match"]);
+    expect(m[0]![1]).toBe(0);
+  });
+
+  it("ignores the backend for an UNCOVERED scorer (ensemble stays pure-TS)", () => {
     let called = false;
     setScorerBackend({
       scoreMatrix: (values) => {
         called = true;
-        return new Float64Array(values.length * values.length);
+        return new Float64Array(values.length * values.length).fill(0.5);
       },
     });
-    // soundex_match is NOT WASM-covered -> pure-TS scoreField (Robert/Rupert
-    // share soundex R163 -> 1.0), so the backend stub must not be called.
-    const m = scoreMatrix(["Robert", "Rupert"], "soundex_match");
+    // ensemble is NOT WASM-covered -> pure-TS scoreField, so the stub's 0.5
+    // must not appear (Robert/Rupert ensemble is soundex-boosted to 0.8).
+    const m = scoreMatrix(["Robert", "Rupert"], "ensemble");
     expect(called).toBe(false);
-    expect(m[0]![1]).toBe(1.0);
+    expect(m[0]![1]).not.toBe(0.5);
   });
 
   it("zeros out null cells after a backend call", () => {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -305,12 +305,13 @@ blocking_strategies:
 # path) -- Python `_NATIVE_SCORER_IDS` (backends.score_buckets) vs TS
 # `WASM_COVERED_SCORERS` (core/wasm/backend SCORER_ID). Every scorer in the
 # `scorers` surface NOT listed here is a pure-language fallback with no kernel.
-# shared: `qgram` (id 5), `date` (id 4), `dice` (id 9), `jaccard` (id 10) are
-# kernel-backed on BOTH surfaces -- Python arrow-native (bucket) AND TS WASM (score-wasm
-# delegates the id to score_one; the WASM output is byte-exact with the pure-TS fallback
-# -- qgram is rational set-Jaccard, date's true-DL==OSA for the equal-length 8-digit
-# inputs it buckets, dice/jaccard are integer bloom-popcount + one divide).
-# python_only: `soundex_match`, `initialism_match`, `alias_match`, `phash`, `ensemble`,
+# shared: `qgram` (id 5), `date` (id 4), `soundex_match` (id 6), `dice` (id 9),
+# `jaccard` (id 10) are kernel-backed on BOTH surfaces -- Python arrow-native (bucket)
+# AND TS WASM (score-wasm delegates the id to score_one; the WASM output is byte-exact
+# with the pure-TS fallback -- qgram is rational set-Jaccard, date's true-DL==OSA for the
+# equal-length 8-digit inputs it buckets, soundex_match is the shared Unicode-folding
+# standard-Soundex spec + empty-guard, dice/jaccard are integer bloom-popcount + one divide).
+# python_only: `initialism_match`, `alias_match`, `phash`, `ensemble`,
 # `radial`, `audio_fp` have an arrow-native (bucket) kernel on Python but no TS WASM
 # port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
@@ -326,6 +327,7 @@ scorer_kernels:
   - jaro_winkler
   - levenshtein
   - qgram
+  - soundex_match
   - token_sort
   python_only:
   - alias_match
@@ -334,7 +336,6 @@ scorer_kernels:
   - initialism_match
   - phash
   - radial
-  - soundex_match
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw


### PR DESCRIPTION
## What and why

`soundex_match` (score_one id 6) is now kernel-backed on BOTH surfaces, closing one of the two cross-language gaps that #2019 (canonical in-house soundex) unblocked. score-core carries the `soundex_match` kernel + the separator-aware canonical `soundex`, and score-wasm's `score_matrix_impl` already delegates every non-special id to `score_one`, so this is a one-line `SCORER_ID` add plus the manifest reclassification - no Rust change.

The WASM output is byte-exact with the pure-TS `soundexMatch` fallback (both are the same Unicode-folding standard-Soundex spec + empty-code guard), so like `exact` the O(n) `buildScoreMatrix` intercept stays pure-TS while the kernel is reachable and byte-exact via `scoreMatrix` - the "shared / kernel-backed" contract.

## Changes

- `SCORER_ID` += `soundex_match: 6` in `src/core/wasm/backend.ts` (auto-joins `WASM_COVERED_SCORERS`) + a doc paragraph on the parity.
- parity manifest `parity/goldenmatch.yaml`: `scorer_kernels` moves `soundex_match` python_only -> shared (both surfaces now kernel-backed).
- `docs-site/suite-matrix.mdx` regenerated (soundex_match -> the "Python + TS" kernel row).
- `tests/unit/wasm-backend.test.ts`: covered-set assertion updated (9 score_one + 2 name scorers); the uncovered-scorer probe repointed to `ensemble` (soundex_match now routes to the backend).
- `tests/parity/wasm-scorer.test.ts`: new soundex_match parity block (9 cases incl. the multi-token separator, empty-guard, and accent-fold cases) - byte-exact vs the pure-TS `scoreField` reference.

## Testing

- `check_api_parity.py goldenmatch` - "parity OK: goldenmatch manifest exactly partitions the real MCP + CLI surface".
- Rebuilt the score-wasm artifact (`build_wasm.sh`) and ran `vitest run tests/parity/wasm-scorer.test.ts` - 60 pass incl. the 9 new soundex_match cases (a stale pre-#2019 artifact correctly failed the two identical-empty-code cases, confirming the empty-guard is exercised).
- Full `vitest run` - 185 files, 3212 pass + 1 expected-fail.
- `tsc --noEmit` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; full vitest suite green
- [ ] Package `CHANGELOG.md` updated if behavior changed (no runtime behavior change - opt-in WASM path, byte-exact with the existing fallback)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_