### PR TITLE
bench: answer-time passage_k override to enable the hybrid passage_k sweep

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -324,6 +324,22 @@ measurement is clean) came back **flat-to-mixed**: `answer_match` **0.4700 → 0
   stays unchanged. If a future corpus/model resurfaces a graph-only precision gap under hybrid,
   the env-A/B here is the way to re-test before re-adding the clause.
 
+## Hybrid passage_k sweep — default 10 is optimal (2026-07-23)
+How many passages hybrid retrieves per question (`passage_k`, default 10) is the retrieval-BREADTH
+knob. MuSiQue/2wiki/hotpot corpora build one Document PER PARAGRAPH (`corpora.py`/`wiki_corpus.py`),
+so there is no finer chunking lever — breadth is the whole of it. The bench engine's `answer()` gained
+an ANSWER-time `GOLDENGRAPH_QA_PASSAGE_K` override (mirroring `GOLDENGRAPH_QA_ANSWER_MODE`) so the
+same-graph env-A/B can sweep it over ONE shared build (unset/invalid -> configured default, byte-identical).
+- **MEASURED (env_ab `GOLDENGRAPH_QA_PASSAGE_K:3,5,10,20`, MuSiQue N=100, one hybrid build, judge on,
+  run 29982270929; `support_recall` 0.8425 identical across all 4 arms = the control):** answer_match
+  0.37 (k=3) -> 0.42 (k=5) -> **0.44 (k=10)** -> 0.43 (k=20); token_f1 0.442 -> 0.485 -> **0.501** -> 0.497.
+  A clear inverted-U peaking at **k=10**: too few passages miss supporting context, too many add
+  distractor noise. (MuSiQue ships 10 context paragraphs/question — 2 supporting + 8 distractor — so
+  k~=10 ~= "one question's worth of context," which is why it's the knee.)
+- **DECISION: keep `passage_k=10` default (bench + library `ask()`), unchanged — it is optimal, not
+  beatable by a tighter/broader k here.** The value is the confirmation + the reusable sweep knob for a
+  future corpus/model. Re-sweep via `ab_env=GOLDENGRAPH_QA_PASSAGE_K:...` before changing the default.
+
 ## CHAT / embedding provider split (2026-07-22)
 `OpenAIClient._ensure_client` (`llm.py`) reads `GOLDENGRAPH_LLM_BASE_URL` /
 `GOLDENGRAPH_LLM_API_KEY` first, falling back to `OPENAI_BASE_URL` / `OPENAI_API_KEY`

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -302,6 +302,16 @@ class GoldenGraphQAEngine:
         retrieval_mode = (
             mode or (os.environ.get("GOLDENGRAPH_QA_ANSWER_MODE") or None) or self._retrieval_mode
         )
+        # Answer-time `passage_k` override so the generic env-A/B (run_engine_ab_env) can SWEEP how
+        # many passages hybrid retrieves per question over ONE shared build (e.g.
+        # `GOLDENGRAPH_QA_PASSAGE_K:3,5,10,20`). Read per-call (not just at __init__) so the flip
+        # takes effect inside `_env_overrides`; unset/invalid -> the engine's configured
+        # `self._passage_k` (byte-identical default). MuSiQue/2wiki docs are paragraph-granular, so
+        # this is the retrieval-BREADTH knob (granularity is fixed at one paragraph per Document).
+        try:
+            passage_k = int(os.environ["GOLDENGRAPH_QA_PASSAGE_K"])
+        except (KeyError, ValueError):
+            passage_k = self._passage_k
         t0 = time.perf_counter()
         before_in, before_out = self._synth_llm.input_tokens, self._synth_llm.output_tokens
         # `provenance_out` collects the source-doc ids of every edge the retrieval/traversal touched.
@@ -319,7 +329,7 @@ class GoldenGraphQAEngine:
             hops=self._retrieval_hops,
             node_budget=self._node_budget,
             passages=handle.get("passages"),
-            passage_k=self._passage_k,
+            passage_k=passage_k,
             query_schema=handle.get("query_schema"),
             provenance_out=provenance,
         )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_engine_answer_mode.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_engine_answer_mode.py
@@ -66,6 +66,44 @@ def test_empty_env_ignored(monkeypatch):
     assert seen["mode"] == "local"  # empty string is not a mode
 
 
+def _capture_passage_k(monkeypatch):
+    seen = {}
+
+    def _fake_ask(question, store, **kw):
+        seen["passage_k"] = kw.get("passage_k")
+        return "Answer: X"
+
+    monkeypatch.setattr("goldengraph.answer.ask", _fake_ask)
+    return seen
+
+
+def _engine_pk(passage_k):
+    return GoldenGraphQAEngine(llm=_Stub(), embedder=_Stub(), passage_k=passage_k)
+
+
+def test_passage_k_env_override_beats_configured(monkeypatch):
+    # GOLDENGRAPH_QA_PASSAGE_K is an ANSWER-time override so run_engine_ab_env can sweep it over
+    # ONE shared build. The engine was constructed with passage_k=10; the env flips it per call.
+    seen = _capture_passage_k(monkeypatch)
+    monkeypatch.setenv("GOLDENGRAPH_QA_PASSAGE_K", "3")
+    _engine_pk(10).answer(_HANDLE, "q?")
+    assert seen["passage_k"] == 3
+
+
+def test_passage_k_unset_uses_configured(monkeypatch):
+    seen = _capture_passage_k(monkeypatch)
+    monkeypatch.delenv("GOLDENGRAPH_QA_PASSAGE_K", raising=False)
+    _engine_pk(7).answer(_HANDLE, "q?")
+    assert seen["passage_k"] == 7  # byte-identical default path
+
+
+def test_passage_k_invalid_env_falls_back(monkeypatch):
+    seen = _capture_passage_k(monkeypatch)
+    monkeypatch.setenv("GOLDENGRAPH_QA_PASSAGE_K", "notanint")
+    _engine_pk(10).answer(_HANDLE, "q?")
+    assert seen["passage_k"] == 10  # non-int env is ignored, not a crash
+
+
 def test_engine_default_retrieval_mode_is_hybrid(monkeypatch):
     # Ship 2026-07-22: the bench engine now defaults to hybrid (GOLDENGRAPH_QA_MODE
     # unset), so build_kg indexes passages and answer() uses hybrid synthesis by


### PR DESCRIPTION
## What and why

Follow-up to the hybrid confirmation (#2 lever). Adds the answer-time `passage_k` override that lets the same-graph env-A/B sweep retrieval **breadth** over one build, and records the sweep result.

## Changes

- **`engines/goldengraph.py`**: `answer()` resolves `passage_k` from `GOLDENGRAPH_QA_PASSAGE_K` per call (mirroring `GOLDENGRAPH_QA_ANSWER_MODE`), falling back to configured `self._passage_k` when unset/invalid — byte-identical for non-sweep callers. Enables `ab_env=GOLDENGRAPH_QA_PASSAGE_K:3,5,10,20`.
- **`goldengraph/CLAUDE.md`**: records the sweep finding.

## Result — default 10 is optimal

env-A/B `GOLDENGRAPH_QA_PASSAGE_K:3,5,10,20`, MuSiQue N=100, one hybrid build, judge on (run `29982270929`; `support_recall` **0.8425 identical across all 4 arms** = clean control):

| passage_k | answer_match | token_f1 |
|---|---|---|
| 3 | 0.3700 | 0.4416 |
| 5 | 0.4200 | 0.4852 |
| **10** | **0.4400** | **0.5008** |
| 20 | 0.4300 | 0.4967 |

Clear inverted-U peaking at **k=10** — too few passages miss supporting context, too many add distractor noise. The current default is optimal; **no default change**. (MuSiQue ships 10 context paragraphs/question, so k≈10 ≈ one question's worth of context.)

## Scope note

MuSiQue / 2WikiMultiHop / HotpotQA build one Document per paragraph, so there is no finer chunking lever — `passage_k` (breadth) is the whole of #3. The override stays as reusable sweep infrastructure for a future corpus/model.

## Testing

- `pytest .../er-kg-bench/tests/test_engine_answer_mode.py` → 8 pass; `ruff` clean.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [ ] `pre-commit run --all-files` is clean
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5