### PR TITLE
Generalize the dead-code detector to all six Python packages

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -8580,7 +8580,6 @@
             "_finding_from_dict",
             "_get_review_queue",
             "_rules_to_yaml",
-            "_serialize_findings",
             "_tool_analyze_data",
             "_tool_approve_reject",
             "_tool_auto_configure",

--- a/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+++ b/docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
@@ -185,6 +185,57 @@ removal of the genuine-dead core are follow-ons: the symbol map can't live in th
 sidecar; the 7-symbol deletion touches the distributed engine + perceptual + web and is a
 separately-reviewed cleanup, not part of the detector PR.
 
+## Multi-package generalization (2026-07-22)
+
+Ran both passes across all six Python packages (`goldenmatch`, `goldencheck`, `goldenflow`,
+`goldenpipe`, `infermap`, `goldenanalysis`). The suite is **remarkably clean** — after the
+resolver fixes below, module orphans are 0/0/1/0/1/0 and symbol-level `strong` is
+29/0/4/11/0/0. Every module orphan is classified (`parity/dead_code/<pkg>.yaml` now exists for
+goldenmatch/goldenflow/infermap; goldencheck/goldenpipe/goldenanalysis have zero); `--check`
+is green for all six.
+
+**Three more resolver-substrate bugs surfaced and fixed** — all the same "a legitimate
+consumer or a real binding is invisible to the scan" class as the Phase-2b BOM/sibling-tests
+finds:
+
+1. **Multi-binding overwrite.** The scoped resolver kept one target per local name, so a file
+   that binds the same name to two modules in different branches — CLI dispatch does
+   `from .mcp.server import run_server` in one command and `from .a2a.server import run_server`
+   in another — credited only the *last* import, falsely flagging the first. Now `sym_binds`
+   /`mod_binds` are set-valued and a use marks **every** candidate binding. (Cleared 6
+   goldenmatch + 1 goldenflow + 1 goldenpipe `run_server`-class FPs.)
+2. **Package-local `scripts/` under-scan.** The use-scan covered `<pkg>/tests` but not the
+   sibling `<pkg>/scripts/`, where byte-parity-corpus and codegen generators live. goldenflow's
+   `_double_metaphone_{primary,alt}_py` (docstring: "byte-parity corpus helper") are consumed
+   only by `scripts/gen_identifiers_corpus.py`; goldenmatch's `sail.session.connect` only by
+   `scripts/bench_sail_100m.py`. **This retroactively cleared the Phase-1 "1 genuine dead
+   candidate" (`sail.session`)** — it was never dead, just script-reached. Both `scripts/` and
+   `tests/` are now scanned.
+3. **`from pkg.sub import <submodule>` test-import under-recording (module level).** The
+   module-level `_scan_test_imports` used a regex that captured only the dotted path after
+   `from`, missing the imported-name-is-a-submodule case — so `from goldenpipe.core import
+   _planner_json` recorded `goldenpipe.core` but not `_planner_json`, false-flagging the
+   parity-test-exercised `_planner_json` as an orphan. Replaced with an AST scan that emits both
+   the module and each `module.name`. (Cleared goldenpipe's 2 module orphans and 2 goldenmatch
+   stale deferrals — `config_lint.docgen`, `sail.session` — that tests/scripts actually reach.)
+
+**One confirmed dead symbol removed** (the generalization proving out on another package):
+`goldencheck.mcp.agent_tools._serialize_findings` — a verbatim duplicate of the copy in
+`mcp/server.py:210`, which is the one actually used (3×); the `agent_tools` copy was shadowed
+and never called. Removed it + its now-orphaned `asdict` import.
+
+**Owner-review "written-but-unwired" candidates (classified/documented, not deleted)** — these
+are the ambiguous middle between dead and intended-public-API, in packages whose roadmap isn't
+mine to prune:
+- `goldenflow.connectors.{gcs.write_gcs, s3.write_s3}` — the cloud **read** side (`read_gcs`/
+  `read_s3`) is wired; the **write** counterparts are 0-reference and not in `__all__`.
+- `goldenflow.history.get_run` — single-record accessor in an otherwise-live module (callers use
+  `list_runs`).
+- `goldenflow.reporters.json_reporter` (module) — the CLI emits via `rich_console` only; a JSON
+  reporter that was never wired (`dead --` deferral, owner to wire `--format json` or remove).
+- `goldenpipe.core._native_loader.*` (11 `*_json`/`native_module`) — the native parity-oracle
+  binding surface (goldenpipe-native is reference-mode, not host-accelerated); dormant by design.
+
 ## Non-goals / limits
 
 - The prototype does not do symbol-level analysis (Phase 2) — it reports whole-module orphans.

--- a/packages/python/goldencheck/goldencheck/mcp/agent_tools.py
+++ b/packages/python/goldencheck/goldencheck/mcp/agent_tools.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import asdict
 from pathlib import Path
 
 from mcp.types import Tool
@@ -260,15 +259,6 @@ AGENT_TOOLS = [
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-
-def _serialize_findings(findings: list[Finding]) -> list[dict]:
-    results = []
-    for f in findings:
-        d = asdict(f)
-        d["severity"] = f.severity.name
-        results.append(d)
-    return results
 
 
 def _finding_from_dict(d: dict) -> Finding:

--- a/parity/dead_code/goldenflow.yaml
+++ b/parity/dead_code/goldenflow.yaml
@@ -1,0 +1,15 @@
+# dead_code_deferred (goldenflow) -- module-level classification map.
+# Spec: docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+# Every module check_dead_code.py flags as reachable from no in-process surface must be
+# EITHER deleted OR listed here with a reason. Reason prefix vocabulary:
+#   surface --  reached out-of-band (external runtime, dynamic dispatch, codegen); NOT dead
+#   fallback -- pure-language reference for a native kernel (native-off path)
+#   oracle --   parity ground-truth the kernel is diffed against
+#   dead --     confirmed dead; scheduled for removal (with the removal ref)
+#
+# Bootstrap 2026-07-22 (multi-package generalization). Format: `module: reason`.
+
+# -- unwired JSON reporter: the CLI emits manifests via reporters.rich_console exclusively;
+#    nothing imports json_reporter (no source / test / script). Plausibly an intended output
+#    format never wired. Owner review: wire into the CLI (`--format json`), or remove.
+goldenflow.reporters.json_reporter: "dead -- unwired JSON reporter; no importer (owner review, see spec)"

--- a/parity/dead_code/goldenmatch.yaml
+++ b/parity/dead_code/goldenmatch.yaml
@@ -17,9 +17,6 @@ goldenmatch.connectors.hubspot: "surface -- dynamic load_connector() 'module:Cla
 goldenmatch.connectors.salesforce: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
 goldenmatch.connectors.snowflake: "surface -- dynamic load_connector() 'module:Class' dispatch (optional dep)"
 
-# -- codegen invoked by a repo script, not imported by the package
-goldenmatch.core.config_lint.docgen: "surface -- codegen, invoked by scripts/gen_lint_docs.py"
-
 # -- Alembic migration runtime loads env + versions by convention (goldenmatch identity migrate)
 goldenmatch.db.alembic.env: "surface -- Alembic runtime entry (loaded by the alembic command)"
 goldenmatch.db.alembic.versions.0001_identity_v1: "surface -- Alembic migration (runtime-discovered)"
@@ -30,8 +27,3 @@ goldenmatch.db.alembic.versions.0004_claim_authority: "surface -- Alembic migrat
 # -- maintenance regeneration scripts (run by hand to refresh committed reference data)
 goldenmatch.refdata.scripts: "surface -- maintenance package (regen scripts, not runtime)"
 goldenmatch.refdata.scripts.fetch_census_surnames: "surface -- maintenance regen script"
-
-# -- GENUINE CANDIDATE: no module and no test imports it; sail/__init__ imports pyspark lazily
-#    inside the identity builders, not via this session helper. Owner review: wire, expose as
-#    [sail]-extra public API, or remove. Left deferred pending that decision.
-goldenmatch.sail.session: "dead -- unwired Spark-session helper; no importer (owner review, see spec)"

--- a/parity/dead_code/infermap.yaml
+++ b/parity/dead_code/infermap.yaml
@@ -1,0 +1,15 @@
+# dead_code_deferred (infermap) -- module-level classification map.
+# Spec: docs/superpowers/specs/2026-07-22-arch-aware-dead-code-detection.md
+# Every module check_dead_code.py flags as reachable from no in-process surface must be
+# EITHER deleted OR listed here with a reason. Reason prefix vocabulary:
+#   surface --  reached out-of-band (external runtime, dynamic dispatch, codegen); NOT dead
+#   fallback -- pure-language reference for a native kernel (native-off path)
+#   oracle --   parity ground-truth the kernel is diffed against
+#   dead --     confirmed dead; scheduled for removal (with the removal ref)
+#
+# Bootstrap 2026-07-22 (multi-package generalization). Format: `module: reason`.
+
+# -- structural typing contract: a `@runtime_checkable` Provider Protocol. Concrete providers
+#    satisfy it STRUCTURALLY (duck-typed), so none import it -- invisible to reachability, but
+#    it is the load-bearing interface definition every provider is checked against. NOT dead.
+infermap.providers.base: "surface -- Provider Protocol (runtime_checkable; implemented structurally, not imported)"

--- a/scripts/check_dead_code.py
+++ b/scripts/check_dead_code.py
@@ -145,20 +145,34 @@ def _ancestors(mod: str) -> list[str]:
 
 
 def _scan_test_imports(pkg: str, src_root: Path) -> set[str]:
-    """Modules imported by the test suite are exercised (roots) even if no source imports
-    them. tests/ lives beside the package dir (../tests from the {pkg}/{pkg} source root)."""
-    tests_dir = src_root.parent / "tests"
-    if not tests_dir.is_dir():
-        return set()
+    """Modules imported by the test suite (and sibling scripts) are exercised (roots) even if
+    no source imports them. `tests/`/`scripts/` live beside the package dir (../ from the
+    {pkg}/{pkg} source root). AST-parsed, NOT regex: a `from {pkg}.core import _planner_json`
+    names the SUBMODULE `{pkg}.core._planner_json` in the imported-name position, which a
+    "dotted path after from/import" regex misses -- the same `from X import <submodule>`
+    under-recording that made the codemap unsound. We emit both the module and each
+    `module.name` candidate; the caller keeps only those that are real modules."""
     hit: set[str] = set()
-    pat = re.compile(rf"\b(?:from|import)\s+({re.escape(pkg)}(?:\.[A-Za-z0-9_]+)*)")
-    for f in tests_dir.rglob("*.py"):
-        try:
-            text = f.read_text(encoding="utf-8-sig", errors="ignore")
-        except OSError:
+    for sib in ("tests", "scripts"):
+        d = src_root.parent / sib
+        if not d.is_dir():
             continue
-        for m in pat.finditer(text):
-            hit.add(m.group(1))
+        for f in d.rglob("*.py"):
+            try:
+                tree = ast.parse(f.read_text(encoding="utf-8-sig", errors="ignore"))
+            except (OSError, SyntaxError):
+                continue
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for a in node.names:
+                        if a.name == pkg or a.name.startswith(pkg + "."):
+                            hit.add(a.name)
+                elif isinstance(node, ast.ImportFrom) and not node.level:
+                    m = node.module or ""
+                    if m == pkg or m.startswith(pkg + "."):
+                        hit.add(m)
+                        for a in node.names:      # `from pkg.sub import submodule` names a module
+                            hit.add(f"{m}.{a.name}")
     return hit
 
 
@@ -357,13 +371,17 @@ def analyze_symbols_scoped(pkg: str) -> dict:
                 defs[(mod, node.name)] = (str(f.relative_to(REPO)), node.lineno)
         top_names[mod] = names
 
-    # resolve uses across source, in-package tests, AND the sibling test suite (the real
-    # goldenmatch tests live at <pkg>/tests, a SIBLING of the <pkg>/<pkg> source root -- not
-    # under it -- so a source-only scan falsely flags every test-only-consumed symbol).
+    # resolve uses across source, in-package tests, the sibling test suite, AND the sibling
+    # scripts/ dir. The real test suite lives at <pkg>/tests (a SIBLING of the <pkg>/<pkg>
+    # source root, not under it), and package-local <pkg>/scripts/ holds maintenance / codegen
+    # / byte-parity-corpus generators that are legitimate consumers of reference helpers (e.g.
+    # goldenflow's `_double_metaphone_*_py` are used only by scripts/gen_identifiers_corpus.py).
+    # A source-only scan falsely flags every symbol consumed only by a test or a script.
     all_py = list(src_root.rglob("*.py"))
-    ext_tests = src_root.parent / "tests"
-    if ext_tests.is_dir():
-        all_py += list(ext_tests.rglob("*.py"))
+    for sib in ("tests", "scripts"):
+        d = src_root.parent / sib
+        if d.is_dir():
+            all_py += list(d.rglob("*.py"))
     used: set[tuple[str, str]] = set()
     for f in all_py:
         try:
@@ -375,13 +393,19 @@ def analyze_symbols_scoped(pkg: str) -> dict:
         in_tree = src_root in f.parents
         this_mod = _module_name(f, src_root, pkg) if in_tree else None
         pkg_of = (this_mod if f.name == "__init__.py" else this_mod.rsplit(".", 1)[0]) if this_mod else pkg
-        sym_binds: dict[str, tuple[str, str]] = {}   # local -> (module, orig)  [symbol import]
-        mod_binds: dict[str, str] = {}               # local -> module          [module alias]
+        # local name -> SET of targets. Set-valued (not scalar) because one file can bind the
+        # SAME local name to different modules in different branches -- CLI dispatch does
+        # `from .mcp.server import run_server` in one command and `from .a2a.server import
+        # run_server` in another. A scalar map lets the second overwrite the first, so a bare
+        # `run_server()` credits only the last binding and the other is falsely flagged. We
+        # can't tell which branch runs, so a use marks EVERY candidate binding used.
+        sym_binds: dict[str, set[tuple[str, str]]] = {}   # local -> {(module, orig), ...}
+        mod_binds: dict[str, set[str]] = {}               # local -> {module, ...}
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):
                 for a in node.names:
                     if a.name == pkg or a.name.startswith(pkg + "."):
-                        mod_binds[a.asname or a.name.split(".")[0]] = a.name
+                        mod_binds.setdefault(a.asname or a.name.split(".")[0], set()).add(a.name)
             elif isinstance(node, ast.ImportFrom):
                 if node.level:
                     base_parts = pkg_of.split(".")
@@ -394,14 +418,14 @@ def analyze_symbols_scoped(pkg: str) -> dict:
                 for a in node.names:
                     local = a.asname or a.name
                     if f"{m}.{a.name}" in known_modules:      # from pkg import submodule
-                        mod_binds[local] = f"{m}.{a.name}"
+                        mod_binds.setdefault(local, set()).add(f"{m}.{a.name}")
                     else:                                      # from module import symbol
-                        sym_binds[local] = (m, a.name)
+                        sym_binds.setdefault(local, set()).add((m, a.name))
         # walk loads
         for node in ast.walk(tree):
             if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
                 if node.id in sym_binds:
-                    used.add(sym_binds[node.id])
+                    used.update(sym_binds[node.id])
                 elif node.id in top_names.get(this_mod, ()):   # same-module use
                     used.add((this_mod, node.id))
             elif isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load):
@@ -410,10 +434,9 @@ def analyze_symbols_scoped(pkg: str) -> dict:
                     continue
                 base = chain[0]
                 if base in mod_binds and len(chain) >= 2:
-                    used.add((mod_binds[base], chain[1]))
+                    used.update((mod, chain[1]) for mod in mod_binds[base])
                 elif base in sym_binds and len(chain) >= 2:
-                    m, orig = sym_binds[base]
-                    used.add((m, orig))                        # attr on an imported symbol => symbol used
+                    used.update(sym_binds[base])               # attr on an imported symbol => symbol used
                 elif base == pkg:                              # goldenmatch.a.b.SYM
                     for i in range(len(chain) - 1, 0, -1):
                         mod = ".".join(chain[:i])


### PR DESCRIPTION
## What and why

Extends the architecture-aware dead-code detector (#2020) from goldenmatch-only to all six Python packages. Running both passes across `goldenmatch`, `goldencheck`, `goldenflow`, `goldenpipe`, `infermap`, `goldenanalysis` confirms the suite is clean — and surfaced three more resolver-substrate bugs (fixed) plus one confirmed dead symbol (removed).

## Results

| Package | module orphans | symbol `strong` |
|---|---|---|
| goldenmatch | 0 uncovered | 29 (known surfaces) |
| goldencheck | 0 | **0** |
| goldenflow | 1 (classified) | 4 (owner-review) |
| goldenpipe | 0 | 11 (native oracle surface) |
| infermap | 1 (classified) | 0 |
| goldenanalysis | 0 | 0 |

`--check` is green for all six; `parity/dead_code/<pkg>.yaml` now covers every module orphan (new files for goldenflow + infermap).

## Three resolver-substrate bugs fixed

All the same "a legitimate consumer or a real binding is invisible to the scan" class as the Phase-2b BOM / sibling-tests finds:

1. **Multi-binding overwrite** — the scoped resolver kept one target per local name, so CLI dispatch that binds `run_server` from both `.mcp.server` and `.a2a.server` in different command branches credited only the last import and false-flagged the first. `sym_binds`/`mod_binds` are now set-valued; a use marks **every** candidate binding. Cleared 6 goldenmatch + 1 goldenflow + 1 goldenpipe FPs.
2. **Package-local `scripts/` under-scan** — the use-scan covered `<pkg>/tests` but not the sibling `<pkg>/scripts/`, where byte-parity-corpus / codegen generators live. goldenflow's `_double_metaphone_*_py` and goldenmatch's `sail.session.connect` are script-only consumers. **This retroactively cleared the Phase-1 "1 genuine dead candidate"** (`sail.session` was never dead, just script-reached).
3. **`from pkg.sub import <submodule>` module-level test-import under-recording** — `_scan_test_imports` used a regex that missed the imported-name-is-a-submodule case (`from goldenpipe.core import _planner_json`), false-flagging the parity-test-exercised `_planner_json`. Replaced with an AST scan. Cleared goldenpipe's 2 orphans + 2 goldenmatch stale deferrals.

## One dead symbol removed

`goldencheck.mcp.agent_tools._serialize_findings` — a verbatim duplicate of the copy in `mcp/server.py:210` (the one actually used, 3×); the `agent_tools` copy was shadowed and never called. Removed it + its now-orphaned `asdict` import.

## Left for owner review (classified/documented, not deleted)

The ambiguous middle between dead and intended-public-API, in packages whose roadmap isn't mine to prune: goldenflow's cloud-**write** connectors (the read side is wired), `history.get_run`, the unwired `json_reporter`; and goldenpipe's native parity-oracle `_native_loader` surface.

## Testing

- `check_dead_code.py <pkg> --check` green for all six packages.
- `check_dead_code.py <pkg> --scoped` clean (counts above).
- goldencheck `agent_tools.py` compiles; `ruff check` clean (no orphaned imports).
- `scripts/test_agent_codemap.py::test_codemap_current` passes (regenerated after the goldencheck removal).

## Checklist

- [x] Tests added/updated and passing locally (the gate self-verifies; codemap gate regenerated)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / spec updated (per-package results + the three resolver fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_