### PR TITLE
perf(er-kg-bench): parallelize the QA answer loop (QA_E2E_ANSWER_WORKERS, default 8)

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldengraph.py
@@ -131,22 +131,53 @@ class _CachingEmbedder:
 
 class _CountingLLM:
     """Wraps any goldengraph LLMClient and estimates token usage per .complete
-    call (len//4), so the bench owns cost accounting regardless of the client."""
+    call (len//4), so the bench owns cost accounting regardless of the client.
+
+    Two counter layers, both fed by every call:
+      * global `input_tokens`/`output_tokens` -- the whole-run cumulative totals,
+        lock-guarded so the parallel BUILD (ingest_corpus fans extraction across
+        worker threads) sums correctly. `build_kg` brackets these before/after.
+      * a thread-local per-call accumulator -- read by `answer()` on its own worker
+        thread so PARALLEL questions can't cross-contaminate per-question token
+        attribution. Before/after deltas on the shared global counter DOUBLE-COUNT
+        when questions overlap (an increment landing inside two questions' [before,
+        after] windows is charged to both), which would also inflate the summed
+        total; the thread-local delta is exact per question and the per-question
+        deltas still sum to the true total. See `answer()`.
+    """
 
     def __init__(self, inner: Any):
         self._inner = inner
         self.input_tokens = 0
         self.output_tokens = 0
         self._lock = threading.Lock()
+        # Per-thread call accumulator. answer() runs entirely on one pool worker and
+        # `ask()` issues its synthesis call synchronously on that same thread, so the
+        # thread-local captures exactly this question's tokens.
+        self._tl = threading.local()
+
+    def _charge(self, in_tok: int, out_tok: int) -> None:
+        with self._lock:
+            self.input_tokens += in_tok
+            self.output_tokens += out_tok
+        self._tl.in_tok = getattr(self._tl, "in_tok", 0) + in_tok
+        self._tl.out_tok = getattr(self._tl, "out_tok", 0) + out_tok
+
+    def reset_thread_tokens(self) -> None:
+        """Zero THIS thread's per-call accumulator (call before a metered section)."""
+        self._tl.in_tok = 0
+        self._tl.out_tok = 0
+
+    def thread_tokens(self) -> tuple[int, int]:
+        """(input, output) charged on THIS thread since the last reset."""
+        return getattr(self._tl, "in_tok", 0), getattr(self._tl, "out_tok", 0)
 
     def complete(self, prompt: str) -> str:
         # Concurrent build calls share this wrapper; guard the counters (the inner
         # OpenAI client is itself thread-safe for concurrent requests). Retry
         # rate-limit/transient errors so high concurrency doesn't drop documents.
         out = _with_retry(lambda: self._inner.complete(prompt))
-        with self._lock:
-            self.input_tokens += max(1, len(prompt) // 4)
-            self.output_tokens += max(1, len(out) // 4)
+        self._charge(max(1, len(prompt) // 4), max(1, len(out) // 4))
         return out
 
     def complete_json(self, prompt: str) -> str:
@@ -154,9 +185,7 @@ class _CountingLLM:
         # when present (the OpenAIClient/Ollama path), else fall back to complete.
         fn = getattr(self._inner, "complete_json", self._inner.complete)
         out = _with_retry(lambda: fn(prompt))
-        with self._lock:
-            self.input_tokens += max(1, len(prompt) // 4)
-            self.output_tokens += max(1, len(out) // 4)
+        self._charge(max(1, len(prompt) // 4), max(1, len(out) // 4))
         return out
 
 
@@ -180,6 +209,11 @@ def _build_synthesis_llm(default_llm):
 class GoldenGraphQAEngine:
     name = "goldengraph"
     fidelity = "real-e2e"
+    # answer() is read-only against the built handle (store.as_of() snapshot queries +
+    # synthesis; `provenance` is a local set) and, since the _CountingLLM fix, tracks
+    # per-question tokens on a thread-local -- so the harness may answer questions in
+    # parallel (QA_E2E_ANSWER_WORKERS).
+    answer_parallel_safe = True
 
     def __init__(
         self,
@@ -316,7 +350,14 @@ class GoldenGraphQAEngine:
         except (KeyError, ValueError):
             passage_k = self._passage_k
         t0 = time.perf_counter()
-        before_in, before_out = self._synth_llm.input_tokens, self._synth_llm.output_tokens
+        # Per-question token attribution via the synth client's THREAD-LOCAL counter,
+        # not a before/after delta on the shared global counter: under parallel
+        # answering (QA_E2E_ANSWER_WORKERS) overlapping questions' [before, after]
+        # windows would each charge the other's synthesis tokens (double-count),
+        # corrupting both per-question tokens AND the summed total. reset->ask->read
+        # on this worker thread is exact, and the per-question deltas still sum to the
+        # run total. `ask()` issues its synthesis call synchronously on this thread.
+        self._synth_llm.reset_thread_tokens()
         # `provenance_out` collects the source-doc ids of every edge the retrieval/traversal touched.
         # The store stamps each edge with its owning document id (ingest doc_ids); intersecting these
         # with the question's gold_supporting_fact_ids is the supporting-fact recall the harness scores.
@@ -344,8 +385,8 @@ class GoldenGraphQAEngine:
             # corpus renders an edge in several docs (base id + `::N` suffixes); the base id IS the gold
             # id, so the intersection still hits. Empty when retrieval surfaced no stored edge.
             retrieved_fact_ids=tuple(sorted(provenance)),
-            input_tokens=self._synth_llm.input_tokens - before_in,
-            output_tokens=self._synth_llm.output_tokens - before_out,
+            input_tokens=self._synth_llm.thread_tokens()[0],
+            output_tokens=self._synth_llm.thread_tokens()[1],
             latency_s=time.perf_counter() - t0,
         )
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/goldenmatch_rag.py
@@ -23,6 +23,7 @@ light lane). The OpenAI client is injectable so the wiring is testable offline."
 from __future__ import annotations
 
 import os
+import threading
 import time
 from typing import Any
 
@@ -49,10 +50,19 @@ class _OpenAIEmbedderAdapter:
         self._model = model
         self._batch = batch
         self._cache: dict[str, np.ndarray] = {}
+        # The corpus cache_key is written on the FIRST answer; under parallel answering
+        # (QA_E2E_ANSWER_WORKERS) several first-wave questions can hit `embed_column`
+        # with the same cache_key at once, so guard the cache read/store. The network
+        # embed itself runs OUTSIDE the lock (query embeds pass cache_key=None and never
+        # touch it), so parallelism is preserved; the lock only makes the store atomic.
+        self._cache_lock = threading.Lock()
 
     def embed_column(self, values, cache_key=None) -> np.ndarray:
-        if cache_key is not None and cache_key in self._cache:
-            return self._cache[cache_key]
+        if cache_key is not None:
+            with self._cache_lock:
+                cached = self._cache.get(cache_key)
+            if cached is not None:
+                return cached
         texts = [v if (v and str(v).strip()) else " " for v in values]
         out: list[list[float]] = []
         for i in range(0, len(texts), self._batch):
@@ -62,7 +72,9 @@ class _OpenAIEmbedderAdapter:
         arr = np.asarray(out, dtype=float)
         arr = arr / (np.linalg.norm(arr, axis=1, keepdims=True) + 1e-12)
         if cache_key is not None:
-            self._cache[cache_key] = arr
+            with self._cache_lock:
+                # First writer wins; concurrent computers produce the same array anyway.
+                arr = self._cache.setdefault(cache_key, arr)
         return arr
 
 

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/graphiti.py
@@ -82,6 +82,13 @@ async def _close_quietly(graphiti) -> None:
 class GraphitiQAEngine:
     name = "graphiti"
     fidelity = "real-e2e"
+    # NOT safe to answer in parallel: answer() drives a SINGLE persistent asyncio loop
+    # (`self._loop.run_until_complete`, which cannot be entered from multiple threads
+    # at once) and attributes per-question tokens via a before/after delta on the
+    # shared `self._counter` (double-counts + corrupts the total under concurrency).
+    # The harness forces sequential answering for this engine (QA_E2E_ANSWER_WORKERS
+    # is ignored). Fixing both would require a per-thread loop + per-call token return.
+    answer_parallel_safe = False
 
     def __init__(
         self,

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/lightrag.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/engines/lightrag.py
@@ -42,6 +42,13 @@ def make_counting_llm_func(inner, counter: dict):
 class LightRAGQAEngine:
     name = "lightrag"
     fidelity = "real-e2e"
+    # NOT safe to answer in parallel: answer() runs on a SINGLE persistent asyncio loop
+    # (reused across build + every query; `run_until_complete` cannot be driven from
+    # multiple threads at once) and attributes per-question tokens via a before/after
+    # delta on the shared `self._counter` (double-counts + corrupts the total under
+    # concurrency). The harness forces sequential answering for this engine
+    # (QA_E2E_ANSWER_WORKERS is ignored).
+    answer_parallel_safe = False
 
     def __init__(
         self, *, llm_model_func: Any, embedding_func: Any, work_root: str | None = None

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py
@@ -3,6 +3,7 @@ the harness builds the KG once, answers every question, scores via metrics, and
 enforces a hard USD cap via goldenmatch's BudgetTracker."""
 from __future__ import annotations
 
+import concurrent.futures as _cf
 import contextlib
 import json
 import os
@@ -327,6 +328,156 @@ def _build_scorecard(engine, corpus, model, scored, *, answered, cost_usd, budge
     }
 
 
+#: Default width of the bounded thread pool that answers questions. Each answer is a
+#: network-bound LLM call (synthesis inside engine.answer + the judge inside
+#: _score_question) that releases the GIL, and questions are independent, so a small
+#: pool cuts the sequential per-question wall ~linearly (~41 min at N=150 was one
+#: question at a time). Override with QA_E2E_ANSWER_WORKERS; `1` forces the
+#: byte-identical sequential path, a non-integer value falls back to this default.
+_DEFAULT_ANSWER_WORKERS = 8
+
+
+def _answer_workers() -> int:
+    """Resolve QA_E2E_ANSWER_WORKERS -> pool width. Default 8; `1` = sequential;
+    a non-integer (or unset) value -> the default. Values < 1 clamp to 1."""
+    raw = os.environ.get("QA_E2E_ANSWER_WORKERS")
+    if raw is None:
+        return _DEFAULT_ANSWER_WORKERS
+    try:
+        v = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_ANSWER_WORKERS
+    return max(1, v)
+
+
+def _engine_answer_workers(engine, requested: int) -> int:
+    """The effective pool width for THIS engine. An engine that declares
+    `answer_parallel_safe = False` (its answer() mutates shared state or drives a
+    single asyncio loop -- e.g. graphiti, lightrag) is forced sequential regardless
+    of the requested width."""
+    if requested <= 1:
+        return 1
+    if not getattr(engine, "answer_parallel_safe", True):
+        return 1
+    return requested
+
+
+def _answer_all(
+    engine,
+    handle,
+    questions,
+    judge,
+    *,
+    mode: str | None = None,
+    workers: int,
+    tracker,
+    model: str,
+    on_result=None,
+    reserve: int = 1,
+    only_indices=None,
+):
+    """Answer `questions` and score each in a bounded thread pool, returning
+    ``(scored_ordered, answered_indices)`` where `scored_ordered` is ordered by the
+    ORIGINAL question index -- independent of completion order and of worker count.
+
+    Shared by all three run_* entry points so the pool + ordering + budget policy live
+    in one place.
+
+    - `mode`: forwarded as ``engine.answer(..., mode=mode)`` when not None (the A/B
+      mode arm); a 2-arg ``engine.answer(handle, q)`` call otherwise.
+    - `tracker`: the shared enforce/budget ``BudgetTracker``. Charged (thread-safe)
+      once per answer with that answer's tokens, and consulted to stop SUBMITTING new
+      tasks once over budget -- in-flight tasks still finish (a small, bounded
+      overshoot). The total after a parallel run equals the sequential total (a
+      sum over the same per-answer tokens, order-independent).
+    - `on_result(idx, ans)`: optional hook, called under no lock as each answer lands
+      (per-arm cost attribution charges the arm's tracker here).
+    - `reserve`: multiply the per-question token estimate when checking ``can_send``,
+      so a caller that answers each question under N arms reserves the whole set up
+      front (keeps A/B arms aligned on the same question set).
+    - `only_indices`: when given, answer exactly these question indices with NO budget
+      gate -- a subsequent A/B arm re-answering the first arm's committed set to stay
+      aligned. When None, the budget gate selects the answered prefix.
+
+    ``workers <= 1`` runs the exact sequential loop (byte-identical fallback)."""
+
+    def _do_answer(q):
+        return engine.answer(handle, q.question) if mode is None else engine.answer(
+            handle, q.question, mode=mode
+        )
+
+    def _charge(i, q, ans):
+        # Budget/enforce tracker (its record_usage is lock-guarded) + optional per-arm
+        # attribution. Judge cost is NOT charged here (eval overhead, per run_engine).
+        tracker.record_usage(ans.input_tokens, ans.output_tokens, model)
+        if on_result is not None:
+            on_result(i, ans)
+
+    scored_map: dict[int, dict] = {}
+    answered: list[int] = []
+
+    # Sequential path -- byte-identical to the pre-parallel loop (gate -> answer ->
+    # record_usage -> score, in question order). Also the forced path for
+    # answer_parallel_safe=False engines.
+    if workers <= 1:
+        indices = list(only_indices) if only_indices is not None else range(len(questions))
+        for i in indices:
+            q = questions[i]
+            if only_indices is None and (
+                tracker.budget_exhausted
+                or not tracker.can_send(_estimate_tokens(q.question) * reserve)
+            ):
+                break
+            ans = _do_answer(q)
+            _charge(i, q, ans)
+            scored_map[i] = _score_question(ans, q, judge)
+            answered.append(i)
+        return [scored_map[i] for i in sorted(scored_map)], sorted(answered)
+
+    # Parallel path -- bounded pool, streaming submission so cost recorded by completed
+    # tasks feeds the budget gate before the next submit (in-flight bounded to
+    # `workers`, so the overshoot past the cap is at most ~workers questions). The
+    # answer AND its scoring (which runs the network-bound judge) both happen on the
+    # worker thread; the main thread only charges the tracker and files the result.
+    def _task(i, q):
+        ans = _do_answer(q)
+        return i, q, ans, _score_question(ans, q, judge)
+
+    src = iter(only_indices) if only_indices is not None else iter(range(len(questions)))
+    with _cf.ThreadPoolExecutor(max_workers=workers) as ex:
+        pending: set = set()
+        src_done = False
+
+        def _fill():
+            nonlocal src_done
+            while not src_done and len(pending) < workers:
+                try:
+                    i = next(src)
+                except StopIteration:
+                    src_done = True
+                    break
+                q = questions[i]
+                if only_indices is None and (
+                    tracker.budget_exhausted
+                    or not tracker.can_send(_estimate_tokens(q.question) * reserve)
+                ):
+                    src_done = True  # over budget: stop submitting, let in-flight finish
+                    break
+                pending.add(ex.submit(_task, i, q))
+
+        _fill()
+        while pending:
+            done, pending = _cf.wait(pending, return_when=_cf.FIRST_COMPLETED)
+            for fut in done:
+                i, q, ans, scored = fut.result()
+                _charge(i, q, ans)
+                scored_map[i] = scored
+                answered.append(i)
+            _fill()
+
+    return [scored_map[i] for i in sorted(scored_map)], sorted(answered)
+
+
 def run_engine(
     engine: QAEngine, corpus, *, model: str, budget_usd: float, judge=None
 ) -> dict:
@@ -346,19 +497,18 @@ def run_engine(
     ):
         _localize_trace(engine, build.handle, corpus)
 
-    scored: list[dict] = []
-    answered = 0
-    for q in corpus.questions:
-        if tracker.budget_exhausted or not tracker.can_send(_estimate_tokens(q.question)):
-            break
-        ans = engine.answer(build.handle, q.question)
-        tracker.record_usage(ans.input_tokens, ans.output_tokens, model)
-        scored.append(_score_question(ans, q, judge))
-        answered += 1
+    # Answer every question under the hard cost cap, in a bounded thread pool
+    # (QA_E2E_ANSWER_WORKERS, default 8; 1 = the sequential path). Results are ordered
+    # by original question index, so the scorecard is independent of worker count.
+    workers = _engine_answer_workers(engine, _answer_workers())
+    scored, answered_idx = _answer_all(
+        engine, build.handle, list(corpus.questions), judge,
+        workers=workers, tracker=tracker, model=model,
+    )
 
     return _build_scorecard(
         engine, corpus, model, scored,
-        answered=answered,
+        answered=len(answered_idx),
         cost_usd=tracker.total_cost_usd,
         budget_exhausted=tracker.budget_exhausted,
     )
@@ -392,21 +542,34 @@ def run_engine_ab(
     enforce.record_usage(build.input_tokens, build.output_tokens, model)
     build_cost = enforce.total_cost_usd
 
-    scored: dict[str, list[dict]] = {m: [] for m in modes}
-    answered = 0
-    for q in corpus.questions:
-        # A question costs one answer PER mode; only start it if the budget can afford
-        # the whole set, so both arms answer exactly the same questions.
-        if enforce.budget_exhausted or not enforce.can_send(
-            _estimate_tokens(q.question) * len(modes)
-        ):
-            break
-        for m in modes:
-            ans = engine.answer(build.handle, q.question, mode=m)
-            enforce.record_usage(ans.input_tokens, ans.output_tokens, model)
-            arm_trackers[m].record_usage(ans.input_tokens, ans.output_tokens, model)
-            scored[m].append(_score_question(ans, q, judge))
-        answered += 1
+    # Answer arm-major (env-free -- the mode rides the answer() kwarg), each arm in a
+    # bounded thread pool. The FIRST arm's budget gate reserves the whole mode-set per
+    # question (reserve=len(modes)), fixing the answered-question set; the remaining
+    # arms re-answer exactly that set (only_indices) so all arms stay aligned. The
+    # shared `enforce` tracker accumulates every arm's cost; per-arm cost is attributed
+    # via on_result. Byte-identical to the old question-major loop when the budget is
+    # not hit; a small bounded overshoot at the cap boundary otherwise.
+    questions = list(corpus.questions)
+    workers = _engine_answer_workers(engine, _answer_workers())
+    scored: dict[str, list[dict]] = {}
+
+    def _arm_charger(m):
+        return lambda i, ans: arm_trackers[m].record_usage(
+            ans.input_tokens, ans.output_tokens, model
+        )
+
+    first = modes[0]
+    scored[first], answered_idx = _answer_all(
+        engine, build.handle, questions, judge, mode=first, workers=workers,
+        tracker=enforce, model=model, on_result=_arm_charger(first), reserve=len(modes),
+    )
+    for m in modes[1:]:
+        scored[m], _ = _answer_all(
+            engine, build.handle, questions, judge, mode=m, workers=workers,
+            tracker=enforce, model=model, on_result=_arm_charger(m),
+            only_indices=answered_idx,
+        )
+    answered = len(answered_idx)
 
     arms = {
         m: _build_scorecard(
@@ -462,22 +625,38 @@ def run_engine_ab_env(
     enforce.record_usage(build.input_tokens, build.output_tokens, model)
     build_cost = enforce.total_cost_usd
 
-    scored: dict[str, list[dict]] = {label: [] for label in labels}
-    answered = 0
-    for q in corpus.questions:
-        # A question costs one answer PER arm; only start it if the budget can afford
-        # the whole set, so every arm answers exactly the same questions.
-        if enforce.budget_exhausted or not enforce.can_send(
-            _estimate_tokens(q.question) * len(arms)
-        ):
-            break
-        for label, env in arms:
-            with _env_overrides(env):
-                ans = engine.answer(build.handle, q.question)
-            enforce.record_usage(ans.input_tokens, ans.output_tokens, model)
-            arm_trackers[label].record_usage(ans.input_tokens, ans.output_tokens, model)
-            scored[label].append(_score_question(ans, q, judge))
-        answered += 1
+    # Answer arm-major, each arm's whole batch under ONE `_env_overrides(env)` context.
+    # This is what makes the env A/B thread-safe: os.environ is process-global, so two
+    # arms' overrides cannot run concurrently -- but WITHIN one arm the env is fixed, so
+    # every worker thread in that arm's pool sees the same (correct) env. The first
+    # arm's budget gate reserves the whole arm-set per question (reserve=len(arms)),
+    # fixing the answered set; the rest re-answer exactly that set (only_indices) so the
+    # arms stay aligned. Byte-identical to the old question-major loop when the budget
+    # is not hit; a small bounded overshoot at the cap boundary otherwise.
+    questions = list(corpus.questions)
+    workers = _engine_answer_workers(engine, _answer_workers())
+    scored: dict[str, list[dict]] = {}
+
+    def _arm_charger(label):
+        return lambda i, ans: arm_trackers[label].record_usage(
+            ans.input_tokens, ans.output_tokens, model
+        )
+
+    first_label, first_env = arms[0]
+    with _env_overrides(first_env):
+        scored[first_label], answered_idx = _answer_all(
+            engine, build.handle, questions, judge, workers=workers,
+            tracker=enforce, model=model, on_result=_arm_charger(first_label),
+            reserve=len(arms),
+        )
+    for label, env in arms[1:]:
+        with _env_overrides(env):
+            scored[label], _ = _answer_all(
+                engine, build.handle, questions, judge, workers=workers,
+                tracker=enforce, model=model, on_result=_arm_charger(label),
+                only_indices=answered_idx,
+            )
+    answered = len(answered_idx)
 
     arm_cards = {
         label: _build_scorecard(

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_parallel.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_answer_parallel.py
@@ -1,0 +1,277 @@
+"""Bounded thread-pool answer loop (QA_E2E_ANSWER_WORKERS).
+
+These are pure-Python / no-network: a deterministic fake engine + fake judge + the
+real BudgetTracker. They lock the guarantees the parallel loop must hold -- output
+independent of worker count and completion order, total cost order-independent, the
+workers=1 byte-identical fallback -- plus the two thread-safety fixes (goldengraph's
+per-question thread-local token counter and the existing 429 backoff)."""
+from __future__ import annotations
+
+import sys
+import threading
+import time
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.qa_e2e.corpora import Document, QACorpus, QAItem  # noqa: E402
+from erkgbench.qa_e2e.harness import (  # noqa: E402
+    AnswerResult,
+    BuildResult,
+    _answer_workers,
+    _engine_answer_workers,
+    run_engine,
+    run_engine_ab,
+)
+
+
+def _qidx(question: str) -> int:
+    # question is "question number {i} ..." -- recover i so the fake is deterministic.
+    return int(question.split()[2])
+
+
+class _FakeEngine:
+    """Deterministic, network-free QAEngine. answer() derives everything from the
+    question index: even -> names the gold (match), odd -> a miss; tokens = 100+i /
+    10+i so per-question cost is a known, order-independent sum. `stagger` sleeps
+    later indices LESS so completion order is the reverse of submission order."""
+
+    name = "fake"
+    fidelity = "real-e2e"
+    answer_parallel_safe = True
+
+    def __init__(self, *, stagger: float = 0.0, mode_suffix: bool = False):
+        self._stagger = stagger
+        self._mode_suffix = mode_suffix
+
+    def build_kg(self, corpus) -> BuildResult:
+        return BuildResult(
+            handle={"n": len(corpus.documents)},
+            input_tokens=500,
+            output_tokens=50,
+            latency_s=0.0,
+        )
+
+    def answer(self, handle, question: str, mode: str | None = None) -> AnswerResult:
+        i = _qidx(question)
+        if self._stagger:
+            # later indices sleep less -> they finish first (reverse of submit order)
+            time.sleep(self._stagger * (100 - i))
+        base = f"Ans{i}" if i % 2 == 0 else f"nope{i}"
+        text = f"the answer is {base}"
+        if self._mode_suffix and mode is not None:
+            text = f"{text} [{mode}]"
+        return AnswerResult(
+            text=text,
+            retrieved_fact_ids=(f"d{i}",),
+            input_tokens=100 + i,
+            output_tokens=10 + i,
+            latency_s=0.0,
+        )
+
+
+class _UnsafeEngine(_FakeEngine):
+    name = "unsafe"
+    answer_parallel_safe = False
+
+    def __init__(self):
+        super().__init__()
+        self.max_concurrent = 0
+        self._live = 0
+        self._lock = threading.Lock()
+
+    def answer(self, handle, question: str, mode: str | None = None) -> AnswerResult:
+        with self._lock:
+            self._live += 1
+            self.max_concurrent = max(self.max_concurrent, self._live)
+        try:
+            time.sleep(0.01)
+            return super().answer(handle, question, mode=mode)
+        finally:
+            with self._lock:
+                self._live -= 1
+
+
+class _FakeJudge:
+    """callable(prompt)->str. Deterministic: YES iff the prediction names the gold
+    ('Ans'). Thread-safe call counter so the parallel path is exercised safely."""
+
+    def __init__(self):
+        self.calls = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, prompt: str) -> str:
+        with self._lock:
+            self.calls += 1
+        return "YES" if "Ans" in prompt else "NO"
+
+
+def _corpus(n: int = 16) -> QACorpus:
+    docs = tuple(Document(id=f"d{i}", text=f"doc body {i}") for i in range(n))
+    qs = tuple(
+        QAItem(
+            id=f"q{i}",
+            question=f"question number {i} about a thing",
+            gold_answer=f"Ans{i}",
+            gold_supporting_fact_ids=(f"d{i}",),
+            hop_count=(i % 3) + 1,
+            ambiguity_level=0.0,
+        )
+        for i in range(n)
+    )
+    return QACorpus(name="fake", documents=docs, questions=qs)
+
+
+# --- QA_E2E_ANSWER_WORKERS resolution ---------------------------------------------
+
+
+def test_answer_workers_default_is_8(monkeypatch):
+    monkeypatch.delenv("QA_E2E_ANSWER_WORKERS", raising=False)
+    assert _answer_workers() == 8
+
+
+def test_answer_workers_one_forces_sequential(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "1")
+    assert _answer_workers() == 1
+
+
+def test_answer_workers_non_int_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "banana")
+    assert _answer_workers() == 8
+
+
+def test_engine_answer_workers_respects_unsafe_flag():
+    assert _engine_answer_workers(_FakeEngine(), 8) == 8
+    assert _engine_answer_workers(_UnsafeEngine(), 8) == 1
+    # requested==1 always sequential regardless of engine
+    assert _engine_answer_workers(_FakeEngine(), 1) == 1
+
+
+# --- Parallel == sequential, cost, ordering ---------------------------------------
+
+
+def _run(workers: int, monkeypatch, *, stagger: float = 0.0, judge=None):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", str(workers))
+    return run_engine(
+        _FakeEngine(stagger=stagger),
+        _corpus(),
+        model="gpt-4o-mini",
+        budget_usd=1000.0,
+        judge=judge,
+    )
+
+
+def test_parallel_scorecard_equals_sequential(monkeypatch):
+    seq = _run(1, monkeypatch)
+    par = _run(8, monkeypatch)
+    # Whole scorecard is byte-equal: same metrics, same per-question order, same
+    # n_answered -- independent of worker count.
+    assert par == seq
+    assert par["n_answered"] == 16
+    assert [r["id"] for r in par["per_question"]] == [f"q{i}" for i in range(16)]
+
+
+def test_parallel_scorecard_equals_sequential_with_judge(monkeypatch):
+    jseq, jpar = _FakeJudge(), _FakeJudge()
+    seq = _run(1, monkeypatch, judge=jseq)
+    par = _run(8, monkeypatch, judge=jpar)
+    assert par == seq
+    # judge ran once per answered question on both paths
+    assert jseq.calls == jpar.calls == 16
+    # even indices name the gold -> YES; odd -> NO ; half the answered set
+    assert par["answer_judge"] == seq["answer_judge"]
+
+
+def test_total_cost_identical_across_worker_counts(monkeypatch):
+    seq = _run(1, monkeypatch)
+    par = _run(8, monkeypatch)
+    assert par["cost_usd"] == seq["cost_usd"]
+    assert par["cost_usd"] > 0.0
+
+
+def test_ordering_stable_under_staggered_completion(monkeypatch):
+    # Later indices finish FIRST (stagger). The sort-by-index must still order the
+    # per-question records by original index, matching the sequential run exactly.
+    seq = _run(1, monkeypatch)
+    par = _run(8, monkeypatch, stagger=0.0005)
+    assert [r["id"] for r in par["per_question"]] == [f"q{i}" for i in range(16)]
+    assert par == seq
+
+
+def test_workers_1_is_the_sequential_path(monkeypatch):
+    # Explicit: =1 answers everything in order with the same metrics a small manual
+    # sequential expectation would give (even indices match -> answer_match 0.5).
+    res = _run(1, monkeypatch)
+    assert res["n_answered"] == 16
+    assert res["answer_match"] == 0.5  # even indices name the gold, odd miss
+    assert res["support_recall"] == 1.0  # every answer returns its own gold fact id
+
+
+# --- Budget cap under parallelism -------------------------------------------------
+
+
+def test_budget_cap_stops_answering_under_parallelism(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "8")
+
+    class _Expensive(_FakeEngine):
+        def answer(self, handle, question, mode=None):
+            i = _qidx(question)
+            return AnswerResult(
+                text=f"the answer is Ans{i}",
+                retrieved_fact_ids=(f"d{i}",),
+                input_tokens=5_000_000,
+                output_tokens=5_000_000,
+                latency_s=0.0,
+            )
+
+    # Tiny cap: build cost alone is fine, but answers are huge -> only a bounded few
+    # (<= workers) get answered before submission stops. Must not crash.
+    res = run_engine(_Expensive(), _corpus(), model="gpt-4o", budget_usd=0.001)
+    assert res["budget_exhausted"] is True
+    assert res["n_answered"] < 16  # capped, partial result
+
+
+# --- A/B (mode-based) parallel == sequential --------------------------------------
+
+
+def test_run_engine_ab_parallel_equals_sequential(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "1")
+    seq = run_engine_ab(
+        _FakeEngine(mode_suffix=True), _corpus(), model="gpt-4o-mini",
+        budget_usd=1000.0, modes=["local", "hybrid"],
+    )
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "8")
+    par = run_engine_ab(
+        _FakeEngine(mode_suffix=True), _corpus(), model="gpt-4o-mini",
+        budget_usd=1000.0, modes=["local", "hybrid"],
+    )
+    assert par == seq
+    assert par["n_answered"] == 16
+    # per-arm cost is attributed and equal across worker counts
+    assert par["arms"]["local"]["cost_usd"] == seq["arms"]["local"]["cost_usd"]
+    assert par["total_cost_usd"] == seq["total_cost_usd"]
+
+
+def test_run_engine_ab_arms_answer_same_question_set(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "8")
+    res = run_engine_ab(
+        _FakeEngine(mode_suffix=True), _corpus(), model="gpt-4o-mini",
+        budget_usd=1000.0, modes=["local", "hybrid"],
+    )
+    a = [r["id"] for r in res["arms"]["local"]["per_question"]]
+    b = [r["id"] for r in res["arms"]["hybrid"]["per_question"]]
+    assert a == b == [f"q{i}" for i in range(16)]
+
+
+# --- Unsafe engine is forced sequential -------------------------------------------
+
+
+def test_unsafe_engine_never_runs_answers_concurrently(monkeypatch):
+    monkeypatch.setenv("QA_E2E_ANSWER_WORKERS", "8")
+    eng = _UnsafeEngine()
+    res = run_engine(eng, _corpus(), model="gpt-4o-mini", budget_usd=1000.0)
+    assert res["n_answered"] == 16
+    # answer_parallel_safe=False -> forced sequential -> only ever one in flight
+    assert eng.max_concurrent == 1

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_counting_llm.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_qa_counting_llm.py
@@ -1,0 +1,134 @@
+"""goldengraph engine thread-safety: the per-question token counter and the 429/5xx
+retry. No wheel / network -- the engine module imports goldengraph lazily inside its
+methods, so `_CountingLLM` / `_with_retry` import free-standing."""
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from urllib.error import HTTPError
+
+_BENCH_ROOT = Path(__file__).resolve().parent.parent
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.qa_e2e.engines import goldengraph as gg  # noqa: E402
+
+
+class _InnerLLM:
+    """Deterministic inner client: the reply length is a fixed function of the prompt
+    length, so token counts are predictable."""
+
+    def complete(self, prompt: str) -> str:
+        return "r" * len(prompt)
+
+
+def test_counting_llm_thread_local_isolates_per_call_tokens():
+    # Each worker thread issues a DISTINCT-length prompt many times; reset->calls->read
+    # on that thread must report ONLY that thread's tokens (no cross-contamination),
+    # while the global counters sum every thread's calls.
+    llm = gg._CountingLLM(_InnerLLM())
+    n_threads, n_calls = 8, 20
+    results: dict[int, tuple[int, int]] = {}
+    barrier = threading.Barrier(n_threads)
+    lock = threading.Lock()
+
+    def worker(tid: int):
+        prompt = "p" * (10 * (tid + 1))  # thread tid's prompt length = 10*(tid+1)
+        barrier.wait()  # maximise interleaving
+        llm.reset_thread_tokens()
+        for _ in range(n_calls):
+            llm.complete(prompt)
+        got = llm.thread_tokens()
+        with lock:
+            results[tid] = got
+
+    threads = [threading.Thread(target=worker, args=(t,)) for t in range(n_threads)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Expected per-thread: n_calls * (max(1, len(prompt)//4), max(1, len(reply)//4)).
+    total_in = total_out = 0
+    for tid in range(n_threads):
+        plen = 10 * (tid + 1)
+        exp_in = n_calls * max(1, plen // 4)
+        exp_out = n_calls * max(1, plen // 4)  # reply length == prompt length
+        assert results[tid] == (exp_in, exp_out), tid
+        total_in += exp_in
+        total_out += exp_out
+
+    # Global counters are the order-independent SUM across all threads.
+    assert llm.input_tokens == total_in
+    assert llm.output_tokens == total_out
+
+
+def test_counting_llm_reset_clears_previous_call_residue():
+    # A pooled worker thread is reused across questions: reset must zero the prior
+    # question's residue so the next delta is exact.
+    llm = gg._CountingLLM(_InnerLLM())
+    llm.reset_thread_tokens()
+    llm.complete("xxxx")
+    first = llm.thread_tokens()
+    assert first[0] >= 1
+    llm.reset_thread_tokens()
+    llm.complete("yyyyyyyy")
+    second = llm.thread_tokens()
+    # second reflects ONLY the second call, not the sum of both
+    assert second == (max(1, 8 // 4), max(1, 8 // 4))
+
+
+def _http_error(code: int) -> HTTPError:
+    return HTTPError("http://x", code, "err", None, None)
+
+
+def test_with_retry_retries_rate_limit_then_succeeds(monkeypatch):
+    # A 429 the first 3 attempts, then success: _with_retry must swallow the 429s and
+    # return the eventual value, invoking fn exactly 4 times (retried, counted once by
+    # the caller since only the successful return records tokens).
+    monkeypatch.setattr(gg.time, "sleep", lambda *_a, **_k: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise _http_error(429)
+        return "ok"
+
+    assert gg._with_retry(fn) == "ok"
+    assert calls["n"] == 4
+
+
+def test_with_retry_reraises_non_retryable(monkeypatch):
+    # A 400 is a real error -> re-raised immediately, no retries.
+    monkeypatch.setattr(gg.time, "sleep", lambda *_a, **_k: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise _http_error(400)
+
+    try:
+        gg._with_retry(fn)
+        raise AssertionError("expected HTTPError")
+    except HTTPError as e:
+        assert e.code == 400
+    assert calls["n"] == 1
+
+
+def test_with_retry_gives_up_after_attempts(monkeypatch):
+    # Persistent 429: exhausts attempts (default 6) then re-raises.
+    monkeypatch.setattr(gg.time, "sleep", lambda *_a, **_k: None)
+    calls = {"n": 0}
+
+    def fn():
+        calls["n"] += 1
+        raise _http_error(429)
+
+    try:
+        gg._with_retry(fn, attempts=6)
+        raise AssertionError("expected HTTPError")
+    except HTTPError as e:
+        assert e.code == 429
+    assert calls["n"] == 6


### PR DESCRIPTION
## Why

The ER-KG QA-e2e harness (`benchmarks/er-kg-bench/erkgbench/qa_e2e/harness.py`) answered questions with a **sequential** `for q in corpus.questions` loop across all three run entry points. Each iteration is a network-bound LLM call (synthesis inside `engine.answer` + the LLM judge inside `_score_question`). At **N=150 that was ~41 min of wall, one question at a time**. The calls release the GIL during network I/O and questions are independent, so a bounded thread pool gives near-linear speedup.

## What changed

- **Shared `_answer_all(engine, handle, questions, judge, *, mode=None, workers, tracker, model, on_result=None, reserve=1, only_indices=None)` helper** — one bounded `ThreadPoolExecutor` implementation used by `run_engine`, `run_engine_ab`, and `run_engine_ab_env`. Streaming submission (in-flight bounded to `workers`) so completed-task cost feeds the budget gate before the next submit.
- **Env knob `QA_E2E_ANSWER_WORKERS`** — default **8**; `1` forces the current sequential path (byte-identical fallback); a non-integer value falls back to 8.
- **Output-equivalence**: results are collected into a per-index map and ordered by the **original question index** before aggregation, so the scorecard / per-arm scorecards are independent of worker count and completion order. Metrics (`answer_match`, `llm_judge`, `support_recall`, counts, `n_answered`) are identical to the sequential run.
- **Total-cost correctness**: the shared `BudgetTracker` is charged once per answer (its `record_usage` is `RLock`-guarded); the reported `total_cost_usd` is an order-independent sum, so parallel == sequential total. Budget-cap semantics: once the enforce tracker is over `budget_usd` the loop **stops submitting** new tasks; in-flight tasks finish (small, bounded overshoot ≤ `workers`). Per-arm trackers stay correct via the `on_result` attribution hook.

## Thread-safety fixes made

- **Per-call token attribution (the real one)** — `goldengraph.py::_CountingLLM`: `answer()` read per-question tokens as a **before/after delta on a shared global counter**. Under concurrency, overlapping questions' `[before, after]` windows each charge the other's synthesis tokens → **double-count**, which corrupts both per-question tokens *and* the summed total. Fixed with a **thread-local per-call accumulator** (`reset_thread_tokens` / `thread_tokens`); each answer runs on one worker thread and `ask()` issues its synthesis call synchronously on that thread, so the delta is exact and the per-question deltas still sum to the run total. (Global lock-guarded counters kept for the parallel *build*, which fans extraction across sub-threads and needs the aggregate.)
- **Embedder cache** — `goldenmatch_rag.py::_OpenAIEmbedderAdapter._cache` (the retrieval path) is written on the first answer; guarded its read/store with a `Lock` (network embed stays outside the lock, query embeds with `cache_key=None` stay lock-free).
- **Unsafe engines forced sequential** — `graphiti` and `lightrag` declare `answer_parallel_safe = False`: both drive a **single persistent asyncio loop** (`run_until_complete` can't be entered from multiple threads) *and* use the before/after shared-counter token pattern. `_engine_answer_workers` forces `workers=1` for them regardless of the env knob.

Already thread-safe, no change needed: `BudgetTracker` (`RLock` on all mutation), `goldengraph._CachingEmbedder` (`Lock`), and `_with_retry` (429/5xx exponential backoff already present). `ms_graphrag` is parallel-safe as-is (fresh `asyncio.run` per call, read-only handle, no shared counter). `engine.answer` is read-only against the built handle for goldengraph (`store.as_of()` snapshot queries; local `provenance` set).

## Per-question token attribution question

`AnswerResult.input_tokens/output_tokens` → `tracker.record_usage(...)` → `tracker.total_cost_usd` → scorecard `cost_usd`. So per-question tokens **do** feed a reported aggregate, and the before/after-shared-counter approach double-counts the total under concurrency — this is why the thread-local fix is load-bearing (not merely informational).

## Tests (TDD, pure-Python, no network)

- `tests/test_qa_answer_parallel.py` — deterministic fake engine + fake judge + real `BudgetTracker`: parallel scorecard byte-equal to sequential (with and without judge), total cost identical across worker counts, ordering stable under staggered completion, `=1` is the sequential path, `QA_E2E_ANSWER_WORKERS` resolution, budget cap still stops under parallelism, `run_engine_ab` arms answer the same set, and an unsafe engine never runs answers concurrently.
- `tests/test_qa_counting_llm.py` — `_CountingLLM` thread-local isolation + global sum; reset clears residue; `_with_retry` retries a rate-limit then succeeds / re-raises a 400 / gives up after attempts.

Local: 18 new tests pass; existing `test_qa_harness`, `test_run_cost`, `test_cost`, `test_engine_retry`, `test_qa_local_vs_auto_ab`, `test_qa_env_ab`, `test_qa_aggregate`, `test_qa_crossover`, `test_qa_ablation` (and more) green. Ruff clean on all touched files. (The 7 `test_engine_answer_mode.py` failures are pre-existing and environmental — they monkeypatch `goldengraph.answer.ask`, and the `goldengraph` wheel isn't installed in this venv; verified identical on the base commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
