### PR TITLE
docs(pg): fix stale extensions-repo pointers + plan identity audit/mediation/MDM SQL surface

### DIFF
--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -25,14 +25,28 @@ psql -h localhost -U postgres \
   -c "SELECT goldenmatch.goldenmatch_score('John', 'Jon', 'jaro_winkler');"
 ```
 
-Package installs are also available:
+Prebuilt release tarballs (Linux x86_64, PostgreSQL 15/16/17) are attached to
+each [`goldenmatch-pg-v*` release](https://github.com/benseverndev-oss/goldenmatch/releases?q=goldenmatch-pg).
+Each tarball unpacks a pgrx package tree (the `.so`, the `.control`, and the SQL
+files) that you copy into your PostgreSQL install:
 
 ```bash
-# Debian / Ubuntu
-curl -LO https://github.com/benseverndev-oss/goldenmatch-extensions/releases/latest/download/postgresql-16-goldenmatch_0.2.0_amd64.deb
-sudo dpkg -i postgresql-16-goldenmatch_0.2.0_amd64.deb
-pip install goldenmatch>=1.1.0
+# Pick the latest goldenmatch-pg-v* release and your PG major version.
+VERSION=0.15.0        # latest goldenmatch-pg-v* tag
+PG=16                 # your PostgreSQL major (15, 16, or 17)
+
+curl -LO "https://github.com/benseverndev-oss/goldenmatch/releases/download/goldenmatch-pg-v${VERSION}/goldenmatch_pg-${VERSION}-pg${PG}-linux-x86_64.tar.gz"
+tar -xzf "goldenmatch_pg-${VERSION}-pg${PG}-linux-x86_64.tar.gz"
+
+# The tree mirrors the PG install prefix -- copy it over pg_config's dirs.
+sudo cp -r "goldenmatch_pg-pg${PG}"/* /
+
+# The extension embeds CPython and calls goldenmatch, so install it too:
+pip install goldenmatch
 ```
+
+Other platforms build from source (`cargo pgrx install`) -- see
+[`packages/rust/extensions/CLAUDE.md`](https://github.com/benseverndev-oss/goldenmatch/blob/main/packages/rust/extensions/CLAUDE.md).
 
 Then enable it:
 

--- a/docs/superpowers/plans/2026-07-24-goldenmatch-pg-identity-audit-mediation-mdm.md
+++ b/docs/superpowers/plans/2026-07-24-goldenmatch-pg-identity-audit-mediation-mdm.md
@@ -1,0 +1,158 @@
+# goldenmatch-pg: identity audit + mediation + MDM SQL surface (post-#1913)
+
+**Status:** planned (not started). **Depends on:** #1913 (closed) — the in-DB
+identity write path, GUC/DSN plumbing, dual `db_path`/in-DB store selection, and
+the `rust_pgrx` CI smoke it shipped are the foundation this reuses wholesale.
+
+## 1. Context — what's already on the SQL surface vs. what's missing
+
+`#1913` (design: `docs/superpowers/specs/2026-07-19-goldenmatch-pg-in-db-identity-write-path-design.md`)
+brought the Postgres extension from read-only identity to a stateful in-DB
+engine. As-built on `origin/main` (pgrx **0.15.0**), the identity SQL surface is:
+
+| Present today | Kind | Bridge fn | Python entrypoint |
+|---|---|---|---|
+| `goldenmatch_identity_resolve` | read | `identity_resolve` | `find_by_record` |
+| `goldenmatch_identity_view` | read | `identity_view` | `get_entity` |
+| `goldenmatch_identity_history` | read | `identity_history` | event log |
+| `goldenmatch_identity_conflicts` | read | `identity_conflicts` | conflicts |
+| `goldenmatch_identity_list` | read | `identity_list` | list |
+| `gm_resolve` | write | `resolve_identities` | `resolve_clusters` |
+| `gm_identity_merge` | write | `identity_merge` | `manual_merge` |
+| `gm_identity_split` | write | `identity_split` | `manual_split` |
+
+The Python identity API (`goldenmatch.identity`) — and the MCP/CLI/REST surfaces —
+expose **three families that never reached SQL**. These are NOT unfinished #1913
+work (they were explicit non-goals of that design); they're the clean next
+extension that brings the SQL surface to identity parity with the other surfaces
+(every-capability-on-every-surface, the North Star commitment).
+
+## 2. The gap — 8 functions, all class-A embedded-Python wrapping
+
+Each is a thin `#[pg_extern]` wrapper → `goldenmatch_bridge::api::*` → embedded
+CPython calling an existing `goldenmatch.identity` entrypoint. No new resolution
+logic, no schema DDL (the Python store owns identity schema — §5 of the #1913
+design), no Python-side changes. Same two templates already in the tree:
+
+- **Read template** — `quick.rs::goldenmatch_identity_resolve` + `api::identity_resolve`.
+  Wrapper takes `db_path: String`, routes through `identity_store_ref(db_path)`
+  (non-empty = SQLite path or explicit DSN; empty = in-DB via the
+  `goldenmatch.identity_dsn` GUC / env). Bridge opens the store, calls the
+  Python fn, closes on all paths, `json.dumps(..., default=str)`.
+- **Write template** — `quick.rs::gm_identity_merge` + `api::identity_merge`.
+  DSN-required (empty rejected with the "set `goldenmatch.identity_dsn`" error);
+  otherwise identical.
+
+### 2a. Audit chain (tamper-evident log)
+
+| New SQL fn | Kind | Python call | Notes |
+|---|---|---|---|
+| `gm_identity_audit(dataset, db_path)` | read | `store.export_audit_log(dataset)` | the raw event log; `dataset`/`db_path` empty = all / in-DB |
+| `gm_identity_audit_verify(dataset, db_path)` | read | `verify_audit_chain(store, dataset=…)` | returns an `AuditVerification` — content + chain integrity |
+| `gm_identity_audit_seal(dataset)` | write | `seal_audit_log(store, dataset=…, actor=…)` | DSN-required; **returns `None` when nothing new to seal** → emit `{"sealed": false}` |
+
+Cross-language note: the audit hashing is already proven byte-identical
+Python↔TS (the `audit.ts` port + conformance harness, ADR 0046). This surface
+just exposes the *same* Python chain through SQL — no new hashing.
+
+### 2b. Mediation (steward conflict resolution)
+
+| New SQL fn | Kind | Python call | Notes |
+|---|---|---|---|
+| `gm_identity_resolve_conflict(dataset, record_a, record_b, resolution, steward, reason)` | write | `mediate_conflict(store, record_a, record_b, resolution, *, steward, reason, dataset)` | `resolution` ∈ `same`/`distinct`/`defer`; DSN-required |
+| `gm_identity_claim(dataset, record_id, entity_id, actor, trust, reason)` | write | `claim_record(store, …)` | steward assertion; DSN-required. **Confirm exact `claim_record` arg list at impl time** |
+
+`mediate_conflict` has a wide kwarg surface (`apply`, `config`, `actor`,
+`trust`); v1 exposes the core (`record_a`, `record_b`, `resolution`, `steward`,
+`reason`, `dataset`) and lets the rest default, matching how the MCP
+`identity_resolve_conflict` tool calls it. Widen later if a caller needs it.
+
+### 2c. MDM reads (steward/operator views)
+
+| New SQL fn | Kind | Python call | Notes |
+|---|---|---|---|
+| `gm_identity_profile(entity_id, db_path)` | read | `entity_profile(store, entity_id)` | `None` when entity absent → `{"found": false}` |
+| `gm_identity_stats(dataset, db_path)` | read | `identity_summary_stats(store, dataset=…)` | graph-level health summary |
+| `gm_identity_worklist(dataset, db_path)` | read | `steward_worklist(store, dataset=…)` | v1 uses default `weak_confidence=0.6`, `limit=50`; add as SQL args only if asked |
+
+## 3. Naming decision
+
+Existing surface has two prefixes: original reads are `goldenmatch_identity_*`;
+the #1913 write path is `gm_*`/`gm_identity_*`. **Use `gm_identity_*` for all 8
+new functions** — they're the newer identity generation, and `gm_identity_*`
+reads cleanly for both reads and writes. (Do not retro-rename the five
+`goldenmatch_identity_*` reads — back-compat; that's an unrelated churn.)
+
+## 4. Serialization (the one impl subtlety)
+
+The read bridge fns return dataclasses (`AuditVerification`, `EntityProfile`,
+`IdentitySummary`, `list[WorklistItem]`), which are **not** JSON-serializable by
+`json.dumps(default=str)` alone (that only rescues leaf values, not the dataclass
+container). Confirm at impl time whether each type exposes `.to_dict()` (the
+existing read fns use `view.to_dict()`) or needs `dataclasses.asdict`. Mirror
+exactly what the MCP tool layer (`mcp/identity-tools`) already does for the same
+types — those tools serialize these today, so a serialization path exists;
+reuse it so SQL output matches MCP/CLI byte-for-byte.
+
+## 5. Versioning / packaging (per-PR tax, do it once)
+
+pgrx **0.15.0 → 0.16.0**. Adding `#[pg_extern]`s means (the `pgrx_sql_sync` gate
+enforces Rust→SQL presence, so all of these are mandatory in the same PR):
+
+1. `sql/goldenmatch_pg--0.16.0.sql` — new base (regenerate via `cargo pgrx schema`, or hand-add the 8 `CREATE FUNCTION`s mirroring the 0.15.0 base).
+2. `sql/goldenmatch_pg--0.15.0--0.16.0.sql` — migration adding the 8 functions.
+3. `.control` `default_version = '0.16.0'` + `Cargo.toml` `version = "0.16.0"` (lockstep).
+4. `cp sql/goldenmatch_pg--0.16.0.sql …` line in **both** `ci.yml` (`rust_pgrx` lane) and `publish-goldenmatch-pg.yml`.
+
+No `api_parity` manifest change: the SQL surface is **not** in `parity/goldenmatch.yaml`
+(only MCP tools / CLI / a2a_skills are gated). The MCP `identity_*` tools already
+exist, so no MCP-side change either.
+
+## 6. CI
+
+Extend the existing `rust_pgrx` smoke (`.github/workflows/ci.yml`, ci-required,
+PG 15/16/17) which already does create → absorb → read → split → merge. Add, in
+the same in-DB dataset: `gm_identity_audit_seal` → `gm_identity_audit_verify`
+(assert `verified: true`) → `gm_identity_profile`/`_stats`/`_worklist` return
+non-error JSON → a `gm_identity_resolve_conflict('distinct', …)` on a seeded
+conflict pair. Reads that take `db_path` also get a SQLite-path smoke to prove
+the dual path (mirror how the existing read smoke passes a temp SQLite file).
+
+## 7. Phasing — recommend ONE PR
+
+The #1913 design phased P1–P4 across PRs because P1 carried real design surface
+(GUC, DSN, connection model, schema ownership). **That infra now exists**, so
+these 8 are pure mechanical additions on one shared pattern. One PR = one version
+bump, one migration file, one smoke extension — cheaper than three stacked pgrx
+version bumps (which conflict on `.control`/SQL and each need the `cp` lines).
+
+Fallback split if review is heavy: (A) MDM reads + audit-read/verify (all reads,
+lowest risk, carries the version bump), (B) writes (audit_seal, resolve_conflict,
+claim). Reads-first means the seal/verify pair lands together (verify is only
+useful once you can seal), so if splitting, keep `audit_seal` with `audit_verify`
+in PR B rather than straddling.
+
+## 8. Risks
+
+- **Writes commit outside the caller's SQL transaction** (the #1913 §3.1
+  property — the store uses its own libpq connection). Same as `gm_identity_merge/split`;
+  idempotent replay is the safety net. Document on the new write fns identically.
+- **`claim_record` arg list unconfirmed** — the one signature not yet read.
+  Confirm before writing its wrapper (§2b).
+- **`seal_audit_log` returns `None`** (nothing new to seal) — the wrapper must
+  not blow up on a `None` (emit `{"sealed": false}`), unlike merge/split which
+  always return a dict.
+- **DuckDB parity: deferred** (same as #1913 — DuckDB has no durable
+  multi-connection server store). Note it in the extensions "deferred by design"
+  table.
+
+## 9. Task checklist (TDD-shaped, one PR)
+
+- [ ] Confirm `claim_record` signature + the five dataclass `.to_dict()` paths (read, don't guess).
+- [ ] `api.rs`: 8 bridge fns (5 read via `open_identity_store`, 3 write DSN-required), mirroring `identity_resolve`/`identity_merge`.
+- [ ] `quick.rs`: 8 `#[pg_extern]` wrappers (reads via `identity_store_ref`, writes DSN-checked).
+- [ ] Version bump 0.15.0→0.16.0: `.control`, `Cargo.toml`, base SQL, migration SQL.
+- [ ] `cp` lines in `ci.yml` + `publish-goldenmatch-pg.yml`.
+- [ ] Extend `rust_pgrx` smoke (§6); confirm `pgrx_sql_sync` gate green.
+- [ ] `cargo fmt` + `cargo clippy -D warnings` on the touched crates (native-ext CI is `-D warnings`).
+- [ ] Docs: add the 8 fns to `docs-site/extensions/sql.mdx`; note DuckDB-deferred.

--- a/packages/python/goldenmatch/AGENTS.md
+++ b/packages/python/goldenmatch/AGENTS.md
@@ -1,9 +1,9 @@
 # GoldenMatch
 
 ## Related Projects
-- **SQL Extensions repo:** `D:\show_case\goldenmatch-extensions` -- Postgres extension + DuckDB UDFs. Has its own CLAUDE.md.
+- **SQL Extensions (in-monorepo):** `packages/rust/extensions/` -- Postgres (pgrx) extension + DuckDB UDFs, over a shared pyo3 `bridge`. See `packages/rust/extensions/CLAUDE.md`. (The standalone `benseverndev-oss/goldenmatch-extensions` repo is ARCHIVED and was folded in here; there is NO separate `D:\show_case\goldenmatch-extensions` checkout.)
 - **PyPI:** `goldenmatch` (Python toolkit), `goldenmatch-duckdb` (DuckDB UDFs)
-- **GitHub:** `benseverndev-oss/goldenmatch`, `benseverndev-oss/goldenmatch-extensions`
+- **GitHub:** `benseverndev-oss/goldenmatch` (extensions live under `packages/rust/extensions/`; the standalone `goldenmatch-extensions` repo is archived)
 
 ## Branch & Merge SOP (all Golden Suite repos)
 - Feature work goes on `feature/<name>` branches, never directly to main
@@ -48,7 +48,7 @@
 
 ## Architecture
 - Pipeline: ingest → column_map → auto_fix → validate → standardize → matchkeys → block → score → cluster → golden → output
-- SQL extensions: see `D:\show_case\goldenmatch-extensions\CLAUDE.md` for Postgres/DuckDB architecture
+- SQL extensions: see `packages/rust/extensions/CLAUDE.md` for Postgres/DuckDB architecture
 - `goldenmatch/core/agent.py` -- AgentSession, profile_for_agent, select_strategy, build_alternatives. Autonomous ER: profiles data -> detects domain -> selects strategy -> runs pipeline -> returns reasoning
 - `goldenmatch/core/review_queue.py` -- ReviewQueue (memory/SQLite/Postgres backends), ReviewItem, gate_pairs(). Confidence gating: >0.95 auto-merge, 0.75-0.95 review, <0.75 reject
 - `goldenmatch/core/memory/` -- Learning Memory: persistent corrections + rule learning. `store.py` (MemoryStore, SQLite/Postgres CRUD, trust-based upsert), `corrections.py` (apply_corrections with dual-hash staleness detection), `learner.py` (MemoryLearner, threshold tuning from 10+ corrections). Config: `MemoryConfig` in schemas.py, optional `memory:` YAML section
@@ -219,8 +219,7 @@ Hosted on Railway, registered on Smithery:
 - DuckDB `.pl()` (Polars conversion) requires `pyarrow` as a dependency
 - Rust `cargo` defaults `CARGO_HOME` to the drive root on Windows when CWD is D: -- always set `CARGO_HOME="C:/Users/bsevern/.cargo"` explicitly
 - `winget install Rustlang.Rustup` fails silently on Windows without Developer Mode -- use `rustup-init.exe -y` with `RUSTUP_WINDOWS_PATH_TYPE=hardlink`
-- goldenmatch-extensions CI: 4 jobs (lint, bridge tests, postgres extension, duckdb tests). Release workflow builds binaries + Docker image on GitHub Release tag
-- goldenmatch-extensions uses `benzsevern` GitHub account (same auth switch requirement as main repo)
+- SQL-extension CI is IN this monorepo: `ci.yml`'s `rust_pgrx` lane (ci-required, PG 15/16/17, `cargo pgrx install` + psql smoke) builds/tests the Postgres extension; `publish-goldenmatch-pg.yml` + `publish-goldenmatch-duckdb.yml` cut the releases. No separate extensions-repo CI.
 - Trunk (pgt.dev) shut down July 2025 -- do not reference it for Postgres extension distribution
 - dbdev (database.dev) only supports SQL/PL/pgSQL extensions (TLE) -- compiled C extensions not eligible
 - Jekyll docs: `{{` in code blocks triggers Liquid template errors -- wrap with `{% raw %}` / `{% endraw %}`

--- a/packages/python/goldenmatch/CLAUDE.md
+++ b/packages/python/goldenmatch/CLAUDE.md
@@ -1,10 +1,10 @@
 # GoldenMatch
 
 ## Related Projects
-- **SQL Extensions repo:** `D:\show_case\goldenmatch-extensions` -- Postgres extension + DuckDB UDFs. Has its own CLAUDE.md.
+- **SQL Extensions (in-monorepo):** `packages/rust/extensions/` -- Postgres (pgrx) extension + DuckDB UDFs, over a shared pyo3 `bridge`. See `packages/rust/extensions/CLAUDE.md`. (The old standalone `benseverndev-oss/goldenmatch-extensions` repo is ARCHIVED (last push 2026-05-01) -- it was folded into this monorepo; do NOT look for a separate `D:\show_case\goldenmatch-extensions` checkout.)
 - **PyPI:** `goldenmatch` (Python toolkit), `goldenmatch-duckdb` (DuckDB UDFs)
 - **npm:** `goldenmatch` (TypeScript port at `packages/goldenmatch-js/`)
-- **GitHub:** `benseverndev-oss/goldenmatch`, `benseverndev-oss/goldenmatch-extensions`
+- **GitHub:** `benseverndev-oss/goldenmatch` (extensions live here now, under `packages/rust/extensions/`; the standalone `goldenmatch-extensions` repo is archived)
 
 ## TypeScript Port
 Lives at `packages/typescript/goldenmatch/`. See that package's CLAUDE.md for npm release flow, edge-safety rules, parity harness, and port-specific gotchas.
@@ -42,7 +42,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 
 ## Architecture
 - Pipeline: ingest → column_map → auto_fix → validate → standardize → matchkeys → block → score → cluster → golden → output
-- SQL extensions: see `D:\show_case\goldenmatch-extensions\CLAUDE.md` for Postgres/DuckDB architecture
+- SQL extensions: see `packages/rust/extensions/CLAUDE.md` for Postgres/DuckDB architecture
 - `goldenmatch/core/agent.py` -- AgentSession, profile_for_agent, select_strategy, build_alternatives. Autonomous ER: profiles data -> detects domain -> selects strategy -> runs pipeline -> returns reasoning
 - `goldenmatch/core/review_queue.py` -- ReviewQueue (memory/SQLite/Postgres backends), ReviewItem, gate_pairs(). Confidence gating: >0.95 auto-merge, 0.75-0.95 review, <0.75 reject
 - `goldenmatch/core/memory/` -- Learning Memory: persistent corrections + rule learning. `store.py` (MemoryStore, SQLite/Postgres CRUD, trust-based upsert), `corrections.py` (apply_corrections with dual-hash staleness detection), `learner.py` (MemoryLearner, threshold tuning from 10+ corrections). Config: `MemoryConfig` in schemas.py, optional `memory:` YAML section
@@ -233,7 +233,7 @@ Root CLAUDE.md owns: branch/merge SOP, GitHub auth dance, Rust + pgrx, PostgreSQ
 - **Idempotency**: replaying the same `(run_name, entity_id, kind)` is a no-op via `has_run_event()`; `evidence_edges` has UNIQUE(entity_id, record_a_id, record_b_id, run_name).
 - **Surfaces**: Python (`goldenmatch.identity.*` + root re-exports), CLI (`goldenmatch identity list/show/resolve/history/conflicts/merge/split`), REST (`/api/v1/identities/...`), web "Identities" tab, MCP (`identity_*` × 6 tools), A2A (6 skills), TS edge-safe core (`InMemoryIdentityStore` + `query.ts` helpers). TS persistent SQLite backend + pipeline-driven population are v2 follow-ups.
 - **Postgres surface**: `goldenmatch/db/migrations/identity_v1.sql` is the canonical schema + analytical views (`v_identities`, `v_identity_pairs`, `v_identity_timeline`). `IdentityStore(backend="postgres", connection=...)` creates the same schema on first connect.
-- **DuckDB / extensions contract**: `docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md` — UDF signatures the `goldenmatch-extensions` repo must expose.
+- **DuckDB / extensions contract**: `docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md` — UDF signatures `packages/rust/extensions/` (Postgres pgrx + DuckDB) must expose.
 - **Test count discipline**: Identity adds 47 Python tests (4 modules under `tests/identity/` + `tests/test_mcp_identity_tools.py` + `tests/web/test_router_identity.py`) and 13 TS tests (`tests/identity/`).
 - **A2A skill count is 38** (`_SKILLS` in `a2a/server.py`). Update `test_agent_card_has_38_skills` in `tests/test_a2a.py` if you add a skill.
 - **`pipeline.run_dedupe_df` result** now has `identity_summary: dict | None` (None when identity disabled).
@@ -368,8 +368,7 @@ Hosted on Railway, registered on Smithery:
 - DuckDB `.pl()` (Polars conversion) requires `pyarrow` as a dependency
 - Rust `cargo` defaults `CARGO_HOME` to the drive root on Windows when CWD is D: -- always set `CARGO_HOME="C:/Users/bsevern/.cargo"` explicitly
 - `winget install Rustlang.Rustup` fails silently on Windows without Developer Mode -- use `rustup-init.exe -y` with `RUSTUP_WINDOWS_PATH_TYPE=hardlink`
-- goldenmatch-extensions CI: 4 jobs (lint, bridge tests, postgres extension, duckdb tests). Release workflow builds binaries + Docker image on GitHub Release tag
-- goldenmatch-extensions uses `benzsevern` GitHub account (same auth switch requirement as main repo)
+- SQL-extension CI is IN this monorepo: `ci.yml`'s `rust_pgrx` lane (ci-required, PG 15/16/17, `cargo pgrx install` + psql smoke) builds/tests the Postgres extension; `publish-goldenmatch-pg.yml` + `publish-goldenmatch-duckdb.yml` cut the releases (tags `goldenmatch-pg-v*` / `goldenmatch-duckdb-v*`). No separate extensions-repo CI.
 - Trunk (pgt.dev) shut down July 2025 -- do not reference it for Postgres extension distribution
 - dbdev (database.dev) only supports SQL/PL/pgSQL extensions (TLE) -- compiled C extensions not eligible
 - `typing_extensions` on Ubuntu CI: system package at `/usr/lib/python3/dist-packages/` overrides pip install -- must `sudo rm -f` the system file first

--- a/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/build_ghsuite.py
+++ b/packages/python/goldenmatch/benchmarks/er-kg-bench/dataset/build_ghsuite.py
@@ -39,8 +39,9 @@ from dataset.concepts_loader import Concept, load_concepts  # pyright: ignore[re
 _HERE = Path(__file__).resolve().parent  # dataset/
 _REPO_ROOT = Path(__file__).resolve().parents[6]  # worktree root
 
-# Extensions checkout (optional; skip silently when absent).
-_EXTENSIONS_DIR = Path("D:/show_case/goldenmatch-extensions")
+# SQL extensions now live in-monorepo (the standalone goldenmatch-extensions
+# repo was archived + folded in). Optional; skip silently when absent.
+_EXTENSIONS_DIR = _REPO_ROOT / "packages" / "rust" / "extensions"
 
 # GitHub repos to search for issues/PRs when the local checkouts miss.
 _DEFAULT_REPOS = [


### PR DESCRIPTION
## Why

While scoping the Postgres identity gap, the build-path question resolved cleanly: the standalone `benseverndev-oss/goldenmatch-extensions` repo is **archived** (last push 2026-05-01) and was folded into this monorepo at `packages/rust/extensions/`. The crate here is the live source of truth — actively developed (the `#1913` in-DB identity workstream), built + smoke-tested by the `rust_pgrx` lane in `ci.yml` (ci-required, PG 15/16/17), and released via `publish-goldenmatch-pg.yml`. But several docs still pointed at a separate `D:\show_case\goldenmatch-extensions` checkout / the archived repo's releases.

## What

**Stale-pointer fixes (the misleading ones):**
- `packages/python/goldenmatch/{CLAUDE.md,AGENTS.md}` — repoint SQL-extensions references to `packages/rust/extensions/` + its `CLAUDE.md`; correct the CI/release story (in-monorepo, no separate extensions-repo CI).
- `docs-site/extensions/sql.mdx` — **user-facing:** the Postgres install block `curl`'d a `.deb` from the archived repo's releases at `v0.2.0`. Releases actually ship `tar.gz` pgrx package trees from the monorepo (`goldenmatch-pg-v*` tags, currently 0.15.0). Rewrote the install to the real tarball flow (`goldenmatch_pg-<ver>-pg<N>-linux-x86_64.tar.gz`) + a source-build pointer.
- `build_ghsuite.py` — `_EXTENSIONS_DIR` pointed at the dead absolute path. It's optional/skip-when-absent, so it has been *silently skipping extension surfaces* since the fold. Repointed to the in-monorepo dir.

**Plan (net-new doc, no code):**
- `docs/superpowers/plans/2026-07-24-goldenmatch-pg-identity-audit-mediation-mdm.md` — the aligned build plan for the next identity SQL phase: the 8 identity functions still missing from Postgres (audit chain: `audit`/`audit_verify`/`audit_seal`; mediation: `resolve_conflict`/`claim`; MDM reads: `profile`/`stats`/`worklist`). All are class-A embedded-Python wrappers over the `#1913` infra, mapped to exact Python entrypoints and the shipped read/write templates. Recommends one PR (one pgrx 0.15.0→0.16.0 bump).

## Risk

Docs-only + a one-line bench-path fix (optional path, skip-when-absent — no behavior change when the dir is present, which it now is). No code paths, no gates beyond docs render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)