### PR TITLE
feat(er-kg-bench): Phase 1 real-world temporal as-of (Wikidata CEO histories)

### DIFF
--- a/.github/workflows/goldengraph-pipeline.yml
+++ b/.github/workflows/goldengraph-pipeline.yml
@@ -151,6 +151,11 @@ jobs:
           python -m pytest tests/test_qa_temporal_store.py -v
           python -m erkgbench.qa_e2e.run_temporal \
             --seed 7 --n-facts 40 --ambiguity 0.6 --out-md TEMPORAL.md
+          # Real-world (Wikidata CEO-history) temporal as-of: the SAME capability on real
+          # successions -- store.as_of respects valid-time; the temporal-blind floor is wrong
+          # on past-date queries.
+          python -m pytest tests/test_realworld_temporal.py -v
+          python scripts/run_realworld_temporal_e2e.py --out-md RESULTS_REALWORLD_TEMPORAL.md
 
       - name: Upload TEMPORAL.md
         if: ${{ always() }}
@@ -158,6 +163,14 @@ jobs:
         with:
           name: goldengraph-temporal
           path: packages/python/goldenmatch/benchmarks/er-kg-bench/TEMPORAL.md
+          if-no-files-found: ignore
+
+      - name: Upload RESULTS_REALWORLD_TEMPORAL.md
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v4
+        with:
+          name: goldengraph-realworld-temporal
+          path: packages/python/goldenmatch/benchmarks/er-kg-bench/RESULTS_REALWORLD_TEMPORAL.md
           if-no-files-found: ignore
 
       - name: KG-vs-KG capability scorecard gate (deterministic, key-free)

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_TINY.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_TINY.json
@@ -1,0 +1,12 @@
+{
+  "meta": {"source": "wikidata", "pulled": "test", "domain": "ceo_temporal", "current_year": 2026},
+  "entities": [
+    {"qid": "Q1", "canonical": "Acme Corp"},
+    {"qid": "Q2", "canonical": "Alice Anderson"},
+    {"qid": "Q3", "canonical": "Bob Brown"}
+  ],
+  "temporal_facts": [
+    {"anchor_qid": "Q1", "relation": "chief_executive_officer",
+     "a_qid": "Q2", "b_qid": "Q3", "tc": 2019, "start_a": 2010}
+  ]
+}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_v1.json
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_v1.json
@@ -1,0 +1,10905 @@
+{
+  "meta": {
+    "source": "wikidata",
+    "pulled": "2026-07-23",
+    "sparql_sha": "549a3d6612093c92",
+    "domain": "ceo_temporal",
+    "current_year": 2026
+  },
+  "entities": [
+    {
+      "qid": "05a921b5e01d75a8bfddb5fea1d5e861",
+      "canonical": "http://www.wikidata.org/.well-known/genid/05a921b5e01d75a8bfddb5fea1d5e861"
+    },
+    {
+      "qid": "4714464e838441aa89288feb1159cdce",
+      "canonical": "http://www.wikidata.org/.well-known/genid/4714464e838441aa89288feb1159cdce"
+    },
+    {
+      "qid": "8d6268b2e1ff156c44856baee4517e69",
+      "canonical": "http://www.wikidata.org/.well-known/genid/8d6268b2e1ff156c44856baee4517e69"
+    },
+    {
+      "qid": "9889e01801534837989a4d7790b55bd6",
+      "canonical": "http://www.wikidata.org/.well-known/genid/9889e01801534837989a4d7790b55bd6"
+    },
+    {
+      "qid": "Q100166272",
+      "canonical": "Stuart Simpson"
+    },
+    {
+      "qid": "Q100276124",
+      "canonical": "Parag Agrawal"
+    },
+    {
+      "qid": "Q100454182",
+      "canonical": "Fumihiko Yuki"
+    },
+    {
+      "qid": "Q100989426",
+      "canonical": "Thomas Sch\u00e4fer"
+    },
+    {
+      "qid": "Q101070644",
+      "canonical": "Tomokuni Tsuji"
+    },
+    {
+      "qid": "Q101243531",
+      "canonical": "Jesper Nielsen"
+    },
+    {
+      "qid": "Q101352",
+      "canonical": "family name"
+    },
+    {
+      "qid": "Q101424348",
+      "canonical": "Zden\u011bk Kab\u00e1tek"
+    },
+    {
+      "qid": "Q101627126",
+      "canonical": "Marjan Rintel"
+    },
+    {
+      "qid": "Q1017062",
+      "canonical": "Burson"
+    },
+    {
+      "qid": "Q1021074",
+      "canonical": "Enercoop"
+    },
+    {
+      "qid": "Q102315490",
+      "canonical": "Gy\u00f6rgy Hajdu"
+    },
+    {
+      "qid": "Q102673",
+      "canonical": "Gazprom"
+    },
+    {
+      "qid": "Q102783130",
+      "canonical": "Charlie Nunn"
+    },
+    {
+      "qid": "Q103814978",
+      "canonical": "Ivan Bedn\u00e1rik"
+    },
+    {
+      "qid": "Q103824349",
+      "canonical": "Melissa Di Donato"
+    },
+    {
+      "qid": "Q1039157",
+      "canonical": "Carl J\u00fcrgen Hogrefe"
+    },
+    {
+      "qid": "Q104157182",
+      "canonical": "Kam Ghaffarian"
+    },
+    {
+      "qid": "Q104249075",
+      "canonical": "Jakob Stausholm"
+    },
+    {
+      "qid": "Q104426506",
+      "canonical": "IDT Media"
+    },
+    {
+      "qid": "Q104432215",
+      "canonical": "Kjell Gunnar Heggenes"
+    },
+    {
+      "qid": "Q104432331",
+      "canonical": "Svein Olav Straand"
+    },
+    {
+      "qid": "Q104521383",
+      "canonical": "Nick Poole"
+    },
+    {
+      "qid": "Q104528496",
+      "canonical": "Stijn Bijnens"
+    },
+    {
+      "qid": "Q104536488",
+      "canonical": "Jon Andr\u00e9 L\u00f8kke"
+    },
+    {
+      "qid": "Q1045681",
+      "canonical": "Carsten Spohr"
+    },
+    {
+      "qid": "Q1046951",
+      "canonical": "Target Corporation"
+    },
+    {
+      "qid": "Q104700881",
+      "canonical": "Kjetil F\u00f8rsvoll"
+    },
+    {
+      "qid": "Q104776",
+      "canonical": "August von Finck"
+    },
+    {
+      "qid": "Q104784751",
+      "canonical": "Alfred F. Kelly Jr."
+    },
+    {
+      "qid": "Q104786710",
+      "canonical": "Dominic Stevens"
+    },
+    {
+      "qid": "Q104805086",
+      "canonical": "Gert de Winter"
+    },
+    {
+      "qid": "Q1048204",
+      "canonical": "Cassa Depositi e Prestiti"
+    },
+    {
+      "qid": "Q104842926",
+      "canonical": "Ganni"
+    },
+    {
+      "qid": "Q104862847",
+      "canonical": "Sean Doyle"
+    },
+    {
+      "qid": "Q1050159",
+      "canonical": "Central Nippon Expressway Company"
+    },
+    {
+      "qid": "Q105081948",
+      "canonical": "Simon Thompson"
+    },
+    {
+      "qid": "Q105167367",
+      "canonical": "Carl Gustaf Wettergren"
+    },
+    {
+      "qid": "Q105221670",
+      "canonical": "Marek Jankovi\u010d"
+    },
+    {
+      "qid": "Q105295968",
+      "canonical": "Manfred Knof"
+    },
+    {
+      "qid": "Q105359010",
+      "canonical": "Sara Catoni"
+    },
+    {
+      "qid": "Q105359033",
+      "canonical": "David Lagerholm"
+    },
+    {
+      "qid": "Q105366826",
+      "canonical": "Jonny Crowe"
+    },
+    {
+      "qid": "Q105394598",
+      "canonical": "David J. Henshall"
+    },
+    {
+      "qid": "Q10561401",
+      "canonical": "Lidk\u00f6ping\u2013Skara\u2013Stenstorps J\u00e4rnv\u00e4g"
+    },
+    {
+      "qid": "Q105647796",
+      "canonical": "Stephen Bird"
+    },
+    {
+      "qid": "Q105713466",
+      "canonical": "Susan Davy"
+    },
+    {
+      "qid": "Q105744027",
+      "canonical": "Kim Povlsen"
+    },
+    {
+      "qid": "Q105810218",
+      "canonical": "Saleza"
+    },
+    {
+      "qid": "Q105811180",
+      "canonical": "Jacques Damas"
+    },
+    {
+      "qid": "Q105825520",
+      "canonical": "Anders Danielsson"
+    },
+    {
+      "qid": "Q105872982",
+      "canonical": "Bob Sternfels"
+    },
+    {
+      "qid": "Q105979056",
+      "canonical": "Cinema Design in Sweden AB"
+    },
+    {
+      "qid": "Q105979074",
+      "canonical": "Lillebj\u00f6rn Gyllfeldt"
+    },
+    {
+      "qid": "Q105979813",
+      "canonical": "Ulf Qvicklund"
+    },
+    {
+      "qid": "Q106028933",
+      "canonical": "Q106028933"
+    },
+    {
+      "qid": "Q106303371",
+      "canonical": "KALUZA + SCHMID"
+    },
+    {
+      "qid": "Q106303701",
+      "canonical": "Steffen Kaluza"
+    },
+    {
+      "qid": "Q106323455",
+      "canonical": "Jaakko Eskola"
+    },
+    {
+      "qid": "Q106323457",
+      "canonical": "H\u00e5kan Agnevall"
+    },
+    {
+      "qid": "Q106371968",
+      "canonical": "Softjourn"
+    },
+    {
+      "qid": "Q106390371",
+      "canonical": "The Cameroon Press and Publishing Company"
+    },
+    {
+      "qid": "Q106410464",
+      "canonical": "Q106410464"
+    },
+    {
+      "qid": "Q106435030",
+      "canonical": "Hans Henrik Kristensen"
+    },
+    {
+      "qid": "Q106435048",
+      "canonical": "Philipp Engedal"
+    },
+    {
+      "qid": "Q106547394",
+      "canonical": "Nils Giske\u00f8degaard"
+    },
+    {
+      "qid": "Q106612786",
+      "canonical": "Vidar Kjesbu"
+    },
+    {
+      "qid": "Q106612852",
+      "canonical": "Geir-Vidar S\u00f8rheim"
+    },
+    {
+      "qid": "Q106647408",
+      "canonical": "Roger Lynch"
+    },
+    {
+      "qid": "Q106755529",
+      "canonical": "Jacek Olczak"
+    },
+    {
+      "qid": "Q10680526",
+      "canonical": "Stockholm Independent Bank"
+    },
+    {
+      "qid": "Q1068351",
+      "canonical": "East Nippon Expressway Company"
+    },
+    {
+      "qid": "Q10685071",
+      "canonical": "Svenska J\u00e4rnv\u00e4gsverkst\u00e4derna"
+    },
+    {
+      "qid": "Q106962330",
+      "canonical": "Petr Dvo\u0159\u00e1k"
+    },
+    {
+      "qid": "Q106986451",
+      "canonical": "Amandine Albizzati"
+    },
+    {
+      "qid": "Q107110562",
+      "canonical": "Marie-Claire Nnana"
+    },
+    {
+      "qid": "Q107214638",
+      "canonical": "FiberCop"
+    },
+    {
+      "qid": "Q107325269",
+      "canonical": "Annemarie Gardshol"
+    },
+    {
+      "qid": "Q107420160",
+      "canonical": "Peter Herweck"
+    },
+    {
+      "qid": "Q107451467",
+      "canonical": "Bob Jordan"
+    },
+    {
+      "qid": "Q107528439",
+      "canonical": "Taitotalo"
+    },
+    {
+      "qid": "Q10773789",
+      "canonical": "Ale\u0161 Hu\u0161\u00e1k"
+    },
+    {
+      "qid": "Q107785714",
+      "canonical": "Linus Media Group"
+    },
+    {
+      "qid": "Q108057935",
+      "canonical": "Hans-Erik Lind"
+    },
+    {
+      "qid": "Q108137858",
+      "canonical": "Thomas H\u00e4u\u00dfner"
+    },
+    {
+      "qid": "Q10819807",
+      "canonical": "Andrej Babi\u0161"
+    },
+    {
+      "qid": "Q108247496",
+      "canonical": "Stefan Hartung"
+    },
+    {
+      "qid": "Q108259354",
+      "canonical": "Geoffrey S Martha"
+    },
+    {
+      "qid": "Q108550690",
+      "canonical": "Robert Playter"
+    },
+    {
+      "qid": "Q108566246",
+      "canonical": "Nikolai Setzer"
+    },
+    {
+      "qid": "Q10857539",
+      "canonical": "Zden\u011bk Hrub\u00fd"
+    },
+    {
+      "qid": "Q108623907",
+      "canonical": "Uday Sareen"
+    },
+    {
+      "qid": "Q108623956",
+      "canonical": "Melanie Evans"
+    },
+    {
+      "qid": "Q108647632",
+      "canonical": "Peter King"
+    },
+    {
+      "qid": "Q108858638",
+      "canonical": "Keizo Shimano"
+    },
+    {
+      "qid": "Q108936810",
+      "canonical": "Markus Krebber"
+    },
+    {
+      "qid": "Q109175226",
+      "canonical": "Pavel Sur\u00fd"
+    },
+    {
+      "qid": "Q109175265",
+      "canonical": "Ji\u0159\u00ed Svoboda"
+    },
+    {
+      "qid": "Q109314050",
+      "canonical": "Sebastian Schmidt"
+    },
+    {
+      "qid": "Q109492715",
+      "canonical": "Mikhail Poluboyarinov"
+    },
+    {
+      "qid": "Q1095857",
+      "canonical": "C. & J. Clark International Ltd"
+    },
+    {
+      "qid": "Q109586134",
+      "canonical": "Gianfranco Nazzi"
+    },
+    {
+      "qid": "Q109609662",
+      "canonical": "C. S. Venkatakrishnan"
+    },
+    {
+      "qid": "Q109767256",
+      "canonical": "Kelly Ortberg"
+    },
+    {
+      "qid": "Q109775839",
+      "canonical": "Sarah London"
+    },
+    {
+      "qid": "Q109782",
+      "canonical": "Heinrich Hiesinger"
+    },
+    {
+      "qid": "Q1100117",
+      "canonical": "Clemens T\u00f6nnies"
+    },
+    {
+      "qid": "Q1103300",
+      "canonical": "Mih\u00e1ly Kajlinger"
+    },
+    {
+      "qid": "Q110409879",
+      "canonical": "Jim Rowan"
+    },
+    {
+      "qid": "Q110471964",
+      "canonical": "Cristiano Amon"
+    },
+    {
+      "qid": "Q110551227",
+      "canonical": "Stefano Antonio Donnarumma"
+    },
+    {
+      "qid": "Q110580207",
+      "canonical": "Klosterman Baking Company"
+    },
+    {
+      "qid": "Q110580696",
+      "canonical": "Kim Klosterman"
+    },
+    {
+      "qid": "Q110580761",
+      "canonical": "Ken Klosterman"
+    },
+    {
+      "qid": "Q110626453",
+      "canonical": "Alfred Stern"
+    },
+    {
+      "qid": "Q110694796",
+      "canonical": "Craig Peters"
+    },
+    {
+      "qid": "Q110775966",
+      "canonical": "Pavel Br\u016f\u017eek"
+    },
+    {
+      "qid": "Q110897639",
+      "canonical": "Tan Su Shan"
+    },
+    {
+      "qid": "Q110929746",
+      "canonical": "Anette Aanesland"
+    },
+    {
+      "qid": "Q110985256",
+      "canonical": "Stephan Leithner"
+    },
+    {
+      "qid": "Q111057942",
+      "canonical": "Alexey Zaytsev"
+    },
+    {
+      "qid": "Q111059160",
+      "canonical": "Alexey Zagorovskiy"
+    },
+    {
+      "qid": "Q111081541",
+      "canonical": "Jamie Fly"
+    },
+    {
+      "qid": "Q111082720",
+      "canonical": "Heinz-J\u00fcrgen Bertram"
+    },
+    {
+      "qid": "Q111253511",
+      "canonical": "Michel Doukeris"
+    },
+    {
+      "qid": "Q111309783",
+      "canonical": "Gerrit Marx"
+    },
+    {
+      "qid": "Q111318110",
+      "canonical": "Morrow Batteries"
+    },
+    {
+      "qid": "Q111387693",
+      "canonical": "Cerence Inc."
+    },
+    {
+      "qid": "Q111606644",
+      "canonical": "Mastodon gGmbH"
+    },
+    {
+      "qid": "Q1118657",
+      "canonical": "Persimmon plc"
+    },
+    {
+      "qid": "Q111872104",
+      "canonical": "Carlos Gallardo Piqu\u00e9"
+    },
+    {
+      "qid": "Q112150058",
+      "canonical": "Osamu Shimada"
+    },
+    {
+      "qid": "Q112150060",
+      "canonical": "Yasuyuki Watanuki"
+    },
+    {
+      "qid": "Q112150088",
+      "canonical": "Y\u014dji Furumiya"
+    },
+    {
+      "qid": "Q112175992",
+      "canonical": "Michal Krapinec"
+    },
+    {
+      "qid": "Q112190710",
+      "canonical": "Thomas Schulz"
+    },
+    {
+      "qid": "Q112190840",
+      "canonical": "Kristian Villumsen"
+    },
+    {
+      "qid": "Q112222645",
+      "canonical": "Grete Fuglem Tenn\u00e5s"
+    },
+    {
+      "qid": "Q112239422",
+      "canonical": "Tsuguhiro Nishimaki"
+    },
+    {
+      "qid": "Q112239431",
+      "canonical": "T\u014dru Obata"
+    },
+    {
+      "qid": "Q112265018",
+      "canonical": "Marco Sesana"
+    },
+    {
+      "qid": "Q11228089",
+      "canonical": "Bontonfilm"
+    },
+    {
+      "qid": "Q112359048",
+      "canonical": "Oliver Scheel"
+    },
+    {
+      "qid": "Q112394761",
+      "canonical": "Vladim\u00edr Mr\u00e1z"
+    },
+    {
+      "qid": "Q112420820",
+      "canonical": "Q112420820"
+    },
+    {
+      "qid": "Q11251919",
+      "canonical": "UK Financial Investments"
+    },
+    {
+      "qid": "Q11278357",
+      "canonical": "7-Eleven Japan"
+    },
+    {
+      "qid": "Q112797162",
+      "canonical": "Stanley A. Deal"
+    },
+    {
+      "qid": "Q11283119",
+      "canonical": "Generali \u010cesk\u00e1 poji\u0161\u0165ovna"
+    },
+    {
+      "qid": "Q113136626",
+      "canonical": "Matt Hicks"
+    },
+    {
+      "qid": "Q11320256",
+      "canonical": "DeNA"
+    },
+    {
+      "qid": "Q113355178",
+      "canonical": "Luka Mucic"
+    },
+    {
+      "qid": "Q113356474",
+      "canonical": "Joaquin Duato"
+    },
+    {
+      "qid": "Q11346537",
+      "canonical": "Livedoor"
+    },
+    {
+      "qid": "Q113493778",
+      "canonical": "H\u00e5kon Volldal"
+    },
+    {
+      "qid": "Q113525711",
+      "canonical": "Batz Group"
+    },
+    {
+      "qid": "Q113552954",
+      "canonical": "Michael Zusman"
+    },
+    {
+      "qid": "Q113556373",
+      "canonical": "Jakub Pap\u00edrn\u00edk"
+    },
+    {
+      "qid": "Q113632708",
+      "canonical": "Ted Decker"
+    },
+    {
+      "qid": "Q113636437",
+      "canonical": "Roy Jakobs"
+    },
+    {
+      "qid": "Q113653910",
+      "canonical": "Thijs de Valk"
+    },
+    {
+      "qid": "Q113674610",
+      "canonical": "Nick Read"
+    },
+    {
+      "qid": "Q1136885",
+      "canonical": "Sanrio"
+    },
+    {
+      "qid": "Q113956100",
+      "canonical": "Giancarlo Fancel"
+    },
+    {
+      "qid": "Q113956221",
+      "canonical": "Maurizio Pescarini"
+    },
+    {
+      "qid": "Q113969",
+      "canonical": "Peter L\u00f6scher"
+    },
+    {
+      "qid": "Q11397048",
+      "canonical": "Yoshiaki Sakit\u014d"
+    },
+    {
+      "qid": "Q113988833",
+      "canonical": "Wael Sawan"
+    },
+    {
+      "qid": "Q114056718",
+      "canonical": "Kristine Aadland"
+    },
+    {
+      "qid": "Q1140680",
+      "canonical": "Flex Ltd."
+    },
+    {
+      "qid": "Q114245560",
+      "canonical": "Gwendoline Cazenave"
+    },
+    {
+      "qid": "Q1142797",
+      "canonical": "Schroders"
+    },
+    {
+      "qid": "Q114359175",
+      "canonical": "John May"
+    },
+    {
+      "qid": "Q114361370",
+      "canonical": "Ron Vachris"
+    },
+    {
+      "qid": "Q114400848",
+      "canonical": "Mehdi Alj"
+    },
+    {
+      "qid": "Q114437297",
+      "canonical": "Unimer Group"
+    },
+    {
+      "qid": "Q11449999",
+      "canonical": "Isao Moriyasu"
+    },
+    {
+      "qid": "Q11463",
+      "canonical": "Adobe"
+    },
+    {
+      "qid": "Q114661529",
+      "canonical": "Supermetrics"
+    },
+    {
+      "qid": "Q114661871",
+      "canonical": "Mikael Thuneberg"
+    },
+    {
+      "qid": "Q114706038",
+      "canonical": "Rob Davis"
+    },
+    {
+      "qid": "Q114755798",
+      "canonical": "Dyn Media"
+    },
+    {
+      "qid": "Q114837486",
+      "canonical": "Ryan McInerney"
+    },
+    {
+      "qid": "Q114837932",
+      "canonical": "Trond Bentestuen"
+    },
+    {
+      "qid": "Q114885864",
+      "canonical": "Helena Hedblom"
+    },
+    {
+      "qid": "Q114957449",
+      "canonical": "Stefan Ortmanns"
+    },
+    {
+      "qid": "Q115014459",
+      "canonical": "Roland N\u00e1tr\u00e1n"
+    },
+    {
+      "qid": "Q115014614",
+      "canonical": "Hungarian Export-Import Bank Plc."
+    },
+    {
+      "qid": "Q115190398",
+      "canonical": "Martin Divi\u0161"
+    },
+    {
+      "qid": "Q115275652",
+      "canonical": "Lars Christian Bacher"
+    },
+    {
+      "qid": "Q1152764",
+      "canonical": "Lloyds Banking Group"
+    },
+    {
+      "qid": "Q115308936",
+      "canonical": "Jochen Hanebeck"
+    },
+    {
+      "qid": "Q115394460",
+      "canonical": "Jonathan Akeroyd"
+    },
+    {
+      "qid": "Q11541601",
+      "canonical": "Rakuten Bank"
+    },
+    {
+      "qid": "Q115523514",
+      "canonical": "Tobias Meyer"
+    },
+    {
+      "qid": "Q115558391",
+      "canonical": "Helen Wong"
+    },
+    {
+      "qid": "Q115592380",
+      "canonical": "Yuen Kuan Moon"
+    },
+    {
+      "qid": "Q115614624",
+      "canonical": "Ariane Gorin"
+    },
+    {
+      "qid": "Q115616635",
+      "canonical": "Klaus Zellmer"
+    },
+    {
+      "qid": "Q115629121",
+      "canonical": "Michael McNamara"
+    },
+    {
+      "qid": "Q115655394",
+      "canonical": "Daniel Belfer"
+    },
+    {
+      "qid": "Q115735259",
+      "canonical": "Omar Abbosh"
+    },
+    {
+      "qid": "Q115735422",
+      "canonical": "Pascal Daloz"
+    },
+    {
+      "qid": "Q115735574",
+      "canonical": "Justin Hotard"
+    },
+    {
+      "qid": "Q115735611",
+      "canonical": "Vimal Kapur"
+    },
+    {
+      "qid": "Q115791856",
+      "canonical": "Amadou Vamoulk\u00e9"
+    },
+    {
+      "qid": "Q115793241",
+      "canonical": "Ron Delia"
+    },
+    {
+      "qid": "Q116141928",
+      "canonical": "Ale\u0161 Bla\u017eek"
+    },
+    {
+      "qid": "Q116142302",
+      "canonical": "Jakub Dus\u00edlek"
+    },
+    {
+      "qid": "Q116284788",
+      "canonical": "Eric Gundersen"
+    },
+    {
+      "qid": "Q116287463",
+      "canonical": "Peter Sirota"
+    },
+    {
+      "qid": "Q1163590",
+      "canonical": "Daniela Trochowski"
+    },
+    {
+      "qid": "Q116376004",
+      "canonical": "Harvey C. Jones"
+    },
+    {
+      "qid": "Q116452644",
+      "canonical": "Netflix, Inc."
+    },
+    {
+      "qid": "Q116491844",
+      "canonical": "Michael M\u00fcller"
+    },
+    {
+      "qid": "Q116501956",
+      "canonical": "Hein Schumacher"
+    },
+    {
+      "qid": "Q116679883",
+      "canonical": "Catherine El Arouni"
+    },
+    {
+      "qid": "Q116858313",
+      "canonical": "Richard Teng"
+    },
+    {
+      "qid": "Q11686899",
+      "canonical": "AtB"
+    },
+    {
+      "qid": "Q116923463",
+      "canonical": "Alan H. Shaw"
+    },
+    {
+      "qid": "Q116935918",
+      "canonical": "K\u014dji Sat\u014d"
+    },
+    {
+      "qid": "Q116969393",
+      "canonical": "Charles Deere Wiman"
+    },
+    {
+      "qid": "Q117031761",
+      "canonical": "Sergej Valer\u2032evi\u010d Vilkov"
+    },
+    {
+      "qid": "Q11707119",
+      "canonical": "TV Nova"
+    },
+    {
+      "qid": "Q117085504",
+      "canonical": "Miroslav \u0160t\u011bp\u00e1n"
+    },
+    {
+      "qid": "Q1172038",
+      "canonical": "Dassault Syst\u00e8mes"
+    },
+    {
+      "qid": "Q117249105",
+      "canonical": "Gunjan Kedia"
+    },
+    {
+      "qid": "Q117249140",
+      "canonical": "Brian Niccol"
+    },
+    {
+      "qid": "Q117289625",
+      "canonical": "Pehr Lagerman"
+    },
+    {
+      "qid": "Q117407",
+      "canonical": "Nick Hayek"
+    },
+    {
+      "qid": "Q117487953",
+      "canonical": "Q117487953"
+    },
+    {
+      "qid": "Q117708223",
+      "canonical": "Louise Beardmore"
+    },
+    {
+      "qid": "Q117715587",
+      "canonical": "Gustaf Mauritz Posse"
+    },
+    {
+      "qid": "Q117747707",
+      "canonical": "Patrick Decker"
+    },
+    {
+      "qid": "Q117768540",
+      "canonical": "Tempogr\u00e1fica"
+    },
+    {
+      "qid": "Q11778744",
+      "canonical": "Micha\u0142 Fr\u0105ckowiak"
+    },
+    {
+      "qid": "Q117790877",
+      "canonical": "Erik S\u00f6derling"
+    },
+    {
+      "qid": "Q117803829",
+      "canonical": "Jeff Kreuser"
+    },
+    {
+      "qid": "Q117824948",
+      "canonical": "Keith D. Jackson"
+    },
+    {
+      "qid": "Q118088909",
+      "canonical": "Joanna Geraghty"
+    },
+    {
+      "qid": "Q118220135",
+      "canonical": "Vanessa Hudson"
+    },
+    {
+      "qid": "Q118351577",
+      "canonical": "Tufan Erginbilgi\u00e7"
+    },
+    {
+      "qid": "Q118482800",
+      "canonical": "Terren Tong"
+    },
+    {
+      "qid": "Q118499866",
+      "canonical": "Maria Black"
+    },
+    {
+      "qid": "Q11852651",
+      "canonical": "Armas Puolimatka"
+    },
+    {
+      "qid": "Q11859650",
+      "canonical": "FINNFUND"
+    },
+    {
+      "qid": "Q118696194",
+      "canonical": "Shin Inukai"
+    },
+    {
+      "qid": "Q118706826",
+      "canonical": "David A. Ricks"
+    },
+    {
+      "qid": "Q118725712",
+      "canonical": "Budapest Water Works"
+    },
+    {
+      "qid": "Q11878398",
+      "canonical": "UniCredit Bank Czech Republic and Slovakia"
+    },
+    {
+      "qid": "Q11888546",
+      "canonical": "Polar"
+    },
+    {
+      "qid": "Q11897629",
+      "canonical": "Oy Tillander Ab"
+    },
+    {
+      "qid": "Q11899907",
+      "canonical": "Vil\u00e9m Posp\u00ed\u0161il"
+    },
+    {
+      "qid": "Q11904427",
+      "canonical": "Ag\u00e8ncia Catalana de Cooperaci\u00f3 al Desenvolupament"
+    },
+    {
+      "qid": "Q11904759",
+      "canonical": "Albert Coma Estadella"
+    },
+    {
+      "qid": "Q119052685",
+      "canonical": "Denis Le Vot"
+    },
+    {
+      "qid": "Q1190669",
+      "canonical": "Japan Freight Railway Company"
+    },
+    {
+      "qid": "Q1190881",
+      "canonical": "Reckitt"
+    },
+    {
+      "qid": "Q11969389",
+      "canonical": "Government Pension Fund Norway"
+    },
+    {
+      "qid": "Q11972595",
+      "canonical": "Grethe Aasved"
+    },
+    {
+      "qid": "Q11972678",
+      "canonical": "Gro Bakstad"
+    },
+    {
+      "qid": "Q119726858",
+      "canonical": "Felix Hlatky"
+    },
+    {
+      "qid": "Q11975353",
+      "canonical": "Hilde Tonne"
+    },
+    {
+      "qid": "Q11989409",
+      "canonical": "Motol and Homolka University Hospital"
+    },
+    {
+      "qid": "Q11993401",
+      "canonical": "Olaug Svarva"
+    },
+    {
+      "qid": "Q11994205",
+      "canonical": "OBOS"
+    },
+    {
+      "qid": "Q119954220",
+      "canonical": "Ernest P\u00e9rez-Mas"
+    },
+    {
+      "qid": "Q120054921",
+      "canonical": "Yi He"
+    },
+    {
+      "qid": "Q12006150",
+      "canonical": "Thor Gjermund Eriksen"
+    },
+    {
+      "qid": "Q12006431",
+      "canonical": "The General Health Insurance Company"
+    },
+    {
+      "qid": "Q12006930",
+      "canonical": "Torbj\u00f8rn R. Skjerve"
+    },
+    {
+      "qid": "Q12010370",
+      "canonical": "Walter Qvam"
+    },
+    {
+      "qid": "Q12017258",
+      "canonical": "Franti\u0161ek Laud\u00e1t"
+    },
+    {
+      "qid": "Q1202053",
+      "canonical": "Vonovia"
+    },
+    {
+      "qid": "Q12022442",
+      "canonical": "Jan Burian"
+    },
+    {
+      "qid": "Q12023680",
+      "canonical": "Jarom\u00edr Soukup"
+    },
+    {
+      "qid": "Q12025314",
+      "canonical": "Ji\u0159\u00ed Kunert"
+    },
+    {
+      "qid": "Q12033072",
+      "canonical": "Lesy \u010cesk\u00e9 republiky"
+    },
+    {
+      "qid": "Q12034446",
+      "canonical": "Lu\u010debn\u00ed z\u00e1vody Draslovka"
+    },
+    {
+      "qid": "Q12035711",
+      "canonical": "Martin Foukal"
+    },
+    {
+      "qid": "Q12035810",
+      "canonical": "Martin Pal\u00e1n"
+    },
+    {
+      "qid": "Q12035832",
+      "canonical": "Martin Roman"
+    },
+    {
+      "qid": "Q12038000",
+      "canonical": "Miroslav Svoboda"
+    },
+    {
+      "qid": "Q12041098",
+      "canonical": "Chamber of Public Notaries of the Czech Republic"
+    },
+    {
+      "qid": "Q12041612",
+      "canonical": "National Bank of Czechoslovakia"
+    },
+    {
+      "qid": "Q12044833",
+      "canonical": "Petr Dvo\u0159\u00e1k"
+    },
+    {
+      "qid": "Q12058450",
+      "canonical": "Technick\u00e1 spr\u00e1va komunikac\u00ed hl. m. Prahy"
+    },
+    {
+      "qid": "Q12058918",
+      "canonical": "Thomayer Hospital"
+    },
+    {
+      "qid": "Q120589578",
+      "canonical": "Zden\u011bk Ertl"
+    },
+    {
+      "qid": "Q120607019",
+      "canonical": "Jaroslav K\u00e1bele"
+    },
+    {
+      "qid": "Q120878232",
+      "canonical": "Theodore Miller"
+    },
+    {
+      "qid": "Q121148056",
+      "canonical": "Bill Anderson"
+    },
+    {
+      "qid": "Q121159761",
+      "canonical": "pelemele FILM GmbH"
+    },
+    {
+      "qid": "Q121358909",
+      "canonical": "Mathias Berg"
+    },
+    {
+      "qid": "Q121831",
+      "canonical": "Ernst Thomke"
+    },
+    {
+      "qid": "Q121834402",
+      "canonical": "Miguel \u00c1ngel L\u00f3pez Borrego"
+    },
+    {
+      "qid": "Q122141",
+      "canonical": "Vodafone"
+    },
+    {
+      "qid": "Q122147756",
+      "canonical": "Q122147756"
+    },
+    {
+      "qid": "Q1223089",
+      "canonical": "Dieter von Holtzbrinck"
+    },
+    {
+      "qid": "Q122443335",
+      "canonical": "Murray Auchincloss"
+    },
+    {
+      "qid": "Q122798086",
+      "canonical": "Sebastian Windeck"
+    },
+    {
+      "qid": "Q122839999",
+      "canonical": "Rudolf L\u00e4derach"
+    },
+    {
+      "qid": "Q122840000",
+      "canonical": "J\u00fcrg L\u00e4derach"
+    },
+    {
+      "qid": "Q122916561",
+      "canonical": "Xavier Capellades"
+    },
+    {
+      "qid": "Q1229223",
+      "canonical": "Sergio Marchionne"
+    },
+    {
+      "qid": "Q123182476",
+      "canonical": "Mario Rossetti"
+    },
+    {
+      "qid": "Q123182536",
+      "canonical": "Giuseppe Gola"
+    },
+    {
+      "qid": "Q123196874",
+      "canonical": "Jason Providakes"
+    },
+    {
+      "qid": "Q12323903",
+      "canonical": "Lars Rebien S\u00f8rensen"
+    },
+    {
+      "qid": "Q123296981",
+      "canonical": "Vincent Clerc"
+    },
+    {
+      "qid": "Q123352677",
+      "canonical": "Emmanuel Gintzburger"
+    },
+    {
+      "qid": "Q123358938",
+      "canonical": "Gernot D\u00f6llner"
+    },
+    {
+      "qid": "Q123424623",
+      "canonical": "Francesc Rubiralta Rubi\u00f3"
+    },
+    {
+      "qid": "Q123434602",
+      "canonical": "Nir Bar Dea"
+    },
+    {
+      "qid": "Q123692",
+      "canonical": "Nicolas Hayek"
+    },
+    {
+      "qid": "Q123752186",
+      "canonical": "SYENSQO"
+    },
+    {
+      "qid": "Q12377489",
+      "canonical": "T\u00f5ive Kivikas"
+    },
+    {
+      "qid": "Q123938479",
+      "canonical": "Dan Davidenko"
+    },
+    {
+      "qid": "Q124026351",
+      "canonical": "Rossignol Group"
+    },
+    {
+      "qid": "Q124026806",
+      "canonical": "Vincent Wauters"
+    },
+    {
+      "qid": "Q124302696",
+      "canonical": "Q124302696"
+    },
+    {
+      "qid": "Q124321858",
+      "canonical": "Mitsuko Tottori"
+    },
+    {
+      "qid": "Q124376118",
+      "canonical": "Heikki Haasmaa"
+    },
+    {
+      "qid": "Q124457779",
+      "canonical": "Electric Coin Company"
+    },
+    {
+      "qid": "Q124463276",
+      "canonical": "Laura Chambers"
+    },
+    {
+      "qid": "Q124480013",
+      "canonical": "Y\u014dichi Kise"
+    },
+    {
+      "qid": "Q124484928",
+      "canonical": "Elo\u00edsa Vaello Marco"
+    },
+    {
+      "qid": "Q124547634",
+      "canonical": "Katalin Walter"
+    },
+    {
+      "qid": "Q124620793",
+      "canonical": "Arturs Kruze"
+    },
+    {
+      "qid": "Q124620820",
+      "canonical": "Kristaps Rjabovs"
+    },
+    {
+      "qid": "Q124641201",
+      "canonical": "Morten Wierod"
+    },
+    {
+      "qid": "Q124807690",
+      "canonical": "Bruno de Boursetty"
+    },
+    {
+      "qid": "Q124844057",
+      "canonical": "Eivind Kallevik"
+    },
+    {
+      "qid": "Q124868557",
+      "canonical": "Tobias Schwarz"
+    },
+    {
+      "qid": "Q1248816",
+      "canonical": "National Hellenic Research Foundation"
+    },
+    {
+      "qid": "Q125081448",
+      "canonical": "TEFAL (company)"
+    },
+    {
+      "qid": "Q125103476",
+      "canonical": "Legitech"
+    },
+    {
+      "qid": "Q125105049",
+      "canonical": "Laurence Raphael"
+    },
+    {
+      "qid": "Q125105520",
+      "canonical": "Marc-Olivier Lifrange"
+    },
+    {
+      "qid": "Q125107077",
+      "canonical": "Per Ove Morberg"
+    },
+    {
+      "qid": "Q125187894",
+      "canonical": "S\u00f6ren Bendig"
+    },
+    {
+      "qid": "Q125257078",
+      "canonical": "Robert A. Michael"
+    },
+    {
+      "qid": "Q125287726",
+      "canonical": "Yann Lechelle"
+    },
+    {
+      "qid": "Q125293726",
+      "canonical": "Pierre-Armand Lemoine"
+    },
+    {
+      "qid": "Q125304907",
+      "canonical": "Kevin J. Wheeler"
+    },
+    {
+      "qid": "Q125306837",
+      "canonical": "Ajita G. Rajendra"
+    },
+    {
+      "qid": "Q125359507",
+      "canonical": "Markus Reder"
+    },
+    {
+      "qid": "Q125424016",
+      "canonical": "Ireneusz F\u0105fara"
+    },
+    {
+      "qid": "Q125452216",
+      "canonical": "Michael R. McMullen"
+    },
+    {
+      "qid": "Q125453309",
+      "canonical": "Padraig McDonnell"
+    },
+    {
+      "qid": "Q125459259",
+      "canonical": "Anna Tumad\u00f3ttir"
+    },
+    {
+      "qid": "Q125523927",
+      "canonical": "Audisto"
+    },
+    {
+      "qid": "Q125535126",
+      "canonical": "Q125535126"
+    },
+    {
+      "qid": "Q125535220",
+      "canonical": "Q125535220"
+    },
+    {
+      "qid": "Q125599966",
+      "canonical": "Lisa M. Barton"
+    },
+    {
+      "qid": "Q125600469",
+      "canonical": "John O. Larsen"
+    },
+    {
+      "qid": "Q125717994",
+      "canonical": "Peter Konieczny"
+    },
+    {
+      "qid": "Q12572999",
+      "canonical": "Brian Krzanich"
+    },
+    {
+      "qid": "Q125936166",
+      "canonical": "Shunsuke Niwa"
+    },
+    {
+      "qid": "Q125966875",
+      "canonical": "Matthew Pine"
+    },
+    {
+      "qid": "Q125973376",
+      "canonical": "Sven Lind"
+    },
+    {
+      "qid": "Q126003124",
+      "canonical": "Karl Wilhelmson"
+    },
+    {
+      "qid": "Q126013265",
+      "canonical": "Vagner Rego"
+    },
+    {
+      "qid": "Q126200528",
+      "canonical": "Helen Lofthouse"
+    },
+    {
+      "qid": "Q126598004",
+      "canonical": "George L. Schultz"
+    },
+    {
+      "qid": "Q126680585",
+      "canonical": "Vicen\u00e7 Margalef"
+    },
+    {
+      "qid": "Q126966053",
+      "canonical": "Konstantinos Nembis"
+    },
+    {
+      "qid": "Q127005",
+      "canonical": "Holtzbrinck Publishing Group"
+    },
+    {
+      "qid": "Q1274252",
+      "canonical": "EC Comics"
+    },
+    {
+      "qid": "Q127583088",
+      "canonical": "Christian Printzell Halvorsen"
+    },
+    {
+      "qid": "Q1276463",
+      "canonical": "EWE TEL"
+    },
+    {
+      "qid": "Q127981813",
+      "canonical": "Schulton"
+    },
+    {
+      "qid": "Q127982366",
+      "canonical": "William Lightfoot Schultz"
+    },
+    {
+      "qid": "Q1281126",
+      "canonical": "Echter Verlag"
+    },
+    {
+      "qid": "Q1283291",
+      "canonical": "Valero Energy"
+    },
+    {
+      "qid": "Q128738",
+      "canonical": "Anheuser-Busch InBev"
+    },
+    {
+      "qid": "Q1288880",
+      "canonical": "Meyer Burger"
+    },
+    {
+      "qid": "Q1289900",
+      "canonical": "Kenneth Frazier"
+    },
+    {
+      "qid": "Q129154131",
+      "canonical": "Jean-Yves Parisot"
+    },
+    {
+      "qid": "Q130018277",
+      "canonical": "Gilles Feith"
+    },
+    {
+      "qid": "Q13014244",
+      "canonical": "GMM Media"
+    },
+    {
+      "qid": "Q130199471",
+      "canonical": "Adrien Ney"
+    },
+    {
+      "qid": "Q130217999",
+      "canonical": "Carmen Sevillano"
+    },
+    {
+      "qid": "Q130302995",
+      "canonical": "Ganesh Moorthy"
+    },
+    {
+      "qid": "Q130320248",
+      "canonical": "Peter Pauli"
+    },
+    {
+      "qid": "Q130320251",
+      "canonical": "Hans Br\u00e4ndle"
+    },
+    {
+      "qid": "Q130324748",
+      "canonical": "Davide Rota"
+    },
+    {
+      "qid": "Q130342816",
+      "canonical": "Unilux"
+    },
+    {
+      "qid": "Q130363715",
+      "canonical": "Giacomo Trovato"
+    },
+    {
+      "qid": "Q130368495",
+      "canonical": "Q130368495"
+    },
+    {
+      "qid": "Q130481772",
+      "canonical": "Gavin Isaacs"
+    },
+    {
+      "qid": "Q1305281",
+      "canonical": "Valeo"
+    },
+    {
+      "qid": "Q13054189",
+      "canonical": "Ucom"
+    },
+    {
+      "qid": "Q130611962",
+      "canonical": "Meg O'Neill"
+    },
+    {
+      "qid": "Q130612644",
+      "canonical": "Elliott Hill"
+    },
+    {
+      "qid": "Q130615370",
+      "canonical": "Ladislav Urb\u00e1nek"
+    },
+    {
+      "qid": "Q130783979",
+      "canonical": "David Joyner"
+    },
+    {
+      "qid": "Q1309851",
+      "canonical": "Vend Marketplaces"
+    },
+    {
+      "qid": "Q1310001",
+      "canonical": "Erste Group"
+    },
+    {
+      "qid": "Q131005",
+      "canonical": "Air France"
+    },
+    {
+      "qid": "Q131008028",
+      "canonical": "Herbert K\u00f6nig"
+    },
+    {
+      "qid": "Q131295887",
+      "canonical": "Christophe De Vusser"
+    },
+    {
+      "qid": "Q131362440",
+      "canonical": "Management Trust Holding AG"
+    },
+    {
+      "qid": "Q131362597",
+      "canonical": "Martin Waldh\u00e4usl"
+    },
+    {
+      "qid": "Q131560265",
+      "canonical": "Eclipsed Sounds, LLC"
+    },
+    {
+      "qid": "Q131675131",
+      "canonical": "BrandUp Factory GmbH"
+    },
+    {
+      "qid": "Q131675218",
+      "canonical": "Tim Meyer"
+    },
+    {
+      "qid": "Q131675552",
+      "canonical": "Ulf Meyer"
+    },
+    {
+      "qid": "Q131720798",
+      "canonical": "Algimantas Markauskas"
+    },
+    {
+      "qid": "Q131764256",
+      "canonical": "Louis Coiffait-Gunn"
+    },
+    {
+      "qid": "Q1318049",
+      "canonical": "WPP plc"
+    },
+    {
+      "qid": "Q13194093",
+      "canonical": "Vladas Algirdas Bumelis"
+    },
+    {
+      "qid": "Q13218598",
+      "canonical": "NatWest Group"
+    },
+    {
+      "qid": "Q1325291",
+      "canonical": "Saxo Bank A/S"
+    },
+    {
+      "qid": "Q1332719",
+      "canonical": "Elmar Degenhart"
+    },
+    {
+      "qid": "Q133289342",
+      "canonical": "RFE/RL, Inc."
+    },
+    {
+      "qid": "Q133502056",
+      "canonical": "Q133502056"
+    },
+    {
+      "qid": "Q133504684",
+      "canonical": "G.-J\u00fcrgen Hogrefe"
+    },
+    {
+      "qid": "Q134125517",
+      "canonical": "Taylor Hennessy"
+    },
+    {
+      "qid": "Q134125699",
+      "canonical": "Elijah Damon"
+    },
+    {
+      "qid": "Q1344481",
+      "canonical": "ENTEGA Plus GmbH"
+    },
+    {
+      "qid": "Q134577466",
+      "canonical": "Hana Materov\u00e1"
+    },
+    {
+      "qid": "Q134594834",
+      "canonical": "Antonio Filosa"
+    },
+    {
+      "qid": "Q134688394",
+      "canonical": "Juli\u00e1n Donado Vara"
+    },
+    {
+      "qid": "Q134703526",
+      "canonical": "Q134703526"
+    },
+    {
+      "qid": "Q1347130",
+      "canonical": "Maurice L\u00e9vy"
+    },
+    {
+      "qid": "Q134882064",
+      "canonical": "Hannes Wiese"
+    },
+    {
+      "qid": "Q135025328",
+      "canonical": "Q135025328"
+    },
+    {
+      "qid": "Q135103340",
+      "canonical": "Jeny Yeung"
+    },
+    {
+      "qid": "Q1351415",
+      "canonical": "Peace Now"
+    },
+    {
+      "qid": "Q135190951",
+      "canonical": "Malik Rebrab"
+    },
+    {
+      "qid": "Q135232415",
+      "canonical": "Dirk-Peter van Leeuwen"
+    },
+    {
+      "qid": "Q135233481",
+      "canonical": "Laura du Rusquec"
+    },
+    {
+      "qid": "Q135256969",
+      "canonical": "Ana Camacho"
+    },
+    {
+      "qid": "Q135257441",
+      "canonical": "Carlos Orueta"
+    },
+    {
+      "qid": "Q1353736",
+      "canonical": "Jeffrey Skilling"
+    },
+    {
+      "qid": "Q135399330",
+      "canonical": "Elisabeth Vike Vardheim"
+    },
+    {
+      "qid": "Q135409161",
+      "canonical": "Agnete Johnsgaard-Lewis"
+    },
+    {
+      "qid": "Q135458872",
+      "canonical": "Josh Swihart"
+    },
+    {
+      "qid": "Q135659053",
+      "canonical": "Daniel M\u00fchl"
+    },
+    {
+      "qid": "Q135686402",
+      "canonical": "Paul H. Sunu"
+    },
+    {
+      "qid": "Q135906224",
+      "canonical": "Giuseppina Di Foggia"
+    },
+    {
+      "qid": "Q135914740",
+      "canonical": "Holywater Tech"
+    },
+    {
+      "qid": "Q1359151",
+      "canonical": "Lloyd Blankfein"
+    },
+    {
+      "qid": "Q135963023",
+      "canonical": "Andreas Heyden"
+    },
+    {
+      "qid": "Q135963027",
+      "canonical": "Max Ehrhardt"
+    },
+    {
+      "qid": "Q135992383",
+      "canonical": "Tan Teck Long"
+    },
+    {
+      "qid": "Q136023672",
+      "canonical": "Dorothea von Boxberg"
+    },
+    {
+      "qid": "Q136051736",
+      "canonical": "Philipp Navratil"
+    },
+    {
+      "qid": "Q136348852",
+      "canonical": "Dmitry Volkov"
+    },
+    {
+      "qid": "Q136359918",
+      "canonical": "Q136359918"
+    },
+    {
+      "qid": "Q136402833",
+      "canonical": "Jan Vl\u010dek"
+    },
+    {
+      "qid": "Q136402840",
+      "canonical": "Daniel Grunt"
+    },
+    {
+      "qid": "Q136524444",
+      "canonical": "apodiscounter"
+    },
+    {
+      "qid": "Q136661156",
+      "canonical": "Hassane El-Khoury"
+    },
+    {
+      "qid": "Q136706318",
+      "canonical": "Andr\u00e9 Heid"
+    },
+    {
+      "qid": "Q136706792",
+      "canonical": "Heid Real Estate Valuation"
+    },
+    {
+      "qid": "Q136706824",
+      "canonical": "Q136706824"
+    },
+    {
+      "qid": "Q136753026",
+      "canonical": "Q136753026"
+    },
+    {
+      "qid": "Q136768233",
+      "canonical": "SWE Volley-Team Spielbetriebsgesellschaft"
+    },
+    {
+      "qid": "Q136768328",
+      "canonical": "Heiko Herzberg"
+    },
+    {
+      "qid": "Q137168946",
+      "canonical": "Joseph E. Creed"
+    },
+    {
+      "qid": "Q1371822",
+      "canonical": "Fran\u00e7ois-Henri Pinault"
+    },
+    {
+      "qid": "Q137187091",
+      "canonical": "Marianne Gjertsen Ebbesen"
+    },
+    {
+      "qid": "Q137190053",
+      "canonical": "Per Widerstr\u00f6m"
+    },
+    {
+      "qid": "Q1372049",
+      "canonical": "Japan Post Holdings"
+    },
+    {
+      "qid": "Q137210428",
+      "canonical": "Lane Riggs"
+    },
+    {
+      "qid": "Q137328248",
+      "canonical": "Itai Pazner"
+    },
+    {
+      "qid": "Q137423339",
+      "canonical": "Anthony Enzor-DeMeo"
+    },
+    {
+      "qid": "Q137440955",
+      "canonical": "Alsco Berufskleidungs-Service GmbH"
+    },
+    {
+      "qid": "Q137547998",
+      "canonical": "Martin Swierzy"
+    },
+    {
+      "qid": "Q137548111",
+      "canonical": "Ren\u00e9 Schneider"
+    },
+    {
+      "qid": "Q137768558",
+      "canonical": "Klaus Becker"
+    },
+    {
+      "qid": "Q137768562",
+      "canonical": "Michael Becker"
+    },
+    {
+      "qid": "Q137808426",
+      "canonical": "Jan Bla\u0161ko"
+    },
+    {
+      "qid": "Q137902160",
+      "canonical": "Q137902160"
+    },
+    {
+      "qid": "Q137910",
+      "canonical": "thyssenkrupp AG"
+    },
+    {
+      "qid": "Q137910592",
+      "canonical": "Chirantan \"CJ\" Desai"
+    },
+    {
+      "qid": "Q137917356",
+      "canonical": "Bogdan Nesvit"
+    },
+    {
+      "qid": "Q137917410",
+      "canonical": "Frank Gey"
+    },
+    {
+      "qid": "Q137917444",
+      "canonical": "Antje Winter"
+    },
+    {
+      "qid": "Q138049088",
+      "canonical": "Pavel Br\u016f\u017eek"
+    },
+    {
+      "qid": "Q138133",
+      "canonical": "RWE"
+    },
+    {
+      "qid": "Q138241552",
+      "canonical": "Anatolii Kasianov"
+    },
+    {
+      "qid": "Q138307691",
+      "canonical": "Gregor Pillen"
+    },
+    {
+      "qid": "Q138307763",
+      "canonical": "Wolfgang Wendt"
+    },
+    {
+      "qid": "Q1383119",
+      "canonical": "Frank Leidenberger"
+    },
+    {
+      "qid": "Q138464460",
+      "canonical": "Q138464460"
+    },
+    {
+      "qid": "Q138527724",
+      "canonical": "Q138527724"
+    },
+    {
+      "qid": "Q138529939",
+      "canonical": "Q138529939"
+    },
+    {
+      "qid": "Q1386366",
+      "canonical": "Timotheus H\u00f6ttges"
+    },
+    {
+      "qid": "Q138660356",
+      "canonical": "Q138660356"
+    },
+    {
+      "qid": "Q138660381",
+      "canonical": "Q138660381"
+    },
+    {
+      "qid": "Q13882231",
+      "canonical": "Alexander McQueen"
+    },
+    {
+      "qid": "Q138834463",
+      "canonical": "Clive Selley"
+    },
+    {
+      "qid": "Q138855712",
+      "canonical": "Katie Milligan"
+    },
+    {
+      "qid": "Q138983610",
+      "canonical": "Mike Radossich"
+    },
+    {
+      "qid": "Q1390577",
+      "canonical": "Twitter"
+    },
+    {
+      "qid": "Q1392181",
+      "canonical": "Muhtar Kent"
+    },
+    {
+      "qid": "Q139255218",
+      "canonical": "Stephanie Mair-Huydts"
+    },
+    {
+      "qid": "Q139414262",
+      "canonical": "Markus Schneider"
+    },
+    {
+      "qid": "Q139493717",
+      "canonical": "Q139493717"
+    },
+    {
+      "qid": "Q139497198",
+      "canonical": "Q139497198"
+    },
+    {
+      "qid": "Q139497282",
+      "canonical": "Q139497282"
+    },
+    {
+      "qid": "Q139619638",
+      "canonical": "Q139619638"
+    },
+    {
+      "qid": "Q139662631",
+      "canonical": "Q139662631"
+    },
+    {
+      "qid": "Q139927511",
+      "canonical": "Q139927511"
+    },
+    {
+      "qid": "Q139997508",
+      "canonical": "Slavneft-Megionneftegaz"
+    },
+    {
+      "qid": "Q139997711",
+      "canonical": "Alexander Alexandrovich Barinov"
+    },
+    {
+      "qid": "Q140069314",
+      "canonical": "Q140069314"
+    },
+    {
+      "qid": "Q140248507",
+      "canonical": "Q140248507"
+    },
+    {
+      "qid": "Q140248791",
+      "canonical": "Q140248791"
+    },
+    {
+      "qid": "Q140420647",
+      "canonical": "Q140420647"
+    },
+    {
+      "qid": "Q140420790",
+      "canonical": "Q140420790"
+    },
+    {
+      "qid": "Q140447596",
+      "canonical": "Hans Hoegstedt"
+    },
+    {
+      "qid": "Q140454733",
+      "canonical": "Q140454733"
+    },
+    {
+      "qid": "Q140454952",
+      "canonical": "Q140454952"
+    },
+    {
+      "qid": "Q140590909",
+      "canonical": "Q140590909"
+    },
+    {
+      "qid": "Q140676761",
+      "canonical": "yoummday"
+    },
+    {
+      "qid": "Q140677672",
+      "canonical": "Pablo Harisch"
+    },
+    {
+      "qid": "Q14090205",
+      "canonical": "Pekka Lundmark"
+    },
+    {
+      "qid": "Q14122110",
+      "canonical": "Josep Maria Tost i Borr\u00e0s"
+    },
+    {
+      "qid": "Q1416687",
+      "canonical": "Finavia"
+    },
+    {
+      "qid": "Q1418",
+      "canonical": "Nokia"
+    },
+    {
+      "qid": "Q14191959",
+      "canonical": "Michael Tsamaz"
+    },
+    {
+      "qid": "Q1424962",
+      "canonical": "IHG Hotels & Resorts"
+    },
+    {
+      "qid": "Q1425170",
+      "canonical": "HC Sparta Praha"
+    },
+    {
+      "qid": "Q1429953",
+      "canonical": "Florian V\u00f6lker"
+    },
+    {
+      "qid": "Q1434895",
+      "canonical": "Stefan von Holtzbrinck"
+    },
+    {
+      "qid": "Q1435702",
+      "canonical": "Whitbread"
+    },
+    {
+      "qid": "Q1437143",
+      "canonical": "L\u00e4derach"
+    },
+    {
+      "qid": "Q1442448",
+      "canonical": "Franz Pischinger"
+    },
+    {
+      "qid": "Q1445487",
+      "canonical": "Frans van Houten"
+    },
+    {
+      "qid": "Q1445880",
+      "canonical": "H\u00e5kan Samuelsson"
+    },
+    {
+      "qid": "Q14511674",
+      "canonical": "Octave Klaba"
+    },
+    {
+      "qid": "Q14594782",
+      "canonical": "SUSE"
+    },
+    {
+      "qid": "Q1460107",
+      "canonical": "Friedrich Joussen"
+    },
+    {
+      "qid": "Q1465005",
+      "canonical": "Orange Polska"
+    },
+    {
+      "qid": "Q1465461",
+      "canonical": "National Grid plc"
+    },
+    {
+      "qid": "Q14662364",
+      "canonical": "AbbVie"
+    },
+    {
+      "qid": "Q1471161",
+      "canonical": "Imperial Brands"
+    },
+    {
+      "qid": "Q1475312",
+      "canonical": "Vinci"
+    },
+    {
+      "qid": "Q1479375",
+      "canonical": "MTR Corporation Limited"
+    },
+    {
+      "qid": "Q1479649",
+      "canonical": "REN TV"
+    },
+    {
+      "qid": "Q14948763",
+      "canonical": "John Smith"
+    },
+    {
+      "qid": "Q14950045",
+      "canonical": "Chartered Institute of Library and Information Professionals"
+    },
+    {
+      "qid": "Q15042554",
+      "canonical": "Andrew Mackenzie"
+    },
+    {
+      "qid": "Q15109662",
+      "canonical": "John Legere"
+    },
+    {
+      "qid": "Q15147789",
+      "canonical": "Luis Gallego"
+    },
+    {
+      "qid": "Q1520122",
+      "canonical": "Getty Images"
+    },
+    {
+      "qid": "Q152051",
+      "canonical": "Bayer"
+    },
+    {
+      "qid": "Q152057",
+      "canonical": "BP"
+    },
+    {
+      "qid": "Q152096",
+      "canonical": "Sainsbury's"
+    },
+    {
+      "qid": "Q15238661",
+      "canonical": "CNH Industrial"
+    },
+    {
+      "qid": "Q1524647",
+      "canonical": "Riad Asmat"
+    },
+    {
+      "qid": "Q1525588",
+      "canonical": "Michael Becker Orgelbau"
+    },
+    {
+      "qid": "Q153571",
+      "canonical": "Brussels Airlines"
+    },
+    {
+      "qid": "Q1537378",
+      "canonical": "Publicis"
+    },
+    {
+      "qid": "Q1537811",
+      "canonical": "Skanska"
+    },
+    {
+      "qid": "Q1541079",
+      "canonical": "Komer\u010dn\u00ed banka"
+    },
+    {
+      "qid": "Q1543874",
+      "canonical": "The Hertz Corporation"
+    },
+    {
+      "qid": "Q1545076",
+      "canonical": "Microchip Technology"
+    },
+    {
+      "qid": "Q154950",
+      "canonical": "Shell"
+    },
+    {
+      "qid": "Q155026",
+      "canonical": "United Parcel Service"
+    },
+    {
+      "qid": "Q1550912",
+      "canonical": "GMV Innovating Solutions"
+    },
+    {
+      "qid": "Q156238",
+      "canonical": "ExxonMobil"
+    },
+    {
+      "qid": "Q1564396",
+      "canonical": "MairDumont"
+    },
+    {
+      "qid": "Q15650949",
+      "canonical": "Ben van Beurden"
+    },
+    {
+      "qid": "Q156578",
+      "canonical": "Volkswagen Group"
+    },
+    {
+      "qid": "Q156776",
+      "canonical": "Swiss International Air Lines"
+    },
+    {
+      "qid": "Q15678788",
+      "canonical": "Fiat Chrysler Automobiles"
+    },
+    {
+      "qid": "Q156829",
+      "canonical": "Air Berlin"
+    },
+    {
+      "qid": "Q15694879",
+      "canonical": "Reinhard Ploss"
+    },
+    {
+      "qid": "Q156959",
+      "canonical": "Merck KGaA"
+    },
+    {
+      "qid": "Q157062",
+      "canonical": "Unilever"
+    },
+    {
+      "qid": "Q1572591",
+      "canonical": "Ren\u00e9 Obermann"
+    },
+    {
+      "qid": "Q157617",
+      "canonical": "Commerzbank AG"
+    },
+    {
+      "qid": "Q157645",
+      "canonical": "Deutsche Post AG"
+    },
+    {
+      "qid": "Q157675",
+      "canonical": "Vattenfall"
+    },
+    {
+      "qid": "Q157852",
+      "canonical": "Deutsche B\u00f6rse"
+    },
+    {
+      "qid": "Q158205",
+      "canonical": "Sanofi"
+    },
+    {
+      "qid": "Q1582880",
+      "canonical": "Hans Vestberg"
+    },
+    {
+      "qid": "Q15842921",
+      "canonical": "Rolf Martin Schmitz"
+    },
+    {
+      "qid": "Q15854029",
+      "canonical": "Werner Baumann"
+    },
+    {
+      "qid": "Q1586568",
+      "canonical": "Harry Hohmeister"
+    },
+    {
+      "qid": "Q15905744",
+      "canonical": "Ivo Nesrovnal"
+    },
+    {
+      "qid": "Q159433",
+      "canonical": "3M"
+    },
+    {
+      "qid": "Q1594600",
+      "canonical": "Heike Werner"
+    },
+    {
+      "qid": "Q15992210",
+      "canonical": "John Nystr\u00f6m"
+    },
+    {
+      "qid": "Q1603219",
+      "canonical": "Kongsberg V\u00e5penfabrikk"
+    },
+    {
+      "qid": "Q160746",
+      "canonical": "Nestl\u00e9"
+    },
+    {
+      "qid": "Q161086",
+      "canonical": "JetBlue Airways"
+    },
+    {
+      "qid": "Q16139697",
+      "canonical": "Saithip Montrikul na Ayudhaya"
+    },
+    {
+      "qid": "Q16161682",
+      "canonical": "Miloslav Ludv\u00edk"
+    },
+    {
+      "qid": "Q16163305",
+      "canonical": "Albert Royo i Marin\u00e9"
+    },
+    {
+      "qid": "Q16189392",
+      "canonical": "Ross McEwan"
+    },
+    {
+      "qid": "Q16193529",
+      "canonical": "Mike Coupe"
+    },
+    {
+      "qid": "Q16193601",
+      "canonical": "Alex Gorsky"
+    },
+    {
+      "qid": "Q16194777",
+      "canonical": "Marc Rowan"
+    },
+    {
+      "qid": "Q1623391",
+      "canonical": "Hogrefe Verlag"
+    },
+    {
+      "qid": "Q162472",
+      "canonical": "FK P\u0159\u00edbram"
+    },
+    {
+      "qid": "Q16269214",
+      "canonical": "Sa\u00efd Alj"
+    },
+    {
+      "qid": "Q16307519",
+      "canonical": "Boosaba Daorueng"
+    },
+    {
+      "qid": "Q163241",
+      "canonical": "Continental AG"
+    },
+    {
+      "qid": "Q1634366",
+      "canonical": "Hugh Grant"
+    },
+    {
+      "qid": "Q1636974",
+      "canonical": "Danske Bank"
+    },
+    {
+      "qid": "Q1641437",
+      "canonical": "Ralph Lauren Corporation"
+    },
+    {
+      "qid": "Q16471828",
+      "canonical": "Group-IB"
+    },
+    {
+      "qid": "Q16476115",
+      "canonical": "Viktoras Butkus"
+    },
+    {
+      "qid": "Q1650162",
+      "canonical": "W. Craig Jelinek"
+    },
+    {
+      "qid": "Q16502557",
+      "canonical": "Marit af Bj\u00f6rkesten"
+    },
+    {
+      "qid": "Q16512361",
+      "canonical": "Catalonia International"
+    },
+    {
+      "qid": "Q16533765",
+      "canonical": "Bruno Duthoit"
+    },
+    {
+      "qid": "Q1655624",
+      "canonical": "Ian Read"
+    },
+    {
+      "qid": "Q16630669",
+      "canonical": "Pavel Vlasov"
+    },
+    {
+      "qid": "Q16633220",
+      "canonical": "Martin Lindqvist"
+    },
+    {
+      "qid": "Q16657998",
+      "canonical": "Maximo Ibarra"
+    },
+    {
+      "qid": "Q1671509",
+      "canonical": "onsemi"
+    },
+    {
+      "qid": "Q16727786",
+      "canonical": "Dave Calhoun"
+    },
+    {
+      "qid": "Q16731607",
+      "canonical": "Mario Longhi"
+    },
+    {
+      "qid": "Q16733839",
+      "canonical": "Flemming \u00d8rnskov"
+    },
+    {
+      "qid": "Q16742113",
+      "canonical": "Kooperativa poji\u0161\u0165ovna"
+    },
+    {
+      "qid": "Q1676085",
+      "canonical": "Ivchenko-Progress"
+    },
+    {
+      "qid": "Q16770026",
+      "canonical": "Takekazu Kaneko"
+    },
+    {
+      "qid": "Q16782619",
+      "canonical": "Ramon Rovira i Pol"
+    },
+    {
+      "qid": "Q168238",
+      "canonical": "OMV"
+    },
+    {
+      "qid": "Q16916495",
+      "canonical": "Varma Mutual Pension Insurance Company"
+    },
+    {
+      "qid": "Q16988458",
+      "canonical": "Risto Murto"
+    },
+    {
+      "qid": "Q16991326",
+      "canonical": "Matti Vuoria"
+    },
+    {
+      "qid": "Q16991444",
+      "canonical": "Merja Yl\u00e4-Anttila"
+    },
+    {
+      "qid": "Q169925",
+      "canonical": "Mozilla Corporation"
+    },
+    {
+      "qid": "Q17000790",
+      "canonical": "Ann Sherry"
+    },
+    {
+      "qid": "Q17021787",
+      "canonical": "Thomas Agnew & Sons"
+    },
+    {
+      "qid": "Q17031875",
+      "canonical": "Liquid Web"
+    },
+    {
+      "qid": "Q17032001",
+      "canonical": "\u00c0ngel Jov\u00e9"
+    },
+    {
+      "qid": "Q170416",
+      "canonical": "Koninklijke Philips NV"
+    },
+    {
+      "qid": "Q17058205",
+      "canonical": "Benedicte Schilbred Fasmer"
+    },
+    {
+      "qid": "Q1705878",
+      "canonical": "Josef Taus"
+    },
+    {
+      "qid": "Q170614",
+      "canonical": "Ryanair"
+    },
+    {
+      "qid": "Q17068357",
+      "canonical": "Mapbox"
+    },
+    {
+      "qid": "Q17096973",
+      "canonical": "Bjarne Hurlen"
+    },
+    {
+      "qid": "Q17108577",
+      "canonical": "Christian Stav"
+    },
+    {
+      "qid": "Q17112795",
+      "canonical": "Tore Torvund"
+    },
+    {
+      "qid": "Q17229450",
+      "canonical": "Masatsugu Nagato"
+    },
+    {
+      "qid": "Q17276640",
+      "canonical": "Catherine O'Brien"
+    },
+    {
+      "qid": "Q1729151",
+      "canonical": "Karel Engli\u0161"
+    },
+    {
+      "qid": "Q17295710",
+      "canonical": "Daniel Bene\u0161"
+    },
+    {
+      "qid": "Q17310744",
+      "canonical": "CELSA"
+    },
+    {
+      "qid": "Q17312125",
+      "canonical": "Jan Sou\u010dek"
+    },
+    {
+      "qid": "Q17335133",
+      "canonical": "Daniel Sz\u00f3r\u00e1d"
+    },
+    {
+      "qid": "Q1735158",
+      "canonical": "Tim Brown"
+    },
+    {
+      "qid": "Q1740534",
+      "canonical": "Vinmonopolet"
+    },
+    {
+      "qid": "Q174769",
+      "canonical": "United Airlines"
+    },
+    {
+      "qid": "Q17507863",
+      "canonical": "4INFO"
+    },
+    {
+      "qid": "Q17516980",
+      "canonical": "Richard H. Anderson"
+    },
+    {
+      "qid": "Q17579992",
+      "canonical": "Piyush Gupta"
+    },
+    {
+      "qid": "Q17685777",
+      "canonical": "Toshihiko Aoyagi"
+    },
+    {
+      "qid": "Q1770909",
+      "canonical": "Kongsberg Gruppen"
+    },
+    {
+      "qid": "Q1783168",
+      "canonical": "Post Office Limited"
+    },
+    {
+      "qid": "Q1794969",
+      "canonical": "Kwon Oh-hyun"
+    },
+    {
+      "qid": "Q1797872",
+      "canonical": "Tonje Sagstuen"
+    },
+    {
+      "qid": "Q1806074",
+      "canonical": "Larry Merlo"
+    },
+    {
+      "qid": "Q18071689",
+      "canonical": "Boris Dobrodeyev"
+    },
+    {
+      "qid": "Q1807170",
+      "canonical": "Powszechny Zak\u0142ad Ubezpiecze\u0144"
+    },
+    {
+      "qid": "Q181114",
+      "canonical": "Stellantis North America"
+    },
+    {
+      "qid": "Q181162",
+      "canonical": "Steve Ballmer"
+    },
+    {
+      "qid": "Q18121649",
+      "canonical": "Andrew Witty"
+    },
+    {
+      "qid": "Q18153753",
+      "canonical": "Joe Swedish"
+    },
+    {
+      "qid": "Q18171895",
+      "canonical": "Balesh Sharma"
+    },
+    {
+      "qid": "Q18224",
+      "canonical": "Maersk"
+    },
+    {
+      "qid": "Q18325550",
+      "canonical": "Flytoget AS"
+    },
+    {
+      "qid": "Q18331193",
+      "canonical": "John Manzoni"
+    },
+    {
+      "qid": "Q18335035",
+      "canonical": "Wilhelm Winterstein"
+    },
+    {
+      "qid": "Q18351457",
+      "canonical": "Q18351457"
+    },
+    {
+      "qid": "Q1848025",
+      "canonical": "Spr\u00e1va \u017eeleznic"
+    },
+    {
+      "qid": "Q1852556",
+      "canonical": "Philip Morris International"
+    },
+    {
+      "qid": "Q18543",
+      "canonical": "Major League Soccer"
+    },
+    {
+      "qid": "Q18594",
+      "canonical": "Sony Interactive Entertainment"
+    },
+    {
+      "qid": "Q186068",
+      "canonical": "Fox News"
+    },
+    {
+      "qid": "Q18634617",
+      "canonical": "Steve Mollenkopf"
+    },
+    {
+      "qid": "Q18644198",
+      "canonical": "Germ\u00e1n de Granda"
+    },
+    {
+      "qid": "Q18689157",
+      "canonical": "Sidoste"
+    },
+    {
+      "qid": "Q1872576",
+      "canonical": "Lowell McAdam"
+    },
+    {
+      "qid": "Q18748951",
+      "canonical": "Carlos Rodriguez"
+    },
+    {
+      "qid": "Q18786186",
+      "canonical": "Mikhail Cherevko"
+    },
+    {
+      "qid": "Q1885456",
+      "canonical": "VK"
+    },
+    {
+      "qid": "Q188920",
+      "canonical": "Delta Air Lines"
+    },
+    {
+      "qid": "Q18921689",
+      "canonical": "Steve Easterbrook"
+    },
+    {
+      "qid": "Q18921712",
+      "canonical": "Jim Farley"
+    },
+    {
+      "qid": "Q190238",
+      "canonical": "Norwegian Broadcasting Corporation"
+    },
+    {
+      "qid": "Q190464",
+      "canonical": "HSBC"
+    },
+    {
+      "qid": "Q1910173",
+      "canonical": "Matthias M\u00fcller"
+    },
+    {
+      "qid": "Q191551",
+      "canonical": "easyJet"
+    },
+    {
+      "qid": "Q1916402",
+      "canonical": "Pearson plc"
+    },
+    {
+      "qid": "Q1921466",
+      "canonical": "Merck Finck"
+    },
+    {
+      "qid": "Q192653",
+      "canonical": "Czech Airlines"
+    },
+    {
+      "qid": "Q19285388",
+      "canonical": "Herbert Diess"
+    },
+    {
+      "qid": "Q19297571",
+      "canonical": "Ola K\u00e4llenius"
+    },
+    {
+      "qid": "Q193326",
+      "canonical": "Goldman Sachs"
+    },
+    {
+      "qid": "Q19360238",
+      "canonical": "Olivier Brandicourt"
+    },
+    {
+      "qid": "Q19383161",
+      "canonical": "Nordea Liv"
+    },
+    {
+      "qid": "Q194360",
+      "canonical": "American Express"
+    },
+    {
+      "qid": "Q19482177",
+      "canonical": "Guillaume Boutin"
+    },
+    {
+      "qid": "Q19661212",
+      "canonical": "Ted Sarandos"
+    },
+    {
+      "qid": "Q19667942",
+      "canonical": "Jarl Mohn"
+    },
+    {
+      "qid": "Q19698200",
+      "canonical": "Orange France"
+    },
+    {
+      "qid": "Q19753941",
+      "canonical": "Fullbeauty Brands"
+    },
+    {
+      "qid": "Q19772432",
+      "canonical": "Thomas Winkelmann"
+    },
+    {
+      "qid": "Q19831035",
+      "canonical": "Parlem"
+    },
+    {
+      "qid": "Q19842482",
+      "canonical": "Paul Tarvin"
+    },
+    {
+      "qid": "Q19843254",
+      "canonical": "Kevin A. Lobo"
+    },
+    {
+      "qid": "Q19867600",
+      "canonical": "Andy Penn"
+    },
+    {
+      "qid": "Q19874731",
+      "canonical": "Jon J. Franklin"
+    },
+    {
+      "qid": "Q19896671",
+      "canonical": "Tim Jenkins"
+    },
+    {
+      "qid": "Q19896679",
+      "canonical": "Zaw Thet"
+    },
+    {
+      "qid": "Q19923099",
+      "canonical": "Hewlett Packard Enterprise"
+    },
+    {
+      "qid": "Q19938961",
+      "canonical": "Amin H. Al-Nasser"
+    },
+    {
+      "qid": "Q19951610",
+      "canonical": "ArianeGroup"
+    },
+    {
+      "qid": "Q19975651",
+      "canonical": "Alison Brittain"
+    },
+    {
+      "qid": "Q2001226",
+      "canonical": "Petr B\u0159\u00edza"
+    },
+    {
+      "qid": "Q2005282",
+      "canonical": "Proximus"
+    },
+    {
+      "qid": "Q20056888",
+      "canonical": "AB - Credit"
+    },
+    {
+      "qid": "Q20102528",
+      "canonical": "Waste Agency of Catalonia"
+    },
+    {
+      "qid": "Q20108105",
+      "canonical": "Fibracat"
+    },
+    {
+      "qid": "Q20112651",
+      "canonical": "Nye Veier"
+    },
+    {
+      "qid": "Q20165",
+      "canonical": "Nissan"
+    },
+    {
+      "qid": "Q20190635",
+      "canonical": "V\u00edctor Manuel Rodr\u00edguez"
+    },
+    {
+      "qid": "Q20215432",
+      "canonical": "Scott Ernest"
+    },
+    {
+      "qid": "Q2031726",
+      "canonical": "Westpac"
+    },
+    {
+      "qid": "Q2042423",
+      "canonical": "Oversea-Chinese Banking Corporation"
+    },
+    {
+      "qid": "Q204277",
+      "canonical": "Fernando Fern\u00e1ndez"
+    },
+    {
+      "qid": "Q204296",
+      "canonical": "Air New Zealand"
+    },
+    {
+      "qid": "Q20532802",
+      "canonical": "Marta Ortega"
+    },
+    {
+      "qid": "Q20631056",
+      "canonical": "Dean Finch"
+    },
+    {
+      "qid": "Q206678",
+      "canonical": "OTE"
+    },
+    {
+      "qid": "Q20670264",
+      "canonical": "Philippe Fortunato"
+    },
+    {
+      "qid": "Q20685561",
+      "canonical": "Keith Skeoch"
+    },
+    {
+      "qid": "Q206921",
+      "canonical": "Pfizer"
+    },
+    {
+      "qid": "Q20718",
+      "canonical": "Samsung Electronics"
+    },
+    {
+      "qid": "Q2071905",
+      "canonical": "BBC Worldwide"
+    },
+    {
+      "qid": "Q20755424",
+      "canonical": "Le\u0161ek Wronka"
+    },
+    {
+      "qid": "Q207983",
+      "canonical": "Monsanto"
+    },
+    {
+      "qid": "Q20800404",
+      "canonical": "Alphabet Inc."
+    },
+    {
+      "qid": "Q208033",
+      "canonical": "Qatar Airways"
+    },
+    {
+      "qid": "Q20855863",
+      "canonical": "Iolanda Batall\u00e9"
+    },
+    {
+      "qid": "Q20857886",
+      "canonical": "Brian Cornell"
+    },
+    {
+      "qid": "Q20858163",
+      "canonical": "Norfolk Southern Corporation"
+    },
+    {
+      "qid": "Q20978753",
+      "canonical": "Glenn J. Williams"
+    },
+    {
+      "qid": "Q21030040",
+      "canonical": "Martin Lund"
+    },
+    {
+      "qid": "Q21030045",
+      "canonical": "Kevin DeNuccio"
+    },
+    {
+      "qid": "Q21032599",
+      "canonical": "Oliver Blume"
+    },
+    {
+      "qid": "Q21066734",
+      "canonical": "Oscar Munoz"
+    },
+    {
+      "qid": "Q21072926",
+      "canonical": "Scott Kirby"
+    },
+    {
+      "qid": "Q21075696",
+      "canonical": "Stefan Larsson"
+    },
+    {
+      "qid": "Q212322",
+      "canonical": "GSK"
+    },
+    {
+      "qid": "Q213140",
+      "canonical": "Japan Airlines"
+    },
+    {
+      "qid": "Q21395999",
+      "canonical": "Petr Witowski"
+    },
+    {
+      "qid": "Q215293",
+      "canonical": "Volvo Cars"
+    },
+    {
+      "qid": "Q215363",
+      "canonical": "Sveriges Television"
+    },
+    {
+      "qid": "Q21551443",
+      "canonical": "Carol Tom\u00e9"
+    },
+    {
+      "qid": "Q21558230",
+      "canonical": "V\u00e1clav Novotn\u00fd"
+    },
+    {
+      "qid": "Q2163279",
+      "canonical": "Rolf Buch"
+    },
+    {
+      "qid": "Q21634546",
+      "canonical": "\u00c9ric Martel"
+    },
+    {
+      "qid": "Q21711860",
+      "canonical": "Vibeke F\u00fcrst Haugen"
+    },
+    {
+      "qid": "Q217493",
+      "canonical": "Paradox Interactive"
+    },
+    {
+      "qid": "Q21950804",
+      "canonical": "REC Silicon"
+    },
+    {
+      "qid": "Q21979835",
+      "canonical": "Isaac Peraire Soler"
+    },
+    {
+      "qid": "Q2199420",
+      "canonical": "Carlos Brito"
+    },
+    {
+      "qid": "Q22003790",
+      "canonical": "\u00c1lex Cruz"
+    },
+    {
+      "qid": "Q22007263",
+      "canonical": "Stefan Oschmann"
+    },
+    {
+      "qid": "Q22007406",
+      "canonical": "John Pettigrew"
+    },
+    {
+      "qid": "Q22031704",
+      "canonical": "ING Australia"
+    },
+    {
+      "qid": "Q22132500",
+      "canonical": "metaphacts"
+    },
+    {
+      "qid": "Q22137354",
+      "canonical": "John A. Addison Jr."
+    },
+    {
+      "qid": "Q22277439",
+      "canonical": "Greg Creed"
+    },
+    {
+      "qid": "Q22278143",
+      "canonical": "Brian Hartzer"
+    },
+    {
+      "qid": "Q2254475",
+      "canonical": "Ben Sherwood"
+    },
+    {
+      "qid": "Q2262672",
+      "canonical": "Sebastian Ebel"
+    },
+    {
+      "qid": "Q22809327",
+      "canonical": "Jaume Peral i Juanola"
+    },
+    {
+      "qid": "Q22810736",
+      "canonical": "Linus Sebastian"
+    },
+    {
+      "qid": "Q22813963",
+      "canonical": "Rostyslav Shurma"
+    },
+    {
+      "qid": "Q2283",
+      "canonical": "Microsoft"
+    },
+    {
+      "qid": "Q2287912",
+      "canonical": "Simon Wolfson"
+    },
+    {
+      "qid": "Q2295406",
+      "canonical": "Smiths Group"
+    },
+    {
+      "qid": "Q22978019",
+      "canonical": "Viliam Sivek"
+    },
+    {
+      "qid": "Q2298325",
+      "canonical": "Boston Dynamics"
+    },
+    {
+      "qid": "Q2303478",
+      "canonical": "Synopsys"
+    },
+    {
+      "qid": "Q23040862",
+      "canonical": "Herbert Tillander"
+    },
+    {
+      "qid": "Q23045376",
+      "canonical": "Talenom"
+    },
+    {
+      "qid": "Q23062326",
+      "canonical": "Tobias Moers"
+    },
+    {
+      "qid": "Q23076",
+      "canonical": "Nederlandse Spoorwegen"
+    },
+    {
+      "qid": "Q2311",
+      "canonical": "Airbus"
+    },
+    {
+      "qid": "Q2316882",
+      "canonical": "ProRail"
+    },
+    {
+      "qid": "Q23317",
+      "canonical": "Audi AG"
+    },
+    {
+      "qid": "Q2337302",
+      "canonical": "Stefan Pischinger"
+    },
+    {
+      "qid": "Q234021",
+      "canonical": "Robert Bosch"
+    },
+    {
+      "qid": "Q23416859",
+      "canonical": "Jean-S\u00e9bastien Jacques"
+    },
+    {
+      "qid": "Q2344783",
+      "canonical": "Stephen J. Hemsley"
+    },
+    {
+      "qid": "Q23564642",
+      "canonical": "Ulrich Meister"
+    },
+    {
+      "qid": "Q2357515",
+      "canonical": "Stryker Corporation"
+    },
+    {
+      "qid": "Q2360847",
+      "canonical": "Zaporizhstal"
+    },
+    {
+      "qid": "Q23809748",
+      "canonical": "Per Utnegaard"
+    },
+    {
+      "qid": "Q23831639",
+      "canonical": "Peter Haase"
+    },
+    {
+      "qid": "Q23883644",
+      "canonical": "Dominic Paul"
+    },
+    {
+      "qid": "Q23905879",
+      "canonical": "Avi Buskila"
+    },
+    {
+      "qid": "Q23970591",
+      "canonical": "Peter Harrison"
+    },
+    {
+      "qid": "Q23979144",
+      "canonical": "Bane NOR"
+    },
+    {
+      "qid": "Q24007496",
+      "canonical": "Andrew Reynolds Smith"
+    },
+    {
+      "qid": "Q24018216",
+      "canonical": "Bj\u00f6rn Rosengren"
+    },
+    {
+      "qid": "Q24049135",
+      "canonical": "Kirill Tatarinov"
+    },
+    {
+      "qid": "Q2405791",
+      "canonical": "O2 Czech Republic"
+    },
+    {
+      "qid": "Q2408676",
+      "canonical": "Gordon Donald Simons"
+    },
+    {
+      "qid": "Q2418452",
+      "canonical": "Theodor Weimer"
+    },
+    {
+      "qid": "Q243278",
+      "canonical": "Rolls-Royce"
+    },
+    {
+      "qid": "Q24429855",
+      "canonical": "Daniel Obajtek"
+    },
+    {
+      "qid": "Q245343",
+      "canonical": "Barclays"
+    },
+    {
+      "qid": "Q24572405",
+      "canonical": "Sergio Bucher"
+    },
+    {
+      "qid": "Q2464046",
+      "canonical": "T\u00f6nnies Holding"
+    },
+    {
+      "qid": "Q246655",
+      "canonical": "Next plc"
+    },
+    {
+      "qid": "Q247489",
+      "canonical": "Merck & Co."
+    },
+    {
+      "qid": "Q24795213",
+      "canonical": "Eddie Wilson"
+    },
+    {
+      "qid": "Q248",
+      "canonical": "Intel"
+    },
+    {
+      "qid": "Q2489897",
+      "canonical": "Karl-Petter L\u00f8ken"
+    },
+    {
+      "qid": "Q24939514",
+      "canonical": "Open Fiber"
+    },
+    {
+      "qid": "Q24954807",
+      "canonical": "Ilya Sachkov"
+    },
+    {
+      "qid": "Q24956110",
+      "canonical": "Jean-Fran\u00e7ois Fallacher"
+    },
+    {
+      "qid": "Q25103691",
+      "canonical": "Entain"
+    },
+    {
+      "qid": "Q25141716",
+      "canonical": "Darius Adamczyk"
+    },
+    {
+      "qid": "Q25266073",
+      "canonical": "Shinji Han'i"
+    },
+    {
+      "qid": "Q2531462",
+      "canonical": "Volkmar Denner"
+    },
+    {
+      "qid": "Q25391216",
+      "canonical": "Charles Ndongo"
+    },
+    {
+      "qid": "Q25394205",
+      "canonical": "Alfa"
+    },
+    {
+      "qid": "Q25499288",
+      "canonical": "Northway Biotech"
+    },
+    {
+      "qid": "Q2565531",
+      "canonical": "Westpac New Zealand"
+    },
+    {
+      "qid": "Q2581305",
+      "canonical": "Willibald Cernko"
+    },
+    {
+      "qid": "Q2587167",
+      "canonical": "Vladimir Lotariev"
+    },
+    {
+      "qid": "Q25894536",
+      "canonical": "Tom\u00e1\u0161 Krsek"
+    },
+    {
+      "qid": "Q259013",
+      "canonical": "Centrica"
+    },
+    {
+      "qid": "Q2590482",
+      "canonical": "Hjo\u2013Stenstorps J\u00e4rnv\u00e4g"
+    },
+    {
+      "qid": "Q2595414",
+      "canonical": "Q2595414"
+    },
+    {
+      "qid": "Q25999295",
+      "canonical": "Yves Gauthier"
+    },
+    {
+      "qid": "Q26207337",
+      "canonical": "Aleksander Kutela"
+    },
+    {
+      "qid": "Q2622748",
+      "canonical": "Shantanu Narayen"
+    },
+    {
+      "qid": "Q26258183",
+      "canonical": "H\u00e5kan Ericsson"
+    },
+    {
+      "qid": "Q26281315",
+      "canonical": "Tom\u00e1\u0161 Salomon"
+    },
+    {
+      "qid": "Q264913",
+      "canonical": "Indra Nooyi"
+    },
+    {
+      "qid": "Q265126",
+      "canonical": "Christopher Mattheisen"
+    },
+    {
+      "qid": "Q265852",
+      "canonical": "Tim Cook"
+    },
+    {
+      "qid": "Q266341",
+      "canonical": "Orange Egypt"
+    },
+    {
+      "qid": "Q26637897",
+      "canonical": "Luis Mayo Mu\u00f1iz"
+    },
+    {
+      "qid": "Q26638506",
+      "canonical": "Jes\u00fas Serrano Mart\u00ednez"
+    },
+    {
+      "qid": "Q266423",
+      "canonical": "Bristol-Myers Squibb"
+    },
+    {
+      "qid": "Q2665980",
+      "canonical": "Guardian Media Group"
+    },
+    {
+      "qid": "Q2666775",
+      "canonical": "Bank Hapoalim B.M."
+    },
+    {
+      "qid": "Q267074",
+      "canonical": "John Donahoe"
+    },
+    {
+      "qid": "Q26836942",
+      "canonical": "Eva Berneke"
+    },
+    {
+      "qid": "Q2695537",
+      "canonical": "V\u00e4sterg\u00f6tland\u2013G\u00f6teborgs J\u00e4rnv\u00e4gar"
+    },
+    {
+      "qid": "Q26989",
+      "canonical": "Infosys"
+    },
+    {
+      "qid": "Q27058352",
+      "canonical": "Emma Walmsley"
+    },
+    {
+      "qid": "Q27058377",
+      "canonical": "Hilde Britt Mellbye"
+    },
+    {
+      "qid": "Q27074",
+      "canonical": "Aston Martin Lagonda"
+    },
+    {
+      "qid": "Q27074910",
+      "canonical": "Harri Hintikka"
+    },
+    {
+      "qid": "Q271117",
+      "canonical": "Andrea Jung"
+    },
+    {
+      "qid": "Q2740294",
+      "canonical": "Matkahuolto"
+    },
+    {
+      "qid": "Q274372",
+      "canonical": "Evoke plc"
+    },
+    {
+      "qid": "Q2744099",
+      "canonical": "Vertex Pharmaceuticals"
+    },
+    {
+      "qid": "Q2745626",
+      "canonical": "Bruce Chizen"
+    },
+    {
+      "qid": "Q27460",
+      "canonical": "Dacia"
+    },
+    {
+      "qid": "Q27530",
+      "canonical": "Mercedes-Benz Group"
+    },
+    {
+      "qid": "Q27585",
+      "canonical": "AOL"
+    },
+    {
+      "qid": "Q27735066",
+      "canonical": "Jim Umpleby"
+    },
+    {
+      "qid": "Q2777746",
+      "canonical": "Fayard"
+    },
+    {
+      "qid": "Q27778959",
+      "canonical": "Mattoni 1873"
+    },
+    {
+      "qid": "Q27839505",
+      "canonical": "James Quincey"
+    },
+    {
+      "qid": "Q27861831",
+      "canonical": "Donald A. Baer"
+    },
+    {
+      "qid": "Q27870055",
+      "canonical": "Guido Reibel"
+    },
+    {
+      "qid": "Q278810",
+      "canonical": "Pennon Group"
+    },
+    {
+      "qid": "Q27882872",
+      "canonical": "Bel\u00e9n Garijo"
+    },
+    {
+      "qid": "Q27894018",
+      "canonical": "Kees van Dijkhuizen"
+    },
+    {
+      "qid": "Q27896387",
+      "canonical": "Markus Duesmann"
+    },
+    {
+      "qid": "Q27969046",
+      "canonical": "Promet Group"
+    },
+    {
+      "qid": "Q28018191",
+      "canonical": "Darren Woods"
+    },
+    {
+      "qid": "Q28027517",
+      "canonical": "Lucid Motors"
+    },
+    {
+      "qid": "Q28135888",
+      "canonical": "Yoast BV"
+    },
+    {
+      "qid": "Q281657",
+      "canonical": "Miles D. White"
+    },
+    {
+      "qid": "Q28228201",
+      "canonical": "Rainer Seele"
+    },
+    {
+      "qid": "Q282717",
+      "canonical": "Gromov Flight Research Institute"
+    },
+    {
+      "qid": "Q2830367",
+      "canonical": "Alain Weill"
+    },
+    {
+      "qid": "Q283852",
+      "canonical": "Turkcell"
+    },
+    {
+      "qid": "Q28402108",
+      "canonical": "Steve Sanghi"
+    },
+    {
+      "qid": "Q28408088",
+      "canonical": "Rafael Villaseca"
+    },
+    {
+      "qid": "Q284672",
+      "canonical": "Bilfinger SE"
+    },
+    {
+      "qid": "Q2849060",
+      "canonical": "Andy Bird"
+    },
+    {
+      "qid": "Q285328",
+      "canonical": "Commonwealth Bank"
+    },
+    {
+      "qid": "Q28536761",
+      "canonical": "James A. Squires"
+    },
+    {
+      "qid": "Q2865328",
+      "canonical": "Arthur Sadoun"
+    },
+    {
+      "qid": "Q287471",
+      "canonical": "ABN AMRO"
+    },
+    {
+      "qid": "Q28752461",
+      "canonical": "Alvaro Ortega"
+    },
+    {
+      "qid": "Q28792551",
+      "canonical": "Mats Rahmstr\u00f6m"
+    },
+    {
+      "qid": "Q28835137",
+      "canonical": "Luigi Ferraris"
+    },
+    {
+      "qid": "Q28858105",
+      "canonical": "Yamagiwa Corporation"
+    },
+    {
+      "qid": "Q28858458",
+      "canonical": "Lars Fruergaard J\u00f8rgensen"
+    },
+    {
+      "qid": "Q28859508",
+      "canonical": "Hy\u014dgo Konagaya"
+    },
+    {
+      "qid": "Q28859512",
+      "canonical": "Tetsu Konagaya"
+    },
+    {
+      "qid": "Q28861839",
+      "canonical": "Jean-Marc Harion"
+    },
+    {
+      "qid": "Q28871936",
+      "canonical": "Kim Fournais"
+    },
+    {
+      "qid": "Q28873696",
+      "canonical": "Peter Rawlinson"
+    },
+    {
+      "qid": "Q28914209",
+      "canonical": "Lars S\u00f8ren Rasmussen"
+    },
+    {
+      "qid": "Q28914897",
+      "canonical": "Allison Kirkby"
+    },
+    {
+      "qid": "Q28920824",
+      "canonical": "Craig Menear"
+    },
+    {
+      "qid": "Q2897681",
+      "canonical": "Bernard Charl\u00e8s"
+    },
+    {
+      "qid": "Q2926681",
+      "canonical": "Bruno Cercley"
+    },
+    {
+      "qid": "Q29359760",
+      "canonical": "GMMTV"
+    },
+    {
+      "qid": "Q2939466",
+      "canonical": "Carlos Tavares"
+    },
+    {
+      "qid": "Q2958994",
+      "canonical": "Charles Edelstenne"
+    },
+    {
+      "qid": "Q29635912",
+      "canonical": "Klaus Harisch"
+    },
+    {
+      "qid": "Q29637",
+      "canonical": "\u0160koda Auto"
+    },
+    {
+      "qid": "Q29641838",
+      "canonical": "David M. Solomon"
+    },
+    {
+      "qid": "Q29973720",
+      "canonical": "Patrice Louvet"
+    },
+    {
+      "qid": "Q30030987",
+      "canonical": "James Hackett"
+    },
+    {
+      "qid": "Q30100510",
+      "canonical": "Derek Neilson"
+    },
+    {
+      "qid": "Q30103078",
+      "canonical": "Dirk Stenkamp"
+    },
+    {
+      "qid": "Q30134813",
+      "canonical": "Alex Mahon"
+    },
+    {
+      "qid": "Q3018516",
+      "canonical": "David Nahmias"
+    },
+    {
+      "qid": "Q30242909",
+      "canonical": "John L. Flannery"
+    },
+    {
+      "qid": "Q30259493",
+      "canonical": "Nel"
+    },
+    {
+      "qid": "Q30284383",
+      "canonical": "Optum"
+    },
+    {
+      "qid": "Q30317564",
+      "canonical": "Albert Le Dirac'h"
+    },
+    {
+      "qid": "Q30321616",
+      "canonical": "Altaba"
+    },
+    {
+      "qid": "Q30338585",
+      "canonical": "Thermo Fisher Scientific Baltics, UAB"
+    },
+    {
+      "qid": "Q30338814",
+      "canonical": "IBM Germany"
+    },
+    {
+      "qid": "Q30349225",
+      "canonical": "Peter Bosek"
+    },
+    {
+      "qid": "Q3044921",
+      "canonical": "Pauline Green"
+    },
+    {
+      "qid": "Q30493955",
+      "canonical": "Robin Hayes"
+    },
+    {
+      "qid": "Q304944",
+      "canonical": "\u010cesk\u00e9 dr\u00e1hy"
+    },
+    {
+      "qid": "Q3066682",
+      "canonical": "Max Gaines"
+    },
+    {
+      "qid": "Q306764",
+      "canonical": "Abbott Laboratories"
+    },
+    {
+      "qid": "Q30729211",
+      "canonical": "Franck Terner"
+    },
+    {
+      "qid": "Q30731145",
+      "canonical": "Michel Paulin"
+    },
+    {
+      "qid": "Q308889",
+      "canonical": "Cessna"
+    },
+    {
+      "qid": "Q309031",
+      "canonical": "Lacoste S.A."
+    },
+    {
+      "qid": "Q309174",
+      "canonical": "Northwest Airlines"
+    },
+    {
+      "qid": "Q30923926",
+      "canonical": "Hiroto Saikawa"
+    },
+    {
+      "qid": "Q30924986",
+      "canonical": "Tatsuo Kijima"
+    },
+    {
+      "qid": "Q3095097",
+      "canonical": "Gandi"
+    },
+    {
+      "qid": "Q310207",
+      "canonical": "McKinsey & Company"
+    },
+    {
+      "qid": "Q3109036",
+      "canonical": "Ole Herman Johannes Krag"
+    },
+    {
+      "qid": "Q31096442",
+      "canonical": "Stefan Bomhard"
+    },
+    {
+      "qid": "Q311394",
+      "canonical": "Infineon Technologies"
+    },
+    {
+      "qid": "Q312",
+      "canonical": "Apple Inc."
+    },
+    {
+      "qid": "Q31202127",
+      "canonical": "Joseph Gorder"
+    },
+    {
+      "qid": "Q31202205",
+      "canonical": "Anthony W. Thomas"
+    },
+    {
+      "qid": "Q31210808",
+      "canonical": "Kevin G. McAllister"
+    },
+    {
+      "qid": "Q312556",
+      "canonical": "Jeff Bezos"
+    },
+    {
+      "qid": "Q3126763",
+      "canonical": "Generali Italia"
+    },
+    {
+      "qid": "Q3140604",
+      "canonical": "ITV plc"
+    },
+    {
+      "qid": "Q3146975",
+      "canonical": "Xylem Inc."
+    },
+    {
+      "qid": "Q3149496",
+      "canonical": "IN Groupe"
+    },
+    {
+      "qid": "Q3155030",
+      "canonical": "Isabelle Saporta"
+    },
+    {
+      "qid": "Q3155690",
+      "canonical": "Issad Rebrab"
+    },
+    {
+      "qid": "Q3158153",
+      "canonical": "Jacques Aschenbroich"
+    },
+    {
+      "qid": "Q3161134",
+      "canonical": "James Harbord"
+    },
+    {
+      "qid": "Q3168302",
+      "canonical": "Jean-Pascal Tricoire"
+    },
+    {
+      "qid": "Q317521",
+      "canonical": "Elon Musk"
+    },
+    {
+      "qid": "Q3181430",
+      "canonical": "PostNord"
+    },
+    {
+      "qid": "Q31890244",
+      "canonical": "Svenska Lantm\u00e4nnens Riksf\u00f6rbund"
+    },
+    {
+      "qid": "Q3210329",
+      "canonical": "La Maison Simons"
+    },
+    {
+      "qid": "Q321441",
+      "canonical": "Roger Smith"
+    },
+    {
+      "qid": "Q323066",
+      "canonical": "William Gaines"
+    },
+    {
+      "qid": "Q32374551",
+      "canonical": "Ed Bastian"
+    },
+    {
+      "qid": "Q32491",
+      "canonical": "Qantas Airways"
+    },
+    {
+      "qid": "Q3264974",
+      "canonical": "Luca de Meo"
+    },
+    {
+      "qid": "Q3265178",
+      "canonical": "Lucian Grainge"
+    },
+    {
+      "qid": "Q327429",
+      "canonical": "W\u00e4rtsil\u00e4"
+    },
+    {
+      "qid": "Q327646",
+      "canonical": "Enron"
+    },
+    {
+      "qid": "Q32855967",
+      "canonical": "Richard Howson"
+    },
+    {
+      "qid": "Q328840",
+      "canonical": "Visa Inc."
+    },
+    {
+      "qid": "Q3295867",
+      "canonical": "The Coca-Cola Company"
+    },
+    {
+      "qid": "Q33105343",
+      "canonical": "J\u00e9r\u00f4me H\u00e9nique"
+    },
+    {
+      "qid": "Q33109758",
+      "canonical": "Christophe Perillat"
+    },
+    {
+      "qid": "Q33110014",
+      "canonical": "Fran\u00e7ois Jackow"
+    },
+    {
+      "qid": "Q33111421",
+      "canonical": "Didier Trutt"
+    },
+    {
+      "qid": "Q33111653",
+      "canonical": "Patrick Llobr\u00e9gat"
+    },
+    {
+      "qid": "Q33120770",
+      "canonical": "Sandrine Dufour"
+    },
+    {
+      "qid": "Q331401",
+      "canonical": "Rex Tillerson"
+    },
+    {
+      "qid": "Q33158035",
+      "canonical": "Guillaume Faury"
+    },
+    {
+      "qid": "Q33184828",
+      "canonical": "Lise Bo\u00ebll"
+    },
+    {
+      "qid": "Q3319873",
+      "canonical": "Norsk Tipping AS"
+    },
+    {
+      "qid": "Q33210227",
+      "canonical": "Thierry Guibert"
+    },
+    {
+      "qid": "Q33226824",
+      "canonical": "Didier Pfleger"
+    },
+    {
+      "qid": "Q33250746",
+      "canonical": "Eric Vallat"
+    },
+    {
+      "qid": "Q3327046",
+      "canonical": "OYSHO"
+    },
+    {
+      "qid": "Q333498",
+      "canonical": "Bombardier"
+    },
+    {
+      "qid": "Q333718",
+      "canonical": "Johnson & Johnson"
+    },
+    {
+      "qid": "Q3339193",
+      "canonical": "RMC BFM"
+    },
+    {
+      "qid": "Q3340974",
+      "canonical": "Nicolas de Tavernost"
+    },
+    {
+      "qid": "Q334800",
+      "canonical": "PepsiCo"
+    },
+    {
+      "qid": "Q3352745",
+      "canonical": "Scaleway"
+    },
+    {
+      "qid": "Q33608129",
+      "canonical": "Zbyn\u011bk Pr\u016f\u0161a"
+    },
+    {
+      "qid": "Q336717",
+      "canonical": "\u010cD Cargo"
+    },
+    {
+      "qid": "Q336735",
+      "canonical": "\u010cEZ Group"
+    },
+    {
+      "qid": "Q3372219",
+      "canonical": "Swedish Social Insurance Agency"
+    },
+    {
+      "qid": "Q3376883",
+      "canonical": "Peter Simons"
+    },
+    {
+      "qid": "Q3391698",
+      "canonical": "Pablo Isla"
+    },
+    {
+      "qid": "Q340135",
+      "canonical": "\u010ceskoslovensk\u00e1 obchodn\u00ed banka"
+    },
+    {
+      "qid": "Q3410475",
+      "canonical": "Groupe actu"
+    },
+    {
+      "qid": "Q341090",
+      "canonical": "\u010cesk\u00e1 po\u0161ta"
+    },
+    {
+      "qid": "Q341100",
+      "canonical": "\u010cesk\u00e1 spo\u0159itelna"
+    },
+    {
+      "qid": "Q341118",
+      "canonical": "Czech News Agency"
+    },
+    {
+      "qid": "Q341134",
+      "canonical": "\u010cesk\u00e1 televize"
+    },
+    {
+      "qid": "Q3432247",
+      "canonical": "Marc Wallenberg"
+    },
+    {
+      "qid": "Q3436288",
+      "canonical": "Robert B. Shapiro"
+    },
+    {
+      "qid": "Q3442764",
+      "canonical": "Ross Levinsohn"
+    },
+    {
+      "qid": "Q3446347",
+      "canonical": "St. Olavs hospital, Trondheim University Hospital"
+    },
+    {
+      "qid": "Q34561213",
+      "canonical": "BWI GmbH"
+    },
+    {
+      "qid": "Q3486990",
+      "canonical": "Vodafone Czech Republic"
+    },
+    {
+      "qid": "Q3490485",
+      "canonical": "Seznam.cz"
+    },
+    {
+      "qid": "Q3500447",
+      "canonical": "Mark Penn"
+    },
+    {
+      "qid": "Q3500487",
+      "canonical": "TV4 AB"
+    },
+    {
+      "qid": "Q3503829",
+      "canonical": "Sundar Pichai"
+    },
+    {
+      "qid": "Q3510372",
+      "canonical": "S\u00e9bastien de Montessus"
+    },
+    {
+      "qid": "Q3511885",
+      "canonical": "T-Mobile US"
+    },
+    {
+      "qid": "Q35243613",
+      "canonical": "Philip Jansen"
+    },
+    {
+      "qid": "Q3528191",
+      "canonical": "Tidjane Thiam"
+    },
+    {
+      "qid": "Q35507309",
+      "canonical": "Jan Juchelka"
+    },
+    {
+      "qid": "Q3563923",
+      "canonical": "V\u00e1clav Marhoul"
+    },
+    {
+      "qid": "Q3569110",
+      "canonical": "Willie Walsh"
+    },
+    {
+      "qid": "Q3591380",
+      "canonical": "\u00c9ric Trappier"
+    },
+    {
+      "qid": "Q360106",
+      "canonical": "David Sarnoff"
+    },
+    {
+      "qid": "Q3622",
+      "canonical": "Beno\u00eet Potier"
+    },
+    {
+      "qid": "Q3622799",
+      "canonical": "Studsvik"
+    },
+    {
+      "qid": "Q3638496",
+      "canonical": "Doug Morris"
+    },
+    {
+      "qid": "Q371522",
+      "canonical": "University of Gothenburg"
+    },
+    {
+      "qid": "Q37156",
+      "canonical": "IBM"
+    },
+    {
+      "qid": "Q37158",
+      "canonical": "Starbucks"
+    },
+    {
+      "qid": "Q372657",
+      "canonical": "Credit Suisse"
+    },
+    {
+      "qid": "Q3759654",
+      "canonical": "Genertel"
+    },
+    {
+      "qid": "Q37800486",
+      "canonical": "Pavel Zima"
+    },
+    {
+      "qid": "Q38076",
+      "canonical": "McDonald's"
+    },
+    {
+      "qid": "Q380912",
+      "canonical": "Neil Aspinall"
+    },
+    {
+      "qid": "Q381100",
+      "canonical": "Prague Public Transit Company"
+    },
+    {
+      "qid": "Q382101",
+      "canonical": "Mia Couto"
+    },
+    {
+      "qid": "Q38458637",
+      "canonical": "Ilham Kadri"
+    },
+    {
+      "qid": "Q385426",
+      "canonical": "Babcock International"
+    },
+    {
+      "qid": "Q38589106",
+      "canonical": "Vasant Narasimhan"
+    },
+    {
+      "qid": "Q3884",
+      "canonical": "Amazon"
+    },
+    {
+      "qid": "Q38903",
+      "canonical": "Universal Music Group"
+    },
+    {
+      "qid": "Q3934610",
+      "canonical": "Riccardo Ruggiero"
+    },
+    {
+      "qid": "Q393762",
+      "canonical": "Agilent Technologies"
+    },
+    {
+      "qid": "Q406643",
+      "canonical": "AirAsia"
+    },
+    {
+      "qid": "Q407448",
+      "canonical": "Air Liquide"
+    },
+    {
+      "qid": "Q4074985",
+      "canonical": "Badr"
+    },
+    {
+      "qid": "Q4082480",
+      "canonical": "Oleg Belozyorov"
+    },
+    {
+      "qid": "Q40993",
+      "canonical": "Porsche"
+    },
+    {
+      "qid": "Q4117408",
+      "canonical": "Akbar Al Baker"
+    },
+    {
+      "qid": "Q4133583",
+      "canonical": "Don Garber"
+    },
+    {
+      "qid": "Q41812531",
+      "canonical": "Andy Jassy"
+    },
+    {
+      "qid": "Q418622",
+      "canonical": "Akio Toyoda"
+    },
+    {
+      "qid": "Q4205845",
+      "canonical": "Ralph Yirikian"
+    },
+    {
+      "qid": "Q42211326",
+      "canonical": "Ian Cockerill"
+    },
+    {
+      "qid": "Q42825991",
+      "canonical": "EWE Netz"
+    },
+    {
+      "qid": "Q42887509",
+      "canonical": "John Flint"
+    },
+    {
+      "qid": "Q42913661",
+      "canonical": "Atsushi Kunishige"
+    },
+    {
+      "qid": "Q43026406",
+      "canonical": "Frank Stietz"
+    },
+    {
+      "qid": "Q43028378",
+      "canonical": "Carl Zeiss NTS"
+    },
+    {
+      "qid": "Q4307679",
+      "canonical": "Fyodor Muravchenko"
+    },
+    {
+      "qid": "Q43384742",
+      "canonical": "Keith Barr"
+    },
+    {
+      "qid": "Q43423083",
+      "canonical": "Q43423083"
+    },
+    {
+      "qid": "Q43449",
+      "canonical": "Creative Commons"
+    },
+    {
+      "qid": "Q4355145",
+      "canonical": "Lennart Gripenberg"
+    },
+    {
+      "qid": "Q43668928",
+      "canonical": "Matthew Hill"
+    },
+    {
+      "qid": "Q4402290",
+      "canonical": "Borregaard"
+    },
+    {
+      "qid": "Q4409579",
+      "canonical": "Vitalii Satskyi"
+    },
+    {
+      "qid": "Q4426788",
+      "canonical": "Sozvezdie"
+    },
+    {
+      "qid": "Q44294",
+      "canonical": "Ford Motor Company"
+    },
+    {
+      "qid": "Q443409",
+      "canonical": "Catherine Stihler"
+    },
+    {
+      "qid": "Q4448394",
+      "canonical": "Sergei Alexandrovsky"
+    },
+    {
+      "qid": "Q44504",
+      "canonical": "Inditex"
+    },
+    {
+      "qid": "Q446378",
+      "canonical": "Gust\u00e1v Slame\u010dka"
+    },
+    {
+      "qid": "Q4506113",
+      "canonical": "Shintaro Tsuji"
+    },
+    {
+      "qid": "Q4546965",
+      "canonical": "MongoDB Inc."
+    },
+    {
+      "qid": "Q4548",
+      "canonical": "Turkish Airlines"
+    },
+    {
+      "qid": "Q456402",
+      "canonical": "M\u00fcnchner Verkehrsgesellschaft mbH (MVG)"
+    },
+    {
+      "qid": "Q457912",
+      "canonical": "B\u00e2loise"
+    },
+    {
+      "qid": "Q4581905",
+      "canonical": "Telemark Bilruter"
+    },
+    {
+      "qid": "Q4582045",
+      "canonical": "Rune Bjerke"
+    },
+    {
+      "qid": "Q45821859",
+      "canonical": "Cindy Rose"
+    },
+    {
+      "qid": "Q458944",
+      "canonical": "Magyar Telekom"
+    },
+    {
+      "qid": "Q459965",
+      "canonical": "Caterpillar Inc."
+    },
+    {
+      "qid": "Q460307",
+      "canonical": "Amcor"
+    },
+    {
+      "qid": "Q460487",
+      "canonical": "Dassault Aviation"
+    },
+    {
+      "qid": "Q460593",
+      "canonical": "Amedeo Felisa"
+    },
+    {
+      "qid": "Q4648219",
+      "canonical": "A. O. Smith"
+    },
+    {
+      "qid": "Q4662637",
+      "canonical": "Aart de Geus"
+    },
+    {
+      "qid": "Q467644",
+      "canonical": "Alexey Miller"
+    },
+    {
+      "qid": "Q467752",
+      "canonical": "Verizon"
+    },
+    {
+      "qid": "Q4678914",
+      "canonical": "Adam Crozier"
+    },
+    {
+      "qid": "Q46867686",
+      "canonical": "Radim Neubauer"
+    },
+    {
+      "qid": "Q47016796",
+      "canonical": "Zolt\u00e1n Urb\u00e1n"
+    },
+    {
+      "qid": "Q4707007",
+      "canonical": "Alan Joyce"
+    },
+    {
+      "qid": "Q47087171",
+      "canonical": "Salil Parekh"
+    },
+    {
+      "qid": "Q471958",
+      "canonical": "Standard Life"
+    },
+    {
+      "qid": "Q4727049",
+      "canonical": "Alison Cooper"
+    },
+    {
+      "qid": "Q4732492",
+      "canonical": "Alliant Energy"
+    },
+    {
+      "qid": "Q47453098",
+      "canonical": "Evgeny Pushkarskii"
+    },
+    {
+      "qid": "Q47498532",
+      "canonical": "Epiroc"
+    },
+    {
+      "qid": "Q47500304",
+      "canonical": "Felix O. Adlon"
+    },
+    {
+      "qid": "Q4750238",
+      "canonical": "An T\u00far Gloine"
+    },
+    {
+      "qid": "Q47506167",
+      "canonical": "Per Lindberg"
+    },
+    {
+      "qid": "Q47524652",
+      "canonical": "Nick Read"
+    },
+    {
+      "qid": "Q47544149",
+      "canonical": "Matt Comyn"
+    },
+    {
+      "qid": "Q47545530",
+      "canonical": "Johan Lundgren"
+    },
+    {
+      "qid": "Q4764240",
+      "canonical": "Angus Russell"
+    },
+    {
+      "qid": "Q4772328",
+      "canonical": "Lord Anthony Crichton-Stuart"
+    },
+    {
+      "qid": "Q47776371",
+      "canonical": "Vincent Steckler"
+    },
+    {
+      "qid": "Q478214",
+      "canonical": "Tesla"
+    },
+    {
+      "qid": "Q4786619",
+      "canonical": "Archie Bethel"
+    },
+    {
+      "qid": "Q4794630",
+      "canonical": "Arne Meidell"
+    },
+    {
+      "qid": "Q48169527",
+      "canonical": "Tom\u00e1\u0161 Budn\u00edk"
+    },
+    {
+      "qid": "Q483915",
+      "canonical": "Nike"
+    },
+    {
+      "qid": "Q48451697",
+      "canonical": "Kongresov\u00e9 centrum Praha"
+    },
+    {
+      "qid": "Q48453376",
+      "canonical": "Q48453376"
+    },
+    {
+      "qid": "Q485593",
+      "canonical": "Red Hat"
+    },
+    {
+      "qid": "Q48815838",
+      "canonical": "Axiom Space"
+    },
+    {
+      "qid": "Q489080",
+      "canonical": "Automatic Data Processing"
+    },
+    {
+      "qid": "Q4891601",
+      "canonical": "Eviny"
+    },
+    {
+      "qid": "Q49053",
+      "canonical": "Schneider Electric"
+    },
+    {
+      "qid": "Q4933658",
+      "canonical": "Bob Phillis"
+    },
+    {
+      "qid": "Q4934",
+      "canonical": "Larry Page"
+    },
+    {
+      "qid": "Q4944779",
+      "canonical": "Boreal Norge"
+    },
+    {
+      "qid": "Q4948829",
+      "canonical": "Pam Fredman"
+    },
+    {
+      "qid": "Q495943",
+      "canonical": "onet.pl"
+    },
+    {
+      "qid": "Q4960507",
+      "canonical": "Anne Lagercrantz"
+    },
+    {
+      "qid": "Q496302",
+      "canonical": "Deere & Company"
+    },
+    {
+      "qid": "Q496531",
+      "canonical": "Shikoku Railway Company"
+    },
+    {
+      "qid": "Q4980554",
+      "canonical": "Hanna Stj\u00e4rne"
+    },
+    {
+      "qid": "Q498366",
+      "canonical": "Kyushu Railway Company"
+    },
+    {
+      "qid": "Q498930",
+      "canonical": "Hokkaido Railway Company"
+    },
+    {
+      "qid": "Q499071",
+      "canonical": "East Japan Railway Company"
+    },
+    {
+      "qid": "Q49971",
+      "canonical": "Ginni Rometty"
+    },
+    {
+      "qid": "Q50071152",
+      "canonical": "Carme Gual Via"
+    },
+    {
+      "qid": "Q5010371",
+      "canonical": "CESNET"
+    },
+    {
+      "qid": "Q50146929",
+      "canonical": "Kevin Sneader"
+    },
+    {
+      "qid": "Q502125",
+      "canonical": "West Japan Railway Company"
+    },
+    {
+      "qid": "Q502509",
+      "canonical": "Smith & Nephew"
+    },
+    {
+      "qid": "Q503038",
+      "canonical": "United Utilities"
+    },
+    {
+      "qid": "Q503308",
+      "canonical": "Southwest Airlines"
+    },
+    {
+      "qid": "Q5039561",
+      "canonical": "Carillion"
+    },
+    {
+      "qid": "Q5045423",
+      "canonical": "Carolyn McCall"
+    },
+    {
+      "qid": "Q5059102",
+      "canonical": "Centene Corporation"
+    },
+    {
+      "qid": "Q507154",
+      "canonical": "Novartis"
+    },
+    {
+      "qid": "Q5072394",
+      "canonical": "Channel Four Television Corporation"
+    },
+    {
+      "qid": "Q50807495",
+      "canonical": "Francesc Orteu"
+    },
+    {
+      "qid": "Q509124",
+      "canonical": "Yves de Silguy"
+    },
+    {
+      "qid": "Q5106728",
+      "canonical": "Chris Grigg"
+    },
+    {
+      "qid": "Q511031",
+      "canonical": "Norsk Hydro"
+    },
+    {
+      "qid": "Q5115191",
+      "canonical": "Chua Sock Koong"
+    },
+    {
+      "qid": "Q513679",
+      "canonical": "Central Japan Railway Company"
+    },
+    {
+      "qid": "Q5137486",
+      "canonical": "Co-operatives UK"
+    },
+    {
+      "qid": "Q51403327",
+      "canonical": "Binance"
+    },
+    {
+      "qid": "Q51841506",
+      "canonical": "Antonio Neri"
+    },
+    {
+      "qid": "Q51844714",
+      "canonical": "About You"
+    },
+    {
+      "qid": "Q5195702",
+      "canonical": "Curtis Carlson"
+    },
+    {
+      "qid": "Q52004072",
+      "canonical": "Manny Maceda"
+    },
+    {
+      "qid": "Q5217607",
+      "canonical": "Dan Clancy"
+    },
+    {
+      "qid": "Q52177144",
+      "canonical": "Shuntaro Furukawa"
+    },
+    {
+      "qid": "Q5221979",
+      "canonical": "Dara Khosrowshahi"
+    },
+    {
+      "qid": "Q52272598",
+      "canonical": "Stephen Squeri"
+    },
+    {
+      "qid": "Q5230577",
+      "canonical": "David Abraham"
+    },
+    {
+      "qid": "Q5232041",
+      "canonical": "David C. Novak"
+    },
+    {
+      "qid": "Q5240333",
+      "canonical": "David Thodey"
+    },
+    {
+      "qid": "Q5242415",
+      "canonical": "Dawn Airey"
+    },
+    {
+      "qid": "Q5265091",
+      "canonical": "Destia"
+    },
+    {
+      "qid": "Q52824679",
+      "canonical": "Dario Scannapieco"
+    },
+    {
+      "qid": "Q52825",
+      "canonical": "ABB Group"
+    },
+    {
+      "qid": "Q5299694",
+      "canonical": "Lamberto Andreotti"
+    },
+    {
+      "qid": "Q5300675",
+      "canonical": "Doug Logan"
+    },
+    {
+      "qid": "Q5301995",
+      "canonical": "Douglas Steenland"
+    },
+    {
+      "qid": "Q5324680",
+      "canonical": "EXFO"
+    },
+    {
+      "qid": "Q53268",
+      "canonical": "Toyota"
+    },
+    {
+      "qid": "Q5335133",
+      "canonical": "Ed Mayo"
+    },
+    {
+      "qid": "Q53464772",
+      "canonical": "Jon Fold von B\u00fclow"
+    },
+    {
+      "qid": "Q53568191",
+      "canonical": "Jeffrey Leiden"
+    },
+    {
+      "qid": "Q53678314",
+      "canonical": "Kotipizza Group"
+    },
+    {
+      "qid": "Q5373565",
+      "canonical": "Emmett Shear"
+    },
+    {
+      "qid": "Q5374450",
+      "canonical": "Agrofert"
+    },
+    {
+      "qid": "Q5375992",
+      "canonical": "Endeavour Mining"
+    },
+    {
+      "qid": "Q5386350",
+      "canonical": "Eric Daniels"
+    },
+    {
+      "qid": "Q54075",
+      "canonical": "SSAB"
+    },
+    {
+      "qid": "Q5413836",
+      "canonical": "Eurostar International"
+    },
+    {
+      "qid": "Q541477",
+      "canonical": "Daimler-Benz AG"
+    },
+    {
+      "qid": "Q54173",
+      "canonical": "General Electric"
+    },
+    {
+      "qid": "Q54263821",
+      "canonical": "Relativity Space"
+    },
+    {
+      "qid": "Q544847",
+      "canonical": "Qualcomm"
+    },
+    {
+      "qid": "Q54644663",
+      "canonical": "Sataporn Panichraksapong"
+    },
+    {
+      "qid": "Q54645751",
+      "canonical": "GMM Channel Holding"
+    },
+    {
+      "qid": "Q54718",
+      "canonical": "Yle"
+    },
+    {
+      "qid": "Q5473565",
+      "canonical": "Kauko Rastas"
+    },
+    {
+      "qid": "Q55103384",
+      "canonical": "Avast Limited"
+    },
+    {
+      "qid": "Q55118101",
+      "canonical": "Zden\u011bk Zemek"
+    },
+    {
+      "qid": "Q5517112",
+      "canonical": "Gail Boudreaux"
+    },
+    {
+      "qid": "Q55174",
+      "canonical": "Meg Whitman"
+    },
+    {
+      "qid": "Q55196710",
+      "canonical": "David Abney"
+    },
+    {
+      "qid": "Q55231934",
+      "canonical": "Shaqued Morag"
+    },
+    {
+      "qid": "Q5524807",
+      "canonical": "Gary C. Kelly"
+    },
+    {
+      "qid": "Q552742",
+      "canonical": "Rosa Luxemburg Foundation"
+    },
+    {
+      "qid": "Q55439664",
+      "canonical": "Robert A. Sauerberg Jr"
+    },
+    {
+      "qid": "Q5552438",
+      "canonical": "Casten Almqvist"
+    },
+    {
+      "qid": "Q55532557",
+      "canonical": "Y\u016bji Fukasawa"
+    },
+    {
+      "qid": "Q55534582",
+      "canonical": "Shin Kaneko"
+    },
+    {
+      "qid": "Q55698517",
+      "canonical": "Michael Manley"
+    },
+    {
+      "qid": "Q55738191",
+      "canonical": "Roman Knap"
+    },
+    {
+      "qid": "Q55776398",
+      "canonical": "Kwalu"
+    },
+    {
+      "qid": "Q5578461",
+      "canonical": "Leon Black"
+    },
+    {
+      "qid": "Q55808357",
+      "canonical": "Jind\u0159ich Fremuth"
+    },
+    {
+      "qid": "Q55819254",
+      "canonical": "David Burritt"
+    },
+    {
+      "qid": "Q55819738",
+      "canonical": "Bob Swan"
+    },
+    {
+      "qid": "Q55882406",
+      "canonical": "Gustav M\u00fctterlein"
+    },
+    {
+      "qid": "Q55978022",
+      "canonical": "Alessandro Pasquale"
+    },
+    {
+      "qid": "Q56035140",
+      "canonical": "Bettina Orlopp"
+    },
+    {
+      "qid": "Q56042353",
+      "canonical": "Ramon Laguarta"
+    },
+    {
+      "qid": "Q5606591",
+      "canonical": "Gregg Steinhafel"
+    },
+    {
+      "qid": "Q5619138",
+      "canonical": "Gunnar Svedberg"
+    },
+    {
+      "qid": "Q56253705",
+      "canonical": "Kazuki Furuya"
+    },
+    {
+      "qid": "Q56299206",
+      "canonical": "Kaan Terzio\u011flu"
+    },
+    {
+      "qid": "Q56349284",
+      "canonical": "Koichi Shingai"
+    },
+    {
+      "qid": "Q56400574",
+      "canonical": "Lapinniemi cotton mill"
+    },
+    {
+      "qid": "Q56452688",
+      "canonical": "\u0160koda Investment"
+    },
+    {
+      "qid": "Q56452730",
+      "canonical": "Josef Bro\u017e"
+    },
+    {
+      "qid": "Q56454873",
+      "canonical": "Randi Marjamaa"
+    },
+    {
+      "qid": "Q56654140",
+      "canonical": "Josef Voj\u00e1\u010dek"
+    },
+    {
+      "qid": "Q566857",
+      "canonical": "Proximus Group"
+    },
+    {
+      "qid": "Q56703648",
+      "canonical": "Hamish Maxwell"
+    },
+    {
+      "qid": "Q5677222",
+      "canonical": "Harvey Golub"
+    },
+    {
+      "qid": "Q5680808",
+      "canonical": "Vladimir Kiriyenko"
+    },
+    {
+      "qid": "Q568183",
+      "canonical": "OVHcloud"
+    },
+    {
+      "qid": "Q56868014",
+      "canonical": "H. Lawrence Culp Jr."
+    },
+    {
+      "qid": "Q56877111",
+      "canonical": "Namal Nawana"
+    },
+    {
+      "qid": "Q5693758",
+      "canonical": "Heather Bresch"
+    },
+    {
+      "qid": "Q57205005",
+      "canonical": "Aireen Omar"
+    },
+    {
+      "qid": "Q5726490",
+      "canonical": "Olof Faxander"
+    },
+    {
+      "qid": "Q573103",
+      "canonical": "TUI Group"
+    },
+    {
+      "qid": "Q57314560",
+      "canonical": "Yoshihito Miyaike"
+    },
+    {
+      "qid": "Q5761148",
+      "canonical": "Centro Cultural Hispano-Guineano"
+    },
+    {
+      "qid": "Q57767177",
+      "canonical": "Rata Books"
+    },
+    {
+      "qid": "Q5783986",
+      "canonical": "Magnus Hall"
+    },
+    {
+      "qid": "Q57915960",
+      "canonical": "Suzanne Scott"
+    },
+    {
+      "qid": "Q580199",
+      "canonical": "Bert De Graeve"
+    },
+    {
+      "qid": "Q58035402",
+      "canonical": "Radio Corporation of America"
+    },
+    {
+      "qid": "Q58131487",
+      "canonical": "Jannicke Hilland"
+    },
+    {
+      "qid": "Q58230523",
+      "canonical": "Six Nations Rugby Ltd"
+    },
+    {
+      "qid": "Q58425865",
+      "canonical": "Andrew J. Cecere"
+    },
+    {
+      "qid": "Q58707",
+      "canonical": "Aeroflot"
+    },
+    {
+      "qid": "Q5902427",
+      "canonical": "Johan Karlstr\u00f6m"
+    },
+    {
+      "qid": "Q59152221",
+      "canonical": "Les Punxes Distribuidora, S.L."
+    },
+    {
+      "qid": "Q59156542",
+      "canonical": "Benjamin Morel"
+    },
+    {
+      "qid": "Q593786",
+      "canonical": "BT Group"
+    },
+    {
+      "qid": "Q5941175",
+      "canonical": "Magnus Lavonius"
+    },
+    {
+      "qid": "Q5955602",
+      "canonical": "Egon Linderoth"
+    },
+    {
+      "qid": "Q59561509",
+      "canonical": "Ian R. Garland"
+    },
+    {
+      "qid": "Q59580617",
+      "canonical": "Vernalis plc"
+    },
+    {
+      "qid": "Q59581320",
+      "canonical": "Simon J. Sturge"
+    },
+    {
+      "qid": "Q59636732",
+      "canonical": "Ervin Nemesdy"
+    },
+    {
+      "qid": "Q59676501",
+      "canonical": "Anne Rigail"
+    },
+    {
+      "qid": "Q59697784",
+      "canonical": "Marieke van de Rakt"
+    },
+    {
+      "qid": "Q597242",
+      "canonical": "Michael O'Leary"
+    },
+    {
+      "qid": "Q5973764",
+      "canonical": "Curt Malmborg"
+    },
+    {
+      "qid": "Q59752660",
+      "canonical": "Zden\u011bk Koz\u00e1k"
+    },
+    {
+      "qid": "Q59752793",
+      "canonical": "Milo\u0161 Petana"
+    },
+    {
+      "qid": "Q59779410",
+      "canonical": "Ji\u0159\u00ed Majstr"
+    },
+    {
+      "qid": "Q5980411",
+      "canonical": "Iain Conn"
+    },
+    {
+      "qid": "Q59821781",
+      "canonical": "Laura Foraster i Lloret"
+    },
+    {
+      "qid": "Q5982488",
+      "canonical": "Ian Narev"
+    },
+    {
+      "qid": "Q60050698",
+      "canonical": "Ren\u00e9 Matera"
+    },
+    {
+      "qid": "Q60056285",
+      "canonical": "Q60056285"
+    },
+    {
+      "qid": "Q60151368",
+      "canonical": "Daniel Kj\u00f8rberg Siraj"
+    },
+    {
+      "qid": "Q602621",
+      "canonical": "Statnett"
+    },
+    {
+      "qid": "Q60439097",
+      "canonical": "Ingo Wortmann"
+    },
+    {
+      "qid": "Q6047302",
+      "canonical": "Intermediate Capital Group"
+    },
+    {
+      "qid": "Q604924",
+      "canonical": "SRI International"
+    },
+    {
+      "qid": "Q605401",
+      "canonical": "Cond\u00e9 Nast"
+    },
+    {
+      "qid": "Q6054541",
+      "canonical": "Nils Posse"
+    },
+    {
+      "qid": "Q60566195",
+      "canonical": "John Arthur Hollows"
+    },
+    {
+      "qid": "Q60629364",
+      "canonical": "Paula Vennells"
+    },
+    {
+      "qid": "Q60671170",
+      "canonical": "Lauri M\u00f6ls\u00e4"
+    },
+    {
+      "qid": "Q608917",
+      "canonical": "Budapesti K\u00f6zleked\u00e9si K\u00f6zpont"
+    },
+    {
+      "qid": "Q6099130",
+      "canonical": "Ivo Luka\u010dovi\u010d"
+    },
+    {
+      "qid": "Q61057080",
+      "canonical": "Emilie Arel"
+    },
+    {
+      "qid": "Q6113311",
+      "canonical": "Jack J. Pelton"
+    },
+    {
+      "qid": "Q61285099",
+      "canonical": "Tibor R\u00e9kasi"
+    },
+    {
+      "qid": "Q6137947",
+      "canonical": "James Leigh-Pemberton"
+    },
+    {
+      "qid": "Q61412379",
+      "canonical": "Barrandov Televizn\u00ed Studio"
+    },
+    {
+      "qid": "Q6155174",
+      "canonical": "Janne Sollie"
+    },
+    {
+      "qid": "Q61718864",
+      "canonical": "Hilmar Rode"
+    },
+    {
+      "qid": "Q61719629",
+      "canonical": "Bill Scotting"
+    },
+    {
+      "qid": "Q61735606",
+      "canonical": "Katrin Adt"
+    },
+    {
+      "qid": "Q6174185",
+      "canonical": "Jeff Jones"
+    },
+    {
+      "qid": "Q61854495",
+      "canonical": "Catalunya Comunicaci\u00f3"
+    },
+    {
+      "qid": "Q6185687",
+      "canonical": "Jes Staley"
+    },
+    {
+      "qid": "Q61887834",
+      "canonical": "Ebba Ljungerud"
+    },
+    {
+      "qid": "Q619121",
+      "canonical": "Apollo Global Management"
+    },
+    {
+      "qid": "Q61931385",
+      "canonical": "Cultural Center of Spain in El Salvador"
+    },
+    {
+      "qid": "Q61957954",
+      "canonical": "Z-Group"
+    },
+    {
+      "qid": "Q61957983",
+      "canonical": "J\u00fcrgen Tinggren"
+    },
+    {
+      "qid": "Q61972716",
+      "canonical": "Fabrizio Palermo"
+    },
+    {
+      "qid": "Q62114985",
+      "canonical": "Hilde Merete Aasheim"
+    },
+    {
+      "qid": "Q621231",
+      "canonical": "Apple Corps"
+    },
+    {
+      "qid": "Q62123272",
+      "canonical": "M\u00fcller & Kapsa"
+    },
+    {
+      "qid": "Q6224507",
+      "canonical": "John C. Lechleiter"
+    },
+    {
+      "qid": "Q6230601",
+      "canonical": "Marcus Wallenberg"
+    },
+    {
+      "qid": "Q6237422",
+      "canonical": "Fredrik Wester"
+    },
+    {
+      "qid": "Q624109",
+      "canonical": "Lee Jae-yong"
+    },
+    {
+      "qid": "Q62429543",
+      "canonical": "Murat Erkan"
+    },
+    {
+      "qid": "Q624375",
+      "canonical": "CVS Health"
+    },
+    {
+      "qid": "Q6256306",
+      "canonical": "Nils \u00d6berg"
+    },
+    {
+      "qid": "Q625713",
+      "canonical": "BHP Group"
+    },
+    {
+      "qid": "Q627039",
+      "canonical": "MITRE Corporation"
+    },
+    {
+      "qid": "Q6282085",
+      "canonical": "Joseph Charles Doumba"
+    },
+    {
+      "qid": "Q6284393",
+      "canonical": "Joseph Jimenez"
+    },
+    {
+      "qid": "Q63099294",
+      "canonical": "Karel Pra\u017e\u00e1k"
+    },
+    {
+      "qid": "Q63109921",
+      "canonical": "Kimmo Maki"
+    },
+    {
+      "qid": "Q632240",
+      "canonical": "Eli Lilly and Company"
+    },
+    {
+      "qid": "Q63325233",
+      "canonical": "Alison Rose"
+    },
+    {
+      "qid": "Q63341599",
+      "canonical": "J\u00fcrgen von Hollen"
+    },
+    {
+      "qid": "Q63345439",
+      "canonical": "Giedrius \u017dunda"
+    },
+    {
+      "qid": "Q63400080",
+      "canonical": "Albert Bourla"
+    },
+    {
+      "qid": "Q63410046",
+      "canonical": "Richard A. Gonzalez"
+    },
+    {
+      "qid": "Q6377142",
+      "canonical": "Kathryn V. Marinello"
+    },
+    {
+      "qid": "Q638098",
+      "canonical": "Royal Mail"
+    },
+    {
+      "qid": "Q6384205",
+      "canonical": "Keith Cochrane"
+    },
+    {
+      "qid": "Q63967288",
+      "canonical": "Ale\u0161 Minx"
+    },
+    {
+      "qid": "Q63975443",
+      "canonical": "Giovanni Caforio"
+    },
+    {
+      "qid": "Q6399442",
+      "canonical": "Khalid A. Al-Falih"
+    },
+    {
+      "qid": "Q64009036",
+      "canonical": "Alain Bellemare"
+    },
+    {
+      "qid": "Q64135949",
+      "canonical": "Maximilian Oertle"
+    },
+    {
+      "qid": "Q64140997",
+      "canonical": "Heiko Fastje"
+    },
+    {
+      "qid": "Q64141008",
+      "canonical": "Hans-Joachim Iken"
+    },
+    {
+      "qid": "Q6419336",
+      "canonical": "Kjell Almskog"
+    },
+    {
+      "qid": "Q642189",
+      "canonical": "Medtronic plc"
+    },
+    {
+      "qid": "Q6438198",
+      "canonical": "Kristin Skogen Lund"
+    },
+    {
+      "qid": "Q6449839",
+      "canonical": "Kv\u00e6rner"
+    },
+    {
+      "qid": "Q64587234",
+      "canonical": "Kjerstin Braathen"
+    },
+    {
+      "qid": "Q64623818",
+      "canonical": "Kjetil Houg"
+    },
+    {
+      "qid": "Q64745663",
+      "canonical": "Laxman Narasimhan"
+    },
+    {
+      "qid": "Q64782751",
+      "canonical": "Fumihiko Nagamatsu"
+    },
+    {
+      "qid": "Q64876086",
+      "canonical": "Q64876086"
+    },
+    {
+      "qid": "Q650467",
+      "canonical": "Wind Telecomunicazioni"
+    },
+    {
+      "qid": "Q65205099",
+      "canonical": "Josep Olivet i Torras"
+    },
+    {
+      "qid": "Q652431",
+      "canonical": "Bridgewater Associates"
+    },
+    {
+      "qid": "Q6535959",
+      "canonical": "Lew Cirne"
+    },
+    {
+      "qid": "Q654073",
+      "canonical": "Disney Entertainment Television"
+    },
+    {
+      "qid": "Q65445",
+      "canonical": "Dieter Zetsche"
+    },
+    {
+      "qid": "Q65503055",
+      "canonical": "Tarek M\u00fcller"
+    },
+    {
+      "qid": "Q65581460",
+      "canonical": "Dov Kotler"
+    },
+    {
+      "qid": "Q66",
+      "canonical": "Boeing"
+    },
+    {
+      "qid": "Q660770",
+      "canonical": "Russian Railways"
+    },
+    {
+      "qid": "Q66385088",
+      "canonical": "Elisabeth Hunter"
+    },
+    {
+      "qid": "Q66438345",
+      "canonical": "Roland Busch"
+    },
+    {
+      "qid": "Q66477676",
+      "canonical": "Noel Quinn"
+    },
+    {
+      "qid": "Q668737",
+      "canonical": "Yum! Brands"
+    },
+    {
+      "qid": "Q669141",
+      "canonical": "Coloplast"
+    },
+    {
+      "qid": "Q67029500",
+      "canonical": "Paul Hudson"
+    },
+    {
+      "qid": "Q671510",
+      "canonical": "NPR"
+    },
+    {
+      "qid": "Q67173589",
+      "canonical": "John Lansing"
+    },
+    {
+      "qid": "Q673818",
+      "canonical": "Rem Viakhirev"
+    },
+    {
+      "qid": "Q67424585",
+      "canonical": "Margrit L\u00f6mkerSuhr"
+    },
+    {
+      "qid": "Q67425000",
+      "canonical": "Oriol Serrano"
+    },
+    {
+      "qid": "Q67512334",
+      "canonical": "Germain Lamonde"
+    },
+    {
+      "qid": "Q6755817",
+      "canonical": "Marc Raibert"
+    },
+    {
+      "qid": "Q6766732",
+      "canonical": "Mark T. Bertolini"
+    },
+    {
+      "qid": "Q677488",
+      "canonical": "Elevance Health, Inc."
+    },
+    {
+      "qid": "Q6775103",
+      "canonical": "Martin C. Faga"
+    },
+    {
+      "qid": "Q6779013",
+      "canonical": "Mary Barra"
+    },
+    {
+      "qid": "Q679322",
+      "canonical": "Saudi Aramco"
+    },
+    {
+      "qid": "Q67932616",
+      "canonical": "Jacob Kam"
+    },
+    {
+      "qid": "Q6823260",
+      "canonical": "Metaswitch"
+    },
+    {
+      "qid": "Q682435",
+      "canonical": "IDEO"
+    },
+    {
+      "qid": "Q6829608",
+      "canonical": "Michael D"
+    },
+    {
+      "qid": "Q6836029",
+      "canonical": "Micha\u0142 Krupi\u0144ski"
+    },
+    {
+      "qid": "Q6855185",
+      "canonical": "Zion Kenan"
+    },
+    {
+      "qid": "Q687934",
+      "canonical": "Weleda"
+    },
+    {
+      "qid": "Q691563",
+      "canonical": "Nord Stream AG"
+    },
+    {
+      "qid": "Q69357927",
+      "canonical": "Bontonland"
+    },
+    {
+      "qid": "Q694107",
+      "canonical": "The Swatch Group"
+    },
+    {
+      "qid": "Q69598904",
+      "canonical": "Josh D'Amaro"
+    },
+    {
+      "qid": "Q696376",
+      "canonical": "Versace"
+    },
+    {
+      "qid": "Q699696",
+      "canonical": "Vladimir Yakunin"
+    },
+    {
+      "qid": "Q7000460",
+      "canonical": "Vy Buss"
+    },
+    {
+      "qid": "Q70092183",
+      "canonical": "Makoto Uchida"
+    },
+    {
+      "qid": "Q7011152",
+      "canonical": "New Relic"
+    },
+    {
+      "qid": "Q7024365",
+      "canonical": "Nicandro Durante"
+    },
+    {
+      "qid": "Q70337768",
+      "canonical": "Juho Ahosola"
+    },
+    {
+      "qid": "Q70426295",
+      "canonical": "Greg Foran"
+    },
+    {
+      "qid": "Q7048063",
+      "canonical": "Nokian Panimo"
+    },
+    {
+      "qid": "Q7050523",
+      "canonical": "Nord-Tr\u00f8ndelag Elektrisitetsverk"
+    },
+    {
+      "qid": "Q705417",
+      "canonical": "DBS Bank"
+    },
+    {
+      "qid": "Q7085834",
+      "canonical": "Ole Enger"
+    },
+    {
+      "qid": "Q7096543",
+      "canonical": "Openreach"
+    },
+    {
+      "qid": "Q71142467",
+      "canonical": "Hiroyuki Nagai"
+    },
+    {
+      "qid": "Q7143480",
+      "canonical": "Pat Gelsinger"
+    },
+    {
+      "qid": "Q7155675",
+      "canonical": "Pavel Kysilka"
+    },
+    {
+      "qid": "Q715583",
+      "canonical": "Costco"
+    },
+    {
+      "qid": "Q716505",
+      "canonical": "Arun Sarin"
+    },
+    {
+      "qid": "Q71656964",
+      "canonical": "Ingrid Dahl Hovland"
+    },
+    {
+      "qid": "Q7176581",
+      "canonical": "Peter Rice"
+    },
+    {
+      "qid": "Q7176651",
+      "canonical": "Peter Rogers"
+    },
+    {
+      "qid": "Q7178409",
+      "canonical": "Petite Galerie"
+    },
+    {
+      "qid": "Q71856160",
+      "canonical": "Philippe Morin"
+    },
+    {
+      "qid": "Q7192785",
+      "canonical": "Pieter Hintjens"
+    },
+    {
+      "qid": "Q721162",
+      "canonical": "Telstra"
+    },
+    {
+      "qid": "Q7243481",
+      "canonical": "Primerica"
+    },
+    {
+      "qid": "Q72539",
+      "canonical": "U.S. Steel"
+    },
+    {
+      "qid": "Q726572",
+      "canonical": "Tessellis"
+    },
+    {
+      "qid": "Q726813",
+      "canonical": "Luxair"
+    },
+    {
+      "qid": "Q7292185",
+      "canonical": "Randy Falco"
+    },
+    {
+      "qid": "Q7306657",
+      "canonical": "Reed Hastings"
+    },
+    {
+      "qid": "Q7310197",
+      "canonical": "Rein Henriksen"
+    },
+    {
+      "qid": "Q731462",
+      "canonical": "Xavier Huillard"
+    },
+    {
+      "qid": "Q73251",
+      "canonical": "Symrise"
+    },
+    {
+      "qid": "Q732670",
+      "canonical": "Australian Securities Exchange"
+    },
+    {
+      "qid": "Q732697",
+      "canonical": "National Theatre"
+    },
+    {
+      "qid": "Q7329143",
+      "canonical": "Richard Solomons"
+    },
+    {
+      "qid": "Q7333751",
+      "canonical": "Rightmove"
+    },
+    {
+      "qid": "Q73426541",
+      "canonical": "Chris Kempczinski"
+    },
+    {
+      "qid": "Q737477",
+      "canonical": "Cameroon radio television"
+    },
+    {
+      "qid": "Q738197",
+      "canonical": "Hiroya Masuda"
+    },
+    {
+      "qid": "Q739084",
+      "canonical": "U.S. Bancorp"
+    },
+    {
+      "qid": "Q7414",
+      "canonical": "The Walt Disney Company"
+    },
+    {
+      "qid": "Q7422719",
+      "canonical": "Sarah Purser"
+    },
+    {
+      "qid": "Q7426870",
+      "canonical": "Satya Nadella"
+    },
+    {
+      "qid": "Q74291660",
+      "canonical": "Dimosthenis Sarigiannis"
+    },
+    {
+      "qid": "Q7437001",
+      "canonical": "Scott Painter"
+    },
+    {
+      "qid": "Q74370310",
+      "canonical": "Christopher Luxon"
+    },
+    {
+      "qid": "Q7494850",
+      "canonical": "Sheri McCoy"
+    },
+    {
+      "qid": "Q7513372",
+      "canonical": "Sigve Brekke"
+    },
+    {
+      "qid": "Q7519563",
+      "canonical": "Simon Power"
+    },
+    {
+      "qid": "Q75366946",
+      "canonical": "Konrad Graf von und zu Eltz gennant Faust von Stromberg"
+    },
+    {
+      "qid": "Q75405697",
+      "canonical": "Richard Norman Kingzett"
+    },
+    {
+      "qid": "Q7552943",
+      "canonical": "Soci\u00e9t\u00e9 de Micro\u00e9lectronique et d'Horlogerie"
+    },
+    {
+      "qid": "Q75681",
+      "canonical": "Frank Appel"
+    },
+    {
+      "qid": "Q75692161",
+      "canonical": "Reshma Kewalramani"
+    },
+    {
+      "qid": "Q757164",
+      "canonical": "Atlas Copco"
+    },
+    {
+      "qid": "Q75814485",
+      "canonical": "Richard Oldfield"
+    },
+    {
+      "qid": "Q7588412",
+      "canonical": "St. James's Place Wealth Management Group"
+    },
+    {
+      "qid": "Q759210",
+      "canonical": "Givenchy"
+    },
+    {
+      "qid": "Q7606236",
+      "canonical": "Stefan Pichler"
+    },
+    {
+      "qid": "Q7609478",
+      "canonical": "Stephen Hester"
+    },
+    {
+      "qid": "Q7610176",
+      "canonical": "Stephen P. MacMillan"
+    },
+    {
+      "qid": "Q7612149",
+      "canonical": "Steve Capus"
+    },
+    {
+      "qid": "Q7612873",
+      "canonical": "Steve Holliday"
+    },
+    {
+      "qid": "Q7613398",
+      "canonical": "Steve Mogford"
+    },
+    {
+      "qid": "Q764850",
+      "canonical": "Bain & Company"
+    },
+    {
+      "qid": "Q7666585",
+      "canonical": "S\u00f8ren Skou"
+    },
+    {
+      "qid": "Q7688294",
+      "canonical": "Tatsumi Kimishima"
+    },
+    {
+      "qid": "Q7698068",
+      "canonical": "Temel Kotil"
+    },
+    {
+      "qid": "Q77026815",
+      "canonical": "John Voppen"
+    },
+    {
+      "qid": "Q77284255",
+      "canonical": "Lars-Olof Larsson"
+    },
+    {
+      "qid": "Q77327597",
+      "canonical": "Lum\u00edr Kapsa"
+    },
+    {
+      "qid": "Q77328063",
+      "canonical": "Franti\u0161ek M\u00fcller"
+    },
+    {
+      "qid": "Q7791178",
+      "canonical": "Thomas J. McInerney"
+    },
+    {
+      "qid": "Q7803096",
+      "canonical": "Tim Armstrong"
+    },
+    {
+      "qid": "Q7803408",
+      "canonical": "Tim Davie"
+    },
+    {
+      "qid": "Q780442",
+      "canonical": "Uber"
+    },
+    {
+      "qid": "Q7816106",
+      "canonical": "Tom Harrison"
+    },
+    {
+      "qid": "Q7820162",
+      "canonical": "Tomoko Namba"
+    },
+    {
+      "qid": "Q7836291",
+      "canonical": "Travis Kalanick"
+    },
+    {
+      "qid": "Q7847309",
+      "canonical": "TrueCar"
+    },
+    {
+      "qid": "Q7849186",
+      "canonical": "Connect Bus Tr\u00f8nderbilene"
+    },
+    {
+      "qid": "Q78899588",
+      "canonical": "Metallbau Windeck GmbH"
+    },
+    {
+      "qid": "Q78902098",
+      "canonical": "Oliver Windeck"
+    },
+    {
+      "qid": "Q7894055",
+      "canonical": "Universal Robots"
+    },
+    {
+      "qid": "Q791285",
+      "canonical": "Avon Products Inc."
+    },
+    {
+      "qid": "Q7935934",
+      "canonical": "Vishal Sikka"
+    },
+    {
+      "qid": "Q795474",
+      "canonical": "Cevital"
+    },
+    {
+      "qid": "Q7970169",
+      "canonical": "Warren East"
+    },
+    {
+      "qid": "Q79799258",
+      "canonical": "IDS Praha"
+    },
+    {
+      "qid": "Q79800215",
+      "canonical": "Bohumil Kvasni\u010dka"
+    },
+    {
+      "qid": "Q79815733",
+      "canonical": "Kazuaki Hasegawa"
+    },
+    {
+      "qid": "Q79960347",
+      "canonical": "Mike Sievert"
+    },
+    {
+      "qid": "Q7999846",
+      "canonical": "Wikidot"
+    },
+    {
+      "qid": "Q8013529",
+      "canonical": "William Jeffrey"
+    },
+    {
+      "qid": "Q80217118",
+      "canonical": "Vasilios Gregoriou"
+    },
+    {
+      "qid": "Q8024771",
+      "canonical": "Windstream Holdings"
+    },
+    {
+      "qid": "Q80356796",
+      "canonical": "David Jones"
+    },
+    {
+      "qid": "Q80482296",
+      "canonical": "James Buckee"
+    },
+    {
+      "qid": "Q8068146",
+      "canonical": "Ze'ev Drori"
+    },
+    {
+      "qid": "Q8074112",
+      "canonical": "Zooko Wilcox-O'Hearn"
+    },
+    {
+      "qid": "Q8074134",
+      "canonical": "ZoomInfo"
+    },
+    {
+      "qid": "Q80788",
+      "canonical": "DNB Bank"
+    },
+    {
+      "qid": "Q8085893",
+      "canonical": "Expedia Group"
+    },
+    {
+      "qid": "Q8093",
+      "canonical": "Nintendo"
+    },
+    {
+      "qid": "Q80970843",
+      "canonical": "Ed Williams"
+    },
+    {
+      "qid": "Q80973035",
+      "canonical": "Peter Brooks-Johnson"
+    },
+    {
+      "qid": "Q80978371",
+      "canonical": "Mark Read"
+    },
+    {
+      "qid": "Q81071198",
+      "canonical": "Mike Henry"
+    },
+    {
+      "qid": "Q81230",
+      "canonical": "Siemens"
+    },
+    {
+      "qid": "Q81345643",
+      "canonical": "Oliver Holbourn"
+    },
+    {
+      "qid": "Q814989",
+      "canonical": "Bekaert"
+    },
+    {
+      "qid": "Q81516586",
+      "canonical": "Paolo Dal Pino"
+    },
+    {
+      "qid": "Q81568897",
+      "canonical": "Dave Jenkinson"
+    },
+    {
+      "qid": "Q81703597",
+      "canonical": "Marshall Zelaznik"
+    },
+    {
+      "qid": "Q81804240",
+      "canonical": "Pentti Palmroth"
+    },
+    {
+      "qid": "Q818846",
+      "canonical": "Novo Nordisk"
+    },
+    {
+      "qid": "Q81941591",
+      "canonical": "Roland Diggelmann"
+    },
+    {
+      "qid": "Q81965",
+      "canonical": "General Motors"
+    },
+    {
+      "qid": "Q821293",
+      "canonical": "Rio Tinto Group"
+    },
+    {
+      "qid": "Q823010",
+      "canonical": "Nyrstar"
+    },
+    {
+      "qid": "Q82353741",
+      "canonical": "Andrew Croft"
+    },
+    {
+      "qid": "Q82355609",
+      "canonical": "Mike Wilson"
+    },
+    {
+      "qid": "Q824323",
+      "canonical": "Bernd T\u00f6nnies"
+    },
+    {
+      "qid": "Q83373455",
+      "canonical": "Q83373455"
+    },
+    {
+      "qid": "Q83410804",
+      "canonical": "Simon Roberts"
+    },
+    {
+      "qid": "Q83780224",
+      "canonical": "Omar Ishrak"
+    },
+    {
+      "qid": "Q83825",
+      "canonical": "Vy"
+    },
+    {
+      "qid": "Q838716",
+      "canonical": "Repsol Oil & Gas Canada"
+    },
+    {
+      "qid": "Q84053114",
+      "canonical": "Arvind Krishna"
+    },
+    {
+      "qid": "Q84077596",
+      "canonical": "Jan Gruntor\u00e1d"
+    },
+    {
+      "qid": "Q84322853",
+      "canonical": "Trowitzsch & Sohn"
+    },
+    {
+      "qid": "Q84557658",
+      "canonical": "Thomas Gottstein"
+    },
+    {
+      "qid": "Q845632",
+      "canonical": "Telenor"
+    },
+    {
+      "qid": "Q84587",
+      "canonical": "Edzard Reuter"
+    },
+    {
+      "qid": "Q848336",
+      "canonical": "Eutelsat"
+    },
+    {
+      "qid": "Q85515959",
+      "canonical": "Antonio Pasquale"
+    },
+    {
+      "qid": "Q85727717",
+      "canonical": "One Medical"
+    },
+    {
+      "qid": "Q85815710",
+      "canonical": "William M. Brown"
+    },
+    {
+      "qid": "Q86060435",
+      "canonical": "Eugen Trowitzsch"
+    },
+    {
+      "qid": "Q86068569",
+      "canonical": "Q86068569"
+    },
+    {
+      "qid": "Q86071968",
+      "canonical": "Michel Vounatsos"
+    },
+    {
+      "qid": "Q86077712",
+      "canonical": "George Scangos"
+    },
+    {
+      "qid": "Q86408516",
+      "canonical": "Bob Chapek"
+    },
+    {
+      "qid": "Q864338",
+      "canonical": "Biogen"
+    },
+    {
+      "qid": "Q864407",
+      "canonical": "The Home Depot"
+    },
+    {
+      "qid": "Q864923",
+      "canonical": "Singtel"
+    },
+    {
+      "qid": "Q86495804",
+      "canonical": "Palmrothin kenk\u00e4tehdas"
+    },
+    {
+      "qid": "Q86582",
+      "canonical": "J\u00fcrgen E. Schrempp"
+    },
+    {
+      "qid": "Q87279969",
+      "canonical": "Stella David"
+    },
+    {
+      "qid": "Q87280077",
+      "canonical": "Giorgio Presca"
+    },
+    {
+      "qid": "Q87407534",
+      "canonical": "Renaud de Lesquen"
+    },
+    {
+      "qid": "Q87607893",
+      "canonical": "Christopher Loughlin"
+    },
+    {
+      "qid": "Q8766",
+      "canonical": "British Airways"
+    },
+    {
+      "qid": "Q877189",
+      "canonical": "FEV"
+    },
+    {
+      "qid": "Q87720395",
+      "canonical": "Pawe\u0142 Surowka"
+    },
+    {
+      "qid": "Q87724232",
+      "canonical": "Petr Kudela"
+    },
+    {
+      "qid": "Q87724235",
+      "canonical": "Jozef Sin\u010d\u00e1k"
+    },
+    {
+      "qid": "Q8774",
+      "canonical": "International Airlines Group"
+    },
+    {
+      "qid": "Q87807134",
+      "canonical": "Chris O'Shea"
+    },
+    {
+      "qid": "Q8793",
+      "canonical": "Boeing Commercial Airplanes"
+    },
+    {
+      "qid": "Q88959995",
+      "canonical": "PPF investi\u010dn\u00ed holding"
+    },
+    {
+      "qid": "Q88960716",
+      "canonical": "Roman Jur\u00e1\u0161"
+    },
+    {
+      "qid": "Q890353",
+      "canonical": "Bofors"
+    },
+    {
+      "qid": "Q892206",
+      "canonical": "Glory"
+    },
+    {
+      "qid": "Q89449105",
+      "canonical": "Hiroki Totoki"
+    },
+    {
+      "qid": "Q898208",
+      "canonical": "Honeywell"
+    },
+    {
+      "qid": "Q899010",
+      "canonical": "Mylan"
+    },
+    {
+      "qid": "Q90151210",
+      "canonical": "Hayk Yesayan"
+    },
+    {
+      "qid": "Q90310670",
+      "canonical": "Beno\u00eet Durteste"
+    },
+    {
+      "qid": "Q90311725",
+      "canonical": "Christophe Evain"
+    },
+    {
+      "qid": "Q905049",
+      "canonical": "Shire plc"
+    },
+    {
+      "qid": "Q916196",
+      "canonical": "Citrix Systems"
+    },
+    {
+      "qid": "Q919646",
+      "canonical": "British Land"
+    },
+    {
+      "qid": "Q92434",
+      "canonical": "Christoph Franz"
+    },
+    {
+      "qid": "Q92747",
+      "canonical": "Eric Schmidt"
+    },
+    {
+      "qid": "Q931207",
+      "canonical": "Kering"
+    },
+    {
+      "qid": "Q9325",
+      "canonical": "Lufthansa"
+    },
+    {
+      "qid": "Q93332451",
+      "canonical": "Robert Swaak"
+    },
+    {
+      "qid": "Q933787",
+      "canonical": "\u0160koda Transportation"
+    },
+    {
+      "qid": "Q936325",
+      "canonical": "Terna S.p.A."
+    },
+    {
+      "qid": "Q9396",
+      "canonical": "Deutsche Telekom"
+    },
+    {
+      "qid": "Q94016219",
+      "canonical": "Mike Roman"
+    },
+    {
+      "qid": "Q944760",
+      "canonical": "Almirall"
+    },
+    {
+      "qid": "Q949610",
+      "canonical": "Shimano"
+    },
+    {
+      "qid": "Q94977557",
+      "canonical": "Jaroslav Starka"
+    },
+    {
+      "qid": "Q95",
+      "canonical": "Google"
+    },
+    {
+      "qid": "Q95071421",
+      "canonical": "Jan Starka"
+    },
+    {
+      "qid": "Q95180163",
+      "canonical": "Ond\u0159ej \u010cern\u00fd"
+    },
+    {
+      "qid": "Q95307",
+      "canonical": "Tom Enders"
+    },
+    {
+      "qid": "Q95383126",
+      "canonical": "Ivan Du\u0161kov"
+    },
+    {
+      "qid": "Q95448424",
+      "canonical": "Zden\u011bk Bene\u0161"
+    },
+    {
+      "qid": "Q95457024",
+      "canonical": "Karel Filip"
+    },
+    {
+      "qid": "Q95461139",
+      "canonical": "Petr Novotn\u00fd"
+    },
+    {
+      "qid": "Q95569597",
+      "canonical": "Robert B. Ford"
+    },
+    {
+      "qid": "Q95692568",
+      "canonical": "Arne Fosen"
+    },
+    {
+      "qid": "Q95713255",
+      "canonical": "Eleonore Adlon"
+    },
+    {
+      "qid": "Q95744193",
+      "canonical": "Arne Veggeland"
+    },
+    {
+      "qid": "Q95744445",
+      "canonical": "Ole Engebret Haugen"
+    },
+    {
+      "qid": "Q9594696",
+      "canonical": "Albino Magaia"
+    },
+    {
+      "qid": "Q96117777",
+      "canonical": "Yonatan Stern"
+    },
+    {
+      "qid": "Q96398626",
+      "canonical": "Paul Cormier"
+    },
+    {
+      "qid": "Q96398640",
+      "canonical": "Paul Stone"
+    },
+    {
+      "qid": "Q96472795",
+      "canonical": "Chris Vogelzang"
+    },
+    {
+      "qid": "Q96474476",
+      "canonical": "Zden\u011bk Zemek"
+    },
+    {
+      "qid": "Q96695268",
+      "canonical": "Henry Schuck"
+    },
+    {
+      "qid": "Q96775410",
+      "canonical": "Michael F. Neidorff"
+    },
+    {
+      "qid": "Q96990627",
+      "canonical": "Ond\u0159ej Vl\u010dek"
+    },
+    {
+      "qid": "Q97022864",
+      "canonical": "R\u00fcdiger Koch"
+    },
+    {
+      "qid": "Q970452",
+      "canonical": "Storstockholms Lokaltrafik"
+    },
+    {
+      "qid": "Q97052945",
+      "canonical": "Wedaverken"
+    },
+    {
+      "qid": "Q971649",
+      "canonical": "Orlen"
+    },
+    {
+      "qid": "Q97197296",
+      "canonical": "CGI Finland"
+    },
+    {
+      "qid": "Q97439162",
+      "canonical": "Stellantis"
+    },
+    {
+      "qid": "Q97496345",
+      "canonical": "Y\u014dz\u014d Shimano"
+    },
+    {
+      "qid": "Q97569309",
+      "canonical": "Jim Ryan"
+    },
+    {
+      "qid": "Q97661800",
+      "canonical": "Vladimir Lysenkov"
+    },
+    {
+      "qid": "Q97662653",
+      "canonical": "Yury Osokin"
+    },
+    {
+      "qid": "Q98081129",
+      "canonical": "Twitch Interactive"
+    },
+    {
+      "qid": "Q982623",
+      "canonical": "Kazuo Inamori"
+    },
+    {
+      "qid": "Q98312534",
+      "canonical": "Nataliya Yarmolenko"
+    },
+    {
+      "qid": "Q98352414",
+      "canonical": "Alois Mayer"
+    },
+    {
+      "qid": "Q983981",
+      "canonical": "Roger Ailes"
+    },
+    {
+      "qid": "Q98401",
+      "canonical": "Ulf Mark Schneider"
+    },
+    {
+      "qid": "Q98520074",
+      "canonical": "Eero M\u00f6ls\u00e4"
+    },
+    {
+      "qid": "Q98529313",
+      "canonical": "Tim Ellis"
+    },
+    {
+      "qid": "Q98800712",
+      "canonical": "Juhani Palmroth"
+    },
+    {
+      "qid": "Q98852224",
+      "canonical": "Q98852224"
+    },
+    {
+      "qid": "Q98960160",
+      "canonical": "Amir Dan Rubin"
+    },
+    {
+      "qid": "Q98960171",
+      "canonical": "Tom X. Lee"
+    },
+    {
+      "qid": "Q99193592",
+      "canonical": "Anna Borg"
+    },
+    {
+      "qid": "Q99573092",
+      "canonical": "Michael Suffredini"
+    },
+    {
+      "qid": "Q99880011",
+      "canonical": "Revathi Advaithi"
+    }
+  ],
+  "temporal_facts": [
+    {
+      "anchor_qid": "Q1017062",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3500447",
+      "b_qid": "Q27861831",
+      "tc": 2012,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q1021074",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106986451",
+      "b_qid": "Q116679883",
+      "tc": 2022,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q102673",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q673818",
+      "b_qid": "Q467644",
+      "tc": 2001,
+      "start_a": 1992
+    },
+    {
+      "anchor_qid": "Q104426506",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124620793",
+      "b_qid": "Q124620820",
+      "tc": 2016,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1046951",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5606591",
+      "b_qid": "Q20857886",
+      "tc": 2014,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q1048204",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q61972716",
+      "b_qid": "Q52824679",
+      "tc": 2021,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q104842926",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q135233481",
+      "b_qid": "Q140447596",
+      "tc": 2026,
+      "start_a": 2024
+    },
+    {
+      "anchor_qid": "Q1050159",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16770026",
+      "b_qid": "Q57314560",
+      "tc": 2014,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q10561401",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15992210",
+      "b_qid": "Q117790877",
+      "tc": 1936,
+      "start_a": 1915
+    },
+    {
+      "anchor_qid": "Q105810218",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q10773789",
+      "b_qid": "Q120589578",
+      "tc": 2012,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q105979056",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105979813",
+      "b_qid": "Q105979074",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q106303371",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106303701",
+      "b_qid": "Q97022864",
+      "tc": 2008,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q106371968",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106410464",
+      "b_qid": "Q117803829",
+      "tc": 2026,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q106390371",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6282085",
+      "b_qid": "Q107110562",
+      "tc": 2002,
+      "start_a": 1988
+    },
+    {
+      "anchor_qid": "Q10680526",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6230601",
+      "b_qid": "Q3432247",
+      "tc": 1958,
+      "start_a": 1946
+    },
+    {
+      "anchor_qid": "Q1068351",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q112239431",
+      "b_qid": "Q100454182",
+      "tc": 2022,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q10685071",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q135025328",
+      "b_qid": "Q117289625",
+      "tc": 1972,
+      "start_a": 1969
+    },
+    {
+      "anchor_qid": "Q107214638",
+      "relation": "chief_executive_officer",
+      "a_qid": "4714464e838441aa89288feb1159cdce",
+      "b_qid": "Q28835137",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q107528439",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q140248791",
+      "b_qid": "Q140248507",
+      "tc": 2023,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q107785714",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22810736",
+      "b_qid": "Q118482800",
+      "tc": 2023,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q1095857",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q87279969",
+      "b_qid": "Q87280077",
+      "tc": 2019,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q110580207",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q110580761",
+      "b_qid": "Q110580696",
+      "tc": 2009,
+      "start_a": 1968
+    },
+    {
+      "anchor_qid": "Q111318110",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115275652",
+      "b_qid": "Q53464772",
+      "tc": 2026,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q111387693",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q114957449",
+      "b_qid": "Q12572999",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q111606644",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64876086",
+      "b_qid": "Q119726858",
+      "tc": 2025,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q1118657",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q81568897",
+      "b_qid": "Q20631056",
+      "tc": 2020,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q11228089",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59752660",
+      "b_qid": "Q12035810",
+      "tc": 2013,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q11251919",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6137947",
+      "b_qid": "Q81345643",
+      "tc": 2016,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q11278357",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56253705",
+      "b_qid": "Q64782751",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q11283119",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105221670",
+      "b_qid": "Q88960716",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q11320256",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7820162",
+      "b_qid": "Q11449999",
+      "tc": 2011,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q11346537",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q11397048",
+      "b_qid": "Q120878232",
+      "tc": 2000,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q113525711",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q135256969",
+      "b_qid": "Q135257441",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q1136885",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4506113",
+      "b_qid": "Q101070644",
+      "tc": 2020,
+      "start_a": 1960
+    },
+    {
+      "anchor_qid": "Q1140680",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115629121",
+      "b_qid": "Q99880011",
+      "tc": 2019,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q1142797",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23970591",
+      "b_qid": "Q75814485",
+      "tc": 2024,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q114437297",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16269214",
+      "b_qid": "Q114400848",
+      "tc": 2021,
+      "start_a": 1986
+    },
+    {
+      "anchor_qid": "Q11463",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2745626",
+      "b_qid": "Q2622748",
+      "tc": 2007,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q114661529",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q114661871",
+      "b_qid": "Q136753026",
+      "tc": 2023,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q114755798",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q135963023",
+      "b_qid": "Q135963027",
+      "tc": 2025,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q115014614",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115014459",
+      "b_qid": "Q47016796",
+      "tc": 2015,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q1152764",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5386350",
+      "b_qid": "Q102783130",
+      "tc": 2021,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q11541601",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q42913661",
+      "b_qid": "Q71142467",
+      "tc": 2014,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q116452644",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7306657",
+      "b_qid": "Q19661212",
+      "tc": 2020,
+      "start_a": 1998
+    },
+    {
+      "anchor_qid": "Q11686899",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6155174",
+      "b_qid": "Q112222645",
+      "tc": 2022,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q11707119",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q136402833",
+      "b_qid": "Q136402840",
+      "tc": 2023,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q1172038",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2897681",
+      "b_qid": "Q115735422",
+      "tc": 2024,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q117768540",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q382101",
+      "b_qid": "Q9594696",
+      "tc": 1980,
+      "start_a": 1979
+    },
+    {
+      "anchor_qid": "Q11859650",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q139497198",
+      "b_qid": "Q139497282",
+      "tc": 2002,
+      "start_a": 1986
+    },
+    {
+      "anchor_qid": "Q118725712",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1103300",
+      "b_qid": "Q102315490",
+      "tc": 1962,
+      "start_a": 1896
+    },
+    {
+      "anchor_qid": "Q11878398",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12025314",
+      "b_qid": "Q116142302",
+      "tc": 2019,
+      "start_a": 1988
+    },
+    {
+      "anchor_qid": "Q11888546",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5473565",
+      "b_qid": "Q27074910",
+      "tc": 1983,
+      "start_a": 1964
+    },
+    {
+      "anchor_qid": "Q11897629",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23040862",
+      "b_qid": "Q11852651",
+      "tc": 1984,
+      "start_a": 1943
+    },
+    {
+      "anchor_qid": "Q11904427",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q50071152",
+      "b_qid": "Q126680585",
+      "tc": 2022,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q1190669",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56349284",
+      "b_qid": "Q118696194",
+      "tc": 2022,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q1190881",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64745663",
+      "b_qid": "Q7024365",
+      "tc": 2022,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q11969389",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q11993401",
+      "b_qid": "Q64623818",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q11989409",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16161682",
+      "b_qid": "Q112420820",
+      "tc": 2025,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q11994205",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q60151368",
+      "b_qid": "Q137187091",
+      "tc": 2025,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q12006431",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q101424348",
+      "b_qid": "Q95383126",
+      "tc": 2026,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q1202053",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2163279",
+      "b_qid": "Q113355178",
+      "tc": 2026,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q12033072",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17335133",
+      "b_qid": "Q56654140",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q12034446",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q110775966",
+      "b_qid": "Q138049088",
+      "tc": 2015,
+      "start_a": 1997
+    },
+    {
+      "anchor_qid": "Q12041098",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12035711",
+      "b_qid": "Q46867686",
+      "tc": 2015,
+      "start_a": 1993
+    },
+    {
+      "anchor_qid": "Q12041612",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q11899907",
+      "b_qid": "Q1729151",
+      "tc": 1934,
+      "start_a": 1926
+    },
+    {
+      "anchor_qid": "Q12058450",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12038000",
+      "b_qid": "Q87724235",
+      "tc": 2019,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q12058918",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95457024",
+      "b_qid": "Q95448424",
+      "tc": 2015,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q121159761",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95713255",
+      "b_qid": "Q47500304",
+      "tc": 2006,
+      "start_a": 1978
+    },
+    {
+      "anchor_qid": "Q122141",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q716505",
+      "b_qid": "Q47524652",
+      "tc": 2018,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q123752186",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q38458637",
+      "b_qid": "Q138983610",
+      "tc": 2026,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q124026351",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2926681",
+      "b_qid": "Q124026806",
+      "tc": 2021,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q124457779",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q8074112",
+      "b_qid": "Q135458872",
+      "tc": 2023,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q1248816",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q80217118",
+      "b_qid": "Q74291660",
+      "tc": 2023,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q125081448",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q33111653",
+      "b_qid": "Q125293726",
+      "tc": 2021,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q125103476",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125105049",
+      "b_qid": "Q125105520",
+      "tc": 2017,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q125523927",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124868557",
+      "b_qid": "Q125187894",
+      "tc": 2018,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q127005",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1223089",
+      "b_qid": "Q1434895",
+      "tc": 2001,
+      "start_a": 1980
+    },
+    {
+      "anchor_qid": "Q1274252",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3066682",
+      "b_qid": "Q323066",
+      "tc": 1947,
+      "start_a": 1944
+    },
+    {
+      "anchor_qid": "Q1276463",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64135949",
+      "b_qid": "Q140069314",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q127981813",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q127982366",
+      "b_qid": "Q126598004",
+      "tc": 1950,
+      "start_a": 1933
+    },
+    {
+      "anchor_qid": "Q1281126",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q108137858",
+      "b_qid": "Q125359507",
+      "tc": 2023,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q1283291",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q31202127",
+      "b_qid": "Q137210428",
+      "tc": 2023,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q128738",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2199420",
+      "b_qid": "Q111253511",
+      "tc": 2021,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q1288880",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q130320248",
+      "b_qid": "Q130320251",
+      "tc": 2017,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q13014244",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16139697",
+      "b_qid": "Q16307519",
+      "tc": 2018,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q130342816",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q27870055",
+      "b_qid": "Q75366946",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q1305281",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3158153",
+      "b_qid": "Q33109758",
+      "tc": 2022,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q13054189",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q90151210",
+      "b_qid": "Q4205845",
+      "tc": 2023,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q1309851",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6438198",
+      "b_qid": "Q127583088",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q1310001",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2581305",
+      "b_qid": "Q30349225",
+      "tc": 2024,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q131005",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30729211",
+      "b_qid": "Q59676501",
+      "tc": 2018,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q131362440",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1705878",
+      "b_qid": "Q131362597",
+      "tc": 2020,
+      "start_a": 1989
+    },
+    {
+      "anchor_qid": "Q131560265",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q134125699",
+      "b_qid": "Q134125517",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q131675131",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q131675552",
+      "b_qid": "Q131675218",
+      "tc": 2025,
+      "start_a": 2024
+    },
+    {
+      "anchor_qid": "Q1318049",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q80978371",
+      "b_qid": "Q45821859",
+      "tc": 2025,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q13218598",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16189392",
+      "b_qid": "Q63325233",
+      "tc": 2019,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1325291",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28871936",
+      "b_qid": "Q115655394",
+      "tc": 2026,
+      "start_a": 1992
+    },
+    {
+      "anchor_qid": "Q133289342",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q111081541",
+      "b_qid": "Q7612149",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q1344481",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137917410",
+      "b_qid": "Q137917444",
+      "tc": 2023,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q1351415",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23905879",
+      "b_qid": "Q55231934",
+      "tc": 2018,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q135914740",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137917356",
+      "b_qid": "Q138241552",
+      "tc": 2025,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q136524444",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q112359048",
+      "b_qid": "Q135659053",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q136706792",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q136706318",
+      "b_qid": "Q136706824",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q136768233",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q136768328",
+      "b_qid": "Q1429953",
+      "tc": 2023,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q1372049",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17229450",
+      "b_qid": "Q738197",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q137440955",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137547998",
+      "b_qid": "Q137548111",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q137910",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q109782",
+      "b_qid": "Q121834402",
+      "tc": 2023,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q138133",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15842921",
+      "b_qid": "Q108936810",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q13882231",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115394460",
+      "b_qid": "Q123352677",
+      "tc": 2016,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q1390577",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q100276124",
+      "b_qid": "Q317521",
+      "tc": 2022,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q139997508",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18786186",
+      "b_qid": "Q139997711",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q140676761",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q29635912",
+      "b_qid": "Q140677672",
+      "tc": 2025,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q1416687",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q139493717",
+      "b_qid": "Q63109921",
+      "tc": 2018,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q1418",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q14090205",
+      "b_qid": "Q115735574",
+      "tc": 2025,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q1424962",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7329143",
+      "b_qid": "Q43384742",
+      "tc": 2017,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q1425170",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22978019",
+      "b_qid": "Q2001226",
+      "tc": 2011,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q1435702",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19975651",
+      "b_qid": "Q23883644",
+      "tc": 2023,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q1437143",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q122839999",
+      "b_qid": "Q122840000",
+      "tc": 1994,
+      "start_a": 1962
+    },
+    {
+      "anchor_qid": "Q14594782",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q103824349",
+      "b_qid": "Q135232415",
+      "tc": 2023,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q1465005",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16533765",
+      "b_qid": "Q24956110",
+      "tc": 2016,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1465461",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7612873",
+      "b_qid": "Q22007406",
+      "tc": 2016,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q14662364",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q63410046",
+      "b_qid": "Q125257078",
+      "tc": 2024,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1471161",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4727049",
+      "b_qid": "Q31096442",
+      "tc": 2020,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q1475312",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q509124",
+      "b_qid": "Q731462",
+      "tc": 2010,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q1479375",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q67932616",
+      "b_qid": "Q135103340",
+      "tc": 2026,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q1479649",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125535220",
+      "b_qid": "Q125535126",
+      "tc": 2015,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q14950045",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104521383",
+      "b_qid": "Q131764256",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q1520122",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5242415",
+      "b_qid": "Q110694796",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q152051",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15854029",
+      "b_qid": "Q121148056",
+      "tc": 2023,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q152057",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q122443335",
+      "b_qid": "Q130611962",
+      "tc": 2025,
+      "start_a": 2024
+    },
+    {
+      "anchor_qid": "Q152096",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16193529",
+      "b_qid": "Q83410804",
+      "tc": 2020,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q15238661",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30100510",
+      "b_qid": "Q111309783",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q1525588",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137768558",
+      "b_qid": "Q137768562",
+      "tc": 1990,
+      "start_a": 1955
+    },
+    {
+      "anchor_qid": "Q153571",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q136023672",
+      "b_qid": "Q140590909",
+      "tc": 2026,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q1537378",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1347130",
+      "b_qid": "Q2865328",
+      "tc": 2017,
+      "start_a": 1987
+    },
+    {
+      "anchor_qid": "Q1537811",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5902427",
+      "b_qid": "Q105825520",
+      "tc": 2018,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q1541079",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30317564",
+      "b_qid": "Q35507309",
+      "tc": 2017,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1543874",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6377142",
+      "b_qid": "Q96398640",
+      "tc": 2020,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q1545076",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28402108",
+      "b_qid": "Q130302995",
+      "tc": 2021,
+      "start_a": 1991
+    },
+    {
+      "anchor_qid": "Q154950",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15650949",
+      "b_qid": "Q113988833",
+      "tc": 2023,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q155026",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55196710",
+      "b_qid": "Q21551443",
+      "tc": 2020,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q1550912",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q26637897",
+      "b_qid": "Q26638506",
+      "tc": 2009,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q156238",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q331401",
+      "b_qid": "Q28018191",
+      "tc": 2017,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q1564396",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q139255218",
+      "b_qid": "Q139414262",
+      "tc": 2020,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q156578",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19285388",
+      "b_qid": "Q21032599",
+      "tc": 2022,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q156776",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q92434",
+      "b_qid": "Q1586568",
+      "tc": 2009,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q15678788",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1229223",
+      "b_qid": "Q55698517",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q156829",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7606236",
+      "b_qid": "Q19772432",
+      "tc": 2017,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q156959",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22007263",
+      "b_qid": "Q27882872",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q157062",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q116501956",
+      "b_qid": "Q204277",
+      "tc": 2025,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q157617",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105295968",
+      "b_qid": "Q56035140",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q157645",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q75681",
+      "b_qid": "Q115523514",
+      "tc": 2023,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q157675",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5783986",
+      "b_qid": "Q99193592",
+      "tc": 2020,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q157852",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2418452",
+      "b_qid": "Q110985256",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q158205",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19360238",
+      "b_qid": "Q67029500",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q159433",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q94016219",
+      "b_qid": "Q85815710",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q1603219",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3109036",
+      "b_qid": "Q17096973",
+      "tc": 1956,
+      "start_a": 1880
+    },
+    {
+      "anchor_qid": "Q160746",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q98401",
+      "b_qid": "Q136051736",
+      "tc": 2025,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q161086",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30493955",
+      "b_qid": "Q118088909",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q1623391",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1039157",
+      "b_qid": "Q133504684",
+      "tc": 1994,
+      "start_a": 1949
+    },
+    {
+      "anchor_qid": "Q162472",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q94977557",
+      "b_qid": "Q95071421",
+      "tc": 2015,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q163241",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1332719",
+      "b_qid": "Q108566246",
+      "tc": 2020,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q1636974",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q101243531",
+      "b_qid": "Q96472795",
+      "tc": 2019,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q1641437",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q21075696",
+      "b_qid": "Q29973720",
+      "tc": 2017,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q16471828",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24954807",
+      "b_qid": "Q136348852",
+      "tc": 2021,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q16512361",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16163305",
+      "b_qid": "Q59821781",
+      "tc": 2018,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q1671509",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q117824948",
+      "b_qid": "Q136661156",
+      "tc": 2020,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q16742113",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q112394761",
+      "b_qid": "Q115190398",
+      "tc": 2008,
+      "start_a": 1998
+    },
+    {
+      "anchor_qid": "Q1676085",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2587167",
+      "b_qid": "Q4307679",
+      "tc": 1989,
+      "start_a": 1968
+    },
+    {
+      "anchor_qid": "Q168238",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28228201",
+      "b_qid": "Q110626453",
+      "tc": 2021,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q16916495",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16991326",
+      "b_qid": "Q16988458",
+      "tc": 2013,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q169925",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124463276",
+      "b_qid": "Q137423339",
+      "tc": 2025,
+      "start_a": 2024
+    },
+    {
+      "anchor_qid": "Q17021787",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q75405697",
+      "b_qid": "Q4772328",
+      "tc": 2013,
+      "start_a": 1955
+    },
+    {
+      "anchor_qid": "Q17031875",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q43668928",
+      "b_qid": "Q43423083",
+      "tc": 2015,
+      "start_a": 1997
+    },
+    {
+      "anchor_qid": "Q170416",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1445487",
+      "b_qid": "Q113636437",
+      "tc": 2022,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q170614",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q597242",
+      "b_qid": "Q24795213",
+      "tc": 2019,
+      "start_a": 1994
+    },
+    {
+      "anchor_qid": "Q17068357",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q116284788",
+      "b_qid": "Q116287463",
+      "tc": 2021,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q17310744",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q123424623",
+      "b_qid": "Q28408088",
+      "tc": 2023,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q1740534",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q27058377",
+      "b_qid": "Q66385088",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q174769",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q21066734",
+      "b_qid": "Q21072926",
+      "tc": 2020,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q17507863",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19896679",
+      "b_qid": "Q19896671",
+      "tc": 2011,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q1770909",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12010370",
+      "b_qid": "Q122147756",
+      "tc": 2016,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q1783168",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q60629364",
+      "b_qid": "Q113674610",
+      "tc": 2019,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q1807170",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6836029",
+      "b_qid": "Q87720395",
+      "tc": 2017,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q181114",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1229223",
+      "b_qid": "Q55698517",
+      "tc": 2018,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q18224",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7666585",
+      "b_qid": "Q123296981",
+      "tc": 2023,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q18325550",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106435030",
+      "b_qid": "Q106435048",
+      "tc": 2017,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q1848025",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q109175226",
+      "b_qid": "Q109175265",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q1852556",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56703648",
+      "b_qid": "Q106755529",
+      "tc": 2021,
+      "start_a": 1984
+    },
+    {
+      "anchor_qid": "Q18543",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5300675",
+      "b_qid": "Q4133583",
+      "tc": 1999,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q18594",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q97569309",
+      "b_qid": "Q89449105",
+      "tc": 2024,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q186068",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q983981",
+      "b_qid": "Q57915960",
+      "tc": 2018,
+      "start_a": 1996
+    },
+    {
+      "anchor_qid": "Q18689157",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q60671170",
+      "b_qid": "Q98520074",
+      "tc": 1977,
+      "start_a": 1944
+    },
+    {
+      "anchor_qid": "Q1885456",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18071689",
+      "b_qid": "Q5680808",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q188920",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17516980",
+      "b_qid": "Q32374551",
+      "tc": 2016,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q190238",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12006150",
+      "b_qid": "Q21711860",
+      "tc": 2022,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q190464",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q42887509",
+      "b_qid": "Q66477676",
+      "tc": 2020,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q191551",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5045423",
+      "b_qid": "Q47545530",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q1916402",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2849060",
+      "b_qid": "Q115735259",
+      "tc": 2024,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q1921466",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104776",
+      "b_qid": "Q18335035",
+      "tc": 1991,
+      "start_a": 1980
+    },
+    {
+      "anchor_qid": "Q192653",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q87724235",
+      "b_qid": "Q87724232",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q193326",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1359151",
+      "b_qid": "Q29641838",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q19383161",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56454873",
+      "b_qid": "Q108057935",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q194360",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5677222",
+      "b_qid": "Q52272598",
+      "tc": 2018,
+      "start_a": 1993
+    },
+    {
+      "anchor_qid": "Q19698200",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24956110",
+      "b_qid": "Q33105343",
+      "tc": 2025,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q19753941",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19842482",
+      "b_qid": "Q61057080",
+      "tc": 2017,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q19831035",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q119954220",
+      "b_qid": "Q122916561",
+      "tc": 2023,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q19923099",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55174",
+      "b_qid": "Q51841506",
+      "tc": 2018,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q19951610",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q117487953",
+      "b_qid": "Q137902160",
+      "tc": 2026,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q2005282",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q33120770",
+      "b_qid": "Q104528496",
+      "tc": 2025,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q20056888",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137808426",
+      "b_qid": "Q63099294",
+      "tc": 2005,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q20102528",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q14122110",
+      "b_qid": "Q21979835",
+      "tc": 2021,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q20108105",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q65205099",
+      "b_qid": "Q20190635",
+      "tc": 2021,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q20112651",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q71656964",
+      "b_qid": "Q110929746",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q20165",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30923926",
+      "b_qid": "Q70092183",
+      "tc": 2019,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q2031726",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22278143",
+      "b_qid": "Q108647632",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q2042423",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115558391",
+      "b_qid": "Q135992383",
+      "tc": 2026,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q204296",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q74370310",
+      "b_qid": "Q70426295",
+      "tc": 2020,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q206678",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q14191959",
+      "b_qid": "Q126966053",
+      "tc": 2024,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q206921",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1655624",
+      "b_qid": "Q63400080",
+      "tc": 2019,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q20718",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1794969",
+      "b_qid": "Q624109",
+      "tc": 2022,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q2071905",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q14948763",
+      "b_qid": "Q7803408",
+      "tc": 2013,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q207983",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3436288",
+      "b_qid": "Q1634366",
+      "tc": 2003,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q20800404",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4934",
+      "b_qid": "Q3503829",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q208033",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4117408",
+      "b_qid": "Q4074985",
+      "tc": 2023,
+      "start_a": 1997
+    },
+    {
+      "anchor_qid": "Q20858163",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q116923463",
+      "b_qid": "Q28536761",
+      "tc": 2015,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q212322",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18121649",
+      "b_qid": "Q27058352",
+      "tc": 2017,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q213140",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q982623",
+      "b_qid": "Q124321858",
+      "tc": 2024,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q215293",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1445880",
+      "b_qid": "Q110409879",
+      "tc": 2022,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q215363",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4980554",
+      "b_qid": "Q4960507",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q217493",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6237422",
+      "b_qid": "Q61887834",
+      "tc": 2018,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q21950804",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7085834",
+      "b_qid": "Q17112795",
+      "tc": 2013,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q22031704",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q108623907",
+      "b_qid": "Q108623956",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q22132500",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23831639",
+      "b_qid": "Q109314050",
+      "tc": 2020,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q2283",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q181162",
+      "b_qid": "Q7426870",
+      "tc": 2014,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q2295406",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24007496",
+      "b_qid": "Q48453376",
+      "tc": 2021,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q2298325",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6755817",
+      "b_qid": "Q108550690",
+      "tc": 2021,
+      "start_a": 1992
+    },
+    {
+      "anchor_qid": "Q2303478",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4662637",
+      "b_qid": "Q116376004",
+      "tc": 1987,
+      "start_a": 1986
+    },
+    {
+      "anchor_qid": "Q23045376",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q139662631",
+      "b_qid": "Q70337768",
+      "tc": 2026,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q23076",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q101627126",
+      "b_qid": "Q2595414",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q2311",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95307",
+      "b_qid": "Q33158035",
+      "tc": 2019,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q2316882",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q77026815",
+      "b_qid": "Q101352",
+      "tc": 2026,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q23317",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q27896387",
+      "b_qid": "Q123358938",
+      "tc": 2023,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q234021",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2531462",
+      "b_qid": "Q108247496",
+      "tc": 2022,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q2357515",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7610176",
+      "b_qid": "Q19843254",
+      "tc": 2012,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q2360847",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4409579",
+      "b_qid": "Q22813963",
+      "tc": 2012,
+      "start_a": 1986
+    },
+    {
+      "anchor_qid": "Q23979144",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12006150",
+      "b_qid": "Q135409161",
+      "tc": 2025,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q2405791",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q48169527",
+      "b_qid": "Q55808357",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q243278",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7970169",
+      "b_qid": "Q118351577",
+      "tc": 2023,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q245343",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6185687",
+      "b_qid": "Q109609662",
+      "tc": 2021,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q2464046",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q824323",
+      "b_qid": "Q1100117",
+      "tc": 1994,
+      "start_a": 1971
+    },
+    {
+      "anchor_qid": "Q246655",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q80356796",
+      "b_qid": "Q2287912",
+      "tc": 2001,
+      "start_a": 1988
+    },
+    {
+      "anchor_qid": "Q247489",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1289900",
+      "b_qid": "Q114706038",
+      "tc": 2021,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q248",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55819738",
+      "b_qid": "Q7143480",
+      "tc": 2021,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q24939514",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q123182476",
+      "b_qid": "Q123182536",
+      "tc": 2023,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q25103691",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q130481772",
+      "b_qid": "Q87279969",
+      "tc": 2025,
+      "start_a": 2024
+    },
+    {
+      "anchor_qid": "Q25394205",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q97661800",
+      "b_qid": "Q97662653",
+      "tc": 1989,
+      "start_a": 1971
+    },
+    {
+      "anchor_qid": "Q25499288",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q63345439",
+      "b_qid": "Q13194093",
+      "tc": 2020,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q2565531",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17000790",
+      "b_qid": "Q7519563",
+      "tc": 2022,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q259013",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5980411",
+      "b_qid": "Q87807134",
+      "tc": 2020,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q2590482",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6054541",
+      "b_qid": "Q117715587",
+      "tc": 1920,
+      "start_a": 1900
+    },
+    {
+      "anchor_qid": "Q266341",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q25999295",
+      "b_qid": "Q28861839",
+      "tc": 2016,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q266423",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5299694",
+      "b_qid": "Q63975443",
+      "tc": 2015,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q2665980",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4933658",
+      "b_qid": "Q5045423",
+      "tc": 2006,
+      "start_a": 1997
+    },
+    {
+      "anchor_qid": "Q2666775",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6855185",
+      "b_qid": "Q65581460",
+      "tc": 2019,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q2695537",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15992210",
+      "b_qid": "Q117790877",
+      "tc": 1936,
+      "start_a": 1897
+    },
+    {
+      "anchor_qid": "Q26989",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7935934",
+      "b_qid": "Q47087171",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q27074",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23062326",
+      "b_qid": "Q460593",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q2740294",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q140420790",
+      "b_qid": "Q140420647",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q274372",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q137328248",
+      "b_qid": "Q137190053",
+      "tc": 2023,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q2744099",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q53568191",
+      "b_qid": "Q75692161",
+      "tc": 2020,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q27460",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q119052685",
+      "b_qid": "Q61735606",
+      "tc": 2025,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q27530",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q65445",
+      "b_qid": "Q19297571",
+      "tc": 2019,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q27585",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7292185",
+      "b_qid": "Q7803096",
+      "tc": 2009,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q2777746",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3155030",
+      "b_qid": "Q33184828",
+      "tc": 2024,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q27778959",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q85515959",
+      "b_qid": "Q55978022",
+      "tc": 2014,
+      "start_a": 1997
+    },
+    {
+      "anchor_qid": "Q278810",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q87607893",
+      "b_qid": "Q105713466",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q27969046",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q60050698",
+      "b_qid": "Q134577466",
+      "tc": 2022,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q28027517",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28873696",
+      "b_qid": "Q136359918",
+      "tc": 2025,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q28135888",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59697784",
+      "b_qid": "Q113653910",
+      "tc": 2021,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q282717",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16630669",
+      "b_qid": "Q47453098",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q283852",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56299206",
+      "b_qid": "Q62429543",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q284672",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23809748",
+      "b_qid": "Q112190710",
+      "tc": 2022,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q285328",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5982488",
+      "b_qid": "Q47544149",
+      "tc": 2018,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q287471",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q27894018",
+      "b_qid": "Q93332451",
+      "tc": 2020,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q28858105",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28859508",
+      "b_qid": "Q28859512",
+      "tc": 1998,
+      "start_a": 1971
+    },
+    {
+      "anchor_qid": "Q29359760",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16139697",
+      "b_qid": "Q54644663",
+      "tc": 2007,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q29637",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q100989426",
+      "b_qid": "Q115616635",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q30259493",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104536488",
+      "b_qid": "Q113493778",
+      "tc": 2022,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q30284383",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18121649",
+      "b_qid": "Q2344783",
+      "tc": 2025,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q30321616",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3442764",
+      "b_qid": "Q7791178",
+      "tc": 2013,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q30338585",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16476115",
+      "b_qid": "Q131720798",
+      "tc": 2008,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q30338814",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q138307691",
+      "b_qid": "Q138307763",
+      "tc": 2024,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q304944",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q103814978",
+      "b_qid": "Q112175992",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q306764",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q281657",
+      "b_qid": "Q95569597",
+      "tc": 2020,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q308889",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6113311",
+      "b_qid": "Q20215432",
+      "tc": 2011,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q309031",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q33210227",
+      "b_qid": "Q33250746",
+      "tc": 2025,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q309174",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17516980",
+      "b_qid": "Q5301995",
+      "tc": 2004,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q3095097",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3018516",
+      "b_qid": "8d6268b2e1ff156c44856baee4517e69",
+      "tc": 2023,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q310207",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q50146929",
+      "b_qid": "Q105872982",
+      "tc": 2021,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q311394",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15694879",
+      "b_qid": "Q115308936",
+      "tc": 2022,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q312",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q265852",
+      "b_qid": "Q106028933",
+      "tc": 2026,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q3126763",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q112265018",
+      "b_qid": "Q113956100",
+      "tc": 2022,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q3140604",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4678914",
+      "b_qid": "Q5045423",
+      "tc": 2018,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q3146975",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q117747707",
+      "b_qid": "Q125966875",
+      "tc": 2024,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q3149496",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q33111421",
+      "b_qid": "Q130368495",
+      "tc": 2024,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q3181430",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q26258183",
+      "b_qid": "Q107325269",
+      "tc": 2019,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q31890244",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105167367",
+      "b_qid": "Q77284255",
+      "tc": 1977,
+      "start_a": 1906
+    },
+    {
+      "anchor_qid": "Q3210329",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2408676",
+      "b_qid": "Q3376883",
+      "tc": 1996,
+      "start_a": 1952
+    },
+    {
+      "anchor_qid": "Q32491",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4707007",
+      "b_qid": "Q118220135",
+      "tc": 2023,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q327429",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106323455",
+      "b_qid": "Q106323457",
+      "tc": 2021,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q327646",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1353736",
+      "b_qid": "Q138464460",
+      "tc": 2024,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q328840",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104784751",
+      "b_qid": "Q114837486",
+      "tc": 2023,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q3295867",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1392181",
+      "b_qid": "Q27839505",
+      "tc": 2018,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q3319873",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1797872",
+      "b_qid": "Q114837932",
+      "tc": 2025,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q3327046",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24572405",
+      "b_qid": "Q130217999",
+      "tc": 2002,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q333498",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64009036",
+      "b_qid": "Q21634546",
+      "tc": 2020,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q333718",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16193601",
+      "b_qid": "Q113356474",
+      "tc": 2022,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q3339193",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2830367",
+      "b_qid": "Q3340974",
+      "tc": 2024,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q334800",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q264913",
+      "b_qid": "Q56042353",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q3352745",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125287726",
+      "b_qid": "9889e01801534837989a4d7790b55bd6",
+      "tc": 2023,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q336717",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q446378",
+      "b_qid": "Q103814978",
+      "tc": 2014,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q336735",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12035832",
+      "b_qid": "Q17295710",
+      "tc": 2011,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q3372219",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5973764",
+      "b_qid": "Q6256306",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q340135",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q60566195",
+      "b_qid": "Q116141928",
+      "tc": 2022,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q3410475",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124807690",
+      "b_qid": "05a921b5e01d75a8bfddb5fea1d5e861",
+      "tc": 2006,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q341090",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55738191",
+      "b_qid": "Q117085504",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q341100",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7155675",
+      "b_qid": "Q26281315",
+      "tc": 2016,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q341118",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59779410",
+      "b_qid": "Q120607019",
+      "tc": 2023,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q341134",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12044833",
+      "b_qid": "Q17312125",
+      "tc": 2023,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q3446347",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q11972595",
+      "b_qid": "Q139619638",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q34561213",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23564642",
+      "b_qid": "Q1383119",
+      "tc": 2018,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q3486990",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18171895",
+      "b_qid": "Q106962330",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q3490485",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6099130",
+      "b_qid": "Q37800486",
+      "tc": 2015,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q3500487",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5552438",
+      "b_qid": "Q121358909",
+      "tc": 2022,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q3511885",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15109662",
+      "b_qid": "Q79960347",
+      "tc": 2020,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q3622799",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124302696",
+      "b_qid": "Q12377489",
+      "tc": 1990,
+      "start_a": 1979
+    },
+    {
+      "anchor_qid": "Q371522",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5619138",
+      "b_qid": "Q4948829",
+      "tc": 2006,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q37156",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q49971",
+      "b_qid": "Q84053114",
+      "tc": 2020,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q37158",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64745663",
+      "b_qid": "Q117249140",
+      "tc": 2024,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q372657",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3528191",
+      "b_qid": "Q84557658",
+      "tc": 2020,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q3759654",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q113956221",
+      "b_qid": "Q130363715",
+      "tc": 2024,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q38076",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18921689",
+      "b_qid": "Q73426541",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q381100",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q21395999",
+      "b_qid": "Q130615370",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q385426",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7176651",
+      "b_qid": "Q4786619",
+      "tc": 2016,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q3884",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q312556",
+      "b_qid": "Q41812531",
+      "tc": 2021,
+      "start_a": 1996
+    },
+    {
+      "anchor_qid": "Q38903",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3638496",
+      "b_qid": "Q3265178",
+      "tc": 2011,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q393762",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125452216",
+      "b_qid": "Q125453309",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q406643",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q57205005",
+      "b_qid": "Q1524647",
+      "tc": 2017,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q407448",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3622",
+      "b_qid": "Q33110014",
+      "tc": 2022,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q40993",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1910173",
+      "b_qid": "Q21032599",
+      "tc": 2015,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q42825991",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q64140997",
+      "b_qid": "Q64141008",
+      "tc": 2011,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q43028378",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30103078",
+      "b_qid": "Q43026406",
+      "tc": 2010,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q43449",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q443409",
+      "b_qid": "Q125459259",
+      "tc": 2024,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q4402290",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4794630",
+      "b_qid": "Q7310197",
+      "tc": 1960,
+      "start_a": 1933
+    },
+    {
+      "anchor_qid": "Q4426788",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q83373455",
+      "b_qid": "Q117031761",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q44294",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30030987",
+      "b_qid": "Q18921712",
+      "tc": 2020,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q44504",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3391698",
+      "b_qid": "Q20532802",
+      "tc": 2022,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q4546965",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18351457",
+      "b_qid": "Q137910592",
+      "tc": 2025,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q4548",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7698068",
+      "b_qid": "Q60056285",
+      "tc": 2016,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q456402",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q131008028",
+      "b_qid": "Q60439097",
+      "tc": 2016,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q457912",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104805086",
+      "b_qid": "Q116491844",
+      "tc": 2023,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q4581905",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104432215",
+      "b_qid": "Q104432331",
+      "tc": 1999,
+      "start_a": 1984
+    },
+    {
+      "anchor_qid": "Q458944",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q265126",
+      "b_qid": "Q61285099",
+      "tc": 2018,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q459965",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q27735066",
+      "b_qid": "Q137168946",
+      "tc": 2025,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q460307",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115793241",
+      "b_qid": "Q125717994",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q460487",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2958994",
+      "b_qid": "Q3591380",
+      "tc": 2013,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q4648219",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125306837",
+      "b_qid": "Q125304907",
+      "tc": 2018,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q467752",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1872576",
+      "b_qid": "Q1582880",
+      "tc": 2018,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q471958",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q20685561",
+      "b_qid": "Q105647796",
+      "tc": 2020,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q4732492",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125600469",
+      "b_qid": "Q125599966",
+      "tc": 2024,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q47498532",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q47506167",
+      "b_qid": "Q114885864",
+      "tc": 2020,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q4750238",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7422719",
+      "b_qid": "Q17276640",
+      "tc": 1940,
+      "start_a": 1903
+    },
+    {
+      "anchor_qid": "Q478214",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q8068146",
+      "b_qid": "Q317521",
+      "tc": 2008,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q483915",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q267074",
+      "b_qid": "Q130612644",
+      "tc": 2024,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q48451697",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q10857539",
+      "b_qid": "Q21558230",
+      "tc": 2013,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q485593",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q96398626",
+      "b_qid": "Q113136626",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q48815838",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q99573092",
+      "b_qid": "Q104157182",
+      "tc": 2024,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q489080",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18748951",
+      "b_qid": "Q118499866",
+      "tc": 2023,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q4891601",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q58131487",
+      "b_qid": "Q114056718",
+      "tc": 2023,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q49053",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3168302",
+      "b_qid": "Q107420160",
+      "tc": 2023,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q4944779",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106547394",
+      "b_qid": "Q104700881",
+      "tc": 2001,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q495943",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105366826",
+      "b_qid": "Q26207337",
+      "tc": 2015,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q496302",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q116969393",
+      "b_qid": "Q114359175",
+      "tc": 2019,
+      "start_a": 1928
+    },
+    {
+      "anchor_qid": "Q496531",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q25266073",
+      "b_qid": "Q112239422",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q498366",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17685777",
+      "b_qid": "Q112150088",
+      "tc": 2022,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q498930",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q112150058",
+      "b_qid": "Q112150060",
+      "tc": 2022,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q499071",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55532557",
+      "b_qid": "Q124480013",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q5010371",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q84077596",
+      "b_qid": "Q113556373",
+      "tc": 2021,
+      "start_a": 1996
+    },
+    {
+      "anchor_qid": "Q502125",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30924986",
+      "b_qid": "Q79815733",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q502509",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q56877111",
+      "b_qid": "Q81941591",
+      "tc": 2019,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q503038",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7613398",
+      "b_qid": "Q117708223",
+      "tc": 2023,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q503308",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5524807",
+      "b_qid": "Q107451467",
+      "tc": 2022,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q5039561",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q32855967",
+      "b_qid": "Q6384205",
+      "tc": 2017,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q5059102",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q96775410",
+      "b_qid": "Q109775839",
+      "tc": 2022,
+      "start_a": 1996
+    },
+    {
+      "anchor_qid": "Q507154",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6284393",
+      "b_qid": "Q38589106",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q5072394",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5230577",
+      "b_qid": "Q30134813",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q511031",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q62114985",
+      "b_qid": "Q124844057",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q513679",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55534582",
+      "b_qid": "Q125936166",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q5137486",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3044921",
+      "b_qid": "Q5335133",
+      "tc": 2009,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q51403327",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q116858313",
+      "b_qid": "Q120054921",
+      "tc": 2025,
+      "start_a": 2023
+    },
+    {
+      "anchor_qid": "Q51844714",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q134882064",
+      "b_qid": "Q65503055",
+      "tc": 2014,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q5265091",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q139927511",
+      "b_qid": "Q124376118",
+      "tc": 2026,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q52825",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24018216",
+      "b_qid": "Q124641201",
+      "tc": 2024,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q5324680",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q71856160",
+      "b_qid": "Q67512334",
+      "tc": 2026,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q53268",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q418622",
+      "b_qid": "Q116935918",
+      "tc": 2023,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q53678314",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q140454952",
+      "b_qid": "Q140454733",
+      "tc": 2021,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q5374450",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q10819807",
+      "b_qid": "Q33608129",
+      "tc": 2014,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q5375992",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3510372",
+      "b_qid": "Q42211326",
+      "tc": 2024,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q54075",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5726490",
+      "b_qid": "Q16633220",
+      "tc": 2011,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q5413836",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105811180",
+      "b_qid": "Q114245560",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q541477",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q84587",
+      "b_qid": "Q86582",
+      "tc": 1995,
+      "start_a": 1987
+    },
+    {
+      "anchor_qid": "Q54173",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q30242909",
+      "b_qid": "Q56868014",
+      "tc": 2018,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q54263821",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q98529313",
+      "b_qid": "Q92747",
+      "tc": 2025,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q544847",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18634617",
+      "b_qid": "Q110471964",
+      "tc": 2021,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q54645751",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16139697",
+      "b_qid": "Q16307519",
+      "tc": 2018,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q54718",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16991444",
+      "b_qid": "Q16502557",
+      "tc": 2025,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q55103384",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q47776371",
+      "b_qid": "Q96990627",
+      "tc": 2019,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q552742",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1163590",
+      "b_qid": "Q1594600",
+      "tc": 2025,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q55776398",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q113552954",
+      "b_qid": "Q123938479",
+      "tc": 2023,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q56400574",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4355145",
+      "b_qid": "Q5941175",
+      "tc": 1909,
+      "start_a": 1908
+    },
+    {
+      "anchor_qid": "Q56452688",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q25894536",
+      "b_qid": "Q56452730",
+      "tc": 2011,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q566857",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19482177",
+      "b_qid": "Q133502056",
+      "tc": 2025,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q568183",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q14511674",
+      "b_qid": "Q30731145",
+      "tc": 2018,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q573103",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1460107",
+      "b_qid": "Q2262672",
+      "tc": 2022,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q5761148",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18644198",
+      "b_qid": "Q134688394",
+      "tc": 1983,
+      "start_a": 1981
+    },
+    {
+      "anchor_qid": "Q57767177",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q20855863",
+      "b_qid": "Q50807495",
+      "tc": 2018,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q58035402",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3161134",
+      "b_qid": "Q360106",
+      "tc": 1930,
+      "start_a": 1922
+    },
+    {
+      "anchor_qid": "Q58230523",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59156542",
+      "b_qid": "Q7816106",
+      "tc": 2023,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q58707",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q109492715",
+      "b_qid": "Q4448394",
+      "tc": 2022,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q59152221",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q67425000",
+      "b_qid": "Q67424585",
+      "tc": 1972,
+      "start_a": 1968
+    },
+    {
+      "anchor_qid": "Q593786",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q35243613",
+      "b_qid": "Q28914897",
+      "tc": 2024,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q59580617",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59581320",
+      "b_qid": "Q59561509",
+      "tc": 2008,
+      "start_a": 2003
+    },
+    {
+      "anchor_qid": "Q602621",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q11975353",
+      "b_qid": "Q135399330",
+      "tc": 2024,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q6047302",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q90311725",
+      "b_qid": "Q90310670",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q604924",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5195702",
+      "b_qid": "Q8013529",
+      "tc": 2014,
+      "start_a": 1998
+    },
+    {
+      "anchor_qid": "Q605401",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55439664",
+      "b_qid": "Q106647408",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q608917",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59636732",
+      "b_qid": "Q124547634",
+      "tc": 2020,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q61412379",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3563923",
+      "b_qid": "Q12023680",
+      "tc": 2013,
+      "start_a": 1991
+    },
+    {
+      "anchor_qid": "Q61854495",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16782619",
+      "b_qid": "Q22809327",
+      "tc": 2019,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q619121",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5578461",
+      "b_qid": "Q16194777",
+      "tc": 2021,
+      "start_a": 1990
+    },
+    {
+      "anchor_qid": "Q61931385",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q124484928",
+      "b_qid": "Q28752461",
+      "tc": 2022,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q61957954",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q96474476",
+      "b_qid": "Q55118101",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q621231",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q380912",
+      "b_qid": "Q6174185",
+      "tc": 2007,
+      "start_a": 1970
+    },
+    {
+      "anchor_qid": "Q62123272",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q77327597",
+      "b_qid": "Q77328063",
+      "tc": 1921,
+      "start_a": 1915
+    },
+    {
+      "anchor_qid": "Q624375",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1806074",
+      "b_qid": "Q130783979",
+      "tc": 2024,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q625713",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15042554",
+      "b_qid": "Q81071198",
+      "tc": 2020,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q627039",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6775103",
+      "b_qid": "Q123196874",
+      "tc": 2017,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q632240",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6224507",
+      "b_qid": "Q118706826",
+      "tc": 2017,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q638098",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q100166272",
+      "b_qid": "Q105081948",
+      "tc": 2021,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q642189",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q83780224",
+      "b_qid": "Q108259354",
+      "tc": 2020,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q6449839",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6419336",
+      "b_qid": "Q2489897",
+      "tc": 2018,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q650467",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q81516586",
+      "b_qid": "Q16657998",
+      "tc": 2008,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q652431",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6766732",
+      "b_qid": "Q123434602",
+      "tc": 2023,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q654073",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2254475",
+      "b_qid": "Q7176581",
+      "tc": 2019,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q66",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16727786",
+      "b_qid": "Q109767256",
+      "tc": 2024,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q660770",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q699696",
+      "b_qid": "Q4082480",
+      "tc": 2015,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q668737",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5232041",
+      "b_qid": "Q22277439",
+      "tc": 2015,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q669141",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28914209",
+      "b_qid": "Q112190840",
+      "tc": 2021,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q671510",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19667942",
+      "b_qid": "Q67173589",
+      "tc": 2019,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q677488",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q18153753",
+      "b_qid": "Q5517112",
+      "tc": 2017,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q679322",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6399442",
+      "b_qid": "Q19938961",
+      "tc": 2015,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q6823260",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q21030045",
+      "b_qid": "Q21030040",
+      "tc": 2015,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q682435",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1735158",
+      "b_qid": "Q98852224",
+      "tc": 2019,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q687934",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q98352414",
+      "b_qid": "Q98312534",
+      "tc": 2020,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q691563",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q111059160",
+      "b_qid": "Q111057942",
+      "tc": 2018,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q69357927",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q59752793",
+      "b_qid": "Q20755424",
+      "tc": 2011,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q694107",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q123692",
+      "b_qid": "Q117407",
+      "tc": 2003,
+      "start_a": 1986
+    },
+    {
+      "anchor_qid": "Q696376",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115394460",
+      "b_qid": "Q123352677",
+      "tc": 2022,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q7000460",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95744193",
+      "b_qid": "Q95744445",
+      "tc": 2017,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q7011152",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6535959",
+      "b_qid": "Q134703526",
+      "tc": 2021,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q7048063",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q138529939",
+      "b_qid": "Q138527724",
+      "tc": 2021,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q7050523",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12006930",
+      "b_qid": "Q17108577",
+      "tc": 2012,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q705417",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17579992",
+      "b_qid": "Q110897639",
+      "tc": 2025,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q7096543",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q138834463",
+      "b_qid": "Q138855712",
+      "tc": 2026,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q715583",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1650162",
+      "b_qid": "Q114361370",
+      "tc": 2023,
+      "start_a": 2012
+    },
+    {
+      "anchor_qid": "Q7178409",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q17032001",
+      "b_qid": "Q11904759",
+      "tc": 1970,
+      "start_a": 1968
+    },
+    {
+      "anchor_qid": "Q721162",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5240333",
+      "b_qid": "Q19867600",
+      "tc": 2015,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q7243481",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22137354",
+      "b_qid": "Q20978753",
+      "tc": 2015,
+      "start_a": 1999
+    },
+    {
+      "anchor_qid": "Q72539",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q16731607",
+      "b_qid": "Q55819254",
+      "tc": 2017,
+      "start_a": 2013
+    },
+    {
+      "anchor_qid": "Q726572",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3934610",
+      "b_qid": "Q130324748",
+      "tc": 2022,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q726813",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q130199471",
+      "b_qid": "Q130018277",
+      "tc": 2020,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q73251",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q111082720",
+      "b_qid": "Q129154131",
+      "tc": 2024,
+      "start_a": 2009
+    },
+    {
+      "anchor_qid": "Q732670",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q104786710",
+      "b_qid": "Q126200528",
+      "tc": 2022,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q732697",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95180163",
+      "b_qid": "Q12022442",
+      "tc": 2013,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q7333751",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q80970843",
+      "b_qid": "Q80973035",
+      "tc": 2013,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q737477",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q115791856",
+      "b_qid": "Q25391216",
+      "tc": 2016,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q739084",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q58425865",
+      "b_qid": "Q117249105",
+      "tc": 2025,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q7414",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q86408516",
+      "b_qid": "Q69598904",
+      "tc": 2026,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q7552943",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q121831",
+      "b_qid": "Q123692",
+      "tc": 1991,
+      "start_a": 1984
+    },
+    {
+      "anchor_qid": "Q757164",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28792551",
+      "b_qid": "Q126013265",
+      "tc": 2024,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q7588412",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q82355609",
+      "b_qid": "Q82353741",
+      "tc": 2018,
+      "start_a": 1991
+    },
+    {
+      "anchor_qid": "Q759210",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q20670264",
+      "b_qid": "Q87407534",
+      "tc": 2020,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q764850",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q52004072",
+      "b_qid": "Q131295887",
+      "tc": 2024,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q780442",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7836291",
+      "b_qid": "Q5221979",
+      "tc": 2017,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q7847309",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q6829608",
+      "b_qid": "Q7437001",
+      "tc": 2026,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q7849186",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q106612786",
+      "b_qid": "Q106612852",
+      "tc": 2012,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q78899588",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q78902098",
+      "b_qid": "Q122798086",
+      "tc": 2023,
+      "start_a": 1994
+    },
+    {
+      "anchor_qid": "Q7894055",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q63341599",
+      "b_qid": "Q105744027",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q791285",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q271117",
+      "b_qid": "Q7494850",
+      "tc": 2012,
+      "start_a": 1998
+    },
+    {
+      "anchor_qid": "Q795474",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3155690",
+      "b_qid": "Q135190951",
+      "tc": 2022,
+      "start_a": 1998
+    },
+    {
+      "anchor_qid": "Q79799258",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q79800215",
+      "b_qid": "Q12017258",
+      "tc": 2019,
+      "start_a": 1994
+    },
+    {
+      "anchor_qid": "Q7999846",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7192785",
+      "b_qid": "Q11778744",
+      "tc": 2010,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q8024771",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q31202205",
+      "b_qid": "Q135686402",
+      "tc": 2023,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q8074134",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q96117777",
+      "b_qid": "Q96695268",
+      "tc": 2019,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q80788",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4582045",
+      "b_qid": "Q64587234",
+      "tc": 2019,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q8085893",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5221979",
+      "b_qid": "Q115614624",
+      "tc": 2024,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q8093",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7688294",
+      "b_qid": "Q52177144",
+      "tc": 2018,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q81230",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q113969",
+      "b_qid": "Q66438345",
+      "tc": 2021,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q814989",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q580199",
+      "b_qid": "Q61957983",
+      "tc": 2019,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q818846",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q12323903",
+      "b_qid": "Q28858458",
+      "tc": 2017,
+      "start_a": 2000
+    },
+    {
+      "anchor_qid": "Q81965",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q321441",
+      "b_qid": "Q6779013",
+      "tc": 2014,
+      "start_a": 1981
+    },
+    {
+      "anchor_qid": "Q821293",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q23416859",
+      "b_qid": "Q104249075",
+      "tc": 2021,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q823010",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q61719629",
+      "b_qid": "Q61718864",
+      "tc": 2016,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q83825",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q95692568",
+      "b_qid": "Q11972678",
+      "tc": 2020,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q838716",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q80482296",
+      "b_qid": "Q18331193",
+      "tc": 2007,
+      "start_a": 1993
+    },
+    {
+      "anchor_qid": "Q84322853",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q55882406",
+      "b_qid": "Q86060435",
+      "tc": 1877,
+      "start_a": 1833
+    },
+    {
+      "anchor_qid": "Q845632",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7513372",
+      "b_qid": "Q17058205",
+      "tc": 2024,
+      "start_a": 2015
+    },
+    {
+      "anchor_qid": "Q848336",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q26836942",
+      "b_qid": "Q24956110",
+      "tc": 2025,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q85727717",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q98960171",
+      "b_qid": "Q98960160",
+      "tc": 2017,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q864338",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q86077712",
+      "b_qid": "Q86071968",
+      "tc": 2017,
+      "start_a": 2010
+    },
+    {
+      "anchor_qid": "Q864407",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q28920824",
+      "b_qid": "Q113632708",
+      "tc": 2022,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q864923",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5115191",
+      "b_qid": "Q115592380",
+      "tc": 2021,
+      "start_a": 2007
+    },
+    {
+      "anchor_qid": "Q86495804",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q81804240",
+      "b_qid": "Q98800712",
+      "tc": 1968,
+      "start_a": 1928
+    },
+    {
+      "anchor_qid": "Q8766",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q22003790",
+      "b_qid": "Q104862847",
+      "tc": 2020,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q877189",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1442448",
+      "b_qid": "Q2337302",
+      "tc": 2003,
+      "start_a": 1978
+    },
+    {
+      "anchor_qid": "Q8774",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q3569110",
+      "b_qid": "Q15147789",
+      "tc": 2020,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q8793",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q31210808",
+      "b_qid": "Q112797162",
+      "tc": 2019,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q88959995",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q15905744",
+      "b_qid": "Q63967288",
+      "tc": 1997,
+      "start_a": 1995
+    },
+    {
+      "anchor_qid": "Q890353",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125107077",
+      "b_qid": "Q5955602",
+      "tc": 1988,
+      "start_a": 1987
+    },
+    {
+      "anchor_qid": "Q892206",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q19874731",
+      "b_qid": "Q81703597",
+      "tc": 2018,
+      "start_a": 2014
+    },
+    {
+      "anchor_qid": "Q898208",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q25141716",
+      "b_qid": "Q115735611",
+      "tc": 2023,
+      "start_a": 2017
+    },
+    {
+      "anchor_qid": "Q899010",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q86068569",
+      "b_qid": "Q5693758",
+      "tc": 2012,
+      "start_a": 2002
+    },
+    {
+      "anchor_qid": "Q905049",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q4764240",
+      "b_qid": "Q16733839",
+      "tc": 2013,
+      "start_a": 2008
+    },
+    {
+      "anchor_qid": "Q916196",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24049135",
+      "b_qid": "Q105394598",
+      "tc": 2017,
+      "start_a": 2016
+    },
+    {
+      "anchor_qid": "Q919646",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q7609478",
+      "b_qid": "Q5106728",
+      "tc": 2009,
+      "start_a": 2004
+    },
+    {
+      "anchor_qid": "Q931207",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1371822",
+      "b_qid": "Q3264974",
+      "tc": 2025,
+      "start_a": 2005
+    },
+    {
+      "anchor_qid": "Q9325",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q92434",
+      "b_qid": "Q1045681",
+      "tc": 2014,
+      "start_a": 2011
+    },
+    {
+      "anchor_qid": "Q933787",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q33226824",
+      "b_qid": "Q95461139",
+      "tc": 2023,
+      "start_a": 2022
+    },
+    {
+      "anchor_qid": "Q936325",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q110551227",
+      "b_qid": "Q135906224",
+      "tc": 2023,
+      "start_a": 2020
+    },
+    {
+      "anchor_qid": "Q9396",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q1572591",
+      "b_qid": "Q1386366",
+      "tc": 2014,
+      "start_a": 2006
+    },
+    {
+      "anchor_qid": "Q944760",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q109586134",
+      "b_qid": "Q111872104",
+      "tc": 2022,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q949610",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q108858638",
+      "b_qid": "Q97496345",
+      "tc": 1995,
+      "start_a": 1992
+    },
+    {
+      "anchor_qid": "Q95",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q92747",
+      "b_qid": "Q3503829",
+      "tc": 2015,
+      "start_a": 2001
+    },
+    {
+      "anchor_qid": "Q970452",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q105359010",
+      "b_qid": "Q105359033",
+      "tc": 2020,
+      "start_a": 2019
+    },
+    {
+      "anchor_qid": "Q97052945",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q125973376",
+      "b_qid": "Q126003124",
+      "tc": 1966,
+      "start_a": 1943
+    },
+    {
+      "anchor_qid": "Q971649",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q24429855",
+      "b_qid": "Q125424016",
+      "tc": 2024,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q97197296",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q138660381",
+      "b_qid": "Q138660356",
+      "tc": 2025,
+      "start_a": 2018
+    },
+    {
+      "anchor_qid": "Q97439162",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q2939466",
+      "b_qid": "Q134594834",
+      "tc": 2025,
+      "start_a": 2021
+    },
+    {
+      "anchor_qid": "Q98081129",
+      "relation": "chief_executive_officer",
+      "a_qid": "Q5373565",
+      "b_qid": "Q5217607",
+      "tc": 2023,
+      "start_a": 2011
+    }
+  ]
+}

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/realworld_temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/erkgbench/qa_e2e/realworld_temporal.py
@@ -1,0 +1,113 @@
+"""Real-world (Wikidata) TEMPORAL as-of capability: a committed CEO-history fixture turned
+into the SAME `TemporalFact` / `TemporalQuestion` types the synthetic temporal bench uses,
+so ALL store build / as-of traversal / temporal-blind floor / scoring in `temporal.py` are
+reused unchanged. Only the DATA changes: real companies whose CEO was later corrected
+(P169 with P580/P582 date qualifiers) instead of the synthetic bi-temporal corpus.
+
+The capability: `store.as_of(D)` answers 'who was CEO as of a PAST year' correctly after a
+succession; a temporal-blind RAG returns the most-recent/last-mentioned CEO -> wrong on past
+queries. Entity resolution is held ORACLE here (surfaces == canonical names), exactly like
+the synthetic temporal bench -- this slice isolates the TEMPORAL capability, orthogonal to
+the ER capability the aggregation slices measure.
+
+The bench NEVER hits live Wikidata -- it reads the committed fixture. Only
+`scripts/pull_wikidata_temporal_fixture.py` touches the network (run by hand).
+"""
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_temporal_entities(fixture_path) -> dict:
+    """qid -> canonical name over the temporal fixture."""
+    data = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
+    return {e["qid"]: e["canonical"] for e in data["entities"]}
+
+
+def generate_realworld_temporal(fixture_path, *, seed: int = 7):
+    """Real-data drop-in for `temporal.generate_temporal`: per succession fact, two dated
+    passages ('As of {start_a}, {company} chief executive officer {ceo_a}.' / 'From {tc},
+    ... {ceo_b}.') + a PAST question (date before the succession -> gold = the earlier CEO)
+    and a CURRENT question (recent date -> gold = the later CEO). Surfaces are canonical
+    names (ER held oracle). Returns (docs, facts, qs) with the same types
+    `temporal.build_temporal_store` / scoring consume."""
+    from .corpora import Document
+    from .temporal import T1, TemporalFact, TemporalQuestion
+
+    data = json.loads(Path(fixture_path).read_text(encoding="utf-8"))
+    canon = {e["qid"]: e["canonical"] for e in data["entities"]}
+    current_year = int(data.get("meta", {}).get("current_year", 2026))
+    _rng = random.Random(seed)  # reserved; keeps signature stable
+    docs, facts, qs = [], [], []
+    for i, tf in enumerate(data["temporal_facts"]):
+        src, rel = tf["anchor_qid"], tf["relation"]
+        a, b, tc = tf["a_qid"], tf["b_qid"], int(tf["tc"])
+        if src not in canon or a not in canon or b not in canon:
+            continue
+        start_a = int(tf.get("start_a", T1))
+        rel_words = rel.replace("_", " ")
+        facts.append(TemporalFact(src, rel, a, b, tc))
+        # Two dated passages a real RAG reads; nothing enforces a slice.
+        docs.append(Document(
+            id=f"{src}::{rel}::{a}::t{start_a}",
+            text=f"As of {start_a}, {canon[src]} {rel_words} {canon[a]}.",
+            src_surface=canon[src], dst_surface=canon[a]))
+        docs.append(Document(
+            id=f"{src}::{rel}::{b}::t{tc}",
+            text=f"From {tc}, {canon[src]} {rel_words} {canon[b]}.",
+            src_surface=canon[src], dst_surface=canon[b]))
+        # build_temporal_store makes the a-edge valid [T1, tc) and the b-edge [tc, inf);
+        # a PAST date strictly before the succession -> a, a CURRENT date >= tc -> b.
+        d_past = tc - 1
+        d_cur = max(tc, current_year)
+        for tag, D, regime, gold in (("p", d_past, "past", a), ("c", d_cur, "current", b)):
+            qs.append(TemporalQuestion(
+                id=f"rwtmp-{i}-{tag}",
+                question=f"As of {D}, who is the {rel_words} of {canon[src]}?",
+                anchor_id=src, relation=rel, D=D, regime=regime, gold_obj=gold))
+    return tuple(docs), facts, qs
+
+
+def run_realworld_temporal(fixture_path, *, seed: int = 7, llm=None):
+    """Mirror of `temporal.run_temporal_deterministic` over the real fixture. Reuses the
+    bi-temporal store build, the as-of traversal, and the temporal-blind floor verbatim;
+    only the surfaces come from the real entities (canonical == oracle id) instead of the
+    synthetic `dials`. Needs the native wheel (via build_temporal_store). Returns a
+    `temporal.TemporalResult` (gg_acc / floor_acc by regime)."""
+    from .temporal import (
+        TemporalResult,
+        _mean_by_regime,
+        as_of_accuracy,
+        build_temporal_store,
+        goldengraph_asof,
+        llm_temporal_rag,
+        temporal_blind_floor,
+    )
+
+    docs, facts, qs = generate_realworld_temporal(fixture_path, seed=seed)
+    store = build_temporal_store(facts)
+    canon = load_temporal_entities(fixture_path)
+    s2c = {name: qid for qid, name in canon.items()}          # oracle: surface -> qid
+    anchor_surf = {qid: {name} for qid, name in canon.items()}
+
+    gg, floor, llm_acc = [], [], []
+    for q in qs:
+        a_surfs = anchor_surf.get(q.anchor_id, set())
+        gg.append((q.regime, as_of_accuracy(
+            goldengraph_asof(store, q.anchor_id, q.relation, q.D), q.gold_obj)))
+        floor.append((q.regime, as_of_accuracy(
+            temporal_blind_floor(docs, a_surfs, q.relation, q.D, surface_to_canon=s2c),
+            q.gold_obj)))
+        if llm is not None and not getattr(llm, "exhausted", False):
+            llm_acc.append((q.regime, as_of_accuracy(
+                llm_temporal_rag(docs, a_surfs, q.relation, q.D, llm, surface_to_canon=s2c),
+                q.gold_obj)))
+    return TemporalResult(
+        gg_acc=_mean_by_regime(gg),
+        floor_acc=_mean_by_regime(floor),
+        llm_acc=_mean_by_regime(llm_acc) if llm_acc else None,
+    )

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/pull_wikidata_temporal_fixture.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/pull_wikidata_temporal_fixture.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""One-off Wikidata SPARQL puller that WRITES the committed CEO-history temporal fixture
+(`erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_v1.json`) for the Phase 1 temporal as-of
+capability slice.
+
+Run BY HAND, never in CI and never imported by the bench. The bench reads only the committed
+JSON. Pulls companies (P31/P279* Q4830453) with >=2 dated CEO statements (P169 + P580 start),
+and for each keeps the LAST TWO consecutive CEOs as a binary succession: a_qid (earlier,
+valid before the succession) -> b_qid (later, from tc = b's start year). start_a = a's start
+year. Deterministic (sorted by qid) so the committed fixture is stable.
+
+Usage:
+    python scripts/pull_wikidata_temporal_fixture.py \
+        --out erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_v1.json --limit 40000
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+import time
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+WDQS_ENDPOINT = "https://query.wikidata.org/sparql"
+USER_AGENT = (
+    "goldenmatch-er-kg-bench/1.0 (https://github.com/benseverndev-oss/goldenmatch; "
+    "ben@goldentruth.io) temporal-capability-fixture-puller"
+)
+
+CEO_QUERY = """SELECT ?company ?companyLabel ?ceo ?ceoLabel ?start WHERE {
+  ?company wdt:P31/wdt:P279* wd:Q4830453 .
+  ?company p:P169 ?st . ?st ps:P169 ?ceo .
+  ?st pq:P580 ?start .
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "en" }
+}
+LIMIT %d"""
+
+
+def _run_sparql(query: str, *, retries: int = 4, timeout: int = 60) -> dict:
+    data = urllib.parse.urlencode({"query": query, "format": "json"}).encode("utf-8")
+    req = urllib.request.Request(
+        WDQS_ENDPOINT, data=data,
+        headers={"User-Agent": USER_AGENT, "Accept": "application/sparql-results+json"},
+    )
+    last: Exception | None = None
+    for attempt in range(retries):
+        try:
+            with urllib.request.urlopen(req, timeout=timeout) as resp:
+                return json.loads(resp.read().decode("utf-8"))
+        except Exception as exc:  # noqa: BLE001 - network puller, retry on anything
+            last = exc
+            wait = 2 ** attempt
+            sys.stderr.write(f"WDQS attempt {attempt + 1} failed ({exc}); retry in {wait}s\n")
+            time.sleep(wait)
+    raise RuntimeError(f"WDQS query failed after {retries} attempts: {last}")
+
+
+def _qid(uri: str) -> str:
+    return uri.rsplit("/", 1)[-1]
+
+
+def _year(iso: str) -> int | None:
+    # Wikidata dates are ISO like "2015-10-02T00:00:00Z" (or "+2015-...").
+    s = iso.lstrip("+")
+    try:
+        return int(s[:4])
+    except ValueError:
+        return None
+
+
+def build_fixture(*, limit: int) -> dict:
+    rows = _run_sparql(CEO_QUERY % limit)["results"]["bindings"]
+    # company qid -> {label, ceos: {ceo_qid: (label, start_year)}}
+    companies: dict[str, dict] = {}
+    for r in rows:
+        cq = _qid(r["company"]["value"])
+        ceoq = _qid(r["ceo"]["value"])
+        y = _year(r["start"]["value"])
+        if y is None or cq == ceoq:
+            continue
+        c = companies.setdefault(cq, {"label": "", "ceos": {}})
+        lbl = r.get("companyLabel", {}).get("value", "")
+        if lbl and lbl != cq:
+            c["label"] = lbl
+        ceo_lbl = r.get("ceoLabel", {}).get("value", "")
+        # keep the EARLIEST start seen per ceo (a ceo can have multiple P580 across roles)
+        prev = c["ceos"].get(ceoq)
+        if prev is None or y < prev[1]:
+            c["ceos"][ceoq] = (ceo_lbl if ceo_lbl and ceo_lbl != ceoq else ceoq, y)
+
+    entities: dict[str, str] = {}
+    facts: list[dict] = []
+    for cq in sorted(companies):
+        c = companies[cq]
+        if not c["label"]:
+            continue
+        # distinct CEOs by start year, ascending; need >=2 with DIFFERENT start years.
+        ceos = sorted(c["ceos"].items(), key=lambda kv: (kv[1][1], kv[0]))
+        if len(ceos) < 2:
+            continue
+        (a_qid, (a_lbl, a_year)), (b_qid, (b_lbl, b_year)) = ceos[-2], ceos[-1]
+        if b_year <= a_year:  # need a real succession (distinct years) to test as-of
+            continue
+        entities[cq] = c["label"]
+        entities[a_qid] = a_lbl
+        entities[b_qid] = b_lbl
+        facts.append({"anchor_qid": cq, "relation": "chief_executive_officer",
+                      "a_qid": a_qid, "b_qid": b_qid, "tc": b_year, "start_a": a_year})
+
+    sparql_sha = hashlib.sha256(CEO_QUERY.encode("utf-8")).hexdigest()[:16]
+    return {
+        "meta": {"source": "wikidata", "pulled": time.strftime("%Y-%m-%d"),
+                 "sparql_sha": sparql_sha, "domain": "ceo_temporal",
+                 "current_year": int(time.strftime("%Y"))},
+        "entities": [{"qid": q, "canonical": entities[q]} for q in sorted(entities)],
+        "temporal_facts": facts,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out", required=True)
+    p.add_argument("--limit", type=int, default=40000)
+    args = p.parse_args(argv)
+    fx = build_fixture(limit=args.limit)
+    Path(args.out).write_text(json.dumps(fx, indent=2), encoding="utf-8")
+    n_facts = len(fx["temporal_facts"])
+    n_ents = len(fx["entities"])
+    sys.stderr.write(f"wrote {args.out}: {n_facts} succession facts, {n_ents} entities "
+                     f"(current_year={fx['meta']['current_year']})\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/run_realworld_temporal_e2e.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/scripts/run_realworld_temporal_e2e.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Phase 1 temporal end-to-end: 'who was CEO as of a past year?' on the committed Wikidata
+CEO-history fixture. goldengraph store.as_of respects valid-time (right in BOTH regimes);
+a temporal-blind RAG returns the most-recent CEO -> wrong on PAST queries. Writes
+RESULTS_REALWORLD_TEMPORAL.md (as-of accuracy by regime, goldengraph vs the temporal-blind
+floor). Needs the goldengraph-native wheel + goldenmatch. Key-free, offline.
+
+Usage:
+    python scripts/run_realworld_temporal_e2e.py \
+        --fixture erkgbench/qa_e2e/fixtures/wikidata_ceo_temporal_v1.json \
+        --out-md results/RESULTS_REALWORLD_TEMPORAL.md
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+_BENCH_ROOT = Path(__file__).resolve().parents[1]
+if str(_BENCH_ROOT) not in sys.path:
+    sys.path.insert(0, str(_BENCH_ROOT))
+
+from erkgbench.qa_e2e.realworld_temporal import _FIXTURE_DIR, run_realworld_temporal
+from erkgbench.qa_e2e.temporal import render_temporal_md
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--fixture", default=str(_FIXTURE_DIR / "wikidata_ceo_temporal_v1.json"))
+    p.add_argument("--out-md", default="results/RESULTS_REALWORLD_TEMPORAL.md")
+    args = p.parse_args(argv)
+
+    t0 = time.perf_counter()
+    res = run_realworld_temporal(Path(args.fixture))
+    wall = time.perf_counter() - t0
+
+    body = render_temporal_md(res)
+    header = (
+        "# Real-world temporal as-of -- goldengraph vs a temporal-blind RAG (Phase 1)\n\n"
+        f"'Who was the CEO of X as of year D?' on the committed Wikidata CEO-history fixture "
+        f"(`{Path(args.fixture).name}`, real successions with P580 start dates). PAST = a year "
+        f"before the succession (gold = the earlier CEO); CURRENT = a recent year. Wall: "
+        f"{wall:.1f}s.\n\n"
+        "goldengraph's `store.as_of(D)` respects valid-time and is right in BOTH regimes; the "
+        "temporal-blind floor returns the most-recent CEO -> correct on CURRENT, WRONG on PAST. "
+        "This is a capability a text-RAG structurally lacks (no valid-time axis).\n\n"
+    )
+    out = Path(args.out_md)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(header + body, encoding="utf-8")
+    print(header + body)
+    print(f"[wrote {out}]")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_temporal.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/tests/test_realworld_temporal.py
@@ -1,0 +1,76 @@
+"""Phase 1 (temporal as-of) real-world capability tests. Wheel-free tests cover the
+generator + the temporal-blind floor (the RAG that can't answer 'as of a past date');
+the wheel-gated test exercises the full store.as_of win."""
+from __future__ import annotations
+
+import pytest
+from erkgbench.qa_e2e.realworld_temporal import (
+    _FIXTURE_DIR,
+    generate_realworld_temporal,
+    load_temporal_entities,
+)
+
+_TINY = _FIXTURE_DIR / "wikidata_ceo_temporal_TINY.json"
+
+
+def test_generate_temporal_shapes_and_gold():
+    """Per succession fact: two dated passages + a PAST question (gold = earlier CEO) and a
+    CURRENT question (gold = later CEO)."""
+    docs, facts, qs = generate_realworld_temporal(_TINY, seed=7)
+    assert len(docs) == 2                      # one 'As of ...' + one 'From ...'
+    assert len(facts) == 1
+    past = next(q for q in qs if q.regime == "past")
+    cur = next(q for q in qs if q.regime == "current")
+    assert past.gold_obj == "Q2"               # Alice, the earlier CEO
+    assert cur.gold_obj == "Q3"                # Bob, after the 2019 succession
+    assert past.D < 2019 <= cur.D              # the correction year is tc=2019
+    # the two passages name the two CEOs
+    text = " ".join(d.text for d in docs)
+    assert "Alice Anderson" in text and "Bob Brown" in text
+
+
+def test_temporal_blind_floor_is_wrong_on_past_right_on_current():
+    """The capability gap, wheel-free: the temporal-blind floor returns the LAST-mentioned
+    CEO regardless of the query date -> correct on the current regime, WRONG on the past
+    regime (it hands back the corrected-away value)."""
+    from erkgbench.qa_e2e.temporal import temporal_blind_floor
+
+    docs, _facts, qs = generate_realworld_temporal(_TINY, seed=7)
+    canon = load_temporal_entities(_TINY)
+    s2c = {name: qid for qid, name in canon.items()}
+    anchor_surfs = {"Acme Corp"}
+    for q in qs:
+        got = temporal_blind_floor(docs, anchor_surfs, q.relation, q.D, surface_to_canon=s2c)
+        if q.regime == "current":
+            assert got == q.gold_obj == "Q3"   # last CEO -> right on current
+        else:
+            assert got == "Q3" and q.gold_obj == "Q2"  # last CEO -> WRONG on past
+
+
+def test_run_temporal_gg_beats_floor_on_past():
+    """Wheel-gated: goldengraph store.as_of respects valid-time (right in BOTH regimes)
+    while the temporal-blind floor collapses on the PAST regime."""
+    try:
+        import goldengraph_native  # noqa: F401
+    except ImportError:
+        pytest.skip("goldengraph-native wheel not installed")
+    from erkgbench.qa_e2e.realworld_temporal import run_realworld_temporal
+
+    res = run_realworld_temporal(_TINY)
+    assert res.gg_acc.get("past", 0.0) >= 0.99      # KG right on past (respects valid-time)
+    assert res.gg_acc.get("current", 0.0) >= 0.99   # and current
+    assert res.floor_acc.get("current", 0.0) >= 0.99  # floor OK on current (not broken)
+    # the capability: KG beats the temporal-blind floor on PAST queries
+    assert res.gg_acc.get("past", 0.0) - res.floor_acc.get("past", 0.0) >= 0.5
+
+
+def test_v1_fixture_loads_and_generates():
+    """The committed real v1 fixture flows through the generator: real successions ->
+    past+current questions with distinct gold, past date < the succession year."""
+    v1 = _FIXTURE_DIR / "wikidata_ceo_temporal_v1.json"
+    docs, facts, qs = generate_realworld_temporal(v1, seed=7)
+    assert len(facts) >= 50 and len(docs) == 2 * len(facts)
+    for q in qs:
+        if q.regime == "past":
+            assert q.gold_obj != next(
+                x.gold_obj for x in qs if x.regime == "current" and x.anchor_id == q.anchor_id)


### PR DESCRIPTION
Phase 1 of the real-world capability benchmark (plan #2074): the SECOND structural capability a RAG can't do -- **temporal as-of** -- on real data.

**Capability:** 'Who was CEO of X as of a PAST year?' `store.as_of(D)` returns the edge true at D (right in BOTH regimes); a temporal-blind RAG returns the most-recent CEO -> correct on CURRENT, **wrong on PAST**. A text-RAG structurally lacks a valid-time axis.

**What:** `realworld_temporal.py` reuses `temporal.py`'s bi-temporal store build / `goldengraph_asof` / `temporal_blind_floor` / scoring **verbatim** -- only the DATA changes: real company CEO successions (P169 + P580 start dates). The puller pulled **550 real successions** (e.g. Gazprom CEO 1992->2001). ER held ORACLE (canonical surfaces), isolating the temporal capability -- orthogonal to the aggregation slices' ER measurement.

**Validation:** 3 wheel-free tests pass locally (generator gold; the temporal-blind floor is WRONG on past / right on current; v1 fixture flows through). 1 wheel-gated test asserts the as-of win (`gg past >= 0.99`, `gg - floor past >= 0.5`). ruff clean, YAML valid. Committed v1 fixture + puller + E2E, wired into `goldengraph-pipeline.yml` beside the synthetic temporal gate; uploads `RESULTS_REALWORLD_TEMPORAL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)