### PR TITLE
feat(ts): analyze-blocking, autoconfig, lineage, explain CLI commands (parity batch 1)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -27,7 +27,7 @@ package does not ship that surface.
 {/* api-surface-matrix:generated:start -- DO NOT EDIT. Regenerate: python scripts/gen_api_surface.py --write */}
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
-| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.18.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
+| [GoldenMatch](#goldenmatch) | `3.8.0` | `1.19.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
 | [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
 | [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -42,7 +42,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | Package | Surface | Shared | Python-only | TS-only |
 |---|---|---|---|---|
 | `goldenmatch` | mcp_tools | 72 | 10 | 8 |
-| `goldenmatch` | cli_commands | 15 | 21 | 1 |
+| `goldenmatch` | cli_commands | 19 | 17 | 1 |
 | `goldenmatch` | a2a_skills | 33 | 14 | 13 |
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
@@ -65,7 +65,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - **No A2A skills surface:** `goldenanalysis`, `infermap`.
 - `goldenmatch` **mcp_tools** — Python-only: `create_domain`, `documents_ingest`, `documents_suggest_schema`, `explain_routing`, `lint_routing`, `list_domains`, `list_plugins`, `plan_routing`, `pprl_auto_config`, `test_domain`.
 - `goldenmatch` **mcp_tools** — TS-only: `build_clusters`, `find_exact_matches`, `find_fuzzy_matches`, `read_file`, `score_pair`, `score_strings`, `server_info`, `write_csv`.
-- `goldenmatch` **cli_commands** — Python-only: `analyze-blocking`, `anomalies`, `autoconfig`, `config`, `explain`, `ingest-docs`, `init`, `interactive`, `label`, `lineage`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
+- `goldenmatch` **cli_commands** — Python-only: `anomalies`, `config`, `ingest-docs`, `init`, `interactive`, `label`, `pprl`, `review`, `rollback`, `runs`, `schedule`, `sensitivity`, `serve-ui`, `setup`, `sync`, `unmerge`, `watch`.
 - `goldenmatch` **cli_commands** — TS-only: `tui`.
 - `goldenmatch` **a2a_skills** — Python-only: `analyze_blocking`, `compare_clusters`, `configure`, `documents_ingest`, `documents_suggest_schema`, `incremental`, `list_runs`, `pprl`, `quality`, `retrieve_similar`, `review`, `rollback`, `schema_match`, `sensitivity`.
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.

--- a/packages/typescript/goldenmatch/CHANGELOG.md
+++ b/packages/typescript/goldenmatch/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to goldenmatch-js are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follows [Semantic Versioning](https://semver.org/) (strict after v1.0.0).
 
+## [1.19.0] - 2026-07-24
+
+### Added
+- **`analyze-blocking`, `autoconfig`, `lineage`, `explain` CLI commands** (cross-language parity batch 1). Four more `cli_commands python_only -> shared` moves; each is thin wiring over a core TS already had. This **discharges the 1.18.0 "Deferred" note** for `lineage` + `analyze-blocking`: the blocker was the missing in-memory dedupe-run context, and these commands simply run `dedupe` first to build it.
+  - `analyze-blocking <files...> [-c config] [--top n] [-o out.json]` - blocking-strategy suggestions (`analyzeBlocking`) over the configured matchkey fields, de-duplicated across matchkeys; falls back to the fields zero-config picks when no `--config` is given. Mirrors Python `analyze-blocking`.
+  - `autoconfig <files...> [-o out.json]` - derive and print the zero-config `GoldenMatchConfig` (`autoConfigure`): matchkeys, scorers, thresholds, blocking. Mirrors Python `autoconfig`.
+  - `lineage <files...> [-c config] [-o lineage.json]` - run a dedupe and persist the per-pair lineage (`buildLineage`). Mirrors Python `lineage`.
+  - `explain <files...> --pair a,b | --cluster id` - plain-language pair/cluster explanation (`explainPair` / `explainCluster`) over a fresh run. Mirrors Python `explain`.
+  - Tests: `tests/unit/cli-parity-batch1.test.ts`.
+
+### Fixed
+- `lineage` CLI output no longer reports `LineageBundle.recordCount` as a record total. That field is a misnomer in `core/lineage.ts` (it is set to `edges.length`), so the command prints the edge count and `stats.totalRecords` separately. The misnomer is now pinned by a test; it is TS-internal (Python's `build_lineage` returns a bare list of edge dicts with no equivalent field), so no cross-language behavior changed.
+
+### Deferred (documented)
+- `sensitivity` + `unmerge` remain `python_only` from the 1.18.0 list: `sensitivity` needs sweep-spec plumbing (a param-sweep description the CLI has no syntax for yet) and `unmerge` needs a *persisted* run to mutate rather than a fresh in-memory one. Still a bounded follow-up, not a silent drop.
+
 ## [1.18.0] - 2026-07-23
 
 ### Added

--- a/packages/typescript/goldenmatch/package.json
+++ b/packages/typescript/goldenmatch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenmatch",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "Entity resolution toolkit — deduplicate, match, and create golden records",
   "type": "module",
   "exports": {

--- a/packages/typescript/goldenmatch/src/cli.ts
+++ b/packages/typescript/goldenmatch/src/cli.ts
@@ -15,7 +15,15 @@ import {
   writeJson,
 } from "./node/connectors/file.js";
 import { dedupe, match, scoreStrings } from "./core/api.js";
-import { evaluateClusters, loadGroundTruthPairs } from "./core/index.js";
+import {
+  buildLineage,
+  evaluateClusters,
+  explainCluster,
+  explainPair,
+  loadGroundTruthPairs,
+} from "./core/index.js";
+import { analyzeBlocking } from "./core/block-analyzer.js";
+import { autoConfigure } from "./core/autoconfig.js";
 import { loadConfigFile } from "./node/config-file.js";
 import { readFileSync, writeFileSync } from "node:fs";
 import {
@@ -1083,6 +1091,163 @@ program
       process.exit(1);
     }
   });
+
+// ---------- analyze-blocking ----------
+program
+  .command("analyze-blocking")
+  .description("Analyze data and suggest optimal blocking strategies")
+  .argument("<files...>", "input file paths (.csv, .tsv, .json, .jsonl)")
+  .option("-c, --config <path>", "config file whose matchkey fields to block on")
+  .option("--top <n>", "how many suggestions to show", (v) => parseInt(v, 10), 5)
+  .option("-o, --output <path>", "save the full suggestion list to JSON")
+  .action((files: string[], opts: { config?: string; top: number; output?: string }) => {
+    const rows = loadFilesWithSource(files);
+    // Block on the configured matchkey fields when a config is supplied;
+    // otherwise fall back to the fields zero-config would pick.
+    const cfg = opts.config ? loadConfigFile(opts.config) : autoConfigure(rows);
+    const columns = [
+      ...new Set(
+        (cfg.matchkeys ?? []).flatMap((mk) =>
+          (mk.fields ?? []).map((f) => f.field).filter((f): f is string => !!f),
+        ),
+      ),
+    ];
+    if (columns.length === 0) {
+      process.stderr.write("No matchkey fields to analyze; pass --config.\n");
+      process.exit(1);
+    }
+    const suggestions = analyzeBlocking(rows, columns);
+    process.stdout.write(
+      `Blocking analysis: ${rows.length} records, ${columns.length} candidate field(s)\n`,
+    );
+    for (const s of suggestions.slice(0, opts.top)) {
+      process.stdout.write(
+        `  ${s.description}\n` +
+          `      groups=${s.group_count} max=${s.max_group_size} ` +
+          `mean=${s.mean_group_size.toFixed(1)} comparisons=${s.total_comparisons} ` +
+          `recall~${(s.estimated_recall * 100).toFixed(1)}% score=${s.score.toFixed(3)}\n`,
+      );
+    }
+    if (opts.output) {
+      writeFileSync(opts.output, JSON.stringify(suggestions, null, 2) + "\n", "utf-8");
+      process.stdout.write(`Suggestions saved to ${opts.output}\n`);
+    }
+  });
+
+// ---------- autoconfig ----------
+program
+  .command("autoconfig")
+  .description("Derive a config from the data (zero-config) and print it")
+  .argument("<files...>", "input file paths (.csv, .tsv, .json, .jsonl)")
+  .option("-o, --output <path>", "save the derived config to JSON")
+  .action((files: string[], opts: { output?: string }) => {
+    const rows = loadFilesWithSource(files);
+    const cfg = autoConfigure(rows);
+    const mks = cfg.matchkeys ?? [];
+    process.stdout.write(
+      `Auto-config derived from ${rows.length} records: ${mks.length} matchkey(s)\n`,
+    );
+    for (const mk of mks) {
+      const fields = (mk.fields ?? [])
+        .map((f) => `${f.field}${f.scorer ? `:${f.scorer}` : ""}`)
+        .join(", ");
+      process.stdout.write(
+        `  ${mk.name ?? "(unnamed)"} [${mk.type}]` +
+          `${mk.threshold != null ? ` threshold=${mk.threshold}` : ""}\n` +
+          `      fields: ${fields || "(none)"}\n`,
+      );
+    }
+    if (cfg.blocking) {
+      process.stdout.write(
+        `  blocking: ${cfg.blocking.strategy ?? "static"}` +
+          `${cfg.blocking.keys ? ` on ${cfg.blocking.keys.join(", ")}` : ""}\n`,
+      );
+    }
+    if (opts.output) {
+      writeFileSync(opts.output, JSON.stringify(cfg, null, 2) + "\n", "utf-8");
+      process.stdout.write(`Config saved to ${opts.output}\n`);
+    }
+  });
+
+// ---------- lineage ----------
+program
+  .command("lineage")
+  .description("Build + persist the per-pair match lineage for a run")
+  .argument("<files...>", "input file paths (.csv, .tsv, .json, .jsonl)")
+  .option("-c, --config <path>", "path to YAML config file")
+  .option("-e, --exact <fields>", "comma-separated exact match fields")
+  .option("-f, --fuzzy <fields>", "fuzzy match fields, e.g. 'name:0.85'")
+  .option("-b, --blocking <fields>", "comma-separated blocking keys")
+  .option("-t, --threshold <value>", "overall fuzzy threshold", parseFloat)
+  .option("-o, --output <path>", "lineage JSON output path", "lineage.json")
+  .action(async (files: string[], opts: SharedMatchOpts & { output: string }) => {
+    const rows = loadFilesWithSource(files);
+    const result = await dedupe(rows, buildOptionsFromFlags(opts));
+    const bundle = buildLineage(result);
+    writeFileSync(opts.output, JSON.stringify(bundle, null, 2) + "\n", "utf-8");
+    // NOTE: bundle.recordCount is edges.length (a misnomer in core/lineage.ts),
+    // so report the pair/edge count and the run's record count separately rather
+    // than echoing it as a record total.
+    process.stdout.write(
+      `Lineage: ${bundle.edges.length} pair edge(s) over ` +
+        `${result.stats.totalRecords} record(s) -> ${opts.output}\n`,
+    );
+  });
+
+// ---------- explain ----------
+program
+  .command("explain")
+  .description("Explain why a pair matched, or summarize a cluster")
+  .argument("<files...>", "input file paths (.csv, .tsv, .json, .jsonl)")
+  .option("-c, --config <path>", "path to YAML config file")
+  .option("-e, --exact <fields>", "comma-separated exact match fields")
+  .option("-f, --fuzzy <fields>", "fuzzy match fields, e.g. 'name:0.85'")
+  .option("-b, --blocking <fields>", "comma-separated blocking keys")
+  .option("-t, --threshold <value>", "overall fuzzy threshold", parseFloat)
+  .option("--pair <a,b>", "explain a record pair by row id, e.g. '0,1'")
+  .option("--cluster <id>", "explain a cluster by id", (v) => parseInt(v, 10))
+  .action(
+    async (
+      files: string[],
+      opts: SharedMatchOpts & { pair?: string; cluster?: number },
+    ) => {
+      if (!opts.pair && opts.cluster == null) {
+        process.stderr.write("Pass --pair <a,b> or --cluster <id>.\n");
+        process.exit(1);
+      }
+      const rows = loadFilesWithSource(files);
+      const result = await dedupe(rows, buildOptionsFromFlags(opts));
+      const mk = (result.config.matchkeys ?? [])[0];
+      if (!mk) {
+        process.stderr.write("No matchkey in the resolved config; nothing to explain.\n");
+        process.exit(1);
+      }
+      if (opts.pair) {
+        const [a, b] = opts.pair.split(",").map((s) => parseInt(s.trim(), 10));
+        const rowA = rows[a as number];
+        const rowB = rows[b as number];
+        if (!rowA || !rowB) {
+          process.stderr.write(`Row id out of range (have ${rows.length} rows).\n`);
+          process.exit(1);
+        }
+        const ex = explainPair(rowA, rowB, mk);
+        process.stdout.write(
+          `${ex.explanation}\n` +
+            `  score=${ex.score.toFixed(4)} confidence=${ex.confidence}\n` +
+            ex.reasoning.map((r) => `  - ${r}\n`).join(""),
+        );
+      } else {
+        const cluster = result.clusters.get(opts.cluster as number);
+        if (!cluster) {
+          process.stderr.write(`Cluster ${opts.cluster} not found.\n`);
+          process.exit(1);
+        }
+        process.stdout.write(
+          explainCluster(opts.cluster as number, cluster, rows, mk).summary + "\n",
+        );
+      }
+    },
+  );
 
 // ---------------------------------------------------------------------------
 // Entry point

--- a/packages/typescript/goldenmatch/src/node/a2a/server.ts
+++ b/packages/typescript/goldenmatch/src/node/a2a/server.ts
@@ -226,7 +226,7 @@ export const AGENT_CARD: AgentCard = {
   name: "goldenmatch-js",
   description:
     "Entity resolution agent -- dedupe, match, profile, score, explain, evaluate.",
-  version: "1.18.0",
+  version: "1.19.0",
   provider: {
     organization: "goldenmatch",
     url: "https://github.com/benseverndev-oss/goldenmatch",

--- a/packages/typescript/goldenmatch/src/node/mcp/server.ts
+++ b/packages/typescript/goldenmatch/src/node/mcp/server.ts
@@ -1164,7 +1164,7 @@ export async function handleTool(
       case "server_info":
         return {
           name: "goldenmatch-js",
-          version: "1.18.0",
+          version: "1.19.0",
           tool_count: TOOLS.length,
           description:
             "Node-only GoldenMatch MCP server over stdio (JSON-RPC 2.0)",
@@ -1591,7 +1591,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "goldenmatch-js", version: "1.18.0" },
+              serverInfo: { name: "goldenmatch-js", version: "1.19.0" },
               capabilities: { tools: {} },
             },
           });

--- a/packages/typescript/goldenmatch/tests/unit/cli-parity-batch1.test.ts
+++ b/packages/typescript/goldenmatch/tests/unit/cli-parity-batch1.test.ts
@@ -1,0 +1,114 @@
+/**
+ * cli-parity-batch1.test.ts -- TS CLI parity batch 1: `analyze-blocking`,
+ * `autoconfig`, `lineage`, and `explain`. These four closed Python-only gaps in
+ * `parity/goldenmatch.yaml` (cli_commands), and each is thin wiring over a core
+ * that already existed in TS.
+ *
+ * Per repo convention (cli-memory / cli-evaluate / cli-compare-incremental) we
+ * test the core logic each subcommand wraps -- plus the small amount of real
+ * logic that lives in the command itself (the matchkey-field derivation
+ * `analyze-blocking` does) -- rather than driving the commander tree.
+ */
+import { describe, it, expect } from "vitest";
+import { analyzeBlocking } from "../../src/core/block-analyzer.js";
+import { autoConfigure } from "../../src/core/autoconfig.js";
+import { buildLineage, explainCluster, explainPair } from "../../src/core/index.js";
+import { dedupe } from "../../src/core/api.js";
+import type { GoldenMatchConfig, Row } from "../../src/core/types.js";
+
+// Surnames spread across distinct soundex codes -- a same-code fixture makes
+// blocking degenerate (one giant block) and is slow/meaningless to analyze.
+const ROWS: Row[] = [
+  { id: "1", name: "Alice Nguyen", email: "a@x.com", city: "Boston" },
+  { id: "2", name: "Alice Nguyen", email: "a@x.com", city: "Boston" },
+  { id: "3", name: "Bob Okafor", email: "b@y.com", city: "Denver" },
+  { id: "4", name: "Carol Petrov", email: "c@z.com", city: "Austin" },
+  { id: "5", name: "Dave Quinn", email: "d@w.com", city: "Fresno" },
+];
+
+/** Mirrors the field-derivation the `analyze-blocking` command performs. */
+function matchkeyColumns(cfg: GoldenMatchConfig): string[] {
+  return [
+    ...new Set(
+      (cfg.matchkeys ?? []).flatMap((mk) =>
+        (mk.fields ?? []).map((f) => f.field).filter((f): f is string => !!f),
+      ),
+    ),
+  ];
+}
+
+describe("analyze-blocking command logic", () => {
+  it("derives de-duplicated matchkey columns from a config", () => {
+    const cfg = {
+      matchkeys: [
+        { name: "a", type: "fuzzy", fields: [{ field: "name" }, { field: "city" }] },
+        { name: "b", type: "exact", fields: [{ field: "name" }] }, // repeat
+      ],
+    } as unknown as GoldenMatchConfig;
+    // "name" appears twice across matchkeys but must be analyzed once.
+    expect(matchkeyColumns(cfg)).toEqual(["name", "city"]);
+  });
+
+  it("suggests blocking strategies with sane group statistics", () => {
+    const suggestions = analyzeBlocking(ROWS, ["name", "city", "email"]);
+    expect(suggestions.length).toBeGreaterThan(0);
+    for (const s of suggestions) {
+      expect(s.group_count).toBeGreaterThan(0);
+      expect(s.max_group_size).toBeGreaterThanOrEqual(1);
+      expect(s.estimated_recall).toBeGreaterThanOrEqual(0);
+      expect(s.estimated_recall).toBeLessThanOrEqual(1);
+      expect(typeof s.description).toBe("string");
+    }
+  });
+});
+
+describe("autoconfig command logic", () => {
+  it("derives a config with at least one matchkey from raw rows", () => {
+    const cfg = autoConfigure(ROWS);
+    const mks = cfg.matchkeys ?? [];
+    expect(mks.length).toBeGreaterThan(0);
+    // every derived matchkey is printable by the command (name + type + fields)
+    for (const mk of mks) {
+      expect(typeof mk.type).toBe("string");
+      expect(Array.isArray(mk.fields)).toBe(true);
+    }
+  });
+});
+
+describe("lineage command logic", () => {
+  it("builds a lineage bundle over a dedupe result", async () => {
+    const result = await dedupe(ROWS, { exact: ["email"] });
+    const bundle = buildLineage(result);
+    expect(Array.isArray(bundle.edges)).toBe(true);
+    expect(typeof bundle.timestamp).toBe("string");
+    // the two identical a@x.com rows matched, so there is at least one edge
+    expect(bundle.edges.length).toBeGreaterThan(0);
+    // NOTE: `recordCount` is a misnomer in the TS bundle -- core/lineage.ts sets
+    // it to `edges.length`, NOT the input row count. Locked here so the CLI's
+    // reporting stays honest (Python's build_lineage returns a bare list of edge
+    // dicts and has no equivalent field, so this is TS-internal, not a parity gap).
+    expect(bundle.recordCount).toBe(bundle.edges.length);
+  });
+});
+
+describe("explain command logic", () => {
+  it("explains a matched pair with a score and reasoning", async () => {
+    const result = await dedupe(ROWS, { exact: ["email"] });
+    const mk = (result.config.matchkeys ?? [])[0]!;
+    const ex = explainPair(ROWS[0]!, ROWS[1]!, mk);
+    expect(ex.score).toBeGreaterThan(0);
+    expect(typeof ex.explanation).toBe("string");
+    expect(["high", "medium", "low"]).toContain(ex.confidence);
+    expect(Array.isArray(ex.reasoning)).toBe(true);
+  });
+
+  it("summarizes a cluster produced by the run", async () => {
+    const result = await dedupe(ROWS, { exact: ["email"] });
+    const mk = (result.config.matchkeys ?? [])[0]!;
+    const [clusterId, cluster] = [...result.clusters.entries()][0]!;
+    const ex = explainCluster(clusterId, cluster, ROWS, mk);
+    expect(ex.clusterId).toBe(clusterId);
+    expect(ex.size).toBeGreaterThan(0);
+    expect(typeof ex.summary).toBe("string");
+  });
+});

--- a/parity/goldenmatch.yaml
+++ b/parity/goldenmatch.yaml
@@ -142,14 +142,18 @@ mcp_tools:
 cli_commands:
   shared:
   - agent-serve
+  - analyze-blocking
+  - autoconfig
   - compare-clusters
   - dedupe
   - demo
   - evaluate
+  - explain
   - identity
   - import-splink
   - incremental
   - info
+  - lineage
   - match
   - mcp-serve
   - memory
@@ -157,16 +161,12 @@ cli_commands:
   - score
   - serve
   python_only:
-  - analyze-blocking
   - anomalies
-  - autoconfig
   - config
-  - explain
   - ingest-docs
   - init
   - interactive
   - label
-  - lineage
   - pprl
   - review
   - rollback


### PR DESCRIPTION
First batch of the cross-language parity push. Four goldenmatch CLI commands move **`python_only` → `shared`**, taking that surface from **21 → 17** Python-exclusive commands.

| Command | Wraps (already in TS) |
|---|---|
| `analyze-blocking <files...> [-c config] [--top n] [-o out]` | `analyzeBlocking` |
| `autoconfig <files...> [-o out]` | `autoConfigure` |
| `lineage <files...> [-c config] [-o lineage.json]` | `buildLineage` |
| `explain <files...> --pair a,b \| --cluster id` | `explainPair` / `explainCluster` |

Each is thin wiring over a core TypeScript already had — no logic reimplemented.

## This discharges a previously documented deferral

The 1.18.0 changelog deferred `lineage` and `analyze-blocking` because they "need an in-memory dedupe-run context that the stateless CLI path doesn't carry." The answer turned out to be simple: run `dedupe` inside the command to build that context. That's what `lineage` and `explain` now do.

Still deferred, honestly: **`sensitivity`** (needs a param-sweep syntax the CLI has no grammar for) and **`unmerge`** (needs a *persisted* run to mutate, not a fresh in-memory one).

## Bug found and fixed along the way

The `lineage` command printed a misleading record total. `LineageBundle.recordCount` is a **misnomer** in `core/lineage.ts` — it's set to `edges.length`, not a record count. The command now reports the edge count and `stats.totalRecords` separately. I pinned the misnomer with a test rather than renaming the field, because it's TS-internal: Python's `build_lineage` returns a bare list of edge dicts and has no equivalent field, so nothing cross-language changed.

## Verification

- **Surface emitter against a real built `dist`**: 20 commands emitted = 19 `shared` + `tui` — exactly matching the manifest, so `api_parity` should be satisfied.
- `check_version_consistency.py` green (32 packages) after the 1.18.0 → 1.19.0 bump across all four lockstep spots.
- `docs-site/suite-matrix.mdx` regenerated via `gen_suite_matrix.py`.
- 6 new tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)