### PR TITLE
feat(ts): port + WASM-back the audio_fp scorer (Python-only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `audio_fp`, `initialism_match` |
+| Rust `-core` kernel — Python + TS | `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `initialism_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 38 | 40 | 12 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 20 | 20 | 16 |
-| `goldenmatch` | scorers | 14 | 3 | 2 |
+| `goldenmatch` | scorers | 15 | 2 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 8 | 11 | 3 |
@@ -69,7 +69,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `list_scorers`, `list_strategies`, `list_transforms`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
-- `goldenmatch` **scorers** — Python-only: `alias_match`, `audio_fp`, `initialism_match`.
+- `goldenmatch` **scorers** — Python-only: `alias_match`, `initialism_match`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -111,6 +111,7 @@ export {
   qgramScore,
   phashSimilarity,
   radialSimilarity,
+  audioFpSimilarity,
   ensembleScore,
   scoreMatrix,
   asString,

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -589,6 +589,66 @@ export function radialSimilarity(a: string, b: string): number {
   return Math.min(1.0, Math.max(0.0, best));
 }
 
+/** Parse a concatenated audio fingerprint: 8 hex chars per u32 word, `0x`/`0X`
+ * prefix tolerated, trailing chars past the last full word dropped. Any non-hex
+ * char in the used prefix -> null (mirrors score-core `audio_fp_from_hex`). */
+function audioFpFromHex(s: string): number[] | null {
+  let h = s;
+  if (h.length >= 2 && (h.startsWith("0x") || h.startsWith("0X"))) h = h.slice(2);
+  const usable = h.length - (h.length % 8);
+  if (!/^[0-9a-fA-F]*$/.test(h.slice(0, usable))) return null;
+  const out: number[] = [];
+  for (let i = 0; i < usable; i += 8) {
+    out.push(parseInt(h.slice(i, i + 8), 16)); // 8 hex digits = one u32 word
+  }
+  return out;
+}
+
+/** Popcount of a 32-bit word (SWAR; `>>> 0` normalizes the signed XOR result). */
+function popcount32(v: number): number {
+  v = v >>> 0;
+  v = v - ((v >>> 1) & 0x55555555);
+  v = (v & 0x33333333) + ((v >>> 2) & 0x33333333);
+  return (((v + (v >>> 4)) & 0x0f0f0f0f) * 0x01010101) >>> 24;
+}
+
+/** Best (minimum) bit-error-rate over all frame offsets of two audio
+ * fingerprints; mirrors score-core `audio_ber_aligned` (need = min(8, la, lb),
+ * 32 bits/band, `bits/(overlap*32)` per offset). Empty input -> BER 1.0. */
+function audioBerAligned(a: readonly number[], b: readonly number[]): number {
+  const la = a.length;
+  const lb = b.length;
+  if (la === 0 || lb === 0) return 1.0;
+  const need = Math.min(8, la, lb);
+  const nb = 32.0; // AUDIO_BANDS - 1
+  let best = 1.0;
+  for (let off = -(lb - 1); off < la; off++) {
+    const lo = Math.max(off, 0);
+    const hi = Math.min(la, off + lb);
+    const overlap = hi - lo;
+    if (overlap < need) continue;
+    let bits = 0;
+    for (let i = lo; i < hi; i++) bits += popcount32(a[i]! ^ b[i - off]!);
+    const ber = bits / (overlap * nb);
+    if (ber < best) best = ber;
+  }
+  return best;
+}
+
+/**
+ * Audio-fingerprint similarity (score_one id 14): `1 - best BER`, the minimum
+ * bit-error-rate over every frame offset of two hex audio fingerprints. Byte-exact
+ * with score-core `audio_fp_similarity` / Python `_audio_fp_score_single` -- the BER
+ * numerator is an integer popcount sum and the rate is a single f64 divide (no
+ * reduction-order divergence). A non-hex value on either side -> 0.0.
+ */
+export function audioFpSimilarity(a: string, b: string): number {
+  const x = audioFpFromHex(a);
+  const y = audioFpFromHex(b);
+  if (x === null || y === null) return 0.0;
+  return 1.0 - audioBerAligned(x, y);
+}
+
 /**
  * Padded character q-gram set of a raw string (Python parity:
  * core/scorer.py::_qgram_set). Lowercases, pads with `n-1` `#` sentinels on
@@ -672,6 +732,8 @@ export function scoreField(
       return phashSimilarity(valA, valB);
     case "radial":
       return radialSimilarity(valA, valB);
+    case "audio_fp":
+      return audioFpSimilarity(valA, valB);
     case "ensemble":
       return ensembleScore(valA, valB);
     case "embedding":

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -507,6 +507,7 @@ export const VALID_SCORERS = new Set([
   "qgram",
   "phash",
   "radial",
+  "audio_fp",
   "given_name_aliased_jw",
   "name_freq_weighted_jw",
 ] as const);

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -75,6 +75,12 @@
  * WASM matrix matches the pure-TS fallback to ~4dp (not byte-exact) — the same 1-ULP
  * reduction-order tolerance the native<->pure Python radial parity carries. A non-hex or
  * mismatched-length profile -> 0.0 on both.
+ *
+ * `audio_fp` (id 14) is `1 - best BER` over two hex audio fingerprints (the minimum
+ * bit-error-rate across every frame offset). Unlike radial, its BER numerator is an
+ * INTEGER popcount sum and the rate is a single f64 divide per offset, so the kernel
+ * and the pure-TS `audioFpSimilarity` are byte-exact (like phash) -- no reduction-order
+ * divergence. A non-hex value on either side -> 0.0.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -89,6 +95,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   phash: 11,
   ensemble: 12,
   radial: 13,
+  audio_fp: 14,
   given_name_aliased_jw: 20,
   name_freq_weighted_jw: 21,
 };

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -381,6 +381,39 @@ d("WASM radial matches the pure-TS scoreField reference (4dp)", () => {
   }
 });
 
+// audio_fp (score_one id 14): 1 - best BER over two hex audio fingerprints (min
+// bit-error-rate across every frame offset). The BER numerator is an INTEGER popcount
+// sum and the rate is one f64 divide per offset, so -- unlike radial -- the kernel and
+// the pure-TS `audioFpSimilarity` are byte-exact (like phash). 8 hex chars per u32 word;
+// non-hex -> 0.0. Asserted byte-exact.
+type AudioFpCase = readonly [a: string, b: string, note: string];
+const AUDIO_FP_CASES: readonly AudioFpCase[] = [
+  ["0000000000000000", "0000000000000000", "identical (8 words) -> 1.0"],
+  ["ffffffffffffffff", "0000000000000000", "all bits differ at best offset"],
+  ["deadbeefcafebabe", "deadbeefcafebabe", "identical multi-word -> 1.0"],
+  ["11111111222222223333333344444444", "2222222233333333", "shorter slides to a matching offset"],
+  ["0x0102030405060708", "0102030405060708", "0x prefix stripped -> 1.0"],
+  ["12345678", "87654321", "single-word BER"],
+  ["nothex00", "12345678", "non-hex -> 0.0"],
+];
+
+d("WASM audio_fp matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of AUDIO_FP_CASES) {
+    it(`audio_fp("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "audio_fp");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "audio_fp");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});
+
 d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
   beforeAll(async () => {
     const ok = await enableWasm();

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -14,6 +14,7 @@ import {
   jaccardSimilarity,
   phashSimilarity,
   radialSimilarity,
+  audioFpSimilarity,
   ensembleScore,
   scoreMatrix,
   applyTransform,
@@ -229,6 +230,30 @@ describe("radial (rotation-aligned Pearson of hex radial profiles)", () => {
   it("signed-byte decode: 0x80..0xff map to negatives", () => {
     // Both sides identical still correlate to 1.0 regardless of sign.
     expect(radialSimilarity("7f80017e", "7f80017e")).toBeCloseTo(1.0, 12);
+  });
+});
+
+describe("audio_fp (offset-aligned bit-error-rate of hex fingerprints)", () => {
+  it("identical fingerprints -> 1.0", () => {
+    expect(audioFpSimilarity("deadbeef", "deadbeef")).toBe(1.0);
+    expect(audioFpSimilarity("deadbeefcafebabe", "deadbeefcafebabe")).toBe(1.0);
+  });
+
+  it("all bits differ over one word -> BER 1.0 -> 0.0", () => {
+    expect(audioFpSimilarity("00000000", "ffffffff")).toBe(0.0);
+  });
+
+  it("one differing bit over 32 -> 1 - 1/32", () => {
+    expect(audioFpSimilarity("00000001", "00000000")).toBe(1 - 1 / 32);
+  });
+
+  it("strips a 0x prefix", () => {
+    expect(audioFpSimilarity("0xdeadbeef", "deadbeef")).toBe(1.0);
+  });
+
+  it("non-hex or empty -> 0.0", () => {
+    expect(audioFpSimilarity("nothex00", "12345678")).toBe(0.0);
+    expect(audioFpSimilarity("", "")).toBe(0.0); // empty -> BER 1.0 -> 0.0
   });
 });
 

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,9 +25,10 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 12 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 13 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
+        "audio_fp",
         "date",
         "dice",
         "ensemble",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -244,6 +244,7 @@ a2a_skills:
 # PluginRegistry validator fallback, so they're NOT in Python VALID_SCORERS).
 scorers:
   shared:
+  - audio_fp
   - date
   - dice
   - embedding
@@ -260,7 +261,6 @@ scorers:
   - token_sort
   python_only:
   - alias_match
-  - audio_fp
   - initialism_match
   ts_only:
   - given_name_aliased_jw
@@ -317,14 +317,16 @@ blocking_strategies:
 # components hold vs rapidfuzz (soundex byte-exact). `phash` (id 11) is also shared:
 # perceptual-hash similarity (1 - hamming/nbits over hex pHashes), integer XOR popcount,
 # byte-exact WASM<->pure-TS like dice/jaccard.
-# python_only: `initialism_match`, `alias_match`, `radial`, `audio_fp` have an
-# arrow-native (bucket) kernel on Python but no TS WASM port yet.
+# python_only: `initialism_match`, `alias_match` have an arrow-native (bucket) kernel
+# on Python but no TS WASM port yet (initialism needs the legal_forms table injected;
+# alias_match is behind score-wasm's off-by-default `alias` cargo feature).
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
 # (Python accepts them via the plugin fallback); a real, declared Python<->TS delta.
 scorer_kernels:
   shared:
+  - audio_fp
   - date
   - dice
   - ensemble
@@ -339,7 +341,6 @@ scorer_kernels:
   - token_sort
   python_only:
   - alias_match
-  - audio_fp
   - initialism_match
   ts_only:
   - given_name_aliased_jw


### PR DESCRIPTION
## What and why

`audio_fp` (offset-aligned audio-fingerprint similarity: `1 - best BER`, the minimum bit-error-rate over every frame offset of two hex fingerprints) was **Python-only**, absent from the TS surface. This ports the pure-TS scorer (the mandatory opt-in-WASM fallback) and wires the kernel, so audio_fp is now a valid TS scorer and kernel-backed on both surfaces. **No Rust change** - score-wasm's `score_matrix_impl` catch-all already routes id 14 to `score_one(14) = audio_fp_similarity`.

Unlike `radial` (f64 Pearson reductions, ~4dp), `audio_fp` is **byte-exact** like `phash`: the BER numerator is an integer popcount sum and the rate is a single f64 divide per offset, so there's no reduction-order divergence between the WASM kernel and pure-TS (confirmed empirically - the parity block asserts `toBe(ref)`).

## Changes

- `src/core/scorer.ts`: `audioFpSimilarity` + `audioFpFromHex` (8 hex chars per u32 word, `0x` prefix tolerated, trailing partial word dropped, non-hex -> null) + `popcount32` (SWAR) + `audioBerAligned` (min BER over frame offsets, `need = min(8, la, lb)`, 32 bits/band); `case "audio_fp"` in `scoreField`; exported via `core/index`.
- `src/core/types.ts`: `VALID_SCORERS` += `audio_fp` (the `scorers` surface).
- `src/core/wasm/backend.ts`: `SCORER_ID` += `audio_fp: 14` (the `scorer_kernels` surface / `WASM_COVERED_SCORERS`) + doc.
- `parity/goldenmatch.yaml`: `audio_fp` moves python_only -> shared in BOTH `scorers` and `scorer_kernels`.
- `docs-site/suite-matrix.mdx` regenerated (audio_fp -> the "Python + TS" kernel row).
- tests: pure-TS `audio_fp` unit block (identical / all-differ / 1-of-32-bit / 0x-prefix / non-hex / empty) + a wasm-scorer byte-exact parity block (WASM `score_one(14)` == pure-TS `audioFpSimilarity`); `wasm-backend` covered-set assertion updated (13 score_one + 2 name scorers).

## Testing

- `check_api_parity.py goldenmatch` - "parity OK".
- `vitest run` - 185 files, 3256 pass + 1 expected-fail; the audio_fp parity block is byte-exact. `tsc --noEmit` clean.

## Follow-ups (the last two python_only scorers)

Both of the remaining scorers need more than a straight port - flagging rather than forcing:
- **`initialism_match`** (id 7) - needs the `legal_forms` reference table injected into score-wasm at `enableWasm()` (the same table-injection mechanism the name scorers ids 20/21 use for their census/alias tables). A real port + a loader change.
- **`alias_match`** (id 8) - **architecturally blocked**: score-wasm builds it behind the `alias` cargo feature that is **off** for the wasm surface (id 8 falls to the 0.0 catch-all), and it also needs business/given-name alias tables installed. Enabling it is a score-wasm build + loader decision, not a TS-only port.

After this PR, every string scorer with a byte-exact-or-tolerance-parity kernel is shared; the two above are the declared remaining deltas.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; full vitest green; tsc clean
- [ ] Package `CHANGELOG.md` updated if behavior changed (new capability on the TS surface; no change to existing scorers)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_