### PR TITLE
feat(goldenmatch-cli): add score and info commands (TS parity)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -822,6 +822,9 @@ Every command and its options/arguments, generated from the Typer app. `choice`-
 | `schedule` | `--every` | text | `None` | Run interval (e.g. 1h, 30m, 6h, 1d) |
 | `schedule` | `--cron` | text | `None` | Cron schedule (e.g. '0 6 * * *') |
 | `schedule` | `--output-dir` | text | `'.'` | Output directory |
+| `score` | `a` | text | **required** | First string. |
+| `score` | `b` | text | **required** | Second string. |
+| `score` | `--scorer` | text | `'jaro_winkler'` | Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble. |
 | `sensitivity` | `files` | text | **required** | Input files (path or path:source_name) |
 | `sensitivity` | `--config` | path | **required** | Config YAML path |
 | `sensitivity` | `--sweep` | text | **required** | Sweep spec: field:start:stop:step (repeatable) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -14,7 +14,7 @@ Live counts (introspected from each package) side by side. `MCP` / `Exports` / `
 
 | Package | MCP tools | Exports | A2A skills | CLI commands | Recipes | TS port |
 |---|---|---|---|---|---|---|
-| `goldenmatch` | 82 | 201 | 47 | 34 | Yes | Yes |
+| `goldenmatch` | 82 | 201 | 47 | 36 | Yes | Yes |
 | `goldencheck` | 19 | 43 | 9 | 22 | Yes | Yes |
 | `goldenflow` | 10 | 36 | 6 | 16 | Yes | Yes |
 | `goldenpipe` | 4 | 20 | 4 | 8 | Yes | Yes |
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 42 | 40 | 8 |
-| `goldenmatch` | cli_commands | 11 | 23 | 3 |
+| `goldenmatch` | cli_commands | 13 | 23 | 1 |
 | `goldenmatch` | a2a_skills | 27 | 20 | 9 |
 | `goldenmatch` | scorers | 17 | 0 | 2 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
@@ -66,7 +66,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **mcp_tools** — Python-only: `analyze_blocking`, `certify_recall`, `compare_clusters`, `config_weaknesses`, `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `export_results`, `get_cluster`, `get_golden_record`, `get_stats`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_profile`, `identity_resolve_conflict`, `identity_show`, `identity_stats`, `identity_worklist`, `incremental`, `lineage`, `lint_routing`, `list_clusters`, `list_domains`, `list_plugins`, `list_runs`, `memory_import`, `plan_routing`, `pprl_auto_config`, `pprl_link`, `retrieve_similar`, `rollback`, `schema_match`, `sensitivity`, `shatter_cluster`, `test_domain`, `unmerge_record`, `upload_dataset`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
 - `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `compare-clusters`, `config`, `explain`, `incremental`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
-- `goldenmatch` **cli_commands** — TS-only: `info`, `score`, `tui`.
+- `goldenmatch` **cli_commands** — TS-only: `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -676,9 +676,11 @@
             "config_load",
             "config_save",
             "config_show",
+            "info_cmd",
             "init_cmd",
             "interactive_cmd",
-            "profile_cmd"
+            "profile_cmd",
+            "score_cmd"
           ],
           "imports": [
             "goldenmatch",
@@ -710,6 +712,7 @@
             "goldenmatch.cli.sync",
             "goldenmatch.cli.watch",
             "goldenmatch.config.loader",
+            "goldenmatch.config.schemas",
             "goldenmatch.config.wizard",
             "goldenmatch.core.analytics",
             "goldenmatch.core.autofix",

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -3230,6 +3230,10 @@
           ]
         },
         {
+          "command": "info",
+          "options": []
+        },
+        {
           "command": "ingest-docs run",
           "options": [
             {
@@ -4026,6 +4030,30 @@
               "required": false,
               "default": "'.'",
               "help": "Output directory"
+            }
+          ]
+        },
+        {
+          "command": "score",
+          "options": [
+            {
+              "name": "a",
+              "type": "text",
+              "required": true,
+              "help": "First string."
+            },
+            {
+              "name": "b",
+              "type": "text",
+              "required": true,
+              "help": "Second string."
+            },
+            {
+              "name": "--scorer",
+              "type": "text",
+              "required": false,
+              "default": "'jaro_winkler'",
+              "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
             }
           ]
         },

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -27,6 +27,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   last TS-only introspection tool. It lists every accepted blocking-strategy name
   (incl. the Python-only `lsh` / `simhash` / `perceptual`), closing the `mcp_tools`
   gap (`ts_only` → `shared`).
+- **`score` and `info` CLI commands (TS-parity).** `goldenmatch score <a> <b>
+  [--scorer NAME]` prints `<scorer>: <0.xxxx>` over `score_strings`; `goldenmatch
+  info` prints the version plus the available scorers / survivorship-strategies /
+  blocking-strategies / transforms, sourced from the actual config allow-lists
+  (`VALID_SCORERS` / `VALID_STRATEGIES` / `BlockingConfig.strategy` /
+  `VALID_SIMPLE_TRANSFORMS`) so the listing can't drift. Both move `cli_commands`
+  `ts_only` → `shared`; only `tui` (≈ the Python `interactive` command) remains
+  TS-only by design.
 
 ## [3.8.0] - 2026-07-22
 

--- a/packages/python/goldenmatch/goldenmatch/cli/main.py
+++ b/packages/python/goldenmatch/goldenmatch/cli/main.py
@@ -332,6 +332,42 @@ def interactive_cmd(
     tui_app.run()
 
 
+@app.command("score")
+def score_cmd(
+    a: str = typer.Argument(..., help="First string."),
+    b: str = typer.Argument(..., help="Second string."),
+    scorer: str = typer.Option(
+        "jaro_winkler", "-s", "--scorer",
+        help="Scorer: exact, jaro_winkler, levenshtein, token_sort, "
+             "soundex_match, dice, jaccard, ensemble.",
+    ),
+) -> None:
+    """Score similarity between two strings."""
+    from goldenmatch import score_strings
+
+    typer.echo(f"{scorer}: {score_strings(a, b, scorer):.4f}")
+
+
+@app.command("info")
+def info_cmd() -> None:
+    """Show package info: version + available scorers/strategies/blocking/transforms."""
+    from typing import get_args
+
+    from goldenmatch.config.schemas import (
+        VALID_SCORERS,
+        VALID_SIMPLE_TRANSFORMS,
+        VALID_STRATEGIES,
+        BlockingConfig,
+    )
+
+    blocking = get_args(BlockingConfig.model_fields["strategy"].annotation)
+    typer.echo(f"GoldenMatch v{__version__}")
+    typer.echo(f"Scorers: {', '.join(sorted(VALID_SCORERS))}")
+    typer.echo(f"Strategies: {', '.join(sorted(VALID_STRATEGIES))}")
+    typer.echo(f"Blocking: {', '.join(sorted(blocking))}")
+    typer.echo(f"Transforms: {', '.join(sorted(VALID_SIMPLE_TRANSFORMS))}")
+
+
 @app.command("profile")
 def profile_cmd(
     files: list[str] = typer.Argument(..., help="File(s) to profile"),

--- a/packages/python/goldenmatch/tests/test_cli_score_info.py
+++ b/packages/python/goldenmatch/tests/test_cli_score_info.py
@@ -1,0 +1,61 @@
+"""TS-parity CLI commands: `score` and `info`.
+
+- score: score similarity between two strings (wraps score_strings).
+- info: package version + available scorers/strategies/blocking/transforms.
+"""
+from __future__ import annotations
+
+import re
+
+from goldenmatch.cli.main import app
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+def test_score_default_scorer():
+    result = runner.invoke(app, ["score", "John Smith", "Jon Smith"])
+    assert result.exit_code == 0
+    # `<scorer>: <0.xxxx>` — default scorer is jaro_winkler.
+    assert re.search(r"jaro_winkler: \d\.\d{4}", result.stdout)
+
+
+def test_score_named_scorer():
+    result = runner.invoke(app, ["score", "apple", "aple", "--scorer", "levenshtein"])
+    assert result.exit_code == 0
+    assert result.stdout.startswith("levenshtein: ")
+    # Score parses as a float in [0, 1].
+    value = float(result.stdout.split(":", 1)[1].strip())
+    assert 0.0 <= value <= 1.0
+
+
+def test_score_exact_identical_is_one():
+    result = runner.invoke(app, ["score", "abc", "abc", "-s", "exact"])
+    assert result.exit_code == 0
+    assert "1.0000" in result.stdout
+
+
+def test_info_lists_surfaces():
+    result = runner.invoke(app, ["info"])
+    assert result.exit_code == 0
+    from goldenmatch import __version__
+
+    assert f"GoldenMatch v{__version__}" in result.stdout
+    for line in ("Scorers:", "Strategies:", "Blocking:", "Transforms:"):
+        assert line in result.stdout
+    # Sourced from the real allow-lists, so representative names appear.
+    assert "jaro_winkler" in result.stdout
+    assert "static" in result.stdout
+
+
+def test_info_sources_from_valid_scorers():
+    """The scorer line must be the actual VALID_SCORERS set (drift-free)."""
+    from goldenmatch.config.schemas import VALID_SCORERS
+
+    result = runner.invoke(app, ["info"])
+    assert result.exit_code == 0
+    scorer_line = next(
+        line for line in result.stdout.splitlines() if line.startswith("Scorers:")
+    )
+    listed = {s.strip() for s in scorer_line.split(":", 1)[1].split(",")}
+    assert listed == set(VALID_SCORERS)

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -3230,6 +3230,10 @@
           ]
         },
         {
+          "command": "info",
+          "options": []
+        },
+        {
           "command": "ingest-docs run",
           "options": [
             {
@@ -4026,6 +4030,30 @@
               "required": false,
               "default": "'.'",
               "help": "Output directory"
+            }
+          ]
+        },
+        {
+          "command": "score",
+          "options": [
+            {
+              "name": "a",
+              "type": "text",
+              "required": true,
+              "help": "First string."
+            },
+            {
+              "name": "b",
+              "type": "text",
+              "required": true,
+              "help": "Second string."
+            },
+            {
+              "name": "--scorer",
+              "type": "text",
+              "required": false,
+              "default": "'jaro_winkler'",
+              "help": "Scorer: exact, jaro_winkler, levenshtein, token_sort, soundex_match, dice, jaccard, ensemble."
             }
           ]
         },

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -9,8 +9,9 @@
 #   1. NAMING ALIASES (resolved 2026-07-05 via non-breaking aliases — both
 #      servers now answer to both names, so these are shared: dedupe/find_duplicates,
 #      match/match_record, explain_pair/explain_match, profile/profile_data, and
-#      explain_cluster (alias of the shared agent_explain_cluster)). CLI info/score/
-#      tui(TS) vs interactive(PY) are NOT aliases (distinct ops) — left as coverage gaps.
+#      explain_cluster (alias of the shared agent_explain_cluster)). CLI info + score
+#      are now SHARED — the Python CLI wraps score_strings + the config allow-lists.
+#      tui(TS) vs interactive(PY) are NOT aliases (distinct ops) — left as a coverage gap.
 #   2. PYTHON-RICHER COVERAGE (intentional — Python is the fuller, STATEFUL server):
 #      get_stats / get_cluster / list_clusters are Python-only BECAUSE the TS MCP is
 #      stateless — its dedupe() returns stats + clusters inline (DedupeResult), so there
@@ -146,10 +147,12 @@ cli_commands:
   - evaluate
   - identity
   - import-splink
+  - info
   - match
   - mcp-serve
   - memory
   - profile
+  - score
   - serve
   python_only:
   - analyze-blocking
@@ -176,8 +179,6 @@ cli_commands:
   - unmerge
   - watch
   ts_only:
-  - info
-  - score
   - tui
 a2a_skills:
   shared:


### PR DESCRIPTION
## Summary

Ports the two remaining TS-only goldenmatch CLI commands into the **Python** CLI, closing the last of the one-surface parity gaps:

| Command | Output |
|---|---|
| `goldenmatch score <a> <b> [--scorer NAME]` | `<scorer>: <0.xxxx>` (over `score_strings`, default `jaro_winkler`) |
| `goldenmatch info` | version + available scorers / strategies / blocking / transforms |

`info` sources its lists from the actual config allow-lists (`VALID_SCORERS` / `VALID_STRATEGIES` / `BlockingConfig.strategy` / `VALID_SIMPLE_TRANSFORMS`) rather than a hardcoded set, so the listing stays in lockstep with the schema and can't drift.

## Parity

Both move `cli_commands` `ts_only → shared` in `parity/goldenmatch.yaml`. Only `tui` remains TS-only — it's the TS analog of the Python `interactive` command (distinct-but-equivalent, intentional). `check_api_parity.py goldenmatch` passes.

## Tests & doc gates

- 5 new CLI tests (`tests/test_cli_score_info.py`) — default/named/exact scorer + `info` surface listing + an assertion that the `info` scorer line equals `VALID_SCORERS` (drift guard). All green.
- Regenerated `docs-site/goldenmatch/config-matrix.mdx`, `docs-site/suite-matrix.mdx`, `docs/agent-codemap.json`, and `agent-manifest.json` (×2). `check_llms_counts.py`, `test_config_matrix.py`, `test_agent_codemap.py`, `test_suite_matrix.py` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_