### PR TITLE
feat(native): native bucket kernel for the two name scorers (ts_only -> shared)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -30,9 +30,9 @@ The Rust / Arrow-native / fused `-core` kernels are the source of truth for scor
 
 | Substrate | Scorers |
 |---|---|
-| Rust `-core` kernel — Python + TS | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
+| Rust `-core` kernel — Python + TS | `alias_match`, `audio_fp`, `date`, `dice`, `ensemble`, `exact`, `given_name_aliased_jw`, `initialism_match`, `jaccard`, `jaro_winkler`, `levenshtein`, `name_freq_weighted_jw`, `phash`, `qgram`, `radial`, `soundex_match`, `token_sort` |
 | Rust `-core` kernel — Python arrow-native only (TS falls back) | — |
-| WASM `-core` kernel — TS only (Python falls back) | `given_name_aliased_jw`, `name_freq_weighted_jw` |
+| WASM `-core` kernel — TS only (Python falls back) | — |
 | Language fallback — no `-core` kernel | `embedding`, `record_embedding` |
 
 ## Cross-language parity (Python ↔ TypeScript)

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -355,6 +355,7 @@
             "_default_n_buckets",
             "_ensure_alias_tables_installed",
             "_ensure_legal_forms_installed",
+            "_ensure_name_tables_installed",
             "_fs_bounded_stream_enabled",
             "_fs_bucket_native_enabled",
             "_ne_effectively_empty",
@@ -382,7 +383,9 @@
             "goldenmatch.core.scorer",
             "goldenmatch.plugins.registry",
             "goldenmatch.refdata",
-            "goldenmatch.refdata.business"
+            "goldenmatch.refdata.business",
+            "goldenmatch.refdata.given_names",
+            "goldenmatch.refdata.surnames"
           ]
         },
         {

--- a/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
+++ b/packages/python/goldenmatch/goldenmatch/backends/score_buckets.py
@@ -292,6 +292,25 @@ _NATIVE_SCORER_IDS: dict[str, int] = {
     # silently zeroing the id via score_one's catch-all.
     "radial": 13,
     "audio_fp": 14,
+    # ids 15/16 = name_freq_weighted_jw / given_name_aliased_jw (the census-IDF /
+    # given-name-alias name scorers). UNLIKE ids 0..=14 these are NOT score_one
+    # scorers -- score_one is stateless and cannot reach reference tables. The
+    # WEIGHTED bucket kernel intercepts 15/16 and dispatches them through
+    # fs-core's `name_freq_weighted_sim` / `given_name_aliased_sim` over the
+    # process-global census/alias tables (`set_name_reference_data`). Two-part
+    # wheel-skew guard at the gating site: routing requires BOTH the
+    # `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability flag AND a successful table
+    # install (`_ensure_name_tables_installed`), folded into one memoized bool; a
+    # stale wheel (score_one catch-all -> 0.0) declines to the pure plugin path.
+    # ADDITIONALLY name_freq_weighted_jw declines native when its field carries a
+    # per-dataset `tf_freqs` table (#1207 default-on): fs-core ports only the
+    # STATIC-census branch, so a tf field stays on the vectorized find_fuzzy_matches
+    # (which applies the tf downweight via the plugin matrix path). Parity is
+    # tolerance-bounded, not byte-exact: the native base JW is rapidfuzz-rs vs the
+    # plugin's rapidfuzz-py -- native is the reference (see the FS name-scorer
+    # story in probabilistic.py + tests/test_native_name_scorer_parity.py).
+    "name_freq_weighted_jw": 15,
+    "given_name_aliased_jw": 16,
 }
 
 
@@ -400,6 +419,66 @@ def _ensure_alias_tables_installed() -> bool:
     except Exception:
         _ALIAS_TABLES_INSTALLED = False
     return _ALIAS_TABLES_INSTALLED
+
+
+# Same tri-state as the two above, for the census surname-IDF + given-name alias
+# tables the weighted-bucket name scorers (ids 15/16) dispatch over.
+_NAME_TABLES_INSTALLED: bool | None = None
+
+
+def _ensure_name_tables_installed() -> bool:
+    """Install the census surname-IDF + given-name alias tables into the native
+    kernel's process-global ``NameRefData`` (via ``set_name_reference_data``)
+    exactly once, so the WEIGHTED bucket ids 15/16 (``name_freq_weighted_jw`` /
+    ``given_name_aliased_jw``) score over the SAME tables the pure plugin scorers
+    do (``refdata.scorer.NameFreqWeightedJW`` / ``GivenNameAliasedJW``).
+
+    Shares the process-global with the FS path's ``_ensure_fs_name_refdata`` (one
+    kernel table), so a benign double-install is skipped via
+    ``has_name_reference_data``.
+
+    Returns True once installed on a kernel exposing ``set_name_reference_data``
+    AND the ``NATIVE_SUPPORTS_NAME_BUCKET_SCORERS`` capability flag; False when the
+    loaded kernel lacks a symbol (a stale wheel whose ``score_one`` catch-all would
+    score ids 15/16 as 0.0) or the census/alias packs are unavailable, so the
+    gating site declines the native route and the pure per-pair plugin mirror (or,
+    at the fast-path guard, the vectorized ``find_fuzzy_matches``) scores the block.
+    Idempotent + memoized; the reference tables are deterministic.
+    """
+    global _NAME_TABLES_INSTALLED
+    if _NAME_TABLES_INSTALLED is not None:
+        return _NAME_TABLES_INSTALLED
+    _mod = native_module()
+    if (
+        _mod is None
+        or not hasattr(_mod, "set_name_reference_data")
+        or not hasattr(_mod, "NATIVE_SUPPORTS_NAME_BUCKET_SCORERS")
+    ):
+        _NAME_TABLES_INSTALLED = False
+        return False
+    try:
+        from goldenmatch.refdata.given_names import export_alias_forms
+        from goldenmatch.refdata.surnames import export_counts
+
+        surname_counts = [(n, float(c)) for n, c in export_counts()]
+        alias_forms = export_alias_forms()
+        # Both packs empty -> the kernel would score every name pair as plain JW
+        # (name_freq_weighted degrades to JW with no census table; given_name_-
+        # aliased to JW with no alias graph). The pure plugin path is the only
+        # faithful route in that case, so decline.
+        if not surname_counts and not alias_forms:
+            _NAME_TABLES_INSTALLED = False
+            return False
+        # Skip a redundant install if the FS path already registered the SAME
+        # deterministic tables into the shared process-global.
+        if not (
+            hasattr(_mod, "has_name_reference_data") and _mod.has_name_reference_data()
+        ):
+            _mod.set_name_reference_data(surname_counts, alias_forms)
+        _NAME_TABLES_INSTALLED = True
+    except Exception:
+        _NAME_TABLES_INSTALLED = False
+    return _NAME_TABLES_INSTALLED
 
 
 # Single source in core._hashing (re-exported here for back-compat). The
@@ -793,8 +872,33 @@ def _resolve_fast_path(
     # kernel safe to default-on: an ensemble field on a name-scorer matchkey no
     # longer drags the whole matchkey onto the slow per-pair path.)
     _fast_scorers = [s for _, _, _, s in field_specs]
+    # The two name scorers are in `_NATIVE_SCORER_IDS` (ids 15/16), but they only
+    # ACTUALLY get a kernel when the census/alias tables are installed on a capable
+    # wheel -- and `name_freq_weighted_jw` additionally declines native when its
+    # field carries a per-dataset `tf_freqs` table (#1207 default-on), since fs-core
+    # ports only the static-census branch. In those cases the fast path would fall
+    # to the O(N^2) per-pair Python loop (the 19x-slow regression the guard below
+    # protects against), so treat them as per-pair-forcing -> decline to the
+    # vectorized `find_fuzzy_matches`, which handles every scorer (incl. the tf
+    # downweight via the plugin matrix path), exactly as before this change.
+    _has_name_scorer = any(
+        s in ("name_freq_weighted_jw", "given_name_aliased_jw") for s in _fast_scorers
+    )
+    _name_native_ok = _ensure_name_tables_installed() if _has_name_scorer else False
+    _name_forces_per_pair: set[str] = set()
+    if _has_name_scorer:
+        for f in mk.fields:
+            s = getattr(f, "scorer", None)
+            if s == "name_freq_weighted_jw":
+                if not _name_native_ok or getattr(f, "tf_freqs", None):
+                    _name_forces_per_pair.add(s)
+            elif s == "given_name_aliased_jw" and not _name_native_ok:
+                _name_forces_per_pair.add(s)
     _per_pair_scorers = [
-        s for s in _fast_scorers if s not in _VEC_SUPPORTED and s not in _NATIVE_SCORER_IDS
+        s
+        for s in _fast_scorers
+        if (s not in _VEC_SUPPORTED and s not in _NATIVE_SCORER_IDS)
+        or s in _name_forces_per_pair
     ]
     if _per_pair_scorers:
         _decline(
@@ -1317,6 +1421,18 @@ def score_buckets(
             # `_ensure_alias_tables_installed` folds both into one memoized bool;
             # only evaluated when a field actually uses alias_match.
             _alias_ok = has_alias and _ensure_alias_tables_installed()
+            # name scorers (bucket ids 15/16) have the same TWO-part guard: the
+            # `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability flag AND a successful
+            # census/alias table install, folded into `_ensure_name_tables_installed`.
+            # `_resolve_fast_path` already keeps a name field OFF the fast path when
+            # this is False (or when name_freq_weighted_jw carries a tf table), so a
+            # fast-path matchkey reaching here with a name field is table-installed;
+            # the guard is defense-in-depth (a stale wheel scores ids 15/16 as 0.0).
+            has_name_scorer = any(
+                spec[3] in ("name_freq_weighted_jw", "given_name_aliased_jw")
+                for spec in _field_specs
+            )
+            _name_ok = has_name_scorer and _ensure_name_tables_installed()
             # Wheel-skew: decline native entirely when a field uses a scorer whose
             # capability symbol the loaded kernel lacks (score_one would silently
             # zero that id); the pure-Python per-pair mirror scores the block.
@@ -1326,6 +1442,7 @@ def score_buckets(
                 or (has_soundex and not _soundex_ok)
                 or (has_initialism and not _initialism_ok)
                 or (has_alias and not _alias_ok)
+                or (has_name_scorer and not _name_ok)
                 or (has_dice and not _dice_ok)
                 or (has_jaccard and not _jaccard_ok)
                 or (has_phash and not _phash_ok)

--- a/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
+++ b/packages/python/goldenmatch/tests/test_cross_surface_consistency.py
@@ -6,7 +6,8 @@ several places -- the drift class the focused consistency audit surfaced.
    identical across surfaces. It was a duplicated literal; now a single source in
    core._hashing, pinned here.
 2. Native scorer-id maps: the integer ids in _NATIVE_SCORER_IDS (score_buckets,
-   the score_block_pairs/score_one namespace) and _NATIVE_FIELD_SCORER_IDS
+   the score_block_pairs/score_one namespace 0-14 PLUS the name-scorer bucket ids
+   15/16 that the bucket kernel routes to fs-core) and _NATIVE_FIELD_SCORER_IDS
    (scorer.py, the score_field_matrix namespace) are hand-maintained mirrors of
    the Rust score-core dispatch. Nothing asserted they match the kernel; a
    renumber would silently mis-dispatch. Pinned canonically + behaviorally.
@@ -43,10 +44,18 @@ class TestNativeScorerIdMaps:
     # `soundex_match` therefore lives in BOTH maps at DIFFERENT ids (bucket 6,
     # field 4); the two are pinned separately so they can't silently collide.
     _SCORE_ONE_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "date": 4, "qgram": 5, "soundex_match": 6, "initialism_match": 7, "alias_match": 8, "dice": 9, "jaccard": 10, "phash": 11, "ensemble": 12, "radial": 13, "audio_fp": 14}
+    # Name-scorer bucket ids EXTEND the bucket namespace beyond score_one (0-14):
+    # the weighted bucket kernel (score_block_pairs/_arrow) intercepts 15/16 and
+    # dispatches them to fs-core's name_freq_weighted_sim/given_name_aliased_sim
+    # over the injected census/alias tables -- they are NOT score_one arms. Pinned
+    # here so a renumber of either the Python map or the Rust NB_* consts fails.
+    _NAME_BUCKET_IDS = {"name_freq_weighted_jw": 15, "given_name_aliased_jw": 16}
     _FIELD_MATRIX_IDS = {"jaro_winkler": 0, "levenshtein": 1, "token_sort": 2, "exact": 3, "soundex_match": 4}
 
     def test_native_scorer_ids_match_score_one_ordering(self):
-        assert _NATIVE_SCORER_IDS == self._SCORE_ONE_IDS
+        # _NATIVE_SCORER_IDS = the score_one namespace (0-14) PLUS the two
+        # name-scorer bucket ids (15/16), which the bucket kernel routes to fs-core.
+        assert _NATIVE_SCORER_IDS == {**self._SCORE_ONE_IDS, **self._NAME_BUCKET_IDS}
 
     def test_native_field_scorer_ids_match_score_field_matrix_ordering(self):
         assert _NATIVE_FIELD_SCORER_IDS == self._FIELD_MATRIX_IDS

--- a/packages/python/goldenmatch/tests/test_native_name_scorer_parity.py
+++ b/packages/python/goldenmatch/tests/test_native_name_scorer_parity.py
@@ -1,0 +1,187 @@
+"""Parity for the weighted-BUCKET name scorers (native ids 15/16) vs the pure
+Python plugin references `NameFreqWeightedJW` / `GivenNameAliasedJW`.
+
+These two scorers were the last Python↔TS `scorer_kernels` asymmetry: WASM-backed
+on TS (score-wasm ids 20/21 over `fs-core`) but pure-Python-plugin-only on Python.
+This wave gives them a NATIVE bucket kernel too — the weighted `score_block_pairs`
+/ `score_block_pairs_arrow` kernels intercept the new bucket ids 15/16 and dispatch
+them through `fs-core`'s `name_freq_weighted_sim` / `given_name_aliased_sim` over
+the process-global census/alias tables (`set_name_reference_data`) — so the metric
+(`scorer_kernels`, read from the bucket `_NATIVE_SCORER_IDS`) can move them to
+`shared`.
+
+UNLIKE `score_one` ids 0..=14, ids 15/16 read host-installed reference tables
+(census surname counts → IDF; given-name nickname classes). Without them the kernel
+degrades a name field to plain Jaro-Winkler, so every test installs the tables first
+(exactly as the fast-path guard `_ensure_name_tables_installed` does).
+
+Parity posture: TOLERANCE-bounded, not bit-exact. The native base JW is rapidfuzz-rs
+whereas the plugin's is rapidfuzz-py; under "Rust is the reference" the native result
+is authoritative. Empirically the two agree to machine epsilon here (name_freq_weighted
+is `jw * weight`, given_name_aliased is `jw` or `1.0` — no FS-style level banding that
+could amplify a borderline JW delta), so a 1e-9 abs tolerance is comfortable.
+
+The fs-core `name_freq_weighted_sim` ports only the STATIC-census branch (not the
+#1207 per-dataset `tf_freqs` downweight), so this test drives the plugin's static
+branch (no `tf_freqs` passed) — matching how the fast-path guard declines native for
+a tf-carrying name field.
+"""
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from goldenmatch.core import _native_loader
+from goldenmatch.refdata.scorer import GivenNameAliasedJW, NameFreqWeightedJW
+
+_TOL = 1e-9
+
+
+def _install(n) -> bool:
+    """Install census + alias tables, mirroring `_ensure_name_tables_installed`.
+    Uses a latest-wins RwLock kernel-side, so test order is irrelevant."""
+    from goldenmatch.refdata.given_names import export_alias_forms
+    from goldenmatch.refdata.surnames import export_counts
+
+    surname_counts = [(name, float(c)) for name, c in export_counts()]
+    alias_forms = export_alias_forms()
+    if not surname_counts and not alias_forms:
+        return False
+    n.set_name_reference_data(surname_counts, alias_forms)
+    return True
+
+
+def _capable(n) -> bool:
+    return (
+        n is not None
+        and hasattr(n, "set_name_reference_data")
+        and hasattr(n, "NATIVE_SUPPORTS_NAME_BUCKET_SCORERS")
+        and hasattr(n, "score_block_pairs")
+    )
+
+
+def _native_pair(n, a: str, b: str, scorer_id: int) -> float | None:
+    """One 2-row block, one name field, weight 1.0, threshold -1 so the pair
+    always emits — the kernel's per-pair weighted score IS the raw sim."""
+    out = n.score_block_pairs([0, 1], [2], [[a, b]], [scorer_id], [1.0], 1.0, -1.0, [])
+    return out[0][2] if out else None
+
+
+# Adversarial corpus: common vs rare surnames (IDF band edges), given-name nickname
+# classes, OOV names, casing, punctuation, empties.
+_SURNAMES = [
+    "Smith", "Smyth", "Smithe", "Jones", "Williams", "Brown", "Nguyen",
+    "Zzyzyx", "Aaronsonovich", "smith", "SMITH", "O'Brien", "", "  ",
+]
+_GIVENS = [
+    "William", "Bill", "Will", "Billy", "Bob", "Robert", "Bobby", "Rob",
+    "Kate", "Catherine", "Kathy", "Xavier", "Zelda", "zzz", "", "  ",
+]
+
+
+def test_name_freq_weighted_bucket_id15_matches_plugin():
+    n = _native_loader.native_module()
+    if not _capable(n):
+        pytest.skip("native kernel lacks the name-bucket-scorer capability")
+    if not _install(n):
+        pytest.skip("census/alias refdata packs unavailable")
+    ref = NameFreqWeightedJW()
+    worst = 0.0
+    for a, b in itertools.combinations_with_replacement(_SURNAMES, 2):
+        got = _native_pair(n, a, b, 15)
+        # Plugin STATIC-census branch (no tf_freqs) — what fs-core ports.
+        exp = ref.score_pair(a, b)
+        assert got == pytest.approx(exp, abs=_TOL), f"nfw {a!r} {b!r}: {got} vs {exp}"
+        worst = max(worst, abs(got - exp))
+    assert worst < _TOL
+
+
+def test_given_name_aliased_bucket_id16_matches_plugin():
+    n = _native_loader.native_module()
+    if not _capable(n):
+        pytest.skip("native kernel lacks the name-bucket-scorer capability")
+    if not _install(n):
+        pytest.skip("census/alias refdata packs unavailable")
+    ref = GivenNameAliasedJW()
+    for a, b in itertools.combinations_with_replacement(_GIVENS, 2):
+        got = _native_pair(n, a, b, 16)
+        exp = ref.score_pair(a, b)
+        assert got == pytest.approx(exp, abs=_TOL), f"gna {a!r} {b!r}: {got} vs {exp}"
+
+
+def test_name_scorer_paths_specific():
+    n = _native_loader.native_module()
+    if not _capable(n):
+        pytest.skip("native kernel lacks the name-bucket-scorer capability")
+    if not _install(n):
+        pytest.skip("census/alias refdata packs unavailable")
+    # given_name_aliased: nickname canonical equality -> 1.0; unrelated -> plain JW.
+    assert _native_pair(n, "Bob", "Robert", 16) == pytest.approx(1.0, abs=_TOL)
+    assert _native_pair(n, "William", "Bill", 16) == pytest.approx(1.0, abs=_TOL)
+    assert _native_pair(n, "Kate", "Catherine", 16) == pytest.approx(1.0, abs=_TOL)
+    assert _native_pair(n, "William", "Walter", 16) == pytest.approx(
+        GivenNameAliasedJW().score_pair("William", "Walter"), abs=_TOL
+    )
+    # name_freq_weighted: the census downweight fires only in the borderline JW
+    # band [0.70, 0.95) (an exact agreement returns raw JW = 1.0, unweighted). A
+    # borderline COMMON-surname pair is pulled below its raw JW; the native score
+    # matches the plugin's downweighted value.
+    from rapidfuzz.distance import JaroWinkler
+
+    ref = NameFreqWeightedJW()
+    raw_jw = JaroWinkler.similarity("Smith", "Smyth")
+    downweighted = _native_pair(n, "Smith", "Smyth", 15)
+    assert downweighted < raw_jw - 1e-6  # common surname pulled down
+    assert downweighted == pytest.approx(ref.score_pair("Smith", "Smyth"), abs=_TOL)
+    # An OOV (rare) surname pair is NOT in the census, so no downweight -> raw JW.
+    assert _native_pair(n, "Zzyzyx", "Zzyzyx", 15) == pytest.approx(1.0, abs=_TOL)
+
+
+def test_name_scorer_bucket_multi_pair_block():
+    """score_block_pairs over a multi-row block dispatching ids 15/16 == the
+    per-pair plugin mirror on every emitted pair."""
+    n = _native_loader.native_module()
+    if not _capable(n):
+        pytest.skip("native kernel lacks the name-bucket-scorer capability")
+    if not _install(n):
+        pytest.skip("census/alias refdata packs unavailable")
+    values = ["William", "Bill", "Robert", "Bob", "Xavier"]
+    row_ids = list(range(len(values)))
+    for scorer_id, ref in ((15, NameFreqWeightedJW()), (16, GivenNameAliasedJW())):
+        emitted = n.score_block_pairs(
+            row_ids, [len(values)], [values], [scorer_id], [1.0], 1.0, -1.0, []
+        )
+        got = {(min(a, b), max(a, b)): s for a, b, s in emitted}
+        for i in range(len(values)):
+            for j in range(i + 1, len(values)):
+                exp = ref.score_pair(values[i], values[j])
+                assert got[(i, j)] == pytest.approx(exp, abs=_TOL), (
+                    f"id{scorer_id} {values[i]!r} {values[j]!r}"
+                )
+
+
+def test_name_scorer_arrow_matches_vec_kernel():
+    """score_block_pairs_arrow (the Arrow-buffer entry the pipeline actually
+    calls) dispatches ids 15/16 identically to the Vec-based score_block_pairs."""
+    pa = pytest.importorskip("pyarrow")
+    n = _native_loader.native_module()
+    if not _capable(n) or not hasattr(n, "score_block_pairs_arrow"):
+        pytest.skip("native kernel lacks the arrow name-bucket path")
+    if not _install(n):
+        pytest.skip("census/alias refdata packs unavailable")
+    values = ["William", "Bill", "Smith", "Smyth", "Zzyzyx"]
+    row_ids = pa.array(list(range(len(values))), type=pa.int64())
+    for scorer_id in (15, 16):
+        vec = n.score_block_pairs(
+            list(range(len(values))), [len(values)], [values], [scorer_id],
+            [1.0], 1.0, -1.0, [],
+        )
+        arrow = n.score_block_pairs_arrow(
+            row_ids, [pa.array(values)], [len(values)], [scorer_id],
+            [1.0], 1.0, -1.0,
+        )
+        vec_map = {(a, b): s for a, b, s in vec}
+        arrow_map = {(a, b): s for a, b, s in arrow}
+        assert vec_map.keys() == arrow_map.keys()
+        for k in vec_map:
+            assert vec_map[k] == pytest.approx(arrow_map[k], abs=_TOL), f"id{scorer_id} {k}"

--- a/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
+++ b/packages/python/goldenmatch/tests/test_score_buckets_fast_path_gate.py
@@ -200,8 +200,13 @@ class TestPerPairPythonPerfGuard:
     (26.97s vs 1.40s) -- enough to blow the per-test timeout on a slow CI runner.
     `_resolve_fast_path` must DECLINE so such a matchkey uses find_fuzzy_matches.
 
-    This is what makes the ensemble kernel safe to default-on: an ensemble field
-    resolving no longer drags a name-scorer matchkey onto the slow per-pair path.
+    UPDATE (name-scorer bucket kernel): `name_freq_weighted_jw` /
+    `given_name_aliased_jw` are now native bucket ids 15/16, so a name matchkey
+    ENGAGES the native fast path when the kernel is capable + the tables install.
+    The guard now only bites for a name field that CANNOT go native --
+    `name_freq_weighted_jw` carrying a per-dataset `tf_freqs` table (fs-core ports
+    only the static-census branch), which declines deterministically regardless of
+    native availability.
     """
 
     def _prepared_df_for(self, *fields: MatchkeyField) -> pl.DataFrame:
@@ -211,8 +216,33 @@ class TestPerPairPythonPerfGuard:
             cols[_xform_sig(f)] = ["alice", "alicia", "bob"]
         return pl.DataFrame(cols)
 
-    def test_declines_when_field_forces_per_pair_python(self):
-        # name_freq_weighted_jw is neither vec-supported nor native-id -> per-pair.
+    def test_declines_when_tf_name_field_forces_per_pair_python(self):
+        # A name_freq_weighted_jw field carrying a per-dataset tf_freqs table can't
+        # go native (fs-core ports only the static-census branch), so it forces the
+        # per-pair Python loop -> the guard must decline to find_fuzzy_matches. This
+        # is env-independent (holds whether or not the native kernel is built).
+        f1 = MatchkeyField(field="name", scorer="name_freq_weighted_jw", weight=1.0)
+        f1.tf_freqs = {"alice": 0.9, "alicia": 0.05, "bob": 0.05}
+        f2 = MatchkeyField(field="alias", scorer="jaro_winkler", weight=1.0)
+        mk = MatchkeyConfig(name="names", type="weighted", threshold=0.7, fields=[f1, f2])
+        result = _resolve_fast_path(
+            mk, self._prepared_df_for(f1, f2),
+            across_files_only=False, source_lookup=None, target_ids=None,
+        )
+        assert result is None, (
+            "a name_freq_weighted_jw field with a tf_freqs table cannot go native "
+            "(no tf branch in fs-core) -> must decline the fast path (perf guard)"
+        )
+
+    def test_name_scorers_engage_when_native_available(self):
+        # Without a tf table, name_freq_weighted_jw / given_name_aliased_jw are
+        # native bucket ids 15/16 -> the fast path engages (native does the work,
+        # no per-pair Python). Requires a capable native kernel + installable
+        # tables; skip on a pure-Python / stale-wheel env (where the guard still
+        # declines them, keeping the vectorized find_fuzzy_matches path).
+        from goldenmatch.backends.score_buckets import _ensure_name_tables_installed
+        if not _ensure_name_tables_installed():
+            pytest.skip("native name-bucket kernel unavailable (pure-Python/stale wheel)")
         f1 = MatchkeyField(field="name", scorer="name_freq_weighted_jw", weight=1.0)
         f2 = MatchkeyField(field="alias", scorer="given_name_aliased_jw", weight=1.0)
         mk = MatchkeyConfig(name="names", type="weighted", threshold=0.7, fields=[f1, f2])
@@ -220,9 +250,9 @@ class TestPerPairPythonPerfGuard:
             mk, self._prepared_df_for(f1, f2),
             across_files_only=False, source_lookup=None, target_ids=None,
         )
-        assert result is None, (
-            "a matchkey with a per-pair-Python scorer (name_freq_weighted_jw) "
-            "must decline the fast path -> find_fuzzy_matches (perf guard)"
+        assert result is not None, (
+            "name scorers (no tf table) are native bucket ids 15/16 -> the fast "
+            "path must engage when the native kernel is capable"
         )
 
     def test_engages_for_vec_supported_scorers(self):

--- a/packages/rust/extensions/native/src/lib.rs
+++ b/packages/rust/extensions/native/src/lib.rs
@@ -76,6 +76,16 @@ fn _native(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // kwarg only when this flag is present, so an OLDER wheel degrades gracefully to the
     // legacy emit-at-neutral native behavior (the numpy fallback still filters).
     m.add("FS_SUPPORTS_REQUIRE_POSITIVE_EVIDENCE", true)?;
+    // Wheel-skew capability flag: the WEIGHTED bucket entries (`score_block_pairs`
+    // / `score_block_pairs_arrow`) dispatch the reference-data name scorers
+    // (`name_freq_weighted_jw` bucket id 15 / `given_name_aliased_jw` id 16)
+    // through the process-registered census / alias tables — DISTINCT from the FS
+    // path's ids 4/5 (FS_SUPPORTS_NAME_SCORERS). Python's `_NATIVE_SCORER_IDS`
+    // gate admits these two bucket scorers only when this flag is present AND
+    // `set_name_reference_data` has been called; an old wheel lacks the flag and
+    // keeps the pure-Python plugin path (score_one's catch-all would score 15/16
+    // as 0.0 otherwise).
+    m.add("NATIVE_SUPPORTS_NAME_BUCKET_SCORERS", true)?;
     m.add_function(wrap_pyfunction!(cluster::connected_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::mst_split_components, m)?)?;
     m.add_function(wrap_pyfunction!(cluster::severe_bridge_count, m)?)?;

--- a/packages/rust/extensions/native/src/score.rs
+++ b/packages/rust/extensions/native/src/score.rs
@@ -12,7 +12,10 @@
 use arrow::array::{Array, ArrayData, Int64Array, LargeStringArray, StringArray};
 use arrow::datatypes::DataType;
 use arrow::pyarrow::PyArrowType;
-use goldenmatch_fs_core::{AliasTable, NameAliases, SurnameFreq, SurnameIdfTable, TfTable};
+use goldenmatch_fs_core::{
+    given_name_aliased_sim, name_freq_weighted_sim, AliasTable, NameAliases, SurnameFreq,
+    SurnameIdfTable, TfTable,
+};
 use goldenmatch_score_core::score_one;
 use numpy::{IntoPyArray, PyArray1, PyArray2};
 use pyo3::exceptions::PyValueError;
@@ -154,6 +157,45 @@ fn name_providers(
     match refdata {
         Some(d) => (Some(&d.surnames), Some(&d.aliases)),
         None => (None, None),
+    }
+}
+
+/// Weighted-BUCKET scorer ids for the two name scorers. `score_one` (score-core)
+/// owns the bucket namespace 0..=14; these extend it for the reference-table-
+/// backed name scorers, which `score_one` (stateless) cannot dispatch. DISTINCT
+/// from the FS namespace (where `name_freq_weighted_jw`/`given_name_aliased_jw`
+/// are ids 4/5) — that map never transfers here. Kept in lockstep with
+/// `backends.score_buckets._NATIVE_SCORER_IDS` (and `core.fused_match`); a skew
+/// is caught by the `native_symbols` gate + the wheel-drift advisory via the
+/// capability flag `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS`.
+pub const NB_NAME_FREQ_WEIGHTED: u8 = 15;
+pub const NB_GIVEN_NAME_ALIASED: u8 = 16;
+
+/// Per-field similarity for the weighted bucket kernels. Intercepts the two
+/// name-scorer bucket ids (15/16) and dispatches them through fs-core's
+/// reference-table-backed sims using the process-global [`NameRefData`]; every
+/// other id delegates to the stateless `score_one`. When the host never
+/// registered name reference data (`name_data == None`) a name-scorer field
+/// degrades to plain Jaro-Winkler (`score_one(0)`), matching the Python plugin's
+/// `if not is_available(): return jw` — though the Python caller only routes
+/// native once the tables are installed, so this is a defensive fallback.
+#[inline]
+fn score_bucket_field(
+    scorer_id: u8,
+    a: &str,
+    b: &str,
+    name_data: &Option<Arc<NameRefData>>,
+) -> f64 {
+    match scorer_id {
+        NB_NAME_FREQ_WEIGHTED => match name_data {
+            Some(d) => name_freq_weighted_sim(a, b, &d.surnames),
+            None => score_one(0, a, b),
+        },
+        NB_GIVEN_NAME_ALIASED => match name_data {
+            Some(d) => given_name_aliased_sim(a, b, &d.aliases),
+            None => score_one(0, a, b),
+        },
+        id => score_one(id, a, b),
     }
 }
 
@@ -408,6 +450,12 @@ pub fn score_block_pairs(
     let exclude: HashSet<(i64, i64)> = exclude.into_iter().collect();
     let n_fields = scorer_ids.len();
 
+    // Snapshot the process-global name reference data ONCE (a cheap Arc clone)
+    // so the name-scorer bucket ids (15/16) can reach the census/alias tables
+    // inside the parallel loop without re-locking per pair. `Arc<NameRefData>`
+    // is Sync, so the rayon closure captures `&name_data` safely.
+    let name_data = current_name_refdata();
+
     // Precompute each block's (offset, size) span so blocks are independent
     // units of parallel work.
     let mut spans: Vec<(usize, usize)> = Vec::with_capacity(block_sizes.len());
@@ -438,7 +486,9 @@ pub fn score_block_pairs(
                                 if let (Some(a), Some(b)) =
                                     (&field_values[f][i], &field_values[f][j])
                                 {
-                                    score_sum += score_one(scorer_ids[f], a, b) * weights[f];
+                                    score_sum +=
+                                        score_bucket_field(scorer_ids[f], a, b, &name_data)
+                                            * weights[f];
                                     weight_sum += weights[f];
                                 }
                             }
@@ -854,6 +904,11 @@ pub fn score_block_pairs_arrow(
         offset += size;
     }
 
+    // Snapshot the process-global name reference data ONCE (cheap Arc clone) so
+    // the name-scorer bucket ids (15/16) reach the census/alias tables inside the
+    // shared span closure. `Arc<NameRefData>` is Sync -> safe for the rayon path.
+    let name_data = current_name_refdata();
+
     // Per-block scorer, shared by the sequential and rayon paths so the two can
     // never diverge. Borrows only Sync data (the arrow arrays, the exclude set,
     // the weight/scorer slices) and holds no mutable state, so it is safe to
@@ -874,7 +929,8 @@ pub fn score_block_pairs_arrow(
                     let mut weight_sum = 0.0_f64;
                     for f in 0..n_fields {
                         if let (Some(a), Some(b)) = (fields[f].get(i), fields[f].get(j)) {
-                            score_sum += score_one(scorer_ids[f], a, b) * weights[f];
+                            score_sum +=
+                                score_bucket_field(scorer_ids[f], a, b, &name_data) * weights[f];
                             weight_sum += weights[f];
                         }
                     }

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -326,10 +326,19 @@ blocking_strategies:
 # WASM == pure-TS byte-exact. `initialism_match` is shared: the kernel needs the ~77-entry
 # legal_forms table injected at enableWasm() (set_legal_forms), which the loader seeds with
 # the ported refdata/business.ts table so WASM == pure-TS byte-exact.
-# ts_only: `given_name_aliased_jw` / `name_freq_weighted_jw` -- the census/alias
-# name scorers -- are kernel-backed on the TS WASM surface (score-wasm ids 20/21
-# over fs-core, injected census/alias tables) but have no Python bucket kernel
-# (Python accepts them via the plugin fallback); a real, declared Python<->TS delta.
+# `given_name_aliased_jw` / `name_freq_weighted_jw` are now shared too: the census/alias
+# name scorers are kernel-backed on BOTH surfaces -- TS WASM (score-wasm ids 20/21 over
+# fs-core) AND Python native (WEIGHTED bucket ids 15/16 in score_block_pairs/_arrow,
+# dispatched through fs-core's `name_freq_weighted_sim`/`given_name_aliased_sim` over the
+# process-global census/alias tables from `set_name_reference_data`, gated on the
+# `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability + `_ensure_name_tables_installed`). ONE
+# fs-core reference on both sides, so Python native == TS WASM by construction. Parity vs
+# the pure-Python plugin is TOLERANCE-bounded (native base JW is rapidfuzz-rs vs the
+# plugin's rapidfuzz-py; empirically machine-epsilon since there is no FS-style level
+# banding) -- native is the reference. `name_freq_weighted_jw` declines native for a field
+# carrying a per-dataset `tf_freqs` table (#1207): fs-core ports only the static-census
+# branch, so those fields stay on the vectorized find_fuzzy_matches (like `date` declining
+# on a stale wheel -- the kernel exists + is reachable, which is the shared contract).
 scorer_kernels:
   shared:
   - alias_match
@@ -338,19 +347,19 @@ scorer_kernels:
   - dice
   - ensemble
   - exact
+  - given_name_aliased_jw
   - initialism_match
   - jaccard
   - jaro_winkler
   - levenshtein
+  - name_freq_weighted_jw
   - phash
   - qgram
   - radial
   - soundex_match
   - token_sort
   python_only: []
-  ts_only:
-  - given_name_aliased_jw
-  - name_freq_weighted_jw
+  ts_only: []
 # scorer_kernels_deferred: the COVERAGE FLOOR. Every scorer in the `scorers` surface
 # that is NOT kernel-backed (absent from `scorer_kernels`) MUST appear here with a
 # reason -- the `check_scorer_coverage` gate FAILS on any uncovered scorer, so a new


### PR DESCRIPTION
## What and why

`name_freq_weighted_jw` / `given_name_aliased_jw` were the **last `scorer_kernels` Python↔TS asymmetry**: WASM-backed on TS (score-wasm ids 20/21 over `fs-core`) but pure-Python-plugin-only on Python. This gives them a native bucket kernel too — closing the surface so **every string scorer is now kernel-backed on both Python and TS** (only the model-backed `embedding`/`record_embedding` pair remains a language fallback).

This is a real kernel extension, not a dict edit: the two names are `score_one`-shaped only on the FS/probabilistic path (ids 4/5), but the **weighted bucket kernel** the `scorer_kernels` metric reads dispatches through the stateless `score_one`, which can't reach reference tables.

## Changes

- **`score.rs`**: `score_block_pairs` / `score_block_pairs_arrow` snapshot the process-global `NameRefData` once and dispatch new bucket ids **15/16** through fs-core's `name_freq_weighted_sim` / `given_name_aliased_sim` (`score_bucket_field` helper). Tables absent → plain JW fallback. Non-name ids stay byte-identical (same `score_one` call). New `NATIVE_SUPPORTS_NAME_BUCKET_SCORERS` capability flag in `lib.rs`.
- **`score_buckets.py`**: adds the two to `_NATIVE_SCORER_IDS`, `_ensure_name_tables_installed()` (shares the FS path's `set_name_reference_data` process-global), and a two-part gate (capability + tables). The **PERF GUARD** keeps a name field off the per-pair fast path unless native can actually handle it — and `name_freq_weighted_jw` carrying a per-dataset `tf_freqs` table (#1207) **declines native** (fs-core ports only the static-census branch) and stays on the vectorized `find_fuzzy_matches`, exactly as before.
- **Manifest** (`parity/goldenmatch.yaml`): both scorers move `scorer_kernels` `ts_only` → `shared`; suite-matrix regenerated (WASM-only row now empty).

## Parity posture

Tolerance-bounded, **native-is-reference** (rapidfuzz-rs base JW vs the plugin's rapidfuzz-py), but empirically **machine-epsilon** — there's no FS-style level banding to amplify a borderline JW delta. One fs-core reference on both sides, so Python native == TS WASM by construction.

## Testing

- New `tests/test_native_name_scorer_parity.py` (5 tests): native bucket ids 15/16 == plugin reference to 1e-9 over adversarial name corpora; Vec vs Arrow-buffer entry parity.
- `tests/test_score_buckets_fast_path_gate.py` updated: name scorers now engage the native fast path (skip-guarded on native availability); a `tf_freqs`-carrying `name_freq_weighted_jw` field still declines deterministically.
- **End-to-end**: a `given_name_aliased_jw` dedupe produces **byte-identical clusters native-on vs native-off**.
- Regression sweep (165 tests across score_buckets / native-parity / refdata / tf-weighting) green; `cargo clippy` clean; `check_api_parity.py goldenmatch` + `check_native_symbols.py goldenmatch` OK.
- Two known-pre-existing failures (`test_qis_native_parity` pure-path pyarrow `.sort()` bug; `test_random_native_parity[33]` issue-#870 tie-order nondeterminism) confirmed independent of this change (reproduce on clean `main`).

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / manifest updated (suite-matrix + parity manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_