### PR TITLE
feat(ts): expose the existing TS servers as CLI commands (parity batch 2)

### DIFF
--- a/docs-site/reference/api-surface.mdx
+++ b/docs-site/reference/api-surface.mdx
@@ -28,11 +28,11 @@ package does not ship that surface.
 | Package | Python (PyPI) | TypeScript (npm) | CLI | MCP tools | REST | A2A | Native / SQL |
 |---------|:-------------:|:----------------:|-----|:---------:|:----:|:---:|--------------|
 | [GoldenMatch](#goldenmatch) | `3.8.0` | `1.18.0` | `goldenmatch` | 82 | ✓ | ✓ | wheel · Postgres · DuckDB |
-| [GoldenCheck](#goldencheck) | `3.2.0` | `0.5.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
-| [GoldenFlow](#goldenflow) | `2.1.0` | `0.16.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
+| [GoldenCheck](#goldencheck) | `3.2.0` | `0.6.0` | `goldencheck` | 19 | ✓ | ✓ | wheel |
+| [GoldenFlow](#goldenflow) | `2.1.0` | `0.17.0` | `goldenflow` | 10 | ✓ | ✓ | wheel |
 | [GoldenPipe](#goldenpipe) | `1.4.0` | `0.3.0` | `goldenpipe` | 4 | ✓ | ✓ | core (WASM) |
 | [GoldenAnalysis](#goldenanalysis) | `0.4.0` | `0.1.0` | `goldenanalysis` | 4 | — | — | core (WASM) |
-| [InferMap](#infermap) | `0.6.0` | `0.6.0` | `infermap` | 4 | — | — | wheel |
+| [InferMap](#infermap) | `0.6.0` | `0.7.0` | `infermap` | 4 | — | — | wheel |
 {/* api-surface-matrix:generated:end */}
 
 ## Python vs TypeScript: the surface boundary

--- a/docs-site/suite-matrix.mdx
+++ b/docs-site/suite-matrix.mdx
@@ -47,10 +47,10 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenmatch` | scorers | 19 | 3 | 0 |
 | `goldenmatch` | transforms | 13 | 0 | 0 |
 | `goldencheck` | mcp_tools | 18 | 1 | 0 |
-| `goldencheck` | cli_commands | 13 | 9 | 0 |
+| `goldencheck` | cli_commands | 14 | 8 | 0 |
 | `goldencheck` | a2a_skills | 9 | 0 | 0 |
 | `goldenflow` | mcp_tools | 10 | 0 | 0 |
-| `goldenflow` | cli_commands | 9 | 7 | 0 |
+| `goldenflow` | cli_commands | 12 | 4 | 0 |
 | `goldenflow` | a2a_skills | 6 | 0 | 0 |
 | `goldenpipe` | mcp_tools | 4 | 0 | 0 |
 | `goldenpipe` | cli_commands | 7 | 1 | 0 |
@@ -58,7 +58,7 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 | `goldenanalysis` | mcp_tools | 4 | 0 | 0 |
 | `goldenanalysis` | cli_commands | 4 | 0 | 0 |
 | `infermap` | mcp_tools | 4 | 0 | 0 |
-| `infermap` | cli_commands | 4 | 1 | 0 |
+| `infermap` | cli_commands | 5 | 0 | 0 |
 
 ## Gaps & asymmetries (auto-detected)
 
@@ -71,9 +71,8 @@ Per surface: values shared by both languages vs each language's exclusives. A no
 - `goldenmatch` **a2a_skills** — TS-only: `agent_approve_reject`, `agent_deduplicate`, `agent_explain_cluster`, `agent_explain_pair`, `agent_match_sources`, `agent_review_queue`, `fix_quality`, `identity_profile`, `identity_stats`, `identity_worklist`, `memory_import`, `scan_quality`, `score`.
 - `goldenmatch` **scorers** — Python-only: `date_diff`, `geo_haversine`, `numeric_diff`.
 - `goldencheck` **mcp_tools** — Python-only: `install_domain`.
-- `goldencheck` **cli_commands** — Python-only: `agent-serve`, `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
-- `goldenflow` **cli_commands** — Python-only: `agent-serve`, `init`, `interactive`, `mcp-serve`, `schedule`, `serve`, `watch`.
+- `goldencheck` **cli_commands** — Python-only: `denial-constraints`, `init`, `learn`, `refs`, `review`, `scan-db`, `schedule`, `serve`.
+- `goldenflow` **cli_commands** — Python-only: `init`, `interactive`, `schedule`, `watch`.
 - `goldenpipe` **cli_commands** — Python-only: `interactive`.
-- `infermap` **cli_commands** — Python-only: `mcp-serve`.
 
 {/* suite-matrix:generated:end */}

--- a/packages/typescript/goldencheck/package.json
+++ b/packages/typescript/goldencheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldencheck",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Data validation that discovers rules from your data. TypeScript port of the goldencheck Python library.",
   "keywords": [
     "data-validation",

--- a/packages/typescript/goldencheck/src/cli.ts
+++ b/packages/typescript/goldencheck/src/cli.ts
@@ -23,7 +23,7 @@ export const program = new Command();
 program
   .name("goldencheck-js")
   .description("Data validation that discovers rules from your data")
-  .version("0.5.0");
+  .version("0.6.0");
 
 // --- scan ---
 program
@@ -197,13 +197,23 @@ program
 // --- mcp-serve ---
 program
   .command("mcp-serve")
-  .description("Start MCP server (stdio)")
-  .option("--transport <type>", "Transport: stdio or http", "stdio")
-  .option("--port <n>", "HTTP port (for http transport)", "8100")
-  .action((_opts: Record<string, unknown>) => {
-    console.log("MCP server — use with Claude Desktop or other MCP clients");
-    console.log("MCP server implementation requires @modelcontextprotocol/sdk");
-    process.exit(1);
+  .description("Start MCP server over stdio (JSON-RPC 2.0)")
+  .action(async () => {
+    // `startMcpServer` is a hand-rolled, zero-dependency JSON-RPC-over-stdio
+    // loop -- it does NOT need @modelcontextprotocol/sdk. This command used to
+    // print that it did and exit(1), so the surface was "shared" in name only.
+    const { startMcpServer } = await import("./node/mcp/server.js");
+    startMcpServer();
+  });
+
+// --- agent-serve (A2A) ---
+program
+  .command("agent-serve")
+  .description("Start the A2A agent server")
+  .option("-p, --port <port>", "port", "8100")
+  .action(async (opts: { port: string }) => {
+    const { runA2aServer } = await import("./node/a2a/server.js");
+    runA2aServer(parseInt(opts.port, 10));
   });
 
 // --- demo ---

--- a/packages/typescript/goldencheck/src/core/engine/notifier.ts
+++ b/packages/typescript/goldencheck/src/core/engine/notifier.ts
@@ -91,7 +91,7 @@ export async function sendWebhook(
 
   const payload = {
     tool: "goldencheck-js",
-    version: "0.5.0",
+    version: "0.6.0",
     trigger,
     file,
     health_grade: grade,

--- a/packages/typescript/goldencheck/src/node/a2a/server.ts
+++ b/packages/typescript/goldencheck/src/node/a2a/server.ts
@@ -29,7 +29,7 @@ import { ReviewQueue, type ReviewItem } from "../../core/agent/review-queue.js";
 
 export const AGENT_CARD = {
   name: "goldencheck-agent",
-  version: "0.5.0",
+  version: "0.6.0",
   description: "Data validation agent that discovers rules from your data.",
   skills: [
     { id: "scan", description: "Scan a data file for quality issues" },

--- a/packages/typescript/goldencheck/src/node/mcp/server.ts
+++ b/packages/typescript/goldencheck/src/node/mcp/server.ts
@@ -375,7 +375,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldencheck", version: "0.5.0" },
+            serverInfo: { name: "goldencheck", version: "0.6.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/goldenflow/package.json
+++ b/packages/typescript/goldenflow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goldenflow",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Data transformation toolkit — standardize, reshape, and normalize messy data. TypeScript port of the goldenflow Python library.",
   "keywords": [
     "data-transformation",

--- a/packages/typescript/goldenflow/src/cli.ts
+++ b/packages/typescript/goldenflow/src/cli.ts
@@ -20,7 +20,7 @@ import { listRuns } from "./node/history.js";
 // Ensure all transforms are registered
 import "./core/transforms/index.js";
 
-const VERSION = "0.16.0";
+const VERSION = "0.17.0";
 
 export const program = new Command()
   .name("goldenflow-js")
@@ -246,6 +246,37 @@ transforms:
     console.log("Demo files created:");
     console.log(`  Data:   ${join(dir, "demo_data.csv")}`);
     console.log(`  Config: ${join(dir, "demo_config.yaml")}`);
+  });
+
+// --- mcp-serve ---
+program
+  .command("mcp-serve")
+  .description("Start MCP server over stdio (JSON-RPC 2.0)")
+  .action(async () => {
+    const { startMcpServer } = await import("./node/mcp/server.js");
+    startMcpServer();
+  });
+
+// --- agent-serve (A2A) ---
+program
+  .command("agent-serve")
+  .description("Start the A2A agent server")
+  .option("-p, --port <port>", "port", "8150")
+  .option("-h, --host <host>", "host", "127.0.0.1")
+  .action(async (opts: { port: string; host: string }) => {
+    const { startA2aServer } = await import("./node/a2a/server.js");
+    startA2aServer({ port: parseInt(opts.port, 10), host: opts.host });
+  });
+
+// --- serve (REST API) ---
+program
+  .command("serve")
+  .description("Start the REST API server")
+  .option("-p, --port <port>", "port", "8000")
+  .option("-h, --host <host>", "host", "127.0.0.1")
+  .action(async (opts: { port: string; host: string }) => {
+    const { runServer } = await import("./node/api/server.js");
+    runServer(parseInt(opts.port, 10), opts.host);
   });
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/packages/typescript/goldenflow/src/node/a2a/server.ts
+++ b/packages/typescript/goldenflow/src/node/a2a/server.ts
@@ -46,7 +46,7 @@ export const AGENT_CARD: {
   name: "GoldenFlow",
   description:
     "Data transformation -- standardize, clean, and normalize data with auto-detection and domain-aware transforms",
-  version: "0.16.0",
+  version: "0.17.0",
   provider: { organization: "Golden Suite" },
   url: "http://localhost:8150",
   skills: [

--- a/packages/typescript/goldenflow/src/node/api/server.ts
+++ b/packages/typescript/goldenflow/src/node/api/server.ts
@@ -14,7 +14,7 @@ function sanitizePath(raw: string): string {
   return resolved;
 }
 
-const VERSION = "0.16.0";
+const VERSION = "0.17.0";
 
 /** Strip stack / errno / syscall fields from objects + Error instances so
  *  unauthenticated callers don't see internal paths / library versions. */

--- a/packages/typescript/goldenflow/src/node/mcp/server.ts
+++ b/packages/typescript/goldenflow/src/node/mcp/server.ts
@@ -348,7 +348,7 @@ export function startMcpServer(): void {
           id,
           result: {
             protocolVersion: "2024-11-05",
-            serverInfo: { name: "goldenflow", version: "0.16.0" },
+            serverInfo: { name: "goldenflow", version: "0.17.0" },
             capabilities: { tools: {} },
           },
         });

--- a/packages/typescript/infermap/package.json
+++ b/packages/typescript/infermap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "infermap",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Schema-to-schema field mapping engine. TypeScript port of the infermap Python library.",
   "keywords": [
     "schema",

--- a/packages/typescript/infermap/src/cli.ts
+++ b/packages/typescript/infermap/src/cli.ts
@@ -28,6 +28,7 @@ Usage:
   infermap apply <source> --config <file> --output <file>
   infermap inspect <source> [--table <name>]
   infermap validate <source> --config <file> [--required <fields>] [--strict]
+  infermap mcp-serve
   infermap --help
 
 Common options:
@@ -272,7 +273,7 @@ async function cmdValidate(argv: string[]): Promise<number> {
 // ---------- entrypoint ----------
 
 // Canonical CLI command set (mirrors the main() dispatch); read by the API-parity emitter.
-export const COMMANDS = ["apply", "inspect", "map", "validate"];
+export const COMMANDS = ["apply", "inspect", "map", "mcp-serve", "validate"];
 
 async function main(): Promise<number> {
   const [, , cmd, ...rest] = process.argv;
@@ -295,6 +296,12 @@ async function main(): Promise<number> {
         return await cmdInspect(rest);
       case "validate":
         return await cmdValidate(rest);
+      case "mcp-serve": {
+        // Zero-dep JSON-RPC-over-stdio loop; runs until stdin closes.
+        const { startMcpServer } = await import("./node/mcp/server.js");
+        startMcpServer();
+        return 0;
+      }
       default:
         process.stderr.write(`Unknown command: ${cmd}\n\n${USAGE}`);
         return 1;

--- a/packages/typescript/infermap/src/node/mcp/server.ts
+++ b/packages/typescript/infermap/src/node/mcp/server.ts
@@ -573,7 +573,7 @@ export function startMcpServer(): void {
             id,
             result: {
               protocolVersion: "2024-11-05",
-              serverInfo: { name: "infermap", version: "0.6.0" },
+              serverInfo: { name: "infermap", version: "0.7.0" },
               capabilities: { tools: {}, resources: {}, prompts: {} },
             },
           });

--- a/parity/goldencheck.yaml
+++ b/parity/goldencheck.yaml
@@ -42,6 +42,7 @@ mcp_tools:
   ts_only: []
 cli_commands:
   shared:
+  - agent-serve
   - baseline
   - demo
   - diff
@@ -56,7 +57,6 @@ cli_commands:
   - validate
   - watch
   python_only:
-  - agent-serve
   - denial-constraints
   - init
   - learn

--- a/parity/goldenflow.yaml
+++ b/parity/goldenflow.yaml
@@ -26,22 +26,22 @@ mcp_tools:
   ts_only: []
 cli_commands:
   shared:
+  - agent-serve
   - demo
   - diff
   - history
   - learn
   - map
+  - mcp-serve
   - profile
+  - serve
   - stream
   - transform
   - validate
   python_only:
-  - agent-serve
   - init
   - interactive
-  - mcp-serve
   - schedule
-  - serve
   - watch
   ts_only: []
 a2a_skills:

--- a/parity/infermap.yaml
+++ b/parity/infermap.yaml
@@ -19,7 +19,7 @@ cli_commands:
   - apply
   - inspect
   - map
-  - validate
-  python_only:
   - mcp-serve
+  - validate
+  python_only: []
   ts_only: []


### PR DESCRIPTION
Batch 2 of the cross-language parity push. **Five** CLI commands move `python_only` → `shared` across three packages. Every server here **already existed in TypeScript** — only the CLI front door was missing, so this is wiring, not new capability.

| Package | Command | Wraps |
|---|---|---|
| goldenflow | `mcp-serve` | `startMcpServer` (stdio JSON-RPC) |
| goldenflow | `agent-serve` | `startA2aServer` (port 8150) |
| goldenflow | `serve` | `runServer` (REST API, port 8000) |
| goldencheck | `agent-serve` | `runA2aServer` (port 8100) |
| infermap | `mcp-serve` | `startMcpServer` |

**infermap now has zero python-only CLI commands** (5/5 shared).

## Bug found on the way

goldencheck's `mcp-serve` was listed as `shared`, but its handler printed *"MCP server implementation requires @modelcontextprotocol/sdk"* and `exit(1)`'d. **That claim is false** — `startMcpServer` in that package is a hand-rolled, zero-dependency JSON-RPC-over-stdio loop that needs no SDK. So the command was parity in name only. It now actually starts the server.

That's worth noting beyond this PR: a manifest can say `shared` while the TS side is a stub. The `api_parity` gate matches on command *names*, so it can't catch this class on its own.

## Note on infermap

Its CLI is a `COMMANDS` array + `switch` (not commander), so `mcp-serve` is added to all three places the emitter and dispatch read: `COMMANDS`, the `switch`, and `USAGE`.

## Verification

Ran the real TS surface emitter against built dists — emitted `cli_commands` match each manifest exactly: **goldenflow 12 = 12 shared, goldencheck 14 = 14 shared, infermap 5 = 5 shared**. `tsc --noEmit` clean on all three. `check_version_consistency` green (32 packages) after goldenflow `0.16.0→0.17.0`, goldencheck `0.5.0→0.6.0`, infermap `0.6.0→0.7.0`. `docs-site/suite-matrix.mdx` regenerated.

Independent of #2096 (batch 1) — disjoint packages and manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)