### PR TITLE
feat(web): interactive identity/cluster force-graph in the web UI

### DIFF
--- a/packages/python/goldenmatch/web/frontend/package.json
+++ b/packages/python/goldenmatch/web/frontend/package.json
@@ -15,6 +15,7 @@
     "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.18",
     "@tanstack/react-table": "^8.21.3",
+    "echarts": "^5.5.0",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/packages/python/goldenmatch/web/frontend/src/components/IdentityGraph.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/IdentityGraph.tsx
@@ -1,0 +1,309 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import * as echarts from "echarts";
+
+/**
+ * IdentityGraph — a collapsed-by-default force-directed graph with
+ * click-to-expand neighborhoods, shared by two surfaces:
+ *
+ *   • the Identities page (durable identity store) — hubs are entities,
+ *     expanding fetches an entity's records + evidence edges; and
+ *   • the run inspector / workbench preview — hubs are clusters, expanding
+ *     fetches a cluster's member rows + scored pairs.
+ *
+ * Both surfaces have the same list→detail API shape, so the component stays
+ * data-agnostic: the caller passes the hub list plus a lazy `expand(id)`
+ * that returns that hub's nodes + internal links. The component owns the
+ * ECharts wiring, the expand/collapse state, per-group coloring, and the
+ * hub→member links that make an expansion burst out of its hub. It scales
+ * with the hub count, not the total record count — the whole point.
+ */
+
+export type GraphHub = { id: string; label: string; size: number };
+/** `group` drives node color/legend: the caller's source name, or the
+ *  special value "conflict" for records in a conflicts_with edge. */
+export type GraphNode = { id: string; label: string; group: string };
+export type GraphLink = {
+  source: string;
+  target: string;
+  value?: number | null;
+  kind?: string;
+};
+export type GraphExpansion = { nodes: GraphNode[]; links: GraphLink[] };
+
+type Props = {
+  hubs: GraphHub[];
+  /** Legend/color name for hub nodes, e.g. "entity" or "cluster". */
+  hubGroup: string;
+  /** Lazily fetch one hub's nodes + internal links (cached after first call). */
+  expand: (id: string) => Promise<GraphExpansion>;
+  height?: number;
+  emptyHint?: string;
+};
+
+// Theme-matched palette (tailwind.config.js tokens). Hub = wordmark gold,
+// conflict = warm red; sources cycle a categorical set that reads on cream.
+const HUB_COLOR = "#d4a017";
+const CONFLICT_COLOR = "#c0392b";
+const PALETTE = [
+  "#0f9488", "#2f6fb0", "#7c5cc4", "#c2557a",
+  "#3f8f3f", "#b0721f", "#5b6b8c", "#8a4fa0",
+];
+const INK = "#534b39"; // ink-600, for chart text
+const MUTED = "#7a6f55"; // ink-500
+
+function hubSymbolSize(n: number): number {
+  if (n <= 1) return 14;
+  if (n === 2) return 20;
+  if (n === 3) return 26;
+  if (n <= 6) return 32;
+  return 40;
+}
+
+export function IdentityGraph({ hubs, hubGroup, expand, height = 560, emptyHint }: Props) {
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const chartRef = useRef<echarts.ECharts | null>(null);
+  const cacheRef = useRef<Map<string, GraphExpansion>>(new Map());
+  // Stable per-group color assignment (first-seen order), so colors don't
+  // reshuffle as new sources appear on expansion.
+  const groupColorRef = useRef<Map<string, string>>(new Map());
+  const groupSeq = useRef(0);
+
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState<Set<string>>(new Set());
+  const [showLabels, setShowLabels] = useState(false);
+  const [, force] = useState(0);
+
+  const colorForGroup = useCallback(
+    (g: string): string => {
+      if (g === hubGroup) return HUB_COLOR;
+      if (g === "conflict") return CONFLICT_COLOR;
+      const seen = groupColorRef.current.get(g);
+      if (seen) return seen;
+      const c = PALETTE[groupSeq.current % PALETTE.length]!;
+      groupSeq.current += 1;
+      groupColorRef.current.set(g, c);
+      return c;
+    },
+    [hubGroup],
+  );
+
+  const toggle = useCallback(
+    async (id: string) => {
+      if (expanded.has(id)) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+        return;
+      }
+      setExpanded((prev) => new Set(prev).add(id));
+      if (!cacheRef.current.has(id)) {
+        setLoading((prev) => new Set(prev).add(id));
+        try {
+          cacheRef.current.set(id, await expand(id));
+        } catch {
+          cacheRef.current.set(id, { nodes: [], links: [] });
+        } finally {
+          setLoading((prev) => {
+            const next = new Set(prev);
+            next.delete(id);
+            return next;
+          });
+          force((n) => n + 1);
+        }
+      }
+    },
+    [expanded, expand],
+  );
+
+  // Keep the click handler pointing at the latest toggle without re-binding.
+  const toggleRef = useRef(toggle);
+  toggleRef.current = toggle;
+
+  // Init chart once.
+  useEffect(() => {
+    if (!elRef.current) return;
+    const chart = echarts.init(elRef.current, undefined, { renderer: "canvas" });
+    chartRef.current = chart;
+    chart.on("click", (p: unknown) => {
+      const params = p as { dataType?: string; data?: { id?: string; __hub?: boolean } };
+      if (params.dataType === "node" && params.data?.__hub && params.data.id) {
+        void toggleRef.current(params.data.id);
+      }
+    });
+    const onResize = () => chart.resize();
+    window.addEventListener("resize", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      chart.dispose();
+      chartRef.current = null;
+    };
+  }, []);
+
+  // Rebuild the option whenever inputs change.
+  useEffect(() => {
+    const chart = chartRef.current;
+    if (!chart) return;
+
+    type Item = { id: string; name: string; symbolSize: number; category: number; value: number; __hub?: boolean; label?: unknown };
+    const nodes: Item[] = [];
+    const links: { source: string; target: string; value: number }[] = [];
+    const seen = new Set<string>();
+
+    // Discover the groups present so the legend + category colors are stable.
+    const groups: string[] = [hubGroup];
+    const groupIndex = new Map<string, number>([[hubGroup, 0]]);
+    const groupOf = (g: string) => {
+      if (!groupIndex.has(g)) {
+        groupIndex.set(g, groups.length);
+        groups.push(g);
+      }
+      return groupIndex.get(g)!;
+    };
+
+    for (const h of hubs) {
+      if (seen.has(h.id)) continue;
+      seen.add(h.id);
+      nodes.push({
+        id: h.id,
+        name: h.label,
+        symbolSize: hubSymbolSize(h.size),
+        category: 0,
+        value: h.size,
+        __hub: true,
+      });
+    }
+    for (const id of expanded) {
+      const exp = cacheRef.current.get(id);
+      if (!exp) continue;
+      for (const n of exp.nodes) {
+        if (!seen.has(n.id)) {
+          seen.add(n.id);
+          nodes.push({
+            id: n.id,
+            name: n.label,
+            symbolSize: 13,
+            category: groupOf(n.group),
+            value: 1,
+            label: showLabels ? { show: true, fontSize: 11 } : undefined,
+          });
+        }
+        // Structural member link: hub → its record, so the cluster bursts out.
+        links.push({ source: id, target: n.id, value: 0.5 });
+      }
+      for (const l of exp.links) {
+        links.push({ source: l.source, target: l.target, value: l.value ?? 1 });
+      }
+    }
+
+    const categories = groups.map((name) => ({ name }));
+    const colors = groups.map(colorForGroup);
+
+    chart.setOption(
+      {
+        backgroundColor: "transparent",
+        color: colors,
+        textStyle: { fontFamily: "Geist, ui-sans-serif, system-ui, sans-serif", color: INK },
+        tooltip: {
+          trigger: "item",
+          confine: true,
+          borderColor: "#ece1c0",
+          backgroundColor: "#fefcf6",
+          textStyle: { color: INK, fontSize: 12 },
+          formatter: (p: unknown) => {
+            const d = (p as { dataType?: string; data?: Item }).data;
+            if (!d || (p as { dataType?: string }).dataType !== "node") return "";
+            if (d.__hub) {
+              const open = expanded.has(d.id);
+              return `<b>${escapeHtml(d.name)}</b><br/>${d.value} record${d.value === 1 ? "" : "s"} · ${open ? "click to collapse" : "click to expand"}`;
+            }
+            return `<b>${escapeHtml(d.name)}</b><br/><span style="color:${MUTED}">${escapeHtml(d.id)}</span>`;
+          },
+        },
+        legend: [
+          {
+            data: groups,
+            bottom: 4,
+            type: "scroll",
+            textStyle: { color: MUTED, fontSize: 11 },
+            inactiveColor: "#cbbb95",
+            itemWidth: 13,
+            itemHeight: 8,
+          },
+        ],
+        series: [
+          {
+            type: "graph",
+            layout: "force",
+            roam: true,
+            categories,
+            // Compute the layout up front so hundreds of hubs settle instantly.
+            force: { repulsion: 95, gravity: 0.06, edgeLength: 58, friction: 0.2, layoutAnimation: false },
+            label: { show: false, color: INK, fontSize: 11, position: "right" },
+            emphasis: { focus: "adjacency", label: { show: true } },
+            lineStyle: { color: "source", opacity: 0.5, width: 0.9, curveness: 0 },
+            data: nodes,
+            links,
+          },
+        ],
+      },
+      { notMerge: true },
+    );
+  }, [hubs, expanded, showLabels, hubGroup, colorForGroup]);
+
+  const nRecords = Array.from(expanded).reduce(
+    (acc, id) => acc + (cacheRef.current.get(id)?.nodes.length ?? 0),
+    0,
+  );
+  const busy = loading.size > 0;
+
+  return (
+    <div>
+      <div className="flex items-center gap-3 mb-3 text-[12px] text-ink-500">
+        <span className="font-mono">
+          {hubs.length} hub{hubs.length === 1 ? "" : "s"}
+        </span>
+        <span aria-hidden>·</span>
+        <span className="font-mono">
+          {expanded.size} expanded{nRecords ? ` · ${nRecords} records` : ""}
+        </span>
+        {busy && <span className="text-gold-600">expanding…</span>}
+        <div className="flex-1" />
+        <label className="flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={showLabels}
+            onChange={(e) => setShowLabels(e.target.checked)}
+          />
+          <span>labels</span>
+        </label>
+        <button
+          className="btn btn-ghost !text-xs !py-1"
+          onClick={() => setExpanded(new Set())}
+          disabled={expanded.size === 0}
+        >
+          Collapse all
+        </button>
+      </div>
+      {hubs.length === 0 ? (
+        <div className="text-sm text-ink-500 py-10 text-center">
+          {emptyHint ?? "Nothing to graph yet."}
+        </div>
+      ) : (
+        <div
+          ref={elRef}
+          style={{ height, width: "100%" }}
+          className="rounded-lg border border-ink-100 bg-paper-50"
+        />
+      )}
+      <p className="mt-2 text-[11px] text-ink-400">
+        Click a {hubGroup} to expand its neighborhood · drag / scroll to roam · hover for detail.
+      </p>
+    </div>
+  );
+}
+
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>]/g, (c) => (c === "&" ? "&amp;" : c === "<" ? "&lt;" : "&gt;"));
+}

--- a/packages/python/goldenmatch/web/frontend/src/components/RunInspector.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/RunInspector.tsx
@@ -7,8 +7,9 @@ import { RunEvaluation } from "./RunEvaluation";
 import { RunLabels } from "./RunLabels";
 import { RunReview } from "./RunReview";
 import { SplitPane } from "./SplitPane";
+import { IdentityGraph, type GraphExpansion } from "./IdentityGraph";
 
-type LeftTab = "clusters" | "review" | "labels" | "evaluation";
+type LeftTab = "clusters" | "graph" | "review" | "labels" | "evaluation";
 
 export function RunInspector({ name }: { name: string }) {
   const [selected, setSelected] = useState<number | undefined>(undefined);
@@ -24,22 +25,82 @@ export function RunInspector({ name }: { name: string }) {
     enabled: selected != null,
   });
 
+  // Adapter: expand a cluster hub into its member rows + scored pairs, so the
+  // whole run reads as one graph that lazy-loads each cluster on click.
+  const expandCluster = async (hubId: string): Promise<GraphExpansion> => {
+    const cid = Number(hubId.slice(2)); // strip the "c:" hub-id prefix
+    const d = await api.cluster(name, cid);
+    return {
+      nodes: d.rows.map((r) => ({
+        id: `r:${r.row_id}`,
+        label: rowLabel(r.columns, r.row_id),
+        group: String(r.columns["__source__"] ?? "record"),
+      })),
+      links: d.pairs.map((p) => ({
+        source: `r:${p.row_id_a}`,
+        target: `r:${p.row_id_b}`,
+        value: p.score,
+      })),
+    };
+  };
+  const clusterHubs = (summaries.data?.items ?? []).map((c) => ({
+    id: `c:${c.cluster_id}`,
+    label: `#${c.cluster_id}`,
+    size: c.size,
+  }));
+
+  const navBar = (
+    <nav className="px-2 pt-2 flex items-center gap-0.5 text-[11px] border-b border-ink-200">
+      <TabButton active={tab === "clusters"} onClick={() => setTab("clusters")}>
+        clusters
+      </TabButton>
+      <TabButton active={tab === "graph"} onClick={() => setTab("graph")}>
+        graph
+      </TabButton>
+      <TabButton active={tab === "review"} onClick={() => setTab("review")}>
+        review
+      </TabButton>
+      <TabButton active={tab === "labels"} onClick={() => setTab("labels")}>
+        labeled
+      </TabButton>
+      <TabButton active={tab === "evaluation"} onClick={() => setTab("evaluation")}>
+        eval
+      </TabButton>
+    </nav>
+  );
+
+  // The force graph wants width, so it takes over the full inspector area
+  // rather than living in the narrow left pane.
+  if (tab === "graph") {
+    return (
+      <div className="h-full flex flex-col">
+        {navBar}
+        <div className="flex-1 min-h-0 overflow-auto p-4">
+          {summaries.isLoading && (
+            <div className="text-sm text-ink-500">Loading clusters…</div>
+          )}
+          {summaries.error && (
+            <div className="text-sm text-red-700 font-mono">
+              {String(summaries.error)}
+            </div>
+          )}
+          {summaries.data && (
+            <IdentityGraph
+              hubs={clusterHubs}
+              hubGroup="cluster"
+              expand={expandCluster}
+              height={620}
+              emptyHint="No clusters in this run."
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+
   const left = (
     <div className="h-full flex flex-col">
-      <nav className="px-2 pt-2 flex items-center gap-0.5 text-[11px] border-b border-ink-200">
-        <TabButton active={tab === "clusters"} onClick={() => setTab("clusters")}>
-          clusters
-        </TabButton>
-        <TabButton active={tab === "review"} onClick={() => setTab("review")}>
-          review
-        </TabButton>
-        <TabButton active={tab === "labels"} onClick={() => setTab("labels")}>
-          labeled
-        </TabButton>
-        <TabButton active={tab === "evaluation"} onClick={() => setTab("evaluation")}>
-          eval
-        </TabButton>
-      </nav>
+      {navBar}
       <div className="flex-1 min-h-0">
         {tab === "clusters" && (
           <>
@@ -108,6 +169,21 @@ export function RunInspector({ name }: { name: string }) {
       {right}
     </SplitPane>
   );
+}
+
+/** Prefer a human-readable column for a row's node label; skip internal
+ *  (`__…__`) columns; fall back to the row id. */
+function rowLabel(columns: Record<string, unknown>, rowId: number): string {
+  for (const key of ["name", "full_name", "email", "company"]) {
+    const v = columns[key];
+    if (typeof v === "string" && v.trim()) return v;
+  }
+  for (const [k, v] of Object.entries(columns)) {
+    if (k.startsWith("__")) continue;
+    if (typeof v === "string" && v.trim()) return v;
+    if (typeof v === "number") return String(v);
+  }
+  return `row ${rowId}`;
 }
 
 function TabButton({

--- a/packages/python/goldenmatch/web/frontend/src/routes/Identities.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/routes/Identities.tsx
@@ -7,12 +7,40 @@ import type {
   IdentitySummary,
   IdentityView,
 } from "../lib/api";
+import { IdentityGraph, type GraphExpansion } from "../components/IdentityGraph";
 
 export function Identities() {
   const qc = useQueryClient();
   const [selected, setSelected] = useState<string | null>(null);
   const [datasetFilter, setDatasetFilter] = useState<string>("");
   const [statusFilter, setStatusFilter] = useState<string>("");
+  const [view, setView] = useState<"list" | "graph">("list");
+
+  // Adapter: expand one entity into its records + evidence edges. Records in a
+  // conflicts_with edge are colored as "conflict"; others by their source.
+  const expandEntity = async (entityId: string): Promise<GraphExpansion> => {
+    const v = await api.identityGet(entityId);
+    const conflict = new Set<string>();
+    for (const e of v.edges) {
+      if (e.kind === "conflicts_with") {
+        conflict.add(e.record_a_id);
+        conflict.add(e.record_b_id);
+      }
+    }
+    return {
+      nodes: v.records.map((r) => ({
+        id: r.record_id,
+        label: recordLabel(r.payload, r.record_id),
+        group: conflict.has(r.record_id) ? "conflict" : r.source || "unknown",
+      })),
+      links: v.edges.map((e) => ({
+        source: e.record_a_id,
+        target: e.record_b_id,
+        value: e.score,
+        kind: e.kind,
+      })),
+    };
+  };
 
   const stats = useQuery<IdentityStatsResponse>({
     queryKey: ["identity-stats", datasetFilter],
@@ -107,8 +135,33 @@ export function Identities() {
             <option value="retired">retired</option>
           </select>
         </div>
+        <div className="ml-auto flex items-end gap-1 rounded-lg bg-ink-100 p-1">
+          <ViewTab active={view === "list"} onClick={() => setView("list")}>
+            list
+          </ViewTab>
+          <ViewTab active={view === "graph"} onClick={() => setView("graph")}>
+            graph
+          </ViewTab>
+        </div>
       </section>
 
+      {view === "graph" && (
+        <section className="card px-5 py-4">
+          <p className="eyebrow mb-3">identity graph</p>
+          <IdentityGraph
+            hubs={(list.data?.items ?? []).map((s) => ({
+              id: s.entity_id,
+              label: s.entity_id.slice(0, 8),
+              size: 2,
+            }))}
+            hubGroup="entity"
+            expand={expandEntity}
+            emptyHint="No identities yet — run a dedupe with identity.enabled."
+          />
+        </section>
+      )}
+
+      {view === "list" && (
       <section className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <div className="card px-5 py-4">
           <p className="eyebrow mb-3">identities</p>
@@ -145,8 +198,45 @@ export function Identities() {
           )}
         </div>
       </section>
+      )}
     </div>
   );
+}
+
+function ViewTab({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={
+        "px-3 py-1 text-[12px] rounded-md transition-colors " +
+        (active
+          ? "bg-paper-50 text-ink-900 shadow-card"
+          : "text-ink-500 hover:text-ink-700")
+      }
+    >
+      {children}
+    </button>
+  );
+}
+
+/** Prefer a human-readable payload field for a record's node label. */
+function recordLabel(payload: Record<string, unknown> | null, fallback: string): string {
+  if (payload) {
+    for (const key of ["name", "full_name", "email", "company"]) {
+      const v = payload[key];
+      if (typeof v === "string" && v.trim()) return v;
+    }
+  }
+  return fallback;
 }
 
 function IdentityRow({ row }: { row: IdentitySummary }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      echarts:
+        specifier: ^5.5.0
+        version: 5.6.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -1512,6 +1515,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  echarts@5.6.0:
+    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+
   electron-to-chromium@1.5.393:
     resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
 
@@ -2382,6 +2388,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2598,6 +2607,9 @@ packages:
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zrender@5.6.1:
+    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
 snapshots:
 
@@ -3559,6 +3571,11 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  echarts@5.6.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.6.1
+
   electron-to-chromium@1.5.393: {}
 
   end-of-stream@1.4.5:
@@ -4384,6 +4401,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1:
     optional: true
 
@@ -4553,3 +4572,7 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
+
+  zrender@5.6.1:
+    dependencies:
+      tslib: 2.3.0


### PR DESCRIPTION
## What and why

Folds the standalone identity-graph playground into the real web frontend as a first-class, interactive force-directed graph. This implements the "Cluster force-graph view" listed as a deferred v2 item in the web-UI design doc. One shared, data-agnostic component is mounted on both surfaces so the same collapse/expand interaction works against both the durable identity store and run-local clusters.

## Changes

- **New `components/IdentityGraph.tsx`** — a collapsed-by-default ECharts force graph with click-to-expand neighborhoods. Data-agnostic: the caller passes a hub list plus a lazy `expand(id)` returning that hub's nodes + internal links. The component owns the ECharts wiring, expand/collapse + result cache, per-group coloring (gold hubs, red conflict records, sourced records), the hub->member links, and a small toolbar (labels toggle, collapse-all, live counts). It scales with the hub count, not the total record count — the initial render is hubs only; expansions load on demand.
- **`routes/Identities.tsx`** — a `list | graph` toggle. In graph mode, one hub per durable entity; clicking a hub lazy-fetches its records + evidence edges (`GET /api/v1/identities/{id}`). Records in a `conflicts_with` edge render as conflicts.
- **`components/RunInspector.tsx`** (workbench preview + `/runs/{name}`) — a new full-width `graph` tab. Hubs are the run's clusters; clicking one lazy-fetches its member rows + scored pairs (`GET /api/v1/runs/{name}/clusters/{id}`), so a whole run reads as one graph that loads each cluster on demand.
- **New dependency: `echarts`** — the first charting library in this frontend (the Sensitivity chart was hand-rolled SVG). Root `pnpm-lock.yaml` updated (web/frontend is a pnpm workspace member).

Theme-matched to the existing paper/ink/gold Tailwind tokens. No backend changes — this is a frontend-only visualization layer over endpoints that already exist.

Note on data model: a workbench *preview* populates run-local clusters, not the durable identity store, so the two graphs are intentionally backed by different sources (identity store on `/identities`; run clusters in the inspector) — the shared component just adapts each.

## Testing

- `npx tsc -b` — clean (exit 0).
- `npx vite build` — clean; bundle +~477 KB gzip from echarts (acceptable per the web-UI notes for a localhost tool; lazy-loading echarts behind the graph views is an easy follow-up).
- `npx vitest run` — all 24 tests pass.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (existing 24 vitest tests pass; typecheck + build clean)
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_