### PR TITLE
docs: generate + gate the api-surface capability matrix (no more version drift)

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -427,6 +427,14 @@ config_matrix:
   - 'scripts/test_suite_matrix.py'
   - 'docs-site/suite-matrix.mdx'
   - 'docs-site/*/recipes.mdx'
+  # Reference api-surface capability matrix: the generated table reads the package
+  # versions (pyproject / package.json) + MCP counts (parity manifests), so a
+  # version bump or a manifest change must re-run its --check.
+  - 'scripts/gen_api_surface.py'
+  - 'scripts/test_api_surface.py'
+  - 'docs-site/reference/api-surface.mdx'
+  - 'packages/python/*/pyproject.toml'
+  - 'packages/typescript/*/package.json'
   - 'parity/*.yaml'
   - '.github/workflows/ci.yml'
   - '.github/filters.yml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3533,7 +3533,7 @@ jobs:
         run: uv sync --all-packages --no-install-package goldenmatch-native --no-install-package goldenflow-native
       - name: Gate unit tests (determinism + markers; run once)
         if: matrix.package == 'goldenmatch'
-        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py -q
+        run: uv run pytest scripts/test_config_matrix.py scripts/test_agent_codemap.py scripts/test_docs_sections.py scripts/test_api_surface.py -q
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"
@@ -3557,6 +3557,7 @@ jobs:
         run: |
           uv run python scripts/gen_suite_matrix.py --check
           uv run pytest scripts/test_suite_matrix.py -q
+          uv run python scripts/gen_api_surface.py --check
         env:
           POLARS_SKIP_CPU_CHECK: "1"
           GOLDENMATCH_NATIVE: "0"

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -22,14 +22,16 @@ What each package ships, at a glance. **MCP** counts are the Python server's too
 (the TS server exposes a subset). A dash means the package does not ship that
 surface.
 
+{/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
 | [GoldenMatch](#goldenmatch) | `3.8.0` | `1.4.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.5.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
-| [GoldenFlow](#goldenflow)   | `2.1.0` | `0.16.0` | `goldenflow`  | 10 | ✓ | ✓ | wheel |
-| [GoldenPipe](#goldenpipe)   | `1.4.0` | `0.3.0` | `goldenpipe`  | 4  | ✓ | ✓ | core (WASM) |
+| [GoldenFlow](#goldenflow) | `2.1.0` | `0.16.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
+| [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
 | [GoldenAnalysis](#goldenanalysis) | `0.4.0` | `0.1.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
-| [InferMap](#infermap)       | `0.6.0` | `0.6.0` | `infermap`    | 4  | — | — | wheel |
+| [InferMap](#infermap) | `0.6.0` | `0.6.0` | `infermap` | 4 | — | — | wheel |
+{/* api-surface-matrix:generated:end */}
 
 ## Install
 

--- a/scripts/gen_api_surface.py
+++ b/scripts/gen_api_surface.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Generate the CAPABILITY MATRIX table in docs-site/reference/api-surface.mdx.
+
+The api-surface page is mostly hand-written prose, but its capability matrix
+(per-package versions + MCP-tool counts) is pure drift-bait -- it sat stale by
+whole major versions until this gate. Only the marker-delimited TABLE is
+generated, and from STATIC sources so the block is byte-identical in every
+environment (the suite-matrix lesson: a live `import <pkg>.mcp.server` needs the
+[mcp] extra and flaps between the dev box and CI):
+
+  - Python version -> packages/python/<pkg>/pyproject.toml  [project].version
+  - TypeScript ver -> packages/typescript/<pkg>/package.json  .version
+  - MCP tool count -> parity/<pkg>.yaml  mcp_tools (shared + python_only) -- the
+                      same env-stable, api_parity-gated source suite-matrix uses
+  - A2A present    -> parity/<pkg>.yaml  a2a_skills present
+  - CLI / REST / Native-SQL -> the editorial META map below (a package gaining a
+                      REST service or a native wheel is a rare, reviewable event;
+                      one place in code beats a number buried in prose)
+
+`--check` also asserts the two inline figures that share the table's static source
+-- the GoldenMatch "**N MCP tools**" line and the coverage note "vs N Python" --
+so those can't drift from it. Two other inline numbers stay hand-maintained on
+purpose: the GoldenFlow "N built-in transforms" count (its registry is populated
+lazily, so a live `list_transforms()` flaps by import order -- the gen_suite_matrix
+live-import trap) and the note's "TS tools" figure (no static source without a
+built dist). Gating those would make the check non-deterministic; they are left as
+prose.
+
+Run:
+  python scripts/gen_api_surface.py --write    # regenerate the table block
+  python scripts/gen_api_surface.py --check     # CI drift gate
+"""
+from __future__ import annotations
+
+import json
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+MARKER_START = (
+    "{/* api-surface-matrix:generated:start -- DO NOT EDIT. "
+    "Regenerate: python scripts/gen_api_surface.py --write */}"
+)
+MARKER_END = "{/* api-surface-matrix:generated:end */}"
+
+ROOT = Path(__file__).resolve().parent.parent
+PAGE = ROOT / "docs-site" / "reference" / "api-surface.mdx"
+PARITY = ROOT / "parity"
+
+PKGS = ["goldenmatch", "goldencheck", "goldenflow", "goldenpipe", "goldenanalysis", "infermap"]
+DISPLAY = {
+    "goldenmatch": "GoldenMatch",
+    "goldencheck": "GoldenCheck",
+    "goldenflow": "GoldenFlow",
+    "goldenpipe": "GoldenPipe",
+    "goldenanalysis": "GoldenAnalysis",
+    "infermap": "InferMap",
+}
+
+# Editorial columns -- change rarely, reviewed here rather than buried in the mdx.
+#   rest:   ships a long-running REST HTTP service (the `<pkg> serve` service-shaped
+#           packages); GoldenAnalysis / InferMap are libraries + CLI + MCP only.
+#   native: the "Native / SQL" cell text. Update when a package gains/loses a native
+#           wheel, WASM core, or SQL extension (a `<pkg>-native` crate + publish
+#           workflow, a `-core` WASM, or the Postgres/DuckDB surfaces).
+META = {
+    "goldenmatch": {"rest": True, "native": "wheel · Postgres · DuckDB"},
+    "goldencheck": {"rest": True, "native": "wheel"},
+    "goldenflow": {"rest": True, "native": "wheel"},
+    "goldenpipe": {"rest": True, "native": "core (WASM)"},
+    "goldenanalysis": {"rest": False, "native": "core (WASM)"},
+    "infermap": {"rest": False, "native": "wheel"},
+}
+
+
+def _load_parity(pkg: str) -> dict:
+    import yaml
+
+    path = PARITY / f"{pkg}.yaml"
+    return yaml.safe_load(path.read_text(encoding="utf-8")) if path.exists() else {}
+
+
+def _py_version(pkg: str) -> str | None:
+    path = ROOT / "packages" / "python" / pkg / "pyproject.toml"
+    if not path.exists():
+        return None
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    return data.get("project", {}).get("version")
+
+
+def _ts_version(pkg: str) -> str | None:
+    path = ROOT / "packages" / "typescript" / pkg / "package.json"
+    if not path.exists():
+        return None
+    return json.loads(path.read_text(encoding="utf-8")).get("version")
+
+
+def _mcp(pkg: str) -> int:
+    body = _load_parity(pkg).get("mcp_tools") or {}
+    return len(body.get("shared", [])) + len(body.get("python_only", []))
+
+
+def _a2a(pkg: str) -> bool:
+    body = _load_parity(pkg).get("a2a_skills") or {}
+    return (len(body.get("shared", [])) + len(body.get("python_only", []))) > 0
+
+
+def render_table() -> str:
+    rows = [
+        "| Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |",
+        "|---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|",
+    ]
+    for p in PKGS:
+        rest = "✓" if META[p]["rest"] else "—"
+        a2a = "✓" if _a2a(p) else "—"
+        rows.append(
+            f"| [{DISPLAY[p]}](#{p}) | `{_py_version(p)}` | `{_ts_version(p)}` | `{p}` "
+            f"| {_mcp(p)} | {rest} | {a2a} | {META[p]['native']} |"
+        )
+    return "\n".join(rows)
+
+
+def render_block() -> str:
+    return f"{MARKER_START}\n{render_table()}\n{MARKER_END}"
+
+
+def _splice(page: str, block: str) -> str:
+    if MARKER_START not in page or MARKER_END not in page:
+        raise SystemExit(
+            f"{PAGE.relative_to(ROOT)} is missing the generated-table markers. "
+            "Add both marker comments around the capability-matrix table first."
+        )
+    i = page.index(MARKER_START)
+    j = page.index(MARKER_END) + len(MARKER_END)
+    return page[:i] + block + page[j:]
+
+
+def check() -> list[str]:
+    """Return a list of drift problems (empty == the page is current)."""
+    page = PAGE.read_text(encoding="utf-8") if PAGE.exists() else ""
+    problems: list[str] = []
+
+    if MARKER_START not in page or MARKER_END not in page:
+        return ["capability-matrix generated markers are missing from the page"]
+
+    current = page[page.index(MARKER_START) : page.index(MARKER_END) + len(MARKER_END)]
+    if current != render_block():
+        problems.append("the capability-matrix table block is stale vs the manifests")
+
+    # Inline figures derived from the SAME static source as the table (the parity
+    # MCP count), so they can't drift from it. Two other inline numbers -- the
+    # GoldenFlow transform count and the note's "TS tools" figure -- are left
+    # hand-maintained ON PURPOSE: neither has an env-stable static source (the
+    # goldenflow transform *registry* is populated lazily, so `list_transforms()`
+    # returns a different count depending on which submodules a process has
+    # imported -- 113 on a base import, more after deep imports -- and gating on a
+    # live import would flap by test order, the very trap gen_suite_matrix avoids;
+    # the TS-tools count needs a built dist). They stay prose.
+    mcp_gm = _mcp("goldenmatch")
+    if f"**{mcp_gm} MCP tools**" not in page:
+        problems.append(f"the inline GoldenMatch MCP-tools figure != {mcp_gm}")
+    if f"vs {mcp_gm} Python" not in page:
+        problems.append(f"the coverage-note 'vs N Python' MCP figure != {mcp_gm}")
+
+    return problems
+
+
+def main() -> int:
+    mode = sys.argv[1] if len(sys.argv) > 1 else "--check"
+    if mode == "--write":
+        page = PAGE.read_text(encoding="utf-8")
+        PAGE.write_text(_splice(page, render_block()), encoding="utf-8")
+        print(f"wrote {PAGE.relative_to(ROOT)}")
+        return 0
+    if mode == "--check":
+        problems = check()
+        if problems:
+            print(
+                f"{PAGE.relative_to(ROOT)} capability matrix is STALE vs the live surface. "
+                "Regenerate the table with: python scripts/gen_api_surface.py --write "
+                "(and update any flagged inline figure)."
+            )
+            for p in problems:
+                print(f"  - {p}")
+            return 1
+        print("api-surface.mdx OK: capability matrix matches the live surface.")
+        return 0
+    print(f"unknown mode {mode!r} (use --write / --check)")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_api_surface.py
+++ b/scripts/test_api_surface.py
@@ -1,0 +1,22 @@
+"""Gate: the api-surface capability matrix must match the live surface (versions +
+MCP counts from the manifests) and the inline figures that mirror it. Mirrors the
+`--check` CI run. Regenerate a stale table with:
+    python scripts/gen_api_surface.py --write
+"""
+from __future__ import annotations
+
+import gen_api_surface as g
+
+
+def test_api_surface_current():
+    problems = g.check()
+    assert problems == [], (
+        "docs-site/reference/api-surface.mdx capability matrix is stale vs the live "
+        "surface. Run: python scripts/gen_api_surface.py --write\n  - "
+        + "\n  - ".join(problems)
+    )
+
+
+def test_api_surface_table_deterministic():
+    # No set-ordering / addresses may leak into the generated block.
+    assert g.render_block() == g.render_block()


### PR DESCRIPTION
## What and why

The `reference/api-surface` capability matrix was hand-maintained and gated by **no** doc test, so its versions and MCP counts rotted (some by a whole major version — fixed by hand in #2053). This makes the drift-prone cells **generated + CI-gated** so they can't rot again. It's the durable fix for the branch's "docs consistency" goal.

## Changes

- **`scripts/gen_api_surface.py`** — marker-delimited generator for the capability table. Every cell comes from a **static, env-stable source** (following the `gen_suite_matrix` discipline — a live `import <pkg>.mcp.server` needs the `[mcp]` extra and flaps between the dev box and CI):
  - Python version ← `pyproject.toml [project].version`
  - TypeScript version ← `package.json .version`
  - MCP count ← `parity/<pkg>.yaml` `mcp_tools` (shared + python_only — the api_parity-gated source `suite-matrix` uses)
  - A2A presence ← parity `a2a_skills`
  - CLI / REST / Native-SQL ← one reviewed editorial `META` map

  `--check` also asserts the two inline figures that share the table's static source (GoldenMatch `**N MCP tools**` + the coverage note `vs N Python`).
- **`scripts/test_api_surface.py`** — currency + determinism gate (mirrors `test_suite_matrix.py`).
- **`docs-site/reference/api-surface.mdx`** — wrapped the table in generated markers (values unchanged; `--write` normalized whitespace).
- **`ci.yml`** — run `test_api_surface.py` in the `config_matrix` doc-gate pytest step and `gen_api_surface.py --check` alongside the suite-matrix check.
- **`filters.yml`** — the `config_matrix` path filter now triggers on the new scripts, `api-surface.mdx`, and every package's `pyproject.toml` / `package.json`, so a version bump re-runs the gate.

## Deliberately left hand-maintained

The GoldenFlow transform count and the note's "TS tools" figure stay prose **on purpose**: the transform *registry* is populated lazily — `list_transforms()` returns **113 on a base import, 124 after deep imports** — so gating it on a live import would flap by test order (the exact trap `gen_suite_matrix` avoids); the TS count needs a built dist. Both are documented in the generator. Gating them would trade a deterministic gate for a flaky one.

## Testing

- Full doc-gate suite (as CI runs it): **66 passed**
- Gate **bites** on version drift and inline-MCP drift (exit 1 with a clear message); passes when current (exit 0)
- Confirmed order-independent — removed an initial live-import transform check after it flapped between isolated (113) and full-suite (124) runs
- `ruff check` clean; `filters.yml` valid YAML
- `api-surface.mdx` diff is markers + whitespace only (no value changes)

## Checklist

- [x] Tests added and passing locally
- [x] Gate wired into CI (`config_matrix` job) + path filter
- [x] No secrets committed
- [x] Deterministic / env-stable (no live imports in the gated path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_