### PR TITLE
feat(ts): WASM-back the ensemble scorer (kernel parity Python + TS)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `ensemble`, `initialism_match`, `phash`, `radial` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match`, `phash`, `radial` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 

--- a/packages/rust/extensions/score-wasm/src/lib.rs
+++ b/packages/rust/extensions/score-wasm/src/lib.rs
@@ -69,6 +69,19 @@ pub fn score_matrix_impl(values: &[&str], scorer_id: u8) -> Vec<f64> {
             // table-absent fallback the pure TS path takes.
             let s = match scorer_id {
                 2 => token_sort_normalized_ratio(values[i], values[j]),
+                // id=12 (ensemble) mirrors id=2's override: score_one(12)'s
+                // `ensemble_similarity` maxes over the UN-normalized score_one(2),
+                // but the pure-TS `ensembleScore` uses the normalized `tokenSortRatio`
+                // -- so the WASM arm recomposes ensemble with the TS-parity normalized
+                // token_sort (jw + normalized token_sort + 0.8*soundex) to stay 4dp
+                // parity with the pure-TS fallback (soundex byte-exact; jw/token_sort
+                // to 4dp, the same bar those scorers hold individually vs rapidfuzz).
+                12 => {
+                    let jw = score_one(0, values[i], values[j]);
+                    let ts = token_sort_normalized_ratio(values[i], values[j]);
+                    let sx = score_one(6, values[i], values[j]);
+                    jw.max(ts).max(0.8 * sx)
+                }
                 ID_GIVEN_NAME_ALIASED_JW => match NAME_ALIASES.get() {
                     Some(t) => given_name_aliased_sim(values[i], values[j], t),
                     None => score_one(0, values[i], values[j]),
@@ -163,6 +176,31 @@ mod tests {
         // token-order differ before normalization).
         let raw = goldenmatch_score_core::score_one(2, "John SMITH", "smith john");
         assert!(raw < 1.0);
+    }
+
+    #[test]
+    fn ensemble_id12_uses_normalized_token_sort() {
+        use goldenmatch_score_core::{score_one, token_sort_normalized_ratio};
+        // id=12 must recompose ensemble with the NORMALIZED token_sort (not the
+        // un-normalized one score_one(12)/ensemble_similarity uses), so it stays
+        // parity with the pure-TS `ensembleScore`.
+        for (a, b) in [
+            ("John SMITH", "smith john"), // token-sort dominates -> 1.0
+            ("Robert", "Rupert"),         // soundex R163 -> 0.8 bonus
+            ("MARTHA", "MARHTA"),         // jw dominates
+            ("", ""),                     // empty -> soundex guard 0.0, jw/ts 1.0
+        ] {
+            let m = score_matrix_impl(&[a, b], 12);
+            let want = score_one(0, a, b)
+                .max(token_sort_normalized_ratio(a, b))
+                .max(0.8 * score_one(6, a, b));
+            assert!((m[1] - want).abs() < 1e-12, "ensemble {a:?}/{b:?}: {} vs {want}", m[1]);
+        }
+        // The normalized token_sort makes "John SMITH"/"smith john" -> 1.0, where
+        // score_one(12) (un-normalized token_sort) would score lower.
+        let m = score_matrix_impl(&["John SMITH", "smith john"], 12);
+        assert!((m[1] - 1.0).abs() < 1e-9);
+        assert!(score_one(12, "John SMITH", "smith john") < 1.0);
     }
 }
 

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -52,6 +52,15 @@
  * soundex_match with an O(n) hash-group specialization (`buildScoreMatrix`), so this
  * id is exercised only when `scoreMatrix` is called directly — but the kernel is
  * reachable and byte-exact, which is the "kernel-backed / shared" contract.
+ *
+ * `ensemble` (id 12) is `max(jaro_winkler, token_sort, 0.8*soundex_match)`. score-wasm
+ * OVERRIDES id 12 (like id 2) to recompose it with the TS-parity NORMALIZED token_sort
+ * (score_one(12)'s `ensemble_similarity` maxes over the un-normalized score_one(2)),
+ * so the WASM matrix matches the pure-TS `ensembleScore` to 4dp — the same tolerance
+ * its `jaro_winkler` / `token_sort` components already hold vs rapidfuzz (its
+ * soundex_match component is byte-exact). Like exact/soundex_match, `buildScoreMatrix`
+ * keeps the O(n) pure-TS `ensembleScoreMatrix` intercept; this id is reached only via a
+ * direct `scoreMatrix` call, where the kernel is reachable + parity-proven.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -63,6 +72,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   soundex_match: 6,
   dice: 9,
   jaccard: 10,
+  ensemble: 12,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -295,3 +295,36 @@ d("WASM soundex_match matches the pure-TS scoreField reference (exact)", () => {
     });
   }
 });
+
+// ensemble (score_one id 12, overridden in score_matrix_impl): max of jaro_winkler,
+// the NORMALIZED token_sort, and 0.8*soundex_match -- the same three the pure-TS
+// `ensembleScore` maxes. The soundex component is byte-exact; jw and token_sort are
+// rapidfuzz (kernel) vs the hand-rolled pure-TS, which agree to 4dp -- so ensemble is
+// asserted to 4dp vs the pure-TS reference (the same bar jaro_winkler / token_sort
+// hold individually), each case chosen so a different component dominates the max.
+type EnsembleCase = readonly [a: string, b: string, note: string];
+const ENSEMBLE_CASES: readonly EnsembleCase[] = [
+  ["John SMITH", "smith john", "normalized token_sort dominates -> 1.0"],
+  ["Robert", "Rupert", "soundex R163 bonus 0.8 dominates lowish jw"],
+  ["MARTHA", "MARHTA", "jaro_winkler dominates (0.9611)"],
+  ["New York Mets", "Mets New York", "token_sort reorder -> 1.0"],
+  ["abc", "abd", "jw dominates a no-soundex-match pair"],
+  ["café", "cafe", "jw on accented input"],
+];
+
+d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of ENSEMBLE_CASES) {
+    it(`ensemble("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "ensemble");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "ensemble");
+      expect(m[0]![1]!).toBeCloseTo(ref!, 4);
+    });
+  }
+});

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -5,7 +5,7 @@ import {
   WASM_COVERED_SCORERS,
   type ScorerBackend,
 } from "../../src/core/wasm/backend.js";
-import { scoreMatrix } from "../../src/core/scorer.js";
+import { scoreMatrix, setSyncEmbedder } from "../../src/core/scorer.js";
 
 const stub: ScorerBackend = {
   scoreMatrix: (values) => new Float64Array(values.length * values.length),
@@ -25,11 +25,12 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 9 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 10 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
         "dice",
+        "ensemble",
         "exact",
         "given_name_aliased_jw",
         "jaccard",
@@ -76,7 +77,7 @@ describe("scoreMatrix backend swap", () => {
     expect(m[0]![1]).toBe(0);
   });
 
-  it("ignores the backend for an UNCOVERED scorer (ensemble stays pure-TS)", () => {
+  it("ignores the backend for an UNCOVERED scorer (embedding stays pure-TS)", () => {
     let called = false;
     setScorerBackend({
       scoreMatrix: (values) => {
@@ -84,11 +85,17 @@ describe("scoreMatrix backend swap", () => {
         return new Float64Array(values.length * values.length).fill(0.5);
       },
     });
-    // ensemble is NOT WASM-covered -> pure-TS scoreField, so the stub's 0.5
-    // must not appear (Robert/Rupert ensemble is soundex-boosted to 0.8).
-    const m = scoreMatrix(["Robert", "Rupert"], "ensemble");
-    expect(called).toBe(false);
-    expect(m[0]![1]).not.toBe(0.5);
+    // embedding is NOT WASM-covered -> pure-TS scoreField (a deterministic stub
+    // embedder makes it a real cosine), so the stub's 0.5 must not appear and
+    // the backend must not be called.
+    setSyncEmbedder((s) => [s.length, s.charCodeAt(0) || 0]);
+    try {
+      const m = scoreMatrix(["abc", "abd"], "embedding");
+      expect(called).toBe(false);
+      expect(m[0]![1]).not.toBe(0.5);
+    } finally {
+      setSyncEmbedder(null);
+    }
   });
 
   it("zeros out null cells after a backend call", () => {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -311,9 +311,12 @@ blocking_strategies:
 # with the pure-TS fallback -- qgram is rational set-Jaccard, date's true-DL==OSA for the
 # equal-length 8-digit inputs it buckets, soundex_match is the shared Unicode-folding
 # standard-Soundex spec + empty-guard, dice/jaccard are integer bloom-popcount + one divide).
-# python_only: `initialism_match`, `alias_match`, `phash`, `ensemble`,
-# `radial`, `audio_fp` have an arrow-native (bucket) kernel on Python but no TS WASM
-# port yet.
+# `ensemble` (id 12) is also shared: score-wasm overrides id 12 to recompose it with
+# the TS-parity normalized token_sort (jw + normalized token_sort + 0.8*soundex_match),
+# matching the pure-TS `ensembleScore` to 4dp -- the same bar its jw/token_sort
+# components hold vs rapidfuzz (soundex byte-exact).
+# python_only: `initialism_match`, `alias_match`, `phash`, `radial`, `audio_fp` have an
+# arrow-native (bucket) kernel on Python but no TS WASM port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
@@ -322,6 +325,7 @@ scorer_kernels:
   shared:
   - date
   - dice
+  - ensemble
   - exact
   - jaccard
   - jaro_winkler
@@ -332,7 +336,6 @@ scorer_kernels:
   python_only:
   - alias_match
   - audio_fp
-  - ensemble
   - initialism_match
   - phash
   - radial


### PR DESCRIPTION
## What and why

`ensemble` (`max(jaro_winkler, token_sort, 0.8*soundex_match)`) is now kernel-backed on BOTH surfaces, closing the second and last gap that #2019 (canonical in-house soundex) unblocked. Its `soundex_match` component became byte-exact with the separator-aware canonical soundex (#2019/#2024), and its `jaro_winkler` / `token_sort` components already hold 4dp vs rapidfuzz - so ensemble now clears the same "shared" bar those components do.

The one subtlety: `score_one(12)`'s `ensemble_similarity` maxes over the UN-normalized `score_one(2)`, but the pure-TS `ensembleScore` uses the normalized `tokenSortRatio`. So score-wasm's `score_matrix_impl` OVERRIDES id 12 (exactly like it overrides id 2) to recompose ensemble with `token_sort_normalized_ratio` - keeping the WASM matrix at 4dp parity with the pure-TS fallback.

## Changes

- `packages/rust/extensions/score-wasm/src/lib.rs`: new `12 =>` arm in `score_matrix_impl` (`jw.max(normalized_token_sort).max(0.8*soundex)`) + a cargo test asserting it uses the normalized token_sort and diverges from `score_one(12)` on reordered input.
- `SCORER_ID` += `ensemble: 12` in `src/core/wasm/backend.ts` (auto-joins `WASM_COVERED_SCORERS`) + a doc paragraph.
- parity manifest `parity/goldenmatch.yaml`: `scorer_kernels` moves `ensemble` python_only -> shared.
- `docs-site/suite-matrix.mdx` regenerated (ensemble -> the "Python + TS" kernel row).
- `tests/unit/wasm-backend.test.ts`: covered-set assertion updated (10 score_one + 2 name scorers); the uncovered-scorer probe repointed to `embedding` (every other `scoreField` scorer is now covered) with a deterministic stub embedder.
- `tests/parity/wasm-scorer.test.ts`: new ensemble parity block (6 cases, each chosen so a different component - normalized token_sort / soundex bonus / jaro_winkler - dominates the max), asserted to 4dp vs the pure-TS reference.

## Testing

- `cargo test` + `cargo clippy` on score-wasm - clean (incl. the new ensemble arm test).
- Rebuilt the score-wasm artifact and ran `vitest run tests/parity/wasm-scorer.test.ts` + `tests/unit/wasm-backend.test.ts` - 73 pass (incl. the 6 new ensemble cases).
- `check_api_parity.py goldenmatch` - "parity OK: goldenmatch manifest exactly partitions the real MCP + CLI surface".
- Full `vitest run` - 185 files, 3218 pass + 1 expected-fail; `tsc --noEmit` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; score-wasm cargo test + clippy clean; full vitest green
- [ ] Package `CHANGELOG.md` updated if behavior changed (no runtime behavior change - opt-in WASM path, 4dp-parity with the existing fallback, and `buildScoreMatrix` keeps ensemble on pure-TS)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_