### PR TITLE
feat(goldenmatch-ts): compare-clusters + incremental CLI commands

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.17.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.18.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.5.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.16.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 72 | 10 | 8 |
-| `goldenmatch` | cli_commands | 13 | 23 | 1 |
+| `goldenmatch` | cli_commands | 15 | 21 | 1 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -65,7 +65,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_domains`, `list_plugins`, `plan_routing`, `pprl_auto_config`, `test_domain`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
-- `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `compare-clusters`, `config`, `explain`, `incremental`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `config`, `explain`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
 - `goldenmatch` **cli_commands** — TS-only: `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.18.0] - 2026-07-23
+
+### Added
+- **`compare-clusters` + `incremental` CLI commands.** TS CLI front doors for two capabilities whose cores TS already had, matching the Python CLI commands (`cli_commands python_only -> shared`). No MCP tool-count change.
+  - `compare-clusters <file_a> <file_b> [-o out.json]` - CCMS comparison of two ER cluster JSON files (`parseClustersJson` + `compareClusters` + `ccmsSummary`); prints UC/MC/PC/OC + TWI, optional JSON output. Mirrors Python `cli/compare.py`.
+  - `incremental <base> -n <new-records> -c <config> [-t thr] [-o out.csv]` - match new records against a base dataset (`runIncremental`); prints processed/matched/new-entity/pair counts, optional CSV of the match pairs. Mirrors Python `cli/incremental.py`.
+  - Tests: `tests/unit/cli-compare-incremental.test.ts` (per the repo convention of testing the wrapped core logic). Both smoke-verified end-to-end against the built CLI.
+
+### Deferred (documented)
+- `sensitivity` / `lineage` / `analyze-blocking` / `unmerge` CLI commands stay `python_only`: they need sweep-spec plumbing or an in-memory dedupe-run context that the stateless CLI path doesn't carry - a bounded follow-up, not a silent drop.
+
 ## [1.17.0] - 2026-07-23
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -17,6 +17,13 @@ import {
 import { dedupe, match, scoreStrings } from "./core/api.js";
 import { evaluateClusters, loadGroundTruthPairs } from "./core/index.js";
 import { loadConfigFile } from "./node/config-file.js";
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  compareClusters,
+  ccmsSummary,
+  parseClustersJson,
+} from "./core/compare-clusters.js";
+import { runIncremental } from "./core/incremental.js";
 import { emitHealerSurface } from "./node/cli-healer.js";
 import type { Row } from "./core/types.js";
 import pkg from "../package.json" with { type: "json" };
@@ -303,6 +310,67 @@ program
       process.exit(1);
     }
   });
+
+// ---------- compare-clusters ----------
+program
+  .command("compare-clusters")
+  .description("Compare two ER clustering outcomes using the CCMS framework")
+  .argument("<file_a>", "first cluster JSON file (baseline / ER1)")
+  .argument("<file_b>", "second cluster JSON file (comparison / ER2)")
+  .option("-o, --output <path>", "save the CCMS summary to JSON")
+  .action((fileA: string, fileB: string, opts: { output?: string }) => {
+    const clustersA = parseClustersJson(JSON.parse(readFileSync(fileA, "utf-8")));
+    const clustersB = parseClustersJson(JSON.parse(readFileSync(fileB, "utf-8")));
+    const s = ccmsSummary(compareClusters(clustersA, clustersB));
+    const pct = (x: number): string => `${(x * 100).toFixed(1)}%`;
+    process.stdout.write(
+      `CCMS Cluster Comparison\n` +
+        `  Unchanged (UC):   ${s["unchanged"]} (${pct(s["unchanged_pct"]!)})\n` +
+        `  Merged (MC):      ${s["merged"]} (${pct(s["merged_pct"]!)})\n` +
+        `  Partitioned (PC): ${s["partitioned"]} (${pct(s["partitioned_pct"]!)})\n` +
+        `  Overlapping (OC): ${s["overlapping"]} (${pct(s["overlapping_pct"]!)})\n` +
+        `  Total References: ${s["rc"]}   ER1 clusters: ${s["cc1"]}   ER2 clusters: ${s["cc2"]}\n` +
+        `  TWI: ${s["twi"]!.toFixed(4)}\n`,
+    );
+    if (opts.output) {
+      writeFileSync(opts.output, JSON.stringify(s, null, 2) + "\n", "utf-8");
+      process.stdout.write(`Summary saved to ${opts.output}\n`);
+    }
+  });
+
+// ---------- incremental ----------
+program
+  .command("incremental")
+  .description("Match new records against an existing base dataset incrementally")
+  .argument("<base_file>", "base dataset file path")
+  .requiredOption("-n, --new-records <path>", "new records CSV to match")
+  .requiredOption("-c, --config <path>", "config YAML path")
+  .option("-t, --threshold <value>", "override threshold", parseFloat)
+  .option("-o, --output <path>", "output CSV path for the match pairs")
+  .action(
+    (
+      baseFile: string,
+      opts: { newRecords: string; config: string; threshold?: number; output?: string },
+    ) => {
+      const baseRows = readFile(baseFile);
+      const newRows = readFile(opts.newRecords);
+      const config = loadConfigFile(opts.config);
+      const r = runIncremental(baseRows, newRows, config, opts.threshold);
+      process.stdout.write(
+        `Incremental Match Results\n` +
+          `  New records processed: ${r.new_records}\n` +
+          `  Matched to base:       ${r.matched_to_base}\n` +
+          `  New entities:          ${r.new_entities}\n` +
+          `  Total match pairs:     ${r.total_pairs}\n`,
+      );
+      if (opts.output && r.matches.length > 0) {
+        writeCsv(opts.output, r.matches as unknown as Row[]);
+        process.stdout.write(`Match pairs saved to ${opts.output}\n`);
+      } else if (opts.output) {
+        process.stdout.write("No matches found - no output written\n");
+      }
+    },
+  );
 
 // ---------- profile ----------
 program

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.17.0",
+  version: "1.18.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1164,7 +1164,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.17.0",
+          version: "1.18.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1591,7 +1591,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.17.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.18.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/tests/unit/cli-compare-incremental.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-compare-incremental.test.ts
@@ -1,0 +1,63 @@
+/**
+ * cli-compare-incremental.test.ts -- TS CLI parity: the `compare-clusters` and
+ * `incremental` commands. Per repo convention (cli-memory/cli-evaluate) we test
+ * the core logic each subcommand wraps rather than driving the commander tree.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  compareClusters,
+  ccmsSummary,
+  parseClustersJson,
+} from "../../src/core/compare-clusters.js";
+import { runIncremental } from "../../src/core/incremental.js";
+import { makeMatchkeyConfig, makeMatchkeyField } from "../../src/core/types.js";
+import type { GoldenMatchConfig, Row } from "../../src/core/types.js";
+
+describe("compare-clusters command logic", () => {
+  it("parses two cluster JSONs and computes a CCMS summary", () => {
+    const a = parseClustersJson({ "0": [0, 1], "1": [2] });
+    const b = parseClustersJson({ "0": [0], "1": [1, 2] });
+    const s = ccmsSummary(compareClusters(a, b));
+    expect(s["rc"]).toBe(3); // total references
+    expect(s["cc1"]).toBe(2);
+    expect(s["cc2"]).toBe(2);
+    expect(typeof s["twi"]).toBe("number");
+    // every ER1 cluster is classified into exactly one bucket
+    expect(s["unchanged"]! + s["merged"]! + s["partitioned"]! + s["overlapping"]!).toBe(2);
+  });
+
+  it("parseClustersJson accepts the {clusters: ...} wrapper + bare-array members", () => {
+    const wrapped = parseClustersJson({ clusters: { "0": { members: [0, 1] } } });
+    const bare = parseClustersJson({ "0": [0, 1] });
+    // both input forms normalize to the same ClusterMembers shape
+    expect(wrapped.get(0)).toEqual(bare.get(0));
+  });
+});
+
+describe("incremental command logic", () => {
+  it("matches new records against the base and counts new entities", () => {
+    const base: Row[] = [
+      { email: "a@x.com", name: "Alice" },
+      { email: "b@x.com", name: "Bob" },
+    ];
+    const newRows: Row[] = [
+      { email: "a@x.com", name: "Alice" }, // matches base 0
+      { email: "c@x.com", name: "Carol" }, // new entity
+    ];
+    const config: GoldenMatchConfig = {
+      matchkeys: [
+        makeMatchkeyConfig({
+          name: "email_mk",
+          type: "weighted",
+          threshold: 0.5,
+          fields: [makeMatchkeyField({ field: "email", scorer: "exact", weight: 1.0 })],
+        }),
+      ],
+    };
+    const r = runIncremental(base, newRows, config);
+    expect(r.new_records).toBe(2);
+    expect(r.matched_to_base).toBe(1);
+    expect(r.new_entities).toBe(1);
+    expect(r.total_pairs).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -142,11 +142,13 @@ mcp_tools:
 cli_commands:
   shared:
   - agent-serve
+  - compare-clusters
   - dedupe
   - demo
   - evaluate
   - identity
   - import-splink
+  - incremental
   - info
   - match
   - mcp-serve
@@ -158,10 +160,8 @@ cli_commands:
   - analyze-blocking
   - anomalies
   - autoconfig
-  - compare-clusters
   - config
   - explain
-  - incremental
   - ingest-docs
   - init
   - interactive


### PR DESCRIPTION
## Summary
Gap 3 of 3 from the parity sweep. Wires TS CLI front doors for two capabilities whose cores TS already had, matching the existing Python CLI commands (`cli_commands python_only → shared`). No MCP tool-count change.

- **`compare-clusters <file_a> <file_b> [-o out.json]`** — CCMS comparison of two ER cluster JSON files (`parseClustersJson` + `compareClusters` + `ccmsSummary`); prints UC/MC/PC/OC + TWI. Mirrors `cli/compare.py`.
- **`incremental <base> -n <new> -c <config> [-t thr] [-o out.csv]`** — match new records against a base dataset (`runIncremental`); prints processed/matched/new-entity/pair counts. Mirrors `cli/incremental.py`.

## Deferred (documented)
- `sensitivity` / `lineage` / `analyze-blocking` / `unmerge` CLI commands stay python-only — they need sweep-spec plumbing or an in-memory dedupe-run context the stateless CLI path doesn't carry. Bounded follow-up.

## Test plan
- `pnpm run typecheck` clean; `npx vitest run tests/unit/cli-compare-incremental.test.ts tests/unit/mcp-server.test.ts` — 26 pass; `npm run build` success; both commands **smoke-verified end-to-end** against the built CLI.
- `gen_suite_matrix`/`gen_api_surface`/`check_version_consistency` — OK (regenerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)