### PR TITLE
chore(bench): wire env_ab LLM cache + record rerank-REFUTED & build-wall findings

### DIFF
--- a/.github/workflows/bench-graphrag-qa.yml
+++ b/.github/workflows/bench-graphrag-qa.yml
@@ -303,6 +303,18 @@ jobs:
           print(f"AB_VAR={name}")
           print(f"AB_VALUES={values}")
           PY
+      # Same prompt-hash extraction cache as the head_to_head job (see the comment
+      # there). env_ab has NO ambiguity matrix, so the key uses inputs.ambiguity; the
+      # `<corpus>-<model>-` restore-keys prefix is SHARED with head_to_head, so a cache
+      # populated by either mode warms the other (same corpus + extraction model).
+      - name: Restore/save the goldengraph extraction LLM cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ${{ github.workspace }}/.gg_llm_cache
+          key: gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-amb${{ inputs.ambiguity }}-${{ github.run_id }}
+          restore-keys: |
+            gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-amb${{ inputs.ambiguity }}-
+            gg-llmcache-${{ inputs.corpus }}-${{ inputs.local_llm != '' && inputs.local_llm || 'api' }}-
       - name: Install goldenmatch + native engine wheel + goldengraph + datasets
         run: |
           # polars: the hybrid path's passage retriever (goldenmatch_rag._make_frame)
@@ -331,6 +343,10 @@ jobs:
           GOLDENGRAPH_LLM_BASE_URL: https://openrouter.ai/api/v1
           GOLDENGRAPH_LLM_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_MODEL: openai/gpt-4o-mini
+          # Points the bench extraction/build client at the actions/cache-persisted dir
+          # (restored above). Only the goldengraph engine's BUILD client is cached; the
+          # answer-time synth client stays uncached. Same dir the cache step persists.
+          GOLDENGRAPH_LLM_CACHE: ${{ github.workspace }}/.gg_llm_cache
           POLARS_SKIP_CPU_CHECK: "1"
           # datasets pulls a fresh-pip pyarrow whose bundled mimalloc SIGSEGVs on the
           # pipeline's worker threads -- the documented repo standard for any lane that

--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -408,3 +408,22 @@ blocking) LOOK alarming in the log but are only ~8.6% of build compute -- a "con
 fix would save <9% and is NOT worth building. The dominant build cost is the per-document LLM
 extraction, which is exactly what the `GOLDENGRAPH_LLM_CACHE` prompt-hash cache targets (warm cache ->
 ~72% build cut). Lesson: a high log-line COUNT is not wall; measure the phase split before optimizing.
+
+## Ball-pruning for hybrid multi-hop QA — REFUTED a SECOND way (path filter), 2026-07-23
+Follow-up to the edge-rerank refutation: tested `GOLDENGRAPH_HYBRID_FILTER=path`
+(`filter_subgraph_to_paths` — keeps seed->answer PATHS, the structurally-correct pruning the
+rerank's support_recall drop pointed to).
+- **MEASURED (env_ab `GOLDENGRAPH_HYBRID_FILTER:none,path`, MuSiQue N=75, hybrid, judge off, run
+  30038160088):** answer_match 0.4667 -> 0.4267 (-0.040); support_recall 0.833 -> **0.589 (-0.244,
+  worse than rerank's -0.12)**. Another loss.
+- **CONCLUSION: pruning the hybrid ball is a DEAD END for multi-hop QA.** Two independent methods
+  (question-cosine rerank AND path-preserving filter) both gut support_recall and fail to lift
+  answer_match. Mechanism: in the hybrid path the model treats PASSAGES as primary truth and the
+  graph as a NAVIGATION aid, so shrinking the graph removes cross-passage bridges with no upside. #4's
+  "answer buried in ~1,700 edges" was a MISdiagnosis of the SYNTHESIS miss -- the failure is multi-hop
+  REASONING over passages+graph, not graph SIZE. Do not pursue graph-context reduction for hybrid QA;
+  a reasoning lever (e.g. `GOLDENGRAPH_SYNTH_SAMPLES` self-consistency voting) is the direction if the
+  SYNTHESIS frontier is revisited.
+- **METHODOLOGY:** the two runs' `none` arms differ by 0.04 (0.507 vs 0.467) at identical config =>
+  LLM nondeterminism sets a ~+/-0.04 answer_match noise floor at N=75. Screen levers at N>=150 (or on
+  the deterministic support_recall) before trusting a ~0.04 delta.

--- a/packages/python/goldengraph/CLAUDE.md
+++ b/packages/python/goldengraph/CLAUDE.md
@@ -380,3 +380,31 @@ full-population `_localize_trace` stage split for free (LLM-free, cached embeddi
   lever), both bigger than the ~15 extraction-addressable entities. The recall levers built for #4
   (`GOLDENGRAPH_RELATION_REPROMPT`, `GOLDENGRAPH_CHUNK_EXTRACT`) stay default-OFF; re-test via the
   same-graph `mode=env_ab` harness before ever shipping one.
+
+## Hybrid ball edge-rerank (question-cosine top-K) — REFUTED (2026-07-23)
+Tested pruning the hybrid ball to the top-K question-relevant edges before synthesis, to fix the
+#4 SYNTHESIS miss (47/53 answer-edge-present but buried in a ~1,700-edge ball that `_format_subgraph`
+serializes whole). Lever: `GOLDENGRAPH_HYBRID_FILTER=rerank` + `GOLDENGRAPH_HYBRID_FILTER_TOPK`
+(embedder cosine question<->edge-text, seed-incident edges always kept), default-off.
+- **MEASURED (env_ab `GOLDENGRAPH_HYBRID_FILTER:none,rerank`, TOPK=40, MuSiQue N=75, hybrid, judge off,
+  one shared build, run 30035422835):** answer_match 0.5067 -> **0.4667 (-0.040)**; token_f1 0.565 ->
+  0.519 (-0.046); support_recall 0.864 -> **0.744 (-0.120)**. A LOSS on every axis.
+- **Why it fails (mechanism, not a bad K):** in the hybrid path provenance is taken from the pruned
+  ball, and the -0.12 support_recall shows the rerank prunes AWAY supporting-fact edges. Multi-hop
+  bridge edges are the casualty: the bridge entity is NOT named in the question, so its edges score
+  low on question<->edge cosine and get dropped -- exactly the edges the answer chain needs. Ranking
+  edges by similarity to the QUESTION is the wrong signal for multi-hop; a larger K only shrinks the
+  harm toward baseline, it cannot manufacture a benefit.
+- **DECISION: REFUTED, not shipped.** PR closed, not merged (a flat/negative default-off knob is dead
+  weight; the value is this finding). If ball-pruning is revisited, the structurally-correct lever is
+  `GOLDENGRAPH_HYBRID_FILTER=path` (`filter_subgraph_to_paths` — keeps seed->answer PATHS, not
+  question-similar edges); A/B that instead.
+
+## Bench build-wall is EXTRACTION, not auto-config (2026-07-23)
+`GOLDENGRAPH_BUILD_DEBUG=1` per-phase split on the MuSiQue N=75 build (run 30035422835, cumulative
+across 12 workers): **extract sum=9972s (72%)**, resolve sum=1193s (8.6%), pre_embed sum=920s (6.6%),
+link sum=795s (5.7%). The 2,522 per-doc `resolve()` auto-config-to-RED cycles (BUDGET_ITERATIONS,
+blocking) LOOK alarming in the log but are only ~8.6% of build compute -- a "configure ER once, reuse"
+fix would save <9% and is NOT worth building. The dominant build cost is the per-document LLM
+extraction, which is exactly what the `GOLDENGRAPH_LLM_CACHE` prompt-hash cache targets (warm cache ->
+~72% build cut). Lesson: a high log-line COUNT is not wall; measure the phase split before optimizing.


### PR DESCRIPTION
Closes the #2064 gap where the prompt-hash extraction cache was wired into the head_to_head goldengraph job only, not `env_ab` (the primary A/B mode). env_ab now restores/saves the same cache (shared `<corpus>-<model>-` restore-key namespace, so caches warm across modes).

Also records two measured findings in `goldengraph/CLAUDE.md`:
- **Edge-rerank@40 REFUTED** (run 30035422835): answer_match -0.04, support_recall -0.12. Question-cosine pruning drops multi-hop bridge edges. PR #2062 closed, not merged.
- **Build wall is EXTRACTION, not auto-config**: `BUILD_DEBUG` split extract 72% >> resolve 8.6%. The configure-once ER fix is not worth building; `GOLDENGRAPH_LLM_CACHE` is the right build lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)