### PR TITLE
feat(ts): port + WASM-back the initialism_match scorer (Python-only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match`, `initialism_match` |
+| Rust `-core` kernel — Python + TS | `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match` |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 38 | 40 | 12 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 20 | 20 | 16 |
-| `goldenmatch` | scorers | 15 | 2 | 2 |
+| `goldenmatch` | scorers | 16 | 1 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 8 | 11 | 3 |
@@ -69,7 +69,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `list_scorers`, `list_strategies`, `list_transforms`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
-- `goldenmatch` **scorers** — Python-only: `alias_match`, `initialism_match`.
+- `goldenmatch` **scorers** — Python-only: `alias_match`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/packages/rust/extensions/score-wasm/src/lib.rs
+++ b/packages/rust/extensions/score-wasm/src/lib.rs
@@ -53,6 +53,14 @@ pub fn install_name_aliases(forms: Vec<String>, canonicals: Vec<String>) {
     let _ = NAME_ALIASES.set(AliasTable::from_forms(grouped));
 }
 
+/// Install the legal-form variant set for `initialism_match` (id 7). Delegates to
+/// score-core's process-global `set_legal_forms` OnceLock (first-wins) so
+/// `score_one(7, ...)` drops the SAME legal forms the pure-TS path does. Shared by
+/// the wasm setter + native tests.
+pub fn install_legal_forms(forms: Vec<String>) {
+    let _ = goldenmatch_score_core::set_legal_forms(forms.into_iter().collect());
+}
+
 /// Full row-major NxN similarity matrix for `values` under `scorer_id`.
 /// Diagonal = 0.0 and the matrix is symmetric, matching the pure-TS
 /// `scoreMatrix` (which fills the upper triangle, mirrors it, and leaves the
@@ -206,7 +214,7 @@ mod tests {
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use super::{install_name_aliases, install_surname_idf, score_matrix_impl};
+    use super::{install_legal_forms, install_name_aliases, install_surname_idf, score_matrix_impl};
     use wasm_bindgen::prelude::*;
 
     /// JS entry: `values` is one string with fields joined by `sep` (a 1-char
@@ -235,5 +243,13 @@ mod wasm {
     #[wasm_bindgen]
     pub fn set_name_aliases(forms: Vec<String>, canonicals: Vec<String>) {
         install_name_aliases(forms, canonicals);
+    }
+
+    /// Install the legal-form variant set for `initialism_match` (id 7). Called
+    /// once by the TS loader at `enableWasm()` with the ported
+    /// `entity_form_variants()` list (`refdata/business.ts`).
+    #[wasm_bindgen]
+    pub fn set_legal_forms(forms: Vec<String>) {
+        install_legal_forms(forms);
     }
 }

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -112,6 +112,8 @@ export {
   phashSimilarity,
   radialSimilarity,
   audioFpSimilarity,
+  deriveInitialism,
+  initialismMatch,
   ensembleScore,
   scoreMatrix,
   asString,

--- a/packages/typescript/goldenmatch/src/core/refdata/business.ts
+++ b/packages/typescript/goldenmatch/src/core/refdata/business.ts
@@ -1,0 +1,43 @@
+/**
+ * Business legal-form reference data — edge-safe port of the entity-TYPE
+ * variants from goldenmatch/refdata/data/legal_forms.json (the subset the
+ * `initialism_match` scorer needs). No node:* imports; the data is embedded.
+ *
+ * These are the normalized entity-type legal-form tokens (Inc, LLC, Corp, Ltd,
+ * GmbH, ...) that the initialism deriver DROPS from a business name before
+ * taking initials, so "International Business Machines Corp" -> "IBM". It
+ * EXCLUDES descriptive tokens ("Industries" / "Group" / "Holdings"), matching
+ * Python `refdata.business.entity_form_variants()` exactly (77 entries). Each
+ * key is `re.sub(r"\s+"," ",v).strip().rstrip(".,").lower()` of the raw variant.
+ */
+
+/** The 77 normalized entity-type legal-form variants (sorted, matching Python
+ *  `sorted(entity_form_variants())`). Injected verbatim into the score-wasm
+ *  kernel at `enableWasm()` so the WASM `initialism_match` drops the SAME forms
+ *  the pure-TS path does. */
+export const LEGAL_FORM_VARIANTS: readonly string[] = [
+  "a.b", "a.g", "a.s", "ab", "ag", "aksjeselskap", "aktiebolag",
+  "aktiengesellschaft", "as", "b.v", "besloten vennootschap", "bv",
+  "charitable trust", "co", "company", "corp", "corporation", "foundation",
+  "g.m.b.h", "gesellschaft mit beschrankter haftung", "gmbh", "inc",
+  "incorporated", "k.g", "kg", "kommanditgesellschaft", "l l c", "l.l.c",
+  "l.l.p", "l.p", "limited", "limited liability co", "limited liability company",
+  "limited liability partnership", "limited partnership", "llc", "llp", "lp",
+  "ltd", "n.v", "naamloze vennootschap", "nv", "oy", "oyj", "p.l.c", "partners",
+  "partnership", "plc", "private limited", "proprietary limited", "pte ltd",
+  "pte. ltd", "pty", "pty ltd", "pty. ltd", "public limited company", "pvt ltd",
+  "pvt. ltd", "s.a", "s.a.r.l", "s.a.s", "s.l", "s.p.a", "s.r.l", "sa", "sarl",
+  "sas", "sl", "sociedad anonima", "sociedad limitada", "societa per azioni",
+  "societe a responsabilite limitee", "societe anonyme",
+  "societe par actions simplifiee", "spa", "srl", "trust",
+];
+
+/** The entity-type legal-form variants as a lookup set (score-time membership
+ *  test for `initialism_match`'s per-token legal-form drop). */
+export const LEGAL_FORMS: ReadonlySet<string> = new Set(LEGAL_FORM_VARIANTS);
+
+/** Injection payload for the score-wasm loader: the variant list the kernel's
+ *  `set_legal_forms` OnceLock is seeded with (so WASM == pure-TS by construction). */
+export function legalFormsInjectionData(): readonly string[] {
+  return LEGAL_FORM_VARIANTS;
+}

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -22,6 +22,7 @@ import { applyNegativeEvidence } from "./autoconfigNegativeEvidence.js";
 import { getScorerBackend, WASM_COVERED_SCORERS } from "./wasm/backend.js";
 import { areEquivalent } from "./refdata/givenNames.js";
 import { isAvailable as surnamesAvailable, surnameRank, surnameIdf } from "./refdata/surnames.js";
+import { LEGAL_FORMS } from "./refdata/business.js";
 
 // ---------------------------------------------------------------------------
 // Helper: coerce unknown to string | null
@@ -649,6 +650,112 @@ export function audioFpSimilarity(a: string, b: string): number {
   return 1.0 - audioBerAligned(x, y);
 }
 
+// ---------------------------------------------------------------------------
+// initialism_match (abbreviation matcher)
+// ---------------------------------------------------------------------------
+
+/** Remove every `(...)` group — a `(` with the nearest following `)` (and the
+ *  text between); a `(` with no later `)` is kept literally. Mirrors score-core
+ *  `strip_parentheticals` / Python `re.sub(r"\([^)]*\)", "", s)`. */
+function stripParentheticals(s: string): string {
+  const chars = Array.from(s);
+  let out = "";
+  let i = 0;
+  while (i < chars.length) {
+    if (chars[i] === "(") {
+      const rel = chars.slice(i + 1).indexOf(")");
+      if (rel !== -1) {
+        i += rel + 2; // skip "(...)" inclusive
+        continue;
+      }
+    }
+    out += chars[i]!;
+    i++;
+  }
+  return out;
+}
+
+/** Python `token.strip().rstrip(".,").lower()` — the per-token legal-form key. */
+function normalizeTokenForLegal(token: string): string {
+  return token.trim().replace(/[.,]+$/, "").toLowerCase();
+}
+
+/** Python `str.isupper()`: at least one cased char and no lowercase cased char. */
+function pyIsUpper(s: string): boolean {
+  let hasCased = false;
+  for (const c of s) {
+    const lower = c.toLowerCase();
+    const upper = c.toUpperCase();
+    if (lower === upper) continue; // uncased
+    hasCased = true;
+    if (c === lower && c !== upper) return false; // a lowercase cased char
+  }
+  return hasCased;
+}
+
+/** Python `str.isalpha()`: non-empty and every char Unicode-alphabetic. */
+function pyIsAlpha(s: string): boolean {
+  if (s.length === 0) return false;
+  for (const c of s) {
+    if (!/\p{Alphabetic}/u.test(c)) return false;
+  }
+  return true;
+}
+
+/**
+ * Derive the initialism (acronym) of a business name, dropping legal-form tokens.
+ * A single already-acronym token (uppercase, alphabetic, 2..6 chars) passes
+ * through; otherwise the first ASCII letter of each surviving token (>= 2).
+ * Mirrors score-core `derive_initialism` / Python `core.acronym.derive_initialism`.
+ */
+export function deriveInitialism(
+  text: string,
+  legalForms: ReadonlySet<string> = LEGAL_FORMS,
+): string {
+  const stripped = stripParentheticals(text);
+  const cleaned: string[] = [];
+  for (const token of stripped.match(/\S+/gu) ?? []) {
+    if (!/[A-Za-z]/.test(token)) continue; // punctuation-only / digits-only
+    if (legalForms.has(normalizeTokenForLegal(token))) continue;
+    cleaned.push(token);
+  }
+  if (cleaned.length === 1) {
+    const tok = cleaned[0]!;
+    const n = Array.from(tok).length;
+    if (pyIsUpper(tok) && pyIsAlpha(tok) && n >= 2 && n <= 6) return tok.toUpperCase();
+    return "";
+  }
+  if (cleaned.length === 0) return "";
+  let initials = "";
+  for (const token of cleaned) {
+    const m = token.match(/[A-Za-z]/);
+    if (m) initials += m[0]!.toUpperCase();
+  }
+  if (Array.from(initials).length < 2) return "";
+  return initials;
+}
+
+/**
+ * `initialism_match` scorer: 1.0 iff one value's derived initialism equals the
+ * other RAW value, or the two derived initialisms match. Byte-exact with
+ * score-core `initialism_match` / Python `_initialism_match_single`. The legal-form
+ * table is caller-supplied (defaults to the ported `LEGAL_FORMS`), so the WASM
+ * kernel -- seeded with the SAME table at `enableWasm()` -- matches byte-for-byte.
+ */
+export function initialismMatch(
+  a: string,
+  b: string,
+  legalForms: ReadonlySet<string> = LEGAL_FORMS,
+): number {
+  const ia = deriveInitialism(a, legalForms);
+  const ib = deriveInitialism(b, legalForms);
+  const matched =
+    (ia !== "" && ia === b) ||
+    (ib !== "" && a === ib) ||
+    (ia !== "" && ib !== "" && ia === ib);
+  return matched ? 1.0 : 0.0;
+}
+
 /**
  * Padded character q-gram set of a raw string (Python parity:
  * core/scorer.py::_qgram_set). Lowercases, pads with `n-1` `#` sentinels on
@@ -734,6 +841,8 @@ export function scoreField(
       return radialSimilarity(valA, valB);
     case "audio_fp":
       return audioFpSimilarity(valA, valB);
+    case "initialism_match":
+      return initialismMatch(valA, valB);
     case "ensemble":
       return ensembleScore(valA, valB);
     case "embedding":

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -675,9 +675,15 @@ function stripParentheticals(s: string): string {
   return out;
 }
 
-/** Python `token.strip().rstrip(".,").lower()` — the per-token legal-form key. */
+/** Python `token.strip().rstrip(".,").lower()` — the per-token legal-form key.
+ *  The trailing `.`/`,` strip is a linear scan (mirroring Rust `trim_end_matches`),
+ *  not an anchored `/[.,]+$/` regex — that backtracks O(n^2) on a token of many
+ *  trailing separators (CodeQL polynomial-ReDoS), and this input is caller data. */
 function normalizeTokenForLegal(token: string): string {
-  return token.trim().replace(/[.,]+$/, "").toLowerCase();
+  const t = token.trim();
+  let end = t.length;
+  while (end > 0 && (t[end - 1] === "." || t[end - 1] === ",")) end--;
+  return t.slice(0, end).toLowerCase();
 }
 
 /** Python `str.isupper()`: at least one cased char and no lowercase cased char. */

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -508,6 +508,7 @@ export const VALID_SCORERS = new Set([
   "phash",
   "radial",
   "audio_fp",
+  "initialism_match",
   "given_name_aliased_jw",
   "name_freq_weighted_jw",
 ] as const);

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -81,6 +81,14 @@
  * INTEGER popcount sum and the rate is a single f64 divide per offset, so the kernel
  * and the pure-TS `audioFpSimilarity` are byte-exact (like phash) -- no reduction-order
  * divergence. A non-hex value on either side -> 0.0.
+ *
+ * `initialism_match` (id 7) is 1.0 iff one value's derived initialism (acronym of a
+ * business name, dropping legal-form tokens) equals the other value, else 0.0. It needs
+ * the ~77-entry `legal_forms` table injected into the kernel at `enableWasm()` (a new
+ * `set_legal_forms` export, mirroring the name scorers' census/alias table injection);
+ * the pure-TS `initialismMatch` uses the SAME ported table (`refdata/business.ts`), so
+ * the WASM matrix is byte-exact with the fallback. Until the table is injected the kernel
+ * scores against an EMPTY legal-form set (no dropping) -- the loader always injects it.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -90,6 +98,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   date: 4,
   qgram: 5,
   soundex_match: 6,
+  initialism_match: 7,
   dice: 9,
   jaccard: 10,
   phash: 11,

--- a/packages/typescript/goldenmatch/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/loader.ts
@@ -15,6 +15,7 @@ import { SCORER_ID } from "./backend.js";
 import type { ScorerBackend } from "./backend.js";
 import { censusInjectionData } from "../refdata/surnames.js";
 import { aliasInjectionEdges } from "../refdata/givenNames.js";
+import { legalFormsInjectionData } from "../refdata/business.js";
 
 export type { LoadOptions };
 
@@ -49,6 +50,7 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<ScorerBacke
     // plain JW for those ids); the CI-built artifact always carries them.
     set_surname_idf?: (names: string[], counts: Float64Array) => void;
     set_name_aliases?: (forms: string[], canonicals: string[]) => void;
+    set_legal_forms?: (forms: string[]) => void;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -69,6 +71,11 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<ScorerBacke
     if (aliases !== null) {
       glue.set_name_aliases(aliases.forms, aliases.canonicals);
     }
+  }
+  // Seed the legal-form variant set for `initialism_match` (id 7) so the WASM
+  // kernel drops the SAME forms the pure-TS `initialismMatch` does.
+  if (typeof glue.set_legal_forms === "function") {
+    glue.set_legal_forms([...legalFormsInjectionData()]);
   }
 
   const SEP = "\x1e";

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -414,6 +414,42 @@ d("WASM audio_fp matches the pure-TS scoreField reference (exact)", () => {
   }
 });
 
+// initialism_match (score_one id 7): 1.0 iff one value's derived initialism (business
+// acronym, dropping legal-form tokens) equals the other value, else 0.0. The kernel
+// needs the ~77-entry legal-form table injected at enableWasm() (set_legal_forms); the
+// loader seeds it with the SAME table the pure-TS `initialismMatch` uses, so the WASM
+// matrix is byte-exact with the fallback (this also verifies the injection round-trips --
+// "Apple Inc." derives "" only if the kernel dropped "Inc" as a legal form).
+type InitialismCase = readonly [a: string, b: string, note: string];
+const INITIALISM_CASES: readonly InitialismCase[] = [
+  ["International Business Machines Corp", "IBM", "acronym match (Corp dropped) -> 1.0"],
+  ["IBM", "International Business Machines Corp", "reverse direction -> 1.0"],
+  ["General Electric Company", "GE", "Company dropped -> 1.0"],
+  ["Hewlett Packard", "HP", "two tokens -> HP"],
+  ["Acme Industries LLC", "AI", "Industries kept, LLC dropped -> AI"],
+  ["Apple Inc.", "AI", "Inc dropped -> Apple stays lowercase -> no match 0.0"],
+  ["National Aeronautics and Space Administration", "NASA", "stopword kept -> NAASA != NASA -> 0.0"],
+  ["IBM", "IBM", "identical acronym -> 1.0"],
+  ["Acme", "Acme", "no derivable initialism -> 0.0"],
+];
+
+d("WASM initialism_match matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of INITIALISM_CASES) {
+    it(`initialism_match("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "initialism_match");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "initialism_match");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});
+
 d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
   beforeAll(async () => {
     const ok = await enableWasm();

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -15,6 +15,8 @@ import {
   phashSimilarity,
   radialSimilarity,
   audioFpSimilarity,
+  initialismMatch,
+  deriveInitialism,
   ensembleScore,
   scoreMatrix,
   applyTransform,
@@ -254,6 +256,32 @@ describe("audio_fp (offset-aligned bit-error-rate of hex fingerprints)", () => {
   it("non-hex or empty -> 0.0", () => {
     expect(audioFpSimilarity("nothex00", "12345678")).toBe(0.0);
     expect(audioFpSimilarity("", "")).toBe(0.0); // empty -> BER 1.0 -> 0.0
+  });
+});
+
+describe("initialism_match (business-name acronym matcher)", () => {
+  it("derives an acronym, dropping legal-form tokens", () => {
+    expect(deriveInitialism("International Business Machines Corp")).toBe("IBM");
+    expect(deriveInitialism("General Electric Company")).toBe("GE");
+    expect(deriveInitialism("Acme Industries LLC")).toBe("AI"); // LLC dropped
+    expect(deriveInitialism("Apple Inc.")).toBe(""); // single lowercase token
+    expect(deriveInitialism("3M Company")).toBe(""); // "3M" not alphabetic
+    expect(deriveInitialism("NASA")).toBe("NASA"); // single acronym passes through
+  });
+
+  it("matches a name against its initialism (either direction), else 0.0", () => {
+    // Values pinned against Python `_initialism_match_single`.
+    expect(initialismMatch("International Business Machines Corp", "IBM")).toBe(1.0);
+    expect(initialismMatch("IBM", "International Business Machines Corp")).toBe(1.0);
+    expect(initialismMatch("General Electric Company", "GE")).toBe(1.0);
+    expect(initialismMatch("Hewlett Packard", "HP")).toBe(1.0);
+    expect(initialismMatch("IBM", "IBM")).toBe(1.0);
+    expect(initialismMatch("Acme", "Acme")).toBe(0.0);
+    expect(initialismMatch("Apple Inc.", "AI")).toBe(0.0);
+    // Stopwords are NOT dropped, so these derive extra initials and miss.
+    expect(initialismMatch("National Aeronautics and Space Administration", "NASA")).toBe(0.0);
+    expect(initialismMatch("AT and T", "ATT")).toBe(0.0);
+    expect(initialismMatch("", "IBM")).toBe(0.0);
   });
 });
 

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,7 +25,7 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 13 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 14 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
         "audio_fp",
@@ -34,6 +34,7 @@ describe("ScorerBackend singleton", () => {
         "ensemble",
         "exact",
         "given_name_aliased_jw",
+        "initialism_match",
         "jaccard",
         "jaro_winkler",
         "levenshtein",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -250,6 +250,7 @@ scorers:
   - embedding
   - ensemble
   - exact
+  - initialism_match
   - jaccard
   - jaro_winkler
   - levenshtein
@@ -261,7 +262,6 @@ scorers:
   - token_sort
   python_only:
   - alias_match
-  - initialism_match
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw
@@ -317,9 +317,11 @@ blocking_strategies:
 # components hold vs rapidfuzz (soundex byte-exact). `phash` (id 11) is also shared:
 # perceptual-hash similarity (1 - hamming/nbits over hex pHashes), integer XOR popcount,
 # byte-exact WASM<->pure-TS like dice/jaccard.
-# python_only: `initialism_match`, `alias_match` have an arrow-native (bucket) kernel
-# on Python but no TS WASM port yet (initialism needs the legal_forms table injected;
-# alias_match is behind score-wasm's off-by-default `alias` cargo feature).
+# python_only: `alias_match` has an arrow-native (bucket) kernel on Python but no TS WASM
+# port yet (it is behind score-wasm's off-by-default `alias` cargo feature + needs the
+# business/given-name alias tables injected). `initialism_match` is now shared: the kernel
+# needs the ~77-entry legal_forms table injected at enableWasm() (set_legal_forms), which the
+# loader seeds with the ported refdata/business.ts table so WASM == pure-TS byte-exact.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
@@ -331,6 +333,7 @@ scorer_kernels:
   - dice
   - ensemble
   - exact
+  - initialism_match
   - jaccard
   - jaro_winkler
   - levenshtein
@@ -341,7 +344,6 @@ scorer_kernels:
   - token_sort
   python_only:
   - alias_match
-  - initialism_match
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw


### PR DESCRIPTION
## What and why

`initialism_match` (1.0 iff one value's derived business-name initialism — the acronym formed after dropping legal-form tokens — equals the other value) was **Python-only**. This ports the pure-TS scorer **and** wires the score-wasm legal-form table injection, so it is now a valid TS scorer and kernel-backed on both surfaces, **byte-exact**.

Unlike the earlier straight ports, initialism needs a **reference table** (like the name scorers ids 20/21): `score_one(7)` drops the ~77-entry `entity_form_variants()` legal-form set, which is process-global state seeded via score-core's `set_legal_forms` OnceLock. The kernel scores against an EMPTY set until seeded, so this adds a new `set_legal_forms` wasm export + loader wiring to inject the table at `enableWasm()` — the **SAME** ported table the pure-TS path uses, making WASM == pure-TS by construction. The parity test doubles as an injection round-trip check (`"Apple Inc."` derives `""` only if the kernel dropped `"Inc"`).

## Changes

- `src/core/refdata/business.ts` (**new**): the 77 normalized entity-type legal-form variants (`LEGAL_FORM_VARIANTS` / `LEGAL_FORMS` + `legalFormsInjectionData()`), matching Python `sorted(entity_form_variants())` exactly.
- `src/core/scorer.ts`: `deriveInitialism` + `initialismMatch` (+ `stripParentheticals`, `normalizeTokenForLegal`, `pyIsUpper`/`pyIsAlpha` replicating the Python `str.isupper()`/`isalpha()` semantics); `case "initialism_match"` in `scoreField`; both exported via `core/index`.
- `packages/rust/extensions/score-wasm/src/lib.rs`: `install_legal_forms` + a `set_legal_forms` wasm export (mirrors `set_name_aliases` / `set_surname_idf`).
- `src/core/wasm/loader.ts`: inject `legalFormsInjectionData()` via `glue.set_legal_forms` at `enableWasm()` (optional → older artifacts degrade to the empty-set kernel).
- `src/core/types.ts` / `wasm/backend.ts`: `VALID_SCORERS` + `SCORER_ID: initialism_match: 7`.
- `parity/goldenmatch.yaml`: `initialism_match` moves python_only -> shared in BOTH surfaces; `docs-site/suite-matrix.mdx` regenerated.
- tests: pure-TS unit block (`deriveInitialism` + `initialismMatch`, values pinned against Python `_initialism_match_single`) + a wasm-scorer byte-exact parity block (9 cases); `wasm-backend` covered-set updated (14 score_one + 2 name scorers).

## Testing

- `check_api_parity.py goldenmatch` — "parity OK".
- `cargo test` + `cargo clippy` on score-wasm — clean.
- `vitest run` — 185 files, 3267 pass + 1 expected-fail; the initialism parity block is byte-exact (verifying the legal-form table injection round-trips). `tsc --noEmit` clean.

## Follow-up — the last python_only scorer

- **`alias_match`** (id 8) — the final one. It is behind score-wasm's off-by-default `alias` cargo feature (id 8 falls to the 0.0 catch-all when the feature is off) **and** needs two host tables injected (business-alias `strip_re` + surface→canonical map, and a given-name normalized→canonical map). Enabling it means turning on the `alias` feature in the score-wasm build + adding `set_business_aliases` / `set_given_name_canonicals` exports + porting both alias tables to TS. That's the next (and last) PR in this arc.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] api_parity gate green; score-wasm cargo test + clippy clean; full vitest green
- [ ] Package `CHANGELOG.md` updated if behavior changed (new capability on the TS surface)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs (`suite-matrix.mdx`) updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_