### PR TITLE
Design + Phase-1 plan: scale-neutral FS domain comparators (date/numeric/geo)

### DIFF
--- a/docs/superpowers/plans/2026-07-23-fs-domain-comparators-phase1-date-diff.md
+++ b/docs/superpowers/plans/2026-07-23-fs-domain-comparators-phase1-date-diff.md
@@ -1,0 +1,161 @@
+# Plan — FS domain comparators, Phase 1: `date_diff`
+
+**Spec:** `docs/superpowers/specs/2026-07-23-fs-domain-comparators-design.md`
+**Scope:** ship the `date_diff` comparator (pure-Python scalar + vectorized numpy matrix), wire it into
+FS scoring + vectorized/bucket lanes + auto-config `date` admission behind a default-OFF flag. Native
+kernel is Phase 3; TS is Phase 4. Every task is failing-test → minimal-impl → commit.
+
+## Invariants held throughout
+
+- Default OFF: `GOLDENMATCH_FS_DOMAIN_COMPARATORS` unset ⇒ auto-config keeps `date → levenshtein`,
+  byte-identical to today. The scorer itself is always *registered* (usable via explicit config) but
+  auto-config only emits it under the flag.
+- `date_diff` returns `float | None` in `[0,1]`, monotone non-increasing in day-distance, `None` on
+  null/unparseable (so `fs_missing_mode` handles it exactly like any missing scorer).
+- Scalar `score_field(a,b,"date_diff")` and the NxN `_date_diff_matrix` are byte-parity (asserted).
+- Commands run from `packages/python/goldenmatch/`. Run tests with
+  `python -m pytest <path> -q -p no:cacheprovider`.
+
+---
+
+## Task 1 — the comparator core (`_date_diff_similarity`) + parse
+
+**Test first** — `tests/test_date_diff_comparator.py`:
+- `_parse_date_ordinal("1990-01-02")` → an int day-ordinal; `"1990/01/02"`, `"19900102"`, `"1990-1-2"`
+  parse equal; `"not a date"`, `None`, `""` → `None`.
+- `_date_diff_similarity("1990-01-02","1990-01-02") == 1.0`
+- same-day > 1-day > 31-day > 366-day > 5y > beyond, strictly non-increasing across the bands.
+- **Transposition floor:** `_date_diff_similarity("1990-01-02","1990-02-01")` ≥ the `≤31-day` band value
+  (MM/DD swap distance 0 → floored to a partial, not a disagree).
+- unparseable/null operand → `None`.
+
+**Impl** — `goldenmatch/core/comparators.py` (new module; keeps scorer.py lean):
+- `_parse_date_ordinal(s: str | None) -> int | None` — tolerant parse (ISO, `/`-sep, compact `YYYYMMDD`,
+  1-digit month/day). Pure stdlib `datetime`; return `None` on failure. Cache nothing (per-value, cheap).
+- `_DATE_BANDS: tuple[tuple[int,float],...]` = `((0,1.0),(1,0.92),(31,0.80),(366,0.60),(1827,0.30))`,
+  else `0.0`. Document the tuning rationale inline (person-data defaults; override via `level_thresholds`).
+- `_date_diff_similarity(a, b) -> float | None`: parse both; `None` if either fails; `d=|oa-ob|`;
+  transposition check (swap month/day on the *string* forms, re-parse, if that distance is 0 set
+  `d=min(d,31)`); return the band value for `d`.
+
+**Commit:** `feat(fs): date_diff comparator core (parse + banded similarity)`
+
+---
+
+## Task 2 — register the scorer + scalar `score_field` branch
+
+**Test first** — extend `tests/test_date_diff_comparator.py`:
+- `from goldenmatch.core.scorer import score_field` — `score_field("1990-01-02","1990-01-02","date_diff") == 1.0`;
+  `score_field(None, x, "date_diff") is None`; unparseable → `None`.
+- `"date_diff" in goldenmatch.config.schemas.VALID_SCORERS`.
+- A `MatchkeyField(scorer="date_diff", levels=3, partial_threshold=0.6)` constructs without a
+  validation error.
+
+**Impl:**
+- `config/schemas.py:21` — add `"date_diff"` to `VALID_SCORERS`.
+- `core/scorer.py:173` `score_field` — add a branch: `if scorer == "date_diff": return _date_diff_similarity(val_a, val_b)`
+  (import from `core.comparators`). Placed so it short-circuits before the generic fuzzy routing.
+
+**Commit:** `feat(fs): register date_diff scorer + scalar score_field branch`
+
+---
+
+## Task 3 — vectorized NxN matrix + FS routing + vec-support
+
+**Test first** — `tests/test_date_diff_comparator.py`:
+- `_date_diff_matrix(vals)` for `vals=["1990-01-02","1990-01-02","1991-01-02", None]` equals, cell by
+  cell, `score_field(vals[i], vals[j], "date_diff")` (with `None`→0.0 in the matrix, matching the
+  `_fuzzy_score_matrix` null-mask convention; the `-1/0` level decision stays in `comparison_vector`).
+- `probabilistic._field_score_matrix(vals, "date_diff")` returns that matrix.
+- `probabilistic.vectorized_scorer_supported("date_diff") is True`.
+- Parity: for a random list of parseable+null dates, `_field_score_matrix_dedup(vals,"date_diff")`
+  equals the full `_date_diff_matrix(vals)` (distinct-collapse is bit-identical).
+
+**Impl:**
+- `core/scorer.py` — `_date_diff_matrix(vals: list[str|None]) -> np.ndarray`: parse each value ONCE to an
+  ordinal array (+ a null mask), then vectorized `|oa-ob|` band lookup via `np.select` / `np.digitize`
+  over the bands; null rows/cols → 0.0. (Transposition handled at parse time by storing both the
+  ordinal and the swapped ordinal, then taking the min-distance — vectorized.)
+- `probabilistic._field_score_matrix:2426` — route `if scorer == "date_diff": return _date_diff_matrix(vals)`
+  before the fuzzy fallthrough.
+- `probabilistic.vectorized_scorer_supported` — add `"date_diff"`.
+- `backends/score_buckets.py:117` `_VEC_SUPPORTED` — add `"date_diff"` so the bucket vec lane takes it
+  (native-absent path; correct either way).
+
+**Commit:** `feat(fs): vectorized date_diff matrix + FS/bucket routing`
+
+---
+
+## Task 4 — end-to-end FS parity: date_diff levels == expected through EM + scoring
+
+**Test first** — `tests/test_date_diff_comparator.py` (or extend `test_probabilistic.py`):
+- Build a tiny frame with a `dob` column + an explicit `MatchkeyConfig` using
+  `MatchkeyField(field="dob", scorer="date_diff", levels=3, partial_threshold=0.6)` alongside a name
+  field. Train EM (fixed seed / `confidence_required=False`) and assert:
+  - a same-DOB pair lands in the top level, a 1-year-apart pair in a lower level, byte-consistent
+    between the scalar `comparison_vector` path and the vectorized `score_probabilistic_vectorized`
+    path (the existing scalar-vs-vectorized parity assertion, extended to date_diff).
+  - `fs_missing_mode`: a null-DOB pair → level −1 (unobserved) under default missing mode.
+
+**Impl:** none expected beyond Tasks 1–3 (this is the integration guard). If the scalar/vectorized paths
+disagree, fix the matrix null/transposition handling until parity holds.
+
+**Commit:** `test(fs): end-to-end date_diff level parity (scalar == vectorized, missing)`
+
+---
+
+## Task 5 — auto-config admits `date → date_diff` behind the flag
+
+**Test first** — `tests/test_fs_autoconfig_v2.py` (new cases):
+- With `GOLDENMATCH_FS_DOMAIN_COMPARATORS` unset: `build_probabilistic_matchkeys` on a frame with a
+  detected `date` column emits that field with `scorer="levenshtein"` (unchanged — byte-identical guard).
+- With `GOLDENMATCH_FS_DOMAIN_COMPARATORS=1`: the same `date` column is emitted with
+  `scorer="date_diff"` (levels/threshold carried through); non-date fields unchanged.
+
+**Impl:**
+- `core/autoconfig.py::build_probabilistic_matchkeys` — at the `col_type == "date"` admission site
+  (near `_DATE_PATTERNS` usage), branch on a new `_fs_domain_comparators_enabled()` helper
+  (`GOLDENMATCH_FS_DOMAIN_COMPARATORS` truthy) to pick `"date_diff"` vs the current `"levenshtein"`.
+  Gate composes with `_fs_autoconfig_v2_enabled()` (v2 is the path that admits dates at all).
+
+**Commit:** `feat(fs): auto-config admits date columns as date_diff (flag, default off)`
+
+---
+
+## Task 6 — scale-neutrality guard + docs
+
+**Test first** — `tests/test_date_diff_comparator.py`:
+- **Determinism:** `date_diff` scoring is a pure function — assert two runs of `_date_diff_matrix` on the
+  same input are identical (guards against accidental N-dependence).
+- (Scale-invariance itself is proven by `scripts/qis_gate.py`, run in CI, not a unit test — see below.)
+
+**Impl / docs:**
+- `packages/python/goldenmatch/CLAUDE.md` — one bullet under Auto-Config: the `date_diff` comparator +
+  `GOLDENMATCH_FS_DOMAIN_COMPARATORS` flag (default off), pointing at the spec.
+- `config/schemas.py` `VALID_SCORERS` doc / any scorer list that mirrors it (grep `VALID_SCORERS` +
+  `SCORERS` const in `web/frontend/src/lib/types.ts` — **note only**, TS wiring is Phase 4).
+- `parity/goldenmatch.yaml` — add `date_diff` to the `scorers` surface and to
+  `scorer_kernels_deferred` with `deferred -- native score-core kernel is Phase 3` (so
+  `check_scorer_coverage` passes: a scorer with no kernel must be classified).
+
+**Commit:** `docs(fs): date_diff comparator flag + scorer-coverage deferral`
+
+---
+
+## Out-of-band validation (not unit tests — run before flipping the default, Phase 4)
+
+- **Accuracy:** `scripts/bench_er_headtohead` off-vs-on on historical_50k / febrl3 / synthetic /
+  dblp_acm via `compare_panels.py`. Gate: no F1 regression anywhere, measurable lift on ≥1 DOB set.
+- **Scale-neutrality:** `python scripts/qis_gate.py` (or the `bench-quality-scale.yml` lane) at
+  50K/100K/500K/1M with the flag ON — assert scale-invariance + absolute-floor hold and wall/peak-RSS
+  are within noise of OFF. This is the measured proof of the spec's structural claim.
+- **Oversized blocks:** `bench-probabilistic` panel unchanged (guard).
+
+## Definition of done (Phase 1)
+
+- `date_diff` usable via explicit config on every FS route (scalar / vectorized / bucket), native-absent
+  fallback correct; scalar == vectorized parity gated.
+- Auto-config emits it for `date` columns only under `GOLDENMATCH_FS_DOMAIN_COMPARATORS=1`; default OFF
+  is byte-identical to today.
+- `check_scorer_coverage` green (deferred kernel entry); full pytest green.
+- Spec's scale claim has a runnable proof (`qis_gate` with the flag on).

--- a/docs/superpowers/specs/2026-07-23-fs-domain-comparators-design.md
+++ b/docs/superpowers/specs/2026-07-23-fs-domain-comparators-design.md
@@ -1,0 +1,179 @@
+# FS domain comparators (date / numeric / geo), scale-neutral by construction
+
+**Status:** draft (design)
+**Date:** 2026-07-23
+**Scope:** the probabilistic (Fellegi-Sunter) path only. No change to weighted/DQbench.
+
+## Problem
+
+FS comparison levels are assigned from a single **generic string similarity** (`_levels_from_similarity`
+buckets one number in [0,1]). Auto-config v2 admits `date` columns as `levenshtein` — a crude proxy:
+`levenshtein("1990-01-02","1991-01-02")` is ~0.9 (looks like near-agreement) while `"1990-01-02"` vs
+`"1990-02-01"` (day/month transposition — a common data-entry error, *should* be a strong partial) is
+also ~0.8. The comparator can't see that one pair is 365 days apart and the other is a transposition.
+The same blindness applies to numeric fields (no absolute/percentage bands) and lat/long (string
+similarity on coordinates is meaningless; haversine distance is the signal). This is Splink's single
+biggest quality lever and where GM is weakest, most visibly on person/DOB data (historical_50k, NCVR
+birth_year) and any geo-bearing set.
+
+## Hard constraint: it cannot affect the scale story
+
+Scale-invariant correctness is the north star (the QIS gate, bounded memory, the 100M-in-9.2min
+envelope). A quality change qualifies **only if** it leaves the pair set, memory footprint, EM shape,
+clustering, and the distributed/native path unchanged. This design is chosen precisely because it
+satisfies that by construction — see "Scale-neutrality proof" below. The alternative quality lever
+(global transitivity-aware clustering / correlation clustering) was **rejected for exactly this
+reason**: it needs the full weighted graph with driver-side materialization — the wall
+`two_phase_wcc` hits when it "collects to driver and wedges the head at 100M" — so connected-components
+stays the only clustering that survives the envelope. Comparators do not touch clustering at all.
+
+## Definition
+
+A **domain comparator** is a scorer that maps a *domain distance* between two parsed values to a
+monotone graded similarity in `[0,1]`, so the existing level machinery (`comparison_vector` +
+`_levels_from_similarity` + `level_thresholds`) buckets it identically to every other scorer. It is
+**not** a new code path — it is a new entry in the scorer routing that already exists in two mirrored
+places:
+
+- scalar / EM E-step: `score_field(val_a, val_b, scorer)` (used by `comparison_vector`, `probabilistic.py:498`)
+- vectorized block: `_field_score_matrix(vals, scorer)` → `_exact_/_soundex_/_fuzzy_score_matrix`
+  (`probabilistic.py:2426`), with `_field_score_matrix_dedup` distinct-value collapse in front.
+
+Both feed the SAME thresholds → the SAME m/u levels → the SAME weights. A comparator that returns a
+`[0,1]` monotone similarity requires **zero** change to EM, weighting, calibration, missing-handling,
+TF, monotonicity enforcement, or clustering.
+
+### The three comparators
+
+1. **`date_diff`** — parse both operands to an ordinal day count; distance = `|days_a − days_b|`.
+   Similarity is a monotone non-increasing step over day-bands, tuned for person data:
+   `same day → 1.0`, `≤1 day → 0.92`, `≤31 days → 0.80`, `≤366 days → 0.60`, `≤~5y → 0.30`, else `0.0`.
+   Transposition guard: if the day/month swap (`YYYY-DD-MM`) yields distance 0, floor similarity at the
+   `≤31-day` band (a MM/DD transposition is a partial, not a disagree). Unparseable / null → `None`
+   (→ level −1/0 per `fs_missing_mode`), preserving today's missing semantics.
+
+2. **`numeric_diff`** — parse to `float64`; `numeric_diff:abs:<eps>` (absolute band) or
+   `numeric_diff:pct:<frac>` (relative band, `|a−b| / max(|a|,|b|,ε)`). Monotone: `0 → 1.0`, within band
+   → graded, beyond → `0.0`. Handles measurements, amounts, ages.
+
+3. **`geo_haversine`** — parse a `lat,long` pair (or two paired fields via a `record`-style concat);
+   great-circle distance in km; monotone bands (`≤0.1km → 1.0`, `≤1km → 0.85`, `≤10km → 0.5`, …).
+
+Bands are the *defaults*; a user (or auto-config) can override with explicit `level_thresholds` — the
+comparator returns the raw graded similarity and the existing `level_thresholds` path buckets it, so the
+knob surface is unchanged.
+
+### Name transposition — explicitly deferred
+
+Cross-column name swap (`first_a==last_b ∧ last_a==first_b`) and "one name is the initial of the other"
+are **cross-field**, so they don't fit the single-field `score_field(a,b,scorer)` signature; they need a
+composite comparator or a post-level bump reaching two columns. Auto-config v2 already drops redundant
+name *composites* (the correlated-comparison fix), which captures part of this. Transposition is a
+separate, higher-cost design (its own field-pair comparator) and is out of scope here — noted so the
+comparator work isn't blocked on it.
+
+## Where each comparator plugs in (the full wiring checklist)
+
+Mirrors how `soundex_match` (a scorer with a numpy matrix but **no** native kernel) already threads the
+system, so the bucket planner and fallbacks are known-good:
+
+1. `config/schemas.py::VALID_SCORERS` — register the three names (+ the `:abs:`/`:pct:` suffix parse).
+2. `core/scorer.py` — `score_field` scalar branch + a `_date_diff_matrix` / `_numeric_diff_matrix` /
+   `_geo_haversine_matrix` (NxN, mirroring `_fuzzy_score_matrix`), routed from
+   `probabilistic._field_score_matrix`. The parse-once step (string → day-ordinal / float / (lat,long))
+   happens on the block's **distinct** values via the existing `_field_score_matrix_dedup` collapse, so
+   a constant/low-cardinality field parses O(distinct), not O(rows).
+3. `probabilistic.vectorized_scorer_supported` + `score_buckets._VEC_SUPPORTED` — add the three so the
+   vectorized/bucket lanes take them (else they fall back to the per-pair loop, still correct).
+4. `core/autoconfig.py::build_probabilistic_matchkeys` (behind `_fs_autoconfig_v2_enabled()` + a new
+   sub-flag `GOLDENMATCH_FS_DOMAIN_COMPARATORS`, default OFF until the panel proves it): replace the
+   `date → levenshtein` admission with `date → date_diff`; admit detected `lat/long` as `geo_haversine`;
+   admit numeric-identity-ish columns as `numeric_diff`. Requires a lat/long `col_type` (today
+   `_GEO_PATTERNS` matches zip/city, not coordinates — small classifier add).
+5. **Native parity (the thesis path):** add `date_diff` / `numeric_diff` / `geo_haversine` string
+   kernels to `goldenmatch-score-core` (pyo3-free) + register in `native/src/lib.rs`
+   (`wrap_pyfunction!`), so the `bucket`/native route is byte-parity with the pure path. Until the
+   kernel ships, the scorer runs the numpy matrix (native-absent fallback), exactly like
+   `soundex_match` — so this is NOT a blocking dependency, and it satisfies `check_native_symbols` /
+   `check_scorer_coverage` (the new scorers go in `scorer_kernels` once kerneled, or
+   `scorer_kernels_deferred` with a `deferred --` reason meanwhile).
+6. TS parity (`packages/typescript/goldenmatch`) — follow-up, mirror the bands (parity harness).
+
+## Scale-neutrality proof (the point of the design)
+
+Each claim is structural, not empirical:
+
+- **Pair set unchanged.** Comparators live at the comparison-vector cell, *inside* a block. Blocking,
+  candidate generation, and the `bucket` route are untouched → identical blocks, identical pairs at
+  every scale. The QIS scale-invariance check (a larger rung's F1 must not fall below the smallest
+  rung's) holds **by construction**: a comparator's output depends only on the two values, never on N,
+  so its behavior at 1M is identical to 1K.
+- **Memory footprint unchanged / lower.** The parsed representation (day-ordinal `int32`, `float64`,
+  or two `float64`) is *narrower* than the source string, and parsing runs over `_field_score_matrix_dedup`
+  distinct values — no new wide frame, no new driver-resident accumulator. The FS memory peaks
+  (`build_blocks` for EM, `score_buckets` frame-residency) are unaffected: the block frames and their
+  width are the same; only the per-cell scalar computation changes.
+- **EM shape unchanged.** EM trains on the same sampled blocks (`GOLDENMATCH_FS_EM_SAMPLE_ROWS` cap);
+  the comparator only changes the similarity→level mapping fed to the identical m-estimation loop. No
+  extra passes, no extra sampling.
+- **Clustering unchanged.** Still connected-components (union-find / native `connected_components`) over
+  pairs above `link_threshold`, MST split for oversized. Comparators change *which* pairs clear the
+  threshold (accuracy), never *how* clustering scales.
+- **Distributed / native path unchanged.** No new driver materialization; the scorer dispatches
+  per-field the same way; native-absent falls back to numpy (bucket-compatible). Nothing crosses the
+  Ray boundary that didn't before.
+- **cost is per-cell arithmetic, and cheaper.** A day-difference or float-subtract is *less* work than
+  a `levenshtein` FFI call — so the scoring wall does not rise; if anything it drops on date/numeric
+  fields.
+
+Net: the change is confined to the value→similarity function. It can move F1 (the goal) but is
+*mechanically incapable* of moving the pair count, the memory gates, or the scale-invariance gate.
+
+## Correctness / gotchas
+
+- **Monotonicity.** Similarity must be non-increasing in distance so `enforce_weight_monotonicity`
+  (isotonic) and the level ordering stay well-behaved. Banded step functions are monotone by
+  construction.
+- **Missing = None, preserved.** Parse failure or null → `score_field` returns `None` → level −1
+  (unobserved) or 0 per `fs_missing_mode`. A comparator must return `None`, never a sentinel distance,
+  on unparseable input — otherwise a garbage date reads as a strong disagree instead of no-evidence.
+- **Determinism + parity.** Native == pure byte-parity is the merge gate (mirror
+  `tests/test_native_bloom_parity.py`); the numpy matrix == scalar `score_field` parity is asserted
+  scorer-by-scorer like `_VEC_SUPPORTED` today.
+- **TF interaction.** TF adjustment fires only on the exact-agreement top level; a `date_diff` exact
+  agreement can still take TF if the field is skewed (rare exact DOB), or opt out — no special-casing
+  needed, it flows through `_apply_tf_adjustment` unchanged.
+- **Default OFF at ship.** `GOLDENMATCH_FS_DOMAIN_COMPARATORS=0` is byte-identical to today
+  (auto-config keeps `date → levenshtein`); flip only on measured panel + QIS non-regression, per the
+  v2-flag precedent.
+
+## Benchmark plan
+
+1. **Accuracy panel** (the standing FS harness): `scripts/bench_er_headtohead` on Febrl3,
+   historical_50k, synthetic, dblp_acm, with a `comparators-off vs -on` diff
+   (`compare_panels.py`, mirroring the `panel-v1-v2` lane). DOB-heavy sets (historical_50k, NCVR
+   birth_year) are where `date_diff` should show the largest lift; dblp_acm should be flat (no dates).
+   Ship gate: no F1 regression on any panel dataset, measurable lift on ≥1 DOB set.
+2. **Scale-neutrality gate** (`scripts/qis_gate.py`): run the 50K/100K/500K/1M matrix with comparators
+   ON; assert (a) scale-invariance still holds, (b) absolute-floor holds, (c) wall + peak RSS within
+   noise of comparators-OFF. This is the explicit proof the design's structural claim survives
+   measurement.
+3. **Oversized-block behavior** (`bench-probabilistic` panel) — unchanged expectation; comparators
+   don't touch block sizing, so this is a guard, not a target.
+4. **Native parity** once kerneled: `native == pure` on a date/numeric/geo fixture in the native lane.
+
+## Phased delivery
+
+- **Phase 1:** `date_diff` (scalar + numpy matrix + parse-on-distinct) + `VALID_SCORERS` + vectorized
+  support + auto-config `date` admission behind the flag. Accuracy panel + QIS gate. Highest-value,
+  smallest surface.
+- **Phase 2:** `numeric_diff` + `geo_haversine` (incl. the lat/long `col_type` classifier).
+- **Phase 3:** native score-core kernels for all three (byte-parity gate) → `scorer_kernels`.
+- **Phase 4:** TS parity port; flip the default after the panel + QIS non-regression.
+- **Deferred:** name transposition (cross-field comparator, separate design).
+
+## Non-goals
+
+- Not touching the weighted/DQbench path or the clustering algorithm.
+- Not a global relational/collective resolution change (that's the scale-hostile lever we rejected).
+- Not name-transposition (cross-field, separate design).


### PR DESCRIPTION
## What and why

Design doc + TDD implementation plan for adding **domain comparators** to the Fellegi-Sunter path — `date_diff`, `numeric_diff`, `geo_haversine` — the biggest FS accuracy lever GM is missing (auto-config v2 currently admits dates as `levenshtein`, which can't see that two DOBs are 365 days apart or a MM/DD transposition).

**Docs only** — no code in this PR. Opened for review of the approach before implementation.

## The core idea (and why it's scale-safe)

A comparator is **just a new scorer**: a function mapping a domain distance to a monotone `[0,1]` similarity, which slots into the two routing points that already exist (`score_field` for scalar/EM, `_field_score_matrix` for the vectorized block) and then flows through the identical level → m/u → weight → calibration machinery. Nothing else changes.

Because it lives at the comparison-vector cell *inside* a block, it is **mechanically incapable of moving the scale story**:
- **Pair set unchanged** — blocking and the `bucket` route are untouched; the QIS scale-invariance check holds by construction (a comparator's output depends only on the two values, never on N).
- **Memory ≤ today** — the parsed form (`int32` day-ordinal / `float64`) is narrower than the source string, parsed on `_field_score_matrix_dedup` distinct values; the FS peaks (`build_blocks`, `score_buckets` residency) are the same frames.
- **EM / clustering / distributed unchanged** — same sampled blocks, same connected-components + MST split, no new driver materialization; native-absent falls back to numpy like `soundex_match`.
- **Cheaper per cell** than a `levenshtein` FFI call.

The spec also records **why the alternative quality lever (global transitivity-aware / correlation clustering) was rejected**: it needs the full weighted graph with driver-side materialization — the exact wall `two_phase_wcc` hits at 100M — so it's disqualified, and survives only as bounded per-component refinement.

## Contents

- **Spec** `docs/superpowers/specs/2026-07-23-fs-domain-comparators-design.md` — the three comparators, the wiring checklist (mirrors `soundex_match`'s known-good threading), the structural scale-neutrality proof, and a benchmark plan that pairs the `bench_er_headtohead` accuracy panel with a mandatory `qis_gate.py` run at 50K/100K/500K/1M.
- **Plan** `docs/superpowers/plans/2026-07-23-fs-domain-comparators-phase1-date-diff.md` — 6 TDD tasks shipping `date_diff` alone (scalar + vectorized numpy matrix + auto-config admission behind `GOLDENMATCH_FS_DOMAIN_COMPARATORS`, default OFF), with exact file anchors (`scorer.py:173`, `schemas.py:21`, `score_buckets.py:117`, `build_probabilistic_matchkeys`) and the out-of-band validation gates.

## Delivery posture

Ships default-OFF; flip only on measured panel lift + QIS non-regression, per the `GOLDENMATCH_FS_AUTOCONFIG_V2` flag precedent. Phase 1 = `date_diff`; numeric/geo, native score-core kernels, and TS parity are later phases. Name-transposition is explicitly deferred (cross-field, separate design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015u3r4roZbcnw1HZTxNQ5Sv)_