### PR TITLE
feat(ts): port + WASM-back the radial scorer (Python-only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match`, `radial` |
+| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 38 | 40 | 12 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 20 | 20 | 16 |
-| `goldenmatch` | scorers | 13 | 4 | 2 |
+| `goldenmatch` | scorers | 14 | 3 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 8 | 11 | 3 |
@@ -69,7 +69,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `list_scorers`, `list_strategies`, `list_transforms`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
-- `goldenmatch` **scorers** — Python-only: `alias_match`, `audio_fp`, `initialism_match`, `radial`.
+- `goldenmatch` **scorers** — Python-only: `alias_match`, `audio_fp`, `initialism_match`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -110,6 +110,7 @@ export {
   jaccardSimilarity,
   qgramScore,
   phashSimilarity,
+  radialSimilarity,
   ensembleScore,
   scoreMatrix,
   asString,

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -521,6 +521,74 @@ export function phashSimilarity(a: string, b: string): number {
   return 1.0 - dist / nbits;
 }
 
+/** Parse a radial-variance profile: 2 hex chars per bin as a SIGNED byte
+ * (`b >= 128 -> b - 256`), `0x`/`0X` prefix tolerated, an odd trailing char
+ * dropped. Any non-hex char in the used prefix -> null (mirrors score-core
+ * `radial_from_hex`, whose `to_digit(16)?` fails there). */
+function radialFromHex(s: string): number[] | null {
+  let h = s;
+  if (h.length >= 2 && (h.startsWith("0x") || h.startsWith("0X"))) h = h.slice(2);
+  const usable = h.length - (h.length % 2);
+  if (!/^[0-9a-fA-F]*$/.test(h.slice(0, usable))) return null;
+  const out: number[] = [];
+  for (let i = 0; i < usable; i += 2) {
+    const byte = parseInt(h.slice(i, i + 2), 16);
+    out.push(byte >= 128 ? byte - 256 : byte);
+  }
+  return out;
+}
+
+/** Pearson correlation of two equal-length int sequences; 0.0 if either is
+ * constant. Mean is `sum/len` (integer sum, one divide) and every reduction
+ * accumulates left-to-right, mirroring score-core `pearson` / Python `_pearson`. */
+function pearson(a: readonly number[], b: readonly number[]): number {
+  const n = a.length;
+  let sa = 0;
+  let sb = 0;
+  for (let i = 0; i < n; i++) {
+    sa += a[i]!;
+    sb += b[i]!;
+  }
+  const ma = sa / n;
+  const mb = sb / n;
+  let da = 0;
+  let db = 0;
+  for (let i = 0; i < n; i++) {
+    const dax = a[i]! - ma;
+    da += dax * dax;
+    const dbx = b[i]! - mb;
+    db += dbx * dbx;
+  }
+  if (da === 0 || db === 0) return 0.0;
+  let num = 0;
+  for (let i = 0; i < n; i++) num += (a[i]! - ma) * (b[i]! - mb);
+  return num / Math.sqrt(da * db);
+}
+
+/**
+ * Radial-variance profile similarity (score_one id 13): the max Pearson over
+ * every cyclic angular shift of `b`, clamped to [0, 1]. Mismatched/empty profiles
+ * or a non-hex value -> 0.0. Mirrors score-core `radial_similarity` /
+ * `radial_align` / Python `radial_align_similarity`; the f64 reductions can differ
+ * ~1 ULP from the WASM kernel's (possible SIMD) order, so parity is ~4dp not
+ * byte-exact.
+ */
+export function radialSimilarity(a: string, b: string): number {
+  const x = radialFromHex(a);
+  const y = radialFromHex(b);
+  if (x === null || y === null) return 0.0;
+  const la = x.length;
+  if (la === 0 || y.length !== la) return 0.0;
+  let best = -1.0;
+  const rotated = new Array<number>(la);
+  for (let shift = 0; shift < la; shift++) {
+    for (let k = 0; k < la; k++) rotated[k] = y[(shift + k) % la]!;
+    const c = pearson(x, rotated);
+    if (c > best) best = c;
+  }
+  return Math.min(1.0, Math.max(0.0, best));
+}
+
 /**
  * Padded character q-gram set of a raw string (Python parity:
  * core/scorer.py::_qgram_set). Lowercases, pads with `n-1` `#` sentinels on
@@ -602,6 +670,8 @@ export function scoreField(
       return qgramScore(valA, valB);
     case "phash":
       return phashSimilarity(valA, valB);
+    case "radial":
+      return radialSimilarity(valA, valB);
     case "ensemble":
       return ensembleScore(valA, valB);
     case "embedding":

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -506,6 +506,7 @@ export const VALID_SCORERS = new Set([
   "jaccard",
   "qgram",
   "phash",
+  "radial",
   "given_name_aliased_jw",
   "name_freq_weighted_jw",
 ] as const);

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -67,6 +67,14 @@
  * soundex_match component is byte-exact). Like exact/soundex_match, `buildScoreMatrix`
  * keeps the O(n) pure-TS `ensembleScoreMatrix` intercept; this id is reached only via a
  * direct `scoreMatrix` call, where the kernel is reachable + parity-proven.
+ *
+ * `radial` (id 13) is rotation-aligned Pearson of two hex radial-variance profiles
+ * (max Pearson over every cyclic shift, clamped to [0,1]). The kernel and the pure-TS
+ * `radialSimilarity` do the identical signed-byte parse + left-to-right f64 reductions,
+ * but the WASM release build may vectorize the Pearson sums in a different order, so the
+ * WASM matrix matches the pure-TS fallback to ~4dp (not byte-exact) — the same 1-ULP
+ * reduction-order tolerance the native<->pure Python radial parity carries. A non-hex or
+ * mismatched-length profile -> 0.0 on both.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -80,6 +88,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   jaccard: 10,
   phash: 11,
   ensemble: 12,
+  radial: 13,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -345,6 +345,42 @@ d("WASM phash matches the pure-TS scoreField reference (exact)", () => {
   }
 });
 
+// radial (score_one id 13): rotation-aligned Pearson of two hex radial-variance
+// profiles (max Pearson over every cyclic shift, clamped to [0,1]). The kernel and
+// the pure-TS `radialSimilarity` do the identical signed-byte parse + left-to-right
+// f64 Pearson reductions, but the WASM release build may vectorize the sums in a
+// different order, so parity is ~4dp (not byte-exact) -- the 1-ULP reduction-order
+// tolerance the native<->pure Python radial parity also carries. Non-hex / mismatched
+// length -> 0.0 on both.
+type RadialCase = readonly [a: string, b: string, note: string];
+const RADIAL_CASES: readonly RadialCase[] = [
+  ["0a1b2c3d", "0a1b2c3d", "identical -> 1.0"],
+  ["0a1b2c3d", "2c3d0a1b", "cyclic rotation aligns -> 1.0"],
+  ["0a1b2c3d", "3d0a1b2c", "another cyclic rotation -> 1.0"],
+  ["01020304", "04030201", "reversed profile (partial correlation)"],
+  ["ff01ff01", "01ff01ff", "signed bytes (0xff = -1) rotation"],
+  ["0a0a0a0a", "01020304", "constant profile -> 0.0 (zero variance)"],
+  ["0a1b2c3d", "0a1b", "length mismatch -> 0.0"],
+  ["zz", "0102", "non-hex -> 0.0"],
+];
+
+d("WASM radial matches the pure-TS scoreField reference (4dp)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of RADIAL_CASES) {
+    it(`radial("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "radial");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "radial");
+      expect(m[0]![1]!).toBeCloseTo(ref!, 9);
+    });
+  }
+});
+
 d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
   beforeAll(async () => {
     const ok = await enableWasm();

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -13,6 +13,7 @@ import {
   diceCoefficient,
   jaccardSimilarity,
   phashSimilarity,
+  radialSimilarity,
   ensembleScore,
   scoreMatrix,
   applyTransform,
@@ -199,6 +200,35 @@ describe("phash (perceptual-hash hex similarity)", () => {
   it("non-hex or empty -> 0.0", () => {
     expect(phashSimilarity("zzzz", "1234")).toBe(0.0);
     expect(phashSimilarity("", "")).toBe(0.0);
+  });
+});
+
+describe("radial (rotation-aligned Pearson of hex radial profiles)", () => {
+  it("identical profile -> 1.0", () => {
+    expect(radialSimilarity("0a1b2c3d", "0a1b2c3d")).toBeCloseTo(1.0, 12);
+  });
+
+  it("a cyclic rotation aligns to 1.0", () => {
+    // radial_align maxes Pearson over every cyclic shift, so a rotation of the
+    // same profile finds a perfect alignment. "2c3d0a1b" and "3d0a1b2c" are the
+    // shift-2 and shift-3 cyclic rotations of [0a,1b,2c,3d].
+    expect(radialSimilarity("0a1b2c3d", "2c3d0a1b")).toBeCloseTo(1.0, 12);
+    expect(radialSimilarity("0a1b2c3d", "3d0a1b2c")).toBeCloseTo(1.0, 12);
+  });
+
+  it("a constant profile has zero variance -> 0.0", () => {
+    expect(radialSimilarity("0a0a0a0a", "01020304")).toBe(0.0);
+  });
+
+  it("mismatched-length / non-hex / empty -> 0.0", () => {
+    expect(radialSimilarity("0a1b2c3d", "0a1b")).toBe(0.0); // length mismatch
+    expect(radialSimilarity("zz", "0102")).toBe(0.0); // non-hex
+    expect(radialSimilarity("", "")).toBe(0.0); // empty
+  });
+
+  it("signed-byte decode: 0x80..0xff map to negatives", () => {
+    // Both sides identical still correlate to 1.0 regardless of sign.
+    expect(radialSimilarity("7f80017e", "7f80017e")).toBeCloseTo(1.0, 12);
   });
 });
 

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,7 +25,7 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 11 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 12 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "date",
@@ -39,6 +39,7 @@ describe("ScorerBackend singleton", () => {
         "name_freq_weighted_jw",
         "phash",
         "qgram",
+        "radial",
         "soundex_match",
         "token_sort",
       ],

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -254,6 +254,7 @@ scorers:
   - levenshtein
   - phash
   - qgram
+  - radial
   - record_embedding
   - soundex_match
   - token_sort
@@ -261,7 +262,6 @@ scorers:
   - alias_match
   - audio_fp
   - initialism_match
-  - radial
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw
@@ -334,13 +334,13 @@ scorer_kernels:
   - levenshtein
   - phash
   - qgram
+  - radial
   - soundex_match
   - token_sort
   python_only:
   - alias_match
   - audio_fp
   - initialism_match
-  - radial
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw


### PR DESCRIPTION
## What and why

`radial` (rotation-aligned Pearson of two hex radial-variance profiles - the max Pearson over every cyclic angular shift, clamped to [0,1]) was **Python-only**, absent from the TS surface. This ports the pure-TS scorer (the mandatory opt-in-WASM fallback) and wires the kernel, so radial is now a valid TS scorer and kernel-backed on both surfaces. **No Rust change** - score-wasm's `score_matrix_impl` catch-all already routes id 13 to `score_one(13) = radial_similarity`.

Unlike the integer scorers (`phash`/`dice`/`jaccard`), radial does **f64 Pearson reductions**, so its WASM<->pure-TS parity is ~4dp (the WASM release build may vectorize the sums in a different order than sequential JS) - the same 1-ULP reduction-order tolerance the native<->pure Python radial parity carries. Empirically it holds to **9dp** on the parity cases.

## Changes

- `src/core/scorer.ts`: `radialSimilarity` + `radialFromHex` (2-hex-per-bin signed byte, `0x` prefix tolerated, odd trailing char dropped, non-hex -> null) + `pearson` (integer-sum mean, left-to-right f64 reductions, constant profile -> 0.0); `case "radial"` in `scoreField`; exported via `core/index`.
- `src/core/types.ts`: `VALID_SCORERS` += `radial` (the `scorers` surface).
- `src/core/wasm/backend.ts`: `SCORER_ID` += `radial: 13` (the `scorer_kernels` surface / `WASM_COVERED_SCORERS`) + doc.
- `parity/goldenmatch.yaml`: `radial` moves python_only -> shared in BOTH `scorers` and `scorer_kernels`.
- `docs-site/suite-matrix.mdx` regenerated (radial -> the "Python + TS" kernel row).
- tests: pure-TS `radial` unit block (identity / cyclic-rotation-aligns-to-1.0 / constant-profile -> 0 / mismatched-length / non-hex / signed-byte) + a wasm-scorer parity block (WASM `score_one(13)` == pure-TS `radialSimilarity` to 9dp); `wasm-backend` covered-set assertion updated (12 score_one + 2 name scorers).

## Testing

- `check_api_parity.py goldenmatch` - "parity OK".
- `vitest run` - 185 files, 3244 pass + 1 expected-fail; the radial parity block holds at 9dp (empirically much tighter than the ~4dp contract). `tsc --noEmit` clean.

## Follow-ups (the remaining python_only scorers)

- **`audio_fp`** - next; audio-fingerprint BER over frame offsets, f64 reductions like radial (4dp parity).
- **`initialism_match`** - needs the `legal_forms` reference table injected into score-wasm (like the name scorers' tables).
- **`alias_match`** - architecturally blocked: score-wasm builds it behind the `alias` cargo feature that is **off** for the wasm surface (id 8 -> 0.0 catch-all), and it needs business/given-name alias tables. Needs a decision (enable the feature + wire tables) rather than a straight port.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; full vitest green; tsc clean
- [ ] Package `CHANGELOG.md` updated if behavior changed (new capability on the TS surface; no change to existing scorers)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_