### PR TITLE
docs(er-kg-bench): lead README with the three differentiated capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ Entity resolution is the stage most GraphRAG pipelines do badly — duplicate su
 | **[goldenmatch-kg](packages/python/goldenmatch-kg/README.md)** | Drop-in GoldenMatch resolution as the ER stage of existing KG frameworks (neo4j-graphrag, LlamaIndex PropertyGraphIndex, Graphiti). One framework-agnostic `resolve_entities` core + per-framework adapters. Lift measured by [ER-KG-Bench](packages/python/goldenmatch/benchmarks/er-kg-bench), not asserted. | in-repo · first PyPI release pending |
 | **[goldengraph](packages/python/goldengraph/README.md)** | Build-your-own-KG from text — `text → LLM extraction → GoldenMatch resolution → a durable bi-temporal store`. Engine (store / query / community detection) is pyo3-free Rust; ER is the differentiator. | in-repo · first PyPI release pending |
 
+**Measured, not asserted** ([ER-KG-Bench](packages/python/goldenmatch/benchmarks/er-kg-bench)): resolution scores **F1 0.602** on the labelled set, ahead of Neo4j-KGBuilder (0.456), neo4j-graphrag (0.403), and MS-GraphRAG / LightRAG / Cognee / mem0 (0.066). Beyond ER quality, a resolved graph does two things a passage-window RAG structurally can't — **exact aggregation** (size-invariant where RAG recall collapses `0.99 → 0.64` as the answer set grows) and **temporal as-of** (`1.000` vs RAG's `0.002` on past-date queries) — both benchmarked on real Wikidata data. What it does *not* differentiate on is multi-hop QA, where a hybrid graph converges to plain text-RAG; the edge is ER + structured queries, and that's what the board measures.
+
 ---
 
 ## Real-world pipelines

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/README.md
@@ -24,6 +24,47 @@ benchmark for how good that built-in dedup actually is. This is one.
 > neighborhood-structured corpus needed to actually *separate* real homographs
 > (see `../clear-kg/RESULTS.md`).
 
+## What the graph does that RAG can't (the three axes)
+
+The differentiated value of a *resolved* knowledge graph is **not** answering
+questions over documents. On multi-hop QA (`answer_match`) a hybrid graph+passage
+engine converges to plain text-RAG — the passages carry the answer and the graph
+is a lossy intermediate (we measured that, and stopped optimizing it). The graph's
+edge is the two things a passage-window retriever *structurally cannot do*: resolve
+entities correctly, and answer **structured queries** — exact **aggregation** and
+**temporal as-of** — over those resolved entities. All three are benchmarked below
+on real, recognizable Wikidata data.
+
+**1. Entity-resolution quality — leads the field.** The headline board (below):
+goldenmatch's built-in dedup scores **F1 0.602** on the labelled record set, ahead
+of every named framework's documented default — Neo4j-KGBuilder 0.456,
+neo4j-graphrag 0.403, MS-GraphRAG / LightRAG / Cognee / mem0 at 0.066 (exact-title
+floors that recover almost no fuzzy variant). Each row runs the framework's *real*
+decision code (see the `fid` fidelity tier), not a strawman.
+
+**2. Exact aggregation — size-invariant where RAG collapses.** "How many
+subsidiaries of X?" on a real Wikidata company fixture (`wikidata_companies_v1.json`,
+15.5k entities). GoldenGraph traverses the resolved graph exactly, so its set-F1
+stays **flat (~1.0) across set sizes** while a passage-window RAG's recall collapses
+past the window (**0.99 → 0.88 → 0.64** for size buckets 2-4 / 5-10 / 11-20). With
+real (imperfect) resolution in play, the **count** query compounds both edges:
+goldenmatch merges alias variants a naive RAG counts twice, so count-accuracy is
+**1.00 / 0.88 / 0.88** vs an ER-blind RAG's **0.38 / 0.38 / 0.00** — a **+0.63 →
++0.88** gap that *widens* with set size. Reproduce:
+`scripts/run_realworld_phase15_e2e.py` + `run_realworld_phase2_e2e.py`.
+
+**3. Temporal as-of — a valid-time axis RAG doesn't have.** "Who was CEO of X **as
+of a past year**?" on **550 real Wikidata CEO successions** (P169 + P580 start
+dates). `store.as_of(D)` returns the person valid at D: **accuracy 1.000 on both
+past and current**. A temporal-blind RAG returns the most-recent CEO — right 0.945
+on current, but **0.002 on past** (2 of 550): no valid-time axis, so it always
+answers with today's value. Reproduce: `scripts/run_realworld_temporal_e2e.py`.
+
+**The honest framing:** we don't lead with QA `answer_match`, because there the
+graph ≈ text-RAG. We lead with ER + aggregation + temporal — where a resolved graph
+does something a passage retriever cannot. (The capability runs live in the
+`goldengraph-pipeline` CI lane and write `RESULTS_REALWORLD_*.md` artifacts.)
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
Makes the capability results visible in the ER-KG-Bench README. Adds a **"What the graph does that RAG can't"** section near the top, leading with the three measured differentiators (and the honest note that QA `answer_match` converges to text-RAG, so it is NOT the headline).

**1. ER quality leaderboard** — goldenmatch F1 **0.602** vs Neo4j-KGBuilder 0.456, neo4j-graphrag 0.403, MS-GraphRAG/LightRAG/Cognee/mem0 0.066.

**2. Exact aggregation** — size-invariant (~1.0) where a passage-window RAG's recall collapses `0.99 -> 0.88 -> 0.64`; plus the compounded ER+aggregation **count** win (GG-minus-ER-blind `+0.63 -> +0.88`, widening with set size). Real Wikidata company fixture.

**3. Temporal as-of** — 550 real Wikidata CEO successions (P169 + P580). `store.as_of(D)` = **1.000** on past and current; temporal-blind RAG = 0.945 current / **0.002 past**.

Doc-only change (README prose). The three capability slices already run in the `goldengraph-pipeline` lane and write `RESULTS_REALWORLD_*.md` artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)