### PR TITLE
docs: publish the independent-semver versioning policy

### DIFF
--- a/docs-site/docs.json
+++ b/docs-site/docs.json
@@ -162,6 +162,7 @@
             "pages": [
               "suite-matrix",
               "reference/api-surface",
+              "reference/versioning",
               "reference/vendor-comparison"
             ]
           },

--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -61,7 +61,9 @@ overlapping surfaces sized to their jobs, not a subset. On the shared core the
 **Versions track independently.** Each surface carries its own semver — npm is not
 pinned to the PyPI number — so a lower TypeScript version reflects a smaller,
 slower-moving surface, not a stale one. (InferMap's TS and Python are at the same
-version; GoldenGraph's TS is ahead of its Python.)
+version; GoldenGraph's TS is ahead of its Python.) See the
+[versioning policy](/reference/versioning) for why the lines are not kept in
+lockstep and how cross-surface parity is guaranteed instead.
 
 ## Install
 

--- a/docs-site/reference/versioning.mdx
+++ b/docs-site/reference/versioning.mdx
@@ -1,0 +1,89 @@
+---
+title: "Versioning policy"
+description: "How the suite versions its Python and TypeScript packages — independent semver per surface, why there is no lockstep, and how cross-surface parity is actually guaranteed."
+keywords: ["versioning", "semver", "npm", "pypi", "parity", "release", "compatibility"]
+---
+
+Every Golden Suite package ships on **two independent release lines** — a Python
+package on PyPI and a TypeScript package on npm. This page explains how those
+lines are numbered and, more importantly, how to *read* a version difference
+between them.
+
+<Note>
+  Short version: **each surface carries its own semver.** A lower npm number is
+  not a "behind" copy of the Python one — it is a separate line for a surface
+  that deliberately covers different (smaller) scope. See
+  [Python vs TypeScript: the surface boundary](/reference/api-surface#python-vs-typescript-the-surface-boundary).
+</Note>
+
+## Each surface versions independently
+
+The PyPI version and the npm version of a package are **not** kept in lockstep,
+and one is not derived from the other. They move at their own cadence:
+
+- GoldenMatch's Python line is well into `3.x` while its TypeScript line is in
+  `1.x` — the `0.x → 1.0.0` jump was a one-time "this is now stable" signal, not
+  an attempt to match PyPI.
+- **InferMap's two lines happen to sit at the same version** — parity, not policy.
+- **GoldenGraph's TypeScript line leads its Python line** — the delta runs the
+  other way.
+
+So the direction and size of a version gap carries no cross-surface meaning on
+its own. For the live numbers, read the generated capability matrix on the
+[API surface](/reference/api-surface) page (it is regenerated and CI-gated, so
+it never drifts).
+
+## What a version does — and does not — guarantee
+
+- **Within one line**, the number is a normal semver contract for *that* surface:
+  no breaking changes before the next major on that package.
+- **Across the two lines**, the shared operations carry the **same public names
+  and the same computation** — but that is guaranteed by a CI gate, **not** by
+  the version numbers matching. The `api_parity` gate fails the build on any
+  *undeclared* drift between the Python and TypeScript surfaces, and scorer
+  outputs are held to a 4-decimal cross-language tolerance.
+
+The practical consequence: **do not infer capabilities from the version delta.**
+"npm is at 1.x, PyPI is at 3.x" does not mean the npm package is missing two
+majors' worth of the shared API. What each surface exposes is defined by the
+[capability matrix](/reference/api-surface#capability-matrix) and the
+[surface boundary](/reference/api-surface#python-vs-typescript-the-surface-boundary),
+not by the version string.
+
+## Why not lockstep
+
+Strict lockstep — forcing both lines to the same number always — would be
+actively misleading here, for two reasons:
+
+1. **The surfaces are deliberately non-equivalent.** The TypeScript package is
+   the edge-safe, stateless *subset* of the Python one (it holds no server-side
+   dataset, ships no distributed engine or web UI). A shared version number
+   would imply an equivalence that does not exist.
+2. **It publishes empty releases.** A breaking change in Python would force a
+   no-op major bump on npm even when zero TypeScript code changed, and vice
+   versa — the standard "lockstep tax," paid to make the number less honest.
+
+Lockstep is the right model for a *binding* that tracks the same surface. These
+are two implementations of an overlapping-but-different surface, so independent
+semver is the honest model. The full rationale (and the rejected alternatives,
+including "aligned majors") lives in the engineering note
+[`docs/versioning-policy.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/docs/versioning-policy.md).
+
+## Why there is no "version-lag" gate
+
+It would be easy to add a CI check that flags a TypeScript package for sitting
+several majors behind its Python sibling — and it would be the wrong check.
+Under this policy a lagging number is **not a defect**; an independent line is
+*supposed* to sit at its own version. Gating it would flag a non-problem and
+pressure teams toward the empty-release lockstep this policy rejects.
+
+What *is* gated is the thing that actually matters:
+
+- **`api_parity`** — fails on any undeclared drift in the shared Python↔TypeScript
+  surface (a tool/command/skill added, renamed, or removed on one side without
+  being reflected in the manifest).
+- **`gen_api_surface`** — regenerates the capability matrix (versions + tool
+  counts) from the manifests and fails if the published page is stale.
+
+Correctness is enforced where it is real — the shared surface and the published
+numbers — and the version strings are left to float honestly.

--- a/docs/versioning-policy.md
+++ b/docs/versioning-policy.md
@@ -1,6 +1,14 @@
 # GoldenMatch versioning policy (npm vs PyPI)
 
-**Status:** Recommendation, 2026-06-15
+> **Adopted (2026-07-23).** The recommendation below is now the suite's standing
+> policy: **independent semver per surface**, no lockstep. The npm `1.0.0`
+> stability milestone shipped (goldenmatch TS is now `1.x`), and the durable,
+> user-facing statement of this policy lives in the docs at
+> `docs-site/reference/versioning.mdx` (published under **Reference → Versioning
+> policy**). This file remains the engineering rationale + rejected-alternatives
+> record; the published page is the citable policy.
+
+**Status:** Recommendation, 2026-06-15 (adopted 2026-07-23)
 **Question:** Should the npm `goldenmatch` package jump `0.13.0` → `2.0.0` to match
 the PyPI package, and then move in lockstep going forward?
 


### PR DESCRIPTION
## What

Track 3 (final) of the Python↔TypeScript surface work. The suite's versioning stance — **independent semver per surface, no lockstep** — already existed as an engineering note (`docs/versioning-policy.md`), but it wasn't discoverable to users, was GoldenMatch-specific, and was dated pre-1.0. This promotes it to a citable, suite-wide, user-facing policy page.

## Changes

- **`docs-site/reference/versioning.mdx`** (new, published under **Reference → Versioning policy**) — states the policy:
  - Each surface carries its own semver; the direction/size of a version gap carries **no** cross-surface meaning (InferMap's lines are at parity; GoldenGraph's TS *leads* its Python).
  - What a version does/doesn't guarantee: shared-surface parity is enforced by the **`api_parity` CI gate**, not by matching version numbers — so don't infer capabilities from the version delta.
  - Why lockstep is rejected: the surfaces are deliberately non-equivalent (TS is the stateless edge subset), so lockstep publishes empty no-op releases and implies a false equivalence.
  - Why there is deliberately **no version-lag gate**: a lagging line isn't a defect under this policy; what *is* gated is the thing that matters (undeclared shared-surface drift via `api_parity`, capability-matrix staleness via `gen_api_surface`).
- **`docs.json`** — add the page to the Reference nav group.
- **`reference/api-surface.mdx`** — link the "Versions track independently" note to the new policy page.
- **`docs/versioning-policy.md`** — mark the recommendation **adopted** and point at the published page as the citable policy (the engineering note stays as the rationale + rejected-alternatives record).

## Relationship to the other tracks

This closes the three-track response to "TS is the smaller, lagging surface":
- **Track 1** (#2055) — reframed the api-surface page as a stateful-vs-stateless *boundary*, not neglect.
- **Track 2** (#2057) — ported the one genuinely-stateless Python-only MCP tool (`compare_clusters`) and validated that the rest are legitimately state/subsystem-bound.
- **Track 3** (this PR) — documents the "lagging" half as deliberate independent semver.

## Verification

Docs-only. `check_docs_sections.py`, `test_docs_sections.py` (8), `gen_api_surface.py --check`, `mint validate`, and `mint broken-links` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01233mTuAaQe8pNDhxGcRhxr)_