### PR TITLE
Auto-wire PassageIndex into ingest_corpus + facade for zero-touch hybrid

### DIFF
--- a/packages/python/goldengraph/goldengraph/__init__.py
+++ b/packages/python/goldengraph/goldengraph/__init__.py
@@ -11,7 +11,7 @@ from .answer import ask, to_cypher
 from .bulk import bulk_load
 from .embed import Embedder, GoldenmatchEmbedder, seed_by_query
 from .extract import Extraction, Mention, Relationship, extract, parse_extraction
-from .ingest import build_batch, ingest
+from .ingest import CorpusBuild, build_batch, ingest
 from .llm import LLMClient, OpenAIClient
 from .passage_index import PassageIndex
 from .profile import (
@@ -36,6 +36,7 @@ __all__ = [
     "build_batch",
     "bulk_load",
     "ingest",
+    "CorpusBuild",
     # SP4c — retrieval + synthesis + query
     "Embedder",
     "GoldenmatchEmbedder",

--- a/packages/python/goldengraph/goldengraph/graph.py
+++ b/packages/python/goldengraph/goldengraph/graph.py
@@ -53,7 +53,8 @@ class GoldenGraph:
     (slices 1/2/3), with the ER scale plan surfaced (`execution_plan`, ADVISORY) and ONE `budget`
     threaded across build + answer LLM work (the cross-controller ceiling)."""
 
-    def __init__(self, *, store, plan, execution_plan, budget, llm, embedder, llm_classifier):
+    def __init__(self, *, store, plan, execution_plan, budget, llm, embedder, llm_classifier,
+                 passages=None, query_schema=None):
         self._store = store
         self._plan = plan
         self._execution_plan = execution_plan
@@ -61,12 +62,18 @@ class GoldenGraph:
         self._llm = llm  # the _BudgetedLLM, reused by ask -> shared pool
         self._embedder = embedder
         self._llm_classifier = llm_classifier
+        # Zero-touch hybrid: the PassageIndex built over the corpus (None when the build skipped
+        # it or the store was wrapped via from_store) + the discovered RelationSchema. Threaded
+        # into every `ask` so mode="hybrid" retrieves passages and query relations canonicalize
+        # through the same schema the edges did -- no per-call wiring by the caller.
+        self._passages = passages
+        self._query_schema = query_schema
 
     @classmethod
     def build(cls, docs, workload, *, llm, embedder, predicates=None, llm_classifier=None,
-              budget=None, resolver=None, corpus_records=None, store=None):
+              budget=None, resolver=None, corpus_records=None, store=None, index_passages=True):
         from .budget import Budget, _BudgetedLLM
-        from .ingest import ingest_corpus
+        from .ingest import CorpusBuild, ingest_corpus
         from .unified import plan_resolver
 
         budget = budget if budget is not None else Budget()
@@ -76,24 +83,46 @@ class GoldenGraph:
         execution_plan = plan_er_execution(docs, corpus_records=corpus_records)
         store = store if store is not None else _new_store()
         bllm = _BudgetedLLM(llm, budget)
-        ingest_corpus(docs, store, llm=bllm, resolver=resolver or planned_resolver, embedder=embedder)
+        # index_passages defaults ON (ask() defaults to the hybrid-capable auto path) so the built
+        # graph answers hybrid out of the box; the passages embed once here via the same embedder.
+        # Guarded on embedder presence -- with no embedder there is nothing to embed passages with,
+        # so skip indexing (ask falls back to local) rather than raise. ingest_corpus returns a
+        # CorpusBuild(schema, passages) when indexing, else the bare schema.
+        do_index = index_passages and embedder is not None
+        result = ingest_corpus(
+            docs, store, llm=bllm, resolver=resolver or planned_resolver, embedder=embedder,
+            index_passages=do_index,
+        )
+        if isinstance(result, CorpusBuild):
+            query_schema, passages = result.schema, result.passages
+        else:
+            query_schema, passages = result, None
         return cls(store=store, plan=plan, execution_plan=execution_plan, budget=budget,
-                   llm=bllm, embedder=embedder, llm_classifier=llm_classifier)
+                   llm=bllm, embedder=embedder, llm_classifier=llm_classifier,
+                   passages=passages, query_schema=query_schema)
 
     @classmethod
     def from_store(cls, store, *, llm, embedder, llm_classifier=None, plan=None,
-                   execution_plan=None, budget=None):
+                   execution_plan=None, budget=None, passages=None, query_schema=None):
         """Wrap an ALREADY-built store (e.g. a reopened/persisted store) in the facade -- skips the
-        build. The llm is wrapped in the same `_BudgetedLLM` seam so `ask` draws from `budget`."""
+        build. The llm is wrapped in the same `_BudgetedLLM` seam so `ask` draws from `budget`.
+        `passages` (a PassageIndex) + `query_schema` are optional -- supply them to keep hybrid
+        answering + schema-aligned routing on a reopened store; None leaves ask on the local
+        fallback (byte-identical to a passage-less build)."""
         from .budget import Budget, _BudgetedLLM
 
         budget = budget if budget is not None else Budget()
         return cls(store=store, plan=plan, execution_plan=execution_plan, budget=budget,
-                   llm=_BudgetedLLM(llm, budget), embedder=embedder, llm_classifier=llm_classifier)
+                   llm=_BudgetedLLM(llm, budget), embedder=embedder, llm_classifier=llm_classifier,
+                   passages=passages, query_schema=query_schema)
 
     def ask(self, query, *, valid_t, tx_t, mode="auto", **ask_kwargs):
         from .answer import ask as _ask
 
+        # Thread the build-time passages + discovered schema by default; an explicit kwarg wins,
+        # so a caller can still override (e.g. pass mode="local" or a different retriever).
+        ask_kwargs.setdefault("passages", self._passages)
+        ask_kwargs.setdefault("query_schema", self._query_schema)
         return _ask(query, self._store, llm=self._llm, embedder=self._embedder,
                     valid_t=valid_t, tx_t=tx_t, mode=mode,
                     query_classifier=self._llm_classifier, **ask_kwargs)

--- a/packages/python/goldengraph/goldengraph/ingest.py
+++ b/packages/python/goldengraph/goldengraph/ingest.py
@@ -14,8 +14,20 @@ import time
 from collections import defaultdict
 from collections.abc import Callable
 from functools import lru_cache
+from typing import NamedTuple
 
 import numpy as np
+
+
+class CorpusBuild(NamedTuple):
+    """Zero-touch corpus-build result: the discovered `RelationSchema` (or None) AND a
+    `PassageIndex` over the source documents, ready to hand to `ask(mode="hybrid")`.
+
+    Returned by `ingest_corpus(..., index_passages=True)` (opt-in; the bare-schema return
+    is preserved when `index_passages` is False, so existing callers are unaffected)."""
+
+    schema: object | None
+    passages: object | None  # goldengraph.passage_index.PassageIndex | None
 
 from .chunk_extract import chunk_extract, chunk_extract_enabled
 from .extract import Extraction, Mention
@@ -840,10 +852,20 @@ def ingest_corpus(
     fp_index: dict[str, str] | None = None,
     max_workers: int | None = None,
     doc_ids=None,
+    index_passages: bool = False,
+    passage_top_k: int = 50,
 ):
     """Build the KG from an ordered list of document texts. Returns the discovered `RelationSchema`
     when `GOLDENGRAPH_SCHEMA_DISCOVER=1` (so the caller can canonicalize QUERY relations through the
     SAME schema the edges were canonicalized with -- the query-side alignment), else None.
+
+    `index_passages=True` ALSO builds a `PassageIndex` over the source `docs` (embedded via
+    `embedder`) and returns a `CorpusBuild(schema, passages)` instead of the bare schema -- the
+    zero-touch wiring for `ask(mode="hybrid")` (index passages at build, retrieve at answer) so a
+    library caller no longer has to hand-build a retriever. Requires an `embedder` (the same one
+    `ask` seeds with); it is the ONLY change to the return contract, and it is opt-in, so every
+    existing caller (return the bare schema) is byte-identical. `passage_top_k` caps how many
+    passages a single answer-time `retrieve` can draw (passage_k must be <= it).
 
     The per-doc LLM work (extraction + fingerprint synthesis) is the build's
     dominant cost and is store-independent, so it runs CONCURRENTLY across docs
@@ -937,4 +959,18 @@ def ingest_corpus(
 
     if timers is not None:
         print(timers.report(wall=time.perf_counter() - t_wall, n_docs=len(docs)), flush=True)
+    if index_passages:
+        # Zero-touch hybrid: embed the source passages ONCE (via the same embedder ask() seeds
+        # with) into a PassageIndex, so `ask(mode="hybrid", passages=...)` works with no
+        # hand-built retriever. Requires an embedder -- raise clearly rather than silently
+        # returning a passage-less build that would degrade hybrid to local at answer time.
+        from .passage_index import PassageIndex
+
+        if embedder is None:
+            raise ValueError(
+                "ingest_corpus(index_passages=True) needs an embedder to embed the passages "
+                "(pass the same embedder ask() uses for seeding)"
+            )
+        passages = PassageIndex.build(doc_ids, docs, embedder, top_k=passage_top_k)
+        return CorpusBuild(schema=discovered_schema, passages=passages)
     return discovered_schema

--- a/packages/python/goldengraph/tests/test_graph_facade.py
+++ b/packages/python/goldengraph/tests/test_graph_facade.py
@@ -75,3 +75,72 @@ def test_from_store_wraps_existing_store_and_budget():
     gg = GoldenGraph.from_store(store, llm=_StubLLM(), embedder=None, budget=b)
     assert gg.store is store and gg.budget is b
     assert gg.plan is None and gg.execution_plan is None  # not built, just wrapped
+
+
+# --- zero-touch hybrid: build indexes passages, ask threads them ------------------------------------
+
+
+class _AxisEmbedder:
+    def embed(self, texts):
+        import numpy as np
+
+        vocab = {"apple": [1.0, 0.0], "banana": [0.0, 1.0]}
+        return np.array(
+            [next((vocab[w] for w in str(t).lower().split() if w in vocab), [0.0, 0.0]) for t in texts],
+            dtype=float,
+        )
+
+
+def test_build_indexes_passages_when_embedder_present():
+    from goldengraph.passage_index import PassageIndex
+
+    gg = GoldenGraph.build(
+        ["apple pie", "banana bread"], workload=["what is X?"], llm=_StubLLM(),
+        embedder=_AxisEmbedder(), resolver=_stub_resolver, store=_RecordingStore(),
+    )
+    assert isinstance(gg._passages, PassageIndex) and len(gg._passages) == 2
+
+
+def test_build_skips_passage_index_without_embedder():
+    # No embedder -> nothing to embed passages with -> no index (ask falls back to local), no raise.
+    gg = GoldenGraph.build(
+        ["only doc"], workload=["what is X?"], llm=_StubLLM(), embedder=None,
+        resolver=_stub_resolver, store=_RecordingStore(),
+    )
+    assert gg._passages is None
+
+
+def test_build_index_passages_opt_out():
+    gg = GoldenGraph.build(
+        ["apple pie"], workload=["what is X?"], llm=_StubLLM(), embedder=_AxisEmbedder(),
+        resolver=_stub_resolver, store=_RecordingStore(), index_passages=False,
+    )
+    assert gg._passages is None
+
+
+def test_ask_threads_build_passages_and_schema(monkeypatch):
+    gg = GoldenGraph.build(
+        ["apple pie", "banana bread"], workload=["what is X?"], llm=_StubLLM(),
+        embedder=_AxisEmbedder(), resolver=_stub_resolver, store=_RecordingStore(),
+    )
+    seen = {}
+
+    def _fake_ask(query, store, **kw):
+        seen.update(kw)
+        return "ok"
+
+    monkeypatch.setattr("goldengraph.answer.ask", _fake_ask)
+    gg.ask("q?", valid_t=1, tx_t=1)
+    assert seen["passages"] is gg._passages  # the built index is threaded by default
+    assert "query_schema" in seen
+
+
+def test_ask_explicit_passages_override_wins(monkeypatch):
+    gg = GoldenGraph.build(
+        ["apple pie"], workload=["what is X?"], llm=_StubLLM(), embedder=_AxisEmbedder(),
+        resolver=_stub_resolver, store=_RecordingStore(),
+    )
+    seen = {}
+    monkeypatch.setattr("goldengraph.answer.ask", lambda query, store, **kw: seen.update(kw) or "ok")
+    gg.ask("q?", valid_t=1, tx_t=1, passages=None)  # caller override
+    assert seen["passages"] is None  # explicit kwarg beats the stored index

--- a/packages/python/goldengraph/tests/test_ingest_passages.py
+++ b/packages/python/goldengraph/tests/test_ingest_passages.py
@@ -1,0 +1,88 @@
+"""Zero-touch hybrid wiring: ingest_corpus(index_passages=True) returns a
+CorpusBuild(schema, passages), and the GoldenGraph facade threads that PassageIndex
+into ask() so mode="hybrid" works out of the box -- no hand-built retriever."""
+from __future__ import annotations
+
+import goldenmatch.core.ann_blocker as _ab
+import pytest
+from goldengraph.ingest import CorpusBuild, ingest_corpus
+from goldengraph.passage_index import PassageIndex
+
+
+@pytest.fixture(autouse=True)
+def _force_numpy_fallback(monkeypatch):
+    monkeypatch.setattr(_ab, "_HAS_FAISS", False)
+
+
+class _StubLLM:
+    def complete(self, prompt: str) -> str:
+        return '{"entities": [], "relationships": []}'
+
+
+class _StubEmbedder:
+    """Deterministic axis-per-keyword embedder (first known word wins)."""
+
+    _VOCAB = {"apple": [1.0, 0.0, 0.0], "banana": [0.0, 1.0, 0.0], "cherry": [0.0, 0.0, 1.0]}
+
+    def embed(self, texts):
+        import numpy as np
+
+        out = []
+        for t in texts:
+            vec = [0.0, 0.0, 0.0]
+            for w in str(t).lower().split():
+                if w in self._VOCAB:
+                    vec = self._VOCAB[w]
+                    break
+            out.append(vec)
+        return np.array(out, dtype=float)
+
+
+class _RecordingStore:
+    """Default ingest path only calls store.append(json) -> wheel-free."""
+
+    def __init__(self):
+        self.appends = 0
+
+    def append(self, _batch_json):
+        self.appends += 1
+
+
+def _stub_resolver(mentions):
+    from goldengraph.resolve import ResolvedEntity
+
+    return [ResolvedEntity(i, m.name, m.typ, [m.name], [f"k{i}"], [i]) for i, m in enumerate(mentions)]
+
+
+_DOCS = ["apple pie recipe", "banana bread", "cherry cobbler"]
+_IDS = ["d1", "d2", "d3"]
+
+
+def test_index_passages_false_returns_bare_schema():
+    # Byte-identical to the prior contract: no CorpusBuild, just the schema (None here).
+    out = ingest_corpus(
+        _DOCS, _RecordingStore(), llm=_StubLLM(), resolver=_stub_resolver, embedder=_StubEmbedder(),
+    )
+    assert not isinstance(out, CorpusBuild)
+    assert out is None  # schema discovery off -> None
+
+
+def test_index_passages_true_returns_corpusbuild_with_working_retriever():
+    store = _RecordingStore()
+    out = ingest_corpus(
+        _DOCS, store, llm=_StubLLM(), resolver=_stub_resolver, embedder=_StubEmbedder(),
+        doc_ids=_IDS, index_passages=True,
+    )
+    assert isinstance(out, CorpusBuild)
+    assert store.appends == 3  # all docs still committed to the store
+    assert isinstance(out.passages, PassageIndex) and len(out.passages) == 3
+    # the returned index is a live retriever over the source passages
+    assert out.passages.retrieve("banana", k=1) == ["banana bread"]
+
+
+def test_index_passages_true_without_embedder_raises():
+    with pytest.raises(ValueError, match="embedder"):
+        ingest_corpus(
+            _DOCS, _RecordingStore(), llm=_StubLLM(), resolver=_stub_resolver,
+            embedder=None, index_passages=True,
+        )


### PR DESCRIPTION
## What and why

Follow-up to #2033 (hybrid synthesis as the default answer mode). That PR shipped a zero-config `PassageIndex` in the goldengraph library but left the honest-scoping gap: a caller still had to hand-build and pass a passage retriever to get the measured +169% hybrid win. This wires the index into the build path so a built graph answers hybrid out of the box.

## Changes

- **`ingest.py`**: `ingest_corpus(index_passages=True)` embeds the source docs once into a `PassageIndex` and returns `CorpusBuild(schema, passages)` instead of the bare schema. Opt-in: the default return is byte-identical, so every existing caller (`graph.py`, the bench engine, `run_substrate_eval`) is unaffected. Requires an embedder (raises clearly rather than silently degrading hybrid to local). `CorpusBuild` NamedTuple exported from the package root.
- **`graph.py`**: `GoldenGraph.build()` indexes passages by default (ask() defaults to the hybrid-capable auto path) and threads both the `PassageIndex` and the discovered `RelationSchema` into every `ask()` — so `GoldenGraph.build(...).ask(...)` answers hybrid with schema-aligned routing, no per-call wiring. Guarded on embedder presence (no embedder -> no index -> local fallback, no raise); `index_passages=False` opts out. `from_store()` accepts optional `passages`/`query_schema` for a reopened store. An explicit `ask(passages=...)` still overrides.

## Testing

- `python -m pytest packages/python/goldengraph` -> 391 passed, 8 skipped.
- New: `tests/test_ingest_passages.py` (opt-in return shape + working retriever + no-embedder raise) and facade cases in `tests/test_graph_facade.py` (build indexes/threads/overrides/opts-out/no-embedder). Also ran `test_passage_index.py`.
- `ruff check` clean on the changed files.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_