### PR TITLE
feat(er-kg-bench): Phase 2 co-occurrence corpus + ER-blind floor (compounded ER+aggregation)

### DIFF
--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/realworld.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/realworld.py
@@ -161,9 +161,11 @@ def _build_realworld_store(docs, km, s2c_cov, typ_of):
     at = 0
     for d in docs:
         parts = d.id.split("::")
-        if len(parts) != 3:
+        if len(parts) < 3:
             continue
-        src_id, rel, dst_id = parts
+        # Co-occurrence docs (Phase 2) carry a `::m{k}` mention suffix (same edge,
+        # a different rendered alias per doc); take the first three components.
+        src_id, rel, dst_id = parts[0], parts[1], parts[2]
         at += 1
         s_surf, o_surf = d.src_surface, d.dst_surface
         extraction = Extraction(
@@ -242,3 +244,152 @@ def run_realworld_aggregation(fixture_path, *, ambiguity: float, passage_k: int,
         gg_setf1=_mean_by_bucket(gg_f1), floor_setf1=_mean_by_bucket(floor_f1),
         gg_count_acc=_mean_by_bucket(gg_count), floor_recall=_mean_by_bucket(floor_rec),
         llm_setf1=_mean_by_bucket(llm_f1) if llm_f1 else None)
+
+
+# --- Phase 2: co-occurrence corpus + ER-blind floor (compounded ER + aggregation) ------
+# Phase 1.5 found the floor is ER-BLIND because (a) it resolves via the ground-truth
+# surface->qid map and (b) each member appears in exactly ONE doc. Phase 2 fixes BOTH: a
+# member recurs under SEVERAL real aliases across docs, and the floor must cluster those
+# variants ITSELF (naive normalization) instead of getting the oracle map. The metric where
+# it bites is COUNT ("how many members?"): goldenmatch's real dedup merges the aliases ->
+# correct count; the ER-blind floor over-counts the un-mergeable ones. That is goldenmatch's
+# core value (dedup) showing up inside the aggregation capability.
+import re as _re
+
+
+def _cooccurrence_surfaces(ent, k: int) -> list:
+    """Up to `k` DISTINCT real surfaces for an entity (canonical + aliases), stable order."""
+    surfaces = list(dict.fromkeys([ent.canonical, *ent.variants]))
+    return surfaces[: max(1, k)]
+
+
+def _word_mentions(text: str, surface: str) -> bool:
+    """Whole-token containment, matching the aggregation floor's `_mentions`."""
+    return _re.search(r"\b" + _re.escape(surface) + r"\b", text) is not None
+
+
+def generate_realworld_cooccurrence(fixture_path, *, mentions_per_member: int = 3, seed: int = 7):
+    """Co-occurrence drop-in for `generate_realworld_aggregation`: each (anchor, member) edge
+    is rendered in UP TO `mentions_per_member` docs, EACH under a DISTINCT real alias of the
+    member -- so a member recurs under several surfaces across docs. Doc ids carry a `::m{k}`
+    suffix to stay unique (the store build takes the first three `::` components). gold_members
+    / gold_count are the TRUE member set, unchanged. Deterministic per seed."""
+    from .aggregation import AggQuestion
+    from .corpora import Document
+    from .engineered import _edge_doc_id
+
+    data = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
+    ents = load_realworld_entities(fixture_path)
+    by_id = {e.id: e for e in ents}
+    _rng = random.Random(seed)  # reserved for future jitter; keeps signature stable
+    docs, qs = [], []
+    for i, fact in enumerate(data["facts"]):
+        src_id, rel = fact["anchor_qid"], fact["relation"]
+        members = [m for m in fact["member_qids"] if m in by_id]
+        rel_words = rel.replace("_", " ")
+        anchor_surfs = _cooccurrence_surfaces(by_id[src_id], mentions_per_member)
+        for m in members:
+            for k, o in enumerate(_cooccurrence_surfaces(by_id[m], mentions_per_member)):
+                s = anchor_surfs[k % len(anchor_surfs)]
+                docs.append(Document(id=f"{_edge_doc_id(src_id, rel, m)}::m{k}",
+                                     text=f"{s} {rel_words} {o}.",
+                                     src_surface=s, dst_surface=o))
+        canon = by_id[src_id].canonical
+        qs.append(AggQuestion(id=f"rwco-list-{i}", kind="list",
+                              question=f"List all entities that {canon} {rel_words}.",
+                              anchor_id=src_id, relation=rel,
+                              gold_members=tuple(members), gold_count=len(members)))
+        qs.append(AggQuestion(id=f"rwco-count-{i}", kind="count",
+                              question=f"How many entities does {canon} {rel_words}?",
+                              anchor_id=src_id, relation=rel,
+                              gold_members=tuple(members), gold_count=len(members)))
+    return tuple(docs), qs
+
+
+def _normalize_surface(s: str) -> str:
+    """Naive RAG-style surface normalization: lowercase + collapse whitespace + strip
+    surrounding punctuation. Merges case/spacing variants but NOT real aliases (acronyms,
+    legal-suffix words, transliterations) -- which is why it over-counts a member that
+    recurs under several aliases."""
+    return _re.sub(r"\s+", " ", s.strip().lower()).strip(".,;:'\"()")
+
+
+def er_blind_floor_count(docs, anchor_surfaces: set, *, passage_k: int,
+                         member_surfaces: set, normalize=_normalize_surface) -> int:
+    """DISTINCT-member count the way an ER-BLIND RAG does: over the first `passage_k` window
+    docs mentioning any anchor surface, collect every member surface present, cluster by
+    `normalize` (NOT the oracle surface->qid map). A member under 3 un-mergeable aliases
+    counts as 3. Contrast the oracle floor (surface->qid) which counts it once."""
+    hits = [d for d in docs if any(_word_mentions(d.text, a) for a in anchor_surfaces)][:passage_k]
+    anchor_norm = {normalize(a) for a in anchor_surfaces}
+    forms: set = set()
+    for d in hits:
+        for surf in member_surfaces:
+            if _word_mentions(d.text, surf):
+                n = normalize(surf)
+                if n not in anchor_norm:
+                    forms.add(n)
+    return len(forms)
+
+
+def oracle_floor_count(docs, anchor_surfaces: set, *, passage_k: int,
+                       surface_to_qid: dict) -> int:
+    """Reference: the SAME window, but resolving each surface to its ground-truth qid
+    (perfect ER). A member under any number of aliases counts ONCE. The
+    oracle-vs-ER-blind gap is the ER contribution the graph's real dedup recovers."""
+    hits = [d for d in docs if any(_word_mentions(d.text, a) for a in anchor_surfaces)][:passage_k]
+    anchor_qids = {surface_to_qid.get(a) for a in anchor_surfaces}
+    qids: set = set()
+    for d in hits:
+        for surf, qid in surface_to_qid.items():
+            if _word_mentions(d.text, surf):
+                qids.add(qid)
+    return len(qids - anchor_qids - {None})
+
+
+def run_realworld_cooccurrence(fixture_path, *, mentions_per_member: int = 3,
+                               passage_k: int = 10, seed: int = 7):
+    """Compounded ER + aggregation on the co-occurrence corpus. Per size bucket, reports
+    COUNT accuracy for THREE arms of the 'how many members?' query:
+      - goldengraph: builds the store from the co-occurrence docs with REAL goldenmatch ER
+        (resolve_mode='real'), traverses, counts distinct store nodes.
+      - oracle floor: window docs resolved surface->qid (perfect ER) -> exact count.
+      - ER-blind floor: window docs clustered by naive normalization -> over-counts aliases.
+    goldengraph's real dedup should beat the ER-blind floor (the compounded win) while the
+    ER-blind floor collapses. Needs the native wheel (PyStore, via _build_realworld_store).
+    Returns {'gg_count_acc', 'oracle_floor_count_acc', 'er_blind_count_acc'} by bucket."""
+    from .aggregation import _mean_by_bucket, count_accuracy, goldengraph_aggregate, size_bucket
+
+    docs, qs = generate_realworld_cooccurrence(
+        fixture_path, mentions_per_member=mentions_per_member, seed=seed)
+    rows = _realworld_entity_surfaces(fixture_path)
+    km = _resolution_km(rows, resolve_mode="real")
+    typ_of = {eid: t for eid, _s, t in rows}
+    s2c_cov: dict = {}
+    surface_to_qid: dict = {}
+    anchor_surfaces: dict = {}
+    member_surfaces_all: set = set()
+    for eid, surf, _t in rows:
+        s2c_cov.setdefault(surf, set()).add(eid)
+        surface_to_qid.setdefault(surf, eid)
+        anchor_surfaces.setdefault(eid, set()).add(surf)
+        member_surfaces_all.add(surf)
+    slice_graph, coverage = _build_realworld_store(docs, km, s2c_cov, typ_of)
+
+    gg, orc, erb = [], [], []
+    for q in (q for q in qs if q.kind == "list"):
+        b = size_bucket(q.gold_count)
+        a_surfs = anchor_surfaces.get(q.anchor_id, set())
+        gg_n = len(goldengraph_aggregate(slice_graph, coverage, q.anchor_id, q.relation))
+        orc_n = oracle_floor_count(docs, a_surfs, passage_k=passage_k,
+                                   surface_to_qid=surface_to_qid)
+        erb_n = er_blind_floor_count(docs, a_surfs, passage_k=passage_k,
+                                     member_surfaces=member_surfaces_all - a_surfs)
+        gg.append((b, count_accuracy(gg_n, q.gold_count)))
+        orc.append((b, count_accuracy(orc_n, q.gold_count)))
+        erb.append((b, count_accuracy(erb_n, q.gold_count)))
+    return {
+        "gg_count_acc": _mean_by_bucket(gg),
+        "oracle_floor_count_acc": _mean_by_bucket(orc),
+        "er_blind_count_acc": _mean_by_bucket(erb),
+    }

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_aggregation.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_aggregation.py
@@ -234,3 +234,69 @@ def test_real_resolution_merges_variants_into_one_node_and_recovers_set():
     q = next(x for x in qs if x.kind == "list")
     got = goldengraph_aggregate(sg, cov, q.anchor_id, q.relation)
     assert set_f1(got, set(q.gold_members))["f1"] >= 0.99
+
+
+# --- Phase 2: co-occurrence corpus + ER-blind floor (compounded ER + aggregation) ------
+def test_cooccurrence_renders_members_under_distinct_aliases():
+    """Phase 2 corpus: a member with >=2 real surfaces is rendered in >=2 docs, EACH under
+    a DISTINCT surface; gold_count is unchanged (the TRUE member set)."""
+    from erkgbench.qa_e2e.realworld import _FIXTURE_DIR, generate_realworld_cooccurrence
+
+    docs, qs = generate_realworld_cooccurrence(
+        _FIXTURE_DIR / "wikidata_companies_TINY.json", mentions_per_member=3, seed=7)
+    q = next(q for q in qs if q.kind == "list")
+    assert q.gold_count == 3  # TINY anchor Q1 has members Q2,Q3,Q4
+    # Q2 "Beta Corp" has canonical + 2 aliases -> rendered in 3 docs under 3 distinct surfaces.
+    q2_docs = [d for d in docs if d.id.startswith("Q1::has_subsidiary::Q2::")]
+    assert len(q2_docs) == 3
+    assert len({d.dst_surface for d in q2_docs}) == 3  # all DISTINCT aliases
+
+
+def test_er_blind_floor_overcounts_while_oracle_floor_is_correct():
+    """The compounded-win mechanism: on the co-occurrence corpus a member recurs under
+    several aliases. The ER-BLIND floor (naive normalization) counts each un-mergeable
+    alias separately -> OVER-counts; the oracle floor (surface->qid) counts each member
+    ONCE. goldenmatch's real dedup lands between the two -- that is the ER contribution."""
+    from erkgbench.qa_e2e.realworld import (
+        _FIXTURE_DIR,
+        _realworld_entity_surfaces,
+        er_blind_floor_count,
+        generate_realworld_cooccurrence,
+        oracle_floor_count,
+    )
+
+    fixture = _FIXTURE_DIR / "wikidata_companies_TINY.json"
+    docs, qs = generate_realworld_cooccurrence(fixture, mentions_per_member=3, seed=7)
+    rows = _realworld_entity_surfaces(fixture)
+    q = next(q for q in qs if q.kind == "list")
+    gold_count = q.gold_count
+
+    anchor_surfaces = {s for eid, s, _t in rows if eid == q.anchor_id}
+    member_surfaces = {s for eid, s, _t in rows if eid != q.anchor_id}
+    surface_to_qid = {s: eid for eid, s, _t in rows}
+
+    er_blind = er_blind_floor_count(
+        docs, anchor_surfaces, passage_k=100, member_surfaces=member_surfaces)
+    oracle = oracle_floor_count(
+        docs, anchor_surfaces, passage_k=100, surface_to_qid=surface_to_qid)
+
+    assert oracle == gold_count            # perfect ER -> exact count
+    assert er_blind > gold_count           # ER-blind -> over-counts the aliases
+    assert er_blind >= oracle              # ER-blindness can only inflate the count
+
+
+def test_cooccurrence_run_gg_beats_er_blind_floor_on_count():
+    """Wheel-gated compounded win: on the co-occurrence corpus, goldengraph's real-ER
+    count-accuracy is >= the ER-blind floor's (its dedup merges aliases the naive floor
+    over-counts). The oracle floor is the perfect-ER ceiling."""
+    _wheel_or_skip()
+    from erkgbench.qa_e2e.realworld import _FIXTURE_DIR, run_realworld_cooccurrence
+
+    res = run_realworld_cooccurrence(
+        _FIXTURE_DIR / "wikidata_companies_TINY.json", mentions_per_member=3, passage_k=100)
+    # single 3-member anchor -> one bucket
+    (gg,) = list(res["gg_count_acc"].values())
+    (orc,) = list(res["oracle_floor_count_acc"].values())
+    (erb,) = list(res["er_blind_count_acc"].values())
+    assert orc >= gg >= erb            # real ER lands between perfect-ER and no-ER
+    assert gg > erb                    # the compounded win: dedup beats the ER-blind floor


### PR DESCRIPTION
Phase 2 of the real-world capability benchmark (plan #2074; follows Phase 0 #2076 + Phase 1.5 #2080).

**Why:** Phase 1.5 showed the floor was ER-BLIND *by construction* (oracle surface→qid map + one doc per member), so the compounded win could not show. Phase 2 fixes both.

**What:**
- `generate_realworld_cooccurrence` — each member recurs under SEVERAL real aliases across docs.
- `er_blind_floor_count` — clusters surfaces by naive normalization (over-counts un-mergeable aliases); `oracle_floor_count` resolves surface→qid (exact). The metric where ER bites is **count** ('how many members?').
- `run_realworld_cooccurrence` — COUNT accuracy by bucket for **goldengraph (real dedup)** vs the oracle floor (perfect-ER ceiling) vs the ER-blind floor. GG's real ER lands between them, **beating the ER-blind floor** — that gap is goldenmatch's dedup value showing up inside the aggregation capability.

**Validation:** 2 wheel-free tests pass locally (co-occurrence renders distinct aliases; ER-blind over-counts while oracle is exact — the mechanism). 1 wheel-gated test asserts the compounded win (`gg_count_acc > er_blind_count_acc`) — runs in `goldengraph-pipeline` via Phase 1.5's existing pytest step. ruff clean. Store-build parse relaxed to accept co-occurrence `::m{k}` doc ids; Phase 0/1.5 paths unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)