### PR TITLE
perf(goldengraph): prompt-hash LLM response cache for bench extraction (GOLDENGRAPH_LLM_CACHE, default off)

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -102,6 +102,22 @@ jobs:
             echo "LOCAL_EMBED_MODEL=nomic-embed-text"
             printf '%s\n' "$OPTS"
           } | grep -E '^[A-Za-z_][A-Za-z0-9_]*=' >> "$GITHUB_ENV"
+      # Persist the prompt-hash LLM extraction cache across runs (goldengraph engine
+      # only). The dominant build cost is per-document extraction LLM calls (~50 min
+      # at N=150); the cache (GOLDENGRAPH_LLM_CACHE) is a small JSON-lines file keyed
+      # by the EXACT prompt+model, so re-running the SAME corpus skips those calls.
+      # Scoped by corpus + extraction model (+ ambiguity for matrix hygiene); the
+      # per-run key suffix + restore-keys prefix restore an older/partial cache and
+      # top it up. Prompt-hash keying is self-invalidating (a prompt change misses
+      # and repopulates), so no code SHA is needed in the key.
+      - name: Restore/save the goldengraph extraction LLM cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.gg_llm_cache
+          key: gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-amb${{ matrix.ambiguity }}-${{ github.run_id }}
+          restore-keys: |
+            gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-amb${{ matrix.ambiguity }}-
+            gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-
       - name: Install goldenmatch + native engine wheel + goldengraph + datasets
         run: |
           python -m pip install --upgrade pip maturin pytest goldenmatch datasets openai polars
@@ -142,6 +158,11 @@ jobs:
           OPENAI_BASE_URL: ${{ inputs.local_llm != '' && 'http://localhost:11434/v1' || '' }}
           OPENAI_MODEL: ${{ inputs.local_llm }}
           OPENAI_EMBED_MODEL: ${{ inputs.local_llm != '' && env.LOCAL_EMBED_MODEL || '' }}
+          # Points the bench extraction/build client at the actions/cache-persisted dir
+          # (restored above). Only the goldengraph engine's BUILD client is cached; the
+          # answer-time synth client stays uncached. Absolute path = the same dir the
+          # cache step persists.
+          GOLDENGRAPH_LLM_CACHE: ${{ github.workspace }}/.gg_llm_cache
           POLARS_SKIP_CPU_CHECK: "1"
         run: |
           mkdir -p results

--- a/packages/python/goldengraph/goldengraph/llm.py
+++ b/packages/python/goldengraph/goldengraph/llm.py
@@ -8,8 +8,11 @@ extraction stays testable + provider-swappable.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
-from typing import Protocol
+import threading
+from typing import Any, Protocol
 
 
 class LLMClient(Protocol):
@@ -112,3 +115,153 @@ class OpenAIClient:
                     getattr(usage, "completion_tokens", 0),
                 )
         return text
+
+
+#: Sentinel distinguishing "no cache entry" from a legitimately cached falsy value
+#: (a model can return "" and it must be served, not re-fetched).
+_MISS = object()
+
+
+class CachingLLMClient:
+    """Persistent, prompt-hash-keyed response cache in front of any `LLMClient`.
+
+    Why this is SAFE for a measurement harness: the key is a stable hash of the
+    EXACT `(model, method, prompt, sorted(kwargs))` tuple, so a cached response IS
+    the model's output for that exact prompt+model. Serving it can never be stale
+    while the prompt matches, and any extraction-code change that alters a prompt
+    yields a NEW key automatically (a miss that repopulates) -- so the cache cannot
+    corrupt a re-run's measurement. All deterministic post-processing (parsing,
+    resolution) still runs on the cached raw response.
+
+    This is a CAPABILITY, not a library default: goldengraph never installs it on
+    its own. Only the bench build path wraps its extraction client with it when the
+    `GOLDENGRAPH_LLM_CACHE` env var points at a backing file. With no path it is a
+    transparent passthrough (byte-identical to the unwrapped client, zero files).
+
+    On a cache HIT the inner client is NOT called, so it incurs no API cost and the
+    inner token counters do not advance; `.input_tokens`/`.output_tokens`/`.model`
+    are read-through views of the inner client so callers keep working.
+
+    `complete_many` with `temperature > 0` is nondeterministic sampling and is NOT
+    cached (freezing a sampled distribution would be wrong) -- it always calls the
+    inner client. Extraction runs `complete`/`complete_json` at temperature 0, so
+    this only spares the self-consistency synthesis path.
+
+    Backing store: JSON-lines (`{"key": <sha256>, "resp": <str|list[str]>}` per
+    line), loaded on init and written through per put under a lock. Thread-safe --
+    `ingest_corpus` parallelizes extraction across documents, so get/put and the
+    file append are all guarded. A corrupt/partial file is treated as empty and
+    overwritten rather than crashing the build.
+    """
+
+    def __init__(self, inner: Any, path: str | None):
+        self._inner = inner
+        # Empty/None path -> caching DISABLED (transparent passthrough, no file).
+        self._path = str(path) if path else None
+        # Model participates in the key so two runs against different models never
+        # collide; captured once (the inner client's model is fixed per instance).
+        self._model = getattr(inner, "model", "") or ""
+        self._lock = threading.Lock()
+        self._cache: dict[str, Any] = {}
+        if self._path:
+            self._load()
+
+    # --- read-through views onto the inner client (cache hits stay cost-free) ---
+    @property
+    def model(self) -> str:
+        return self._model
+
+    @property
+    def input_tokens(self) -> int:
+        return getattr(self._inner, "input_tokens", 0)
+
+    @property
+    def output_tokens(self) -> int:
+        return getattr(self._inner, "output_tokens", 0)
+
+    # --- LLMClient protocol ---
+    def complete(self, prompt: str) -> str:
+        return self._cached("complete", prompt, self._inner.complete)
+
+    def complete_json(self, prompt: str) -> str:
+        # Mirror `_CountingLLM`: fall back to `complete` (and its key) when the inner
+        # client has no JSON-constrained method (test stubs / bare clients), so the
+        # cached response and its key both reflect what was actually invoked.
+        fn = getattr(self._inner, "complete_json", None)
+        if fn is None:
+            return self._cached("complete", prompt, self._inner.complete)
+        return self._cached("complete_json", prompt, fn)
+
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        if self._path is None or (temperature and temperature > 0):
+            # Disabled -> transparent passthrough; temperature>0 is nondeterministic
+            # sampling and must never be frozen in the cache.
+            return self._inner.complete_many(prompt, n=n, temperature=temperature)
+        key = self._key("complete_many", prompt, n=n, temperature=temperature)
+        hit = self._get(key)
+        if hit is not _MISS:
+            return list(hit)  # defensive copy so a caller can't mutate the cache
+        resp = list(self._inner.complete_many(prompt, n=n, temperature=temperature))
+        self._put(key, resp)
+        return resp
+
+    # --- internals ---
+    def _cached(self, method: str, prompt: str, call) -> str:
+        if self._path is None:
+            # Disabled -> transparent passthrough (no hashing/locking, no file).
+            return call(prompt)
+        key = self._key(method, prompt)
+        hit = self._get(key)
+        if hit is not _MISS:
+            return hit
+        resp = call(prompt)
+        self._put(key, resp)
+        return resp
+
+    def _key(self, method: str, prompt: str, **kwargs: Any) -> str:
+        payload = json.dumps(
+            [self._model, method, prompt, sorted(kwargs.items())],
+            sort_keys=True,
+            ensure_ascii=True,
+            separators=(",", ":"),
+        )
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+    def _get(self, key: str) -> Any:
+        with self._lock:
+            return self._cache.get(key, _MISS)
+
+    def _put(self, key: str, resp: Any) -> None:
+        with self._lock:
+            if key in self._cache:
+                return  # a concurrent writer already stored it -> one file line/key
+            self._cache[key] = resp
+            if self._path:
+                try:
+                    with open(self._path, "a", encoding="utf-8") as fh:
+                        fh.write(json.dumps({"key": key, "resp": resp}, ensure_ascii=True) + "\n")
+                except OSError:
+                    pass  # never let a cache write failure break the build
+
+    def _load(self) -> None:
+        if not self._path or not os.path.exists(self._path):
+            return
+        try:
+            cache: dict[str, Any] = {}
+            with open(self._path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    rec = json.loads(line)
+                    cache[rec["key"]] = rec["resp"]
+            self._cache = cache
+        except (OSError, ValueError, KeyError, TypeError):
+            # Corrupt or partially-written file: treat as empty and overwrite it so
+            # subsequent write-through appends start from a clean, well-formed file.
+            self._cache = {}
+            try:
+                with open(self._path, "w", encoding="utf-8"):
+                    pass
+            except OSError:
+                pass

--- a/packages/python/goldengraph/tests/test_llm_cache.py
+++ b/packages/python/goldengraph/tests/test_llm_cache.py
@@ -1,0 +1,285 @@
+"""Unit tests for the prompt-hash `CachingLLMClient` (bench extraction cache).
+
+The cache is a measurement-harness optimization: keying on the EXACT prompt (+
+model + method) means a cached response IS the model's output for that prompt, so
+serving it can never be stale as long as the prompt matches. Any extraction-code
+change that alters a prompt yields a new key automatically.
+
+`llm.py` imports only stdlib (os/typing + the cache's hashlib/json/threading), so
+we load it by file path under a synthetic module name -- the same bypass
+`test_native_loader` uses to dodge `goldengraph/__init__`'s heavy deps (numpy, the
+native engine wheel). The unit under test is pure-Python and network-free.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+_LLM_PATH = Path(__file__).parent.parent / "goldengraph" / "llm.py"
+
+
+def _load_llm():
+    spec = importlib.util.spec_from_file_location("_gg_llm_under_test", _LLM_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_LLM = _load_llm()
+CachingLLMClient = _LLM.CachingLLMClient
+
+
+class FakeInner:
+    """Counts calls per method; returns a deterministic response per prompt so a
+    cache HIT (which must NOT call this) is distinguishable from a MISS. Exposes
+    `.model` + `.input_tokens`/`.output_tokens` like the real clients."""
+
+    def __init__(self, model="fake-model"):
+        self.model = model
+        self.calls = {"complete": 0, "complete_json": 0, "complete_many": 0}
+        self.input_tokens = 0
+        self.output_tokens = 0
+
+    def complete(self, prompt: str) -> str:
+        self.calls["complete"] += 1
+        self.input_tokens += len(prompt)
+        self.output_tokens += 1
+        return f"complete::{prompt}"
+
+    def complete_json(self, prompt: str) -> str:
+        self.calls["complete_json"] += 1
+        self.input_tokens += len(prompt)
+        self.output_tokens += 1
+        return json.dumps({"prompt": prompt, "method": "complete_json"})
+
+    def complete_many(self, prompt: str, *, n: int, temperature: float) -> list[str]:
+        self.calls["complete_many"] += 1
+        self.input_tokens += len(prompt) * n
+        self.output_tokens += n
+        return [f"many::{prompt}::{i}::t{temperature}" for i in range(n)]
+
+
+def _cache(tmp_path, inner=None, name="cache.jsonl"):
+    inner = inner or FakeInner()
+    client = CachingLLMClient(inner, str(tmp_path / name))
+    return client, inner
+
+
+# 1. Miss then hit: same prompt twice -> inner called ONCE; both returns equal.
+def test_miss_then_hit_complete(tmp_path):
+    client, inner = _cache(tmp_path)
+    a = client.complete("hello")
+    b = client.complete("hello")
+    assert a == b == "complete::hello"
+    assert inner.calls["complete"] == 1
+
+
+# 2. Different prompt or different model -> different key -> inner called again.
+def test_different_prompt_is_a_new_key(tmp_path):
+    client, inner = _cache(tmp_path)
+    client.complete("p1")
+    client.complete("p2")
+    assert inner.calls["complete"] == 2
+
+
+def test_different_model_is_a_new_key(tmp_path):
+    path = str(tmp_path / "shared.jsonl")
+    inner_a = FakeInner(model="model-a")
+    inner_b = FakeInner(model="model-b")
+    ca = CachingLLMClient(inner_a, path)
+    cb = CachingLLMClient(inner_b, path)
+    ca.complete("same-prompt")
+    # cb reloads ca's on-disk entry but its model differs -> different key -> miss.
+    cb.complete("same-prompt")
+    assert inner_a.calls["complete"] == 1
+    assert inner_b.calls["complete"] == 1
+
+
+# 3. complete / complete_json / complete_many cache INDEPENDENTLY; temperature>0 not cached.
+def test_methods_cache_independently(tmp_path):
+    client, inner = _cache(tmp_path)
+    # same prompt string, three different methods -> three distinct keys.
+    client.complete("x")
+    client.complete("x")
+    client.complete_json("x")
+    client.complete_json("x")
+    client.complete_many("x", n=2, temperature=0.0)
+    client.complete_many("x", n=2, temperature=0.0)
+    assert inner.calls == {"complete": 1, "complete_json": 1, "complete_many": 1}
+
+
+def test_complete_many_returns_cached_list(tmp_path):
+    client, inner = _cache(tmp_path)
+    first = client.complete_many("q", n=3, temperature=0.0)
+    second = client.complete_many("q", n=3, temperature=0.0)
+    assert first == second == ["many::q::0::t0.0", "many::q::1::t0.0", "many::q::2::t0.0"]
+    assert inner.calls["complete_many"] == 1
+    # a mutation of a returned list must not poison the cache.
+    second.append("tampered")
+    assert client.complete_many("q", n=3, temperature=0.0) == first
+
+
+def test_complete_many_n_is_part_of_key(tmp_path):
+    client, inner = _cache(tmp_path)
+    client.complete_many("q", n=2, temperature=0.0)
+    client.complete_many("q", n=3, temperature=0.0)
+    assert inner.calls["complete_many"] == 2
+
+
+def test_complete_many_positive_temperature_is_not_cached(tmp_path):
+    client, inner = _cache(tmp_path)
+    client.complete_many("q", n=2, temperature=0.7)
+    client.complete_many("q", n=2, temperature=0.7)
+    # nondeterministic sampling -> never frozen -> inner called EVERY time.
+    assert inner.calls["complete_many"] == 2
+    # and nothing was written to disk for the sampled calls.
+    assert not Path(str(tmp_path / "cache.jsonl")).exists() or (
+        Path(str(tmp_path / "cache.jsonl")).read_text(encoding="utf-8").strip() == ""
+    )
+
+
+# 4. Disabled (no path) -> passthrough, inner called every time, zero cache files.
+def test_disabled_passthrough_no_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inner = FakeInner()
+    client = CachingLLMClient(inner, None)
+    client.complete("a")
+    client.complete("a")
+    client.complete_json("a")
+    client.complete_json("a")
+    assert inner.calls["complete"] == 2
+    assert inner.calls["complete_json"] == 2
+    # no file written anywhere under the cwd.
+    assert list(Path(tmp_path).glob("**/*.jsonl")) == []
+
+
+def test_disabled_empty_string_passthrough(tmp_path):
+    inner = FakeInner()
+    client = CachingLLMClient(inner, "")
+    client.complete("a")
+    client.complete("a")
+    assert inner.calls["complete"] == 2
+
+
+# 5. Persistence round-trip: a fresh instance on the same file serves from disk.
+def test_persistence_round_trip(tmp_path):
+    path = str(tmp_path / "persist.jsonl")
+    inner1 = FakeInner()
+    c1 = CachingLLMClient(inner1, path)
+    r1 = c1.complete("persisted")
+    assert inner1.calls["complete"] == 1
+
+    inner2 = FakeInner()
+    c2 = CachingLLMClient(inner2, path)
+    r2 = c2.complete("persisted")
+    assert r2 == r1
+    assert inner2.calls["complete"] == 0  # served from disk, inner untouched
+
+
+# 6. Corrupt cache file -> treated as empty, no crash, rebuilds.
+def test_corrupt_cache_file_is_tolerated(tmp_path):
+    path = tmp_path / "corrupt.jsonl"
+    path.write_text("this is not json\n{also bad\n", encoding="utf-8")
+    inner = FakeInner()
+    client = CachingLLMClient(inner, str(path))  # must not raise
+    out = client.complete("after-corruption")
+    assert out == "complete::after-corruption"
+    assert inner.calls["complete"] == 1
+    # rebuilds cleanly: a fresh instance reads the rewritten file and hits.
+    inner2 = FakeInner()
+    client2 = CachingLLMClient(inner2, str(path))
+    assert client2.complete("after-corruption") == out
+    assert inner2.calls["complete"] == 0
+
+
+def test_partial_last_line_is_tolerated(tmp_path):
+    # A crash mid-append can leave a truncated final line.
+    path = tmp_path / "partial.jsonl"
+    good = json.dumps({"key": "abc", "resp": "cached-value"})
+    path.write_text(good + "\n{\"key\": \"def\", \"resp\": \"tru", encoding="utf-8")
+    inner = FakeInner()
+    client = CachingLLMClient(inner, str(path))  # must not raise
+    # rebuilt to empty, so a new call misses and repopulates without crashing.
+    assert client.complete("z") == "complete::z"
+
+
+# 7. Thread-safety: concurrent gets/puts don't lose entries or corrupt the file.
+#    (The cache deliberately does NOT single-flight -- holding the lock across the
+#    network call would serialize the parallel build. A rare concurrent double-miss
+#    recomputes a key, but the file stays one-line-per-key and nothing is lost.)
+def test_thread_safety_stress(tmp_path):
+    path = str(tmp_path / "stress.jsonl")
+    inner = FakeInner()
+    client = CachingLLMClient(inner, path)
+    prompts = [f"prompt-{i}" for i in range(200)]
+
+    def hammer(p):
+        return client.complete(p)
+
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        futures = [ex.submit(hammer, p) for p in prompts for _ in range(4)]
+        results = [f.result() for f in futures]
+
+    assert all(r.startswith("complete::") for r in results)
+    # every distinct prompt was computed at least once, and the cache stopped the
+    # 800 concurrent calls from each hitting the model (well below one-per-call).
+    assert len(prompts) <= inner.calls["complete"] < len(futures)
+
+    # the file is well-formed (every line parses) and holds each key EXACTLY once,
+    # covering every prompt -- no lost entries, no corruption despite the races.
+    lines = [ln for ln in Path(path).read_text(encoding="utf-8").splitlines() if ln.strip()]
+    keys = [json.loads(ln)["key"] for ln in lines]
+    assert len(keys) == len(set(keys)) == len(prompts)
+
+    # a fresh instance reloads all of them and never calls inner.
+    inner2 = FakeInner()
+    client2 = CachingLLMClient(inner2, path)
+    for p in prompts:
+        client2.complete(p)
+    assert inner2.calls["complete"] == 0
+
+
+def test_token_counters_passthrough_and_hits_are_free(tmp_path):
+    client, inner = _cache(tmp_path)
+    client.complete("costed")
+    after_miss_in = client.input_tokens
+    after_miss_out = client.output_tokens
+    assert after_miss_in == inner.input_tokens == len("costed")
+    assert after_miss_out == inner.output_tokens == 1
+    # a HIT advances neither the inner counters nor the passthrough view.
+    client.complete("costed")
+    assert client.input_tokens == after_miss_in
+    assert client.output_tokens == after_miss_out
+
+
+def test_model_passthrough(tmp_path):
+    client, inner = _cache(tmp_path, inner=FakeInner(model="gpt-4o-mini"))
+    assert client.model == "gpt-4o-mini"
+
+
+def test_complete_json_falls_back_when_inner_lacks_it(tmp_path):
+    class OnlyComplete:
+        model = "m"
+
+        def __init__(self):
+            self.n = 0
+
+        def complete(self, prompt):
+            self.n += 1
+            return f"c::{prompt}"
+
+    inner = OnlyComplete()
+    client = CachingLLMClient(inner, str(tmp_path / "fb.jsonl"))
+    assert client.complete_json("p") == "c::p"
+    client.complete_json("p")  # cached
+    assert inner.n == 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -192,9 +192,34 @@ class GoldenGraphQAEngine:
         retrieval_mode: str | None = None,
         passage_k: int | None = None,
     ):
-        self._llm = _CountingLLM(llm)
-        # Cascade seam: synthesis may use a separate (larger) model; extraction stays on self._llm.
-        self._synth_llm = _build_synthesis_llm(self._llm)
+        base_llm = _CountingLLM(llm)
+        # Cascade seam: synthesis may use a separate (larger) model; extraction stays
+        # on the base client. Build the synth client FIRST, off the UNcached base --
+        # answers must reflect the current model, so only the extraction/build client
+        # is cached (below). When GOLDENGRAPH_SYNTHESIS_MODEL is unset, synth IS the
+        # base client; caching only the build wrapper keeps synthesis uncached even
+        # in that shared-object case.
+        self._synth_llm = _build_synthesis_llm(base_llm)
+        # Prompt-hash LLM response cache for the (network-bound, ~50 min at N=150)
+        # extraction build: re-running the QA bench on the same corpus then skips the
+        # identical per-document LLM calls. Opt-in + measurement-safe -- the key is the
+        # exact prompt, so a cached response IS the model's output for that prompt and
+        # can never be stale while the prompt matches; a prompt change misses and
+        # repopulates. GOLDENGRAPH_LLM_CACHE unset/empty -> byte-identical (no wrap).
+        # The env value is a DIRECTORY (what the workflow's actions/cache persists);
+        # the JSON-lines backing file lives inside it.
+        self._llm = base_llm
+        cache_dir = os.environ.get("GOLDENGRAPH_LLM_CACHE", "").strip()
+        if cache_dir:
+            from goldengraph.llm import CachingLLMClient
+
+            try:
+                os.makedirs(cache_dir, exist_ok=True)
+            except OSError:
+                pass
+            self._llm = CachingLLMClient(
+                base_llm, os.path.join(cache_dir, "extraction_cache.jsonl")
+            )
         # Cache embeddings across the whole run: the build's cross-doc linking and
         # answer-time seeding both re-embed the same entity texts many times, which
         # is the O(N^2) network wall at large N.


### PR DESCRIPTION
## What

Adds an opt-in, prompt-hash-keyed **LLM response cache** in front of GoldenGraph's extraction calls so re-running the QA bench on the same corpus skips the ~50-min LLM extraction build.

## Why (measured)

The QA bench's dominant cost is `goldengraph.ingest.ingest_corpus`, which makes per-document LLM extraction calls (network-bound; ~50 min at N=150). Every re-run on the same corpus repeats identical calls. A response cache keyed by the exact prompt makes re-runs near-free for the build phase.

**Why this can't corrupt a measurement:** the key is a stable sha256 of `(model, method, prompt, sorted(kwargs))`. A cached response *is* the model's output for that exact prompt+model, so serving it is never stale as long as the prompt matches. Any extraction-code change that alters a prompt yields a **new key automatically** (a miss that repopulates), and all deterministic post-processing (parsing, resolution) still re-runs on the cached raw response. It is prompt-hash **self-invalidating**, so no code SHA is needed in any cache key.

## The change

- **`CachingLLMClient`** (`goldengraph/llm.py`) implements the `LLMClient` protocol wrapping an inner client. On a hit it returns the cached response **without** calling the inner client (no API cost; inner token counters don't advance; `.input_tokens`/`.output_tokens`/`.model` are read-through views so callers keep working). On a miss it calls, stores, returns. `complete_many` caches the list keyed including `n`+`temperature`, but **skips caching when `temperature > 0`** (never freeze a sampled distribution) — extraction runs `complete`/`complete_json` at temp 0, so this only spares the self-consistency synth path.
  - Backing store: JSON-lines file, load-on-init + write-through per put, guarded by a lock (`ingest_corpus` parallelizes extraction across documents). A corrupt/partial file is treated as empty and overwritten — never crashes the build.

- **Env flag (default off = byte-identical):** `GOLDENGRAPH_LLM_CACHE`. Unset/empty ⇒ caching disabled ⇒ the wrapper is never installed and behavior is byte-identical to today.

- **Bench-only wiring** (`engines/goldengraph.py`): only when `GOLDENGRAPH_LLM_CACHE` is set is the **extraction/build** client wrapped. The **library default is unchanged everywhere** — goldengraph and all non-bench callers stay uncached.

- **Answer-time synth client stays uncached:** the synth client is now built off the *uncached* base client first, so it stays uncached even in the shared-object case (when `GOLDENGRAPH_SYNTHESIS_MODEL` is unset, synth *is* the base client) — only the build wrapper is cached.

- **Workflow** (`bench-graphrag-qa.yml`): an `actions/cache` (restore+save) step on the goldengraph job persists the cache directory across runs, keyed by `corpus` + extraction model (+ ambiguity for matrix hygiene) with a restore-keys prefix so a partial/older cache still restores and tops up. `GOLDENGRAPH_LLM_CACHE` points at that directory. Guarded to the goldengraph engine job only; no other jobs change.

## Tests

`packages/python/goldengraph/tests/test_llm_cache.py` (16 tests, pure-Python, no network): miss-then-hit, key differentiation by prompt/model/method, `complete`/`complete_json`/`complete_many` cache independently, `complete_many` temp>0 not cached, disabled passthrough (no files written), persistence round-trip, corrupt + partial-last-line tolerance, and a `ThreadPoolExecutor` stress test. All 16 pass locally.

## Not done (intentional)

Draft only — do NOT merge. No bench workflow was run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
