### PR TITLE
feat(goldenmatch-a2a): add profile/suggest_config/memory_export/suggest_pprl skills (TS parity)

### DIFF
--- a/docs-site/goldenmatch/agent.mdx
+++ b/docs-site/goldenmatch/agent.mdx
@@ -1,6 +1,6 @@
 ---
 title: "ER agent"
-description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 43 skills, confidence-gated review queue, and Python API."
+description: "GoldenMatch as an autonomous entity resolution agent: A2A protocol, 47 skills, confidence-gated review queue, and Python API."
 keywords: ["agent", "A2A", "entity resolution", "autonomous", "review queue", "MCP"]
 ---
 

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 81 | 201 | 43 | 34 | Yes | Yes |
+| `goldenmatch` | 81 | 201 | 47 | 34 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 19 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -43,7 +43,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 41 | 40 | 9 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
-| `goldenmatch` | a2a_skills | 23 | 20 | 13 |
+| `goldenmatch` | a2a_skills | 27 | 20 | 9 |
 | `goldenmatch` | scorers | 17 | 0 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
@@ -68,7 +68,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `compare-clusters`, `config`, `explain`, `incremental`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
-- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `memory_export`, `profile`, `scan_quality`, `score`, `suggest_config`, `suggest_pprl`.
+- `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -197,6 +197,7 @@
             "goldenmatch.core.agent",
             "goldenmatch.core.autoconfig",
             "goldenmatch.core.block_analyzer",
+            "goldenmatch.core.blocker",
             "goldenmatch.core.memory.store",
             "goldenmatch.core.quality",
             "goldenmatch.core.review_queue",

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -15,6 +15,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   discover the valid scorer / transform / survivorship-strategy names before building
   a config. Closes the corresponding `mcp_tools` / `a2a_skills` cross-language parity
   gap (both trios move `ts_only` → `shared`).
+- **Capability-gap A2A skills (TS-parity).** `profile`, `suggest_config`,
+  `memory_export`, and `suggest_pprl` are now advertised on the Python A2A agent card
+  (47 skills) — closing four `a2a_skills` gaps the TS card already carried. `profile`
+  summarizes a dataset's columns via `profile_for_agent`; `suggest_config` returns a
+  shorthand `{exact, fuzzy, blocking, threshold}` from `auto_configure`; `memory_export`
+  and `suggest_pprl` delegate to the identical MCP dispatch. All four move
+  `ts_only` → `shared`.
 
 ## [3.8.0] - 2026-07-22
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -218,7 +218,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 
 ### Integration
 - **REST API + MCP Server** — 81 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
-- **A2A Agent** — 43 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
+- **A2A Agent** — 47 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
 - **Enterprise connectors** — Snowflake, Databricks, BigQuery, HubSpot, Salesforce

--- a/packages/python/goldenmatch/goldenmatch/a2a/server.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/server.py
@@ -360,6 +360,37 @@ _SKILLS = [
         "inputModes": ["application/json"],
         "outputModes": ["application/json"],
     },
+    # Capability-gap skills (parity with the TS A2A surface): file-based
+    # profiling / config-suggestion / memory-export / PPRL-recommendation the
+    # TS card already advertised but the Python card omitted.
+    {
+        "id": "profile",
+        "name": "Profile",
+        "description": "Profile a dataset's columns (types, null rates, cardinality).",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "suggest_config",
+        "name": "Suggest Config",
+        "description": "Suggest a dedupe config (exact/fuzzy/blocking/threshold) from a dataset.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "memory_export",
+        "name": "Memory Export",
+        "description": "Export Learning Memory corrections + learned thresholds.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
+    {
+        "id": "suggest_pprl",
+        "name": "Suggest PPRL",
+        "description": "Inspect a dataset for sensitive PII and recommend whether to use privacy-preserving record linkage.",
+        "inputModes": ["application/json"],
+        "outputModes": ["application/json"],
+    },
 ]
 
 

--- a/packages/python/goldenmatch/goldenmatch/a2a/skills.py
+++ b/packages/python/goldenmatch/goldenmatch/a2a/skills.py
@@ -487,6 +487,71 @@ def dispatch_skill(skill_id: str, params: dict, allow_pprl: bool = False) -> dic
         strategies = sorted(VALID_STRATEGIES)
         return {"strategies": strategies, "count": len(strategies)}
 
+    # ── Capability-gap skills (parity with the TS A2A surface) ────────────────
+    # File-based, stateless-per-request. `memory_export` / `suggest_pprl` delegate
+    # to the identical MCP dispatch (same JSON contract, same pattern as the
+    # identity_* / list_corrections skills above); `profile` / `suggest_config`
+    # are file-based summarizers over profile_for_agent / auto_configure.
+    if skill_id == "memory_export":
+        from goldenmatch.mcp.memory_tools import _dispatch as _memory_dispatch
+        return _memory_dispatch("memory_export", params)
+
+    if skill_id == "suggest_pprl":
+        from goldenmatch.mcp.agent_tools import _dispatch as _agent_dispatch
+        return _agent_dispatch("suggest_pprl", params, AgentSession)
+
+    if skill_id == "profile":
+        import polars as pl
+
+        df = pl.read_csv(
+            params["file_path"], encoding="utf8-lossy", ignore_errors=True
+        )
+        prof = profile_for_agent(df)
+        return {
+            "row_count": prof.row_count,
+            "has_sensitive": prof.has_sensitive,
+            "columns": [
+                {
+                    "name": f.name,
+                    "type": f.type,
+                    "uniqueness": f.uniqueness,
+                    "null_rate": f.null_rate,
+                    "avg_length": f.avg_length,
+                }
+                for f in prof.fields
+            ],
+        }
+
+    if skill_id == "suggest_config":
+        from pathlib import Path as _Path
+
+        from goldenmatch.core.autoconfig import auto_configure
+        from goldenmatch.core.blocker import collect_blocking_fields
+
+        fp = params["file_path"]
+        cfg = auto_configure([(fp, _Path(fp).stem)])
+        exact: list[str] = []
+        fuzzy: dict[str, float] = {}
+        threshold = 0.85
+        for mk in cfg.get_matchkeys():
+            if mk.type == "exact":
+                exact.extend(f.field for f in mk.fields if f.field)
+            else:
+                th = float(mk.threshold) if mk.threshold is not None else 0.85
+                threshold = th
+                for f in mk.fields:
+                    if f.field:
+                        fuzzy[f.field] = th
+        blocking = collect_blocking_fields(cfg.blocking) if cfg.blocking else []
+        return {
+            "suggested": {
+                "exact": sorted(set(exact)),
+                "fuzzy": fuzzy,
+                "blocking": blocking,
+                "threshold": threshold,
+            }
+        }
+
     raise ValueError(f"Unknown skill: {skill_id}")
 
 

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -8,7 +8,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 ## Interfaces
 - MCP Server: `goldenmatch mcp-serve` (81 tools across data, agent, identity, memory, routing, and document groups)
 - Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (81 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
-- A2A Server: `goldenmatch agent-serve --port 8200` (43 skills advertised in the agent card)
+- A2A Server: `goldenmatch agent-serve --port 8200` (47 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~201 exports
 - TypeScript / Edge: `npm install goldenmatch` — same API in browsers, Cloudflare Workers, Vercel Edge, Deno; optional WASM via `await enableWasm()` swaps in the Rust score-core kernel, and `enableSuggestWasm()` brings the config-suggestion "healer" (`dedupe({suggest, heal})`) to TS via suggest-core (pure-TS stays the default + byte-identical fallback)

--- a/packages/python/goldenmatch/tests/test_a2a.py
+++ b/packages/python/goldenmatch/tests/test_a2a.py
@@ -35,7 +35,7 @@ def test_agent_card_has_required_fields():
     assert card["authentication"]["schemes"] == ["bearer"]
 
 
-def test_agent_card_has_43_skills():
+def test_agent_card_has_47_skills():
     """v1.7-v1.12 added autoconfig+controller_telemetry (10->12); v2.0 added
     six identity_* skills (12->18); v1.19.x Phase 3 added add_correction
     (18->19); the MCP tool-coverage parity pass added 12 (19->31); #1089 added
@@ -44,16 +44,19 @@ def test_agent_card_has_43_skills():
     added identity_audit_seal / identity_audit_verify (35->37); the healer added
     review_config (37->38); document ingest added documents_suggest_schema /
     documents_ingest (38->40); the registry-introspection parity pass added
-    list_scorers / list_transforms / list_strategies (40->43)."""
+    list_scorers / list_transforms / list_strategies (40->43); the
+    capability-gap parity pass added profile / suggest_config / memory_export /
+    suggest_pprl (43->47)."""
     from goldenmatch.a2a.server import build_agent_card
 
     card = build_agent_card("http://localhost:8080")
-    assert len(card["skills"]) == 43
+    assert len(card["skills"]) == 47
     ids = {s["id"] for s in card["skills"]}
     assert "autoconfig" in ids
     assert "retrieve_similar" in ids
     assert "review_config" in ids
     assert {"list_scorers", "list_transforms", "list_strategies"} <= ids
+    assert {"profile", "suggest_config", "memory_export", "suggest_pprl"} <= ids
     assert {"identity_claim", "identity_resolve_conflict", "identity_audit"} <= ids
     assert {"identity_audit_seal", "identity_audit_verify"} <= ids
     assert "controller_telemetry" in ids
@@ -740,3 +743,72 @@ def test_a2a_exposes_reconciled_canonical_ids():
     from goldenmatch.a2a.server import _SKILLS
     ids = {s["id"] for s in _SKILLS}
     assert {"autoconfig", "compare_strategies", "transform"} <= ids
+
+
+# ── Capability-gap skills (profile / suggest_config / memory_export / suggest_pprl) ──
+
+
+def test_dispatch_profile(tmp_path):
+    """profile skill summarizes a dataset's columns via profile_for_agent."""
+    import polars as pl
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({
+        "id": [1, 2, 3],
+        "name": ["Alice", "Bob", "Carol"],
+    }).write_csv(str(csv_path))
+
+    result = dispatch_skill("profile", {"file_path": str(csv_path)})
+    assert result["row_count"] == 3
+    assert "has_sensitive" in result
+    cols = {c["name"] for c in result["columns"]}
+    assert cols == {"id", "name"}
+    for c in result["columns"]:
+        assert {"name", "type", "uniqueness", "null_rate", "avg_length"} <= set(c)
+
+
+def test_dispatch_suggest_config(tmp_path):
+    """suggest_config skill returns a shorthand exact/fuzzy/blocking/threshold."""
+    import polars as pl
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({
+        "first_name": ["Alice", "Bob", "Alice"],
+        "last_name": ["Smith", "Jones", "Smyth"],
+        "email": ["a@x.com", "b@x.com", "a@x.com"],
+    }).write_csv(str(csv_path))
+
+    result = dispatch_skill("suggest_config", {"file_path": str(csv_path)})
+    suggested = result["suggested"]
+    assert set(suggested) == {"exact", "fuzzy", "blocking", "threshold"}
+    assert isinstance(suggested["exact"], list)
+    assert isinstance(suggested["fuzzy"], dict)
+    assert isinstance(suggested["blocking"], list)
+    assert isinstance(suggested["threshold"], float)
+
+
+def test_dispatch_memory_export(tmp_path):
+    """memory_export skill delegates to the MCP memory dispatch (empty store)."""
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    result = dispatch_skill("memory_export", {"path": str(tmp_path / "mem.db")})
+    assert result["count"] == 0
+    assert result["corrections"] == []
+
+
+def test_dispatch_suggest_pprl(tmp_path):
+    """suggest_pprl skill delegates to the MCP agent dispatch and recommends."""
+    import polars as pl
+    from goldenmatch.a2a.skills import dispatch_skill
+
+    csv_path = tmp_path / "data.csv"
+    pl.DataFrame({
+        "name": ["Alice", "Bob"],
+        "city": ["NYC", "LA"],
+    }).write_csv(str(csv_path))
+
+    result = dispatch_skill("suggest_pprl", {"file_path": str(csv_path)})
+    assert "needs_pprl" in result
+    assert "recommendation" in result

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -201,8 +201,12 @@ a2a_skills:
   - list_strategies
   - list_transforms
   - match
+  - memory_export
   - memory_stats
+  - profile
   - review_config
+  - suggest_config
+  - suggest_pprl
   - transform
   python_only:
   - analyze_blocking
@@ -233,12 +237,8 @@ a2a_skills:
   - agent_match_sources
   - agent_review_queue
   - fix_quality
-  - memory_export
-  - profile
   - scan_quality
   - score
-  - suggest_config
-  - suggest_pprl
 
 # scorers surface (config.schemas.VALID_SCORERS <-> types.ts VALID_SCORERS).
 # python_only: multimodal media comparators (ADR 0022) with no TS port yet.


### PR DESCRIPTION
## Summary

Closes four `a2a_skills` cross-language parity gaps that the TS agent card already
carried but the Python A2A card omitted. The Python card now advertises **47 skills**.

| Skill | Behavior |
|---|---|
| `profile` | Summarize a dataset's columns (types, null rates, cardinality) via `profile_for_agent`. |
| `suggest_config` | Shorthand `{exact, fuzzy, blocking, threshold}` from `auto_configure`. |
| `memory_export` | Delegate to the MCP memory dispatch (corrections + learned thresholds). |
| `suggest_pprl` | Delegate to the MCP agent dispatch (sensitive-PII inspection + PPRL recommendation). |

`memory_export` / `suggest_pprl` reuse the existing MCP dispatch (identical JSON
contract, same pattern as the `identity_*` / `list_corrections` skills); `profile` /
`suggest_config` are file-based summarizers over `profile_for_agent` / `auto_configure`.

## Parity

All four move `ts_only` → `shared` in `parity/goldenmatch.yaml`. `check_api_parity.py
goldenmatch` passes; the Python surface now emits 47 a2a_skills.

## Tests & doc gates

- `test_agent_card_has_47_skills` (was 43) + 4 new `dispatch_skill` tests.
- Regenerated `docs/agent-codemap.json`, `docs-site/suite-matrix.mdx`, and the
  README / `llms.txt` / `agent.mdx` skill counts (43 → 47). `check_llms_counts.py`,
  `test_config_matrix.py`, `test_agent_codemap.py`, `test_suite_matrix.py` all green.
- (`config-matrix.mdx` and `agent-manifest.json` regenerate identically — A2A skills
  don't feed those.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_