### PR TITLE
feat(pg): identity audit chain + steward mediation + MDM reads in SQL (goldenmatch_pg 0.16.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2915,9 +2915,11 @@ jobs:
           cargo pgrx install "--pg-config=/usr/lib/postgresql/${PG_VERSION}/bin/pg_config" --release --features "pg${PG_VERSION}" --no-default-features
           # pgrx 0.12.9 doesn't auto-emit the SQL extension file — copy the
           # handwritten ones into PG's extension dir so `CREATE EXTENSION`
-          # (installs default_version, now 0.15.0) and `ALTER EXTENSION ... UPDATE`
+          # (installs default_version, now 0.16.0) and `ALTER EXTENSION ... UPDATE`
           # find them. The schema files are the canonical declaration of public
           # function signatures.
+          cp sql/goldenmatch_pg--0.16.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
+          cp sql/goldenmatch_pg--0.15.0--0.16.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.15.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.14.0--0.15.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
           cp sql/goldenmatch_pg--0.14.0.sql "/usr/share/postgresql/${PG_VERSION}/extension/"
@@ -3366,6 +3368,79 @@ jobs:
                 RAISE EXCEPTION 'gm_identity_merge: expected absorbed entity to own 0 records + keeper to own 3, got absorbed=% keeper=%', back_recs, big_recs;
               END IF;
               RAISE NOTICE 'gm_identity_merge: % (keeper records=%)', merge_res, big_recs;
+            END $$;
+            -- 0.16.0: identity audit chain + steward mediation + MDM operator
+            -- reads over the SAME in-DB dataset. All 8 new gm_identity_*
+            -- functions. Empty dataset = the global chain / whole graph, so the
+            -- seal covers every event resolve/split/merge emitted regardless of
+            -- per-event dataset tagging.
+            DO $$
+            DECLARE
+              big_entity text; rec_a text; rec_b text;
+              seal_res jsonb; verify_res jsonb; audit_res jsonb;
+              prof jsonb; stats_res jsonb; worklist_res jsonb;
+              conflict_res jsonb; claim_res jsonb;
+            BEGIN
+              SELECT entity_id INTO big_entity
+                FROM source_records GROUP BY entity_id ORDER BY count(*) DESC LIMIT 1;
+              SELECT record_id INTO rec_a
+                FROM source_records WHERE entity_id = big_entity ORDER BY record_id LIMIT 1;
+              SELECT record_id INTO rec_b
+                FROM source_records WHERE entity_id = big_entity ORDER BY record_id OFFSET 1 LIMIT 1;
+
+              -- AUDIT SEAL: resolve/split/merge emitted events -> a global seal
+              -- folds them, so there IS something new to seal.
+              seal_res := goldenmatch.gm_identity_audit_seal('')::jsonb;
+              IF (seal_res->>'sealed')::boolean IS NOT TRUE THEN
+                RAISE EXCEPTION 'gm_identity_audit_seal: expected sealed=true (events exist), got %', seal_res;
+              END IF;
+
+              -- AUDIT VERIFY: replay the seal chain + content hashes -> intact.
+              verify_res := goldenmatch.gm_identity_audit_verify('', '')::jsonb;
+              IF (verify_res->>'ok')::boolean IS NOT TRUE THEN
+                RAISE EXCEPTION 'gm_identity_audit_verify: expected ok=true, got %', verify_res;
+              END IF;
+
+              -- AUDIT READ: the append-only log page is non-empty.
+              audit_res := goldenmatch.gm_identity_audit('', '')::jsonb;
+              IF (audit_res->>'total')::int < 1 OR jsonb_array_length(audit_res->'items') < 1 THEN
+                RAISE EXCEPTION 'gm_identity_audit: expected a non-empty log, got %', audit_res;
+              END IF;
+
+              -- PROFILE: the surviving entity owns its 3 records.
+              prof := goldenmatch.gm_identity_profile(big_entity, '')::jsonb;
+              IF (prof->>'record_count')::int <> 3 THEN
+                RAISE EXCEPTION 'gm_identity_profile: expected record_count=3 for %, got %', big_entity, prof;
+              END IF;
+
+              -- STATS: whole-graph health summary reports the entities.
+              stats_res := goldenmatch.gm_identity_stats('', '')::jsonb;
+              IF (stats_res->>'total_entities')::int < 1 THEN
+                RAISE EXCEPTION 'gm_identity_stats: expected total_entities>=1, got %', stats_res;
+              END IF;
+
+              -- WORKLIST: returns an items array (may be empty; assert the shape).
+              worklist_res := goldenmatch.gm_identity_worklist('', '')::jsonb;
+              IF jsonb_typeof(worklist_res->'items') <> 'array' THEN
+                RAISE EXCEPTION 'gm_identity_worklist: expected an items array, got %', worklist_res;
+              END IF;
+
+              -- RESOLVE_CONFLICT: a `defer` verdict logs a mediation edge only
+              -- (no structural change), proving the write path loads.
+              conflict_res := goldenmatch.gm_identity_resolve_conflict('', rec_a, rec_b, 'defer', 'ci-smoke')::jsonb;
+              IF conflict_res->>'resolution' IS NULL THEN
+                RAISE EXCEPTION 'gm_identity_resolve_conflict: expected a verdict, got %', conflict_res;
+              END IF;
+
+              -- CLAIM: re-claim a record into the entity it already lives in -> a
+              -- safe no-op move (moved=false), proving the claim write path loads.
+              claim_res := goldenmatch.gm_identity_claim(big_entity, rec_a, 'ci-smoke')::jsonb;
+              IF (claim_res->>'moved')::boolean IS NOT FALSE THEN
+                RAISE EXCEPTION 'gm_identity_claim(same entity): expected moved=false, got %', claim_res;
+              END IF;
+
+              RAISE NOTICE 'gm_identity audit/mediation/MDM smoke OK: sealed=% verify_ok=% audit_total=% profile_recs=%',
+                seal_res->>'sealed', verify_res->>'ok', audit_res->>'total', prof->>'record_count';
             END $$;
           EOSQL
           echo "=== PG ${PG_VERSION} smoke passed ==="

--- a/.github/workflows/publish-goldenmatch-pg.yml
+++ b/.github/workflows/publish-goldenmatch-pg.yml
@@ -105,6 +105,8 @@ jobs:
           # canonical SQL file there. Path layout: <PKG_DIR>/usr/share/postgresql/<N>/extension/
           EXT_DIR="${PKG_DIR}/usr/share/postgresql/${PG_VERSION}/extension"
           mkdir -p "${EXT_DIR}"
+          cp sql/goldenmatch_pg--0.16.0.sql "${EXT_DIR}/"
+          cp sql/goldenmatch_pg--0.15.0--0.16.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.15.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.14.0--0.15.0.sql "${EXT_DIR}/"
           cp sql/goldenmatch_pg--0.14.0.sql "${EXT_DIR}/"

--- a/docs-site/extensions/sql.mdx
+++ b/docs-site/extensions/sql.mdx
@@ -184,6 +184,68 @@ SELECT goldenmatch.gm_embed('John Smith');  -- real[]
   The DuckDB embedding UDF needs the optional embed runtime: `pip install goldenmatch-duckdb[embed]`.
 </Note>
 
+## Identity graph (stateful, PostgreSQL)
+
+PostgreSQL can maintain a durable, event-sourced **identity graph** in-database:
+stable entity ids that survive across runs, incremental absorb of new records,
+steward corrections, a tamper-evident audit log, and MDM operator views. This is
+Postgres-only (it needs a durable multi-connection store); DuckDB stays the
+stateless dedupe surface.
+
+Point the extension at the database it runs in with a superuser GUC (or the
+`GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` server env), then resolve
+a table into a named dataset:
+
+```sql
+ALTER SYSTEM SET goldenmatch.identity_dsn = 'postgresql://user:pass@localhost/mydb';
+SELECT pg_reload_conf();
+
+SELECT goldenmatch.gm_configure('idjob',
+  '{"matchkeys":[{"name":"email","type":"exact","fields":[{"field":"email","scorer":"exact"}]}],"identity":{"source_pk_column":"id"}}');
+
+-- Resolve a table into the in-DB identity dataset (create / absorb / merge,
+-- incremental across runs). Re-running absorbs new rows into existing ids.
+SELECT goldenmatch.gm_resolve('idjob', 'customers', 'people');
+```
+
+The read functions serve that in-DB dataset when `db_path` is empty (pass a
+SQLite path or a libpq DSN to read an external store instead). Every function
+returns JSON identical to the MCP / REST / CLI surfaces.
+
+| Function | Purpose |
+|---|---|
+| `gm_resolve(job, table, dataset)` | Resolve a table into the dataset (create/absorb/merge) |
+| `goldenmatch_identity_resolve(record_id, db_path)` | Resolve a `{source}:{pk}` record to its entity |
+| `goldenmatch_identity_view(entity_id, db_path)` | Full identity view + event log |
+| `goldenmatch_identity_history(entity_id, db_path)` | Temporal event log for one identity |
+| `goldenmatch_identity_list(dataset, status, db_path)` | List identities (empty filters = all) |
+| `goldenmatch_identity_conflicts(dataset, db_path)` | Open `conflicts_with` edges |
+| `gm_identity_profile(entity_id, db_path)` | MDM profile of one entity (sources, records, version) |
+| `gm_identity_stats(dataset, db_path)` | Graph-level health summary |
+| `gm_identity_worklist(dataset, db_path)` | Prioritized steward queue (conflicts / weak confidence) |
+| `gm_identity_merge(dataset, entity_a, entity_b)` | Steward merge (keep A, absorb B) |
+| `gm_identity_split(dataset, entity_id, record_id)` | Steward split a record into a fresh identity |
+| `gm_identity_claim(entity_id, record_id, reason)` | Steward claim a record into an entity |
+| `gm_identity_resolve_conflict(dataset, record_a, record_b, resolution, reason)` | Steward verdict (`same`/`distinct`/`defer`) |
+| `gm_identity_audit(dataset, db_path)` | Append-only audit-log page |
+| `gm_identity_audit_seal(dataset)` | Anchor the audit log with a new tamper-evidence seal |
+| `gm_identity_audit_verify(dataset, db_path)` | Replay the seal chain and report integrity |
+
+```sql
+-- Steward workflow: profile an entity, seal + verify the audit chain.
+SELECT goldenmatch.gm_identity_profile('<entity_id>', '');   -- '' = the in-DB dataset
+SELECT goldenmatch.gm_identity_audit_seal('');               -- '' = the global chain
+SELECT goldenmatch.gm_identity_audit_verify('', '');         -- {"ok": true, ...}
+```
+
+<Note>
+  The write functions (`gm_resolve`, `gm_identity_merge` / `_split` / `_claim`,
+  `gm_identity_resolve_conflict`, `gm_identity_audit_seal`) commit on the store's
+  own connection to the configured DSN, not the caller's SQL transaction; replay
+  is idempotent. They require `goldenmatch.identity_dsn` (or the env fallback) to
+  be set. Empty optional args (`dataset`, `reason`) mean "unset".
+</Note>
+
 ## Requirements
 
 - Python 3.11+

--- a/docs/agent-codemap.json
+++ b/docs/agent-codemap.json
@@ -5593,8 +5593,10 @@
             "_effective_hash",
             "_fold_step",
             "_normalize_dt",
+            "audit_log_page",
             "event_content_hash",
             "seal_audit_log",
+            "seal_result_dict",
             "verify_audit_chain"
           ],
           "imports": [
@@ -5722,7 +5724,8 @@
             "_iter_entities",
             "entity_profile",
             "identity_summary_stats",
-            "steward_worklist"
+            "steward_worklist",
+            "steward_worklist_page"
           ],
           "imports": [
             "goldenmatch.identity.model",

--- a/packages/python/goldenmatch/goldenmatch/identity/__init__.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/__init__.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 from goldenmatch.identity.audit import (
     AuditVerification,
+    audit_log_page,
     event_content_hash,
     seal_audit_log,
+    seal_result_dict,
     verify_audit_chain,
 )
 from goldenmatch.identity.mediation import (
@@ -41,6 +43,7 @@ from goldenmatch.identity.profile import (
     entity_profile,
     identity_summary_stats,
     steward_worklist,
+    steward_worklist_page,
 )
 from goldenmatch.identity.query import (
     IdentityView,
@@ -146,10 +149,13 @@ __all__ = [
     "entity_profile",
     "identity_summary_stats",
     "steward_worklist",
+    "steward_worklist_page",
     "AuditSeal",
     "AuditVerification",
+    "audit_log_page",
     "event_content_hash",
     "seal_audit_log",
+    "seal_result_dict",
     "verify_audit_chain",
     "ClaimType",
     "EvidenceRef",

--- a/packages/python/goldenmatch/goldenmatch/identity/audit.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/audit.py
@@ -125,6 +125,37 @@ class AuditVerification:
             )
         return "audit chain BROKEN: " + ", ".join(parts)
 
+    def as_dict(self) -> dict[str, Any]:
+        """JSON-ready verdict, the single serialization the MCP tool, the REST
+        surface, and the SQL ``gm_identity_audit_verify`` bridge all emit."""
+        return {
+            "ok": self.ok,
+            "events_checked": self.events_checked,
+            "seals_checked": self.seals_checked,
+            "content_mismatches": self.content_mismatches,
+            "seal_mismatches": self.seal_mismatches,
+            "missing_sealed_events": self.missing_sealed_events,
+            "summary": self.summary(),
+        }
+
+
+def seal_result_dict(seal: AuditSeal | None) -> dict[str, Any]:
+    """JSON-ready result for a ``seal_audit_log`` call. ``None`` (nothing new to
+    seal) → ``{"sealed": False, ...}``; a fresh seal → its anchor fields. Single
+    source for the MCP ``identity_audit_seal`` tool and the SQL
+    ``gm_identity_audit_seal`` bridge."""
+    if seal is None:
+        return {"sealed": False, "reason": "no new events to seal"}
+    return {
+        "sealed": True,
+        "seal_id": seal.seal_id,
+        "root_hash": seal.root_hash,
+        "event_count": seal.event_count,
+        "last_event_id": seal.last_event_id,
+        "dataset": seal.dataset,
+        "actor": seal.actor,
+    }
+
 
 def seal_audit_log(
     store: IdentityStore,
@@ -238,3 +269,31 @@ def verify_audit_chain(
         seal_mismatches=seal_mismatches,
         missing_sealed_events=missing_sealed_events,
     )
+
+
+def audit_log_page(
+    store: IdentityStore,
+    *,
+    dataset: str | None = None,
+    actor: str | None = None,
+    limit: int = 500,
+) -> dict[str, Any]:
+    """JSON-ready page of the append-only audit log for compliance export.
+
+    Returns ``{"items": [...], "total": n}`` where ``items`` is truncated to
+    ``limit`` (most recent-order preserved from ``export_audit_log``) and
+    ``total`` is the full unfiltered-by-limit count. Single source for the MCP
+    ``identity_audit`` tool and the SQL ``gm_identity_audit`` bridge."""
+    events = store.export_audit_log(dataset=dataset, actor=actor)
+    items = [
+        {
+            "event_id": e.event_id, "entity_id": e.entity_id, "kind": e.kind,
+            "actor": e.actor, "trust": e.trust,
+            "claim_type": e.claim_type, "evidence_ref": e.evidence_ref,
+            "previous_claim_id": e.previous_claim_id,
+            "recorded_at": e.recorded_at.isoformat() if e.recorded_at else None,
+            "run_name": e.run_name, "dataset": e.dataset, "payload": e.payload,
+        }
+        for e in events[:limit]
+    ]
+    return {"items": items, "total": len(events)}

--- a/packages/python/goldenmatch/goldenmatch/identity/audit.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/audit.py
@@ -41,8 +41,27 @@ if TYPE_CHECKING:
 def _normalize_dt(value: Any) -> str:
     """Stable string form of a timestamp, identical on the insert side (a
     ``datetime``) and the read-back side (``_to_dt`` returns a ``datetime``),
-    so the content hash round-trips across a store write/read."""
+    so the content hash round-trips across a store write/read.
+
+    **Dropping the tzinfo is load-bearing for the Postgres backend.** Events are
+    created with a naive ``datetime.now()`` and hashed *before* insert, but the
+    Postgres schema stores ``recorded_at`` as ``TIMESTAMPTZ`` and hands back a
+    tz-AWARE datetime, whose ``isoformat()`` carries a ``+00:00`` offset the
+    write-side hash never saw. Every stamped event therefore re-hashed to a
+    different value and ``verify_audit_chain`` reported phantom "content
+    edit(s)" on a perfectly clean in-DB store (caught by the `rust_pgrx`
+    `gm_identity_audit_verify` smoke). Keeping the wall clock exactly as the
+    driver returned it -- in the session timezone the naive value was written in
+    -- makes the read-back string identical to the written one.
+
+    Naive values (every SQLite event, and the write side on both backends) are
+    untouched, so existing entry hashes and the seals chained over them stay
+    valid -- the same back-compat constraint that governs the claim-authority
+    fields in ``event_content_hash`` below.
+    """
     if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.replace(tzinfo=None)
         return value.isoformat()
     return str(value)
 

--- a/packages/python/goldenmatch/goldenmatch/identity/profile.py
+++ b/packages/python/goldenmatch/goldenmatch/identity/profile.py
@@ -292,3 +292,18 @@ def steward_worklist(
         it.entity_id,
     ))
     return items[:limit]
+
+
+def steward_worklist_page(
+    store: IdentityStore,
+    dataset: str | None = None,
+    *,
+    weak_confidence: float = 0.6,
+    limit: int = 50,
+) -> dict[str, Any]:
+    """JSON-ready steward worklist: ``{"items": [...]}``. Single source for the
+    MCP ``identity_worklist`` tool and the SQL ``gm_identity_worklist`` bridge."""
+    items = steward_worklist(
+        store, dataset, weak_confidence=weak_confidence, limit=limit
+    )
+    return {"items": [it.as_dict() for it in items]}

--- a/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
+++ b/packages/python/goldenmatch/goldenmatch/mcp/identity_tools.py
@@ -26,6 +26,7 @@ from mcp.types import TextContent, Tool
 
 from goldenmatch.identity import (
     IdentityStore,
+    audit_log_page,
     claim_record,
     entity_profile,
     find_by_record,
@@ -38,7 +39,8 @@ from goldenmatch.identity import (
     manual_split,
     mediate_conflict,
     seal_audit_log,
-    steward_worklist,
+    seal_result_dict,
+    steward_worklist_page,
     verify_audit_chain,
 )
 
@@ -463,50 +465,20 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
     if name == "identity_audit":
         limit = int(args.get("limit", 500))
         with _open(args) as s:
-            events = s.export_audit_log(
-                dataset=args.get("dataset"), actor=args.get("actor")
+            return audit_log_page(
+                s, dataset=args.get("dataset"), actor=args.get("actor"), limit=limit
             )
-        items = [
-            {
-                "event_id": e.event_id, "entity_id": e.entity_id, "kind": e.kind,
-                "actor": e.actor, "trust": e.trust,
-                "claim_type": e.claim_type, "evidence_ref": e.evidence_ref,
-                "previous_claim_id": e.previous_claim_id,
-                "recorded_at": e.recorded_at.isoformat() if e.recorded_at else None,
-                "run_name": e.run_name, "dataset": e.dataset, "payload": e.payload,
-            }
-            for e in events[:limit]
-        ]
-        return {"items": items, "total": len(events)}
 
     if name == "identity_audit_seal":
         actor, _ = _actor_trust(args)
         with _open(args) as s:
-            seal = seal_audit_log(s, actor=actor, dataset=args.get("dataset"))
-        if seal is None:
-            return {"sealed": False, "reason": "no new events to seal"}
-        return {
-            "sealed": True,
-            "seal_id": seal.seal_id,
-            "root_hash": seal.root_hash,
-            "event_count": seal.event_count,
-            "last_event_id": seal.last_event_id,
-            "dataset": seal.dataset,
-            "actor": seal.actor,
-        }
+            return seal_result_dict(
+                seal_audit_log(s, actor=actor, dataset=args.get("dataset"))
+            )
 
     if name == "identity_audit_verify":
         with _open(args) as s:
-            result = verify_audit_chain(s, dataset=args.get("dataset"))
-        return {
-            "ok": result.ok,
-            "events_checked": result.events_checked,
-            "seals_checked": result.seals_checked,
-            "content_mismatches": result.content_mismatches,
-            "seal_mismatches": result.seal_mismatches,
-            "missing_sealed_events": result.missing_sealed_events,
-            "summary": result.summary(),
-        }
+            return verify_audit_chain(s, dataset=args.get("dataset")).as_dict()
 
     if name == "identity_show":
         with _open(args) as s:
@@ -524,13 +496,12 @@ def _dispatch(name: str, args: dict) -> dict[str, Any]:
 
     if name == "identity_worklist":
         with _open(args) as s:
-            items = steward_worklist(
+            return steward_worklist_page(
                 s,
                 dataset=args.get("dataset"),
                 weak_confidence=float(args.get("weak_confidence", 0.6)),
                 limit=int(args.get("limit", 50)),
             )
-        return {"items": [it.as_dict() for it in items]}
 
     raise ValueError(f"unknown identity tool: {name}")
 

--- a/packages/python/goldenmatch/tests/identity/test_audit_chain.py
+++ b/packages/python/goldenmatch/tests/identity/test_audit_chain.py
@@ -10,7 +10,7 @@ provable. These tests lock the two integrity layers:
 from __future__ import annotations
 
 import sqlite3
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 from goldenmatch.identity import IdentityStore
@@ -309,7 +309,7 @@ def test_content_hash_ignores_tzinfo_for_the_same_wall_clock():
     ``gm_identity_audit_verify`` smoke caught exactly this.
     """
     naive = datetime(2026, 7, 24, 13, 22, 25, 55123)
-    aware = naive.replace(tzinfo=timezone.utc)
+    aware = naive.replace(tzinfo=UTC)
 
     def _ev(recorded_at):
         return IdentityEvent(

--- a/packages/python/goldenmatch/tests/identity/test_audit_chain.py
+++ b/packages/python/goldenmatch/tests/identity/test_audit_chain.py
@@ -10,6 +10,7 @@ provable. These tests lock the two integrity layers:
 from __future__ import annotations
 
 import sqlite3
+from datetime import datetime, timezone
 
 import pytest
 from goldenmatch.identity import IdentityStore
@@ -291,3 +292,44 @@ def test_pre_hashchain_events_seal_and_verify(tmp_path):
         assert res.ok is True
     finally:
         s.close()
+
+
+# ── timezone normalization (Postgres TIMESTAMPTZ round-trip) ──────────────────
+
+
+def test_content_hash_ignores_tzinfo_for_the_same_wall_clock():
+    """A tz-AWARE ``recorded_at`` must hash identically to the naive value that
+    was actually written.
+
+    Events are hashed *before* insert from a naive ``datetime.now()``, but the
+    Postgres schema stores ``recorded_at`` as ``TIMESTAMPTZ`` and reads back a
+    tz-aware datetime. Without normalization every stamped event re-hashed to a
+    different value and ``verify_audit_chain`` reported phantom "content
+    edit(s)" on a clean in-DB store -- the `rust_pgrx`
+    ``gm_identity_audit_verify`` smoke caught exactly this.
+    """
+    naive = datetime(2026, 7, 24, 13, 22, 25, 55123)
+    aware = naive.replace(tzinfo=timezone.utc)
+
+    def _ev(recorded_at):
+        return IdentityEvent(
+            entity_id="e1", kind="created", payload={"reason": "init"},
+            run_name="r1", dataset="people", actor="agent:x", trust=0.5,
+            recorded_at=recorded_at,
+        )
+
+    assert event_content_hash(_ev(naive)) == event_content_hash(_ev(aware))
+
+
+def test_naive_content_hash_is_pinned_so_existing_seals_stay_valid():
+    """Back-compat lock: the naive-datetime hash must not move. Any change to
+    ``event_content_hash`` / ``_normalize_dt`` that shifts this value silently
+    invalidates every seal chained over already-stored events."""
+    ev = IdentityEvent(
+        entity_id="e1", kind="created", payload={"reason": "init"},
+        run_name="r1", dataset="people", actor="agent:x", trust=0.5,
+        recorded_at=datetime(2026, 7, 24, 13, 22, 25, 55123),
+    )
+    assert event_content_hash(ev) == (
+        "fbb6f4093d6a5e943a07c96c0e2a8f93eafaf97d4a1ddbec66ed0792c8c2292a"
+    )

--- a/packages/rust/extensions/CLAUDE.md
+++ b/packages/rust/extensions/CLAUDE.md
@@ -110,7 +110,8 @@ essentially the whole single-record transform surface. Released
 
 DuckDB UDFs + Postgres pg_extern functions implementing the contract at
 `docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md`
-(monorepo root). Five read-only functions per backend:
+(monorepo root). Five read-only functions per backend (the 0.4.0 baseline —
+PostgreSQL has since added the stateful write + audit/MDM surface, see below):
 
 | Function | Args |
 |---|---|
@@ -125,9 +126,19 @@ DuckDB UDFs + Postgres pg_extern functions implementing the contract at
   Python UDFs cannot easily read session settings; pgrx + pyo3 settings
   round-trips add complexity for no real benefit. Explicit-arg also reads
   better at the SQL call site.
-- **Read-only**: writes must go through the Python `goldenmatch identity
-  merge/split` CLI, REST `/api/v1/identities/{id}/{merge,split}`, or MCP
-  `identity_merge` / `identity_split` tools in the main goldenmatch package.
+- **DuckDB is read-only; PostgreSQL is now a full stateful surface.** The five
+  functions above were the whole surface in 0.4.0. **PostgreSQL since gained the
+  in-DB write path** — `gm_resolve` (#1913 P1, stateful create/absorb/merge into
+  a Postgres-native dataset via the `goldenmatch.identity_dsn` GUC), the reads
+  serving the in-DB dataset on empty `db_path` (#1913 P2), steward
+  `gm_identity_merge`/`gm_identity_split` (#1913 P3), and (0.16.0) the audit
+  chain `gm_identity_audit`/`_audit_seal`/`_audit_verify`, steward mediation
+  `gm_identity_resolve_conflict`/`gm_identity_claim`, and MDM reads
+  `gm_identity_profile`/`_stats`/`_worklist` — 8 class-A bridge wrappers over
+  `goldenmatch.identity`, serialization single-sourced with the MCP tool layer.
+  The write functions are Postgres-only (DuckDB has no durable multi-connection
+  store). DuckDB identity stays read-only; its writes still go through the Python
+  CLI / REST / MCP.
 - **Python dep**: requires `goldenmatch>=1.15.0` (ships `goldenmatch.identity.*`).
 - **Tests**: `duckdb/tests/test_identity.py` -- 9 cases against a
   tmp_path-seeded SQLite identity DB. Postgres-side is CI-only.
@@ -138,7 +149,8 @@ DuckDB UDFs + Postgres pg_extern functions implementing the contract at
 
 Both backends expose the same function set (DuckDB UDFs <-> Postgres
 `pg_extern`, JSON in/JSON out): core scoring/dedupe/match, the 13 core-API
-parity functions, 8 `goldenflow_*` transforms, 5 read-only identity functions,
+parity functions, 8 `goldenflow_*` transforms, the identity functions (5 reads on
+both backends; PostgreSQL additionally has the stateful write + audit/MDM set),
 job-management (`gm_*`), and Learning Memory (`correction_add`/`_list` +
 `memory_learn`/`memory_stats`).
 
@@ -167,7 +179,7 @@ exposed in SQL. These are deferred by design, not gaps -- the rationale:
 | LLM family (`llm_score_pairs`, `llm_cluster_pairs`, `llm_extract_features`) | Needs network + API keys; not safe/deterministic inside a SQL engine. |
 | boost / rerank (`boost_accuracy`, `rerank_top_pairs`) | Bootstraps a HuggingFace cross-encoder (model download); too heavy for a UDF. |
 | `run_graph_er` | Multi-table + relationship config; not a single-table call. |
-| Identity **writes** (`manual_merge`, `manual_split`, `resolve_clusters`) | SQL identity surface is read-only by design; writes go through the Python CLI / REST `/api/v1/identities/...` / MCP `identity_merge`/`identity_split`. |
+| Identity **writes** (`manual_merge`, `manual_split`, `resolve_clusters`, mediation, claims, audit seal) | **PostgreSQL exposes these** (`gm_resolve`, `gm_identity_merge`/`_split`/`_claim`/`_resolve_conflict`/`_audit_seal`) over the `goldenmatch.identity_dsn` store. **DuckDB defers** — no durable multi-connection identity store; its writes go through the Python CLI / REST `/api/v1/identities/...` / MCP. |
 | `auto_map_columns` | InferMap schema mapping -- a separate package, not goldenmatch core. |
 | lineage / output writers (`build_lineage`, `write_output`, `generate_dedupe_report`) | Run-coupled / file-emitting; SQL callers get the data back directly and persist it themselves. |
 
@@ -177,7 +189,7 @@ lockstep (bridge fn + pgrx wrapper + handwritten SQL on the Postgres side;
 
 ## Gotchas
 - **Bridge tests SIGSEGV in pyarrow's mimalloc unless `ARROW_DEFAULT_MEMORY_POOL=system` (2026-07-10).** The `rust` lane's `cargo test --workspace` (bridge is the sole member) intermittently/near-deterministically crashed with `signal: 11 SIGSEGV`. Root cause (gdb): `mi_thread_init` in `pyarrow/libarrow.so`'s bundled **mimalloc** allocator, on a **worker thread** (`start_thread`→`clone3`) calling `pyarrow.array()` (`ConvertPySequence`). goldenmatch's pipeline (the `test_autoconfig_*`/`test_dedupe_*` controller tests) spawns polars/`ThreadPoolExecutor` workers that allocate through pyarrow's mimalloc, whose per-thread heap init faults under this embedded CPython. It is NOT a test-thread race (repro'd at `--test-threads=1`) and NOT goldenmatch logic (each test passes in isolation); it's the *accumulated* thread churn across the 46-test process. Fix: force pyarrow onto the system memory pool via `ARROW_DEFAULT_MEMORY_POOL=system` (the documented Arrow knob), set in CI on the test step. **Verified: 20/20 clean with it vs 20/20 SIGSEGV without**, on a clean py3.12 + `pip install goldenmatch pyarrow` repro (matches CI). A `std::env::set_var` in `init()` would be unsound (env mutation with live threads is exactly the hazard here), so the fix is the process env, not code. Follow-up to weigh: the `rust_pgrx` lane also embeds pyarrow — if it ever shows the same crash, set the pool there too.
-- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain `sql/goldenmatch_pg--0.7.0.sql` (the current `default_version` base) manually, plus the chained upgrade scripts (`--0.5.0--0.6.0.sql`, `--0.6.0--0.7.0.sql`). Bumping the extension version means adding a new `--X.Y.Z.sql` base + `--<prev>--X.Y.Z.sql` migration, bumping `default_version` in `goldenmatch_pg.control` AND `version` in `Cargo.toml`, and adding the hardcoded `cp sql/goldenmatch_pg--*.sql` lines in root `.github/workflows/ci.yml` + `publish-goldenmatch-pg.yml` (the orphaned `packages/.../.github` copies are ignored). A new function in an ALREADY-PUBLISHED version is wrong: published versions are immutable, so the function goes in the NEXT version's base + migration, NOT retro-added to the released base (bit gm_embed/#737 -- it shipped into 0.6.0 which was already released, fixed by moving it to 0.7.0). **CI guard (`pgrx_sql_sync` job → `scripts/check_pgrx_sql_sync.py`):** since the SQL is hand-maintained, a CI job asserts every `#[pg_extern]` in the crate appears as a `CREATE FUNCTION "<name>"` in the base SQL for the current `default_version`. Adding a `#[pg_extern]` without wiring it into the SQL now fails on the PR (Python-only, no pgrx toolchain) instead of surfacing at the pgrx build/smoke, if at all. It enforces Rust→SQL presence only (name-based, no `pg_extern(name=…)` overrides exist in this crate); `extension_sql!` helpers with no matching `#[pg_extern]` are reported as info, not errors.
+- pgrx 0.12.9 does NOT auto-generate SQL files -- must maintain the base SQL for the current `default_version` (now `sql/goldenmatch_pg--0.16.0.sql`) manually, plus the full chain of upgrade scripts (`--0.5.0--0.6.0.sql` … `--0.15.0--0.16.0.sql`). Bumping the extension version means adding a new `--X.Y.Z.sql` base + `--<prev>--X.Y.Z.sql` migration, bumping `default_version` in `goldenmatch_pg.control` AND `version` in `Cargo.toml`, and adding the hardcoded `cp sql/goldenmatch_pg--*.sql` lines in root `.github/workflows/ci.yml` + `publish-goldenmatch-pg.yml` (the orphaned `packages/.../.github` copies are ignored). A new function in an ALREADY-PUBLISHED version is wrong: published versions are immutable, so the function goes in the NEXT version's base + migration, NOT retro-added to the released base (bit gm_embed/#737 -- it shipped into 0.6.0 which was already released, fixed by moving it to 0.7.0). **CI guard (`pgrx_sql_sync` job → `scripts/check_pgrx_sql_sync.py`):** since the SQL is hand-maintained, a CI job asserts every `#[pg_extern]` in the crate appears as a `CREATE FUNCTION "<name>"` in the base SQL for the current `default_version`. Adding a `#[pg_extern]` without wiring it into the SQL now fails on the PR (Python-only, no pgrx toolchain) instead of surfacing at the pgrx build/smoke, if at all. It enforces Rust→SQL presence only (name-based, no `pg_extern(name=…)` overrides exist in this crate); `extension_sql!` helpers with no matching `#[pg_extern]` are reported as info, not errors.
 - pgrx extension functions are in `goldenmatch` schema -- use `goldenmatch.function_name()` in psql, or explicit `::TEXT` casts
 - `cargo` defaults CARGO_HOME to drive root on Windows when CWD is D: -- always set explicitly
 - DuckDB UDFs cannot query same connection (deadlock) -- use `con.cursor()` for table reads

--- a/packages/rust/extensions/bridge/src/api.rs
+++ b/packages/rust/extensions/bridge/src/api.rs
@@ -1216,6 +1216,218 @@ pub fn identity_split(
     })
 }
 
+// ─── Identity audit / mediation / MDM SQL surface (post-#1913) ───────────
+//
+// Class-A embedded-Python wrappers over `goldenmatch.identity`, mirroring the
+// #1913 read (`open_identity_store` on a `db_path`/DSN store ref) and write
+// (DSN-required) templates above. Serialization is single-sourced with the MCP
+// tool layer via the `*_dict`/`as_dict`/`*_page` helpers in
+// `goldenmatch.identity`, so SQL output is byte-identical to the MCP surface.
+
+/// `json.dumps(obj, default=str)` — the serialization every identity bridge fn
+/// (and the MCP tool layer) uses, so a dict/dataclass round-trips identically
+/// across the SQL and MCP surfaces.
+fn dumps_default_str<'py>(py: Python<'py>, obj: Bound<'py, PyAny>) -> Result<String, BridgeError> {
+    let json_mod = py.import("json")?;
+    let dumps_kwargs = PyDict::new(py);
+    dumps_kwargs.set_item("default", py.import("builtins")?.getattr("str")?)?;
+    let s: String = json_mod
+        .call_method("dumps", (obj,), Some(&dumps_kwargs))?
+        .extract()?;
+    Ok(s)
+}
+
+/// Append-only audit-log page: JSON `{"items": [...], "total": n}`. Empty
+/// `dataset` = every dataset. `store_ref` is a SQLite path or a libpq DSN
+/// (the pgrx wrapper substitutes the in-DB DSN when the caller passes empty).
+pub fn identity_audit(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let audit_page = identity.getattr("audit_log_page")?;
+        let store = open_identity_store(py, store_ref)?;
+        let kwargs = PyDict::new(py);
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let result = audit_page.call((store.clone(),), Some(&kwargs));
+        let _ = store.call_method0("close");
+        dumps_default_str(py, result?)
+    })
+}
+
+/// Replay the seal chain + per-event content hashes and report integrity as the
+/// JSON verdict (`{"ok", "events_checked", ..., "summary"}`).
+pub fn identity_audit_verify(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let verify = identity.getattr("verify_audit_chain")?;
+        let store = open_identity_store(py, store_ref)?;
+        let kwargs = PyDict::new(py);
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let result = verify.call((store.clone(),), Some(&kwargs));
+        let _ = store.call_method0("close");
+        let verdict = result?.call_method0("as_dict")?;
+        dumps_default_str(py, verdict)
+    })
+}
+
+/// Full MDM profile of one entity, or `{"found": false}` when the entity does
+/// not exist (mirrors `identity_resolve`'s absent-record shape).
+pub fn identity_profile(store_ref: &str, entity_id: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let profile_fn = identity.getattr("entity_profile")?;
+        let store = open_identity_store(py, store_ref)?;
+        let prof = profile_fn.call1((store.clone(), entity_id));
+        let _ = store.call_method0("close");
+        let prof = prof?;
+        if prof.is_none() {
+            return Ok("{\"found\": false}".to_string());
+        }
+        let d = prof.call_method0("as_dict")?;
+        dumps_default_str(py, d)
+    })
+}
+
+/// Graph-level identity health summary (JSON). Empty `dataset` = whole graph.
+pub fn identity_stats(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let stats_fn = identity.getattr("identity_summary_stats")?;
+        let store = open_identity_store(py, store_ref)?;
+        let kwargs = PyDict::new(py);
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let result = stats_fn.call((store.clone(),), Some(&kwargs));
+        let _ = store.call_method0("close");
+        let d = result?.call_method0("as_dict")?;
+        dumps_default_str(py, d)
+    })
+}
+
+/// Prioritized steward worklist: JSON `{"items": [...]}` (active entities with
+/// open conflicts and/or weak confidence). Empty `dataset` = all datasets.
+pub fn identity_worklist(store_ref: &str, dataset: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let worklist_fn = identity.getattr("steward_worklist_page")?;
+        let store = open_identity_store(py, store_ref)?;
+        let kwargs = PyDict::new(py);
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let result = worklist_fn.call((store.clone(),), Some(&kwargs));
+        let _ = store.call_method0("close");
+        dumps_default_str(py, result?)
+    })
+}
+
+/// Seal the audit log (steward write). JSON `{"sealed": false, ...}` when there
+/// is nothing new to seal, else the new seal-anchor fields. DSN-required.
+pub fn identity_audit_seal(dsn: &str, dataset: &str, actor: &str) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "identity_audit_seal requires a non-empty identity DSN (set the \
+             goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let seal_fn = identity.getattr("seal_audit_log")?;
+        let seal_result = identity.getattr("seal_result_dict")?;
+        let store = open_identity_store(py, dsn)?;
+        let kwargs = PyDict::new(py);
+        if !actor.is_empty() {
+            kwargs.set_item("actor", actor)?;
+        }
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let seal = seal_fn.call((store.clone(),), Some(&kwargs));
+        let _ = store.call_method0("close");
+        let d = seal_result.call1((seal?,))?;
+        dumps_default_str(py, d)
+    })
+}
+
+/// Steward conflict mediation write. `resolution` ∈ `same` / `distinct` /
+/// `defer`. Empty `reason` / `dataset` mean "unset". DSN-required.
+pub fn identity_resolve_conflict(
+    dsn: &str,
+    record_a_id: &str,
+    record_b_id: &str,
+    resolution: &str,
+    reason: &str,
+    dataset: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "identity_resolve_conflict requires a non-empty identity DSN (set \
+             the goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let mediate = identity.getattr("mediate_conflict")?;
+        let store = open_identity_store(py, dsn)?;
+        let kwargs = PyDict::new(py);
+        if !reason.is_empty() {
+            kwargs.set_item("reason", reason)?;
+        }
+        if !dataset.is_empty() {
+            kwargs.set_item("dataset", dataset)?;
+        }
+        let result = mediate.call(
+            (store.clone(), record_a_id, record_b_id, resolution),
+            Some(&kwargs),
+        );
+        let _ = store.call_method0("close");
+        dumps_default_str(py, result?)
+    })
+}
+
+/// Steward claim write: attach `record_id` to `entity_id` (moving it out of any
+/// prior entity). Empty `reason` means "unset". DSN-required.
+pub fn identity_claim(
+    dsn: &str,
+    entity_id: &str,
+    record_id: &str,
+    reason: &str,
+) -> Result<String, BridgeError> {
+    crate::init()?;
+    if dsn.trim().is_empty() {
+        return Err(BridgeError::InvalidConfig(
+            "identity_claim requires a non-empty identity DSN (set the \
+             goldenmatch.identity_dsn GUC)"
+                .to_string(),
+        ));
+    }
+    Python::with_gil(|py| {
+        let identity = py.import("goldenmatch.identity")?;
+        let claim = identity.getattr("claim_record")?;
+        let store = open_identity_store(py, dsn)?;
+        let kwargs = PyDict::new(py);
+        if !reason.is_empty() {
+            kwargs.set_item("reason", reason)?;
+        }
+        let result = claim.call((store.clone(), entity_id, record_id), Some(&kwargs));
+        let _ = store.call_method0("close");
+        dumps_default_str(py, result?)
+    })
+}
+
 // ─── Correction CRUD (Phase 6A of #437 surface sync) ────────────────────
 //
 // File pair-level + field-level + cluster-decision corrections into the

--- a/packages/rust/extensions/postgres/Cargo.toml
+++ b/packages/rust/extensions/postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "goldenmatch_pg"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
 authors = ["Ben Severn <benzsevern@gmail.com>"]

--- a/packages/rust/extensions/postgres/goldenmatch_pg.control
+++ b/packages/rust/extensions/postgres/goldenmatch_pg.control
@@ -1,5 +1,5 @@
 comment = 'Entity resolution toolkit -- deduplicate, match, and maintain golden records'
-default_version = '0.15.0'
+default_version = '0.16.0'
 module_pathname = '$libdir/goldenmatch_pg'
 relocatable = false
 schema = goldenmatch

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.15.0--0.16.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.15.0--0.16.0.sql
@@ -1,0 +1,89 @@
+-- Upgrade goldenmatch_pg 0.15.0 -> 0.16.0
+--
+-- Extends the in-SQL identity surface (post-#1913) with the audit chain,
+-- steward mediation, and MDM operator reads that were already on the Python /
+-- MCP / REST surfaces but not in SQL:
+--
+--   Reads (db_path = SQLite path or libpq DSN; empty = the in-DB dataset):
+--     gm_identity_audit(dataset, db_path)        -- append-only audit-log page
+--     gm_identity_audit_verify(dataset, db_path) -- seal-chain integrity verdict
+--     gm_identity_profile(entity_id, db_path)    -- one entity's MDM profile
+--     gm_identity_stats(dataset, db_path)        -- graph-level health summary
+--     gm_identity_worklist(dataset, db_path)     -- prioritized steward queue
+--
+--   Writes (DSN-resolved via goldenmatch.identity_dsn, like gm_identity_merge):
+--     gm_identity_audit_seal(dataset)            -- anchor the audit log
+--     gm_identity_resolve_conflict(dataset, record_a, record_b, resolution,
+--                                  reason)       -- steward conflict verdict
+--     gm_identity_claim(entity_id, record_id, reason) -- attach record to entity
+--
+-- All delegate to goldenmatch.identity through the bridge; serialization is
+-- single-sourced with the MCP tool layer, so output is byte-identical across
+-- surfaces. Empty optional args (dataset / reason) mean "unset".
+
+CREATE FUNCTION "gm_identity_audit"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_verify"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_verify_wrapper';
+
+CREATE FUNCTION "gm_identity_profile"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_profile_wrapper';
+
+CREATE FUNCTION "gm_identity_stats"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_stats_wrapper';
+
+CREATE FUNCTION "gm_identity_worklist"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_worklist_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_seal"(
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_seal_wrapper';
+
+CREATE FUNCTION "gm_identity_resolve_conflict"(
+    "dataset" TEXT,
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "resolution" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_resolve_conflict_wrapper';
+
+CREATE FUNCTION "gm_identity_claim"(
+    "entity_id" TEXT,
+    "record_id" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_claim_wrapper';

--- a/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.16.0.sql
+++ b/packages/rust/extensions/postgres/sql/goldenmatch_pg--0.16.0.sql
@@ -1,0 +1,913 @@
+-- goldenmatch_pg SQL extension schema v0.5.0
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline tables (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS goldenmatch._jobs (
+    name TEXT PRIMARY KEY,
+    config_json JSONB NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT now(),
+    last_run_at TIMESTAMPTZ,
+    status TEXT DEFAULT 'configured',
+    -- v1.7-v1.12: most-recent run's AutoConfigController telemetry. NULL when
+    -- the job used an explicit config (controller didn't fire) or hasn't run.
+    last_telemetry_json JSONB
+);
+-- ALTER for upgrades from extension installs that pre-date the telemetry column.
+ALTER TABLE goldenmatch._jobs ADD COLUMN IF NOT EXISTS last_telemetry_json JSONB;
+
+CREATE TABLE IF NOT EXISTS goldenmatch._pairs (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    id_a BIGINT,
+    id_b BIGINT,
+    score DOUBLE PRECISION,
+    matchkey TEXT,
+    field_scores JSONB
+);
+CREATE INDEX IF NOT EXISTS idx_pairs_job ON goldenmatch._pairs(job_name, id_a, id_b);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._clusters (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_id BIGINT,
+    is_golden BOOLEAN DEFAULT FALSE
+);
+CREATE INDEX IF NOT EXISTS idx_clusters_job ON goldenmatch._clusters(job_name, cluster_id);
+
+CREATE TABLE IF NOT EXISTS goldenmatch._golden (
+    job_name TEXT REFERENCES goldenmatch._jobs(name) ON DELETE CASCADE,
+    cluster_id BIGINT,
+    record_data JSONB
+);
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-based functions (primary interface)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_table"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_table_wrapper';
+
+CREATE FUNCTION "goldenmatch_match_tables"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_tables_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Pipeline functions (job management)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "gm_configure"(
+    "job_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_configure_wrapper';
+
+CREATE FUNCTION "gm_run"(
+    "job_name" TEXT,
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_run_wrapper';
+
+-- In-DB stateful identity resolution (#1913 P1). Resolves a job's table into a
+-- Postgres-native identity dataset (create/absorb/merge, incremental across
+-- runs). Writes go to the DSN from the goldenmatch.identity_dsn GUC.
+CREATE FUNCTION "gm_resolve"(
+    "job_name" TEXT,
+    "table_name" TEXT,
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_resolve_wrapper';
+
+CREATE FUNCTION "gm_jobs"() RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_jobs_wrapper';
+
+CREATE FUNCTION "gm_golden"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_golden_wrapper';
+
+CREATE FUNCTION "gm_drop"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_drop_wrapper';
+
+CREATE FUNCTION "gm_pairs"(
+    "job_name" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_pairs_wrapper';
+
+CREATE FUNCTION "gm_clusters"(
+    "job_name" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_clusters_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Table-returning functions (structured results)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe_pairs"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("id_a" BIGINT, "id_b" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_pairs_wrapper';
+
+CREATE FUNCTION "goldenmatch_dedupe_clusters"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("cluster_id" BIGINT, "record_id" BIGINT, "cluster_size" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_clusters_wrapper';
+
+-- Two-table record linkage: match a target table against a reference table,
+-- returning the (target_id, reference_id, score) linkage as rows. target_id /
+-- reference_id are 0-based row indices into the respective input tables.
+CREATE FUNCTION "goldenmatch_match_pairs"(
+    "target_table" TEXT,
+    "reference_table" TEXT,
+    "config_json" TEXT
+) RETURNS TABLE ("target_id" BIGINT, "reference_id" BIGINT, "score" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_pairs_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Scalar functions
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_score"(
+    "value_a" TEXT,
+    "value_b" TEXT,
+    "scorer" TEXT DEFAULT 'jaro_winkler'
+) RETURNS DOUBLE PRECISION
+STRICT PARALLEL RESTRICTED
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_wrapper';
+
+CREATE FUNCTION "goldenmatch_score_pair"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_pair_wrapper';
+
+CREATE FUNCTION "goldenmatch_explain"(
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "config" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_explain_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- JSON-based functions (programmatic use)
+-- ══════════════════════════════════════════════════════════════════════
+
+CREATE FUNCTION "goldenmatch_dedupe"(
+    "rows_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_wrapper';
+
+CREATE FUNCTION "goldenmatch_match"(
+    "target_json" TEXT,
+    "reference_json" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_match_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- AutoConfig + controller telemetry (v1.7-v1.12)
+-- ══════════════════════════════════════════════════════════════════════
+
+-- Run AutoConfigController on a table and return the committed GoldenMatchConfig
+-- as JSON. Pipe the output into goldenmatch_dedupe_full to apply it.
+-- `mode` selects the strategy: 'standard' (default, iterative controller) or
+-- 'probabilistic' (Fellegi-Sunter matchkeys). The DEFAULT keeps 1-arg calls.
+CREATE FUNCTION "goldenmatch_autoconfig"(
+    "table_name" TEXT,
+    "mode" TEXT DEFAULT 'standard'
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_wrapper';
+
+-- Same as above but returns the controller telemetry blob (stop_reason,
+-- decisions, health, indicator priors, committed NE).
+CREATE FUNCTION "goldenmatch_autoconfig_telemetry"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autoconfig_telemetry_wrapper';
+
+-- Deduplicate a table with a *full* GoldenMatchConfig JSON (supports
+-- negative_evidence / Path Y, per-matchkey scorers, standardization, etc.).
+CREATE FUNCTION "goldenmatch_dedupe_full"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_wrapper';
+
+-- Same as above but returns the controller telemetry from that run.
+CREATE FUNCTION "goldenmatch_dedupe_full_telemetry"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_dedupe_full_telemetry_wrapper';
+
+-- Retrieve the telemetry from the most recent gm_run of a named job.
+-- Returns '{"available":false}' for jobs that haven't run or used an
+-- explicit config.
+CREATE FUNCTION "gm_telemetry"(
+    "job_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_telemetry_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Identity Graph (v2.0)
+-- ══════════════════════════════════════════════════════════════════════
+-- Contract: docs/superpowers/specs/2026-05-12-identity-graph-duckdb-contract.md
+-- All identity functions accept the path to the identity store as an explicit
+-- second arg. For SQLite pass the filesystem path; for Postgres pass the libpq
+-- DSN. Empty-string filters mean "no filter on that dimension".
+
+-- Resolve a `{source}:{source_pk}` record id to its identity view JSON.
+-- Returns {"found": false} when the record has no identity.
+CREATE FUNCTION "goldenmatch_identity_resolve"(
+    "record_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_resolve_wrapper';
+
+-- Return the full identity view JSON for a given entity_id.
+CREATE FUNCTION "goldenmatch_identity_view"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_view_wrapper';
+
+-- Return the temporal event log for an identity as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_history"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_history_wrapper';
+
+-- List `conflicts_with` evidence edges as a JSON array.
+CREATE FUNCTION "goldenmatch_identity_conflicts"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_conflicts_wrapper';
+
+-- List identities filtered by dataset and status (empty = no filter).
+CREATE FUNCTION "goldenmatch_identity_list"(
+    "dataset" TEXT,
+    "status" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_identity_list_wrapper';
+
+-- ══════════════════════════════════════════════════════════════════════
+-- Core-API parity (mirrors duckdb/core_apis.py -- 13 UDFs)
+-- ══════════════════════════════════════════════════════════════════════
+-- Wrappers over goldenmatch's function-shaped core APIs. IDENTICAL JSON
+-- in / JSON out contract to the DuckDB `goldenmatch_*` core-API UDFs so the
+-- two backends are interchangeable. Table-input functions read the table via
+-- SPI (`row_to_json`, like goldenmatch_dedupe_table); JSON-in functions take
+-- the payloads directly. All read-only -- no REVOKE.
+
+-- Profile a table (column stats, types, quality signals) as JSON.
+CREATE FUNCTION "goldenmatch_profile_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_profile_table_wrapper';
+
+-- Otsu threshold over a JSON array of scores. Returns SQL NULL when the
+-- distribution is unimodal / too few scores.
+CREATE FUNCTION "goldenmatch_suggest_threshold"(
+    "scores_json" TEXT
+) RETURNS DOUBLE PRECISION
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_suggest_threshold_wrapper';
+
+-- Domain profile for a JSON array of column names, as JSON.
+CREATE FUNCTION "goldenmatch_detect_domain"(
+    "columns_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_domain_wrapper';
+
+-- Extract structured features from text. kind: product/electronics (default),
+-- software, biblio/bibliographic. Returns the features as JSON.
+CREATE FUNCTION "goldenmatch_extract_features"(
+    "text" TEXT,
+    "kind" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_extract_features_wrapper';
+
+-- Evaluate predicted pairs (JSON array) or clusters (JSON object) against a
+-- ground-truth JSON array of [a, b] pairs. Returns EvalResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_evaluate"(
+    "pairs_json" TEXT,
+    "ground_truth_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_evaluate_wrapper';
+
+-- CCMS comparison of two clusterings (JSON objects). Returns
+-- CompareResult.summary() JSON.
+CREATE FUNCTION "goldenmatch_compare_clusters"(
+    "a_json" TEXT,
+    "b_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_compare_clusters_wrapper';
+
+-- Run validation rules (JSON array of ValidationRule) over a table. Returns
+-- {report, valid_rows, quarantine_rows, quarantine} JSON.
+CREATE FUNCTION "goldenmatch_validate_table"(
+    "table_name" TEXT,
+    "rules_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_validate_table_wrapper';
+
+-- Apply auto-fixes to a table. Returns {fixes, fixed_rows, rows} JSON.
+CREATE FUNCTION "goldenmatch_autofix_table"(
+    "table_name" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_autofix_table_wrapper';
+
+-- Flag suspicious records in a table. sensitivity: low/medium/high. Returns
+-- a JSON array of anomaly dicts.
+CREATE FUNCTION "goldenmatch_detect_anomalies"(
+    "table_name" TEXT,
+    "sensitivity" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_detect_anomalies_wrapper';
+
+-- Validate (table, full GoldenMatchConfig JSON) before a run. Returns
+-- {has_errors, config_was_modified, findings} JSON.
+CREATE FUNCTION "goldenmatch_preflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_preflight_wrapper';
+
+-- Post-run signal report for (table, config). Derives pair_scores by running
+-- dedupe_df on the table. Returns {signals, adjustments, advisories} JSON.
+CREATE FUNCTION "goldenmatch_postflight"(
+    "table_name" TEXT,
+    "config_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_postflight_wrapper';
+
+-- Train Fellegi-Sunter m/u probabilities via EM. Returns the EMResult JSON;
+-- pass it straight to goldenmatch_score_probabilistic.
+CREATE FUNCTION "goldenmatch_train_em"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "params_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_train_em_wrapper';
+
+-- Score record pairs with trained Fellegi-Sunter probabilities. Returns a
+-- JSON array of [a, b, score] triples above the link threshold.
+CREATE FUNCTION "goldenmatch_score_probabilistic"(
+    "rows_json" TEXT,
+    "matchkey_json" TEXT,
+    "em_result_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_score_probabilistic_wrapper';
+
+-- ─── Correction CRUD (v0.5.0, Phase 6A of #437 surface sync) ──────────
+--
+-- File pair-level / field-level / cluster-decision corrections into
+-- the goldenmatch MemoryStore. Read with `correction_list` or via
+-- the `goldenmatch.corrections` view (no auth required for reads).
+--
+-- Permissions: `correction_add` is REVOKEd from PUBLIC at the bottom
+-- of this file and granted to `goldenmatch_correction_writer`. Roles
+-- needing write access must be GRANTed that role.
+
+CREATE FUNCTION "correction_add"(
+    "decision" TEXT,
+    "dataset" TEXT,
+    "id_a" BIGINT DEFAULT NULL,
+    "id_b" BIGINT DEFAULT NULL,
+    "cluster_id" BIGINT DEFAULT NULL,
+    "field_name" TEXT DEFAULT NULL,
+    "original_value" TEXT DEFAULT NULL,
+    "corrected_value" TEXT DEFAULT NULL,
+    "cluster_score" DOUBLE PRECISION DEFAULT NULL,
+    "cluster_outcome" TEXT DEFAULT NULL,
+    "reason" TEXT DEFAULT NULL,
+    "matchkey_name" TEXT DEFAULT NULL,
+    "source" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_add_wrapper';
+
+CREATE FUNCTION "correction_list"(
+    "dataset" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'correction_list_wrapper';
+
+-- Learning Memory: force a MemoryLearner pass; returns JSON
+-- { "count": N, "adjustments": [...] }. Needs >= 10 corrections per matchkey.
+CREATE FUNCTION "memory_learn"(
+    "matchkey_name" TEXT DEFAULT NULL,
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_learn_wrapper';
+
+-- Learning Memory status: JSON
+-- { "total_corrections": N, "last_learn_time": ISO|null, "adjustments": [...] }.
+CREATE FUNCTION "memory_stats"(
+    "memory_path" TEXT DEFAULT NULL
+) RETURNS TEXT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'memory_stats_wrapper';
+
+-- Read-only view over the correction store. Wraps `correction_list`
+-- with `json_array_elements` so callers can write SQL like
+-- `SELECT * FROM goldenmatch.corrections WHERE dataset = 'customers'`.
+-- View access uses the default GRANT chain; no special role required.
+CREATE OR REPLACE VIEW goldenmatch.corrections AS
+SELECT
+    (entry->>'id')::TEXT              AS id,
+    (entry->>'id_a')::BIGINT          AS id_a,
+    (entry->>'id_b')::BIGINT          AS id_b,
+    (entry->>'decision')::TEXT        AS decision,
+    (entry->>'source')::TEXT          AS source,
+    (entry->>'trust')::DOUBLE PRECISION AS trust,
+    (entry->>'reason')::TEXT          AS reason,
+    (entry->>'dataset')::TEXT         AS dataset,
+    (entry->>'matchkey_name')::TEXT   AS matchkey_name,
+    (entry->>'field_name')::TEXT      AS field_name,
+    (entry->>'original_value')::TEXT  AS original_value,
+    (entry->>'corrected_value')::TEXT AS corrected_value,
+    (entry->>'cluster_score')::DOUBLE PRECISION AS cluster_score,
+    (entry->>'cluster_outcome')::TEXT AS cluster_outcome,
+    (entry->>'created_at')::TIMESTAMPTZ AS created_at
+FROM jsonb_array_elements(
+    goldenmatch.correction_list(NULL, NULL)::jsonb
+) AS entry;
+
+-- ─── Permissions ──────────────────────────────────────────────────────
+--
+-- `correction_add` writes into the Learning Memory store; default
+-- REVOKE from PUBLIC so accidental SELECT-from-anywhere can't file
+-- correctness signals. Grant `goldenmatch_correction_writer` to any
+-- role that needs to file corrections.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'goldenmatch_correction_writer') THEN
+        CREATE ROLE goldenmatch_correction_writer NOLOGIN;
+    END IF;
+END
+$$;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_add(
+    TEXT, TEXT, BIGINT, BIGINT, BIGINT, TEXT, TEXT, TEXT,
+    DOUBLE PRECISION, TEXT, TEXT, TEXT, TEXT, TEXT
+) TO goldenmatch_correction_writer;
+
+REVOKE EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.correction_list(TEXT, TEXT) TO goldenmatch_correction_writer;
+
+-- memory_learn mutates the store (writes learned adjustments); gate it like
+-- correction_add. memory_stats is read-only status (counts + thresholds, no
+-- correction contents) and stays available to PUBLIC.
+REVOKE EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION goldenmatch.memory_learn(TEXT, TEXT) TO goldenmatch_correction_writer;
+GRANT SELECT ON goldenmatch.corrections TO goldenmatch_correction_writer;
+
+-- ─── GoldenFlow transforms (src/goldenflow.rs) ────────────────────────────
+--
+-- 8 scalar text -> text wrappers over goldenflow's transform registry,
+-- mirroring the DuckDB goldenflow_* UDFs (goldenmatch_duckdb/goldenflow.py).
+-- Closes the last DuckDB <-> Postgres parity gap. All STRICT (NULL in -> NULL
+-- out); the bridge fails open (passes the input through unchanged when
+-- goldenflow isn't installed / the transform errors), so these are read-only
+-- and safe for PUBLIC -- no REVOKE.
+
+-- Normalize an email address. Wraps goldenflow `email_normalize`.
+CREATE FUNCTION "goldenflow_normalize_email"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_email_wrapper';
+
+-- Normalize a phone number to E.164. Wraps goldenflow `phone_e164`.
+CREATE FUNCTION "goldenflow_normalize_phone"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_phone_wrapper';
+
+-- Normalize a date to ISO-8601. Wraps goldenflow `date_iso8601`.
+CREATE FUNCTION "goldenflow_normalize_date"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_date_wrapper';
+
+-- Proper-case a personal name. Wraps goldenflow `name_proper`.
+CREATE FUNCTION "goldenflow_normalize_name_proper"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_normalize_name_proper_wrapper';
+
+-- Canonicalize a URL. Wraps goldenflow `url_normalize`.
+CREATE FUNCTION "goldenflow_canonicalize_url"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_url_wrapper';
+
+-- Standardize a postal address. Wraps goldenflow `address_standardize`.
+CREATE FUNCTION "goldenflow_canonicalize_address"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_canonicalize_address_wrapper';
+
+-- Strip leading/trailing whitespace. Wraps goldenflow `strip`.
+CREATE FUNCTION "goldenflow_strip"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_strip_wrapper';
+
+-- Collapse internal whitespace runs. Wraps goldenflow `collapse_whitespace`.
+CREATE FUNCTION "goldenflow_whitespace_normalize"(
+    "value" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenflow_whitespace_normalize_wrapper';
+
+-- ── Native Core graph kernels (#509) ──────────────────────────────────────
+-- Native-direct: these call the pyo3-free goldenmatch-graph-core crate in pure
+-- Rust (NO embedded CPython). DuckDB<->Postgres lockstep with core_kernels.py.
+-- Accept-both: int64 ids on the bare name, string ids on the _str sibling
+-- (a first-seen str<->i64 dictionary wraps the i64 kernel).
+
+-- Canonical max-score pairs over int64 id arrays. Returns (a, b, s) rows.
+CREATE FUNCTION "goldenmatch_pair_dedup"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_wrapper';
+
+-- String-id variant: same kernel via a first-seen str<->i64 dictionary.
+CREATE FUNCTION "goldenmatch_pair_dedup_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[]
+) RETURNS TABLE ("a" TEXT, "b" TEXT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_pair_dedup_str_wrapper';
+
+-- Connected components over int64 edge arrays + an int64 id universe.
+-- Returns (component_index, member) rows.
+CREATE FUNCTION "goldenmatch_connected_components"(
+    "id_a" BIGINT[],
+    "id_b" BIGINT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" BIGINT[]
+) RETURNS TABLE ("component" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_wrapper';
+
+-- String-id variant of connected components.
+CREATE FUNCTION "goldenmatch_connected_components_str"(
+    "id_a" TEXT[],
+    "id_b" TEXT[],
+    "score" DOUBLE PRECISION[],
+    "all_ids" TEXT[]
+) RETURNS TABLE ("component" BIGINT, "member" TEXT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_connected_components_str_wrapper';
+
+-- Embed one text with a local in-house model (a saved GoldenEmbedModel dir)
+-- via goldenembed-rs (pure Rust, no embedded CPython). Returns the vector as
+-- float8[].
+CREATE FUNCTION "goldenmatch_embed_local"(
+    "text" TEXT,
+    "model_path" TEXT
+) RETURNS double precision[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_embed_local_wrapper';
+
+-- Embed one text with the in-house model, model dir from GOLDENEMBED_MODEL_DIR
+-- (loaded once per backend process). Returns real[] (float4) -- parity with the
+-- DataFusion goldenmatch_embed UDF, including NULL -> "" (so NOT STRICT). #737.
+CREATE FUNCTION "gm_embed"(
+    "text" TEXT  /* nullable: NULL -> "" */
+) RETURNS real[]
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_embed_wrapper';
+
+-- Canonical record fingerprint (64 hex) of a JSON record object. The
+-- cross-surface stable record-id hash; matches the DuckDB
+-- goldenmatch_record_fingerprint UDF + the Python identity path.
+CREATE FUNCTION "goldenmatch_record_fingerprint"(
+    "record_json" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_record_fingerprint_wrapper';
+
+-- goldenmatch_hnsw_pairs (added in 0.10.0): native HNSW ANN blocking over a
+-- row-major flat real[] corpus. See the 0.9.0->0.10.0 migration for details.
+CREATE FUNCTION "goldenmatch_hnsw_pairs"(
+    "flat_vecs" real[],
+    "dim" INT,
+    "k" INT,
+    "threshold" DOUBLE PRECISION
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT, "s" DOUBLE PRECISION)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_hnsw_pairs_wrapper';
+
+-- goldenmatch_lsh_pairs (added in 0.11.0): native MinHash-LSH token blocking
+-- over a text[] corpus. See the 0.10.0->0.11.0 migration for details.
+CREATE FUNCTION "goldenmatch_lsh_pairs"(
+    "texts" TEXT[],
+    "mode" TEXT,
+    "k" INT,
+    "num_perms" INT,
+    "num_bands" INT,
+    "seed" BIGINT
+) RETURNS TABLE ("a" BIGINT, "b" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_lsh_pairs_wrapper';
+
+-- goldenmatch_perceptual_phash (added in 0.12.0): native-direct (no CPython)
+-- 64-bit DCT perceptual image hash over a row-major flat luma grid + its row
+-- width. The kernel resizes to 32x32 internally. The unsigned 64-bit hash is
+-- returned bit-reinterpreted as BIGINT. See the 0.11.0->0.12.0 migration.
+CREATE FUNCTION "goldenmatch_perceptual_phash"(
+    "grid" double precision[],
+    "ncols" INT
+) RETURNS BIGINT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_phash_wrapper';
+
+-- goldenmatch_perceptual_hamming (added in 0.12.0): Hamming distance between two
+-- 64-bit pHashes (the near-duplicate blocking predicate). Correct on the BIGINT
+-- bit patterns goldenmatch_perceptual_phash returns.
+CREATE FUNCTION "goldenmatch_perceptual_hamming"(
+    "a" BIGINT,
+    "b" BIGINT
+) RETURNS INT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldenmatch_perceptual_hamming_wrapper';
+
+-- ── GoldenCheck deep-profiling surface (added in 0.13.0) ────────────────────
+-- Native-direct (no CPython) over the pyo3-free goldencheck-core kernels — the
+-- same reference kernel the goldencheck[native] wheel + the DuckDB goldencheck_*
+-- UDFs run (cross-surface parity roadmap P5). The multi-column functions take a
+-- column-major flat text[] (all of column 0's rows, then column 1's, …) + n_cols.
+
+-- goldencheck_benford: leading-digit (1..9) histogram; element d-1 is the count
+-- of values whose first significant digit is d (non-positive/non-finite skipped).
+CREATE FUNCTION "goldencheck_benford"(
+    "values" double precision[]
+) RETURNS BIGINT[]
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_benford_wrapper';
+
+-- goldencheck_near_duplicates: cluster near-duplicate string values; one
+-- (cluster, member) row per clustered element (member = 0-based position);
+-- singletons omitted; NULL elements treated as the empty string.
+CREATE FUNCTION "goldencheck_near_duplicates"(
+    "values" TEXT[],
+    "min_similarity" DOUBLE PRECISION
+) RETURNS TABLE ("cluster" BIGINT, "member" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_near_duplicates_wrapper';
+
+-- goldencheck_discover_fds: strict single-column functional dependencies among
+-- n_cols equal-length columns; (det, dep) 0-based column-index pairs.
+CREATE FUNCTION "goldencheck_discover_fds"(
+    "flat" TEXT[],
+    "n_cols" INT
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_fds_wrapper';
+
+-- goldencheck_discover_approx_fds: near-strict FDs + their violation counts;
+-- (det, dep, violations) where det->dep holds for >= min_confidence of rows.
+CREATE FUNCTION "goldencheck_discover_approx_fds"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "min_confidence" DOUBLE PRECISION
+) RETURNS TABLE ("det" BIGINT, "dep" BIGINT, "violations" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_discover_approx_fds_wrapper';
+
+-- goldencheck_composite_keys: minimal composite keys (column subsets of size
+-- 2..max_size whose tuples are all distinct); one (key_id, col_index) row per
+-- column in each key. Constant + individually-unique columns are excluded first.
+CREATE FUNCTION "goldencheck_composite_keys"(
+    "flat" TEXT[],
+    "n_cols" INT,
+    "max_size" INT
+) RETURNS TABLE ("key_id" BIGINT, "col_index" BIGINT)
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'goldencheck_composite_keys_wrapper';
+
+CREATE FUNCTION "gm_identity_merge"(
+    "dataset" TEXT,
+    "entity_a" TEXT,
+    "entity_b" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_merge_wrapper';
+
+CREATE FUNCTION "gm_identity_split"(
+    "dataset" TEXT,
+    "entity_id" TEXT,
+    "record_id" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_split_wrapper';
+
+-- ── Identity audit / mediation / MDM SQL surface (added in 0.16.0) ──
+CREATE FUNCTION "gm_identity_audit"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_verify"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_verify_wrapper';
+
+CREATE FUNCTION "gm_identity_profile"(
+    "entity_id" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_profile_wrapper';
+
+CREATE FUNCTION "gm_identity_stats"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_stats_wrapper';
+
+CREATE FUNCTION "gm_identity_worklist"(
+    "dataset" TEXT,
+    "db_path" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_worklist_wrapper';
+
+CREATE FUNCTION "gm_identity_audit_seal"(
+    "dataset" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_audit_seal_wrapper';
+
+CREATE FUNCTION "gm_identity_resolve_conflict"(
+    "dataset" TEXT,
+    "record_a" TEXT,
+    "record_b" TEXT,
+    "resolution" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_resolve_conflict_wrapper';
+
+CREATE FUNCTION "gm_identity_claim"(
+    "entity_id" TEXT,
+    "record_id" TEXT,
+    "reason" TEXT
+) RETURNS TEXT
+STRICT
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'gm_identity_claim_wrapper';

--- a/packages/rust/extensions/postgres/src/pipeline.rs
+++ b/packages/rust/extensions/postgres/src/pipeline.rs
@@ -485,6 +485,100 @@ pub fn gm_identity_split(dataset: String, entity_id: String, record_id: String) 
     }
 }
 
+// ── Identity audit / mediation writes (post-#1913) ───────────────────────
+//
+// Steward writes into the in-DB Postgres identity dataset, DSN-resolved via
+// `resolve_identity_dsn()` like `gm_identity_merge`/`gm_identity_split`. Empty
+// optional args (`reason`, `dataset`) mean "unset". Like all in-DB identity
+// writes (§3.1 of the #1913 design), these commit on the store's own libpq
+// connection, NOT the caller's SQL transaction; replay is idempotent.
+
+/// Seal the audit log for tamper-evidence (steward write). Returns
+/// `{"sealed": false, ...}` when there is nothing new to seal, else the new
+/// seal-anchor JSON. `dataset` empty = the global seal chain.
+#[pg_extern]
+pub fn gm_identity_audit_seal(dataset: String) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB audit seal needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+    match goldenmatch_bridge::api::identity_audit_seal(&dsn, &dataset, "") {
+        Ok(s) => s,
+        Err(e) => pgrx::error!(
+            "goldenmatch: gm_identity_audit_seal(dataset={}) failed: {}",
+            dataset,
+            e
+        ),
+    }
+}
+
+/// Steward conflict mediation (steward write). `resolution` ∈ `same` /
+/// `distinct` / `defer`; `same` keeps the entity, `distinct` splits `record_b`
+/// out, `defer` only logs. Empty `reason` / `dataset` mean "unset". Returns the
+/// mediation result JSON.
+#[pg_extern]
+pub fn gm_identity_resolve_conflict(
+    dataset: String,
+    record_a: String,
+    record_b: String,
+    resolution: String,
+    reason: String,
+) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB conflict mediation needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+    match goldenmatch_bridge::api::identity_resolve_conflict(
+        &dsn,
+        &record_a,
+        &record_b,
+        &resolution,
+        &reason,
+        &dataset,
+    ) {
+        Ok(s) => s,
+        Err(e) => pgrx::error!(
+            "goldenmatch: gm_identity_resolve_conflict(a={}, b={}, resolution={}) failed: {}",
+            record_a,
+            record_b,
+            resolution,
+            e
+        ),
+    }
+}
+
+/// Steward claim (steward write): attach `record_id` to `entity_id`, moving it
+/// out of any prior entity + emitting a `claimed` event. Empty `reason` = unset.
+/// Returns the claim result JSON.
+#[pg_extern]
+pub fn gm_identity_claim(entity_id: String, record_id: String, reason: String) -> String {
+    let dsn = resolve_identity_dsn().unwrap_or_else(|| {
+        pgrx::error!(
+            "goldenmatch: in-DB identity claim needs a DSN — set \
+             `ALTER SYSTEM SET goldenmatch.identity_dsn = '...'` (or the \
+             GOLDENMATCH_IDENTITY_DSN / GOLDENMATCH_DATABASE_URL backend env) \
+             pointing at this database"
+        )
+    });
+    match goldenmatch_bridge::api::identity_claim(&dsn, &entity_id, &record_id, &reason) {
+        Ok(s) => s,
+        Err(e) => pgrx::error!(
+            "goldenmatch: gm_identity_claim(entity={}, record={}) failed: {}",
+            entity_id,
+            record_id,
+            e
+        ),
+    }
+}
+
 /// Resolve the identity DSN: the `goldenmatch.identity_dsn` GUC first, then the
 /// `GOLDENMATCH_IDENTITY_DSN` / `GOLDENMATCH_DATABASE_URL` backend env. Returns
 /// `None` (→ a clear error at the call site) when nothing is configured. A

--- a/packages/rust/extensions/postgres/src/quick.rs
+++ b/packages/rust/extensions/postgres/src/quick.rs
@@ -406,3 +406,67 @@ pub fn goldenmatch_identity_list(dataset: String, status: String, db_path: Strin
         Err(e) => pgrx::error!("goldenmatch: {}", e),
     }
 }
+
+// ── Identity audit / MDM reads (post-#1913) ──────────────────────────────
+//
+// Audit chain (`gm_identity_audit` / `_audit_verify`) + MDM operator views
+// (`gm_identity_profile` / `_stats` / `_worklist`). Reads, so they take the
+// same `db_path` store ref as the `goldenmatch_identity_*` reads above (empty
+// → the in-DB Postgres dataset via `goldenmatch.identity_dsn`). Empty
+// `dataset` = no dataset filter.
+
+/// Append-only audit-log page (JSON `{"items": [...], "total": n}`). Empty
+/// ``dataset`` = every dataset; empty ``db_path`` reads the in-DB dataset.
+#[pg_extern]
+pub fn gm_identity_audit(dataset: String, db_path: String) -> String {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_audit(&store_ref, &dataset) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Replay the seal chain + content hashes and report integrity (JSON verdict).
+/// Empty ``db_path`` reads the in-DB dataset.
+#[pg_extern]
+pub fn gm_identity_audit_verify(dataset: String, db_path: String) -> String {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_audit_verify(&store_ref, &dataset) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Full MDM profile of one entity (JSON), or ``{"found": false}`` when absent.
+/// Empty ``db_path`` reads the in-DB dataset.
+#[pg_extern]
+pub fn gm_identity_profile(entity_id: String, db_path: String) -> String {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_profile(&store_ref, &entity_id) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Graph-level identity health summary (JSON). Empty ``dataset`` = whole graph;
+/// empty ``db_path`` reads the in-DB dataset.
+#[pg_extern]
+pub fn gm_identity_stats(dataset: String, db_path: String) -> String {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_stats(&store_ref, &dataset) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}
+
+/// Prioritized steward worklist (JSON `{"items": [...]}`) — active entities with
+/// open conflicts and/or weak confidence. Empty ``dataset`` = all; empty
+/// ``db_path`` reads the in-DB dataset.
+#[pg_extern]
+pub fn gm_identity_worklist(dataset: String, db_path: String) -> String {
+    let store_ref = identity_store_ref(db_path);
+    match goldenmatch_bridge::api::identity_worklist(&store_ref, &dataset) {
+        Ok(json) => json,
+        Err(e) => pgrx::error!("goldenmatch: {}", e),
+    }
+}


### PR DESCRIPTION
## Why

`#1913` (closed) brought Postgres from read-only identity to a stateful in-DB engine: `gm_resolve` (create/absorb/merge), the reads serving the in-DB dataset on empty `db_path`, and steward `gm_identity_merge`/`_split`. Its **explicit non-goals** — the audit chain, conflict mediation, and MDM operator reads — were still Python/MCP-only, so the SQL surface lagged the every-capability-on-every-surface commitment. This closes that with the remaining **8 functions**.

## What

**New SQL functions** (pgrx `0.15.0` → `0.16.0`):

| Function | Kind | Python entrypoint |
|---|---|---|
| `gm_identity_audit(dataset, db_path)` | read | `store.export_audit_log` |
| `gm_identity_audit_verify(dataset, db_path)` | read | `verify_audit_chain` |
| `gm_identity_profile(entity_id, db_path)` | read | `entity_profile` |
| `gm_identity_stats(dataset, db_path)` | read | `identity_summary_stats` |
| `gm_identity_worklist(dataset, db_path)` | read | `steward_worklist` |
| `gm_identity_audit_seal(dataset)` | write | `seal_audit_log` |
| `gm_identity_resolve_conflict(dataset, a, b, resolution, reason)` | write | `mediate_conflict` |
| `gm_identity_claim(entity_id, record_id, reason)` | write | `claim_record` |

Reads take the same `db_path` store ref as the existing identity reads (empty → the in-DB dataset via `goldenmatch.identity_dsn`); writes are DSN-required like `gm_identity_merge`.

## The one design decision worth calling out

The three audit results had **no** single serializer — the MCP handler built those dicts inline. Rather than duplicate that field-by-field in Rust (a guaranteed drift surface), I **single-sourced it in Python**: added `AuditVerification.as_dict()`, `seal_result_dict()`, `audit_log_page()`, `steward_worklist_page()`, and refactored `mcp/identity_tools.py` to call them. SQL output is now byte-identical to MCP *by construction*, and the MCP handler got shorter.

The bridge deliberately does **not** reuse the MCP `_dispatch`: `goldenmatch/mcp/identity_tools.py` hard-imports `from mcp.types import ...`, and the extension host installs `goldenmatch` without the optional `mcp` extra. It calls `goldenmatch.identity` directly, like every existing identity bridge fn.

## Verification

Locally green: `pgrx_sql_sync` **79/79**, `ruff` clean, `cargo check` + `clippy -D warnings` clean on the bridge, **58** Python identity/MCP tests pass (the MCP dedup keeps the existing assertions green). The pgrx build + psql smoke are CI-only (`rust_pgrx`, PG 15/16/17) — that lane is extended here: seal → verify(`ok`) → audit page, profile `record_count`, stats, worklist shape, a `defer` mediation verdict, and a same-entity claim (`moved=false`).

## Docs

New **Identity graph** section in `docs-site/extensions/sql.mdx` (the in-DB identity surface was previously undocumented there, including the `#1913` functions), and corrected the now-stale *"SQL identity surface is read-only by design"* claims in the extensions `CLAUDE.md`.

DuckDB parity stays **deferred by design** (no durable multi-connection identity store), consistent with `#1913`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)