### PR TITLE
docs(goldengraph): record that SELECT does not transfer to the hybrid path

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -269,8 +269,9 @@ the final hop"; it did NOT guard "don't answer with a plausible neighbor".
   which is why it ships DEFAULT ON while voting stays opt-in.
 - **`GOLDENGRAPH_SYNTH_SELECT=0` (or `false`/'') restores the pre-clause prompt
   byte-identical** (`_local_prompt()` == `_LOCAL_PROMPT`; locked by
-  `tests/test_synthesis_select.py`). NEXT: broader-N / multi-seed confirmation, and whether
-  the same type-check helps the hybrid path (`_HYBRID_PROMPT`, currently unchanged).
+  `tests/test_synthesis_select.py`). NEXT: broader-N / multi-seed confirmation. (Whether the
+  same type-check helps the HYBRID path was tested and REFUTED — see "SELECT does NOT transfer
+  to the hybrid path" below; `_HYBRID_PROMPT` stays unchanged.)
 
 ## Hybrid synthesis is the DEFAULT answer mode (2026-07-22) — the BIG lever
 The synthesis-precision follow-through. The KG is a LOSSY intermediate — the extracted
@@ -303,6 +304,25 @@ env-A/B settled it.
   helps exactly the callers who supply a retriever and is a safe no-op (local) for those who
   don't. Adding a passage store to goldengraph is the follow-up to make hybrid complete.
   `answer_judge 0.51` on the hybrid arm is a different quality tier than local's ~0.21.
+
+## SELECT does NOT transfer to the hybrid path — measured flat, NOT shipped (2026-07-22)
+Answers the open `NEXT` from the SELECT section ("whether the same type-check helps the
+hybrid path"). It does not. The confound-free same-graph env-A/B (`env_ab`,
+`GOLDENGRAPH_SYNTH_SELECT_HYBRID:0,1` over ONE hybrid MuSiQue N=100 build, judge on, run
+`29950498168`; `support_recall` **0.8525 == 0.8525** across arms = the control, so the
+measurement is clean) came back **flat-to-mixed**: `answer_match` **0.4700 → 0.4600
+(−0.0100)**, `token_f1` 0.5298 → 0.5392 (+0.0094). The headline metric went slightly DOWN.
+- **Why it doesn't transfer:** SELECT fixes the WRONG-NODE miss in the graph-ONLY (local)
+  path, where the model has only entities to choose among. The hybrid path already hands the
+  model the raw **passages** as ground truth, which disambiguate the answer directly — so the
+  SELECT preamble is largely redundant there; it just lengthens the prompt and slightly
+  perturbs the headline. The graph-only precision lever does **not** stack on the
+  passages-primary path.
+- **DECISION: not shipped.** The prototype (`_HYBRID_SELECT_PREAMBLE` + a
+  `GOLDENGRAPH_SYNTH_SELECT_HYBRID` flag on `synthesize_hybrid`, PR #2041) was CLOSED, not
+  merged — a flat, default-off knob is dead weight; the value is this finding. `_HYBRID_PROMPT`
+  stays unchanged. If a future corpus/model resurfaces a graph-only precision gap under hybrid,
+  the env-A/B here is the way to re-test before re-adding the clause.
 
 ## CHAT / embedding provider split (2026-07-22)
 `OpenAIClient._ensure_client` (`llm.py`) reads `GOLDENGRAPH_LLM_BASE_URL` /


### PR DESCRIPTION
## What and why

Records a measured negative result and **drops** the prototype it evaluated. The synthesis-precision SELECT clause lifted the graph-only (local) path +18.7%, so we tested whether it helps the passages-primary **hybrid** path. It does not — so the flag/preamble prototype is not shipped; only the finding lands.

## Measurement

Confound-free same-graph env-A/B (`env_ab`, `GOLDENGRAPH_SYNTH_SELECT_HYBRID:0,1` over ONE hybrid MuSiQue N=100 build, judge on, run `29950498168`):

| metric | SELECT_HYBRID=0 | =1 | Δ |
|---|---|---|---|
| answer_match | 0.4700 | 0.4600 | **−0.0100** |
| token_f1 | 0.5298 | 0.5392 | +0.0094 |
| **support_recall (control)** | 0.8525 | 0.8525 | **0.0000** ✓ |

Control identical → clean measurement; the headline went slightly **down**. Flat-to-mixed, nothing like the local +18.7%.

**Why:** hybrid already hands the model the raw passages as ground truth, which disambiguate the answer directly, so the graph-only wrong-node guard is redundant there. The graph-only precision lever does not stack on the passages-primary path.

## Changes

- **`goldengraph/CLAUDE.md`** only — a new "SELECT does NOT transfer to the hybrid path" section with the numbers + the re-test recipe, and the SELECT section's dangling `NEXT` updated to point at it. No code change; the prototype flag + `_HYBRID_SELECT_PREAMBLE` were dropped (branch reset off main), so `_HYBRID_PROMPT` is byte-unchanged.

## Testing

- Docs-only; no code touched. `goldengraph-pipeline` runs on the doc change and is a no-op for behavior.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (n/a — docs only)
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed (n/a — no behavior change)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5