### PR TITLE
feat(goldencheck-ts): add history + evaluate CLI commands (Python parity)

### DIFF
--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -47,7 +47,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | scorers | 17 | 0 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
-| `goldencheck` | cli_commands | 8 | 11 | 3 |
+| `goldencheck` | cli_commands | 10 | 9 | 3 |
 | `goldencheck` | a2a_skills | 9 | 0 | 0 |
 | `goldenflow` | mcp_tools | 10 | 0 | 0 |
 | `goldenflow` | cli_commands | 9 | 7 | 0 |
@@ -71,7 +71,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
-- `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `evaluate`, `history`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
+- `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldencheck` **cli_commands** — TS-only: `health-score`, `list-domains`, `profile`.
 - `goldenflow` **cli_commands** — Python-only: `agent-serve`, `init`, `interactive`, `mcp-serve`, `schedule`, `serve`, `watch`.
 - `goldenpipe` **cli_commands** — Python-only: `interactive`.

--- a/packages/typescript/goldencheck/.gitignore
+++ b/packages/typescript/goldencheck/.gitignore
@@ -1,1 +1,4 @@
 package-lock.json
+
+# Runtime artifacts the CLI writes (scan records to .goldencheck/history.jsonl by default)
+.goldencheck/

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -4,6 +4,8 @@
  * Port of goldencheck/cli/main.py using Commander.js.
  */
 
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { Command } from "commander";
 import { readFile } from "./node/reader.js";
@@ -13,6 +15,8 @@ import { Severity, healthScore, type Finding } from "./core/types.js";
 import { reportJson } from "./core/reporters/json.js";
 import { ciCheck } from "./core/reporters/ci.js";
 import { listAvailableDomains } from "./core/semantic/domains/index.js";
+import { recordScan, loadHistory } from "./core/engine/history.js";
+import { evaluateScan, type ExpectedFinding } from "./core/engine/evaluate.js";
 
 export const program = new Command();
 
@@ -31,6 +35,7 @@ program
   .option("--no-tui", "CLI output (no TUI)")
   .option("--llm-boost", "Enhance with LLM analysis")
   .option("--baseline <path>", "Baseline file for drift detection")
+  .option("--no-history", "Don't record this scan in history")
   .action((file: string, opts: Record<string, unknown>) => {
     const data = readFile(file);
     const result = scanData(data, {
@@ -38,6 +43,12 @@ program
       domain: opts["domain"] as string | undefined,
     });
     const findings = applyConfidenceDowngrade(result.findings, false);
+
+    // Record the scan in .goldencheck/history.jsonl (default on; --no-history
+    // opts out). Commander sets `history` false when --no-history is passed.
+    if (opts["history"] !== false) {
+      recordScan(file, result.profile, findings);
+    }
 
     if (opts["json"]) {
       console.log(reportJson(findings, result.profile));
@@ -225,6 +236,101 @@ program
     console.log("\nAvailable domain packs:");
     for (const d of domains) {
       console.log(`  - ${d}`);
+    }
+  });
+
+// --- history ---
+program
+  .command("history [file]")
+  .description("Show scan history — scores, grades, and trends over time")
+  .option("-n, --last <n>", "Show last N scans")
+  .option("--json", "Output as JSON")
+  .action((file: string | undefined, opts: Record<string, unknown>) => {
+    // recordScan stores the resolved absolute path, so filter by the same.
+    const fileFilter = file ? resolve(file) : undefined;
+    const lastN = opts["last"] !== undefined ? Number(opts["last"]) : undefined;
+    const records = loadHistory(fileFilter, lastN);
+
+    if (records.length === 0) {
+      console.log("No scan history found. Run a scan first.");
+      return;
+    }
+
+    if (opts["json"]) {
+      console.log(JSON.stringify(records, null, 2));
+      return;
+    }
+
+    console.log(
+      `${"Date".padEnd(20)} ${"File".padEnd(24)} ${"Score".padStart(5)} ` +
+        `${"Grade".padStart(5)} ${"Errors".padStart(6)} ${"Warnings".padStart(8)}`,
+    );
+    for (const r of records) {
+      const ts = r.timestamp.slice(0, 16).replace("T", " ");
+      console.log(
+        `${ts.padEnd(20)} ${r.file.padEnd(24)} ${String(r.score).padStart(5)} ` +
+          `${r.grade.padStart(5)} ${String(r.errors).padStart(6)} ${String(r.warnings).padStart(8)}`,
+      );
+    }
+
+    const first = records[0]!;
+    const latest = records[records.length - 1]!;
+    if (records.length >= 2 && first.file === latest.file) {
+      console.log(`\nTrend: ${first.file} ${first.score} -> ${latest.score}`);
+    }
+  });
+
+// --- evaluate ---
+program
+  .command("evaluate <file>")
+  .description("Evaluate scan accuracy against a ground-truth JSON file")
+  .requiredOption(
+    "-g, --ground-truth <path>",
+    "JSON file with expected findings (array of {column, check})",
+  )
+  .option("--min-f1 <n>", "Minimum F1 score; exit 1 if below", "0")
+  .option("--json", "Output results as JSON")
+  .action((file: string, opts: Record<string, unknown>) => {
+    const gtPath = opts["groundTruth"] as string;
+    let expected: ExpectedFinding[];
+    try {
+      expected = JSON.parse(readFileSync(gtPath, "utf-8")) as ExpectedFinding[];
+    } catch (e) {
+      console.error(
+        `Error: could not read ground-truth file '${gtPath}': ${(e as Error).message}`,
+      );
+      process.exit(1);
+    }
+
+    const data = readFile(file);
+    const result = scanData(data);
+    const findings = applyConfidenceDowngrade(result.findings, false);
+    const ev = evaluateScan(findings, expected);
+
+    if (opts["json"]) {
+      console.log(JSON.stringify(ev, null, 2));
+    } else {
+      console.log(`Precision:       ${ev.precision.toFixed(4)}`);
+      console.log(`Recall:          ${ev.recall.toFixed(4)}`);
+      console.log(`F1:              ${ev.f1.toFixed(4)}`);
+      console.log(`True positives:  ${ev.truePositives}`);
+      console.log(`False positives: ${ev.falsePositives}`);
+      console.log(`False negatives: ${ev.falseNegatives}`);
+
+      if (ev.fpDetails.length > 0) {
+        console.log("\nFalse positives:");
+        for (const [col, chk] of ev.fpDetails) console.log(`  ${col}: ${chk}`);
+      }
+      if (ev.fnDetails.length > 0) {
+        console.log("\nFalse negatives (missed):");
+        for (const [col, chk] of ev.fnDetails) console.log(`  ${col}: ${chk}`);
+      }
+    }
+
+    const minF1 = Number(opts["minF1"] ?? 0);
+    if (ev.f1 < minF1) {
+      console.error(`\nF1 ${ev.f1.toFixed(4)} is below minimum ${minF1.toFixed(4)}`);
+      process.exit(1);
     }
   });
 

--- a/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
+++ b/packages/typescript/goldencheck/tests/unit/cli/commands.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { program } from "../../../src/cli.js";
+
+// Importing cli.ts is side-effect-free: the `program.parse()` call at the bottom
+// is guarded by an `import.meta.url === argv[1]` check, so it doesn't run here.
+
+describe("goldencheck CLI command registration", () => {
+  const names = program.commands.map((c) => c.name());
+
+  it("registers the history + evaluate commands (TS parity with Python)", () => {
+    expect(names).toContain("history");
+    expect(names).toContain("evaluate");
+  });
+
+  it("evaluate requires a --ground-truth option", () => {
+    const evaluate = program.commands.find((c) => c.name() === "evaluate");
+    expect(evaluate).toBeDefined();
+    const gt = evaluate!.options.find((o) => o.long === "--ground-truth");
+    expect(gt).toBeDefined();
+    expect(gt!.required).toBe(true);
+    // --min-f1 gate is present for CI-style accuracy checks.
+    expect(evaluate!.options.some((o) => o.long === "--min-f1")).toBe(true);
+  });
+
+  it("scan gained a --no-history opt-out (history recorded by default)", () => {
+    const scan = program.commands.find((c) => c.name() === "scan");
+    expect(scan).toBeDefined();
+    expect(scan!.options.some((o) => o.long === "--no-history")).toBe(true);
+  });
+
+  it("history accepts an optional file filter + --last / --json", () => {
+    const history = program.commands.find((c) => c.name() === "history");
+    expect(history).toBeDefined();
+    expect(history!.options.some((o) => o.long === "--last")).toBe(true);
+    expect(history!.options.some((o) => o.long === "--json")).toBe(true);
+  });
+});

--- a/parity/goldencheck.yaml
+++ b/parity/goldencheck.yaml
@@ -6,8 +6,12 @@
 # Review: MCP tools near-parity (only install_domain is Python-only — INTENTIONAL: the TS
 #   core exposes a read-only domain registry (listAvailableDomains / getDomainTypes /
 #   DOMAIN_REGISTRY, src/core/index.ts) with no install path, so there is no TS operation
-#   to reconcile). CLI: Python ships the richer surface (servers + ops); TS adds
-#   health-score/list-domains/profile convenience commands. No naming divergence.
+#   to reconcile). CLI: Python still ships more commands, but they are servers/daemons/
+#   interactive (agent-serve/serve/schedule/scan-db/init/review) or unported engines
+#   (denial-constraints/refs/learn). `history` + `evaluate` are now SHARED — the TS port
+#   already carries the engines (core/engine/history.ts + evaluateScan), so the CLI
+#   commands were wired over them. TS also adds health-score/list-domains/profile
+#   convenience commands. No naming divergence.
 # a2a_skills: FULL A2A parity — Python and TS expose the same 9 AgentCard skill ids
 #   (analyze_data, compare_domains, configure, explain, fix, handoff, review, scan, validate).
 #   No divergence.
@@ -40,7 +44,9 @@ cli_commands:
   - baseline
   - demo
   - diff
+  - evaluate
   - fix
+  - history
   - mcp-serve
   - scan
   - validate
@@ -48,8 +54,6 @@ cli_commands:
   python_only:
   - agent-serve
   - denial-constraints
-  - evaluate
-  - history
   - init
   - learn
   - refs


### PR DESCRIPTION
## What and why

The TS goldencheck port already shipped the underlying engines (`core/engine/history.ts` — `recordScan`/`loadHistory`; `core/engine/evaluate.ts` — `evaluateScan`) but only exposed them programmatically — the two CLI commands were **Python-only**. This closes that genuine `cli_commands` parity gap by wiring Commander commands over the existing engines (no new engine logic).

This is the second of the genuine cross-language closures from the gap audit (the remaining goldencheck Python-only CLI commands are intentional — servers/daemons/interactive wizards or unported engines like `denial-constraints`/`refs`).

## Changes

- **`history [file]`** (`--last`/`-n`, `--json`): shows recorded scans (score / grade / errors / warnings) + a trend line, mirroring Python's history table. Filters by resolved path (the engine's storage convention).
- **`evaluate <file>`** (`-g`/`--ground-truth <json>`, `--min-f1`, `--json`): scans the file, compares findings to a ground-truth JSON array of `{column, check}`, prints precision / recall / F1 + TP/FP/FN (+ FP/FN detail), and exits 1 below `--min-f1` — matching the Python command.
- **`scan --no-history`**: `scan` now records to `.goldencheck/history.jsonl` **by default** (matching Python's default-record + `--no-history` opt-out), which is what makes `history` populated. Added `.goldencheck/` to the package `.gitignore` so the runtime artifact isn't accidentally committed.
- **Manifest** (`parity/goldencheck.yaml`): `history` + `evaluate` move `cli_commands` `python_only` → `shared`; the review-comment updated. `docs-site/suite-matrix.mdx` regenerated (goldencheck CLI 8 → 10 shared).

## Testing

- Functional smoke: `scan` records → `history` displays the table + trend → `evaluate` computes P/R/F1 against a ground-truth JSON.
- New `tests/unit/cli/commands.test.ts` (4 tests): asserts `history`/`evaluate` are registered, `evaluate` requires `--ground-truth` and has `--min-f1`, `scan` has `--no-history`, `history` has `--last`/`--json`.
- Full goldencheck TS suite: **266 passed** (28 files); `tsc --noEmit` clean.
- `check_api_parity.py goldencheck` — parity OK; `config_matrix` + `agent_codemap` + `check_llms_counts` gates green.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / manifest updated (suite-matrix + parity manifest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_