### PR TITLE
feat(goldenmatch-mcp): add list_blocking_strategies tool (TS parity)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -864,7 +864,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 
 ## MCP tools
 
-81 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
+82 MCP tool(s) exposed by `goldenmatch.mcp.server` -- the programmatic / agent surface. Config-bearing tools take the same knobs as above.
 
 | Tool | Description |
 |---|---|
@@ -918,6 +918,7 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `learn_thresholds` | Force a MemoryLearner pass over accumulated corrections. Returns the list of LearnedAdjustments produced (matchkey_name, threshold, sample_size, learned_at). Requires >= 10 corrections per matchkey before threshold tuning fires; otherwise returns an empty list. |
 | `lineage` | Field-level provenance for the loaded run: for each scored pair, the per-field scores that produced the match, plus cluster id. Optionally write a lineage JSON to a directory. |
 | `lint_routing` | Flag config/env overrides that force a slow path (e.g. CLUSTERING_THRESHOLD=0 when the edge set fits driver RAM). ERROR at scale; would_refuse mirrors the runtime guard. |
+| `list_blocking_strategies` | List all blocking strategy names. |
 | `list_clusters` | List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts. |
 | `list_corrections` | List stored Learning Memory corrections, optionally filtered by dataset. Returns id_a, id_b, decision, source, trust, reason, matchkey_name, dataset, original_score, created_at. |
 | `list_domains` | List available domain extraction rulebooks (built-in + user-defined). |

--- a/docs-site/goldenmatch/mcp.mdx
+++ b/docs-site/goldenmatch/mcp.mdx
@@ -1,10 +1,10 @@
 ---
 title: "MCP server"
-description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 81 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
+description: "Connect GoldenMatch to Claude Desktop, Claude Code, and other MCP clients — 82 tools for autonomous entity resolution, data inspection, Learning Memory, and Identity Graph."
 keywords: ["mcp", "claude desktop", "model context protocol", "entity resolution", "learning memory"]
 ---
 
-GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 81 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
+GoldenMatch provides an MCP (Model Context Protocol) server for integration with Claude Desktop, Claude Code, and other MCP-compatible AI assistants. 82 tools total, spanning agent-level tools for autonomous ER, data tools for inspection and management, config-suggestion and PPRL tools, Learning Memory tools for persisting steward decisions, and Identity Graph tools.
 
 <Tip>
   Looking for AI-to-AI autonomy? See the [ER Agent (A2A)](/goldenmatch/agent) page for agent framework integration (LangChain, CrewAI, AutoGen).

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,13 +14,13 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 81 | 201 | 47 | 34 | Yes | Yes |
+| `goldenmatch` | 82 | 201 | 47 | 34 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 19 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
 | `goldenanalysis` | 4 | 8 | — | 4 | Yes | Yes |
 | `infermap` | 4 | 19 | — | 5 | Yes | Yes |
-| **suite** | **122** | | | | | |
+| **suite** | **123** | | | | | |
 
 ## Compute substrate — the Rust `-core` kernel is the reference
 
@@ -41,7 +41,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
-| `goldenmatch` | mcp_tools | 41 | 40 | 9 |
+| `goldenmatch` | mcp_tools | 42 | 40 | 8 |
 | `goldenmatch` | cli_commands | 11 | 23 | 3 |
 | `goldenmatch` | a2a_skills | 27 | 20 | 9 |
 | `goldenmatch` | scorers | 17 | 0 | 2 |
@@ -64,7 +64,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `analyze_blocking`, `certify_recall`, `compare_clusters`, `config_weaknesses`, `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `export_results`, `get_cluster`, `get_golden_record`, `get_stats`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_profile`, `identity_resolve_conflict`, `identity_show`, `identity_stats`, `identity_worklist`, `incremental`, `lineage`, `lint_routing`, `list_clusters`, `list_domains`, `list_plugins`, `list_runs`, `memory_import`, `plan_routing`, `pprl_auto_config`, `pprl_link`, `retrieve_similar`, `rollback`, `schema_match`, `sensitivity`, `shatter_cluster`, `test_domain`, `unmerge_record`, `upload_dataset`.
-- `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `list_blocking_strategies`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
+- `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
 - `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `compare-clusters`, `config`, `explain`, `incremental`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
 - `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5997,6 +5997,7 @@
             "_tool_get_golden_record",
             "_tool_get_stats",
             "_tool_lineage",
+            "_tool_list_blocking_strategies",
             "_tool_list_clusters",
             "_tool_list_domains",
             "_tool_list_runs",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -4532,6 +4532,10 @@
           "description": "Flag config/env overrides that force a slow path (e.g. CLUSTERING_THRESHOLD=0 when the edge set fits driver RAM). ERROR at scale; would_refuse mirrors the runtime guard."
         },
         {
+          "name": "list_blocking_strategies",
+          "description": "List all blocking strategy names."
+        },
+        {
           "name": "list_clusters",
           "description": "List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts."
         },

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ Zero-config gets good results and returns the config it chose; the healer (`revi
 - DQbench composite 91.04; PPRL 92.4% F1 on FEBRL4; a durable Identity Graph (stable entity_ids that survive across runs)
 
 ## AI-native surface
-- Every package ships an MCP server (122 tools across the suite), a REST API, and most an A2A agent surface
+- Every package ships an MCP server (123 tools across the suite), a REST API, and most an A2A agent surface
 - One aggregator container exposes the whole suite: `docker run ghcr.io/benseverndev-oss/goldensuite-mcp:latest`
 - Hosted remote MCP on Smithery, plus the official MCP Registry: `io.github.benseverndev-oss/{goldenmatch,goldencheck,goldenflow,goldenpipe,infermap}`
 

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -22,6 +22,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   shorthand `{exact, fuzzy, blocking, threshold}` from `auto_configure`; `memory_export`
   and `suggest_pprl` delegate to the identical MCP dispatch. All four move
   `ts_only` → `shared`.
+- **`list_blocking_strategies` MCP tool (TS-parity).** Now exposed on the Python MCP
+  server (82 tools) as a stateless serializer over `BlockingConfig.strategy` — the
+  last TS-only introspection tool. It lists every accepted blocking-strategy name
+  (incl. the Python-only `lsh` / `simhash` / `perceptual`), closing the `mcp_tools`
+  gap (`ts_only` → `shared`).
 
 ## [3.8.0] - 2026-07-22
 

--- a/packages/python/goldenmatch/README.md
+++ b/packages/python/goldenmatch/README.md
@@ -106,7 +106,7 @@ Zero-config gets you most of the way in one pass; the healing loop closes the ga
 - **96.4% F1 zero-config** on DBLP-ACM (hand-tuned ceiling: 91.8%). [DQBench ER score: 91.04 no-LLM](https://github.com/benseverndev-oss/dqbench)
 - **Learning Memory** — corrections from stewards, unmerges, and LLM votes persist to disk and apply automatically on the next run; survives row reorders via record-hash re-anchoring (v1.6.0)
 - **Privacy-preserving** — match across organizations without sharing raw data (PPRL, 92.4% F1)
-- **81 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
+- **82 MCP tools** — use from Claude Desktop, Claude Code, or any AI assistant ([Smithery](https://smithery.ai/servers/benzsevern/goldenmatch))
 - **Production-ready** — Postgres sync, daemon mode, lineage tracking, review queues
 
 ### Run on unstructured input (document ingest)
@@ -217,7 +217,7 @@ section documents the durable auto-config and scale-safety behaviour.)
 - **In-house embedding (cloud-free)** — back the `embedding` / `record_embedding` scorer with a small numpy + ONNX model trained in-process on your labeled pairs (`goldenmatch.embeddings.inhouse.train_embedder`); set the matchkey field's `model="inhouse:<path>"`. No cloud calls, no torch. **Within ~0.2pp of Vertex AI on structured ER** (Railway-validated 3-way comparison, #506 / PR #543) — febrl3 in-house 0.9488 vs Vertex 0.9512, DBLP-ACM 0.9709 vs 0.9708, synthetic-20k 0.9814 vs 0.9834. Use it when you want embedding-grade recall without a cloud dependency.
 
 ### Integration
-- **REST API + MCP Server** — 81 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
+- **REST API + MCP Server** — 82 MCP tools for matching, explaining, reviewing, data quality, transforms, AutoConfigController telemetry, identity-graph operations, and Learning Memory
 - **A2A Agent** — 47 skills for AI-to-AI autonomous entity resolution (incl. `autoconfig` + `controller_telemetry`)
 - **AutoConfigController telemetry visible from every surface** (v1.7-v1.12 surface-parity arc, PRs #156-#161) — web ControllerPanel, TUI Controller tab (`Ctrl+A`), CLI `goldenmatch autoconfig`, REST `POST /autoconfig` + `GET /controller/telemetry`, Postgres `goldenmatch_autoconfig` + `gm_telemetry`, DuckDB UDF equivalents, MCP/A2A telemetry tools. Every surface returns the same JSON shape (`stop_reason`, `health`, refit decisions, indicator column priors, `negative_evidence` / Path Y).
 - **Database sync** — incremental Postgres matching with persistent ANN index
@@ -731,7 +731,7 @@ Guides you through GPU mode selection, Vertex AI / Colab / local GPU configurati
 | Privacy-preserving (PPRL) | Built-in (92.4% F1) | No | No | No | No |
 | Interactive TUI | Yes | No | No | No | No |
 | Golden record synthesis | 5 strategies | No | No | No | No |
-| MCP server (AI integration) | Yes (81 tools) | No | No | No | No |
+| MCP server (AI integration) | Yes (82 tools) | No | No | No | No |
 | Database sync | Postgres + DuckDB | No | No | No | Spark/DuckDB |
 | Single `pip install` | Yes | Yes | Yes | No (Java/Spark) | Yes |
 | Polars-native | Yes | No (pandas) | No (pandas) | No (Spark) | Yes (DuckDB) |
@@ -1294,7 +1294,7 @@ pip install goldenmatch[mcp]
 goldenmatch mcp-serve data.csv
 ```
 
-81 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
+82 tools available: deduplicate files, match records, explain decisions, review borderline pairs, privacy-preserving linkage, configure rules, scan data quality, run transforms, synthesize golden records, and manage Learning Memory (`list_corrections`, `add_correction`, `learn_thresholds`, `memory_stats`, `memory_export`).
 
 ### Local files with the remote server
 

--- a/packages/python/goldenmatch/goldenmatch/mcp/server.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/server.py
@@ -366,6 +366,11 @@ _BASE_TOOLS = [
         inputSchema={"type": "object", "properties": {}},
     ),
     Tool(
+        name="list_blocking_strategies",
+        description="List all blocking strategy names.",
+        inputSchema={"type": "object", "properties": {}},
+    ),
+    Tool(
         name="create_domain",
         description="Create a custom domain extraction rulebook. Define patterns for a specific data domain (medical devices, automotive parts, real estate, etc.).",
         inputSchema={
@@ -1090,6 +1095,8 @@ def _handle_tool(name: str, args: dict) -> dict:
         return _tool_list_transforms()
     elif name == "list_strategies":
         return _tool_list_strategies()
+    elif name == "list_blocking_strategies":
+        return _tool_list_blocking_strategies()
     elif name == "create_domain":
         return _tool_create_domain(args)
     elif name == "test_domain":
@@ -1654,6 +1661,23 @@ def _tool_list_strategies() -> dict:
     from goldenmatch.config.schemas import VALID_STRATEGIES
 
     strategies = sorted(VALID_STRATEGIES)
+    return {"strategies": strategies, "count": len(strategies)}
+
+
+def _tool_list_blocking_strategies() -> dict:
+    """List all blocking-strategy names (parity with the TS MCP tool).
+
+    Derived from ``BlockingConfig.strategy`` (the same source the ``api_parity``
+    gate's ``blocking_strategies`` surface reads), so the Python set stays in
+    lockstep with the schema — it includes the Python-only ``lsh`` / ``simhash``
+    / ``perceptual`` strategies the TS port lacks (declared in
+    ``parity/goldenmatch.yaml``). Mirrors the TS ``list_blocking_strategies``
+    (`{ strategies: [...] }`)."""
+    from typing import get_args
+
+    from goldenmatch.config.schemas import BlockingConfig
+
+    strategies = sorted(get_args(BlockingConfig.model_fields["strategy"].annotation))
     return {"strategies": strategies, "count": len(strategies)}
 
 

--- a/packages/python/goldenmatch/llms.txt
+++ b/packages/python/goldenmatch/llms.txt
@@ -6,8 +6,8 @@
 Zero-config gets good results and returns the config it chose; the healer (`review_config`) reviews the results and suggests ranked, self-verified tweaks; apply them, results improve, repeat — closing the gap to expert-tuned without you being the expert. Wired into the default pipeline: `dedupe_df` attaches candidate suggestions to `result.suggestions` when a free signal fires (`dedupe_df(suggest=True)` verified, `heal=True` full loop; disable with `GOLDENMATCH_SUGGEST_ON_DEDUPE=0`). Needs `goldenmatch[native]`; degrades gracefully without it. Docs: https://docs.bensevern.dev/goldenmatch/config-suggestions
 
 ## Interfaces
-- MCP Server: `goldenmatch mcp-serve` (81 tools across data, agent, identity, memory, routing, and document groups)
-- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (81 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
+- MCP Server: `goldenmatch mcp-serve` (82 tools across data, agent, identity, memory, routing, and document groups)
+- Remote MCP: https://goldenmatch-mcp-production.up.railway.app/mcp/ (82 tools, Smithery: https://smithery.ai/servers/benzsevern/goldenmatch)
 - A2A Server: `goldenmatch agent-serve --port 8200` (47 skills advertised in the agent card)
 - CLI: `goldenmatch dedupe`, `goldenmatch match`, `goldenmatch autoconfig`, `goldenmatch memory ...`, `goldenmatch identity ...`, + more
 - Python API: `import goldenmatch` — `dedupe_df()`, `match_df()`, `score_strings()`, `evaluate()`, ~201 exports

--- a/packages/python/goldenmatch/tests/test_mcp_new_tools.py
+++ b/packages/python/goldenmatch/tests/test_mcp_new_tools.py
@@ -16,7 +16,7 @@ import pytest
 # ── Registration ──────────────────────────────────────────────────────────────
 
 
-def test_total_tool_count_is_81():
+def test_total_tool_count_is_82():
     from goldenmatch.mcp.agent_tools import AGENT_TOOLS
     from goldenmatch.mcp.identity_tools import IDENTITY_TOOLS
     from goldenmatch.mcp.memory_tools import MEMORY_TOOLS
@@ -26,9 +26,9 @@ def test_total_tool_count_is_81():
     assert len(AGENT_TOOLS) == 19   # +1 retrieve_similar (#1089) +1 upload_dataset
     assert len(MEMORY_TOOLS) == 7
     assert len(IDENTITY_TOOLS) == 15  # +3 MDM ops (#1114) +5 agent-memory ops (#1075/#1078)
-    assert len(_BASE_TOOLS) == 35   # +3 registry-introspection tools (list_scorers/transforms/strategies)
+    assert len(_BASE_TOOLS) == 36   # +3 registry-introspection + list_blocking_strategies (TS parity)
     assert len(ROUTING_TOOLS) == 3  # plan_routing / explain_routing / lint_routing
-    assert len(TOOLS) == 81   # 78 + 3 list_* registry-introspection tools (TS parity)
+    assert len(TOOLS) == 82   # 81 + list_blocking_strategies (TS parity)
     # No duplicate tool names across the whole surface.
     names = [t.name for t in TOOLS]
     assert len(names) == len(set(names))
@@ -42,9 +42,23 @@ def test_new_tool_names_registered():
         "evaluate", "analyze_blocking", "compare_clusters", "schema_match",
         "lineage", "list_runs", "rollback", "sensitivity", "incremental",
         "identity_show", "memory_import", "config_weaknesses", "review_config",
-        "convert_splink_config",
+        "convert_splink_config", "list_blocking_strategies",
     ):
         assert new in names, f"{new} missing from TOOLS"
+
+
+def test_list_blocking_strategies_handler():
+    """The list_blocking_strategies tool serializes the schema's accepted
+    strategy names (TS parity), incl. the Python-only lsh/simhash/perceptual."""
+    from goldenmatch.mcp.server import _handle_tool
+
+    result = _handle_tool("list_blocking_strategies", {})
+    strategies = result["strategies"]
+    assert result["count"] == len(strategies)
+    # The 8 cross-language shared strategies plus the 3 Python-only ones.
+    assert {"static", "adaptive", "multi_pass", "learned"} <= set(strategies)
+    assert {"lsh", "simhash", "perceptual"} <= set(strategies)
+    assert strategies == sorted(strategies)
 
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -4532,6 +4532,10 @@
           "description": "Flag config/env overrides that force a slow path (e.g. CLUSTERING_THRESHOLD=0 when the edge set fits driver RAM). ERROR at scale; would_refuse mirrors the runtime guard."
         },
         {
+          "name": "list_blocking_strategies",
+          "description": "List all blocking strategy names."
+        },
+        {
           "name": "list_clusters",
           "description": "List duplicate clusters found in the dataset. Returns cluster IDs, sizes, and member counts."
         },

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -72,6 +72,7 @@ mcp_tools:
   - identity_resolve
   - identity_split
   - learn_thresholds
+  - list_blocking_strategies
   - list_corrections
   - list_scorers
   - list_strategies
@@ -132,7 +133,6 @@ mcp_tools:
   - build_clusters
   - find_exact_matches
   - find_fuzzy_matches
-  - list_blocking_strategies
   - read_file
   - score_pair
   - score_strings


### PR DESCRIPTION
## Summary

Exposes **`list_blocking_strategies`** on the Python MCP server (81 → **82 tools**) — the last TS-only introspection tool, a direct analog to the `list_scorers` / `list_transforms` / `list_strategies` trio.

The handler serializes `BlockingConfig.strategy` (the same source the `api_parity` `blocking_strategies` surface reads), so the listing stays in lockstep with the schema and includes the Python-only `lsh` / `simhash` / `perceptual` strategies the TS port lacks.

## Parity

Moves `list_blocking_strategies` `mcp_tools` `ts_only → shared` in `parity/goldenmatch.yaml`. `check_api_parity.py goldenmatch` passes; the Python surface now emits 82 MCP tools.

## Tests & doc gates

- `test_total_tool_count_is_82` (was 81) + registration entry + a focused handler test. `test_mcp_new_tools.py` 18/18 green.
- Regenerated `docs/agent-codemap.json`, `docs-site/suite-matrix.mdx`, `config-matrix.mdx`, `agent-manifest.json`, and the README / `llms.txt` / `mcp.mdx` counts (81 → 82) + root `llms.txt` suite total (122 → 123). `check_llms_counts.py`, `test_config_matrix.py`, `test_agent_codemap.py`, `test_suite_matrix.py` all green.

Kept MCP-only (no A2A skill) since the TS card doesn't advertise it either — adding one would open a new reverse gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_