### PR TITLE
feat(ts): port + WASM-back the alias_match scorer (Python-only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,8 +30,8 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
-| Rust `-core` kernel — Python arrow-native only (TS falls back) | `alias_match` |
+| Rust `-core` kernel — Python + TS | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python arrow-native only (TS falls back) | — |
 | WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 38 | 40 | 12 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 20 | 20 | 16 |
-| `goldenmatch` | scorers | 16 | 1 | 2 |
+| `goldenmatch` | scorers | 17 | 0 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 8 | 11 | 3 |
@@ -69,7 +69,6 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `list_scorers`, `list_strategies`, `list_transforms`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
-- `goldenmatch` **scorers** — Python-only: `alias_match`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/packages/rust/extensions/score-wasm/Cargo.lock
+++ b/packages/rust/extensions/score-wasm/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -26,6 +35,7 @@ name = "goldenmatch-score-core"
 version = "0.1.0"
 dependencies = [
  "rapidfuzz",
+ "regex",
  "unicode-normalization",
 ]
 
@@ -37,6 +47,12 @@ dependencies = [
  "goldenmatch-score-core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "once_cell"
@@ -67,6 +83,35 @@ name = "rapidfuzz"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "270e04e5ea61d40841942bb15e451c29ee1618637bcf97fc7ede5dd4a9b1601b"
+
+[[package]]
+name = "regex"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustversion"

--- a/packages/rust/extensions/score-wasm/Cargo.toml
+++ b/packages/rust/extensions/score-wasm/Cargo.toml
@@ -18,10 +18,12 @@ name = "goldenmatch_score_wasm"
 crate-type = ["cdylib", "rlib"]  # cdylib for wasm; rlib so host unit tests link
 
 [dependencies]
-# default-features = false drops the `alias` feature (score_one id 8 + the `regex`
-# engine): alias_match is a Python-bucket-only kernel with no wasm export, so the
-# edge bundle stays free of the heavy `regex` dependency.
-goldenmatch-score-core = { path = "../score-core", default-features = false }
+# The `alias` feature (score_one id 8 + the `regex` engine) is ENABLED: alias_match
+# is WASM-backed via injected business/given-name tables (`set_business_aliases` /
+# `set_given_name_canonicals`), so the edge bundle carries the `regex` engine
+# (~+36 KB) to canonicalize legal-form suffixes byte-for-byte with Python. Every
+# other score-core default feature is inherited.
+goldenmatch-score-core = { path = "../score-core", features = ["alias"] }
 # `fs-core` carries the name scorers (name_freq_weighted_jw / given_name_aliased_jw)
 # as `*_sim` fns over INJECTED reference-data tables -- it bundles no data and its
 # only dep is `score-core` (default-features = false, so no regex reaches the edge

--- a/packages/rust/extensions/score-wasm/src/lib.rs
+++ b/packages/rust/extensions/score-wasm/src/lib.rs
@@ -61,6 +61,30 @@ pub fn install_legal_forms(forms: Vec<String>) {
     let _ = goldenmatch_score_core::set_legal_forms(forms.into_iter().collect());
 }
 
+/// Install the business alias table for `alias_match` (id 8). Delegates to
+/// score-core's process-global `set_business_aliases` OnceLock (first-wins).
+/// `variants` are the normalized legal-form variants (score-core rebuilds them
+/// into the SAME trailing-suffix regex Python compiles); `surface_forms[i]` maps
+/// to `canonicals[i]` (parallel arrays keep the wasm-bindgen boundary flat -- no
+/// nested `Vec<(String, String)>`). Shared by the wasm setter + native tests.
+pub fn install_business_aliases(
+    variants: Vec<String>,
+    surface_forms: Vec<String>,
+    canonicals: Vec<String>,
+) {
+    let pairs: Vec<(String, String)> = surface_forms.into_iter().zip(canonicals).collect();
+    let _ = goldenmatch_score_core::set_business_aliases(variants, pairs);
+}
+
+/// Install the given-name canonical map for `alias_match` (id 8) from parallel
+/// `(normalized, canonical)` arrays (`normalized[i]` -> `canonicals[i]`, the
+/// pre-resolved lex-first `min(canonical set)` computed host-side). Delegates to
+/// score-core's process-global `set_given_name_canonicals` OnceLock (first-wins).
+pub fn install_given_name_canonicals(normalized: Vec<String>, canonicals: Vec<String>) {
+    let pairs: Vec<(String, String)> = normalized.into_iter().zip(canonicals).collect();
+    let _ = goldenmatch_score_core::set_given_name_canonicals(pairs);
+}
+
 /// Full row-major NxN similarity matrix for `values` under `scorer_id`.
 /// Diagonal = 0.0 and the matrix is symmetric, matching the pure-TS
 /// `scoreMatrix` (which fills the upper triangle, mirrors it, and leaves the
@@ -174,6 +198,50 @@ mod tests {
     }
 
     #[test]
+    fn alias_match_id8_dispatches_to_score_core() {
+        // The ONLY test that installs the process-global alias tables (business +
+        // given-name OnceLocks, first-wins), so it never races a different-content
+        // setter. id 8 flows through score_matrix_impl's `_ => score_one` arm.
+        install_business_aliases(
+            // A tiny legal-form variant list (strip_re alternation) + a
+            // surface->canonical alias map (google/alphabet inc -> alphabet).
+            vec!["inc".into(), "llc".into(), "corp".into()],
+            vec![
+                "alphabet".into(),
+                "google".into(),
+                "google".into(),
+                "alphabet".into(),
+            ],
+            vec![
+                "alphabet".into(),
+                "alphabet".into(),
+                "alphabet".into(),
+                "alphabet".into(),
+            ],
+        );
+        install_given_name_canonicals(
+            vec!["bob".into(), "robert".into(), "bill".into(), "william".into()],
+            vec![
+                "robert".into(),
+                "robert".into(),
+                "william".into(),
+                "william".into(),
+            ],
+        );
+
+        // Business: "Google LLC" and "Alphabet Inc." both canonicalize to
+        // "alphabet" (legal form stripped, surface mapped) -> 1.0.
+        let m = score_matrix_impl(&["Google LLC", "Alphabet Inc."], 8);
+        assert_eq!(m[1], 1.0);
+        // Given-name: "Bob" and "Robert" share canonical "robert" -> 1.0.
+        let m2 = score_matrix_impl(&["Bob", "Robert"], 8);
+        assert_eq!(m2[1], 1.0);
+        // Unrelated -> 0.0 (no shared canonical on either table).
+        let m3 = score_matrix_impl(&["Acme", "Umbrella"], 8);
+        assert_eq!(m3[1], 0.0);
+    }
+
+    #[test]
     fn token_sort_id2_normalizes_and_is_order_invariant() {
         // id=2 must use the TS-parity normalized path: order-invariant + case/
         // punctuation-insensitive. "John SMITH" vs "smith john" -> 1.0.
@@ -214,7 +282,10 @@ mod tests {
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
-    use super::{install_legal_forms, install_name_aliases, install_surname_idf, score_matrix_impl};
+    use super::{
+        install_business_aliases, install_given_name_canonicals, install_legal_forms,
+        install_name_aliases, install_surname_idf, score_matrix_impl,
+    };
     use wasm_bindgen::prelude::*;
 
     /// JS entry: `values` is one string with fields joined by `sep` (a 1-char
@@ -251,5 +322,25 @@ mod wasm {
     #[wasm_bindgen]
     pub fn set_legal_forms(forms: Vec<String>) {
         install_legal_forms(forms);
+    }
+
+    /// Install the business alias table for `alias_match` (id 8). Called once by
+    /// the TS loader at `enableWasm()` with the ported legal-form variants +
+    /// surface->canonical alias map (`refdata/business.ts`).
+    #[wasm_bindgen]
+    pub fn set_business_aliases(
+        variants: Vec<String>,
+        surface_forms: Vec<String>,
+        canonicals: Vec<String>,
+    ) {
+        install_business_aliases(variants, surface_forms, canonicals);
+    }
+
+    /// Install the given-name canonical map for `alias_match` (id 8) from parallel
+    /// `(normalized, canonical)` arrays. Called once by the TS loader at
+    /// `enableWasm()` with the pre-resolved lex-first nickname map.
+    #[wasm_bindgen]
+    pub fn set_given_name_canonicals(normalized: Vec<String>, canonicals: Vec<String>) {
+        install_given_name_canonicals(normalized, canonicals);
     }
 }

--- a/packages/typescript/goldenmatch/src/core/index.ts
+++ b/packages/typescript/goldenmatch/src/core/index.ts
@@ -114,6 +114,7 @@ export {
   audioFpSimilarity,
   deriveInitialism,
   initialismMatch,
+  aliasMatch,
   ensembleScore,
   scoreMatrix,
   asString,

--- a/packages/typescript/goldenmatch/src/core/refdata/business.ts
+++ b/packages/typescript/goldenmatch/src/core/refdata/business.ts
@@ -41,3 +41,177 @@ export const LEGAL_FORMS: ReadonlySet<string> = new Set(LEGAL_FORM_VARIANTS);
 export function legalFormsInjectionData(): readonly string[] {
   return LEGAL_FORM_VARIANTS;
 }
+
+// ---- alias_match support (business canonicalization) ------------------------
+// Port of `refdata.business.strip_legal_form` + `refdata.business_aliases`
+// (`canonical_company_form`). Used by the `alias_match` scorer (score_one id 8):
+// two names alias-match when they canonicalize to the SAME non-empty business
+// key. Distinct from the initialism data above: strip_legal_form uses ALL legal
+// forms (`variants_normalized`, incl. the descriptive "group"/"holdings"/
+// "industries" tokens), whereas `entity_form_variants()` (LEGAL_FORM_VARIANTS)
+// excludes descriptors — so this file carries BOTH sets.
+
+/** The 81 normalized legal-form variants — the FULL `variants_normalized` set
+ *  (`sorted(refdata.business.known_variants())`), a superset of the 77 entity
+ *  variants above by the 4 descriptor tokens (group / holding / holdings /
+ *  industries). `strip_legal_form` strips ANY of these as a trailing suffix.
+ *  Injected into the score-wasm kernel's `set_business_aliases` so WASM builds
+ *  the identical strip regex the pure path scans for. */
+export const LEGAL_FORM_VARIANTS_ALL: readonly string[] = [
+  "a.b", "a.g", "a.s", "ab", "ag", "aksjeselskap", "aktiebolag",
+  "aktiengesellschaft", "as", "b.v", "besloten vennootschap", "bv",
+  "charitable trust", "co", "company", "corp", "corporation", "foundation",
+  "g.m.b.h", "gesellschaft mit beschrankter haftung", "gmbh", "group", "holding",
+  "holdings", "inc", "incorporated", "industries", "k.g", "kg",
+  "kommanditgesellschaft", "l l c", "l.l.c", "l.l.p", "l.p", "limited",
+  "limited liability co", "limited liability company",
+  "limited liability partnership", "limited partnership", "llc", "llp", "lp",
+  "ltd", "n.v", "naamloze vennootschap", "nv", "oy", "oyj", "p.l.c", "partners",
+  "partnership", "plc", "private limited", "proprietary limited", "pte ltd",
+  "pte. ltd", "pty", "pty ltd", "pty. ltd", "public limited company", "pvt ltd",
+  "pvt. ltd", "s.a", "s.a.r.l", "s.a.s", "s.l", "s.p.a", "s.r.l", "sa", "sarl",
+  "sas", "sl", "sociedad anonima", "sociedad limitada", "societa per azioni",
+  "societe a responsabilite limitee", "societe anonyme",
+  "societe par actions simplifiee", "spa", "srl", "trust",
+];
+
+/** surface form -> canonical company key (`business_aliases._state.surface_to_
+ *  canonical`). Every value is already normalized (lowercase, legal-form-
+ *  stripped); a canonical maps to itself so a record already in canonical form
+ *  is recognized. First-canonical-wins collisions are pre-resolved in the source
+ *  data file, so this is a flat map. */
+export const BUSINESS_ALIAS_MAP: ReadonlyMap<string, string> = new Map([
+  ["3m", "minnesota mining and manufacturing"],
+  ["acme", "acme"],
+  ["alphabet", "alphabet"],
+  ["big blue", "international business machines"],
+  ["facebook", "meta"],
+  ["federal express", "federal express"],
+  ["fedex", "federal express"],
+  ["ge", "general electric"],
+  ["general electric", "general electric"],
+  ["google", "alphabet"],
+  ["ibm", "international business machines"],
+  ["international business machines", "international business machines"],
+  ["kentucky fried chicken", "kentucky fried chicken"],
+  ["kfc", "kentucky fried chicken"],
+  ["meta", "meta"],
+  ["meta platforms", "meta"],
+  ["minnesota mining and manufacturing", "minnesota mining and manufacturing"],
+  ["philip morris", "philip morris international"],
+  ["philip morris international", "philip morris international"],
+  ["pmi", "philip morris international"],
+]);
+
+// Leading-separator class `[\s,\-.]` (whitespace / comma / hyphen / period) and
+// trailing-separator class `[\s.,]` (whitespace / period / comma — NO hyphen),
+// matching Python's `strip_legal_form` regex. Single-char tests are O(1) — NOT
+// the alternation+quantifier `[\s,\-.]+(?:v...)[\s.,]*$` pattern (which is a
+// polynomial-ReDoS class on caller data); the whole strip is a linear scan.
+function isLeadSep(ch: string): boolean {
+  return ch === "," || ch === "-" || ch === "." || /\s/.test(ch);
+}
+function isTrailSep(ch: string): boolean {
+  return ch === "." || ch === "," || /\s/.test(ch);
+}
+
+/** Collapse whitespace runs to one space and trim — Python `re.sub(r"\s+"," ",s)
+ *  .strip()`. `\s+` (single class + quantifier, no alternation) is linear. */
+function collapseWs(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+// Variants sorted DESCENDING by length then lexicographically — the SAME order
+// score-core's `set_business_aliases` builds the regex alternation in, so the
+// longest legal form wins at a given position ("limited liability company" beats
+// "limited"/"company"). Variants are ASCII, so UTF-16 `.length` == codepoint
+// count (the parity edge documented in score-core).
+const STRIP_VARIANTS_SORTED: readonly string[] = [...LEGAL_FORM_VARIANTS_ALL].sort(
+  (a, b) => b.length - a.length || (a < b ? -1 : a > b ? 1 : 0),
+);
+
+/** Linear equivalent of ONE `pattern.sub("", cleaned)` for the anchored strip
+ *  regex `[\s,\-.]+(?:variant)[\s.,]*$`. Returns the start index of the leftmost
+ *  match (a separator run, followed by a variant, followed by trailing seps to
+ *  end-of-string), or -1 if none. Leftmost-run + longest-variant mirrors the
+ *  regex's leftmost-match + DESC-length alternation. */
+function findStripMatch(s: string): number {
+  const low = s.toLowerCase(); // ASCII: same length, so indices align with `s`
+  const n = low.length;
+  for (let i = 0; i < n; i++) {
+    // Only start at a separator-RUN start (i == 0 or the prior char is a non-sep).
+    if (!isLeadSep(low[i]!) || (i > 0 && isLeadSep(low[i - 1]!))) continue;
+    // Consume the whole leading-separator run (greedy `[\s,\-.]+`).
+    let j = i;
+    while (j < n && isLeadSep(low[j]!)) j++;
+    for (const v of STRIP_VARIANTS_SORTED) {
+      if (!low.startsWith(v, j)) continue;
+      // The remainder after the variant must be all trailing-seps to `$`.
+      let allTrail = true;
+      for (let p = j + v.length; p < n; p++) {
+        if (!isTrailSep(low[p]!)) {
+          allTrail = false;
+          break;
+        }
+      }
+      if (allTrail) return i; // longest qualifying variant at the leftmost run
+    }
+  }
+  return -1;
+}
+
+/** Remove a trailing legal-form suffix — port of `refdata.business.strip_legal_
+ *  form`. Whitespace-collapse, then iteratively (bounded 4×, like Python) strip
+ *  the anchored trailing form so compound suffixes ("Acme Holdings Inc") peel one
+ *  per pass. `null` → `null`; no known suffix → whitespace-collapsed passthrough. */
+export function stripLegalForm(value: string | null): string | null {
+  if (value === null) return null;
+  let cleaned = collapseWs(value);
+  if (!cleaned) return cleaned;
+  for (let pass = 0; pass < 4; pass++) {
+    const at = findStripMatch(cleaned);
+    // Python: `new = pattern.sub("", cleaned).strip()`. No match → `new` == cleaned.
+    const next = at >= 0 ? cleaned.slice(0, at).trim() : cleaned.trim();
+    if (next === cleaned || next === "") {
+      if (next !== "") cleaned = next; // keep `cleaned` when a strip would empty it
+      break;
+    }
+    cleaned = next;
+  }
+  return cleaned;
+}
+
+/** Business `_normalize`: `strip_legal_form` → whitespace-collapse → lowercase.
+ *  Byte-for-byte with `refdata.business_aliases._normalize`. */
+export function businessNormalize(name: string): string {
+  const stripped = stripLegalForm(name) ?? "";
+  return collapseWs(stripped).toLowerCase();
+}
+
+/** Canonical company key — port of `business_aliases.canonical_company_form`.
+ *  Normalize, then map surface→canonical with an idempotent passthrough default.
+ *  `null` → `null`; empty/whitespace-only → `""`. */
+export function canonicalCompanyForm(name: string | null): string | null {
+  if (name === null) return null;
+  const norm = businessNormalize(name);
+  if (!norm) return "";
+  return BUSINESS_ALIAS_MAP.get(norm) ?? norm;
+}
+
+/** Injection payload for the score-wasm loader's `set_business_aliases`: the FULL
+ *  variant list (the kernel rebuilds the strip regex) + the surface→canonical map
+ *  as parallel arrays (flat wasm-bindgen boundary). WASM == pure-TS by
+ *  construction (same variants → same regex → same canonicalization). */
+export function businessAliasInjectionData(): {
+  variants: readonly string[];
+  surfaceForms: string[];
+  canonicals: string[];
+} {
+  const surfaceForms: string[] = [];
+  const canonicals: string[] = [];
+  for (const [surface, canonical] of BUSINESS_ALIAS_MAP) {
+    surfaceForms.push(surface);
+    canonicals.push(canonical);
+  }
+  return { variants: LEGAL_FORM_VARIANTS_ALL, surfaceForms, canonicals };
+}

--- a/packages/typescript/goldenmatch/src/core/refdata/givenNames.ts
+++ b/packages/typescript/goldenmatch/src/core/refdata/givenNames.ts
@@ -78,6 +78,52 @@ export function aliasInjectionEdges(): {
   return forms.length === 0 ? null : { forms, canonicals };
 }
 
+/**
+ * *A* canonical formal name for `name` — port of `given_names.canonical_form`.
+ * Lex-first (`min`) when the form belongs to multiple canonicals ("kate" →
+ * "catherine"). OOV / unavailable → the normalized input; empty → `""`; `null`
+ * → `null`. Used by the `alias_match` scorer's given-name half.
+ */
+export function canonicalForm(name: string | null): string | null {
+  if (name === null) return null;
+  const norm = normalize(name);
+  if (!norm) return "";
+  const state = load();
+  if (state === null) return norm;
+  const cset = state.canonicals.get(norm);
+  if (cset === undefined) return norm;
+  // Lex-first, matching Python `min(canon_set)`.
+  let best: string | undefined;
+  for (const c of cset) if (best === undefined || c < best) best = c;
+  return best ?? norm;
+}
+
+/**
+ * Parallel `(normalized, canonical)` arrays for injecting into the score-wasm
+ * `alias_match` kernel (`set_given_name_canonicals`). Each `normalized[i]` maps
+ * to `canonicals[i]` = the pre-resolved lex-first `min(canonical set)` — the
+ * SAME resolution `canonicalForm` applies, done host-side so the kernel needs
+ * only a normalize + lookup. `null` when the table is unavailable.
+ */
+export function canonicalInjectionPairs(): {
+  normalized: string[];
+  canonicals: string[];
+} | null {
+  const state = load();
+  if (state === null) return null;
+  const normalized: string[] = [];
+  const canonicals: string[] = [];
+  for (const [form, cset] of state.canonicals) {
+    let best: string | undefined;
+    for (const c of cset) if (best === undefined || c < best) best = c;
+    if (best !== undefined) {
+      normalized.push(form);
+      canonicals.push(best);
+    }
+  }
+  return normalized.length === 0 ? null : { normalized, canonicals };
+}
+
 /** True iff a and b share at least one canonical. Symmetric, reflexive. */
 export function areEquivalent(a: string | null, b: string | null): boolean {
   if (a === null || b === null) return false;

--- a/packages/typescript/goldenmatch/src/core/scorer.ts
+++ b/packages/typescript/goldenmatch/src/core/scorer.ts
@@ -20,9 +20,9 @@ import { pairKey } from "./cluster.js";
 import { applyTransforms, soundex } from "./transforms.js";
 import { applyNegativeEvidence } from "./autoconfigNegativeEvidence.js";
 import { getScorerBackend, WASM_COVERED_SCORERS } from "./wasm/backend.js";
-import { areEquivalent } from "./refdata/givenNames.js";
+import { areEquivalent, canonicalForm } from "./refdata/givenNames.js";
 import { isAvailable as surnamesAvailable, surnameRank, surnameIdf } from "./refdata/surnames.js";
-import { LEGAL_FORMS } from "./refdata/business.js";
+import { LEGAL_FORMS, canonicalCompanyForm } from "./refdata/business.js";
 
 // ---------------------------------------------------------------------------
 // Helper: coerce unknown to string | null
@@ -763,6 +763,27 @@ export function initialismMatch(
 }
 
 /**
+ * `alias_match` scorer: 1.0 iff both values canonicalize to the same NON-EMPTY
+ * business alias OR the same given-name canonical; else 0.0. Byte-exact with
+ * score-core `alias_match` / Python `_alias_match_single` ("Acme Inc" ↔ "Acme
+ * Incorporated" → business "acme"; "Bob" ↔ "Robert" → given "robert"). The two
+ * reference tables (legal-form variants + surface→canonical alias map; given-
+ * name nickname map) are embedded in the refdata modules and injected verbatim
+ * into the WASM kernel at `enableWasm()`, so WASM matches byte-for-byte.
+ * Canonicalization is an idempotent passthrough for OOV names, so two different
+ * OOV names never match.
+ */
+export function aliasMatch(a: string, b: string): number {
+  const cbA = canonicalCompanyForm(a) ?? "";
+  const cbB = canonicalCompanyForm(b) ?? "";
+  if (cbA !== "" && cbA === cbB) return 1.0;
+  const cgA = canonicalForm(a) ?? "";
+  const cgB = canonicalForm(b) ?? "";
+  if (cgA !== "" && cgA === cgB) return 1.0;
+  return 0.0;
+}
+
+/**
  * Padded character q-gram set of a raw string (Python parity:
  * core/scorer.py::_qgram_set). Lowercases, pads with `n-1` `#` sentinels on
  * each side, then returns the FULL set of length-`n` substrings.
@@ -849,6 +870,8 @@ export function scoreField(
       return audioFpSimilarity(valA, valB);
     case "initialism_match":
       return initialismMatch(valA, valB);
+    case "alias_match":
+      return aliasMatch(valA, valB);
     case "ensemble":
       return ensembleScore(valA, valB);
     case "embedding":

--- a/packages/typescript/goldenmatch/src/core/types.ts
+++ b/packages/typescript/goldenmatch/src/core/types.ts
@@ -509,6 +509,7 @@ export const VALID_SCORERS = new Set([
   "radial",
   "audio_fp",
   "initialism_match",
+  "alias_match",
   "given_name_aliased_jw",
   "name_freq_weighted_jw",
 ] as const);

--- a/packages/typescript/goldenmatch/src/core/wasm/backend.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/backend.ts
@@ -89,6 +89,16 @@
  * the pure-TS `initialismMatch` uses the SAME ported table (`refdata/business.ts`), so
  * the WASM matrix is byte-exact with the fallback. Until the table is injected the kernel
  * scores against an EMPTY legal-form set (no dropping) -- the loader always injects it.
+ *
+ * `alias_match` (id 8) is 1.0 iff both values canonicalize to the same non-empty business
+ * alias OR the same given-name canonical, else 0.0. It needs TWO tables injected at
+ * `enableWasm()`: the business alias table (the FULL 81-entry legal-form variant list,
+ * from which the kernel rebuilds the trailing-suffix strip regex, + the surface→canonical
+ * alias map — `set_business_aliases`) and the pre-resolved given-name nickname map
+ * (`set_given_name_canonicals`). The pure-TS `aliasMatch` uses the SAME ported tables
+ * (`refdata/business.ts` + `refdata/givenNames.ts`), so the WASM matrix is byte-exact with
+ * the fallback. Until both tables are injected the kernel's `alias_match` returns 0.0 for
+ * the un-installed half -- the loader always injects both.
  */
 export const SCORER_ID: Readonly<Record<string, number>> = {
   jaro_winkler: 0,
@@ -99,6 +109,7 @@ export const SCORER_ID: Readonly<Record<string, number>> = {
   qgram: 5,
   soundex_match: 6,
   initialism_match: 7,
+  alias_match: 8,
   dice: 9,
   jaccard: 10,
   phash: 11,

--- a/packages/typescript/goldenmatch/src/core/wasm/loader.ts
+++ b/packages/typescript/goldenmatch/src/core/wasm/loader.ts
@@ -14,8 +14,8 @@ import {
 import { SCORER_ID } from "./backend.js";
 import type { ScorerBackend } from "./backend.js";
 import { censusInjectionData } from "../refdata/surnames.js";
-import { aliasInjectionEdges } from "../refdata/givenNames.js";
-import { legalFormsInjectionData } from "../refdata/business.js";
+import { aliasInjectionEdges, canonicalInjectionPairs } from "../refdata/givenNames.js";
+import { legalFormsInjectionData, businessAliasInjectionData } from "../refdata/business.js";
 
 export type { LoadOptions };
 
@@ -51,6 +51,12 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<ScorerBacke
     set_surname_idf?: (names: string[], counts: Float64Array) => void;
     set_name_aliases?: (forms: string[], canonicals: string[]) => void;
     set_legal_forms?: (forms: string[]) => void;
+    set_business_aliases?: (
+      variants: string[],
+      surfaceForms: string[],
+      canonicals: string[],
+    ) => void;
+    set_given_name_canonicals?: (normalized: string[], canonicals: string[]) => void;
   };
   await glue.default({ module_or_path: bytes });
 
@@ -76,6 +82,20 @@ export async function instantiateBackend(bytes: Uint8Array): Promise<ScorerBacke
   // kernel drops the SAME forms the pure-TS `initialismMatch` does.
   if (typeof glue.set_legal_forms === "function") {
     glue.set_legal_forms([...legalFormsInjectionData()]);
+  }
+  // Seed BOTH `alias_match` (id 8) tables: the business alias table (FULL legal-
+  // form variant list — the kernel rebuilds the strip regex from it — + the
+  // surface→canonical map) and the pre-resolved given-name nickname map, so the
+  // WASM `alias_match` canonicalizes over the SAME tables the pure-TS path does.
+  if (typeof glue.set_business_aliases === "function") {
+    const biz = businessAliasInjectionData();
+    glue.set_business_aliases([...biz.variants], biz.surfaceForms, biz.canonicals);
+  }
+  if (typeof glue.set_given_name_canonicals === "function") {
+    const given = canonicalInjectionPairs();
+    if (given !== null) {
+      glue.set_given_name_canonicals(given.normalized, given.canonicals);
+    }
   }
 
   const SEP = "\x1e";

--- a/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/parity/wasm-scorer.test.ts
@@ -450,6 +450,47 @@ d("WASM initialism_match matches the pure-TS scoreField reference (exact)", () =
   }
 });
 
+// alias_match (score_one id 8): 1.0 iff both values canonicalize to the same non-empty
+// business alias OR the same given-name canonical, else 0.0. The kernel needs TWO tables
+// injected at enableWasm() -- the business alias table (set_business_aliases: the FULL
+// legal-form variant list, from which the kernel rebuilds the strip regex, + the
+// surface->canonical map) and the given-name nickname map (set_given_name_canonicals).
+// The loader seeds both with the SAME tables the pure-TS `aliasMatch` uses, so the WASM
+// matrix is byte-exact with the fallback (this also verifies both injections round-trip:
+// "Google"->"alphabet" needs the alias map, "Acme Group"->"acme" needs the strip regex,
+// "Bob"<->"Robert" needs the given-name map).
+type AliasCase = readonly [a: string, b: string, note: string];
+const ALIAS_CASES: readonly AliasCase[] = [
+  ["Acme Inc", "Acme Incorporated", "legal-form strip -> shared 'acme' -> 1.0"],
+  ["Google", "Alphabet Inc.", "surface->canonical alias map -> 'alphabet' -> 1.0"],
+  ["IBM", "International Business Machines", "alias map both directions -> 1.0"],
+  ["FedEx", "Federal Express", "brand alias -> 'federal express' -> 1.0"],
+  ["Acme Group", "Acme", "descriptor variant stripped -> shared 'acme' -> 1.0"],
+  ["Acme Holdings Inc.", "Acme", "compound suffix peels -> 'acme' -> 1.0"],
+  ["Bob", "Robert", "given-name nickname map -> 'robert' -> 1.0"],
+  ["Kate", "Catherine", "given-name lex-first canonical -> 1.0"],
+  ["Acme", "Globex", "different OOV companies -> 0.0"],
+  ["William", "Walter", "unrelated given names -> 0.0"],
+  ["", "", "empty canonical never matches -> 0.0"],
+];
+
+d("WASM alias_match matches the pure-TS scoreField reference (exact)", () => {
+  beforeAll(async () => {
+    const ok = await enableWasm();
+    if (!ok) throw new Error("artifact present but enableWasm() failed");
+  });
+  afterAll(() => disableWasm());
+
+  for (const [a, b, note] of ALIAS_CASES) {
+    it(`alias_match("${a}","${b}") ${note}`, () => {
+      const ref = scoreField(a, b, "alias_match");
+      expect(ref).not.toBeNull();
+      const m = scoreMatrix([a, b], "alias_match");
+      expect(m[0]![1]!).toBe(ref!);
+    });
+  }
+});
+
 d("WASM ensemble matches the pure-TS scoreField reference (4dp)", () => {
   beforeAll(async () => {
     const ok = await enableWasm();

--- a/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/scorer.test.ts
@@ -17,11 +17,14 @@ import {
   audioFpSimilarity,
   initialismMatch,
   deriveInitialism,
+  aliasMatch,
   ensembleScore,
   scoreMatrix,
   applyTransform,
 } from "../../src/core/index.js";
 import type { MatchkeyConfig, MatchkeyField, Row } from "../../src/core/index.js";
+import { canonicalCompanyForm } from "../../src/core/refdata/business.js";
+import { canonicalForm } from "../../src/core/refdata/givenNames.js";
 
 describe("jaro / jaroWinkler", () => {
   it("jaro MARTHA ~= MARHTA matches Python (0.9444)", () => {
@@ -282,6 +285,49 @@ describe("initialism_match (business-name acronym matcher)", () => {
     expect(initialismMatch("National Aeronautics and Space Administration", "NASA")).toBe(0.0);
     expect(initialismMatch("AT and T", "ATT")).toBe(0.0);
     expect(initialismMatch("", "IBM")).toBe(0.0);
+  });
+});
+
+describe("alias_match (business + given-name canonical equality)", () => {
+  it("canonicalizes a company name (legal-form strip + alias map)", () => {
+    // Pinned against Python `refdata.business_aliases.canonical_company_form`.
+    expect(canonicalCompanyForm("Acme Inc")).toBe("acme");
+    expect(canonicalCompanyForm("Acme Incorporated")).toBe("acme");
+    expect(canonicalCompanyForm("Acme Holdings Inc.")).toBe("acme"); // compound suffix peels
+    expect(canonicalCompanyForm("Acme Limited Liability Company")).toBe("acme");
+    expect(canonicalCompanyForm("Acme-Inc")).toBe("acme"); // hyphen is a leading separator
+    expect(canonicalCompanyForm("Acme Group")).toBe("acme"); // descriptor variant stripped
+    expect(canonicalCompanyForm("Google LLC")).toBe("alphabet"); // surface -> canonical
+    expect(canonicalCompanyForm("International Business Machines Corp")).toBe(
+      "international business machines",
+    );
+    expect(canonicalCompanyForm("Globex")).toBe("globex"); // OOV -> normalized passthrough
+    expect(canonicalCompanyForm("Inc")).toBe("inc"); // no leading sep -> nothing stripped
+    expect(canonicalCompanyForm("")).toBe("");
+    expect(canonicalCompanyForm(null)).toBeNull();
+  });
+
+  it("canonicalizes a given name (lex-first nickname resolution)", () => {
+    // Pinned against Python `refdata.given_names.canonical_form`.
+    expect(canonicalForm("Bob")).toBe("robert");
+    expect(canonicalForm("Robert")).toBe("robert");
+    expect(canonicalForm("Kate")).toBe("catherine"); // lex-first across canonicals
+    expect(canonicalForm("Xander")).toBe("alexander");
+    expect(canonicalForm("Zzz")).toBe("zzz"); // OOV passthrough
+  });
+
+  it("matches on a shared non-empty business OR given canonical, else 0.0", () => {
+    // Pinned against Python `_alias_match_single`.
+    expect(aliasMatch("Acme Inc", "Acme Incorporated")).toBe(1.0);
+    expect(aliasMatch("Google", "Alphabet Inc.")).toBe(1.0);
+    expect(aliasMatch("IBM", "International Business Machines")).toBe(1.0);
+    expect(aliasMatch("FedEx", "Federal Express")).toBe(1.0);
+    expect(aliasMatch("Acme Group", "Acme")).toBe(1.0);
+    expect(aliasMatch("Bob", "Robert")).toBe(1.0); // given-name half
+    expect(aliasMatch("Kate", "Catherine")).toBe(1.0);
+    expect(aliasMatch("Acme", "Globex")).toBe(0.0); // different OOV companies
+    expect(aliasMatch("William", "Walter")).toBe(0.0); // unrelated given names
+    expect(aliasMatch("", "")).toBe(0.0); // empty canonical never matches
   });
 });
 

--- a/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/wasm-backend.test.ts
@@ -25,9 +25,10 @@ describe("ScorerBackend singleton", () => {
     expect(getScorerBackend()).toBeNull();
   });
 
-  it("covers the 14 score_one scorers + the 2 fs-core name scorers", () => {
+  it("covers the 15 score_one scorers + the 2 fs-core name scorers", () => {
     expect([...WASM_COVERED_SCORERS].sort()).toEqual(
       [
+        "alias_match",
         "audio_fp",
         "date",
         "dice",

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -244,6 +244,7 @@ a2a_skills:
 # PluginRegistry validator fallback, so they're NOT in Python VALID_SCORERS).
 scorers:
   shared:
+  - alias_match
   - audio_fp
   - date
   - dice
@@ -260,8 +261,7 @@ scorers:
   - record_embedding
   - soundex_match
   - token_sort
-  python_only:
-  - alias_match
+  python_only: []
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw
@@ -317,17 +317,22 @@ blocking_strategies:
 # components hold vs rapidfuzz (soundex byte-exact). `phash` (id 11) is also shared:
 # perceptual-hash similarity (1 - hamming/nbits over hex pHashes), integer XOR popcount,
 # byte-exact WASM<->pure-TS like dice/jaccard.
-# python_only: `alias_match` has an arrow-native (bucket) kernel on Python but no TS WASM
-# port yet (it is behind score-wasm's off-by-default `alias` cargo feature + needs the
-# business/given-name alias tables injected). `initialism_match` is now shared: the kernel
-# needs the ~77-entry legal_forms table injected at enableWasm() (set_legal_forms), which the
-# loader seeds with the ported refdata/business.ts table so WASM == pure-TS byte-exact.
+# `alias_match` (id 8) is now shared: score-wasm ENABLES the `alias` cargo feature (the
+# `regex` engine, ~+36 KB) and the kernel needs TWO tables injected at enableWasm() --
+# the business alias table (set_business_aliases: the FULL 81-entry legal-form variant
+# list, from which the kernel rebuilds the trailing-suffix strip regex, + the surface->
+# canonical alias map) and the given-name nickname map (set_given_name_canonicals). The
+# loader seeds both with the ported refdata/business.ts + refdata/givenNames.ts tables so
+# WASM == pure-TS byte-exact. `initialism_match` is shared: the kernel needs the ~77-entry
+# legal_forms table injected at enableWasm() (set_legal_forms), which the loader seeds with
+# the ported refdata/business.ts table so WASM == pure-TS byte-exact.
 # ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
 # name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
 # over fs-core, injected census/alias tables) but have no Python bucket kernel
 # (Python accepts them via the plugin fallback); a real, declared Python<->TS delta.
 scorer_kernels:
   shared:
+  - alias_match
   - audio_fp
   - date
   - dice
@@ -342,8 +347,7 @@ scorer_kernels:
   - radial
   - soundex_match
   - token_sort
-  python_only:
-  - alias_match
+  python_only: []
   ts_only:
   - given_name_aliased_jw
   - name_freq_weighted_jw


### PR DESCRIPTION
## What and why

`alias_match` (score_one id 8) was the **last Python-only scorer**. Porting it closes the scorer cross-language parity roadmap: every entity-resolution scorer is now kernel-backed on **both** Python (arrow-native bucket) **and** TS (score-wasm), except the two intentionally TS-only census/alias name scorers and the model-backed embedding pair.

`alias_match` is `1.0` iff two values canonicalize to the same non-empty business alias OR the same given-name canonical, else `0.0` — byte-exact with score-core `alias_match` / Python `_alias_match_single`.

## Changes

- **score-wasm**: enable the `alias` cargo feature (the `regex` engine) on the score-core dep; add `set_business_aliases` / `set_given_name_canonicals` wasm exports + `install_*` helpers. score-core already carried the alias subsystem behind the feature — the wasm surface just turns it on and injects the tables. New cargo test exercises id 8 dispatch.
- **TS pure path**: `refdata/business.ts` gains the FULL 81-entry legal-form variant set + surface→canonical alias map + `stripLegalForm` / `businessNormalize` / `canonicalCompanyForm`; `refdata/givenNames.ts` gains `canonicalForm` (lex-first) + `canonicalInjectionPairs`. `scorer.ts` gains `aliasMatch` + the `scoreField` case; wired into `VALID_SCORERS`, `SCORER_ID: 8`, and `core/index` exports.
- **ReDoS-safe strip**: the business legal-form strip is a **linear scan, not a regex** — the anchored `[\s,\-.]+(?:variant)[\s.,]*$` pattern on caller data is the polynomial-ReDoS class CodeQL flags; the scan reproduces its leftmost-match + DESC-length-alternation semantics exactly.
- **Loader**: injects both tables at `enableWasm()` so WASM canonicalizes over the SAME tables the pure path uses — byte-exact by construction.
- **Manifest**: `alias_match` moves `python_only → shared` in both `scorers` and `scorer_kernels`; `docs-site/suite-matrix.mdx` regenerated (scorers surface now 17 shared / 0 python-only / 2 ts-only).

## Testing

- `cargo test` + `cargo clippy --all-targets` (score-wasm, alias feature on) — green (7 tests incl. new id-8 dispatch).
- Pure-TS canonicalization validated byte-for-byte against Python `canonical_company_form` / `canonical_form` / `_alias_match_single` on a battery of adversarial cases (legal-form strips, compound suffixes, hyphen separators, descriptor variants, brand aliases, lex-first nicknames).
- `pnpm --filter goldenmatch build` + `tsc --noEmit` — clean.
- Full vitest: **185 files, 3281 passed + 1 expected-fail**; WASM parity suite **108 passed** (built the score-wasm artifact locally to un-skip, incl. the new `alias_match` byte-exact block).
- `check_api_parity.py goldenmatch` — parity OK (structure + scorer coverage floor).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / manifest updated (suite-matrix + parity manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_