### PR TITLE
perf(web): lazy-load echarts behind the graph views

### DIFF
--- a/packages/python/goldenmatch/web/frontend/src/components/IdentityGraphLazy.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/IdentityGraphLazy.tsx
@@ -1,0 +1,34 @@
+import { lazy, Suspense, type ComponentProps } from "react";
+import type { IdentityGraph as IdentityGraphInner } from "./IdentityGraph";
+
+/**
+ * Lazy boundary for {@link IdentityGraph}. The inner module statically imports
+ * `echarts` (~1 MB / ~477 KB gzip), so importing it eagerly would put echarts
+ * in the main bundle even for users who never open a graph view. Splitting it
+ * behind `React.lazy` moves echarts into its own chunk that loads only when a
+ * graph view actually mounts (the Identities "graph" toggle or the inspector
+ * "graph" tab). Consumers import from HERE, not from `./IdentityGraph`.
+ */
+const LazyIdentityGraph = lazy(() =>
+  import("./IdentityGraph").then((m) => ({ default: m.IdentityGraph })),
+);
+
+// Re-export the data types (erased at build time — no echarts pulled in).
+export type {
+  GraphHub,
+  GraphNode,
+  GraphLink,
+  GraphExpansion,
+} from "./IdentityGraph";
+
+export function IdentityGraph(props: ComponentProps<typeof IdentityGraphInner>) {
+  return (
+    <Suspense
+      fallback={
+        <div className="text-sm text-ink-500 py-10 text-center">Loading graph…</div>
+      }
+    >
+      <LazyIdentityGraph {...props} />
+    </Suspense>
+  );
+}

--- a/packages/python/goldenmatch/web/frontend/src/components/RunInspector.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/components/RunInspector.tsx
@@ -7,7 +7,7 @@ import { RunEvaluation } from "./RunEvaluation";
 import { RunLabels } from "./RunLabels";
 import { RunReview } from "./RunReview";
 import { SplitPane } from "./SplitPane";
-import { IdentityGraph, type GraphExpansion } from "./IdentityGraph";
+import { IdentityGraph, type GraphExpansion } from "./IdentityGraphLazy";
 
 type LeftTab = "clusters" | "graph" | "review" | "labels" | "evaluation";
 

--- a/packages/python/goldenmatch/web/frontend/src/routes/Identities.tsx
+++ b/packages/python/goldenmatch/web/frontend/src/routes/Identities.tsx
@@ -7,7 +7,7 @@ import type {
   IdentitySummary,
   IdentityView,
 } from "../lib/api";
-import { IdentityGraph, type GraphExpansion } from "../components/IdentityGraph";
+import { IdentityGraph, type GraphExpansion } from "../components/IdentityGraphLazy";
 
 export function Identities() {
   const qc = useQueryClient();


### PR DESCRIPTION
## What and why

Follow-up to #2037 (the identity/cluster force-graph). That PR added `echarts` as a static import, which put ~477 KB gzip in the main bundle for every user, even those who never open a graph view. This splits echarts into its own chunk that loads only when a graph view actually mounts.

Note: #2037 merged the graph feature; this lazy-load did not make it into that merge (the merge queue merged the feature at its pre-lazy-load head before the change could be added), so it lands here as a fresh follow-up.

## Changes

- New `components/IdentityGraphLazy.tsx` — a thin `React.lazy` boundary around `IdentityGraph` (the module that statically imports echarts), with a "Loading graph…" Suspense fallback. Re-exports the graph data types (erased at build, no echarts pulled).
- `routes/Identities.tsx` and `components/RunInspector.tsx` now import the graph from `IdentityGraphLazy` instead of `IdentityGraph` — the only change is the import path.

## Testing

Measured with `npx vite build`:

| bundle | before | after |
|---|---|---|
| main `index.js` | 1,519 KB / 477 KB gzip | **487 KB / 139 KB gzip** |
| lazy `IdentityGraph.js` (echarts, on demand) | — | 1,033 KB / 338 KB gzip |

- `npx tsc -b` — clean (exit 0).
- `npx vite build` — clean; echarts confirmed in a separate chunk.
- `npx vitest run` — all 24 tests pass (list view is the default, so the lazy chunk isn't pulled in tests).

A user who never opens a graph now pays nothing for echarts; the graph views show a one-time "Loading graph…" fallback while the chunk fetches.

## Checklist

- [x] Tests added/updated and passing locally for the changed package (existing 24 vitest tests pass; typecheck + build clean)
- [ ] `pre-commit run --all-files` is clean (ruff, whitespace, no secrets)
- [ ] Package `CHANGELOG.md` updated if behavior changed
- [x] No secrets, tokens, or `.env` files committed
- [ ] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta

---
_Generated by [Claude Code](https://claude.ai/code/session_01PGpSskwUD2ikaSkTkffyta)_