### PR TITLE
feat(ts): port + WASM-back the phash scorer (Python-only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `qgram`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match`, `phash`, `radial` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match`, `radial` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 38 | 40 | 12 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 20 | 20 | 16 |
-| `goldenmatch` | scorers | 12 | 5 | 2 |
+| `goldenmatch` | scorers | 13 | 4 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 8 | 11 | 3 |
@@ -69,7 +69,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `list_scorers`, `list_strategies`, `list_transforms`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
-- `goldenmatch` **scorers** — Python-only: `alias_match`, `audio_fp`, `initialism_match`, `phash`, `radial`.
+- `goldenmatch` **scorers** — Python-only: `alias_match`, `audio_fp`, `initialism_match`, `radial`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -109,6 +109,7 @@ export {
   diceCoefficient,
   jaccardSimilarity,
   qgramScore,
+  phashSimilarity,
   ensembleScore,
   scoreMatrix,
   asString,

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -469,6 +469,58 @@ export function jaccardSimilarity(a: string, b: string): number {
   return intersection / union;
 }
 
+/** Left-pad an odd-length hex to even and strip an optional `0x`/`0X` prefix
+ * (mirrors score-core `norm_phash_hex`; the prefix strip needs length >= 2). */
+function normPhashHex(s: string): string {
+  let h = s;
+  if (h.length >= 2 && (h.startsWith("0x") || h.startsWith("0X"))) h = h.slice(2);
+  if (h.length % 2 !== 0) h = "0" + h;
+  return h;
+}
+
+/** Strictly decode an even-length ASCII-hex string to bytes, or null on any
+ * non-hex char (mirrors score-core `decode_hex`, whose `to_digit(16)?` fails on
+ * non-hex; `hexToBytes`/`parseInt` would silently coerce bad hex to 0). */
+function decodeHexStrict(hex: string): Uint8Array | null {
+  if (hex.length % 2 !== 0 || !/^[0-9a-fA-F]*$/.test(hex)) return null;
+  const out = new Uint8Array(hex.length >>> 1);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+/** Popcount of a single byte (Brian Kernighan). */
+function popcountByte(b: number): number {
+  let count = 0;
+  while (b !== 0) {
+    b &= b - 1;
+    count++;
+  }
+  return count;
+}
+
+/**
+ * Perceptual-hash similarity on two hex pHash strings: `1 - hamming/nbits`, where
+ * `nbits` counts over the LONGER hash (the tail of the longer XORs against 0, so
+ * every set bit there counts as a difference). Byte-exact with score-core
+ * `phash_similarity` (score_one id 11) and Python `_phash_score_single`. A non-hex
+ * value on either side -> 0.0.
+ */
+export function phashSimilarity(a: string, b: string): number {
+  const pa = decodeHexStrict(normPhashHex(a));
+  const pb = decodeHexStrict(normPhashHex(b));
+  if (pa === null || pb === null) return 0.0;
+  const nbits = Math.max(pa.length, pb.length) * 8;
+  if (nbits === 0) return 0.0;
+  const m = Math.min(pa.length, pb.length);
+  let dist = 0;
+  for (let i = 0; i < m; i++) dist += popcountByte(pa[i]! ^ pb[i]!);
+  for (let i = m; i < pa.length; i++) dist += popcountByte(pa[i]!);
+  for (let i = m; i < pb.length; i++) dist += popcountByte(pb[i]!);
+  return 1.0 - dist / nbits;
+}
+
 /**
  * Padded character q-gram set of a raw string (Python parity:
  * core/scorer.py::_qgram_set). Lowercases, pads with `n-1` `#` sentinels on
@@ -548,6 +600,8 @@ export function scoreField(
       return jaccardSimilarity(valA, valB);
     case "qgram":
       return qgramScore(valA, valB);
+    case "phash":
+      return phashSimilarity(valA, valB);
     case "ensemble":
       return ensembleScore(valA, valB);
     case "embedding":

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -505,6 +505,7 @@ export const VALID_SCORERS = new Set([
   "dice",
   "jaccard",
   "qgram",
+  "phash",
   "given_name_aliased_jw",
   "name_freq_weighted_jw",
 ] as const);

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -53,6 +53,12 @@
  * id is exercised only when `scoreMatrix` is called directly — but the kernel is
  * reachable and byte-exact, which is the "kernel-backed / shared" contract.
  *
+ * `phash` (id 11) is perceptual-hash similarity: `1 - hamming/nbits` over two hex
+ * pHash strings. The kernel and the pure-TS `phashSimilarity` do the identical strict
+ * hex decode + XOR popcount + one f64 divide, so the WASM matrix is byte-exact with the
+ * fallback on any valid hex (a non-hex value -> 0.0 on both). Same integer-popcount
+ * shape as dice/jaccard.
+ *
  * `ensemble` (id 12) is `max(jaro_winkler, token_sort, 0.8*soundex_match)`. score-wasm
  * OVERRIDES id 12 (like id 2) to recompose it with the TS-parity NORMALIZED token_sort
  * (score_one(12)'s `ensemble_similarity` maxes over the un-normalized score_one(2)),
@@ -72,6 +78,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   soundex_match: 6,
   dice: 9,
   jaccard: 10,
+  phash: 11,
   ensemble: 12,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -312,6 +312,39 @@ const ENSEMBLE_CASES: readonly EnsembleCase[] = [
   ["café", "cafe", "jw on accented input"],
 ];
 
+// phash (score_one id 11): perceptual-hash similarity 1 - hamming/nbits over two hex
+// pHashes. The kernel and the pure-TS `phashSimilarity` do the identical strict hex
+// decode + XOR popcount + one f64 divide (nbits over the LONGER hash), so the WASM
+// matrix is byte-exact with the fallback on any valid hex (non-hex -> 0.0 both). Same
+// integer-popcount shape as dice/jaccard. Asserted byte-exact.
+type PhashCase = readonly [a: string, b: string, note: string];
+const PHASH_CASES: readonly PhashCase[] = [
+  ["ffffffffffffffff", "ffffffffffffffff", "identical -> 1.0"],
+  ["0000000000000000", "ffffffffffffffff", "all 64 bits differ -> 0.0"],
+  ["ff00ff00ff00ff00", "ff00ff00ff00ff01", "one bit differs over 64 -> 63/64"],
+  ["0x1234", "1234", "0x prefix stripped -> 1.0"],
+  ["abc", "0abc", "odd length left-pads to even -> 1.0"],
+  ["ff", "ffff", "different lengths: tail of the longer counts -> 0.5"],
+  ["zzzz", "1234", "non-hex -> 0.0"],
+];
+
+d("WASM phash matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of PHASH_CASES) {
+    it(`phash("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "phash");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "phash");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});
+
 d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
   beforeAll(async () => {
     const ok = await enableWasm();

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -12,6 +12,7 @@ import {
   soundexMatch,
   diceCoefficient,
   jaccardSimilarity,
+  phashSimilarity,
   ensembleScore,
   scoreMatrix,
   applyTransform,
@@ -167,6 +168,37 @@ describe("dice / jaccard (bloom filter hex)", () => {
   it("mismatched all-zero lengths -> 0 (no crash)", () => {
     expect(diceCoefficient("0000", "000000")).toBe(0.0);
     expect(jaccardSimilarity("0000", "000000")).toBe(0.0);
+  });
+});
+
+describe("phash (perceptual-hash hex similarity)", () => {
+  it("identical -> 1.0", () => {
+    expect(phashSimilarity("ffffffffffffffff", "ffffffffffffffff")).toBe(1.0);
+  });
+
+  it("all bits differ -> 0.0", () => {
+    expect(phashSimilarity("0000000000000000", "ffffffffffffffff")).toBe(0.0);
+  });
+
+  it("one bit differs over 64 bits -> 63/64", () => {
+    expect(phashSimilarity("ff00ff00ff00ff00", "ff00ff00ff00ff01")).toBe(63 / 64);
+  });
+
+  it("strips a 0x/0X prefix and left-pads odd length", () => {
+    expect(phashSimilarity("0x1234", "1234")).toBe(1.0);
+    expect(phashSimilarity("abc", "0abc")).toBe(1.0); // odd -> "0abc" both sides
+  });
+
+  it("mismatched lengths: every set bit in the longer's tail is a difference", () => {
+    // "ff" (8 bits) vs "ffff" (16 bits): nbits=16, common byte matches, tail 0xff
+    // contributes 8 differences -> 1 - 8/16 = 0.5.
+    expect(phashSimilarity("ff", "ffff")).toBe(0.5);
+    expect(phashSimilarity("ffff", "ff")).toBe(0.5); // symmetric
+  });
+
+  it("non-hex or empty -> 0.0", () => {
+    expect(phashSimilarity("zzzz", "1234")).toBe(0.0);
+    expect(phashSimilarity("", "")).toBe(0.0);
   });
 });
 

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,7 +25,7 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 10 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 11 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
@@ -37,6 +37,7 @@ describe("ScorerBackend singleton", () => {
         "jaro_winkler",
         "levenshtein",
         "name_freq_weighted_jw",
+        "phash",
         "qgram",
         "soundex_match",
         "token_sort",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -252,6 +252,7 @@ scorers:
   - jaccard
   - jaro_winkler
   - levenshtein
+  - phash
   - qgram
   - record_embedding
   - soundex_match
@@ -260,7 +261,6 @@ scorers:
   - alias_match
   - audio_fp
   - initialism_match
-  - phash
   - radial
   ts_only:
   - given_name_aliased_jw
@@ -314,8 +314,10 @@ blocking_strategies:
 # `ensemble` (id 12) is also shared: score-wasm overrides id 12 to recompose it with
 # the TS-parity normalized token_sort (jw + normalized token_sort + 0.8*soundex_match),
 # matching the pure-TS `ensembleScore` to 4dp -- the same bar its jw/token_sort
-# components hold vs rapidfuzz (soundex byte-exact).
-# python_only: `initialism_match`, `alias_match`, `phash`, `radial`, `audio_fp` have an
+# components hold vs rapidfuzz (soundex byte-exact). `phash` (id 11) is also shared:
+# perceptual-hash similarity (1 - hamming/nbits over hex pHashes), integer XOR popcount,
+# byte-exact WASM<->pure-TS like dice/jaccard.
+# python_only: `initialism_match`, `alias_match`, `radial`, `audio_fp` have an
 # arrow-native (bucket) kernel on Python but no TS WASM port yet.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
@@ -330,6 +332,7 @@ scorer_kernels:
   - jaccard
   - jaro_winkler
   - levenshtein
+  - phash
   - qgram
   - soundex_match
   - token_sort
@@ -337,7 +340,6 @@ scorer_kernels:
   - alias_match
   - audio_fp
   - initialism_match
-  - phash
   - radial
   ts_only:
   - given_name_aliased_jw


### PR DESCRIPTION
## What and why

`phash` (perceptual-hash similarity, `1 - hamming/nbits` over two hex pHash strings) was **Python-only** - absent from the TS surface entirely (`scoreField` threw "Unknown scorer"). Unlike `soundex_match`/`ensemble` (which already had pure-TS fallbacks and just needed the kernel wired), the remaining `python_only` scorers have no TS implementation at all, so each is a real port: the pure-TS scorer (the mandatory opt-in-WASM fallback) **plus** the kernel wiring, moving the scorer across **both** the `scorers` and `scorer_kernels` surfaces.

`phash` is the most tractable of the five: it's the same integer-popcount shape as `dice`/`jaccard`, so it's **byte-exact** WASM<->pure-TS. No Rust change was needed - score-wasm's `score_matrix_impl` catch-all already routes id 11 to `score_one(11) = phash_similarity`.

## Changes

- `src/core/scorer.ts`: `phashSimilarity` + `normPhashHex` / `decodeHexStrict` / `popcountByte` helpers; `case "phash"` in `scoreField`; exported via `core/index`. The strict hex decode returns 0.0 on any non-hex char (mirroring score-core `decode_hex`, whose `to_digit(16)?` fails where the lenient `parseInt` would coerce bad hex to 0).
- `src/core/types.ts`: `VALID_SCORERS` += `phash` (the `scorers` surface).
- `src/core/wasm/backend.ts`: `SCORER_ID` += `phash: 11` (the `scorer_kernels` surface / `WASM_COVERED_SCORERS`) + doc.
- `parity/goldenmatch.yaml`: `phash` moves python_only -> shared in BOTH `scorers` and `scorer_kernels`.
- `docs-site/suite-matrix.mdx` regenerated (phash -> the "Python + TS" kernel row).
- tests: pure-TS `phash` unit block (artifact-independent pinned values: identical / all-differ / 63-of-64 / 0x-prefix / odd-pad / mismatched-length-tail / non-hex) + a wasm-scorer byte-exact parity block (WASM `score_one(11)` == pure-TS `phashSimilarity`); `wasm-backend` covered-set assertion updated (11 score_one + 2 name scorers).

## Testing

- `check_api_parity.py goldenmatch` - "parity OK: goldenmatch manifest exactly partitions the real MCP + CLI surface".
- `vitest run tests/unit/scorer.test.ts tests/unit/wasm-backend.test.ts tests/parity/wasm-scorer.test.ts` - 132 pass (incl. the pure-TS phash block + the 7 byte-exact WASM parity cases).
- Full `vitest run` - 185 files, 3231 pass + 1 expected-fail; `tsc --noEmit` clean.

## Follow-ups (the remaining python_only scorers)

- `radial` / `audio_fp` - perceptual-profile scorers with **f64 reductions** (radial needed a 1e-9 tolerance even native<->pure on Python), so their WASM parity is 4dp-ish, not byte-exact.
- `initialism_match` - needs the `legal_forms` reference table injected (like the name scorers' census/alias tables).
- `alias_match` - architecturally blocked: score-wasm builds it behind the `alias` cargo feature that is **off** for the wasm surface (id 8 falls to the 0.0 catch-all), and it also needs business/given-name alias tables installed.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; full vitest green; tsc clean
- [ ] Package `CHANGELOG.md` updated if behavior changed (new capability on the TS surface; no change to existing scorers)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_