### PR TITLE
feat(goldencheck): mine baseline FDs via the native kernels, not per-pair Polars

### DIFF
--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -7665,7 +7665,8 @@
           ],
           "imports": [
             "goldencheck._polars_lazy",
-            "goldencheck.baseline.models"
+            "goldencheck.baseline.models",
+            "goldencheck.core.kernels"
           ]
         },
         {
@@ -8951,6 +8952,7 @@
           "defines": [
             "FunctionalDependencyProfiler",
             "_discover_python",
+            "_discover_strict_ids",
             "_select_candidates"
           ],
           "imports": [

--- a/packages/python/goldencheck/CHANGELOG.md
+++ b/packages/python/goldencheck/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to GoldenCheck will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- **Baseline functional-dependency mining runs the native-gated FD kernels
+  instead of a per-pair Polars `group_by`.** `baseline/constraints.py` now feeds
+  its candidate columns to the strict (`discover_functional_dependencies`) and
+  approximate (`discover_approximate_fds`) kernels — the same native-gated,
+  single-source kernels `relations/` already uses — so the compute is Rust when
+  `goldencheck[native]` is installed and a pure-Python (Polars-free) fallback
+  otherwise; the Polars engine is out of the FD-mining path (a step in the
+  Polars eviction). Two behavior refinements fall out of the shared kernels: a
+  **unique/near-unique determinant no longer produces a spurious FD** (the old
+  `group_by` scored it at confidence 1.0 for trivially "determining" every
+  column; the strict pass skips it), and the approximate pass applies the shared
+  average-group-size guard. Genuine strict and approximate dependencies are
+  discovered unchanged. As a side effect, the `core.kernels`
+  `discover_functional_dependencies` fallback is now Polars-free too.
+
 ### Added
 
 - **`profile`, `health-score`, and `list-domains` CLI commands (TS parity).** The

--- a/packages/python/goldencheck/goldencheck/baseline/constraints.py
+++ b/packages/python/goldencheck/goldencheck/baseline/constraints.py
@@ -5,6 +5,10 @@ import logging
 
 from goldencheck._polars_lazy import pl
 from goldencheck.baseline.models import FunctionalDependency, TemporalOrder
+from goldencheck.core.kernels import (
+    discover_approximate_fds,
+    discover_functional_dependencies,
+)
 
 __all__ = ["mine_constraints"]
 
@@ -58,8 +62,23 @@ def _mine_functional_dependencies(
     df: pl.DataFrame,
     min_confidence: float,
 ) -> list[FunctionalDependency]:
-    """Return merged FDs with confidence >= *min_confidence*."""
-    # Select the 30 lowest-cardinality columns to avoid O(2^n) blowup.
+    """Return merged FDs with confidence >= *min_confidence*.
+
+    Runs the native-gated FD kernels over the candidate columns instead of a
+    per-pair Polars ``group_by``: the strict pass (``discover_functional_dependencies``,
+    confidence 1.0) and the approximate pass (``discover_approximate_fds``,
+    confidence in ``[min_confidence, 1.0)`` = ``1 - violations/n_rows``) together
+    cover the ``>= min_confidence`` range. The Rust kernel interns each column
+    once and reuses it across every pair (early-exit on the first violation for
+    the strict pass); the no-native fallback does its distinct-/mode-counting in
+    pure Python. Either way the FD-mining compute leaves the Polars engine (the
+    baseline module's Polars-eviction step) — only candidate selection still
+    inspects the frame. The strict pass also drops the trivial FDs a
+    ``group_by`` counted as confidence 1.0 (a unique determinant "determines"
+    every column), and the approximate pass applies the shared average-group-size
+    guard, so near-unique determinants no longer surface spurious dependencies.
+    """
+    # Select the 30 lowest-cardinality columns to avoid O(k^2) blowup.
     cardinalities: list[tuple[str, int]] = []
     for col in df.columns:
         n_unique = df[col].n_unique()
@@ -69,38 +88,24 @@ def _mine_functional_dependencies(
     # Sort ascending by cardinality and take up to _MAX_COLS.
     cardinalities.sort(key=lambda x: x[1])
     candidate_cols = [col for col, _ in cardinalities[:_MAX_COLS]]
+    if len(candidate_cols) < 2:
+        return []
 
     n_rows = len(df)
+    # Pull each candidate column out once (extraction, not compute) so the
+    # kernels run on plain Python lists — no Polars in the FD-mining path.
+    values = [df[c].to_list() for c in candidate_cols]
 
-    # Accumulate: determinant -> {dependent -> max_confidence}
+    # Accumulate: determinant -> {dependent -> max_confidence}. The strict and
+    # approximate passes are disjoint by construction (0 vs >=1 violations).
     det_to_deps: dict[str, dict[str, float]] = {}
-
-    for det in candidate_cols:
-        for dep in candidate_cols:
-            if det == dep:
-                continue
-
-            # Confidence = fraction of rows where the dependent value matches
-            # the most frequent dependent value for that determinant group.
-            # This is the standard TANE/approximate-FD definition and handles
-            # cases where a single group has a few exceptions gracefully.
-            grouped = (
-                df.select([det, dep])
-                .group_by([det, dep])
-                .agg(pl.len().alias("_cnt"))
-                .group_by(det)
-                .agg(pl.col("_cnt").max().alias("_mode_cnt"))
-            )
-            consistent_count = grouped["_mode_cnt"].sum()
-            confidence = consistent_count / n_rows
-
-            if confidence >= min_confidence:
-                if det not in det_to_deps:
-                    det_to_deps[det] = {}
-                # Keep the highest confidence seen for this dep.
-                prev = det_to_deps[det].get(dep, 0.0)
-                if confidence > prev:
-                    det_to_deps[det][dep] = confidence
+    for i, j in discover_functional_dependencies(values):
+        det_to_deps.setdefault(candidate_cols[i], {})[candidate_cols[j]] = 1.0
+    for i, j, viol in discover_approximate_fds(values, min_confidence):
+        confidence = 1.0 - viol / n_rows
+        dep_map = det_to_deps.setdefault(candidate_cols[i], {})
+        if confidence > dep_map.get(candidate_cols[j], 0.0):
+            dep_map[candidate_cols[j]] = confidence
 
     # Merge: for each determinant, combine all dependent columns into one FD.
     # Use the minimum confidence across dependents (most conservative).

--- a/packages/python/goldencheck/goldencheck/core/kernels.py
+++ b/packages/python/goldencheck/goldencheck/core/kernels.py
@@ -120,14 +120,11 @@ def discover_functional_dependencies(
                 (int(i), int(j))
                 for i, j in native_module().discover_functional_dependencies(arrays)
             ]
-        except Exception:  # noqa: BLE001 - any native failure -> Polars path
+        except Exception:  # noqa: BLE001 - any native failure -> pure-Python path
             pass
-    from goldencheck._polars_lazy import pl
-    from goldencheck.relations.functional_dependency import _discover_python
+    from goldencheck.relations.functional_dependency import _discover_strict_ids
 
-    names = [f"c{i}" for i in range(len(cols))]
-    df = pl.DataFrame({n: c for n, c in zip(names, cols)})
-    return _discover_python(df, names, df.height)
+    return _discover_strict_ids(cols, len(cols[0]) if cols else 0)
 
 
 # ── approximate functional dependencies ──────────────────────────────────────

--- a/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
+++ b/packages/python/goldencheck/goldencheck/relations/functional_dependency.py
@@ -50,6 +50,30 @@ def _select_candidates(frame, n_rows: int) -> list[str]:
     return [c for _nu, c in scored[:_MAX_CANDIDATES]]
 
 
+def _discover_strict_ids(cols_values: list[list], n_rows: int) -> list[tuple[int, int]]:
+    """List-based, Polars-free strict FD discovery: ``det -> dep`` holds iff
+    ``n_distinct(det, dep) == n_distinct(det)``. Returns ``(det_idx, dep_idx)``
+    pairs into ``cols_values``; skips trivial pairs (unique determinant, constant
+    dependent) identically to the kernel.
+
+    This is the shared compute core: the frame-based :func:`_discover_python`
+    below delegates to it after pulling columns to lists, and
+    ``core.kernels.discover_functional_dependencies`` calls it directly on its
+    list input — so the fallback never routes through the Polars engine (the
+    baseline / relations Polars-eviction discipline)."""
+    distinct = [len(set(c)) for c in cols_values]
+    out: list[tuple[int, int]] = []
+    for i in range(len(cols_values)):
+        if distinct[i] == n_rows:  # unique determinant -> trivial
+            continue
+        for j in range(len(cols_values)):
+            if i == j or distinct[j] <= 1:
+                continue
+            if len(set(zip(cols_values[i], cols_values[j]))) == distinct[i]:
+                out.append((i, j))
+    return out
+
+
 def _discover_python(frame, cols: list[str], n_rows: int) -> list[tuple[int, int]]:
     """Polars-free mirror of the kernel: det->dep holds iff
     n_distinct(det, dep) == n_distinct(det). Skips trivial pairs identically.
@@ -61,18 +85,8 @@ def _discover_python(frame, cols: list[str], n_rows: int) -> list[tuple[int, int
     a safety net). Values are pulled out of the Polars frame once with
     ``to_list``; the engine no longer runs the distinct counts."""
     frame = to_frame(frame)
-    lists = {c: frame.column(c).to_list() for c in cols}
-    distinct = {c: len(set(lists[c])) for c in cols}
-    out: list[tuple[int, int]] = []
-    for i, det in enumerate(cols):
-        if distinct[det] == n_rows:  # unique determinant -> trivial
-            continue
-        for j, dep in enumerate(cols):
-            if i == j or distinct[dep] <= 1:
-                continue
-            if len(set(zip(lists[det], lists[dep]))) == distinct[det]:
-                out.append((i, j))
-    return out
+    values = [frame.column(c).to_list() for c in cols]
+    return _discover_strict_ids(values, n_rows)
 
 
 class FunctionalDependencyProfiler:

--- a/packages/python/goldencheck/tests/baseline/test_constraints.py
+++ b/packages/python/goldencheck/tests/baseline/test_constraints.py
@@ -94,6 +94,22 @@ def test_no_fd_on_random_data():
     assert fds == [], f"Expected no FDs on random data, got: {fds}"
 
 
+def test_unique_determinant_not_reported_as_fd():
+    """A unique determinant trivially "determines" every other column, but that
+    is a spurious FD. The native-kernel path (strict pass) skips unique
+    determinants, so — unlike the old per-pair ``group_by`` miner, which scored
+    them at confidence 1.0 — the unique ``noise`` column yields no FD, while the
+    genuine ``zip_code -> city`` dependency is still discovered."""
+    df = _zip_city_df(200)  # includes noise = range(200), a unique determinant
+    fds, _, _ = mine_constraints(df, min_confidence=0.95)
+    assert not any(
+        fd.determinant == ["noise"] for fd in fds
+    ), f"unique determinant should not yield an FD, got: {fds}"
+    assert any(
+        "zip_code" in fd.determinant and "city" in fd.dependent for fd in fds
+    ), f"expected zip_code->city FD to survive, got: {fds}"
+
+
 def test_fds_merged_same_determinant():
     """A->B and A->C should be merged into a single FD A->[B,C]."""
     # state_code -> city AND state_code -> region both hold


### PR DESCRIPTION
## What and why

The baseline constraint miner (`baseline/constraints.py::_mine_functional_dependencies`) reimplemented approximate-FD mining as a **per-pair Polars `group_by` loop** that touched no native kernel — unlike its sibling `relations/approx_fd.py`, which already dispatches to the native `discover_approximate_fds`. It was the one FD path in goldencheck still doing its compute in the Polars engine. This routes it through the shared, native-gated kernels, closing that gap and advancing the Polars-eviction discipline.

## Changes

- **`baseline/constraints.py`** — replace the per-pair `group_by` with the shared `core.kernels` FD entry points:
  - strict pass → `discover_functional_dependencies` (confidence 1.0)
  - approximate pass → `discover_approximate_fds(min_confidence)` (confidence `1 − viol/n`)

  Together they cover the `>= min_confidence` range. Compute is Rust when `goldencheck[native]` is installed, pure-Python (Polars-free) fallback otherwise. Candidate selection still inspects the frame; only the compute changed.
- **`relations/functional_dependency.py`** — extract a list-based, Polars-free `_discover_strict_ids`; the frame-based `_discover_python` delegates to it.
- **`core/kernels.py`** — point the `discover_functional_dependencies` fallback at `_discover_strict_ids` (it previously built a transient `pl.DataFrame`), so that fallback — shared with the DuckDB/Postgres SQL surfaces — now works without Polars too.

### Behavior refinements (from using the shared kernels)

- A **unique/near-unique determinant no longer produces a spurious FD**. The old `group_by` scored it at confidence 1.0 (a unique column trivially "determines" every other column); the strict pass skips it.
- The approximate pass applies the shared average-group-size guard.
- Genuine strict + approximate dependencies are discovered unchanged.

## Testing

- `pytest packages/python/goldencheck` — **838 passed, 526 skipped** (skips are native/optional-dep gated)
- New `test_unique_determinant_not_reported_as_fd` locks the no-spurious-FD guarantee
- Verified fallback output on a strict+approx+unique-determinant frame: `city→zip` (1.0), `zip→city` (0.995), and **no** `noise→…` spurious FD
- `ruff check` clean on all changed files
- Native↔fallback equality for the underlying kernels is already gated by `tests/core/test_kernels.py` + `test_native_parity.py`; the baseline miner calls those kernels, and CI's native lane runs `test_constraints.py` against the built wheel
- `check_api_parity.py goldencheck` — OK (internal change, no surface delta)

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] Package `CHANGELOG.md` updated (behavior change documented under `[Unreleased]`)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a — no workflow change; CHANGELOG covers the behavior note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_