### PR TITLE
feat(goldenmatch): promote name scorers to first-class VALID_SCORERS (TS parity)

### DIFF
--- a/docs-site/goldenmatch/config-matrix.mdx
+++ b/docs-site/goldenmatch/config-matrix.mdx
@@ -970,10 +970,12 @@ _`VALID_SCORERS` -- `MatchkeyField.scorer` / `NegativeEvidenceField.scorer`._
 | `embedding` | Cosine similarity of a model embedding of the field. | Semantic matching | 0.0-1.0 |
 | `ensemble` | Best of several sub-scorers (max of jaro_winkler / token_sort / soundex). | Names with reordering | 0.0-1.0 |
 | `exact` | Exact string equality after transforms. | Email, phone, ID | 0 or 1 |
+| `given_name_aliased_jw` | Jaro-Winkler with alias-aware exact collapse of given-name variants (Bob &lt;-> Robert). | Given names | 0.0-1.0 |
 | `initialism_match` | Matches initials/acronyms against their expansions. | Acronyms, initials | 0 or 1 |
 | `jaccard` | Jaccard overlap of token/character sets or bloom filters. | PPRL | 0.0-1.0 |
 | `jaro_winkler` | Jaro-Winkler edit distance with a shared-prefix bonus. | Names | 0.0-1.0 |
 | `levenshtein` | Normalized Levenshtein edit distance. | General strings | 0.0-1.0 |
+| `name_freq_weighted_jw` | Jaro-Winkler modulated by US-Census surname frequency (rare surnames weigh more). | Surnames | 0.0-1.0 |
 | `phash` | Perceptual-hash Hamming similarity. | Images | 0.0-1.0 |
 | `qgram` | Q-gram (n-gram) overlap similarity. | General strings, typos | 0.0-1.0 |
 | `radial` | Rotation/crop-invariant radial-variance similarity. | Rotated/cropped images | 0.0-1.0 |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -44,7 +44,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | mcp_tools | 42 | 40 | 8 |
 | `goldenmatch` | cli_commands | 13 | 23 | 1 |
 | `goldenmatch` | a2a_skills | 27 | 20 | 9 |
-| `goldenmatch` | scorers | 17 | 0 | 2 |
+| `goldenmatch` | scorers | 19 | 0 | 0 |
 | `goldenmatch` | transforms | 12 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
 | `goldencheck` | cli_commands | 13 | 9 | 0 |
@@ -69,7 +69,6 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **cli_commands** — TS-only: `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `identity_audit`, `identity_audit_seal`, `identity_audit_verify`, `identity_claim`, `identity_resolve_conflict`, `identity_show`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `scan_quality`, `score`.
-- `goldenmatch` **scorers** — TS-only: `given_name_aliased_jw`, `name_freq_weighted_jw`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
 - `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
 - `goldenflow` **cli_commands** — Python-only: `agent-serve`, `init`, `interactive`, `mcp-serve`, `schedule`, `serve`, `watch`.

--- a/docs/agent-manifest.json
+++ b/docs/agent-manifest.json
@@ -4737,6 +4737,12 @@
               "range": "0 or 1"
             },
             {
+              "value": "given_name_aliased_jw",
+              "meaning": "Jaro-Winkler with alias-aware exact collapse of given-name variants (Bob <-> Robert).",
+              "best_for": "Given names",
+              "range": "0.0-1.0"
+            },
+            {
               "value": "initialism_match",
               "meaning": "Matches initials/acronyms against their expansions.",
               "best_for": "Acronyms, initials",
@@ -4758,6 +4764,12 @@
               "value": "levenshtein",
               "meaning": "Normalized Levenshtein edit distance.",
               "best_for": "General strings",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "name_freq_weighted_jw",
+              "meaning": "Jaro-Winkler modulated by US-Census surname frequency (rare surnames weigh more).",
+              "best_for": "Surnames",
               "range": "0.0-1.0"
             },
             {

--- a/packages/python/goldenmatch/CHANGELOG.md
+++ b/packages/python/goldenmatch/CHANGELOG.md
@@ -36,6 +36,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
   `ts_only` → `shared`; only `tui` (≈ the Python `interactive` command) remains
   TS-only by design.
 
+### Changed
+
+- **`name_freq_weighted_jw` / `given_name_aliased_jw` are now first-class
+  `VALID_SCORERS` (TS-parity).** The census-frequency-weighted and alias-aware
+  given-name Jaro-Winkler scorers (`refdata/scorer.py`) were accepted only via the
+  PluginRegistry validator fallback, so they were absent from `VALID_SCORERS` and
+  the `scorers` parity surface listed them TS-only. They're registered at
+  `import goldenmatch` (via `_api` → `refdata`), so promoting them to `VALID_SCORERS`
+  lets a config referencing them validate AND score with no manual
+  `import goldenmatch.refdata` (verified by a fresh-process test). Both move the
+  `scorers` surface `ts_only` → `shared` — the goldenmatch↔TS scorer surface is now
+  at full parity. No behavior change for existing configs.
+
 ## [3.8.0] - 2026-07-22
 
 ### Added

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -41,6 +41,13 @@ VALID_SCORERS = frozenset({
     # ("IBM" <-> "International Business Machines") and alias canonicalization
     # ("Acme Inc" <-> "Acme Incorporated", "Bob" <-> "Robert").
     "initialism_match", "alias_match",
+    # Reference-data name scorers (refdata/scorer.py): Jaro-Winkler modulated by
+    # US-Census surname frequency (rare surnames weigh more) and an alias-aware
+    # given-name variant (Bob<->Robert). Registered into the PluginRegistry when
+    # `goldenmatch` is imported (via _api -> refdata), so a config referencing
+    # them validates + scores without a manual `import goldenmatch.refdata`.
+    # Kernel-backed on both surfaces (bucket ids 15/16; TS score-wasm).
+    "name_freq_weighted_jw", "given_name_aliased_jw",
 })
 
 VALID_STRATEGIES = frozenset({

--- a/packages/python/goldenmatch/goldenmatch/config/schemas.py
+++ b/packages/python/goldenmatch/goldenmatch/config/schemas.py
@@ -50,6 +50,13 @@ VALID_SCORERS = frozenset({
     "name_freq_weighted_jw", "given_name_aliased_jw",
 })
 
+# Scorers valid as MATCHKEY scorers but NOT as negative-evidence scorers: the NE
+# path runs the native `score_one` kernel (ids 0..=3), while the reference-data
+# name scorers are FS kernel ids 4/5 with no NE path. Enforced in
+# NegativeEvidenceField (they were implicitly excluded before their promotion to
+# VALID_SCORERS).
+_NE_UNSUPPORTED_SCORERS = frozenset({"name_freq_weighted_jw", "given_name_aliased_jw"})
+
 VALID_STRATEGIES = frozenset({
     "most_recent", "source_priority", "most_complete", "majority_vote", "first_non_null",
     # v1.18 additions (#golden-strategies)
@@ -336,6 +343,16 @@ class NegativeEvidenceField(BaseModel):
             raise ValueError(
                 f"Invalid scorer '{self.scorer}'. Must be one of "
                 f"{sorted(VALID_SCORERS)}"
+            )
+        # Negative evidence uses the native `score_one` kernel (ids 0..=3); the
+        # reference-data name scorers are FS kernel ids 4/5 and have no NE path,
+        # so reject them here even though they are valid MATCHKEY scorers. (They
+        # were implicitly excluded before their promotion to VALID_SCORERS.)
+        if self.scorer in _NE_UNSUPPORTED_SCORERS:
+            raise ValueError(
+                f"Scorer '{self.scorer}' is not supported as a negative-evidence "
+                f"scorer (reference-data name scorers have no NE kernel path). "
+                f"Use one of the standard scorers for negative evidence."
             )
         return self
 

--- a/packages/python/goldenmatch/tests/test_fs_name_scorers_native.py
+++ b/packages/python/goldenmatch/tests/test_fs_name_scorers_native.py
@@ -149,13 +149,22 @@ def test_missing_pack_declines_even_with_flag(monkeypatch):
 
 def test_name_scorer_not_a_valid_negative_evidence_scorer():
     # NE never uses a reference-data name scorer: the config layer rejects it
-    # outright (it's not in NegativeEvidenceField's allowed scorer list), so the
-    # kernel NE path (score_one 0..=3) is never asked to run one. The defensive
+    # outright, so the kernel NE path (score_one 0..=3) is never asked to run one.
+    # Since the name scorers were promoted to VALID_SCORERS (they're first-class
+    # MATCHKEY scorers now), the rejection is an EXPLICIT NE exclusion
+    # (`_NE_UNSUPPORTED_SCORERS`), not "absent from VALID_SCORERS". The defensive
     # `_fs_native_eligible` NE gate is belt-and-suspenders for this invariant.
     import pytest
-    from goldenmatch.config.schemas import NegativeEvidenceField
+    from goldenmatch.config.schemas import (
+        _NE_UNSUPPORTED_SCORERS,
+        VALID_SCORERS,
+        NegativeEvidenceField,
+    )
 
     for scorer in _NAME_SCORER_IDS:
+        # First-class matchkey scorer, but excluded from the NE path.
+        assert scorer in VALID_SCORERS
+        assert scorer in _NE_UNSUPPORTED_SCORERS
         with pytest.raises(Exception):
             NegativeEvidenceField(field="x", scorer=scorer, threshold=0.9, penalty_bits=10.0)
 

--- a/packages/python/goldenmatch/tests/test_name_scorers_first_class.py
+++ b/packages/python/goldenmatch/tests/test_name_scorers_first_class.py
@@ -1,0 +1,57 @@
+"""The reference-data name scorers are first-class VALID_SCORERS (TS parity).
+
+`name_freq_weighted_jw` / `given_name_aliased_jw` used to be accepted only via the
+PluginRegistry validator fallback (registered by importing `goldenmatch.refdata`),
+so they were NOT in `VALID_SCORERS` and the `scorers` parity surface listed them
+TS-only. They're now first-class: `import goldenmatch` registers them (via
+`_api` -> `refdata`), so a config referencing them validates + scores with no
+manual `import goldenmatch.refdata`.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from goldenmatch.config.schemas import VALID_SCORERS, MatchkeyField
+from goldenmatch.core.scorer import score_field
+
+_NAME_SCORERS = ("name_freq_weighted_jw", "given_name_aliased_jw")
+
+
+def test_name_scorers_in_valid_scorers():
+    for s in _NAME_SCORERS:
+        assert s in VALID_SCORERS, f"{s} should be first-class in VALID_SCORERS"
+
+
+def test_matchkey_field_validates_name_scorers():
+    for s in _NAME_SCORERS:
+        field = MatchkeyField(
+            field="name", transforms=["lowercase"], scorer=s, weight=1.0
+        )
+        assert field.scorer == s
+
+
+def test_name_scorers_score_end_to_end():
+    # given_name_aliased_jw canonicalizes nickname aliases to an exact 1.0.
+    assert score_field("Bob", "Robert", "given_name_aliased_jw") == 1.0
+    # name_freq_weighted_jw is a Jaro-Winkler variant; identical strings -> 1.0.
+    assert score_field("Smith", "Smith", "name_freq_weighted_jw") == 1.0
+
+
+def test_bare_import_goldenmatch_registers_scorers():
+    """A fresh process importing ONLY `goldenmatch` can validate + score with the
+    name scorers — proving the promotion isn't a validate-but-crash footgun."""
+    code = (
+        "import goldenmatch\n"
+        "from goldenmatch.config.schemas import MatchkeyField\n"
+        "from goldenmatch.core.scorer import score_field\n"
+        "MatchkeyField(field='name', transforms=['lowercase'],"
+        " scorer='name_freq_weighted_jw', weight=1.0)\n"
+        "assert score_field('Bob', 'Robert', 'given_name_aliased_jw') == 1.0\n"
+        "print('OK')\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout

--- a/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
+++ b/packages/python/goldensuite-mcp/goldensuite_mcp/agent-manifest.json
@@ -4737,6 +4737,12 @@
               "range": "0 or 1"
             },
             {
+              "value": "given_name_aliased_jw",
+              "meaning": "Jaro-Winkler with alias-aware exact collapse of given-name variants (Bob <-> Robert).",
+              "best_for": "Given names",
+              "range": "0.0-1.0"
+            },
+            {
               "value": "initialism_match",
               "meaning": "Matches initials/acronyms against their expansions.",
               "best_for": "Acronyms, initials",
@@ -4758,6 +4764,12 @@
               "value": "levenshtein",
               "meaning": "Normalized Levenshtein edit distance.",
               "best_for": "General strings",
+              "range": "0.0-1.0"
+            },
+            {
+              "value": "name_freq_weighted_jw",
+              "meaning": "Jaro-Winkler modulated by US-Census surname frequency (rare surnames weigh more).",
+              "best_for": "Surnames",
               "range": "0.0-1.0"
             },
             {

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -242,9 +242,11 @@ a2a_skills:
   - score
 
 # scorers surface (config.schemas.VALID_SCORERS <-> types.ts VALID_SCORERS).
-# python_only: multimodal media comparators (ADR 0022) with no TS port yet.
-# ts_only: census/alias name-scorer plugins (Python accepts them via the
-# PluginRegistry validator fallback, so they're NOT in Python VALID_SCORERS).
+# FULL parity as of the name-scorer promotion: the census/alias name scorers
+# (given_name_aliased_jw / name_freq_weighted_jw) are now FIRST-CLASS in Python
+# VALID_SCORERS (were plugin-registry-only), matching the TS VALID_SCORERS — so
+# both move ts_only -> shared. refdata registers them at `import goldenmatch`, so
+# a config referencing them validates + scores without a manual refdata import.
 scorers:
   shared:
   - alias_match
@@ -254,10 +256,12 @@ scorers:
   - embedding
   - ensemble
   - exact
+  - given_name_aliased_jw
   - initialism_match
   - jaccard
   - jaro_winkler
   - levenshtein
+  - name_freq_weighted_jw
   - phash
   - qgram
   - radial
@@ -265,9 +269,7 @@ scorers:
   - soundex_match
   - token_sort
   python_only: []
-  ts_only:
-  - given_name_aliased_jw
-  - name_freq_weighted_jw
+  ts_only: []
 # transforms surface (config.schemas.VALID_SIMPLE_TRANSFORMS <-> types.ts
 # VALID_TRANSFORMS). Currently in exact parity -- no declared deltas.
 transforms:

--- a/scripts/config_matrix/registry.py
+++ b/scripts/config_matrix/registry.py
@@ -68,6 +68,8 @@ REGISTRY: dict[str, PackageSpec] = {
                 "radial": {"meaning": "Rotation/crop-invariant radial-variance similarity.", "range": "0.0-1.0", "best_for": "Rotated/cropped images"},
                 "initialism_match": {"meaning": "Matches initials/acronyms against their expansions.", "range": "0 or 1", "best_for": "Acronyms, initials"},
                 "alias_match": {"meaning": "Matches known name aliases and nicknames (Bob <-> Robert).", "range": "0 or 1", "best_for": "Names with nicknames"},
+                "given_name_aliased_jw": {"meaning": "Jaro-Winkler with alias-aware exact collapse of given-name variants (Bob <-> Robert).", "range": "0.0-1.0", "best_for": "Given names"},
+                "name_freq_weighted_jw": {"meaning": "Jaro-Winkler modulated by US-Census surname frequency (rare surnames weigh more).", "range": "0.0-1.0", "best_for": "Surnames"},
             }),
             ("Blocking strategies", "goldenmatch.config.schemas:BlockingConfig.strategy", "`BlockingConfig.strategy`", {
                 "static": {"meaning": "Group records by an exact blocking key.", "best_for": "Clean data with reliable keys"},


### PR DESCRIPTION
## Summary

Promotes `name_freq_weighted_jw` (census-frequency-weighted Jaro-Winkler) and `given_name_aliased_jw` (alias-aware given-name Jaro-Winkler) to first-class members of `VALID_SCORERS`, closing the last `scorers` parity gap.

These scorers live in `refdata/scorer.py` and were accepted only via the **PluginRegistry validator fallback** — so they were absent from `VALID_SCORERS`, and the `scorers` parity surface listed them TS-only (TS already carries both in its `VALID_SCORERS`).

## Why this is safe (not a validate-but-crash footgun)

I traced the runtime dispatch: `core/scorer.py` resolves an unknown scorer via `PluginRegistry.get_scorer(...)` and **raises `ValueError` if it's unregistered**. The key finding: **`import goldenmatch` already registers both** (via `_api` → `refdata` → `register_scorers()` at import time). So any code path that could reference a scorer has imported `goldenmatch`, meaning a config using these names now validates *and* scores with no manual `import goldenmatch.refdata`. A **fresh-process subprocess test** proves this end-to-end.

## Parity

Both move `scorers` `ts_only → shared` in `parity/goldenmatch.yaml` — the goldenmatch↔TS scorer surface is now at **full parity** (0 ts_only, 0 python_only). They were already `shared` in `scorer_kernels` (kernel-backed both surfaces via #2032), so `check_scorer_coverage` stays satisfied. `check_api_parity.py goldenmatch` passes.

## Tests & doc gates

- `tests/test_name_scorers_first_class.py` — membership, `MatchkeyField` validation, end-to-end scoring, and the fresh-process guarantee (4 tests).
- Ran the affected modules (`test_cross_surface_consistency`, `test_plugins`, `test_autoconfig_negative_evidence`, `test_refdata_given_names`, `test_tf_name_weighting_1207`) — 75 pass.
- Added config-matrix decision hints (`best_for`/`range`/`meaning`) for both scorers; regenerated `config-matrix.mdx`, `suite-matrix.mdx`, and `agent-manifest.json` (×2). All doc-gate tests green.

No behavior change for existing configs. (The curated web-workbench `SCORERS` dropdown is deliberately left unchanged — it's already a subset of `VALID_SCORERS` and not part of the parity surface.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_