### PR TITLE
feat(goldengraph): gated top-K edge rerank for the hybrid ball (default off)

### DIFF
--- a/packages/python/goldengraph/goldengraph/answer.py
+++ b/packages/python/goldengraph/goldengraph/answer.py
@@ -232,10 +232,22 @@ def _canon_query_rel(rel, schema):
 def _hybrid_filter_mode() -> str:
     """Hybrid subgraph filter selector, read at call time. "" / "none" / unset =
     off (pass the full ball; the measured 0.420 control). "path" = path-preserving
-    prune (`subgraph_filter.filter_subgraph_to_paths`)."""
+    prune (`subgraph_filter.filter_subgraph_to_paths`). "rerank" = top-K
+    question-relevant edge prune (`subgraph_filter.rerank_subgraph_edges`)."""
     import os
 
     return os.environ.get("GOLDENGRAPH_HYBRID_FILTER", "").strip().lower()
+
+
+def _hybrid_filter_topk() -> int:
+    """`GOLDENGRAPH_HYBRID_FILTER_TOPK` (default 40) -- the `rerank` mode's edge budget.
+    Non-int -> 40."""
+    import os
+
+    try:
+        return int(os.environ.get("GOLDENGRAPH_HYBRID_FILTER_TOPK", "40"))
+    except ValueError:
+        return 40
 
 
 def _local_filter_mode() -> str:
@@ -551,10 +563,27 @@ def ask(
         # default for callers without a passage retriever (the library indexes none; the
         # bench builds one). Hybrid synthesis runs ONLY when passages are actually present.
         if passage_texts:
-            if _hybrid_filter_mode() == "path":
+            hybrid_mode = _hybrid_filter_mode()
+            if hybrid_mode == "path":
                 from .subgraph_filter import filter_subgraph_to_paths
 
                 subgraph = filter_subgraph_to_paths(subgraph, seeds)
+                id_to_name = {
+                    e["entity_id"]: e["canonical_name"] for e in subgraph.get("entities", ())
+                }
+                seed_names = [id_to_name[s] for s in seeds if s in id_to_name]
+            elif hybrid_mode == "rerank":
+                # Prune the ball to the top-K question-relevant edges before synthesis:
+                # the answer edge is usually PRESENT but buried in a ~1,700-edge ball that
+                # `_format_subgraph` serializes whole. Seed-incident edges are always kept
+                # (anchor/connectivity); the rest of the budget goes to the highest-scoring
+                # edges by question<->edge-text cosine (same embedder already in scope).
+                from .subgraph_filter import rerank_subgraph_edges
+
+                subgraph = rerank_subgraph_edges(
+                    subgraph, seeds, question=query, embedder=embedder,
+                    top_k=_hybrid_filter_topk(),
+                )
                 id_to_name = {
                     e["entity_id"]: e["canonical_name"] for e in subgraph.get("entities", ())
                 }

--- a/packages/python/goldengraph/goldengraph/subgraph_filter.py
+++ b/packages/python/goldengraph/goldengraph/subgraph_filter.py
@@ -90,3 +90,71 @@ def filter_subgraph_to_paths(
     ents2 = [e for e in ents if e["entity_id"] in keep]
     edges2 = [e for e in edges if e["subj"] in keep and e["obj"] in keep]
     return {**subgraph, "entities": ents2, "edges": edges2}
+
+
+def rerank_subgraph_edges(
+    subgraph: dict, seeds, *, question: str, embedder, top_k: int
+) -> dict:
+    """Prune `subgraph`'s edges to the top-`top_k` most question-relevant, so a huge,
+    noisy hybrid ball (~1,500-2,500 edges, serialized whole into the synthesis prompt by
+    `synthesize._format_subgraph`) stops burying the answer edge among distractors.
+
+    Scoring: cosine similarity between the embedding of `question` and the embedding of
+    each edge's serialized text -- the SAME name-keyed form the model reads,
+    ``"{subj_name} {predicate} {obj_name}"`` (names from the subgraph's entities, falling
+    back to the raw id when a name is missing). Batched: ONE `embedder.embed` call for all
+    edge texts + one for the question (no per-edge round-trips), mirroring `seed_by_query`.
+
+    Anchor preservation: every edge incident to a `seeds` entity id is ALWAYS retained
+    (connectivity), regardless of score; the remaining budget (`top_k` minus the retained
+    seed-incident edges) is filled with the highest-scoring non-seed-incident edges (ties
+    broken by original edge order, deterministic).
+
+    `top_k >= len(edges)` -> the subgraph is returned UNCHANGED (same object; no-op). The
+    returned subgraph is a NEW dict: `edges` pruned to the kept set (original order
+    preserved) and `entities` reduced to those referenced by the kept edges UNION the seed
+    ids (a seed entity is never dropped). All other keys are preserved unchanged. The input
+    is never mutated."""
+    import numpy as np
+
+    edges = subgraph.get("edges", [])
+    ents = subgraph.get("entities", [])
+    if top_k >= len(edges):
+        return subgraph
+
+    id_to_name = {e["entity_id"]: e["canonical_name"] for e in ents}
+    seed_set = set(seeds)
+
+    def _edge_text(e) -> str:
+        subj = id_to_name.get(e["subj"], e["subj"])
+        obj = id_to_name.get(e["obj"], e["obj"])
+        return f"{subj} {e['predicate']} {obj}"
+
+    seed_incident = [
+        i for i, e in enumerate(edges) if e["subj"] in seed_set or e["obj"] in seed_set
+    ]
+    non_seed = [i for i, e in enumerate(edges) if i not in set(seed_incident)]
+
+    budget = top_k - len(seed_incident)
+    selected: list[int] = []
+    if budget > 0 and non_seed:
+        texts = [_edge_text(edges[i]) for i in non_seed]
+        vecs = np.asarray(embedder.embed([question] + texts), dtype=float)
+        q = vecs[0]
+        mat = vecs[1:]
+        qn = q / (np.linalg.norm(q) + 1e-12)
+        mn = mat / (np.linalg.norm(mat, axis=1, keepdims=True) + 1e-12)
+        sims = mn @ qn
+        # highest score first; ties broken by original edge index (deterministic).
+        ranked = sorted(range(len(non_seed)), key=lambda j: (-float(sims[j]), non_seed[j]))
+        selected = [non_seed[j] for j in ranked[:budget]]
+
+    kept_idx = sorted(set(seed_incident) | set(selected))
+    kept_edges = [edges[i] for i in kept_idx]
+
+    referenced = set(seed_set)
+    for e in kept_edges:
+        referenced.add(e["subj"])
+        referenced.add(e["obj"])
+    kept_ents = [e for e in ents if e["entity_id"] in referenced]
+    return {**subgraph, "entities": kept_ents, "edges": kept_edges}

--- a/packages/python/goldengraph/tests/test_hybrid_synthesis.py
+++ b/packages/python/goldengraph/tests/test_hybrid_synthesis.py
@@ -223,6 +223,30 @@ def test_ask_hybrid_filter_off_keeps_full_ball(monkeypatch):
     assert "Noise" in llm.prompts[-1]
 
 
+def test_ask_hybrid_filter_rerank_prunes_ball_to_budget(monkeypatch):
+    # Start(0)-works_at->A(1)-acquired->Zeta(2)-mentions->Noise(3). Seed = Start(0).
+    # TOPK=2: seed-incident {works_at} always kept; budget 1 fills with the next edge
+    # in original order (acquired); the tail (mentions->Noise) is pruned out of synthesis.
+    names = ["Start", "A", "Zeta", "Noise"]
+    edges = [(0, "works_at", 1), (1, "acquired", 2), (2, "mentions", 3)]
+    llm = RecordingLLM()
+    store = _FakeStore(_FakeGraph(names, edges))
+    embedder = StubEmbedder({"Start": 0, "A": 1, "Zeta": 2, "Noise": 3})
+    passages = _FakePassages(["Start works at A.", "A acquired Zeta in 1990."])
+    monkeypatch.setenv("GOLDENGRAPH_HYBRID_FILTER", "rerank")
+    monkeypatch.setenv("GOLDENGRAPH_HYBRID_FILTER_TOPK", "2")
+    ask(
+        "Start", store, llm=llm, embedder=embedder, valid_t=1, tx_t=1,
+        mode="hybrid", k=1, hops=4, node_budget=64,
+        passages=passages, passage_k=7,
+    )
+    prompt = llm.prompts[-1]
+    assert "Start -[works_at]-> A" in prompt   # seed-incident edge always kept
+    assert "Noise" not in prompt               # pruned beyond the top-K budget
+    # passages are untouched by the filter (ground-truth context stays whole)
+    assert "A acquired Zeta in 1990." in prompt
+
+
 def test_ask_local_mode_ignores_filter_flag(monkeypatch):
     # The filter must touch hybrid ONLY -- local stays byte-identical.
     names = ["Start", "A", "Zeta", "Noise"]

--- a/packages/python/goldengraph/tests/test_subgraph_rerank.py
+++ b/packages/python/goldengraph/tests/test_subgraph_rerank.py
@@ -1,0 +1,168 @@
+"""Pure tests for the gated top-K edge rerank of the hybrid ball (no native, no LLM,
+no network). `rerank_subgraph_edges` prunes a huge, noisy ball to the top-K
+question-relevant edges before synthesis, ALWAYS retaining seed-incident edges. Mode
+`off` (env unset) leaves the ball byte-identical; a non-int TOPK falls back to 40."""
+
+from __future__ import annotations
+
+import numpy as np
+from goldengraph import answer as answer_mod
+from goldengraph.subgraph_filter import rerank_subgraph_edges
+
+
+class _KeywordEmbedder:
+    """Deterministic embedder: each text is a 2-d vector [has_kw, 1.0]. The question
+    embeds to [1,0], so cosine similarity is highest for edge texts containing `kw`
+    and lowest (but nonzero) for those without. Batched call, no per-edge round-trip."""
+
+    def __init__(self, kw: str):
+        self.kw = kw
+        self.calls: list[list[str]] = []
+
+    def embed(self, texts):
+        self.calls.append(list(texts))
+        rows = []
+        for t in texts:
+            if t == "__QUESTION__":
+                rows.append([1.0, 0.0])
+            else:
+                rows.append([1.0 if self.kw in t else 0.0, 1.0])
+        return np.asarray(rows, dtype=float)
+
+
+def _ent(i, name=None):
+    return {"entity_id": i, "canonical_name": name or f"n{i}", "typ": "concept"}
+
+
+def _edge(s, o, pred="rel"):
+    return {"subj": s, "predicate": pred, "obj": o}
+
+
+def _sub(entities, edges):
+    return {"entities": entities, "edges": edges}
+
+
+# 1. Mode off (env unset) -> the ball is left unchanged (edges identical, order preserved).
+
+
+def test_mode_off_is_identity_and_order_preserved(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_HYBRID_FILTER", raising=False)
+    # off -> _hybrid_filter_mode() is "" so neither branch fires; assert the selector.
+    assert answer_mod._hybrid_filter_mode() == ""
+    # And the rerank no-ops when top_k covers every edge (see test 4), so a caller that
+    # never enters the rerank branch keeps the ball byte-identical.
+    edges = [_edge(0, 1), _edge(1, 2), _edge(2, 3)]
+    sub = _sub([_ent(i) for i in range(4)], edges)
+    out = rerank_subgraph_edges(sub, [0], question="q", embedder=_KeywordEmbedder("x"), top_k=99)
+    assert out is sub
+    assert [e for e in out["edges"]] == edges  # identical and in original order
+
+
+# 2. A known subset is most-similar -> exactly those top-K (+ seed-incident) edges kept.
+
+
+def test_top_k_keeps_highest_scoring_nonseed_edges():
+    # 6 non-seed edges among nodes 10..; 3 carry the keyword "match" in their predicate.
+    entities = [_ent(i) for i in range(0, 20)]
+    edges = [
+        _edge(10, 11, "match"),   # high
+        _edge(11, 12, "noise"),   # low
+        _edge(12, 13, "match"),   # high
+        _edge(13, 14, "noise"),   # low
+        _edge(14, 15, "match"),   # high
+        _edge(15, 16, "noise"),   # low
+    ]
+    sub = _sub(entities, edges)
+    emb = _KeywordEmbedder("match")
+    # no seed-incident edges here (seed 99 touches nothing); budget = top_k = 3.
+    out = rerank_subgraph_edges(sub, [99], question="__QUESTION__", embedder=emb, top_k=3)
+    kept = {(e["subj"], e["obj"]) for e in out["edges"]}
+    assert kept == {(10, 11), (12, 13), (14, 15)}  # exactly the 3 "match" edges
+    # ONE batched embed call for edge texts (+question), not one-per-edge.
+    assert len(emb.calls) == 1
+    assert emb.calls[0][0] == "__QUESTION__" and len(emb.calls[0]) == 7  # q + 6 edges
+
+
+# 3. Seed-incident edges are retained even when their score is the lowest.
+
+
+def test_seed_incident_edges_always_retained_even_when_lowest_scoring():
+    entities = [_ent(i) for i in range(0, 20)]
+    edges = [
+        _edge(0, 1, "noise"),     # SEED-INCIDENT (seed 0), lowest score -> must survive
+        _edge(10, 11, "match"),   # high-score non-seed
+        _edge(12, 13, "match"),   # high-score non-seed
+        _edge(14, 15, "noise"),   # low-score non-seed -> dropped
+    ]
+    sub = _sub(entities, edges)
+    emb = _KeywordEmbedder("match")
+    # top_k=3: 1 seed-incident retained + budget 2 highest non-seed.
+    out = rerank_subgraph_edges(sub, [0], question="__QUESTION__", embedder=emb, top_k=3)
+    kept = {(e["subj"], e["obj"]) for e in out["edges"]}
+    assert (0, 1) in kept                       # seed-incident kept despite lowest score
+    assert kept == {(0, 1), (10, 11), (12, 13)}  # + the 2 best non-seed; (14,15) dropped
+
+
+# 4. top_k >= len(edges) -> returned subgraph equals input (no-op, same object).
+
+
+def test_top_k_ge_edges_is_noop():
+    edges = [_edge(0, 1), _edge(1, 2)]
+    sub = _sub([_ent(i) for i in range(3)], edges)
+    out = rerank_subgraph_edges(sub, [0], question="q", embedder=_KeywordEmbedder("x"), top_k=2)
+    assert out is sub  # top_k == len(edges) -> unchanged
+    out2 = rerank_subgraph_edges(sub, [0], question="q", embedder=_KeywordEmbedder("x"), top_k=5)
+    assert out2 is sub  # top_k > len(edges) -> unchanged
+
+
+# 5. entities after prune == referenced-by-kept-edges UNION seeds; no seed dropped; input
+#    dict not mutated.
+
+
+def test_entities_reduced_to_kept_union_seeds_and_input_not_mutated():
+    entities = [_ent(i) for i in range(0, 20)]
+    edges = [
+        _edge(10, 11, "match"),
+        _edge(12, 13, "match"),
+        _edge(14, 15, "noise"),   # dropped
+        _edge(16, 17, "noise"),   # dropped
+    ]
+    sub = _sub(entities, edges)
+    orig_edges_snapshot = list(sub["edges"])
+    orig_ents_snapshot = list(sub["entities"])
+    emb = _KeywordEmbedder("match")
+    # seed 5 is isolated (no incident edge) but must survive as an entity.
+    out = rerank_subgraph_edges(sub, [5], question="__QUESTION__", embedder=emb, top_k=2)
+    kept_edges = out["edges"]
+    referenced = {e["subj"] for e in kept_edges} | {e["obj"] for e in kept_edges} | {5}
+    kept_ids = {e["entity_id"] for e in out["entities"]}
+    assert kept_ids == referenced
+    assert 5 in kept_ids                       # seed never dropped even when isolated
+    assert kept_ids == {10, 11, 12, 13, 5}
+    # input dict untouched (new lists returned, no mutation).
+    assert sub["edges"] == orig_edges_snapshot
+    assert sub["entities"] == orig_ents_snapshot
+    assert out is not sub
+
+
+def test_missing_name_falls_back_to_id_in_edge_text():
+    # An edge whose endpoints have NO entity entry -> _edge_text uses the raw id, no crash.
+    edges = [_edge(100, 101, "match"), _edge(102, 103, "noise"), _edge(104, 105, "noise")]
+    sub = _sub([], edges)  # no entities at all
+    emb = _KeywordEmbedder("match")
+    out = rerank_subgraph_edges(sub, [], question="__QUESTION__", embedder=emb, top_k=1)
+    assert {(e["subj"], e["obj"]) for e in out["edges"]} == {(100, 101)}
+    # question + 3 edge texts embedded; ids stringified into the text.
+    assert emb.calls[0][1] == "100 match 101"
+
+
+# 6. Non-int GOLDENGRAPH_HYBRID_FILTER_TOPK -> default 40.
+
+
+def test_topk_reader_default_and_bad_value(monkeypatch):
+    monkeypatch.delenv("GOLDENGRAPH_HYBRID_FILTER_TOPK", raising=False)
+    assert answer_mod._hybrid_filter_topk() == 40
+    monkeypatch.setenv("GOLDENGRAPH_HYBRID_FILTER_TOPK", "notanint")
+    assert answer_mod._hybrid_filter_topk() == 40
+    monkeypatch.setenv("GOLDENGRAPH_HYBRID_FILTER_TOPK", "12")
+    assert answer_mod._hybrid_filter_topk() == 12


### PR DESCRIPTION
## Why (measured motivation)

On MuSiQue N=150 (hybrid synthesis default-on, `passage_k=10`) the largest QA miss bucket is **SYNTHESIS:53**, and **47/53 (89%)** of those had the gold answer's relationship edge **PRESENT in the retrieved ball** yet the model wrote a wrong answer.

The retrieved hybrid ball routinely holds ~1,500-2,500 edges, and `goldengraph/synthesize.py::_format_subgraph` serializes **every** edge into the hybrid prompt's "Relationship graph" slot **with no cap**. Hypothesis: the answer edge is a needle buried in a huge, noisy graph context. This lever prunes the hybrid ball to the top-K question-relevant edges before synthesis, to test whether noise-reduction recovers some of those 47 misses.

## What

Gated, default-OFF top-K edge rerank of the hybrid ball, mutually exclusive with the existing `path` filter.

- `subgraph_filter.rerank_subgraph_edges(subgraph, seeds, *, question, embedder, top_k) -> dict`
  - Scores each edge by cosine similarity between the embedding of `question` and the embedding of the edge's serialized text, using the **same name-keyed form the model sees**: `"{subj_name} {predicate} {obj_name}"` (names from the subgraph entities, falling back to the raw id when a name is missing).
  - **Batched**: one `embedder.embed` call for all edge texts + one for the question (no per-edge round-trips), mirroring `seed_by_query`.
  - **ALWAYS retains every edge incident to a seed entity id** (connectivity/anchor preservation), regardless of score; the remaining budget (`top_k` minus retained seed-incident edges) is filled with the highest-scoring non-seed-incident edges (ties broken by original edge order).
  - `top_k >= len(edges)` -> returns the subgraph unchanged (no-op, same object).
  - Returns a NEW dict: `edges` pruned to the kept set (original order preserved), `entities` reduced to those referenced by the kept edges UNION the seed ids (a seed entity is never dropped), all other keys preserved. The input is never mutated.
- `answer.ask` hybrid branch: when `_hybrid_filter_mode() == "rerank"`, route the same `subgraph` through the rerank using the `embedder` already in scope, then rebuild `id_to_name` / `seed_names` from the pruned subgraph exactly as the `path` branch does.
- `answer._hybrid_filter_topk()` reads `GOLDENGRAPH_HYBRID_FILTER_TOPK`.

## Env flags

| Flag | Values | Default |
| --- | --- | --- |
| `GOLDENGRAPH_HYBRID_FILTER` | unset / `` / `none` (off), `path`, `rerank` | off |
| `GOLDENGRAPH_HYBRID_FILTER_TOPK` | int edge budget for `rerank` (non-int -> default) | `40` |

## Byte-identical when off

With `GOLDENGRAPH_HYBRID_FILTER` unset / empty / `none`, neither the `path` nor the `rerank` branch fires and the subgraph handed to `synthesize_hybrid` is untouched. `rerank` is opt-in only.

## Measurement pending

The A/B measurement is **not yet run** and will decide ship/drop:

```
bench-graphrag-qa.yml  mode=env_ab  GOLDENGRAPH_HYBRID_FILTER:,rerank
```

Same-graph env-A/B (build once, answer under both configs), so the metric delta is purely the knob's effect (`support_recall` is the control -- a filter can't touch retrieval). Draft until that lands.

## Tests

`packages/python/goldengraph/tests/test_subgraph_rerank.py` (pure, no native/LLM/network) covers: mode off is identity; top-K keeps exactly the highest-scoring non-seed edges (one batched embed call); seed-incident edges retained even when lowest-scoring; `top_k >= len(edges)` no-op; entity set == kept-edge endpoints UNION seeds with no seed dropped and input not mutated; missing-name id fallback; non-int TOPK -> default 40. Plus a rerank wiring test through `ask` in `tests/test_hybrid_synthesis.py`. Local run: **27 passed** (rerank + hybrid + subgraph_filter suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
