### PR TITLE
bench(er-kg-bench): guard OpenAI client base_url against empty OPENAI_BASE_URL

### DIFF
--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -351,3 +351,32 @@ blocked a bench run mid-synthesis; the cap is on the CHAT model only (embeddings
 separate, un-exhausted limit), so the fix is to split providers (chat->OpenRouter,
 embeds->OpenAI), not move everything. The `env_ab` bench job wires this via
 `OPENROUTER_API_KEY` + model `openai/gpt-4o-mini` (revertible by dropping 3 env lines).
+
+## #4 post-hybrid extraction miss bucket — DROP (2026-07-23)
+Measured, confound-free (PR #2056 fixed the empty-`OPENAI_BASE_URL` embedder bug that had
+collapsed hybrid to entity-only, run 30010330554), how much of GoldenGraph's remaining QA miss is
+genuinely extraction-limited now that hybrid synthesis is default-on. The instrument: one
+`head_to_head` run with `GOLDENGRAPH_QA_TRACE=1` + `GOLDENGRAPH_QA_TRACE_LIMIT=0` emits the
+full-population `_localize_trace` stage split for free (LLM-free, cached embeddings).
+- **MEASURED (MuSiQue N=150, hybrid default-on, `passage_k=10`, `GOLDENGRAPH_EXTRACTOR=api`, judge on,
+  run 30020312632):** confound cleared (zero `UnsupportedProtocol`/embedding-failed lines); headline
+  recovered from the confounded 0.167 back to its clean ceiling — `answer_match` 0.393 full /
+  **0.45 on the entity-subset (n=100)**, `llm_judge` 0.453 / 0.52, matching the known ~0.44 k=10 level.
+  Stage split: **`{EXTRACTION:68, RETRIEVAL-BROKEN-CHAIN:3, RETRIEVAL-BUDGET:26, SYNTHESIS:53}`**.
+- **Why the big EXTRACTION bucket does NOT mean an extraction frontier:** the split is
+  BUILD-determined (classified against entity-graph node names, `graph_names`), so it counts every
+  non-entity gold as EXTRACTION by construction. Of the 68: >=37 are structurally non-entity answers
+  (12 dates, 5 numbers, 20 phrases) that can NEVER be graph nodes and are recoverable ONLY via
+  hybrid's passage path; of the 31 short golds most are still ordinals/percentages/place-phrases
+  ("third-largest", "74th", "48.8 percent", "northeastern Oklahoma"), leaving only ~15 plausibly
+  extraction-addressable named entities (~10% of questions). Because the headline has already
+  recovered to its hybrid-on ceiling, hybrid's passage path is demonstrably already answering the
+  non-entity half — the EXTRACTION bucket overlaps hybrid's passage wins.
+- **DECISION: DROP #4.** Per the go/drop rule (headline already high + big but build-determined
+  EXTRACTION bucket → overlaps hybrid's passage recovery), entity-extraction-recall work is not the
+  lever — it would chase a bucket that is mostly non-entity answers hybrid already handles. The two
+  larger REAL frontiers here are **SYNTHESIS:53** (retrieved-but-wrong-answer, 35% — a prompt/synthesis
+  lever) and **RETRIEVAL-BUDGET:26** (reachable-from-seeds-but-outside-the-ball, 17% — a retrieval-budget
+  lever), both bigger than the ~15 extraction-addressable entities. The recall levers built for #4
+  (`GOLDENGRAPH_RELATION_REPROMPT`, `GOLDENGRAPH_CHUNK_EXTRACT`) stay default-OFF; re-test via the
+  same-graph `mode=env_ab` harness before ever shipping one.

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -257,11 +257,14 @@ class GoldenGraphQAEngine:
             # so they always build the index. The warning keeps a genuinely-absent
             # backend from silently degrading a paid run unnoticed.
             try:
-                from openai import OpenAI
-
                 from .goldenmatch_rag import _OpenAIEmbedderAdapter
+                from .text_rag import make_openai_client
 
-                adapter = _OpenAIEmbedderAdapter(OpenAI(), _passage_embed_model())
+                # `make_openai_client()` resolves OPENAI_BASE_URL the guarded way: the paid
+                # head_to_head lane sets it to the EMPTY string, which a bare OpenAI() would
+                # use verbatim -> protocol-less URL -> every passage embed fails
+                # (httpx.UnsupportedProtocol) -> hybrid silently collapses to entity-only.
+                adapter = _OpenAIEmbedderAdapter(make_openai_client(), _passage_embed_model())
                 passages = _PassageRetriever(
                     [d.id for d in corpus.documents],
                     [d.text for d in corpus.documents],

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
@@ -100,9 +100,9 @@ class _BaseGoldenmatchRAGEngine:
         client: Any | None = None,
     ):
         if client is None:
-            from openai import OpenAI
+            from .text_rag import make_openai_client
 
-            client = OpenAI()
+            client = make_openai_client()
         self._client = client
         self._model = model
         self._embedder = _OpenAIEmbedderAdapter(client, embedding_model)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/text_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/text_rag.py
@@ -22,6 +22,22 @@ from ..harness import AnswerResult, BuildResult
 
 _EMBED_BATCH = 256
 
+
+def make_openai_client():
+    """Construct an OpenAI client whose base_url is resolved the SAME guarded way as the
+    judge/chat clients (`run_qa_e2e._make_judge`). A bare `OpenAI()` reads `OPENAI_BASE_URL`
+    from the env, and the paid head_to_head lane sets it to the EMPTY string (chat +
+    embeddings both to OpenAI directly). The SDK uses that empty value verbatim, producing a
+    protocol-less URL that fails every request with `httpx.UnsupportedProtocol` -- which, on
+    the embedding path, silently collapses retrieval. `'' or <default>` falls through to the
+    OpenAI default; a non-empty value (the local nomic/Ollama lane) is honored as-is."""
+    from openai import OpenAI
+
+    base = os.environ.get("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+    key = os.environ.get("OPENAI_API_KEY") or None
+    return OpenAI(base_url=base, api_key=key)
+
+
 _PROMPT = (
     "Answer the question using ONLY the passages below. These questions are often "
     "MULTI-HOP -- you may need to combine facts from several passages. Give the "
@@ -60,9 +76,7 @@ class TextRAGQAEngine:
         # Lazy client construction so importing this module for the registry never
         # needs an API key; tests inject a stub.
         if client is None:
-            from openai import OpenAI
-
-            client = OpenAI()
+            client = make_openai_client()
         self._client = client
         self._model = model
         self._embedding_model = embedding_model

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_openai_client_base_url.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_openai_client_base_url.py
@@ -8,6 +8,14 @@ This locks the empty -> OpenAI-default fall-through while honoring a real (local
 Pure, no network (constructs the client; never calls it)."""
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
+
+def _host(client) -> str:
+    # Compare the parsed hostname exactly (not a substring/startswith) so the assertion
+    # can't be satisfied by an unexpected host embedded elsewhere in the URL.
+    return urlparse(str(client.base_url)).hostname or ""
+
 
 def test_empty_base_url_falls_through_to_openai_default(monkeypatch):
     from erkgbench.qa_e2e.engines.text_rag import make_openai_client
@@ -16,7 +24,7 @@ def test_empty_base_url_falls_through_to_openai_default(monkeypatch):
     monkeypatch.setenv("OPENAI_BASE_URL", "")  # the head_to_head lane's setting
     client = make_openai_client()
     # An empty base_url would have become a protocol-less URL; the guard yields the default.
-    assert str(client.base_url).startswith("https://api.openai.com")
+    assert _host(client) == "api.openai.com"
 
 
 def test_nonempty_base_url_is_honored(monkeypatch):
@@ -25,7 +33,9 @@ def test_nonempty_base_url_is_honored(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")  # local nomic/Ollama lane
     client = make_openai_client()
-    assert str(client.base_url).startswith("http://localhost:11434")
+    parsed = urlparse(str(client.base_url))
+    assert parsed.hostname == "localhost"
+    assert parsed.port == 11434
 
 
 def test_unset_base_url_uses_openai_default(monkeypatch):
@@ -34,4 +44,4 @@ def test_unset_base_url_uses_openai_default(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
     client = make_openai_client()
-    assert str(client.base_url).startswith("https://api.openai.com")
+    assert _host(client) == "api.openai.com"

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_openai_client_base_url.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_openai_client_base_url.py
@@ -1,0 +1,37 @@
+"""Guarded OpenAI client construction (`text_rag.make_openai_client`).
+
+The paid head_to_head lane sets OPENAI_BASE_URL to the EMPTY string (chat + embeddings
+both to OpenAI directly). A bare `OpenAI()` uses that empty value verbatim, producing a
+protocol-less URL that fails EVERY request with httpx.UnsupportedProtocol -- on the
+embedding path this silently collapsed goldengraph's hybrid retrieval to entity-only.
+This locks the empty -> OpenAI-default fall-through while honoring a real (local) base_url.
+Pure, no network (constructs the client; never calls it)."""
+from __future__ import annotations
+
+
+def test_empty_base_url_falls_through_to_openai_default(monkeypatch):
+    from erkgbench.qa_e2e.engines.text_rag import make_openai_client
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "")  # the head_to_head lane's setting
+    client = make_openai_client()
+    # An empty base_url would have become a protocol-less URL; the guard yields the default.
+    assert str(client.base_url).startswith("https://api.openai.com")
+
+
+def test_nonempty_base_url_is_honored(monkeypatch):
+    from erkgbench.qa_e2e.engines.text_rag import make_openai_client
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "http://localhost:11434/v1")  # local nomic/Ollama lane
+    client = make_openai_client()
+    assert str(client.base_url).startswith("http://localhost:11434")
+
+
+def test_unset_base_url_uses_openai_default(monkeypatch):
+    from erkgbench.qa_e2e.engines.text_rag import make_openai_client
+
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    client = make_openai_client()
+    assert str(client.base_url).startswith("https://api.openai.com")


### PR DESCRIPTION
## What and why

The paid `bench-graphrag-qa` head_to_head lane bakes `OPENAI_BASE_URL=''` (chat + embeddings both to OpenAI directly, no OpenRouter split). A bare `OpenAI()` reads that empty string from the env and uses it verbatim as `base_url`, producing a protocol-less URL that fails every request with `httpx.UnsupportedProtocol`. On goldengraph the failure was silent and severe: every hybrid **passage embed** threw, so retrieval collapsed to entity-only answering. A MuSiQue N=150 run (30010330554) headlined `answer_match=0.1667` vs the known ~0.44 at `passage_k=10`, and the localize miss-bucket trace never emitted — confounding the #4 extraction-quality measurement.

## Changes

- Add one shared `text_rag.make_openai_client()` that resolves `base_url` the same guarded way the chat/judge clients already do (`OPENAI_BASE_URL or "https://api.openai.com/v1"`): empty → OpenAI default; a non-empty value (local nomic/Ollama lane) honored as-is; `api_key` from env.
- Route all three previously-bare `OpenAI()` embedder/RAG call sites through it: goldengraph's hybrid passage embedder, plus the `text_rag` and `goldenmatch_rag` control engines (equally confounded under a full head_to_head).
- The goldengraph `try/except ImportError` degrade-to-no-passages path is preserved (`make_openai_client()` does the `from openai import OpenAI` internally).

## Testing

- `python -m pytest tests/test_openai_client_base_url.py tests/test_passage_embed_model.py -q` → 4 passed. New test asserts empty `OPENAI_BASE_URL` → OpenAI default, non-empty honored, unset → default.
- `ruff check` clean on all four files; import sanity on the three edited modules.

## Checklist

- [x] Tests added/updated and passing locally for the changed package
- [x] `ruff check` clean on the changed files
- [ ] Package `CHANGELOG.md` updated if behavior changed (bench harness only, not shipped package)
- [x] No secrets, tokens, or `.env` files committed
- [x] Docs / `CLAUDE.md` updated if a workflow or gotcha changed (n/a — bench wiring fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018aF5eunXPReEq1SYDNiYY5)_